### PR TITLE
Add initial documentation pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ Run the complete script with:
 python examples/basic/kalman_filter.py
 ```
 
+## Documentation
+
+The `docs/` directory contains the first project documentation pages:
+
+- [Getting started](docs/getting-started.md) covers installation, development
+  setup, backend selection, and running examples.
+- [API overview](docs/api-overview.md) maps the main packages and points to the
+  most common public entry points.
+- [Examples](examples/README.md) lists the executable examples and what each
+  one demonstrates.
+
 ## Backends
 
 PyRecEst imports `pyrecest.backend` dynamically. The default backend is NumPy.

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -1,0 +1,113 @@
+# API Overview
+
+PyRecEst exposes most user-facing classes through package-level imports such as
+`pyrecest.distributions`, `pyrecest.filters`, `pyrecest.sampling`,
+`pyrecest.smoothers`, `pyrecest.evaluation`, and `pyrecest.utils`.
+
+Use backend-compatible arrays from `pyrecest.backend` in examples and user code
+when the same code should run on more than one numerical backend.
+
+```python
+from pyrecest.backend import array, diag
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.filters import KalmanFilter
+```
+
+## Package Map
+
+### `pyrecest.backend`
+
+Dynamic backend facade used by the rest of the project. The default backend is
+NumPy. PyTorch and JAX support are selected through `PYRECEST_BACKEND` before
+importing `pyrecest`.
+
+### `pyrecest.distributions`
+
+Probability distributions and density representations on linear spaces,
+periodic spaces, spheres, hyperspheres, hypertori, Cartesian-product spaces,
+and rigid-body state spaces.
+
+Common starting points include:
+
+- `GaussianDistribution` for Euclidean Gaussian states;
+- `GaussianMixture` and `LinearMixture` for mixtures on linear spaces;
+- `VonMisesDistribution` and wrapped distributions for circular states;
+- `VonMisesFisherDistribution`, `BinghamDistribution`, and related classes for
+  hyperspherical states;
+- `HypertoroidalFourierDistribution` and hypertoroidal grid or wrapped-normal
+  distributions for toroidal states.
+
+### `pyrecest.filters`
+
+Recursive Bayesian estimators and trackers. The package includes standard
+linear and unscented Kalman filters, particle filters, grid filters,
+manifold-specific filters, multi-target trackers, extended-object trackers, and
+track-management utilities.
+
+Common starting points include:
+
+- `KalmanFilter` for linear Gaussian Euclidean state estimation;
+- `UnscentedKalmanFilter` and `UKFOnManifolds` for nonlinear models;
+- `EuclideanParticleFilter` and manifold-specific particle filters;
+- `VonMisesFilter`, `VonMisesFisherFilter`, and Fourier or grid filters for
+  directional estimation;
+- `MultiBernoulliTracker`, `GlobalNearestNeighbor`, `JPDAF`, and
+  `TrackManager` for tracking workflows.
+
+### `pyrecest.smoothers`
+
+Backward-pass smoothers that refine filter estimates after a measurement
+sequence has been processed.
+
+Common starting points include:
+
+- `RauchTungStriebelSmoother`;
+- `UnscentedRauchTungStriebelSmoother`.
+
+### `pyrecest.sampling`
+
+Samplers and grid generators for Euclidean and manifold domains.
+
+Common starting points include:
+
+- `GaussianSampler`;
+- `FibonacciGridSampler`;
+- `SphericalFibonacciSampler`;
+- `HealpixHopfSampler`;
+- `LeopardiSampler`;
+- `get_grid_hypersphere`.
+
+### `pyrecest.evaluation`
+
+Simulation, measurement generation, evaluation, plotting, and result summary
+helpers for filter and tracker experiments.
+
+Common starting points include:
+
+- `generate_groundtruth`;
+- `generate_measurements`;
+- `perform_predict_update_cycles`;
+- `evaluate_for_variables`;
+- `summarize_filter_results`;
+- `plot_results`.
+
+### `pyrecest.utils`
+
+Reusable utility helpers for assignment, association models, history recording,
+multi-session assignment, and point-set registration.
+
+Common starting points include:
+
+- `murty_k_best_assignments`;
+- `LogisticPairwiseAssociationModel`;
+- `HistoryRecorder`;
+- `solve_multisession_assignment`;
+- `estimate_thin_plate_spline`.
+
+## Where To Look Next
+
+- Use [the examples guide](../examples/README.md) for small runnable workflows.
+- Use `tests/` as executable reference coverage for APIs that do not yet have
+  dedicated tutorials.
+- Use module docstrings and class docstrings for detailed mathematical notes
+  where they are available.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,90 @@
+# Getting Started
+
+This guide covers the shortest path from installation to running a PyRecEst
+example.
+
+## Requirements
+
+PyRecEst supports Python 3.11 or newer and earlier than Python 3.15.
+
+## Install From PyPI
+
+Install the default NumPy-backed package with:
+
+```bash
+python -m pip install pyrecest
+```
+
+Optional extras install additional backend or domain-specific dependencies:
+
+```bash
+python -m pip install "pyrecest[pytorch_support]"
+python -m pip install "pyrecest[jax_support]"
+python -m pip install "pyrecest[healpy_support]"
+```
+
+## Install For Development
+
+From a source checkout, install all optional dependencies with Poetry:
+
+```bash
+poetry install --with dev --all-extras
+```
+
+The repository also provides a conda environment:
+
+```bash
+conda env create -f environment.yml
+```
+
+Run the test suite from the repository root:
+
+```bash
+python -m pytest
+```
+
+## Run A First Example
+
+The Kalman filter example is the smallest end-to-end filter workflow:
+
+```bash
+python examples/basic/kalman_filter.py
+```
+
+It creates a one-dimensional constant-velocity model, predicts with a linear
+system matrix, updates with scalar position measurements, and prints the current
+position and velocity estimate after each measurement.
+
+## Choose A Backend
+
+PyRecEst imports `pyrecest.backend` dynamically. The default backend is NumPy.
+Set `PYRECEST_BACKEND` before Python imports `pyrecest` to use another backend.
+
+On bash-compatible shells:
+
+```bash
+PYRECEST_BACKEND=pytorch python examples/basic/kalman_filter.py
+PYRECEST_BACKEND=jax python examples/basic/kalman_filter.py
+```
+
+On PowerShell:
+
+```powershell
+$env:PYRECEST_BACKEND = "pytorch"
+python examples/basic/kalman_filter.py
+Remove-Item Env:PYRECEST_BACKEND
+```
+
+Install the matching optional extra before selecting a non-default backend.
+
+Some examples and APIs are backend-specific. For example,
+`examples/basic/multi_target_tracking.py` currently checks for the NumPy backend
+at runtime.
+
+## Explore More Usage
+
+- Start with [the examples guide](../examples/README.md) for runnable scripts.
+- Look at [the API overview](api-overview.md) to find the package that owns a
+  concept.
+- Use `tests/` as executable reference material for advanced APIs that do not
+  have dedicated tutorials yet.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,35 @@
+# PyRecEst Documentation
+
+PyRecEst is a Python library for recursive Bayesian estimation on Euclidean
+spaces and manifolds. The library includes distributions, filters, trackers,
+smoothers, samplers, evaluation helpers, and a backend abstraction for NumPy,
+PyTorch, and JAX.
+
+These Markdown pages are the starting point for project documentation. They are
+kept lightweight so they can be read directly on GitHub while the project grows
+toward a generated documentation site.
+
+## Start Here
+
+- [Getting started](getting-started.md): install PyRecEst, run the examples,
+  choose a backend, and set up a development checkout.
+- [API overview](api-overview.md): understand the main packages and where common
+  public classes live.
+- [Examples](../examples/README.md): browse executable scripts that demonstrate
+  basic workflows.
+
+## Current Documentation Scope
+
+The README gives the shortest install and Kalman filter quickstart. The pages in
+this directory add more orientation, but the tests are still the most complete
+source of usage coverage for many advanced distributions, filters, trackers,
+smoothers, samplers, and evaluation helpers.
+
+Good next documentation additions would be:
+
+- generated API reference from public docstrings;
+- task-focused tutorials for distributions, filters, smoothers, tracking, and
+  evaluation;
+- shape and convention notes for measurements, state vectors, covariances, and
+  grids;
+- backend compatibility notes for APIs that do not support every backend.

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,22 @@
 This directory contains small executable examples that demonstrate common
 PyRecEst workflows.
 
+Run examples from the repository root after installing PyRecEst or after
+installing a development checkout.
+
 ## Basic examples
+
+### Gaussian multiplication
+
+`basic/gaussian_multiplication.py` multiplies several two-dimensional Gaussian
+distributions and checks the result against the closed-form information
+representation.
+
+Run it with:
+
+```bash
+python examples/basic/gaussian_multiplication.py
+```
 
 ### Kalman filter
 
@@ -21,8 +36,35 @@ Run it from the repository root with:
 python examples/basic/kalman_filter.py
 ```
 
