### PR TITLE
[codex] Fix KernelSME empty gated update

### DIFF
--- a/src/pyrecest/filters/kernel_sme_filter.py
+++ b/src/pyrecest/filters/kernel_sme_filter.py
@@ -196,6 +196,12 @@ class KernelSMEFilter(AbstractMultitargetTracker):
             dists = dists**2  # Squared Mahalanobis distances are usually considered
             # Filter out all that are incompatible with all tracks
             measurements = measurements[:, any(dists < gating_threshold, axis=0)]
+            n_meas = measurements.shape[1]
+
+        if n_meas == 0:
+            if self.log_posterior_estimates:
+                self.store_posterior_estimates()
+            return
 
         test_points = KernelSMEFilter.gen_test_points(measurements, kernel_width)
         pseudo_meas = KernelSMEFilter.calc_pseudo_meas(
@@ -383,7 +389,7 @@ class KernelSMEFilter(AbstractMultitargetTracker):
                     (lambda_vec**2) * Pij[i, j, :]
                 )  # noqa: E203
 
-                # --- clutter-related terms (3)–(6) ---
+                # --- clutter-related terms (3)- (6) ---
                 clutter_i = clutter_pdf[i]
                 clutter_j = clutter_pdf[j]
                 midpoint = 0.5 * (testPoints[:, i] + testPoints[:, j])

--- a/src/pyrecest/filters/kernel_sme_filter.py
+++ b/src/pyrecest/filters/kernel_sme_filter.py
@@ -389,7 +389,7 @@ class KernelSMEFilter(AbstractMultitargetTracker):
                     (lambda_vec**2) * Pij[i, j, :]
                 )  # noqa: E203
 
-                # --- clutter-related terms (3)- (6) ---
+                # --- clutter-related terms (3)–(6) ---
                 clutter_i = clutter_pdf[i]
                 clutter_j = clutter_pdf[j]
                 midpoint = 0.5 * (testPoints[:, i] + testPoints[:, j])

--- a/tests/filters/test_kernel_sme_filter.py
+++ b/tests/filters/test_kernel_sme_filter.py
@@ -376,6 +376,33 @@ class TestKernelSMEFilter(unittest.TestCase):
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
         reason="Not supported on this backend",
     )
+    def test_gating_rejecting_all_measurements_keeps_prior(self):
+        tracker = KernelSMEFilter()
+        tracker.filter_state = self.gaussians_2DCV
+        prior_x = copy.deepcopy(tracker.x)
+        prior_c = copy.deepcopy(tracker.C)
+
+        far_measurements = array([[100.0, -100.0], [100.0, -100.0]])
+
+        tracker.update_linear(
+            far_measurements,
+            self.measurement_matrix_2DCV,
+            eye(2),
+            0,
+            zeros(2),
+            1,
+            True,
+            gating_threshold=1.0,
+        )
+
+        npt.assert_allclose(tracker.x, prior_x)
+        npt.assert_allclose(tracker.C, prior_c)
+        self.assertEqual(tracker.posterior_estimates_over_time.shape, (12, 1))
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
     def test_logging(self):
         tracker = KernelSMEFilter()
         tracker.filter_state = self.gaussians_2DCV


### PR DESCRIPTION
## Summary

- Treat an empty Kernel SME measurement set after gating as a no-op posterior update.
- Preserve state and covariance when all measurements are rejected by gating.
- Add a regression test covering the all-measurements-rejected path.

## Root Cause

`KernelSMEFilter.update_linear` filtered measurements during gating, then unconditionally called `gen_test_points`. If gating rejected every measurement, `gen_test_points` attempted `vstack([])` and failed.

## Validation

- Not run locally; this Codex workspace is read-only.
- Added `test_gating_rejecting_all_measurements_keeps_prior` to cover the previously failing path.
