### PR TITLE
[codex] Ignore pylint redefined-builtin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ disable = [
   "use-symbolic-message-instead",
   "C",
   "W0221",
+  "redefined-builtin",
   "cyclic-import",
 ]
 


### PR DESCRIPTION
## Summary
- add `redefined-builtin` to the global `pylint` disable list in `pyproject.toml`
- keep the change scoped to the shared lint configuration

## Why
`pylint` should ignore `redefined-builtin` consistently across the project instead of requiring local suppressions.

## Validation
- parsed `pyproject.toml` successfully with `python -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"`
