### PR TITLE
Add SO3 Dirac distribution

### DIFF
--- a/src/pyrecest/distributions/__init__.py
+++ b/src/pyrecest/distributions/__init__.py
@@ -254,6 +254,7 @@ from .nonperiodic.linear_mixture import LinearMixture
 from .se2_dirac_distribution import SE2DiracDistribution
 from .se3_cart_prod_stacked_distribution import SE3CartProdStackedDistribution
 from .se3_dirac_distribution import SE3DiracDistribution
+from .so3_dirac_distribution import SO3DiracDistribution
 
 # Aliases for brevity and compatibility with libDirectional
 HypertoroidalWNDistribution = HypertoroidalWrappedNormalDistribution
@@ -413,5 +414,6 @@ __all__ = aliases + [
     "SE2DiracDistribution",
     "SE3CartProdStackedDistribution",
     "SE3DiracDistribution",
+    "SO3DiracDistribution",
     "SE2BinghamDistribution",
 ]

--- a/src/pyrecest/distributions/so3_dirac_distribution.py
+++ b/src/pyrecest/distributions/so3_dirac_distribution.py
@@ -6,41 +6,34 @@ from pyrecest.backend import (
     all,
     amax,
     arccos,
-    argmax,
     array,
     asarray,
     clip,
-    column_stack,
     linalg,
     ndim,
-    outer,
     reshape,
     spatial,
     sum,
     where,
-    zeros,
 )
 
-from .abstract_dirac_distribution import AbstractDiracDistribution
+from .hypersphere_subset.hyperhemispherical_dirac_distribution import (
+    HyperhemisphericalDiracDistribution,
+)
 
 
-class SO3DiracDistribution(AbstractDiracDistribution):
+class SO3DiracDistribution(HyperhemisphericalDiracDistribution):
     """Weighted Dirac distribution on SO(3).
 
-    The distribution stores rotations as unit quaternions with scalar-first
-    coordinates ``(w, x, y, z)``. Since ``q`` and ``-q`` represent the same
+    The distribution stores rotations as unit quaternions with scalar-last
+    coordinates ``(x, y, z, w)``. Since ``q`` and ``-q`` represent the same
     rotation, quaternions are canonicalized to a nonnegative scalar component
     during construction.
     """
 
     def __init__(self, d, w=None):
         quaternions = self._normalize_quaternions(d)
-        self.dim = 3
         super().__init__(quaternions, w=w)
-
-    @property
-    def input_dim(self):
-        return 4
 
     @staticmethod
     def _normalize_quaternions(quaternions):
@@ -53,29 +46,8 @@ class SO3DiracDistribution(AbstractDiracDistribution):
         assert all(norms > 0.0), "SO(3) quaternions must be nonzero."
 
         normalized = quaternions / reshape(norms, (-1, 1))
-        sign = where(normalized[:, 0:1] < 0.0, -1.0, 1.0)
+        sign = where(normalized[:, -1:] < 0.0, -1.0, 1.0)
         return sign * normalized
-
-    @staticmethod
-    def _as_xyzw(quaternions):
-        quaternions = SO3DiracDistribution._normalize_quaternions(quaternions)
-        return column_stack(
-            (quaternions[:, 1], quaternions[:, 2], quaternions[:, 3], quaternions[:, 0])
-        )
-
-    @staticmethod
-    def _as_wxyz(quaternions_xyzw):
-        quaternions_xyzw = asarray(quaternions_xyzw)
-        if ndim(quaternions_xyzw) == 1:
-            quaternions_xyzw = reshape(quaternions_xyzw, (1, 4))
-        return column_stack(
-            (
-                quaternions_xyzw[:, 3],
-                quaternions_xyzw[:, 0],
-                quaternions_xyzw[:, 1],
-                quaternions_xyzw[:, 2],
-            )
-        )
 
     @staticmethod
     def _require_rotation_method(method_name):
@@ -100,44 +72,22 @@ class SO3DiracDistribution(AbstractDiracDistribution):
                 3,
             ), "Rotation matrices must have shape (..., 3, 3)."
 
-        quaternions_xyzw = spatial.Rotation.from_matrix(rotation_matrices).as_quat()
-        return cls(cls._as_wxyz(quaternions_xyzw), w=w)
+        quaternions = spatial.Rotation.from_matrix(rotation_matrices).as_quat()
+        return cls(quaternions, w=w)
 
     def as_quaternions(self):
-        """Return canonical scalar-first unit quaternions shaped ``(n, 4)``."""
+        """Return canonical scalar-last unit quaternions shaped ``(n, 4)``."""
         return self.d
 
     def as_rotation_matrices(self):
         """Return Dirac locations as rotation matrices shaped ``(n, 3, 3)``."""
         self._require_rotation_method("from_quat")
