### PR TITLE
Add task tutorial documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ The `docs/` directory contains the first project documentation pages:
   most common public entry points.
 - [API reference](docs/reference/index.md) contains generated package reference
   pages built with MkDocs and mkdocstrings.
+- [Task tutorials](docs/tutorials/index.md) show common distribution, filtering,
+  tracking, and evaluation workflows.
 - [Shapes and conventions](docs/conventions.md) documents common vector,
   matrix, measurement-set, batch, and manifold-coordinate shapes.
 - [Examples](examples/README.md) lists the executable examples and what each

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -90,6 +90,8 @@ at runtime.
 
 ## Explore More Usage
 
+- Work through [the task tutorials](tutorials/index.md) for distribution,
+  filtering, tracking, and evaluation workflows.
 - Start with [the examples guide](examples.md) for runnable scripts.
 - Look at [the API overview](api-overview.md) to find the package that owns a
   concept.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,8 @@ toward a generated documentation site.
   choose a backend, and set up a development checkout.
 - [API overview](api-overview.md): understand the main packages and where common
   public classes live.
+- [Task tutorials](tutorials/index.md): work through common distribution,
+  filtering, tracking, and evaluation tasks.
 - [Shapes and conventions](conventions.md): learn the expected state,
   measurement, covariance, batch, and manifold-coordinate shapes.
 - [Examples](examples.md): browse executable scripts that demonstrate basic
@@ -31,8 +33,6 @@ smoothers, samplers, and evaluation helpers.
 
 Good next documentation additions would be:
 
-- task-focused tutorials for distributions, filters, smoothers, tracking, and
-  evaluation;
 - deeper convention notes for grids, state-space subdivisions, and advanced
   tracker outputs;
 - backend compatibility notes for APIs that do not support every backend.

--- a/docs/tutorials/evaluate-a-simulation.md
+++ b/docs/tutorials/evaluate-a-simulation.md
@@ -1,0 +1,83 @@
+# Evaluate A Simulation
+
+PyRecEst includes evaluation helpers for generating simulated scenarios, running
+filters, saving the raw evaluation output, and summarizing errors and runtimes.
+
+This tutorial runs the built-in `R2randomWalk` scenario with a Kalman filter.
+The short run count keeps the example fast; larger experiments should use many
+more runs.
+
+```python
+import tempfile
+import warnings
+
+from pyrecest.evaluation import (
+    evaluate_for_simulation_config,
+    summarize_filter_results,
+)
+
+
+filter_configs = [{"name": "kf", "parameter": None}]
+
+with tempfile.TemporaryDirectory() as output_dir:
+    (
+        last_filter_states,
+        runtimes,
+        run_failed,
+        groundtruths,
+        measurements,
+        scenario_config,
+        expanded_filter_configs,
+        evaluation_config,
+    ) = evaluate_for_simulation_config(
+        "R2randomWalk",
+        filter_configs,
+        n_runs=3,
+        n_timesteps=5,
+        initial_seed=1,
+        save_folder=output_dir,
+        auto_warning_on_off=False,
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        summaries = summarize_filter_results(
+            scenario_config=scenario_config,
+            filter_configs=expanded_filter_configs,
+            runtimes=runtimes,
+            groundtruths=groundtruths,
+            run_failed=run_failed,
+            last_filter_states=last_filter_states,
+        )
+
+for result in summaries:
+    print(
+        f"{result['name']}: "
+        f"error_mean={float(result['error_mean']):.3f}, "
+        f"error_std={float(result['error_std']):.3f}, "
+        f"time_mean={float(result['time_mean']):.4f}, "
+        f"failure_rate={float(result['failure_rate']):.3f}"
+    )
+```
+
+## What To Notice
+
+- `evaluate_for_simulation_config()` accepts either a built-in scenario name or
+  a scenario configuration dictionary.
+- `filter_configs` use compact filter names such as `kf` for Kalman filter and
+  `pf` for particle filter.
+- A list or tuple in `parameter` expands into multiple filter configurations.
+  For example, `{"name": "pf", "parameter": [51, 81]}` runs two particle-filter
+  settings.
+- The function saves a timestamped `.npy` file in `save_folder` and also returns
+  the arrays needed for immediate analysis.
+- `summarize_filter_results()` computes aggregate error, runtime, and failure
+  statistics from the returned evaluation data.
+
+## Useful Variations
+
+- Increase `n_runs` for more reliable summary statistics.
+- Set `extract_all_point_estimates=True` when you need estimates at every time
+  step instead of only final states.
+- Use `evaluate_for_file()` when ground truth and measurements already exist in
+  a saved data file.

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,0 +1,24 @@
+# Task Tutorials
+
+These tutorials focus on common PyRecEst tasks. Each page uses the public
+package-level imports and backend-compatible arrays that are recommended for
+user code.
+
+## Tutorials
+
+- [Use a distribution](use-a-distribution.md): create distributions, multiply
+  Gaussian factors, and compare the result with the information-form update.
+- [Write a filter loop](write-a-filter-loop.md): run a Kalman predict/update
+  loop and inspect the posterior state.
+- [Run a tracker](run-a-tracker.md): initialize a labeled multi-Bernoulli
+  tracker and process cluttered measurements.
+- [Evaluate a simulation](evaluate-a-simulation.md): run a built-in scenario,
+  save evaluation output, and summarize filter performance.
+
+## Related Material
+
+- [Getting started](../getting-started.md) covers installation and backend
+  selection.
+- [API overview](../api-overview.md) maps the main packages.
+- [Examples](../../examples/README.md) lists the executable scripts in the
+  repository.

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -20,5 +20,5 @@ user code.
 - [Getting started](../getting-started.md) covers installation and backend
   selection.
 - [API overview](../api-overview.md) maps the main packages.
