### PR TITLE
Add SO3 product particle filter

### DIFF
--- a/src/pyrecest/distributions/so3_dirac_distribution.py
+++ b/src/pyrecest/distributions/so3_dirac_distribution.py
@@ -3,9 +3,11 @@
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
     abs,
+    all,
     amax,
     array,
     asarray,
+    clip,
     linalg,
     ndim,
     spatial,

--- a/src/pyrecest/filters/__init__.py
+++ b/src/pyrecest/filters/__init__.py
@@ -75,6 +75,7 @@ from .multi_bernoulli_tracker import BernoulliComponent, MultiBernoulliTracker
 from .piecewise_constant_filter import PiecewiseConstantFilter
 from .random_matrix_tracker import RandomMatrixTracker
 from .se2_ukf import SE2UKF
+from .so3_product_particle_filter import SO3ProductParticleFilter
 from .state_space_subdivision_filter import StateSpaceSubdivisionFilter
 from .toroidal_particle_filter import ToroidalParticleFilter
 from .toroidal_wrapped_normal_filter import ToroidalWrappedNormalFilter
@@ -183,6 +184,7 @@ __all__ = [
     "solve_global_nearest_neighbor",
     "SE2FilterMixin",
     "SE2UKF",
+    "SO3ProductParticleFilter",
     "StateSpaceSubdivisionFilter",
     "ToroidalFilterMixin",
     "ToroidalParticleFilter",

--- a/src/pyrecest/filters/so3_product_particle_filter.py
+++ b/src/pyrecest/filters/so3_product_particle_filter.py
@@ -1,0 +1,411 @@
+"""Particle filter for Cartesian products of SO(3)."""
+
+from collections.abc import Callable
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import (
+    all,
+    array,
+    diag,
+    exp,
+    ndim,
+    ones,
+    random,
+    reshape,
+    stack,
+    sum,
+    to_numpy,
+    zeros,
+)
+from pyrecest.distributions import SO3DiracDistribution
+from pyrecest.distributions._so3_helpers import geodesic_distance, normalize_quaternions
+from pyrecest.distributions.cart_prod.hyperhemisphere_cart_prod_dirac_distribution import (
+    HyperhemisphereCartProdDiracDistribution,
+)
+from pyrecest.distributions.so3_tangent_gaussian_distribution import (
+    SO3TangentGaussianDistribution,
+)
+
+from .abstract_particle_filter import AbstractParticleFilter
+
+
+class SO3ProductParticleFilter(AbstractParticleFilter):
+    """Particle filter for states on ``SO(3)^K``.
+
+    Particles are exposed as scalar-last unit quaternions with shape
+    ``(n_particles, num_rotations, 4)``. Internally, the filter stores them in
+    PyRecEst's existing hyperhemisphere Cartesian-product Dirac distribution.
+    """
+
+    def __init__(
+        self,
+        n_particles: int,
+        num_rotations: int,
+        initial_particles=None,
+        weights=None,
+    ) -> None:
+        if n_particles <= 0:
+            raise ValueError("n_particles must be positive.")
+        if num_rotations <= 0:
+            raise ValueError("num_rotations must be positive.")
+
+        self.num_rotations = int(num_rotations)
+        particles = self._identity_particles(n_particles, self.num_rotations)
+        if initial_particles is not None:
+            particles = self._as_particle_array(initial_particles, self.num_rotations)
+            if particles.shape[0] != n_particles:
+                raise ValueError("initial_particles must contain n_particles entries.")
+
+        if weights is None:
+            weights = ones(n_particles) / n_particles
+        else:
+            weights = self._normalize_weights(weights)
+
+        initial_filter_state = HyperhemisphereCartProdDiracDistribution(
+            self._flatten_particles(particles),
+            weights,
+            dim_hemisphere=3,
+            n_hemispheres=self.num_rotations,
+        )
+        super().__init__(initial_filter_state=initial_filter_state)
+
+    @staticmethod
+    def _identity_particles(n_particles, num_rotations):
+        return array(
+            [
+                [[0.0, 0.0, 0.0, 1.0] for _ in range(num_rotations)]
+                for _ in range(n_particles)
+            ],
+            dtype=float,
+        )
+
+    @staticmethod
+    def _as_particle_array(particles, num_rotations):
+        particles = array(particles, dtype=float)
+
+        if ndim(particles) == 1:
+            if particles.shape[0] != 4 * num_rotations:
+                raise ValueError("A flat SO(3)^K particle must have length 4K.")
+            particles = reshape(particles, (1, num_rotations, 4))
+        elif ndim(particles) == 2:
+            if particles.shape == (num_rotations, 4):
+                particles = reshape(particles, (1, num_rotations, 4))
+            elif particles.shape[-1] == 4 * num_rotations:
+                particles = reshape(particles, (particles.shape[0], num_rotations, 4))
+            else:
+                raise ValueError(
+                    "SO(3)^K particles must have shape (K, 4), (n, 4K), or "
+                    "(n, K, 4)."
+                )
+        elif ndim(particles) == 3:
+            if particles.shape[1:] != (num_rotations, 4):
+                raise ValueError("SO(3)^K particles must have shape (n, K, 4).")
+        else:
+            raise ValueError(
+                "SO(3)^K particles must have shape (4K,), (K, 4), "
+                "(n, 4K), or (n, K, 4)."
+            )
+
+        normalized = normalize_quaternions(reshape(particles, (-1, 4)))
+        return reshape(normalized, particles.shape)
+
+    @staticmethod
+    def _as_product_point(rotation, num_rotations):
+        particles = SO3ProductParticleFilter._as_particle_array(rotation, num_rotations)
+        if particles.shape[0] != 1:
+            raise ValueError("Expected a single SO(3)^K product point.")
+        return particles[0]
+
+    @staticmethod
+    def _flatten_particles(particles):
+        return reshape(particles, (particles.shape[0], 4 * particles.shape[1]))
+
+    @staticmethod
+    def _normalize_weights(weights):
+        weights = array(weights, dtype=float)
+        if ndim(weights) != 1:
+            weights = reshape(weights, (-1,))
+        if not all(weights >= 0.0):
+            raise ValueError("Particle weights must be nonnegative.")
+        weight_sum = sum(weights)
+        if weight_sum <= 0.0:
+            raise ValueError("At least one particle weight must be positive.")
+        return weights / weight_sum
+
+    @staticmethod
+    def _as_tangent_array(tangent_vectors, n_particles, num_rotations):
+        tangent_vectors = array(tangent_vectors, dtype=float)
+
+        if ndim(tangent_vectors) == 1:
+            if tangent_vectors.shape[0] != 3 * num_rotations:
+                raise ValueError("A flat SO(3)^K tangent vector must have length 3K.")
+            tangent_vectors = reshape(tangent_vectors, (1, num_rotations, 3))
+        elif ndim(tangent_vectors) == 2:
+            if tangent_vectors.shape == (num_rotations, 3):
+                tangent_vectors = reshape(tangent_vectors, (1, num_rotations, 3))
+            elif tangent_vectors.shape[-1] == 3 * num_rotations:
+                tangent_vectors = reshape(
+                    tangent_vectors, (tangent_vectors.shape[0], num_rotations, 3)
+                )
+            else:
+                raise ValueError(
+                    "SO(3)^K tangent vectors must have shape (K, 3), "
+                    "(n, 3K), or (n, K, 3)."
+                )
+        elif ndim(tangent_vectors) == 3:
+            if tangent_vectors.shape[1:] != (num_rotations, 3):
+                raise ValueError("SO(3)^K tangent vectors must have shape (n, K, 3).")
+        else:
+            raise ValueError(
+                "SO(3)^K tangent vectors must have shape (3K,), (K, 3), "
+                "(n, 3K), or (n, K, 3)."
+            )
+
+        if tangent_vectors.shape[0] == 1 and n_particles != 1:
+            tangent_vectors = stack(
+                [tangent_vectors[0] for _ in range(n_particles)], axis=0
+            )
+        if tangent_vectors.shape[0] != n_particles:
+            raise ValueError("Tangent vector batch size must match particle count.")
+
+        return tangent_vectors
+
+    @staticmethod
+    def _sample_tangent_noise(covariance, n_particles, num_rotations):
+        if covariance is None:
+            return zeros((n_particles, num_rotations, 3))
+
+        covariance = array(covariance, dtype=float)
+        if ndim(covariance) == 2:
+            if covariance.shape == (3, 3):
+                components = [
+                    random.multivariate_normal(
+                        mean=zeros(3), cov=covariance, size=n_particles
+                    )
+                    for _ in range(num_rotations)
+                ]
+                return stack(components, axis=1)
+            if covariance.shape == (3 * num_rotations, 3 * num_rotations):
+                samples = random.multivariate_normal(
+                    mean=zeros(3 * num_rotations), cov=covariance, size=n_particles
+                )
+                return reshape(samples, (n_particles, num_rotations, 3))
+        elif ndim(covariance) == 3 and covariance.shape == (num_rotations, 3, 3):
+            components = [
+                random.multivariate_normal(
+                    mean=zeros(3), cov=covariance[i], size=n_particles
+                )
+                for i in range(num_rotations)
+            ]
+            return stack(components, axis=1)
+
+        raise ValueError(
+            "tangent_noise_covariance must have shape (3, 3), (K, 3, 3), "
+            "or (3K, 3K)."
+        )
+
+    @property
+    def n_particles(self):
+        return self.filter_state.d.shape[0]
+
+    @property
+    def particles(self):
+        """Return particles with shape ``(n_particles, num_rotations, 4)``."""
+        return reshape(self.filter_state.d, (self.n_particles, self.num_rotations, 4))
+
+    @property
+    def weights(self):
+        """Return normalized particle weights."""
+        return self.filter_state.w
+
+    def set_particles(self, particles, weights=None):
+        """Replace particles and optionally weights."""
+        particles = self._as_particle_array(particles, self.num_rotations)
+        if particles.shape[0] != self.n_particles:
+            raise ValueError("New particles must match the existing particle count.")
+        self.filter_state.d = self._flatten_particles(particles)
+        if weights is not None:
+            weights = self._normalize_weights(weights)
+            if weights.shape[0] != self.n_particles:
+                raise ValueError("weights must match the particle count.")
+            self.filter_state.w = weights
+
+    def mean(self):
+        """Return the component-wise chordal mean product rotation."""
+        means = [
+            SO3DiracDistribution(self.particles[:, i, :], self.weights).mean()
+            for i in range(self.num_rotations)
+        ]
+        return stack(means, axis=0)
+
+    def mode(self):
+        """Return the highest-weight product particle."""
+        return reshape(self.filter_state.mode(), (self.num_rotations, 4))
+
+    def get_point_estimate(self):
+        """Return the component-wise SO(3) mean."""
+        return self.mean()
+
+    def effective_sample_size(self):
+        """Return the particle effective sample size."""
+        return 1.0 / sum(self.weights**2)
+
+    def resample_systematic(self):
+        """Systematically resample particles and reset weights to uniform."""
+        weights = self._normalize_weights(self.weights)
+        weights_list = [float(weight) for weight in to_numpy(weights).reshape(-1)]
+        n_particles = len(weights_list)
+        start = float(to_numpy(random.rand(1)).reshape(-1)[0]) / n_particles
+        positions = [start + i / n_particles for i in range(n_particles)]
+
+        indices = []
+        cumulative_weight = weights_list[0]
+        source_index = 0
+        for position in positions:
+            while position > cumulative_weight and source_index < n_particles - 1:
+                source_index += 1
+                cumulative_weight += weights_list[source_index]
+            indices.append(source_index)
+
+        index_array = array(indices)
+        self.filter_state.d = self.filter_state.d[index_array]
+        self.filter_state.w = ones(n_particles) / n_particles
+        return index_array
+
+    def _apply_tangent_delta(self, particles, tangent_delta):
+        tangent_delta = self._as_tangent_array(
+            tangent_delta, particles.shape[0], self.num_rotations
+        )
+        updated_components = [
+            SO3TangentGaussianDistribution.exp_map(
+                tangent_delta[:, i, :], base=particles[:, i, :]
+            )
+            for i in range(self.num_rotations)
+        ]
+        return stack(updated_components, axis=1)
+
+    def predict_with_tangent_delta(self, tangent_delta, tangent_noise_covariance=None):
+        """Apply tangent-space deltas and optional tangent Gaussian noise."""
+        tangent_delta = self._as_tangent_array(
+            tangent_delta, self.n_particles, self.num_rotations
+        )
+        tangent_noise = self._sample_tangent_noise(
+            tangent_noise_covariance, self.n_particles, self.num_rotations
+        )
+        self.set_particles(
+            self._apply_tangent_delta(self.particles, tangent_delta + tangent_noise)
+        )
+
+    def predict_identity(self, noise_distribution=None):
+        """Predict with identity dynamics and optional tangent Gaussian noise."""
+        self.predict_with_tangent_delta(
+            zeros((self.num_rotations, 3)),
+            tangent_noise_covariance=noise_distribution,
+        )
+
+    def predict_nonlinear(
+        self,
+        f: Callable,
+        noise_distribution=None,
+        function_is_vectorized: bool = True,
+        shift_instead_of_add: bool = True,
+    ):
+        """Apply a nonlinear transition on product particles."""
+        if not shift_instead_of_add:
+            raise NotImplementedError("Only tangent-space noise is supported.")
+        if function_is_vectorized:
+            predicted_particles = f(self.particles)
+        else:
+            predicted_particles = stack(
+                [f(self.particles[i]) for i in range(self.n_particles)], axis=0
+            )
+        predicted_particles = self._as_particle_array(
+            predicted_particles, self.num_rotations
+        )
+        tangent_noise = self._sample_tangent_noise(
+            noise_distribution, self.n_particles, self.num_rotations
+        )
+        self.set_particles(
+            self._apply_tangent_delta(predicted_particles, tangent_noise)
+        )
+
+    def update_with_likelihood(
+        self,
+        likelihood: Callable,
+        measurement=None,
+        resample: bool = True,
+        ess_threshold=None,
+    ):
+        """Update weights from a likelihood evaluated on product particles."""
+        if measurement is None:
+            likelihood_values = likelihood(self.particles)
+        else:
+            likelihood_values = likelihood(measurement, self.particles)
+        likelihood_values = array(likelihood_values, dtype=float)
+        if likelihood_values.shape != self.weights.shape:
+            raise ValueError("likelihood must return one value per particle.")
+        if not all(likelihood_values >= 0.0):
+            raise ValueError("likelihood values must be nonnegative.")
+
+        self.filter_state.w = self._normalize_weights(self.weights * likelihood_values)
+        ess = self.effective_sample_size()
+        threshold = self.n_particles / 2.0 if ess_threshold is None else ess_threshold
+        if resample and ess < threshold:
+            self.resample_systematic()
+        return ess
+
+    def update_with_geodesic_likelihood(
+        self,
+        measurement,
+        noise_std,
+        *,
+        mask=None,
+        resample: bool = True,
+        ess_threshold=None,
+    ):
+        """Update with an isotropic masked geodesic likelihood on SO(3)^K."""
+        if noise_std <= 0.0:
+            raise ValueError("noise_std must be positive.")
+
+        measurement = self._as_product_point(measurement, self.num_rotations)
+        if mask is None:
+            mask = ones(self.num_rotations)
+        else:
+            mask = array(mask, dtype=float)
+            if mask.shape != (self.num_rotations,):
+                raise ValueError("mask must have shape (num_rotations,).")
+
+        distances = stack(
+            [
+                geodesic_distance(self.particles[:, i, :], measurement[i, :])
+                for i in range(self.num_rotations)
+            ],
+            axis=1,
+        )
+        quadratic = sum(mask * distances**2, axis=1) / (noise_std**2)
+        likelihood_values = exp(-0.5 * quadratic)
+        return self.update_with_likelihood(
+            lambda _: likelihood_values,
+            resample=resample,
+            ess_threshold=ess_threshold,
+        )
+
+    @staticmethod
+    def from_covariance_diagonal(
+        n_particles,
+        mean,
+        covariance_diagonal,
+    ):
+        """Create a filter by sampling tangent noise around ``mean``."""
+        mean = SO3ProductParticleFilter._as_product_point(
+            mean, num_rotations=len(covariance_diagonal) // 3
+        )
+        num_rotations = mean.shape[0]
+        covariance = diag(array(covariance_diagonal, dtype=float))
+        tangent_noise = SO3ProductParticleFilter._sample_tangent_noise(
+            covariance, n_particles, num_rotations
+        )
+        initial_filter = SO3ProductParticleFilter(n_particles, num_rotations)
+        initial_filter.set_particles(stack([mean for _ in range(n_particles)], axis=0))
+        initial_filter.predict_with_tangent_delta(tangent_noise)
+        return initial_filter

--- a/src/pyrecest/filters/so3_product_particle_filter.py
+++ b/src/pyrecest/filters/so3_product_particle_filter.py
@@ -19,22 +19,22 @@ from pyrecest.backend import (
 )
 from pyrecest.distributions import SO3DiracDistribution
 from pyrecest.distributions._so3_helpers import geodesic_distance, normalize_quaternions
-from pyrecest.distributions.cart_prod.hyperhemisphere_cart_prod_dirac_distribution import (
-    HyperhemisphereCartProdDiracDistribution,
-)
 from pyrecest.distributions.so3_tangent_gaussian_distribution import (
     SO3TangentGaussianDistribution,
 )
 
-from .abstract_particle_filter import AbstractParticleFilter
+from .hyperhemisphere_cart_prod_particle_filter import (
+    HyperhemisphereCartProdParticleFilter,
+)
 
 
-class SO3ProductParticleFilter(AbstractParticleFilter):
+class SO3ProductParticleFilter(HyperhemisphereCartProdParticleFilter):
     """Particle filter for states on ``SO(3)^K``.
 
     Particles are exposed as scalar-last unit quaternions with shape
     ``(n_particles, num_rotations, 4)``. Internally, the filter stores them in
-    PyRecEst's existing hyperhemisphere Cartesian-product Dirac distribution.
+    the generic hyperhemisphere Cartesian-product particle filter with
+    ``dim_hemisphere=3``.
     """
 
     def __init__(
@@ -50,24 +50,21 @@ class SO3ProductParticleFilter(AbstractParticleFilter):
             raise ValueError("num_rotations must be positive.")
 
         self.num_rotations = int(num_rotations)
+        super().__init__(
+            n_particles=n_particles,
+            dim_hemisphere=3,
+            n_hemispheres=self.num_rotations,
+        )
+
         particles = self._identity_particles(n_particles, self.num_rotations)
         if initial_particles is not None:
             particles = self._as_particle_array(initial_particles, self.num_rotations)
             if particles.shape[0] != n_particles:
                 raise ValueError("initial_particles must contain n_particles entries.")
 
-        if weights is None:
-            weights = ones(n_particles) / n_particles
-        else:
+        if weights is not None:
             weights = self._normalize_weights(weights)
-
-        initial_filter_state = HyperhemisphereCartProdDiracDistribution(
-            self._flatten_particles(particles),
-            weights,
-            dim_hemisphere=3,
-            n_hemispheres=self.num_rotations,
-        )
-        super().__init__(initial_filter_state=initial_filter_state)
+        self.set_particles(particles, weights=weights)
 
     @staticmethod
     def _identity_particles(n_particles, num_rotations):

--- a/tests/filters/test_so3_product_particle_filter.py
+++ b/tests/filters/test_so3_product_particle_filter.py
@@ -3,8 +3,11 @@ import unittest
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array, diag, linalg, ones, pi, random, sin, cos, stack
-from pyrecest.filters import SO3ProductParticleFilter
+from pyrecest.backend import array, cos, diag, linalg, ones, pi, random, sin, stack
+from pyrecest.filters import (
+    HyperhemisphereCartProdParticleFilter,
+    SO3ProductParticleFilter,
+)
 
 ATOL = 1e-6
 
@@ -21,6 +24,9 @@ class SO3ProductParticleFilterTest(unittest.TestCase):
     def test_initializes_identity_particles(self):
         filt = SO3ProductParticleFilter(n_particles=5, num_rotations=2)
 
+        self.assertIsInstance(filt, HyperhemisphereCartProdParticleFilter)
+        self.assertEqual(filt.filter_state.dim_hemisphere, 3)
+        self.assertEqual(filt.filter_state.n_hemispheres, 2)
         self.assertEqual(filt.particles.shape, (5, 2, 4))
         self.assertEqual(filt.filter_state.d.shape, (5, 8))
         npt.assert_allclose(linalg.norm(filt.particles, axis=-1), ones((5, 2)))

--- a/tests/filters/test_so3_product_particle_filter.py
+++ b/tests/filters/test_so3_product_particle_filter.py
@@ -1,0 +1,125 @@
+import unittest
+
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array, diag, linalg, ones, pi, random, sin, cos, stack
+from pyrecest.filters import SO3ProductParticleFilter
+
+ATOL = 1e-6
+
+
+def z_quaternion(angle):
+    return array([0.0, 0.0, sin(angle / 2.0), cos(angle / 2.0)])
+
+
+def x_quaternion(angle):
+    return array([sin(angle / 2.0), 0.0, 0.0, cos(angle / 2.0)])
+
+
+class SO3ProductParticleFilterTest(unittest.TestCase):
+    def test_initializes_identity_particles(self):
+        filt = SO3ProductParticleFilter(n_particles=5, num_rotations=2)
+
+        self.assertEqual(filt.particles.shape, (5, 2, 4))
+        self.assertEqual(filt.filter_state.d.shape, (5, 8))
+        npt.assert_allclose(linalg.norm(filt.particles, axis=-1), ones((5, 2)))
+        npt.assert_allclose(filt.weights, ones(5) / 5)
+        npt.assert_allclose(filt.effective_sample_size(), 5.0)
+
+    def test_set_particles_normalizes_and_canonicalizes(self):
+        filt = SO3ProductParticleFilter(n_particles=2, num_rotations=2)
+        particles = array(
+            [
+                [[0.0, 0.0, 0.0, -2.0], [0.0, 0.0, 1.0, 1.0]],
+                [[0.0, 0.0, 0.0, 3.0], [-1.0, 0.0, 0.0, -1.0]],
+            ]
+        )
+
+        filt.set_particles(particles, weights=array([1.0, 3.0]))
+
+        npt.assert_allclose(linalg.norm(filt.particles, axis=-1), ones((2, 2)))
+        self.assertGreaterEqual(float(filt.particles[0, 0, -1]), 0.0)
+        self.assertGreaterEqual(float(filt.particles[1, 1, -1]), 0.0)
+        npt.assert_allclose(filt.weights, array([0.25, 0.75]))
+
+    def test_predict_with_tangent_delta_rotates_each_component(self):
+        filt = SO3ProductParticleFilter(n_particles=3, num_rotations=2)
+        tangent_delta = array([0.0, 0.0, pi / 2.0, pi / 4.0, 0.0, 0.0])
+
+        filt.predict_with_tangent_delta(tangent_delta)
+
+        expected = array([z_quaternion(pi / 2.0), x_quaternion(pi / 4.0)])
+        npt.assert_allclose(filt.particles[0], expected, atol=ATOL)
+        npt.assert_allclose(filt.particles[1], expected, atol=ATOL)
+
+    def test_predict_identity_with_full_tangent_noise_covariance(self):
+        random.seed(0)
+        filt = SO3ProductParticleFilter(n_particles=4, num_rotations=2)
+
+        filt.predict_identity(diag(array([0.01, 0.01, 0.01, 0.02, 0.02, 0.02])))
+
+        self.assertEqual(filt.particles.shape, (4, 2, 4))
+        npt.assert_allclose(linalg.norm(filt.particles, axis=-1), ones((4, 2)))
+
+    def test_update_with_geodesic_likelihood_prefers_matching_particle(self):
+        filt = SO3ProductParticleFilter(n_particles=2, num_rotations=1)
+        filt.set_particles(
+            array([[[0.0, 0.0, 0.0, 1.0]], [z_quaternion(pi / 2.0)]]),
+            weights=array([0.5, 0.5]),
+        )
+
+        ess = filt.update_with_geodesic_likelihood(
+            array([[0.0, 0.0, 0.0, 1.0]]),
+            noise_std=0.2,
+            resample=False,
+        )
+
+        self.assertLess(float(ess), 2.0)
+        self.assertGreater(float(filt.weights[0]), float(filt.weights[1]))
+
+    def test_update_mask_ignores_unobserved_rotations(self):
+        filt = SO3ProductParticleFilter(n_particles=2, num_rotations=2)
+        filt.set_particles(
+            stack(
+                [
+                    array([[0.0, 0.0, 0.0, 1.0], z_quaternion(0.0)]),
+                    array([[0.0, 0.0, 0.0, 1.0], z_quaternion(pi / 2.0)]),
+                ],
+                axis=0,
+            )
+        )
+
+        filt.update_with_geodesic_likelihood(
+            array([[0.0, 0.0, 0.0, 1.0], z_quaternion(0.0)]),
+            noise_std=0.2,
+            mask=array([1.0, 0.0]),
+            resample=False,
+        )
+
+        npt.assert_allclose(filt.weights, array([0.5, 0.5]), atol=ATOL)
+
+    def test_systematic_resampling_resets_weights(self):
+        random.seed(0)
+        filt = SO3ProductParticleFilter(n_particles=3, num_rotations=1)
+        filt.set_particles(
+            array(
+                [
+                    [[0.0, 0.0, 0.0, 1.0]],
+                    [z_quaternion(pi / 4.0)],
+                    [z_quaternion(pi / 2.0)],
+                ]
+            ),
+            weights=array([0.8, 0.1, 0.1]),
+        )
+
+        indices = filt.resample_systematic()
+
+        self.assertEqual(indices.shape, (3,))
+        self.assertEqual(filt.particles.shape, (3, 1, 4))
+        npt.assert_allclose(filt.weights, ones(3) / 3)
+        npt.assert_allclose(linalg.norm(filt.particles, axis=-1), ones((3, 1)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `SO3ProductParticleFilter` for particle filtering on SO(3)^K with scalar-last quaternion particles
- support tangent-space prediction, nonlinear transitions, masked geodesic likelihood updates, ESS, and systematic resampling
- export the filter and add focused tests across initialization, prediction, measurement updates, masking, and resampling
- fix missing `all`/`clip` imports in `SO3DiracDistribution` needed by the existing SO(3) distance helpers

## Validation
- `python -m pytest -q tests\filters\test_so3_product_particle_filter.py tests\distributions\test_so3_dirac_distribution.py tests\distributions\test_so3_tangent_gaussian_distribution.py`
- `python -m ruff check src\pyrecest\filters\so3_product_particle_filter.py tests\filters\test_so3_product_particle_filter.py src\pyrecest\filters\__init__.py src\pyrecest\distributions\so3_dirac_distribution.py`
- `python -m pylint src\pyrecest\filters\so3_product_particle_filter.py tests\filters\test_so3_product_particle_filter.py`
- `python -m mypy --ignore-missing-imports src\pyrecest\filters\so3_product_particle_filter.py tests\filters\test_so3_product_particle_filter.py`

Also previously validated the new filter test under `PYRECEST_BACKEND=numpy`, `PYRECEST_BACKEND=jax`, and `PYRECEST_BACKEND=pytorch`.