### PR TITLE
Consolidate multisession assignment and ROI similarity utilities

### DIFF
--- a/src/pyrecest/utils/__init__.py
+++ b/src/pyrecest/utils/__init__.py
@@ -1,21 +1,51 @@
+"""Utility helpers for :mod:`pyrecest`."""
 
 from .association_models import LogisticPairwiseAssociationModel
 from .history_recorder import HistoryRecorder
 from .assignment import murty_k_best_assignments
-
+from .multisession_assignment import (
+    MultiSessionAssignmentResult,
+    solve_multisession_assignment,
+    solve_multisession_assignment_from_similarity,
+    tracks_to_index_matrix,
+    tracks_to_session_labels,
+)
+from .multisession_assignment_observation_costs import (
+    solve_multisession_assignment_with_observation_costs,
+)
 from .nonrigid_point_set_registration import (
     ThinPlateSplineRegistrationResult,
     ThinPlateSplineTransform,
     estimate_thin_plate_spline,
     joint_tps_registration_assignment,
 )
+from .roi_similarity import (
+    build_roi_cost_matrix,
+    pairwise_centroid_distances,
+    pairwise_roi_similarity,
+    roi_centroid,
+    weighted_roi_cosine_similarity,
+    weighted_roi_jaccard,
+)
 
 __all__ = [
     "LogisticPairwiseAssociationModel",
+    "MultiSessionAssignmentResult",
     "HistoryRecorder",
     "ThinPlateSplineRegistrationResult",
     "ThinPlateSplineTransform",
+    "build_roi_cost_matrix",
     "estimate_thin_plate_spline",
     "joint_tps_registration_assignment",
     "murty_k_best_assignments",
+    "pairwise_centroid_distances",
+    "pairwise_roi_similarity",
+    "roi_centroid",
+    "solve_multisession_assignment",
+    "solve_multisession_assignment_from_similarity",
+    "solve_multisession_assignment_with_observation_costs",
+    "tracks_to_index_matrix",
+    "tracks_to_session_labels",
+    "weighted_roi_cosine_similarity",
+    "weighted_roi_jaccard",
 ]