+### Multi-target tracking
+
+`basic/multi_target_tracking.py` runs a small linear/Gaussian
+multi-Bernoulli-tracker scenario with two labeled targets, missed detections,
+and clutter measurements.
+
+Run it with:
+
+```bash
+python examples/basic/multi_target_tracking.py
+```
+
+This example currently requires the NumPy backend.
+
+### von Mises-Fisher multiplication
+
+`basic/von_mises_fisher_multiplication.py` multiplies two von Mises-Fisher
+distributions on the unit sphere and verifies the analytic product relation.
+
+Run it with:
+
+```bash
+python examples/basic/von_mises_fisher_multiplication.py
+```
+
+## Backend selection
+
 Select a non-default backend by setting `PYRECEST_BACKEND` before running the
-script, for example:
+script. For example, on a bash-compatible shell:
 
 ```bash
 PYRECEST_BACKEND=pytorch python examples/basic/kalman_filter.py


### PR DESCRIPTION
## Summary

- Add a lightweight `docs/` landing page for project documentation.
- Add a getting-started guide covering installation, development setup, examples, and backend selection.
- Add an API overview that maps the main public packages and common entry points.
- Link the new docs from the README and expand the examples index to cover all current basic examples.

## Validation

- Checked local Markdown links resolve.
- Checked touched Markdown files are ASCII.
- Ran `git diff --check` and `git diff --cached --check`.
- Smoke-ran all documented basic examples with `PYTHONPATH=src`:
  - `python examples/basic/kalman_filter.py`
  - `python examples/basic/gaussian_multiplication.py`
  - `python examples/basic/von_mises_fisher_multiplication.py`
  - `python examples/basic/multi_target_tracking.py`