### PR TITLE
Add SO3 representation conversion support

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,5 @@
 [flake8]
 max-line-length = 180
 extend-ignore = E203
+per-file-ignores =
+    src/pyrecest/distributions/conversion.py:E402,F401

--- a/docs/representation-conversion.md
+++ b/docs/representation-conversion.md
@@ -40,6 +40,8 @@ owns it. For example:
   coefficients from samples or grid values.
 - `GaussianDistribution.from_distribution(...)` performs Gaussian moment
   matching when the source exposes `mean()` and `covariance()`.
+- SO(3) tangent-Gaussian conversions are registered separately and use local
+  tangent-space moment matching.
 
 ## Metadata
 
@@ -94,7 +96,15 @@ aliases. Useful aliases include:
   hyperhemispherical grid representations;
 - `"fourier"` for circular or hypertoroidal Fourier representations;
 - explicit aliases such as `"linear_dirac"`, `"circular_grid"`,
-  `"hypertoroidal_grid"`, and `"circular_fourier"`.
+  `"hypertoroidal_grid"`, and `"circular_fourier"`;
+- SO(3)-specific aliases such as `"so3_dirac"`, `"so3_particles"`,
+  `"so3_tangent_gaussian"`, `"so3_gaussian"`, `"so3_product_dirac"`,
+  `"so3_product_particles"`, `"so3_product_tangent_gaussian"`, and
+  `"so3_product_gaussian"`.
+
+For SO(3) and SO(3)^K distributions, `"particles"`/`"dirac"` resolve to
+SO(3)-specific Dirac representations, and `"gaussian"` resolves to the
+corresponding tangent-Gaussian approximation.
 
 Aliases are case-insensitive, and hyphens or spaces are normalized to
 underscores. Custom aliases can be registered with `register_conversion_alias`:
@@ -114,3 +124,5 @@ Common conversion parameters depend on the target representation:
 - `n_grid_points` for hypertoroidal grids.
 - `no_of_grid_points` and `grid_type` for hypersphere-subset grids.
 - `n` for Fourier representations.
+- `covariance_regularization` for optional diagonal regularization when fitting
+  SO(3) tangent-Gaussian approximations from few Dirac particles.

--- a/src/pyrecest/distributions/conversion.py
+++ b/src/pyrecest/distributions/conversion.py
@@ -326,7 +326,6 @@ def _resolve_alias_entry(distribution, alias_entry: _ConversionAlias):
     return target_type
 
 
-# pylint: disable=too-many-locals,too-many-return-statements,too-many-branches
 def _resolve_builtin_alias(distribution, alias: str):
     # Imports stay local to avoid import cycles with pyrecest.distributions.
     from .circle.abstract_circular_distribution import AbstractCircularDistribution
@@ -366,12 +365,33 @@ def _resolve_builtin_alias(distribution, alias: str):
     from .nonperiodic.abstract_linear_distribution import AbstractLinearDistribution
     from .nonperiodic.gaussian_distribution import GaussianDistribution
     from .nonperiodic.linear_dirac_distribution import LinearDiracDistribution
+    from .so3_dirac_distribution import SO3DiracDistribution
+    from .so3_product_dirac_distribution import SO3ProductDiracDistribution
+    from .so3_product_tangent_gaussian_distribution import (
+        SO3ProductTangentGaussianDistribution,
+    )
+    from .so3_tangent_gaussian_distribution import SO3TangentGaussianDistribution
 
     if alias in ("gaussian", "normal", "moment_matched_gaussian"):
+        if isinstance(distribution, (SO3DiracDistribution, SO3TangentGaussianDistribution)):
+            return SO3TangentGaussianDistribution
+        if isinstance(
+            distribution,
+            (SO3ProductDiracDistribution, SO3ProductTangentGaussianDistribution),
+        ):
+            return SO3ProductTangentGaussianDistribution
         return GaussianDistribution
 
     if alias in ("linear_dirac", "linear_particles"):
         return LinearDiracDistribution
+    if alias in ("so3_dirac", "so3_particles"):
+        return SO3DiracDistribution
+    if alias in ("so3_product_dirac", "so3_product_particles"):
+        return SO3ProductDiracDistribution
+    if alias in ("so3_tangent_gaussian", "so3_gaussian"):
+        return SO3TangentGaussianDistribution
+    if alias in ("so3_product_tangent_gaussian", "so3_product_gaussian"):
+        return SO3ProductTangentGaussianDistribution
     if alias == "circular_dirac":
         return CircularDiracDistribution
     if alias == "hypertoroidal_dirac":
@@ -382,6 +402,14 @@ def _resolve_builtin_alias(distribution, alias: str):
         return HyperhemisphericalDiracDistribution
 
     if alias in ("particles", "dirac", "samples"):