--- a/src/pyrecest/utils/multisession_assignment.py
+++ b/src/pyrecest/utils/multisession_assignment.py
@@ -1,0 +1,764 @@
+"""Global multi-session association utilities.
+
+This module solves a common batch-linking problem for longitudinal cell tracking:
+start from pairwise ROI matching costs between imaging sessions and recover a set
+of globally consistent tracks, with at most one detection per session on each
+track. The formulation supports skipped sessions through optional cross-session
+edges and a configurable gap penalty.
+
+The optimization is a minimum-cost path-cover problem on a DAG. Relative to
+leaving every observation disconnected, each admissible edge contributes a
+*gain* of
+
+``start_cost + end_cost - adjusted_link_cost``.
+
+Only edges with positive gain can improve the objective, so the solver operates
+on admissible candidate edges rather than on all ``N^2`` observation pairs. The
+resulting sparse bipartite matching problem is solved as a rectangular linear
+assignment with per-row dummy "unmatched" columns using SciPy's sparse
+Jonker-Volgenant implementation.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, TypeAlias
+
+from pyrecest.backend import (  # pylint: disable=no-name-in-module
+    __backend_name__,
+    arange,
+    asarray,
+    cast,
+    concatenate,
+    empty,
+    full,
+    isfinite,
+    ones,
+    to_numpy,
+    where,
+    zeros,
+)
+from scipy.optimize import linprog
+from scipy.sparse import coo_matrix
+from scipy.sparse.csgraph import min_weight_full_bipartite_matching
+
+ArrayLike: TypeAlias = Any
+Observation: TypeAlias = tuple[int, int]
+MatchedEdge: TypeAlias = tuple[Observation, Observation, float]
+PairwiseCostsInput: TypeAlias = Mapping[tuple[int, int], Any] | Sequence[Any]
+SessionSizesInput: TypeAlias = Mapping[int, int] | Sequence[int]
+TrackInput: TypeAlias = Mapping[int, int] | Sequence[Observation]
+
+
+@dataclass(frozen=True)
+class MultiSessionAssignmentResult:
+    """Result of :func:`solve_multisession_assignment`.
+
+    Attributes
+    ----------
+    tracks
+        One dictionary per recovered track. Keys are session indices and values
+        are detection indices within that session.
+    matched_edges
+        Directed edges selected by the optimizer as
+        ``((source_session, source_detection), (target_session, target_detection), adjusted_cost)``.
+        The reported edge cost already includes the configured gap penalty.
+    total_cost
+        Objective value of the globally optimal assignment, including track
+        start and end costs.
+    """
+
+    tracks: list[dict[int, int]]
+    matched_edges: list[MatchedEdge]
+    total_cost: float
+
+    def observation_to_track_index(self) -> dict[Observation, int]:
+        """Return a mapping from observation to recovered track index."""
+        mapping: dict[Observation, int] = {}
+        for track_idx, track in enumerate(self.tracks):
+            for session_idx, detection_idx in track.items():
+                mapping[(session_idx, detection_idx)] = track_idx
+        return mapping
+
+    def to_session_labels(
+        self,
+        session_sizes: SessionSizesInput | None = None,
+        *,
+        fill_value: int = -1,
+    ) -> tuple[ArrayLike, ...]:
+        """Convert the recovered tracks to dense per-session label arrays.
+
+        Parameters
+        ----------
+        session_sizes
+            Optional per-session detection counts. When omitted, sizes are
+            inferred from the track content.
+        fill_value
+            Value used for unassigned detections.
+        """
+
+        return tracks_to_session_labels(
+            self.tracks,
+            session_sizes=session_sizes,
+            fill_value=fill_value,
+        )
+
+    def to_index_matrix(
+        self,
+        session_sizes: SessionSizesInput | None = None,
+        *,
+        fill_value: int = -1,
+    ) -> ArrayLike:
+        """Convert the recovered tracks to a dense track-by-session index matrix.
+
+        Each row corresponds to one recovered track and each column corresponds
+        to one session. Entries store the detection index assigned to that track
+        in that session or ``fill_value`` if the track is absent.
+        """
+
+        return tracks_to_index_matrix(
+            self.tracks,
+            session_sizes=session_sizes,
+            fill_value=fill_value,
+        )
+
+
+def solve_multisession_assignment(  # pylint: disable=too-many-locals
+    pairwise_costs: PairwiseCostsInput,
+    session_sizes: SessionSizesInput | None = None,
+    *,
+    start_cost: float = 0.0,
+    end_cost: float = 0.0,
+    gap_penalty: float = 0.0,
+    cost_threshold: float | None = None,
+) -> MultiSessionAssignmentResult:
+    """Recover globally consistent tracks across multiple sessions.
+
+    Parameters
+    ----------
+    pairwise_costs
+        Either a mapping from ``(source_session, target_session)`` to a cost
+        matrix of shape ``(n_source, n_target)``, or a sequence of consecutive
+        session-to-session cost matrices. When a sequence is supplied, matrix
+        ``k`` is interpreted as the cost matrix for session ``k`` to session
+        ``k + 1``.
+    session_sizes
+        Optional per-session detection counts. This is only required when some
+        sessions have no pairwise cost matrix, or when isolated singleton
+        detections should still be represented in the result. A sequence is
+        interpreted as counts for sessions ``0, 1, ..., S-1``.
+    start_cost
+        Penalty for starting a new track.
+    end_cost
+        Penalty for ending a track.
+    gap_penalty
+        Additional penalty applied per skipped session for non-consecutive
+        edges. This penalty is added on top of the supplied edge cost.
+    cost_threshold
+        Optional upper bound for admissible link costs after gap penalties are
+        applied. Edges with larger costs are forbidden.
+
+    Returns
+    -------
+    MultiSessionAssignmentResult
+        Globally optimal tracks and the selected directed edges.
+
+    Notes
+    -----
+    Let ``N`` be the total number of observations. If every observation starts
+    as a singleton track, the baseline cost is
+
+    ``N * (start_cost + end_cost)``.
+
+    Adding an admissible edge with adjusted cost ``c`` merges two track ends and
+    therefore changes the objective by ``c - start_cost - end_cost``. The
+    implementation maximizes the total gain
+
+    ``start_cost + end_cost - c``
+
+    subject to at-most-one-predecessor and at-most-one-successor constraints.
+    This is equivalent to the minimum-cost path-cover objective. Internally,
+    the sparse matching problem is reduced to a rectangular assignment in which
+    every source observation can either connect to an admissible successor or to
+    its own dummy "unmatched" column.
+    """
+
+    assert __backend_name__ != "jax", "Not supported on JAX backend"
+
+    _validate_scalar_cost("start_cost", start_cost)
+    _validate_scalar_cost("end_cost", end_cost)
+    _validate_scalar_cost("gap_penalty", gap_penalty)
+    if cost_threshold is not None:
+        _validate_scalar_cost("cost_threshold", cost_threshold)
+
+    normalized_pairwise_costs = _normalize_pairwise_costs(pairwise_costs)
+    normalized_session_sizes = _normalize_session_sizes(session_sizes)
+    session_sizes_map = _infer_and_validate_session_sizes(
+        normalized_pairwise_costs,
+        normalized_session_sizes,
+    )
+
+    if not session_sizes_map:
+        return MultiSessionAssignmentResult(tracks=[], matched_edges=[], total_cost=0.0)
+
+    session_order = sorted(session_sizes_map)
+    session_positions = {
+        session_idx: position for position, session_idx in enumerate(session_order)
+    }
+    session_offsets = _build_session_offsets(session_sizes_map)
+    global_to_observation, _ = _build_observation_index(session_sizes_map)
+    n_observations = len(global_to_observation)
+
+    if n_observations == 0:
+        return MultiSessionAssignmentResult(tracks=[], matched_edges=[], total_cost=0.0)
+
+    left_nodes, right_nodes, edge_gains, adjusted_costs = _build_candidate_edges(
+        normalized_pairwise_costs,
+        session_sizes_map,
+        session_positions,
+        session_offsets,
+        start_cost=start_cost,
+        end_cost=end_cost,
+        gap_penalty=gap_penalty,
+        cost_threshold=cost_threshold,
+    )
+
+    selected_edge_mask = _solve_max_weight_matching(
+        left_nodes,
+        right_nodes,
+        edge_gains,
+        n_observations,
+    )
+
+    predecessors = full(n_observations, -1, dtype=int)
+    successors = full(n_observations, -1, dtype=int)
+    matched_edges: list[MatchedEdge] = []
+
+    for edge_index in where(selected_edge_mask)[0]:
+        source_global = int(left_nodes[edge_index])
+        target_global = int(right_nodes[edge_index])
+
+        if successors[source_global] != -1 or predecessors[target_global] != -1:
+            raise RuntimeError("The selected edges do not define a valid matching.")
+
+        successors[source_global] = target_global
+        predecessors[target_global] = source_global
+        matched_edges.append(
+            (
+                global_to_observation[source_global],
+                global_to_observation[target_global],
+                float(adjusted_costs[edge_index]),
+            )
+        )
+
+    tracks = _reconstruct_tracks(
+        global_to_observation,
+        predecessors,
+        successors,
+        session_positions,
+    )
+
+    matched_edges.sort(
+        key=lambda edge: (
+            session_positions[edge[0][0]],
+            edge[0][1],
+            session_positions[edge[1][0]],
+            edge[1][1],
+        )
+    )
+
+    baseline_cost = float(n_observations) * (float(start_cost) + float(end_cost))
+    total_cost = baseline_cost - float(edge_gains[selected_edge_mask].sum())
+
+    observation_count = sum(len(track) for track in tracks)
+    if observation_count != n_observations:
+        raise RuntimeError("Failed to reconstruct a full observation cover.")
+
+    observation_to_track = {}
+    for track_index, track in enumerate(tracks):
+        for session_index, detection_index in track.items():
+            observation_to_track[(session_index, detection_index)] = track_index
+    for edge in matched_edges:
+        if observation_to_track[edge[0]] != observation_to_track[edge[1]]:
+            raise RuntimeError("Recovered edges are inconsistent with reconstructed tracks.")
+
+    return MultiSessionAssignmentResult(
+        tracks=tracks,
+        matched_edges=matched_edges,
+        total_cost=total_cost,
+    )
+
+
+def tracks_to_session_labels(
+    tracks: Sequence[TrackInput],
+    session_sizes: SessionSizesInput | None = None,
+    *,
+    fill_value: int = -1,
+) -> tuple[ArrayLike, ...]:
+    """Convert explicit tracks to dense per-session label arrays."""
+
+    assert __backend_name__ != "jax", "Not supported on JAX backend"
+
+    inferred_sizes = _normalize_session_sizes(session_sizes)
+    max_session_index = max(inferred_sizes, default=-1)
+
+    for track in tracks:
+        for session_index, detection_index in _iter_track_items(track):
+            if detection_index < 0:
+                raise ValueError(
+                    f"Detection indices must be non-negative, got {detection_index}."
+                )
+            max_session_index = max(max_session_index, int(session_index))
+            candidate_size = int(detection_index) + 1
+            current_size = inferred_sizes.get(int(session_index), 0)
+            if session_sizes is None:
+                inferred_sizes[int(session_index)] = max(current_size, candidate_size)
+            elif candidate_size > current_size:
+                raise ValueError(
+                    f"Track references detection {detection_index} in session {session_index}, "
+                    f"but session_sizes only allows {current_size} detections."
+                )
+
+    labels = [
+        full(inferred_sizes.get(session_index, 0), fill_value, dtype=int)
+        for session_index in range(max_session_index + 1)
+    ]
+
+    for track_index, track in enumerate(tracks):
+        for session_index, detection_index in _iter_track_items(track):
+            if labels[session_index][detection_index] != fill_value:
+                raise ValueError("Each detection can only belong to a single track.")
+            labels[session_index][detection_index] = track_index
+
+    return tuple(labels)
+
+
+def solve_multisession_assignment_from_similarity(
+    pairwise_similarities: PairwiseCostsInput,
+    session_sizes: SessionSizesInput | None = None,
+    *,
+    start_cost: float = 0.0,
+    end_cost: float = 0.0,
+    gap_penalty: float = 0.0,
+    similarity_threshold: float | None = None,
+) -> MultiSessionAssignmentResult:
+    """Recover globally consistent tracks from pairwise similarity matrices."""
+
+    normalized_similarities = _normalize_pairwise_costs(pairwise_similarities)
+    converted_costs: dict[tuple[int, int], ArrayLike] = {}
+
+    for key, similarity_matrix in normalized_similarities.items():
+        similarity_array = asarray(similarity_matrix, dtype=float)
+        if not bool(isfinite(similarity_array).all()):
+            raise ValueError("Similarity matrices must contain only finite values.")
+        cost_matrix = 1.0 - similarity_array
+        if similarity_threshold is not None:
+            cost_matrix = cost_matrix.copy()
+            cost_matrix[similarity_array < float(similarity_threshold)] = math.inf
+        converted_costs[key] = cost_matrix
+
+    return solve_multisession_assignment(
+        converted_costs,
+        session_sizes=session_sizes,
+        start_cost=start_cost,
+        end_cost=end_cost,
+        gap_penalty=gap_penalty,
+    )
+
+
+def tracks_to_index_matrix(
+    tracks: Sequence[TrackInput],
+    session_sizes: SessionSizesInput | None = None,
+    *,
+    fill_value: int = -1,
+) -> ArrayLike:
+    """Convert explicit tracks to a dense track-by-session index matrix."""
+
+    assert __backend_name__ != "jax", "Not supported on JAX backend"
+
+    normalized_sizes = _normalize_session_sizes(session_sizes)
+    max_session_index = max(normalized_sizes, default=-1)
+
+    normalized_tracks: list[list[Observation]] = []
+    for track in tracks:
+        items = _iter_track_items(track)
+        for session_index, _ in items:
+            max_session_index = max(max_session_index, int(session_index))
+        normalized_tracks.append(items)
+
+    if max_session_index < 0:
+        return full((len(tracks), 0), fill_value, dtype=int)
+
+    index_matrix = full(
+        (len(normalized_tracks), max_session_index + 1),
+        fill_value,
+        dtype=int,
+    )
+
+    for track_index, items in enumerate(normalized_tracks):
+        for session_index, detection_index in items:
+            index_matrix[track_index, session_index] = detection_index
+
+    return index_matrix
+
+
+def _validate_scalar_cost(name: str, value: float) -> None:
+    if not math.isfinite(value):
+        raise ValueError(f"{name} must be finite.")
+
+
+def _normalize_pairwise_costs(
+    pairwise_costs: PairwiseCostsInput,
+) -> dict[tuple[int, int], ArrayLike]:
+    normalized_costs: dict[tuple[int, int], ArrayLike] = {}
+    if isinstance(pairwise_costs, Mapping):
+        for key, value in pairwise_costs.items():
+            if len(key) != 2:
+                raise ValueError("Each pairwise-cost key must contain two session indices.")
+            source_session, target_session = int(key[0]), int(key[1])
+            if source_session >= target_session:
+                raise ValueError(
+                    "Pairwise-cost keys must satisfy source_session < target_session."
+                )
+            matrix = asarray(value, dtype=float)
+            if matrix.ndim != 2:
+                raise ValueError("Each pairwise cost matrix must be two-dimensional.")
+            normalized_costs[(source_session, target_session)] = matrix
+        return normalized_costs
+
+    for session_idx, value in enumerate(pairwise_costs):
+        matrix = asarray(value, dtype=float)
+        if matrix.ndim != 2:
+            raise ValueError("Each pairwise cost matrix must be two-dimensional.")
+        normalized_costs[(session_idx, session_idx + 1)] = matrix
+    return normalized_costs
+
+
+def _normalize_session_sizes(
+    session_sizes: SessionSizesInput | None,
+) -> dict[int, int]:
+    if session_sizes is None:
+        return {}
+    if isinstance(session_sizes, Mapping):
+        normalized = {
+            int(session_idx): int(size) for session_idx, size in session_sizes.items()
+        }
+    else:
+        normalized = {session_idx: int(size) for session_idx, size in enumerate(session_sizes)}
+    for session_idx, size in normalized.items():
+        if size < 0:
+            raise ValueError(f"Session {session_idx} has a negative detection count.")
+    return normalized
+
+
+def _infer_and_validate_session_sizes(
+    pairwise_costs: Mapping[tuple[int, int], ArrayLike],
+    session_sizes: Mapping[int, int],
+) -> dict[int, int]:
+    inferred_sizes = dict(session_sizes)
+    for (source_session, target_session), cost_matrix in pairwise_costs.items():
+        source_size, target_size = cost_matrix.shape
+        _check_or_set_session_size(inferred_sizes, source_session, source_size)
+        _check_or_set_session_size(inferred_sizes, target_session, target_size)
+
+    if not inferred_sizes and not pairwise_costs:
+        raise ValueError("No observations were provided. Supply pairwise_costs or session_sizes.")
+
+    return dict(sorted(inferred_sizes.items()))
+
+
+def _check_or_set_session_size(
+    inferred_sizes: dict[int, int],
+    session_idx: int,
+    candidate_size: int,
+) -> None:
+    if session_idx in inferred_sizes and inferred_sizes[session_idx] != candidate_size:
+        raise ValueError(
+            f"Inconsistent detection count for session {session_idx}: "
+            f"expected {inferred_sizes[session_idx]}, got {candidate_size}."
+        )
+    inferred_sizes[session_idx] = int(candidate_size)
+
+
+def _compute_session_gap(
+    session_positions: Mapping[int, int],
+    source_session: int,
+    target_session: int,
+) -> int:
+    gap = int(session_positions[target_session]) - int(session_positions[source_session]) - 1
+    if gap < 0:
+        raise ValueError("Session indices must define a forward-in-time edge ordering.")
+    return gap
+
+
+def _build_session_offsets(session_sizes: Mapping[int, int]) -> dict[int, int]:
+    offsets: dict[int, int] = {}
+    offset = 0
+    for session_idx in sorted(session_sizes):
+        offsets[session_idx] = offset
+        offset += int(session_sizes[session_idx])
+    return offsets
+
+
+def _build_observation_index(
+    session_sizes: Mapping[int, int],
+) -> tuple[list[Observation], dict[Observation, int]]:
+    global_to_observation: list[Observation] = []
+    observation_to_global: dict[Observation, int] = {}
+
+    for session_idx in sorted(session_sizes):
+        for detection_idx in range(session_sizes[session_idx]):
+            observation = (session_idx, detection_idx)
+            observation_to_global[observation] = len(global_to_observation)
+            global_to_observation.append(observation)
+
+    return global_to_observation, observation_to_global
+
+
+def _build_candidate_edges(  # pylint: disable=too-many-arguments,too-many-locals
+    pairwise_costs: Mapping[tuple[int, int], ArrayLike],
+    session_sizes: Mapping[int, int],
+    session_positions: Mapping[int, int],
+    session_offsets: Mapping[int, int],
+    *,
+    start_cost: float,
+    end_cost: float,
+    gap_penalty: float,
+    cost_threshold: float | None,
+) -> tuple[ArrayLike, ArrayLike, ArrayLike, ArrayLike]:
+    left_nodes: list[ArrayLike] = []
+    right_nodes: list[ArrayLike] = []
+    edge_gains: list[ArrayLike] = []
+    adjusted_costs: list[ArrayLike] = []
+
+    for (source_session, target_session), cost_matrix in sorted(pairwise_costs.items()):
+        expected_shape = (session_sizes[source_session], session_sizes[target_session])
+        if cost_matrix.shape != expected_shape:
+            raise ValueError(
+                f"Pairwise matrix {(source_session, target_session)} has shape "
+                f"{cost_matrix.shape}, expected {expected_shape}."
+            )
+
+        gap = _compute_session_gap(
+            session_positions,
+            source_session,
+            target_session,
+        )
+        adjusted_matrix = asarray(cost_matrix, dtype=float) + float(gap_penalty) * gap
+        gain_matrix = (float(start_cost) + float(end_cost)) - adjusted_matrix
+
+        valid_mask = isfinite(adjusted_matrix) & (gain_matrix > 0.0)
+        if cost_threshold is not None:
+            valid_mask &= adjusted_matrix <= float(cost_threshold)
+
+        source_indices, target_indices = where(valid_mask)
+        if source_indices.shape[0] == 0:
+            continue
+
+        left_nodes.append(session_offsets[source_session] + cast(source_indices, int))
+        right_nodes.append(session_offsets[target_session] + cast(target_indices, int))
+        edge_gains.append(cast(gain_matrix[valid_mask], float))
+        adjusted_costs.append(cast(adjusted_matrix[valid_mask], float))
+
+    if not edge_gains:
+        return (
+            empty(0, dtype=int),
+            empty(0, dtype=int),
+            empty(0, dtype=float),
+            empty(0, dtype=float),
+        )
+
+    return (
+        concatenate(left_nodes),
+        concatenate(right_nodes),
+        concatenate(edge_gains),
+        concatenate(adjusted_costs),
+    )
+
+
+def _solve_max_weight_matching(
+    left_nodes: ArrayLike,
+    right_nodes: ArrayLike,
+    edge_gains: ArrayLike,
+    num_nodes: int,
+) -> ArrayLike:
+    try:
+        return _solve_max_weight_matching_sparse(
+            left_nodes,
+            right_nodes,
+            edge_gains,
+            num_nodes,
+        )
+    except ValueError:
+        return _solve_max_weight_matching_via_linprog(
+            left_nodes,
+            right_nodes,
+            edge_gains,
+            num_nodes,
+        )
+
+
+def _solve_max_weight_matching_sparse(  # pylint: disable=too-many-locals
+    left_nodes: ArrayLike,
+    right_nodes: ArrayLike,
+    edge_gains: ArrayLike,
+    num_nodes: int,
+) -> ArrayLike:
+    """Solve the sparse bipartite matching problem with LAPJVsp."""
+
+    num_edges = int(edge_gains.size)
+    if num_edges == 0 or num_nodes == 0:
+        return zeros(num_edges, dtype=bool)
+
+    left_nodes = asarray(left_nodes, dtype=int)
+    right_nodes = asarray(right_nodes, dtype=int)
+    edge_gains = asarray(edge_gains, dtype=float)
+
+    row_ids = concatenate((left_nodes, arange(num_nodes, dtype=int)))
+    col_ids = concatenate((right_nodes, num_nodes + arange(num_nodes, dtype=int)))
+
+    base_weight = min(1.0, 0.5 * float(edge_gains.min()))
+    base_weight = max(base_weight, math.nextafter(0.0, 1.0))
+    weights = concatenate(
+        (
+            edge_gains + base_weight,
+            full(num_nodes, base_weight, dtype=float),
+        )
+    )
+
+    biadjacency = coo_matrix(
+        (
+            to_numpy(weights),
+            (to_numpy(row_ids), to_numpy(col_ids)),
+        ),
+        shape=(num_nodes, 2 * num_nodes),
+    ).tocsr()
+
+    matched_rows, matched_cols = min_weight_full_bipartite_matching(
+        biadjacency,
+        maximize=True,
+    )
+
+    if matched_rows.size != num_nodes:
+        raise RuntimeError("Sparse assignment did not produce a full row cover.")
+
+    edge_lookup = {
+        (int(source_node), int(target_node)): edge_index
+        for edge_index, (source_node, target_node) in enumerate(
+            zip(to_numpy(left_nodes), to_numpy(right_nodes))
+        )
+    }
+    selected_edge_mask = zeros(num_edges, dtype=bool)
+
+    for source_node, assigned_column in zip(matched_rows, matched_cols):
+        assigned_column = int(assigned_column)
+        if assigned_column >= num_nodes:
+            continue
+        edge_index = edge_lookup.get((int(source_node), assigned_column))
+        if edge_index is None:
+            raise RuntimeError("Sparse assignment selected a non-admissible edge.")
+        selected_edge_mask[edge_index] = True
+
+    return selected_edge_mask
+
+
+def _solve_max_weight_matching_via_linprog(
+    left_nodes: ArrayLike,
+    right_nodes: ArrayLike,
+    edge_gains: ArrayLike,
+    num_nodes: int,
+) -> ArrayLike:
+    """Fallback solver that keeps the original LP formulation."""
+
+    num_edges = int(edge_gains.shape[0])
+    if num_edges == 0 or num_nodes == 0:
+        return zeros(num_edges, dtype=bool)
+
+    edge_ids = arange(num_edges, dtype=int)
+    row_ids = concatenate((left_nodes, num_nodes + right_nodes))
+    col_ids = concatenate((edge_ids, edge_ids))
+
+    constraint_matrix = coo_matrix(
+        (
+            to_numpy(ones(2 * num_edges, dtype=float)),
+            (to_numpy(row_ids), to_numpy(col_ids)),
+        ),
+        shape=(2 * num_nodes, num_edges),
+    ).tocsr()
+
+    solution = linprog(
+        c=-to_numpy(edge_gains),
+        A_ub=constraint_matrix,
+        b_ub=to_numpy(ones(2 * num_nodes, dtype=float)),
+        bounds=(0.0, 1.0),
+        method="highs",
+    )
+
+    if not solution.success:
+        raise RuntimeError(
+            "Global multi-session association failed: "
+            f"{solution.message}"
+        )
+
+    return asarray(solution.x > 0.5, dtype=bool)
+
+
+def _reconstruct_tracks(
+    global_to_observation: Sequence[Observation],
+    predecessors: ArrayLike,
+    successors: ArrayLike,
+    session_positions: Mapping[int, int],
+) -> list[dict[int, int]]:
+    visited: set[int] = set()
+    tracks: list[dict[int, int]] = []
+
+    for node_idx in range(len(global_to_observation)):
+        if predecessors[node_idx] != -1 or node_idx in visited:
+            continue
+
+        track: dict[int, int] = {}
+        current_node = node_idx
+        while current_node != -1:
+            if current_node in visited:
+                raise RuntimeError("Encountered a cycle while reconstructing tracks.")
+            visited.add(current_node)
+            session_idx, detection_idx = global_to_observation[current_node]
+            track[session_idx] = detection_idx
+            current_node = int(successors[current_node])
+        tracks.append(track)
+
+    for node_idx in range(len(global_to_observation)):
+        if node_idx in visited:
+            continue
+        session_idx, detection_idx = global_to_observation[node_idx]
+        tracks.append({session_idx: detection_idx})
+        visited.add(node_idx)
+
+    tracks.sort(
+        key=lambda track: (
+            min(session_positions[session_idx] for session_idx in track),
+            min(track[session_idx] for session_idx in track),
+            len(track),
+        )
+    )
+    return tracks
+
+
+def _iter_track_items(track: TrackInput) -> list[Observation]:
+    if isinstance(track, Mapping):
+        items = list(track.items())
+    else:
+        items = [(int(session_idx), int(detection_idx)) for session_idx, detection_idx in track]
+    items.sort(key=lambda item: item[0])
+    return [(int(session_idx), int(detection_idx)) for session_idx, detection_idx in items]
+
+
+__all__ = [
+    "MultiSessionAssignmentResult",
+    "solve_multisession_assignment",
+    "solve_multisession_assignment_from_similarity",
+    "tracks_to_index_matrix",
+    "tracks_to_session_labels",
+]

--- a/src/pyrecest/utils/multisession_assignment_observation_costs.py
+++ b/src/pyrecest/utils/multisession_assignment_observation_costs.py
@@ -1,0 +1,227 @@
+"""Extensions for multi-session assignment with observation-specific start/end costs."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from typing import Any, TypeAlias
+
+from pyrecest.backend import asarray, full, isfinite
+
+from .multisession_assignment import (
+    MultiSessionAssignmentResult,
+    PairwiseCostsInput,
+    SessionSizesInput,
+    _compute_session_gap,
+    _infer_and_validate_session_sizes,
+    _normalize_pairwise_costs,
+    _normalize_session_sizes,
+    solve_multisession_assignment,
+)
+
+ObservationCostsInput: TypeAlias = Mapping[int, Any] | Sequence[Any]
+
+
+def solve_multisession_assignment_with_observation_costs(  # pylint: disable=too-many-arguments,too-many-locals
+    pairwise_costs: PairwiseCostsInput,
+    session_sizes: SessionSizesInput | None = None,
+    *,
+    start_cost: float = 0.0,
+    end_cost: float = 0.0,
+    start_costs: ObservationCostsInput | None = None,
+    end_costs: ObservationCostsInput | None = None,
+    gap_penalty: float = 0.0,
+    cost_threshold: float | None = None,
+) -> MultiSessionAssignmentResult:
+    """Solve global multi-session assignment with heterogeneous birth/death costs.
+
+    This is a thin wrapper around :func:`solve_multisession_assignment`. It encodes
+    observation-specific start/end costs into transformed pairwise costs and then
+    maps the reported objective value and matched-edge costs back to the original
+    problem.
+    """
+
+    normalized_pairwise = _normalize_pairwise_costs(pairwise_costs)
+    normalized_sizes = _normalize_session_sizes(session_sizes)
+    session_sizes_map = _infer_and_validate_session_sizes(
+        normalized_pairwise,
+        normalized_sizes,
+    )
+
+    if not session_sizes_map:
+        return MultiSessionAssignmentResult(tracks=[], matched_edges=[], total_cost=0.0)
+
+    normalized_start_costs = _normalize_observation_costs(
+        start_costs,
+        session_sizes_map,
+        default_value=float(start_cost),
+        name="start_costs",
+    )
+    normalized_end_costs = _normalize_observation_costs(
+        end_costs,
+        session_sizes_map,
+        default_value=float(end_cost),
+        name="end_costs",
+    )
+
+    max_start_cost = max(
+        float(costs.max()) if costs.size else float(start_cost)
+        for costs in normalized_start_costs.values()
+    )
+    max_end_cost = max(
+        float(costs.max()) if costs.size else float(end_cost)
+        for costs in normalized_end_costs.values()
+    )
+
+    session_order = sorted(session_sizes_map)
+    session_positions = {
+        session_idx: position for position, session_idx in enumerate(session_order)
+    }
+
+    transformed_pairwise = _transform_pairwise_costs(
+        normalized_pairwise,
+        session_positions,
+        normalized_start_costs,
+        normalized_end_costs,
+        uniform_start_cost=max_start_cost,
+        uniform_end_cost=max_end_cost,
+        gap_penalty=float(gap_penalty),
+        cost_threshold=cost_threshold,
+    )
+
+    base_result = solve_multisession_assignment(
+        transformed_pairwise,
+        session_sizes=session_sizes_map,
+        start_cost=max_start_cost,
+        end_cost=max_end_cost,
+        gap_penalty=gap_penalty,
+        cost_threshold=None,
+    )
+
+    actual_baseline = sum(
+        float(costs.sum()) for costs in normalized_start_costs.values()
+    ) + sum(float(costs.sum()) for costs in normalized_end_costs.values())
+    uniform_baseline = sum(session_sizes_map.values()) * (max_start_cost + max_end_cost)
+    total_cost = float(base_result.total_cost - uniform_baseline + actual_baseline)
+
+    adjusted_edges = [
+        (
+            source,
+            target,
+            float(
+                transformed_cost
+                - max_end_cost
+                - max_start_cost
+                + normalized_end_costs[source[0]][source[1]]
+                + normalized_start_costs[target[0]][target[1]]
+            ),
+        )
+        for source, target, transformed_cost in base_result.matched_edges
+    ]
+
+    return MultiSessionAssignmentResult(
+        tracks=base_result.tracks,
+        matched_edges=adjusted_edges,
+        total_cost=total_cost,
+    )
+
+
+def _normalize_observation_costs(
+    observation_costs: ObservationCostsInput | None,
+    session_sizes: Mapping[int, int],
+    *,
+    default_value: float,
+    name: str,
+) -> dict[int, Any]:
+    if observation_costs is None:
+        raw_entries: dict[int, Any] = {}
+    elif isinstance(observation_costs, Mapping):
+        raw_entries = {int(session_idx): value for session_idx, value in observation_costs.items()}
+    else:
+        raw_entries = dict(enumerate(observation_costs))
+
+    unknown_sessions = sorted(set(raw_entries) - set(session_sizes))
+    if unknown_sessions:
+        raise ValueError(
+            f"{name} specifies unknown sessions {unknown_sessions}; "
+            f"known sessions are {sorted(session_sizes)}."
+        )
+
+    normalized: dict[int, Any] = {}
+    for session_idx in sorted(session_sizes):
+        session_size = int(session_sizes[session_idx])
+        if session_idx not in raw_entries:
+            values = full(session_size, float(default_value), dtype=float)
+        else:
+            values = _normalize_observation_cost_entry(
+                raw_entries[session_idx],
+                session_size,
+                session_idx=session_idx,
+                name=name,
+            )
+        if not bool(isfinite(values).all()):
+            raise ValueError(f"{name} for session {session_idx} must contain only finite values.")
+        normalized[session_idx] = values
+    return normalized
+
+
+def _normalize_observation_cost_entry(
+    value: Any,
+    session_size: int,
+    *,
+    session_idx: int,
+    name: str,
+) -> Any:
+    values = asarray(value, dtype=float)
+    if values.ndim == 0:
+        return full(session_size, float(values), dtype=float)
+    if values.ndim != 1:
+        raise ValueError(
+            f"{name} entry for session {session_idx} must be a scalar or a one-dimensional array."
+        )
+    if int(values.size) != int(session_size):
+        raise ValueError(
+            f"{name} entry for session {session_idx} has length {values.size}, expected {session_size}."
+        )
+    return values
+
+
+def _transform_pairwise_costs(  # pylint: disable=too-many-arguments,too-many-locals
+    pairwise_costs: Mapping[tuple[int, int], Any],
+    session_positions: Mapping[int, int],
+    start_costs: Mapping[int, Any],
+    end_costs: Mapping[int, Any],
+    *,
+    uniform_start_cost: float,
+    uniform_end_cost: float,
+    gap_penalty: float,
+    cost_threshold: float | None,
+) -> dict[tuple[int, int], Any]:
+    transformed: dict[tuple[int, int], Any] = {}
+    for (source_session, target_session), matrix in pairwise_costs.items():
+        gap = _compute_session_gap(
+            session_positions,
+            source_session,
+            target_session,
+        )
+        matrix_array = asarray(matrix, dtype=float)
+        source_end = end_costs[source_session][:, None]
+        target_start = start_costs[target_session][None, :]
+        transformed_matrix = (
+            matrix_array
+            - source_end
+            - target_start
+            + float(uniform_end_cost)
+            + float(uniform_start_cost)
+        )
+
+        if cost_threshold is not None:
+            adjusted_original = matrix_array + float(gap_penalty) * gap
+            transformed_matrix = transformed_matrix.copy()
+            transformed_matrix[adjusted_original > float(cost_threshold)] = math.inf
+
+        transformed[(source_session, target_session)] = transformed_matrix
+    return transformed
+
+
+__all__ = ["solve_multisession_assignment_with_observation_costs"]

