### PR TITLE
[codex] Export score-native multisession helpers

### DIFF
--- a/src/pyrecest/utils/__init__.py
+++ b/src/pyrecest/utils/__init__.py
@@ -8,6 +8,11 @@ from .multisession_assignment import (
     solve_multisession_assignment,
     tracks_to_session_labels,
 )
+from .multisession_assignment_score import (
+    solve_multisession_assignment_from_similarity,
+    stitch_tracks_from_pairwise_scores,
+    tracks_to_index_matrix,
+)
 from .nonrigid_point_set_registration import (
     ThinPlateSplineRegistrationResult,
     ThinPlateSplineTransform,
@@ -18,6 +23,9 @@ from .nonrigid_point_set_registration import (
 __all__ = [
     "MultiSessionAssignmentResult",
     "solve_multisession_assignment",
+    "solve_multisession_assignment_from_similarity",
+    "stitch_tracks_from_pairwise_scores",
+    "tracks_to_index_matrix",
     "tracks_to_session_labels",
     "LogisticPairwiseAssociationModel",
     "HistoryRecorder",


### PR DESCRIPTION
## Summary

- Re-export `solve_multisession_assignment_from_similarity`, `stitch_tracks_from_pairwise_scores`, and `tracks_to_index_matrix` from `pyrecest.utils`.
- Add the same helpers to `pyrecest.utils.__all__`.

## Context

PR #1821 merged the score-native multisession helper module, but the public `pyrecest.utils` import path still only exposed the cost-native helpers. This keeps the wrapper helpers reachable without reviving superseded PR #1822.

## Validation

- Not run locally; this is a connector-only one-file export change.