### PR TITLE
[codex] add gaussian multiplication example

### DIFF
--- a/examples/basic/gaussian_multiplication.py
+++ b/examples/basic/gaussian_multiplication.py
@@ -1,0 +1,77 @@
+"""Example for multiplying multiple Gaussian distributions.
+
+The product of normalized Gaussian densities is proportional to another
+Gaussian. This script creates three two-dimensional Gaussian factors,
+multiplies them with :meth:`GaussianDistribution.multiply`, and verifies the
+result against the closed-form information representation.
+"""
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import allclose, array, diag, linalg, zeros
+from pyrecest.distributions import GaussianDistribution
+
+
+def multiply_all(distributions):
+    """Multiply all Gaussian distributions in sequence."""
+    product = distributions[0]
+    for distribution in distributions[1:]:
+        product = product.multiply(distribution)
+    return product
+
+
+def multiply_all_information_form(distributions):
+    """Compute the normalized Gaussian product in information form."""
+    precision_sum = zeros(distributions[0].C.shape)
+    weighted_mean_sum = zeros(distributions[0].mu.shape)
+
+    for distribution in distributions:
+        precision = linalg.inv(distribution.C)
+        precision_sum = precision_sum + precision
+        weighted_mean_sum = weighted_mean_sum + precision @ distribution.mu
+
+    covariance = linalg.inv(precision_sum)
+    mean = covariance @ weighted_mean_sum
+    return GaussianDistribution(mean, covariance, check_validity=False)
+
+
+def create_gaussian_factors():
+    """Create Gaussian factors to be multiplied."""
+    return [
+        GaussianDistribution(array([0.0, 1.0]), diag(array([4.0, 1.0]))),
+        GaussianDistribution(array([1.0, -0.5]), diag(array([1.0, 2.25]))),
+        GaussianDistribution(array([-0.75, 0.25]), diag(array([0.5, 0.75]))),
+    ]
+
+
+def run_example():
+    """Run the Gaussian multiplication example."""
+    distributions = create_gaussian_factors()
+    product = multiply_all(distributions)
+    reference_product = multiply_all_information_form(distributions)
+    return distributions, product, reference_product
+
+
+def main():
+    """Print the multiplied Gaussian and a closed-form consistency check."""
+    distributions, product, reference_product = run_example()
+
+    print("Gaussian factors:")
+    for index, distribution in enumerate(distributions, start=1):
+        print(f"  factor {index}")
+        print(f"    mean = {distribution.mu}")
+        print(f"    covariance =\n{distribution.C}")
+
+    print("\nProduct computed with GaussianDistribution.multiply():")
+    print(f"  mean = {product.mu}")
+    print(f"  covariance =\n{product.C}")
+
+    print("\nClosed-form information result:")
+    print(f"  mean = {reference_product.mu}")
+    print(f"  covariance =\n{reference_product.C}")
+
+    print("\nMatches closed form:")
+    print(bool(allclose(product.mu, reference_product.mu) and allclose(product.C, reference_product.C)))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
@@ -4,7 +4,7 @@ import copy
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import dot, linalg, ndim, random, reshape
+from pyrecest.backend import linalg, matvec, ndim, random, reshape
 from scipy.linalg import cholesky
 
 from .abstract_linear_distribution import AbstractLinearDistribution
@@ -97,9 +97,13 @@ class GaussianDistribution(AbstractLinearDistribution):
 
     def multiply(self, other):
         assert self.dim == other.dim
-        K = linalg.solve(self.C + other.C, self.C)
-        new_mu = self.mu + dot(K, (other.mu - self.mu))
-        new_C = self.C - dot(K, self.C)
+        self_precision = linalg.inv(self.C)
+        other_precision = linalg.inv(other.C)
+        new_C = linalg.inv(self_precision + other_precision)
+        new_mu = matvec(
+            new_C,
+            matvec(self_precision, self.mu) + matvec(other_precision, other.mu),
+        )
         return GaussianDistribution(new_mu, new_C, check_validity=False)
 
     def convolve(self, other):

--- a/tests/distributions/test_gaussian_distribution.py
+++ b/tests/distributions/test_gaussian_distribution.py
@@ -5,7 +5,7 @@ import pyrecest.backend
 import scipy
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import allclose, array, linspace
+from pyrecest.backend import allclose, array, diag, linalg, linspace, matvec, to_numpy
 from pyrecest.distributions import GaussianDistribution
 from scipy.stats import multivariate_normal
 
@@ -61,6 +61,30 @@ class GaussianDistributionTest(unittest.TestCase):
         g_shifted = g.shift(shift_by)
 
         self.assertTrue(allclose(g_shifted.mode(), mu + shift_by, atol=1e-6))
+
+    def test_multiply_matches_information_form(self):
+        distributions = [
+            GaussianDistribution(array([0.0, 1.0]), diag(array([4.0, 1.0]))),
+            GaussianDistribution(array([1.0, -0.5]), diag(array([1.0, 2.25]))),
+            GaussianDistribution(array([-0.75, 0.25]), diag(array([0.5, 0.75]))),
+        ]
+
+        product = distributions[0]
+        for distribution in distributions[1:]:
+            product = product.multiply(distribution)
+
+        precision_sum = sum(linalg.inv(distribution.C) for distribution in distributions)
+        weighted_mean_sum = sum(
+            matvec(linalg.inv(distribution.C), distribution.mu)
+            for distribution in distributions
+        )
+        expected_covariance = linalg.inv(precision_sum)
+        expected_mean = matvec(expected_covariance, weighted_mean_sum)
+
+        npt.assert_allclose(to_numpy(product.mu), to_numpy(expected_mean), atol=1e-10)
+        npt.assert_allclose(
+            to_numpy(product.C), to_numpy(expected_covariance), atol=1e-10
+        )
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",


### PR DESCRIPTION
## Summary

- Added `examples/basic/gaussian_multiplication.py` to demonstrate multiplying Gaussian distributions and checking the result against the closed-form information representation.
- Fixed `GaussianDistribution.multiply()` to compute the Gaussian product in information form instead of using backend `dot()` for matrix products.
- Added a regression test for multiplying multiple Gaussian factors.

## Validation

- `PYTHONPATH=src python examples/basic/gaussian_multiplication.py`
- `PYTHONPATH=src python -m pytest tests/distributions/test_gaussian_distribution.py`
- `PYTHONPATH=src PYRECEST_BACKEND=pytorch python examples/basic/gaussian_multiplication.py`
- `PYTHONPATH=src PYRECEST_BACKEND=pytorch python -m pytest tests/distributions/test_gaussian_distribution.py`
- `PYTHONPATH=src PYRECEST_BACKEND=jax python examples/basic/gaussian_multiplication.py`
- `PYTHONPATH=src PYRECEST_BACKEND=jax python -m pytest tests/distributions/test_gaussian_distribution.py`