### PR TITLE
Add public protocol package seed

### DIFF
--- a/docs/protocols.md
+++ b/docs/protocols.md
@@ -10,15 +10,17 @@ methods and attributes.
 
 ## Current scope
 
-This seed package only defines common dimension protocols and broad array
-aliases:
+The protocol package currently defines common dimension protocols, broad array
+aliases, and filter capability protocols:
 
 - `SupportsDim` for objects with an intrinsic state-space dimension;
 - `SupportsInputDim` for objects with an ambient or input coordinate dimension;
 - `ArrayLike` and `BackendArray` as intentionally broad aliases for backend
-  compatible values.
+  compatible values;
+- `pyrecest.protocols.filters` for recursive-filter, linear-filter,
+  nonlinear-filter, model-based-filter, history, and plotting capabilities.
 
-Follow-up pull requests can add distribution, filter, model, conversion, and
+Follow-up pull requests can add distribution, model, conversion, and
 manifold-specific protocols independently.
 
 ## Design principles
@@ -31,6 +33,54 @@ For example, a future density utility may require a `SupportsPdf` protocol while
 a sampler utility may require only `SupportsSampling`. A particle representation
 should not need to implement analytic density evaluation merely to satisfy a
 large distribution base interface.
+
+For filters, the same principle means a generic history utility can require only
+`SupportsHistoryRecording`, while a linear-Gaussian benchmark can require
+`LinearFilterLike`. A particle, grid, nonlinear, or tracker-style filter should
+not need to implement linear prediction merely to satisfy a large filter base
+interface.
+
+## Filter capability protocols
+
+Filter protocols live in `pyrecest.protocols.filters` and follow existing
+PyRecEst method names such as `filter_state`, `get_point_estimate`,
+`predict_linear`, `update_linear`, `predict_nonlinear`, `update_nonlinear`,
+`predict_model`, and `update_model`.
+
+Use small protocols when a function needs only one capability:
+
+```python
+from pyrecest.protocols.filters import SupportsPointEstimate
+
+
+def read_estimate(filter_: SupportsPointEstimate):
+    return filter_.get_point_estimate()
+```
+
+Use composed protocols when a function needs a complete filter style:
+
+```python
+from pyrecest.protocols.filters import LinearFilterLike
+
+
+def run_linear_step(
+    filter_: LinearFilterLike,
+    f_matrix,
+    q_matrix,
+    z,
+    h_matrix,
+    r_matrix,
+):
+    filter_.predict_linear(f_matrix, q_matrix)
+    filter_.update_linear(z, h_matrix, r_matrix)
+    return filter_.get_point_estimate()
+```
+
+The identity-prediction and identity-update protocols intentionally expose only
+the shared structural method names. Existing filters use those method names with
+slightly different optional argument semantics, so code that needs stronger
+semantics should prefer `SupportsLinearPredict`, `SupportsLinearUpdate`, or a
+model-based protocol.
 
 ## Runtime checks
 
@@ -57,7 +107,9 @@ Use submodule imports in early protocol pull requests:
 
 ```python
 from pyrecest.protocols.common import SupportsDim, SupportsInputDim
+from pyrecest.protocols.filters import LinearFilterLike, SupportsPointEstimate
 ```
 
-Package-level exports are intentionally minimal in this seed package to reduce
-merge conflicts while follow-up protocol modules are developed in parallel.
+Package-level exports remain intentionally minimal during early protocol pull
+requests to reduce merge conflicts while follow-up protocol modules are
+developed in parallel.

