### PR TITLE
Improve core API docstrings

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/von_mises_fisher_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/von_mises_fisher_distribution.py
@@ -29,7 +29,23 @@ from .abstract_hyperspherical_distribution import AbstractHypersphericalDistribu
 
 
 class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
+    """von Mises-Fisher distribution on the unit hypersphere.
+
+    The distribution is defined on unit vectors in ``R^d``. In PyRecEst,
+    ``input_dim`` is ``d`` and ``dim`` is the manifold dimension ``d - 1``.
+    """
+
     def __init__(self, mu, kappa):
+        """Create a von Mises-Fisher distribution.
+
+        Parameters
+        ----------
+        mu : array-like, shape (d,)
+            Unit mean direction in the embedding space.
+        kappa : float
+            Positive concentration parameter. Larger values concentrate more
+            mass around ``mu``.
+        """
         AbstractHypersphericalDistribution.__init__(self, dim=mu.shape[0] - 1)
         epsilon = 1e-6
         assert mu.ndim == 1, "mu must be a vector"
@@ -50,23 +66,39 @@ class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
             )
 
     def pdf(self, xs):
+        """Evaluate the density at unit vectors.
+
+        Parameters
+        ----------
+        xs : array-like, shape (d,) or (..., d)
+            Unit-vector evaluation point or batch of points in the embedding
+            space.
+        """
         assert xs.shape[-1] == self.input_dim
 
         return self.C * exp(self.kappa * xs @ self.mu)
 
     def mean_direction(self):
+        """Return the unit mean direction with shape ``(d,)``."""
         return self.mu
 
     def sample(self, n):
-        """
-        Generate n von Mises-Fisher distributed random vectors.
+        """Generate random unit vectors from the distribution.
 
-        Parameters:
-        n (int): Number of samples to generate.
+        Parameters
+        ----------
+        n : int
+            Number of samples to generate.
 
