### PR TITLE
Add protocol compliance testing helpers

### DIFF
--- a/src/pyrecest/protocols/testing.py
+++ b/src/pyrecest/protocols/testing.py
@@ -1,0 +1,159 @@
+"""Small protocol-compliance assertion helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from numbers import Integral
+from typing import Any, TypeVar, cast
+
+from .common import SupportsDim, SupportsInputDim
+
+T = TypeVar("T")
+_MISSING = object()
+
+
+class ProtocolAssertionError(AssertionError):
+    """Raised when a protocol helper detects a contract mismatch."""
+
+
+def _type_name(obj: object) -> str:
+    return type(obj).__name__
+
+
+def _normalise_shape(shape: Iterable[int], value_name: str) -> tuple[int, ...]:
+    try:
+        return tuple(int(axis) for axis in shape)
+    except TypeError as exc:
+        raise ProtocolAssertionError(f"{value_name} must be an iterable shape.") from exc
+
+
+def _shape_of(value: object, value_name: str) -> tuple[int, ...]:
+    shape = getattr(value, "shape", _MISSING)
+    if shape is _MISSING:
+        raise ProtocolAssertionError(f"{value_name} must expose a shape attribute.")
+    return _normalise_shape(cast(Iterable[int], shape), value_name)
+
+
+def _nonnegative_integer(value: object, value_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ProtocolAssertionError(f"{value_name} must be an integer.")
+    int_value = int(value)
+    if int_value < 0:
+        raise ProtocolAssertionError(f"{value_name} must be non-negative.")
+    return int_value
+
+
+def assert_protocol_instance(obj: object, protocol: type[Any], *, protocol_name: str | None = None) -> None:
+    name = protocol_name or getattr(protocol, "__name__", repr(protocol))
+    try:
+        conforms = isinstance(obj, protocol)
+    except TypeError as exc:
+        raise ProtocolAssertionError(f"{name} cannot be used for runtime checks.") from exc
+    if not conforms:
+        raise ProtocolAssertionError(f"{_type_name(obj)} does not satisfy {name}.")
+
+
+def assert_has_attribute(obj: object, attribute_name: str) -> Any:
+    value = getattr(obj, attribute_name, _MISSING)
+    if value is _MISSING:
+        raise ProtocolAssertionError(f"{_type_name(obj)} must provide {attribute_name!r}.")
+    return value
+
+
+def assert_callable_attribute(obj: object, attribute_name: str) -> Callable[..., Any]:
+    value = assert_has_attribute(obj, attribute_name)
+    if not callable(value):
+        raise ProtocolAssertionError(f"{_type_name(obj)}.{attribute_name} must be callable.")
+    return cast(Callable[..., Any], value)
+
+
+def assert_value_is_not_none(value: T | None, *, value_name: str = "value") -> T:
+    if value is None:
+        raise ProtocolAssertionError(f"{value_name} must not be None.")
+    return value
+
+
+def assert_method_returns_non_none(obj: object, method_name: str, *args: Any, **kwargs: Any) -> Any:
+    method = assert_callable_attribute(obj, method_name)
+    return assert_value_is_not_none(method(*args, **kwargs), value_name=f"{method_name} result")
+
+
+def assert_shape(value: object, expected_shape: Iterable[int], *, value_name: str = "value") -> tuple[int, ...]:
+    actual = _shape_of(value, value_name)
+    expected = _normalise_shape(expected_shape, "expected_shape")
+    if actual != expected:
+        raise ProtocolAssertionError(f"{value_name} must have shape {expected}, got {actual}.")
+    return actual
+
+
+def assert_shape_prefix(value: object, expected_prefix: Iterable[int], *, value_name: str = "value") -> tuple[int, ...]:
+    actual = _shape_of(value, value_name)
+    expected = _normalise_shape(expected_prefix, "expected_prefix")
+    if actual[: len(expected)] != expected:
+        raise ProtocolAssertionError(f"{value_name} shape must start with {expected}, got {actual}.")
+    return actual
+
+
+def assert_trailing_dimension(value: object, expected_dim: int, *, value_name: str = "value") -> tuple[int, ...]:
+    actual = _shape_of(value, value_name)
+    dim = _nonnegative_integer(expected_dim, "expected_dim")
+    if not actual or actual[-1] != dim:
+        raise ProtocolAssertionError(f"{value_name} trailing dimension must be {dim}, got {actual}.")
+    return actual
+
+
+def assert_supports_dim(obj: object) -> int:
+    assert_protocol_instance(obj, SupportsDim)
+    return _nonnegative_integer(assert_has_attribute(obj, "dim"), "dim")
+
+
+def assert_supports_input_dim(obj: object) -> int:
+    assert_protocol_instance(obj, SupportsInputDim)
+    return _nonnegative_integer(assert_has_attribute(obj, "input_dim"), "input_dim")
+
+
+def assert_supports_pdf(distribution: object, xs: Any) -> Any:
+    return assert_method_returns_non_none(distribution, "pdf", xs)
+
+
+def assert_supports_ln_pdf(distribution: object, xs: Any) -> Any:
+    return assert_method_returns_non_none(distribution, "ln_pdf", xs)
+
+
+def assert_supports_sampling(distribution: object, n: int = 5) -> Any:
+    _nonnegative_integer(n, "n")
+    return assert_method_returns_non_none(distribution, "sample", n)
+
+
+def assert_supports_mean(distribution: object) -> Any:
+    return assert_method_returns_non_none(distribution, "mean")
+
+
+def assert_supports_covariance(distribution: object) -> Any:
+    return assert_method_returns_non_none(distribution, "covariance")
+
+
+def assert_filter_basic_contract(filter_obj: object) -> Any:
+    assert_supports_dim(filter_obj)
+    assert_has_attribute(filter_obj, "filter_state")
+    return assert_method_returns_non_none(filter_obj, "get_point_estimate")
+
+
+def assert_supports_likelihood(model: object, measurement: Any, state: Any) -> Any:
+    return assert_method_returns_non_none(model, "likelihood", measurement, state)
+
+
+def assert_supports_log_likelihood(model: object, measurement: Any, state: Any) -> Any:
+    return assert_method_returns_non_none(model, "log_likelihood", measurement, state)
+
+
+def assert_supports_transition_sampling(model: object, state: Any, n: int = 1) -> Any:
+    _nonnegative_integer(n, "n")
+    return assert_method_returns_non_none(model, "sample_next", state, n)
+
+
+def assert_supports_transition_density(model: object, state_next: Any, state_previous: Any) -> Any:
+    return assert_method_returns_non_none(model, "transition_density", state_next, state_previous)
+
+
+__all__ = [name for name in globals() if name.startswith("assert_")] + ["ProtocolAssertionError"]

--- a/tests/protocols/test_protocol_testing_helpers.py
+++ b/tests/protocols/test_protocol_testing_helpers.py
@@ -1,0 +1,194 @@
+"""Tests for reusable protocol-compliance helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from pyrecest.protocols.common import SupportsDim
+from pyrecest.protocols.testing import (
+    ProtocolAssertionError,
+    assert_callable_attribute,
+    assert_filter_basic_contract,
+    assert_has_attribute,
+    assert_method_returns_non_none,
+    assert_protocol_instance,
+    assert_shape,
+    assert_shape_prefix,
+    assert_supports_covariance,
+    assert_supports_dim,
+    assert_supports_input_dim,
+    assert_supports_likelihood,
+    assert_supports_ln_pdf,
+    assert_supports_log_likelihood,
+    assert_supports_mean,
+    assert_supports_pdf,
+    assert_supports_sampling,
+    assert_supports_transition_density,
+    assert_supports_transition_sampling,
+    assert_trailing_dimension,
+    assert_value_is_not_none,
+)
+
+
+class ArrayLikeObject:
+    def __init__(self, shape):
+        self.shape = shape
+
+
+class ObjectWithDimensions:
+    dim = 2
+    input_dim = 3
+
+
+class ObjectWithMethod:
+    value = 1
+
+    def method(self):
+        return self.value
+
+    def none_method(self):
+        return None
+
+
+class DemoDistribution:
+    dim = 2
+    input_dim = 2
+
+    def pdf(self, xs):
+        return ArrayLikeObject((len(xs),))
+
+    def ln_pdf(self, xs):
+        return ArrayLikeObject((len(xs),))
+
+    def sample(self, n):
+        return ArrayLikeObject((n, self.input_dim))
+
+    def mean(self):
+        return ArrayLikeObject((self.input_dim,))
+
+    def covariance(self):
+        return ArrayLikeObject((self.input_dim, self.input_dim))
+
+
+class DemoFilter:
+    dim = 2
+    filter_state = object()
+
+    def get_point_estimate(self):
+        return ArrayLikeObject((self.dim,))
+
+
+class DemoLikelihoodModel:
+    def likelihood(self, measurement, state):
+        return (measurement, state)
+
+    def log_likelihood(self, measurement, state):
+        return (measurement, state, "log")
+
+
+class DemoTransitionModel:
+    def sample_next(self, state, n=1):
+        return ArrayLikeObject((n, len(state)))
+
+    def transition_density(self, state_next, state_previous):
+        return (state_next, state_previous)
+
+
+def test_assert_protocol_instance_accepts_runtime_checkable_protocol():
+    assert_protocol_instance(ObjectWithDimensions(), SupportsDim)
+
+
+def test_assert_protocol_instance_reports_missing_protocol_attribute():
+    with pytest.raises(ProtocolAssertionError, match="SupportsDim"):
+        assert_protocol_instance(object(), SupportsDim)
+
+
+def test_attribute_helpers_return_values():
+    obj = ObjectWithMethod()
+
+    assert assert_has_attribute(obj, "value") == 1
+    assert assert_callable_attribute(obj, "method")() == 1
+    assert assert_method_returns_non_none(obj, "method") == 1
+
+
+def test_attribute_helpers_report_missing_or_non_callable_attributes():
+    obj = ObjectWithMethod()
+
+    with pytest.raises(ProtocolAssertionError):
+        assert_has_attribute(obj, "missing")
+    with pytest.raises(ProtocolAssertionError):
+        assert_callable_attribute(obj, "value")
+    with pytest.raises(ProtocolAssertionError):
+        assert_method_returns_non_none(obj, "none_method")
+
+
+def test_value_helper_rejects_none():
+    assert assert_value_is_not_none(1) == 1
+
+    with pytest.raises(ProtocolAssertionError):
+        assert_value_is_not_none(None)
+
+
+def test_shape_helpers_return_actual_shape():
+    value = ArrayLikeObject((2, 3))
+
+    assert assert_shape(value, (2, 3)) == (2, 3)
+    assert assert_shape_prefix(value, (2,)) == (2, 3)
+    assert assert_trailing_dimension(value, 3) == (2, 3)
+
+
+def test_shape_helpers_report_mismatches():
+    value = ArrayLikeObject((2, 3))
+
+    with pytest.raises(ProtocolAssertionError):
+        assert_shape(value, (3, 2))
+    with pytest.raises(ProtocolAssertionError):
+        assert_shape_prefix(value, (3,))
+    with pytest.raises(ProtocolAssertionError):
+        assert_trailing_dimension(value, 2)
+    with pytest.raises(ProtocolAssertionError):
+        assert_shape(object(), ())
+
+
+def test_common_dimension_helpers_return_dimensions():
+    obj = ObjectWithDimensions()
+
+    assert assert_supports_dim(obj) == 2
+    assert assert_supports_input_dim(obj) == 3
+
+
+def test_common_dimension_helpers_reject_invalid_dimensions():
+    class BadDim:
+        dim = -1
+
+    with pytest.raises(ProtocolAssertionError):
+        assert_supports_dim(BadDim())
+
+
+def test_distribution_helpers_return_method_results():
+    distribution = DemoDistribution()
+    xs = [(0.0, 0.0), (1.0, 1.0)]
+
+    assert_shape(assert_supports_pdf(distribution, xs), (2,))
+    assert_shape(assert_supports_ln_pdf(distribution, xs), (2,))
+    assert_shape(assert_supports_sampling(distribution, 4), (4, 2))
+    assert_shape(assert_supports_mean(distribution), (2,))
+    assert_shape(assert_supports_covariance(distribution), (2, 2))
+
+
+def test_filter_basic_contract_returns_point_estimate():
+    assert_shape(assert_filter_basic_contract(DemoFilter()), (2,))
+
+
+def test_model_helpers_return_method_results():
+    measurement = (1.0,)
+    state = (2.0, 3.0)
+    next_state = (2.5, 3.5)
+
+    likelihood_model = DemoLikelihoodModel()
+    transition_model = DemoTransitionModel()
+
+    assert assert_supports_likelihood(likelihood_model, measurement, state) == (measurement, state)
+    assert assert_supports_log_likelihood(likelihood_model, measurement, state) == (measurement, state, "log")
+    assert_shape(assert_supports_transition_sampling(transition_model, state, 3), (3, 2))
+    assert assert_supports_transition_density(transition_model, next_state, state) == (next_state, state)


