### PR TITLE
Add grid-filter model adapters

### DIFF
--- a/src/pyrecest/filters/abstract_grid_filter.py
+++ b/src/pyrecest/filters/abstract_grid_filter.py
@@ -48,5 +48,73 @@ class AbstractGridFilter(AbstractFilter):
         self.filter_state.grid_values = grid_vals_new
         self.filter_state.normalize_in_place(warn_unnorm=False)
 
+    def update_model(self, measurement_model, z):
+        """Update the grid state using a reusable likelihood model.
+
+        Parameters
+        ----------
+        measurement_model : object
+            Model object exposing either ``likelihood_values(z, grid)`` or a
+            callable ``likelihood(z, grid)`` attribute. The method must return
+            one likelihood value per point of ``self.filter_state.get_grid()``.
+        z : array-like
+            Measurement passed to the model.
+
+        Notes
+        -----
+        This adapter preserves the existing :meth:`update_nonlinear` API and
+        simply delegates to it after extracting the likelihood capability from
+        the model object.
+        """
+        if hasattr(measurement_model, "likelihood_values"):
+            likelihood = measurement_model.likelihood_values
+        elif hasattr(measurement_model, "likelihood") and callable(
+            measurement_model.likelihood
+        ):
+            likelihood = measurement_model.likelihood
+        else:
+            raise TypeError(
+                "measurement_model must expose likelihood_values(z, grid) "
+                "or a callable likelihood(z, grid) attribute."
+            )
+        self.update_nonlinear(likelihood, z)
+
+    def predict_model(self, transition_model):
+        """Predict using a reusable grid transition-density model.
+
+        Parameters
+        ----------
+        transition_model : object
+            Model object exposing either ``transition_density_for_filter(self)``
+            or a ``transition_density`` attribute compatible with this filter's
+            density-based prediction method.
+
+        Notes
+        -----
+        This generic adapter is intentionally conservative: concrete grid
+        filters still define the actual density-based prediction method. If a
+        filter does not expose ``predict_nonlinear_via_transition_density``, a
+        clear ``NotImplementedError`` is raised.
+        """
+        predict_via_density = getattr(
+            self, "predict_nonlinear_via_transition_density", None
+        )
+        if not callable(predict_via_density):
+            raise NotImplementedError(
+                f"{type(self).__name__} does not implement "
+                "predict_nonlinear_via_transition_density."
+            )
+
+        if hasattr(transition_model, "transition_density_for_filter"):
+            transition_density = transition_model.transition_density_for_filter(self)
+        elif hasattr(transition_model, "transition_density"):
+            transition_density = transition_model.transition_density
+        else:
+            raise TypeError(
+                "transition_model must expose transition_density_for_filter(filter) "
+                "or a transition_density attribute."
+            )
+        predict_via_density(transition_density)
+
     def plot_filter_state(self):
         self.filter_state.plot_state()

--- a/src/pyrecest/filters/abstract_grid_filter.py
+++ b/src/pyrecest/filters/abstract_grid_filter.py
@@ -114,7 +114,7 @@ class AbstractGridFilter(AbstractFilter):
                 "transition_model must expose transition_density_for_filter(filter) "
                 "or a transition_density attribute."
             )
-        predict_via_density(transition_density)
+        predict_via_density(transition_density)  # pylint: disable=not-callable
 
     def plot_filter_state(self):
         self.filter_state.plot_state()

--- a/src/pyrecest/models/__init__.py
+++ b/src/pyrecest/models/__init__.py
@@ -21,6 +21,11 @@ from .adapters import (
     sample_next_state,
 )
 from .additive_noise import AdditiveNoiseMeasurementModel, AdditiveNoiseTransitionModel
