### PR TITLE
[codex] Fix Shapely boundary sampling

### DIFF
--- a/src/pyrecest/evaluation/eot_shape_database.py
+++ b/src/pyrecest/evaluation/eot_shape_database.py
@@ -23,7 +23,7 @@ class PolygonWithSampling(Polygon):  # pylint: disable=abstract-method
         if isinstance(self.boundary, LineString):
             lines = [self.boundary]
         elif isinstance(self.boundary, MultiLineString):
-            lines = list(self.boundary)
+            lines = list(self.boundary.geoms)
         else:
             raise ValueError("Unsupported boundary type")
 

--- a/tests/test_eot_shape_database.py
+++ b/tests/test_eot_shape_database.py
@@ -2,6 +2,7 @@ import unittest
 
 from pyrecest.evaluation.eot_shape_database import (
     Cross,
+    PolygonWithSampling,
     Star,
     StarFish,
     StarShapedPolygon,
@@ -28,6 +29,24 @@ class TestStarShapedPolygon(unittest.TestCase):
             self.square_star_convex_poly.compute_kernel().area,
             self.square_star_convex_poly.area,
         )
+
+    def test_sample_on_boundary_with_hole(self):
+        polygon_with_hole = PolygonWithSampling(
+            [(-1.0, -1.0), (-1.0, 1.0), (1.0, 1.0), (1.0, -1.0)],
+            holes=[
+                [
+                    (-0.25, -0.25),
+                    (-0.25, 0.25),
+                    (0.25, 0.25),
+                    (0.25, -0.25),
+                ]
+            ],
+        )
+
+        self.assertEqual(polygon_with_hole.boundary.geom_type, "MultiLineString")
+        samples = polygon_with_hole.sample_on_boundary(5)
+
+        self.assertEqual(samples.shape, (5, 2))
 
 
 class TestStar(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Use `self.boundary.geoms` when sampling from `MultiLineString` boundaries.
- Add a regression test for sampling a polygon with a hole, whose boundary is a `MultiLineString` under Shapely.

## Root cause
Shapely 2 no longer supports direct iteration over multi-part geometries. `list(self.boundary)` can therefore raise `TypeError` for polygons with multi-part boundaries.

## Validation
- Inspected the branch diff through the GitHub connector.
- Not run locally: this Codex session has a read-only filesystem, so changes were applied via GitHub API rather than a local checkout.