### PR TITLE
[codex] Add rigid EKF spline tracker

### DIFF
--- a/src/pyrecest/filters/__init__.py
+++ b/src/pyrecest/filters/__init__.py
@@ -58,6 +58,7 @@ from .mem_ekf_tracker import MEMEKFTracker, MemEkfTracker
 from .multi_bernoulli_tracker import BernoulliComponent, MultiBernoulliTracker
 from .piecewise_constant_filter import PiecewiseConstantFilter
 from .random_matrix_tracker import RandomMatrixTracker
+from .rigid_ekf_spline_tracker import RigidEKFSplineTracker, RigidEkfSplineTracker
 from .se2_ukf import SE2UKF
 from .state_space_subdivision_filter import StateSpaceSubdivisionFilter
 from .toroidal_particle_filter import ToroidalParticleFilter
@@ -142,6 +143,8 @@ __all__ = [
     "MemEkfTracker",
     "PiecewiseConstantFilter",
     "RandomMatrixTracker",
+    "RigidEKFSplineTracker",
+    "RigidEkfSplineTracker",
     "Track",
     "TrackManager",
     "TrackManagerStepResult",

--- a/src/pyrecest/filters/ekf_spline_tracker.py
+++ b/src/pyrecest/filters/ekf_spline_tracker.py
@@ -27,6 +27,21 @@ class EKFSplineTracker(AbstractExtendedObjectTracker):
     the currently predicted closed spline, then corrected with an EKF update.
     """
 
+    def _initialize_extended_object_tracker(
+        self,
+        log_prior_estimates=False,
+        log_posterior_estimates=False,
+        log_prior_extents=False,
+        log_posterior_extents=False,
+    ):
+        """Initialize shared extended-object tracker logging state."""
+        super().__init__(
+            log_prior_estimates=log_prior_estimates,
+            log_posterior_estimates=log_posterior_estimates,
+            log_prior_extents=log_prior_extents,
+            log_posterior_extents=log_posterior_extents,
+        )
+
     # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
     def __init__(
         self,

--- a/src/pyrecest/filters/rigid_ekf_spline_tracker.py
+++ b/src/pyrecest/filters/rigid_ekf_spline_tracker.py
@@ -1,0 +1,138 @@
+# pylint: disable=duplicate-code,no-member,no-name-in-module,super-init-not-called,too-many-instance-attributes
+from pyrecest.backend import array, diag, eye, zeros
+
+from .ekf_spline_tracker import EKFSplineTracker
+
+
+class RigidEKFSplineTracker(EKFSplineTracker):
+    """EKF spline tracker with a fixed body-frame spline extent.
+
+    The state is ``[x, y, orientation, speed, turn_rate]``. In contrast to
+    :class:`EKFSplineTracker`, this tracker does not estimate scale factors;
+    measurements are projected onto the unscaled closed spline contour.
+    """
+
+    # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
+    def __init__(
+        self,
+        control_points=None,
+        kinematic_state=None,
+        covariance=None,
+        process_noise=None,
+        measurement_noise=None,
+        dt=1.0,
+        acceleration_variance=0.0,
+        turn_rate_variance=0.0,
+        orientation_correction=True,
+        finite_difference_step=1e-5,
+        closest_point_grid_size=11,
+        closest_point_iterations=8,
+        log_prior_estimates=False,
+        log_posterior_estimates=False,
+        log_prior_extents=False,
+        log_posterior_extents=False,
+    ):
+        self._initialize_extended_object_tracker(
+            log_prior_estimates=log_prior_estimates,
+            log_posterior_estimates=log_posterior_estimates,
+            log_prior_extents=log_prior_extents,
+            log_posterior_extents=log_posterior_extents,
+        )
+        self.measurement_dim = 2
+        self.kinematic_dim = 5
+        self.state_dim = 5
+        self._spline_basis = array(
+            [
+                [0.5, -1.0, 0.5],
+                [-1.0, 1.0, 0.0],
+                [0.5, 0.5, 0.0],
+            ]
+        )
+        if control_points is None:
+            control_points = self.default_control_points()
+        self.control_points = self._validate_control_points(control_points)
+        self.num_control_points = self.control_points.shape[0]
+        self._segment_anchors = self._compute_segment_anchors()
+
+        self.state = array(self._normalize_kinematic_state(kinematic_state))
+        self._unit_scale_state = array([1.0, 1.0])
+
+        if covariance is None:
+            covariance = diag(array([0.2, 0.2, 0.02, 0.05, 0.02]))
+        self.covariance = self._as_covariance_matrix(
+            covariance,
+            self.state_dim,
+            "covariance",
+        )
+        if process_noise is None:
+            process_noise = zeros((self.state_dim, self.state_dim))
+        self.process_noise = self._as_covariance_matrix(
+            process_noise,
+            self.state_dim,
+            "process_noise",
+            require_positive_semidefinite=False,
+        )
+        if measurement_noise is None:
+            measurement_noise = 0.05 * eye(self.measurement_dim)
+        self.measurement_noise = self._as_covariance_matrix(
+            measurement_noise,
+            self.measurement_dim,
+            "measurement_noise",
+            require_positive_semidefinite=False,
+        )
+
+        self.dt = float(dt)
+        self.acceleration_variance = float(acceleration_variance)
+        self.turn_rate_variance = float(turn_rate_variance)
+        self.scale_process_noise = 0.0
+        # Keep the inherited EKF update from treating velocity columns as scales.
+        self.scale_correction = True
+        self.orientation_correction = bool(orientation_correction)
+        self.finite_difference_step = float(finite_difference_step)
+        self.closest_point_grid_size = int(closest_point_grid_size)
+        self.closest_point_iterations = int(closest_point_iterations)
+        if self.finite_difference_step <= 0.0:
+            raise ValueError("finite_difference_step must be positive")
+        if self.closest_point_grid_size <= 1:
+            raise ValueError("closest_point_grid_size must be greater than one")
+        if self.closest_point_iterations < 0:
+            raise ValueError("closest_point_iterations must be non-negative")
+        self.last_quadratic_form = None
+        self._sync_state_views()
+
+    def _sync_state_views(self):
+        self.kinematic_state = self.state
+        self.scale_state = self._unit_scale_state
+
+    def _predict_measurement_from_state(self, state, measurement):
+        position = state[:2]
+        orientation = state[2]
+        rotation_matrix = self._rotation_matrix(orientation)
+        body_measurement = rotation_matrix.T @ (measurement - position)
+        body_spline_point, _, _ = self._project_measurement_to_body_spline(
+            body_measurement,
+            self._unit_scale_state,
+        )
+        return position + rotation_matrix @ body_spline_point
+
+    def get_scaled_control_points(self, global_frame=False):
+        control_points = array(self.control_points)
+        if not global_frame:
+            return control_points
+        rotation_matrix = self._rotation_matrix(self.state[2])
+        return (rotation_matrix @ control_points.T).T + self.state[:2]
+
+    def get_point_estimate(self):
+        return self.state
+
+    def get_point_estimate_kinematics(self):
+        return self.kinematic_state
+
+    def get_point_estimate_extent(self, flatten_matrix=False):
+        control_points = self.get_scaled_control_points()
+        if flatten_matrix:
+            return control_points.flatten()
+        return control_points
+
+
+RigidEkfSplineTracker = RigidEKFSplineTracker

--- a/tests/filters/test_rigid_ekf_spline_tracker.py
+++ b/tests/filters/test_rigid_ekf_spline_tracker.py
@@ -1,0 +1,97 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+import pyrecest.backend
+from pyrecest.backend import array, diag, eye, linalg
+from pyrecest.filters import RigidEKFSplineTracker, RigidEkfSplineTracker
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ != "numpy",
+    reason="Finite-difference spline tracker tests are numpy-backend checks.",
+)
+class TestRigidEKFSplineTracker(unittest.TestCase):
+    def setUp(self):
+        self.tracker = RigidEKFSplineTracker(
+            kinematic_state=array([0.0, 0.0, 0.0, 0.0, 0.0]),
+            covariance=diag(array([0.1, 0.1, 0.01, 0.01, 0.01])),
+            measurement_noise=0.01 * eye(2),
+        )
+
+    def test_initialization_and_alias(self):
+        self.assertIs(RigidEkfSplineTracker, RigidEKFSplineTracker)
+        self.assertEqual(self.tracker.state.shape, (5,))
+        self.assertEqual(self.tracker.get_scaled_control_points().shape, (8, 2))
+        self.assertEqual(
+            self.tracker.get_point_estimate_extent(flatten_matrix=True).shape,
+            (16,),
+        )
+        npt.assert_allclose(self.tracker.scale_state, array([1.0, 1.0]), atol=1e-12)
+
+    def test_contour_and_bounding_box_shapes(self):
+        contour_points = self.tracker.get_contour_points(16)
+        box = self.tracker.get_bounding_box(32)
+        dimensions = np.asarray(box["dimension"])
+
+        self.assertTupleEqual(tuple(contour_points.shape), (16, 2))
+        self.assertTupleEqual(tuple(box["center_xy"].shape), (2,))
+        self.assertTupleEqual(tuple(dimensions.shape), (2,))
+        self.assertTrue(np.all(dimensions > 0.0))
+
+    def test_predict_uses_constant_turn_kinematics(self):
+        starting_state = array([0.0, 0.0, 0.0, 2.0, 0.2])
+        covariance = diag(array([1e-4, 1e-4, 1e-4, 1e-4, 1e-4]))
+        tracker = RigidEKFSplineTracker(
+            kinematic_state=starting_state,
+            covariance=covariance,
+            measurement_noise=0.01 * eye(2),
+        )
+
+        tracker.predict(dt=0.5)
+
+        predicted_pose = tracker.get_point_estimate_kinematics()[:3]
+        npt.assert_allclose(
+            predicted_pose,
+            array([1.0, 0.0, 0.1]),
+            rtol=0.0,
+            atol=1e-4,
+        )
+        covariance_eigenvalues = linalg.eigvalsh(tracker.covariance)
+        self.assertGreater(float(np.min(covariance_eigenvalues)), -1e-10)
+
+    def test_update_moves_position_without_changing_extent(self):
+        tracker = RigidEKFSplineTracker(
+            covariance=diag(array([0.05, 0.05, 0.01, 0.01, 0.01])),
+            measurement_noise=0.01 * eye(2),
+        )
+        prior_extent = tracker.get_point_estimate_extent()
+
+        tracker.update(array([3.0, 0.0]))
+
+        self.assertGreater(float(tracker.kinematic_state[0]), 0.0)
+        npt.assert_allclose(tracker.get_point_estimate_extent(), prior_extent, atol=1e-12)
+        self.assertIsNotNone(tracker.last_quadratic_form)
+        covariance_eigenvalues = linalg.eigvalsh(tracker.covariance)
+        self.assertGreater(float(np.min(covariance_eigenvalues)), -1e-10)
+
+    def test_orientation_correction_can_be_disabled(self):
+        tracker = RigidEKFSplineTracker(
+            covariance=diag(array([0.05, 0.05, 0.2, 0.01, 0.01])),
+            measurement_noise=0.01 * eye(2),
+            orientation_correction=False,
+        )
+
+        tracker.update(array([2.5, 0.7]))
+
+        self.assertEqual(float(tracker.kinematic_state[2]), 0.0)
+
+    def test_update_accepts_multiple_measurement_layouts(self):
+        measurement_rows = array([[3.0, 0.2], [0.0, 1.5], [-2.5, -0.1]])
+        tracker = RigidEKFSplineTracker(measurement_noise=0.01 * eye(2))
+
+        for measurement_batch in (measurement_rows, measurement_rows.T):
+            tracker.update(measurement_batch)
+            self.assertIsNotNone(tracker.last_quadratic_form)


### PR DESCRIPTION
## Summary

Adds `RigidEKFSplineTracker` / `RigidEkfSplineTracker` as a stacked follow-up to the EKF spline tracker PR.

The rigid variant reuses the PyRecEst EKF spline projection and finite-difference update machinery, but keeps the extent fixed: the state is only `[x, y, orientation, speed, turn_rate]`, measurements project onto the unscaled closed spline contour, and extent extraction returns the fixed control polygon.

## User impact

Users can instantiate the rigid spline tracker from `pyrecest.filters` when they want a spline-shaped extended target with fixed shape and only kinematic state estimation.

## Tests

Added `tests/filters/test_rigid_ekf_spline_tracker.py` for public exports, 5-D state shape, contour and bounding-box outputs, constant-turn prediction, fixed-extent update behavior, disabled orientation correction, and multiple measurement layouts.

Local tests were not run in this desktop session because Python execution is unavailable in the read-only sandbox; the PR is opened as draft for CI validation.