### PR TITLE
Add systematic distribution representation conversion

### DIFF
--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -41,6 +41,10 @@ Common starting points include:
 - `HypertoroidalFourierDistribution` and hypertoroidal grid or wrapped-normal
   distributions for toroidal states.
 
+Use `pyrecest.distributions.conversion.convert_distribution(...)` to convert
+between analytic, Dirac/particle, grid, Fourier, and moment-matched
+representations. See [representation conversion](representation-conversion.md).
+
 ### `pyrecest.filters`
 
 Recursive Bayesian estimators and trackers. The package includes standard

--- a/docs/representation-conversion.md
+++ b/docs/representation-conversion.md
@@ -4,8 +4,7 @@ PyRecEst distributions often support several representations of the same
 uncertainty state: analytic densities, Dirac/particle sets, grids, Fourier
 series, mixtures, and moment-matched approximations.
 
-Use `convert_distribution` or the method alias `approximate_as` to make these
-conversions explicit and discoverable.
+Use `convert_distribution` to make these conversions explicit and discoverable.
 
 ```python
 from pyrecest.backend import array, eye
@@ -16,12 +15,9 @@ prior = GaussianDistribution(array([0.0, 0.0]), eye(2))
 particles = convert_distribution(prior, LinearDiracDistribution, n_particles=1000)
 ```
 
-The same conversion can be written from the source distribution when the source
-inherits from one of the common PyRecEst distribution base classes:
-
-```python
-particles = prior.approximate_as(LinearDiracDistribution, n_particles=1000)
-```
+Some PyRecEst distribution base classes also expose convenience wrappers such as
+`convert_to(...)` and `approximate_as(...)`; these delegate to the same generic
+conversion gateway when available.
 
 ## Target-centric conversions
 

--- a/docs/representation-conversion.md
+++ b/docs/representation-conversion.md
@@ -1,0 +1,92 @@
+# Representation Conversion
+
+PyRecEst distributions often support several representations of the same
+uncertainty state: analytic densities, Dirac/particle sets, grids, Fourier
+series, mixtures, and moment-matched approximations.
+
+Use `convert_distribution` or the method alias `approximate_as` to make these
+conversions explicit and discoverable.
+
+```python
+from pyrecest.backend import array, eye
+from pyrecest.distributions import GaussianDistribution, LinearDiracDistribution
+from pyrecest.distributions.conversion import convert_distribution
+
+prior = GaussianDistribution(array([0.0, 0.0]), eye(2))
+particles = convert_distribution(prior, LinearDiracDistribution, n_particles=1000)
+```
+
+The same conversion can be written from the source distribution when the source
+inherits from one of the common PyRecEst distribution base classes:
+
+```python
+particles = prior.approximate_as(LinearDiracDistribution, n_particles=1000)
+```
+
+## Target-centric conversions
+
+Conversions are target-centric. A target class can expose
+`from_distribution(distribution, ...)`, and the generic conversion gateway will
+call it.
+
+This keeps domain-specific approximation logic close to the representation that
+owns it. For example:
+
+- `LinearDiracDistribution.from_distribution(...)` samples a source density.
+- `CircularGridDistribution.from_distribution(...)` evaluates a circular density
+  on a grid.
+- `CircularFourierDistribution.from_distribution(...)` builds Fourier
+  coefficients from samples or grid values.
+- `GaussianDistribution.from_distribution(...)` performs Gaussian moment
+  matching when the source exposes `mean()` and `covariance()`.
+
+## Metadata
+
+Use `return_info=True` when you need to know how the conversion was performed.
+
+```python
+result = convert_distribution(
+    prior,
+    LinearDiracDistribution,
+    n_particles=1000,
+    return_info=True,
+)
+
+particles = result.distribution
+print(result.method)
+print(result.exact)
+```
+
+Identity conversions are exact. Sampling, grid approximation, Fourier
+truncation, and moment matching are reported as approximate unless a converter
+explicitly marks them as exact.
+
+## Custom conversions
+
+Third-party representations can register conversions without editing central
+dispatch code.
+
+```python
+from pyrecest.distributions.conversion import register_conversion
+
+
+@register_conversion(MyDistribution, MyParticleDistribution)
+def my_distribution_to_particles(distribution, n_particles):
+    return MyParticleDistribution(distribution.sample(n_particles))
+```
+
+After registration, the normal gateway works:
+
+```python
+particles = convert_distribution(source, MyParticleDistribution, n_particles=1000)
+```
+
+## Common parameters
+
+Common conversion parameters depend on the target representation:
+
+- `n_particles` for Dirac/particle approximations.
+- `no_of_gridpoints` for one-dimensional circular grids.
+- `n_grid_points` for hypertoroidal grids.
+- `no_of_grid_points` and `grid_type` for hypersphere-subset grids.
+- `n` for Fourier representations.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
   - Guides:
       - Shapes and Conventions: conventions.md
       - Backend Compatibility: backend-compatibility.md
