### PR TITLE
[codex] Fix EOT fixed-count array handling

### DIFF
--- a/src/pyrecest/evaluation/generate_measurements.py
+++ b/src/pyrecest/evaluation/generate_measurements.py
@@ -78,7 +78,7 @@ def generate_measurements(groundtruth, simulation_config):
                     PolygonWithSampling  # Evil class surgery to add sampling methods
                 )
 
-            if simulation_config.get("n_meas_at_individual_time_step", None):
+            if "n_meas_at_individual_time_step" in simulation_config:
                 assert (
                     "intensity_lambda" not in simulation_config
                 ), "Cannot use both intensity_lambda and n_meas_at_individual_time_step."

--- a/tests/test_generate_measurements_eot_fixed_counts.py
+++ b/tests/test_generate_measurements_eot_fixed_counts.py
@@ -1,0 +1,27 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.evaluation import generate_measurements
+from shapely.geometry import Polygon
+
+
+class TestGenerateMeasurementsEotFixedCounts(unittest.TestCase):
+    def test_eot_accepts_numpy_array_fixed_measurement_counts(self):
+        simulation_param = {
+            "eot": True,
+            "target_shape": Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]),
+            "eot_sampling_style": "within",
+            "n_timesteps": 2,
+            "n_meas_at_individual_time_step": np.array([2, 3]),
+        }
+        groundtruth = np.zeros((2, 2))
+
+        measurements = generate_measurements(groundtruth, simulation_param)
+
+        self.assertEqual(measurements[0].shape, (2, 2))
+        self.assertEqual(measurements[1].shape, (3, 2))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Detect EOT fixed measurement counts by key presence instead of truthiness.
- Add a regression test that passes `n_meas_at_individual_time_step` as a NumPy array.

## Root Cause

`generate_measurements` evaluated `simulation_config.get("n_meas_at_individual_time_step", None)` in a boolean context. NumPy arrays with more than one element cannot be converted to a single truth value, so valid fixed-count EOT configs using arrays raised `ValueError`.

## Validation

- Not run locally; this workspace is read-only and the change was made through the GitHub connector.
- Added `tests/test_generate_measurements_eot_fixed_counts.py` to cover the failure mode.