### PR TITLE
Add manifold and state-space protocols

### DIFF
--- a/src/pyrecest/protocols/manifolds.py
+++ b/src/pyrecest/protocols/manifolds.py
@@ -1,0 +1,135 @@
+"""Public manifold and state-space capability protocols."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Protocol, runtime_checkable
+
+from .common import ArrayLike, BackendArray, SupportsDim, SupportsInputDim
+
+__all__ = [
+    "EmbeddedManifoldLike",
+    "FiniteMeasureManifoldLike",
+    "ManifoldLike",
+    "StateSpaceLike",
+    "SupportsAngularError",
+    "SupportsCoordinateNormalization",
+    "SupportsDistance",
+    "SupportsDomainFunctionIntegration",
+    "SupportsDomainIntegration",
+    "SupportsHypersphericalCoordinateConversion",
+    "SupportsIntegrationBoundaries",
+    "SupportsManifoldSize",
+]
+
+
+@runtime_checkable
+class SupportsManifoldSize(Protocol):
+    """Object exposing the total measure of a finite-measure state space."""
+
+    def get_manifold_size(self) -> BackendArray:
+        """Return the total measure of the state manifold or domain."""
+        raise NotImplementedError
+
+    def get_ln_manifold_size(self) -> BackendArray:
+        """Return the logarithm of :meth:`get_manifold_size`."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsDistance(Protocol):
+    """Object exposing a distance on its state space."""
+
+    def distance(self, x: ArrayLike, y: ArrayLike) -> BackendArray:
+        """Return the distance between two states or batches of states."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsCoordinateNormalization(Protocol):
+    """Object that can project or wrap states into canonical coordinates."""
+
+    def normalize(self, x: ArrayLike) -> BackendArray:
+        """Return ``x`` represented in canonical coordinates for the state space."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsAngularError(Protocol):
+    """Object exposing a periodic angular-error operation."""
+
+    def angular_error(self, alpha: ArrayLike, beta: ArrayLike) -> BackendArray:
+        """Return the wrapped angular error between two angular states."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsDomainIntegration(Protocol):
+    """Object that can integrate its represented density over a domain."""
+
+    def integrate(self, integration_boundaries: ArrayLike | None = None) -> BackendArray:
+        """Integrate over the state space or an explicitly supplied subdomain."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsDomainFunctionIntegration(Protocol):
+    """Object exposing integration of arbitrary functions over its domain."""
+
+    def integrate_fun_over_domain(
+        self,
+        f: Callable[..., BackendArray],
+        dim: int,
+    ) -> BackendArray:
+        """Integrate ``f`` over the full domain for the given intrinsic dimension."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsIntegrationBoundaries(Protocol):
+    """Object exposing full-domain integration boundaries."""
+
+    def get_full_integration_boundaries(self, dim: int) -> BackendArray:
+        """Return coordinate boundaries for the full integration domain."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsHypersphericalCoordinateConversion(Protocol):
+    """Object exposing hyperspherical/ambient coordinate conversions."""
+
+    def hypersph_to_cart(
+        self,
+        hypersph_coords: ArrayLike,
+        mode: str = "colatitude",
+    ) -> BackendArray:
+        """Convert hyperspherical coordinates to ambient Cartesian coordinates."""
+        raise NotImplementedError
+
+    def cart_to_hypersph(
+        self,
+        cart_coords: ArrayLike,
+        mode: str = "colatitude",
+    ) -> BackendArray:
+        """Convert ambient Cartesian coordinates to hyperspherical coordinates."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class StateSpaceLike(SupportsDim, SupportsInputDim, Protocol):
+    """Minimal protocol for objects tied to a state space."""
+
+
+@runtime_checkable
+class ManifoldLike(StateSpaceLike, Protocol):
+    """Minimal protocol for objects tied to a known manifold."""
+
+
+@runtime_checkable
+class EmbeddedManifoldLike(ManifoldLike, Protocol):
+    """Marker protocol for manifolds represented in ambient coordinates."""
+
+
+@runtime_checkable
+class FiniteMeasureManifoldLike(ManifoldLike, SupportsManifoldSize, Protocol):
+    """Protocol for manifolds or domains with a finite total measure."""

--- a/tests/protocols/test_manifold_protocols.py
+++ b/tests/protocols/test_manifold_protocols.py
@@ -1,0 +1,105 @@
+"""Smoke tests for public manifold and state-space protocols."""
+
+from __future__ import annotations
+
+from pyrecest.protocols.manifolds import (
+    EmbeddedManifoldLike,
+    FiniteMeasureManifoldLike,
+    ManifoldLike,
+    StateSpaceLike,
+    SupportsAngularError,
+    SupportsCoordinateNormalization,
+    SupportsDistance,
+    SupportsDomainFunctionIntegration,
+    SupportsDomainIntegration,
+    SupportsHypersphericalCoordinateConversion,
+    SupportsIntegrationBoundaries,
+    SupportsManifoldSize,
+)
+
+
+class MinimalStateSpace:
+    dim = 2
+    input_dim = 3
+
+
+class FiniteMeasureStateSpace(MinimalStateSpace):
+    def get_manifold_size(self):
+        return 4.0
+
+    def get_ln_manifold_size(self):
+        return 1.3862943611198906
+
+
+class DistanceStateSpace:
+    def distance(self, x, y):
+        return abs(x - y)
+
+
+class CoordinateNormalizingStateSpace:
+    def normalize(self, x):
+        return x
+
+
+class PeriodicStateSpace:
+    def angular_error(self, alpha, beta):
+        return alpha - beta
+
+
+class IntegratingStateSpace:
+    def integrate(self, integration_boundaries=None):
+        del integration_boundaries
+        return 1.0
+
+    def integrate_fun_over_domain(self, f, dim):
+        return f(*range(dim))
+
+    def get_full_integration_boundaries(self, dim):
+        return [(0.0, 1.0)] * dim
+
+
+class HypersphericalCoordinateConverter:
+    def hypersph_to_cart(self, hypersph_coords, mode="colatitude"):
+        del mode
+        return hypersph_coords
+
+    def cart_to_hypersph(self, cart_coords, mode="colatitude"):
+        del mode
+        return cart_coords
+
+
+def test_state_space_protocols_are_runtime_checkable():
+    obj = MinimalStateSpace()
+
+    assert isinstance(obj, StateSpaceLike)
+    assert isinstance(obj, ManifoldLike)
+    assert isinstance(obj, EmbeddedManifoldLike)
+    assert not isinstance(obj, FiniteMeasureManifoldLike)
+
+
+def test_finite_measure_manifold_protocol_is_runtime_checkable():
+    obj = FiniteMeasureStateSpace()
+
+    assert isinstance(obj, SupportsManifoldSize)
+    assert isinstance(obj, FiniteMeasureManifoldLike)
+
+
+def test_geometric_operation_protocols_are_runtime_checkable():
+    assert isinstance(DistanceStateSpace(), SupportsDistance)
+    assert isinstance(CoordinateNormalizingStateSpace(), SupportsCoordinateNormalization)
+    assert isinstance(PeriodicStateSpace(), SupportsAngularError)
+
+
+def test_domain_integration_protocols_are_runtime_checkable():
+    obj = IntegratingStateSpace()
+
+    assert isinstance(obj, SupportsDomainIntegration)
+    assert isinstance(obj, SupportsDomainFunctionIntegration)
+    assert isinstance(obj, SupportsIntegrationBoundaries)
+
+
+def test_coordinate_conversion_protocol_is_runtime_checkable():
+    assert isinstance(
+        HypersphericalCoordinateConverter(),
+        SupportsHypersphericalCoordinateConversion,
+    )


### PR DESCRIPTION
## Summary

Adds the manifold/state-space protocol PR on top of the public protocol seed:

- `pyrecest.protocols.manifolds`
- `StateSpaceLike`, `ManifoldLike`, `EmbeddedManifoldLike`, and `FiniteMeasureManifoldLike`
- finite-domain protocol `SupportsManifoldSize`
- geometric/domain operation protocols:
  - `SupportsDistance`
  - `SupportsCoordinateNormalization`
  - `SupportsAngularError`
  - `SupportsDomainIntegration`
  - `SupportsDomainFunctionIntegration`
  - `SupportsIntegrationBoundaries`
  - `SupportsHypersphericalCoordinateConversion`
- runtime-check smoke tests for all new protocols
- protocol documentation updates
- convention notes for `dim`, `input_dim`, and finite-measure domain size

## Scope

This PR is intentionally additive. It does not modify existing distributions, filters, models, conversion logic, or abstract base classes. The new protocols are imported from `pyrecest.protocols.manifolds` only; package-level protocol exports remain minimal to avoid conflicts with parallel protocol PRs.

## Design notes

`ManifoldLike` requires only `dim` and `input_dim`. `get_manifold_size()` is intentionally separated into `SupportsManifoldSize` / `FiniteMeasureManifoldLike` so non-compact state spaces do not have to pretend to have a finite domain measure.

## Tests

```bash
PYTHONPATH=src python -m compileall -q src/pyrecest/protocols tests/protocols/test_manifold_protocols.py
PYTHONPATH=src pytest -q tests/protocols/test_manifold_protocols.py
```

Result from the prepared patch:

```text
5 passed
```