### PR TITLE
Add backend compatibility tests for representation conversion

### DIFF
--- a/docs/backend-compatibility.md
+++ b/docs/backend-compatibility.md
@@ -101,6 +101,33 @@ also supports explicit state passing in some random functions. Code that needs
 fully functional JAX-style random handling should pass and manage state
 deliberately instead of relying only on implicit global state.
 
+## Representation Conversion
+
+The distribution representation-conversion gateway is tested under the same
+backend matrix as the rest of the suite. The portable baseline currently covers:
+
+- Euclidean analytic-to-particle conversion, for example
+  `GaussianDistribution -> LinearDiracDistribution` through sampling;
+- particle-to-Gaussian conversion through moment matching;
+- class-based and alias-based routes such as `LinearDiracDistribution` and
+  `"particles"`;
+- backend-independent argument validation for missing or unsupported conversion
+  parameters.
+
+Conversion results are expected to keep arrays in the active backend
+representation when the source and target representation are backend-portable.
+For example, running with `PYRECEST_BACKEND=pytorch` should produce PyTorch
+tensors for linear Dirac particles, while `PYRECEST_BACKEND=jax` should produce
+JAX arrays.
+
+Backend portability is route-specific. A conversion that delegates to a target
+class's `from_distribution(...)` method inherits that target's backend support.
+Routes based on SciPy-heavy grids, manifold operations, plotting, or
+backend-specific samplers may still be NumPy-only or have explicit PyTorch/JAX
+limitations. When adding a new conversion route, add a focused backend test if
+the route is intended to be portable, or document and test the explicit
+restriction if it is not.
+
 ## Choosing A Backend
 
 Start with NumPy when learning the library, reproducing examples, or using

--- a/src/pyrecest/distributions/conversion.py
+++ b/src/pyrecest/distributions/conversion.py
@@ -326,6 +326,9 @@ def _resolve_alias_entry(distribution, alias_entry: _ConversionAlias):
     return target_type
 
 
+# The built-in resolver intentionally maps a compact user-facing alias vocabulary
+# across several distribution domains while keeping imports lazy to avoid cycles.
+# pylint: disable-next=too-many-locals,too-many-return-statements,too-many-branches
 def _resolve_builtin_alias(distribution, alias: str):
     # Imports stay local to avoid import cycles with pyrecest.distributions.
     from .circle.abstract_circular_distribution import AbstractCircularDistribution

--- a/tests/distributions/test_conversion_backend_compatibility.py
+++ b/tests/distributions/test_conversion_backend_compatibility.py
@@ -1,7 +1,7 @@
 import unittest
 
 # pylint: disable=no-name-in-module,no-member,redefined-builtin
-import pyrecest.backend as backend
+from pyrecest import backend
 from pyrecest.backend import allclose, array, diag, is_array, random, sum as backend_sum, to_numpy
 from pyrecest.distributions import GaussianDistribution, LinearDiracDistribution
 from pyrecest.distributions.conversion import ConversionError, can_convert, convert_distribution

