### PR TITLE
[codex] Fix summarize run count warning

### DIFF
--- a/src/pyrecest/evaluation/summarize_filter_results.py
+++ b/src/pyrecest/evaluation/summarize_filter_results.py
@@ -35,7 +35,7 @@ def summarize_filter_results(
             "Either last_filter_states or last_estimates must be provided."
         )
 
-    if groundtruths.shape[1] < 1000:
+    if groundtruths.shape[0] < 1000:
         warnings.warn("Using less than 1000 runs. This may lead to unreliable results.")
 
     extract_mean = get_extract_mean(

--- a/tests/test_evaluation_summarize_filter_results.py
+++ b/tests/test_evaluation_summarize_filter_results.py
@@ -20,7 +20,7 @@ class TestSummarizeFilterResultsWarnings(unittest.TestCase):
         for index in np.ndindex(groundtruths.shape):
             groundtruths[index] = np.zeros(2)
 
-        last_estimates = np.zeros((1, n_runs, 2))
+        last_filter_states = np.zeros((1, n_runs, 2))
         runtimes = np.ones((1, n_runs))
         run_failed = np.zeros((1, n_runs), dtype=bool)
 
@@ -32,7 +32,7 @@ class TestSummarizeFilterResultsWarnings(unittest.TestCase):
                 runtimes=runtimes,
                 groundtruths=groundtruths,
                 run_failed=run_failed,
-                last_estimates=last_estimates,
+                last_filter_states=last_filter_states,
             )
 
         warning_messages = [str(warning.message) for warning in caught]

--- a/tests/test_evaluation_summarize_filter_results.py
+++ b/tests/test_evaluation_summarize_filter_results.py
@@ -1,0 +1,45 @@
+import unittest
+import warnings
+
+import numpy as np
+
+# pylint: disable=no-name-in-module,no-member
+import pyrecest.backend
+from pyrecest.evaluation import summarize_filter_results
+
+
+class TestSummarizeFilterResultsWarnings(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
+    def test_run_count_warning_uses_run_axis(self):
+        n_runs = 1000
+        n_timesteps = 2
+        groundtruths = np.empty((n_runs, n_timesteps), dtype=object)
+        for index in np.ndindex(groundtruths.shape):
+            groundtruths[index] = np.zeros(2)
+
+        last_estimates = np.zeros((1, n_runs, 2))
+        runtimes = np.ones((1, n_runs))
+        run_failed = np.zeros((1, n_runs), dtype=bool)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            summarize_filter_results(
+                scenario_config={"manifold": "Euclidean", "mtt": False},
+                filter_configs=[{"name": "kf", "parameter": None}],
+                runtimes=runtimes,
+                groundtruths=groundtruths,
+                run_failed=run_failed,
+                last_estimates=last_estimates,
+            )
+
+        warning_messages = [str(warning.message) for warning in caught]
+        self.assertFalse(
+            any("Using less than 1000 runs" in message for message in warning_messages)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Check the run axis when warning about fewer than 1000 runs in `summarize_filter_results`.
- Add a regression test covering 1000 runs with only two timesteps, which used to warn incorrectly.

## Validation
- Not run locally; this session has no writable local checkout. Verified the GitHub compare shows only the intended source and test files changed.