### PR TITLE
[codex] Publish PyPI artifacts from GitHub release assets

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -12,6 +12,10 @@ on:
   #checkov:skip=CKV_GHA_7:workflow_dispatch inputs are intentional for manual release control
   workflow_dispatch:
     inputs:
+      release_tag:
+        description: "GitHub Release tag whose assets should be published"
+        required: true
+        type: string
       target_index:
         description: "Package index to publish to for manual runs"
         required: true
@@ -36,6 +40,7 @@ jobs:
     outputs:
       package_name: ${{ steps.meta.outputs.package_name }}
       version: ${{ steps.meta.outputs.version }}
+      release_tag: ${{ steps.release.outputs.release_tag }}
       target_index: ${{ steps.target.outputs.target_index }}
       environment_name: ${{ steps.target.outputs.environment_name }}
       publish_allowed: ${{ steps.gate.outputs.publish_allowed }}
@@ -44,7 +49,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.event.workflow_run.head_sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -65,6 +70,26 @@ jobs:
           print(f"package_name={poetry['name']}")
           print(f"version={poetry['version']}")
           PY
+
+      - name: Resolve release tag
+        id: release
+        shell: bash
+        env:
+          MANUAL_RELEASE_TAG: ${{ github.event.inputs.release_tag }}
+          PACKAGE_VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            RELEASE_TAG="${MANUAL_RELEASE_TAG}"
+          else
+            RELEASE_TAG="${PACKAGE_VERSION}"
+          fi
+
+          if [ -z "${RELEASE_TAG}" ]; then
+            echo "::error::Could not resolve GitHub Release tag to publish."
+            exit 1
+          fi
+
+          echo "release_tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Resolve target index
         id: target
@@ -97,11 +122,31 @@ jobs:
         uses: actions/github-script@v8
         env:
           VERSION: ${{ steps.meta.outputs.version }}
+          RELEASE_TAG: ${{ steps.release.outputs.release_tag }}
         with:
           script: |
             const version = process.env.VERSION;
+            const releaseTag = process.env.RELEASE_TAG || version;
+
+            const getRelease = async () => {
+              const response = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: releaseTag,
+              });
+              return response.data;
+            };
 
             if (context.eventName === "workflow_dispatch") {
+              try {
+                await getRelease();
+              } catch (error) {
+                if (error.status === 404) {
+                  core.setFailed(`No GitHub release found for tag ${releaseTag}.`);
+                  return;
+                }
+                throw error;
+              }
               core.setOutput("publish_allowed", "true");
               return;
             }
@@ -134,15 +179,10 @@ jobs:
 
             let release;
             try {
-              const response = await github.rest.repos.getReleaseByTag({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                tag: version,
-              });
-              release = response.data;
+              release = await getRelease();
             } catch (error) {
               if (error.status === 404) {
-                core.info(`No GitHub release found for tag ${version}; skipping publish.`);
+                core.info(`No GitHub release found for tag ${releaseTag}; skipping publish.`);
                 core.setOutput("publish_allowed", "false");
                 return;
               }
@@ -157,7 +197,7 @@ jobs:
               publishedAt < upstreamStartedAt
             ) {
               core.info(
-                `Release ${version} was not created by the completed upstream run; skipping publish.`
+                `Release ${releaseTag} was not created by the completed upstream run; skipping publish.`
               );
               core.setOutput("publish_allowed", "false");
               return;
@@ -176,12 +216,6 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Check out source for manual publish
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -191,32 +225,33 @@ jobs:
         shell: bash
         run: mkdir -p dist
 
-      - name: Install build and validation tools
+      - name: Install validation tools
         shell: bash
-        run: python -m pip install --upgrade poetry twine
+        run: python -m pip install --upgrade twine
 
       - name: Download release assets from GitHub Release
-        if: ${{ github.event_name == 'workflow_run' }}
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
-          VERSION: ${{ needs.resolve.outputs.version }}
+          RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
         run: |
           python - <<'PY'
           import json
           import os
           import pathlib
+          import urllib.parse
           import urllib.request
 
           owner = os.environ["OWNER"]
           repo = os.environ["REPO"]
-          version = os.environ["VERSION"]
+          release_tag = os.environ["RELEASE_TAG"]
           token = os.environ["GITHUB_TOKEN"]
+          encoded_release_tag = urllib.parse.quote(release_tag, safe="")
 
           req = urllib.request.Request(
-              f"https://api.github.com/repos/{owner}/{repo}/releases/tags/{version}",
+              f"https://api.github.com/repos/{owner}/{repo}/releases/tags/{encoded_release_tag}",
               headers={
                   "Accept": "application/vnd.github+json",
                   "Authorization": f"Bearer {token}",
@@ -236,7 +271,7 @@ jobs:
 
           if not wanted:
               raise SystemExit(
-                  f"No wheel or source distribution assets found on release {version}."
+                  f"No wheel or source distribution assets found on release {release_tag}."
               )
 
           for asset in wanted:
@@ -255,11 +290,6 @@ jobs:
               target.write_bytes(data)
               print(f"Downloaded {target}")
           PY
-
-      - name: Build distributions for manual publish
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        shell: bash
-        run: python -m poetry build
 
       - name: Check distributions
         shell: bash

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -20,7 +20,7 @@ on:
         description: "Package index to publish to for manual runs"
         required: true
         type: choice
-        default: testpypi
+        default: pypi
         options:
           - testpypi
           - pypi

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -13,8 +13,8 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: "GitHub Release tag whose assets should be published"
-        required: true
+        description: "GitHub Release tag to publish; leave blank for the latest release"
+        required: false
         type: string
       target_index:
         description: "Package index to publish to for manual runs"
@@ -45,11 +45,35 @@ jobs:
       environment_name: ${{ steps.target.outputs.environment_name }}
       publish_allowed: ${{ steps.gate.outputs.publish_allowed }}
     steps:
+      - name: Resolve manual release tag
+        id: manual_release
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: actions/github-script@v8
+        env:
+          RELEASE_TAG_INPUT: ${{ github.event.inputs.release_tag }}
+        with:
+          script: |
+            const input = (process.env.RELEASE_TAG_INPUT || "").trim();
+
+            if (input) {
+              core.setOutput("release_tag", input);
+              return;
+            }
+
+            const response = await github.rest.repos.getLatestRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            const releaseTag = response.data.tag_name;
+
+            core.info(`No release tag input; using latest release ${releaseTag}.`);
+            core.setOutput("release_tag", releaseTag);
+
       - name: Check out source
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag || github.event.workflow_run.head_sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && steps.manual_release.outputs.release_tag || github.event.workflow_run.head_sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -75,7 +99,7 @@ jobs:
         id: release
         shell: bash
         env:
-          MANUAL_RELEASE_TAG: ${{ github.event.inputs.release_tag }}
+          MANUAL_RELEASE_TAG: ${{ steps.manual_release.outputs.release_tag }}
           PACKAGE_VERSION: ${{ steps.meta.outputs.version }}
         run: |
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then


### PR DESCRIPTION
## Summary

- Make the manual `release_tag` input optional; when it is left blank, the workflow resolves the latest GitHub Release and uses that tag.
- Default manual publishes to PyPI while keeping TestPyPI selectable.
- Download wheel and sdist assets from the resolved GitHub Release for both automatic and manual publishes.
- Remove the manual `poetry build` path so PyPI/TestPyPI receives the same artifacts that are attached to the GitHub Release.

## Validation

- Reviewed the generated diff for `.github/workflows/publish-to-pypi.yml`.
- Did not run `actionlint` because this environment does not have a local checkout of the repository.