### PR TITLE
Document representation conversion support matrix

### DIFF
--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -45,7 +45,8 @@ Use `pyrecest.distributions.conversion.convert_distribution(...)` to convert
 between analytic, Dirac/particle, grid, Fourier, and moment-matched
 representations. The target may be a concrete class or an alias such as
 `"particles"`, `"gaussian"`, `"grid"`, or `"fourier"`. See
-[representation conversion](representation-conversion.md).
+[representation conversion](representation-conversion.md) for the support
+matrix, required parameters, and approximation semantics.
 
 ### `pyrecest.filters`
 

--- a/docs/representation-conversion.md
+++ b/docs/representation-conversion.md
@@ -105,12 +105,49 @@ from pyrecest.distributions.conversion import register_conversion_alias
 register_conversion_alias("my_particles", MyParticleDistribution)
 ```
 
+## Support matrix
+
+The table below documents the routes supported by the generic conversion
+gateway. A route is supported when the alias resolver can select a target class
+and that target class either implements `from_distribution(...)`, is already the
+source type, or has an explicitly registered converter.
+
+| Source representation | Target / alias | Concrete target selected | Required parameters | Method | Exact? |
+| --- | --- | --- | --- | --- | --- |
+| Any distribution | same concrete class | requested class | none | identity conversion | yes |
+| Any registered source type | registered target class | registered target class | converter-specific | registered converter | converter-specific |
+| Any distribution accepted by a registered alias | registered alias | alias target or resolver result | alias/converter-specific | registered converter or target `from_distribution(...)` | converter-specific |
+| `AbstractLinearDistribution` | `"particles"`, `"dirac"`, `"samples"`, `"linear_dirac"` | `LinearDiracDistribution` | `n_particles` | sampling through `from_distribution(...)` | no |
+| distribution exposing `mean()` and `covariance()` | `"gaussian"`, `"normal"`, `"moment_matched_gaussian"` | `GaussianDistribution` | none | moment matching through `GaussianDistribution.from_distribution(...)` | no, except identity |
+| `GaussianDistribution` | `LinearDiracDistribution` or linear particle aliases | `LinearDiracDistribution` | `n_particles` | Gaussian sampling | no |
+| `LinearDiracDistribution` | Gaussian aliases | `GaussianDistribution` | none | weighted empirical mean/covariance | no |
+| `AbstractCircularDistribution` | `"particles"`, `"dirac"`, `"samples"`, `"circular_dirac"` | `CircularDiracDistribution` | `n_particles` | circular sampling | no |
+| `AbstractCircularDistribution` | `"grid"`, `"circular_grid"` | `CircularGridDistribution` | `no_of_gridpoints` | evaluate density on circular grid | no |
+| `AbstractCircularDistribution` | `"fourier"`, `"circular_fourier"` | `CircularFourierDistribution` | `n` | Fourier approximation | no |
+| `AbstractHypertoroidalDistribution` | `"particles"`, `"dirac"`, `"samples"`, `"hypertoroidal_dirac"` | `HypertoroidalDiracDistribution` | `n_particles` | hypertoroidal sampling | no |
+| `AbstractHypertoroidalDistribution` | `"grid"`, `"hypertoroidal_grid"` | `HypertoroidalGridDistribution` | `n_grid_points` | evaluate density on hypertoroidal grid | no |
+| `AbstractHypertoroidalDistribution` | `"fourier"`, `"hypertoroidal_fourier"` | `HypertoroidalFourierDistribution` | target-specific Fourier parameters | Fourier approximation | no |
+| `AbstractHypersphericalDistribution` | `"particles"`, `"dirac"`, `"samples"`, `"hyperspherical_dirac"` | `HypersphericalDiracDistribution` | `n_particles` | hyperspherical sampling | no |
+| `AbstractHypersphericalDistribution` | `"grid"`, `"hyperspherical_grid"` | `HypersphericalGridDistribution` | `no_of_grid_points`, `grid_type` | evaluate density on hyperspherical grid | no |
+| `AbstractHyperhemisphericalDistribution` | `"particles"`, `"dirac"`, `"samples"`, `"hyperhemispherical_dirac"` | `HyperhemisphericalDiracDistribution` | `n_particles` | hyperhemispherical sampling | no |
+| `AbstractHyperhemisphericalDistribution` | `"grid"`, `"hyperhemispherical_grid"` | `HyperhemisphericalGridDistribution` | `no_of_grid_points`, `grid_type` | evaluate density on hyperhemispherical grid | no |
+
+The `"samples"` alias currently follows the same route as `"particles"` and
+returns a weighted Dirac representation, not a raw unweighted sample array. Use
+the source distribution's `sample(...)` method directly when raw samples are
+needed.
+
 ## Common parameters
 
 Common conversion parameters depend on the target representation:
 
-- `n_particles` for Dirac/particle approximations.
-- `no_of_gridpoints` for one-dimensional circular grids.
-- `n_grid_points` for hypertoroidal grids.
-- `no_of_grid_points` and `grid_type` for hypersphere-subset grids.
-- `n` for Fourier representations.
+| Parameter | Used by | Meaning |
+| --- | --- | --- |
+| `n_particles` | Dirac/particle targets | Number of samples used to form the weighted Dirac approximation. |
+| `no_of_gridpoints` | `CircularGridDistribution` | Number of circular grid points. |
+| `n_grid_points` | `HypertoroidalGridDistribution` | Number of grid points per toroidal dimension. |
+| `no_of_grid_points` | hypersphere-subset grid targets | Number of hyperspherical or hyperhemispherical grid points. |
+| `grid_type` | hypersphere-subset grid targets | Grid construction method, such as a Leopardi-style grid where supported. |
+| `n` | Fourier targets | Fourier truncation/order parameter used by the target representation. |
+| `return_info` | conversion gateway | Return a `ConversionResult` instead of only the converted distribution. |
+| `copy_if_same` | conversion gateway | Return a deep copy for identity conversion instead of the original object. |

--- a/src/pyrecest/distributions/conversion.py
+++ b/src/pyrecest/distributions/conversion.py
@@ -13,6 +13,8 @@ import copy
 import inspect
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from functools import lru_cache
+from importlib import import_module
 from typing import Any
 
 
@@ -66,8 +68,123 @@ class _ConversionAlias:
     description: str | None = None
 
 
+ClassSpec = tuple[str, str]
+AliasDomain = tuple[ClassSpec, ClassSpec]
+
 _CONVERSION_REGISTRY: list[_RegisteredConversion] = []
 _CONVERSION_ALIAS_REGISTRY: dict[str, _ConversionAlias] = {}
+
+_ABSTRACT_CIRCULAR: ClassSpec = (
+    "pyrecest.distributions.circle.abstract_circular_distribution",
+    "AbstractCircularDistribution",
+)
+_ABSTRACT_HYPERHEMISPHERICAL: ClassSpec = (
+    "pyrecest.distributions.hypersphere_subset.abstract_hyperhemispherical_distribution",
+    "AbstractHyperhemisphericalDistribution",
+)
+_ABSTRACT_HYPERSPHERICAL: ClassSpec = (
+    "pyrecest.distributions.hypersphere_subset.abstract_hyperspherical_distribution",
+    "AbstractHypersphericalDistribution",
+)
+_ABSTRACT_HYPERTOROIDAL: ClassSpec = (
+    "pyrecest.distributions.hypertorus.abstract_hypertoroidal_distribution",
+    "AbstractHypertoroidalDistribution",
+)
+_ABSTRACT_LINEAR: ClassSpec = (
+    "pyrecest.distributions.nonperiodic.abstract_linear_distribution",
+    "AbstractLinearDistribution",
+)
+_CIRCULAR_DIRAC: ClassSpec = (
+    "pyrecest.distributions.circle.circular_dirac_distribution",
+    "CircularDiracDistribution",
+)
+_CIRCULAR_FOURIER: ClassSpec = (
+    "pyrecest.distributions.circle.circular_fourier_distribution",
+    "CircularFourierDistribution",
+)
+_CIRCULAR_GRID: ClassSpec = (
+    "pyrecest.distributions.circle.circular_grid_distribution",
+    "CircularGridDistribution",
+)
+_GAUSSIAN: ClassSpec = (
+    "pyrecest.distributions.nonperiodic.gaussian_distribution",
+    "GaussianDistribution",
+)
+_HYPERHEMISPHERICAL_DIRAC: ClassSpec = (
+    "pyrecest.distributions.hypersphere_subset.hyperhemispherical_dirac_distribution",
+    "HyperhemisphericalDiracDistribution",
+)
+_HYPERHEMISPHERICAL_GRID: ClassSpec = (
+    "pyrecest.distributions.hypersphere_subset.hyperhemispherical_grid_distribution",
+    "HyperhemisphericalGridDistribution",
+)
+_HYPERSPHERICAL_DIRAC: ClassSpec = (
+    "pyrecest.distributions.hypersphere_subset.hyperspherical_dirac_distribution",
+    "HypersphericalDiracDistribution",
+)
+_HYPERSPHERICAL_GRID: ClassSpec = (
+    "pyrecest.distributions.hypersphere_subset.hyperspherical_grid_distribution",
+    "HypersphericalGridDistribution",
+)
+_HYPERTOROIDAL_DIRAC: ClassSpec = (
+    "pyrecest.distributions.hypertorus.hypertoroidal_dirac_distribution",
+    "HypertoroidalDiracDistribution",
+)
+_HYPERTOROIDAL_FOURIER: ClassSpec = (
+    "pyrecest.distributions.hypertorus.hypertoroidal_fourier_distribution",
+    "HypertoroidalFourierDistribution",
+)
+_HYPERTOROIDAL_GRID: ClassSpec = (
+    "pyrecest.distributions.hypertorus.hypertoroidal_grid_distribution",
+    "HypertoroidalGridDistribution",
+)
+_LINEAR_DIRAC: ClassSpec = (
+    "pyrecest.distributions.nonperiodic.linear_dirac_distribution",
+    "LinearDiracDistribution",
+)
+
+_DIRECT_BUILTIN_ALIAS_CLASS_SPECS: dict[str, ClassSpec] = {
+    "circular_dirac": _CIRCULAR_DIRAC,
+    "circular_fourier": _CIRCULAR_FOURIER,
+    "circular_grid": _CIRCULAR_GRID,
+    "gaussian": _GAUSSIAN,
+    "hyperhemispherical_dirac": _HYPERHEMISPHERICAL_DIRAC,
+    "hyperhemispherical_grid": _HYPERHEMISPHERICAL_GRID,
+    "hyperspherical_dirac": _HYPERSPHERICAL_DIRAC,
+    "hyperspherical_grid": _HYPERSPHERICAL_GRID,
+    "hypertoroidal_dirac": _HYPERTOROIDAL_DIRAC,
+    "hypertoroidal_fourier": _HYPERTOROIDAL_FOURIER,
+    "hypertoroidal_grid": _HYPERTOROIDAL_GRID,
+    "linear_dirac": _LINEAR_DIRAC,
+    "linear_particles": _LINEAR_DIRAC,
+    "moment_matched_gaussian": _GAUSSIAN,
+    "normal": _GAUSSIAN,
+}
+
+_PARTICLE_ALIAS_DOMAINS: tuple[AliasDomain, ...] = (
+    (_ABSTRACT_CIRCULAR, _CIRCULAR_DIRAC),
+    (_ABSTRACT_HYPERTOROIDAL, _HYPERTOROIDAL_DIRAC),
+    (_ABSTRACT_HYPERHEMISPHERICAL, _HYPERHEMISPHERICAL_DIRAC),
+    (_ABSTRACT_HYPERSPHERICAL, _HYPERSPHERICAL_DIRAC),
+    (_ABSTRACT_LINEAR, _LINEAR_DIRAC),
+)
+_GRID_ALIAS_DOMAINS: tuple[AliasDomain, ...] = (
+    (_ABSTRACT_CIRCULAR, _CIRCULAR_GRID),
+    (_ABSTRACT_HYPERTOROIDAL, _HYPERTOROIDAL_GRID),
+    (_ABSTRACT_HYPERHEMISPHERICAL, _HYPERHEMISPHERICAL_GRID),
+    (_ABSTRACT_HYPERSPHERICAL, _HYPERSPHERICAL_GRID),
+)
+_FOURIER_ALIAS_DOMAINS: tuple[AliasDomain, ...] = (
+    (_ABSTRACT_CIRCULAR, _CIRCULAR_FOURIER),
+    (_ABSTRACT_HYPERTOROIDAL, _HYPERTOROIDAL_FOURIER),
+)
+_DOMAIN_BUILTIN_ALIAS_CLASS_SPECS: dict[str, tuple[AliasDomain, ...]] = {
+    "dirac": _PARTICLE_ALIAS_DOMAINS,
+    "fourier": _FOURIER_ALIAS_DOMAINS,
+    "grid": _GRID_ALIAS_DOMAINS,
+    "particles": _PARTICLE_ALIAS_DOMAINS,
+    "samples": _PARTICLE_ALIAS_DOMAINS,
+}
 
 
 def register_conversion(
@@ -327,103 +444,49 @@ def _resolve_alias_entry(distribution, alias_entry: _ConversionAlias):
 
 
 def _resolve_builtin_alias(distribution, alias: str):
-    # Imports stay local to avoid import cycles with pyrecest.distributions.
-    from .circle.abstract_circular_distribution import AbstractCircularDistribution
-    from .circle.circular_dirac_distribution import CircularDiracDistribution
-    from .circle.circular_fourier_distribution import CircularFourierDistribution
-    from .circle.circular_grid_distribution import CircularGridDistribution
-    from .hypersphere_subset.abstract_hyperhemispherical_distribution import (
-        AbstractHyperhemisphericalDistribution,
-    )
-    from .hypersphere_subset.abstract_hyperspherical_distribution import (
-        AbstractHypersphericalDistribution,
-    )
-    from .hypersphere_subset.hyperhemispherical_dirac_distribution import (
-        HyperhemisphericalDiracDistribution,
-    )
-    from .hypersphere_subset.hyperhemispherical_grid_distribution import (
-        HyperhemisphericalGridDistribution,
-    )
-    from .hypersphere_subset.hyperspherical_dirac_distribution import (
-        HypersphericalDiracDistribution,
-    )
-    from .hypersphere_subset.hyperspherical_grid_distribution import (
-        HypersphericalGridDistribution,
-    )
-    from .hypertorus.abstract_hypertoroidal_distribution import (
-        AbstractHypertoroidalDistribution,
-    )
-    from .hypertorus.hypertoroidal_dirac_distribution import (
-        HypertoroidalDiracDistribution,
-    )
-    from .hypertorus.hypertoroidal_fourier_distribution import (
-        HypertoroidalFourierDistribution,
-    )
-    from .hypertorus.hypertoroidal_grid_distribution import (
-        HypertoroidalGridDistribution,
-    )
-    from .nonperiodic.abstract_linear_distribution import AbstractLinearDistribution
-    from .nonperiodic.gaussian_distribution import GaussianDistribution
-    from .nonperiodic.linear_dirac_distribution import LinearDiracDistribution
+    target_type = _resolve_direct_builtin_alias(alias)
+    if target_type is not None:
+        return target_type
 
-    if alias in ("gaussian", "normal", "moment_matched_gaussian"):
-        return GaussianDistribution
-
-    if alias in ("linear_dirac", "linear_particles"):
-        return LinearDiracDistribution
-    if alias == "circular_dirac":
-        return CircularDiracDistribution
-    if alias == "hypertoroidal_dirac":
-        return HypertoroidalDiracDistribution
-    if alias == "hyperspherical_dirac":
-        return HypersphericalDiracDistribution
-    if alias == "hyperhemispherical_dirac":
-        return HyperhemisphericalDiracDistribution
-
-    if alias in ("particles", "dirac", "samples"):
-        if isinstance(distribution, AbstractCircularDistribution):
-            return CircularDiracDistribution
-        if isinstance(distribution, AbstractHypertoroidalDistribution):
-            return HypertoroidalDiracDistribution
-        if isinstance(distribution, AbstractHyperhemisphericalDistribution):
-            return HyperhemisphericalDiracDistribution
-        if isinstance(distribution, AbstractHypersphericalDistribution):
-            return HypersphericalDiracDistribution
-        if isinstance(distribution, AbstractLinearDistribution):
-            return LinearDiracDistribution
-
-    if alias == "circular_grid":
-        return CircularGridDistribution
-    if alias == "hypertoroidal_grid":
-        return HypertoroidalGridDistribution
-    if alias == "hyperspherical_grid":
-        return HypersphericalGridDistribution
-    if alias == "hyperhemispherical_grid":
-        return HyperhemisphericalGridDistribution
-
-    if alias == "grid":
-        if isinstance(distribution, AbstractCircularDistribution):
-            return CircularGridDistribution
-        if isinstance(distribution, AbstractHypertoroidalDistribution):
-            return HypertoroidalGridDistribution
-        if isinstance(distribution, AbstractHyperhemisphericalDistribution):
-            return HyperhemisphericalGridDistribution
-        if isinstance(distribution, AbstractHypersphericalDistribution):
-            return HypersphericalGridDistribution
-
-    if alias == "circular_fourier":
-        return CircularFourierDistribution
-    if alias == "hypertoroidal_fourier":
-        return HypertoroidalFourierDistribution
-    if alias == "fourier":
-        if isinstance(distribution, AbstractCircularDistribution):
-            return CircularFourierDistribution
-        if isinstance(distribution, AbstractHypertoroidalDistribution):
-            return HypertoroidalFourierDistribution
+    domain_aliases = _DOMAIN_BUILTIN_ALIAS_CLASS_SPECS.get(alias)
+    if domain_aliases is not None:
+        target_type = _resolve_domain_builtin_alias(distribution, domain_aliases)
+        if target_type is not None:
+            return target_type
 
     raise ConversionError(
         f"Unknown conversion alias '{alias}'. Use a concrete target class or register the alias with register_conversion_alias(...)."
     )
+
+
+def _resolve_direct_builtin_alias(alias: str) -> type | None:
+    class_spec = _DIRECT_BUILTIN_ALIAS_CLASS_SPECS.get(alias)
+    if class_spec is None:
+        return None
+    return _resolve_class(class_spec)
+
+
+def _resolve_domain_builtin_alias(
+    distribution, alias_domains: tuple[AliasDomain, ...]
+) -> type | None:
+    for source_class_spec, target_class_spec in alias_domains:
+        if isinstance(distribution, _resolve_class(source_class_spec)):
+            return _resolve_class(target_class_spec)
+    return None
+
+
+def _resolve_class(class_spec: ClassSpec) -> type:
+    module_name, class_name = class_spec
+    return _import_distribution_class(module_name, class_name)
+
+
+@lru_cache(maxsize=None)
+def _import_distribution_class(module_name: str, class_name: str) -> type:
+    module = import_module(module_name)
+    distribution_class = getattr(module, class_name)
+    if not isinstance(distribution_class, type):
+        raise ConversionError(f"{module_name}.{class_name} is not a class.")
+    return distribution_class
 
 
 def _matching_registered_conversions(distribution, target_type: type):


### PR DESCRIPTION
Adds a docs-only support matrix for the representation-conversion gateway introduced in #1929 and extended in #1931.

Main changes:
- documents supported conversion routes for linear, circular, hypertoroidal, hyperspherical, and hyperhemispherical representations
- lists concrete target classes selected by aliases such as `"particles"`, `"gaussian"`, `"grid"`, and `"fourier"`
- records required conversion parameters such as `n_particles`, `no_of_gridpoints`, `n_grid_points`, `no_of_grid_points`, `grid_type`, and `n`
- clarifies approximation semantics and the current meaning of the `"samples"` alias
- links the API overview to the support matrix

This PR targets `feature/representation-conversion-aliases` so it can be merged into #1931 before that branch is merged to `main`.