### PR TITLE
[codex] Fix deviation failure warning without metadata

### DIFF
--- a/src/pyrecest/evaluation/determine_all_deviations.py
+++ b/src/pyrecest/evaluation/determine_all_deviations.py
@@ -47,11 +47,11 @@ def determine_all_deviations(
                 warnings.warn("No estimate for this filter, setting error to inf.")
                 all_deviations_last_mat[config_no][run] = float("inf")
 
-        if any(isinf(all_deviations_last_mat[config_no])):
-            print(
-                f"Warning: {result_curr_config['filterName']} with {result_curr_config['filterParams']} "
-                f"parameters apparently failed {sum(isinf(all_deviations_last_mat[config_no]))} "
-                "times. Check if this is plausible."
+        failed_mask = isinf(all_deviations_last_mat[config_no])
+        if any(failed_mask):
+            warnings.warn(
+                f"Filter result {config_no} apparently failed "
+                f"{int(sum(failed_mask))} times. Check if this is plausible."
             )
 
     return all_deviations_last_mat

--- a/tests/test_determine_all_deviations.py
+++ b/tests/test_determine_all_deviations.py
@@ -1,12 +1,32 @@
 import unittest
 import warnings
 
-import numpy as np
-
 # pylint: disable=no-name-in-module,no-member
 import pyrecest.backend
-from pyrecest.backend import array, isinf, to_numpy
+from pyrecest.backend import all, array, isinf, linalg
 from pyrecest.evaluation import determine_all_deviations
+
+
+class _ObjectMatrix:
+    """Small 2-D object container matching the function's indexing contract."""
+
+    ndim = 2
+
+    def __init__(self, rows):
+        self._rows = rows
+        self.shape = (len(rows), len(rows[0]) if rows else 0)
+
+    def __getitem__(self, key):
+        if isinstance(key, tuple):
+            row, col = key
+            return self._rows[row][col]
+        return self._rows[key]
+
+    def __iter__(self):
+        return iter(self._rows)
+
+    def __len__(self):
+        return len(self._rows)
 
 
 @unittest.skipIf(
@@ -15,23 +35,24 @@ from pyrecest.evaluation import determine_all_deviations
 )
 class TestDetermineAllDeviations(unittest.TestCase):
     def test_missing_estimates_do_not_require_filter_metadata(self):
-        groundtruths = np.empty((2, 1), dtype=object)
-        groundtruths[0, 0] = array([1.0, 2.0])
-        groundtruths[1, 0] = array([3.0, 4.0])
-        results = np.empty((1, 2), dtype=object)
-        results[0, 0] = None
-        results[0, 1] = None
+        groundtruths = _ObjectMatrix(
+            [
+                [array([1.0, 2.0])],
+                [array([3.0, 4.0])],
+            ]
+        )
+        results = _ObjectMatrix([[None, None]])
 
         with warnings.catch_warnings(record=True) as caught_warnings:
             warnings.simplefilter("always")
             deviations = determine_all_deviations(
                 results,
                 lambda filter_state: filter_state,
-                lambda estimate, truth: np.linalg.norm(estimate - truth),
+                lambda estimate, truth: linalg.norm(estimate - truth),
                 groundtruths,
             )
 
-        self.assertTrue(np.all(to_numpy(isinf(deviations))))
+        self.assertTrue(all(isinf(deviations)))
         self.assertTrue(
             any(
                 "Filter result 0 apparently failed 2 times" in str(warning.message)

--- a/tests/test_determine_all_deviations.py
+++ b/tests/test_determine_all_deviations.py
@@ -1,9 +1,10 @@
 import unittest
 import warnings
 
-# pylint: disable=no-name-in-module,no-member
+# pylint: disable=no-name-in-module,no-member,too-few-public-methods
 import pyrecest.backend
-from pyrecest.backend import all, array, isinf, linalg
+from pyrecest.backend import all as backend_all
+from pyrecest.backend import array, isinf, linalg
 from pyrecest.evaluation import determine_all_deviations
 
 
@@ -52,7 +53,7 @@ class TestDetermineAllDeviations(unittest.TestCase):
                 groundtruths,
             )
 
-        self.assertTrue(all(isinf(deviations)))
+        self.assertTrue(backend_all(isinf(deviations)))
         self.assertTrue(
             any(
                 "Filter result 0 apparently failed 2 times" in str(warning.message)

--- a/tests/test_determine_all_deviations.py
+++ b/tests/test_determine_all_deviations.py
@@ -1,0 +1,44 @@
+import unittest
+import warnings
+
+import numpy as np
+
+# pylint: disable=no-name-in-module,no-member
+import pyrecest.backend
+from pyrecest.backend import array, isinf
+from pyrecest.evaluation import determine_all_deviations
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ == "jax",
+    reason="Not supported on this backend",
+)
+class TestDetermineAllDeviations(unittest.TestCase):
+    def test_missing_estimates_do_not_require_filter_metadata(self):
+        groundtruths = np.empty((2, 1), dtype=object)
+        groundtruths[0, 0] = array([1.0, 2.0])
+        groundtruths[1, 0] = array([3.0, 4.0])
+        results = np.empty((1, 2), dtype=object)
+        results[0, 0] = None
+        results[0, 1] = None
+
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            warnings.simplefilter("always")
+            deviations = determine_all_deviations(
+                results,
+                lambda filter_state: filter_state,
+                lambda estimate, truth: np.linalg.norm(estimate - truth),
+                groundtruths,
+            )
+
+        self.assertTrue(np.all(isinf(deviations)))
+        self.assertTrue(
+            any(
+                "Filter result 0 apparently failed 2 times" in str(warning.message)
+                for warning in caught_warnings
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_determine_all_deviations.py
+++ b/tests/test_determine_all_deviations.py
@@ -5,7 +5,7 @@ import numpy as np
 
 # pylint: disable=no-name-in-module,no-member
 import pyrecest.backend
-from pyrecest.backend import array, isinf
+from pyrecest.backend import array, isinf, to_numpy
 from pyrecest.evaluation import determine_all_deviations
 
 
@@ -31,7 +31,7 @@ class TestDetermineAllDeviations(unittest.TestCase):
                 groundtruths,
             )
 
-        self.assertTrue(np.all(isinf(deviations)))
+        self.assertTrue(np.all(to_numpy(isinf(deviations))))
         self.assertTrue(
             any(
                 "Filter result 0 apparently failed 2 times" in str(warning.message)


### PR DESCRIPTION
## Summary

- Stop indexing failed result rows as if they contained `filterName` and `filterParams` metadata.
- Emit a warning using the result row index and the number of infinite deviations instead.
- Add a regression test where missing estimates trigger the warning path without crashing.

## Root Cause

`determine_all_deviations` receives result rows, but the failure-warning path treated each row like a filter config dictionary. If a missing estimate produced an infinite deviation, the warning code could raise a secondary exception while trying to access nonexistent metadata keys.

## Validation

- Not run locally; this workspace is read-only and the change was made through the GitHub connector.
- Added `tests/test_determine_all_deviations.py` to cover the missing-estimate warning path.