### PR TITLE
[codex] Derive GNN gate from measurement dimension

### DIFF
--- a/src/pyrecest/filters/global_nearest_neighbor.py
+++ b/src/pyrecest/filters/global_nearest_neighbor.py
@@ -32,7 +32,8 @@ class GlobalNearestNeighbor(AbstractNearestNeighborTracker):
             "distance_metric_pos": "Mahalanobis",
             "square_dist": True,
             "max_new_tracks": 10,
-            "gating_distance_threshold": chi2.ppf(0.999, 2),
+            "gating_probability": 0.999,
+            "gating_distance_threshold": None,
             "pairwise_cost_weight": 1.0,
         }
         if association_param is None:
@@ -49,6 +50,21 @@ class GlobalNearestNeighbor(AbstractNearestNeighborTracker):
             log_prior_estimates=log_prior_estimates,
             log_posterior_estimates=log_posterior_estimates,
         )
+
+    def _get_gating_distance_threshold(self, measurement_dim):
+        gating_distance_threshold = self.association_param[
+            "gating_distance_threshold"
+        ]
+        if gating_distance_threshold is not None:
+            return gating_distance_threshold
+
+        chi_square_quantile = chi2.ppf(
+            self.association_param["gating_probability"],
+            measurement_dim,
+        )
+        if self.association_param.get("square_dist", True):
+            return chi_square_quantile
+        return chi_square_quantile**0.5
 
     @staticmethod
     def _validate_pairwise_cost_matrix(pairwise_cost_matrix, n_targets, n_meas):
@@ -188,6 +204,9 @@ class GlobalNearestNeighbor(AbstractNearestNeighborTracker):
         else:
             raise ValueError("Association scheme not recognized")
 
+        if self.association_param.get("square_dist", True):
+            dists = dists**2
+
         pairwise_cost_matrix = self._validate_pairwise_cost_matrix(
             pairwise_cost_matrix, n_targets, n_meas
         )
@@ -196,7 +215,7 @@ class GlobalNearestNeighbor(AbstractNearestNeighborTracker):
         # Pad to square and add max_new_tracks rows and columns
         pad_to = max(n_targets, n_meas) + self.association_param["max_new_tracks"]
         association_matrix = full(
-            (pad_to, pad_to), self.association_param["gating_distance_threshold"]
+            (pad_to, pad_to), self._get_gating_distance_threshold(measurements.shape[0])
         )
         association_matrix[: dists.shape[0], : dists.shape[1]] = dists
 

--- a/tests/filters/test_global_nearest_neighbor_gating_threshold.py
+++ b/tests/filters/test_global_nearest_neighbor_gating_threshold.py
@@ -6,13 +6,33 @@ from pyrecest.filters.global_nearest_neighbor import GlobalNearestNeighbor
 
 
 class GlobalNearestNeighborGatingThresholdTest(unittest.TestCase):
-    def test_default_gating_threshold_uses_unsquared_chi_square_quantile(self):
+    def test_default_gate_is_derived_from_measurement_dimension(self):
         tracker = GlobalNearestNeighbor()
 
+        self.assertIsNone(tracker.association_param["gating_distance_threshold"])
         self.assertAlmostEqual(
-            tracker.association_param["gating_distance_threshold"],
+            tracker._get_gating_distance_threshold(2),
             chi2.ppf(0.999, 2),
         )
+        self.assertAlmostEqual(
+            tracker._get_gating_distance_threshold(3),
+            chi2.ppf(0.999, 3),
+        )
+
+    def test_unsquared_gate_uses_square_root_chi_square_quantile(self):
+        tracker = GlobalNearestNeighbor(association_param={"square_dist": False})
+
+        self.assertAlmostEqual(
+            tracker._get_gating_distance_threshold(2),
+            chi2.ppf(0.999, 2) ** 0.5,
+        )
+
+    def test_explicit_gate_threshold_is_preserved(self):
+        tracker = GlobalNearestNeighbor(
+            association_param={"gating_distance_threshold": 7.5}
+        )
+
+        self.assertEqual(tracker._get_gating_distance_threshold(3), 7.5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Replace the fixed default GNN gate threshold with `gating_probability=0.999` and `gating_distance_threshold=None`.
- Derive the gate threshold in `find_association()` from the current measurement dimension.
- Square computed distances when `square_dist=True`, and use the square-root chi-square threshold when `square_dist=False`.
- Expand the gating threshold regression test to cover 2-D, 3-D, unsquared, and explicit-threshold behavior.

## Root cause
The GNN default gate was a single numeric chi-square threshold tied to 2-D measurements. That made the default inappropriate for other measurement dimensions and left the `square_dist` setting disconnected from the actual distance scale.

## Notes
This PR is stacked on #1845, which removes the accidental extra square from the original default threshold. Once #1845 lands, this can be retargeted to `main` if desired.

## Validation
- Verified the branch diff against `codex/fix-gnn-gating-threshold` contains only the dimension-aware GNN gating changes and test updates.
- Not run locally; this Codex session has a read-only filesystem, so CI should run the test matrix on the PR.