### PR TITLE
Add ROI similarity and observation-cost assignment helpers

### DIFF
--- a/src/pyrecest/utils/__init__.py
+++ b/src/pyrecest/utils/__init__.py
@@ -1,5 +1,6 @@
 """Utility helpers for :mod:`pyrecest`."""
 
+# pylint: disable=duplicate-code
 from .assignment import murty_k_best_assignments
 from .association_models import LogisticPairwiseAssociationModel
 from .history_recorder import HistoryRecorder
@@ -7,6 +8,9 @@ from .multisession_assignment import (
     MultiSessionAssignmentResult,
     solve_multisession_assignment,
     tracks_to_session_labels,
+)
+from .multisession_assignment_observation_costs import (
+    solve_multisession_assignment_with_observation_costs,
 )
 from .multisession_assignment_score import (
     solve_multisession_assignment_from_similarity,
@@ -19,11 +23,20 @@ from .nonrigid_point_set_registration import (
     estimate_thin_plate_spline,
     joint_tps_registration_assignment,
 )
+from .roi_similarity import (
+    build_roi_cost_matrix,
+    pairwise_centroid_distances,
+    pairwise_roi_similarity,
+    roi_centroid,
+    weighted_roi_cosine_similarity,
+    weighted_roi_jaccard,
+)
 
 __all__ = [
     "MultiSessionAssignmentResult",
     "solve_multisession_assignment",
     "solve_multisession_assignment_from_similarity",
+    "solve_multisession_assignment_with_observation_costs",
     "stitch_tracks_from_pairwise_scores",
     "tracks_to_index_matrix",
     "tracks_to_session_labels",
@@ -31,7 +44,13 @@ __all__ = [
     "HistoryRecorder",
     "ThinPlateSplineRegistrationResult",
     "ThinPlateSplineTransform",
+    "build_roi_cost_matrix",
     "estimate_thin_plate_spline",
     "joint_tps_registration_assignment",
     "murty_k_best_assignments",
+    "pairwise_centroid_distances",
+    "pairwise_roi_similarity",
+    "roi_centroid",
+    "weighted_roi_cosine_similarity",
+    "weighted_roi_jaccard",
 ]

--- a/src/pyrecest/utils/multisession_assignment_observation_costs.py
+++ b/src/pyrecest/utils/multisession_assignment_observation_costs.py
@@ -1,0 +1,244 @@
+"""Extensions for multi-session assignment with observation-specific start/end costs."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from typing import Any, TypeAlias
+
+from pyrecest.backend import (  # pylint: disable=no-name-in-module
+    asarray,
+    copy as backend_copy,
+    float64,
+    full,
+    isfinite,
+)
+from pyrecest.backend import size as backend_size  # pylint: disable=no-name-in-module
+
+from .multisession_assignment import (
+    MultiSessionAssignmentResult,
+    PairwiseCostsInput,
+    SessionSizesInput,
+    _infer_and_validate_session_sizes,
+    _normalize_pairwise_costs,
+    _normalize_session_sizes,
+    solve_multisession_assignment,
+)
+
+ObservationCostsInput: TypeAlias = Mapping[int, Any] | Sequence[Any]
+
+
+def solve_multisession_assignment_with_observation_costs(  # pylint: disable=too-many-arguments,too-many-locals
+    pairwise_costs: PairwiseCostsInput,
+    session_sizes: SessionSizesInput | None = None,
+    *,
+    start_cost: float = 0.0,
+    end_cost: float = 0.0,
+    start_costs: ObservationCostsInput | None = None,
+    end_costs: ObservationCostsInput | None = None,
+    gap_penalty: float = 0.0,
+    cost_threshold: float | None = None,
+) -> MultiSessionAssignmentResult:
+    """Solve global multi-session assignment with heterogeneous birth/death costs.
+
+    This is a thin wrapper around :func:`solve_multisession_assignment`. It encodes
+    observation-specific start/end costs into transformed pairwise costs and then
+    maps the reported objective value and matched-edge costs back to the original
+    problem.
+    """
+
+    normalized_pairwise = _normalize_pairwise_costs(pairwise_costs)
+    normalized_sizes = _normalize_session_sizes(session_sizes)
+    session_sizes_map = _infer_and_validate_session_sizes(
+        normalized_pairwise,
+        normalized_sizes,
+    )
+
+    if not session_sizes_map:
+        return MultiSessionAssignmentResult(tracks=[], matched_edges=[], total_cost=0.0)
+
+    normalized_start_costs = _normalize_observation_costs(
+        start_costs,
+        session_sizes_map,
+        default_value=float(start_cost),
+        name="start_costs",
+    )
+    normalized_end_costs = _normalize_observation_costs(
+        end_costs,
+        session_sizes_map,
+        default_value=float(end_cost),
+        name="end_costs",
+    )
+
+    max_start_cost = max(
+        float(costs.max()) if backend_size(costs) else float(start_cost)
+        for costs in normalized_start_costs.values()
+    )
+    max_end_cost = max(
+        float(costs.max()) if backend_size(costs) else float(end_cost)
+        for costs in normalized_end_costs.values()
+    )
+
+    session_order = sorted(session_sizes_map)
+    session_positions = {
+        session_idx: position for position, session_idx in enumerate(session_order)
+    }
+
+    transformed_pairwise = _transform_pairwise_costs(
+        normalized_pairwise,
+        session_positions,
+        normalized_start_costs,
+        normalized_end_costs,
+        uniform_start_cost=max_start_cost,
+        uniform_end_cost=max_end_cost,
+        gap_penalty=float(gap_penalty),
+        cost_threshold=cost_threshold,
+    )
+
+    base_result = solve_multisession_assignment(
+        transformed_pairwise,
+        session_sizes=session_sizes_map,
+        start_cost=max_start_cost,
+        end_cost=max_end_cost,
+        gap_penalty=gap_penalty,
+        cost_threshold=None,
+    )
+
+    actual_baseline = sum(
+        float(costs.sum()) for costs in normalized_start_costs.values()
+    ) + sum(float(costs.sum()) for costs in normalized_end_costs.values())
+    uniform_baseline = sum(session_sizes_map.values()) * (max_start_cost + max_end_cost)
+    total_cost = float(base_result.total_cost - uniform_baseline + actual_baseline)
+
+    adjusted_edges = [
+        (
+            source,
+            target,
+            float(
+                transformed_cost
+                - max_end_cost
+                - max_start_cost
+                + normalized_end_costs[source[0]][source[1]]
+                + normalized_start_costs[target[0]][target[1]]
+            ),
+        )
+        for source, target, transformed_cost in base_result.matched_edges
+    ]
+
+    return MultiSessionAssignmentResult(
+        tracks=base_result.tracks,
+        matched_edges=adjusted_edges,
+        total_cost=total_cost,
+    )
+
+
+def _normalize_observation_costs(
+    observation_costs: ObservationCostsInput | None,
+    session_sizes: Mapping[int, int],
+    *,
+    default_value: float,
+    name: str,
+) -> dict[int, Any]:
+    if observation_costs is None:
+        raw_entries: dict[int, Any] = {}
+    elif isinstance(observation_costs, Mapping):
+        raw_entries = {int(session_idx): value for session_idx, value in observation_costs.items()}
+    else:
+        raw_entries = dict(enumerate(observation_costs))
+
+    unknown_sessions = sorted(set(raw_entries) - set(session_sizes))
+    if unknown_sessions:
+        raise ValueError(
+            f"{name} specifies unknown sessions {unknown_sessions}; "
+            f"known sessions are {sorted(session_sizes)}."
+        )
+
+    normalized: dict[int, Any] = {}
+    for session_idx in sorted(session_sizes):
+        session_size = int(session_sizes[session_idx])
+        if session_idx not in raw_entries:
+            values = full((session_size,), float(default_value), dtype=float64)
+        else:
+            values = _normalize_observation_cost_entry(
+                raw_entries[session_idx],
+                session_size,
+                session_idx=session_idx,
+                name=name,
+            )
+        if not bool(isfinite(values).all()):
+            raise ValueError(f"{name} for session {session_idx} must contain only finite values.")
+        normalized[session_idx] = values
+    return normalized
+
+
+def _normalize_observation_cost_entry(
+    value: Any,
+    session_size: int,
+    *,
+    session_idx: int,
+    name: str,
+) -> Any:
+    values = asarray(value, dtype=float64)
+    if values.ndim == 0:
+        return full((session_size,), float(values), dtype=float64)
+    if values.ndim != 1:
+        raise ValueError(
+            f"{name} entry for session {session_idx} must be a scalar or a one-dimensional array."
+        )
+    if int(backend_size(values)) != int(session_size):
+        raise ValueError(
+            f"{name} entry for session {session_idx} has length {backend_size(values)}, expected {session_size}."
+        )
+    return values
+
+
+def _compute_session_gap(
+    session_positions: Mapping[int, int],
+    source_session: int,
+    target_session: int,
+) -> int:
+    gap = int(session_positions[target_session]) - int(session_positions[source_session]) - 1
+    if gap < 0:
+        raise ValueError("Session indices must define a forward-in-time edge ordering.")
+    return gap
+
+
+def _transform_pairwise_costs(  # pylint: disable=too-many-arguments,too-many-locals
+    pairwise_costs: Mapping[tuple[int, int], Any],
+    session_positions: Mapping[int, int],
+    start_costs: Mapping[int, Any],
+    end_costs: Mapping[int, Any],
+    *,
+    uniform_start_cost: float,
+    uniform_end_cost: float,
+    gap_penalty: float,
+    cost_threshold: float | None,
+) -> dict[tuple[int, int], Any]:
+    transformed: dict[tuple[int, int], Any] = {}
+    for (source_session, target_session), matrix in pairwise_costs.items():
+        gap = _compute_session_gap(
+            session_positions,
+            source_session,
+            target_session,
+        )
+        matrix_array = asarray(matrix, dtype=float64)
+        source_end = end_costs[source_session][:, None]
+        target_start = start_costs[target_session][None, :]
+        transformed_matrix = (
+            matrix_array
+            - source_end
+            - target_start
+            + float(uniform_end_cost)
+            + float(uniform_start_cost)
+        )
+
+        if cost_threshold is not None:
+            adjusted_original = matrix_array + float(gap_penalty) * gap
+            transformed_matrix = backend_copy(transformed_matrix)
+            transformed_matrix[adjusted_original > float(cost_threshold)] = math.inf
+
+        transformed[(source_session, target_session)] = transformed_matrix
+    return transformed
+
+
+__all__ = ["solve_multisession_assignment_with_observation_costs"]

--- a/src/pyrecest/utils/roi_similarity.py
+++ b/src/pyrecest/utils/roi_similarity.py
@@ -1,0 +1,431 @@
+"""Utilities for weighted ROI similarity and association-cost construction.
+
+These helpers are aimed at session-to-session identity matching where segmented
+cells are represented as dense footprint images or as sparse pixel lists such as
+Suite2p ``stat.npy`` entries. In contrast to binary IoU, the weighted metrics
+implemented here preserve per-pixel footprint strengths (e.g. ``lam``) and can
+therefore distinguish ROIs with identical support but different spatial weight
+profiles.
+"""
+
+# pylint: disable=duplicate-code
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+
+from pyrecest.backend import (  # pylint: disable=no-name-in-module
+    __backend_name__,
+    all as backend_all,
+    any as backend_any,
+    array,
+    asarray,
+    copy as backend_copy,
+    dot,
+    full,
+    full_like,
+    isfinite,
+    nonzero,
+    ones,
+    size as backend_size,
+    sqrt,
+    stack,
+    sum as backend_sum,
+    zeros,
+)
+
+
+_SUPPORTED_METRICS = {"weighted_jaccard", "cosine"}
+
+
+def _raise_if_unsupported_jax_backend(function_name):
+    if __backend_name__ == "jax":
+        raise NotImplementedError(
+            f"{function_name} is not supported with the JAX backend because "
+            "it builds result matrices with item assignment."
+        )
+
+
+def _looks_like_sparse_coordinate_container(roi) -> bool:
+    """Return ``True`` if ``roi`` looks like ``(ypix, xpix[, weights])``."""
+
+    if not isinstance(roi, (tuple, list)) or len(roi) not in (2, 3):
+        return False
+
+    first = asarray(roi[0])
+    second = asarray(roi[1])
+    return first.ndim <= 1 and second.ndim <= 1
+
+
+# pylint: disable=too-many-branches
+# pylint: disable=too-many-return-statements
+# pylint: disable=too-many-statements
+def _extract_roi_pixels_and_weights(roi, exclude_overlap=False):
+    """Extract sparse ROI coordinates and non-negative weights."""
+
+    if isinstance(roi, Mapping):
+        if "ypix" not in roi or "xpix" not in roi:
+            raise KeyError(
+                "Sparse ROI mappings must provide both 'ypix' and 'xpix' keys."
+            )
+
+        ypix = asarray(roi["ypix"], dtype=int).ravel()
+        xpix = asarray(roi["xpix"], dtype=int).ravel()
+
+        if "lam" in roi:
+            weights = asarray(roi["lam"], dtype=float).ravel()
+        elif "weights" in roi:
+            weights = asarray(roi["weights"], dtype=float).ravel()
+        else:
+            weights = ones(ypix.shape[0], dtype=float)
+
+        if exclude_overlap and "overlap" in roi:
+            overlap = asarray(roi["overlap"], dtype=bool).ravel()
+            if overlap.shape != ypix.shape:
+                raise ValueError(
+                    "Suite2p-style 'overlap' flags must match the ROI pixel count."
+                )
+            keep = ~overlap
+            ypix = ypix[keep]
+            xpix = xpix[keep]
+            weights = weights[keep]
+
+    elif _looks_like_sparse_coordinate_container(roi):
+        ypix = asarray(roi[0], dtype=int).ravel()
+        xpix = asarray(roi[1], dtype=int).ravel()
+        if len(roi) == 3:
+            weights = asarray(roi[2], dtype=float).ravel()
+        else:
+            weights = ones(ypix.shape[0], dtype=float)
+
+    else:
+        mask = asarray(roi, dtype=float)
+        if mask.ndim != 2:
+            raise ValueError(
+                "Dense ROI representations must be two-dimensional arrays."
+            )
+        if not bool(backend_all(isfinite(mask))):
+            raise ValueError("Dense ROI masks must contain only finite values.")
+        if bool(backend_any(mask < 0)):
+            raise ValueError("Dense ROI masks must not contain negative weights.")
+        ypix, xpix = nonzero(mask)
+        ypix = asarray(ypix, dtype=int)
+        xpix = asarray(xpix, dtype=int)
+        weights = asarray(mask[ypix, xpix], dtype=float)
+
+    if ypix.shape != xpix.shape:
+        raise ValueError(
+            "ROI coordinate vectors 'ypix' and 'xpix' must have the same length."
+        )
+    if weights.shape != ypix.shape:
+        raise ValueError("ROI weights must have the same length as 'ypix' and 'xpix'.")
+    if not bool(backend_all(isfinite(weights))):
+        raise ValueError("ROI weights must be finite.")
+    if bool(backend_any(weights < 0)):
+        raise ValueError("ROI weights must be non-negative.")
+
+    nonzero_mask = weights > 0
+    ypix = ypix[nonzero_mask]
+    xpix = xpix[nonzero_mask]
+    weights = weights[nonzero_mask]
+    return ypix, xpix, weights
+
+
+def _sparsify_roi(roi, exclude_overlap=False):
+    """Return a sparse pixel->weight dictionary for ``roi``."""
+
+    ypix, xpix, weights = _extract_roi_pixels_and_weights(
+        roi, exclude_overlap=exclude_overlap
+    )
+
+    sparse = {}
+    for y, x, weight in zip(ypix.tolist(), xpix.tolist(), weights.tolist()):
+        key = (int(y), int(x))
+        sparse[key] = sparse.get(key, 0.0) + float(weight)
+    return sparse
+
+
+def _weighted_jaccard_from_sparse(sparse_a, sparse_b) -> float:
+    if not sparse_a and not sparse_b:
+        return 0.0
+
+    keys = set(sparse_a) | set(sparse_b)
+    numerator = 0.0
+    denominator = 0.0
+    for key in keys:
+        weight_a = sparse_a.get(key, 0.0)
+        weight_b = sparse_b.get(key, 0.0)
+        numerator += min(weight_a, weight_b)
+        denominator += max(weight_a, weight_b)
+    return numerator / denominator if denominator > 0.0 else 0.0
+
+
+def _cosine_from_sparse(sparse_a, sparse_b) -> float:
+    if not sparse_a or not sparse_b:
+        return 0.0
+
+    if len(sparse_a) > len(sparse_b):
+        sparse_a, sparse_b = sparse_b, sparse_a
+
+    dot_product = sum(
+        weight * sparse_b.get(key, 0.0) for key, weight in sparse_a.items()
+    )
+    norm_a = math.sqrt(sum(weight * weight for weight in sparse_a.values()))
+    norm_b = math.sqrt(sum(weight * weight for weight in sparse_b.values()))
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return dot_product / (norm_a * norm_b)
+
+
+def _similarity_from_sparse(sparse_a, sparse_b, metric):
+    if metric == "weighted_jaccard":
+        return _weighted_jaccard_from_sparse(sparse_a, sparse_b)
+    if metric == "cosine":
+        return _cosine_from_sparse(sparse_a, sparse_b)
+    raise ValueError(
+        f"Unsupported ROI similarity metric '{metric}'. Supported metrics are "
+        f"{sorted(_SUPPORTED_METRICS)}."
+    )
+
+
+def weighted_roi_jaccard(roi_a, roi_b, exclude_overlap=False) -> float:
+    """Compute a weighted Jaccard similarity between two ROIs."""
+
+    sparse_a = _sparsify_roi(roi_a, exclude_overlap=exclude_overlap)
+    sparse_b = _sparsify_roi(roi_b, exclude_overlap=exclude_overlap)
+    return _weighted_jaccard_from_sparse(sparse_a, sparse_b)
+
+
+def weighted_roi_cosine_similarity(roi_a, roi_b, exclude_overlap=False) -> float:
+    """Compute cosine similarity between two weighted ROI footprints."""
+
+    sparse_a = _sparsify_roi(roi_a, exclude_overlap=exclude_overlap)
+    sparse_b = _sparsify_roi(roi_b, exclude_overlap=exclude_overlap)
+    return _cosine_from_sparse(sparse_a, sparse_b)
+
+
+def pairwise_roi_similarity(
+    reference_rois,
+    query_rois,
+    metric="weighted_jaccard",
+    exclude_overlap=False,
+):
+    """Build a pairwise ROI similarity matrix."""
+
+    _raise_if_unsupported_jax_backend("pairwise_roi_similarity")
+    if metric not in _SUPPORTED_METRICS:
+        raise ValueError(
+            f"Unsupported ROI similarity metric '{metric}'. Supported metrics are "
+            f"{sorted(_SUPPORTED_METRICS)}."
+        )
+
+    n_reference = len(reference_rois)
+    n_query = len(query_rois)
+    similarities = zeros((n_reference, n_query), dtype=float)
+
+    sparse_reference = [
+        _sparsify_roi(roi, exclude_overlap=exclude_overlap) for roi in reference_rois
+    ]
+    sparse_query = [
+        _sparsify_roi(roi, exclude_overlap=exclude_overlap) for roi in query_rois
+    ]
+
+    for i, sparse_ref in enumerate(sparse_reference):
+        for j, sparse_query_roi in enumerate(sparse_query):
+            similarities[i, j] = _similarity_from_sparse(
+                sparse_ref, sparse_query_roi, metric=metric
+            )
+
+    return similarities
+
+
+# pylint: disable=too-many-branches
+def roi_centroid(
+    roi,
+    use_weights=True,
+    prefer_med=True,
+    exclude_overlap=False,
+):
+    """Return the centroid of an ROI as ``[y, x]``."""
+
+    if prefer_med and isinstance(roi, Mapping) and "med" in roi:
+        med = asarray(roi["med"], dtype=float).ravel()
+        if med.shape != (2,):
+            raise ValueError("ROI field 'med' must contain exactly two entries [y, x].")
+        if not bool(backend_all(isfinite(med))):
+            raise ValueError("ROI field 'med' must contain only finite values.")
+        return med
+
+    ypix, xpix, weights = _extract_roi_pixels_and_weights(
+        roi, exclude_overlap=exclude_overlap
+    )
+    if backend_size(ypix) == 0:
+        return array([math.nan, math.nan], dtype=float)
+
+    ypix = asarray(ypix, dtype=float)
+    xpix = asarray(xpix, dtype=float)
+    weights = asarray(weights, dtype=float)
+    if use_weights:
+        total_weight = float(backend_sum(weights))
+        if total_weight > 0.0:
+            return array(
+                [
+                    float(dot(ypix, weights)) / total_weight,
+                    float(dot(xpix, weights)) / total_weight,
+                ],
+                dtype=float,
+            )
+
+    return array(
+        [
+            float(backend_sum(ypix)) / float(backend_size(ypix)),
+            float(backend_sum(xpix)) / float(backend_size(xpix)),
+        ],
+        dtype=float,
+    )
+
+
+def pairwise_centroid_distances(
+    reference_rois,
+    query_rois,
+    use_weights=True,
+    prefer_med=True,
+    exclude_overlap=False,
+):
+    """Build a pairwise Euclidean centroid-distance matrix."""
+
+    _raise_if_unsupported_jax_backend("pairwise_centroid_distances")
+    n_reference = len(reference_rois)
+    n_query = len(query_rois)
+    distances = full((n_reference, n_query), math.inf, dtype=float)
+    if n_reference == 0 or n_query == 0:
+        return distances
+
+    reference_centroids = stack(
+        [
+            roi_centroid(
+                roi,
+                use_weights=use_weights,
+                prefer_med=prefer_med,
+                exclude_overlap=exclude_overlap,
+            )
+            for roi in reference_rois
+        ],
+        axis=0,
+    )
+    query_centroids = stack(
+        [
+            roi_centroid(
+                roi,
+                use_weights=use_weights,
+                prefer_med=prefer_med,
+                exclude_overlap=exclude_overlap,
+            )
+            for roi in query_rois
+        ],
+        axis=0,
+    )
+
+    valid_query_centroids = backend_all(isfinite(query_centroids), axis=1)
+    for i, ref_centroid in enumerate(reference_centroids):
+        if not bool(backend_all(isfinite(ref_centroid))):
+            continue
+        deltas = query_centroids - ref_centroid
+        distances[i, valid_query_centroids] = sqrt(
+            backend_sum(
+                deltas[valid_query_centroids] * deltas[valid_query_centroids],
+                axis=1,
+            )
+        )
+
+    return distances
+
+
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-positional-arguments
+# pylint: disable=too-many-locals
+def build_roi_cost_matrix(
+    reference_rois,
+    query_rois,
+    footprint_metric="weighted_jaccard",
+    footprint_weight=1.0,
+    centroid_weight=0.0,
+    centroid_scale=1.0,
+    max_centroid_distance=None,
+    min_similarity=None,
+    exclude_overlap=False,
+    use_weighted_centroids=True,
+    prefer_med=True,
+    return_components=False,
+):
+    """Construct a pairwise association-cost matrix for ROI matching."""
+
+    _raise_if_unsupported_jax_backend("build_roi_cost_matrix")
+    if footprint_metric not in _SUPPORTED_METRICS:
+        raise ValueError(
+            f"Unsupported ROI similarity metric '{footprint_metric}'. Supported "
+            f"metrics are {sorted(_SUPPORTED_METRICS)}."
+        )
+    if footprint_weight < 0.0:
+        raise ValueError("footprint_weight must be non-negative.")
+    if centroid_weight < 0.0:
+        raise ValueError("centroid_weight must be non-negative.")
+    if centroid_scale <= 0.0:
+        raise ValueError("centroid_scale must be positive.")
+    if max_centroid_distance is not None and max_centroid_distance < 0.0:
+        raise ValueError("max_centroid_distance must be non-negative.")
+
+    similarity_matrix = pairwise_roi_similarity(
+        reference_rois,
+        query_rois,
+        metric=footprint_metric,
+        exclude_overlap=exclude_overlap,
+    )
+    cost_matrix = footprint_weight * (1.0 - similarity_matrix)
+
+    need_centroids = centroid_weight > 0.0 or max_centroid_distance is not None
+    centroid_distance_matrix = None
+    if need_centroids:
+        centroid_distance_matrix = pairwise_centroid_distances(
+            reference_rois,
+            query_rois,
+            use_weights=use_weighted_centroids,
+            prefer_med=prefer_med,
+            exclude_overlap=exclude_overlap,
+        )
+        cost_matrix = cost_matrix + centroid_weight * (
+            centroid_distance_matrix / centroid_scale
+        )
+
+    if min_similarity is not None:
+        cost_matrix = backend_copy(cost_matrix)
+        cost_matrix[similarity_matrix < min_similarity] = math.inf
+
+    if max_centroid_distance is not None:
+        if centroid_distance_matrix is None:
+            centroid_distance_matrix = pairwise_centroid_distances(
+                reference_rois,
+                query_rois,
+                use_weights=use_weighted_centroids,
+                prefer_med=prefer_med,
+                exclude_overlap=exclude_overlap,
+            )
+        cost_matrix = backend_copy(cost_matrix)
+        cost_matrix[centroid_distance_matrix > max_centroid_distance] = math.inf
+
+    if return_components:
+        if centroid_distance_matrix is None:
+            centroid_distance_matrix = full_like(cost_matrix, math.nan, dtype=float)
+        return cost_matrix, similarity_matrix, centroid_distance_matrix
+
+    return cost_matrix
+
+
+__all__ = [
+    "build_roi_cost_matrix",
+    "pairwise_centroid_distances",
+    "pairwise_roi_similarity",
+    "roi_centroid",
+    "weighted_roi_cosine_similarity",
+    "weighted_roi_jaccard",
+]

--- a/tests/test_multisession_assignment_observation_costs.py
+++ b/tests/test_multisession_assignment_observation_costs.py
@@ -1,0 +1,149 @@
+"""Tests for observation-specific multi-session assignment costs."""
+
+# pylint: disable=duplicate-code
+import unittest
+
+from pyrecest.backend import (  # pylint: disable=no-name-in-module
+    __backend_name__,
+    array,
+)
+from pyrecest.utils import (
+    solve_multisession_assignment,
+    solve_multisession_assignment_with_observation_costs,
+)
+
+
+class TestMultiSessionAssignmentObservationCosts(unittest.TestCase):
+    @staticmethod
+    def _canonical_tracks(tracks):
+        return sorted(tuple(sorted(track.items())) for track in tracks)
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on JAX backend",
+    )
+    def test_matches_base_solver_when_costs_are_uniform(self):
+        pairwise_costs = [
+            array([[0.1, 8.0], [8.0, 0.2]], dtype=float),
+            array([[0.1, 8.0], [8.0, 0.2]], dtype=float),
+        ]
+        expected = solve_multisession_assignment(
+            pairwise_costs,
+            start_cost=5.0,
+            end_cost=5.0,
+            cost_threshold=10.0,
+        )
+        actual = solve_multisession_assignment_with_observation_costs(
+            pairwise_costs,
+            start_cost=5.0,
+            end_cost=5.0,
+            cost_threshold=10.0,
+        )
+
+        self.assertEqual(
+            self._canonical_tracks(actual.tracks),
+            self._canonical_tracks(expected.tracks),
+        )
+        self.assertEqual(
+            [(source, target) for source, target, _ in actual.matched_edges],
+            [(source, target) for source, target, _ in expected.matched_edges],
+        )
+        for (_, _, actual_cost), (_, _, expected_cost) in zip(
+            actual.matched_edges,
+            expected.matched_edges,
+        ):
+            self.assertAlmostEqual(actual_cost, expected_cost)
+        self.assertAlmostEqual(actual.total_cost, expected.total_cost)
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on JAX backend",
+    )
+    def test_detection_specific_start_costs_bias_target_choice(self):
+        result = solve_multisession_assignment_with_observation_costs(
+            [array([[1.5, 1.5]], dtype=float)],
+            start_cost=0.0,
+            end_cost=2.0,
+            start_costs={1: array([0.0, 3.0], dtype=float)},
+        )
+
+        expected_tracks = [
+            ((0, 0), (1, 1)),
+            ((1, 0),),
+        ]
+        self.assertEqual(self._canonical_tracks(result.tracks), expected_tracks)
+        self.assertEqual(result.matched_edges, [((0, 0), (1, 1), 1.5)])
+        self.assertAlmostEqual(result.total_cost, 5.5)
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on JAX backend",
+    )
+    def test_detection_specific_end_costs_bias_source_choice(self):
+        result = solve_multisession_assignment_with_observation_costs(
+            [array([[1.5], [1.5]], dtype=float)],
+            start_cost=2.0,
+            end_cost=0.0,
+            end_costs={0: array([0.0, 3.0], dtype=float)},
+        )
+
+        expected_tracks = [
+            ((0, 0),),
+            ((0, 1), (1, 0)),
+        ]
+        self.assertEqual(self._canonical_tracks(result.tracks), expected_tracks)
+        self.assertEqual(result.matched_edges, [((0, 1), (1, 0), 1.5)])
+        self.assertAlmostEqual(result.total_cost, 5.5)
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on JAX backend",
+    )
+    def test_sequence_scalar_cost_entries_are_broadcast_per_session(self):
+        result = solve_multisession_assignment_with_observation_costs(
+            [array([[2.5, 2.5]], dtype=float)],
+            start_cost=0.0,
+            end_cost=1.0,
+            start_costs=[0.0, 3.0],
+        )
+
+        self.assertEqual(len(result.matched_edges), 1)
+        self.assertAlmostEqual(result.total_cost, 7.5)
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on JAX backend",
+    )
+    def test_cost_threshold_is_applied_in_original_cost_domain(self):
+        result = solve_multisession_assignment_with_observation_costs(
+            {(0, 2): array([[0.3]], dtype=float)},
+            session_sizes=[1, 0, 1],
+            start_cost=4.0,
+            end_cost=4.0,
+            start_costs={2: array([10.0], dtype=float)},
+            gap_penalty=0.5,
+            cost_threshold=0.75,
+        )
+
+        self.assertEqual(
+            self._canonical_tracks(result.tracks), [((0, 0),), ((2, 0),)]
+        )
+        self.assertEqual(result.matched_edges, [])
+
+    def test_rejects_unknown_sessions(self):
+        with self.assertRaises(ValueError):
+            solve_multisession_assignment_with_observation_costs(
+                [array([[1.0]], dtype=float)],
+                start_costs={2: array([1.0], dtype=float)},
+            )
+
+    def test_rejects_mismatched_lengths(self):
+        with self.assertRaises(ValueError):
+            solve_multisession_assignment_with_observation_costs(
+                [array([[1.0, 1.0]], dtype=float)],
+                start_costs={1: array([1.0], dtype=float)},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_roi_similarity.py
+++ b/tests/test_roi_similarity.py
@@ -1,0 +1,204 @@
+import math
+import unittest
+
+import numpy.testing as npt
+
+from pyrecest.backend import (  # pylint: disable=no-name-in-module
+    __backend_name__,
+    array,
+)
+from pyrecest.utils.roi_similarity import (
+    build_roi_cost_matrix,
+    pairwise_centroid_distances,
+    pairwise_roi_similarity,
+    roi_centroid,
+    weighted_roi_cosine_similarity,
+    weighted_roi_jaccard,
+)
+
+
+_SKIP_JAX_BACKEND = unittest.skipIf(
+    __backend_name__ == "jax",
+    reason="Not supported on JAX backend",
+)
+_REQUIRE_JAX_BACKEND = unittest.skipUnless(
+    __backend_name__ == "jax",
+    reason="JAX backend required",
+)
+
+
+class TestWeightedRoiSimilarity(unittest.TestCase):
+    def test_weighted_jaccard_uses_suite2p_lam(self):
+        roi_a = {
+            "ypix": array([0, 0]),
+            "xpix": array([0, 1]),
+            "lam": array([1.0, 1.0]),
+        }
+        roi_b = {
+            "ypix": array([0, 0]),
+            "xpix": array([0, 1]),
+            "lam": array([1.0, 0.5]),
+        }
+
+        self.assertAlmostEqual(weighted_roi_jaccard(roi_a, roi_b), 0.75)
+
+    def test_cosine_similarity_supports_dense_weighted_masks(self):
+        roi_a = array([[0.0, 2.0], [0.0, 1.0]])
+        roi_b = array([[0.0, 1.0], [0.0, 1.0]])
+
+        expected = 3.0 / math.sqrt(10.0)
+        self.assertAlmostEqual(weighted_roi_cosine_similarity(roi_a, roi_b), expected)
+
+    def test_exclude_overlap_drops_suite2p_overlapping_pixels(self):
+        roi_a = {
+            "ypix": array([0, 0, 1]),
+            "xpix": array([0, 1, 1]),
+            "lam": array([1.0, 1.0, 1.0]),
+            "overlap": array([False, True, False], dtype=bool),
+        }
+        roi_b = {
+            "ypix": array([0, 1]),
+            "xpix": array([0, 1]),
+            "lam": array([1.0, 1.0]),
+        }
+
+        self.assertAlmostEqual(weighted_roi_jaccard(roi_a, roi_b), 2.0 / 3.0)
+        self.assertAlmostEqual(
+            weighted_roi_jaccard(roi_a, roi_b, exclude_overlap=True), 1.0
+        )
+
+    @_SKIP_JAX_BACKEND
+    def test_pairwise_similarity_recovers_crossed_order(self):
+        reference_rois = [
+            {
+                "ypix": array([0, 0]),
+                "xpix": array([0, 1]),
+                "lam": array([1.0, 0.8]),
+            },
+            {
+                "ypix": array([5, 5]),
+                "xpix": array([5, 6]),
+                "lam": array([1.0, 1.0]),
+            },
+        ]
+        query_rois = [reference_rois[1], reference_rois[0]]
+
+        similarity_matrix = pairwise_roi_similarity(reference_rois, query_rois)
+
+        npt.assert_allclose(similarity_matrix, array([[0.0, 1.0], [1.0, 0.0]]))
+
+    @_REQUIRE_JAX_BACKEND
+    def test_pairwise_similarity_rejects_jax_backend(self):
+        with self.assertRaisesRegex(NotImplementedError, "JAX backend"):
+            pairwise_roi_similarity([], [])
+
+
+class TestRoiCentroids(unittest.TestCase):
+    def test_centroid_prefers_med_when_present(self):
+        roi = {
+            "ypix": array([0, 2]),
+            "xpix": array([0, 2]),
+            "lam": array([1.0, 3.0]),
+            "med": array([10.0, 20.0]),
+        }
+
+        npt.assert_allclose(roi_centroid(roi), array([10.0, 20.0]))
+        npt.assert_allclose(
+            roi_centroid(roi, prefer_med=False), array([1.5, 1.5])
+        )
+
+    @_SKIP_JAX_BACKEND
+    def test_pairwise_centroid_distances_use_med_if_available(self):
+        reference_rois = [
+            {"ypix": array([0]), "xpix": array([0]), "med": array([1.0, 1.0])}
+        ]
+        query_rois = [
+            {"ypix": array([0]), "xpix": array([0]), "med": array([4.0, 5.0])}
+        ]
+
+        distances = pairwise_centroid_distances(reference_rois, query_rois)
+        npt.assert_allclose(distances, array([[5.0]]))
+
+    @_SKIP_JAX_BACKEND
+    def test_pairwise_centroid_distances_handles_empty_queries(self):
+        reference_rois = [
+            {"ypix": array([0]), "xpix": array([0]), "med": array([1.0, 1.0])}
+        ]
+
+        distances = pairwise_centroid_distances(reference_rois, [])
+        self.assertEqual(distances.shape, (1, 0))
+
+    @_REQUIRE_JAX_BACKEND
+    def test_pairwise_centroid_distances_rejects_jax_backend(self):
+        with self.assertRaisesRegex(NotImplementedError, "JAX backend"):
+            pairwise_centroid_distances([], [])
+
+
+class TestRoiCostMatrix(unittest.TestCase):
+    @_SKIP_JAX_BACKEND
+    def test_build_roi_cost_matrix_combines_similarity_and_centroid_gating(self):
+        reference_rois = [
+            {
+                "ypix": array([0, 0]),
+                "xpix": array([0, 1]),
+                "lam": array([1.0, 1.0]),
+                "med": array([0.0, 0.5]),
+            },
+            {
+                "ypix": array([5, 5]),
+                "xpix": array([5, 6]),
+                "lam": array([1.0, 1.0]),
+                "med": array([5.0, 5.5]),
+            },
+        ]
+        query_rois = [reference_rois[1], reference_rois[0]]
+
+        cost_matrix, similarity_matrix, centroid_distances = build_roi_cost_matrix(
+            reference_rois,
+            query_rois,
+            centroid_weight=0.25,
+            centroid_scale=1.0,
+            max_centroid_distance=2.0,
+            return_components=True,
+        )
+
+        self.assertTrue(math.isinf(float(cost_matrix[0, 0])))
+        self.assertTrue(math.isinf(float(cost_matrix[1, 1])))
+        self.assertEqual(cost_matrix[0, 1], 0.0)
+        self.assertEqual(cost_matrix[1, 0], 0.0)
+        npt.assert_allclose(similarity_matrix, array([[0.0, 1.0], [1.0, 0.0]]))
+        npt.assert_allclose(
+            centroid_distances,
+            array(
+                [
+                    [math.sqrt(50.0), 0.0],
+                    [0.0, math.sqrt(50.0)],
+                ]
+            ),
+        )
+
+    @_SKIP_JAX_BACKEND
+    def test_build_roi_cost_matrix_rejects_low_similarity(self):
+        reference_rois = [
+            {"ypix": array([0]), "xpix": array([0]), "lam": array([1.0])}
+        ]
+        query_rois = [
+            {"ypix": array([3]), "xpix": array([3]), "lam": array([1.0])}
+        ]
+
+        cost_matrix = build_roi_cost_matrix(
+            reference_rois,
+            query_rois,
+            min_similarity=0.1,
+        )
+
+        self.assertTrue(math.isinf(float(cost_matrix[0, 0])))
+
+    @_REQUIRE_JAX_BACKEND
+    def test_build_roi_cost_matrix_rejects_jax_backend(self):
+        with self.assertRaisesRegex(NotImplementedError, "JAX backend"):
+            build_roi_cost_matrix([], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This is the focused replacement for the still-useful pieces from #1816 after #1821 already landed the core multisession assignment solver.

- Add reusable weighted ROI similarity utilities for dense masks, sparse coordinate lists, and Suite2p-style ROI mappings.
- Add observation-specific start/end cost support for multisession assignment.
- Add tests for the ROI utilities and heterogeneous assignment costs.
- Export the new utilities, plus the score-native helpers already present on `main`.

## Notes

This PR intentionally does not replay the stale `multisession_assignment.py` changes from #1816. The observation-cost helper was adjusted to work with the current `main` implementation by keeping its session-gap helper local instead of importing a private helper that no longer exists.

## Validation

Not run locally in this read-only Codex environment; GitHub CI should validate the branch.