-        Returns:
-        array: n von Mises-Fisher distributed random vectors.
-        # Requires scipy 1.11 or later
+        Returns
+        -------
+        array-like, shape (n, d)
+            Random samples on the unit hypersphere.
+
+        Notes
+        -----
+        Sampling currently requires the NumPy backend and SciPy's
+        ``vonmises_fisher`` implementation.
         """
         assert (
             pyrecest.backend.__backend_name__ == "numpy"
@@ -82,6 +114,7 @@ class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
         return samples
 
     def sample_deterministic(self):
+        """Return deterministic sigma points matched to the mean direction."""
         samples = zeros((self.dim + 1, self.dim * 2 + 1))
         samples[0, 0] = 1
         m1 = iv(self.dim / 2, self.kappa, 1) / iv(self.dim / 2 + 1, self.kappa, 1)
@@ -97,6 +130,7 @@ class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
         return samples
 
     def get_rotation_matrix(self):
+        """Return an orthogonal matrix whose first column is ``mu``."""
         M = zeros((self.dim + 1, self.dim + 1))
         M[:, 0] = self.mu
         Q, R = linalg.qr(M)
@@ -105,11 +139,13 @@ class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
         return Q
 
     def mean_resultant_vector(self):
+        """Return the mean resultant vector with shape ``(d,)``."""
         r = self.a_d(self.input_dim, self.kappa) * self.mu
         return r
 
     @staticmethod
     def from_distribution(d):
+        """Fit a von Mises-Fisher distribution to mean-resultant information."""
         assert d.input_dim >= 2, "mu must be at least 2-D for the circular case"
 
         m = d.mean_resultant_vector()
@@ -117,6 +153,14 @@ class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
 
     @staticmethod
     def from_mean_resultant_vector(m):
+        """Create a distribution from a mean resultant vector.
+
+        Parameters
+        ----------
+        m : array-like, shape (d,)
+            Mean resultant vector. Its direction becomes ``mu`` and its norm is
+            inverted to estimate ``kappa``.
+        """
         assert ndim(m) == 1, "mu must be a vector"
         assert len(m) >= 2, "mu must be at least 2 for the circular case"
 
@@ -128,21 +172,25 @@ class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
         return V
 
     def mode(self):
+        """Return the modal direction, equal to ``mu``."""
         return self.mu
 
     def set_mean(self, new_mean):
+        """Replace the mean direction and return the distribution."""
         assert new_mean.shape == self.mu.shape
         dist = self
         dist.mu = copy.deepcopy(new_mean)
         return dist
 
     def set_mode(self, new_mode):
+        """Replace the modal direction and return the distribution."""
         assert new_mode.shape == self.mu.shape
         dist = self
         dist.mu = copy.deepcopy(new_mode)
         return dist
 
     def multiply(self, other: "VonMisesFisherDistribution"):
+        """Multiply two vMF densities and return the normalized product."""
         assert self.mu.shape == other.mu.shape
 
         mu_ = self.kappa * self.mu + other.kappa * other.mu
@@ -151,6 +199,10 @@ class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
         return VonMisesFisherDistribution(mu_, kappa_)
 
     def convolve(self, other: "VonMisesFisherDistribution"):
+        """Convolve with a zonal vMF distribution.
+
+        ``other`` must be zonal around the final coordinate axis.
+        """
         assert other.mu[-1] == 1, "Other is not zonal"
         assert all(self.mu.shape == other.mu.shape)
         d = self.dim + 1
@@ -165,6 +217,7 @@ class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
 
     @staticmethod
     def a_d(d: Union[int, int32, int64], kappa):
+        """Return the ratio of modified Bessel functions used by vMF moments."""
         bessel1 = array(iv(d / 2, kappa))
         bessel2 = array(iv(d / 2 - 1, kappa))
         if isnan(bessel1) or isnan(bessel2):
@@ -173,6 +226,7 @@ class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
 
     @staticmethod
     def a_d_inverse(d: Union[int, int32, int64], x: float):
+        """Numerically invert :meth:`a_d` for dimension ``d`` and value ``x``."""
         kappa_ = x * (d - x**2) / (1 - x**2)
         if isnan(kappa_):
             print(f"Initial kappa_ is NaN for d={d}, x={x}")

--- a/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
@@ -11,6 +11,26 @@ from .abstract_linear_distribution import AbstractLinearDistribution
 
 
 class GaussianDistribution(AbstractLinearDistribution):
+    """Multivariate Gaussian distribution on a Euclidean space.
+
+    Parameters
+    ----------
+    mu : array-like, shape (n,) or scalar
+        Mean vector. Scalar input is treated as a one-dimensional Gaussian.
+    C : array-like, shape (n, n) or scalar
+        Positive-definite covariance matrix. Scalar input is treated as the
+        covariance of a one-dimensional Gaussian.
+    check_validity : bool, optional
+        If true, validate that ``C`` is positive definite.
+
+    Attributes
+    ----------
+    mu : array-like, shape (n,)
+        Mean vector.
+    C : array-like, shape (n, n)
+        Covariance matrix.
+    """
+
     def __init__(self, mu, C, check_validity=True):
         assert ndim(mu) <= 1, "mu must be 1-dimensional"
         if ndim(mu) == 0:
@@ -36,11 +56,32 @@ class GaussianDistribution(AbstractLinearDistribution):
         self.C = C
 
     def set_mean(self, new_mean):
+        """Return a copy with a replaced mean vector.
+
+        Parameters
+        ----------
+        new_mean : array-like, shape (n,)
+            New mean vector.
+        """
         new_dist = copy.deepcopy(self)
         new_dist.mu = new_mean
         return new_dist
 
     def pdf(self, xs):
+        """Evaluate the probability density.
+
+        Parameters
+        ----------
+        xs : array-like, shape (n,) or (..., n)
+            Evaluation point or batch of evaluation points. For a
+            one-dimensional Gaussian, one-dimensional arrays are interpreted as
+            a batch of scalar evaluation points.
+
+        Returns
+        -------
+        array-like
+            Density values with one value per evaluation point.
+        """
         assert (
             self.dim == 1 and xs.ndim <= 1 or xs.shape[-1] == self.dim
         ), "Dimension incorrect"
@@ -75,27 +116,53 @@ class GaussianDistribution(AbstractLinearDistribution):
         return pdfvals
 
     def shift(self, shift_by):
+        """Return a copy with its mean shifted by ``shift_by``.
+
+        Parameters
+        ----------
+        shift_by : array-like, shape (n,) or scalar
+            Additive shift for the mean vector.
+        """
         assert shift_by.ndim == 0 and self.dim == 1 or shift_by.shape[0] == self.dim
         new_gaussian = copy.deepcopy(self)
         new_gaussian.mu = self.mu + shift_by
         return new_gaussian
 
     def mean(self):
+        """Return the mean vector with shape ``(n,)``."""
         return self.mu
 
     def mode(self, starting_point=None):
+        """Return the mode of the Gaussian, equal to the mean vector."""
         _ = starting_point
         return self.mu
 
     def set_mode(self, new_mode):
+        """Return a copy with a replaced mode.
+
+        For a Gaussian distribution, the mode and mean are identical.
+        """
         new_dist = copy.deepcopy(self)
         new_dist.mu = new_mode
         return new_dist
 
     def covariance(self):
+        """Return the covariance matrix with shape ``(n, n)``."""
         return self.C
 
     def multiply(self, other):
+        """Multiply two Gaussian densities and return the normalized product.
+
+        Parameters
+        ----------
+        other : GaussianDistribution
+            Gaussian distribution with the same dimension as ``self``.
+
+        Returns
+        -------
+        GaussianDistribution
+            Gaussian proportional to the pointwise product of both densities.
+        """
         assert self.dim == other.dim
         self_precision = linalg.inv(self.C)
         other_precision = linalg.inv(other.C)
@@ -107,12 +174,31 @@ class GaussianDistribution(AbstractLinearDistribution):
         return GaussianDistribution(new_mu, new_C, check_validity=False)
 
     def convolve(self, other):
+        """Convolve two independent Gaussian distributions.
+
+        Parameters
+        ----------
+        other : GaussianDistribution
+            Gaussian distribution with the same dimension as ``self``.
+
+        Returns
+        -------
+        GaussianDistribution
+            Gaussian whose mean and covariance are the sums of both operands.
+        """
         assert self.dim == other.dim
         new_mu = self.mu + other.mu
         new_C = self.C + other.C
         return GaussianDistribution(new_mu, new_C, check_validity=False)
 
     def marginalize_out(self, dimensions):
+        """Return the marginal distribution after dropping dimensions.
+
+        Parameters
+        ----------
+        dimensions : int or iterable of int
+            Zero-based state dimensions to remove from the distribution.
+        """
         if isinstance(dimensions, int):  # Make it iterable if single integer
             dimensions = [dimensions]
         assert all(dim <= self.dim for dim in dimensions)
@@ -124,10 +210,17 @@ class GaussianDistribution(AbstractLinearDistribution):
         return GaussianDistribution(new_mu, new_C, check_validity=False)
 
     def sample(self, n):
+        """Draw ``n`` random samples with shape ``(n, dim)``."""
         return random.multivariate_normal(mean=self.mu, cov=self.C, size=n)
 
     @staticmethod
     def from_distribution(distribution):
+        """Approximate or convert another distribution as a Gaussian.
+
+        Gaussian mixtures are converted with ``to_gaussian``. Other
+        distributions must expose mean and covariance information compatible
+        with :class:`GaussianDistribution`.
+        """
         from .gaussian_mixture import GaussianMixture
 
         if isinstance(distribution, GaussianMixture):

--- a/src/pyrecest/filters/kalman_filter.py
+++ b/src/pyrecest/filters/kalman_filter.py
@@ -9,7 +9,24 @@ from .manifold_mixins import EuclideanFilterMixin
 
 
 class KalmanFilter(AbstractFilter, EuclideanFilterMixin):
+    """Kalman filter for linear Gaussian Euclidean state-space models.
+
+    The filter state is stored as a :class:`GaussianDistribution` with mean
+    vector shape ``(n,)`` and covariance matrix shape ``(n, n)``. Prediction
+    uses ``x_k = F x_{k-1} + u + w`` and updates use
+    ``z_k = H x_k + v``.
+    """
+
     def __init__(self, initial_state):
+        """Create a Kalman filter from a Gaussian state.
+
+        Parameters
+        ----------
+        initial_state : GaussianDistribution or tuple
+            Initial state distribution. Tuples must contain ``(mean,
+            covariance)`` with mean shape ``(n,)`` or scalar shape for a
+            one-dimensional state, and covariance shape ``(n, n)``.
+        """
         EuclideanFilterMixin.__init__(self)
         AbstractFilter.__init__(self, self._coerce_state(initial_state))
 
@@ -34,11 +51,12 @@ class KalmanFilter(AbstractFilter, EuclideanFilterMixin):
 
     @property
     def dim(self):
-        """Returns the dimension of the state."""
+        """Return the dimension ``n`` of the Euclidean state vector."""
         return self._filter_state.dim
 
     @property
     def filter_state(self) -> GaussianDistribution:
+        """Return a Gaussian copy of the current filter state."""
         return GaussianDistribution(
             self._filter_state.mu,
             self._filter_state.C,
@@ -50,16 +68,23 @@ class KalmanFilter(AbstractFilter, EuclideanFilterMixin):
         """
         Set the filter state.
 