-        return array(spatial.Rotation.from_quat(self._as_xyzw(self.d)).as_matrix())
-
-    def moment(self):
-        """Return the weighted quaternion second-moment matrix."""
-        moment_matrix = zeros((self.input_dim, self.input_dim))
-        for idx in range(self.d.shape[0]):
-            moment_matrix = moment_matrix + self.w[idx] * outer(
-                self.d[idx], self.d[idx]
-            )
-        return moment_matrix / sum(self.w)
-
-    def mean_axis(self):
-        """Return the principal quaternion axis of the Dirac mixture."""
-        moment_matrix = self.moment()
-        eigenvalues, eigenvectors = linalg.eigh(0.5 * (moment_matrix + moment_matrix.T))
-        mean_quaternion = eigenvectors[:, argmax(eigenvalues)]
-        return self._normalize_quaternions(mean_quaternion)[0]
-
-    def mean(self):
-        """Return the mean rotation as a canonical scalar-first quaternion."""
-        return self.mean_axis()
+        return array(spatial.Rotation.from_quat(self.d).as_matrix())
 
     def mean_rotation_matrix(self):
         """Return the mean rotation as a 3-by-3 rotation matrix."""
         self._require_rotation_method("from_quat")
-        return array(
-            spatial.Rotation.from_quat(self._as_xyzw(self.mean())).as_matrix()
-        )[0]
+        return array(spatial.Rotation.from_quat(self.mean()).as_matrix())
 
     @staticmethod
     def geodesic_distance(rotation_a, rotation_b):
@@ -159,11 +109,6 @@ class SO3DiracDistribution(AbstractDiracDistribution):
         ), "n_particles must be a positive integer"
         return SO3DiracDistribution(distribution.sample(n_particles))
 
-    def mode(self, rel_tol=0.001):
-        """Return the highest-weight Dirac location as a canonical quaternion."""
-        _ = rel_tol
-        return self.d[int(argmax(self.w))]
-
     def angular_error_mean(self, rotation):
         """Return the weighted mean angular error to ``rotation`` in radians."""
         return sum(self.w * self.distance_to(rotation))
@@ -172,5 +117,5 @@ class SO3DiracDistribution(AbstractDiracDistribution):
         """Return whether all stored quaternions are normalized and canonical."""
         norms = linalg.norm(self.d, None, -1)
         return bool(
-            amax(abs(norms - 1.0)) <= tolerance and all(self.d[:, 0] >= -tolerance)
+            amax(abs(norms - 1.0)) <= tolerance and all(self.d[:, -1] >= -tolerance)
         )

