### PR TITLE
Add representation conversion aliases

### DIFF
--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -43,7 +43,9 @@ Common starting points include:
 
 Use `pyrecest.distributions.conversion.convert_distribution(...)` to convert
 between analytic, Dirac/particle, grid, Fourier, and moment-matched
-representations. See [representation conversion](representation-conversion.md).
+representations. The target may be a concrete class or an alias such as
+`"particles"`, `"gaussian"`, `"grid"`, or `"fourier"`. See
+[representation conversion](representation-conversion.md).
 
 ### `pyrecest.filters`
 

--- a/docs/representation-conversion.md
+++ b/docs/representation-conversion.md
@@ -8,16 +8,21 @@ Use `convert_distribution` to make these conversions explicit and discoverable.
 
 ```python
 from pyrecest.backend import array, eye
-from pyrecest.distributions import GaussianDistribution, LinearDiracDistribution
+from pyrecest.distributions import GaussianDistribution
 from pyrecest.distributions.conversion import convert_distribution
 
 prior = GaussianDistribution(array([0.0, 0.0]), eye(2))
-particles = convert_distribution(prior, LinearDiracDistribution, n_particles=1000)
+particles = convert_distribution(prior, "particles", n_particles=1000)
 ```
 
 Some PyRecEst distribution base classes also expose convenience wrappers such as
 `convert_to(...)` and `approximate_as(...)`; these delegate to the same generic
 conversion gateway when available.
+
+```python
+particles = prior.approximate_as("particles", n_particles=1000)
+gaussian = particles.approximate_as("gaussian")
+```
 
 ## Target-centric conversions
 
@@ -43,7 +48,7 @@ Use `return_info=True` when you need to know how the conversion was performed.
 ```python
 result = convert_distribution(
     prior,
-    LinearDiracDistribution,
+    "particles",
     n_particles=1000,
     return_info=True,
 )
@@ -75,6 +80,29 @@ After registration, the normal gateway works:
 
 ```python
 particles = convert_distribution(source, MyParticleDistribution, n_particles=1000)
