### PR TITLE
Add Fibonacci rejection sampler

### DIFF
--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -72,6 +72,7 @@ Common starting points include:
 
 - `GaussianSampler`;
 - `FibonacciGridSampler`;
+- `FibonacciRejectionSampler`;
 - `SphericalFibonacciSampler`;
 - `HealpixHopfSampler`;
 - `LeopardiSampler`;

--- a/src/pyrecest/sampling/__init__.py
+++ b/src/pyrecest/sampling/__init__.py
@@ -2,6 +2,7 @@ from .abstract_sampler import AbstractSampler
 from .euclidean_sampler import (
     AbstractEuclideanSampler,
     FibonacciGridSampler,
+    FibonacciRejectionSampler,
     GaussianSampler,
 )
 from .hyperspherical_sampler import (
@@ -21,6 +22,7 @@ __all__ = [
     "AbstractEuclideanSampler",
     "GaussianSampler",
     "FibonacciGridSampler",
+    "FibonacciRejectionSampler",
     "get_grid_hypersphere",
     "CircularUniformSampler",
     "AbstractHypersphericalUniformSampler",

--- a/src/pyrecest/sampling/euclidean_sampler.py
+++ b/src/pyrecest/sampling/euclidean_sampler.py
@@ -31,6 +31,7 @@ class FibonacciRejectionSampler(AbstractEuclideanSampler):
         n_candidates: int,
         dim: int,
         max_density: float,
+        *,
         bounding_box=None,
     ):
         """Sample an arbitrary bounded density with deterministic Fibonacci proposals.
@@ -61,10 +62,16 @@ class FibonacciRejectionSampler(AbstractEuclideanSampler):
 
         if n_candidates == 0:
             samples = np.empty((0, dim))
-            return samples, self._get_info(n_candidates, samples, bounding_box, max_density)
+            return samples, self._get_info(
+                n_candidates, samples, bounding_box, max_density
+            )
 
-        proposal_grid = FibonacciGridSampler().get_uniform_samples(n_candidates, dim + 1)
-        candidate_samples = self._map_to_bounding_box(proposal_grid[:, :dim], bounding_box)
+        proposal_grid = FibonacciGridSampler().get_uniform_samples(
+            n_candidates, dim + 1
+        )
+        candidate_samples = self._map_to_bounding_box(
+            proposal_grid[:, :dim], bounding_box
+        )
         density_values = self._evaluate_pdf(pdf, candidate_samples, n_candidates)
 
         if np.any(density_values < 0):
@@ -101,7 +108,9 @@ class FibonacciRejectionSampler(AbstractEuclideanSampler):
         if not np.all(np.isfinite(bounding_box)):
             raise ValueError("bounding_box must be finite")
         if np.any(bounding_box[:, 1] <= bounding_box[:, 0]):
-            raise ValueError("bounding_box upper bounds must be greater than lower bounds")
+            raise ValueError(
+                "bounding_box upper bounds must be greater than lower bounds"
+            )
 
         return n_candidates, dim, max_density, bounding_box
 

--- a/src/pyrecest/sampling/euclidean_sampler.py
+++ b/src/pyrecest/sampling/euclidean_sampler.py
@@ -18,6 +18,125 @@ class GaussianSampler(AbstractEuclideanSampler):
         return GaussianDistribution(zeros(dim), eye(dim)).sample(n_samples)
 
 
+class FibonacciRejectionSampler(AbstractEuclideanSampler):
+    """Deterministic rejection sampler using Fibonacci proposal grids."""
+
+    def sample_stochastic(self, n_samples: int, dim: int):
+        raise NotImplementedError("Use sample_rejection with a density function.")
+
+    def sample_rejection(
+        self,
+        pdf,
+        n_candidates: int,
+        dim: int,
+        max_density: float,
+        bounding_box=None,
+    ):
+        """Sample an arbitrary bounded density with deterministic Fibonacci proposals.
+
+        Parameters
+        ----------
+        pdf : callable
+            Density function accepting an array of shape ``(n_candidates, dim)``.
+        n_candidates : int
+            Number of deterministic proposal points before rejection.
+        dim : int
+            Dimension of the Euclidean domain.
+        max_density : float
+            Upper bound on ``pdf`` inside the bounding box.
+        bounding_box : np.ndarray of shape (dim, 2), optional
+            Lower and upper bounds for each dimension. Defaults to the unit hypercube.
+
+        Returns
+        -------
+        samples : np.ndarray of shape (n_accepted, dim)
+            Accepted samples.
+        info : dict
+            Rejection metadata.
+        """
+        n_candidates, dim, max_density, bounding_box = self._validate_rejection_args(
+            n_candidates, dim, max_density, bounding_box
+        )
+
+        if n_candidates == 0:
+            samples = np.empty((0, dim))
+            return samples, self._get_info(n_candidates, samples, bounding_box, max_density)
+
+        proposal_grid = FibonacciGridSampler().get_uniform_samples(n_candidates, dim + 1)
+        candidate_samples = self._map_to_bounding_box(proposal_grid[:, :dim], bounding_box)
+        density_values = self._evaluate_pdf(pdf, candidate_samples, n_candidates)
+
+        if np.any(density_values < 0):
+            raise ValueError("pdf must be nonnegative")
+        if np.any(density_values > max_density * (1.0 + 1e-12)):
+            raise ValueError("max_density must upper-bound pdf on the bounding box")
+
+        rejection_threshold = proposal_grid[:, dim] * max_density
+        accepted = rejection_threshold <= density_values
+        samples = candidate_samples[accepted]
+        info = self._get_info(n_candidates, samples, bounding_box, max_density)
+        return samples, info
+
+    @staticmethod
+    def _validate_rejection_args(n_candidates, dim, max_density, bounding_box):
+        n_candidates = int(n_candidates)
+        dim = int(dim)
+        max_density = float(max_density)
+
+        if n_candidates < 0:
+            raise ValueError("n_candidates must be nonnegative")
+        if dim < 1:
+            raise ValueError("dim must be positive")
+        if not np.isfinite(max_density) or max_density <= 0:
+            raise ValueError("max_density must be positive and finite")
+
+        if bounding_box is None:
+            bounding_box = np.column_stack((np.zeros(dim), np.ones(dim)))
+        else:
+            bounding_box = np.asarray(bounding_box, dtype=float)
+
+        if bounding_box.shape != (dim, 2):
+            raise ValueError("bounding_box must have shape (dim, 2)")
+        if not np.all(np.isfinite(bounding_box)):
+            raise ValueError("bounding_box must be finite")
+        if np.any(bounding_box[:, 1] <= bounding_box[:, 0]):
+            raise ValueError("bounding_box upper bounds must be greater than lower bounds")
+
+        return n_candidates, dim, max_density, bounding_box
+
+    @staticmethod
+    def _map_to_bounding_box(unit_samples, bounding_box):
+        lower = bounding_box[:, 0]
+        width = bounding_box[:, 1] - bounding_box[:, 0]
+        return unit_samples * width + lower
+
+    @staticmethod
+    def _evaluate_pdf(pdf, samples, n_candidates):
+        density_values = np.asarray(pdf(samples), dtype=float)
+        if density_values.ndim == 0:
+            density_values = np.full(n_candidates, density_values)
+        else:
+            density_values = density_values.reshape(-1)
+
+        if density_values.shape[0] != n_candidates:
+            raise ValueError("pdf must return one density value per candidate sample")
+        if not np.all(np.isfinite(density_values)):
+            raise ValueError("pdf must return finite density values")
+        return density_values
+
+    @staticmethod
+    def _get_info(n_candidates, samples, bounding_box, max_density):
+        n_accepted = samples.shape[0]
+        return {
+            "n_candidates": n_candidates,
+            "n_accepted": n_accepted,
+            "n_rejected": n_candidates - n_accepted,
+            "acceptance_rate": n_accepted / n_candidates if n_candidates else 0.0,
+            "bounding_box": bounding_box,
+            "max_density": max_density,
+        }
+
+
 def _is_prime(n):
     if n < 2:
         return False

--- a/tests/test_euclidean_sampler.py
+++ b/tests/test_euclidean_sampler.py
@@ -3,7 +3,12 @@ import unittest
 import numpy as np
 import numpy.testing as npt
 from pyrecest.backend import mean, ones, random, std, zeros
-from pyrecest.sampling.euclidean_sampler import FibonacciGridSampler, GaussianSampler
+from pyrecest.sampling import FibonacciRejectionSampler as PublicFibonacciRejectionSampler
+from pyrecest.sampling.euclidean_sampler import (
+    FibonacciGridSampler,
+    FibonacciRejectionSampler,
+    GaussianSampler,
+)
 from scipy.stats import shapiro
 
 
@@ -117,6 +122,122 @@ class TestFibonacciGridSampler(unittest.TestCase):
             self.assertEqual(V.shape, (d, d))
             self.assertEqual(R.shape, (d,))
             npt.assert_allclose(V.T @ V, np.eye(d), atol=1e-12)
+
+
+class TestFibonacciRejectionSampler(unittest.TestCase):
+    def setUp(self):
+        self.sampler = FibonacciRejectionSampler()
+
+    def test_unit_density_accepts_all_unit_cube_candidates(self):
+        """A unit-density target with max_density=1 should accept all candidates."""
+        n_candidates = 25
+        samples, info = self.sampler.sample_rejection(
+            lambda xs: np.ones(xs.shape[0]),
+            n_candidates=n_candidates,
+            dim=2,
+            max_density=1.0,
+        )
+        expected = FibonacciGridSampler().get_uniform_samples(n_candidates, 3)[:, :2]
+
+        self.assertEqual(samples.shape, (n_candidates, 2))
+        npt.assert_allclose(samples, expected)
+        self.assertEqual(info["n_candidates"], n_candidates)
+        self.assertEqual(info["n_accepted"], n_candidates)
+        self.assertEqual(info["n_rejected"], 0)
+        self.assertEqual(info["acceptance_rate"], 1.0)
+        npt.assert_allclose(info["bounding_box"], np.array([[0.0, 1.0], [0.0, 1.0]]))
+
+    def test_bounding_box_mapping(self):
+        """Accepted samples should be mapped from the unit grid into the bounding box."""
+        n_candidates = 30
+        bounding_box = np.array([[-2.0, 2.0], [10.0, 20.0]])
+        samples, _ = self.sampler.sample_rejection(
+            lambda xs: np.ones(xs.shape[0]),
+            n_candidates=n_candidates,
+            dim=2,
+            max_density=1.0,
+            bounding_box=bounding_box,
+        )
+        unit_samples = FibonacciGridSampler().get_uniform_samples(n_candidates, 3)[:, :2]
+        expected = unit_samples * np.array([4.0, 10.0]) + np.array([-2.0, 10.0])
+
+        npt.assert_allclose(samples, expected)
+        self.assertTrue(np.all(samples[:, 0] >= -2.0))
+        self.assertTrue(np.all(samples[:, 0] <= 2.0))
+        self.assertTrue(np.all(samples[:, 1] >= 10.0))
+        self.assertTrue(np.all(samples[:, 1] <= 20.0))
+
+    def test_rejection_rule_matches_fibonacci_ordinate(self):
+        """The last Fibonacci-grid coordinate should drive deterministic rejection."""
+        n_candidates = 40
+        samples, info = self.sampler.sample_rejection(
+            lambda xs: np.full(xs.shape[0], 0.5),
+            n_candidates=n_candidates,
+            dim=1,
+            max_density=1.0,
+        )
+        proposal_grid = FibonacciGridSampler().get_uniform_samples(n_candidates, 2)
+        expected = proposal_grid[proposal_grid[:, 1] <= 0.5, :1]
+
+        npt.assert_allclose(samples, expected)
+        self.assertEqual(info["n_accepted"], expected.shape[0])
+        self.assertEqual(info["n_rejected"], n_candidates - expected.shape[0])
+
+    def test_sampling_is_deterministic(self):
+        """Repeated calls with the same density should return identical accepted samples."""
+        pdf = lambda xs: np.exp(-np.sum(xs**2, axis=1))
+        bounding_box = np.array([[-1.0, 1.0], [-1.0, 1.0]])
+        samples1, info1 = self.sampler.sample_rejection(pdf, 60, 2, 1.0, bounding_box)
+        samples2, info2 = self.sampler.sample_rejection(pdf, 60, 2, 1.0, bounding_box)
+
+        npt.assert_array_equal(samples1, samples2)
+        self.assertEqual(info1["n_accepted"], info2["n_accepted"])
+        self.assertEqual(info1["n_rejected"], info2["n_rejected"])
+
+    def test_zero_candidates(self):
+        """Requesting no candidates should return empty samples and zero metadata."""
+        samples, info = self.sampler.sample_rejection(
+            lambda xs: np.ones(xs.shape[0]),
+            n_candidates=0,
+            dim=2,
+            max_density=1.0,
+        )
+
+        self.assertEqual(samples.shape, (0, 2))
+        self.assertEqual(info["n_candidates"], 0)
+        self.assertEqual(info["n_accepted"], 0)
+        self.assertEqual(info["n_rejected"], 0)
+        self.assertEqual(info["acceptance_rate"], 0.0)
+
+    def test_max_density_must_bound_pdf(self):
+        """The sampler should reject invalid density upper bounds."""
+        with self.assertRaises(ValueError):
+            self.sampler.sample_rejection(
+                lambda xs: np.ones(xs.shape[0]),
+                n_candidates=10,
+                dim=1,
+                max_density=0.5,
+            )
+
+    def test_invalid_bounding_box(self):
+        """Bounding boxes need one lower and one upper value per dimension."""
+        with self.assertRaises(ValueError):
+            self.sampler.sample_rejection(
+                lambda xs: np.ones(xs.shape[0]),
+                n_candidates=10,
+                dim=2,
+                max_density=1.0,
+                bounding_box=np.array([[0.0, 1.0]]),
+            )
+
+    def test_sample_stochastic_is_not_available(self):
+        """Density-free stochastic sampling is not the rejection sampler interface."""
+        with self.assertRaises(NotImplementedError):
+            self.sampler.sample_stochastic(10, 2)
+
+    def test_public_sampling_import(self):
+        """FibonacciRejectionSampler should be exported from pyrecest.sampling."""
+        self.assertIs(PublicFibonacciRejectionSampler, FibonacciRejectionSampler)
 
 
 if __name__ == "__main__":

--- a/tests/test_euclidean_sampler.py
+++ b/tests/test_euclidean_sampler.py
@@ -3,7 +3,9 @@ import unittest
 import numpy as np
 import numpy.testing as npt
 from pyrecest.backend import mean, ones, random, std, zeros
-from pyrecest.sampling import FibonacciRejectionSampler as PublicFibonacciRejectionSampler
+from pyrecest.sampling import (
+    FibonacciRejectionSampler as PublicFibonacciRejectionSampler,
+)
 from pyrecest.sampling import HaltonGridSampler as PublicHaltonGridSampler
 from pyrecest.sampling import SobolGridSampler as PublicSobolGridSampler
 from pyrecest.sampling.euclidean_sampler import (
@@ -127,6 +129,7 @@ class TestFibonacciGridSampler(unittest.TestCase):
             self.assertEqual(R.shape, (d,))
             npt.assert_allclose(V.T @ V, np.eye(d), atol=1e-12)
 
+
 class TestFibonacciRejectionSampler(unittest.TestCase):
     def setUp(self):
         self.sampler = FibonacciRejectionSampler()
@@ -161,7 +164,9 @@ class TestFibonacciRejectionSampler(unittest.TestCase):
             max_density=1.0,
             bounding_box=bounding_box,
         )
-        unit_samples = FibonacciGridSampler().get_uniform_samples(n_candidates, 3)[:, :2]
+        unit_samples = FibonacciGridSampler().get_uniform_samples(n_candidates, 3)[
+            :, :2
+        ]
         expected = unit_samples * np.array([4.0, 10.0]) + np.array([-2.0, 10.0])
 
         npt.assert_allclose(samples, expected)
@@ -188,10 +193,17 @@ class TestFibonacciRejectionSampler(unittest.TestCase):
 
     def test_sampling_is_deterministic(self):
         """Repeated calls with the same density should return identical accepted samples."""
-        pdf = lambda xs: np.exp(-np.sum(xs**2, axis=1))
+
+        def pdf(xs):
+            return np.exp(-np.sum(xs**2, axis=1))
+
         bounding_box = np.array([[-1.0, 1.0], [-1.0, 1.0]])
-        samples1, info1 = self.sampler.sample_rejection(pdf, 60, 2, 1.0, bounding_box)
-        samples2, info2 = self.sampler.sample_rejection(pdf, 60, 2, 1.0, bounding_box)
+        samples1, info1 = self.sampler.sample_rejection(
+            pdf, 60, 2, 1.0, bounding_box=bounding_box
+        )
+        samples2, info2 = self.sampler.sample_rejection(
+            pdf, 60, 2, 1.0, bounding_box=bounding_box
+        )
 
         npt.assert_array_equal(samples1, samples2)
         self.assertEqual(info1["n_accepted"], info2["n_accepted"])


### PR DESCRIPTION
## Summary

- add `FibonacciRejectionSampler` for deterministic rejection sampling from bounded Euclidean densities
- use `(dim + 1)` Fibonacci unit-hypercube grids, mapping the first `dim` coordinates into a bounding box and the final coordinate to the rejection ordinate
- return accepted samples plus rejection metadata
- export and document the new sampler
- cover acceptance, bounding-box mapping, deterministic rejection, metadata, validation, and public imports

## Validation

- `PYTHONPATH=src python -m pytest tests/test_euclidean_sampler.py`
- `PYTHONPATH=src python -m pytest tests/test_euclidean_sampler.py tests/test_hyperspherical_sampler.py tests/test_hypertoroidal_sampler.py`
- `git diff --check`