--- a/src/pyrecest/distributions/so3_dirac_distribution.py
+++ b/src/pyrecest/distributions/so3_dirac_distribution.py
@@ -1,0 +1,176 @@
+"""Dirac distribution on SO(3)."""
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import (
+    abs,
+    all,
+    amax,
+    arccos,
+    argmax,
+    array,
+    asarray,
+    clip,
+    column_stack,
+    linalg,
+    ndim,
+    outer,
+    reshape,
+    spatial,
+    sum,
+    where,
+    zeros,
+)
+
+from .abstract_dirac_distribution import AbstractDiracDistribution
+
+
+class SO3DiracDistribution(AbstractDiracDistribution):
+    """Weighted Dirac distribution on SO(3).
+
+    The distribution stores rotations as unit quaternions with scalar-first
+    coordinates ``(w, x, y, z)``. Since ``q`` and ``-q`` represent the same
+    rotation, quaternions are canonicalized to a nonnegative scalar component
+    during construction.
+    """
+
+    def __init__(self, d, w=None):
+        quaternions = self._normalize_quaternions(d)
+        self.dim = 3
+        super().__init__(quaternions, w=w)
+
+    @property
+    def input_dim(self):
+        return 4
+
+    @staticmethod
+    def _normalize_quaternions(quaternions):
+        quaternions = array(quaternions, dtype=float)
+        if ndim(quaternions) == 1:
+            quaternions = reshape(quaternions, (1, 4))
+
+        assert quaternions.shape[-1] == 4, "SO(3) quaternions must have length 4."
+        norms = linalg.norm(quaternions, None, -1)
+        assert all(norms > 0.0), "SO(3) quaternions must be nonzero."
+
+        normalized = quaternions / reshape(norms, (-1, 1))
+        sign = where(normalized[:, 0:1] < 0.0, -1.0, 1.0)
+        return sign * normalized
+
+    @staticmethod
+    def _as_xyzw(quaternions):
+        quaternions = SO3DiracDistribution._normalize_quaternions(quaternions)
+        return column_stack(
+            (quaternions[:, 1], quaternions[:, 2], quaternions[:, 3], quaternions[:, 0])
+        )
+
+    @staticmethod
+    def _as_wxyz(quaternions_xyzw):
+        quaternions_xyzw = asarray(quaternions_xyzw)
+        if ndim(quaternions_xyzw) == 1:
+            quaternions_xyzw = reshape(quaternions_xyzw, (1, 4))
+        return column_stack(
+            (
+                quaternions_xyzw[:, 3],
+                quaternions_xyzw[:, 0],
+                quaternions_xyzw[:, 1],
+                quaternions_xyzw[:, 2],
+            )
+        )
+
+    @staticmethod
+    def _require_rotation_method(method_name):
+        if not hasattr(spatial.Rotation, method_name):
+            raise NotImplementedError(
+                f"Rotation.{method_name} is not supported by the active backend."
+            )
+
+    @classmethod
+    def from_rotation_matrices(cls, rotation_matrices, w=None):
+        """Create an SO(3) Dirac distribution from rotation matrices."""
+        cls._require_rotation_method("from_matrix")
+        rotation_matrices = asarray(rotation_matrices)
+        if ndim(rotation_matrices) == 2:
+            assert rotation_matrices.shape == (
+                3,
+                3,
+            ), "A single rotation matrix must have shape (3, 3)."
+        else:
+            assert rotation_matrices.shape[-2:] == (
+                3,
+                3,
+            ), "Rotation matrices must have shape (..., 3, 3)."
+
+        quaternions_xyzw = spatial.Rotation.from_matrix(rotation_matrices).as_quat()
+        return cls(cls._as_wxyz(quaternions_xyzw), w=w)
+
+    def as_quaternions(self):
+        """Return canonical scalar-first unit quaternions shaped ``(n, 4)``."""
+        return self.d
+
+    def as_rotation_matrices(self):
+        """Return Dirac locations as rotation matrices shaped ``(n, 3, 3)``."""
+        self._require_rotation_method("from_quat")
+        return array(spatial.Rotation.from_quat(self._as_xyzw(self.d)).as_matrix())
+
+    def moment(self):
+        """Return the weighted quaternion second-moment matrix."""
+        moment_matrix = zeros((self.input_dim, self.input_dim))
+        for idx in range(self.d.shape[0]):
+            moment_matrix = moment_matrix + self.w[idx] * outer(
+                self.d[idx], self.d[idx]
+            )
+        return moment_matrix / sum(self.w)
+
+    def mean_axis(self):
+        """Return the principal quaternion axis of the Dirac mixture."""
+        moment_matrix = self.moment()
+        eigenvalues, eigenvectors = linalg.eigh(0.5 * (moment_matrix + moment_matrix.T))
+        mean_quaternion = eigenvectors[:, argmax(eigenvalues)]
+        return self._normalize_quaternions(mean_quaternion)[0]
+
+    def mean(self):
+        """Return the mean rotation as a canonical scalar-first quaternion."""
+        return self.mean_axis()
+
+    def mean_rotation_matrix(self):
+        """Return the mean rotation as a 3-by-3 rotation matrix."""
+        self._require_rotation_method("from_quat")
+        return array(
+            spatial.Rotation.from_quat(self._as_xyzw(self.mean())).as_matrix()
+        )[0]
+
+    @staticmethod
+    def geodesic_distance(rotation_a, rotation_b):
+        """Return the SO(3) geodesic distance between quaternions in radians."""
+        quat_a = SO3DiracDistribution._normalize_quaternions(rotation_a)
+        quat_b = SO3DiracDistribution._normalize_quaternions(rotation_b)
+        inner = abs(sum(quat_a * quat_b, axis=-1))
+        return 2.0 * arccos(clip(inner, 0.0, 1.0))
+
+    def distance_to(self, rotation):
+        """Return geodesic distances from all Dirac locations to ``rotation``."""
+        return self.geodesic_distance(self.d, rotation)
+
+    @staticmethod
+    def from_distribution(distribution, n_particles):
+        """Create an SO(3) Dirac distribution by sampling another distribution."""
+        assert (
+            isinstance(n_particles, int) and n_particles > 0
+        ), "n_particles must be a positive integer"
+        return SO3DiracDistribution(distribution.sample(n_particles))
+
+    def mode(self, rel_tol=0.001):
+        """Return the highest-weight Dirac location as a canonical quaternion."""
+        _ = rel_tol
+        return self.d[int(argmax(self.w))]
+
+    def angular_error_mean(self, rotation):
+        """Return the weighted mean angular error to ``rotation`` in radians."""
+        return sum(self.w * self.distance_to(rotation))
+
+    def is_valid(self, tolerance=1e-6):
+        """Return whether all stored quaternions are normalized and canonical."""
+        norms = linalg.norm(self.d, None, -1)
+        return bool(
+            amax(abs(norms - 1.0)) <= tolerance and all(self.d[:, 0] >= -tolerance)
+        )

