### PR TITLE
Add linear Gaussian model objects

### DIFF
--- a/src/pyrecest/models/__init__.py
+++ b/src/pyrecest/models/__init__.py
@@ -1,0 +1,1 @@
+"""Reusable state-space model objects."""

--- a/src/pyrecest/models/__init__.py
+++ b/src/pyrecest/models/__init__.py
@@ -1,1 +1,13 @@
-"""Reusable state-space model objects."""
+"""Reusable model objects for recursive estimation."""
+
+from .linear_gaussian import IdentityGaussianMeasurementModel
+from .linear_gaussian import IdentityGaussianTransitionModel
+from .linear_gaussian import LinearGaussianMeasurementModel
+from .linear_gaussian import LinearGaussianTransitionModel
+
+__all__ = [
+    "IdentityGaussianMeasurementModel",
+    "IdentityGaussianTransitionModel",
+    "LinearGaussianMeasurementModel",
+    "LinearGaussianTransitionModel",
+]

--- a/src/pyrecest/models/linear_gaussian.py
+++ b/src/pyrecest/models/linear_gaussian.py
@@ -1,2 +1,159 @@
-"""Linear Gaussian models."""
+"""Reusable linear Gaussian transition and measurement models."""
 
+from pyrecest.backend import asarray, eye, matmul, matvec, ndim, reshape, transpose, zeros
+from pyrecest.distributions import GaussianDistribution
+
+
+def _as_matrix(value, name):
+    arr = asarray(value)
+    if ndim(arr) != 2:
+        raise ValueError(f"{name} must be two-dimensional")
+    return arr
+
+
+def _as_vector(value, name):
+    arr = asarray(value)
+    if ndim(arr) == 0:
+        arr = reshape(arr, (1,))
+    if ndim(arr) != 1:
+        raise ValueError(f"{name} must be one-dimensional")
+    return arr
+
+
+def _shape(value):
+    return tuple(value.shape)
+
+
+def _as_square(value, name):
+    arr = _as_matrix(value, name)
+    if arr.shape[0] != arr.shape[1]:
+        raise ValueError(f"{name} must be square")
+    return arr
+
+
+def _mean(distribution):
+    mean = getattr(distribution, "mean", None)
+    if callable(mean):
+        return mean()
+    if mean is not None:
+        return mean
+    return distribution.mu
+
+
+def _covariance(distribution):
+    covariance = getattr(distribution, "covariance", None)
+    if callable(covariance):
+        return covariance()
+    if covariance is not None:
+        return covariance
+    return distribution.C
+
+
+class LinearGaussianTransitionModel:
+    """Transition model ``x_next = F x + u + w`` with Gaussian noise."""
+
+    def __init__(self, matrix, noise_cov, offset=None):
+        self.matrix = _as_matrix(matrix, "matrix")
+        self.noise_cov = _as_square(noise_cov, "noise_cov")
+        self.predicted_dim, self.state_dim = _shape(self.matrix)
+        if _shape(self.noise_cov) != (self.predicted_dim, self.predicted_dim):
+            raise ValueError("noise_cov has incompatible shape")
+        self.offset = None if offset is None else _as_vector(offset, "offset")
+        if self.offset is not None and _shape(self.offset) != (self.predicted_dim,):
+            raise ValueError("offset has incompatible shape")
+
+    @property
+    def sys_noise_cov(self):
+        return self.noise_cov
+
+    @property
+    def system_noise_cov(self):
+        return self.noise_cov
+
+    @property
+    def sys_input(self):
+        return self.offset
+
+    @property
+    def system_matrix(self):
+        return self.matrix
+
+    def predict_mean(self, state_mean):
+        state_mean = _as_vector(state_mean, "state_mean")
+        if _shape(state_mean) != (self.state_dim,):
+            raise ValueError("state_mean has incompatible shape")
+        result = matvec(self.matrix, state_mean)
+        if self.offset is not None:
+            result = result + self.offset
+        return result
+
+    def predict_covariance(self, state_covariance):
+        state_covariance = _as_square(state_covariance, "state_covariance")
+        if _shape(state_covariance) != (self.state_dim, self.state_dim):
+            raise ValueError("state_covariance has incompatible shape")
+        return matmul(matmul(self.matrix, state_covariance), transpose(self.matrix)) + self.noise_cov
+
+    def predict_distribution(self, state_distribution, check_validity=False):
+        return GaussianDistribution(
+            self.predict_mean(_mean(state_distribution)),
+            self.predict_covariance(_covariance(state_distribution)),
+            check_validity=check_validity,
+        )
+
+    def noise_distribution(self, check_validity=False):
+        return GaussianDistribution(zeros((self.predicted_dim,)), self.noise_cov, check_validity=check_validity)
+
+
+class IdentityGaussianTransitionModel(LinearGaussianTransitionModel):
+    def __init__(self, dim, noise_cov, offset=None):
+        super().__init__(eye(dim), noise_cov, offset=offset)
+
+
+class LinearGaussianMeasurementModel:
+    """Measurement model ``z = H x + v`` with Gaussian noise."""
+
+    def __init__(self, matrix, noise_cov):
+        self.matrix = _as_matrix(matrix, "matrix")
+        self.noise_cov = _as_square(noise_cov, "noise_cov")
+        self.measurement_dim, self.state_dim = _shape(self.matrix)
+        if _shape(self.noise_cov) != (self.measurement_dim, self.measurement_dim):
+            raise ValueError("noise_cov has incompatible shape")
+
+    @property
+    def meas_noise(self):
+        return self.noise_cov
+
+    @property
+    def measurement_noise_cov(self):
+        return self.noise_cov
+
+    @property
+    def measurement_matrix(self):
+        return self.matrix
+
+    def predict_mean(self, state_mean):
+        state_mean = _as_vector(state_mean, "state_mean")
+        if _shape(state_mean) != (self.state_dim,):
+            raise ValueError("state_mean has incompatible shape")
+        return matvec(self.matrix, state_mean)
+
+    def innovation_covariance(self, state_covariance):
+        state_covariance = _as_square(state_covariance, "state_covariance")
+        if _shape(state_covariance) != (self.state_dim, self.state_dim):
+            raise ValueError("state_covariance has incompatible shape")
+        return matmul(matmul(self.matrix, state_covariance), transpose(self.matrix)) + self.noise_cov
+
+    def predict_distribution(self, state_distribution, check_validity=False):
+        return GaussianDistribution(
+            self.predict_mean(_mean(state_distribution)),
+            self.innovation_covariance(_covariance(state_distribution)),
+            check_validity=check_validity,
+        )
+
+    def noise_distribution(self, check_validity=False):
+        return GaussianDistribution(zeros((self.measurement_dim,)), self.noise_cov, check_validity=check_validity)
+
+
+class IdentityGaussianMeasurementModel(LinearGaussianMeasurementModel):
+    def __init__(self, dim, noise_cov):
+        super().__init__(eye(dim), noise_cov)

