### PR TITLE
[codex] Add numerical circular KL divergence

### DIFF
--- a/src/pyrecest/distributions/circle/abstract_circular_distribution.py
+++ b/src/pyrecest/distributions/circle/abstract_circular_distribution.py
@@ -1,7 +1,7 @@
 import matplotlib.pyplot as plt
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array, cos, linspace, mod, pi, sin
+from pyrecest.backend import array, cos, linspace, log, mod, pi, sin
 
 from ..hypertorus.abstract_hypertoroidal_distribution import (
     AbstractHypertoroidalDistribution,
@@ -40,6 +40,30 @@ class AbstractCircularDistribution(AbstractHypertoroidalDistribution):
             return 1.0 - self.integrate_numerically(array([x_mod, starting_point_mod]))
 
         return self.integrate_numerically(array([starting_point_mod, x_mod]))
+
+    def kld_numerical(self, other):
+        """
+        Calculates the Kullback-Leibler divergence numerically.
+
+        Args:
+            other (AbstractCircularDistribution): Distribution to compare against.
+
+        Returns:
+            : The Kullback-Leibler divergence D_KL(self || other).
+        """
+        assert isinstance(other, AbstractCircularDistribution)
+        assert (
+            self.dim == other.dim
+        ), "Cannot compare distributions with different number of dimensions."
+
+        def kld_fun(*args):
+            x = array(args)
+            pdf_self = self.pdf(x)
+            if pdf_self <= 0.0:
+                return 0.0 * pdf_self
+            return pdf_self * log(pdf_self / other.pdf(x))
+
+        return self.integrate_fun_over_domain(kld_fun, self.dim)
 
     def to_vm(self):
         """

--- a/tests/distributions/test_abstract_circular_distribution.py
+++ b/tests/distributions/test_abstract_circular_distribution.py
@@ -4,8 +4,8 @@ import unittest
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import allclose, arange, array, pi
-from pyrecest.distributions import VonMisesDistribution, WrappedNormalDistribution
+from pyrecest.backend import allclose, arange, array, log, pi
+from pyrecest.distributions import CircularUniformDistribution, VonMisesDistribution, WrappedNormalDistribution
 
 
 class AbstractCircularDistributionTest(unittest.TestCase):
@@ -84,6 +84,27 @@ class AbstractCircularDistributionTest(unittest.TestCase):
                             rtol=1e-10,
                         )
                     )
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
+    def test_kld_numerical(self):
+        """Tests numerical computation of the Kullback-Leibler divergence."""
+        uniform = CircularUniformDistribution()
+        vm = VonMisesDistribution(array(0.3), array(1.8))
+
+        for dist in self.distributions:
+            with self.subTest(distribution=dist):
+                self.assertTrue(allclose(dist.kld_numerical(dist), 0.0, atol=1e-10))
+
+        self.assertTrue(
+            allclose(
+                vm.kld_numerical(uniform),
+                log(2.0 * pi) - vm.entropy(),
+                rtol=1e-8,
+            )
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `AbstractCircularDistribution.kld_numerical(other)` for numerical Kullback-Leibler divergence over the circular domain.
- Cover the new method with circular distribution tests for zero self-divergence and `KL(VonMises || uniform)` against the entropy identity.

## Validation
- Inspected the generated diff through the GitHub API.
- Local test execution was not available in this read-only workspace; CI should run on the PR branch.