### PR TITLE
Add public distribution capability protocols

### DIFF
--- a/src/pyrecest/filters/abstract_particle_filter.py
+++ b/src/pyrecest/filters/abstract_particle_filter.py
@@ -55,7 +55,10 @@ class AbstractParticleFilter(AbstractFilter):
         function_is_vectorized: bool = True,
         shift_instead_of_add: bool = True,
     ):
-        assert noise_distribution is None or self.filter_state.dim == noise_distribution.dim
+        assert (
+            noise_distribution is None
+            or self.filter_state.dim == noise_distribution.dim
+        )
 
         if function_is_vectorized:
             d_f_applied = f(self.filter_state.d)
@@ -84,7 +87,9 @@ class AbstractParticleFilter(AbstractFilter):
         self._filter_state.d = updated_particles
 
     def predict_nonlinear_nonadditive(self, f, samples, weights):
-        assert samples.shape[0] == weights.shape[0], "samples and weights must match in size"
+        assert (
+            samples.shape[0] == weights.shape[0]
+        ), "samples and weights must match in size"
 
         weights = weights / sum(weights)
         n_particles = self.filter_state.w.shape[0]
@@ -111,7 +116,9 @@ class AbstractParticleFilter(AbstractFilter):
             samples = new_state.sample(self.filter_state.w.shape[0])
             assert samples.shape == self.filter_state.d.shape
             self._filter_state.d = samples
-            self._filter_state.w = ones_like(self.filter_state.w) / self.filter_state.w.shape[0]
+            self._filter_state.w = (
+                ones_like(self.filter_state.w) / self.filter_state.w.shape[0]
+            )
 
     def update_model(self, measurement_model, measurement=None):
         """Update using a reusable particle measurement model."""
@@ -125,7 +132,12 @@ class AbstractParticleFilter(AbstractFilter):
             measurement=measurement,
         )
 
