### PR TITLE
Add docstring references for distributions and filters

### DIFF
--- a/src/pyrecest/distributions/cart_prod/partially_wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/partially_wrapped_normal_distribution.py
@@ -38,6 +38,16 @@ from .abstract_hypercylindrical_distribution import AbstractHypercylindricalDist
 
 
 class PartiallyWrappedNormalDistribution(AbstractHypercylindricalDistribution):
+    """Partially wrapped normal distribution on periodic-linear domains.
+
+    References
+    ----------
+    Kurz, G., Gilitschenski, I., & Hanebeck, U. D. (2014). The Partially
+    Wrapped Normal Distribution for SE(2) Estimation. Proceedings of the
+    2014 IEEE International Conference on Multisensor Fusion and Information
+    Integration.
+    """
+
     def __init__(self, mu, C, bound_dim: Union[int, int32, int64]):
         assert bound_dim >= 0, "bound_dim must be non-negative"
         assert ndim(mu) == 1, "mu must be a 1-dimensional array"

--- a/src/pyrecest/distributions/cart_prod/se2_pwn_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/se2_pwn_distribution.py
@@ -18,10 +18,12 @@ class SE2PWNDistribution(PartiallyWrappedNormalDistribution, AbstractSE2Distribu
     The first component is the rotation angle (periodic), the second and
     third components are the 2-D translation (linear).
 
-    Based on:
-        Gerhard Kurz, Igor Gilitschenski, Uwe D. Hanebeck,
-        "The Partially Wrapped Normal Distribution for SE(2) Estimation",
-        Proc. IEEE MFI 2014.
+    References
+    ----------
+    Kurz, G., Gilitschenski, I., & Hanebeck, U. D. (2014). The Partially
+    Wrapped Normal Distribution for SE(2) Estimation. Proceedings of the
+    2014 IEEE International Conference on Multisensor Fusion and Information
+    Integration.
     """
 
     def __init__(self, mu, C):

--- a/src/pyrecest/distributions/circle/circular_fourier_distribution.py
+++ b/src/pyrecest/distributions/circle/circular_fourier_distribution.py
@@ -30,8 +30,17 @@ from .circular_dirac_distribution import CircularDiracDistribution
 
 
 class CircularFourierDistribution(AbstractCircularDistribution):
-    """
-    Circular Fourier Distribution. This is based on my implementation for pytorch in pyDirectional
+    """Circular distribution represented by a Fourier series.
+
+    References
+    ----------
+    Pfaff, F., Kurz, G., & Hanebeck, U. D. (2015). Multimodal Circular
+    Filtering Using Fourier Series. Proceedings of the 18th International
+    Conference on Information Fusion.
+
+    Pfaff, F., Kurz, G., & Hanebeck, U. D. (2016). Nonlinear Prediction for
+    Circular Filtering Using Fourier Series. Proceedings of the 19th
+    International Conference on Information Fusion.
     """
 
     # pylint: disable=too-many-arguments, too-many-positional-arguments

--- a/src/pyrecest/distributions/circle/von_mises_distribution.py
+++ b/src/pyrecest/distributions/circle/von_mises_distribution.py
@@ -23,6 +23,14 @@ from .abstract_circular_distribution import AbstractCircularDistribution
 
 
 class VonMisesDistribution(AbstractCircularDistribution):
+    """Von Mises distribution on the circle.
+
+    References
+    ----------
+    Jammalamadaka, S. R., & SenGupta, A. (2001). Topics in Circular
+    Statistics. World Scientific.
+    """
+
     def __init__(
         self,
         mu,

--- a/src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py
@@ -5,6 +5,14 @@ from .abstract_circular_distribution import AbstractCircularDistribution
 
 
 class WrappedCauchyDistribution(AbstractCircularDistribution):
+    """Wrapped Cauchy distribution on the circle.
+
+    References
+    ----------
+    Jammalamadaka, S. R., & SenGupta, A. (2001). Topics in Circular
+    Statistics. World Scientific.
+    """
+
     def __init__(self, mu, gamma):
         AbstractCircularDistribution.__init__(self)
         self.mu = mod(mu, 2 * pi)

--- a/src/pyrecest/distributions/circle/wrapped_laplace_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_laplace_distribution.py
@@ -5,6 +5,15 @@ from .abstract_circular_distribution import AbstractCircularDistribution
 
 
 class WrappedLaplaceDistribution(AbstractCircularDistribution):
+    """Wrapped Laplace distribution on the circle.
+
+    References
+    ----------
+    Jammalamadaka, S. R., & Kozubowski, T. J. (2004). New families of
+    wrapped distributions for modeling skew circular data. Communications in
+    Statistics - Theory and Methods, 33(9), 2059-2074.
+    """
+
     def __init__(self, lambda_, kappa_):
         AbstractCircularDistribution.__init__(self)
         assert lambda_.shape in ((1,), ())

--- a/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
@@ -34,8 +34,12 @@ from .von_mises_distribution import VonMisesDistribution
 class WrappedNormalDistribution(
     AbstractCircularDistribution, HypertoroidalWrappedNormalDistribution
 ):
-    """
-    This class implements the wrapped normal distribution.
+    """Wrapped normal distribution on the circle.
+
+    References
+    ----------
+    Jammalamadaka, S. R., & SenGupta, A. (2001). Topics in Circular
+    Statistics. World Scientific.
     """
 
     MAX_SIGMA_BEFORE_UNIFORM = 10

--- a/src/pyrecest/distributions/hypersphere_subset/bingham_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/bingham_distribution.py
@@ -25,6 +25,14 @@ from .abstract_hyperspherical_distribution import AbstractHypersphericalDistribu
 
 
 class BinghamDistribution(AbstractHypersphericalDistribution):
+    """Bingham distribution on the hypersphere.
+
+    References
+    ----------
+    Bingham, C. (1974). An antipodally symmetric distribution on the sphere.
+    The Annals of Statistics, 2(6), 1201-1225.
+    """
+
     def __init__(self, Z, M):
         AbstractHypersphericalDistribution.__init__(self, M.shape[0] - 1)
 

--- a/src/pyrecest/distributions/hypersphere_subset/von_mises_fisher_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/von_mises_fisher_distribution.py
@@ -29,6 +29,15 @@ from .abstract_hyperspherical_distribution import AbstractHypersphericalDistribu
 
 
 class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
+    """Von Mises-Fisher distribution on the hypersphere.
+
+    References
+    ----------
+    Fisher, R. (1953). Dispersion on a sphere. Proceedings of the Royal
+    Society of London. Series A, Mathematical and Physical Sciences,
+    217(1130), 295-305.
+    """
+
     def __init__(self, mu, kappa):
         AbstractHypersphericalDistribution.__init__(self, dim=mu.shape[0] - 1)
         epsilon = 1e-6

--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_fourier_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_fourier_distribution.py
@@ -56,6 +56,12 @@ class HypertoroidalFourierDistribution(
         - 'identity':  pdf(x) = sum_k C_k exp(i k⋅x)
         - 'sqrt':      pdf(x) = | sum_k C_k exp(i k⋅x) |^2
         - 'log':       pdf(x) ∝ exp(sum_k C_k exp(i k⋅x))  (no auto-normalization)
+
+    References
+    ----------
+    Pfaff, F., Kurz, G., & Hanebeck, U. D. (2016). Multivariate Angular
+    Filtering Using Fourier Series. Journal of Advances in Information
+    Fusion, 11(2), 206-226.
     """
 
     def __init__(self, coeff_mat, transformation: str = "sqrt"):

--- a/src/pyrecest/distributions/hypertorus/toroidal_vm_matrix_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/toroidal_vm_matrix_distribution.py
@@ -27,11 +27,17 @@ _2pi = 2.0 * pi
 class ToroidalVMMatrixDistribution(AbstractToroidalDistribution):
     """Bivariate von Mises distribution, matrix version.
 
-    See:
-    - Mardia, K. V. Statistics of Directional Data. JRSS-B, 1975.
-    - Mardia, K. V. & Jupp, P. E. Directional Statistics. Wiley, 1999.
-    - Kurz, Hanebeck. Toroidal Information Fusion Based on the Bivariate
-      von Mises Distribution. MFI 2015.
+    References
+    ----------
+    Mardia, K. V. (1975). Statistics of Directional Data. Journal of the
+    Royal Statistical Society: Series B, 37, 349-393.
+
+    Mardia, K. V., & Jupp, P. E. (1999). Directional Statistics. Wiley.
+
+    Kurz, G., & Hanebeck, U. D. (2015). Toroidal Information Fusion Based on
+    the Bivariate von Mises Distribution. Proceedings of the 2015 IEEE
+    International Conference on Multisensor Fusion and Information
+    Integration.
     """
 
     def __init__(self, mu, kappa, A):

--- a/src/pyrecest/distributions/hypertorus/toroidal_von_mises_sine_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/toroidal_von_mises_sine_distribution.py
@@ -7,6 +7,14 @@ from .abstract_toroidal_bivar_vm_distribution import AbstractToroidalBivarVMDist
 
 
 class ToroidalVonMisesSineDistribution(AbstractToroidalBivarVMDistribution):
+    """Bivariate von Mises sine model on the torus.
+
+    References
+    ----------
+    Singh, H., Hnizdo, V., & Demchuk, E. (2002). Probabilistic model for
+    two dependent circular variables. Biometrika, 89(3), 719-723.
+    """
+
     def __init__(self, mu, kappa, lambda_):
         AbstractToroidalBivarVMDistribution.__init__(self, mu, kappa)
         assert lambda_.shape == ()

--- a/src/pyrecest/distributions/hypertorus/toroidal_wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/toroidal_wrapped_normal_distribution.py
@@ -12,8 +12,14 @@ from .hypertoroidal_wrapped_normal_distribution import (
 class ToroidalWrappedNormalDistribution(
     HypertoroidalWrappedNormalDistribution, AbstractToroidalDistribution
 ):
-    """
-    Toroidal Wrapped Normal Distribution.
+    """Bivariate wrapped normal distribution on the torus.
+
+    References
+    ----------
+    Kurz, G., Gilitschenski, I., Dolgov, M., & Hanebeck, U. D. (2014).
+    Bivariate Angular Estimation Under Consideration of Dependencies Using
+    Directional Statistics. Proceedings of the 53rd IEEE Conference on
+    Decision and Control.
     """
 
     def mean_4D(self):

--- a/src/pyrecest/filters/circular_particle_filter.py
+++ b/src/pyrecest/filters/circular_particle_filter.py
@@ -10,6 +10,14 @@ from .manifold_mixins import CircularFilterMixin
 
 
 class CircularParticleFilter(HypertoroidalParticleFilter, CircularFilterMixin):
+    """Sequential importance resampling particle filter on the circle.
+
+    References
+    ----------
+    Kurz, G., Gilitschenski, I., & Hanebeck, U. D. (2015). Recursive
+    Bayesian Filtering in Circular State Spaces. arXiv preprint.
+    """
+
     # pylint: disable=non-parent-init-called,super-init-not-called
     def __init__(self, n_particles: Union[int, int32, int64]) -> None:
         """

--- a/src/pyrecest/filters/toroidal_wrapped_normal_filter.py
+++ b/src/pyrecest/filters/toroidal_wrapped_normal_filter.py
@@ -9,6 +9,20 @@ from .manifold_mixins import ToroidalFilterMixin
 
 
 class ToroidalWrappedNormalFilter(AbstractFilter, ToroidalFilterMixin):
+    """Filter based on the bivariate wrapped normal distribution.
+
+    References
+    ----------
+    Kurz, G., Gilitschenski, I., Dolgov, M., & Hanebeck, U. D. (2014).
+    Bivariate Angular Estimation Under Consideration of Dependencies Using
+    Directional Statistics. Proceedings of the 53rd IEEE Conference on
+    Decision and Control.
+
+    Kurz, G., Pfaff, F., & Hanebeck, U. D. (2017). Nonlinear Toroidal
+    Filtering Based on Bivariate Wrapped Normal Distributions. Proceedings of
+    the 20th International Conference on Information Fusion.
+    """
+
     def __init__(self):
         ToroidalFilterMixin.__init__(self)
         AbstractFilter.__init__(

--- a/src/pyrecest/filters/von_mises_fisher_filter.py
+++ b/src/pyrecest/filters/von_mises_fisher_filter.py
@@ -7,6 +7,14 @@ from .manifold_mixins import HypersphericalFilterMixin
 
 
 class VonMisesFisherFilter(AbstractFilter, HypersphericalFilterMixin):
+    """Filter based on the von Mises-Fisher distribution.
+
+    References
+    ----------
+    Kurz, G., Gilitschenski, I., & Hanebeck, U. D. (2016). Unscented von
+    Mises-Fisher Filtering. IEEE Signal Processing Letters.
+    """
+
     def __init__(self):
         HypersphericalFilterMixin.__init__(self)
         AbstractFilter.__init__(

--- a/src/pyrecest/filters/wrapped_normal_filter.py
+++ b/src/pyrecest/filters/wrapped_normal_filter.py
@@ -10,6 +10,18 @@ from .manifold_mixins import CircularFilterMixin
 
 
 class WrappedNormalFilter(AbstractFilter, CircularFilterMixin):
+    """Filter based on the wrapped normal distribution.
+
+    References
+    ----------
+    Kurz, G., Gilitschenski, I., & Hanebeck, U. D. (2013). Recursive
+    Nonlinear Filtering for Angular Data Based on Circular Distributions.
+    Proceedings of the 2013 American Control Conference.
+
+    Kurz, G., Gilitschenski, I., & Hanebeck, U. D. (2015). Recursive
+    Bayesian Filtering in Circular State Spaces. arXiv preprint.
+    """
+
     def __init__(self, wn=None):
         """Initialize the filter."""
         if wn is None:


### PR DESCRIPTION
## Summary

- Add class-level reference sections for selected distributions whose mathematical definitions directly correspond to original papers or standard references.
- Expand abbreviated references for Fourier, partially wrapped normal, and toroidal von Mises/wrapped normal implementations.
- Add concise filter references for circular particle, wrapped normal, toroidal wrapped normal, and von Mises-Fisher filters.

## Impact

This keeps the bibliography close to the API surface users encounter without turning `CITATION.cff` into a broad literature list.

## Validation

- `git diff --check`
- `python -m compileall -q <touched files>`
- `python -m ruff check <touched files>`