### PR TITLE
Cancel in-progress test workflow runs on new PR commits

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add the same workflow-level `concurrency` block used by `mega-linter.yml`
- cancel older `Test workflow` runs when a new commit is pushed to the same PR branch
- keep the change limited to `.github/workflows/tests.yml`

## Details
Using
```yaml
concurrency:
  group: ${{ github.ref }}-${{ github.workflow }}
  cancel-in-progress: true
```
causes GitHub Actions to cancel the currently running test workflow for that PR when the next `pull_request` update is triggered by a new push.