-        :param new_state: Provide GaussianDistribution or mean and covariance as state.
+        Parameters
+        ----------
+        new_state : GaussianDistribution or tuple
+            Replacement state distribution. Tuples must contain ``(mean,
+            covariance)``.
         """
         self._filter_state = self._coerce_state(new_state)
 
     def predict_identity(self, sys_noise_cov, sys_input=None):
-        """
-        Predicts the next state assuming identity transition matrix.
+        """Predict one step with an identity transition matrix.
 
-        :param sys_noise_cov: System noise covariance.
-        :param sys_input: System input.
+        Parameters
+        ----------
+        sys_noise_cov : array-like, shape (n, n)
+            Additive process-noise covariance.
+        sys_input : array-like, shape (n,), optional
+            Additive deterministic input applied after the identity transition.
         """
         self.predict_linear(eye(self.dim), sys_noise_cov, sys_input)
 
@@ -69,12 +94,16 @@ class KalmanFilter(AbstractFilter, EuclideanFilterMixin):
         sys_noise_cov,
         sys_input=None,
     ):
-        """
-        Predicts the next state assuming a linear system model.
+        """Predict one step with a linear Gaussian system model.
 
-        :param system_matrix: System transition matrix.
-        :param sys_noise_cov: System noise covariance.
-        :param sys_input: System input.
+        Parameters
+        ----------
+        system_matrix : array-like, shape (n, n)
+            State-transition matrix ``F``.
+        sys_noise_cov : array-like, shape (n, n)
+            Additive process-noise covariance ``Q``.
+        sys_input : array-like, shape (n,), optional
+            Additive deterministic input ``u``.
         """
         new_mean, new_covariance = linear_gaussian_predict(
             mean=self._filter_state.mu,
@@ -90,11 +119,14 @@ class KalmanFilter(AbstractFilter, EuclideanFilterMixin):
         )
 
     def update_identity(self, meas_noise, measurement):
-        """
-        Update the filter state with measurement, assuming identity measurement matrix.
+        """Update with a measurement matrix equal to the identity.
 
-        :param measurement: Measurement.
-        :param meas_noise: Measurement noise covariance.
+        Parameters
+        ----------
+        meas_noise : array-like, shape (n, n)
+            Measurement-noise covariance.
+        measurement : array-like, shape (n,)
+            Measurement vector.
         """
         self.update_linear(
             measurement=measurement,
@@ -108,12 +140,17 @@ class KalmanFilter(AbstractFilter, EuclideanFilterMixin):
         measurement_matrix,
         meas_noise,
     ):