-    def update_identity(self, meas_noise, measurement, shift_instead_of_add: bool = True):
+    def update_identity(
+        self,
+        meas_noise,
+        measurement,
+        shift_instead_of_add: bool = True,
+    ):
         assert (
             measurement is None
             or measurement.shape == (meas_noise.dim,)
@@ -146,10 +158,14 @@ class AbstractParticleFilter(AbstractFilter):
         if measurement is None:
             self._filter_state = self.filter_state.reweigh(likelihood)
         else:
-            self._filter_state = self.filter_state.reweigh(lambda x: likelihood(measurement, x))
+            self._filter_state = self.filter_state.reweigh(
+                lambda x: likelihood(measurement, x)
+            )
 
         self._filter_state.d = self.filter_state.sample(self.filter_state.w.shape[0])
-        self._filter_state.w = 1 / self.filter_state.w.shape[0] * ones_like(self.filter_state.w)
+        self._filter_state.w = (
+            1 / self.filter_state.w.shape[0] * ones_like(self.filter_state.w)
+        )
 
     def association_likelihood(self, likelihood: AbstractManifoldSpecificDistribution):
         likelihood_val = sum(likelihood.pdf(self.filter_state.d) * self.filter_state.w)

--- a/src/pyrecest/filters/abstract_particle_filter.py
+++ b/src/pyrecest/filters/abstract_particle_filter.py
@@ -2,7 +2,6 @@ import copy
 from collections.abc import Callable
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
-# pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import hstack, ndim, ones_like, random, sum, vmap, vstack
 from pyrecest.distributions.abstract_manifold_specific_distribution import (
     AbstractManifoldSpecificDistribution,
@@ -23,14 +22,7 @@ class AbstractParticleFilter(AbstractFilter):
         )
 
     def predict_model(self, transition_model):
-        """Predict using a reusable particle transition model.
-
-        The model must expose a ``sample_next`` callable. If the model has a
-        truthy ``function_is_vectorized`` attribute, ``sample_next`` is called
-        once with all current particle locations. Otherwise, it is called once
-        per particle and the returned particles are stacked using the same
-        convention as :meth:`predict_nonlinear`.
-        """
+        """Predict using a reusable particle transition model."""
         if not hasattr(transition_model, "sample_next"):
             raise TypeError(
                 "Particle-filter transition models must expose a sample_next callable."
@@ -63,10 +55,7 @@ class AbstractParticleFilter(AbstractFilter):
         function_is_vectorized: bool = True,
         shift_instead_of_add: bool = True,
     ):
-        assert (
-            noise_distribution is None
-            or self.filter_state.dim == noise_distribution.dim
-        )
+        assert noise_distribution is None or self.filter_state.dim == noise_distribution.dim
 
         if function_is_vectorized:
             d_f_applied = f(self.filter_state.d)
@@ -78,29 +67,24 @@ class AbstractParticleFilter(AbstractFilter):
         if noise_distribution is None:
             updated_particles = d_f_applied
         else:
-            # Cannot easily use vmap because control flow depends on data for some lower level function
             updated_particles = []
             for i in range(n_particles):
                 if not shift_instead_of_add:
-                    noise = noise_distribution.sample(
-                        1
-                    )  # Assuming sample(1) returns a single row of values
+                    noise = noise_distribution.sample(1)
                     updated_particles.append(d_f_applied[i] + noise)
                 else:
                     noise_curr = noise_distribution.set_mean(d_f_applied[i])
                     updated_particles.append(noise_curr.sample(1))
 
-        if self.filter_state.dim == 1:
-            updated_particles = hstack(updated_particles)
-        else:
-            updated_particles = vstack(updated_particles)
+            if self.filter_state.dim == 1:
+                updated_particles = hstack(updated_particles)
+            else:
+                updated_particles = vstack(updated_particles)
 
         self._filter_state.d = updated_particles
 
     def predict_nonlinear_nonadditive(self, f, samples, weights):
-        assert (
-            samples.shape[0] == weights.shape[0]
-        ), "samples and weights must match in size"
+        assert samples.shape[0] == weights.shape[0], "samples and weights must match in size"
 
         weights = weights / sum(weights)
         n_particles = self.filter_state.w.shape[0]
@@ -121,28 +105,16 @@ class AbstractParticleFilter(AbstractFilter):
         if self._filter_state is None:
             self._filter_state = copy.deepcopy(new_state)
         elif isinstance(new_state, type(self.filter_state)):
-            assert (
-                self.filter_state.d.shape == new_state.d.shape
-            )  # This also ensures the dimension and type stays the same
+            assert self.filter_state.d.shape == new_state.d.shape
             self._filter_state = copy.deepcopy(new_state)
         else:
-            # Sample if it does not inherit from the previous distribution
             samples = new_state.sample(self.filter_state.w.shape[0])
-            assert (
-                samples.shape == self.filter_state.d.shape
-            )  # This also ensures the dimension and type stays the same
+            assert samples.shape == self.filter_state.d.shape
             self._filter_state.d = samples
-            self._filter_state.w = (
-                ones_like(self.filter_state.w) / self.filter_state.w.shape[0]
-            )
+            self._filter_state.w = ones_like(self.filter_state.w) / self.filter_state.w.shape[0]
 
     def update_model(self, measurement_model, measurement=None):
-        """Update using a reusable particle measurement model.
-
-        The model must expose a ``likelihood`` callable. If ``measurement`` is
-        provided, the callable is interpreted as ``likelihood(measurement,
-        particles)``. Otherwise it is interpreted as ``likelihood(particles)``.
-        """
+        """Update using a reusable particle measurement model."""
         if not hasattr(measurement_model, "likelihood"):
             raise TypeError(
                 "Particle-filter measurement models must expose a likelihood callable."
@@ -153,9 +125,7 @@ class AbstractParticleFilter(AbstractFilter):
             measurement=measurement,
         )
 
-    def update_identity(
-        self, meas_noise, measurement, shift_instead_of_add: bool = True
-    ):
+    def update_identity(self, meas_noise, measurement, shift_instead_of_add: bool = True):
         assert (
             measurement is None
             or measurement.shape == (meas_noise.dim,)
@@ -176,14 +146,10 @@ class AbstractParticleFilter(AbstractFilter):
         if measurement is None:
             self._filter_state = self.filter_state.reweigh(likelihood)
         else:
-            self._filter_state = self.filter_state.reweigh(
-                lambda x: likelihood(measurement, x)
-            )
+            self._filter_state = self.filter_state.reweigh(lambda x: likelihood(measurement, x))
 
         self._filter_state.d = self.filter_state.sample(self.filter_state.w.shape[0])
-        self._filter_state.w = (
-            1 / self.filter_state.w.shape[0] * ones_like(self.filter_state.w)
-        )
+        self._filter_state.w = 1 / self.filter_state.w.shape[0] * ones_like(self.filter_state.w)
 
     def association_likelihood(self, likelihood: AbstractManifoldSpecificDistribution):
         likelihood_val = sum(likelihood.pdf(self.filter_state.d) * self.filter_state.w)

--- a/src/pyrecest/protocols/distributions.py
+++ b/src/pyrecest/protocols/distributions.py
@@ -1,0 +1,125 @@
+"""Public distribution capability protocols for PyRecEst components."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from .common import ArrayLike, BackendArray, SupportsDim, SupportsInputDim
+
+
+@runtime_checkable
+class SupportsPdf(Protocol):
+    """Object supporting probability density evaluation."""
+
+    def pdf(self, xs: ArrayLike) -> BackendArray:
+        """Evaluate density values at ``xs``."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsLnPdf(Protocol):
+    """Object supporting log-density evaluation using PyRecEst's ``ln_pdf`` name."""
+
+    def ln_pdf(self, xs: ArrayLike) -> BackendArray:
+        """Evaluate log-density values at ``xs``."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsSampling(Protocol):
+    """Object supporting random sampling."""
+
+    def sample(self, n: Any) -> BackendArray:
+        """Draw ``n`` samples."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsMean(Protocol):
+    """Object exposing a mean or manifold-appropriate mean representative."""
+
+    def mean(self) -> BackendArray:
+        """Return the mean representative."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsCovariance(Protocol):
+    """Object exposing covariance information."""
+
+    def covariance(self) -> BackendArray:
+        """Return the covariance representation."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsMode(Protocol):
+    """Object exposing a mode computation."""
+
+    def mode(self, *args: Any, **kwargs: Any) -> BackendArray:
+        """Return a mode of the represented distribution."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsModeSetting(Protocol):
+    """Object supporting construction or mutation with a new mode."""
+
+    def set_mode(self, mode: ArrayLike) -> Any:
+        """Set or return a representation with the requested mode."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsMultiplication(Protocol):
+    """Object supporting normalized or representation-specific density products."""
+
+    def multiply(self, other: Any) -> Any:
+        """Multiply this distribution with ``other``."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsConvolution(Protocol):
+    """Object supporting convolution with another compatible distribution."""
+
+    def convolve(self, other: Any) -> Any:
+        """Convolve this distribution with ``other``."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class DensityLike(SupportsDim, SupportsPdf, Protocol):
+    """Minimal density-like object with intrinsic dimension and ``pdf``."""
+
+
+@runtime_checkable
+class LogDensityLike(SupportsDim, SupportsLnPdf, Protocol):
+    """Minimal log-density-like object with intrinsic dimension and ``ln_pdf``."""
+
+
+@runtime_checkable
+class ManifoldDensityLike(
+    SupportsDim,
+    SupportsInputDim,
+    SupportsPdf,
+    SupportsMean,
+    Protocol,
+):
+    """Minimal manifold-aware density-like object."""
+
+
+__all__ = [
+    "DensityLike",
+    "LogDensityLike",
+    "ManifoldDensityLike",
+    "SupportsConvolution",
+    "SupportsCovariance",
+    "SupportsLnPdf",
+    "SupportsMean",
+    "SupportsMode",
+    "SupportsModeSetting",
+    "SupportsMultiplication",
+    "SupportsPdf",
+    "SupportsSampling",
+]

--- a/tests/protocols/test_distribution_protocols.py
+++ b/tests/protocols/test_distribution_protocols.py
@@ -1,0 +1,122 @@
+"""Tests for public distribution capability protocols."""
+
+from __future__ import annotations
+
+from pyrecest.backend import array, eye
+from pyrecest.distributions import GaussianDistribution, VonMisesDistribution
+from pyrecest.protocols.common import SupportsDim, SupportsInputDim
+from pyrecest.protocols.distributions import (
+    DensityLike,
+    LogDensityLike,
+    ManifoldDensityLike,
+    SupportsConvolution,
+    SupportsCovariance,
+    SupportsLnPdf,
+    SupportsMean,
+    SupportsMode,
+    SupportsModeSetting,
+    SupportsMultiplication,
+    SupportsPdf,
+    SupportsSampling,
+)
+
+
+class MinimalDensity:
+    dim = 1
+
+    def pdf(self, xs):
+        return xs
+
+
+class MinimalManifoldDensity:
+    dim = 1
+    input_dim = 2
+
+    def pdf(self, xs):
+        return xs
+
+    def mean(self):
+        return array([1.0, 0.0])
+
+
+class MinimalLogDensity:
+    dim = 1
+
+    def ln_pdf(self, xs):
+        return xs
+
+
+def test_distribution_protocols_are_runtime_checkable_for_gaussian():
+    gaussian = GaussianDistribution(array([0.0, 0.0]), eye(2))
+
+    assert isinstance(gaussian, SupportsDim)
+    assert isinstance(gaussian, SupportsInputDim)
+    assert isinstance(gaussian, SupportsPdf)
+    assert isinstance(gaussian, SupportsLnPdf)
+    assert isinstance(gaussian, SupportsSampling)
+    assert isinstance(gaussian, SupportsMean)
+    assert isinstance(gaussian, SupportsCovariance)
+    assert isinstance(gaussian, SupportsMode)
+    assert isinstance(gaussian, SupportsModeSetting)
+    assert isinstance(gaussian, SupportsMultiplication)
+    assert isinstance(gaussian, SupportsConvolution)
+    assert isinstance(gaussian, DensityLike)
+    assert isinstance(gaussian, LogDensityLike)
+    assert isinstance(gaussian, ManifoldDensityLike)
+
+
+def test_distribution_protocols_are_runtime_checkable_for_circular_distribution():
+    von_mises = VonMisesDistribution(0.0, 1.0)
+
+    assert isinstance(von_mises, SupportsDim)
+    assert isinstance(von_mises, SupportsInputDim)
+    assert isinstance(von_mises, SupportsPdf)
+    assert isinstance(von_mises, SupportsLnPdf)
+    assert isinstance(von_mises, SupportsSampling)
+    assert isinstance(von_mises, SupportsMean)
+    assert isinstance(von_mises, SupportsMultiplication)
+    assert isinstance(von_mises, SupportsConvolution)
+    assert isinstance(von_mises, DensityLike)
+    assert isinstance(von_mises, LogDensityLike)
+    assert isinstance(von_mises, ManifoldDensityLike)
+
+
+def test_density_like_accepts_structural_implementations_without_inheritance():
+    density = MinimalDensity()
+
+    assert isinstance(density, SupportsPdf)
+    assert isinstance(density, DensityLike)
+
+
+def test_log_density_like_accepts_structural_implementations_without_inheritance():
+    density = MinimalLogDensity()
+
+    assert isinstance(density, SupportsLnPdf)
+    assert isinstance(density, LogDensityLike)
+
+
+def test_manifold_density_like_accepts_structural_implementations_without_inheritance():
+    density = MinimalManifoldDensity()
+
+    assert isinstance(density, SupportsInputDim)
+    assert isinstance(density, SupportsPdf)
+    assert isinstance(density, SupportsMean)
+    assert isinstance(density, ManifoldDensityLike)
+
+
+def test_sampling_protocol_does_not_imply_density_protocol():
+    class SampleOnlyDistribution:
+        def sample(self, n):
+            return array([0.0] * n)
+
+    distribution = SampleOnlyDistribution()
+
+    assert isinstance(distribution, SupportsSampling)
+    assert not isinstance(distribution, SupportsPdf)
+
+
+def test_pdf_protocol_does_not_imply_sampling_protocol():
+    distribution = MinimalDensity()
+
+    assert isinstance(distribution, SupportsPdf)
+    assert not isinstance(distribution, SupportsSampling)


### PR DESCRIPTION
## Summary

Adds public distribution capability protocols under `pyrecest.protocols.distributions`:

- `SupportsPdf`
- `SupportsLnPdf`
- `SupportsSampling`
- `SupportsMean`
- `SupportsCovariance`
- `SupportsMode`
- `SupportsModeSetting`
- `SupportsMultiplication`
- `SupportsConvolution`
- composite protocols `DensityLike`, `LogDensityLike`, and `ManifoldDensityLike`

The protocols are small, runtime-checkable, structural contracts. They do not require existing or user-defined distributions to inherit from PyRecEst abstract base classes.

## Scope

This PR is additive and intentionally leaves `pyrecest.protocols.__init__` unchanged. Protocols are imported from the distribution submodule to keep parallel protocol PRs low-conflict:

```python
from pyrecest.protocols.distributions import SupportsPdf, SupportsSampling
```

## Stacking

This PR is stacked on #1952 (`feature/public-protocol-seed`) because that PR provides the public `pyrecest.protocols` package shell.

## Tests

Focused local checks prepared for this change:

```bash
PYTHONPATH=src python -m compileall -q src/pyrecest/protocols tests/protocols
PYTHONPATH=src pytest -q tests/protocols
```

Sandbox result before pushing the PR branch:

```text
8 passed
```