+        if isinstance(distribution, SO3DiracDistribution):
+            return SO3DiracDistribution
+        if isinstance(distribution, SO3ProductDiracDistribution):
+            return SO3ProductDiracDistribution
+        if isinstance(distribution, SO3TangentGaussianDistribution):
+            return SO3DiracDistribution
+        if isinstance(distribution, SO3ProductTangentGaussianDistribution):
+            return SO3ProductDiracDistribution
         if isinstance(distribution, AbstractCircularDistribution):
             return CircularDiracDistribution
         if isinstance(distribution, AbstractHypertoroidalDistribution):
@@ -425,9 +453,6 @@ def _resolve_builtin_alias(distribution, alias: str):
     raise ConversionError(
         f"Unknown conversion alias '{alias}'. Use a concrete target class or register the alias with register_conversion_alias(...)."
     )
-
-
-# pylint: enable=too-many-locals,too-many-return-statements,too-many-branches
 
 
 def _matching_registered_conversions(distribution, target_type: type):
@@ -514,6 +539,9 @@ def _validate_conversion_arguments(
             f"{conversion_name} got unsupported conversion argument(s): "
             f"{', '.join(sorted(unknown))}. Accepted arguments: {accepted}."
         )
+
+
+from . import so3_conversion as _so3_conversion  # noqa: F401,E402  pylint: disable=wrong-import-position,unused-import
 
 
 __all__ = [

--- a/src/pyrecest/distributions/so3_conversion.py
+++ b/src/pyrecest/distributions/so3_conversion.py
@@ -1,0 +1,171 @@
+"""Conversion registrations for SO(3) distribution representations."""
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array, diag, matmul, reshape, sum, transpose
+
+from .conversion import register_conversion
+from .so3_dirac_distribution import SO3DiracDistribution
+from .so3_product_dirac_distribution import SO3ProductDiracDistribution
+from .so3_product_tangent_gaussian_distribution import (
+    SO3ProductTangentGaussianDistribution,
+)
+from .so3_tangent_gaussian_distribution import SO3TangentGaussianDistribution
+
+
+def _sample_so3_product_dirac(distribution, n_particles):
+    """Create an SO(3)^K Dirac approximation by sampling a source distribution."""
+    if not isinstance(n_particles, int) or n_particles <= 0:
+        raise ValueError("n_particles must be a positive integer")
+    return SO3ProductDiracDistribution(distribution.sample(n_particles))
+
+
+def _so3_tangent_gaussian_from_dirac(
+    distribution,
+    n_particles=None,
+    covariance_regularization=0.0,
+    check_validity=False,
+):
+    """Create an SO(3) tangent Gaussian approximation.
+
+    Dirac inputs are moment-matched in the local tangent chart. Non-Dirac inputs
+    can be converted by sampling first when ``n_particles`` is supplied.
+    """
+    if isinstance(distribution, SO3TangentGaussianDistribution):
+        return SO3TangentGaussianDistribution(
+            distribution.mean(),
+            distribution.covariance(),
+            check_validity=check_validity,
+        )
+
+    if not hasattr(distribution, "as_quaternions") or not hasattr(distribution, "w"):
+        if n_particles is None:
+            raise ValueError(
+                "SO3 tangent Gaussian conversion requires a weighted SO(3) "
+                "Dirac representation or n_particles for sampling-based "
+                "approximation."
+            )
+        distribution = SO3DiracDistribution.from_distribution(distribution, n_particles)
+
+    rotations = distribution.as_quaternions()
+    weights = reshape(distribution.w, (-1, 1))
+    initial_mean = distribution.mean()
+
+    tangent_vectors = SO3TangentGaussianDistribution.log_map(
+        rotations, base=initial_mean
+    )
+    tangent_mean = sum(weights * tangent_vectors, axis=0)
+    refined_mean = SO3TangentGaussianDistribution.exp_map(
+        tangent_mean, base=initial_mean
+    )[0]
+
+    residuals = SO3TangentGaussianDistribution.log_map(
+        rotations, base=refined_mean
+    )
+    residual_mean = sum(weights * residuals, axis=0)
+    centered = residuals - residual_mean
+    covariance = matmul(transpose(weights * centered), centered)
+
+    if covariance_regularization != 0.0:
+        covariance = covariance + covariance_regularization * diag(
+            array([1.0, 1.0, 1.0])
+        )
+
+    return SO3TangentGaussianDistribution(
+        refined_mean, covariance, check_validity=check_validity
+    )
+
+
+def _so3_product_tangent_gaussian_from_dirac(
+    distribution,
+    n_particles=None,
+    covariance_regularization=0.0,
+    check_validity=False,
+):
+    """Create an SO(3)^K tangent Gaussian approximation.
+
+    Dirac inputs are moment-matched in the local tangent chart. Non-Dirac inputs
+    can be converted by sampling first when ``n_particles`` is supplied.
+    """
+    if isinstance(distribution, SO3ProductTangentGaussianDistribution):
+        return SO3ProductTangentGaussianDistribution(
+            distribution.mean(),
+            distribution.covariance(),
+            num_rotations=distribution.num_rotations,
+            check_validity=check_validity,
+        )
+
+    if not hasattr(distribution, "as_quaternions") or not hasattr(distribution, "w"):
+        if n_particles is None:
+            raise ValueError(
+                "SO3 product tangent Gaussian conversion requires a weighted "
+                "SO(3)^K Dirac representation or n_particles for "
+                "sampling-based approximation."
+            )
+        distribution = _sample_so3_product_dirac(distribution, n_particles)
+
+    if not hasattr(distribution, "num_rotations"):
+        raise ValueError(
+            "SO(3)^K tangent Gaussian moment matching requires a product "
+            "Dirac distribution with num_rotations."
+        )
+
+    rotations = distribution.as_quaternions()
+    weights = reshape(distribution.w, (-1, 1))
+    num_rotations = distribution.num_rotations
+    initial_mean = distribution.mean()
+
+    tangent_vectors = SO3ProductTangentGaussianDistribution.log_map(
+        rotations, base=initial_mean, num_rotations=num_rotations
+    )
+    tangent_mean = sum(weights * tangent_vectors, axis=0)
+    refined_mean = SO3ProductTangentGaussianDistribution.exp_map(
+        tangent_mean, base=initial_mean, num_rotations=num_rotations
+    )[0]
+
+    residuals = SO3ProductTangentGaussianDistribution.log_map(
+        rotations, base=refined_mean, num_rotations=num_rotations
+    )
+    residual_mean = sum(weights * residuals, axis=0)
+    centered = residuals - residual_mean
+    covariance = matmul(transpose(weights * centered), centered)
+
+    if covariance_regularization != 0.0:
+        covariance = covariance + covariance_regularization * diag(
+            array([1.0] * (3 * num_rotations))
+        )
+
+    return SO3ProductTangentGaussianDistribution(
+        refined_mean,
+        covariance,
+        num_rotations=num_rotations,
+        check_validity=check_validity,
+    )
+
+
+register_conversion(
+    SO3TangentGaussianDistribution,
+    SO3DiracDistribution,
+    SO3DiracDistribution.from_distribution,
+    method="SO3DiracDistribution.from_distribution",
+)
+register_conversion(
+    SO3ProductTangentGaussianDistribution,
+    SO3ProductDiracDistribution,
+    _sample_so3_product_dirac,
+    method="SO3ProductDiracDistribution.from_distribution",
+)
+register_conversion(
+    SO3DiracDistribution,
+    SO3TangentGaussianDistribution,
+    _so3_tangent_gaussian_from_dirac,
+    method="SO3TangentGaussianDistribution.from_distribution",
+)
+register_conversion(
+    SO3ProductDiracDistribution,
+    SO3ProductTangentGaussianDistribution,
+    _so3_product_tangent_gaussian_from_dirac,
+    method="SO3ProductTangentGaussianDistribution.from_distribution",
+)
+
+
+__all__ = []

--- a/tests/distributions/test_conversion.py
+++ b/tests/distributions/test_conversion.py
@@ -10,6 +10,16 @@ from pyrecest.distributions.conversion import (
     convert_distribution,
     register_conversion_alias,
 )
+from pyrecest.distributions.so3_dirac_distribution import SO3DiracDistribution
+from pyrecest.distributions.so3_product_dirac_distribution import (
+    SO3ProductDiracDistribution,
+)
+from pyrecest.distributions.so3_product_tangent_gaussian_distribution import (
+    SO3ProductTangentGaussianDistribution,
+)
+from pyrecest.distributions.so3_tangent_gaussian_distribution import (
+    SO3TangentGaussianDistribution,
+)
 
 
 class ConversionTest(unittest.TestCase):
@@ -136,6 +146,93 @@ class ConversionTest(unittest.TestCase):
 
         self.assertTrue(can_convert(gaussian, "particles"))
         self.assertFalse(can_convert(gaussian, "not_a_representation"))
+
+    def test_so3_tangent_gaussian_to_dirac_alias(self):
+        random.seed(0)
+        distribution = SO3TangentGaussianDistribution(
+            array([0.0, 0.0, 0.0, 1.0]), 0.01 * eye(3)
+        )
+
+        particles = convert_distribution(distribution, "particles", n_particles=8)
+
+        self.assertIsInstance(particles, SO3DiracDistribution)
+        self.assertEqual(particles.d.shape, (8, 4))
+        self.assertTrue(particles.is_valid())
+
+    def test_so3_dirac_to_tangent_gaussian_alias(self):
+        base = array([0.0, 0.0, 0.0, 1.0])
+        rotations = SO3TangentGaussianDistribution.exp_map(
+            array(
+                [
+                    [0.01, 0.0, 0.0],
+                    [-0.01, 0.0, 0.0],
+                    [0.0, 0.02, 0.0],
+                    [0.0, -0.02, 0.0],
+                ]
+            ),
+            base=base,
+        )
+        particles = SO3DiracDistribution(rotations, array([0.25, 0.25, 0.25, 0.25]))
+
+        gaussian = particles.approximate_as("so3_tangent_gaussian")
+
+        self.assertIsInstance(gaussian, SO3TangentGaussianDistribution)
+        self.assertEqual(gaussian.mean().shape, (4,))
+        self.assertEqual(gaussian.covariance().shape, (3, 3))
+        self.assertTrue(gaussian.is_valid())
+
+    def test_so3_generic_gaussian_alias_is_tangent_gaussian(self):
+        base = array([0.0, 0.0, 0.0, 1.0])
+        rotations = SO3TangentGaussianDistribution.exp_map(
+            array([[0.01, 0.0, 0.0], [-0.01, 0.0, 0.0]]),
+            base=base,
+        )
+        particles = SO3DiracDistribution(rotations, array([0.5, 0.5]))
+
+        gaussian = convert_distribution(
+            particles, "gaussian", covariance_regularization=1e-9
+        )
+
+        self.assertIsInstance(gaussian, SO3TangentGaussianDistribution)
+        self.assertEqual(gaussian.covariance().shape, (3, 3))
+
+    def test_so3_product_tangent_gaussian_to_dirac_alias(self):
+        random.seed(0)
+        mean = array([[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.0, 1.0]])
+        distribution = SO3ProductTangentGaussianDistribution(mean, 0.01 * eye(6))
+
+        particles = convert_distribution(distribution, "particles", n_particles=8)
+
+        self.assertIsInstance(particles, SO3ProductDiracDistribution)
+        self.assertEqual(particles.d.shape, (8, 2, 4))
+        self.assertEqual(particles.num_rotations, 2)
+        self.assertTrue(particles.is_valid())
+
+    def test_so3_product_dirac_to_tangent_gaussian_alias(self):
+        mean = array([[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.0, 1.0]])
+        rotations = SO3ProductTangentGaussianDistribution.exp_map(
+            array(
+                [
+                    [0.01, 0.0, 0.0, 0.0, 0.02, 0.0],
+                    [-0.01, 0.0, 0.0, 0.0, -0.02, 0.0],
+                    [0.0, 0.01, 0.0, 0.02, 0.0, 0.0],
+                    [0.0, -0.01, 0.0, -0.02, 0.0, 0.0],
+                ]
+            ),
+            base=mean,
+            num_rotations=2,
+        )
+        particles = SO3ProductDiracDistribution(
+            rotations, array([0.25, 0.25, 0.25, 0.25])
+        )
+
+        gaussian = convert_distribution(particles, "so3_product_tangent_gaussian")
+
+        self.assertIsInstance(gaussian, SO3ProductTangentGaussianDistribution)
+        self.assertEqual(gaussian.mean().shape, (2, 4))
+        self.assertEqual(gaussian.covariance().shape, (6, 6))
+        self.assertEqual(gaussian.num_rotations, 2)
+        self.assertTrue(gaussian.is_valid())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR is stacked on #1931 and adds SO(3) / SO(3)^K support to the representation-conversion gateway.

Main changes:
- adds SO(3)-aware aliases such as `so3_dirac`, `so3_particles`, `so3_tangent_gaussian`, `so3_product_dirac`, and `so3_product_tangent_gaussian`
- makes generic `particles` / `dirac` aliases resolve to SO(3)-specific Dirac representations for SO(3) and SO(3)^K sources
- makes generic `gaussian` resolve to tangent-Gaussian approximations for SO(3) / SO(3)^K sources
- adds `so3_conversion.py` with registered converters rather than modifying the SO(3) distribution classes directly
- supports SO(3) tangent-Gaussian -> SO(3) Dirac via sampling
- supports SO(3) Dirac -> SO(3) tangent Gaussian via local tangent-space moment matching
- supports SO(3)^K product tangent-Gaussian -> product Dirac via sampling
- supports SO(3)^K product Dirac -> product tangent Gaussian via local tangent-space moment matching
- adds tests for SO(3) and SO(3)^K conversions
- updates representation-conversion docs

Notes:
- This PR should be retargeted to `main` after #1931 is merged.
- The implementation keeps SO(3)-specific fitting code in a small registration module to avoid expanding the core conversion gateway too much.