### PR TITLE
Add SO3 product tangent Gaussian distribution

### DIFF
--- a/src/pyrecest/distributions/__init__.py
+++ b/src/pyrecest/distributions/__init__.py
@@ -255,6 +255,9 @@ from .se2_dirac_distribution import SE2DiracDistribution
 from .se3_cart_prod_stacked_distribution import SE3CartProdStackedDistribution
 from .se3_dirac_distribution import SE3DiracDistribution
 from .so3_dirac_distribution import SO3DiracDistribution
+from .so3_product_tangent_gaussian_distribution import (
+    SO3ProductTangentGaussianDistribution,
+)
 
 # Aliases for brevity and compatibility with libDirectional
 HypertoroidalWNDistribution = HypertoroidalWrappedNormalDistribution
@@ -415,5 +418,6 @@ __all__ = aliases + [
     "SE3CartProdStackedDistribution",
     "SE3DiracDistribution",
     "SO3DiracDistribution",
+    "SO3ProductTangentGaussianDistribution",
     "SE2BinghamDistribution",
 ]

--- a/src/pyrecest/distributions/_so3_helpers.py
+++ b/src/pyrecest/distributions/_so3_helpers.py
@@ -5,11 +5,15 @@ from pyrecest.backend import (
     abs,
     all,
     arccos,
+    arctan2,
     array,
     clip,
+    concatenate,
+    cos,
     linalg,
     ndim,
     reshape,
+    sin,
     stack,
     sum,
     where,
@@ -29,14 +33,82 @@ def as_batch(values, width, name):
 
 
 def normalize_quaternions(quaternions):
-    """Return canonical scalar-last unit quaternions shaped ``(n, 4)``."""
-    quaternions = as_batch(quaternions, 4, "SO(3) quaternions")
-    norms = linalg.norm(quaternions, None, -1)
+    """Return canonical scalar-last unit quaternions."""
+    quaternions = array(quaternions, dtype=float)
+    if ndim(quaternions) == 1:
+        assert quaternions.shape[0] == 4, "SO(3) quaternions must have length 4."
+        quaternions = reshape(quaternions, (1, 4))
+    else:
+        assert quaternions.shape[-1] == 4, "SO(3) quaternions must have length 4."
+
+    norms = linalg.norm(quaternions, axis=-1)
     assert all(norms > 0.0), "SO(3) quaternions must be nonzero."
 
-    normalized = quaternions / reshape(norms, (-1, 1))
-    sign = where(normalized[:, -1:] < 0.0, -1.0, 1.0)
-    return sign * normalized
+    normalized = quaternions / reshape(norms, tuple(norms.shape) + (1,))
+    return where(normalized[..., -1:] < 0.0, -normalized, normalized)
+
+
+def quaternion_conjugate(quaternions):
+    """Return conjugates of scalar-last unit quaternions."""
+    return normalize_quaternions(quaternions) * array([-1.0, -1.0, -1.0, 1.0])
+
+
+def quaternion_multiply(left, right):
+    """Return Hamilton products of scalar-last unit quaternions."""
+    left = normalize_quaternions(left)
+    right = normalize_quaternions(right)
+
+    x1, y1, z1, w1 = left[..., 0], left[..., 1], left[..., 2], left[..., 3]
+    x2, y2, z2, w2 = right[..., 0], right[..., 1], right[..., 2], right[..., 3]
+    product = stack(
+        (
+            w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+            w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+            w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
+            w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
+        ),
+        axis=-1,
+    )
+    return normalize_quaternions(product)
+
+
+def exp_map_identity(tangent_vectors):
+    """Map SO(3) tangent vectors at identity to scalar-last quaternions."""
+    tangent_vectors = array(tangent_vectors, dtype=float)
+    if ndim(tangent_vectors) == 1:
+        assert tangent_vectors.shape[0] == 3, "SO(3) tangent vectors must have length 3."
+        tangent_vectors = reshape(tangent_vectors, (1, 3))
+    else:
+        assert tangent_vectors.shape[-1] == 3, "SO(3) tangent vectors must have length 3."
+
+    angles = linalg.norm(tangent_vectors, axis=-1)
+    angles_col = reshape(angles, tuple(angles.shape) + (1,))
+    safe_angles = where(angles_col > 1e-12, angles_col, 1.0)
+    vector_scale = where(
+        angles_col > 1e-12,
+        sin(0.5 * angles_col) / safe_angles,
+        0.5 - angles_col**2 / 48.0,
+    )
+    return normalize_quaternions(
+        concatenate((tangent_vectors * vector_scale, cos(0.5 * angles_col)), axis=-1)
+    )
+
+
+def log_map_identity(rotations):
+    """Map scalar-last SO(3) quaternions to tangent vectors at identity."""
+    rotations = normalize_quaternions(rotations)
+    vector_part = rotations[..., :3]
+    scalar_part = clip(rotations[..., 3], -1.0, 1.0)
+    vector_norm = linalg.norm(vector_part, axis=-1)
+    angles = 2.0 * arctan2(vector_norm, scalar_part)
+    vector_norm_col = reshape(vector_norm, tuple(vector_norm.shape) + (1,))
+    safe_norm = where(vector_norm_col > 1e-12, vector_norm_col, 1.0)
+    scale = where(
+        vector_norm_col > 1e-12,
+        reshape(angles, tuple(angles.shape) + (1,)) / safe_norm,
+        2.0,
+    )
+    return vector_part * scale
 
 
 def geodesic_distance(rotation_a, rotation_b):
@@ -51,10 +123,10 @@ def quaternions_to_rotation_matrices(quaternions):
     """Convert scalar-last quaternions to rotation matrices."""
     quaternions = normalize_quaternions(quaternions)
     x, y, z, w = (
-        quaternions[:, 0],
-        quaternions[:, 1],
-        quaternions[:, 2],
-        quaternions[:, 3],
+        quaternions[..., 0],
+        quaternions[..., 1],
+        quaternions[..., 2],
+        quaternions[..., 3],
     )
     row_0 = stack(
         (1.0 - 2.0 * (y * y + z * z), 2.0 * (x * y - z * w), 2.0 * (x * z + y * w)),

--- a/src/pyrecest/distributions/so3_product_tangent_gaussian_distribution.py
+++ b/src/pyrecest/distributions/so3_product_tangent_gaussian_distribution.py
@@ -5,12 +5,7 @@ from pyrecest.backend import (
     abs,
     all,
     amax,
-    arccos,
-    arctan2,
     array,
-    clip,
-    concatenate,
-    cos,
     diag,
     linalg,
     log,
@@ -19,15 +14,22 @@ from pyrecest.backend import (
     pi,
     random,
     reshape,
-    sin,
     stack,
     sum,
     take,
     transpose,
-    where,
     zeros,
 )
 
+from ._so3_helpers import (
+    exp_map_identity,
+    geodesic_distance as so3_geodesic_distance,
+    log_map_identity,
+    normalize_quaternions,
+    quaternion_conjugate,
+    quaternion_multiply,
+    quaternions_to_rotation_matrices,
+)
 from .abstract_bounded_domain_distribution import AbstractBoundedDomainDistribution
 from .nonperiodic.gaussian_distribution import GaussianDistribution
 
@@ -62,16 +64,7 @@ class SO3ProductTangentGaussianDistribution(AbstractBoundedDomainDistribution):
     def get_manifold_size(self):
         return pi ** (2 * self.num_rotations)
 
-    @staticmethod
-    def _normalize_quaternions(quaternions):
-        quaternions = array(quaternions, dtype=float)
-        assert quaternions.shape[-1] == 4, "SO(3) quaternions must have length 4."
-
-        norms = linalg.norm(quaternions, axis=-1)
-        assert all(norms > 0.0), "SO(3) quaternions must be nonzero."
-
-        normalized = quaternions / reshape(norms, tuple(norms.shape) + (1,))
-        return where(normalized[..., -1:] < 0.0, -normalized, normalized)
+    _normalize_quaternions = staticmethod(normalize_quaternions)
 
     @staticmethod
     def _as_product_point(rotations, num_rotations=None):
@@ -181,64 +174,10 @@ class SO3ProductTangentGaussianDistribution(AbstractBoundedDomainDistribution):
 
         return tangent_vectors, inferred_num_rotations
 
-    @staticmethod
-    def _quaternion_conjugate(quaternions):
-        quaternions = SO3ProductTangentGaussianDistribution._normalize_quaternions(
-            quaternions
-        )
-        return quaternions * array([-1.0, -1.0, -1.0, 1.0])
-
-    @staticmethod
-    def _quaternion_multiply(left, right):
-        left = SO3ProductTangentGaussianDistribution._normalize_quaternions(left)
-        right = SO3ProductTangentGaussianDistribution._normalize_quaternions(right)
-
-        x1, y1, z1, w1 = left[..., 0], left[..., 1], left[..., 2], left[..., 3]
-        x2, y2, z2, w2 = right[..., 0], right[..., 1], right[..., 2], right[..., 3]
-        product = stack(
-            (
-                w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
-                w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
-                w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
-                w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
-            ),
-            -1,
-        )
-        return SO3ProductTangentGaussianDistribution._normalize_quaternions(product)
-
-    @staticmethod
-    def _exp_map_so3_identity(tangent_vectors):
-        angles = linalg.norm(tangent_vectors, axis=-1)
-        angles_col = reshape(angles, tuple(angles.shape) + (1,))
-        safe_angles = where(angles_col > 1e-12, angles_col, 1.0)
-        vector_scale = where(
-            angles_col > 1e-12,
-            sin(0.5 * angles_col) / safe_angles,
-            0.5 - angles_col**2 / 48.0,
-        )
-        return SO3ProductTangentGaussianDistribution._normalize_quaternions(
-            concatenate(
-                (tangent_vectors * vector_scale, cos(0.5 * angles_col)), axis=-1
-            )
-        )
-
-    @staticmethod
-    def _log_map_so3_identity(rotations):
-        rotations = SO3ProductTangentGaussianDistribution._normalize_quaternions(
-            rotations
-        )
-        vector_part = rotations[..., :3]
-        scalar_part = clip(rotations[..., 3], -1.0, 1.0)
-        vector_norm = linalg.norm(vector_part, axis=-1)
-        angles = 2.0 * arctan2(vector_norm, scalar_part)
-        vector_norm_col = reshape(vector_norm, tuple(vector_norm.shape) + (1,))
-        safe_norm = where(vector_norm_col > 1e-12, vector_norm_col, 1.0)
-        scale = where(
-            vector_norm_col > 1e-12,
-            reshape(angles, tuple(angles.shape) + (1,)) / safe_norm,
-            2.0,
-        )
-        return vector_part * scale
+    _quaternion_conjugate = staticmethod(quaternion_conjugate)
+    _quaternion_multiply = staticmethod(quaternion_multiply)
+    _exp_map_so3_identity = staticmethod(exp_map_identity)
+    _log_map_so3_identity = staticmethod(log_map_identity)
 
     @staticmethod
     def exp_map(tangent_vectors, base=None, num_rotations=None):
@@ -335,8 +274,7 @@ class SO3ProductTangentGaussianDistribution(AbstractBoundedDomainDistribution):
             rotation_b, num_rotations=inferred_num_rotations
         )
 
-        inner = abs(sum(rotation_a * rotation_b, axis=-1))
-        distances = 2.0 * arccos(clip(inner, 0.0, 1.0))
+        distances = so3_geodesic_distance(rotation_a, rotation_b)
         if reduce:
             return sum(distances, axis=-1)
         return distances
@@ -344,39 +282,7 @@ class SO3ProductTangentGaussianDistribution(AbstractBoundedDomainDistribution):
     @staticmethod
     def as_rotation_matrices(quaternions):
         """Convert scalar-last quaternions to rotation matrices."""
-        quaternions = SO3ProductTangentGaussianDistribution._normalize_quaternions(
-            quaternions
-        )
-        x = quaternions[..., 0]
-        y = quaternions[..., 1]
-        z = quaternions[..., 2]
-        w = quaternions[..., 3]
-
-        row_0 = stack(
-            (
-                1.0 - 2.0 * (y * y + z * z),
-                2.0 * (x * y - z * w),
-                2.0 * (x * z + y * w),
-            ),
-            -1,
-        )
-        row_1 = stack(
-            (
-                2.0 * (x * y + z * w),
-                1.0 - 2.0 * (x * x + z * z),
-                2.0 * (y * z - x * w),
-            ),
-            -1,
-        )
-        row_2 = stack(
-            (
-                2.0 * (x * z - y * w),
-                2.0 * (y * z + x * w),
-                1.0 - 2.0 * (x * x + y * y),
-            ),
-            -1,
-        )
-        return stack((row_0, row_1, row_2), -2)
+        return quaternions_to_rotation_matrices(quaternions)
 
     def pdf(self, xs):
         """Evaluate the tangent Gaussian density at SO(3)^K rotations."""

--- a/src/pyrecest/distributions/so3_product_tangent_gaussian_distribution.py
+++ b/src/pyrecest/distributions/so3_product_tangent_gaussian_distribution.py
@@ -1,0 +1,491 @@
+"""Tangent-space Gaussian distribution on Cartesian products of SO(3)."""
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import (
+    abs,
+    all,
+    amax,
+    arccos,
+    arctan2,
+    array,
+    clip,
+    concatenate,
+    cos,
+    diag,
+    linalg,
+    log,
+    matmul,
+    ndim,
+    pi,
+    random,
+    reshape,
+    sin,
+    stack,
+    sum,
+    take,
+    transpose,
+    where,
+    zeros,
+)
+
+from .abstract_bounded_domain_distribution import AbstractBoundedDomainDistribution
+from .nonperiodic.gaussian_distribution import GaussianDistribution
+
+
+class SO3ProductTangentGaussianDistribution(AbstractBoundedDomainDistribution):
+    """Gaussian distribution in a tangent chart of SO(3)^K.
+
+    Rotations are represented as scalar-last unit quaternions ``(x, y, z, w)``.
+    The mean is stored as a product point with shape ``(K, 4)`` and covariance is
+    a full matrix on the flattened tangent vector in ``R^(3K)``.
+    """
+
+    def __init__(self, mu, C, num_rotations=None, check_validity=True):
+        mean, inferred_num_rotations = self._as_product_point(
+            mu, num_rotations=num_rotations
+        )
+        super().__init__(dim=3 * inferred_num_rotations)
+        self.num_rotations = inferred_num_rotations
+        self.mu = mean
+
+        C = array(C, dtype=float)
+        expected_shape = (self.dim, self.dim)
+        assert C.shape == expected_shape, f"C must have shape {expected_shape}."
+        if check_validity:
+            linalg.cholesky(C)
+        self.C = C
+
+    @property
+    def input_dim(self):
+        return 4 * self.num_rotations
+
+    def get_manifold_size(self):
+        return pi ** (2 * self.num_rotations)
+
+    @staticmethod
+    def _normalize_quaternions(quaternions):
+        quaternions = array(quaternions, dtype=float)
+        assert quaternions.shape[-1] == 4, "SO(3) quaternions must have length 4."
+
+        norms = linalg.norm(quaternions, axis=-1)
+        assert all(norms > 0.0), "SO(3) quaternions must be nonzero."
+
+        normalized = quaternions / reshape(norms, tuple(norms.shape) + (1,))
+        return where(normalized[..., -1:] < 0.0, -normalized, normalized)
+
+    @staticmethod
+    def _as_product_point(rotations, num_rotations=None):
+        rotations = array(rotations, dtype=float)
+
+        if ndim(rotations) == 1:
+            assert (
+                rotations.shape[0] % 4 == 0
+            ), "Flattened SO(3)^K rotations need 4 entries per component."
+            inferred_num_rotations = rotations.shape[0] // 4
+            rotations = reshape(rotations, (inferred_num_rotations, 4))
+        elif ndim(rotations) == 2:
+            assert rotations.shape[-1] == 4, "SO(3) quaternions must have length 4."
+            inferred_num_rotations = rotations.shape[0]
+        else:
+            raise ValueError("A product point must have shape (K, 4) or (4 * K,).")
+
+        if num_rotations is not None and inferred_num_rotations != num_rotations:
+            raise ValueError("num_rotations does not match input shape.")
+
+        return (
+            SO3ProductTangentGaussianDistribution._normalize_quaternions(rotations),
+            inferred_num_rotations,
+        )
+
+    @staticmethod
+    def _as_product_batch(rotations, num_rotations=None):
+        rotations = array(rotations, dtype=float)
+
+        if ndim(rotations) == 1:
+            assert (
+                rotations.shape[0] % 4 == 0
+            ), "Flattened SO(3)^K rotations need 4 entries per component."
+            inferred_num_rotations = rotations.shape[0] // 4
+            rotations = reshape(rotations, (1, inferred_num_rotations, 4))
+        elif ndim(rotations) == 2:
+            if rotations.shape[-1] == 4 and (
+                num_rotations is None or rotations.shape[0] == num_rotations
+            ):
+                inferred_num_rotations = rotations.shape[0]
+                rotations = reshape(rotations, (1, inferred_num_rotations, 4))
+            else:
+                assert (
+                    rotations.shape[-1] % 4 == 0
+                ), "Flattened SO(3)^K rotations need 4 entries per component."
+                inferred_num_rotations = rotations.shape[-1] // 4
+                rotations = reshape(
+                    rotations, (rotations.shape[0], inferred_num_rotations, 4)
+                )
+        elif ndim(rotations) == 3:
+            assert rotations.shape[-1] == 4, "SO(3) quaternions must have length 4."
+            inferred_num_rotations = rotations.shape[1]
+        else:
+            raise ValueError(
+                "SO(3)^K rotations must have shape (K, 4), (4 * K,), "
+                "(n, K, 4), or (n, 4 * K)."
+            )
+
+        if num_rotations is not None and inferred_num_rotations != num_rotations:
+            raise ValueError("num_rotations does not match input shape.")
+
+        return (
+            SO3ProductTangentGaussianDistribution._normalize_quaternions(rotations),
+            inferred_num_rotations,
+        )
+
+    @staticmethod
+    def _as_tangent_batch(tangent_vectors, num_rotations=None):
+        tangent_vectors = array(tangent_vectors, dtype=float)
+
+        if ndim(tangent_vectors) == 1:
+            assert (
+                tangent_vectors.shape[0] % 3 == 0
+            ), "Flattened SO(3)^K tangent vectors need 3 entries per component."
+            inferred_num_rotations = tangent_vectors.shape[0] // 3
+            tangent_vectors = reshape(tangent_vectors, (1, inferred_num_rotations, 3))
+        elif ndim(tangent_vectors) == 2:
+            if tangent_vectors.shape[-1] == 3 and (
+                num_rotations is None or tangent_vectors.shape[0] == num_rotations
+            ):
+                inferred_num_rotations = tangent_vectors.shape[0]
+                tangent_vectors = reshape(
+                    tangent_vectors, (1, inferred_num_rotations, 3)
+                )
+            else:
+                assert (
+                    tangent_vectors.shape[-1] % 3 == 0
+                ), "Flattened SO(3)^K tangent vectors need 3 entries per component."
+                inferred_num_rotations = tangent_vectors.shape[-1] // 3
+                tangent_vectors = reshape(
+                    tangent_vectors,
+                    (tangent_vectors.shape[0], inferred_num_rotations, 3),
+                )
+        elif ndim(tangent_vectors) == 3:
+            assert (
+                tangent_vectors.shape[-1] == 3
+            ), "SO(3) tangent vectors must have length 3."
+            inferred_num_rotations = tangent_vectors.shape[1]
+        else:
+            raise ValueError(
+                "SO(3)^K tangent vectors must have shape (K, 3), (3 * K,), "
+                "(n, K, 3), or (n, 3 * K)."
+            )
+
+        if num_rotations is not None and inferred_num_rotations != num_rotations:
+            raise ValueError("num_rotations does not match input shape.")
+
+        return tangent_vectors, inferred_num_rotations
+
+    @staticmethod
+    def _quaternion_conjugate(quaternions):
+        quaternions = SO3ProductTangentGaussianDistribution._normalize_quaternions(
+            quaternions
+        )
+        return quaternions * array([-1.0, -1.0, -1.0, 1.0])
+
+    @staticmethod
+    def _quaternion_multiply(left, right):
+        left = SO3ProductTangentGaussianDistribution._normalize_quaternions(left)
+        right = SO3ProductTangentGaussianDistribution._normalize_quaternions(right)
+
+        x1, y1, z1, w1 = left[..., 0], left[..., 1], left[..., 2], left[..., 3]
+        x2, y2, z2, w2 = right[..., 0], right[..., 1], right[..., 2], right[..., 3]
+        product = stack(
+            (
+                w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+                w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+                w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
+                w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
+            ),
+            -1,
+        )
+        return SO3ProductTangentGaussianDistribution._normalize_quaternions(product)
+
+    @staticmethod
+    def _exp_map_so3_identity(tangent_vectors):
+        angles = linalg.norm(tangent_vectors, axis=-1)
+        angles_col = reshape(angles, tuple(angles.shape) + (1,))
+        safe_angles = where(angles_col > 1e-12, angles_col, 1.0)
+        vector_scale = where(
+            angles_col > 1e-12,
+            sin(0.5 * angles_col) / safe_angles,
+            0.5 - angles_col**2 / 48.0,
+        )
+        return SO3ProductTangentGaussianDistribution._normalize_quaternions(
+            concatenate(
+                (tangent_vectors * vector_scale, cos(0.5 * angles_col)), axis=-1
+            )
+        )
+
+    @staticmethod
+    def _log_map_so3_identity(rotations):
+        rotations = SO3ProductTangentGaussianDistribution._normalize_quaternions(
+            rotations
+        )
+        vector_part = rotations[..., :3]
+        scalar_part = clip(rotations[..., 3], -1.0, 1.0)
+        vector_norm = linalg.norm(vector_part, axis=-1)
+        angles = 2.0 * arctan2(vector_norm, scalar_part)
+        vector_norm_col = reshape(vector_norm, tuple(vector_norm.shape) + (1,))
+        safe_norm = where(vector_norm_col > 1e-12, vector_norm_col, 1.0)
+        scale = where(
+            vector_norm_col > 1e-12,
+            reshape(angles, tuple(angles.shape) + (1,)) / safe_norm,
+            2.0,
+        )
+        return vector_part * scale
+
+    @staticmethod
+    def exp_map(tangent_vectors, base=None, num_rotations=None):
+        """Map flattened tangent vectors to SO(3)^K product quaternions."""
+        tangent_vectors, inferred_num_rotations = (
+            SO3ProductTangentGaussianDistribution._as_tangent_batch(
+                tangent_vectors, num_rotations=num_rotations
+            )
+        )
+
+        if base is None:
+            base, _ = SO3ProductTangentGaussianDistribution._as_product_point(
+                stack(
+                    [
+                        array([0.0, 0.0, 0.0, 1.0])
+                        for _ in range(inferred_num_rotations)
+                    ],
+                    0,
+                ),
+                num_rotations=inferred_num_rotations,
+            )
+        else:
+            base, _ = SO3ProductTangentGaussianDistribution._as_product_point(
+                base, num_rotations=inferred_num_rotations
+            )
+
+        components = []
+        for i in range(inferred_num_rotations):
+            delta = SO3ProductTangentGaussianDistribution._exp_map_so3_identity(
+                tangent_vectors[:, i, :]
+            )
+            components.append(
+                SO3ProductTangentGaussianDistribution._quaternion_multiply(
+                    base[i, :], delta
+                )
+            )
+        return stack(components, 1)
+
+    @staticmethod
+    def log_map(rotations, base=None, num_rotations=None):
+        """Map SO(3)^K product quaternions to flattened tangent vectors."""
+        rotations, inferred_num_rotations = (
+            SO3ProductTangentGaussianDistribution._as_product_batch(
+                rotations, num_rotations=num_rotations
+            )
+        )
+
+        if base is None:
+            base, _ = SO3ProductTangentGaussianDistribution._as_product_point(
+                stack(
+                    [
+                        array([0.0, 0.0, 0.0, 1.0])
+                        for _ in range(inferred_num_rotations)
+                    ],
+                    0,
+                ),
+                num_rotations=inferred_num_rotations,
+            )
+        else:
+            base, _ = SO3ProductTangentGaussianDistribution._as_product_point(
+                base, num_rotations=inferred_num_rotations
+            )
+
+        tangent_components = []
+        for i in range(inferred_num_rotations):
+            relative_rotation = (
+                SO3ProductTangentGaussianDistribution._quaternion_multiply(
+                    SO3ProductTangentGaussianDistribution._quaternion_conjugate(
+                        base[i, :]
+                    ),
+                    rotations[:, i, :],
+                )
+            )
+            tangent_components.append(
+                SO3ProductTangentGaussianDistribution._log_map_so3_identity(
+                    relative_rotation
+                )
+            )
+
+        tangent_vectors = stack(tangent_components, 1)
+        return reshape(
+            tangent_vectors, (tangent_vectors.shape[0], 3 * inferred_num_rotations)
+        )
+
+    @staticmethod
+    def geodesic_distance(rotation_a, rotation_b, reduce=True, num_rotations=None):
+        """Return component-wise or summed SO(3)^K geodesic distances."""
+        rotation_a, inferred_num_rotations = (
+            SO3ProductTangentGaussianDistribution._as_product_batch(
+                rotation_a, num_rotations=num_rotations
+            )
+        )
+        rotation_b, _ = SO3ProductTangentGaussianDistribution._as_product_batch(
+            rotation_b, num_rotations=inferred_num_rotations
+        )
+
+        inner = abs(sum(rotation_a * rotation_b, axis=-1))
+        distances = 2.0 * arccos(clip(inner, 0.0, 1.0))
+        if reduce:
+            return sum(distances, axis=-1)
+        return distances
+
+    @staticmethod
+    def as_rotation_matrices(quaternions):
+        """Convert scalar-last quaternions to rotation matrices."""
+        quaternions = SO3ProductTangentGaussianDistribution._normalize_quaternions(
+            quaternions
+        )
+        x = quaternions[..., 0]
+        y = quaternions[..., 1]
+        z = quaternions[..., 2]
+        w = quaternions[..., 3]
+
+        row_0 = stack(
+            (
+                1.0 - 2.0 * (y * y + z * z),
+                2.0 * (x * y - z * w),
+                2.0 * (x * z + y * w),
+            ),
+            -1,
+        )
+        row_1 = stack(
+            (
+                2.0 * (x * y + z * w),
+                1.0 - 2.0 * (x * x + z * z),
+                2.0 * (y * z - x * w),
+            ),
+            -1,
+        )
+        row_2 = stack(
+            (
+                2.0 * (x * z - y * w),
+                2.0 * (y * z + x * w),
+                1.0 - 2.0 * (x * x + y * y),
+            ),
+            -1,
+        )
+        return stack((row_0, row_1, row_2), -2)
+
+    def pdf(self, xs):
+        """Evaluate the tangent Gaussian density at SO(3)^K rotations."""
+        tangent_vectors = self.tangent_vectors(xs)
+        gaussian = GaussianDistribution(zeros(self.dim), self.C, check_validity=False)
+        return gaussian.pdf(tangent_vectors)
+
+    def ln_pdf(self, xs):
+        """Evaluate the natural logarithm of the tangent Gaussian density."""
+        residual = self.tangent_vectors(xs)
+        precision = linalg.inv(self.C)
+        quadratic = sum(residual * matmul(residual, precision), axis=-1)
+        log_det = 2.0 * sum(log(diag(linalg.cholesky(self.C))))
+        return -0.5 * (self.dim * log(2.0 * pi) + log_det + quadratic)
+
+    def tangent_vectors(self, rotations):
+        """Return flattened log-map coordinates around the distribution mean."""
+        return self.log_map(rotations, base=self.mu, num_rotations=self.num_rotations)
+
+    def tangent_vectors_product(self, rotations):
+        """Return log-map coordinates with shape ``(n, K, 3)``."""
+        tangent_vectors = self.tangent_vectors(rotations)
+        return reshape(
+            tangent_vectors, (tangent_vectors.shape[0], self.num_rotations, 3)
+        )
+
+    def sample_tangent(self, n):
+        """Draw tangent-space Gaussian samples with shape ``(n, 3 * K)``."""
+        samples = random.multivariate_normal(mean=zeros(self.dim), cov=self.C, size=n)
+        if ndim(samples) == 1:
+            return reshape(samples, (1, self.dim))
+        return samples
+
+    def sample(self, n):
+        """Draw ``n`` SO(3)^K samples as scalar-last unit quaternions."""
+        return self.exp_map(
+            self.sample_tangent(n), base=self.mu, num_rotations=self.num_rotations
+        )
+
+    def mean(self):
+        """Return the mean product rotation with shape ``(K, 4)``."""
+        return self.mu
+
+    def mode(self):
+        """Return the modal product rotation with shape ``(K, 4)``."""
+        return self.mu
+
+    def mean_rotation_matrices(self):
+        """Return rotation matrices of the mean product rotation."""
+        return self.as_rotation_matrices(self.mu)
+
+    def covariance(self):
+        """Return the full ``(3K, 3K)`` tangent covariance matrix."""
+        return self.C
+
+    def set_mean(self, new_mean):
+        """Return a copy with a replaced mean product rotation."""
+        return self.set_mode(new_mean)
+
+    def set_mode(self, new_mode):
+        """Return a copy with a replaced modal product rotation."""
+        return self.__class__(new_mode, self.C, check_validity=False)
+
+    def marginalize_rotation(self, rotation_index):
+        """Return the one-component SO(3) tangent Gaussian marginal."""
+        return self.marginalize_rotations([rotation_index])
+
+    def marginalize_rotations(self, rotation_indices):
+        """Return the marginal over selected SO(3) components."""
+        if isinstance(rotation_indices, int):
+            rotation_indices = [rotation_indices]
+        rotation_indices_array = array(rotation_indices)
+        tangent_indices = [
+            3 * rotation_index + offset
+            for rotation_index in rotation_indices
+            for offset in range(3)
+        ]
+        tangent_indices = array(tangent_indices)
+        new_covariance = take(
+            take(self.C, tangent_indices, axis=0), tangent_indices, axis=1
+        )
+        new_mean = reshape(
+            take(self.mu, rotation_indices_array, axis=0),
+            (len(rotation_indices), 4),
+        )
+        return SO3ProductTangentGaussianDistribution(
+            new_mean,
+            new_covariance,
+            num_rotations=len(rotation_indices),
+            check_validity=False,
+        )
+
+    def distance_to(self, rotations, reduce=True):
+        """Return geodesic distances from the mean to ``rotations``."""
+        return self.geodesic_distance(
+            self.mu, rotations, reduce=reduce, num_rotations=self.num_rotations
+        )
+
+    def is_valid(self, tolerance=1e-6):
+        """Return whether the mean and covariance have valid SO(3)^K dimensions."""
+        mean_norms = linalg.norm(self.mu, axis=-1)
+        covariance_is_symmetric = amax(abs(self.C - transpose(self.C))) <= tolerance
+        return bool(
+            amax(abs(mean_norms - 1.0)) <= tolerance
+            and all(self.mu[:, -1] >= -tolerance)
+            and covariance_is_symmetric
+        )
+
+    @staticmethod
+    def from_covariance_diagonal(mu, covariance_diagonal):
+        """Create a product tangent Gaussian from a diagonal covariance vector."""
+        return SO3ProductTangentGaussianDistribution(mu, diag(covariance_diagonal))

--- a/src/pyrecest/distributions/so3_tangent_gaussian_distribution.py
+++ b/src/pyrecest/distributions/so3_tangent_gaussian_distribution.py
@@ -4,11 +4,7 @@
 from pyrecest.backend import (
     abs,
     amax,
-    arctan2,
     array,
-    clip,
-    concatenate,
-    cos,
     diag,
     linalg,
     log,
@@ -16,19 +12,19 @@ from pyrecest.backend import (
     ndim,
     pi,
     random,
-    reshape,
-    sin,
-    stack,
     sum,
     transpose,
-    where,
     zeros,
 )
 
 from ._so3_helpers import (
     as_batch,
+    exp_map_identity,
     geodesic_distance,
+    log_map_identity,
     normalize_quaternions,
+    quaternion_conjugate,
+    quaternion_multiply,
     quaternions_to_rotation_matrices,
 )
 from .abstract_bounded_domain_distribution import AbstractBoundedDomainDistribution
@@ -64,28 +60,8 @@ class SO3TangentGaussianDistribution(AbstractBoundedDomainDistribution):
     def _as_tangent_batch(tangent_vectors):
         return as_batch(tangent_vectors, 3, "SO(3) tangent vectors")
 
-    @staticmethod
-    def _quaternion_conjugate(quaternions):
-        quaternions = SO3TangentGaussianDistribution._normalize_quaternions(quaternions)
-        return quaternions * array([-1.0, -1.0, -1.0, 1.0])
-
-    @staticmethod
-    def _quaternion_multiply(left, right):
-        left = SO3TangentGaussianDistribution._normalize_quaternions(left)
-        right = SO3TangentGaussianDistribution._normalize_quaternions(right)
-
-        x1, y1, z1, w1 = left[:, 0], left[:, 1], left[:, 2], left[:, 3]
-        x2, y2, z2, w2 = right[:, 0], right[:, 1], right[:, 2], right[:, 3]
-        product = stack(
-            (
-                w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
-                w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
-                w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
-                w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
-            ),
-            axis=-1,
-        )
-        return SO3TangentGaussianDistribution._normalize_quaternions(product)
+    _quaternion_conjugate = staticmethod(quaternion_conjugate)
+    _quaternion_multiply = staticmethod(quaternion_multiply)
 
     @staticmethod
     def exp_map(tangent_vectors, base=None):
@@ -96,20 +72,7 @@ class SO3TangentGaussianDistribution(AbstractBoundedDomainDistribution):
         tangent_vectors = SO3TangentGaussianDistribution._as_tangent_batch(
             tangent_vectors
         )
-        angles = linalg.norm(tangent_vectors, None, -1)
-        angles_col = reshape(angles, (-1, 1))
-        safe_angles = where(angles_col > 1e-12, angles_col, 1.0)
-        vector_scale = where(
-            angles_col > 1e-12,
-            sin(0.5 * angles_col) / safe_angles,
-            0.5 - angles_col**2 / 48.0,
-        )
-        delta_quaternions = concatenate(
-            (tangent_vectors * vector_scale, cos(0.5 * angles_col)), axis=-1
-        )
-        delta_quaternions = SO3TangentGaussianDistribution._normalize_quaternions(
-            delta_quaternions
-        )
+        delta_quaternions = exp_map_identity(tangent_vectors)
 
         if base is None:
             return delta_quaternions
@@ -129,16 +92,7 @@ class SO3TangentGaussianDistribution(AbstractBoundedDomainDistribution):
                 SO3TangentGaussianDistribution._quaternion_conjugate(base), rotations
             )
 
-        vector_part = rotations[:, :3]
-        scalar_part = clip(rotations[:, 3], -1.0, 1.0)
-        vector_norm = linalg.norm(vector_part, None, -1)
-        angles = 2.0 * arctan2(vector_norm, scalar_part)
-        vector_norm_col = reshape(vector_norm, (-1, 1))
-        safe_norm = where(vector_norm_col > 1e-12, vector_norm_col, 1.0)
-        scale = where(
-            vector_norm_col > 1e-12, reshape(angles, (-1, 1)) / safe_norm, 2.0
-        )
-        return vector_part * scale
+        return log_map_identity(rotations)
 
     geodesic_distance = staticmethod(geodesic_distance)
 

--- a/tests/distributions/so3_test_helpers.py
+++ b/tests/distributions/so3_test_helpers.py
@@ -1,9 +1,11 @@
 """Shared test helpers for SO(3) distributions."""
 
+import math
+
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array, cos, eye, sin, to_numpy
+from pyrecest.backend import array, cos, eye, linalg, pi, sin, sqrt, to_numpy
 
 ATOL = 1e-6
 
@@ -16,6 +18,11 @@ def scalar(value):
 def z_quaternion(angle):
     """Return a scalar-last quaternion for a rotation around the z axis."""
     return array([0.0, 0.0, sin(angle / 2.0), cos(angle / 2.0)])
+
+
+def x_quaternion(angle):
+    """Return a scalar-last quaternion for a rotation around the x axis."""
+    return array([sin(angle / 2.0), 0.0, 0.0, cos(angle / 2.0)])
 
 
 def z_rotation(angle):
@@ -34,3 +41,18 @@ def assert_matches_z_rotation(test_case, rotation_matrix, angle):
     npt.assert_allclose(rotation_matrix, z_rotation(angle), atol=ATOL)
     npt.assert_allclose(rotation_matrix.T @ rotation_matrix, eye(3), atol=ATOL)
     test_case.assertEqual(rotation_matrix.shape, (3, 3))
+
+
+def assert_pdf_peak_matches_log_pdf(test_case, dist, covariance, tangent_dim, offset):
+    """Assert that a tangent Gaussian peaks at its mode with matching log density."""
+    mode_pdf = scalar(dist.pdf(dist.mode()))
+    offset_pdf = scalar(dist.pdf(offset))
+    expected_mode_pdf = 1.0 / scalar(
+        sqrt((2.0 * pi) ** tangent_dim * linalg.det(covariance))
+    )
+
+    test_case.assertGreater(mode_pdf, offset_pdf)
+    npt.assert_allclose(mode_pdf, expected_mode_pdf, atol=ATOL)
+    npt.assert_allclose(
+        scalar(dist.ln_pdf(dist.mode())), math.log(mode_pdf), atol=ATOL
+    )

--- a/tests/distributions/test_so3_product_tangent_gaussian_distribution.py
+++ b/tests/distributions/test_so3_product_tangent_gaussian_distribution.py
@@ -1,0 +1,165 @@
+import math
+import unittest
+
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import (
+    array,
+    cos,
+    diag,
+    eye,
+    linalg,
+    ones,
+    pi,
+    random,
+    sin,
+    sqrt,
+    to_numpy,
+)
+from pyrecest.distributions import SO3ProductTangentGaussianDistribution
+
+ATOL = 1e-6
+
+
+def scalar(value):
+    return float(to_numpy(value).reshape(-1)[0])
+
+
+def z_quaternion(angle):
+    return array([0.0, 0.0, sin(angle / 2.0), cos(angle / 2.0)])
+
+
+def x_quaternion(angle):
+    return array([sin(angle / 2.0), 0.0, 0.0, cos(angle / 2.0)])
+
+
+def z_rotation(angle):
+    return array(
+        [
+            [cos(angle), -sin(angle), 0.0],
+            [sin(angle), cos(angle), 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+
+
+class SO3ProductTangentGaussianDistributionTest(unittest.TestCase):
+    def test_constructor_normalizes_flat_mean_and_covariance(self):
+        covariance = diag(array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]))
+        mean = array([0.0, 0.0, 0.0, -2.0, 0.0, 0.0, sqrt(0.5), sqrt(0.5)])
+
+        dist = SO3ProductTangentGaussianDistribution(mean, covariance)
+
+        self.assertEqual(dist.num_rotations, 2)
+        self.assertEqual(dist.dim, 6)
+        self.assertEqual(dist.input_dim, 8)
+        npt.assert_allclose(dist.mean()[0], array([0.0, 0.0, 0.0, 1.0]), atol=ATOL)
+        npt.assert_allclose(dist.covariance(), covariance, atol=ATOL)
+        npt.assert_allclose(dist.get_manifold_size(), pi**4, atol=ATOL)
+        self.assertTrue(dist.is_valid())
+
+    def test_exp_log_roundtrip_with_base_product_rotation(self):
+        base = array(
+            [
+                z_quaternion(pi / 3.0),
+                x_quaternion(pi / 5.0),
+            ]
+        )
+        tangent_vectors = array(
+            [
+                [0.1, -0.2, 0.05, 0.02, 0.0, -0.03],
+                [0.0, 0.0, 0.0, -0.1, 0.2, -0.05],
+            ]
+        )
+
+        rotations = SO3ProductTangentGaussianDistribution.exp_map(
+            tangent_vectors, base=base
+        )
+        roundtrip = SO3ProductTangentGaussianDistribution.log_map(rotations, base=base)
+
+        self.assertEqual(rotations.shape, (2, 2, 4))
+        npt.assert_allclose(roundtrip, tangent_vectors, atol=ATOL)
+
+    def test_pdf_and_ln_pdf_peak_at_mode(self):
+        covariance = diag(array([0.2, 0.3, 0.4, 0.5, 0.6, 0.7]))
+        dist = SO3ProductTangentGaussianDistribution(
+            array([z_quaternion(0.0), x_quaternion(0.0)]), covariance
+        )
+        offset = SO3ProductTangentGaussianDistribution.exp_map(
+            array([0.4, 0.0, 0.0, 0.0, -0.2, 0.0]), base=dist.mean()
+        )
+
+        mode_pdf = scalar(dist.pdf(dist.mode()))
+        offset_pdf = scalar(dist.pdf(offset))
+        expected_mode_pdf = 1.0 / scalar(sqrt((2.0 * pi) ** 6 * linalg.det(covariance)))
+
+        self.assertGreater(mode_pdf, offset_pdf)
+        npt.assert_allclose(mode_pdf, expected_mode_pdf, atol=ATOL)
+        npt.assert_allclose(
+            scalar(dist.ln_pdf(dist.mode())), math.log(mode_pdf), atol=ATOL
+        )
+
+    def test_sampling_returns_unit_product_quaternions(self):
+        random.seed(0)
+        dist = SO3ProductTangentGaussianDistribution.from_covariance_diagonal(
+            array([z_quaternion(0.0), x_quaternion(0.0)]),
+            array([0.01, 0.01, 0.01, 0.02, 0.02, 0.02]),
+        )
+
+        samples = dist.sample(8)
+        single_sample = dist.sample(1)
+
+        self.assertEqual(samples.shape, (8, 2, 4))
+        self.assertEqual(single_sample.shape, (1, 2, 4))
+        npt.assert_allclose(linalg.norm(samples, axis=-1), ones((8, 2)), atol=ATOL)
+        npt.assert_allclose(
+            linalg.norm(single_sample, axis=-1), ones((1, 2)), atol=ATOL
+        )
+
+    def test_geodesic_distance_component_and_sum(self):
+        identity_product = array([z_quaternion(0.0), x_quaternion(0.0)])
+        rotated_product = array([z_quaternion(pi / 2.0), x_quaternion(pi / 4.0)])
+
+        component_distances = SO3ProductTangentGaussianDistribution.geodesic_distance(
+            identity_product, rotated_product, reduce=False
+        )
+        summed_distances = SO3ProductTangentGaussianDistribution.geodesic_distance(
+            identity_product, rotated_product
+        )
+
+        npt.assert_allclose(
+            component_distances, array([[pi / 2.0, pi / 4.0]]), atol=ATOL
+        )
+        npt.assert_allclose(summed_distances, array([3.0 * pi / 4.0]), atol=ATOL)
+
+    def test_marginalize_rotations(self):
+        covariance = diag(array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]))
+        dist = SO3ProductTangentGaussianDistribution(
+            array([z_quaternion(0.0), x_quaternion(pi / 2.0)]), covariance
+        )
+
+        marginal = dist.marginalize_rotation(1)
+
+        self.assertIsInstance(marginal, SO3ProductTangentGaussianDistribution)
+        self.assertEqual(marginal.num_rotations, 1)
+        self.assertEqual(marginal.dim, 3)
+        npt.assert_allclose(marginal.mean()[0], x_quaternion(pi / 2.0), atol=ATOL)
+        npt.assert_allclose(
+            marginal.covariance(), diag(array([0.4, 0.5, 0.6])), atol=ATOL
+        )
+
+    def test_mean_rotation_matrices(self):
+        dist = SO3ProductTangentGaussianDistribution.from_covariance_diagonal(
+            array([z_quaternion(0.0), z_quaternion(pi / 2.0)]),
+            array([0.1, 0.1, 0.1, 0.1, 0.1, 0.1]),
+        )
+        expected_rotation_matrices = array([eye(3), z_rotation(pi / 2.0)])
+
+        npt.assert_allclose(
+            dist.mean_rotation_matrices(), expected_rotation_matrices, atol=ATOL
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/distributions/test_so3_product_tangent_gaussian_distribution.py
+++ b/tests/distributions/test_so3_product_tangent_gaussian_distribution.py
@@ -1,4 +1,3 @@
-import math
 import unittest
 
 import numpy.testing as npt
@@ -6,42 +5,22 @@ import numpy.testing as npt
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
     array,
-    cos,
     diag,
     eye,
     linalg,
     ones,
     pi,
     random,
-    sin,
     sqrt,
-    to_numpy,
 )
 from pyrecest.distributions import SO3ProductTangentGaussianDistribution
-
-ATOL = 1e-6
-
-
-def scalar(value):
-    return float(to_numpy(value).reshape(-1)[0])
-
-
-def z_quaternion(angle):
-    return array([0.0, 0.0, sin(angle / 2.0), cos(angle / 2.0)])
-
-
-def x_quaternion(angle):
-    return array([sin(angle / 2.0), 0.0, 0.0, cos(angle / 2.0)])
-
-
-def z_rotation(angle):
-    return array(
-        [
-            [cos(angle), -sin(angle), 0.0],
-            [sin(angle), cos(angle), 0.0],
-            [0.0, 0.0, 1.0],
-        ]
-    )
+from tests.distributions.so3_test_helpers import (
+    ATOL,
+    assert_pdf_peak_matches_log_pdf,
+    x_quaternion,
+    z_quaternion,
+    z_rotation,
+)
 
 
 class SO3ProductTangentGaussianDistributionTest(unittest.TestCase):
@@ -90,15 +69,7 @@ class SO3ProductTangentGaussianDistributionTest(unittest.TestCase):
             array([0.4, 0.0, 0.0, 0.0, -0.2, 0.0]), base=dist.mean()
         )
 
