### PR TITLE
Refactor SO3 product Dirac onto hyperhemisphere product base

### DIFF
--- a/src/pyrecest/distributions/cart_prod/hyperhemisphere_cart_prod_dirac_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/hyperhemisphere_cart_prod_dirac_distribution.py
@@ -1,24 +1,132 @@
 import copy
 from collections.abc import Callable
 
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import argmax, array, linalg, outer, reshape, stack, sum, where
+
 from ..abstract_dirac_distribution import AbstractDiracDistribution
+from ..hypersphere_subset.abstract_hypersphere_subset_distribution import (
+    AbstractHypersphereSubsetDistribution,
+)
+from .abstract_cart_prod_distribution import AbstractCartProdDistribution
 
 
-class HyperhemisphereCartProdDiracDistribution(AbstractDiracDistribution):
-    def __init__(self, d, w, dim_hemisphere, n_hemispheres):
+class HyperhemisphereCartProdDiracDistribution(
+    AbstractDiracDistribution, AbstractCartProdDistribution
+):
+    def __init__(
+        self, d, w=None, dim_hemisphere=None, n_hemispheres=None, *, store_flat=True
+    ):
         """
         Initialize a Dirac distribution with given Dirac locations and weights.
 
         :param d: Dirac locations as a numpy array.
         :param w: Weights of Dirac locations as a numpy array. If not provided, defaults to uniform weights.
         """
-        super().__init__(d, w)
+        assert dim_hemisphere is not None, "Hemisphere dimension must be specified."
+        assert n_hemispheres is not None, "Number of hemispheres must be specified."
         self.dim_hemisphere = dim_hemisphere
         self.n_hemispheres = n_hemispheres
-        assert self.d.shape[-1] == (
-            (1 + dim_hemisphere) * n_hemispheres
-        ), "Dimension is not correct."
+        self._store_flat = store_flat
+        particles = self._as_component_array(d, dim_hemisphere, n_hemispheres)
+        if store_flat:
+            particles = reshape(
+                particles,
+                (particles.shape[0], self.input_dim),
+            )
+
+        super().__init__(particles, w)
         self.dim = dim_hemisphere * n_hemispheres
