### PR TITLE
Move UKF sigma points to sampling

### DIFF
--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -71,6 +71,7 @@ Samplers and grid generators for Euclidean and manifold domains.
 Common starting points include:
 
 - `GaussianSampler`;
+- `MerweScaledSigmaPoints` and `JulierSigmaPoints`;
 - `FibonacciGridSampler`;
 - `SphericalFibonacciSampler`;
 - `HealpixHopfSampler`;

--- a/src/pyrecest/filters/_ukf.py
+++ b/src/pyrecest/filters/_ukf.py
@@ -1,5 +1,4 @@
 """
-Implementations of Merwe-scaled and Julier sigma-point generators and an
 Unscented Kalman Filter (UKF), replacing the former dependency on the
 ``bayesian_filters`` package.
 """
@@ -7,13 +6,10 @@ Unscented Kalman Filter (UKF), replacing the former dependency on the
 from collections import namedtuple
 from copy import deepcopy
 
-import pyrecest.backend
-
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
     asarray,
 )
-from pyrecest.backend import copy as backend_copy
 from pyrecest.backend import (
     einsum,
     empty,
@@ -21,12 +17,12 @@ from pyrecest.backend import (
     expand_dims,
     eye,
     float64,
-    full,
     linalg,
     reshape,
     transpose,
     zeros,
 )
+from pyrecest.sampling.sigma_points import JulierSigmaPoints, MerweScaledSigmaPoints
 
 # ---------------------------------------------------------------------------
 # Model configuration container
@@ -34,128 +30,12 @@ from pyrecest.backend import (
 
 _UKFModel = namedtuple("_UKFModel", ["dim_x", "dim_z", "dt", "hx", "fx", "points"])
 
-# ---------------------------------------------------------------------------
-# Sigma-point generators
-# ---------------------------------------------------------------------------
-
-
-class MerweScaledSigmaPoints:
-    """Merwe scaled sigma points (van der Merwe, 2004).
-
-    Parameters
-    ----------
-    n:
-        State dimension.
-    alpha:
-        Spread of sigma points around the mean (typically 1e-3).
-    beta:
-        Prior knowledge of the distribution (2 is optimal for Gaussians).
-    kappa:
-        Secondary scaling parameter (typically 0).
-    """
-
-    def __init__(self, n: int, alpha: float, beta: float, kappa: float):
-        assert pyrecest.backend.__backend_name__ not in (
-            "jax",
-        ), "MerweScaledSigmaPoints is not supported on the JAX backend"
-        self.n = n
-        self.alpha = alpha
-        self.beta = beta
-        self.kappa = kappa
-        self._compute_weights()
-
-    # ------------------------------------------------------------------
-    def _compute_weights(self):
-        n = self.n
-        lam = self.alpha**2 * (n + self.kappa) - n
-
-        self.Wm = full(2 * n + 1, 0.5 / (n + lam))
-        self.Wm[0] = lam / (n + lam)
-
-        self.Wc = backend_copy(self.Wm)
-        self.Wc[0] = lam / (n + lam) + (1.0 - self.alpha**2 + self.beta)
-
-    # ------------------------------------------------------------------
-    def sigma_points(self, x, P):
-        """Return ``(2n+1, n)`` sigma-point matrix.
-
-        Parameters
-        ----------
-        x:
-            State mean, shape ``(n,)``.
-        P:
-            State covariance, shape ``(n, n)``.
-        """
-        n = self.n
-        lam = self.alpha**2 * (n + self.kappa) - n
-
-        x = reshape(asarray(x, dtype=float64), (-1,))
-        P = asarray(P, dtype=float64)
-
-        U = linalg.cholesky((n + lam) * P)  # lower-triangular
-
-        sigmas = empty((2 * n + 1, n))
-        sigmas[0] = x
-        for i in range(n):
-            sigmas[i + 1] = x + U[:, i]
-            sigmas[n + i + 1] = x - U[:, i]
-        return sigmas
-
-
-class JulierSigmaPoints:
-    """Julier sigma points (Julier & Uhlmann, 1997).
-
-    Parameters
-    ----------
-    n:
-        State dimension.
-    kappa:
-        Scaling parameter (``n + kappa`` should be non-zero).
-    """
-
-    def __init__(self, n: int, kappa: float = 0.0):
-        assert pyrecest.backend.__backend_name__ not in (
-            "jax",
-        ), "JulierSigmaPoints is not supported on the JAX backend"
-        self.n = n
-        self.kappa = kappa
-        self._compute_weights()
-
-    # ------------------------------------------------------------------
-    def _compute_weights(self):
-        n = self.n
-        k = n + self.kappa
-
-        self.Wm = full(2 * n + 1, 0.5 / k)
-        self.Wm[0] = self.kappa / k
-
-        self.Wc = backend_copy(self.Wm)
-
-    # ------------------------------------------------------------------
-    def sigma_points(self, x, P):
-        """Return ``(2n+1, n)`` sigma-point matrix.
-
-        Parameters
-        ----------
-        x:
-            State mean, shape ``(n,)``.
-        P:
-            State covariance, shape ``(n, n)``.
-        """
-        n = self.n
-        k = n + self.kappa
-
-        x = reshape(asarray(x, dtype=float64), (-1,))
-        P = asarray(P, dtype=float64)
-
-        U = linalg.cholesky(k * P)  # lower-triangular
-
-        sigmas = empty((2 * n + 1, n))
-        sigmas[0] = x
-        for i in range(n):
-            sigmas[i + 1] = x + U[:, i]
-            sigmas[n + i + 1] = x - U[:, i]
-        return sigmas
+__all__ = [
+    "_UKFModel",
+    "JulierSigmaPoints",
+    "MerweScaledSigmaPoints",
+    "UnscentedKalmanFilter",
+]
 
 
 # ---------------------------------------------------------------------------

--- a/src/pyrecest/filters/circular_ukf.py
+++ b/src/pyrecest/filters/circular_ukf.py
@@ -14,8 +14,9 @@ import pyrecest.backend
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import array, atleast_1d, mod, pi, sign
 from pyrecest.distributions import GaussianDistribution
+from pyrecest.sampling.sigma_points import MerweScaledSigmaPoints
 
-from ._ukf import MerweScaledSigmaPoints, UnscentedKalmanFilter, _UKFModel
+from ._ukf import UnscentedKalmanFilter, _UKFModel
 from .abstract_filter import AbstractFilter
 from .manifold_mixins import CircularFilterMixin
 

--- a/src/pyrecest/filters/fourier_rhm_tracker.py
+++ b/src/pyrecest/filters/fourier_rhm_tracker.py
@@ -19,8 +19,8 @@ from pyrecest.backend import (
     zeros,
     zeros_like,
 )
+from pyrecest.sampling.sigma_points import MerweScaledSigmaPoints
 
-from ._ukf import MerweScaledSigmaPoints
 from .abstract_extended_object_tracker import AbstractExtendedObjectTracker
 
 

--- a/src/pyrecest/filters/hyperspherical_ukf.py
+++ b/src/pyrecest/filters/hyperspherical_ukf.py
@@ -27,8 +27,8 @@ from pyrecest.backend import (  # pylint: disable=redefined-builtin
     zeros,
 )
 from pyrecest.distributions import GaussianDistribution
+from pyrecest.sampling.sigma_points import MerweScaledSigmaPoints
 
-from ._ukf import MerweScaledSigmaPoints
 from ._ukf import UnscentedKalmanFilter as BayesianFiltersUKF
 from ._ukf import _UKFModel
 from .abstract_filter import AbstractFilter

--- a/src/pyrecest/filters/kernel_sme_filter.py
+++ b/src/pyrecest/filters/kernel_sme_filter.py
@@ -28,8 +28,8 @@ from pyrecest.backend import (
     zeros_like,
 )
 from pyrecest.distributions import GaussianDistribution
+from pyrecest.sampling.sigma_points import JulierSigmaPoints
 
-from ._ukf import JulierSigmaPoints
 from .abstract_multitarget_tracker import AbstractMultitargetTracker
 
 

--- a/src/pyrecest/filters/unscented_kalman_filter.py
+++ b/src/pyrecest/filters/unscented_kalman_filter.py
@@ -4,8 +4,8 @@ from typing import Callable
 import pyrecest.backend
 from pyrecest.backend import atleast_1d, zeros
 from pyrecest.distributions import GaussianDistribution
+from pyrecest.sampling.sigma_points import MerweScaledSigmaPoints
 
-from ._ukf import MerweScaledSigmaPoints
 from ._ukf import UnscentedKalmanFilter as BayesianFiltersUKF
 from ._ukf import _UKFModel
 from .abstract_filter import AbstractFilter

--- a/src/pyrecest/sampling/__init__.py
+++ b/src/pyrecest/sampling/__init__.py
@@ -15,6 +15,7 @@ from .hyperspherical_sampler import (
     get_grid_hypersphere,
 )
 from .hypertoroidal_sampler import CircularUniformSampler
+from .sigma_points import JulierSigmaPoints, MerweScaledSigmaPoints
 
 __all__ = [
     "AbstractSampler",
@@ -30,4 +31,6 @@ __all__ = [
     "HealpixHopfSampler",
     "FibonacciHopfSampler",
     "LeopardiSampler",
+    "JulierSigmaPoints",
+    "MerweScaledSigmaPoints",
 ]

--- a/src/pyrecest/sampling/sigma_points.py
+++ b/src/pyrecest/sampling/sigma_points.py
@@ -1,0 +1,124 @@
+"""
+Sigma-point sampling schemes for unscented transforms.
+"""
+
+import pyrecest.backend
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import asarray, empty, float64, full, linalg, reshape
+from pyrecest.backend import copy as backend_copy
+
+
+class MerweScaledSigmaPoints:
+    """Merwe scaled sigma points (van der Merwe, 2004).
+
+    Parameters
+    ----------
+    n:
+        State dimension.
+    alpha:
+        Spread of sigma points around the mean (typically 1e-3).
+    beta:
+        Prior knowledge of the distribution (2 is optimal for Gaussians).
+    kappa:
+        Secondary scaling parameter (typically 0).
+    """
+
+    def __init__(self, n: int, alpha: float, beta: float, kappa: float):
+        assert pyrecest.backend.__backend_name__ not in (
+            "jax",
+        ), "MerweScaledSigmaPoints is not supported on the JAX backend"
+        self.n = n
+        self.alpha = alpha
+        self.beta = beta
+        self.kappa = kappa
+        self._compute_weights()
+
+    def _compute_weights(self):
+        n = self.n
+        lam = self.alpha**2 * (n + self.kappa) - n
+
+        self.Wm = full(2 * n + 1, 0.5 / (n + lam))
+        self.Wm[0] = lam / (n + lam)
+
+        self.Wc = backend_copy(self.Wm)
+        self.Wc[0] = lam / (n + lam) + (1.0 - self.alpha**2 + self.beta)
+
+    def sigma_points(self, x, P):
+        """Return ``(2n+1, n)`` sigma-point matrix.
+
+        Parameters
+        ----------
+        x:
+            State mean, shape ``(n,)``.
+        P:
+            State covariance, shape ``(n, n)``.
+        """
+        n = self.n
+        lam = self.alpha**2 * (n + self.kappa) - n
+
+        x = reshape(asarray(x, dtype=float64), (-1,))
+        P = asarray(P, dtype=float64)
+
+        U = linalg.cholesky((n + lam) * P)  # lower-triangular
+
+        sigmas = empty((2 * n + 1, n))
+        sigmas[0] = x
+        for i in range(n):
+            sigmas[i + 1] = x + U[:, i]
+            sigmas[n + i + 1] = x - U[:, i]
+        return sigmas
+
+
+class JulierSigmaPoints:
+    """Julier sigma points (Julier and Uhlmann, 1997).
+
+    Parameters
+    ----------
+    n:
+        State dimension.
+    kappa:
+        Scaling parameter (``n + kappa`` should be non-zero).
+    """
+
+    def __init__(self, n: int, kappa: float = 0.0):
+        assert pyrecest.backend.__backend_name__ not in (
+            "jax",
+        ), "JulierSigmaPoints is not supported on the JAX backend"
+        self.n = n
+        self.kappa = kappa
+        self._compute_weights()
+
+    def _compute_weights(self):
+        n = self.n
+        k = n + self.kappa
+
+        self.Wm = full(2 * n + 1, 0.5 / k)
+        self.Wm[0] = self.kappa / k
+
+        self.Wc = backend_copy(self.Wm)
+
+    def sigma_points(self, x, P):
+        """Return ``(2n+1, n)`` sigma-point matrix.
+
+        Parameters
+        ----------
+        x:
+            State mean, shape ``(n,)``.
+        P:
+            State covariance, shape ``(n, n)``.
+        """
+        n = self.n
+        k = n + self.kappa
+
+        x = reshape(asarray(x, dtype=float64), (-1,))
+        P = asarray(P, dtype=float64)
+
+        U = linalg.cholesky(k * P)  # lower-triangular
+
+        sigmas = empty((2 * n + 1, n))
+        sigmas[0] = x
+        for i in range(n):
+            sigmas[i + 1] = x + U[:, i]
+            sigmas[n + i + 1] = x - U[:, i]
+        return sigmas

--- a/src/pyrecest/smoothers/unscented_rauch_tung_striebel_smoother.py
+++ b/src/pyrecest/smoothers/unscented_rauch_tung_striebel_smoother.py
@@ -11,7 +11,7 @@ from typing import Callable, Sequence
 import pyrecest.backend
 from pyrecest.backend import asarray, copy, linalg, ndim, outer, stack, zeros
 from pyrecest.distributions import GaussianDistribution
-from pyrecest.filters._ukf import MerweScaledSigmaPoints
+from pyrecest.sampling.sigma_points import MerweScaledSigmaPoints
 
 from .abstract_smoother import AbstractSmoother
 

--- a/tests/test_sigma_points.py
+++ b/tests/test_sigma_points.py
@@ -1,0 +1,45 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+import pyrecest.backend
+from pyrecest.sampling import JulierSigmaPoints, MerweScaledSigmaPoints
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+    reason="Sigma-point tests use NumPy assertions",
+)
+class TestSigmaPoints(unittest.TestCase):
+    def test_merwe_scaled_sigma_points_match_moments(self):
+        mean = np.array([1.0, -2.0])
+        covariance = np.array([[2.0, 0.4], [0.4, 1.0]])
+        points = MerweScaledSigmaPoints(n=2, alpha=0.5, beta=2.0, kappa=0.0)
+
+        sigmas = points.sigma_points(mean, covariance)
+        weighted_mean = points.Wm @ sigmas
+        deviations = sigmas - weighted_mean
+        weighted_covariance = deviations.T @ (deviations * points.Wc[:, None])
+
+        self.assertEqual(sigmas.shape, (5, 2))
+        npt.assert_allclose(weighted_mean, mean)
+        npt.assert_allclose(weighted_covariance, covariance)
+
+    def test_julier_sigma_points_match_moments(self):
+        mean = np.array([0.5, 1.5])
+        covariance = np.array([[1.5, 0.2], [0.2, 0.5]])
+        points = JulierSigmaPoints(n=2, kappa=1.0)
+
+        sigmas = points.sigma_points(mean, covariance)
+        weighted_mean = points.Wm @ sigmas
+        deviations = sigmas - weighted_mean
+        weighted_covariance = deviations.T @ (deviations * points.Wc[:, None])
+
+        self.assertEqual(sigmas.shape, (5, 2))
+        npt.assert_allclose(weighted_mean, mean)
+        npt.assert_allclose(weighted_covariance, covariance)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sigma_points.py
+++ b/tests/test_sigma_points.py
@@ -3,12 +3,12 @@ import unittest
 import numpy as np
 import numpy.testing as npt
 
-import pyrecest.backend
+from pyrecest.backend import __backend_name__
 from pyrecest.sampling import JulierSigmaPoints, MerweScaledSigmaPoints
 
 
 @unittest.skipIf(
-    pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+    __backend_name__ in ("pytorch", "jax"),
     reason="Sigma-point tests use NumPy assertions",
 )
 class TestSigmaPoints(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Move `MerweScaledSigmaPoints` and `JulierSigmaPoints` from the filter internals into `pyrecest.sampling.sigma_points`.
- Export the sigma-point schemes from `pyrecest.sampling` and update filter/smoother imports to use the sampling module.
- Keep compatibility re-exports from `pyrecest.filters._ukf`, add focused moment tests, and document the sampling API entry points.

## Validation
- `PYTHONPATH=src python -m pytest tests/test_sigma_points.py tests/filters/test_circular_ukf.py tests/filters/test_hyperspherical_ukf.py tests/filters/test_kernel_sme_filter.py tests/filters/test_fourier_rhm_tracker.py tests/filters/test_unscented_kalman_filter.py tests/smoothers/test_unscented_rauch_tung_striebel_smoother.py`
- `python -m ruff check src/pyrecest/sampling/sigma_points.py src/pyrecest/sampling/__init__.py src/pyrecest/filters/_ukf.py src/pyrecest/filters/circular_ukf.py src/pyrecest/filters/fourier_rhm_tracker.py src/pyrecest/filters/hyperspherical_ukf.py src/pyrecest/filters/kernel_sme_filter.py src/pyrecest/filters/unscented_kalman_filter.py src/pyrecest/smoothers/unscented_rauch_tung_striebel_smoother.py tests/test_sigma_points.py`

Note: a whole-repo `ruff check docs src tests` still fails on existing backend re-export warnings unrelated to this change.