### PR TITLE
[codex] Add size to the backend interface

### DIFF
--- a/pyrecest/_backend/__init__.py
+++ b/pyrecest/_backend/__init__.py
@@ -138,6 +138,7 @@ BACKEND_ATTRIBUTES = {
         "set_default_dtype",
         "set_diag",
         "shape",
+        "size",
         "sign",
         "sin",
         "sinh",

--- a/pyrecest/_backend/_common.py
+++ b/pyrecest/_backend/_common.py
@@ -5,3 +5,25 @@ from numpy import pi
 
 def comb(n, k):
     return _math.factorial(n) // _math.factorial(k) // _math.factorial(n - k)
+
+
+def size(x, axis=None):
+    """Return the total number of elements or the length of a given axis."""
+    if hasattr(x, "numel"):
+        if axis is None:
+            return x.numel()
+        return x.shape[axis]
+
+    shape = getattr(x, "shape", None)
+    if shape is None:
+        if axis is not None:
+            raise ValueError("axis is only supported for array-like inputs")
+        return 1
+
+    if axis is not None:
+        return shape[axis]
+
+    result = 1
+    for dim in shape:
+        result *= dim
+    return result

--- a/pyrecest/tests/test_backend_size.py
+++ b/pyrecest/tests/test_backend_size.py
@@ -1,0 +1,15 @@
+import unittest
+
+from pyrecest.backend import array, size
+
+
+class TestBackendSize(unittest.TestCase):
+    def test_size_returns_total_number_of_elements(self):
+        self.assertEqual(size(array([[1, 2, 3], [4, 5, 6]])), 6)
+
+    def test_size_returns_axis_length(self):
+        self.assertEqual(size(array([[1, 2, 3], [4, 5, 6]]), axis=1), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- expose `size` in the backend interface contract
- implement a shared `size(x, axis=None)` helper in `pyrecest/_backend/_common.py`
- add a regression test covering total element count and axis-specific size

## Why

PyRecEst already exposes backend-agnostic helpers such as `shape` and `ndim`, but not `size`. Adding `pyrecest.backend.size` makes backend-neutral code simpler across NumPy, JAX, and PyTorch.

The implementation uses the existing importer fallback to `pyrecest._backend._common`, so the new helper is available consistently for the supported backends without duplicating per-backend wrappers.

## Validation

- added `pyrecest/tests/test_backend_size.py`
- not run in this environment