+```
+
+## String aliases
+
+The conversion gateway accepts concrete classes and a small set of built-in
+aliases. Useful aliases include:
+
+- `"particles"`, `"dirac"`, and `"samples"` for domain-aware Dirac/particle
+  representations;
+- `"gaussian"` and `"moment_matched_gaussian"` for Gaussian moment matching;
+- `"grid"` for domain-aware circular, hypertoroidal, hyperspherical, or
+  hyperhemispherical grid representations;
+- `"fourier"` for circular or hypertoroidal Fourier representations;
+- explicit aliases such as `"linear_dirac"`, `"circular_grid"`,
+  `"hypertoroidal_grid"`, and `"circular_fourier"`.
+
+Aliases are case-insensitive, and hyphens or spaces are normalized to
+underscores. Custom aliases can be registered with `register_conversion_alias`:
+
+```python
+from pyrecest.distributions.conversion import register_conversion_alias
+
+register_conversion_alias("my_particles", MyParticleDistribution)
 ```
 
 ## Common parameters

--- a/src/pyrecest/distributions/abstract_distribution_type.py
+++ b/src/pyrecest/distributions/abstract_distribution_type.py
@@ -7,16 +7,17 @@ class AbstractDistributionType(ABC):
     regardless of their domain (uniform, mixture, custom, etc.)
     """
 
-    def convert_to(self, target_type: type, /, *, return_info: bool = False, **kwargs):
+    def convert_to(self, target_type, /, *, return_info: bool = False, **kwargs):
         """Convert or approximate this distribution as ``target_type``.
 
         This is a convenience wrapper around
-        :func:`pyrecest.distributions.convert_distribution`.
+        :func:`pyrecest.distributions.convert_distribution`. ``target_type`` may
+        be either a concrete distribution class or a registered conversion alias.
 
         Parameters
         ----------
         target_type
-            Concrete target representation class.
+            Concrete target representation class or conversion alias.
         return_info
             If true, return a ``ConversionResult`` containing metadata.
         **kwargs
@@ -28,9 +29,7 @@ class AbstractDistributionType(ABC):
             self, target_type, return_info=return_info, **kwargs
         )
 
-    def approximate_as(
-        self, target_type: type, /, *, return_info: bool = False, **kwargs
-    ):
+    def approximate_as(self, target_type, /, *, return_info: bool = False, **kwargs):
         """Alias for :meth:`convert_to` emphasizing approximate conversions."""
         return self.convert_to(
             target_type, return_info=return_info, **kwargs

--- a/src/pyrecest/distributions/abstract_manifold_specific_distribution.py
+++ b/src/pyrecest/distributions/abstract_manifold_specific_distribution.py
@@ -25,6 +25,33 @@ class AbstractManifoldSpecificDistribution(ABC):
     def get_ln_manifold_size(self):
         return log(self.get_manifold_size())
 
+    def convert_to(self, target_type, /, *, return_info: bool = False, **kwargs):
+        """Convert or approximate this distribution as ``target_type``.
+
+        This is a convenience wrapper around
+        :func:`pyrecest.distributions.convert_distribution`. ``target_type`` may
+        be either a concrete distribution class or a registered conversion
+        alias such as ``"particles"`` or ``"gaussian"``.
+
+        Parameters
+        ----------
+        target_type
+            Concrete target representation class or conversion alias.
+        return_info
+            If true, return a ``ConversionResult`` containing metadata.
+        **kwargs
+            Conversion parameters required by the target representation.
+        """
+        from .conversion import convert_distribution
+
+        return convert_distribution(
+            self, target_type, return_info=return_info, **kwargs
+        )
+
+    def approximate_as(self, target_type, /, *, return_info: bool = False, **kwargs):
+        """Alias for :meth:`convert_to` emphasizing approximate conversions."""
+        return self.convert_to(target_type, return_info=return_info, **kwargs)
+
     @property
     def dim(self) -> int:
         """Get dimension of the manifold."""

--- a/src/pyrecest/distributions/conversion.py
+++ b/src/pyrecest/distributions/conversion.py
@@ -59,7 +59,15 @@ class _RegisteredConversion:
     method: str
 
 
+@dataclass
+class _ConversionAlias:
+    target_type_or_resolver: type | Callable[[Any], type]
+    default_kwargs: dict[str, Any] = field(default_factory=dict)
+    description: str | None = None
+
+
 _CONVERSION_REGISTRY: list[_RegisteredConversion] = []
+_CONVERSION_ALIAS_REGISTRY: dict[str, _ConversionAlias] = {}
 
 
 def register_conversion(
@@ -111,9 +119,50 @@ def register_conversion(
     return _decorator
 
 
+def register_conversion_alias(
+    alias: str,
+    target_type_or_resolver: type | Callable[[Any], type],
+    *,
+    default_kwargs: dict[str, Any] | None = None,
+    description: str | None = None,
+) -> None:
+    """Register a string alias for a target representation.
+
+    Parameters
+    ----------
+    alias
+        Alias accepted by :func:`convert_distribution`, for example
+        ``"particles"`` or ``"gaussian"``. Aliases are case-insensitive;
+        hyphens and spaces are normalized to underscores.
+    target_type_or_resolver
+        Concrete target class or callable ``resolver(source_distribution)``
+        returning a concrete target class. Resolvers make aliases domain-aware.
+    default_kwargs
+        Optional conversion arguments supplied by default. User-provided
+        keyword arguments override these defaults.
+    description
+        Optional human-readable description used by
+        :func:`registered_conversion_aliases`.
+    """
+
+    _CONVERSION_ALIAS_REGISTRY[_normalize_alias(alias)] = _ConversionAlias(
+        target_type_or_resolver=target_type_or_resolver,
+        default_kwargs=dict(default_kwargs or {}),
+        description=description,
+    )
+
+
+def registered_conversion_aliases() -> tuple[tuple[str, str | None], ...]:
+    """Return registered custom conversion aliases."""
+
+    return tuple(
+        (alias, entry.description) for alias, entry in _CONVERSION_ALIAS_REGISTRY.items()
+    )
+
+
 def convert_distribution(
     distribution,
-    target_type: type,
+    target_type,
     /,
     *,
     return_info: bool = False,
@@ -136,7 +185,8 @@ def convert_distribution(
     target_type
         Concrete target representation class, such as
         ``LinearDiracDistribution``, ``CircularGridDistribution``, or
-        ``GaussianDistribution``.
+        ``GaussianDistribution``; or a conversion alias such as ``"particles"``,
+        ``"gaussian"``, ``"grid"``, or ``"fourier"``.
     return_info
         If false, return the converted distribution directly. If true, return a
         :class:`ConversionResult`.
@@ -152,10 +202,16 @@ def convert_distribution(
         Converted distribution, or metadata wrapper if ``return_info=True``.
     """
 
+    target_type, alias_kwargs, target_alias = _resolve_target_type(
+        distribution, target_type
+    )
+    conversion_kwargs = {**alias_kwargs, **kwargs}
+
     if not isinstance(target_type, type):
-        raise TypeError("target_type must be a distribution class.")
+        raise TypeError("target_type must be a distribution class or conversion alias.")
 
     source_type = type(distribution)
+    method_prefix = f"alias:{target_alias}->" if target_alias is not None else ""
 
     if isinstance(distribution, target_type):
         converted = copy.deepcopy(distribution) if copy_if_same else distribution
@@ -163,21 +219,23 @@ def convert_distribution(
             distribution=converted,
             source_type=source_type,
             target_type=target_type,
-            method="identity",
+            method=f"{method_prefix}identity",
             exact=True,
-            parameters=dict(kwargs),
+            parameters=dict(conversion_kwargs),
         )
         return result if return_info else result.distribution
 
     for entry in _matching_registered_conversions(distribution, target_type):
-        converted = _call_conversion_callable(entry.converter, distribution, kwargs)
+        converted = _call_conversion_callable(
+            entry.converter, distribution, conversion_kwargs
+        )
         result = ConversionResult(
             distribution=converted,
             source_type=source_type,
             target_type=target_type,
-            method=entry.method,
+            method=f"{method_prefix}{entry.method}",
             exact=entry.exact,
-            parameters=dict(kwargs),
+            parameters=dict(conversion_kwargs),
         )
         return result if return_info else result.distribution
 
@@ -186,16 +244,16 @@ def convert_distribution(
         converted = _call_conversion_callable(
             from_distribution,
             distribution,
-            kwargs,
+            conversion_kwargs,
             conversion_name=f"{target_type.__name__}.from_distribution",
         )
         result = ConversionResult(
             distribution=converted,
             source_type=source_type,
             target_type=target_type,
-            method=f"{target_type.__name__}.from_distribution",
+            method=f"{method_prefix}{target_type.__name__}.from_distribution",
             exact=False,
-            parameters=dict(kwargs),
+            parameters=dict(conversion_kwargs),
         )
         return result if return_info else result.distribution
 
@@ -205,12 +263,17 @@ def convert_distribution(
     )
 
 
-def can_convert(distribution, target_type: type) -> bool:
+def can_convert(distribution, target_type) -> bool:
     """Return whether a conversion route exists.
 
     This only checks for a route. It does not verify that all conversion
     arguments required by the route have been supplied.
     """
+
+    try:
+        target_type, _, _ = _resolve_target_type(distribution, target_type)
+    except ConversionError:
+        return False
 
     if not isinstance(target_type, type):
         return False
@@ -227,6 +290,139 @@ def registered_conversions() -> tuple[tuple[type, type, str, bool], ...]:
     return tuple(
         (entry.source_type, entry.target_type, entry.method, entry.exact)
         for entry in _CONVERSION_REGISTRY
+    )
+
+
+def _normalize_alias(alias: str) -> str:
+    return alias.strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _resolve_target_type(distribution, target_type):
+    if isinstance(target_type, str):
+        return _resolve_conversion_alias(distribution, target_type)
+    return target_type, {}, None
+
+
+def _resolve_conversion_alias(distribution, alias: str):
+    alias_normalized = _normalize_alias(alias)
+    custom_alias = _CONVERSION_ALIAS_REGISTRY.get(alias_normalized)
+    if custom_alias is not None:
+        target_type = _resolve_alias_entry(distribution, custom_alias)
+        return target_type, custom_alias.default_kwargs, alias_normalized
+
+    target_type = _resolve_builtin_alias(distribution, alias_normalized)
+    return target_type, {}, alias_normalized
+
+
+def _resolve_alias_entry(distribution, alias_entry: _ConversionAlias):
+    target_type_or_resolver = alias_entry.target_type_or_resolver
+    if isinstance(target_type_or_resolver, type):
+        return target_type_or_resolver
+    target_type = target_type_or_resolver(distribution)
+    if not isinstance(target_type, type):
+        raise ConversionError(
+            "Conversion alias resolver must return a distribution class."
+        )
+    return target_type
+
+
+def _resolve_builtin_alias(distribution, alias: str):
+    # Imports stay local to avoid import cycles with pyrecest.distributions.
+    from .circle.abstract_circular_distribution import AbstractCircularDistribution
+    from .circle.circular_dirac_distribution import CircularDiracDistribution
+    from .circle.circular_fourier_distribution import CircularFourierDistribution
+    from .circle.circular_grid_distribution import CircularGridDistribution
+    from .hypersphere_subset.abstract_hyperhemispherical_distribution import (
+        AbstractHyperhemisphericalDistribution,
+    )
+    from .hypersphere_subset.abstract_hyperspherical_distribution import (
+        AbstractHypersphericalDistribution,
+    )
+    from .hypersphere_subset.hyperhemispherical_dirac_distribution import (
+        HyperhemisphericalDiracDistribution,
+    )
+    from .hypersphere_subset.hyperhemispherical_grid_distribution import (
+        HyperhemisphericalGridDistribution,
+    )
+    from .hypersphere_subset.hyperspherical_dirac_distribution import (
+        HypersphericalDiracDistribution,
+    )
+    from .hypersphere_subset.hyperspherical_grid_distribution import (
+        HypersphericalGridDistribution,
+    )
+    from .hypertorus.abstract_hypertoroidal_distribution import (
+        AbstractHypertoroidalDistribution,
+    )
+    from .hypertorus.hypertoroidal_dirac_distribution import (
+        HypertoroidalDiracDistribution,
+    )
+    from .hypertorus.hypertoroidal_fourier_distribution import (
+        HypertoroidalFourierDistribution,
+    )
+    from .hypertorus.hypertoroidal_grid_distribution import (
+        HypertoroidalGridDistribution,
+    )
+    from .nonperiodic.abstract_linear_distribution import AbstractLinearDistribution
+    from .nonperiodic.gaussian_distribution import GaussianDistribution
+    from .nonperiodic.linear_dirac_distribution import LinearDiracDistribution
+
+    if alias in ("gaussian", "normal", "moment_matched_gaussian"):
+        return GaussianDistribution
+
+    if alias in ("linear_dirac", "linear_particles"):
+        return LinearDiracDistribution
+    if alias == "circular_dirac":
+        return CircularDiracDistribution
+    if alias == "hypertoroidal_dirac":
+        return HypertoroidalDiracDistribution
+    if alias == "hyperspherical_dirac":
+        return HypersphericalDiracDistribution
+    if alias == "hyperhemispherical_dirac":
+        return HyperhemisphericalDiracDistribution
+
+    if alias in ("particles", "dirac", "samples"):
+        if isinstance(distribution, AbstractCircularDistribution):
+            return CircularDiracDistribution
+        if isinstance(distribution, AbstractHypertoroidalDistribution):
+            return HypertoroidalDiracDistribution
+        if isinstance(distribution, AbstractHyperhemisphericalDistribution):
+            return HyperhemisphericalDiracDistribution
+        if isinstance(distribution, AbstractHypersphericalDistribution):
+            return HypersphericalDiracDistribution
+        if isinstance(distribution, AbstractLinearDistribution):
+            return LinearDiracDistribution
+
+    if alias == "circular_grid":
+        return CircularGridDistribution
+    if alias == "hypertoroidal_grid":
+        return HypertoroidalGridDistribution
+    if alias == "hyperspherical_grid":
+        return HypersphericalGridDistribution
+    if alias == "hyperhemispherical_grid":
+        return HyperhemisphericalGridDistribution
+
+    if alias == "grid":
+        if isinstance(distribution, AbstractCircularDistribution):
+            return CircularGridDistribution
+        if isinstance(distribution, AbstractHypertoroidalDistribution):
+            return HypertoroidalGridDistribution
+        if isinstance(distribution, AbstractHyperhemisphericalDistribution):
+            return HyperhemisphericalGridDistribution
+        if isinstance(distribution, AbstractHypersphericalDistribution):
+            return HypersphericalGridDistribution
+
+    if alias == "circular_fourier":
+        return CircularFourierDistribution
+    if alias == "hypertoroidal_fourier":
+        return HypertoroidalFourierDistribution
+    if alias == "fourier":
+        if isinstance(distribution, AbstractCircularDistribution):
+            return CircularFourierDistribution
+        if isinstance(distribution, AbstractHypertoroidalDistribution):
+            return HypertoroidalFourierDistribution
+
+    raise ConversionError(
+        f"Unknown conversion alias '{alias}'. Use a concrete target class or register the alias with register_conversion_alias(...)."
     )
 
 
@@ -315,5 +511,7 @@ __all__ = [
     "can_convert",
     "convert_distribution",
     "register_conversion",
+    "register_conversion_alias",
+    "registered_conversion_aliases",
     "registered_conversions",
 ]

--- a/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
@@ -228,5 +228,13 @@ class GaussianDistribution(AbstractLinearDistribution):
                 distribution.to_gaussian()
             )  # Assuming to_gaussian method is defined in GaussianMixtureDistribution
         else:
-            gaussian = GaussianDistribution(distribution.mean, distribution.covariance)
+            mean = distribution.mean
+            if callable(mean):
+                mean = mean()
+
+            covariance = distribution.covariance
+            if callable(covariance):
+                covariance = covariance()
+
+            gaussian = GaussianDistribution(mean, covariance, check_validity=False)
         return gaussian

--- a/tests/distributions/test_conversion.py
+++ b/tests/distributions/test_conversion.py
@@ -1,13 +1,14 @@
 import unittest
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array, eye, random
+from pyrecest.backend import allclose, array, eye, random
 from pyrecest.distributions import GaussianDistribution, LinearDiracDistribution
 from pyrecest.distributions.conversion import (
     ConversionError,
     ConversionResult,
     can_convert,
     convert_distribution,
+    register_conversion_alias,
 )
 
 
@@ -73,6 +74,68 @@ class ConversionTest(unittest.TestCase):
                 n_particles=5,
                 wrong_name=True,
             )
+
+    def test_manifold_specific_distribution_supports_approximate_as(self):
+        random.seed(0)
+        gaussian = GaussianDistribution(array([0.0, 0.0]), eye(2))
+
+        particles = gaussian.approximate_as(
+            LinearDiracDistribution, n_particles=25
+        )
+
+        self.assertIsInstance(particles, LinearDiracDistribution)
+        self.assertEqual(particles.d.shape[0], 25)
+
+    def test_linear_dirac_to_gaussian_uses_moment_matching(self):
+        particles = LinearDiracDistribution(
+            array([[0.0, 0.0], [2.0, 0.0]]), array([0.5, 0.5])
+        )
+
+        gaussian = convert_distribution(particles, GaussianDistribution)
+
+        self.assertIsInstance(gaussian, GaussianDistribution)
+        self.assertTrue(allclose(gaussian.mean(), particles.mean()))
+        self.assertTrue(allclose(gaussian.covariance(), particles.covariance()))
+
+    def test_builtin_string_alias_particles(self):
+        random.seed(0)
+        gaussian = GaussianDistribution(array([0.0, 0.0]), eye(2))
+
+        particles = convert_distribution(gaussian, "particles", n_particles=25)
+
+        self.assertIsInstance(particles, LinearDiracDistribution)
+        self.assertEqual(particles.d.shape[0], 25)
+
+    def test_builtin_string_alias_gaussian(self):
+        particles = LinearDiracDistribution(
+            array([[0.0, 0.0], [2.0, 0.0]]), array([0.5, 0.5])
+        )
+
+        gaussian = particles.approximate_as("gaussian")
+
+        self.assertIsInstance(gaussian, GaussianDistribution)
+        self.assertTrue(allclose(gaussian.mean(), particles.mean()))
+
+    def test_custom_string_alias(self):
+        random.seed(0)
+        register_conversion_alias("test_particles", LinearDiracDistribution)
+        gaussian = GaussianDistribution(array([0.0, 0.0]), eye(2))
+
+        particles = convert_distribution(gaussian, "test_particles", n_particles=5)
+
+        self.assertIsInstance(particles, LinearDiracDistribution)
+
+    def test_unknown_string_alias_raises_helpful_error(self):
+        gaussian = GaussianDistribution(array([0.0, 0.0]), eye(2))
+
+        with self.assertRaises(ConversionError):
+            convert_distribution(gaussian, "not_a_representation")
+
+    def test_can_convert_supports_string_aliases(self):
+        gaussian = GaussianDistribution(array([0.0, 0.0]), eye(2))
+
+        self.assertTrue(can_convert(gaussian, "particles"))
+        self.assertFalse(can_convert(gaussian, "not_a_representation"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR follows up on #1929 by making the representation-conversion gateway more ergonomic.

Main changes:
- allows `convert_distribution(...)` targets to be string aliases such as `"particles"`, `"gaussian"`, `"grid"`, and `"fourier"`
- adds built-in domain-aware aliases for linear, circular, hypertoroidal, hyperspherical, and hyperhemispherical representations
- adds `register_conversion_alias(...)` and `registered_conversion_aliases()` for custom aliases
- adds `convert_to(...)` / `approximate_as(...)` convenience methods to `AbstractManifoldSpecificDistribution`, so analytic distributions such as `GaussianDistribution` can use the method form
- fixes `GaussianDistribution.from_distribution(...)` to use method-style `mean()` and `covariance()` access when available
- extends conversion tests for aliases, custom aliases, manifold-specific method helpers, and Dirac-to-Gaussian moment matching
- updates the representation-conversion documentation and API overview

Notes:
- The public import path remains `pyrecest.distributions.conversion` in this PR.
- A later small cleanup PR can re-export the conversion API from `pyrecest.distributions` if desired.