+
+    @property
+    def component_dim(self):
+        return self.dim_hemisphere + 1
+
+    @property
+    def input_dim(self):
+        return self.component_dim * self.n_hemispheres
+
+    @staticmethod
+    def _as_component_array(d, dim_hemisphere, n_hemispheres):
+        particles = array(d)
+        component_dim = dim_hemisphere + 1
+        input_dim = component_dim * n_hemispheres
+
+        if particles.ndim == 2:
+            if particles.shape[-1] != input_dim:
+                raise ValueError("Dimension is not correct.")
+            return reshape(
+                particles, (particles.shape[0], n_hemispheres, component_dim)
+            )
+
+        if particles.ndim == 3:
+            if particles.shape[1:] != (n_hemispheres, component_dim):
+                raise ValueError("Dimension is not correct.")
+            return particles
+
+        raise ValueError(
+            "Dirac locations must have shape (n, total_dim) or "
+            "(n, n_hemispheres, dim_hemisphere + 1)."
+        )
+
+    def as_component_array(self):
+        """Return locations with shape ``(n, n_hemispheres, dim_hemisphere + 1)``."""
+        return self._as_component_array(self.d, self.dim_hemisphere, self.n_hemispheres)
+
+    def as_flat_array(self):
+        """Return locations with shape ``(n, (dim_hemisphere + 1) * n_hemispheres)``."""
+        return reshape(self.as_component_array(), (self.d.shape[0], self.input_dim))
+
+    def component_particles(self, component_index):
+        """Return Dirac locations for one hyperhemisphere component."""
+        return self.as_component_array()[:, component_index, :]
+
+    def get_manifold_size(self):
+        hemisphere_size = (
+            0.5
+            * AbstractHypersphereSubsetDistribution.compute_unit_hypersphere_surface(
+                self.dim_hemisphere
+            )
+        )
+        return hemisphere_size**self.n_hemispheres
+
+    def moment(self, component_index=None):
+        """Return weighted second moments for the product components."""
+        if component_index is not None:
+            return self._moment_for_component(component_index)
+        return stack(
+            [self._moment_for_component(i) for i in range(self.n_hemispheres)], 0
+        )
+
+    def _moment_for_component(self, component_index):
+        particles = self.component_particles(component_index)
+        weighted_outer_products = stack(
+            [
+                self.w[i] * outer(particles[i, :], particles[i, :])
+                for i in range(self.d.shape[0])
+            ],
+            0,
+        )
+        return sum(weighted_outer_products, axis=0) / sum(self.w)
+
+    def mean_axis(self, component_index=None):
+        """Return weighted principal axes for the product components."""
+        if component_index is not None:
+            return self._mean_axis_for_component(component_index)
+        return stack(
+            [self._mean_axis_for_component(i) for i in range(self.n_hemispheres)], 0
+        )
+
+    def _mean_axis_for_component(self, component_index):
+        eigenvalues, eigenvectors = linalg.eigh(
+            self._moment_for_component(component_index)
+        )
+        axis = eigenvectors[:, argmax(eigenvalues)]
+        axis = axis / linalg.norm(axis)
+        return where(axis[-1:] < 0.0, -axis, axis)
+
+    def mean(self):
+        return self.mean_axis()
 
     def apply_function_component_wise(
         self, f: Callable, f_supports_multiple: bool = True
@@ -32,7 +140,11 @@ class HyperhemisphereCartProdDiracDistribution(AbstractDiracDistribution):
         assert f_supports_multiple, "Function must support multiple inputs."
         dist = copy.deepcopy(self)
         for i in range(self.n_hemispheres):
-            dist.d[
-                i * self.dim_hemisphere : (i + 1) * self.dim_hemisphere  # noqa: E203
-            ] = f(self.d[i])
+            component_values = f(self.component_particles(i))
+            if self._store_flat:
+                start = i * self.component_dim
+                stop = (i + 1) * self.component_dim
+                dist.d[:, start:stop] = component_values
+            else:
+                dist.d[:, i, :] = component_values
         return dist

--- a/src/pyrecest/distributions/so3_product_dirac_distribution.py
+++ b/src/pyrecest/distributions/so3_product_dirac_distribution.py
@@ -1,16 +1,14 @@
 """Dirac distributions on Cartesian products of SO(3)."""
 
-# pylint: disable=no-name-in-module,no-member
+# pylint: disable=no-name-in-module,no-member,arguments-renamed
 from pyrecest.backend import (
     abs,
     all,
     arange,
     arccos,
-    argmax,
     array,
     clip,
     linalg,
-    outer,
     pi,
     random,
     reshape,
@@ -19,16 +17,15 @@ from pyrecest.backend import (
     where,
 )
 
-from .abstract_dirac_distribution import AbstractDiracDistribution
-from .cart_prod.abstract_cart_prod_distribution import AbstractCartProdDistribution
+from .cart_prod.hyperhemisphere_cart_prod_dirac_distribution import (
+    HyperhemisphereCartProdDiracDistribution,
+)
 from .hypersphere_subset.hyperhemispherical_dirac_distribution import (
     HyperhemisphericalDiracDistribution,
 )
 
 
-class SO3ProductDiracDistribution(
-    AbstractDiracDistribution, AbstractCartProdDistribution
-):
+class SO3ProductDiracDistribution(HyperhemisphereCartProdDiracDistribution):
     """Weighted Dirac distribution on SO(3)^K.
 
     Rotations are represented as scalar-last unit quaternions ``(x, y, z, w)``.
@@ -42,12 +39,13 @@ class SO3ProductDiracDistribution(
             d, num_rotations=num_rotations
         )
         self.num_rotations = inferred_num_rotations
-        self.dim = 3 * self.num_rotations
-        super().__init__(quaternions, w=w)
-
-    @property
-    def input_dim(self):
-        return 4 * self.num_rotations
+        super().__init__(
+            quaternions,
+            w=w,
+            dim_hemisphere=3,
+            n_hemispheres=inferred_num_rotations,
+            store_flat=False,
+        )
 
     def get_manifold_size(self):
         return pi ** (2 * self.num_rotations)
@@ -72,9 +70,10 @@ class SO3ProductDiracDistribution(
                     and inferred_num_rotations != num_rotations
                 ):
                     raise ValueError("num_rotations does not match input shape.")
-                quaternions = reshape(
+                quaternions = SO3ProductDiracDistribution._as_component_array(
                     quaternions,
-                    (quaternions.shape[0], inferred_num_rotations, 4),
+                    dim_hemisphere=3,
+                    n_hemispheres=inferred_num_rotations,
                 )
         elif quaternions.ndim == 3:
             if quaternions.shape[-1] != 4:
@@ -112,7 +111,7 @@ class SO3ProductDiracDistribution(
 
     def as_flat_quaternions(self):
         """Return Dirac locations with shape ``(n, 4 * K)``."""
-        return reshape(self.d, (self.d.shape[0], 4 * self.num_rotations))
+        return self.as_flat_array()
 
     def sample(self, n):
         indices = random.choice(arange(self.d.shape[0]), n, p=self.w)
@@ -123,7 +122,9 @@ class SO3ProductDiracDistribution(
 
     def marginalize_rotation(self, rotation_index):
         """Return the single SO(3) marginal at ``rotation_index``."""
-        return HyperhemisphericalDiracDistribution(self.d[:, rotation_index, :], self.w)
+        return HyperhemisphericalDiracDistribution(
+            self.component_particles(rotation_index), self.w
+        )
 
     def marginalize_rotations(self, rotation_indices):
         """Return the SO(3)^L marginal selected by ``rotation_indices``."""
@@ -137,20 +138,10 @@ class SO3ProductDiracDistribution(
         """
         if rotation_index is not None:
             return self._moment_for_rotation(rotation_index)
-        return stack(
-            [self._moment_for_rotation(i) for i in range(self.num_rotations)], 0
-        )
+        return super().moment()
 
     def _moment_for_rotation(self, rotation_index):
-        quaternions = self.d[:, rotation_index, :]
-        weighted_outer_products = stack(
-            [
-                self.w[i] * outer(quaternions[i, :], quaternions[i, :])
-                for i in range(self.d.shape[0])
-            ],
-            0,
-        )
-        return sum(weighted_outer_products, axis=0) / sum(self.w)
+        return self._moment_for_component(rotation_index)
 
     def mean_quaternion(self, rotation_index=None):
         """Return the weighted chordal quaternion mean."""
@@ -162,12 +153,7 @@ class SO3ProductDiracDistribution(
         )
 
     def _mean_quaternion_for_rotation(self, rotation_index):
-        eigenvalues, eigenvectors = linalg.eigh(
-            self._moment_for_rotation(rotation_index)
-        )
-        mean_quaternion = eigenvectors[:, argmax(eigenvalues)]
-        mean_quaternion = mean_quaternion / linalg.norm(mean_quaternion)
-        return self._canonicalize_quaternions(mean_quaternion)
+        return self._mean_axis_for_component(rotation_index)
 
     def mean(self):
         """Return the weighted chordal quaternion mean for each component."""

--- a/tests/distributions/test_so3_product_dirac_distribution.py
+++ b/tests/distributions/test_so3_product_dirac_distribution.py
@@ -6,6 +6,9 @@ import numpy.testing as npt
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import array, linalg, ones, pi, random, sum
 from pyrecest.distributions import SO3ProductDiracDistribution
+from pyrecest.distributions.cart_prod.hyperhemisphere_cart_prod_dirac_distribution import (
+    HyperhemisphereCartProdDiracDistribution,
+)
 from pyrecest.distributions.hypersphere_subset.hyperhemispherical_dirac_distribution import (
     HyperhemisphericalDiracDistribution,
 )
@@ -75,6 +78,10 @@ class SO3ProductDiracDistributionTest(unittest.TestCase):
         self.assertEqual(dist.d.shape, (2, 2, 4))
         self.assertEqual(dist.as_flat_quaternions().shape, (2, 8))
         npt.assert_allclose(dist.as_flat_quaternions(), flat_locations)
+        self.assertIsInstance(dist, HyperhemisphereCartProdDiracDistribution)
+        self.assertEqual(dist.dim_hemisphere, 3)
+        self.assertEqual(dist.n_hemispheres, 2)
+        npt.assert_allclose(dist.as_component_array(), dist.as_quaternions())
 
     def test_single_particle_input_with_num_rotations(self):
         locations = array(


### PR DESCRIPTION
## Summary
- extend `HyperhemisphereCartProdDiracDistribution` with product shape helpers, manifold size, moments, and component-wise means while preserving flat storage by default
- make `SO3ProductDiracDistribution` inherit from the hyperhemisphere product Dirac distribution with `dim_hemisphere=3`
- add a focused test assertion that the SO(3) product distribution is a hyperhemisphere product specialization

## Validation
- `PYTHONPATH=src python -m pytest -q tests\distributions\test_so3_product_dirac_distribution.py tests\filters\test_hyperhemisphere_cart_prod_particle_filter.py`
- `PYTHONPATH=src python -m black --check src\pyrecest\distributions\cart_prod\hyperhemisphere_cart_prod_dirac_distribution.py src\pyrecest\distributions\so3_product_dirac_distribution.py tests\distributions\test_so3_product_dirac_distribution.py`
- `PYTHONPATH=src python -m ruff check src\pyrecest\distributions\cart_prod\hyperhemisphere_cart_prod_dirac_distribution.py src\pyrecest\distributions\so3_product_dirac_distribution.py tests\distributions\test_so3_product_dirac_distribution.py`
- `PYTHONPATH=src python -m pylint src\pyrecest\distributions\cart_prod\hyperhemisphere_cart_prod_dirac_distribution.py src\pyrecest\distributions\so3_product_dirac_distribution.py`
- `PYTHONPATH=src python -m mypy --ignore-missing-imports src\pyrecest\distributions\cart_prod\hyperhemisphere_cart_prod_dirac_distribution.py src\pyrecest\distributions\so3_product_dirac_distribution.py`