### PR TITLE
[codex] Fix JAX randint backend

### DIFF
--- a/src/pyrecest/_backend/jax/random.py
+++ b/src/pyrecest/_backend/jax/random.py
@@ -74,7 +74,7 @@ uniform = rand
 
 def _randint(state, size, *args, **kwargs):
     state, key = jax.random.split(state)
-    return state, jax.random.uniform(key, size, *args, **kwargs)
+    return state, jax.random.randint(key, size, *args, **kwargs)
 
 
 def randint(size, *args, **kwargs):

--- a/tests/test_backend_random.py
+++ b/tests/test_backend_random.py
@@ -1,0 +1,27 @@
+import unittest
+
+import numpy as _np
+
+# pylint: disable=no-name-in-module,no-member
+import pyrecest.backend
+from pyrecest.backend import random
+
+
+class TestBackendRandom(unittest.TestCase):
+    def test_randint_returns_integer_samples_in_bounds(self):
+        if pyrecest.backend.__backend_name__ == "jax":
+            samples = random.randint((64,), minval=0, maxval=5)
+        elif pyrecest.backend.__backend_name__ == "pytorch":
+            samples = random.randint(0, 5, (64,))
+        else:
+            samples = random.randint(0, 5, size=(64,))
+
+        samples_np = _np.asarray(samples)
+        self.assertEqual(samples_np.shape, (64,))
+        self.assertTrue(_np.issubdtype(samples_np.dtype, _np.integer))
+        self.assertTrue(_np.all(samples_np >= 0))
+        self.assertTrue(_np.all(samples_np < 5))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix the JAX random backend so `random.randint` delegates to `jax.random.randint` instead of `jax.random.uniform`.

This keeps the function name and backend contract aligned: JAX now returns integer samples for integer random draws, matching the behavior expected from the NumPy/autograd and PyTorch backends.

## Root Cause

The JAX `_randint` helper split the PRNG key correctly, but then called `jax.random.uniform`, so callers got floating-point samples from `random.randint`.

## Tests

Added `tests/test_backend_random.py` to check that `random.randint` returns integer samples with the requested shape and bounds under each backend's existing call signature.

Not run locally because this Codex workspace is read-only and the change was applied through the GitHub connector. The repository's PR CI should run the numpy, pytorch, and jax backend matrix.