### PR TITLE
[codex] Add MEM-EKF* tracker

### DIFF
--- a/src/pyrecest/filters/__init__.py
+++ b/src/pyrecest/filters/__init__.py
@@ -52,6 +52,7 @@ from .manifold_mixins import (
     SE2FilterMixin,
     ToroidalFilterMixin,
 )
+from .mem_ekf_star_tracker import MEMEKFStarTracker, MemEkfStarTracker
 from .mem_ekf_tracker import MEMEKFTracker, MemEkfTracker
 from .multi_bernoulli_tracker import BernoulliComponent, MultiBernoulliTracker
 from .piecewise_constant_filter import PiecewiseConstantFilter
@@ -133,7 +134,9 @@ __all__ = [
     "BernoulliComponent",
     "MultiBernoulliTracker",
     "LinPeriodicParticleFilter",
+    "MEMEKFStarTracker",
     "MEMEKFTracker",
+    "MemEkfStarTracker",
     "MemEkfTracker",
     "PiecewiseConstantFilter",
     "RandomMatrixTracker",

--- a/src/pyrecest/filters/__init__.py
+++ b/src/pyrecest/filters/__init__.py
@@ -54,6 +54,7 @@ from .manifold_mixins import (
 )
 from .mem_ekf_star_tracker import MEMEKFStarTracker, MemEkfStarTracker
 from .mem_ekf_tracker import MEMEKFTracker, MemEkfTracker
+from .mem_soekf_tracker import MEMSOEKFTracker, MemSoekfTracker
 from .multi_bernoulli_tracker import BernoulliComponent, MultiBernoulliTracker
 from .piecewise_constant_filter import PiecewiseConstantFilter
 from .random_matrix_tracker import RandomMatrixTracker
@@ -136,8 +137,10 @@ __all__ = [
     "LinPeriodicParticleFilter",
     "MEMEKFStarTracker",
     "MEMEKFTracker",
+    "MEMSOEKFTracker",
     "MemEkfStarTracker",
     "MemEkfTracker",
+    "MemSoekfTracker",
     "PiecewiseConstantFilter",
     "RandomMatrixTracker",
     "Track",

--- a/src/pyrecest/filters/mem_ekf_star_tracker.py
+++ b/src/pyrecest/filters/mem_ekf_star_tracker.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+# pylint: disable=no-name-in-module,no-member,duplicate-code
+from pyrecest.backend import array, cos, eye, linalg, sin
+
+from .mem_ekf_tracker import MEMEKFTracker
+
+
+class MEMEKFStarTracker(MEMEKFTracker):
+    """Moment-corrected MEM-EKF* tracker for one 2-D elliptical object.
+
+    Compared with :class:`MEMEKFTracker`, this variant follows the MEM-EKF*
+    moment approximation. It includes shape-parameter uncertainty in the
+    measurement covariance and uses the covariance of the quadratic
+    pseudo-measurement ``[dx^2, dy^2, dx * dy]``.
+    """
+
+    @staticmethod
+    def _trace_3_by_3(matrix):
+        return matrix[0, 0] + matrix[1, 1] + matrix[2, 2]
+
+    def _extent_row_jacobians(self):
+        orientation, semi_axis_1, semi_axis_2 = self.shape_state
+        first_row_jacobian = array(
+            [
+                [-semi_axis_1 * sin(orientation), cos(orientation), 0.0],
+                [-semi_axis_2 * cos(orientation), 0.0, -sin(orientation)],
+            ]
+        )
+        second_row_jacobian = array(
+            [
+                [semi_axis_1 * cos(orientation), sin(orientation), 0.0],
+                [-semi_axis_2 * sin(orientation), 0.0, cos(orientation)],
+            ]
+        )
+        return first_row_jacobian, second_row_jacobian
+
+    def _shape_noise_covariance(self, multiplicative_noise_cov):
+        first_row_jacobian, second_row_jacobian = self._extent_row_jacobians()
+
+        def epsilon(row_jacobian_m, row_jacobian_n):
+            return self._trace_3_by_3(
+                self.shape_covariance
+                @ row_jacobian_n.T
+                @ multiplicative_noise_cov
+                @ row_jacobian_m
+            )
+
+        shape_noise_covariance = array(
+            [
+                [
+                    epsilon(first_row_jacobian, first_row_jacobian),
+                    epsilon(first_row_jacobian, second_row_jacobian),
+                ],
+                [
+                    epsilon(second_row_jacobian, first_row_jacobian),
+                    epsilon(second_row_jacobian, second_row_jacobian),
+                ],
+            ]
+        )
+        return self._symmetrize(shape_noise_covariance)
+
+    def _shape_pseudo_jacobian_star(self, multiplicative_noise_cov):
+        first_row_jacobian, second_row_jacobian = self._extent_row_jacobians()
+        extent_transform = self._extent_transform()
+        first_extent_row = extent_transform[0, :]
+        second_extent_row = extent_transform[1, :]
+
+        return array(
+            [
+                2.0
+                * first_extent_row
+                @ multiplicative_noise_cov
+                @ first_row_jacobian,
+                2.0
+                * second_extent_row
+                @ multiplicative_noise_cov
+                @ second_row_jacobian,
+                first_extent_row @ multiplicative_noise_cov @ second_row_jacobian
+                + second_extent_row @ multiplicative_noise_cov @ first_row_jacobian,
+            ]
+        )
+
+    @staticmethod
+    def _pseudo_measurement_covariance(innovation_covariance):
+        sigma_11 = innovation_covariance[0, 0]
+        sigma_12 = innovation_covariance[0, 1]
+        sigma_22 = innovation_covariance[1, 1]
+        return array(
+            [
+                [
+                    2.0 * sigma_11**2,
+                    2.0 * sigma_12**2,
+                    2.0 * sigma_11 * sigma_12,
+                ],
+                [
+                    2.0 * sigma_12**2,
+                    2.0 * sigma_22**2,
+                    2.0 * sigma_22 * sigma_12,
+                ],
+                [
+                    2.0 * sigma_11 * sigma_12,
+                    2.0 * sigma_22 * sigma_12,
+                    sigma_11 * sigma_22 + sigma_12**2,
+                ],
+            ]
+        )
+
+    # pylint: disable=too-many-locals
+    def _update_single_measurement(
+        self,
+        measurement,
+        measurement_matrix,
+        meas_noise_cov,
+        multiplicative_noise_cov,
+    ):
+        extent_transform = self._extent_transform()
+        shape_pseudo_jacobian = self._shape_pseudo_jacobian_star(
+            multiplicative_noise_cov
+        )
+        shape_noise_covariance = self._shape_noise_covariance(multiplicative_noise_cov)
+
+        predicted_measurement = measurement_matrix @ self.kinematic_state
+        innovation = measurement - predicted_measurement
+        innovation_covariance = self._symmetrize(
+            measurement_matrix @ self.covariance @ measurement_matrix.T
+            + extent_transform @ multiplicative_noise_cov @ extent_transform.T
+            + shape_noise_covariance
+            + meas_noise_cov
+        )
+        if self.covariance_regularization > 0.0:
+            innovation_covariance = innovation_covariance + (
+                self.covariance_regularization * eye(self.measurement_dim)
+            )
+
+        kinematic_cross_covariance = self.covariance @ measurement_matrix.T
+        kinematic_gain = linalg.solve(
+            innovation_covariance.T,
+            kinematic_cross_covariance.T,
+        ).T
+        self.kinematic_state = self.kinematic_state + kinematic_gain @ innovation
+        self.covariance = self._symmetrize(
+            self.covariance - kinematic_gain @ innovation_covariance @ kinematic_gain.T
+        )
+
+        pseudo_measurement = array(
+            [innovation[0] ** 2, innovation[1] ** 2, innovation[0] * innovation[1]]
+        )
+        sigma_11 = innovation_covariance[0, 0]
+        sigma_12 = innovation_covariance[0, 1]
+        sigma_22 = innovation_covariance[1, 1]
+        pseudo_mean = array([sigma_11, sigma_22, sigma_12])
+        pseudo_covariance = self._pseudo_measurement_covariance(
+            innovation_covariance
+        )
+        if self.covariance_regularization > 0.0:
+            pseudo_covariance = pseudo_covariance + (
+                self.covariance_regularization * eye(3)
+            )
+
+        shape_cross_covariance = self.shape_covariance @ shape_pseudo_jacobian.T
+        shape_gain = linalg.solve(pseudo_covariance.T, shape_cross_covariance.T).T
+        self.shape_state = self.shape_state + shape_gain @ (
+            pseudo_measurement - pseudo_mean
+        )
+        self.shape_covariance = self._symmetrize(
+            self.shape_covariance - shape_gain @ pseudo_covariance @ shape_gain.T
+        )
+
+
+MemEkfStarTracker = MEMEKFStarTracker

--- a/src/pyrecest/filters/mem_soekf_tracker.py
+++ b/src/pyrecest/filters/mem_soekf_tracker.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+# pylint: disable=no-name-in-module,no-member,duplicate-code,too-many-locals
+from pyrecest.backend import (
+    array,
+    concatenate,
+    cos,
+    diag,
+    eye,
+    linalg,
+    sin,
+    trace,
+    zeros,
+)
+
+from .mem_ekf_tracker import MEMEKFTracker
+
+
+class MEMSOEKFTracker(MEMEKFTracker):
+    """Second-order MEM-EKF tracker for one 2-D elliptical extended object.
+
+    The tracker uses the same multiplicative-error-model state convention as
+    :class:`MEMEKFTracker`, but performs the measurement update with the SOEKF
+    pseudo-measurement ``[dx, dy, dx^2, dx * dy, dy^2]``. The state is locally
+    shifted to the predicted measurement before each single-measurement update,
+    matching the robust centering used by the reference MEM-SOEKF equations.
+    """
+
+    def __init__(self, *args, finite_difference_step=1e-5, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.finite_difference_step = float(finite_difference_step)
+        if self.finite_difference_step <= 0.0:
+            raise ValueError("finite_difference_step must be positive")
+
+    @staticmethod
+    def _extent_transform_from_shape(shape_state):
+        orientation, semi_axis_1, semi_axis_2 = shape_state
+        rotation_matrix = array(
+            [
+                [cos(orientation), -sin(orientation)],
+                [sin(orientation), cos(orientation)],
+            ]
+        )
+        return rotation_matrix @ diag(array([semi_axis_1, semi_axis_2]))
+
+    @staticmethod
+    def _extent_row_jacobians_from_shape(shape_state):
+        orientation, semi_axis_1, semi_axis_2 = shape_state
+        first_row_jacobian = array(
+            [
+                [-semi_axis_1 * sin(orientation), cos(orientation), 0.0],
+                [-semi_axis_2 * cos(orientation), 0.0, -sin(orientation)],
+            ]
+        )
+        second_row_jacobian = array(
+            [
+                [semi_axis_1 * cos(orientation), sin(orientation), 0.0],
+                [-semi_axis_2 * sin(orientation), 0.0, cos(orientation)],
+            ]
+        )
+        return first_row_jacobian, second_row_jacobian
+
+    def _shape_pseudo_jacobian_soekf(self, multiplicative_noise_cov):
+        first_row_jacobian, second_row_jacobian = self._extent_row_jacobians_from_shape(
+            self.shape_state
+        )
+        extent_transform = self._extent_transform()
+        first_extent_row = extent_transform[0, :]
+        second_extent_row = extent_transform[1, :]
+
+        return array(
+            [
+                2.0 * first_extent_row @ multiplicative_noise_cov @ first_row_jacobian,
+                first_extent_row @ multiplicative_noise_cov @ second_row_jacobian
+                + second_extent_row @ multiplicative_noise_cov @ first_row_jacobian,
+                2.0 * second_extent_row @ multiplicative_noise_cov @ second_row_jacobian,
+            ]
+        )
+
+    def _shape_pseudo_hessians_soekf(self, multiplicative_noise_cov):
+        def shape_pseudo_mean(shape_state):
+            extent_transform = self._extent_transform_from_shape(shape_state)
+            first_extent_row = extent_transform[0, :]
+            second_extent_row = extent_transform[1, :]
+            return array(
+                [
+                    first_extent_row @ multiplicative_noise_cov @ first_extent_row,
+                    first_extent_row @ multiplicative_noise_cov @ second_extent_row,
+                    second_extent_row @ multiplicative_noise_cov @ second_extent_row,
+                ]
+            )
+
+        return self._finite_difference_hessians(shape_pseudo_mean, self.shape_state)
+
+    def _evaluate_augmented_measurement(self, augmented_state, measurement_matrix):
+        kinematic_dim = self.kinematic_state.shape[0]
+        shape_start = kinematic_dim
+        multiplicative_noise_start = shape_start + 3
+        additive_noise_start = multiplicative_noise_start + self.measurement_dim
+
+        kinematic_delta = augmented_state[:kinematic_dim]
+        shape_state = augmented_state[shape_start:multiplicative_noise_start]
+        multiplicative_noise = augmented_state[
+            multiplicative_noise_start:additive_noise_start
+        ]
+        additive_noise = augmented_state[
+            additive_noise_start : additive_noise_start + self.measurement_dim
+        ]
+
+        local_measurement = (
+            measurement_matrix @ kinematic_delta
+            + self._extent_transform_from_shape(shape_state) @ multiplicative_noise
+            + additive_noise
+        )
+        return array(
+            [
+                local_measurement[0],
+                local_measurement[1],
+                local_measurement[0] ** 2,
+                local_measurement[0] * local_measurement[1],
+                local_measurement[1] ** 2,
+            ]
+        )
+
+    def _finite_difference_jacobian(self, function, point):
+        point = array(point)
+        step = self.finite_difference_step
+        perturbations = step * eye(point.shape[0])
+        columns = []
+        for dim_index in range(point.shape[0]):
+            perturbation = perturbations[dim_index, :]
+            columns.append(
+                (function(point + perturbation) - function(point - perturbation))
+                / (2.0 * step)
+            )
+        return array(columns).T
+
+    def _finite_difference_hessians(self, function, point):
+        point = array(point)
+        step = self.finite_difference_step
+        perturbations = step * eye(point.shape[0])
+        output_dim = function(point).shape[0]
+        hessians = []
+        for output_index in range(output_dim):
+            rows = []
+            for row_index in range(point.shape[0]):
+                row = []
+                row_perturbation = perturbations[row_index, :]
+                for col_index in range(point.shape[0]):
+                    col_perturbation = perturbations[col_index, :]
+                    second_difference = (
+                        function(point + row_perturbation + col_perturbation)[
+                            output_index
+                        ]
+                        - function(point + row_perturbation - col_perturbation)[
+                            output_index
+                        ]
+                        - function(point - row_perturbation + col_perturbation)[
+                            output_index
+                        ]
+                        + function(point - row_perturbation - col_perturbation)[
+                            output_index
+                        ]
+                    ) / (4.0 * step**2)
+                    row.append(second_difference)
+                rows.append(row)
+            hessians.append(rows)
+        return array(hessians)
+
+    @staticmethod
+    def _replace_shape_pseudo_jacobian(jacobian, shape_jacobian, shape_start):
+        rows = []
+        shape_stop = shape_start + 3
+        for row_index in range(jacobian.shape[0]):
+            row = []
+            for col_index in range(jacobian.shape[1]):
+                if row_index >= 2 and shape_start <= col_index < shape_stop:
+                    value = shape_jacobian[row_index - 2, col_index - shape_start]
+                else:
+                    value = jacobian[row_index, col_index]
+                row.append(value)
+            rows.append(row)
+        return array(rows)
+
+    @staticmethod
+    def _add_shape_pseudo_hessians(hessians, shape_hessians, shape_start):
+        corrected_hessians = []
+        shape_stop = shape_start + 3
+        for output_index in range(hessians.shape[0]):
+            rows = []
+            for row_index in range(hessians.shape[1]):
+                row = []
+                for col_index in range(hessians.shape[2]):
+                    value = hessians[output_index, row_index, col_index]
+                    if (
+                        output_index >= 2
+                        and shape_start <= row_index < shape_stop
+                        and shape_start <= col_index < shape_stop
+                    ):
+                        value = value + shape_hessians[
+                            output_index - 2,
+                            row_index - shape_start,
+                            col_index - shape_start,
+                        ]
+                    row.append(value)
+                rows.append(row)
+            corrected_hessians.append(rows)
+        return array(corrected_hessians)
+
+    def _second_order_moments(
+        self,
+        augmented_mean,
+        augmented_covariance,
+        measurement_matrix,
+        multiplicative_noise_cov,
+    ):
+        def measurement_function(augmented_state):
+            return self._evaluate_augmented_measurement(
+                augmented_state,
+                measurement_matrix,
+            )
+
+        shape_start = self.kinematic_state.shape[0]
+        jacobian = self._finite_difference_jacobian(
+            measurement_function,
+            augmented_mean,
+        )
+        jacobian = self._replace_shape_pseudo_jacobian(
+            jacobian,
+            self._shape_pseudo_jacobian_soekf(multiplicative_noise_cov),
+            shape_start,
+        )
+
+        hessians = self._finite_difference_hessians(
+            measurement_function,
+            augmented_mean,
+        )
+        hessians = self._add_shape_pseudo_hessians(
+            hessians,
+            self._shape_pseudo_hessians_soekf(multiplicative_noise_cov),
+            shape_start,
+        )
+
+        nominal_measurement = measurement_function(augmented_mean)
+        expected_measurement = []
+        covariance_rows = []
+        for row_index in range(nominal_measurement.shape[0]):
+            expected_measurement.append(
+                nominal_measurement[row_index]
+                + 0.5 * trace(hessians[row_index] @ augmented_covariance)
+            )
+            covariance_row = []
+            for col_index in range(nominal_measurement.shape[0]):
+                covariance_row.append(
+                    jacobian[row_index, :]
+                    @ augmented_covariance
+                    @ jacobian[col_index, :]
+                    + 0.5
+                    * trace(
+                        hessians[row_index]
+                        @ augmented_covariance
+                        @ hessians[col_index]
+                        @ augmented_covariance
+                    )
+                )
+            covariance_rows.append(covariance_row)
+
+        return (
+            array(expected_measurement),
+            self._symmetrize(array(covariance_rows)),
+            jacobian,
+        )
+
+    def _update_single_measurement(
+        self,
+        measurement,
+        measurement_matrix,
+        meas_noise_cov,
+        multiplicative_noise_cov,
+    ):
+        kinematic_dim = self.kinematic_state.shape[0]
+        augmented_mean = concatenate(
+            [
+                zeros(kinematic_dim),
+                self.shape_state,
+                zeros(self.measurement_dim),
+                zeros(self.measurement_dim),
+            ]
+        )
+        augmented_covariance = linalg.block_diag(
+            self.covariance,
+            self.shape_covariance,
+            multiplicative_noise_cov,
+            meas_noise_cov,
+        )
+        (
+            expected_measurement,
+            measurement_covariance,
+            jacobian,
+        ) = self._second_order_moments(
+            augmented_mean,
+            augmented_covariance,
+            measurement_matrix,
+            multiplicative_noise_cov,
+        )
+        if self.covariance_regularization > 0.0:
+            measurement_covariance = measurement_covariance + (
+                self.covariance_regularization * eye(expected_measurement.shape[0])
+            )
+
+        predicted_measurement = measurement_matrix @ self.kinematic_state
+        shifted_measurement = measurement - predicted_measurement
+        pseudo_measurement = array(
+            [
+                shifted_measurement[0],
+                shifted_measurement[1],
+                shifted_measurement[0] ** 2,
+                shifted_measurement[0] * shifted_measurement[1],
+                shifted_measurement[1] ** 2,
+            ]
+        )
+
+        cross_covariance = augmented_covariance @ jacobian.T
+        gain = linalg.solve(measurement_covariance.T, cross_covariance.T).T
+        updated_augmented_mean = augmented_mean + gain @ (
+            pseudo_measurement - expected_measurement
+        )
+        updated_augmented_covariance = self._symmetrize(
+            augmented_covariance - gain @ measurement_covariance @ gain.T
+        )
+
+        shape_start = kinematic_dim
+        shape_stop = shape_start + 3
+        self.kinematic_state = self.kinematic_state + updated_augmented_mean[:kinematic_dim]
+        self.covariance = self._symmetrize(
+            updated_augmented_covariance[:kinematic_dim, :kinematic_dim]
+        )
+        self.shape_state = updated_augmented_mean[shape_start:shape_stop]
+        self.shape_covariance = self._symmetrize(
+            updated_augmented_covariance[shape_start:shape_stop, shape_start:shape_stop]
+        )
+
+
+MemSoekfTracker = MEMSOEKFTracker

--- a/tests/filters/test_mem_ekf_star_tracker.py
+++ b/tests/filters/test_mem_ekf_star_tracker.py
@@ -1,0 +1,118 @@
+import unittest
+
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member,protected-access,duplicate-code
+import pyrecest.backend
+from pyrecest.backend import all, array, diag, eye, linalg
+from pyrecest.filters import MEMEKFStarTracker, MemEkfStarTracker
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ != "numpy",
+    reason="MEM-EKF* tracker tests currently use numpy.testing assertions",
+)
+class TestMEMEKFStarTracker(unittest.TestCase):
+    def setUp(self):
+        self.kinematic_state = array([0.0, 0.0, 1.0, -1.0])
+        self.covariance = diag(array([0.1, 0.1, 0.01, 0.01]))
+        self.shape_state = array([0.0, 2.0, 1.0])
+        self.shape_covariance = diag(array([0.01, 0.1, 0.2]))
+        self.measurement_matrix = array(
+            [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+            ]
+        )
+        self.tracker = MEMEKFStarTracker(
+            self.kinematic_state,
+            self.covariance,
+            self.shape_state,
+            self.shape_covariance,
+            measurement_matrix=self.measurement_matrix,
+        )
+
+    def test_initialization_and_alias(self):
+        self.assertIs(MemEkfStarTracker, MEMEKFStarTracker)
+        npt.assert_allclose(self.tracker.kinematic_state, self.kinematic_state)
+        npt.assert_allclose(self.tracker.shape_state, self.shape_state)
+        npt.assert_allclose(
+            self.tracker.get_point_estimate_extent(),
+            diag(array([4.0, 1.0])),
+        )
+
+    def test_shape_noise_covariance_accounts_for_shape_uncertainty(self):
+        shape_noise_covariance = self.tracker._shape_noise_covariance(0.25 * eye(2))
+
+        npt.assert_allclose(
+            shape_noise_covariance,
+            diag(array([0.0275, 0.06])),
+            atol=1e-12,
+        )
+
+    def test_pseudo_jacobian_uses_mem_ekf_star_ordering(self):
+        pseudo_jacobian = self.tracker._shape_pseudo_jacobian_star(0.25 * eye(2))
+
+        npt.assert_allclose(
+            pseudo_jacobian,
+            array(
+                [
+                    [0.0, 1.0, 0.0],
+                    [0.0, 0.0, 0.5],
+                    [0.75, 0.0, 0.0],
+                ]
+            ),
+            atol=1e-12,
+        )
+
+    def test_pseudo_measurement_covariance_is_centered(self):
+        pseudo_covariance = self.tracker._pseudo_measurement_covariance(
+            array([[2.0, 0.5], [0.5, 3.0]])
+        )
+
+        npt.assert_allclose(
+            pseudo_covariance,
+            array(
+                [
+                    [8.0, 0.5, 2.0],
+                    [0.5, 18.0, 3.0],
+                    [2.0, 3.0, 6.25],
+                ]
+            ),
+        )
+
+    def test_update_moves_centroid_and_updates_shape(self):
+        tracker = MEMEKFStarTracker(
+            array([0.0, 0.0, 0.0, 0.0]),
+            diag(array([0.1, 0.1, 0.01, 0.01])),
+            array([0.0, 1.0, 1.0]),
+            diag(array([0.001, 0.5, 0.01])),
+            measurement_matrix=self.measurement_matrix,
+        )
+        prior_shape_covariance = tracker.shape_covariance.copy()
+
+        tracker.update(array([2.0, 0.0]), meas_noise_cov=0.01 * eye(2))
+
+        self.assertGreater(tracker.kinematic_state[0], 0.0)
+        self.assertGreater(tracker.shape_state[1], 1.0)
+        self.assertLess(tracker.shape_covariance[1, 1], prior_shape_covariance[1, 1])
+        self.assertTrue(all(linalg.eigvalsh(tracker.covariance) > 0.0))
+        self.assertTrue(all(linalg.eigvalsh(tracker.shape_covariance) > -1e-12))
+
+    def test_update_accepts_multiple_measurement_layouts(self):
+        tracker = MEMEKFStarTracker(
+            array([0.0, 0.0, 0.0, 0.0]),
+            diag(array([0.1, 0.1, 0.01, 0.01])),
+            array([0.0, 1.0, 1.0]),
+            diag(array([0.001, 0.5, 0.01])),
+            measurement_matrix=self.measurement_matrix,
+        )
+
+        tracker.update(array([[2.0, 0.0]]), meas_noise_cov=0.01 * eye(2))
+
+        self.assertGreater(tracker.kinematic_state[0], 0.0)
+        self.assertGreater(tracker.shape_state[1], 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/filters/test_mem_soekf_tracker.py
+++ b/tests/filters/test_mem_soekf_tracker.py
@@ -1,0 +1,104 @@
+import unittest
+
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member,protected-access,duplicate-code
+import pyrecest.backend
+from pyrecest.backend import all, array, diag, eye, linalg
+from pyrecest.filters import MEMSOEKFTracker, MemSoekfTracker
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ != "numpy",
+    reason="MEM-SOEKF tracker tests currently use numpy.testing assertions",
+)
+class TestMEMSOEKFTracker(unittest.TestCase):
+    def setUp(self):
+        self.kinematic_state = array([0.0, 0.0, 1.0, -1.0])
+        self.covariance = diag(array([0.1, 0.1, 0.01, 0.01]))
+        self.shape_state = array([0.0, 2.0, 1.0])
+        self.shape_covariance = diag(array([0.01, 0.1, 0.2]))
+        self.measurement_matrix = array(
+            [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+            ]
+        )
+        self.tracker = MEMSOEKFTracker(
+            self.kinematic_state,
+            self.covariance,
+            self.shape_state,
+            self.shape_covariance,
+            measurement_matrix=self.measurement_matrix,
+        )
+
+    def test_initialization_and_alias(self):
+        self.assertIs(MemSoekfTracker, MEMSOEKFTracker)
+        npt.assert_allclose(self.tracker.kinematic_state, self.kinematic_state)
+        npt.assert_allclose(self.tracker.shape_state, self.shape_state)
+        npt.assert_allclose(
+            self.tracker.get_point_estimate_extent(),
+            diag(array([4.0, 1.0])),
+        )
+
+    def test_pseudo_jacobian_uses_soekf_ordering(self):
+        pseudo_jacobian = self.tracker._shape_pseudo_jacobian_soekf(0.25 * eye(2))
+
+        npt.assert_allclose(
+            pseudo_jacobian,
+            array(
+                [
+                    [0.0, 1.0, 0.0],
+                    [0.75, 0.0, 0.0],
+                    [0.0, 0.0, 0.5],
+                ]
+            ),
+            atol=1e-12,
+        )
+
+    def test_pseudo_hessians_include_shape_moment_curvature(self):
+        pseudo_hessians = self.tracker._shape_pseudo_hessians_soekf(0.25 * eye(2))
+
+        self.assertEqual(pseudo_hessians.shape, (3, 3, 3))
+        npt.assert_allclose(pseudo_hessians[0, 0, 0], -1.5, atol=1e-5)
+        npt.assert_allclose(pseudo_hessians[0, 1, 1], 0.5, atol=1e-5)
+        npt.assert_allclose(pseudo_hessians[2, 0, 0], 1.5, atol=1e-5)
+        npt.assert_allclose(pseudo_hessians[2, 2, 2], 0.5, atol=1e-5)
+
+    def test_update_moves_centroid_and_updates_shape(self):
+        tracker = MEMSOEKFTracker(
+            array([0.0, 0.0, 0.0, 0.0]),
+            diag(array([0.1, 0.1, 0.01, 0.01])),
+            array([0.0, 1.0, 1.0]),
+            diag(array([0.001, 0.5, 0.01])),
+            measurement_matrix=self.measurement_matrix,
+            covariance_regularization=1e-9,
+        )
+        prior_shape_covariance = tracker.shape_covariance.copy()
+
+        tracker.update(array([2.0, 0.0]), meas_noise_cov=0.01 * eye(2))
+
+        self.assertGreater(tracker.kinematic_state[0], 0.0)
+        self.assertGreater(tracker.shape_state[1], 1.0)
+        self.assertLess(tracker.shape_covariance[1, 1], prior_shape_covariance[1, 1])
+        self.assertTrue(all(linalg.eigvalsh(tracker.covariance) > -1e-10))
+        self.assertTrue(all(linalg.eigvalsh(tracker.shape_covariance) > -1e-10))
+
+    def test_update_accepts_multiple_measurement_layouts(self):
+        tracker = MEMSOEKFTracker(
+            array([0.0, 0.0, 0.0, 0.0]),
+            diag(array([0.1, 0.1, 0.01, 0.01])),
+            array([0.0, 1.0, 1.0]),
+            diag(array([0.001, 0.5, 0.01])),
+            measurement_matrix=self.measurement_matrix,
+            covariance_regularization=1e-9,
+        )
+
+        tracker.update(array([[2.0, 0.0]]), meas_noise_cov=0.01 * eye(2))
+
+        self.assertGreater(tracker.kinematic_state[0], 0.0)
+        self.assertGreater(tracker.shape_state[1], 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a stacked MEM-EKF* tracker on top of the MEM-EKF implementation in #1850. The new tracker reuses the MEM-EKF state representation and prediction API, while overriding the measurement update with the MEM-EKF* moment approximation.

The MEM-EKF* update adds the shape-uncertainty covariance term `C_II`, uses the `[dx^2, dy^2, dx * dy]` pseudo-measurement ordering, and uses the centered covariance of that pseudo-measurement.

## Tests

Added focused tests for export aliases, the shape-uncertainty covariance term, MEM-EKF* pseudo-Jacobian ordering, centered pseudo-measurement covariance, update behavior, and alternate measurement layout handling.

Local execution was not available in this read-only workspace, so validation is via GitHub Actions for this PR.