### PR TITLE
[codex] Fix hypertoroidal nonadditive particle prediction

### DIFF
--- a/src/pyrecest/filters/hypertoroidal_particle_filter.py
+++ b/src/pyrecest/filters/hypertoroidal_particle_filter.py
@@ -10,10 +10,7 @@ from pyrecest.backend import (
     linspace,
     mod,
     pi,
-    random,
-    sum,
     tile,
-    zeros_like,
 )
 from pyrecest.distributions import (
     AbstractHypertoroidalDistribution,
@@ -56,12 +53,5 @@ class HypertoroidalParticleFilter(AbstractParticleFilter, HypertoroidalFilterMix
         self.filter_state.d = mod(self.filter_state.d, 2.0 * pi)
 
     def predict_nonlinear_nonadditive(self, f: Callable, samples, weights):
-        assert samples.shape == weights.size, "samples and weights must match in size"
-
-        weights /= sum(weights)
-        n = self.filter_state.shape[0]
-        noise_ids = random.choice(arange(weights.size), size=n, p=weights)
-        d = zeros_like(self.filter_state)
-        for i in range(n):
-            d[i, :] = f(self.filter_state[i, :], samples[noise_ids[i, :]])
-        self.filter_state = d
+        super().predict_nonlinear_nonadditive(f, samples, weights)
+        self.filter_state.d = mod(self.filter_state.d, 2.0 * pi)

--- a/tests/filters/test_hypertoroidal_particle_filter.py
+++ b/tests/filters/test_hypertoroidal_particle_filter.py
@@ -4,8 +4,15 @@ import numpy.testing as npt
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import all as backend_all
-from pyrecest.backend import array, ones, pi, random, zeros, zeros_like
+from pyrecest.backend import (
+    all as backend_all,
+    array,
+    ones,
+    pi,
+    random,
+    zeros,
+    zeros_like,
+)
 from pyrecest.distributions import HypertoroidalWNDistribution
 from pyrecest.filters import HypertoroidalParticleFilter
 

--- a/tests/filters/test_hypertoroidal_particle_filter.py
+++ b/tests/filters/test_hypertoroidal_particle_filter.py
@@ -4,7 +4,8 @@ import numpy.testing as npt
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array, pi, random, zeros, zeros_like
+from pyrecest.backend import all as backend_all
+from pyrecest.backend import array, ones, pi, random, zeros, zeros_like
 from pyrecest.distributions import HypertoroidalWNDistribution
 from pyrecest.filters import HypertoroidalParticleFilter
 
@@ -42,6 +43,24 @@ class HypertoroidalParticleFilterTest(unittest.TestCase):
             self.forced_mean,
         )
         self.assertEqual(self.hpf.get_point_estimate().shape, (3,))
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax", reason="Backend not supported'"
+    )
+    def test_predict_nonlinear_nonadditive(self):
+        n_noise_samples = 10
+        samples = random.uniform(size=(n_noise_samples, 3))
+        weights = ones(n_noise_samples) / n_noise_samples
+
+        def f(x, w):
+            return x + w
+
+        old_shape = self.hpf.filter_state.d.shape
+        self.hpf.predict_nonlinear_nonadditive(f, samples, weights)
+
+        self.assertEqual(self.hpf.filter_state.d.shape, old_shape)
+        self.assertTrue(bool(backend_all(self.hpf.filter_state.d >= 0.0)))
+        self.assertTrue(bool(backend_all(self.hpf.filter_state.d < 2.0 * pi)))
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax", reason="Backend not supported'"


### PR DESCRIPTION
## Summary

Fix `HypertoroidalParticleFilter.predict_nonlinear_nonadditive` so it reuses the base particle-filter nonadditive prediction logic and then wraps particles back onto the torus with `mod(..., 2*pi)`.

This avoids treating `filter_state` as if it were a raw particle array. `filter_state` is a `HypertoroidalDiracDistribution`; the raw particles live in `filter_state.d`.

## Root Cause

The hypertoroidal override used `self.filter_state.shape`, `zeros_like(self.filter_state)`, and `self.filter_state[i, :]`, which are array operations on a distribution object. Its input validation also compared the full `samples.shape` tuple to `weights.size`, rejecting valid `(n_samples, dim)` noise samples.

## Tests

Added a regression test in `tests/filters/test_hypertoroidal_particle_filter.py` that calls `predict_nonlinear_nonadditive`, checks the particle shape is preserved, and verifies the resulting angular particles remain in `[0, 2*pi)`.

Not run locally because this Codex workspace is read-only and the change was applied through the GitHub connector. The repository's PR CI should run the backend matrix.