-        """
-        Update the filter state with measurement, assuming a linear measurement model.
+        """Update the state with a linear Gaussian measurement model.
 
-        :param measurement: Measurement.
-        :param measurement_matrix: Measurement matrix.
-        :param meas_noise: Covariance matrix for measurement.
+        Parameters
+        ----------
+        measurement : array-like, shape (m,)
+            Measurement vector ``z``.
+        measurement_matrix : array-like, shape (m, n)
+            Measurement matrix ``H`` mapping state vectors to measurement
+            vectors.
+        meas_noise : array-like, shape (m, m)
+            Measurement-noise covariance ``R``.
         """
         new_mean, new_covariance = linear_gaussian_update(
             mean=self._filter_state.mu,
@@ -129,5 +166,5 @@ class KalmanFilter(AbstractFilter, EuclideanFilterMixin):
         )
 
     def get_point_estimate(self):
-        """Returns the mean of the current filter state."""
+        """Return the posterior mean vector with shape ``(n,)``."""
         return self._filter_state.mu

--- a/src/pyrecest/filters/multi_bernoulli_tracker.py
+++ b/src/pyrecest/filters/multi_bernoulli_tracker.py
@@ -76,6 +76,10 @@ class MultiBernoulliTracker(AbstractMultitargetTracker):
     To keep the implementation lightweight and close to the rest of PyRecEst, this
     tracker retains a single multi-Bernoulli posterior via a best-assignment
     approximation similar in spirit to the existing nearest-neighbor tracker.
+
+    Measurements are represented as arrays with shape ``(m, num_measurements)``.
+    The measurement matrix has shape ``(m, n)``, where ``n`` is the single-target
+    state dimension and ``m`` is the measurement dimension.
     """
 
     # pylint: disable=too-many-arguments,too-many-positional-arguments
@@ -87,6 +91,26 @@ class MultiBernoulliTracker(AbstractMultitargetTracker):
         log_prior_estimates=True,
         log_posterior_estimates=True,
     ):
