### PR TITLE
Add manifold exponential moving average

### DIFF
--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -51,6 +51,7 @@ Common starting points include:
 
 - `KalmanFilter` for linear Gaussian Euclidean state estimation;
 - `UnscentedKalmanFilter` and `UKFOnManifolds` for nonlinear models;
+- `ManifoldExponentialMovingAverage` for streaming manifold-valued samples;
 - `EuclideanParticleFilter` and manifold-specific particle filters;
 - `VonMisesFilter`, `VonMisesFisherFilter`, and Fourier or grid filters for
   directional estimation;

--- a/src/pyrecest/filters/__init__.py
+++ b/src/pyrecest/filters/__init__.py
@@ -53,6 +53,7 @@ from .kalman_filter import KalmanFilter
 from .kernel_sme_filter import KernelSMEFilter
 from .lin_bounded_particle_filter import LinBoundedParticleFilter
 from .lin_periodic_particle_filter import LinPeriodicParticleFilter
+from .manifold_exponential_moving_average import ManifoldExponentialMovingAverage
 from .manifold_mixins import (
     AbstractFilterManifoldMixin,
     AbstractHypersphereSubsetFilter,
@@ -157,6 +158,7 @@ __all__ = [
     "LinBoundedParticleFilter",
     "LinPeriodicFilterMixin",
     "BernoulliComponent",
+    "ManifoldExponentialMovingAverage",
     "MultiBernoulliTracker",
     "MultipleExtendedObjectStepResult",
     "LinPeriodicParticleFilter",

--- a/src/pyrecest/filters/manifold_exponential_moving_average.py
+++ b/src/pyrecest/filters/manifold_exponential_moving_average.py
@@ -1,0 +1,87 @@
+"""Exponential moving average for states on manifolds."""
+
+from typing import Any, Callable
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import asarray
+
+from .abstract_filter import AbstractFilter
+
+
+class ManifoldExponentialMovingAverage(AbstractFilter):
+    """Exponential moving average on a manifold.
+
+    The estimate is updated by moving from the current state toward each new
+    sample in the tangent space at the current estimate:
+
+    ``x_new = phi(x, alpha * phi_inv(x, sample))``.
+
+    Parameters
+    ----------
+    initial_state:
+        Initial manifold element. If ``None``, the first update initializes the
+        estimate directly from the first sample.
+    alpha:
+        Weight of the new sample. Must be in ``[0, 1]``.
+    phi:
+        Retraction with signature ``phi(state, tangent_vector) -> state``.
+    phi_inv:
+        Inverse retraction with signature
+        ``phi_inv(state_ref, state) -> tangent_vector``.
+    """
+
+    def __init__(
+        self,
+        initial_state: Any,
+        alpha: float,
+        phi: Callable,
+        phi_inv: Callable,
+    ):
+        if not callable(phi):
+            raise TypeError("phi must be callable")
+        if not callable(phi_inv):
+            raise TypeError("phi_inv must be callable")
+
+        self.phi = phi
+        self.phi_inv = phi_inv
+        self._alpha = self._validate_alpha(alpha)
+
+        AbstractFilter.__init__(self, initial_state)
+
+    @staticmethod
+    def _validate_alpha(alpha: float) -> float:
+        alpha = float(alpha)
+        if alpha < 0.0 or alpha > 1.0:
+            raise ValueError("alpha must be between 0 and 1")
+        return alpha
+
+    @property
+    def alpha(self) -> float:
+        """Weight assigned to each new sample."""
+        return self._alpha
+
+    @alpha.setter
+    def alpha(self, alpha: float):
+        self._alpha = self._validate_alpha(alpha)
+
+    @property
+    def filter_state(self):
+        """Return the current manifold estimate."""
+        return self._filter_state
+
+    @filter_state.setter
+    def filter_state(self, new_state):
+        self._filter_state = new_state
+
+    def update(self, sample):
+        """Update the moving average with a new manifold-valued sample."""
+        if self._filter_state is None:
+            self._filter_state = sample
+            return
+
+        tangent_update = self.alpha * asarray(self.phi_inv(self._filter_state, sample))
+        self._filter_state = self.phi(self._filter_state, tangent_update)
+
+    def get_point_estimate(self):
+        """Return the current manifold estimate."""
+        return self._filter_state

--- a/tests/filters/test_manifold_exponential_moving_average.py
+++ b/tests/filters/test_manifold_exponential_moving_average.py
@@ -1,0 +1,87 @@
+import unittest
+
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array, pi
+from pyrecest.filters import ManifoldExponentialMovingAverage
+
+
+def _phi_euclidean(state, xi):
+    return state + xi
+
+
+def _phi_inv_euclidean(state_ref, state):
+    return state - state_ref
+
+
+def _phi_so2(state, xi):
+    return state + xi[0]
+
+
+def _phi_inv_so2(state_ref, state):
+    diff = state - state_ref
+    return array([(diff + pi) % (2.0 * pi) - pi])
+
+
+class TestManifoldExponentialMovingAverage(unittest.TestCase):
+    def test_update_matches_euclidean_ema(self):
+        ema = ManifoldExponentialMovingAverage(
+            initial_state=array([0.0, 0.0]),
+            alpha=0.25,
+            phi=_phi_euclidean,
+            phi_inv=_phi_inv_euclidean,
+        )
+
+        ema.update(array([4.0, -2.0]))
+        npt.assert_allclose(ema.get_point_estimate(), array([1.0, -0.5]))
+
+        ema.update(array([4.0, -2.0]))
+        npt.assert_allclose(ema.filter_state, array([1.75, -0.875]))
+
+    def test_first_update_initializes_empty_estimate(self):
+        sample = array([2.0, 3.0])
+        ema = ManifoldExponentialMovingAverage(
+            initial_state=None,
+            alpha=0.5,
+            phi=_phi_euclidean,
+            phi_inv=_phi_inv_euclidean,
+        )
+
+        ema.update(sample)
+
+        npt.assert_allclose(ema.get_point_estimate(), sample)
+
+    def test_circle_update_uses_shortest_tangent_direction(self):
+        ema = ManifoldExponentialMovingAverage(
+            initial_state=3.0,
+            alpha=0.5,
+            phi=_phi_so2,
+            phi_inv=_phi_inv_so2,
+        )
+
+        ema.update(-3.0)
+
+        npt.assert_allclose(ema.get_point_estimate(), pi, atol=1e-12)
+
+    def test_alpha_must_be_between_zero_and_one(self):
+        with self.assertRaises(ValueError):
+            ManifoldExponentialMovingAverage(
+                initial_state=0.0,
+                alpha=1.1,
+                phi=_phi_so2,
+                phi_inv=_phi_inv_so2,
+            )
+
+        ema = ManifoldExponentialMovingAverage(
+            initial_state=0.0,
+            alpha=1.0,
+            phi=_phi_so2,
+            phi_inv=_phi_inv_so2,
+        )
+        with self.assertRaises(ValueError):
+            ema.alpha = -0.1
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `ManifoldExponentialMovingAverage`, a generic exponential moving average filter for manifold-valued samples. The update moves the current estimate toward each new sample in the local tangent space using the same `phi` / `phi_inv` retraction convention used by `UKFOnManifolds`.

The class supports initializing from an explicit initial state or from the first observed sample, validates the EMA weight, exposes the current estimate through `filter_state` and `get_point_estimate`, and is exported from `pyrecest.filters`.

## Tests

- `PYTHONPATH=src python -m pytest tests/filters/test_manifold_exponential_moving_average.py tests/filters/test_ukf_on_manifolds.py -q`
- `PYTHONPATH=src python -m pytest tests/filters -q` timed out after 5 minutes in the local environment without producing a failure report.