### PR TITLE
Update workflow actions for Node 24

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Create Pull Request with applied fixes
         id: cpr
         if: github.ref == 'refs/heads/main' && steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'pull_request' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.head_commit.message, 'skip fix')
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
           commit-message: "[MegaLinter] Apply linters automatic fixes"
@@ -127,7 +127,7 @@ jobs:
         run: sudo chown -Rc $UID .git/
       - name: Commit and push applied linter fixes
         if: steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'commit' && github.ref != 'refs/heads/main' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.head_commit.message, 'skip fix')
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           branch: ${{ github.event.pull_request.head.ref || github.head_ref || github.ref }}
           commit_message: "[MegaLinter] Apply linters fixes"

--- a/.github/workflows/tags-and-publishing.yml
+++ b/.github/workflows/tags-and-publishing.yml
@@ -240,7 +240,7 @@ jobs:
 
       - name: Upload release notes artifact for dry runs
         if: ${{ env.DRY_RUN == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-notes-${{ env.VERSION }}
           path: RELEASE_NOTES.md

--- a/.github/workflows/update-requirements.yml
+++ b/.github/workflows/update-requirements.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Create Pull Request with applied fixes
         id: cpr
         if: github.ref == 'refs/heads/main' && env.changes_made == 'true' && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'pull_request' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.head_commit.message, 'skip fix')
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
           commit-message: "Update requirements"
@@ -117,7 +117,7 @@ jobs:
 
       - name: Commit and push new requirements.txt and requirements-dev.txt
         if: env.changes_made == 'true' && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'commit' && github.ref != 'refs/heads/main' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.head_commit.message, 'skip fix')
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           branch: ${{ github.event.pull_request.head.ref || github.head_ref || github.ref }}
           commit_message: "Update requirements"


### PR DESCRIPTION
## Summary
- Update `actions/upload-artifact` from `v4` to `v7` in the dry-run release-notes artifact upload step.
- Update `peter-evans/create-pull-request` from `v7` to `v8` in the MegaLinter and requirements workflows.
- Update `stefanzweifel/git-auto-commit-action` from `v5` to `v7` in the MegaLinter and requirements workflows.

## Why
GitHub Actions is deprecating JavaScript actions that run on Node.js 20. The updated action major versions declare `runs.using: node24` in their action metadata.

## Impact
This removes the Node.js 20 runtime deprecation exposure from the affected workflow steps without changing their configuration, artifact names, branches, labels, or commit settings.

## Validation
- Ran `git diff --check`.
- Verified `actions/upload-artifact@v7`, `peter-evans/create-pull-request@v8`, and `stefanzweifel/git-auto-commit-action@v7` all declare `runs.using: node24`.
- Confirmed remaining `actions/upload-artifact@v6` references already use Node 24 and were intentionally left unchanged.