### PR TITLE
[codex] Fix EOT measurement timestep poses

### DIFF
--- a/src/pyrecest/evaluation/generate_measurements.py
+++ b/src/pyrecest/evaluation/generate_measurements.py
@@ -2,7 +2,17 @@ import numpy as np
 from beartype import beartype
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
-from pyrecest.backend import array, dot, get_backend_name, mod, pi, squeeze, tile, zeros
+from pyrecest.backend import (
+    array,
+    dot,
+    get_backend_name,
+    mod,
+    pi,
+    squeeze,
+    tile,
+    to_numpy,
+    zeros,
+)
 from pyrecest.distributions import (
     AbstractHypertoroidalDistribution,
     GaussianDistribution,
@@ -13,6 +23,10 @@ from pyrecest.evaluation.eot_shape_database import PolygonWithSampling
 from scipy.stats import poisson
 from shapely.affinity import rotate, translate
 from shapely.geometry import Polygon
+
+
+def _as_shapely_scalar(value):
+    return float(to_numpy(value))
 
 
 # pylint: disable=too-many-branches,too-many-locals,too-many-statements
@@ -57,16 +71,18 @@ def generate_measurements(groundtruth, simulation_config):
         ), "Currently only StarConvexPolygon (based on shapely Polygons) are supported as target shapes."
 
         for t in range(simulation_config["n_timesteps"]):
-            if groundtruth[0].shape[-1] == 2:
-                curr_shape = translate(
-                    shape, groundtruth[0][..., 0], yoff=groundtruth[0][..., 1]
-                )
-            elif groundtruth[0].shape[-1] == 3:
+            curr_groundtruth = groundtruth[t]
+            if curr_groundtruth.shape[-1] == 2:
+                x = _as_shapely_scalar(curr_groundtruth[..., 0])
+                y = _as_shapely_scalar(curr_groundtruth[..., 1])
+                curr_shape = translate(shape, xoff=x, yoff=y)
+            elif curr_groundtruth.shape[-1] == 3:
+                angle = _as_shapely_scalar(curr_groundtruth[..., 0])
+                x = _as_shapely_scalar(curr_groundtruth[..., 1])
+                y = _as_shapely_scalar(curr_groundtruth[..., 2])
                 curr_shape = rotate(
-                    translate(
-                        shape, groundtruth[0][..., 1], yoff=groundtruth[0][..., 2]
-                    ),
-                    angle=groundtruth[0][..., 0],
+                    translate(shape, xoff=x, yoff=y),
+                    angle=angle,
                     origin="centroid",
                 )
             else:

--- a/src/pyrecest/evaluation/generate_measurements.py
+++ b/src/pyrecest/evaluation/generate_measurements.py
@@ -2,17 +2,7 @@ import numpy as np
 from beartype import beartype
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
-from pyrecest.backend import (
-    array,
-    dot,
-    get_backend_name,
-    mod,
-    pi,
-    squeeze,
-    tile,
-    to_numpy,
-    zeros,
-)
+from pyrecest.backend import array, dot, get_backend_name, mod, pi, squeeze, tile, zeros
 from pyrecest.distributions import (
     AbstractHypertoroidalDistribution,
     GaussianDistribution,
@@ -26,7 +16,14 @@ from shapely.geometry import Polygon
 
 
 def _as_shapely_scalar(value):
-    return float(to_numpy(value))
+    if np.isscalar(value):
+        return float(value)
+    if hasattr(value, "item"):
+        try:
+            return float(value.item())
+        except (TypeError, ValueError):
+            pass
+    return float(np.asarray(value).reshape(-1)[0])
 
 
 # pylint: disable=too-many-branches,too-many-locals,too-many-statements

--- a/tests/test_generate_measurements_eot.py
+++ b/tests/test_generate_measurements_eot.py
@@ -1,0 +1,40 @@
+# pylint: disable=duplicate-code
+import unittest
+
+from pyrecest.backend import all as backend_all, array
+from pyrecest.evaluation import generate_measurements
+from shapely.geometry import Polygon
+
+
+class TestGenerateMeasurementsEot(unittest.TestCase):
+    def assert_all_between(self, values, lower, upper):
+        self.assertTrue(bool(backend_all(lower < values)))
+        self.assertTrue(bool(backend_all(values < upper)))
+
+    def test_eot_measurements_use_current_timestep_pose(self):
+        simulation_param = {
+            "eot": True,
+            "target_shape": Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]),
+            "eot_sampling_style": "within",
+            "n_timesteps": 2,
+            "n_meas_at_individual_time_step": [5, 5],
+        }
+        groundtruth = array(
+            [
+                [0.0, 0.0],
+                [10.0, 20.0],
+            ]
+        )
+
+        measurements = generate_measurements(groundtruth, simulation_param)
+
+        first_timestep = measurements[0]
+        second_timestep = measurements[1]
+        self.assert_all_between(first_timestep[:, 0], -1e-12, 1.0 + 1e-12)
+        self.assert_all_between(first_timestep[:, 1], -1e-12, 1.0 + 1e-12)
+        self.assert_all_between(second_timestep[:, 0], 10.0 - 1e-12, 11.0 + 1e-12)
+        self.assert_all_between(second_timestep[:, 1], 20.0 - 1e-12, 21.0 + 1e-12)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_generate_measurements_eot.py
+++ b/tests/test_generate_measurements_eot.py
@@ -7,6 +7,8 @@ from shapely.geometry import Polygon
 
 
 class TestGenerateMeasurementsEot(unittest.TestCase):
+    """Regression coverage for EOT measurement placement over time."""
+
     def assert_all_between(self, values, lower, upper):
         self.assertTrue(bool(backend_all(lower < values)))
         self.assertTrue(bool(backend_all(values < upper)))


### PR DESCRIPTION
## Summary

- Use the current timestep's ground truth when translating or rotating EOT target shapes in `generate_measurements`.
- Add a regression test that generates fixed-count EOT measurements for two distant poses and verifies each timestep's samples stay within the corresponding translated shape.

## Root Cause

The EOT generation loop iterated over `t`, but referenced `groundtruth[0]` when placing the target shape. Moving targets therefore produced every timestep's measurements around the first pose.

## Validation

- Not run locally; this workspace is read-only and the change was made through the GitHub connector.
- Added `tests/test_generate_measurements_eot.py` to cover the failure mode.