--- a/src/pyrecest/utils/roi_similarity.py
+++ b/src/pyrecest/utils/roi_similarity.py
@@ -1,0 +1,416 @@
+"""Utilities for weighted ROI similarity and association-cost construction.
+
+These helpers are aimed at session-to-session identity matching where segmented
+cells are represented as dense footprint images or as sparse pixel lists such as
+Suite2p ``stat.npy`` entries. In contrast to binary IoU, the weighted metrics
+implemented here preserve per-pixel footprint strengths (e.g. ``lam``) and can
+therefore distinguish ROIs with identical support but different spatial weight
+profiles.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+
+from pyrecest.backend import (  # pylint: disable=no-name-in-module
+    all as backend_all,
+    any as backend_any,
+    array,
+    asarray,
+    dot,
+    full,
+    full_like,
+    isfinite,
+    nonzero,
+    ones,
+    sqrt,
+    stack,
+    sum as backend_sum,
+    zeros,
+)
+
+
+_SUPPORTED_METRICS = {"weighted_jaccard", "cosine"}
+
+
+def _looks_like_sparse_coordinate_container(roi) -> bool:
+    """Return ``True`` if ``roi`` looks like ``(ypix, xpix[, weights])``."""
+
+    if not isinstance(roi, (tuple, list)) or len(roi) not in (2, 3):
+        return False
+
+    first = asarray(roi[0])
+    second = asarray(roi[1])
+    return first.ndim <= 1 and second.ndim <= 1
+
+
+# pylint: disable=too-many-branches
+# pylint: disable=too-many-return-statements
+# pylint: disable=too-many-statements
+def _extract_roi_pixels_and_weights(roi, exclude_overlap=False):
+    """Extract sparse ROI coordinates and non-negative weights."""
+
+    if isinstance(roi, Mapping):
+        if "ypix" not in roi or "xpix" not in roi:
+            raise KeyError(
+                "Sparse ROI mappings must provide both 'ypix' and 'xpix' keys."
+            )
+
+        ypix = asarray(roi["ypix"], dtype=int).ravel()
+        xpix = asarray(roi["xpix"], dtype=int).ravel()
+
+        if "lam" in roi:
+            weights = asarray(roi["lam"], dtype=float).ravel()
+        elif "weights" in roi:
+            weights = asarray(roi["weights"], dtype=float).ravel()
+        else:
+            weights = ones(ypix.shape[0], dtype=float)
+
+        if exclude_overlap and "overlap" in roi:
+            overlap = asarray(roi["overlap"], dtype=bool).ravel()
+            if overlap.shape != ypix.shape:
+                raise ValueError(
+                    "Suite2p-style 'overlap' flags must match the ROI pixel count."
+                )
+            keep = ~overlap
+            ypix = ypix[keep]
+            xpix = xpix[keep]
+            weights = weights[keep]
+
+    elif _looks_like_sparse_coordinate_container(roi):
+        ypix = asarray(roi[0], dtype=int).ravel()
+        xpix = asarray(roi[1], dtype=int).ravel()
+        if len(roi) == 3:
+            weights = asarray(roi[2], dtype=float).ravel()
+        else:
+            weights = ones(ypix.shape[0], dtype=float)
+
+    else:
+        mask = asarray(roi, dtype=float)
+        if mask.ndim != 2:
+            raise ValueError(
+                "Dense ROI representations must be two-dimensional arrays."
+            )
+        if not bool(backend_all(isfinite(mask))):
+            raise ValueError("Dense ROI masks must contain only finite values.")
+        if bool(backend_any(mask < 0)):
+            raise ValueError("Dense ROI masks must not contain negative weights.")
+        ypix, xpix = nonzero(mask)
+        ypix = asarray(ypix, dtype=int)
+        xpix = asarray(xpix, dtype=int)
+        weights = asarray(mask[ypix, xpix], dtype=float)
+
+    if ypix.shape != xpix.shape:
+        raise ValueError(
+            "ROI coordinate vectors 'ypix' and 'xpix' must have the same length."
+        )
+    if weights.shape != ypix.shape:
+        raise ValueError("ROI weights must have the same length as 'ypix' and 'xpix'.")
+    if not bool(backend_all(isfinite(weights))):
+        raise ValueError("ROI weights must be finite.")
+    if bool(backend_any(weights < 0)):
+        raise ValueError("ROI weights must be non-negative.")
+
+    nonzero_mask = weights > 0
+    ypix = ypix[nonzero_mask]
+    xpix = xpix[nonzero_mask]
+    weights = weights[nonzero_mask]
+    return ypix, xpix, weights
+
+
+def _sparsify_roi(roi, exclude_overlap=False):
+    """Return a sparse pixel->weight dictionary for ``roi``."""
+
+    ypix, xpix, weights = _extract_roi_pixels_and_weights(
+        roi, exclude_overlap=exclude_overlap
+    )
+
+    sparse = {}
+    for y, x, weight in zip(ypix.tolist(), xpix.tolist(), weights.tolist()):
+        key = (int(y), int(x))
+        sparse[key] = sparse.get(key, 0.0) + float(weight)
+    return sparse
+
+
+def _weighted_jaccard_from_sparse(sparse_a, sparse_b) -> float:
+    if not sparse_a and not sparse_b:
+        return 0.0
+
+    keys = set(sparse_a) | set(sparse_b)
+    numerator = 0.0
+    denominator = 0.0
+    for key in keys:
+        weight_a = sparse_a.get(key, 0.0)
+        weight_b = sparse_b.get(key, 0.0)
+        numerator += min(weight_a, weight_b)
+        denominator += max(weight_a, weight_b)
+    return numerator / denominator if denominator > 0.0 else 0.0
+
+
+def _cosine_from_sparse(sparse_a, sparse_b) -> float:
+    if not sparse_a or not sparse_b:
+        return 0.0
+
+    if len(sparse_a) > len(sparse_b):
+        sparse_a, sparse_b = sparse_b, sparse_a
+
+    dot_product = sum(
+        weight * sparse_b.get(key, 0.0) for key, weight in sparse_a.items()
+    )
+    norm_a = math.sqrt(sum(weight * weight for weight in sparse_a.values()))
+    norm_b = math.sqrt(sum(weight * weight for weight in sparse_b.values()))
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return dot_product / (norm_a * norm_b)
+
+
+def _similarity_from_sparse(sparse_a, sparse_b, metric):
+    if metric == "weighted_jaccard":
+        return _weighted_jaccard_from_sparse(sparse_a, sparse_b)
+    if metric == "cosine":
+        return _cosine_from_sparse(sparse_a, sparse_b)
+    raise ValueError(
+        f"Unsupported ROI similarity metric '{metric}'. Supported metrics are "
+        f"{sorted(_SUPPORTED_METRICS)}."
+    )
+
+
+def weighted_roi_jaccard(roi_a, roi_b, exclude_overlap=False) -> float:
+    """Compute a weighted Jaccard similarity between two ROIs."""
+
+    sparse_a = _sparsify_roi(roi_a, exclude_overlap=exclude_overlap)
+    sparse_b = _sparsify_roi(roi_b, exclude_overlap=exclude_overlap)
+    return _weighted_jaccard_from_sparse(sparse_a, sparse_b)
+
+
+def weighted_roi_cosine_similarity(roi_a, roi_b, exclude_overlap=False) -> float:
+    """Compute cosine similarity between two weighted ROI footprints."""
+
+    sparse_a = _sparsify_roi(roi_a, exclude_overlap=exclude_overlap)
+    sparse_b = _sparsify_roi(roi_b, exclude_overlap=exclude_overlap)
+    return _cosine_from_sparse(sparse_a, sparse_b)
+
+
+def pairwise_roi_similarity(
+    reference_rois,
+    query_rois,
+    metric="weighted_jaccard",
+    exclude_overlap=False,
+):
+    """Build a pairwise ROI similarity matrix."""
+
+    if metric not in _SUPPORTED_METRICS:
+        raise ValueError(
+            f"Unsupported ROI similarity metric '{metric}'. Supported metrics are "
+            f"{sorted(_SUPPORTED_METRICS)}."
+        )
+
+    n_reference = len(reference_rois)
+    n_query = len(query_rois)
+    similarities = zeros((n_reference, n_query), dtype=float)
+
+    sparse_reference = [
+        _sparsify_roi(roi, exclude_overlap=exclude_overlap) for roi in reference_rois
+    ]
+    sparse_query = [
+        _sparsify_roi(roi, exclude_overlap=exclude_overlap) for roi in query_rois
+    ]
+
+    for i, sparse_ref in enumerate(sparse_reference):
+        for j, sparse_query_roi in enumerate(sparse_query):
+            similarities[i, j] = _similarity_from_sparse(
+                sparse_ref, sparse_query_roi, metric=metric
+            )
+
+    return similarities
+
+
+# pylint: disable=too-many-branches
+def roi_centroid(
+    roi,
+    use_weights=True,
+    prefer_med=True,
+    exclude_overlap=False,
+):
+    """Return the centroid of an ROI as ``[y, x]``."""
+
+    if prefer_med and isinstance(roi, Mapping) and "med" in roi:
+        med = asarray(roi["med"], dtype=float).ravel()
+        if med.shape != (2,):
+            raise ValueError("ROI field 'med' must contain exactly two entries [y, x].")
+        if not bool(backend_all(isfinite(med))):
+            raise ValueError("ROI field 'med' must contain only finite values.")
+        return med
+
+    ypix, xpix, weights = _extract_roi_pixels_and_weights(
+        roi, exclude_overlap=exclude_overlap
+    )
+    if ypix.size == 0:
+        return array([math.nan, math.nan], dtype=float)
+
+    ypix = asarray(ypix, dtype=float)
+    xpix = asarray(xpix, dtype=float)
+    weights = asarray(weights, dtype=float)
+    if use_weights:
+        total_weight = float(backend_sum(weights))
+        if total_weight > 0.0:
+            return array(
+                [
+                    float(dot(ypix, weights)) / total_weight,
+                    float(dot(xpix, weights)) / total_weight,
+                ],
+                dtype=float,
+            )
+
+    return array(
+        [
+            float(backend_sum(ypix)) / float(ypix.size),
+            float(backend_sum(xpix)) / float(xpix.size),
+        ],
+        dtype=float,
+    )
+
+
+def pairwise_centroid_distances(
+    reference_rois,
+    query_rois,
+    use_weights=True,
+    prefer_med=True,
+    exclude_overlap=False,
+):
+    """Build a pairwise Euclidean centroid-distance matrix."""
+
+    n_reference = len(reference_rois)
+    n_query = len(query_rois)
+    distances = full((n_reference, n_query), math.inf, dtype=float)
+    if n_reference == 0 or n_query == 0:
+        return distances
+
+    reference_centroids = stack(
+        [
+            roi_centroid(
+                roi,
+                use_weights=use_weights,
+                prefer_med=prefer_med,
+                exclude_overlap=exclude_overlap,
+            )
+            for roi in reference_rois
+        ],
+        axis=0,
+    )
+    query_centroids = stack(
+        [
+            roi_centroid(
+                roi,
+                use_weights=use_weights,
+                prefer_med=prefer_med,
+                exclude_overlap=exclude_overlap,
+            )
+            for roi in query_rois
+        ],
+        axis=0,
+    )
+
+    valid_query_centroids = backend_all(isfinite(query_centroids), axis=1)
+    for i, ref_centroid in enumerate(reference_centroids):
+        if not bool(backend_all(isfinite(ref_centroid))):
+            continue
+        deltas = query_centroids - ref_centroid
+        distances[i, valid_query_centroids] = sqrt(
+            backend_sum(
+                deltas[valid_query_centroids] * deltas[valid_query_centroids],
+                axis=1,
+            )
+        )
+
+    return distances
+
+
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-positional-arguments
+# pylint: disable=too-many-locals
+def build_roi_cost_matrix(
+    reference_rois,
+    query_rois,
+    footprint_metric="weighted_jaccard",
+    footprint_weight=1.0,
+    centroid_weight=0.0,
+    centroid_scale=1.0,
+    max_centroid_distance=None,
+    min_similarity=None,
+    exclude_overlap=False,
+    use_weighted_centroids=True,
+    prefer_med=True,
+    return_components=False,
+):
+    """Construct a pairwise association-cost matrix for ROI matching."""
+
+    if footprint_metric not in _SUPPORTED_METRICS:
+        raise ValueError(
+            f"Unsupported ROI similarity metric '{footprint_metric}'. Supported "
+            f"metrics are {sorted(_SUPPORTED_METRICS)}."
+        )
+    if footprint_weight < 0.0:
+        raise ValueError("footprint_weight must be non-negative.")
+    if centroid_weight < 0.0:
+        raise ValueError("centroid_weight must be non-negative.")
+    if centroid_scale <= 0.0:
+        raise ValueError("centroid_scale must be positive.")
+    if max_centroid_distance is not None and max_centroid_distance < 0.0:
+        raise ValueError("max_centroid_distance must be non-negative.")
+
+    similarity_matrix = pairwise_roi_similarity(
+        reference_rois,
+        query_rois,
+        metric=footprint_metric,
+        exclude_overlap=exclude_overlap,
+    )
+    cost_matrix = footprint_weight * (1.0 - similarity_matrix)
+
+    need_centroids = centroid_weight > 0.0 or max_centroid_distance is not None
+    centroid_distance_matrix = None
+    if need_centroids:
+        centroid_distance_matrix = pairwise_centroid_distances(
+            reference_rois,
+            query_rois,
+            use_weights=use_weighted_centroids,
+            prefer_med=prefer_med,
+            exclude_overlap=exclude_overlap,
+        )
+        cost_matrix = cost_matrix + centroid_weight * (
+            centroid_distance_matrix / centroid_scale
+        )
+
+    if min_similarity is not None:
+        cost_matrix = cost_matrix.copy()
+        cost_matrix[similarity_matrix < min_similarity] = math.inf
+
+    if max_centroid_distance is not None:
+        if centroid_distance_matrix is None:
+            centroid_distance_matrix = pairwise_centroid_distances(
+                reference_rois,
+                query_rois,
+                use_weights=use_weighted_centroids,
+                prefer_med=prefer_med,
+                exclude_overlap=exclude_overlap,
+            )
+        cost_matrix = cost_matrix.copy()
+        cost_matrix[centroid_distance_matrix > max_centroid_distance] = math.inf
+
+    if return_components:
+        if centroid_distance_matrix is None:
+            centroid_distance_matrix = full_like(cost_matrix, math.nan, dtype=float)
+        return cost_matrix, similarity_matrix, centroid_distance_matrix
+
+    return cost_matrix
+
+
+__all__ = [
+    "build_roi_cost_matrix",
+    "pairwise_centroid_distances",
+    "pairwise_roi_similarity",
+    "roi_centroid",
+    "weighted_roi_cosine_similarity",
+    "weighted_roi_jaccard",
+]

--- a/tests/test_multisession_assignment.py
+++ b/tests/test_multisession_assignment.py
@@ -1,0 +1,313 @@
+"""Tests for global multi-session association."""
+
+import random
+import unittest
+from unittest.mock import patch
+
+import pyrecest.utils.multisession_assignment as multisession_assignment_module
+from pyrecest.backend import (  # pylint: disable=no-name-in-module
+    __backend_name__,
+    array,
+    array_equal,
+)
+from pyrecest.utils import (
+    solve_multisession_assignment,
+    solve_multisession_assignment_from_similarity,
+    tracks_to_index_matrix,
+    tracks_to_session_labels,
+)
+
+
+class TestMultiSessionAssignment(unittest.TestCase):
+    @staticmethod
+    def _canonical_tracks(tracks):
+        return sorted(tuple(sorted(track.items())) for track in tracks)
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_singletons_without_edges(self):
+        result = solve_multisession_assignment(
+            {},
+            session_sizes=[2, 1, 2],
+            start_cost=1.0,
+            end_cost=1.0,
+        )
+
+        expected_tracks = [
+            ((0, 0),),
+            ((0, 1),),
+            ((1, 0),),
+            ((2, 0),),
+            ((2, 1),),
+        ]
+        self.assertEqual(self._canonical_tracks(result.tracks), expected_tracks)
+        self.assertAlmostEqual(result.total_cost, 10.0)
+        self.assertEqual(result.matched_edges, [])
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_consecutive_costs_form_two_long_tracks(self):
+        result = solve_multisession_assignment(
+            [
+                array([[0.1, 8.0], [8.0, 0.2]], dtype=float),
+                array([[0.1, 8.0], [8.0, 0.2]], dtype=float),
+            ],
+            start_cost=5.0,
+            end_cost=5.0,
+            cost_threshold=10.0,
+        )
+
+        expected_tracks = [
+            ((0, 0), (1, 0), (2, 0)),
+            ((0, 1), (1, 1), (2, 1)),
+        ]
+        self.assertEqual(self._canonical_tracks(result.tracks), expected_tracks)
+        self.assertAlmostEqual(result.total_cost, 20.6)
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_cross_gap_linking_is_supported(self):
+        result = solve_multisession_assignment(
+            {(0, 2): array([[0.3]], dtype=float)},
+            session_sizes=[1, 0, 1],
+            start_cost=4.0,
+            end_cost=4.0,
+            gap_penalty=0.5,
+        )
+
+        expected_tracks = [((0, 0), (2, 0))]
+        self.assertEqual(self._canonical_tracks(result.tracks), expected_tracks)
+        self.assertAlmostEqual(result.total_cost, 8.8)
+        self.assertEqual(result.matched_edges, [((0, 0), (2, 0), 0.8)])
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_global_solution_beats_pairwise_greedy_choice(self):
+        result = solve_multisession_assignment(
+            [
+                array([[0.0, 1.0], [1.0, 100.0]], dtype=float),
+                array([[100.0, 0.0], [0.0, 100.0]], dtype=float),
+            ],
+            start_cost=10.0,
+            end_cost=10.0,
+            cost_threshold=150.0,
+        )
+
+        expected_tracks = [
+            ((0, 0), (1, 1), (2, 0)),
+            ((0, 1), (1, 0), (2, 1)),
+        ]
+        self.assertEqual(self._canonical_tracks(result.tracks), expected_tracks)
+        self.assertAlmostEqual(result.total_cost, 42.0)
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_tracks_to_session_labels(self):
+        result = solve_multisession_assignment(
+            {(0, 2): array([[0.3]], dtype=float)},
+            session_sizes=[1, 0, 1],
+            start_cost=4.0,
+            end_cost=4.0,
+            gap_penalty=0.5,
+        )
+
+        labels = result.to_session_labels(session_sizes=[1, 0, 1])
+        self.assertTrue(array_equal(labels[0], array([0])))
+        self.assertEqual(labels[1].shape[0], 0)
+        self.assertTrue(array_equal(labels[2], array([0])))
+
+        labels_from_function = tracks_to_session_labels(
+            result.tracks, session_sizes=[1, 0, 1]
+        )
+        self.assertTrue(array_equal(labels_from_function[0], array([0])))
+        self.assertEqual(labels_from_function[1].shape[0], 0)
+        self.assertTrue(array_equal(labels_from_function[2], array([0])))
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_rejects_inconsistent_session_sizes(self):
+        pairwise_costs = {
+            (0, 1): array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]),
+            (1, 2): array([[0.0], [0.0], [0.0], [0.0]]),
+        }
+
+        with self.assertRaises(ValueError):
+            solve_multisession_assignment(pairwise_costs)
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_drops_non_beneficial_links_even_without_threshold(self):
+        result = solve_multisession_assignment(
+            [array([[5.0]], dtype=float)],
+            start_cost=1.0,
+            end_cost=1.0,
+        )
+
+        self.assertEqual(
+            self._canonical_tracks(result.tracks), [((0, 0),), ((1, 0),)]
+        )
+        self.assertAlmostEqual(result.total_cost, 4.0)
+
+    @staticmethod
+    def _assert_valid_matching(mask, left_nodes, right_nodes):
+        selected_left = left_nodes[mask]
+        selected_right = right_nodes[mask]
+        assert len(selected_left) == len(set(int(value) for value in selected_left))
+        assert len(selected_right) == len(set(int(value) for value in selected_right))
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_similarity_wrapper_respects_threshold(self):
+        result = solve_multisession_assignment_from_similarity(
+            [array([[0.95, 0.20], [0.30, 0.90]], dtype=float)],
+            start_cost=1.0,
+            end_cost=1.0,
+            similarity_threshold=0.80,
+        )
+
+        expected_tracks = [
+            ((0, 0), (1, 0)),
+            ((0, 1), (1, 1)),
+        ]
+        self.assertEqual(self._canonical_tracks(result.tracks), expected_tracks)
+        self.assertAlmostEqual(result.total_cost, 4.15)
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_similarity_wrapper_supports_gap_links(self):
+        result = solve_multisession_assignment_from_similarity(
+            {(0, 2): array([[0.95]], dtype=float)},
+            session_sizes=[1, 0, 1],
+            start_cost=1.0,
+            end_cost=1.0,
+            gap_penalty=0.10,
+            similarity_threshold=0.90,
+        )
+
+        self.assertEqual(self._canonical_tracks(result.tracks), [((0, 0), (2, 0))])
+        self.assertAlmostEqual(result.total_cost, 2.15)
+        self.assertEqual(result.matched_edges[0][0], (0, 0))
+        self.assertEqual(result.matched_edges[0][1], (2, 0))
+        self.assertAlmostEqual(result.matched_edges[0][2], 0.15)
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_tracks_to_index_matrix(self):
+        tracks = [{0: 2, 2: 1}, {1: 0}]
+        index_matrix = tracks_to_index_matrix(tracks, session_sizes=[3, 1, 2])
+        self.assertTrue(
+            array_equal(
+                index_matrix,
+                array([[2, -1, 1], [-1, 0, -1]]),
+            )
+        )
+
+        result = solve_multisession_assignment(
+            {(0, 2): array([[0.3]], dtype=float)},
+            session_sizes=[1, 0, 1],
+            start_cost=4.0,
+            end_cost=4.0,
+            gap_penalty=0.5,
+        )
+        self.assertTrue(
+            array_equal(
+                result.to_index_matrix(session_sizes=[1, 0, 1]),
+                array([[0, -1, 0]]),
+            )
+        )
+
+    def test_sparse_backend_matches_previous_linprog_backend(self):
+        rng = random.Random(42)  # nosec B311
+        num_nodes = 12
+        all_pairs = [
+            (left, right) for left in range(num_nodes) for right in range(num_nodes)
+        ]
+        selected_pairs = rng.sample(range(len(all_pairs)), 40)
+
+        left_nodes = array([all_pairs[index][0] for index in selected_pairs], dtype=int)
+        right_nodes = array([all_pairs[index][1] for index in selected_pairs], dtype=int)
+        edge_gains = array(
+            [rng.uniform(0.1, 10.0) for _ in range(len(selected_pairs))],
+            dtype=float,
+        )
+
+        solve_matching = getattr(
+            multisession_assignment_module,
+            "_solve_max_weight_matching",
+        )
+        solve_matching_via_linprog = getattr(
+            multisession_assignment_module,
+            "_solve_max_weight_matching_via_linprog",
+        )
+        sparse_mask = solve_matching(
+            left_nodes,
+            right_nodes,
+            edge_gains,
+            num_nodes,
+        )
+        linprog_mask = solve_matching_via_linprog(
+            left_nodes,
+            right_nodes,
+            edge_gains,
+            num_nodes,
+        )
+
+        self._assert_valid_matching(sparse_mask, left_nodes, right_nodes)
+        self._assert_valid_matching(linprog_mask, left_nodes, right_nodes)
+        self.assertAlmostEqual(
+            float(edge_gains[sparse_mask].sum()),
+            float(edge_gains[linprog_mask].sum()),
+        )
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on JAX backend",
+    )
+    def test_sparse_backend_falls_back_to_linprog_when_requested(self):
+        pairwise_costs = [
+            array([[0.1, 8.0], [8.0, 0.2]], dtype=float),
+            array([[0.1, 8.0], [8.0, 0.2]], dtype=float),
+        ]
+
+        with patch.object(
+            multisession_assignment_module,
+            "min_weight_full_bipartite_matching",
+            side_effect=ValueError("forced sparse-backend failure"),
+        ):
+            result = solve_multisession_assignment(
+                pairwise_costs,
+                start_cost=5.0,
+                end_cost=5.0,
+                cost_threshold=10.0,
+            )
+
+        expected_tracks = [
+            ((0, 0), (1, 0), (2, 0)),
+            ((0, 1), (1, 1), (2, 1)),
+        ]
+        self.assertEqual(self._canonical_tracks(result.tracks), expected_tracks)
+        self.assertAlmostEqual(result.total_cost, 20.6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_multisession_assignment_observation_costs.py
+++ b/tests/test_multisession_assignment_observation_costs.py
@@ -1,0 +1,148 @@
+"""Tests for observation-specific multi-session assignment costs."""
+
+import unittest
+
+from pyrecest.backend import (  # pylint: disable=no-name-in-module
+    __backend_name__,
+    array,
+)
+from pyrecest.utils import (
+    solve_multisession_assignment,
+    solve_multisession_assignment_with_observation_costs,
+)
+
+
+class TestMultiSessionAssignmentObservationCosts(unittest.TestCase):
+    @staticmethod
+    def _canonical_tracks(tracks):
+        return sorted(tuple(sorted(track.items())) for track in tracks)
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on JAX backend",
+    )
+    def test_matches_base_solver_when_costs_are_uniform(self):
+        pairwise_costs = [
+            array([[0.1, 8.0], [8.0, 0.2]], dtype=float),
+            array([[0.1, 8.0], [8.0, 0.2]], dtype=float),
+        ]
+        expected = solve_multisession_assignment(
+            pairwise_costs,
+            start_cost=5.0,
+            end_cost=5.0,
+            cost_threshold=10.0,
+        )
+        actual = solve_multisession_assignment_with_observation_costs(
+            pairwise_costs,
+            start_cost=5.0,
+            end_cost=5.0,
+            cost_threshold=10.0,
+        )
+
+        self.assertEqual(
+            self._canonical_tracks(actual.tracks),
+            self._canonical_tracks(expected.tracks),
+        )
+        self.assertEqual(
+            [(source, target) for source, target, _ in actual.matched_edges],
+            [(source, target) for source, target, _ in expected.matched_edges],
+        )
+        for (_, _, actual_cost), (_, _, expected_cost) in zip(
+            actual.matched_edges,
+            expected.matched_edges,
+        ):
+            self.assertAlmostEqual(actual_cost, expected_cost)
+        self.assertAlmostEqual(actual.total_cost, expected.total_cost)
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on JAX backend",
+    )
+    def test_detection_specific_start_costs_bias_target_choice(self):
+        result = solve_multisession_assignment_with_observation_costs(
+            [array([[1.5, 1.5]], dtype=float)],
+            start_cost=0.0,
+            end_cost=2.0,
+            start_costs={1: array([0.0, 3.0], dtype=float)},
+        )
+
+        expected_tracks = [
+            ((0, 0), (1, 1)),
+            ((1, 0),),
+        ]
+        self.assertEqual(self._canonical_tracks(result.tracks), expected_tracks)
+        self.assertEqual(result.matched_edges, [((0, 0), (1, 1), 1.5)])
+        self.assertAlmostEqual(result.total_cost, 5.5)
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on JAX backend",
+    )
+    def test_detection_specific_end_costs_bias_source_choice(self):
+        result = solve_multisession_assignment_with_observation_costs(
+            [array([[1.5], [1.5]], dtype=float)],
+            start_cost=2.0,
+            end_cost=0.0,
+            end_costs={0: array([0.0, 3.0], dtype=float)},
+        )
+
+        expected_tracks = [
+            ((0, 0),),
+            ((0, 1), (1, 0)),
+        ]
+        self.assertEqual(self._canonical_tracks(result.tracks), expected_tracks)
+        self.assertEqual(result.matched_edges, [((0, 1), (1, 0), 1.5)])
+        self.assertAlmostEqual(result.total_cost, 5.5)
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on JAX backend",
+    )
+    def test_sequence_scalar_cost_entries_are_broadcast_per_session(self):
+        result = solve_multisession_assignment_with_observation_costs(
+            [array([[2.5, 2.5]], dtype=float)],
+            start_cost=0.0,
+            end_cost=1.0,
+            start_costs=[0.0, 3.0],
+        )
+
+        self.assertEqual(len(result.matched_edges), 1)
+        self.assertAlmostEqual(result.total_cost, 7.5)
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on JAX backend",
+    )
+    def test_cost_threshold_is_applied_in_original_cost_domain(self):
+        result = solve_multisession_assignment_with_observation_costs(
+            {(0, 2): array([[0.3]], dtype=float)},
+            session_sizes=[1, 0, 1],
+            start_cost=4.0,
+            end_cost=4.0,
+            start_costs={2: array([10.0], dtype=float)},
+            gap_penalty=0.5,
+            cost_threshold=0.75,
+        )
+
+        self.assertEqual(
+            self._canonical_tracks(result.tracks), [((0, 0),), ((2, 0),)]
+        )
+        self.assertEqual(result.matched_edges, [])
+
+    def test_rejects_unknown_sessions(self):
+        with self.assertRaises(ValueError):
+            solve_multisession_assignment_with_observation_costs(
+                [array([[1.0]], dtype=float)],
+                start_costs={2: array([1.0], dtype=float)},
+            )
+
+    def test_rejects_mismatched_lengths(self):
+        with self.assertRaises(ValueError):
+            solve_multisession_assignment_with_observation_costs(
+                [array([[1.0, 1.0]], dtype=float)],
+                start_costs={1: array([1.0], dtype=float)},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_roi_similarity.py
+++ b/tests/test_roi_similarity.py
@@ -1,0 +1,171 @@
+import math
+import unittest
+
+import numpy.testing as npt
+
+from pyrecest.backend import array  # pylint: disable=no-name-in-module
+from pyrecest.utils.roi_similarity import (
+    build_roi_cost_matrix,
+    pairwise_centroid_distances,
+    pairwise_roi_similarity,
+    roi_centroid,
+    weighted_roi_cosine_similarity,
+    weighted_roi_jaccard,
+)
+
+
+class TestWeightedRoiSimilarity(unittest.TestCase):
+    def test_weighted_jaccard_uses_suite2p_lam(self):
+        roi_a = {
+            "ypix": array([0, 0]),
+            "xpix": array([0, 1]),
+            "lam": array([1.0, 1.0]),
+        }
+        roi_b = {
+            "ypix": array([0, 0]),
+            "xpix": array([0, 1]),
+            "lam": array([1.0, 0.5]),
+        }
+
+        self.assertAlmostEqual(weighted_roi_jaccard(roi_a, roi_b), 0.75)
+
+    def test_cosine_similarity_supports_dense_weighted_masks(self):
+        roi_a = array([[0.0, 2.0], [0.0, 1.0]])
+        roi_b = array([[0.0, 1.0], [0.0, 1.0]])
+
+        expected = 3.0 / math.sqrt(10.0)
+        self.assertAlmostEqual(weighted_roi_cosine_similarity(roi_a, roi_b), expected)
+
+    def test_exclude_overlap_drops_suite2p_overlapping_pixels(self):
+        roi_a = {
+            "ypix": array([0, 0, 1]),
+            "xpix": array([0, 1, 1]),
+            "lam": array([1.0, 1.0, 1.0]),
+            "overlap": array([False, True, False], dtype=bool),
+        }
+        roi_b = {
+            "ypix": array([0, 1]),
+            "xpix": array([0, 1]),
+            "lam": array([1.0, 1.0]),
+        }
+
+        self.assertAlmostEqual(weighted_roi_jaccard(roi_a, roi_b), 2.0 / 3.0)
+        self.assertAlmostEqual(
+            weighted_roi_jaccard(roi_a, roi_b, exclude_overlap=True), 1.0
+        )
+
+    def test_pairwise_similarity_recovers_crossed_order(self):
+        reference_rois = [
+            {
+                "ypix": array([0, 0]),
+                "xpix": array([0, 1]),
+                "lam": array([1.0, 0.8]),
+            },
+            {
+                "ypix": array([5, 5]),
+                "xpix": array([5, 6]),
+                "lam": array([1.0, 1.0]),
+            },
+        ]
+        query_rois = [reference_rois[1], reference_rois[0]]
+
+        similarity_matrix = pairwise_roi_similarity(reference_rois, query_rois)
+
+        npt.assert_allclose(similarity_matrix, array([[0.0, 1.0], [1.0, 0.0]]))
+
+
+class TestRoiCentroids(unittest.TestCase):
+    def test_centroid_prefers_med_when_present(self):
+        roi = {
+            "ypix": array([0, 2]),
+            "xpix": array([0, 2]),
+            "lam": array([1.0, 3.0]),
+            "med": array([10.0, 20.0]),
+        }
+
+        npt.assert_allclose(roi_centroid(roi), array([10.0, 20.0]))
+        npt.assert_allclose(
+            roi_centroid(roi, prefer_med=False), array([1.5, 1.5])
+        )
+
+    def test_pairwise_centroid_distances_use_med_if_available(self):
+        reference_rois = [
+            {"ypix": array([0]), "xpix": array([0]), "med": array([1.0, 1.0])}
+        ]
+        query_rois = [
+            {"ypix": array([0]), "xpix": array([0]), "med": array([4.0, 5.0])}
+        ]
+
+        distances = pairwise_centroid_distances(reference_rois, query_rois)
+        npt.assert_allclose(distances, array([[5.0]]))
+
+    def test_pairwise_centroid_distances_handles_empty_queries(self):
+        reference_rois = [
+            {"ypix": array([0]), "xpix": array([0]), "med": array([1.0, 1.0])}
+        ]
+
+        distances = pairwise_centroid_distances(reference_rois, [])
+        self.assertEqual(distances.shape, (1, 0))
+
+
+class TestRoiCostMatrix(unittest.TestCase):
+    def test_build_roi_cost_matrix_combines_similarity_and_centroid_gating(self):
+        reference_rois = [
+            {
+                "ypix": array([0, 0]),
+                "xpix": array([0, 1]),
+                "lam": array([1.0, 1.0]),
+                "med": array([0.0, 0.5]),
+            },
+            {
+                "ypix": array([5, 5]),
+                "xpix": array([5, 6]),
+                "lam": array([1.0, 1.0]),
+                "med": array([5.0, 5.5]),
+            },
+        ]
+        query_rois = [reference_rois[1], reference_rois[0]]
+
+        cost_matrix, similarity_matrix, centroid_distances = build_roi_cost_matrix(
+            reference_rois,
+            query_rois,
+            centroid_weight=0.25,
+            centroid_scale=1.0,
+            max_centroid_distance=2.0,
+            return_components=True,
+        )
+
+        self.assertTrue(math.isinf(float(cost_matrix[0, 0])))
+        self.assertTrue(math.isinf(float(cost_matrix[1, 1])))
+        self.assertEqual(cost_matrix[0, 1], 0.0)
+        self.assertEqual(cost_matrix[1, 0], 0.0)
+        npt.assert_allclose(similarity_matrix, array([[0.0, 1.0], [1.0, 0.0]]))
+        npt.assert_allclose(
+            centroid_distances,
+            array(
+                [
+                    [math.sqrt(50.0), 0.0],
+                    [0.0, math.sqrt(50.0)],
+                ]
+            ),
+        )
+
+    def test_build_roi_cost_matrix_rejects_low_similarity(self):
+        reference_rois = [
+            {"ypix": array([0]), "xpix": array([0]), "lam": array([1.0])}
+        ]
+        query_rois = [
+            {"ypix": array([3]), "xpix": array([3]), "lam": array([1.0])}
+        ]
+
+        cost_matrix = build_roi_cost_matrix(
+            reference_rois,
+            query_rois,
+            min_similarity=0.1,
+        )
+
+        self.assertTrue(math.isinf(float(cost_matrix[0, 0])))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR consolidates the generic multi-session assignment work and the reusable ROI-similarity utilities into a single branch against `main`.

It is intended as a cleaned-up merge target for the overlapping open work in:
- #1804
- #1806
- the utility-level core of #1803

## Included

### From #1804 / #1806
- generic `solve_multisession_assignment`
- `MultiSessionAssignmentResult`
- similarity-input wrapper `solve_multisession_assignment_from_similarity`
- dense exports/helpers:
  - `tracks_to_session_labels`
  - `tracks_to_index_matrix`
  - `result.to_session_labels(...)`
  - `result.to_index_matrix(...)`
- observation-specific start/end cost support via
  `solve_multisession_assignment_with_observation_costs`
- associated tests for the above

### From #1803
- reusable weighted ROI similarity utilities in `pyrecest.utils.roi_similarity`
- centroid helpers and fused ROI cost-matrix construction
- associated tests
- public exports in `pyrecest.utils`

## Intentional consolidation choices
- Use #1804 as the main backbone for the multi-session assignment implementation.
- Treat #1806 as overlapping/superseded by the consolidated multi-session core already represented here.
- Keep the reusable ROI-similarity layer from #1803 in PyRecEst because it is utility-level and works with dense masks, sparse coordinate lists, and generic mapping-based ROI formats.
- Do not add Track2p- or Suite2p-specific file I/O / pipeline orchestration here beyond the utility interfaces already present in the ROI helpers.

## Notes
- This PR is meant to provide a single merge candidate instead of merging the overlapping branches separately.
- If desired, the older overlapping PRs can be closed after this is reviewed.