-- [Examples](../../examples/README.md) lists the executable scripts in the
+- [Examples](../examples.md) lists the executable scripts in the
   repository.

--- a/docs/tutorials/run-a-tracker.md
+++ b/docs/tutorials/run-a-tracker.md
@@ -1,0 +1,91 @@
+# Run A Tracker
+
+Trackers maintain target state estimates over time. This tutorial initializes a
+small labeled multi-Bernoulli tracker with two one-dimensional targets, then
+processes two cluttered measurement sets.
+
+This example currently requires the NumPy backend.
+
+```python
+from pyrecest.backend import array, diag, get_backend_name
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.filters import BernoulliComponent, MultiBernoulliTracker
+
+
+if get_backend_name() != "numpy":
+    raise RuntimeError("This tutorial currently requires the numpy backend.")
+
+initial_covariance = diag(array([0.5, 0.25]))
+initial_components = [
+    BernoulliComponent(
+        0.95,
+        GaussianDistribution(array([0.0, 1.0]), initial_covariance),
+        label="target-1",
+    ),
+    BernoulliComponent(
+        0.95,
+        GaussianDistribution(array([10.0, -0.8]), initial_covariance),
+        label="target-2",
+    ),
+]
+
+tracker = MultiBernoulliTracker(
+    initial_components,
+    tracker_param={
+        "survival_probability": 0.99,
+        "detection_probability": 0.92,
+        "clutter_intensity": 0.02,
+        "gating_probability": 0.999,
+        "gating_distance_threshold": None,
+        "pruning_threshold": 0.05,
+        "maximum_number_of_components": 10,
+        "birth_existence_probability": 0.7,
+        "birth_covariance": None,
+        "measurement_to_state_matrix": None,
+    },
+    log_prior_estimates=False,
+    log_posterior_estimates=False,
+)
+
+system_matrix = array([[1.0, 1.0], [0.0, 1.0]])
+system_noise_covariance = diag(array([0.03, 0.01]))
+measurement_matrix = array([[1.0, 0.0]])
+measurement_noise_covariance = array([[0.16]])
+measurements_by_step = [
+    array([[1.10, 9.15, 5.00]]),
+    array([[2.05, 8.35]]),
+]
+
+for step, measurements in enumerate(measurements_by_step, start=1):
+    tracker.predict_linear(system_matrix, system_noise_covariance)
+    tracker.update_linear(
+        measurements,
+        measurement_matrix,
+        measurement_noise_covariance,
+    )
+
+    labels, estimates = tracker.get_labeled_point_estimate(number_of_targets=2)
+    print(f"step {step}")
+    for column, label in enumerate(labels):
+        print(
+            f"  {label}: position={float(estimates[0, column]):.3f}, "
+            f"velocity={float(estimates[1, column]):.3f}"
+        )
+```
+
+Run the longer executable example with:
+
+```bash
+python examples/basic/multi_target_tracking.py
+```
+
+## What To Notice
+
+- Each `BernoulliComponent` has an existence probability, a state distribution,
+  and a persistent label.
+- The measurement array has shape `(measurement_dim, n_measurements)`.
+- `predict_linear()` propagates every component through the linear motion model.
+- `update_linear()` associates measurements, handles clutter according to the
+  tracker parameters, and updates component states.
+- `get_labeled_point_estimate()` returns labels and a state matrix whose columns
+  correspond to labeled target estimates.