-        mode_pdf = scalar(dist.pdf(dist.mode()))
-        offset_pdf = scalar(dist.pdf(offset))
-        expected_mode_pdf = 1.0 / scalar(sqrt((2.0 * pi) ** 6 * linalg.det(covariance)))
-
-        self.assertGreater(mode_pdf, offset_pdf)
-        npt.assert_allclose(mode_pdf, expected_mode_pdf, atol=ATOL)
-        npt.assert_allclose(
-            scalar(dist.ln_pdf(dist.mode())), math.log(mode_pdf), atol=ATOL
-        )
+        assert_pdf_peak_matches_log_pdf(self, dist, covariance, 6, offset)
 
     def test_sampling_returns_unit_product_quaternions(self):
         random.seed(0)

--- a/tests/distributions/test_so3_tangent_gaussian_distribution.py
+++ b/tests/distributions/test_so3_tangent_gaussian_distribution.py
@@ -1,15 +1,14 @@
-import math
 import unittest
 
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array, diag, linalg, ones, pi, random, sqrt
+from pyrecest.backend import array, diag, linalg, ones, pi, random
 from pyrecest.distributions import SO3TangentGaussianDistribution
 from tests.distributions.so3_test_helpers import (
     ATOL,
+    assert_pdf_peak_matches_log_pdf,
     assert_matches_z_rotation,
-    scalar,
     z_quaternion,
 )
 
