### PR TITLE
Refactor shared registration helpers to address pylint R0801

### DIFF
--- a/pyrecest/utils/_registration_common.py
+++ b/pyrecest/utils/_registration_common.py
@@ -1,0 +1,102 @@
+"""Shared helper utilities for point-set registration modules."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from pyrecest.backend import asarray, empty, full, int64, isfinite, mean, sqrt, where, zeros
+from scipy.optimize import linear_sum_assignment
+
+
+def as_point_array(points, *, expected_dim: int | None = None):
+    """Validate a point array with shape ``(n_points, dim)``.
+
+    Parameters
+    ----------
+    points:
+        Candidate point array.
+    expected_dim:
+        If given, require exactly this ambient dimension. Otherwise only require
+        a positive point dimension.
+    """
+    point_array = asarray(points)
+    if point_array.ndim != 2:
+        raise ValueError("points must have shape (n_points, dim).")
+    if point_array.shape[0] == 0:
+        raise ValueError("At least one point is required.")
+    if expected_dim is None:
+        if point_array.shape[1] == 0:
+            raise ValueError("Point dimension must be positive.")
+    elif point_array.shape[1] != expected_dim:
+        raise ValueError(f"Only {expected_dim}D point sets are currently supported.")
+    return point_array
+
+
+def validate_pair(source_points, target_points, *, expected_dim: int | None = None):
+    """Validate a matched source/target point-set pair."""
+    source = as_point_array(source_points, expected_dim=expected_dim)
+    target = as_point_array(target_points, expected_dim=expected_dim)
+    if source.shape != target.shape:
+        raise ValueError("source_points and target_points must have the same shape.")
+    return source, target
+
+
+def validate_cost_matrix_shape(cost_matrix, n_reference: int, n_moving: int) -> None:
+    """Validate the shape returned by a registration association cost."""
+    if cost_matrix.shape != (n_reference, n_moving):
+        raise ValueError(
+            "cost_function must return an array of shape (n_reference, n_moving)."
+        )
+
+
+def solve_gated_assignment(cost_matrix, *, max_cost: float = float("inf")):
+    """Solve one-to-one assignment with optional gating and non-finite rejection."""
+    costs = asarray(cost_matrix)
+    if costs.ndim != 2:
+        raise ValueError("cost_matrix must be two-dimensional.")
+    if costs.shape[0] == 0:
+        return zeros((0,), dtype=int64)
+    if costs.shape[1] == 0:
+        return zeros((costs.shape[0],), dtype=int64) - 1
+
+    finite_mask = isfinite(costs)
+    finite_costs = costs[finite_mask]
+    if finite_costs.shape[0] == 0:
+        return zeros((costs.shape[0],), dtype=int64) - 1
+
+    dummy_cost = float(max_cost) if math.isfinite(max_cost) else float(finite_costs.max() + 1.0)
+    padded_size = max(costs.shape[0], costs.shape[1])
+    sanitized_costs = where(finite_mask, costs, dummy_cost)
+    padded_costs = full((padded_size, padded_size), dummy_cost)
+    padded_costs[: costs.shape[0], : costs.shape[1]] = sanitized_costs
+
+    row_indices, col_indices = linear_sum_assignment(padded_costs)
+    assignment = zeros((costs.shape[0],), dtype=int64) - 1
+
+    for row_index, col_index in zip(row_indices, col_indices):
+        if row_index >= costs.shape[0] or col_index >= costs.shape[1]:
+            continue
+        if isfinite(costs[row_index, col_index]) and costs[row_index, col_index] <= max_cost:
+            assignment[row_index] = int(col_index)
+
+    return assignment
+
+
+def build_matched_costs(costs, assignment):
+    """Extract matched row/column indices and costs from an assignment array."""
+    matched_reference_indices = where(assignment >= 0)[0]
+    matched_moving_indices = assignment[matched_reference_indices]
+    matched_costs = (
+        costs[matched_reference_indices, matched_moving_indices]
+        if matched_reference_indices.shape[0] > 0
+        else empty((0,))
+    )
+    return matched_reference_indices, matched_moving_indices, matched_costs
+
+
+def compute_rmse(matched_costs) -> float:
+    """Compute the root-mean-square error of a matched-cost vector."""
+    if matched_costs.shape[0] > 0:
+        return float(sqrt(mean(matched_costs * matched_costs)))
+    return float("inf")

--- a/pyrecest/utils/nonrigid_point_set_registration.py
+++ b/pyrecest/utils/nonrigid_point_set_registration.py
@@ -8,7 +8,6 @@ tracking, where ROI centroids can undergo local distortions between sessions.
 
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass
 from typing import Any, Callable
 
@@ -20,23 +19,26 @@ from pyrecest.backend import (
     asarray,
     cast,
     concatenate,
-    empty,
     eye,
-    full,
     int64,
-    isfinite,
     log,
     maximum,
-    mean,
     ones,
     quantile,
-    sqrt,
     where,
     zeros,
 )
 from pyrecest.backend import linalg
-from scipy.optimize import linear_sum_assignment
 from scipy.spatial.distance import cdist
+
+from ._registration_common import (
+    as_point_array,
+    build_matched_costs,
+    compute_rmse,
+    solve_gated_assignment as _solve_gated_assignment,
+    validate_cost_matrix_shape,
+    validate_pair,
+)
 
 NonRigidAssociationCostFn = Callable[[Any, Any], Any]
 
@@ -106,7 +108,7 @@ class ThinPlateSplineTransform:
 
     def apply(self, points):
         """Apply the transform to an ``(n_points, 2)`` array of points."""
-        point_array = _as_point_array(points)
+        point_array = as_point_array(points, expected_dim=2)
 
         basis = zeros((point_array.shape[0], 0))
         if self.control_points.shape[0] > 0:
@@ -130,25 +132,6 @@ class ThinPlateSplineRegistrationResult:  # pylint: disable=too-many-instance-at
     rmse: float
     n_iterations: int
     converged: bool
-
-
-def _as_point_array(points):
-    point_array = asarray(points)
-    if point_array.ndim != 2:
-        raise ValueError("points must have shape (n_points, dim).")
-    if point_array.shape[0] == 0:
-        raise ValueError("At least one point is required.")
-    if point_array.shape[1] != 2:
-        raise ValueError("Only 2D point sets are currently supported.")
-    return point_array
-
-
-def _validate_pair(source_points, target_points):
-    source = _as_point_array(source_points)
-    target = _as_point_array(target_points)
-    if source.shape != target.shape:
-        raise ValueError("source_points and target_points must have the same shape.")
-    return source, target
 
 
 def _tps_kernel_from_distances(distances, epsilon: float = 1e-12):
@@ -180,7 +163,7 @@ def estimate_thin_plate_spline(
     if regularization < 0.0:
         raise ValueError("regularization must be non-negative.")
 
-    source, target = _validate_pair(source_points, target_points)
+    source, target = validate_pair(source_points, target_points, expected_dim=2)
     n_points = source.shape[0]
 
     if n_points < 3:
@@ -208,46 +191,34 @@ def estimate_thin_plate_spline(
     )
 
 
-def _solve_gated_assignment(cost_matrix, *, max_cost: float = float("inf")):
-    costs = asarray(cost_matrix)
-    if costs.ndim != 2:
-        raise ValueError("cost_matrix must be two-dimensional.")
-    if costs.shape[0] == 0:
-        return zeros((0,), dtype=int64)
-    if costs.shape[1] == 0:
-        return zeros((costs.shape[0],), dtype=int64) - 1
-
-    finite_mask = isfinite(costs)
-    finite_costs = costs[finite_mask]
-    if finite_costs.shape[0] == 0:
-        return zeros((costs.shape[0],), dtype=int64) - 1
-
-    dummy_cost = float(max_cost) if math.isfinite(max_cost) else float(finite_costs.max() + 1.0)
-    padded_size = max(costs.shape[0], costs.shape[1])
-    sanitized_costs = where(finite_mask, costs, dummy_cost)
-    padded_costs = full((padded_size, padded_size), dummy_cost)
-    padded_costs[: costs.shape[0], : costs.shape[1]] = sanitized_costs
-
-    row_indices, col_indices = linear_sum_assignment(padded_costs)
-    assignment = zeros((costs.shape[0],), dtype=int64) - 1
-
-    for row_index, col_index in zip(row_indices, col_indices):
-        if row_index >= costs.shape[0] or col_index >= costs.shape[1]:
-            continue
-        if isfinite(costs[row_index, col_index]) and costs[row_index, col_index] <= max_cost:
-            assignment[row_index] = int(col_index)
-
-    return assignment
-
-
 def _default_cost(transformed_reference_points, moving_points):
     return cdist(transformed_reference_points, moving_points, metric="euclidean")
 
 
-def _compute_rmse(matched_costs) -> float:
-    if matched_costs.shape[0] > 0:
-        return float(sqrt(mean(matched_costs * matched_costs)))
-    return float("inf")
+def _build_registration_result(
+    transform: ThinPlateSplineTransform,
+    assignment: Any,
+    transformed_reference_points: Any,
+    costs: Any,
+    *,
+    iteration: int,
+    converged: bool,
+) -> ThinPlateSplineRegistrationResult:
+    matched_reference_indices, matched_moving_indices, matched_costs = build_matched_costs(
+        costs, assignment
+    )
+    rmse = compute_rmse(matched_costs)
+    return ThinPlateSplineRegistrationResult(
+        transform=transform,
+        assignment=assignment,
+        matched_reference_indices=cast(matched_reference_indices, int64),
+        matched_moving_indices=cast(matched_moving_indices, int64),
+        transformed_reference_points=transformed_reference_points,
+        matched_costs=matched_costs,
+        rmse=rmse,
+        n_iterations=iteration,
+        converged=converged,
+    )
 
 
 def joint_tps_registration_assignment(  # pylint: disable=too-many-arguments,too-many-locals
@@ -299,8 +270,8 @@ def joint_tps_registration_assignment(  # pylint: disable=too-many-arguments,too
             "joint_tps_registration_assignment is not supported on the JAX backend."
         )
 
-    reference = _as_point_array(reference_points)
-    moving = _as_point_array(moving_points)
+    reference = as_point_array(reference_points, expected_dim=2)
+    moving = as_point_array(moving_points, expected_dim=2)
 
     if max_iterations <= 0:
         raise ValueError("max_iterations must be positive.")
@@ -322,32 +293,19 @@ def joint_tps_registration_assignment(  # pylint: disable=too-many-arguments,too
     for iteration in range(1, max_iterations + 1):
         transformed_reference = transform.apply(reference)
         current_costs = asarray(association_cost(transformed_reference, moving))
-        if current_costs.shape != (reference.shape[0], moving.shape[0]):
-            raise ValueError(
-                "cost_function must return an array of shape (n_reference, n_moving)."
-            )
+        validate_cost_matrix_shape(current_costs, reference.shape[0], moving.shape[0])
 
         new_assignment = _solve_gated_assignment(current_costs, max_cost=max_cost)
         matched_reference_indices = where(new_assignment >= 0)[0]
 
         if matched_reference_indices.shape[0] < min_matches:
             assignment = new_assignment
-            matched_moving_indices = assignment[matched_reference_indices]
-            matched_costs = (
-                current_costs[matched_reference_indices, matched_moving_indices]
-                if matched_reference_indices.shape[0] > 0
-                else empty((0,))
-            )
-            rmse = _compute_rmse(matched_costs)
-            return ThinPlateSplineRegistrationResult(
-                transform=transform,
-                assignment=assignment,
-                matched_reference_indices=cast(matched_reference_indices, int64),
-                matched_moving_indices=cast(matched_moving_indices, int64),
-                transformed_reference_points=transformed_reference,
-                matched_costs=matched_costs,
-                rmse=rmse,
-                n_iterations=iteration,
+            return _build_registration_result(
+                transform,
+                assignment,
+                transformed_reference,
+                current_costs,
+                iteration=iteration,
                 converged=False,
             )
 
@@ -373,23 +331,12 @@ def joint_tps_registration_assignment(  # pylint: disable=too-many-arguments,too
 
     transformed_reference = transform.apply(reference)
     final_costs = asarray(association_cost(transformed_reference, moving))
-    matched_reference_indices = where(assignment >= 0)[0]
-    matched_moving_indices = assignment[matched_reference_indices]
-    matched_costs = (
-        final_costs[matched_reference_indices, matched_moving_indices]
-        if matched_reference_indices.shape[0] > 0
-        else empty((0,))
-    )
-    rmse = _compute_rmse(matched_costs)
-
-    return ThinPlateSplineRegistrationResult(
-        transform=transform,
-        assignment=assignment,
-        matched_reference_indices=cast(matched_reference_indices, int64),
-        matched_moving_indices=cast(matched_moving_indices, int64),
-        transformed_reference_points=transformed_reference,
-        matched_costs=matched_costs,
-        rmse=rmse,
-        n_iterations=iteration,
+    validate_cost_matrix_shape(final_costs, reference.shape[0], moving.shape[0])
+    return _build_registration_result(
+        transform,
+        assignment,
+        transformed_reference,
+        final_costs,
+        iteration=iteration,
         converged=converged,
     )

--- a/pyrecest/utils/point_set_registration.py
+++ b/pyrecest/utils/point_set_registration.py
@@ -13,7 +13,6 @@ rotation, or affine deformation must be estimated before data association.
 
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass
 from typing import Any, Callable, Literal
 
@@ -26,22 +25,26 @@ from pyrecest.backend import (
     asarray,
     cast,
     concatenate,
-    empty,
     eye,
     full,
     int64,
-    isfinite,
     linalg,
-    mean,
     ones,
     quantile,
     sqrt,
     sum,
-    where,
     zeros,
 )
-from scipy.optimize import linear_sum_assignment
 from scipy.spatial.distance import cdist
+
+from ._registration_common import (
+    as_point_array,
+    build_matched_costs,
+    compute_rmse,
+    solve_gated_assignment as _solve_gated_assignment,
+    validate_cost_matrix_shape,
+    validate_pair,
+)
 
 TransformModel = Literal["translation", "rigid", "affine"]
 AssociationCostFn = Callable
@@ -87,7 +90,7 @@ class AffineTransform:
 
     def apply(self, points) -> Any:
         """Apply the transform to an ``(n_points, dim)`` array of points."""
-        points_array = _as_point_array(points)
+        points_array = as_point_array(points)
         if points_array.shape[1] != self.dim:
             raise ValueError("Point dimension does not match transform dimension.")
         return (self.matrix @ points_array.T).T + self.offset
@@ -113,25 +116,6 @@ class RegistrationResult:  # pylint: disable=too-many-instance-attributes
     rmse: float
     n_iterations: int
     converged: bool
-
-
-def _as_point_array(points):
-    points_array = asarray(points)
-    if points_array.ndim != 2:
-        raise ValueError("points must have shape (n_points, dim).")
-    if points_array.shape[0] == 0:
-        raise ValueError("At least one point is required.")
-    if points_array.shape[1] == 0:
-        raise ValueError("Point dimension must be positive.")
-    return points_array
-
-
-def _validate_pair(source_points, target_points):
-    source = _as_point_array(source_points)
-    target = _as_point_array(target_points)
-    if source.shape != target.shape:
-        raise ValueError("source_points and target_points must have the same shape.")
-    return source, target
 
 
 def _normalize_weights(weights, n_points):
@@ -182,7 +166,7 @@ def estimate_transform(  # pylint: disable=too-many-locals
     """
     assert pyrecest.backend.__backend_name__ != "jax", "Not supported for the JAX backend."
 