--- a/tests/distributions/test_so3_dirac_distribution.py
+++ b/tests/distributions/test_so3_dirac_distribution.py
@@ -1,0 +1,70 @@
+import unittest
+
+import numpy.testing as npt
+import pyrecest.backend
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array, cos, eye, pi, sin, stack
+from pyrecest.distributions import SO3DiracDistribution
+
+ATOL = 1e-6
+
+
+class SO3DiracDistributionTest(unittest.TestCase):
+    def test_constructor_normalizes_and_canonicalizes_quaternions(self):
+        dist = SO3DiracDistribution(
+            array([[-2.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 3.0]]),
+            array([2.0 / 3.0, 1.0 / 3.0]),
+        )
+
+        npt.assert_allclose(dist.d[0], array([1.0, 0.0, 0.0, 0.0]), atol=ATOL)
+        npt.assert_allclose(dist.d[1], array([0.0, 0.0, 0.0, 1.0]), atol=ATOL)
+        npt.assert_allclose(dist.w, array([2.0 / 3.0, 1.0 / 3.0]), atol=ATOL)
+        self.assertTrue(dist.is_valid())
+
+    def test_antipodal_quaternions_have_same_mean(self):
+        angle = pi / 3.0
+        quat = array([cos(angle / 2.0), 0.0, 0.0, sin(angle / 2.0)])
+        dist = SO3DiracDistribution(stack([quat, -quat], axis=0))
+
+        npt.assert_allclose(dist.mean(), quat, atol=ATOL)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "pytorch",
+        reason="Rotation matrix conversion is not supported on the PyTorch backend.",
+    )
+    def test_rotation_matrix_roundtrip(self):
+        quarter_turn_z = array([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+        rotations = stack([eye(3), quarter_turn_z], axis=0)
+
+        dist = SO3DiracDistribution.from_rotation_matrices(rotations)
+
+        npt.assert_allclose(dist.as_rotation_matrices(), rotations, atol=ATOL)
+
+    def test_geodesic_distance_respects_antipodal_equivalence(self):
+        identity = array([1.0, 0.0, 0.0, 0.0])
+        identity_antipodal = array([-1.0, 0.0, 0.0, 0.0])
+        quarter_turn = array([cos(pi / 4.0), 0.0, 0.0, sin(pi / 4.0)])
+
+        npt.assert_allclose(
+            SO3DiracDistribution.geodesic_distance(identity, identity_antipodal),
+            array([0.0]),
+            atol=ATOL,
+        )
+        npt.assert_allclose(
+            SO3DiracDistribution.geodesic_distance(identity, quarter_turn),
+            array([pi / 2.0]),
+            atol=ATOL,
+        )
+
+    def test_mode_returns_highest_weight_canonical_quaternion(self):
+        dist = SO3DiracDistribution(
+            array([[1.0, 0.0, 0.0, 0.0], [-0.5, 0.5, 0.5, 0.5]]),
+            array([0.1, 0.9]),
+        )
+
+        npt.assert_allclose(dist.mode(), array([0.5, -0.5, -0.5, -0.5]), atol=ATOL)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/distributions/test_so3_dirac_distribution.py
+++ b/tests/distributions/test_so3_dirac_distribution.py
@@ -6,25 +6,33 @@ import pyrecest.backend
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import array, cos, eye, pi, sin, stack
 from pyrecest.distributions import SO3DiracDistribution
+from pyrecest.distributions.hypersphere_subset.hyperhemispherical_dirac_distribution import (
+    HyperhemisphericalDiracDistribution,
+)
 
 ATOL = 1e-6
 
 
 class SO3DiracDistributionTest(unittest.TestCase):
+    def test_inherits_hyperhemispherical_dirac_distribution(self):
+        dist = SO3DiracDistribution(array([0.0, 0.0, 0.0, 1.0]))
+
+        self.assertIsInstance(dist, HyperhemisphericalDiracDistribution)
+
     def test_constructor_normalizes_and_canonicalizes_quaternions(self):
         dist = SO3DiracDistribution(
-            array([[-2.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 3.0]]),
+            array([[0.0, 0.0, 0.0, -2.0], [0.0, 0.0, 0.0, 3.0]]),
             array([2.0 / 3.0, 1.0 / 3.0]),
         )
 
-        npt.assert_allclose(dist.d[0], array([1.0, 0.0, 0.0, 0.0]), atol=ATOL)
+        npt.assert_allclose(dist.d[0], array([0.0, 0.0, 0.0, 1.0]), atol=ATOL)
         npt.assert_allclose(dist.d[1], array([0.0, 0.0, 0.0, 1.0]), atol=ATOL)
         npt.assert_allclose(dist.w, array([2.0 / 3.0, 1.0 / 3.0]), atol=ATOL)
         self.assertTrue(dist.is_valid())
 
     def test_antipodal_quaternions_have_same_mean(self):
         angle = pi / 3.0
-        quat = array([cos(angle / 2.0), 0.0, 0.0, sin(angle / 2.0)])
+        quat = array([0.0, 0.0, sin(angle / 2.0), cos(angle / 2.0)])
         dist = SO3DiracDistribution(stack([quat, -quat], axis=0))
 
         npt.assert_allclose(dist.mean(), quat, atol=ATOL)
@@ -42,9 +50,9 @@ class SO3DiracDistributionTest(unittest.TestCase):
         npt.assert_allclose(dist.as_rotation_matrices(), rotations, atol=ATOL)
 
     def test_geodesic_distance_respects_antipodal_equivalence(self):
-        identity = array([1.0, 0.0, 0.0, 0.0])
-        identity_antipodal = array([-1.0, 0.0, 0.0, 0.0])
-        quarter_turn = array([cos(pi / 4.0), 0.0, 0.0, sin(pi / 4.0)])
+        identity = array([0.0, 0.0, 0.0, 1.0])
+        identity_antipodal = array([0.0, 0.0, 0.0, -1.0])
+        quarter_turn = array([0.0, 0.0, sin(pi / 4.0), cos(pi / 4.0)])
 
         npt.assert_allclose(
             SO3DiracDistribution.geodesic_distance(identity, identity_antipodal),
@@ -59,11 +67,11 @@ class SO3DiracDistributionTest(unittest.TestCase):
 
     def test_mode_returns_highest_weight_canonical_quaternion(self):
         dist = SO3DiracDistribution(
-            array([[1.0, 0.0, 0.0, 0.0], [-0.5, 0.5, 0.5, 0.5]]),
+            array([[0.0, 0.0, 0.0, 1.0], [0.5, 0.5, 0.5, -0.5]]),
             array([0.1, 0.9]),
         )
 
-        npt.assert_allclose(dist.mode(), array([0.5, -0.5, -0.5, -0.5]), atol=ATOL)
+        npt.assert_allclose(dist.mode(), array([-0.5, -0.5, -0.5, 0.5]), atol=ATOL)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `SO3DiracDistribution` as a thin subclass of `HyperhemisphericalDiracDistribution` for weighted Dirac components on SO(3), stored as scalar-last unit quaternions `(x, y, z, w)`.
- Canonicalize antipodal quaternion signs by the scalar coordinate and reuse the inherited hyperhemispherical Dirac moment, mean-axis, mean, and mode behavior.
- Expose quaternion/rotation-matrix conversion helpers, SO(3) geodesic distance helpers, validation, exports, and focused unit tests.

## Validation
- `python -m unittest tests.distributions.test_so3_dirac_distribution`
- `$env:PYRECEST_BACKEND='numpy'; python -m pytest -q tests/distributions/test_so3_dirac_distribution.py`
- `$env:PYRECEST_BACKEND='jax'; python -m pytest -q tests/distributions/test_so3_dirac_distribution.py`
- `$env:PYRECEST_BACKEND='pytorch'; python -m pytest -q tests/distributions/test_so3_dirac_distribution.py` (5 passed, 1 expected skip for rotation-matrix conversion)
- `python -m black --check src/pyrecest/distributions/so3_dirac_distribution.py tests/distributions/test_so3_dirac_distribution.py`
- `python -m ruff check src/pyrecest/distributions/so3_dirac_distribution.py tests/distributions/test_so3_dirac_distribution.py src/pyrecest/distributions/__init__.py`
- `python -m pylint src/pyrecest/distributions/so3_dirac_distribution.py tests/distributions/test_so3_dirac_distribution.py`
- `python -m mypy --ignore-missing-imports src/pyrecest/distributions/so3_dirac_distribution.py tests/distributions/test_so3_dirac_distribution.py`