### PR TITLE
Fix hyperhemispherical uniform sampling

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/hyperhemispherical_uniform_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/hyperhemispherical_uniform_distribution.py
@@ -29,11 +29,9 @@ class HyperhemisphericalUniformDistribution(
             numpy.ndarray: n sampled points.
         """
         s = HypersphericalUniformDistribution(self.dim).sample(n)
-        # Mirror ones with negative on the last dimension up for hemisphere. This
-        # may give a disadvantage to ones with exactly zero at the first dimension but
-        # since this is hit with quasi probability zero, we neglect
-        # this.
-        s = (1 - 2 * (s[-1, :] < 0)) * s
+        # Mirror samples with negative last coordinate up to the hemisphere.
+        # Samples exactly on the equator are left unchanged; this has probability zero.
+        s = (1 - 2 * (s[:, -1:] < 0)) * s
         return s
 
     def get_manifold_size(self) -> float:

--- a/tests/distributions/test_hyperhemispherical_uniform_distribution.py
+++ b/tests/distributions/test_hyperhemispherical_uniform_distribution.py
@@ -1,11 +1,23 @@
 """Test for uniform distribution for hyperhemispheres"""
 
 import unittest
+from unittest.mock import patch
 
+import numpy.testing as npt
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import allclose, linalg, ones, pi, random, reshape
+from pyrecest.backend import (
+    all,
+    allclose,
+    array,
+    linalg,
+    ones,
+    pi,
+    random,
+    reshape,
+    to_numpy,
+)
 from pyrecest.distributions import HyperhemisphericalUniformDistribution
 
 
@@ -54,6 +66,46 @@ class TestHyperhemisphericalUniformDistribution(unittest.TestCase):
     def test_integrate_S3(self):
         hhud = HyperhemisphericalUniformDistribution(3)
         self.assertAlmostEqual(hhud.integrate(), 1, delta=1e-6)
+
+    @patch(
+        "pyrecest.distributions.hypersphere_subset."
+        "hyperhemispherical_uniform_distribution.HypersphericalUniformDistribution.sample"
+    )
+    def test_sample_mirrors_each_point_with_negative_last_coordinate(self, sample_mock):
+        raw_samples = array(
+            [
+                [0.0, 0.0, -1.0],
+                [0.0, -1.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ]
+        )
+        expected_samples = array(
+            [
+                [-0.0, -0.0, 1.0],
+                [0.0, -1.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ]
+        )
+        sample_mock.return_value = raw_samples
+
+        samples = HyperhemisphericalUniformDistribution(2).sample(4)
+
+        npt.assert_allclose(to_numpy(samples), to_numpy(expected_samples))
+        self.assertTrue(bool(to_numpy(all(samples[:, -1] >= 0.0))))
+
+    @patch(
+        "pyrecest.distributions.hypersphere_subset."
+        "hyperhemispherical_uniform_distribution.HypersphericalUniformDistribution.sample"
+    )
+    def test_single_sample_is_not_forced_into_positive_orthant(self, sample_mock):
+        raw_sample = array([[-0.6, -0.8, 0.0]])
+        sample_mock.return_value = raw_sample
+
+        sample = HyperhemisphericalUniformDistribution(2).sample(1)
+
+        npt.assert_allclose(to_numpy(sample), to_numpy(raw_sample))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Fix `HyperhemisphericalUniformDistribution.sample` to mirror each sampled point based on its own last coordinate.
- Update the sampler comment to describe the hemisphere projection accurately.
- Add regression tests for per-row mirroring and the single-sample equator case.

## Root cause
`HypersphericalUniformDistribution.sample(n)` returns samples shaped `(n, dim + 1)`, but the hyperhemisphere sampler checked `s[-1, :]`, which reads the last sampled row instead of the last coordinate of every sample. For `n == 1`, that could force all coordinates positive instead of only projecting to the upper hemisphere.

## Validation
- `$env:PYTHONPATH='src'; $env:PYRECEST_BACKEND='numpy'; python -m pytest -q tests/distributions/test_hyperhemispherical_uniform_distribution.py`
- `$env:PYTHONPATH='src'; $env:PYRECEST_BACKEND='numpy'; python -m pytest -q tests/distributions/test_hyperhemispherical_uniform_distribution.py tests/distributions/test_hyperspherical_uniform_distribution.py`
- `$env:PYTHONPATH='src'; $env:PYRECEST_BACKEND='pytorch'; python -m pytest -q tests/distributions/test_hyperhemispherical_uniform_distribution.py`
- `$env:PYTHONPATH='src'; $env:PYRECEST_BACKEND='jax'; python -m pytest -q tests/distributions/test_hyperhemispherical_uniform_distribution.py`
- `python -m black --check src/pyrecest/distributions/hypersphere_subset/hyperhemispherical_uniform_distribution.py tests/distributions/test_hyperhemispherical_uniform_distribution.py`
- `python -m ruff check src/pyrecest/distributions/hypersphere_subset/hyperhemispherical_uniform_distribution.py tests/distributions/test_hyperhemispherical_uniform_distribution.py`