--- a/src/pyrecest/models/linear_gaussian.py
+++ b/src/pyrecest/models/linear_gaussian.py
@@ -1,0 +1,2 @@
+"""Linear Gaussian models."""
+

--- a/src/pyrecest/models/placeholder.txt
+++ b/src/pyrecest/models/placeholder.txt
@@ -1,0 +1,1 @@
+placeholder

--- a/src/pyrecest/models/placeholder.txt
+++ b/src/pyrecest/models/placeholder.txt
@@ -1,1 +1,0 @@
-placeholder

--- a/tests/models/test_linear_gaussian_models.py
+++ b/tests/models/test_linear_gaussian_models.py
@@ -1,0 +1,76 @@
+import unittest
+
+import numpy.testing as npt
+from pyrecest.backend import array, diag, eye, to_numpy
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.models import IdentityGaussianMeasurementModel
+from pyrecest.models import IdentityGaussianTransitionModel
+from pyrecest.models import LinearGaussianMeasurementModel
+from pyrecest.models import LinearGaussianTransitionModel
+
+
+class LinearGaussianModelsTest(unittest.TestCase):
+    def test_transition_predict_distribution(self):
+        model = LinearGaussianTransitionModel(
+            array([[1.0, 1.0], [0.0, 1.0]]),
+            diag(array([0.1, 0.2])),
+            array([0.5, -0.25]),
+        )
+        state = GaussianDistribution(array([2.0, 0.5]), diag(array([1.0, 2.0])))
+        predicted = model.predict_distribution(state)
+
+        npt.assert_allclose(to_numpy(predicted.mu), to_numpy(array([3.0, 0.25])), atol=1e-12)
+        npt.assert_allclose(to_numpy(predicted.C), to_numpy(array([[3.1, 2.0], [2.0, 2.2]])), atol=1e-12)
+
+    def test_transition_noise_distribution_and_alias(self):
+        noise_cov = diag(array([0.1, 0.2]))
+        model = LinearGaussianTransitionModel(eye(2), noise_cov)
+
+        self.assertIs(model.system_noise_cov, model.sys_noise_cov)
+        noise = model.noise_distribution()
+
+        npt.assert_allclose(to_numpy(noise.mu), to_numpy(array([0.0, 0.0])), atol=1e-12)
+        npt.assert_allclose(to_numpy(noise.C), to_numpy(noise_cov), atol=1e-12)
+
+    def test_measurement_predict_distribution(self):
+        model = LinearGaussianMeasurementModel(array([[1.0, 0.0]]), array([[0.25]]))
+        state = GaussianDistribution(array([2.0, 0.5]), diag(array([1.0, 2.0])))
+        predicted = model.predict_distribution(state)
+
+        npt.assert_allclose(to_numpy(predicted.mu), to_numpy(array([2.0])), atol=1e-12)
+        npt.assert_allclose(to_numpy(predicted.C), to_numpy(array([[1.25]])), atol=1e-12)
+
+    def test_measurement_noise_distribution_and_alias(self):
+        noise_cov = array([[0.25]])
+        model = LinearGaussianMeasurementModel(array([[1.0, 0.0]]), noise_cov)
+
+        self.assertIs(model.measurement_noise_cov, model.meas_noise)
+        noise = model.noise_distribution()
+
+        npt.assert_allclose(to_numpy(noise.mu), to_numpy(array([0.0])), atol=1e-12)
+        npt.assert_allclose(to_numpy(noise.C), to_numpy(noise_cov), atol=1e-12)
+
+    def test_identity_models(self):
+        transition_model = IdentityGaussianTransitionModel(2, diag(array([0.1, 0.2])))
+        measurement_model = IdentityGaussianMeasurementModel(2, diag(array([0.3, 0.4])))
+
+        npt.assert_allclose(to_numpy(transition_model.system_matrix), to_numpy(eye(2)), atol=1e-12)
+        npt.assert_allclose(to_numpy(measurement_model.measurement_matrix), to_numpy(eye(2)), atol=1e-12)
+
+    def test_rejects_incompatible_shapes(self):
+        with self.assertRaises(ValueError):
+            LinearGaussianTransitionModel(array([[1.0, 0.0]]), diag(array([0.1, 0.2])))
+        with self.assertRaises(ValueError):
+            LinearGaussianMeasurementModel(array([[1.0, 0.0]]), diag(array([0.1, 0.2])))
+
+        transition_model = LinearGaussianTransitionModel(eye(2), diag(array([0.1, 0.2])))
+        with self.assertRaises(ValueError):
+            transition_model.predict_mean(array([1.0, 2.0, 3.0]))
+
+        measurement_model = LinearGaussianMeasurementModel(array([[1.0, 0.0]]), array([[0.25]]))
+        with self.assertRaises(ValueError):
+            measurement_model.predict_mean(array([1.0, 2.0, 3.0]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds reusable linear Gaussian model objects under `pyrecest.models`:

- `LinearGaussianTransitionModel`
- `IdentityGaussianTransitionModel`
- `LinearGaussianMeasurementModel`
- `IdentityGaussianMeasurementModel`

These classes package the transition equation

```text
x_k = F x_{k-1} + u + w,    w ~ N(0, Q)
```

and the measurement equation

```text
z_k = H x_k + v,            v ~ N(0, R)
```

without changing any existing filter APIs.

## Motivation

This is PR2 from the reusable-model-object roadmap. It provides concrete linear Gaussian models that later PRs can adapt into `KalmanFilter.predict_model(...)` / `update_model(...)` while preserving existing calls such as `predict_linear(...)` and `update_linear(...)`.

## Changes

- Adds `src/pyrecest/models/__init__.py`
- Adds `src/pyrecest/models/linear_gaussian.py`
- Adds `tests/models/test_linear_gaussian_models.py`
- Adds shape validation for transition, measurement, covariance, and input vectors
- Adds Gaussian prediction helpers:
  - `predict_mean(...)`
  - `predict_covariance(...)`
  - `predict_distribution(...)`
  - `innovation_covariance(...)`
  - `noise_distribution(...)`
- Adds compatibility aliases:
  - `system_matrix`
  - `system_noise_cov` / `sys_noise_cov`
  - `measurement_matrix`
  - `measurement_noise_cov` / `meas_noise`

## Non-goals

- Does not modify `KalmanFilter`
- Does not add `predict_model(...)` / `update_model(...)`
- Does not deprecate existing matrix-based APIs
- Does not introduce a full model protocol hierarchy

## Suggested test command

```bash
poetry run pytest tests/models/test_linear_gaussian_models.py
```