--- a/docs/tutorials/use-a-distribution.md
+++ b/docs/tutorials/use-a-distribution.md
@@ -1,0 +1,56 @@
+# Use A Distribution
+
+This tutorial creates Gaussian distributions, multiplies them, and checks the
+result against the closed-form information representation.
+
+Use `pyrecest.backend` arrays when you want code that can run on supported
+numerical backends.
+
+```python
+from pyrecest.backend import array, diag, linalg, zeros
+from pyrecest.distributions import GaussianDistribution
+
+
+factors = [
+    GaussianDistribution(array([0.0, 1.0]), diag(array([4.0, 1.0]))),
+    GaussianDistribution(array([1.0, -0.5]), diag(array([1.0, 2.25]))),
+    GaussianDistribution(array([-0.75, 0.25]), diag(array([0.5, 0.75]))),
+]
+
+product = factors[0]
+for factor in factors[1:]:
+    product = product.multiply(factor)
+
+precision_sum = zeros(product.C.shape)
+weighted_mean_sum = zeros(product.mu.shape)
+for factor in factors:
+    precision = linalg.inv(factor.C)
+    precision_sum = precision_sum + precision
+    weighted_mean_sum = weighted_mean_sum + precision @ factor.mu
+
+reference_covariance = linalg.inv(precision_sum)
+reference_mean = reference_covariance @ weighted_mean_sum
+
+print("product mean:", product.mu)
+print("reference mean:", reference_mean)
+print("product covariance:")
+print(product.C)
+print("reference covariance:")
+print(reference_covariance)
+```
+
+Run the same task as an executable example with:
+
+```bash
+python examples/basic/gaussian_multiplication.py
+```
+
+## What To Notice
+
+- `GaussianDistribution(mu, C)` stores the mean in `mu` and covariance in `C`.
+- `multiply()` returns a new distribution representing the normalized product.
+- The information-form check adds precisions and precision-weighted means, which
+  is a useful way to verify Gaussian products.
+- Other distribution families follow the same broad pattern: construct the
+  distribution, call methods such as `pdf`, `sample`, `multiply`, or
+  `get_point_estimate`, and keep arrays backend-compatible where possible.

--- a/docs/tutorials/write-a-filter-loop.md
+++ b/docs/tutorials/write-a-filter-loop.md
@@ -1,0 +1,59 @@
+# Write A Filter Loop
+
+Most recursive filters alternate between prediction and update:
+
+1. Predict the next state using the system model.
+2. Update the state with the current measurement.
+3. Read the posterior estimate or keep the filter state for the next step.
+
+The following example runs a one-dimensional constant-velocity Kalman filter.
+The state is `[position, velocity]`, and each measurement observes position.
+
+```python
+from pyrecest.backend import array, diag
+from pyrecest.filters import KalmanFilter
+
+
+dt = 1.0
+system_matrix = array([[1.0, dt], [0.0, 1.0]])
+measurement_matrix = array([[1.0, 0.0]])
+system_noise_cov = diag(array([0.05, 0.01]))
+measurement_noise_cov = array([[0.25]])
+measurements = [0.9, 2.0, 3.1, 3.9, 5.2]
+
+kalman_filter = KalmanFilter(
+    (array([0.0, 1.0]), diag(array([1.0, 1.0])))
+)
+
+for step, measurement in enumerate(measurements, start=1):
+    kalman_filter.predict_linear(system_matrix, system_noise_cov)
+    kalman_filter.update_linear(
+        array([measurement]), measurement_matrix, measurement_noise_cov
+    )
+
+    position, velocity = kalman_filter.get_point_estimate()
+    print(
+        f"{step}: position={float(position):.3f}, "
+        f"velocity={float(velocity):.3f}"
+    )
+
+print("final covariance:")
+print(kalman_filter.filter_state.C)
+```
+
+Run the same task as an executable example with:
+
+```bash
+python examples/basic/kalman_filter.py
+```
+
+## What To Notice
+
+- `KalmanFilter` accepts either a `GaussianDistribution` or a `(mean,
+  covariance)` tuple as its initial state.
+- `predict_linear()` applies the system matrix and system-noise covariance.
+- `update_linear()` applies the measurement matrix and measurement-noise
+  covariance.
+- `get_point_estimate()` returns the current posterior mean.
+- `filter_state` returns a `GaussianDistribution` snapshot of the current
+  posterior state.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,15 @@ nav:
   - Home: index.md
   - Getting Started: getting-started.md
   - Examples: examples.md
+  - Guides:
+      - Shapes and Conventions: conventions.md
+      - Backend Compatibility: backend-compatibility.md
+  - Tutorials:
+      - Overview: tutorials/index.md
+      - Use a Distribution: tutorials/use-a-distribution.md
+      - Write a Filter Loop: tutorials/write-a-filter-loop.md
+      - Run a Tracker: tutorials/run-a-tracker.md
+      - Evaluate a Simulation: tutorials/evaluate-a-simulation.md
   - API Overview: api-overview.md
   - API Reference:
       - Reference Index: reference/index.md


### PR DESCRIPTION
## Summary

- Add a `docs/tutorials/` section with task-focused documentation.
- Cover four common workflows: using distributions, writing a Kalman filter loop, running a multi-Bernoulli tracker, and evaluating a simulation.
- Link the new tutorials from the README, docs landing page, and getting-started guide.

## Validation

- Checked all local Markdown links resolve.
- Checked touched Markdown files are ASCII.
- Ran `git diff --check` and `git diff --cached --check`.
- Executed every Python code block in `docs/tutorials/*.md` with `PYTHONPATH=src`.