### PR TITLE
Add SO3 tangent Gaussian distribution

### DIFF
--- a/src/pyrecest/distributions/__init__.py
+++ b/src/pyrecest/distributions/__init__.py
@@ -254,6 +254,7 @@ from .nonperiodic.linear_mixture import LinearMixture
 from .se2_dirac_distribution import SE2DiracDistribution
 from .se3_cart_prod_stacked_distribution import SE3CartProdStackedDistribution
 from .se3_dirac_distribution import SE3DiracDistribution
+from .so3_tangent_gaussian_distribution import SO3TangentGaussianDistribution
 
 # Aliases for brevity and compatibility with libDirectional
 HypertoroidalWNDistribution = HypertoroidalWrappedNormalDistribution
@@ -413,5 +414,6 @@ __all__ = aliases + [
     "SE2DiracDistribution",
     "SE3CartProdStackedDistribution",
     "SE3DiracDistribution",
+    "SO3TangentGaussianDistribution",
     "SE2BinghamDistribution",
 ]

--- a/src/pyrecest/distributions/_so3_helpers.py
+++ b/src/pyrecest/distributions/_so3_helpers.py
@@ -1,0 +1,46 @@
+"""Shared helper functions for SO(3) distributions."""
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import (
+    abs,
+    all,
+    arccos,
+    array,
+    clip,
+    linalg,
+    ndim,
+    reshape,
+    sum,
+    where,
+)
+
+
+def as_batch(values, width, name):
+    """Return values with a fixed trailing width as a two-dimensional batch."""
+    values = array(values, dtype=float)
+    if ndim(values) == 1:
+        assert values.shape[0] == width, f"{name} must have length {width}."
+        values = reshape(values, (1, width))
+    else:
+        assert values.shape[-1] == width, f"{name} must have length {width}."
+        values = reshape(values, (-1, width))
+    return values
+
+
+def normalize_quaternions(quaternions):
+    """Return canonical scalar-last unit quaternions shaped ``(n, 4)``."""
+    quaternions = as_batch(quaternions, 4, "SO(3) quaternions")
+    norms = linalg.norm(quaternions, None, -1)
+    assert all(norms > 0.0), "SO(3) quaternions must be nonzero."
+
+    normalized = quaternions / reshape(norms, (-1, 1))
+    sign = where(normalized[:, -1:] < 0.0, -1.0, 1.0)
+    return sign * normalized
+
+
+def geodesic_distance(rotation_a, rotation_b):
+    """Return the SO(3) geodesic distance between quaternions in radians."""
+    quat_a = normalize_quaternions(rotation_a)
+    quat_b = normalize_quaternions(rotation_b)
+    inner = abs(sum(quat_a * quat_b, axis=-1))
+    return 2.0 * arccos(clip(inner, 0.0, 1.0))

--- a/src/pyrecest/distributions/so3_dirac_distribution.py
+++ b/src/pyrecest/distributions/so3_dirac_distribution.py
@@ -3,20 +3,16 @@
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
     abs,
-    all,
     amax,
-    arccos,
     array,
     asarray,
-    clip,
     linalg,
     ndim,
-    reshape,
     spatial,
     sum,
-    where,
 )
 
+from ._so3_helpers import geodesic_distance, normalize_quaternions
 from .hypersphere_subset.hyperhemispherical_dirac_distribution import (
     HyperhemisphericalDiracDistribution,
 )
@@ -35,19 +31,7 @@ class SO3DiracDistribution(HyperhemisphericalDiracDistribution):
         quaternions = self._normalize_quaternions(d)
         super().__init__(quaternions, w=w)
 
-    @staticmethod
-    def _normalize_quaternions(quaternions):
-        quaternions = array(quaternions, dtype=float)
-        if ndim(quaternions) == 1:
-            quaternions = reshape(quaternions, (1, 4))
-
-        assert quaternions.shape[-1] == 4, "SO(3) quaternions must have length 4."
-        norms = linalg.norm(quaternions, None, -1)
-        assert all(norms > 0.0), "SO(3) quaternions must be nonzero."
-
-        normalized = quaternions / reshape(norms, (-1, 1))
-        sign = where(normalized[:, -1:] < 0.0, -1.0, 1.0)
-        return sign * normalized
+    _normalize_quaternions = staticmethod(normalize_quaternions)
 
     @staticmethod
     def _require_rotation_method(method_name):
