### PR TITLE
Re-export representation conversion API

### DIFF
--- a/src/pyrecest/distributions/__init__.py
+++ b/src/pyrecest/distributions/__init__.py
@@ -22,6 +22,16 @@ from .abstract_periodic_grid_distribution import AbstractPeriodicGridDistributio
 from .abstract_se2_distribution import AbstractSE2Distribution
 from .abstract_se3_distribution import AbstractSE3Distribution
 from .abstract_uniform_distribution import AbstractUniformDistribution
+from .conversion import (
+    ConversionError,
+    ConversionResult,
+    can_convert,
+    convert_distribution,
+    register_conversion,
+    register_conversion_alias,
+    registered_conversion_aliases,
+    registered_conversions,
+)
 from .cart_prod.abstract_cart_prod_distribution import AbstractCartProdDistribution
 from .cart_prod.abstract_custom_lin_bounded_cart_prod_distribution import (
     AbstractCustomLinBoundedCartProdDistribution,
@@ -286,6 +296,14 @@ aliases = [
 
 __all__ = aliases + [
     "GvMDistribution",
+    "ConversionError",
+    "ConversionResult",
+    "can_convert",
+    "convert_distribution",
+    "register_conversion",
+    "register_conversion_alias",
+    "registered_conversion_aliases",
+    "registered_conversions",
     "GeneralizedKSineSkewedVonMisesDistribution",
     "AbstractBoundedDomainDistribution",
     "AbstractBoundedNonPeriodicDistribution",

--- a/tests/distributions/test_conversion_exports.py
+++ b/tests/distributions/test_conversion_exports.py
@@ -1,0 +1,27 @@
+import unittest
+
+from pyrecest import distributions
+
+
+CONVERSION_EXPORTS = (
+    "ConversionError",
+    "ConversionResult",
+    "can_convert",
+    "convert_distribution",
+    "register_conversion",
+    "register_conversion_alias",
+    "registered_conversion_aliases",
+    "registered_conversions",
+)
+
+
+class ConversionExportTest(unittest.TestCase):
+    def test_conversion_api_is_reexported_from_distributions_package(self):
+        for name in CONVERSION_EXPORTS:
+            with self.subTest(name=name):
+                self.assertTrue(hasattr(distributions, name))
+                self.assertIn(name, distributions.__all__)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This stacked PR implements Task A on top of #1931.

Main changes:
- re-exports the representation conversion API from `pyrecest.distributions`
- adds the exported conversion symbols to `pyrecest.distributions.__all__`
- updates conversion tests to use the package-level import path
- adds a regression test that verifies all conversion symbols are package-level attributes and listed in `__all__`
- updates the representation-conversion guide and API overview to use `pyrecest.distributions.convert_distribution(...)`

This should be retargeted to `main` after #1931 is merged.