+        """Create a multi-Bernoulli tracker.
+
+        Parameters
+        ----------
+        initial_prior : iterable, optional
+            Initial Bernoulli components. Each item can be a
+            :class:`BernoulliComponent`, ``(existence_probability, state)``,
+            ``(existence_probability, state, label)``, or a single-target state
+            accepted by :class:`KalmanFilter`.
+        tracker_param : dict, optional
+            Tracker parameters. Supported keys include survival and detection
+            probabilities, clutter intensity, gating settings, pruning and
+            capping limits, and optional birth settings.
+        birth_components : iterable, optional
+            Bernoulli components appended during prediction.
+        log_prior_estimates : bool, optional
+            If true, store prior estimates after prediction.
+        log_posterior_estimates : bool, optional
+            If true, store posterior estimates after update.
+        """
         if tracker_param is None:
             tracker_param = {
                 "survival_probability": 0.99,
@@ -343,6 +367,7 @@ class MultiBernoulliTracker(AbstractMultitargetTracker):
 
     @property
     def dim(self):
+        """Return the single-target state dimension ``n``."""
         if not self.bernoulli_components:
             raise ValueError(
                 "Cannot provide the state dimension if no Bernoulli components exist."
@@ -351,10 +376,12 @@ class MultiBernoulliTracker(AbstractMultitargetTracker):
 
     @property
     def filter_state(self):
+        """Return a deep copy of the active Bernoulli components."""
         return copy.deepcopy(self.bernoulli_components)
 
     @filter_state.setter
     def filter_state(self, new_state):
+        """Replace active Bernoulli components and assign missing labels."""
         self.bernoulli_components = self._normalize_components(new_state)
         self._assign_missing_labels(self.bernoulli_components)
         if self.log_prior_estimates:
@@ -412,7 +439,14 @@ class MultiBernoulliTracker(AbstractMultitargetTracker):
         ]
 
     def get_labeled_components(self, copy_components=True):
-        """Return active Bernoulli components keyed by track label."""
+        """Return active Bernoulli components keyed by track label.
+
+        Parameters
+        ----------
+        copy_components : bool, optional
+            If true, return deep copies. If false, return references to the
+            tracker-owned components.
+        """
         return {
             copy.deepcopy(component.label): (
                 copy.deepcopy(component) if copy_components else component
@@ -421,14 +455,30 @@ class MultiBernoulliTracker(AbstractMultitargetTracker):
         }
 
     def get_component_by_label(self, label, copy_component=True):
-        """Return a Bernoulli component by track label."""
+        """Return a Bernoulli component by track label.
+
+        Parameters
+        ----------
+        label : hashable
+            Track label to retrieve.
+        copy_component : bool, optional
+            If true, return a deep copy. If false, return the tracker-owned
+            component.
+        """
         for component in self.bernoulli_components:
             if component.label == label:
                 return copy.deepcopy(component) if copy_component else component
         raise KeyError(f"No Bernoulli component with label {label!r} exists.")
 
     def get_track_labels(self, number_of_targets=None):
-        """Return the labels of the extracted target states."""
+        """Return the labels of the extracted target states.
+
+        Parameters
+        ----------
+        number_of_targets : int, optional
+            Number of most likely target states to extract. If omitted, use the
+            MAP cardinality estimate.
+        """
         labels, _ = self.get_labeled_point_estimate(
             flatten_vector=False,
             number_of_targets=number_of_targets,
@@ -441,6 +491,20 @@ class MultiBernoulliTracker(AbstractMultitargetTracker):
         The state extraction follows a common multi-Bernoulli convention: the MAP
         cardinality is used, and the states of the Bernoulli components with the
         highest existence probabilities are returned.
+
+        Parameters
+        ----------
+        flatten_vector : bool, optional
+            If true, flatten the output into a one-dimensional vector.
+        number_of_targets : int, optional
+            Number of most likely target states to extract. If omitted, use the
+            MAP cardinality estimate.
+
+        Returns
+        -------
+        array-like, shape (n, number_of_targets)
+            Extracted point estimates. If ``flatten_vector`` is true, the result
+            is flattened.
         """
         _, point_estimates = self.get_labeled_point_estimate(
             flatten_vector=flatten_vector,
@@ -449,7 +513,15 @@ class MultiBernoulliTracker(AbstractMultitargetTracker):
         return point_estimates
 
     def get_labeled_point_estimate(self, flatten_vector=False, number_of_targets=None):
-        """Return extracted target states together with persistent labels."""
+        """Return extracted target states together with persistent labels.
+
+        Returns
+        -------
+        tuple
+            ``(labels, point_estimates)`` where labels is a list of persistent
+            track labels and point estimates has shape ``(n, number_of_targets)``
+            unless ``flatten_vector`` is true.
+        """
         if not self.bernoulli_components:
             point_estimates = array([]) if flatten_vector else empty((0, 0))
             return [], point_estimates
@@ -510,7 +582,23 @@ class MultiBernoulliTracker(AbstractMultitargetTracker):
     def predict_linear(
         self, system_matrices, sys_noises, inputs=None, birth_components=None
     ):
-        """Predict all Bernoulli components with a linear/Gaussian model."""
+        """Predict all Bernoulli components with a linear/Gaussian model.
+
+        Parameters
+        ----------
+        system_matrices : array-like, shape (n, n) or (n, n, num_components)
+            Shared or per-component state-transition matrices.
+        sys_noises : array-like or GaussianDistribution
+            Shared process-noise covariance with shape ``(n, n)``,
+            per-component covariances with shape ``(n, n, num_components)``, or
+            a zero-mean :class:`GaussianDistribution`.
+        inputs : array-like, optional
+            Shared input with shape ``(n,)`` or per-component inputs with shape
+            ``(n, num_components)``.
+        birth_components : iterable, optional
+            Components appended after prediction instead of the tracker's stored
+            birth components.
+        """
         if isinstance(sys_noises, GaussianDistribution):
             assert backend_all(sys_noises.mu == 0)
             sys_noises = sys_noises.C
@@ -552,7 +640,17 @@ class MultiBernoulliTracker(AbstractMultitargetTracker):
             self.store_prior_estimates()
 
     def find_association(self, measurements, measurement_matrix, cov_mats_meas):
-        """Find the best measurement-to-Bernoulli association."""
+        """Find the best measurement-to-Bernoulli association.
+
+        Parameters
+        ----------
+        measurements : array-like, shape (m,) or (m, num_measurements)
+            Measurement vector or measurement matrix.
+        measurement_matrix : array-like, shape (m, n)
+            Linear map from state vectors to measurement vectors.
+        cov_mats_meas : array-like, shape (m, m) or (m, m, num_measurements)
+            Shared or per-measurement covariance matrices.
+        """
         assert (
             pyrecest.backend.__backend_name__ == "numpy"
         ), "Only supported for numpy backend"
@@ -581,7 +679,19 @@ class MultiBernoulliTracker(AbstractMultitargetTracker):
 
     # pylint: disable=too-many-locals
     def update_linear(self, measurements, measurement_matrix, cov_mats_meas):
-        """Update the multi-Bernoulli tracker with linear/Gaussian measurements."""
+        """Update the tracker with linear/Gaussian measurements.
+
+        Parameters
+        ----------
+        measurements : array-like, shape (m,) or (m, num_measurements)
+            Measurement vector or matrix whose columns are individual
+            measurements.
+        measurement_matrix : array-like, shape (m, n)
+            Linear map from state vectors to measurement vectors.
+        cov_mats_meas : array-like, shape (m, m) or (m, m, num_measurements)
+            Shared measurement-noise covariance or per-measurement covariance
+            matrices.
+        """
         assert (
             pyrecest.backend.__backend_name__ == "numpy"
         ), "Only supported for numpy backend"


### PR DESCRIPTION
## Summary

- Add shape-oriented class and method docstrings for `KalmanFilter`.
- Document `GaussianDistribution` constructor inputs, density evaluation, operations, and sampling shapes.
- Document `VonMisesFisherDistribution` embedding-space conventions, sampling, moments, products, and helpers.
- Expand `MultiBernoulliTracker` docs for initialization, extraction, prediction, association, and measurement update shapes.

## Validation

- `git diff --check`
- `python -m compileall -q src\pyrecest\filters\kalman_filter.py src\pyrecest\filters\multi_bernoulli_tracker.py src\pyrecest\distributions\nonperiodic\gaussian_distribution.py src\pyrecest\distributions\hypersphere_subset\von_mises_fisher_distribution.py`
- `PYTHONPATH=src python -m pytest tests/filters/test_kalman_filter.py tests/filters/test_multi_bernoulli_tracker.py`
- `PYTHONPATH=src python -m pytest tests/distributions/test_gaussian_distribution.py tests/distributions/test_von_mises_fisher_distribution.py`