### PR TITLE
[codex] Fix Dirac distribution mode selection

### DIFF
--- a/src/pyrecest/distributions/abstract_dirac_distribution.py
+++ b/src/pyrecest/distributions/abstract_dirac_distribution.py
@@ -9,6 +9,7 @@ from beartype import beartype
 from pyrecest.backend import (
     all,
     apply_along_axis,
+    argmax,
     int32,
     int64,
     isclose,
@@ -118,12 +119,13 @@ class AbstractDiracDistribution(AbstractDistributionType):
         raise NotImplementedError("PDF:UNDEFINED, not supported")
 
     def mode(self, rel_tol=0.001):
-        highest_val, ind = max(self.w)
-        if (highest_val / self.w.size) < (1 + rel_tol):
+        ind = int(argmax(self.w))
+        highest_val = float(self.w[ind])
+        if highest_val * self.w.shape[0] < (1 + rel_tol):
             warnings.warn(
                 "The samples may be equally weighted, .mode is likely to return a bad result."
             )
-        return self.d[ind, :]
+        return self.d[ind]
 
     def mode_numerical(self, _=None):
         raise NotImplementedError("PDF:UNDEFINED, not supported")

--- a/tests/distributions/test_abstract_dirac_distribution.py
+++ b/tests/distributions/test_abstract_dirac_distribution.py
@@ -1,12 +1,33 @@
 import unittest
+import warnings
 
 import matplotlib
+import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import random
+from pyrecest.backend import array, random
+from pyrecest.distributions import LinearDiracDistribution
 
 
 class TestAbstractDiracDistribution(unittest.TestCase):
+    def test_mode_returns_highest_weighted_dirac(self):
+        dist = LinearDiracDistribution(
+            array(
+                [
+                    [0.0, 0.0],
+                    [1.0, 2.0],
+                    [3.0, 4.0],
+                ]
+            ),
+            array([0.1, 0.7, 0.2]),
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            mode = dist.mode()
+
+        npt.assert_allclose(mode, array([1.0, 2.0]))
+
     def _test_plot_helper(self, name, dist, dim, dirac_cls, **kwargs):
         if dirac_cls is None:
             return  # Prevent failure if no classes are set


### PR DESCRIPTION
## Summary
- Fix `AbstractDiracDistribution.mode()` to select the maximum-weight Dirac with backend `argmax` instead of unpacking `max(self.w)`.
- Return the selected Dirac location directly so the method works for row-shaped and one-dimensional sample arrays.
- Correct the equally-weighted warning check to compare the maximum weight against the uniform-weight baseline.
- Add a regression test covering a weighted Dirac distribution whose mode should be the highest-weighted sample without warnings.

## Validation
- Not run locally; this session has a read-only filesystem, so the change was made through the GitHub connector. CI should run on the PR.