### PR TITLE
Allow CI workflows on PRs to any branch

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -9,13 +9,14 @@ permissions:
   contents: write
 
 on: # yamllint disable-line rule:truthy
-  # Trigger mega-linter at every push. Action will also be visible from Pull Requests to main
+  # Trigger mega-linter on pushes to main. The action will also be visible
+  # from Pull Requests to any branch.
   push:
     branches:
       - main
   pull_request:
     branches:
-      - main
+      - "**"
 
 env: # Comment env block if you do not want to apply fixes
   # Apply linter fixes configuration

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ on:
       - main
   pull_request:
     branches:
-      - main
+      - "**"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}


### PR DESCRIPTION
## Summary
- allow the test workflow to run for pull requests targeting any branch
- allow the MegaLinter workflow to run for pull requests targeting any branch
- keep existing push triggers limited to `main`

## Testing
- Not run locally; workflow-only change verified by inspecting the branch diff.