-    source, target = _validate_pair(source_points, target_points)
+    source, target = validate_pair(source_points, target_points)
     n_points, dim = source.shape
     min_matches = _minimum_required_matches(model, dim)
     if n_points < min_matches:
@@ -238,47 +222,11 @@ def solve_gated_assignment(cost_matrix, *, max_cost: float = float("inf")):
     or ``-1`` if the row is left unmatched.
     """
     assert pyrecest.backend.__backend_name__ != "jax", "Not supported for the JAX backend."
-
-    costs = asarray(cost_matrix)
-    if costs.ndim != 2:
-        raise ValueError("cost_matrix must be two-dimensional.")
-    if costs.shape[0] == 0:
-        return zeros((0,), dtype=int64)
-    if costs.shape[1] == 0:
-        return zeros((costs.shape[0],), dtype=int64) - 1
-
-    finite_mask = isfinite(costs)
-    finite_costs = costs[finite_mask]
-    if len(finite_costs) == 0:
-        return zeros((costs.shape[0],), dtype=int64) - 1
-
-    if math.isfinite(max_cost):
-        dummy_cost = float(max_cost)
-    else:
-        dummy_cost = float(finite_costs.max() + 1.0)
-
-    padded_size = max(costs.shape)
-    padded_costs = full((padded_size, padded_size), dummy_cost)
-    padded_costs[: costs.shape[0], : costs.shape[1]] = costs
-    row_indices, col_indices = linear_sum_assignment(padded_costs)
-
-    assignment = zeros((costs.shape[0],), dtype=int64) - 1
-    for row_index, col_index in zip(row_indices, col_indices):
-        if row_index >= costs.shape[0] or col_index >= costs.shape[1]:
-            continue
-        if costs[row_index, col_index] <= max_cost:
-            assignment[row_index] = int(col_index)
-    return assignment
+    return _solve_gated_assignment(cost_matrix, max_cost=max_cost)
 
 
 def _default_cost(transformed_reference_points, moving_points):
     return cdist(transformed_reference_points, moving_points, metric="euclidean")
-
-
-def _compute_rmse(matched_costs) -> float:
-    if len(matched_costs) > 0:
-        return float(sqrt(mean(matched_costs**2)))
-    return float("inf")
 
 
 def _build_registration_result(
@@ -290,14 +238,10 @@ def _build_registration_result(
     iteration: int,
     converged: bool,
 ) -> RegistrationResult:
-    matched_reference_indices = where(assignment >= 0)[0]
-    matched_moving_indices = assignment[matched_reference_indices]
-    matched_costs = (
-        costs[matched_reference_indices, matched_moving_indices]
-        if len(matched_reference_indices) > 0
-        else empty((0,))
+    matched_reference_indices, matched_moving_indices, matched_costs = build_matched_costs(
+        costs, assignment
     )
-    rmse = _compute_rmse(matched_costs)
+    rmse = compute_rmse(matched_costs)
     return RegistrationResult(
         transform=transform,
         assignment=assignment,
@@ -364,8 +308,8 @@ def joint_registration_assignment(  # pylint: disable=too-many-arguments,too-man
     """
     assert pyrecest.backend.__backend_name__ != "jax", "Not supported for the JAX backend."
 