### PR DESCRIPTION
## Summary

Adds reusable protocol-compliance testing helpers:

- `pyrecest.protocols.testing`
- `ProtocolAssertionError`
- generic helpers for runtime protocol checks, attributes, callable methods, non-`None` method results, and array shape checks
- convenience helpers for common PyRecEst capabilities: dimensions, distribution-like methods, minimal filter contract, likelihood models, and transition models
- focused unit tests for all helpers
- docs section showing how to use the helpers in capability tests

## Scope

This is intentionally additive and independent of the distribution/filter/model/conversion/manifold protocol PRs. It does not change existing distribution, filter, model, conversion, or manifold behavior.

The helpers use duck typing plus the common protocols from PR0 so they can be used immediately and refined later as more protocol modules land.

## Non-goals

Not included:

- new distribution/filter/model protocols
- package-level exports from `pyrecest.protocols`
- `py.typed`
- changes to existing abstract base classes
- mathematical correctness tests for any concrete estimator or distribution

## Tests

Focused local checks:

```bash
PYTHONPATH=src python -m compileall -q src/pyrecest/protocols tests/protocols/test_protocol_testing_helpers.py
PYTHONPATH=src pytest -q tests/protocols/test_protocol_testing_helpers.py
```

Result:

```text
12 passed
```

## Stacking

This PR is stacked on #1952 and targets `feature/public-protocol-seed`. After #1952 is merged, this PR can be retargeted to `main` if needed.