@@ -89,13 +73,7 @@ class SO3DiracDistribution(HyperhemisphericalDiracDistribution):
         self._require_rotation_method("from_quat")
         return array(spatial.Rotation.from_quat(self.mean()).as_matrix())
 
-    @staticmethod
-    def geodesic_distance(rotation_a, rotation_b):
-        """Return the SO(3) geodesic distance between quaternions in radians."""
-        quat_a = SO3DiracDistribution._normalize_quaternions(rotation_a)
-        quat_b = SO3DiracDistribution._normalize_quaternions(rotation_b)
-        inner = abs(sum(quat_a * quat_b, axis=-1))
-        return 2.0 * arccos(clip(inner, 0.0, 1.0))
+    geodesic_distance = staticmethod(geodesic_distance)
 
     def distance_to(self, rotation):
         """Return geodesic distances from all Dirac locations to ``rotation``."""

--- a/src/pyrecest/distributions/so3_tangent_gaussian_distribution.py
+++ b/src/pyrecest/distributions/so3_tangent_gaussian_distribution.py
@@ -1,0 +1,262 @@
+"""Tangent-space Gaussian distribution on SO(3)."""
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import (
+    abs,
+    all,
+    amax,
+    arccos,
+    arctan2,
+    array,
+    clip,
+    concatenate,
+    cos,
+    diag,
+    linalg,
+    log,
+    matmul,
+    ndim,
+    pi,
+    random,
+    reshape,
+    sin,
+    stack,
+    sum,
+    transpose,
+    where,
+    zeros,
+)
+
+from .abstract_bounded_domain_distribution import AbstractBoundedDomainDistribution
+from .nonperiodic.gaussian_distribution import GaussianDistribution
+
+
+class SO3TangentGaussianDistribution(AbstractBoundedDomainDistribution):
+    """Gaussian distribution in a local tangent chart of SO(3).
+
+    Rotations are represented as scalar-last unit quaternions ``(x, y, z, w)``.
+    The density is evaluated by mapping rotations into the tangent space at the
+    mean via ``log(mean^{-1} * rotation)`` and applying a 3-D Gaussian there.
+    This is a local tangent approximation, not a globally wrapped density.
+    """
+
+    def __init__(self, mu, C, check_validity=True):
+        super().__init__(dim=3)
+        self.mu = self._normalize_quaternions(mu)[0]
+
+        C = array(C, dtype=float)
+        assert ndim(C) == 2 and C.shape == (3, 3), "C must have shape (3, 3)."
+        if check_validity:
+            linalg.cholesky(C)
+        self.C = C
+
+    @property
+    def input_dim(self):
+        return 4
+
+    @staticmethod
+    def _as_batch(values, width, name):
+        values = array(values, dtype=float)
+        if ndim(values) == 1:
+            assert values.shape[0] == width, f"{name} must have length {width}."
+            values = reshape(values, (1, width))
+        else:
+            assert values.shape[-1] == width, f"{name} must have length {width}."
+            values = reshape(values, (-1, width))
+        return values
+
+    @staticmethod
+    def _normalize_quaternions(quaternions):
+        quaternions = SO3TangentGaussianDistribution._as_batch(
+            quaternions, 4, "SO(3) quaternions"
+        )
+        norms = linalg.norm(quaternions, None, -1)
+        assert all(norms > 0.0), "SO(3) quaternions must be nonzero."
+
+        normalized = quaternions / reshape(norms, (-1, 1))
+        sign = where(normalized[:, -1:] < 0.0, -1.0, 1.0)
+        return sign * normalized
+
+    @staticmethod
+    def _as_tangent_batch(tangent_vectors):
+        return SO3TangentGaussianDistribution._as_batch(
+            tangent_vectors, 3, "SO(3) tangent vectors"
+        )
+
+    @staticmethod
+    def _quaternion_conjugate(quaternions):
+        quaternions = SO3TangentGaussianDistribution._normalize_quaternions(quaternions)
+        return quaternions * array([-1.0, -1.0, -1.0, 1.0])
+
+    @staticmethod
+    def _quaternion_multiply(left, right):
+        left = SO3TangentGaussianDistribution._normalize_quaternions(left)
+        right = SO3TangentGaussianDistribution._normalize_quaternions(right)
+
+        x1, y1, z1, w1 = left[:, 0], left[:, 1], left[:, 2], left[:, 3]
+        x2, y2, z2, w2 = right[:, 0], right[:, 1], right[:, 2], right[:, 3]
+        product = stack(
+            (
+                w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+                w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+                w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
+                w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
+            ),
+            axis=-1,
+        )
+        return SO3TangentGaussianDistribution._normalize_quaternions(product)
+
+    @staticmethod
+    def exp_map(tangent_vectors, base=None):
+        """Map tangent vectors to SO(3) quaternions.
+
+        If ``base`` is given, the returned rotations are ``base * Exp(v)``.
+        """
+        tangent_vectors = SO3TangentGaussianDistribution._as_tangent_batch(
+            tangent_vectors
+        )
+        angles = linalg.norm(tangent_vectors, None, -1)
+        angles_col = reshape(angles, (-1, 1))
+        safe_angles = where(angles_col > 1e-12, angles_col, 1.0)
+        vector_scale = where(
+            angles_col > 1e-12,
+            sin(0.5 * angles_col) / safe_angles,
+            0.5 - angles_col**2 / 48.0,
+        )
+        delta_quaternions = concatenate(
+            (tangent_vectors * vector_scale, cos(0.5 * angles_col)), axis=-1
+        )
+        delta_quaternions = SO3TangentGaussianDistribution._normalize_quaternions(
+            delta_quaternions
+        )
+
+        if base is None:
+            return delta_quaternions
+        return SO3TangentGaussianDistribution._quaternion_multiply(
+            base, delta_quaternions
+        )
+
+    @staticmethod
+    def log_map(rotations, base=None):
+        """Map SO(3) quaternions to tangent vectors.
+
+        If ``base`` is given, this returns ``Log(base^{-1} * rotations)``.
+        """
+        rotations = SO3TangentGaussianDistribution._normalize_quaternions(rotations)
+        if base is not None:
+            rotations = SO3TangentGaussianDistribution._quaternion_multiply(
+                SO3TangentGaussianDistribution._quaternion_conjugate(base), rotations
+            )
+
+        vector_part = rotations[:, :3]
+        scalar_part = clip(rotations[:, 3], -1.0, 1.0)
+        vector_norm = linalg.norm(vector_part, None, -1)
+        angles = 2.0 * arctan2(vector_norm, scalar_part)
+        vector_norm_col = reshape(vector_norm, (-1, 1))
+        safe_norm = where(vector_norm_col > 1e-12, vector_norm_col, 1.0)
+        scale = where(
+            vector_norm_col > 1e-12, reshape(angles, (-1, 1)) / safe_norm, 2.0
+        )
+        return vector_part * scale
+
+    @staticmethod
+    def geodesic_distance(rotation_a, rotation_b):
+        """Return the SO(3) geodesic distance between quaternions in radians."""
+        quat_a = SO3TangentGaussianDistribution._normalize_quaternions(rotation_a)
+        quat_b = SO3TangentGaussianDistribution._normalize_quaternions(rotation_b)
+        inner = abs(sum(quat_a * quat_b, axis=-1))
+        return 2.0 * arccos(clip(inner, 0.0, 1.0))
+
+    @staticmethod
+    def as_rotation_matrices(quaternions):
+        """Convert scalar-last quaternions to rotation matrices."""
+        quaternions = SO3TangentGaussianDistribution._normalize_quaternions(quaternions)
+        x, y, z, w = (
+            quaternions[:, 0],
+            quaternions[:, 1],
+            quaternions[:, 2],
+            quaternions[:, 3],
+        )
+        row_0 = stack(
+            (1.0 - 2.0 * (y * y + z * z), 2.0 * (x * y - z * w), 2.0 * (x * z + y * w)),
+            axis=-1,
+        )
+        row_1 = stack(
+            (2.0 * (x * y + z * w), 1.0 - 2.0 * (x * x + z * z), 2.0 * (y * z - x * w)),
+            axis=-1,
+        )
+        row_2 = stack(
+            (2.0 * (x * z - y * w), 2.0 * (y * z + x * w), 1.0 - 2.0 * (x * x + y * y)),
+            axis=-1,
+        )
+        return stack((row_0, row_1, row_2), axis=-2)
+
+    def pdf(self, xs):
+        """Evaluate the tangent Gaussian density at SO(3) quaternions."""
+        tangent_vectors = self.log_map(xs, base=self.mu)
+        gaussian = GaussianDistribution(zeros(3), self.C, check_validity=False)
+        return gaussian.pdf(tangent_vectors)
+
+    def ln_pdf(self, xs):
+        """Evaluate the natural logarithm of the tangent Gaussian density."""
+        tangent_vectors = self.log_map(xs, base=self.mu)
+        residual = tangent_vectors
+        precision = linalg.inv(self.C)
+        quadratic = sum(residual * matmul(residual, precision), axis=-1)
+        log_det = 2.0 * sum(log(diag(linalg.cholesky(self.C))))
+        return -0.5 * (3.0 * log(2.0 * pi) + log_det + quadratic)
+
+    def tangent_vectors(self, rotations):
+        """Return log-map coordinates of rotations around the distribution mean."""
+        return self.log_map(rotations, base=self.mu)
+
+    def sample_tangent(self, n):
+        """Draw tangent-space Gaussian samples with shape ``(n, 3)``."""
+        return random.multivariate_normal(mean=zeros(3), cov=self.C, size=n)
+
+    def sample(self, n):
+        """Draw ``n`` SO(3) samples as scalar-last unit quaternions."""
+        return self.exp_map(self.sample_tangent(n), base=self.mu)
+
+    def mean(self):
+        """Return the mean rotation as a scalar-last unit quaternion."""
+        return self.mu
+
+    def mode(self):
+        """Return the modal rotation as a scalar-last unit quaternion."""
+        return self.mu
+
+    def mean_rotation_matrix(self):
+        """Return the mean rotation matrix."""
+        return self.as_rotation_matrices(self.mu)[0]
+
+    def covariance(self):
+        """Return the 3-by-3 tangent covariance matrix."""
+        return self.C
+
+    def set_mean(self, new_mean):
+        """Return a copy with a replaced mean rotation."""
+        return self.set_mode(new_mean)
+
+    def set_mode(self, new_mode):
+        """Return a copy with a replaced modal rotation."""
+        new_dist = self.__class__(new_mode, self.C, check_validity=False)
+        return new_dist
+
+    def get_manifold_size(self):
+        """Return the embedding half-sphere volume used for unit quaternions."""
+        return pi**2
+
+    def is_valid(self, tolerance=1e-6):
+        """Return whether the mean and covariance have valid SO(3) dimensions."""
+        covariance_is_symmetric = amax(abs(self.C - transpose(self.C))) <= tolerance
+        return bool(
+            abs(linalg.norm(self.mu) - 1.0) <= tolerance
+            and self.mu[-1] >= -tolerance
+            and covariance_is_symmetric
+        )
+
+    @staticmethod
+    def from_covariance_diagonal(mu, covariance_diagonal):
+        """Create a tangent Gaussian from a diagonal covariance vector."""
+        return SO3TangentGaussianDistribution(mu, diag(covariance_diagonal))

