### PR TITLE
Use Poetry for devcontainer setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
   "name": "Python 3",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "mcr.microsoft.com/devcontainers/python:0-3.11",
+  "image": "mcr.microsoft.com/devcontainers/python:1-3.13-bookworm",
 
   // Features to add to the dev container. More info: https://containers.dev/features.
   // "features": {},
@@ -12,7 +12,7 @@
   // "forwardPorts": [],
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "pip3 install --user -r requirements-dev.txt",
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
 
   "remoteEnv": {
     "PYTHONPATH": "${containerWorkspaceFolder}/src"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+sudo apt-get update
+sudo apt-get install -y \
+  build-essential \
+  cmake \
+  gfortran \
+  libcfitsio-dev \
+  libcurl4-openssl-dev \
+  libfftw3-dev \
+  libgeos-dev \
+  libhealpix-cxx-dev \
+  liblapack-dev \
+  libopenblas-dev \
+  ninja-build \
+  pkg-config \
+  zlib1g-dev
+
+python -m pip install --user --upgrade pip wheel "poetry>=2.0,<3.0" "poetry-plugin-export>=1.8,<2.0"
+python -m poetry env use python
+python -m poetry install --with dev --extras "healpy_support" --extras "pytorch_support"


### PR DESCRIPTION
## Summary
- update the devcontainer image from Python 3.11 to Python 3.13, which is already covered by the test matrix
- replace the requirements-dev.txt pip install with a post-create script that installs the same system build dependencies used by CI and sets up dependencies with Poetry
- install Poetry 2.x plus the export plugin so the devcontainer matches the Poetry-based workflows

## Validation
- compared `codex/devcontainer-poetry-setup` against `main`; the branch is ahead by only the devcontainer JSON update and new post-create script
- did not run a full devcontainer build in this environment