### PR TITLE
[codex] Fix groundtruth input timestep indexing

### DIFF
--- a/src/pyrecest/evaluation/generate_groundtruth.py
+++ b/src/pyrecest/evaluation/generate_groundtruth.py
@@ -30,7 +30,9 @@ def generate_groundtruth(simulation_param, x0=None):
     # Initialize ground truth
     groundtruth = np.empty(simulation_param["n_timesteps"], dtype=object)
 
-    has_inputs = "inputs" in simulation_param and simulation_param["inputs"] is not None
+    has_inputs = (
+        "inputs" in simulation_param and simulation_param["inputs"] is not None
+    )
     if has_inputs:
         assert (
             simulation_param["inputs"].shape[1] == simulation_param["n_timesteps"] - 1
@@ -69,7 +71,9 @@ def generate_groundtruth(simulation_param, x0=None):
                             simulation_param["inputs"][:, t - 1],
                         )
                 else:
-                    assert not has_inputs, "No inputs accepted for the identity system model."
+                    assert (
+                        not has_inputs
+                    ), "No inputs accepted for the identity system model."
                     state_to_add_noise_to = previous_state
 
                 groundtruth[t][target_no, :] = state_to_add_noise_to + simulation_param[

--- a/src/pyrecest/evaluation/generate_groundtruth.py
+++ b/src/pyrecest/evaluation/generate_groundtruth.py
@@ -30,7 +30,8 @@ def generate_groundtruth(simulation_param, x0=None):
     # Initialize ground truth
     groundtruth = np.empty(simulation_param["n_timesteps"], dtype=object)
 
-    if "inputs" in simulation_param:
+    has_inputs = "inputs" in simulation_param and simulation_param["inputs"] is not None
+    if has_inputs:
         assert (
             simulation_param["inputs"].shape[1] == simulation_param["n_timesteps"] - 1
         ), "Mismatch in number of timesteps."
@@ -40,44 +41,36 @@ def generate_groundtruth(simulation_param, x0=None):
     for t in range(1, simulation_param["n_timesteps"]):
         groundtruth[t] = empty_like(groundtruth[0])
         for target_no in range(simulation_param["n_targets"]):
+            previous_state = groundtruth[t - 1][target_no, :]
             if "gen_next_state_with_noise" in simulation_param:
-                if (
-                    "inputs" not in simulation_param
-                    or simulation_param["inputs"] is None
-                ):
+                if not has_inputs:
                     groundtruth[t][target_no, :] = simulation_param[
                         "gen_next_state_with_noise"
-                    ](groundtruth[t - 1, target_no, :])
+                    ](previous_state)
                 else:
                     groundtruth[t][target_no, :] = simulation_param[
                         "gen_next_state_with_noise"
                     ](
-                        groundtruth[t - 1][target_no, :],
-                        simulation_param["inputs"][t - 1, :],
+                        previous_state,
+                        simulation_param["inputs"][:, t - 1],
                     )
 
             elif "sys_noise" in simulation_param:
                 if "gen_next_state_without_noise" in simulation_param:
-                    if (
-                        "inputs" not in simulation_param
-                        or simulation_param["inputs"] is None
-                    ):
+                    if not has_inputs:
                         state_to_add_noise_to = simulation_param[
                             "gen_next_state_without_noise"
-                        ](groundtruth[t - 1, target_no, :])
+                        ](previous_state)
                     else:
                         state_to_add_noise_to = simulation_param[
                             "gen_next_state_without_noise"
                         ](
-                            groundtruth[:, t - 1, target_no],
-                            simulation_param["inputs"][t - 1, :],
+                            previous_state,
+                            simulation_param["inputs"][:, t - 1],
                         )
                 else:
-                    assert (
-                        "inputs" not in simulation_param
-                        or simulation_param["inputs"] is None
-                    ), "No inputs accepted for the identity system model."
-                    state_to_add_noise_to = groundtruth[t - 1][target_no, :]
+                    assert not has_inputs, "No inputs accepted for the identity system model."
+                    state_to_add_noise_to = previous_state
 
                 groundtruth[t][target_no, :] = state_to_add_noise_to + simulation_param[
                     "sys_noise"

--- a/tests/test_generate_groundtruth_inputs.py
+++ b/tests/test_generate_groundtruth_inputs.py
@@ -1,0 +1,69 @@
+# pylint: disable=no-name-in-module,no-member,too-few-public-methods
+import unittest
+
+import numpy as np
+
+import pyrecest.backend
+from pyrecest.backend import array, eye, to_numpy
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.evaluation import generate_groundtruth
+
+
+class _ZeroNoise:
+    def sample(self, _n):
+        return array([0.0, 0.0])
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+    reason="Groundtruth generation mutates arrays in-place.",
+)
+class TestGenerateGroundtruthInputs(unittest.TestCase):
+    def _base_simulation_param(self):
+        return {
+            "n_timesteps": 4,
+            "n_targets": 1,
+            "initial_prior": GaussianDistribution(array([0.0, 0.0]), eye(2)),
+            "inputs": array(
+                [
+                    [1.0, 2.0, 3.0],
+                    [10.0, 20.0, 30.0],
+                ]
+            ),
+        }
+
+    def _assert_input_driven_groundtruth(self, simulation_param):
+        groundtruth = generate_groundtruth(simulation_param, x0=array([0.0, 0.0]))
+        actual = np.array([to_numpy(state) for state in groundtruth])
+        np.testing.assert_allclose(
+            actual,
+            np.array(
+                [
+                    [0.0, 0.0],
+                    [1.0, 10.0],
+                    [3.0, 30.0],
+                    [6.0, 60.0],
+                ]
+            ),
+        )
+
+    def test_gen_next_state_with_noise_uses_input_columns(self):
+        simulation_param = self._base_simulation_param()
+        simulation_param["gen_next_state_with_noise"] = (
+            lambda previous_state, current_input: previous_state + current_input
+        )
+
+        self._assert_input_driven_groundtruth(simulation_param)
+
+    def test_gen_next_state_without_noise_uses_input_columns(self):
+        simulation_param = self._base_simulation_param()
+        simulation_param["sys_noise"] = _ZeroNoise()
+        simulation_param["gen_next_state_without_noise"] = (
+            lambda previous_state, current_input: previous_state + current_input
+        )
+
+        self._assert_input_driven_groundtruth(simulation_param)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Treat `inputs` columns as transition timesteps in `generate_groundtruth`.
- Use the previous timestep object-array entry consistently instead of indexing the 1D object array with multiple axes.
- Add regression tests for both `gen_next_state_with_noise` and `gen_next_state_without_noise` input-driven groundtruth generation.

## Root Cause

`generate_groundtruth` validated inputs as `(input_dim, n_timesteps - 1)`, but consumed them as `inputs[t - 1, :]`. That swapped the input dimension and timestep dimension and could raise `IndexError` for normal input shapes. The `gen_next_state_without_noise` input path also indexed the 1D object-array `groundtruth` as if it were a dense multidimensional array.

## Validation

- Not run locally; this workspace is read-only and the change was made through the GitHub connector.
- Added `tests/test_generate_groundtruth_inputs.py` to cover both input-driven transition paths.