--- a/src/pyrecest/distributions/so3_tangent_gaussian_distribution.py
+++ b/src/pyrecest/distributions/so3_tangent_gaussian_distribution.py
@@ -3,9 +3,7 @@
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
     abs,
-    all,
     amax,
-    arccos,
     arctan2,
     array,
     clip,
@@ -27,6 +25,7 @@ from pyrecest.backend import (
     zeros,
 )
 
+from ._so3_helpers import as_batch, geodesic_distance, normalize_quaternions
 from .abstract_bounded_domain_distribution import AbstractBoundedDomainDistribution
 from .nonperiodic.gaussian_distribution import GaussianDistribution
 
@@ -54,34 +53,11 @@ class SO3TangentGaussianDistribution(AbstractBoundedDomainDistribution):
     def input_dim(self):
         return 4
 
-    @staticmethod
-    def _as_batch(values, width, name):
-        values = array(values, dtype=float)
-        if ndim(values) == 1:
-            assert values.shape[0] == width, f"{name} must have length {width}."
-            values = reshape(values, (1, width))
-        else:
-            assert values.shape[-1] == width, f"{name} must have length {width}."
-            values = reshape(values, (-1, width))
-        return values
-
-    @staticmethod
-    def _normalize_quaternions(quaternions):
-        quaternions = SO3TangentGaussianDistribution._as_batch(
-            quaternions, 4, "SO(3) quaternions"
-        )
-        norms = linalg.norm(quaternions, None, -1)
-        assert all(norms > 0.0), "SO(3) quaternions must be nonzero."
-
-        normalized = quaternions / reshape(norms, (-1, 1))
-        sign = where(normalized[:, -1:] < 0.0, -1.0, 1.0)
-        return sign * normalized
+    _normalize_quaternions = staticmethod(normalize_quaternions)
 
     @staticmethod
     def _as_tangent_batch(tangent_vectors):
