### PR TITLE
Fix SO3 Dirac chordal distance clip import

### DIFF
--- a/src/pyrecest/distributions/so3_dirac_distribution.py
+++ b/src/pyrecest/distributions/so3_dirac_distribution.py
@@ -6,6 +6,7 @@ from pyrecest.backend import (
     amax,
     array,
     asarray,
+    clip,
     linalg,
     ndim,
     spatial,


### PR DESCRIPTION
## Summary
- import the backend `clip` helper in `SO3DiracDistribution`
- restores `chordal_distance` after it started calling `clip` without a local binding

## Validation
- `PYTHONPATH=src pytest tests/distributions/test_so3_dirac_distribution.py -q`