### PR TITLE
[codex] Align distribution method signatures

### DIFF
--- a/src/pyrecest/distributions/cart_prod/custom_hypercylindrical_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/custom_hypercylindrical_distribution.py
@@ -44,9 +44,9 @@ class CustomHypercylindricalDistribution(
         )
         return chhd
 
-    def integrate(self):
+    def integrate(self, integration_boundaries=None):
         # Call the integrate method from the superclass
-        return AbstractHypercylindricalDistribution.integrate(self)
+        return AbstractHypercylindricalDistribution.integrate(self, integration_boundaries)
 
     def condition_on_periodic(self, input_periodic, normalize=True):
         # Call the condition_on_periodic method from the superclass

--- a/src/pyrecest/distributions/cart_prod/hypercylindrical_dirac_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/hypercylindrical_dirac_distribution.py
@@ -47,9 +47,9 @@ class HypercylindricalDiracDistribution(
         # Perform the weighted sum using matrix multiplication
         return self.w @ S
 
-    def plot(self):
+    def plot(self, *args, **kwargs):
         assert self.dim <= 3, "Plotting not supported for this dimension"
-        LinearDiracDistribution.plot(self)
+        LinearDiracDistribution.plot(self, *args, **kwargs)
         if self.bound_dim >= 1:
             plt.xlim(0, 2 * pi)
         if self.bound_dim >= 2:

--- a/src/pyrecest/distributions/cart_prod/mardia_sutton_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/mardia_sutton_distribution.py
@@ -119,12 +119,13 @@ class MardiaSuttonDistribution(AbstractHypercylindricalDistribution):
         s_gauss = array(norm.rvs(loc=muc, scale=float(sigmac)))
         return column_stack([s_vm, s_gauss])
 
-    def linear_covariance(self):
+    def linear_covariance(self, approximate_mean=None):
         """Return the intrinsic linear variance as a (1, 1) matrix.
 
         Returns:
             C (1, 1): [[sigma^2]]
         """
+        _ = approximate_mean
         return array([[self.sigma**2]])
 
     def marginalize_linear(self):

--- a/src/pyrecest/distributions/cart_prod/partially_wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/partially_wrapped_normal_distribution.py
@@ -173,7 +173,8 @@ class PartiallyWrappedNormalDistribution(AbstractHypercylindricalDistribution):
     def to_gaussian(self):
         return GaussianDistribution(self.mu, self.C)
 
-    def linear_covariance(self):
+    def linear_covariance(self, approximate_mean=None):
+        _ = approximate_mean
         return self.C[self.bound_dim :, self.bound_dim :]  # noqa: E203
 
     def marginalize_periodic(self):

--- a/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
@@ -62,7 +62,8 @@ class WrappedNormalDistribution(
         return sqrt(self.C)
 
     # pylint: disable=too-many-locals
-    def pdf(self, xs):
+    def pdf(self, xs, m: Union[int, int32, int64] = 3):
+        _ = m
         if self.sigma <= 0:
             raise ValueError(f"sigma must be >0, but received {self.sigma}.")
         xs = array(xs)

--- a/src/pyrecest/distributions/conditional/s2_cond_s2_grid_distribution.py
+++ b/src/pyrecest/distributions/conditional/s2_cond_s2_grid_distribution.py
@@ -81,6 +81,7 @@ class S2CondS2GridDistribution(SdCondSdGridDistribution):
         no_of_grid_points,
         fun_does_cartesian_product=False,
         grid_type="leopardi",
+        dim=6,
     ):
         """
         Construct an :class:`S2CondS2GridDistribution` from a callable.
@@ -105,11 +106,14 @@ class S2CondS2GridDistribution(SdCondSdGridDistribution):
         -------
         S2CondS2GridDistribution
         """
+        if dim != 6:
+            raise ValueError("S2CondS2GridDistribution is fixed to dim=6.")
+
         sdsd = SdCondSdGridDistribution.from_function(
             fun,
             no_of_grid_points,
             fun_does_cartesian_product,
             grid_type,
-            dim=6,
+            dim=dim,
         )
         return S2CondS2GridDistribution(sdsd.grid, sdsd.grid_values)

--- a/src/pyrecest/distributions/hypersphere_subset/abstract_hyperhemispherical_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/abstract_hyperhemispherical_distribution.py
@@ -93,7 +93,7 @@ class AbstractHyperhemisphericalDistribution(AbstractHypersphereSubsetDistributi
             n, burn_in, skipping, proposal=proposal, start_point=start_point
         )
 
-    def mean_direction_numerical(self):
+    def mean_direction_numerical(self, integration_boundaries=None):
         warning_msg = (
             "The result is the mean direction on the upper hemisphere along the last dimension. "
             "It is not a mean of a symmetric distribution, which would not have a proper mean. "
@@ -102,7 +102,9 @@ class AbstractHyperhemisphericalDistribution(AbstractHypersphereSubsetDistributi
         )
         warnings.warn(warning_msg)
 
-        if self.dim == 1:
+        if integration_boundaries is not None:
+            mu = super().mean_direction_numerical(integration_boundaries)
+        elif self.dim == 1:
             mu = super().mean_direction_numerical([0, pi])
         elif self.dim <= 3:
             mu = super().mean_direction_numerical(

--- a/src/pyrecest/distributions/hypersphere_subset/abstract_hypersphere_subset_dirac_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/abstract_hypersphere_subset_dirac_distribution.py
@@ -29,7 +29,8 @@ class AbstractHypersphereSubsetDiracDistribution(
         result = -sum(self.w * log(self.w))
         return result
 
-    def integrate(self, integration_boundaries=None):
+    def integrate(self, left=None, right=None):
+        _ = left, right
         raise NotImplementedError()
 
     def mean_axis(self):

--- a/src/pyrecest/distributions/hypersphere_subset/abstract_spherical_harmonics_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/abstract_spherical_harmonics_distribution.py
@@ -81,7 +81,12 @@ class AbstractSphericalHarmonicsDistribution(
         else:
             warnings.warn("Warning: Currently cannot normalize")
 
-    def integrate(self):
+    def integrate(self, integration_boundaries=None):
+        if integration_boundaries is not None:
+            raise NotImplementedError(
+                "Analytical spherical-harmonics integration only supports the full domain."
+            )
+
         if self.transformation == "identity":
             int_val = self.coeff_mat[0, 0] * sqrt(4.0 * pi)
         elif self.transformation == "sqrt":

--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py
@@ -40,9 +40,10 @@ class HypertoroidalDiracDistribution(
         AbstractHypertoroidalDistribution.__init__(self, dim)
         AbstractDiracDistribution.__init__(self, atleast_1d(mod(d, 2.0 * pi)), w=w)
 
-    def plot(self):
+    def plot(self, resolution=128, **kwargs):
+        _ = resolution
         assert self.dim <= 3, "Plotting not supported for this dimension"
-        LinearDiracDistribution.plot(self)
+        LinearDiracDistribution.plot(self, **kwargs)
         if self.dim >= 1:
             plt.xlim(0, 2 * pi)
         if self.dim >= 2:

--- a/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
@@ -83,7 +83,8 @@ class GaussianDistribution(AbstractLinearDistribution):
     def mean(self):
         return self.mu
 
-    def mode(self):
+    def mode(self, starting_point=None):
+        _ = starting_point
         return self.mu
 
     def set_mode(self, new_mode):

--- a/src/pyrecest/filters/hyperspherical_particle_filter.py
+++ b/src/pyrecest/filters/hyperspherical_particle_filter.py
@@ -39,9 +39,11 @@ class HypersphericalParticleFilter(AbstractParticleFilter, HypersphericalFilterM
     def predict_identity(self, noise_distribution):
         self.predict_nonlinear(lambda x: x, noise_distribution)
 
-    def update_identity(self, noise_distribution, z):
-        noise_copy = copy.deepcopy(noise_distribution)
-        noise_copy.set_mean(z)
+    def update_identity(self, meas_noise, measurement, shift_instead_of_add: bool = True):
+        if not shift_instead_of_add:
+            raise NotImplementedError()
+        noise_copy = copy.deepcopy(meas_noise)
+        noise_copy.set_mean(measurement)
         self.update_nonlinear(noise_copy.pdf)
 
     def update_nonlinear(self, likelihood, z=None):

--- a/src/pyrecest/filters/joint_probabilistic_data_association_filter.py
+++ b/src/pyrecest/filters/joint_probabilistic_data_association_filter.py
@@ -338,10 +338,18 @@ class JointProbabilisticDataAssociationFilter(AbstractNearestNeighborTracker):
         return map_association
 
     # pylint: disable=too-many-locals,too-many-arguments,too-many-positional-arguments
-    def update_linear(self, measurements, measurement_matrix, covMatsMeas):
+    def update_linear(
+        self,
+        measurements,
+        measurement_matrix,
+        covMatsMeas,
+        pairwise_cost_matrix=None,
+    ):
         assert (
             pyrecest.backend.__backend_name__ == "numpy"
         ), "Only supported for numpy backend"
+        if pairwise_cost_matrix is not None:
+            raise NotImplementedError("JPDAF does not support pairwise_cost_matrix.")
 
         if len(self.filter_bank) == 0:
             warnings.warn("Currently, there are zero targets")

--- a/src/pyrecest/sampling/hyperspherical_sampler.py
+++ b/src/pyrecest/sampling/hyperspherical_sampler.py
@@ -323,11 +323,12 @@ class AbstractHopfBasedS3Sampler(AbstractHypersphericalUniformSampler):
 
 # pylint: disable=too-many-locals
 class HealpixHopfSampler(AbstractHopfBasedS3Sampler):
-    def get_grid(self, grid_density_parameter):
+    def get_grid(self, grid_density_parameter, dim: int = 3):
         """
         Hopf coordinates are (θ, ϕ, ψ) where θ and ϕ are the angles for the sphere and ψ is the angle on the circle
         First parameter is the number of points on the sphere, second parameter is the number of points on the circle.
         """
+        assert dim == 3, "HealpixHopfSampler is only implemented for S3 (dim=3)"
         import healpy as hp
 
         if isinstance(grid_density_parameter, int):
@@ -373,11 +374,12 @@ class HealpixHopfSampler(AbstractHopfBasedS3Sampler):
 
 
 class FibonacciHopfSampler(AbstractHopfBasedS3Sampler):
-    def get_grid(self, grid_density_parameter):
+    def get_grid(self, grid_density_parameter, dim: int = 3):
         """
         Hopf coordinates are (θ, ϕ, ψ) where θ and ϕ are the angles for the sphere and ψ is the angle on the circle
         First parameter is the number of points on the sphere, second parameter is the number of points on the circle.
         """
+        assert dim == 3, "FibonacciHopfSampler is only implemented for S3 (dim=3)"
         if isinstance(grid_density_parameter, int):
             grid_density_parameter = [grid_density_parameter]
 


### PR DESCRIPTION
## Summary

This updates several distribution, filter, and sampler methods to accept interface-compatible optional arguments while preserving the existing behavior.

## Changes

- Pass optional integration boundaries through custom hypercylindrical integration and hyperhemispherical numerical mean computation.
- Accept unused compatibility arguments for covariance, mode, PDF, plotting, and sampler grid methods.
- Add explicit guards for unsupported optional parameters in S2 conditional grids, spherical harmonics integration, JPDAF pairwise costs, and hyperspherical identity updates.

## Validation

- Verified the branch diff against `main` contains only the supplied compatibility-signature changes.
- Tests were not run locally because this thread is not backed by a writable local checkout of the repository.