-        return SO3TangentGaussianDistribution._as_batch(
-            tangent_vectors, 3, "SO(3) tangent vectors"
-        )
+        return as_batch(tangent_vectors, 3, "SO(3) tangent vectors")
 
     @staticmethod
     def _quaternion_conjugate(quaternions):
@@ -159,13 +135,7 @@ class SO3TangentGaussianDistribution(AbstractBoundedDomainDistribution):
         )
         return vector_part * scale
 
-    @staticmethod
-    def geodesic_distance(rotation_a, rotation_b):
-        """Return the SO(3) geodesic distance between quaternions in radians."""
-        quat_a = SO3TangentGaussianDistribution._normalize_quaternions(rotation_a)
-        quat_b = SO3TangentGaussianDistribution._normalize_quaternions(rotation_b)
-        inner = abs(sum(quat_a * quat_b, axis=-1))
-        return 2.0 * arccos(clip(inner, 0.0, 1.0))
+    geodesic_distance = staticmethod(geodesic_distance)
 
     @staticmethod
     def as_rotation_matrices(quaternions):

--- a/tests/distributions/test_so3_tangent_gaussian_distribution.py
+++ b/tests/distributions/test_so3_tangent_gaussian_distribution.py
@@ -1,0 +1,121 @@
+import math
+import unittest
+
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import (
+    array,
+    cos,
+    diag,
+    eye,
+    linalg,
+    ones,
+    pi,
+    random,
+    sin,
+    sqrt,
+    to_numpy,
+)
+from pyrecest.distributions import SO3TangentGaussianDistribution
+
+ATOL = 1e-6
+
+
+def scalar(value):
+    return float(to_numpy(value).reshape(-1)[0])
+
+
+def z_quaternion(angle):
+    return array([0.0, 0.0, sin(angle / 2.0), cos(angle / 2.0)])
+
+
+def z_rotation(angle):
+    return array(
+        [
+            [cos(angle), -sin(angle), 0.0],
+            [sin(angle), cos(angle), 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+
+
+class SO3TangentGaussianDistributionTest(unittest.TestCase):
+    def test_constructor_normalizes_and_canonicalizes_mean(self):
+        covariance = diag(array([0.1, 0.2, 0.3]))
+        dist = SO3TangentGaussianDistribution(array([0.0, 0.0, 0.0, -2.0]), covariance)
+
+        npt.assert_allclose(dist.mean(), array([0.0, 0.0, 0.0, 1.0]), atol=ATOL)
+        npt.assert_allclose(dist.covariance(), covariance, atol=ATOL)
+        self.assertTrue(dist.is_valid())
+
+    def test_exp_log_roundtrip_with_base_rotation(self):
+        base = z_quaternion(pi / 3.0)
+        tangent_vectors = array([[0.1, -0.2, 0.05], [0.0, 0.0, 0.0]])
+
+        rotations = SO3TangentGaussianDistribution.exp_map(tangent_vectors, base=base)
+        roundtrip = SO3TangentGaussianDistribution.log_map(rotations, base=base)
+
+        npt.assert_allclose(roundtrip, tangent_vectors, atol=ATOL)
+
+    def test_pdf_and_ln_pdf_peak_at_mode(self):
+        covariance = diag(array([0.2, 0.3, 0.4]))
+        dist = SO3TangentGaussianDistribution(array([0.0, 0.0, 0.0, 1.0]), covariance)
+        offset = SO3TangentGaussianDistribution.exp_map(array([0.4, 0.0, 0.0]))
+
+        mode_pdf = scalar(dist.pdf(dist.mode()))
+        offset_pdf = scalar(dist.pdf(offset))
+        expected_mode_pdf = 1.0 / scalar(sqrt((2.0 * pi) ** 3 * linalg.det(covariance)))
+
+        self.assertGreater(mode_pdf, offset_pdf)
+        npt.assert_allclose(mode_pdf, expected_mode_pdf, atol=ATOL)
+        npt.assert_allclose(
+            scalar(dist.ln_pdf(dist.mode())), math.log(mode_pdf), atol=ATOL
+        )
+
+    def test_sampling_returns_unit_quaternions(self):
+        random.seed(0)
+        dist = SO3TangentGaussianDistribution.from_covariance_diagonal(
+            array([0.0, 0.0, 0.0, 1.0]), array([0.01, 0.01, 0.01])
+        )
+
+        samples = dist.sample(8)
+
+        self.assertEqual(samples.shape, (8, 4))
+        npt.assert_allclose(linalg.norm(samples, None, -1), ones(8), atol=ATOL)
+
+    def test_geodesic_distance_respects_antipodal_equivalence(self):
+        identity = array([0.0, 0.0, 0.0, 1.0])
+        identity_antipodal = array([0.0, 0.0, 0.0, -1.0])
+        quarter_turn = z_quaternion(pi / 2.0)
+
+        npt.assert_allclose(
+            SO3TangentGaussianDistribution.geodesic_distance(
+                identity, identity_antipodal
+            ),
+            array([0.0]),
+            atol=ATOL,
+        )
+        npt.assert_allclose(
+            SO3TangentGaussianDistribution.geodesic_distance(identity, quarter_turn),
+            array([pi / 2.0]),
+            atol=ATOL,
+        )
+
+    def test_mean_rotation_matrix_matches_quaternion(self):
+        dist = SO3TangentGaussianDistribution(
+            z_quaternion(pi / 2.0), diag(array([0.1, 0.1, 0.1]))
+        )
+
+        npt.assert_allclose(
+            dist.mean_rotation_matrix(), z_rotation(pi / 2.0), atol=ATOL
+        )
+        npt.assert_allclose(
+            dist.mean_rotation_matrix().T @ dist.mean_rotation_matrix(),
+            eye(3),
+            atol=ATOL,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `SO3TangentGaussianDistribution` for local tangent-space Gaussian uncertainty on SO(3), represented with scalar-last unit quaternions `(x, y, z, w)`.
- Provide backend-compatible SO(3) exp/log maps, quaternion composition, geodesic distance, quaternion-to-rotation-matrix conversion, sampling, `pdf`/`ln_pdf`, mean/mode, and covariance accessors.
- Share SO(3) quaternion normalization and geodesic-distance helpers with `SO3DiracDistribution` to avoid duplicate implementation.
- Export the new distribution and add focused tests for normalization, exp/log roundtrip, density behavior, sampling, geodesic distance, and rotation-matrix conversion.

## Validation
- `python -m unittest tests.distributions.test_so3_tangent_gaussian_distribution`
- `$env:PYRECEST_BACKEND='numpy'; python -m pytest -q tests/distributions/test_so3_tangent_gaussian_distribution.py`
- `$env:PYRECEST_BACKEND='jax'; python -m pytest -q tests/distributions/test_so3_tangent_gaussian_distribution.py`
- `$env:PYRECEST_BACKEND='pytorch'; python -m pytest -q tests/distributions/test_so3_tangent_gaussian_distribution.py`
- `python -m unittest tests.distributions.test_so3_tangent_gaussian_distribution tests.distributions.test_gaussian_distribution tests.smoothers.test_so3_chordal_mean_smoother`
- `python -m black --check src/pyrecest/distributions/so3_tangent_gaussian_distribution.py tests/distributions/test_so3_tangent_gaussian_distribution.py`
- `python -m ruff check src/pyrecest/distributions/so3_tangent_gaussian_distribution.py tests/distributions/test_so3_tangent_gaussian_distribution.py src/pyrecest/distributions/__init__.py`
- `python -m pylint src/pyrecest/distributions/so3_tangent_gaussian_distribution.py tests/distributions/test_so3_tangent_gaussian_distribution.py`
- `python -m mypy --ignore-missing-imports src/pyrecest/distributions/so3_tangent_gaussian_distribution.py tests/distributions/test_so3_tangent_gaussian_distribution.py`
- `$env:PYTHONPATH='src'; python -m pytest -q tests/distributions/test_so3_dirac_distribution.py tests/distributions/test_so3_tangent_gaussian_distribution.py`
- `$env:PYTHONPATH='src'; python -m black --check src/pyrecest/distributions/_so3_helpers.py src/pyrecest/distributions/so3_dirac_distribution.py src/pyrecest/distributions/so3_tangent_gaussian_distribution.py tests/distributions/test_so3_dirac_distribution.py tests/distributions/test_so3_tangent_gaussian_distribution.py`
- `$env:PYTHONPATH='src'; python -m ruff check src/pyrecest/distributions/_so3_helpers.py src/pyrecest/distributions/so3_dirac_distribution.py src/pyrecest/distributions/so3_tangent_gaussian_distribution.py tests/distributions/test_so3_dirac_distribution.py tests/distributions/test_so3_tangent_gaussian_distribution.py`
- `$env:PYTHONPATH='src'; python -m pylint tools/update_init_helper.py src/pyrecest/distributions/_so3_helpers.py src/pyrecest/distributions/so3_dirac_distribution.py src/pyrecest/distributions/so3_tangent_gaussian_distribution.py`