@@ -37,15 +36,7 @@ class SO3TangentGaussianDistributionTest(unittest.TestCase):
         dist = SO3TangentGaussianDistribution(array([0.0, 0.0, 0.0, 1.0]), covariance)
         offset = SO3TangentGaussianDistribution.exp_map(array([0.4, 0.0, 0.0]))
 
-        mode_pdf = scalar(dist.pdf(dist.mode()))
-        offset_pdf = scalar(dist.pdf(offset))
-        expected_mode_pdf = 1.0 / scalar(sqrt((2.0 * pi) ** 3 * linalg.det(covariance)))
-
-        self.assertGreater(mode_pdf, offset_pdf)
-        npt.assert_allclose(mode_pdf, expected_mode_pdf, atol=ATOL)
-        npt.assert_allclose(
-            scalar(dist.ln_pdf(dist.mode())), math.log(mode_pdf), atol=ATOL
-        )
+        assert_pdf_peak_matches_log_pdf(self, dist, covariance, 3, offset)
 
     def test_sampling_returns_unit_quaternions(self):
         random.seed(0)


### PR DESCRIPTION
## Summary
- add `SO3ProductTangentGaussianDistribution` for full-covariance tangent Gaussian densities on SO(3)^K
- support product and flattened mean/tangent/rotation representations, component-wise exp/log maps, density evaluation, sampling, geodesic distances, rotation matrix conversion, and product marginals
- export the new distribution and cover it with focused tests

## Validation
- `python -m unittest tests.distributions.test_so3_product_tangent_gaussian_distribution`
- `PYRECEST_BACKEND=numpy python -m pytest -q tests\distributions\test_so3_product_tangent_gaussian_distribution.py`
- `PYRECEST_BACKEND=jax python -m pytest -q tests\distributions\test_so3_product_tangent_gaussian_distribution.py`
- `PYRECEST_BACKEND=pytorch python -m pytest -q tests\distributions\test_so3_product_tangent_gaussian_distribution.py`
- `python -m pytest -q tests\distributions\test_so3_product_tangent_gaussian_distribution.py tests\distributions\test_so3_dirac_distribution.py`
- `python -m ruff check src\pyrecest\distributions\so3_product_tangent_gaussian_distribution.py tests\distributions\test_so3_product_tangent_gaussian_distribution.py src\pyrecest\distributions\__init__.py`
- `python -m pylint src\pyrecest\distributions\so3_product_tangent_gaussian_distribution.py tests\distributions\test_so3_product_tangent_gaussian_distribution.py`
- `python -m mypy --ignore-missing-imports src\pyrecest\distributions\so3_product_tangent_gaussian_distribution.py tests\distributions\test_so3_product_tangent_gaussian_distribution.py`