-    reference = _as_point_array(reference_points)
-    moving = _as_point_array(moving_points)
+    reference = as_point_array(reference_points)
+    moving = as_point_array(moving_points)
     if reference.shape[1] != moving.shape[1]:
         raise ValueError("reference_points and moving_points must have the same dimension.")
     if max_iterations <= 0:
@@ -393,14 +337,11 @@ def joint_registration_assignment(  # pylint: disable=too-many-arguments,too-man
     for iteration in range(1, max_iterations + 1):
         transformed_reference = transform.apply(reference)
         current_costs = asarray(association_cost(transformed_reference, moving))
-        if current_costs.shape != (reference.shape[0], moving.shape[0]):
-            raise ValueError(
-                "cost_function must return an array of shape (n_reference, n_moving)."
-            )
+        validate_cost_matrix_shape(current_costs, reference.shape[0], moving.shape[0])
 
         new_assignment = solve_gated_assignment(current_costs, max_cost=max_cost)
-        matched_reference_indices = where(new_assignment >= 0)[0]
-        if len(matched_reference_indices) < min_matches:
+        matched_reference_indices = new_assignment >= 0
+        if matched_reference_indices.sum() < min_matches:
             assignment = new_assignment
             return _build_registration_result(
                 transform,
@@ -411,6 +352,7 @@ def joint_registration_assignment(  # pylint: disable=too-many-arguments,too-man
                 converged=False,
             )
 
+        matched_reference_indices = (new_assignment >= 0).nonzero()[0]
         matched_moving_indices = new_assignment[matched_reference_indices]
         updated_transform = estimate_transform(
             reference[matched_reference_indices],
@@ -433,6 +375,7 @@ def joint_registration_assignment(  # pylint: disable=too-many-arguments,too-man
 
     transformed_reference = transform.apply(reference)
     final_costs = asarray(association_cost(transformed_reference, moving))
+    validate_cost_matrix_shape(final_costs, reference.shape[0], moving.shape[0])
     return _build_registration_result(
         transform,
         assignment,

--- a/pyrecest/utils/point_set_registration.py
+++ b/pyrecest/utils/point_set_registration.py
@@ -33,6 +33,7 @@ from pyrecest.backend import (
     quantile,
     sqrt,
     sum,
+    where,
     zeros,
 )
 from scipy.spatial.distance import cdist
@@ -340,8 +341,8 @@ def joint_registration_assignment(  # pylint: disable=too-many-arguments,too-man
         validate_cost_matrix_shape(current_costs, reference.shape[0], moving.shape[0])
 
         new_assignment = solve_gated_assignment(current_costs, max_cost=max_cost)
-        matched_reference_indices = new_assignment >= 0
-        if matched_reference_indices.sum() < min_matches:
+        matched_reference_indices = where(new_assignment >= 0)[0]
+        if matched_reference_indices.shape[0] < min_matches:
             assignment = new_assignment
             return _build_registration_result(
                 transform,
@@ -352,7 +353,6 @@ def joint_registration_assignment(  # pylint: disable=too-many-arguments,too-man
                 converged=False,
             )
 
-        matched_reference_indices = (new_assignment >= 0).nonzero()[0]
         matched_moving_indices = new_assignment[matched_reference_indices]
         updated_transform = estimate_transform(
             reference[matched_reference_indices],


### PR DESCRIPTION
## Summary
- extract shared point-set registration internals into `pyrecest/utils/_registration_common.py`
- reuse the shared helpers from both rigid/affine and TPS registration modules
- keep the public `solve_gated_assignment(...)` entry point in `point_set_registration.py`
- remove the duplicated point-array validation, gated Hungarian assignment, match-cost extraction, and RMSE logic that triggered `pylint` `R0801`

## Why
MegaLinter reported substantial duplicate code between:
- `pyrecest/utils/point_set_registration.py`
- `pyrecest/utils/nonrigid_point_set_registration.py`

In this case, the linter signal is meaningful for the low-level helper logic: both modules had near-identical implementations of point validation, gated assignment, and result assembly. Those pieces are now shared instead of merely suppressed.

## Notes
- I did **not** try to fully unify the outer registration loops, because the affine/rigid and TPS update steps still differ in a way that is easier to review and maintain separately.
- The shared gated assignment helper now consistently sanitizes non-finite costs before padding and rejects non-finite matches at assignment time.