+      - Representation Conversion: representation-conversion.md
   - Tutorials:
       - Overview: tutorials/index.md
       - Use a Distribution: tutorials/use-a-distribution.md

--- a/src/pyrecest/distributions/abstract_distribution_type.py
+++ b/src/pyrecest/distributions/abstract_distribution_type.py
@@ -6,3 +6,32 @@ class AbstractDistributionType(ABC):
     This class represents an abstract base for specific types of distributions,
     regardless of their domain (uniform, mixture, custom, etc.)
     """
+
+    def convert_to(self, target_type: type, /, *, return_info: bool = False, **kwargs):
+        """Convert or approximate this distribution as ``target_type``.
+
+        This is a convenience wrapper around
+        :func:`pyrecest.distributions.convert_distribution`.
+
+        Parameters
+        ----------
+        target_type
+            Concrete target representation class.
+        return_info
+            If true, return a ``ConversionResult`` containing metadata.
+        **kwargs
+            Conversion parameters required by the target representation.
+        """
+        from .conversion import convert_distribution
+
+        return convert_distribution(
+            self, target_type, return_info=return_info, **kwargs
+        )
+
+    def approximate_as(
+        self, target_type: type, /, *, return_info: bool = False, **kwargs
+    ):
+        """Alias for :meth:`convert_to` emphasizing approximate conversions."""
+        return self.convert_to(
+            target_type, return_info=return_info, **kwargs
+        )

--- a/src/pyrecest/distributions/conversion.py
+++ b/src/pyrecest/distributions/conversion.py
@@ -1,0 +1,319 @@
+"""Systematic conversion between distribution representations.
+
+The conversion layer is intentionally target-centric: a concrete target
+representation can implement ``from_distribution(...)`` and the generic
+``convert_distribution`` gateway will route to it. This keeps manifold-specific
+logic close to the representation that owns it while giving users a single,
+discoverable API.
+"""
+
+from __future__ import annotations
+
+import copy
+import inspect
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class ConversionError(ValueError):
+    """Raised when a distribution representation conversion is unavailable."""
+
+
+@dataclass
+class ConversionResult:
+    """Distribution conversion result and metadata.
+
+    Attributes
+    ----------
+    distribution
+        Converted distribution instance.
+    source_type
+        Concrete source distribution type.
+    target_type
+        Requested target distribution type.
+    method
+        Human-readable conversion method used by the gateway.
+    exact
+        Whether the conversion is mathematically exact as a distribution
+        representation. Moment matching, sampling, and grid approximation
+        should be reported as approximate.
+    parameters
+        Conversion parameters that were passed to the conversion routine.
+    """
+
+    distribution: Any
+    source_type: type
+    target_type: type
+    method: str
+    exact: bool
+    parameters: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class _RegisteredConversion:
+    source_type: type
+    target_type: type
+    converter: Callable[..., Any]
+    exact: bool
+    method: str
+
+
+_CONVERSION_REGISTRY: list[_RegisteredConversion] = []
+
+
+def register_conversion(
+    source_type: type,
+    target_type: type,
+    converter: Callable[..., Any] | None = None,
+    *,
+    exact: bool = False,
+    method: str | None = None,
+):
+    """Register a custom conversion between two representation classes.
+
+    Parameters
+    ----------
+    source_type
+        Source type accepted by the converter. Subclasses are accepted.
+    target_type
+        Target type produced by the converter. Subclasses of this target may
+        also use the registered conversion.
+    converter
+        Callable with signature ``converter(source, **kwargs)``. When omitted,
+        this function acts as a decorator.
+    exact
+        Whether the conversion is exact.
+    method
+        Optional human-readable method name used in :class:`ConversionResult`.
+
+    Returns
+    -------
+    Callable
+        The original converter, enabling decorator use.
+    """
+
+    def _decorator(func: Callable[..., Any]):
+        _CONVERSION_REGISTRY.insert(
+            0,
+            _RegisteredConversion(
+                source_type=source_type,
+                target_type=target_type,
+                converter=func,
+                exact=exact,
+                method=method or func.__name__,
+            ),
+        )
+        return func
+
+    if converter is not None:
+        return _decorator(converter)
+    return _decorator
+
+
+def convert_distribution(
+    distribution,
+    target_type: type,
+    /,
+    *,
+    return_info: bool = False,
+    copy_if_same: bool = False,
+    **kwargs,
+):
+    """Convert or approximate ``distribution`` as ``target_type``.
+
+    The gateway supports three cases, in order:
+
+    1. identity conversion when ``distribution`` already is an instance of
+       ``target_type``;
+    2. explicitly registered conversions;
+    3. target classes exposing ``from_distribution(distribution, ...)``.
+
+    Parameters
+    ----------
+    distribution
+        Source distribution instance.
+    target_type
+        Concrete target representation class, such as
+        ``LinearDiracDistribution``, ``CircularGridDistribution``, or
+        ``GaussianDistribution``.
+    return_info
+        If false, return the converted distribution directly. If true, return a
+        :class:`ConversionResult`.
+    copy_if_same
+        If true, identity conversion returns a deep copy instead of the same
+        object.
+    **kwargs
+        Parameters required by the target conversion.
+
+    Returns
+    -------
+    object or ConversionResult
+        Converted distribution, or metadata wrapper if ``return_info=True``.
+    """
+
+    if not isinstance(target_type, type):
+        raise TypeError("target_type must be a distribution class.")
+
+    source_type = type(distribution)
+
+    if isinstance(distribution, target_type):
+        converted = copy.deepcopy(distribution) if copy_if_same else distribution
+        result = ConversionResult(
+            distribution=converted,
+            source_type=source_type,
+            target_type=target_type,
+            method="identity",
+            exact=True,
+            parameters=dict(kwargs),
+        )
+        return result if return_info else result.distribution
+
+    for entry in _matching_registered_conversions(distribution, target_type):
+        converted = _call_conversion_callable(entry.converter, distribution, kwargs)
+        result = ConversionResult(
+            distribution=converted,
+            source_type=source_type,
+            target_type=target_type,
+            method=entry.method,
+            exact=entry.exact,
+            parameters=dict(kwargs),
+        )
+        return result if return_info else result.distribution
+
+    from_distribution = getattr(target_type, "from_distribution", None)
+    if callable(from_distribution):
+        converted = _call_conversion_callable(
+            from_distribution,
+            distribution,
+            kwargs,
+            conversion_name=f"{target_type.__name__}.from_distribution",
+        )
+        result = ConversionResult(
+            distribution=converted,
+            source_type=source_type,
+            target_type=target_type,
+            method=f"{target_type.__name__}.from_distribution",
+            exact=False,
+            parameters=dict(kwargs),
+        )
+        return result if return_info else result.distribution
+
+    raise ConversionError(
+        f"No conversion registered for {source_type.__name__} -> {target_type.__name__}. "
+        f"Implement {target_type.__name__}.from_distribution(...) or register one with register_conversion(...)."
+    )
+
+
+def can_convert(distribution, target_type: type) -> bool:
+    """Return whether a conversion route exists.
+
+    This only checks for a route. It does not verify that all conversion
+    arguments required by the route have been supplied.
+    """
+
+    if not isinstance(target_type, type):
+        return False
+    if isinstance(distribution, target_type):
+        return True
+    if any(_matching_registered_conversions(distribution, target_type)):
+        return True
+    return callable(getattr(target_type, "from_distribution", None))
+
+
+def registered_conversions() -> tuple[tuple[type, type, str, bool], ...]:
+    """Return a compact snapshot of explicitly registered conversions."""
+
+    return tuple(
+        (entry.source_type, entry.target_type, entry.method, entry.exact)
+        for entry in _CONVERSION_REGISTRY
+    )
+
+
+def _matching_registered_conversions(distribution, target_type: type):
+    return (
+        entry
+        for entry in _CONVERSION_REGISTRY
+        if isinstance(distribution, entry.source_type)
+        and issubclass(target_type, entry.target_type)
+    )
+
+
+def _call_conversion_callable(
+    func: Callable[..., Any],
+    distribution,
+    kwargs: dict[str, Any],
+    *,
+    conversion_name: str | None = None,
+):
+    name = conversion_name or getattr(func, "__name__", repr(func))
+    _validate_conversion_arguments(func, kwargs, name)
+    try:
+        return func(distribution, **kwargs)
+    except TypeError as exc:
+        raise ConversionError(f"Could not call {name}: {exc}") from exc
+
+
+def _validate_conversion_arguments(
+    func: Callable[..., Any], kwargs: dict[str, Any], conversion_name: str
+) -> None:
+    try:
+        signature = inspect.signature(func)
+    except (TypeError, ValueError):
+        return
+
+    params = list(signature.parameters.values())
+    has_var_keyword = any(
+        param.kind == inspect.Parameter.VAR_KEYWORD for param in params
+    )
+    accepted_kwargs: set[str] = set()
+    required_kwargs: set[str] = set()
+    skipped_source_argument = False
+
+    for param in params:
+        if (
+            not skipped_source_argument
+            and param.kind
+            in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            )
+        ):
+            skipped_source_argument = True
+            continue
+
+        if param.kind in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        ):
+            accepted_kwargs.add(param.name)
+            if param.default is inspect.Parameter.empty:
+                required_kwargs.add(param.name)
+
+    missing = required_kwargs - set(kwargs)
+    if missing:
+        raise ConversionError(
+            f"{conversion_name} is missing required conversion argument(s): "
+            f"{', '.join(sorted(missing))}."
+        )
+
+    if has_var_keyword:
+        return
+
+    unknown = set(kwargs) - accepted_kwargs
+    if unknown:
+        accepted = ", ".join(sorted(accepted_kwargs)) or "no keyword arguments"
+        raise ConversionError(
+            f"{conversion_name} got unsupported conversion argument(s): "
+            f"{', '.join(sorted(unknown))}. Accepted arguments: {accepted}."
+        )
+
+
+__all__ = [
+    "ConversionError",
+    "ConversionResult",
+    "can_convert",
+    "convert_distribution",
+    "register_conversion",
+    "registered_conversions",
+]

--- a/tests/distributions/test_conversion.py
+++ b/tests/distributions/test_conversion.py
@@ -1,0 +1,79 @@
+import unittest
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array, eye, random
+from pyrecest.distributions import GaussianDistribution, LinearDiracDistribution
+from pyrecest.distributions.conversion import (
+    ConversionError,
+    ConversionResult,
+    can_convert,
+    convert_distribution,
+)
+
+
+class ConversionTest(unittest.TestCase):
+    def test_convert_distribution_uses_target_from_distribution(self):
+        random.seed(0)
+        gaussian = GaussianDistribution(array([0.0, 0.0]), eye(2))
+
+        particles = convert_distribution(
+            gaussian, LinearDiracDistribution, n_particles=25
+        )
+
+        self.assertIsInstance(particles, LinearDiracDistribution)
+        self.assertEqual(particles.d.shape[0], 25)
+
+    def test_return_info(self):
+        random.seed(0)
+        gaussian = GaussianDistribution(array([0.0, 0.0]), eye(2))
+
+        result = convert_distribution(
+            gaussian,
+            LinearDiracDistribution,
+            n_particles=5,
+            return_info=True,
+        )
+
+        self.assertIsInstance(result, ConversionResult)
+        self.assertIsInstance(result.distribution, LinearDiracDistribution)
+        self.assertEqual(result.source_type, GaussianDistribution)
+        self.assertEqual(result.target_type, LinearDiracDistribution)
+        self.assertEqual(result.method, "LinearDiracDistribution.from_distribution")
+        self.assertFalse(result.exact)
+
+    def test_identity_conversion_is_exact(self):
+        gaussian = GaussianDistribution(array([0.0, 0.0]), eye(2))
+
+        result = convert_distribution(
+            gaussian, GaussianDistribution, return_info=True
+        )
+
+        self.assertIs(result.distribution, gaussian)
+        self.assertTrue(result.exact)
+        self.assertEqual(result.method, "identity")
+
+    def test_can_convert_reports_route_only(self):
+        gaussian = GaussianDistribution(array([0.0, 0.0]), eye(2))
+
+        self.assertTrue(can_convert(gaussian, LinearDiracDistribution))
+
+    def test_missing_required_conversion_argument_raises_helpful_error(self):
+        gaussian = GaussianDistribution(array([0.0, 0.0]), eye(2))
+
+        with self.assertRaises(ConversionError):
+            convert_distribution(gaussian, LinearDiracDistribution)
+
+    def test_unknown_conversion_argument_raises_helpful_error(self):
+        gaussian = GaussianDistribution(array([0.0, 0.0]), eye(2))
+
+        with self.assertRaises(ConversionError):
+            convert_distribution(
+                gaussian,
+                LinearDiracDistribution,
+                n_particles=5,
+                wrong_name=True,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds a first systematic representation-conversion layer for PyRecEst.

Main changes:
- adds `pyrecest.distributions.conversion`
- introduces `convert_distribution`, `can_convert`, `register_conversion`, and `ConversionResult`
- delegates to existing target-side `from_distribution(...)` hooks
- adds `convert_to(...)` / `approximate_as(...)` convenience methods to `AbstractDistributionType`
- adds tests for Gaussian-to-Dirac conversion, identity conversion, conversion metadata, and argument validation
- adds documentation and MkDocs navigation for representation conversion

Design notes:
- The implementation is target-centric and intentionally non-disruptive: existing representation-specific conversion logic stays in the target class.
- The first public import path is `pyrecest.distributions.conversion`; a later cleanup PR can re-export the gateway from `pyrecest.distributions` if desired.
- This PR focuses on the conversion gateway and avoids larger refactors of the distribution inheritance hierarchy.