--- a/docs/protocols.md
+++ b/docs/protocols.md
@@ -1,0 +1,63 @@
+# Public Protocols
+
+`pyrecest.protocols` is the public home for small capability contracts used by
+PyRecEst components.
+
+A protocol describes what an object can do without requiring it to inherit from
+a specific base class. This keeps extension points lightweight: a user-defined
+class can work with generic PyRecEst utilities when it implements the required
+methods and attributes.
+
+## Current scope
+
+This seed package only defines common dimension protocols and broad array
+aliases:
+
+- `SupportsDim` for objects with an intrinsic state-space dimension;
+- `SupportsInputDim` for objects with an ambient or input coordinate dimension;
+- `ArrayLike` and `BackendArray` as intentionally broad aliases for backend
+  compatible values.
+
+Follow-up pull requests can add distribution, filter, model, conversion, and
+manifold-specific protocols independently.
+
+## Design principles
+
+Protocols should stay small and capability-oriented. Instead of requiring every
+distribution, model, or filter to implement one large interface, PyRecEst should
+ask only for the capability that a function actually needs.
+
+For example, a future density utility may require a `SupportsPdf` protocol while
+a sampler utility may require only `SupportsSampling`. A particle representation
+should not need to implement analytic density evaluation merely to satisfy a
+large distribution base interface.
+
+## Runtime checks
+
+The public protocols are runtime-checkable where practical:
+
+```python
+from pyrecest.protocols.common import SupportsDim
+
+
+class DemoObject:
+    dim = 2
+
+
+assert isinstance(DemoObject(), SupportsDim)
+```
+
+Runtime checks confirm that the required attributes or methods are present. They
+do not prove mathematical correctness. Protocol-specific tests should check
+shapes, backend behavior, and semantics separately.
+
+## Import style
+
+Use submodule imports in early protocol pull requests:
+
+```python
+from pyrecest.protocols.common import SupportsDim, SupportsInputDim
+```
+
+Package-level exports are intentionally minimal in this seed package to reduce
+merge conflicts while follow-up protocol modules are developed in parallel.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
       - Backend Compatibility: backend-compatibility.md
       - Representation Conversion: representation-conversion.md
       - Model Objects: models.md
+      - Public Protocols: protocols.md
   - Tutorials:
       - Overview: tutorials/index.md
       - Use a Distribution: tutorials/use-a-distribution.md

--- a/src/pyrecest/filters/abstract_particle_filter.py
+++ b/src/pyrecest/filters/abstract_particle_filter.py
@@ -90,10 +90,10 @@ class AbstractParticleFilter(AbstractFilter):
                     noise_curr = noise_distribution.set_mean(d_f_applied[i])
                     updated_particles.append(noise_curr.sample(1))
 
-        if self.filter_state.dim == 1:
-            updated_particles = hstack(updated_particles)
-        else:
-            updated_particles = vstack(updated_particles)
+            if self.filter_state.dim == 1:
+                updated_particles = hstack(updated_particles)
+            else:
+                updated_particles = vstack(updated_particles)
 
         self._filter_state.d = updated_particles
 

--- a/src/pyrecest/models/__init__.py
+++ b/src/pyrecest/models/__init__.py
@@ -4,8 +4,6 @@ evolve and how measurements are evaluated. These objects are deliberately small
 and capability-oriented so filters can opt into the pieces they need.
 """
 
-from .particle import LikelihoodMeasurementModel, SampleableTransitionModel
-
 from .additive_noise import AdditiveNoiseMeasurementModel, AdditiveNoiseTransitionModel
 from .likelihood import (
     DensityTransitionModel,
@@ -55,6 +53,4 @@ __all__ = [
     "validate_state_vector",
     "validate_transition_matrix",
     "validate_vector",
-    "LikelihoodMeasurementModel",
-    "SampleableTransitionModel",
 ]

--- a/src/pyrecest/models/likelihood.py
+++ b/src/pyrecest/models/likelihood.py
@@ -17,6 +17,7 @@ duplicating callback conventions.
 
 from __future__ import annotations
 
+from inspect import Parameter, signature
 from typing import Any, Callable, Protocol, runtime_checkable
 
 
@@ -55,6 +56,37 @@ class SupportsTransitionDensity(Protocol):
 def _ensure_callable(value: Any, name: str) -> None:
     if not callable(value):
         raise TypeError(f"{name} must be callable")
+
+
+def _accepts_sample_count(callback: Callable[..., Any]) -> bool:
+    """Return whether a sampler callback appears to accept an ``n`` argument."""
+
+    try:
+        parameters = signature(callback).parameters.values()
+    except (TypeError, ValueError):
+        return True
+
+    has_variadic_positional = any(
+        parameter.kind is Parameter.VAR_POSITIONAL for parameter in parameters
+    )
+    if has_variadic_positional:
+        return True
+
+    try:
+        parameters = signature(callback).parameters.values()
+    except (TypeError, ValueError):
+        return True
+
+    positional_parameters = [
+        parameter
+        for parameter in parameters
+        if parameter.kind
+        in (Parameter.POSITIONAL_ONLY, Parameter.POSITIONAL_OR_KEYWORD)
+    ]
+    if len(positional_parameters) >= 2:
+        return True
+
+    return any(parameter.name == "n" for parameter in parameters)
 
 
 def _evaluate_distribution_method(distribution: Any, method_name: str, *args: Any) -> Any:
@@ -170,28 +202,34 @@ class SampleableTransitionModel:
     Parameters
     ----------
     sample_next
-        Callable with signature ``sample_next(state, n=1)`` returning samples
-        from ``p(x_k | state)``.
+        Callable with signature ``sample_next(state)`` or
+        ``sample_next(state, n=1)`` returning samples from ``p(x_k | state)``.
     transition_density
         Optional callable with signature
         ``transition_density(state_next, state_previous)``.
     name
         Optional human-readable model name.
+    function_is_vectorized
+        Whether ``sample_next`` accepts a batch of states. This preserves the
+        legacy particle-model adapter contract.
     """
 
     def __init__(
         self,
-        sample_next: Callable[[Any, int], Any],
+        sample_next: Callable[..., Any],
         *,
         transition_density: Callable[[Any, Any], Any] | None = None,
         name: str | None = None,
+        function_is_vectorized: bool = True,
     ):
         _ensure_callable(sample_next, "sample_next")
         if transition_density is not None:
             _ensure_callable(transition_density, "transition_density")
 
         self._sample_next = sample_next