--- a/tests/distributions/test_conversion_backend_compatibility.py
+++ b/tests/distributions/test_conversion_backend_compatibility.py
@@ -1,0 +1,142 @@
+import unittest
+
+# pylint: disable=no-name-in-module,no-member,redefined-builtin
+import pyrecest.backend as backend
+from pyrecest.backend import allclose, array, diag, is_array, random, sum as backend_sum, to_numpy
+from pyrecest.distributions import GaussianDistribution, LinearDiracDistribution
+from pyrecest.distributions.conversion import ConversionError, can_convert, convert_distribution
+
+
+SUPPORTED_BACKENDS = ("numpy", "pytorch", "jax")
+
+
+def _as_bool(value) -> bool:
+    if isinstance(value, (bool, int, float)):
+        return bool(value)
+    try:
+        value_np = to_numpy(value)
+    except AttributeError:
+        return bool(value)
+    if hasattr(value_np, "item"):
+        return bool(value_np.item())
+    return bool(value_np)
+
+
+def _as_float(value) -> float:
+    if isinstance(value, (bool, int, float)):
+        return float(value)
+    try:
+        value_np = to_numpy(value)
+    except AttributeError:
+        return float(value)
+    if hasattr(value_np, "item"):
+        return float(value_np.item())
+    return float(value_np)
+
+
+class ConversionBackendCompatibilityTest(unittest.TestCase):
+    """Conversion tests that are intentionally run under each CI backend.
+
+    The repository test workflow executes the complete test suite with the
+    ``numpy``, ``pytorch``, and ``jax`` backends. These tests exercise the
+    conversion gateway in a backend-sensitive way: converted arrays must stay in
+    the active backend representation, deterministic moment matching must agree
+    numerically, and argument validation must not depend on the selected
+    backend.
+    """
+
+    def setUp(self):
+        self.backend_name = backend.get_backend_name()
+        if self.backend_name not in SUPPORTED_BACKENDS:
+            self.skipTest(
+                f"Conversion backend compatibility is defined for {SUPPORTED_BACKENDS}, "
+                f"not {self.backend_name!r}."
+            )
+
+    def test_gaussian_to_particles_alias_preserves_active_backend_arrays(self):
+        random.seed(42)
+        gaussian = GaussianDistribution(
+            array([0.0, 1.0]),
+            diag(array([1.0, 2.0])),
+            check_validity=False,
+        )
+
+        particles = convert_distribution(gaussian, "particles", n_particles=11)
+
+        self.assertIsInstance(particles, LinearDiracDistribution)
+        self.assertTrue(is_array(particles.d), self.backend_name)
+        self.assertTrue(is_array(particles.w), self.backend_name)
+        self.assertEqual(tuple(particles.d.shape), (11, 2))
+        self.assertEqual(tuple(particles.w.shape), (11,))
+        self.assertAlmostEqual(_as_float(backend_sum(particles.w)), 1.0, places=6)
+
+    def test_particles_to_gaussian_alias_preserves_active_backend_arrays(self):
+        particles = LinearDiracDistribution(
+            array([[0.0, 0.0], [2.0, 0.0], [2.0, 2.0]]),
+            array([0.25, 0.25, 0.5]),
+        )
+
+        gaussian = convert_distribution(particles, "gaussian")
+
+        self.assertIsInstance(gaussian, GaussianDistribution)
+        self.assertTrue(is_array(gaussian.mean()), self.backend_name)
+        self.assertTrue(is_array(gaussian.covariance()), self.backend_name)
+        self.assertTrue(_as_bool(allclose(gaussian.mean(), particles.mean())))
+        self.assertTrue(_as_bool(allclose(gaussian.covariance(), particles.covariance())))
+
+    def test_class_and_alias_targets_are_consistent_on_active_backend(self):
+        random.seed(7)
+        gaussian = GaussianDistribution(
+            array([0.0, 0.0]),
+            diag(array([1.0, 1.0])),
+            check_validity=False,
+        )
+
+        by_class = convert_distribution(
+            gaussian, LinearDiracDistribution, n_particles=5
+        )
+        by_alias = convert_distribution(gaussian, "particles", n_particles=5)
+
+        self.assertIsInstance(by_class, LinearDiracDistribution)
+        self.assertIsInstance(by_alias, LinearDiracDistribution)
+        self.assertEqual(tuple(by_class.d.shape), tuple(by_alias.d.shape))
+        self.assertTrue(is_array(by_class.d), self.backend_name)
+        self.assertTrue(is_array(by_alias.d), self.backend_name)
+
+    def test_conversion_route_detection_is_backend_independent(self):
+        gaussian = GaussianDistribution(
+            array([0.0, 0.0]),
+            diag(array([1.0, 1.0])),
+            check_validity=False,
+        )
+        particles = LinearDiracDistribution(
+            array([[0.0, 0.0], [1.0, 1.0]]), array([0.5, 0.5])
+        )
+
+        self.assertTrue(can_convert(gaussian, "particles"))
+        self.assertTrue(can_convert(gaussian, LinearDiracDistribution))
+        self.assertTrue(can_convert(particles, "gaussian"))
+        self.assertTrue(can_convert(particles, GaussianDistribution))
+        self.assertFalse(can_convert(gaussian, "not_a_representation"))
+
+    def test_conversion_argument_validation_is_backend_independent(self):
+        gaussian = GaussianDistribution(
+            array([0.0, 0.0]),
+            diag(array([1.0, 1.0])),
+            check_validity=False,
+        )
+
+        with self.assertRaises(ConversionError):
+            convert_distribution(gaussian, "particles")
+
+        with self.assertRaises(ConversionError):
+            convert_distribution(
+                gaussian,
+                "particles",
+                n_particles=5,
+                unsupported_argument=True,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds backend-sensitive tests for the distribution representation-conversion gateway.

It is intentionally based on `feature/representation-conversion-aliases` / #1931 because it tests alias-based routes introduced there.

Main changes:
- adds `tests/distributions/test_conversion_backend_compatibility.py`
- checks `GaussianDistribution -> LinearDiracDistribution` via the `"particles"` alias
- checks `LinearDiracDistribution -> GaussianDistribution` via the `"gaussian"` alias
- verifies class-based and alias-based routes produce backend-native arrays
- verifies particle weights stay normalized
- verifies deterministic Dirac-to-Gaussian moment matching
- verifies `can_convert(...)` and argument validation behave consistently across backends
- documents representation-conversion backend expectations in `docs/backend-compatibility.md`

The repository workflow already runs the full test suite under the NumPy, PyTorch, and JAX backend matrix, so these tests should exercise all three backends automatically.