### PR TITLE
[codex] Fix groundtruth object-array indexing

### DIFF
--- a/tests/test_generate_groundtruth.py
+++ b/tests/test_generate_groundtruth.py
@@ -1,0 +1,89 @@
+import unittest
+from unittest.mock import Mock
+
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+import pyrecest.backend
+from pyrecest.backend import array, eye, zeros
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.evaluation import generate_groundtruth
+
+
+def _zero_noise():
+    noise = Mock()
+    noise.sample.return_value = zeros(2)
+    return noise
+
+
+class TestGenerateGroundtruth(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
+    def test_custom_noisy_transition_reads_previous_object_entry(self):
+        x0 = array([[0.0, 1.0], [2.0, 3.0]])
+        step = array([1.0, -1.0])
+        simulation_param = {
+            "initial_prior": GaussianDistribution(zeros(2), eye(2)),
+            "n_targets": 2,
+            "n_timesteps": 3,
+            "gen_next_state_with_noise": lambda state: state + step,
+        }
+
+        groundtruth = generate_groundtruth(simulation_param, x0)
+
+        npt.assert_allclose(groundtruth[0], x0)
+        npt.assert_allclose(groundtruth[1], x0 + step)
+        npt.assert_allclose(groundtruth[2], x0 + 2.0 * step)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
+    def test_custom_noiseless_transition_reads_previous_object_entry(self):
+        x0 = array([[0.0, 1.0], [2.0, 3.0]])
+        step = array([0.5, 1.0])
+        simulation_param = {
+            "initial_prior": GaussianDistribution(zeros(2), eye(2)),
+            "n_targets": 2,
+            "n_timesteps": 3,
+            "sys_noise": _zero_noise(),
+            "gen_next_state_without_noise": lambda state: state + step,
+        }
+
+        groundtruth = generate_groundtruth(simulation_param, x0)
+
+        npt.assert_allclose(groundtruth[0], x0)
+        npt.assert_allclose(groundtruth[1], x0 + step)
+        npt.assert_allclose(groundtruth[2], x0 + 2.0 * step)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
+    def test_custom_transition_with_inputs_uses_column_controls(self):
+        x0 = array([[0.0, 1.0], [2.0, 3.0]])
+        inputs = array([[1.0, 0.5, -0.25], [-2.0, 1.5, 0.75]])
+        simulation_param = {
+            "initial_prior": GaussianDistribution(zeros(2), eye(2)),
+            "n_targets": 2,
+            "n_timesteps": 4,
+            "inputs": inputs,
+            "sys_noise": _zero_noise(),
+            "gen_next_state_without_noise": lambda state, control: state + control,
+        }
+
+        groundtruth = generate_groundtruth(simulation_param, x0)
+        expected_first_step = x0 + inputs[:, 0]
+        expected_second_step = expected_first_step + inputs[:, 1]
+        expected_third_step = expected_second_step + inputs[:, 2]
+
+        npt.assert_allclose(groundtruth[0], x0)
+        npt.assert_allclose(groundtruth[1], expected_first_step)
+        npt.assert_allclose(groundtruth[2], expected_second_step)
+        npt.assert_allclose(groundtruth[3], expected_third_step)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Read prior ground-truth states through the per-timestep object-array entry before indexing target rows.
- Reuse a `has_inputs` flag so `inputs=None` is treated the same as missing inputs.
- Use column-oriented controls (`inputs[:, t - 1]`) to match the existing `(input_dim, n_timesteps - 1)` assertion.
- Add regression tests for noisy transitions, noiseless transitions, and input-driven transitions over multiple targets.

## Root cause
`generate_groundtruth` stores each timestep as an element in a one-dimensional object array. Some custom transition paths indexed it as if it were a dense multidimensional array, which raises before transition callbacks can run. The input-driven branch also read rows from `inputs` even though the function validates inputs as timestep columns.

## Validation
- Inspected the branch diff through the GitHub connector.
- Not run locally: this Codex session has a read-only filesystem, so changes were applied via GitHub API rather than a local checkout.