### PR TITLE
[codex] Fix GNN default gating threshold

### DIFF
--- a/src/pyrecest/filters/global_nearest_neighbor.py
+++ b/src/pyrecest/filters/global_nearest_neighbor.py
@@ -32,7 +32,7 @@ class GlobalNearestNeighbor(AbstractNearestNeighborTracker):
             "distance_metric_pos": "Mahalanobis",
             "square_dist": True,
             "max_new_tracks": 10,
-            "gating_distance_threshold": chi2.ppf(0.999, 2) ** 2,
+            "gating_distance_threshold": chi2.ppf(0.999, 2),
             "pairwise_cost_weight": 1.0,
         }
         if association_param is None:

--- a/tests/filters/test_global_nearest_neighbor_gating_threshold.py
+++ b/tests/filters/test_global_nearest_neighbor_gating_threshold.py
@@ -1,0 +1,19 @@
+import unittest
+
+from scipy.stats import chi2
+
+from pyrecest.filters.global_nearest_neighbor import GlobalNearestNeighbor
+
+
+class GlobalNearestNeighborGatingThresholdTest(unittest.TestCase):
+    def test_default_gating_threshold_uses_unsquared_chi_square_quantile(self):
+        tracker = GlobalNearestNeighbor()
+
+        self.assertAlmostEqual(
+            tracker.association_param["gating_distance_threshold"],
+            chi2.ppf(0.999, 2),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Remove the extra square from `GlobalNearestNeighbor`'s default `gating_distance_threshold`.
- Add a focused regression test that checks the default threshold is `chi2.ppf(0.999, 2)`.

## Root cause
`scipy.spatial.distance.cdist(..., "mahalanobis")` returns the Mahalanobis distance, while the default threshold was set to `chi2.ppf(0.999, 2) ** 2`. That squared the chi-square quantile a second time and made the default gate much too permissive.

## Validation
- Verified the branch diff contains only the GNN threshold change and the new regression test.
- Not run locally; this Codex session has a read-only filesystem, so CI should run the test matrix on the PR.