### PR TITLE
Add Sobol and Halton proposal grid samplers

### DIFF
--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -72,6 +72,8 @@ Common starting points include:
 
 - `GaussianSampler`;
 - `FibonacciGridSampler`;
+- `SobolGridSampler`;
+- `HaltonGridSampler`;
 - `SphericalFibonacciSampler`;
 - `HealpixHopfSampler`;
 - `LeopardiSampler`;

--- a/src/pyrecest/sampling/__init__.py
+++ b/src/pyrecest/sampling/__init__.py
@@ -3,6 +3,8 @@ from .euclidean_sampler import (
     AbstractEuclideanSampler,
     FibonacciGridSampler,
     GaussianSampler,
+    HaltonGridSampler,
+    SobolGridSampler,
 )
 from .hyperspherical_sampler import (
     AbstractHopfBasedS3Sampler,
@@ -21,6 +23,8 @@ __all__ = [
     "AbstractEuclideanSampler",
     "GaussianSampler",
     "FibonacciGridSampler",
+    "SobolGridSampler",
+    "HaltonGridSampler",
     "get_grid_hypersphere",
     "CircularUniformSampler",
     "AbstractHypersphericalUniformSampler",

--- a/src/pyrecest/sampling/euclidean_sampler.py
+++ b/src/pyrecest/sampling/euclidean_sampler.py
@@ -4,6 +4,7 @@ import warnings
 import numpy as np
 from pyrecest.backend import eye, zeros
 from scipy.special import erfinv as scipy_erfinv
+from scipy.stats import qmc
 
 from ..distributions.nonperiodic.gaussian_distribution import GaussianDistribution
 from .abstract_sampler import AbstractSampler
@@ -16,6 +17,60 @@ class AbstractEuclideanSampler(AbstractSampler):
 class GaussianSampler(AbstractEuclideanSampler):
     def sample_stochastic(self, n_samples: int, dim: int):
         return GaussianDistribution(zeros(dim), eye(dim)).sample(n_samples)
+
+
+class _QMCProposalGridSampler(AbstractEuclideanSampler):
+    """Base class for deterministic low-discrepancy proposal grids."""
+
+    def sample_stochastic(self, n_samples: int, dim: int):
+        """Return deterministic proposal points on the unit hypercube."""
+        return self.get_uniform_samples(n_samples, dim)
+
+    def get_uniform_samples(self, n_samples: int, dim: int):
+        """Return deterministic proposal points in ``[0, 1)^dim``.
+
+        Parameters
+        ----------
+        n_samples : int
+            Number of proposal points.
+        dim : int
+            Dimension of the unit hypercube.
+
+        Returns
+        -------
+        np.ndarray of shape (n_samples, dim)
+        """
+        n_samples, dim = self._validate_grid_args(n_samples, dim)
+        if n_samples == 0:
+            return np.empty((0, dim))
+        return self._make_engine(dim).random(n_samples)
+
+    @staticmethod
+    def _validate_grid_args(n_samples: int, dim: int):
+        n_samples = int(n_samples)
+        dim = int(dim)
+        if n_samples < 0:
+            raise ValueError("n_samples must be nonnegative")
+        if dim < 1:
+            raise ValueError("dim must be positive")
+        return n_samples, dim
+
+    def _make_engine(self, dim: int):
+        raise NotImplementedError
+
+
+class SobolGridSampler(_QMCProposalGridSampler):
+    """Deterministic Sobol proposal grid on the Euclidean unit hypercube."""
+
+    def _make_engine(self, dim: int):
+        return qmc.Sobol(d=dim, scramble=False)
+
+
+class HaltonGridSampler(_QMCProposalGridSampler):
+    """Deterministic Halton proposal grid on the Euclidean unit hypercube."""
+
+    def _make_engine(self, dim: int):
+        return qmc.Halton(d=dim, scramble=False)
 
 
 def _is_prime(n):

--- a/tests/test_euclidean_sampler.py
+++ b/tests/test_euclidean_sampler.py
@@ -3,7 +3,14 @@ import unittest
 import numpy as np
 import numpy.testing as npt
 from pyrecest.backend import mean, ones, random, std, zeros
-from pyrecest.sampling.euclidean_sampler import FibonacciGridSampler, GaussianSampler
+from pyrecest.sampling import HaltonGridSampler as PublicHaltonGridSampler
+from pyrecest.sampling import SobolGridSampler as PublicSobolGridSampler
+from pyrecest.sampling.euclidean_sampler import (
+    FibonacciGridSampler,
+    GaussianSampler,
+    HaltonGridSampler,
+    SobolGridSampler,
+)
 from scipy.stats import shapiro
 
 
@@ -117,6 +124,64 @@ class TestFibonacciGridSampler(unittest.TestCase):
             self.assertEqual(V.shape, (d, d))
             self.assertEqual(R.shape, (d,))
             npt.assert_allclose(V.T @ V, np.eye(d), atol=1e-12)
+
+
+class TestDeterministicProposalGridSamplers(unittest.TestCase):
+    def test_sobol_first_points(self):
+        """Sobol samples should match the unscrambled low-discrepancy sequence."""
+        samples = SobolGridSampler().get_uniform_samples(4, 2)
+        expected = np.array(
+            [
+                [0.0, 0.0],
+                [0.5, 0.5],
+                [0.75, 0.25],
+                [0.25, 0.75],
+            ]
+        )
+        npt.assert_allclose(samples, expected)
+
+    def test_halton_first_points(self):
+        """Halton samples should match the unscrambled low-discrepancy sequence."""
+        samples = HaltonGridSampler().get_uniform_samples(5, 2)
+        expected = np.array(
+            [
+                [0.0, 0.0],
+                [0.5, 1.0 / 3.0],
+                [0.25, 2.0 / 3.0],
+                [0.75, 1.0 / 9.0],
+                [0.125, 4.0 / 9.0],
+            ]
+        )
+        npt.assert_allclose(samples, expected)
+
+    def test_proposal_grids_are_deterministic(self):
+        """Repeated calls should return identical proposal grids."""
+        for sampler in (SobolGridSampler(), HaltonGridSampler()):
+            with self.subTest(sampler=sampler.__class__.__name__):
+                samples1 = sampler.get_uniform_samples(16, 3)
+                samples2 = sampler.get_uniform_samples(16, 3)
+                npt.assert_array_equal(samples1, samples2)
+
+    def test_sample_stochastic_returns_unit_hypercube_proposals(self):
+        """The sampler interface should return deterministic unit-hypercube points."""
+        for sampler in (SobolGridSampler(), HaltonGridSampler()):
+            with self.subTest(sampler=sampler.__class__.__name__):
+                samples = sampler.sample_stochastic(8, 3)
+                self.assertEqual(samples.shape, (8, 3))
+                self.assertTrue(np.all(samples >= 0.0))
+                self.assertTrue(np.all(samples < 1.0))
+
+    def test_zero_samples(self):
+        """Requesting zero proposals should return an empty two-dimensional array."""
+        for sampler in (SobolGridSampler(), HaltonGridSampler()):
+            with self.subTest(sampler=sampler.__class__.__name__):
+                samples = sampler.get_uniform_samples(0, 3)
+                self.assertEqual(samples.shape, (0, 3))
+
+    def test_public_sampling_imports(self):
+        """Sobol and Halton samplers should be exported from pyrecest.sampling."""
+        self.assertIs(PublicSobolGridSampler, SobolGridSampler)
+        self.assertIs(PublicHaltonGridSampler, HaltonGridSampler)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add deterministic Sobol and Halton unit-hypercube proposal grid samplers
- export both samplers from `pyrecest.sampling`
- document the new sampler entry points in the API overview
- cover deterministic sequence values, repeatability, range, zero-sample behavior, and public imports

## Validation

- `PYTHONPATH=src python -m pytest tests/test_euclidean_sampler.py`
- `PYTHONPATH=src python -m pytest tests/test_euclidean_sampler.py tests/test_hyperspherical_sampler.py tests/test_hypertoroidal_sampler.py`