### PR TITLE
[codex] Fix PyTorch backend std signature

### DIFF
--- a/src/pyrecest/_backend/pytorch/__init__.py
+++ b/src/pyrecest/_backend/pytorch/__init__.py
@@ -148,7 +148,29 @@ mod = _box_binary_scalar(target=_torch.remainder, box_x2=False)
 power = _box_binary_scalar(target=_torch.pow, box_x2=False)
 
 
-std = _preserve_input_dtype(_add_default_dtype_by_casting(target=_torch.std))
+def std(
+    a,
+    axis=None,
+    dtype=None,
+    out=None,
+    ddof=0,
+    keepdims=False,
+    *,
+    correction=0,
+):
+    if ddof != 0 and correction != 0:
+        raise ValueError("ddof and correction cannot both be nonzero")
+    if correction == 0:
+        correction = ddof
+    if dtype is not None:
+        a = cast(a, dtype=dtype)
+
+    kwargs = {"dim": axis, "correction": correction, "keepdim": keepdims}
+    if out is not None:
+        kwargs["out"] = out
+
+    return _torch.std(a, **kwargs)
+
 
 def cov(input, correction=1, fweights=None, aweights=None, bias=False):
     # for pyrecest

--- a/tests/test_pytorch_backend.py
+++ b/tests/test_pytorch_backend.py
@@ -1,0 +1,47 @@
+import unittest
+
+try:
+    from pyrecest._backend import pytorch as pytorch_backend
+except ModuleNotFoundError:
+    pytorch_backend = None
+
+
+@unittest.skipIf(pytorch_backend is None, "PyTorch is not installed")
+class TestPytorchBackendStd(unittest.TestCase):
+    def test_std_accepts_numpy_style_axis_and_ddof(self):
+        values = pytorch_backend.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+
+        population_std = pytorch_backend.std(values, axis=0)
+        sample_std = pytorch_backend.std(values, axis=0, ddof=1)
+
+        self.assertTrue(
+            pytorch_backend.allclose(
+                population_std,
+                pytorch_backend.array([1.632993161855452, 1.632993161855452]),
+            )
+        )
+        self.assertTrue(
+            pytorch_backend.allclose(sample_std, pytorch_backend.array([2.0, 2.0]))
+        )
+
+    def test_std_accepts_keepdims_and_dtype(self):
+        values = pytorch_backend.array(
+            [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=pytorch_backend.float32
+        )
+
+        result = pytorch_backend.std(
+            values, axis=0, keepdims=True, dtype=pytorch_backend.float64
+        )
+
+        self.assertEqual(result.shape, (1, 2))
+        self.assertEqual(result.dtype, pytorch_backend.float64)
+
+    def test_std_rejects_conflicting_ddof_and_correction(self):
+        values = pytorch_backend.array([1.0, 2.0, 3.0])
+
+        with self.assertRaises(ValueError):
+            pytorch_backend.std(values, ddof=1, correction=1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pytorch_backend.py
+++ b/tests/test_pytorch_backend.py
@@ -1,5 +1,7 @@
 import unittest
+from typing import Any
 
+pytorch_backend: Any
 try:
     from pyrecest._backend import pytorch as pytorch_backend
 except ModuleNotFoundError:


### PR DESCRIPTION
## Summary

- Replace the PyTorch backend `std` wrapper with a NumPy-compatible signature for `axis`, `ddof`, `keepdims`, `dtype`, `out`, and `correction`.
- Add focused PyTorch backend tests covering population vs. sample standard deviation, `keepdims`, `dtype`, and conflicting `ddof`/`correction` arguments.

## Notes

This intentionally excludes the `SE2PartiallyWrappedNormalDistribution` alias and other unrelated changes from #1807.

## Validation

- Not run locally; this workspace is read-only and the branch was created through the GitHub API.
- Verified the GitHub compare contains only `src/pyrecest/_backend/pytorch/__init__.py` and `tests/test_pytorch_backend.py`.