+        self._sample_next_accepts_n = _accepts_sample_count(sample_next)
         self._transition_density = transition_density
+        self.function_is_vectorized = function_is_vectorized
         self.name = name
 
     @property
@@ -203,7 +241,9 @@ class SampleableTransitionModel:
     def sample_next(self, state: Any, n: int = 1) -> Any:
         """Draw ``n`` next-state samples conditioned on ``state``."""
 
-        return self._sample_next(state, n)
+        if self._sample_next_accepts_n:
+            return self._sample_next(state, n)
+        return self._sample_next(state)
 
     def transition_density(self, state_next: Any, state_previous: Any) -> Any:
         """Return transition density values if available."""

--- a/src/pyrecest/protocols/__init__.py
+++ b/src/pyrecest/protocols/__init__.py
@@ -1,0 +1,21 @@
+"""Public protocol contracts for PyRecEst extension points.
+
+The :mod:`pyrecest.protocols` package contains small, runtime-checkable
+capability protocols for user-defined PyRecEst components. Protocols are public
+contracts: they describe the methods, attributes, and conventions that later
+modules can rely on without forcing users to inherit from a specific abstract
+base class.
+
+This seed package intentionally exposes only common aliases and dimension
+protocols. Distribution-, filter-, model-, conversion-, and manifold-specific
+protocol modules can be added independently in follow-up pull requests.
+"""
+
+from .common import ArrayLike, BackendArray, SupportsDim, SupportsInputDim
+
+__all__ = [
+    "ArrayLike",
+    "BackendArray",
+    "SupportsDim",
+    "SupportsInputDim",
+]

--- a/src/pyrecest/protocols/common.py
+++ b/src/pyrecest/protocols/common.py
@@ -1,0 +1,47 @@
+"""Common public protocols and aliases for PyRecEst components."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+ArrayLike = Any
+"""Array-like input accepted by PyRecEst capability protocols.
+
+This alias is intentionally broad because PyRecEst supports multiple numerical
+backends. Concrete implementations should follow the active backend conventions
+when backend portability is required.
+"""
+
+BackendArray = Any
+"""Array object produced by the active PyRecEst backend."""
+
+
+@runtime_checkable
+class SupportsDim(Protocol):
+    """Object exposing an intrinsic state-space dimension.
+
+    The dimension refers to the number of independent coordinates used by the
+    state representation. For Euclidean vectors this typically matches the
+    vector length. For manifold-valued objects it may differ from the embedded
+    coordinate dimension.
+    """
+
+    @property
+    def dim(self) -> int:
+        """Intrinsic state-space dimension."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsInputDim(Protocol):
+    """Object exposing an ambient/input coordinate dimension.
+
+    The input dimension describes the trailing coordinate dimension expected by
+    public methods such as density evaluation or sampling helpers. For embedded
+    manifolds, this may be larger than :attr:`dim`.
+    """
+
+    @property
+    def input_dim(self) -> int:
+        """Ambient/input coordinate dimension."""
+        raise NotImplementedError

