### PR TITLE
Add likelihood and sampleable transition model objects

### DIFF
--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -1,8 +1,9 @@
 # API Overview
 
 PyRecEst exposes most user-facing classes through package-level imports such as
-`pyrecest.distributions`, `pyrecest.filters`, `pyrecest.sampling`,
-`pyrecest.smoothers`, `pyrecest.evaluation`, and `pyrecest.utils`.
+`pyrecest.distributions`, `pyrecest.filters`, `pyrecest.models`,
+`pyrecest.sampling`, `pyrecest.smoothers`, `pyrecest.evaluation`, and
+`pyrecest.utils`.
 
 Use backend-compatible arrays from `pyrecest.backend` in examples and user code
 when the same code should run on more than one numerical backend.
@@ -11,6 +12,7 @@ when the same code should run on more than one numerical backend.
 from pyrecest.backend import array, diag
 from pyrecest.distributions import GaussianDistribution
 from pyrecest.filters import KalmanFilter
+from pyrecest.models import LikelihoodMeasurementModel
 ```
 
 See [Shapes and conventions](conventions.md) for the expected vector, matrix,
@@ -46,6 +48,24 @@ between analytic, Dirac/particle, grid, Fourier, and moment-matched
 representations. The target may be a concrete class or an alias such as
 `"particles"`, `"gaussian"`, `"grid"`, or `"fourier"`. See
 [representation conversion](representation-conversion.md).
+
+### `pyrecest.models`
+
+Reusable transition and measurement model objects that describe model
+capabilities independently of a concrete filter. The initial model layer focuses
+on likelihood-based measurement models and transition models that can either
+sample next states or evaluate transition densities.
+
+Common starting points include:
+
+- `LikelihoodMeasurementModel` for particle-filter or grid-filter style
+  measurement likelihoods;
+- `SampleableTransitionModel` for transition models that can draw samples from
+  a next-state distribution;
+- `DensityTransitionModel` for transition models that can evaluate transition
+  densities.
+
+See [model objects](models.md) for usage patterns and conventions.
 
 ### `pyrecest.filters`
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -1,0 +1,54 @@
+# Model Objects
+
+Model objects describe transition and measurement capabilities independently of a concrete filter implementation.
+
+This initial model layer focuses on likelihood- and sampling-based capabilities for particle filters, grid filters, and other callback-based estimators.
+
+## Measurement likelihoods
+
+Use `LikelihoodMeasurementModel` when a measurement update is represented by a likelihood callback:
+
+```python
+from pyrecest.models import LikelihoodMeasurementModel
+
+measurement_model = LikelihoodMeasurementModel(likelihood)
+weight = measurement_model.likelihood(measurement, state)
+```
+
+The callback convention is `likelihood(measurement, state)`.
+
+A `log_likelihood` callback may also be supplied when the log-domain form is preferable.
+
+## State-conditioned distributions
+
+`LikelihoodMeasurementModel.from_distribution_factory(...)` builds a likelihood model from a callable that returns a conditional measurement distribution for a state. The returned distribution must expose a density method such as `pdf`.
+
+## Sampleable transitions
+
+Use `SampleableTransitionModel` when the transition model can draw next-state samples:
+
+```python
+from pyrecest.models import SampleableTransitionModel
+
+transition_model = SampleableTransitionModel(sample_next)
+samples = transition_model.sample_next(state, n=100)
+```
+
+The callback convention is `sample_next(state, n=1)`.
+
+## Density-based transitions
+
+Use `DensityTransitionModel` when the transition model can evaluate a transition density:
+
+```python
+from pyrecest.models import DensityTransitionModel
+
+transition_model = DensityTransitionModel(transition_density)
+density = transition_model.transition_density(state_next, state_previous)
+```
+
+The callback convention is `transition_density(state_next, state_previous)`.
+
+## Scope
+
+These model objects are additive infrastructure. They do not deprecate existing filter APIs and do not modify filter behavior by themselves. Filter-specific adapters can consume these objects in later changes.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -11,6 +11,7 @@ the examples and tests when working with less common APIs.
 
 - [Distributions](distributions.md)
 - [Filters](filters.md)
+- [Models](models.md)
 - [Smoothers](smoothers.md)
 - [Sampling](sampling.md)
 - [Evaluation](evaluation.md)

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -1,0 +1,3 @@
+# Models
+
+API reference for the `pyrecest.models` package.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
       - Shapes and Conventions: conventions.md
       - Backend Compatibility: backend-compatibility.md
       - Representation Conversion: representation-conversion.md
+      - Model Objects: models.md
   - Tutorials:
       - Overview: tutorials/index.md
       - Use a Distribution: tutorials/use-a-distribution.md
@@ -22,6 +23,7 @@ nav:
       - Reference Index: reference/index.md
       - Distributions: reference/distributions.md
       - Filters: reference/filters.md
+      - Models: reference/models.md
       - Smoothers: reference/smoothers.md
       - Sampling: reference/sampling.md
       - Evaluation: reference/evaluation.md

--- a/src/pyrecest/models/__init__.py
+++ b/src/pyrecest/models/__init__.py
@@ -1,0 +1,26 @@
+"""Reusable transition and measurement model objects.
+
+The model package contains filter-independent objects that describe how states
+evolve and how measurements are evaluated. These objects are deliberately small
+and capability-oriented so filters can opt into the pieces they need.
+"""
+
+from .likelihood import (
+    DensityTransitionModel,
+    LikelihoodMeasurementModel,
+    SampleableTransitionModel,
+    SupportsLikelihood,
+    SupportsLogLikelihood,
+    SupportsTransitionDensity,
+    SupportsTransitionSampling,
+)
+
+__all__ = [
+    "DensityTransitionModel",
+    "LikelihoodMeasurementModel",
+    "SampleableTransitionModel",
+    "SupportsLikelihood",
+    "SupportsLogLikelihood",
+    "SupportsTransitionDensity",
+    "SupportsTransitionSampling",
+]

--- a/src/pyrecest/models/likelihood.py
+++ b/src/pyrecest/models/likelihood.py
@@ -1,0 +1,273 @@
+"""Likelihood- and sampling-based reusable model objects.
+
+These classes provide generic, filter-independent containers for model
+capabilities commonly needed by particle filters, grid filters, and other
+likelihood-based estimators.
+
+The conventions are intentionally simple:
+
+- measurement likelihoods use ``likelihood(measurement, state)``;
+- transition samplers use ``sample_next(state, n=1)``;
+- transition densities use ``transition_density(state_next, state_previous)``.
+
+The classes do not modify filters directly. They only make the model
+capabilities explicit so filter adapters can consume them later without
+duplicating callback conventions.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class SupportsLikelihood(Protocol):
+    """Protocol for measurement models that can evaluate ``p(z | x)``."""
+
+    def likelihood(self, measurement: Any, state: Any) -> Any:
+        """Return the likelihood of ``measurement`` for ``state``."""
+
+
+@runtime_checkable
+class SupportsLogLikelihood(Protocol):
+    """Protocol for measurement models that can evaluate log-likelihoods."""
+
+    def log_likelihood(self, measurement: Any, state: Any) -> Any:
+        """Return the log-likelihood of ``measurement`` for ``state``."""
+
+
+@runtime_checkable
+class SupportsTransitionSampling(Protocol):
+    """Protocol for transition models that can sample ``p(x_k | x_{k-1})``."""
+
+    def sample_next(self, state: Any, n: int = 1) -> Any:
+        """Draw ``n`` next-state samples conditioned on ``state``."""
+
+
+@runtime_checkable
+class SupportsTransitionDensity(Protocol):
+    """Protocol for transition models that can evaluate ``p(x_k | x_{k-1})``."""
+
+    def transition_density(self, state_next: Any, state_previous: Any) -> Any:
+        """Return transition density values."""
+
+
+def _ensure_callable(value: Any, name: str) -> None:
+    if not callable(value):
+        raise TypeError(f"{name} must be callable")
+
+
+def _evaluate_distribution_method(distribution: Any, method_name: str, *args: Any) -> Any:
+    method = getattr(distribution, method_name, None)
+    if method is None or not callable(method):
+        raise AttributeError(
+            f"Distribution object of type {type(distribution).__name__!r} "
+            f"does not provide callable method {method_name!r}."
+        )
+    return method(*args)
+
+
+class LikelihoodMeasurementModel:
+    """Measurement model specified by a likelihood callback.
+
+    Parameters
+    ----------
+    likelihood
+        Callable with signature ``likelihood(measurement, state)`` returning
+        values proportional to ``p(measurement | state)``.
+    log_likelihood
+        Optional callable with signature ``log_likelihood(measurement, state)``.
+        If omitted, :meth:`log_likelihood` raises :class:`NotImplementedError`.
+    name
+        Optional human-readable model name used in diagnostics and examples.
+
+    Notes
+    -----
+    This class is intentionally representation-agnostic. ``measurement`` and
+    ``state`` can be scalars, backend arrays, particles, manifold coordinates,
+    or any other objects understood by the provided callback.
+    """
+
+    def __init__(
+        self,
+        likelihood: Callable[[Any, Any], Any],
+        *,
+        log_likelihood: Callable[[Any, Any], Any] | None = None,
+        name: str | None = None,
+    ):
+        _ensure_callable(likelihood, "likelihood")
+        if log_likelihood is not None:
+            _ensure_callable(log_likelihood, "log_likelihood")
+
+        self._likelihood = likelihood
+        self._log_likelihood = log_likelihood
+        self.name = name
+
+    @classmethod
+    def from_distribution_factory(
+        cls,
+        distribution_factory: Callable[[Any], Any],
+        *,
+        pdf_method: str = "pdf",
+        log_pdf_method: str | None = None,
+        name: str | None = None,
+    ) -> "LikelihoodMeasurementModel":
+        """Create a likelihood model from a state-conditioned distribution.
+
+        Parameters
+        ----------
+        distribution_factory
+            Callable returning the conditional measurement distribution for a
+            state, for example ``lambda x: GaussianDistribution(h(x), R)``.
+        pdf_method
+            Name of the density method on the returned distribution. PyRecEst
+            distributions commonly expose ``pdf``.
+        log_pdf_method
+            Optional name of the log-density method on the returned
+            distribution.
+        name
+            Optional human-readable model name.
+        """
+
+        _ensure_callable(distribution_factory, "distribution_factory")
+
+        def likelihood(measurement: Any, state: Any) -> Any:
+            distribution = distribution_factory(state)
+            return _evaluate_distribution_method(distribution, pdf_method, measurement)
+
+        if log_pdf_method is None:
+            log_likelihood = None
+        else:
+
+            def log_likelihood(measurement: Any, state: Any) -> Any:
+                distribution = distribution_factory(state)
+                return _evaluate_distribution_method(distribution, log_pdf_method, measurement)
+
+        return cls(likelihood, log_likelihood=log_likelihood, name=name)
+
+    @property
+    def has_log_likelihood(self) -> bool:
+        """Whether this model has an explicit log-likelihood callback."""
+
+        return self._log_likelihood is not None
+
+    def likelihood(self, measurement: Any, state: Any) -> Any:
+        """Return values proportional to ``p(measurement | state)``."""
+
+        return self._likelihood(measurement, state)
+
+    def log_likelihood(self, measurement: Any, state: Any) -> Any:
+        """Return ``log p(measurement | state)`` if available."""
+
+        if self._log_likelihood is None:
+            raise NotImplementedError("No log_likelihood callback was provided.")
+        return self._log_likelihood(measurement, state)
+
+
+class SampleableTransitionModel:
+    """Transition model specified by a next-state sampler.
+
+    Parameters
+    ----------
+    sample_next
+        Callable with signature ``sample_next(state, n=1)`` returning samples
+        from ``p(x_k | state)``.
+    transition_density
+        Optional callable with signature
+        ``transition_density(state_next, state_previous)``.
+    name
+        Optional human-readable model name.
+    """
+
+    def __init__(
+        self,
+        sample_next: Callable[[Any, int], Any],
+        *,
+        transition_density: Callable[[Any, Any], Any] | None = None,
+        name: str | None = None,
+    ):
+        _ensure_callable(sample_next, "sample_next")
+        if transition_density is not None:
+            _ensure_callable(transition_density, "transition_density")
+
+        self._sample_next = sample_next
+        self._transition_density = transition_density
+        self.name = name
+
+    @property
+    def has_transition_density(self) -> bool:
+        """Whether this model also has a transition-density callback."""
+
+        return self._transition_density is not None
+
+    def sample_next(self, state: Any, n: int = 1) -> Any:
+        """Draw ``n`` next-state samples conditioned on ``state``."""
+
+        return self._sample_next(state, n)
+
+    def transition_density(self, state_next: Any, state_previous: Any) -> Any:
+        """Return transition density values if available."""
+
+        if self._transition_density is None:
+            raise NotImplementedError("No transition_density callback was provided.")
+        return self._transition_density(state_next, state_previous)
+
+
+class DensityTransitionModel:
+    """Transition model specified by a transition-density callback.
+
+    Parameters
+    ----------
+    transition_density
+        Callable with signature ``transition_density(state_next,
+        state_previous)`` returning values proportional to
+        ``p(state_next | state_previous)``.
+    sample_next
+        Optional callable with signature ``sample_next(state, n=1)``.
+    name
+        Optional human-readable model name.
+    """
+
+    def __init__(
+        self,
+        transition_density: Callable[[Any, Any], Any],
+        *,
+        sample_next: Callable[[Any, int], Any] | None = None,
+        name: str | None = None,
+    ):
+        _ensure_callable(transition_density, "transition_density")
+        if sample_next is not None:
+            _ensure_callable(sample_next, "sample_next")
+
+        self._transition_density = transition_density
+        self._sample_next = sample_next
+        self.name = name
+
+    @property
+    def has_sampler(self) -> bool:
+        """Whether this model also has a sampler callback."""
+
+        return self._sample_next is not None
+
+    def transition_density(self, state_next: Any, state_previous: Any) -> Any:
+        """Return values proportional to ``p(state_next | state_previous)``."""
+
+        return self._transition_density(state_next, state_previous)
+
+    def sample_next(self, state: Any, n: int = 1) -> Any:
+        """Draw ``n`` next-state samples if a sampler is available."""
+
+        if self._sample_next is None:
+            raise NotImplementedError("No sample_next callback was provided.")
+        return self._sample_next(state, n)
+
+
+__all__ = [
+    "DensityTransitionModel",
+    "LikelihoodMeasurementModel",
+    "SampleableTransitionModel",
+    "SupportsLikelihood",
+    "SupportsLogLikelihood",
+    "SupportsTransitionDensity",
+    "SupportsTransitionSampling",
+]

--- a/tests/models/test_likelihood_sampleable_models.py
+++ b/tests/models/test_likelihood_sampleable_models.py
@@ -1,0 +1,133 @@
+import unittest
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import allclose, arange, array, exp, reshape
+
+from pyrecest.models import (
+    DensityTransitionModel,
+    LikelihoodMeasurementModel,
+    SampleableTransitionModel,
+    SupportsLikelihood,
+    SupportsLogLikelihood,
+    SupportsTransitionDensity,
+    SupportsTransitionSampling,
+)
+
+
+class DummyDistribution:
+    def __init__(self, offset):
+        self.offset = offset
+
+    def pdf(self, measurement):
+        return measurement + self.offset
+
+    def log_pdf(self, measurement):
+        return measurement - self.offset
+
+
+class LikelihoodMeasurementModelTest(unittest.TestCase):
+    def test_likelihood_callback(self):
+        model = LikelihoodMeasurementModel(
+            lambda measurement, state: exp(-0.5 * (measurement - state) ** 2),
+            name="unit-test-likelihood",
+        )
+
+        measurement = array([1.0, 2.0])
+        state = array([1.0, 0.0])
+
+        expected = exp(-0.5 * (measurement - state) ** 2)
+
+        self.assertIsInstance(model, SupportsLikelihood)
+        self.assertEqual(model.name, "unit-test-likelihood")
+        self.assertTrue(allclose(model.likelihood(measurement, state), expected))
+
+    def test_log_likelihood_callback(self):
+        model = LikelihoodMeasurementModel(
+            lambda measurement, state: measurement + state,
+            log_likelihood=lambda measurement, state: measurement - state,
+        )
+
+        self.assertIsInstance(model, SupportsLogLikelihood)
+        self.assertTrue(model.has_log_likelihood)
+        self.assertTrue(allclose(model.log_likelihood(array([3.0]), array([1.0])), array([2.0])))
+
+    def test_missing_log_likelihood_raises(self):
+        model = LikelihoodMeasurementModel(lambda measurement, state: measurement + state)
+
+        self.assertFalse(model.has_log_likelihood)
+        with self.assertRaises(NotImplementedError):
+            model.log_likelihood(array([1.0]), array([0.0]))
+
+    def test_from_distribution_factory(self):
+        model = LikelihoodMeasurementModel.from_distribution_factory(
+            lambda state: DummyDistribution(state),
+            log_pdf_method="log_pdf",
+        )
+
+        self.assertTrue(allclose(model.likelihood(array([2.0]), array([3.0])), array([5.0])))
+        self.assertTrue(allclose(model.log_likelihood(array([2.0]), array([3.0])), array([-1.0])))
+
+    def test_non_callable_likelihood_rejected(self):
+        with self.assertRaises(TypeError):
+            LikelihoodMeasurementModel(None)
+
+
+class SampleableTransitionModelTest(unittest.TestCase):
+    def test_sample_next_callback(self):
+        def sample_next(state, n=1):
+            return state + reshape(arange(n), (n, 1))
+
+        model = SampleableTransitionModel(sample_next, name="unit-test-transition")
+
+        self.assertIsInstance(model, SupportsTransitionSampling)
+        self.assertEqual(model.name, "unit-test-transition")
+        self.assertFalse(model.has_transition_density)
+        self.assertTrue(allclose(model.sample_next(array([10.0]), n=3), array([[10.0], [11.0], [12.0]])))
+
+    def test_optional_transition_density(self):
+        model = SampleableTransitionModel(
+            lambda state, n=1: state + reshape(arange(n), (n, 1)),
+            transition_density=lambda state_next, state_previous: exp(-0.5 * (state_next - state_previous) ** 2),
+        )
+
+        self.assertTrue(model.has_transition_density)
+        self.assertTrue(allclose(model.transition_density(array([1.0]), array([1.0])), array([1.0])))
+
+    def test_missing_transition_density_raises(self):
+        model = SampleableTransitionModel(lambda state, n=1: state)
+
+        with self.assertRaises(NotImplementedError):
+            model.transition_density(array([1.0]), array([0.0]))
+
+
+class DensityTransitionModelTest(unittest.TestCase):
+    def test_transition_density_callback(self):
+        model = DensityTransitionModel(
+            lambda state_next, state_previous: exp(-0.5 * (state_next - state_previous) ** 2)
+        )
+
+        self.assertIsInstance(model, SupportsTransitionDensity)
+        self.assertFalse(model.has_sampler)
+        self.assertTrue(allclose(model.transition_density(array([2.0]), array([2.0])), array([1.0])))
+
+    def test_optional_sampler(self):
+        def sample_next(state, n=1):
+            return state + reshape(arange(n), (n, 1))
+
+        model = DensityTransitionModel(
+            lambda state_next, state_previous: exp(-0.5 * (state_next - state_previous) ** 2),
+            sample_next=sample_next,
+        )
+
+        self.assertTrue(model.has_sampler)
+        self.assertTrue(allclose(model.sample_next(array([4.0]), n=2), array([[4.0], [5.0]])))
+
+    def test_missing_sampler_raises(self):
+        model = DensityTransitionModel(lambda state_next, state_previous: state_next + state_previous)
+
+        with self.assertRaises(NotImplementedError):
+            model.sample_next(array([1.0]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds the first filter-independent model objects for likelihood- and sampling-based estimators:

- `LikelihoodMeasurementModel`
- `SampleableTransitionModel`
- `DensityTransitionModel`
- runtime-checkable capability protocols:
  - `SupportsLikelihood`
  - `SupportsLogLikelihood`
  - `SupportsTransitionSampling`
  - `SupportsTransitionDensity`

The change is deliberately additive. It does not modify filter behavior and does not deprecate existing APIs.

## Motivation

Particle filters, grid filters, and related estimators commonly need the same capabilities expressed with different ad hoc callback conventions:

- evaluate `p(z | x)`;
- sample `p(x_k | x_{k-1})`;
- evaluate `p(x_k | x_{k-1})`.

This PR provides reusable model objects for those capabilities so later filter adapter PRs can consume a shared model interface.

## Scope

Included:

- new `pyrecest.models` package;
- likelihood/sampling/density model classes;
- tests for callback forwarding, optional capabilities, protocol conformance, and distribution-factory wrapping;
- documentation page for model objects;
- generated API reference page entry;
- API overview update.

Not included:

- no filter adapter methods yet;
- no evaluation integration yet;
- no deprecation of existing filter APIs.

## Testing

Not run locally in this environment. Suggested checks:

```bash
pytest tests/models/test_likelihood_sampleable_models.py
mkdocs build --strict
```