### PR TITLE
[codex] Fix GPRHM contour point count

### DIFF
--- a/src/pyrecest/filters/gprhm_tracker.py
+++ b/src/pyrecest/filters/gprhm_tracker.py
@@ -115,7 +115,7 @@ class GPRHMTracker(AbstractExtendedObjectTracker):
     def get_contour_points(self, n: int = 100):
         angles = linspace(0.0, 2 * pi, n, endpoint=False)
         star_point = self.H @ self.m
-        extents = self.get_extents_on_grid()
+        extents = self.get_extents_on_grid(n)
         coords = pol2cart(angles, extents) + reshape(star_point, (-1, 1))
         return coords.T
 

--- a/tests/filters/test_gprhm_tracker.py
+++ b/tests/filters/test_gprhm_tracker.py
@@ -49,6 +49,13 @@ class TestGPRHMTracker(unittest.TestCase):
         self.n_measurements = 10
         self.R = eye(2) * 0.1  # Measurement noise covariance
 
+    def test_get_contour_points_honors_requested_count(self):
+        requested_points = 32
+
+        predicted_points = self.tracker.get_contour_points(requested_points)
+
+        self.assertEqual(predicted_points.shape, (requested_points, 2))
+
     def test_iou_after_updates(self):
         for _ in range(self.n_steps):
             points_from_contour_no_noise = random_points_on_contour(


### PR DESCRIPTION
## Summary

- Pass the requested contour point count through to `GPRHMTracker.get_extents_on_grid`.
- Add a regression test that calls `get_contour_points` with a non-default count.

## Root Cause

`GPRHMTracker.get_contour_points(n)` created `n` angular samples, but always computed extents with the default `get_extents_on_grid()` count of 100. For any `n != 100`, the angle and extent arrays had incompatible lengths.

## Validation

- Not run locally; this Codex workspace is read-only.
- Added `test_get_contour_points_honors_requested_count` to cover the previously failing path.