### PR TITLE
Add conversion protocol contracts

### DIFF
--- a/src/pyrecest/protocols/conversions.py
+++ b/src/pyrecest/protocols/conversions.py
@@ -1,0 +1,88 @@
+"""Public protocols for distribution representation conversion."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, TypeAlias, runtime_checkable
+
+ConversionTarget: TypeAlias = type[Any] | str
+"""Target accepted by PyRecEst conversion helpers."""
+
+ConversionParameters: TypeAlias = dict[str, Any]
+"""Keyword parameters passed to a conversion route."""
+
+
+@runtime_checkable
+class SupportsFromDistribution(Protocol):
+    """Target representation that can build itself from a source distribution."""
+
+    @classmethod
+    def from_distribution(cls, distribution: Any, /, *args: Any, **kwargs: Any) -> Any:
+        """Create a target representation from ``distribution``."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsConvertTo(Protocol):
+    """Object exposing the exact-or-approximate conversion convenience method."""
+
+    def convert_to(
+        self,
+        target_type: ConversionTarget,
+        /,
+        *,
+        return_info: bool = False,
+        **kwargs: Any,
+    ) -> Any:
+        """Convert or approximate this object as ``target_type``."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsApproximateAs(Protocol):
+    """Object exposing an explicitly approximation-oriented conversion method."""
+
+    def approximate_as(
+        self,
+        target_type: ConversionTarget,
+        /,
+        *,
+        return_info: bool = False,
+        **kwargs: Any,
+    ) -> Any:
+        """Approximate this object as ``target_type``."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsDistributionConversion(SupportsConvertTo, SupportsApproximateAs, Protocol):
+    """Object exposing both PyRecEst conversion convenience wrappers."""
+
+
+@runtime_checkable
+class DistributionConverter(Protocol):
+    """Callable registered as a concrete source-to-target conversion route."""
+
+    def __call__(self, distribution: Any, /, **kwargs: Any) -> Any:
+        """Convert ``distribution`` using keyword conversion parameters."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class ConversionAliasResolver(Protocol):
+    """Callable resolving a conversion alias to a concrete target class."""
+
+    def __call__(self, distribution: Any, /) -> type[Any]:
+        """Return the concrete target class for ``distribution``."""
+        raise NotImplementedError
+
+
+__all__ = [
+    "ConversionAliasResolver",
+    "ConversionParameters",
+    "ConversionTarget",
+    "DistributionConverter",
+    "SupportsApproximateAs",
+    "SupportsConvertTo",
+    "SupportsDistributionConversion",
+    "SupportsFromDistribution",
+]

--- a/tests/protocols/test_conversion_protocols.py
+++ b/tests/protocols/test_conversion_protocols.py
@@ -1,0 +1,96 @@
+"""Tests for public conversion capability protocols."""
+
+from __future__ import annotations
+
+from pyrecest.distributions.abstract_distribution_type import AbstractDistributionType
+from pyrecest.distributions.conversion import ConversionResult
+from pyrecest.protocols.conversions import (
+    ConversionAliasResolver,
+    ConversionParameters,
+    ConversionTarget,
+    DistributionConverter,
+    SupportsApproximateAs,
+    SupportsConvertTo,
+    SupportsDistributionConversion,
+    SupportsFromDistribution,
+)
+
+
+class SourceDistribution(AbstractDistributionType):
+    """Minimal source distribution with PyRecEst conversion wrappers."""
+
+
+class TargetDistribution:
+    """Minimal target representation using target-centric construction."""
+
+    def __init__(self, source, parameters):
+        self.source = source
+        self.parameters = parameters
+
+    @classmethod
+    def from_distribution(cls, distribution, /, **kwargs):
+        return cls(distribution, dict(kwargs))
+
+
+def convert_to_target(distribution, /, **kwargs):
+    return TargetDistribution.from_distribution(distribution, **kwargs)
+
+
+def resolve_target(distribution, /):
+    if distribution is None:
+        raise TypeError("distribution must not be None")
+    return TargetDistribution
+
+
+def test_conversion_protocols_are_importable():
+    assert ConversionTarget is not None
+    assert ConversionParameters is not None
+    assert SupportsFromDistribution is not None
+    assert SupportsConvertTo is not None
+    assert SupportsApproximateAs is not None
+    assert SupportsDistributionConversion is not None
+
+
+def test_from_distribution_protocol_is_runtime_checkable_on_target_class():
+    assert isinstance(TargetDistribution, SupportsFromDistribution)
+    assert issubclass(TargetDistribution, SupportsFromDistribution)
+
+
+def test_distribution_conversion_wrappers_are_runtime_checkable():
+    source = SourceDistribution()
+
+    assert isinstance(source, SupportsConvertTo)
+    assert isinstance(source, SupportsApproximateAs)
+    assert isinstance(source, SupportsDistributionConversion)
+
+
+def test_registered_conversion_callable_protocols_are_runtime_checkable():
+    source = SourceDistribution()
+
+    assert isinstance(convert_to_target, DistributionConverter)
+    assert isinstance(resolve_target, ConversionAliasResolver)
+    assert convert_to_target(source, scale=2).parameters == {"scale": 2}
+    assert resolve_target(source) is TargetDistribution
+
+
+def test_conversion_wrapper_protocol_matches_existing_gateway_behavior():
+    source = SourceDistribution()
+
+    converted = source.convert_to(TargetDistribution, scale=2)
+
+    assert isinstance(converted, TargetDistribution)
+    assert converted.source is source
+    assert converted.parameters == {"scale": 2}
+
+
+def test_approximate_as_protocol_supports_return_info():
+    source = SourceDistribution()
+
+    result = source.approximate_as(TargetDistribution, return_info=True, scale=3)
+
+    assert isinstance(result, ConversionResult)
+    assert isinstance(result.distribution, TargetDistribution)
+    assert result.distribution.source is source
+    assert result.distribution.parameters == {"scale": 3}
+    assert result.target_type is TargetDistribution
+    assert result.exact is False


### PR DESCRIPTION
## Summary

Adds PR4 from the public protocol roadmap: conversion and approximation capability protocols.

This PR adds:

- `pyrecest.protocols.conversions`
- `SupportsFromDistribution` for target classes exposing `from_distribution(...)`
- `SupportsConvertTo` for objects exposing `convert_to(...)`
- `SupportsApproximateAs` for objects exposing `approximate_as(...)`
- `SupportsDistributionConversion` for objects exposing both wrapper methods
- callable protocols for registered converters and alias resolvers
- protocol smoke tests against the existing conversion gateway behavior
- documentation updates for public protocols and representation conversion

## Scope

This is intentionally additive. It does not change the conversion gateway, distribution base classes, registry behavior, or package-level protocol exports.

The PR is based on `feature/public-protocol-seed` / PR #1952, because the public protocol package seed is still open at the time this branch was created.

## Tests

Prepared locally for the patch:

```bash
PYTHONPATH=src python -m compileall -q \
  src/pyrecest/protocols \
  tests/protocols/test_conversion_protocols.py

PYTHONPATH=src pytest -q tests/protocols/test_conversion_protocols.py
```

Result in the prepared checkout:

```text
6 passed
```

## Notes

CI may still report failures inherited from the current PR0/base branch if those are not fixed before this branch is checked. In particular, PR #1952 currently reports unrelated `src/pyrecest/models/__init__.py` duplicate import lint/type errors.