### PR TITLE
[codex] Fix PyTorch choice without replacement

### DIFF
--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -11,19 +11,43 @@ from torch.distributions.multivariate_normal import (
 from ._dtype import _allow_complex_dtype, _modify_func_default_dtype
 
 
+def _choice_size(size):
+    if size is None:
+        return None, 1
+    if not hasattr(size, "__iter__"):
+        size = (size,)
+    size = tuple(int(dim) for dim in size)
+    return size, int(_torch.prod(_torch.tensor(size)).item())
+
+
 def choice(a, size=None, replace=True, p=None):
     assert _torch.is_tensor(a), "a must be a tensor"
+    size, num_samples = _choice_size(size)
     if p is not None:
         assert _torch.is_tensor(p), "p must be a tensor"
         if not replace:
-            raise ValueError("Sampling without replacement is not supported with PyTorch when probabilities are given.")
-        
-        p = _torch.tensor(p, dtype=_torch.float32)
+            raise ValueError(
+                "Sampling without replacement is not supported with PyTorch when probabilities are given."
+            )
+
+        p = _torch.as_tensor(p, dtype=_torch.float32, device=a.device)
         p = p / p.sum()  # Normalize probabilities
-        indices = _torch.multinomial(p, num_samples=_torch.prod(_torch.tensor(size)), replacement=True)
+        indices = _torch.multinomial(p, num_samples=num_samples, replacement=True)
+        if size is not None:
+            indices = indices.reshape(size)
+    elif replace:
+        indices = _torch.randint(0, len(a), size or (), device=a.device)
     else:
-        indices = _torch.randint(0, len(a), size)
-    
+        if num_samples > len(a):
+            raise ValueError(
+                "Cannot take a larger sample than population when 'replace=False'."
+            )
+        indices = _torch.randperm(len(a), device=a.device)[:num_samples]
+        if size is None:
+            indices = indices[0]
+        else:
+            indices = indices.reshape(size)
+
     return a[indices]
 
 

--- a/tests/test_backend_interface.py
+++ b/tests/test_backend_interface.py
@@ -13,7 +13,7 @@ class TestBackendInterface(unittest.TestCase):
         self.assertFalse(isscalar([1]))
 
     @unittest.skipUnless(
-        pyrecest.backend.__backend_name__ == "pytorch",
+        pyrecest.backend.__backend_name__ == "pytorch",  # pylint: disable=no-member
         reason="PyTorch-specific backend behavior",
     )
     def test_pytorch_choice_without_replacement_returns_unique_values(self):

--- a/tests/test_backend_interface.py
+++ b/tests/test_backend_interface.py
@@ -1,6 +1,7 @@
 import unittest
 
-from pyrecest.backend import array, isscalar
+import pyrecest.backend
+from pyrecest.backend import array, isscalar, random
 
 
 class TestBackendInterface(unittest.TestCase):
@@ -10,3 +11,16 @@ class TestBackendInterface(unittest.TestCase):
         self.assertFalse(isscalar(array(1)))
         self.assertFalse(isscalar(array([1])))
         self.assertFalse(isscalar([1]))
+
+    @unittest.skipUnless(
+        pyrecest.backend.__backend_name__ == "pytorch",
+        reason="PyTorch-specific backend behavior",
+    )
+    def test_pytorch_choice_without_replacement_returns_unique_values(self):
+        values = array([0, 1, 2, 3])
+        random.seed(0)
+
+        samples = random.choice(values, size=values.shape[0], replace=False)
+
+        self.assertEqual(samples.shape, values.shape)
+        self.assertEqual(len(set(samples.tolist())), values.shape[0])


### PR DESCRIPTION
## Summary
- Fix the PyTorch backend `random.choice(..., replace=False)` path to sample unique indices with `torch.randperm` instead of `torch.randint`.
- Normalize PyTorch `choice` size handling so sampled indices are reshaped to the requested output size.
- Add a PyTorch-only regression test that samples the full population without replacement and verifies the results are unique.

## Root cause
The unweighted PyTorch `choice` branch ignored `replace=False` and always used `torch.randint`, which samples each index independently and can return duplicates.

## Validation
- Not run locally; this session has a read-only filesystem, so the change was made through the GitHub connector. CI should run on the PR.