+from .grid import (
+    GridLikelihoodMeasurementModel,
+    GridTransitionDensityFactoryModel,
+    GridTransitionDensityModel,
+)
 from .likelihood import (
     DensityTransitionModel,
     LikelihoodMeasurementModel,
@@ -50,6 +55,9 @@ __all__ = [
     "AdditiveNoiseMeasurementModel",
     "AdditiveNoiseTransitionModel",
     "DensityTransitionModel",
+    "GridLikelihoodMeasurementModel",
+    "GridTransitionDensityFactoryModel",
+    "GridTransitionDensityModel",
     "IdentityGaussianMeasurementModel",
     "IdentityGaussianTransitionModel",
     "LikelihoodMeasurementModel",

--- a/src/pyrecest/models/grid.py
+++ b/src/pyrecest/models/grid.py
@@ -1,0 +1,87 @@
+"""Reusable model objects for grid-based filters.
+
+The classes in this module are deliberately small wrappers around the two
+capabilities grid filters need most often:
+
+* evaluating a measurement likelihood on all grid points; and
+* providing a precomputed transition density for grid-based prediction.
+
+They are intentionally not tied to one concrete grid-filter class. Concrete
+filters may still impose additional requirements on the transition-density
+object, for example a manifold-specific conditional grid distribution.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+GridLikelihoodFunction = Callable[[Any, Any], Any]
+GridTransitionDensityFactory = Callable[[Any], Any]
+
+
+@dataclass(frozen=True)
+class GridLikelihoodMeasurementModel:
+    """Measurement model that evaluates likelihoods on a filter grid.
+
+    Parameters
+    ----------
+    likelihood : callable
+        Function with signature ``likelihood(measurement, grid)`` returning one
+        non-negative likelihood value per grid point. The returned shape should
+        be compatible with the grid distribution's ``grid_values``.
+
+    Notes
+    -----
+    This model is useful for grid filters whose update step multiplies the
+    current grid weights by likelihood values evaluated at the support grid.
+    """
+
+    likelihood: GridLikelihoodFunction
+
+    def likelihood_values(self, measurement: Any, grid: Any) -> Any:
+        """Evaluate the measurement likelihood on ``grid``."""
+        return self.likelihood(measurement, grid)
+
+
+@dataclass(frozen=True)
+class GridTransitionDensityModel:
+    """Transition model backed by a precomputed conditional grid density.
+
+    Parameters
+    ----------
+    transition_density : object
+        Conditional grid distribution or transition-density object understood by
+        the concrete grid filter. For example, ``HyperhemisphericalGridFilter``
+        expects an ``SdHalfCondSdHalfGridDistribution``.
+    """
+
+    transition_density: Any
+
+    def transition_density_for_filter(self, _filter: Any) -> Any:
+        """Return the precomputed transition density for ``_filter``."""
+        return self.transition_density
+
+
+@dataclass(frozen=True)
+class GridTransitionDensityFactoryModel:
+    """Transition model that lazily creates a conditional grid density.
+
+    Parameters
+    ----------
+    transition_density_factory : callable
+        Function with signature ``transition_density_factory(filter)`` returning
+        a transition-density object compatible with the given filter.
+
+    Notes
+    -----
+    This is useful when the density depends on the active filter grid or the
+    number of grid points. The factory is called by the filter adapter at
+    prediction time.
+    """
+
+    transition_density_factory: GridTransitionDensityFactory
+
+    def transition_density_for_filter(self, filter_instance: Any) -> Any:
+        """Create a transition density compatible with ``filter_instance``."""
+        return self.transition_density_factory(filter_instance)

--- a/tests/filters/test_grid_filter_model_adapters.py
+++ b/tests/filters/test_grid_filter_model_adapters.py
@@ -1,0 +1,119 @@
+import unittest
+import warnings
+
+import pyrecest.backend
+from pyrecest.backend import allclose, array
+from pyrecest.distributions import HyperhemisphericalWatsonDistribution
+from pyrecest.distributions.hypersphere_subset.watson_distribution import (
+    WatsonDistribution,
+)
+from pyrecest.filters.hyperhemispherical_grid_filter import (
+    HyperhemisphericalGridFilter,
+)
+from pyrecest.models import (
+    GridLikelihoodMeasurementModel,
+    GridTransitionDensityFactoryModel,
+    GridTransitionDensityModel,
+)
+
+
+class TestGridFilterModelAdapters(unittest.TestCase):
+    def setUp(self):
+        self.n_grid = 50
+        self.dim = 2
+        self.initial_distribution = HyperhemisphericalWatsonDistribution(
+            array([0.0, 0.0, 1.0]), 5.0
+        )
+        self.measurement = array([0.0, 0.0, 1.0])
+        self.system_noise = WatsonDistribution(array([0.0, 0.0, 1.0]), 3.0)
+
+    def _initialized_filter(self):
+        filter_instance = HyperhemisphericalGridFilter(self.n_grid, self.dim)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            filter_instance.filter_state = self.initial_distribution
+        return filter_instance
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on JAX backend",
+    )
+    def test_update_model_matches_update_nonlinear(self):
+        reference_filter = self._initialized_filter()
+        model_filter = self._initialized_filter()
+
+        def likelihood(measurement, grid):
+            return HyperhemisphericalWatsonDistribution(measurement, 2.0).pdf(grid)
+
+        reference_filter.update_nonlinear(likelihood, self.measurement)
+        model_filter.update_model(
+            GridLikelihoodMeasurementModel(likelihood), self.measurement
+        )
+
+        self.assertTrue(
+            bool(
+                allclose(
+                    reference_filter.filter_state.grid_values,
+                    model_filter.filter_state.grid_values,
+                )
+            )
+        )
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on JAX backend",
+    )
+    def test_predict_model_matches_transition_density_prediction(self):
+        reference_filter = self._initialized_filter()
+        model_filter = self._initialized_filter()
+        transition_density = HyperhemisphericalGridFilter.sys_noise_to_transition_density(
+            self.system_noise, self.n_grid
+        )
+
+        reference_filter.predict_nonlinear_via_transition_density(transition_density)
+        model_filter.predict_model(GridTransitionDensityModel(transition_density))
+
+        self.assertTrue(
+            bool(
+                allclose(
+                    reference_filter.filter_state.grid_values,
+                    model_filter.filter_state.grid_values,
+                )
+            )
+        )
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on JAX backend",
+    )
+    def test_predict_model_accepts_transition_density_factory(self):
+        reference_filter = self._initialized_filter()
+        model_filter = self._initialized_filter()
+
+        transition_density = HyperhemisphericalGridFilter.sys_noise_to_transition_density(
+            self.system_noise, self.n_grid
+        )
+        reference_filter.predict_nonlinear_via_transition_density(transition_density)
+
+        def transition_density_factory(filter_instance):
+            return HyperhemisphericalGridFilter.sys_noise_to_transition_density(
+                self.system_noise,
+                filter_instance.filter_state.grid_values.shape[0],
+            )
+
+        model_filter.predict_model(
+            GridTransitionDensityFactoryModel(transition_density_factory)
+        )
+
+        self.assertTrue(
+            bool(
+                allclose(
+                    reference_filter.filter_state.grid_values,
+                    model_filter.filter_state.grid_values,
+                )
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Summary

This PR adds a small reusable model-object layer for grid-based filters and wires it into the generic grid-filter base.

It adds:

- `pyrecest.models.GridLikelihoodMeasurementModel`
- `pyrecest.models.GridTransitionDensityModel`
- `pyrecest.models.GridTransitionDensityFactoryModel`
- `AbstractGridFilter.update_model(...)`
- `AbstractGridFilter.predict_model(...)`
- adapter-equivalence tests for likelihood updates and transition-density predictions

# Motivation

Grid filters need two reusable capabilities:

1. evaluate a measurement likelihood on all grid points;
2. provide a conditional transition density for grid prediction.

The existing APIs already support these operations directly through `update_nonlinear(...)` and, for suitable concrete grid filters, `predict_nonlinear_via_transition_density(...)`. This PR adds thin model-object adapters on top of those existing methods rather than changing the algorithms.

# Scope

This is intentionally narrow:

- no deprecation of existing APIs;
- no broad refactor of all grid filters;
- no automatic dispatch or registry;
- no application-specific model classes.

`predict_model(...)` is implemented on `AbstractGridFilter` but deliberately raises a clear `NotImplementedError` for grid filters that do not expose `predict_nonlinear_via_transition_density(...)`.

# Testing

Adds `tests/filters/test_grid_filter_model_adapters.py` with checks that:

- `update_model(GridLikelihoodMeasurementModel(...), z)` matches direct `update_nonlinear(...)`;
- `predict_model(GridTransitionDensityModel(...))` matches direct `predict_nonlinear_via_transition_density(...)` on `HyperhemisphericalGridFilter`;
- `predict_model(GridTransitionDensityFactoryModel(...))` supports lazy transition-density construction.

Suggested local command:

```bash
pytest tests/filters/test_grid_filter_model_adapters.py tests/filters/test_hyperhemispherical_grid_filter.py
```

# Backward compatibility

This PR is additive. Existing methods such as `update_nonlinear(...)`, `predict_identity(...)`, and `predict_nonlinear_via_transition_density(...)` remain unchanged.