### PR TITLE
[codex] Fix scalar filter parameter expansion

### DIFF
--- a/src/pyrecest/evaluation/evaluate_for_variables.py
+++ b/src/pyrecest/evaluation/evaluate_for_variables.py
@@ -7,6 +7,22 @@ import numpy as np
 from .iterate_configs_and_runs import iterate_configs_and_runs
 
 
+def _filter_parameter_values(parameter):
+    if parameter is None:
+        return [None]
+    if isinstance(parameter, (list, tuple)):
+        return list(parameter) or [None]
+    return [parameter]
+
+
+def _expand_filter_configs(filter_configs):
+    return [
+        {"name": filter_config["name"], "parameter": parameter}
+        for filter_config in filter_configs
+        for parameter in _filter_parameter_values(filter_config["parameter"])
+    ]
+
+
 # pylint: disable=R0913,R0914, too-many-positional-arguments
 def evaluate_for_variables(
     groundtruths,
@@ -32,11 +48,7 @@ def evaluate_for_variables(
         "auto_warning_on_off": auto_warning_on_off,
     }
 
-    filter_configs = [
-        {"name": f["name"], "parameter": p}
-        for f in filter_configs
-        for p in (f["parameter"] or [None])
-    ]
+    filter_configs = _expand_filter_configs(filter_configs)
 
     (
         last_filter_states,  # pylint: disable=R0801

--- a/tests/test_evaluate_for_variables.py
+++ b/tests/test_evaluate_for_variables.py
@@ -1,0 +1,28 @@
+import unittest
+
+from pyrecest.evaluation.evaluate_for_variables import _expand_filter_configs
+
+
+class TestEvaluateForVariables(unittest.TestCase):
+    def test_expand_filter_configs_accepts_scalar_parameters(self):
+        filter_configs = [
+            {"name": "kf", "parameter": None},
+            {"name": "pf", "parameter": 100},
+            {"name": "pf", "parameter": [51, 81]},
+        ]
+
+        expanded_filter_configs = _expand_filter_configs(filter_configs)
+
+        self.assertEqual(
+            expanded_filter_configs,
+            [
+                {"name": "kf", "parameter": None},
+                {"name": "pf", "parameter": 100},
+                {"name": "pf", "parameter": 51},
+                {"name": "pf", "parameter": 81},
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_evaluate_for_variables.py
+++ b/tests/test_evaluate_for_variables.py
@@ -1,3 +1,4 @@
+# pylint: disable=protected-access
 import unittest
 
 from pyrecest.evaluation.evaluate_for_variables import _expand_filter_configs


### PR DESCRIPTION
## Summary
- Handle scalar filter parameters when expanding evaluation filter configs
- Preserve existing behavior for `None`, lists, and tuples
- Add a regression test covering scalar, list, and `None` parameters

## Validation
- Added `tests/test_evaluate_for_variables.py`
- Not run locally because this Codex workspace is read-only