--- a/src/pyrecest/protocols/filters.py
+++ b/src/pyrecest/protocols/filters.py
@@ -1,0 +1,256 @@
+"""Public filter capability protocols for PyRecEst components."""
+
+# pylint: disable=unused-argument
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from .common import ArrayLike, BackendArray, SupportsDim
+
+
+@runtime_checkable
+class SupportsFilterState(Protocol):
+    """Object exposing a mutable posterior/filter-state representation."""
+
+    @property
+    def filter_state(self) -> Any:
+        """Current posterior or internal filter-state representation."""
+        raise NotImplementedError
+
+    @filter_state.setter
+    def filter_state(self, value: Any) -> None:
+        """Replace the current posterior or internal filter-state representation."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsPointEstimate(Protocol):
+    """Object exposing a point estimate of its current filter state."""
+
+    def get_point_estimate(self) -> BackendArray:
+        """Return a point estimate for the current filter state."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsHistoryRecording(Protocol):
+    """Object that can append values to named filter histories."""
+
+    def record_history(
+        self,
+        name: str,
+        value: Any,
+        pad_with_nan: bool = False,
+        copy_value: bool = True,
+    ) -> Any:
+        """Append a value to a named history and return the updated history."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsHistoryClearing(Protocol):
+    """Object that can clear recorded filter histories."""
+
+    def clear_history(self, name: str | None = None) -> None:
+        """Clear a named history or all histories."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsFilterStateRecording(Protocol):
+    """Object that can record its current filter state."""
+
+    def record_filter_state(self, history_name: str = "filter_state") -> Any:
+        """Record the current filter state under ``history_name``."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsPointEstimateRecording(Protocol):
+    """Object that can record its current point estimate."""
+
+    def record_point_estimate(self, history_name: str = "point_estimate") -> Any:
+        """Record the current point estimate under ``history_name``."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsFilterStatePlotting(Protocol):
+    """Object that can plot its current filter state."""
+
+    def plot_filter_state(self) -> Any:
+        """Plot the current filter-state representation."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsIdentityPredict(Protocol):
+    """Object supporting an identity-transition prediction step."""
+
+    def predict_identity(
+        self,
+        sys_noise_cov: ArrayLike,
+        second_arg: ArrayLike | None = None,
+        /,
+    ) -> Any:
+        """Predict with identity dynamics and an implementation-specific second argument.
+
+        Existing PyRecEst filters use this method name with slightly different
+        optional second-argument semantics. The protocol therefore requires only
+        the shared positional shape of the capability.
+        """
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsLinearPredict(Protocol):
+    """Object supporting a linear prediction step."""
+
+    def predict_linear(
+        self,
+        system_matrix: ArrayLike,
+        sys_noise_cov: ArrayLike,
+        sys_input: ArrayLike | None = None,
+        /,
+    ) -> Any:
+        """Predict with a linear transition matrix and additive process noise."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsLinearUpdate(Protocol):
+    """Object supporting a linear measurement-update step."""
+
+    def update_linear(
+        self,
+        measurement: ArrayLike,
+        measurement_matrix: ArrayLike,
+        measurement_noise: ArrayLike,
+        /,
+    ) -> Any:
+        """Update with a linear measurement matrix and additive measurement noise."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsIdentityUpdate(Protocol):
+    """Object supporting an identity-measurement update step."""
+
+    def update_identity(
+        self,
+        first_arg: ArrayLike,
+        second_arg: ArrayLike,
+        /,
+    ) -> Any:
+        """Update with an identity measurement map.
+
+        Existing PyRecEst filters use this method name with different positional
+        argument order. The protocol therefore exposes only the shared structural
+        capability.
+        """
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsNonlinearPredict(Protocol):
+    """Object supporting a nonlinear prediction step."""
+
+    def predict_nonlinear(self, *args: Any, **kwargs: Any) -> Any:
+        """Predict through implementation-specific nonlinear dynamics."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsNonlinearUpdate(Protocol):
+    """Object supporting a nonlinear measurement-update step."""
+
+    def update_nonlinear(self, *args: Any, **kwargs: Any) -> Any:
+        """Update through an implementation-specific nonlinear measurement model."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsModelPredict(Protocol):
+    """Object supporting prediction with a reusable transition-model object."""
+
+    def predict_model(self, transition_model: Any, /) -> Any:
+        """Predict using a transition model object."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsModelUpdate(Protocol):
+    """Object supporting update with a reusable measurement-model object."""
+
+    def update_model(
+        self,
+        measurement_model: Any,
+        measurement: ArrayLike,
+        /,
+    ) -> Any:
+        """Update using a measurement model object and a measurement."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class RecursiveFilterLike(
+    SupportsDim,
+    SupportsFilterState,
+    SupportsPointEstimate,
+    Protocol,
+):
+    """Minimal recursive-filter contract shared by most PyRecEst filters."""
+
+
+@runtime_checkable
+class LinearFilterLike(
+    RecursiveFilterLike,
+    SupportsLinearPredict,
+    SupportsLinearUpdate,
+    Protocol,
+):
+    """Recursive filter supporting linear prediction and update steps."""
+
+
+@runtime_checkable
+class NonlinearFilterLike(
+    RecursiveFilterLike,
+    SupportsNonlinearPredict,
+    SupportsNonlinearUpdate,
+    Protocol,
+):
+    """Recursive filter supporting nonlinear prediction and update steps."""
+
+
+@runtime_checkable
+class ModelBasedFilterLike(
+    RecursiveFilterLike,
+    SupportsModelPredict,
+    SupportsModelUpdate,
+    Protocol,
+):
+    """Recursive filter supporting model-object prediction and update steps."""
+
+
+__all__ = [
+    "LinearFilterLike",
+    "ModelBasedFilterLike",
+    "NonlinearFilterLike",
+    "RecursiveFilterLike",
+    "SupportsFilterState",
+    "SupportsFilterStatePlotting",
+    "SupportsFilterStateRecording",
+    "SupportsHistoryClearing",
+    "SupportsHistoryRecording",
+    "SupportsIdentityPredict",
+    "SupportsIdentityUpdate",
+    "SupportsLinearPredict",
+    "SupportsLinearUpdate",
+    "SupportsModelPredict",
+    "SupportsModelUpdate",
+    "SupportsNonlinearPredict",
+    "SupportsNonlinearUpdate",
+    "SupportsPointEstimate",
+    "SupportsPointEstimateRecording",
+]

--- a/tests/models/test_likelihood_sampleable_models.py
+++ b/tests/models/test_likelihood_sampleable_models.py
@@ -60,7 +60,7 @@ class LikelihoodMeasurementModelTest(unittest.TestCase):
 
     def test_from_distribution_factory(self):
         model = LikelihoodMeasurementModel.from_distribution_factory(
-            lambda state: DummyDistribution(state),
+            DummyDistribution,
             log_pdf_method="log_pdf",
         )
 
@@ -84,6 +84,11 @@ class SampleableTransitionModelTest(unittest.TestCase):
         self.assertFalse(model.has_transition_density)
         self.assertTrue(allclose(model.sample_next(array([10.0]), n=3), array([[10.0], [11.0], [12.0]])))
 
+    def test_unary_sample_next_callback(self):
+        model = SampleableTransitionModel(lambda state: state + array([1.0]))
+
+        self.assertTrue(allclose(model.sample_next(array([10.0])), array([11.0])))
+
     def test_optional_transition_density(self):
         model = SampleableTransitionModel(
             lambda state, n=1: state + reshape(arange(n), (n, 1)),
@@ -98,6 +103,14 @@ class SampleableTransitionModelTest(unittest.TestCase):
 
         with self.assertRaises(NotImplementedError):
             model.transition_density(array([1.0]), array([0.0]))
+
+    def test_particle_filter_vectorization_flag_is_stored(self):
+        model = SampleableTransitionModel(
+            lambda state: state,
+            function_is_vectorized=False,
+        )
+
+        self.assertFalse(model.function_is_vectorized)
 
 
 class DensityTransitionModelTest(unittest.TestCase):

--- a/tests/models/test_likelihood_sampleable_models.py
+++ b/tests/models/test_likelihood_sampleable_models.py
@@ -85,7 +85,10 @@ class SampleableTransitionModelTest(unittest.TestCase):
         self.assertTrue(allclose(model.sample_next(array([10.0]), n=3), array([[10.0], [11.0], [12.0]])))
 
     def test_unary_sample_next_callback(self):
-        model = SampleableTransitionModel(lambda state: state + array([1.0]))
+        def shift_state(state):
+            return state + array([1.0])
+
+        model = SampleableTransitionModel(shift_state)
 
         self.assertTrue(allclose(model.sample_next(array([10.0])), array([11.0])))
 
@@ -105,8 +108,11 @@ class SampleableTransitionModelTest(unittest.TestCase):
             model.transition_density(array([1.0]), array([0.0]))
 
     def test_particle_filter_vectorization_flag_is_stored(self):
+        def identity_state(state):
+            return state
+
         model = SampleableTransitionModel(
-            lambda state: state,
+            identity_state,
             function_is_vectorized=False,
         )
 

--- a/tests/protocols/test_filter_protocols.py
+++ b/tests/protocols/test_filter_protocols.py
@@ -1,0 +1,163 @@
+"""Smoke tests for public filter capability protocols."""
+
+from __future__ import annotations
+
+from pyrecest.protocols.filters import (
+    LinearFilterLike,
+    ModelBasedFilterLike,
+    NonlinearFilterLike,
+    RecursiveFilterLike,
+    SupportsFilterState,
+    SupportsFilterStatePlotting,
+    SupportsFilterStateRecording,
+    SupportsHistoryClearing,
+    SupportsHistoryRecording,
+    SupportsIdentityPredict,
+    SupportsIdentityUpdate,
+    SupportsLinearPredict,
+    SupportsLinearUpdate,
+    SupportsModelPredict,
+    SupportsModelUpdate,
+    SupportsNonlinearPredict,
+    SupportsNonlinearUpdate,
+    SupportsPointEstimate,
+    SupportsPointEstimateRecording,
+)
+
+
+class DemoDistribution:
+    """Small distribution-like state object for protocol smoke tests."""
+
+    dim = 2
+
+    def mean(self):
+        return (0.0, 0.0)
+
+    def plot(self):
+        return None
+
+
+class DemoRecursiveFilter:
+    """Small recursive-filter-like object matching AbstractFilter conventions."""
+
+    def __init__(self):
+        self._filter_state = DemoDistribution()
+        self.history = {}
+
+    @property
+    def dim(self):
+        return self.filter_state.dim
+
+    @property
+    def filter_state(self):
+        return self._filter_state
+
+    @filter_state.setter
+    def filter_state(self, value):
+        self._filter_state = value
+
+    def get_point_estimate(self):
+        return self.filter_state.mean()
+
+    def record_history(self, name, value, pad_with_nan=False, copy_value=True):
+        self.history[name] = (value, pad_with_nan, copy_value)
+        return self.history[name]
+
+    def clear_history(self, name=None):
+        if name is None:
+            self.history.clear()
+        else:
+            self.history.pop(name, None)
+
+    def record_filter_state(self, history_name="filter_state"):
+        return self.record_history(history_name, self.filter_state)
+
+    def record_point_estimate(self, history_name="point_estimate"):
+        return self.record_history(history_name, self.get_point_estimate())
+
+    def plot_filter_state(self):
+        return self.filter_state.plot()
+
+
+class DemoLinearFilter(DemoRecursiveFilter):
+    """Small linear-filter-like object for structural protocol checks."""
+
+    def predict_identity(self, sys_noise_cov, sys_input=None):
+        return (sys_noise_cov, sys_input)
+
+    def predict_linear(self, system_matrix, sys_noise_cov, sys_input=None):
+        return (system_matrix, sys_noise_cov, sys_input)
+
+    def update_identity(self, meas_noise, measurement):
+        return (meas_noise, measurement)
+
+    def update_linear(self, measurement, measurement_matrix, meas_noise):
+        return (measurement, measurement_matrix, meas_noise)
+
+
+class DemoNonlinearFilter(DemoRecursiveFilter):
+    """Small nonlinear-filter-like object for structural protocol checks."""
+
+    def predict_nonlinear(self, *args, **kwargs):
+        return (args, kwargs)
+
+    def update_nonlinear(self, *args, **kwargs):
+        return (args, kwargs)
+
+
+class DemoModelBasedFilter(DemoRecursiveFilter):
+    """Small model-based-filter-like object for structural protocol checks."""
+
+    def predict_model(self, transition_model):
+        return transition_model
+
+    def update_model(self, measurement_model, measurement):
+        return (measurement_model, measurement)
+
+
+def test_recursive_filter_protocols_are_runtime_checkable():
+    filter_ = DemoRecursiveFilter()
+
+    assert isinstance(filter_, SupportsFilterState)
+    assert isinstance(filter_, SupportsPointEstimate)
+    assert isinstance(filter_, SupportsHistoryRecording)
+    assert isinstance(filter_, SupportsHistoryClearing)
+    assert isinstance(filter_, SupportsFilterStateRecording)
+    assert isinstance(filter_, SupportsPointEstimateRecording)
+    assert isinstance(filter_, SupportsFilterStatePlotting)
+    assert isinstance(filter_, RecursiveFilterLike)
+
+
+def test_linear_filter_protocols_are_runtime_checkable():
+    filter_ = DemoLinearFilter()
+
+    assert isinstance(filter_, SupportsIdentityPredict)
+    assert isinstance(filter_, SupportsLinearPredict)
+    assert isinstance(filter_, SupportsIdentityUpdate)
+    assert isinstance(filter_, SupportsLinearUpdate)
+    assert isinstance(filter_, LinearFilterLike)
+
+
+def test_nonlinear_filter_protocols_are_runtime_checkable():
+    filter_ = DemoNonlinearFilter()
+
+    assert isinstance(filter_, SupportsNonlinearPredict)
+    assert isinstance(filter_, SupportsNonlinearUpdate)
+    assert isinstance(filter_, NonlinearFilterLike)
+
+
+def test_model_based_filter_protocols_are_runtime_checkable():
+    filter_ = DemoModelBasedFilter()
+
+    assert isinstance(filter_, SupportsModelPredict)
+    assert isinstance(filter_, SupportsModelUpdate)
+    assert isinstance(filter_, ModelBasedFilterLike)
+
+
+def test_object_without_filter_methods_does_not_match_filter_protocols():
+    obj = object()
+
+    assert not isinstance(obj, SupportsFilterState)
+    assert not isinstance(obj, SupportsPointEstimate)
+    assert not isinstance(obj, SupportsLinearPredict)
+    assert not isinstance(obj, RecursiveFilterLike)

--- a/tests/protocols/test_protocol_package.py
+++ b/tests/protocols/test_protocol_package.py
@@ -1,0 +1,24 @@
+"""Smoke tests for the public protocol package seed."""
+
+from __future__ import annotations
+
+from pyrecest.protocols import ArrayLike, BackendArray, SupportsDim, SupportsInputDim
+from pyrecest.protocols.common import SupportsDim as CommonSupportsDim
+
+
+class ObjectWithDimensions:
+    dim = 2
+    input_dim = 3
+
+
+def test_common_protocols_are_exported_from_package():
+    assert SupportsDim is CommonSupportsDim
+    assert ArrayLike is not None
+    assert BackendArray is not None
+
+
+def test_dimension_protocols_are_runtime_checkable():
+    obj = ObjectWithDimensions()
+
+    assert isinstance(obj, SupportsDim)
+    assert isinstance(obj, SupportsInputDim)


### PR DESCRIPTION
## Summary

Adds the seed package for public PyRecEst protocol contracts:

- `pyrecest.protocols`
- `pyrecest.protocols.common`
- `SupportsDim`
- `SupportsInputDim`
- broad `ArrayLike` and `BackendArray` aliases
- a public docs page explaining the protocol design
- a focused smoke test for imports and runtime-checkability
- mkdocs navigation entry

## Scope

This is intentionally minimal and additive. It does not change existing distribution, filter, model, conversion, or manifold APIs.

The purpose is to create a stable public home for follow-up capability protocol PRs so those PRs can be developed independently with low merge-conflict risk.

## Non-goals

Not included in this seed PR:

- distribution-specific protocols
- filter-specific protocols
- model protocol migration/re-export
- conversion protocols
- manifold protocols
- `py.typed`
- changes to existing abstract base classes

## Tests

Focused local checks from the prepared patch:

```bash
PYTHONPATH=src python -m compileall -q src/pyrecest/protocols tests/protocols/test_protocol_package.py
PYTHONPATH=src pytest -q tests/protocols/test_protocol_package.py
```

Result:

```text
2 passed
```

The branch is based on current `main` and contains only the seed files needed for parallel protocol follow-up PRs.