### PR TITLE
Fix sparse multisession backend runtime array binding and regression tests

### DIFF
--- a/pyrecest/tests/test_multisession_assignment.py
+++ b/pyrecest/tests/test_multisession_assignment.py
@@ -3,6 +3,9 @@
 import unittest
 from unittest.mock import patch
 
+import numpy as np
+
+import pyrecest.utils.multisession_assignment as multisession_assignment_module
 from pyrecest.backend import (  # pylint: disable=no-name-in-module
     __backend_name__,
     array,
@@ -15,6 +18,14 @@ class TestMultiSessionAssignment(unittest.TestCase):
     @staticmethod
     def _canonical_tracks(tracks):
         return sorted(tuple(sorted(track.items())) for track in tracks)
+
+    @staticmethod
+    def _assert_valid_matching(mask, left_nodes, right_nodes):
+        selected_indices = np.flatnonzero(mask)
+        if selected_indices.size == 0:
+            return
+        assert np.unique(left_nodes[selected_indices]).size == selected_indices.size
+        assert np.unique(right_nodes[selected_indices]).size == selected_indices.size
 
     @unittest.skipIf(
         __backend_name__ == "jax",
@@ -151,6 +162,10 @@ class TestMultiSessionAssignment(unittest.TestCase):
         self.assertEqual(self._canonical_tracks(result.tracks), [((0, 0),), ((1, 0),)])
         self.assertAlmostEqual(result.total_cost, 4.0)
 
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
     def test_sparse_backend_matches_previous_linprog_backend(self):
         rng = np.random.default_rng(42)
         num_nodes = 12
@@ -181,6 +196,10 @@ class TestMultiSessionAssignment(unittest.TestCase):
             float(edge_gains[linprog_mask].sum()),
         )
 
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
     def test_sparse_backend_falls_back_to_linprog_when_requested(self):
         pairwise_costs = [
             np.array([[0.1, 8.0], [8.0, 0.2]], dtype=float),

--- a/pyrecest/tests/test_multisession_assignment.py
+++ b/pyrecest/tests/test_multisession_assignment.py
@@ -1,15 +1,18 @@
 """Tests for global multi-session association."""
 
+# pylint: disable=protected-access
+
 import unittest
 from unittest.mock import patch
-
-import numpy as np
 
 import pyrecest.utils.multisession_assignment as multisession_assignment_module
 from pyrecest.backend import (  # pylint: disable=no-name-in-module
     __backend_name__,
     array,
     array_equal,
+    sum as backend_sum,
+    unique,
+    where,
 )
 from pyrecest.utils import solve_multisession_assignment, tracks_to_session_labels
 
@@ -21,11 +24,11 @@ class TestMultiSessionAssignment(unittest.TestCase):
 
     @staticmethod
     def _assert_valid_matching(mask, left_nodes, right_nodes):
-        selected_indices = np.flatnonzero(mask)
-        if selected_indices.size == 0:
+        selected_indices = where(mask)[0]
+        if len(selected_indices) == 0:
             return
-        assert np.unique(left_nodes[selected_indices]).size == selected_indices.size
-        assert np.unique(right_nodes[selected_indices]).size == selected_indices.size
+        assert len(unique(left_nodes[selected_indices])) == len(selected_indices)
+        assert len(unique(right_nodes[selected_indices])) == len(selected_indices)
 
     @unittest.skipIf(
         __backend_name__ == "jax",
@@ -167,14 +170,18 @@ class TestMultiSessionAssignment(unittest.TestCase):
         reason="Not supported on this backend",
     )
     def test_sparse_backend_matches_previous_linprog_backend(self):
-        rng = np.random.default_rng(42)
         num_nodes = 12
         all_pairs = [(left, right) for left in range(num_nodes) for right in range(num_nodes)]
-        selected_pairs = rng.choice(len(all_pairs), size=40, replace=False)
+        selected_pairs = [
+            (index * 37 + 11) % len(all_pairs) for index in range(40)
+        ]
 
-        left_nodes = np.array([all_pairs[index][0] for index in selected_pairs], dtype=int)
-        right_nodes = np.array([all_pairs[index][1] for index in selected_pairs], dtype=int)
-        edge_gains = rng.uniform(0.1, 10.0, size=selected_pairs.size)
+        left_nodes = array([all_pairs[index][0] for index in selected_pairs], dtype=int)
+        right_nodes = array([all_pairs[index][1] for index in selected_pairs], dtype=int)
+        edge_gains = array(
+            [0.1 + ((index * 17) % 97) / 10.0 for index in range(len(selected_pairs))],
+            dtype=float,
+        )
 
         sparse_mask = multisession_assignment_module._solve_max_weight_matching(
             left_nodes,
@@ -192,8 +199,8 @@ class TestMultiSessionAssignment(unittest.TestCase):
         self._assert_valid_matching(sparse_mask, left_nodes, right_nodes)
         self._assert_valid_matching(linprog_mask, left_nodes, right_nodes)
         self.assertAlmostEqual(
-            float(edge_gains[sparse_mask].sum()),
-            float(edge_gains[linprog_mask].sum()),
+            float(backend_sum(edge_gains[sparse_mask])),
+            float(backend_sum(edge_gains[linprog_mask])),
         )
 
     @unittest.skipIf(
@@ -202,8 +209,8 @@ class TestMultiSessionAssignment(unittest.TestCase):
     )
     def test_sparse_backend_falls_back_to_linprog_when_requested(self):
         pairwise_costs = [
-            np.array([[0.1, 8.0], [8.0, 0.2]], dtype=float),
-            np.array([[0.1, 8.0], [8.0, 0.2]], dtype=float),
+            array([[0.1, 8.0], [8.0, 0.2]], dtype=float),
+            array([[0.1, 8.0], [8.0, 0.2]], dtype=float),
         ]
 
         with patch.object(

--- a/pyrecest/utils/__init__.py
+++ b/pyrecest/utils/__init__.py
@@ -1,8 +1,5 @@
 """Utility helpers for :mod:`pyrecest`."""
 
-import numpy as _np
-
-from . import multisession_assignment as _multisession_assignment
 from .multisession_assignment import (
     MultiSessionAssignmentResult,
     solve_multisession_assignment,
@@ -15,8 +12,6 @@ from .nonrigid_point_set_registration import (
     estimate_thin_plate_spline,
     joint_tps_registration_assignment,
 )
-
-_multisession_assignment.np = _np
 
 __all__ = [
     "MultiSessionAssignmentResult",

--- a/pyrecest/utils/__init__.py
+++ b/pyrecest/utils/__init__.py
@@ -1,5 +1,8 @@
 """Utility helpers for :mod:`pyrecest`."""
 
+import numpy as _np
+
+from . import multisession_assignment as _multisession_assignment
 from .multisession_assignment import (
     MultiSessionAssignmentResult,
     solve_multisession_assignment,
@@ -12,6 +15,8 @@ from .nonrigid_point_set_registration import (
     estimate_thin_plate_spline,
     joint_tps_registration_assignment,
 )
+
+_multisession_assignment.np = _np
 
 __all__ = [
     "MultiSessionAssignmentResult",

--- a/pyrecest/utils/multisession_assignment.py
+++ b/pyrecest/utils/multisession_assignment.py
@@ -24,10 +24,11 @@ from __future__ import annotations
 import math
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from pyrecest.backend import (  # pylint: disable=no-name-in-module
     __backend_name__,
+    amin,
     arange,
     asarray,
     cast,
@@ -43,9 +44,7 @@ from scipy.optimize import linprog
 from scipy.sparse import coo_matrix
 from scipy.sparse.csgraph import min_weight_full_bipartite_matching
 
-if TYPE_CHECKING:
-    import numpy as np
-
+BackendArray = Any
 Observation = tuple[int, int]
 MatchedEdge = tuple[Observation, Observation, float]
 PairwiseCostsInput = Mapping[tuple[int, int], Any] | Sequence[Any]
@@ -88,7 +87,7 @@ class MultiSessionAssignmentResult:
         session_sizes: SessionSizesInput | None = None,
         *,
         fill_value: int = -1,
-    ) -> tuple[np.ndarray, ...]:
+    ) -> tuple[BackendArray, ...]:
         """Convert the recovered tracks to dense per-session label arrays.
 
         Parameters
@@ -280,7 +279,7 @@ def tracks_to_session_labels(
     session_sizes: SessionSizesInput | None = None,
     *,
     fill_value: int = -1,
-) -> tuple[np.ndarray, ...]:
+) -> tuple[BackendArray, ...]:
     """Convert explicit tracks to dense per-session label arrays.
 
     Parameters
@@ -298,7 +297,7 @@ def tracks_to_session_labels(
 
     Returns
     -------
-    tuple[np.ndarray, ...]
+    tuple[BackendArray, ...]
         One integer array per session, indexed by session number.
     """
 
@@ -345,9 +344,9 @@ def _validate_scalar_cost(name: str, value: float) -> None:
 
 def _normalize_pairwise_costs(
     pairwise_costs: PairwiseCostsInput,
-) -> dict[tuple[int, int], np.ndarray]:
+) -> dict[tuple[int, int], BackendArray]:
     if isinstance(pairwise_costs, Mapping):
-        normalized: dict[tuple[int, int], np.ndarray] = {}
+        normalized: dict[tuple[int, int], BackendArray] = {}
         for key, value in pairwise_costs.items():
             if len(key) != 2:
                 raise ValueError("Each pairwise-cost key must contain two session indices.")
@@ -385,7 +384,7 @@ def _normalize_session_sizes(
 
 
 def _infer_and_validate_session_sizes(
-    pairwise_costs: Mapping[tuple[int, int], np.ndarray],
+    pairwise_costs: Mapping[tuple[int, int], BackendArray],
     session_sizes: Mapping[int, int],
 ) -> dict[int, int]:
     inferred_sizes = dict(session_sizes)
@@ -438,7 +437,7 @@ def _build_observation_index(
 
 
 def _build_candidate_edges(  # pylint: disable=too-many-arguments,too-many-locals
-    pairwise_costs: Mapping[tuple[int, int], np.ndarray],
+    pairwise_costs: Mapping[tuple[int, int], BackendArray],
     session_sizes: Mapping[int, int],
     session_positions: Mapping[int, int],
     session_offsets: Mapping[int, int],
@@ -447,11 +446,11 @@ def _build_candidate_edges(  # pylint: disable=too-many-arguments,too-many-local
     end_cost: float,
     gap_penalty: float,
     cost_threshold: float | None,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-    left_nodes: list[np.ndarray] = []
-    right_nodes: list[np.ndarray] = []
-    edge_gains: list[np.ndarray] = []
-    adjusted_costs: list[np.ndarray] = []
+) -> tuple[BackendArray, BackendArray, BackendArray, BackendArray]:
+    left_nodes: list[BackendArray] = []
+    right_nodes: list[BackendArray] = []
+    edge_gains: list[BackendArray] = []
+    adjusted_costs: list[BackendArray] = []
 
     for (source_session, target_session), cost_matrix in sorted(pairwise_costs.items()):
         expected_shape = (session_sizes[source_session], session_sizes[target_session])
@@ -500,11 +499,11 @@ def _build_candidate_edges(  # pylint: disable=too-many-arguments,too-many-local
 
 
 def _solve_max_weight_matching(
-    left_nodes: np.ndarray,
-    right_nodes: np.ndarray,
-    edge_gains: np.ndarray,
+    left_nodes: BackendArray,
+    right_nodes: BackendArray,
+    edge_gains: BackendArray,
     num_nodes: int,
-) -> np.ndarray:
+) -> BackendArray:
     try:
         return _solve_max_weight_matching_sparse(
             left_nodes,
@@ -521,12 +520,12 @@ def _solve_max_weight_matching(
         )
 
 
-def _solve_max_weight_matching_sparse(
-    left_nodes: np.ndarray,
-    right_nodes: np.ndarray,
-    edge_gains: np.ndarray,
+def _solve_max_weight_matching_sparse(  # pylint: disable=too-many-locals
+    left_nodes: BackendArray,
+    right_nodes: BackendArray,
+    edge_gains: BackendArray,
     num_nodes: int,
-) -> np.ndarray:
+) -> BackendArray:
     """Solve the sparse bipartite matching problem with LAPJVsp.
 
     The optional-matching objective is turned into a full rectangular
@@ -537,23 +536,24 @@ def _solve_max_weight_matching_sparse(
     requirement that sparse edge weights are non-zero.
     """
 
-    num_edges = int(edge_gains.size)
+    left_nodes = asarray(left_nodes, dtype=int)
+    right_nodes = asarray(right_nodes, dtype=int)
+    edge_gains = asarray(edge_gains, dtype=float)
+
+    num_edges = int(edge_gains.shape[0])
     if num_edges == 0 or num_nodes == 0:
-        return np.zeros(num_edges, dtype=bool)
+        return zeros(num_edges, dtype=bool)
 
-    left_nodes = np.asarray(left_nodes, dtype=int)
-    right_nodes = np.asarray(right_nodes, dtype=int)
-    edge_gains = np.asarray(edge_gains, dtype=float)
+    node_ids = arange(num_nodes, dtype=int)
+    row_ids = concatenate((left_nodes, node_ids))
+    col_ids = concatenate((right_nodes, num_nodes + node_ids))
 
-    row_ids = np.concatenate((left_nodes, np.arange(num_nodes, dtype=int)))
-    col_ids = np.concatenate((right_nodes, num_nodes + np.arange(num_nodes, dtype=int)))
-
-    base_weight = min(1.0, 0.5 * float(np.min(edge_gains)))
-    base_weight = max(base_weight, np.nextafter(0.0, 1.0))
-    weights = np.concatenate(
+    base_weight = min(1.0, 0.5 * float(amin(edge_gains)))
+    base_weight = max(base_weight, math.ulp(0.0))
+    weights = concatenate(
         (
             edge_gains + base_weight,
-            np.full(num_nodes, base_weight, dtype=float),
+            full(num_nodes, base_weight, dtype=float),
         )
     )
 
@@ -574,7 +574,7 @@ def _solve_max_weight_matching_sparse(
         (int(source_node), int(target_node)): edge_index
         for edge_index, (source_node, target_node) in enumerate(zip(left_nodes, right_nodes))
     }
-    selected_edge_mask = np.zeros(num_edges, dtype=bool)
+    selected_edge_mask = zeros(num_edges, dtype=bool)
 
     for source_node, assigned_column in zip(matched_rows, matched_cols):
         assigned_column = int(assigned_column)
@@ -589,11 +589,11 @@ def _solve_max_weight_matching_sparse(
 
 
 def _solve_max_weight_matching_via_linprog(
-    left_nodes: np.ndarray,
-    right_nodes: np.ndarray,
-    edge_gains: np.ndarray,
+    left_nodes: BackendArray,
+    right_nodes: BackendArray,
+    edge_gains: BackendArray,
     num_nodes: int,
-) -> np.ndarray:
+) -> BackendArray:
     """Fallback solver that keeps the original LP formulation."""
 
     num_edges = int(edge_gains.shape[0])
@@ -628,8 +628,8 @@ def _solve_max_weight_matching_via_linprog(
 
 def _reconstruct_tracks(
     global_to_observation: Sequence[Observation],
-    predecessors: np.ndarray,
-    successors: np.ndarray,
+    predecessors: BackendArray,
+    successors: BackendArray,
     session_positions: Mapping[int, int],
 ) -> list[dict[int, int]]:
     visited: set[int] = set()


### PR DESCRIPTION
## Summary
- route the sparse multisession matching helper through `pyrecest.backend` instead of a direct NumPy binding
- keep the regression tests backend-only while covering sparse-vs-linprog parity and the fallback path
- keep the follow-on PR narrowly scoped to make the faster sparse backend branch reviewable

## Why
PR #1751 already contains the sparse backend implementation, but the branch still has two blockers:
1. `pyrecest.utils.multisession_assignment` used `np` at runtime inside the sparse matching helper even though direct NumPy usage should go through `pyrecest.backend`
2. `pyrecest/tests/test_multisession_assignment.py` needed to exercise the sparse helper and fallback path without adding direct NumPy usage

This stacked PR fixes those issues without changing the solver logic itself.

## Notes
- base branch: `multisess2`
- intended as a follow-on/fixup PR for #1751
