### PR TITLE
Add Poetry build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,10 @@ description = "Framework for recursive Bayesian estimation in Python."
 readme = "README.md"
 authors = ["Florian Pfaff <pfaff@ias.uni-stuttgart.de>"]
 version = "1.1.1"
+
+[build-system]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
+build-backend = "poetry.core.masonry.api"
  
 [tool.poetry.dependencies]
 python = ">=3.11,<3.15"


### PR DESCRIPTION
## Summary
- declare Poetry's PEP 517 build backend in `pyproject.toml`
- ensure generic source builds use `poetry-core` metadata instead of falling back to setuptools

## Why
Without an explicit `[build-system]`, `python -m pip wheel --no-deps .` fell back to setuptools and produced a `pyrecest-0.0.0` wheel, while Poetry built `pyrecest-1.1.1` and warned about the missing backend.

## Validation
- `python -m pip wheel --no-deps . -w .codex-wheel-test`
- inspected wheel metadata: `Name: pyrecest`, `Version: 1.1.1`, root package `pyrecest`
- `python -m poetry build`
- `PYTHONPATH=src python -c "import pyrecest, pyrecest.backend as backend; print(pyrecest.__name__, backend.__name__, backend.__backend_name__)"`
- `python -m poetry check` (passes with existing deprecation warnings about legacy `[tool.poetry]` metadata)