### PR TITLE
Add SO3 distance helpers

### DIFF
--- a/src/pyrecest/distributions/so3_dirac_distribution.py
+++ b/src/pyrecest/distributions/so3_dirac_distribution.py
@@ -13,6 +13,7 @@ from pyrecest.backend import (
     ndim,
     reshape,
     spatial,
+    sqrt,
     sum,
     where,
 )
@@ -97,9 +98,21 @@ class SO3DiracDistribution(HyperhemisphericalDiracDistribution):
         inner = abs(sum(quat_a * quat_b, axis=-1))
         return 2.0 * arccos(clip(inner, 0.0, 1.0))
 
+    @staticmethod
+    def chordal_distance(rotation_a, rotation_b):
+        """Return the SO(3) Frobenius chordal distance between quaternions."""
+        quat_a = SO3DiracDistribution._normalize_quaternions(rotation_a)
+        quat_b = SO3DiracDistribution._normalize_quaternions(rotation_b)
+        inner = abs(sum(quat_a * quat_b, axis=-1))
+        return 2.0 * sqrt(2.0) * sqrt(clip(1.0 - inner**2, 0.0, 1.0))
+
     def distance_to(self, rotation):
         """Return geodesic distances from all Dirac locations to ``rotation``."""
         return self.geodesic_distance(self.d, rotation)
+
+    def chordal_distance_to(self, rotation):
+        """Return chordal distances from all Dirac locations to ``rotation``."""
+        return self.chordal_distance(self.d, rotation)
 
     @staticmethod
     def from_distribution(distribution, n_particles):
@@ -112,6 +125,10 @@ class SO3DiracDistribution(HyperhemisphericalDiracDistribution):
     def angular_error_mean(self, rotation):
         """Return the weighted mean angular error to ``rotation`` in radians."""
         return sum(self.w * self.distance_to(rotation))
+
+    def chordal_error_mean(self, rotation):
+        """Return the weighted mean chordal error to ``rotation``."""
+        return sum(self.w * self.chordal_distance_to(rotation))
 
     def is_valid(self, tolerance=1e-6):
         """Return whether all stored quaternions are normalized and canonical."""

--- a/tests/distributions/test_so3_dirac_distribution.py
+++ b/tests/distributions/test_so3_dirac_distribution.py
@@ -4,7 +4,7 @@ import numpy.testing as npt
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array, cos, eye, pi, sin, stack
+from pyrecest.backend import array, cos, eye, linalg, pi, sin, sqrt, stack
 from pyrecest.distributions import SO3DiracDistribution
 from pyrecest.distributions.hypersphere_subset.hyperhemispherical_dirac_distribution import (
     HyperhemisphericalDiracDistribution,
@@ -64,6 +64,47 @@ class SO3DiracDistributionTest(unittest.TestCase):
             array([pi / 2.0]),
             atol=ATOL,
         )
+
+    def test_chordal_distance_matches_so3_frobenius_metric(self):
+        identity = array([0.0, 0.0, 0.0, 1.0])
+        identity_antipodal = array([0.0, 0.0, 0.0, -1.0])
+        quarter_turn = array([0.0, 0.0, sin(pi / 4.0), cos(pi / 4.0)])
+        half_turn = array([0.0, 0.0, 1.0, 0.0])
+        quarter_turn_matrix = array(
+            [[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]]
+        )
+
+        npt.assert_allclose(
+            SO3DiracDistribution.chordal_distance(identity, identity_antipodal),
+            array([0.0]),
+            atol=ATOL,
+        )
+        npt.assert_allclose(
+            SO3DiracDistribution.chordal_distance(identity, quarter_turn),
+            linalg.norm(eye(3) - quarter_turn_matrix),
+            atol=ATOL,
+        )
+        npt.assert_allclose(
+            SO3DiracDistribution.chordal_distance(identity, half_turn),
+            array([2.0 * sqrt(2.0)]),
+            atol=ATOL,
+        )
+
+    def test_so3_distance_methods_accept_batches(self):
+        identity = array([0.0, 0.0, 0.0, 1.0])
+        quarter_turn = array([0.0, 0.0, sin(pi / 4.0), cos(pi / 4.0)])
+        dist = SO3DiracDistribution(
+            stack([identity, quarter_turn], axis=0), array([0.25, 0.75])
+        )
+
+        npt.assert_allclose(
+            dist.distance_to(identity), array([0.0, pi / 2.0]), atol=ATOL
+        )
+        npt.assert_allclose(
+            dist.chordal_distance_to(identity), array([0.0, 2.0]), atol=ATOL
+        )
+        npt.assert_allclose(dist.angular_error_mean(identity), 0.75 * pi / 2.0)
+        npt.assert_allclose(dist.chordal_error_mean(identity), 1.5, atol=ATOL)
 
     def test_mode_returns_highest_weight_canonical_quaternion(self):
         dist = SO3DiracDistribution(


### PR DESCRIPTION
## Summary
- add `SO3DiracDistribution.chordal_distance` for the SO(3) Frobenius chordal metric from scalar-last quaternions
- add instance helpers for chordal distances and weighted chordal error means
- extend SO(3) Dirac tests for geodesic/chordal distances, antipodal equivalence, batch inputs, and consistency with the matrix Frobenius metric

## Validation
- `python -m unittest tests.distributions.test_so3_dirac_distribution`
- `PYRECEST_BACKEND=numpy python -m pytest -q tests\distributions\test_so3_dirac_distribution.py`
- `PYRECEST_BACKEND=jax python -m pytest -q tests\distributions\test_so3_dirac_distribution.py`
- `PYRECEST_BACKEND=pytorch python -m pytest -q tests\distributions\test_so3_dirac_distribution.py`
- `python -m pytest -q tests\distributions\test_so3_dirac_distribution.py tests\smoothers\test_so3_chordal_mean_smoother.py`
- `python -m ruff check src\pyrecest\distributions\so3_dirac_distribution.py tests\distributions\test_so3_dirac_distribution.py`
- `python -m pylint src\pyrecest\distributions\so3_dirac_distribution.py tests\distributions\test_so3_dirac_distribution.py`
- `python -m mypy --ignore-missing-imports src\pyrecest\distributions\so3_dirac_distribution.py tests\distributions\test_so3_dirac_distribution.py`