### PR TITLE
Add public model capability protocols

### DIFF
--- a/src/pyrecest/models/__init__.py
+++ b/src/pyrecest/models/__init__.py
@@ -4,15 +4,21 @@ evolve and how measurements are evaluated. These objects are deliberately small
 and capability-oriented so filters can opt into the pieces they need.
 """
 
+from pyrecest.protocols.models import (
+    SupportsLikelihood,
+    SupportsLinearGaussianMeasurement,
+    SupportsLinearGaussianTransition,
+    SupportsLogLikelihood,
+    SupportsPredictedDistribution,
+    SupportsTransitionDensity,
+    SupportsTransitionSampling,
+)
+
 from .additive_noise import AdditiveNoiseMeasurementModel, AdditiveNoiseTransitionModel
 from .likelihood import (
     DensityTransitionModel,
     LikelihoodMeasurementModel,
     SampleableTransitionModel,
-    SupportsLikelihood,
-    SupportsLogLikelihood,
-    SupportsTransitionDensity,
-    SupportsTransitionSampling,
 )
 from .linear_gaussian import IdentityGaussianMeasurementModel
 from .linear_gaussian import IdentityGaussianTransitionModel
@@ -34,16 +40,19 @@ __all__ = [
     "AdditiveNoiseMeasurementModel",
     "AdditiveNoiseTransitionModel",
     "DensityTransitionModel",
-    "LikelihoodMeasurementModel",
-    "SampleableTransitionModel",
-    "SupportsLikelihood",
-    "SupportsLogLikelihood",
-    "SupportsTransitionDensity",
-    "SupportsTransitionSampling",
     "IdentityGaussianMeasurementModel",
     "IdentityGaussianTransitionModel",
+    "LikelihoodMeasurementModel",
     "LinearGaussianMeasurementModel",
     "LinearGaussianTransitionModel",
+    "SampleableTransitionModel",
+    "SupportsLikelihood",
+    "SupportsLinearGaussianMeasurement",
+    "SupportsLinearGaussianTransition",
+    "SupportsLogLikelihood",
+    "SupportsPredictedDistribution",
+    "SupportsTransitionDensity",
+    "SupportsTransitionSampling",
     "infer_state_dim_from_distribution",
     "validate_covariance_matrix",
     "validate_matrix",

--- a/src/pyrecest/models/likelihood.py
+++ b/src/pyrecest/models/likelihood.py
@@ -12,45 +12,22 @@ The conventions are intentionally simple:
 
 The classes do not modify filters directly. They only make the model
 capabilities explicit so filter adapters can consume them later without
-duplicating callback conventions.
+duplicating callback conventions. The public capability protocols live in
+:mod:`pyrecest.protocols.models` and are re-exported here for backwards
+compatibility.
 """
 
 from __future__ import annotations
 
 from inspect import Parameter, signature
-from typing import Any, Callable, Protocol, runtime_checkable
+from typing import Any, Callable
 
-
-@runtime_checkable
-class SupportsLikelihood(Protocol):
-    """Protocol for measurement models that can evaluate ``p(z | x)``."""
-
-    def likelihood(self, measurement: Any, state: Any) -> Any:
-        """Return the likelihood of ``measurement`` for ``state``."""
-
-
-@runtime_checkable
-class SupportsLogLikelihood(Protocol):
-    """Protocol for measurement models that can evaluate log-likelihoods."""
-
-    def log_likelihood(self, measurement: Any, state: Any) -> Any:
-        """Return the log-likelihood of ``measurement`` for ``state``."""
-
-
-@runtime_checkable
-class SupportsTransitionSampling(Protocol):
-    """Protocol for transition models that can sample ``p(x_k | x_{k-1})``."""
-
-    def sample_next(self, state: Any, n: int = 1) -> Any:
-        """Draw ``n`` next-state samples conditioned on ``state``."""
-
-
-@runtime_checkable
-class SupportsTransitionDensity(Protocol):
-    """Protocol for transition models that can evaluate ``p(x_k | x_{k-1})``."""
-
-    def transition_density(self, state_next: Any, state_previous: Any) -> Any:
-        """Return transition density values."""
+from pyrecest.protocols.models import (
+    SupportsLikelihood,
+    SupportsLogLikelihood,
+    SupportsTransitionDensity,
+    SupportsTransitionSampling,
+)
 
 
 def _ensure_callable(value: Any, name: str) -> None:
@@ -100,25 +77,7 @@ def _evaluate_distribution_method(distribution: Any, method_name: str, *args: An
 
 
 class LikelihoodMeasurementModel:
-    """Measurement model specified by a likelihood callback.
-
-    Parameters
-    ----------
-    likelihood
-        Callable with signature ``likelihood(measurement, state)`` returning
-        values proportional to ``p(measurement | state)``.
-    log_likelihood
-        Optional callable with signature ``log_likelihood(measurement, state)``.
-        If omitted, :meth:`log_likelihood` raises :class:`NotImplementedError`.
-    name
-        Optional human-readable model name used in diagnostics and examples.
-
-    Notes
-    -----
-    This class is intentionally representation-agnostic. ``measurement`` and
-    ``state`` can be scalars, backend arrays, particles, manifold coordinates,
-    or any other objects understood by the provided callback.
-    """
+    """Measurement model specified by a likelihood callback."""
 
     def __init__(
         self,
@@ -144,22 +103,7 @@ class LikelihoodMeasurementModel:
         log_pdf_method: str | None = None,
         name: str | None = None,
     ) -> "LikelihoodMeasurementModel":
-        """Create a likelihood model from a state-conditioned distribution.
-
-        Parameters
-        ----------
-        distribution_factory
-            Callable returning the conditional measurement distribution for a
-            state, for example ``lambda x: GaussianDistribution(h(x), R)``.
-        pdf_method
-            Name of the density method on the returned distribution. PyRecEst
-            distributions commonly expose ``pdf``.
-        log_pdf_method
-            Optional name of the log-density method on the returned
-            distribution.
-        name
-            Optional human-readable model name.
-        """
+        """Create a likelihood model from a state-conditioned distribution."""
 
         _ensure_callable(distribution_factory, "distribution_factory")
 
@@ -197,22 +141,7 @@ class LikelihoodMeasurementModel:
 
 
 class SampleableTransitionModel:
-    """Transition model specified by a next-state sampler.
-
-    Parameters
-    ----------
-    sample_next
-        Callable with signature ``sample_next(state)`` or
-        ``sample_next(state, n=1)`` returning samples from ``p(x_k | state)``.
-    transition_density
-        Optional callable with signature
-        ``transition_density(state_next, state_previous)``.
-    name
-        Optional human-readable model name.
-    function_is_vectorized
-        Whether ``sample_next`` accepts a batch of states. This preserves the
-        legacy particle-model adapter contract.
-    """
+    """Transition model specified by a next-state sampler."""
 
     def __init__(
         self,
@@ -254,19 +183,7 @@ class SampleableTransitionModel:
 
 
 class DensityTransitionModel:
-    """Transition model specified by a transition-density callback.
-
-    Parameters
-    ----------
-    transition_density
-        Callable with signature ``transition_density(state_next,
-        state_previous)`` returning values proportional to
-        ``p(state_next | state_previous)``.
-    sample_next
-        Optional callable with signature ``sample_next(state, n=1)``.
-    name
-        Optional human-readable model name.
-    """
+    """Transition model specified by a transition-density callback."""
 
     def __init__(
         self,

--- a/src/pyrecest/protocols/models.py
+++ b/src/pyrecest/protocols/models.py
@@ -1,0 +1,159 @@
+"""Public model capability protocols for PyRecEst.
+
+These protocols describe reusable transition and measurement model capabilities
+without requiring user-defined models to inherit from concrete PyRecEst model
+classes. They are intentionally small so filters, adapters, and evaluation code
+can request only the capabilities they need.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from .common import ArrayLike, BackendArray
+
+
+@runtime_checkable
+class SupportsLikelihood(Protocol):
+    """Measurement model that can evaluate likelihood values ``p(z | x)``."""
+
+    def likelihood(self, measurement: ArrayLike, state: ArrayLike) -> BackendArray:
+        """Return the likelihood of ``measurement`` conditioned on ``state``."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsLogLikelihood(Protocol):
+    """Measurement model that can evaluate log-likelihood values."""
+
+    def log_likelihood(self, measurement: ArrayLike, state: ArrayLike) -> BackendArray:
+        """Return ``log p(measurement | state)``."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsTransitionSampling(Protocol):
+    """Transition model that can sample from ``p(x_k | x_{k-1})``."""
+
+    def sample_next(self, state: ArrayLike, n: int = 1) -> BackendArray:
+        """Draw ``n`` next-state samples conditioned on ``state``."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsTransitionDensity(Protocol):
+    """Transition model that can evaluate ``p(x_k | x_{k-1})``."""
+
+    def transition_density(
+        self, state_next: ArrayLike, state_previous: ArrayLike
+    ) -> BackendArray:
+        """Return transition density values."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsPredictedDistribution(Protocol):
+    """Model that can propagate a distribution into a predicted distribution."""
+
+    def predict_distribution(
+        self, state_distribution: Any, *args: Any, **kwargs: Any
+    ) -> Any:
+        """Return the distribution implied by propagating ``state_distribution``."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsLinearGaussianTransition(Protocol):
+    """Linear Gaussian transition model with explicit matrix and noise terms."""
+
+    @property
+    def state_dim(self) -> int:
+        """Input state dimension."""
+        raise NotImplementedError
+
+    @property
+    def predicted_dim(self) -> int:
+        """Predicted state dimension."""
+        raise NotImplementedError
+
+    @property
+    def system_matrix(self) -> BackendArray:
+        """Linear transition matrix."""
+        raise NotImplementedError
+
+    @property
+    def system_noise_cov(self) -> BackendArray:
+        """Additive system-noise covariance matrix."""
+        raise NotImplementedError
+
+    def predict_mean(self, state_mean: ArrayLike) -> BackendArray:
+        """Return the predicted mean for ``state_mean``."""
+        raise NotImplementedError
+
+    def predict_covariance(self, state_covariance: ArrayLike) -> BackendArray:
+        """Return the predicted covariance for ``state_covariance``."""
+        raise NotImplementedError
+
+    def predict_distribution(
+        self, state_distribution: Any, *args: Any, **kwargs: Any
+    ) -> Any:
+        """Return the predicted distribution for ``state_distribution``."""
+        raise NotImplementedError
+
+    def noise_distribution(self, *args: Any, **kwargs: Any) -> Any:
+        """Return the additive system-noise distribution."""
+        raise NotImplementedError
+
+
+@runtime_checkable
+class SupportsLinearGaussianMeasurement(Protocol):
+    """Linear Gaussian measurement model with explicit matrix and noise terms."""
+
+    @property
+    def state_dim(self) -> int:
+        """Input state dimension."""
+        raise NotImplementedError
+
+    @property
+    def measurement_dim(self) -> int:
+        """Measurement dimension."""
+        raise NotImplementedError
+
+    @property
+    def measurement_matrix(self) -> BackendArray:
+        """Linear measurement matrix."""
+        raise NotImplementedError
+
+    @property
+    def measurement_noise_cov(self) -> BackendArray:
+        """Additive measurement-noise covariance matrix."""
+        raise NotImplementedError
+
+    def predict_mean(self, state_mean: ArrayLike) -> BackendArray:
+        """Return the predicted measurement mean for ``state_mean``."""
+        raise NotImplementedError
+
+    def innovation_covariance(self, state_covariance: ArrayLike) -> BackendArray:
+        """Return the innovation covariance for ``state_covariance``."""
+        raise NotImplementedError
+
+    def predict_distribution(
+        self, state_distribution: Any, *args: Any, **kwargs: Any
+    ) -> Any:
+        """Return the predicted measurement distribution for ``state_distribution``."""
+        raise NotImplementedError
+
+    def noise_distribution(self, *args: Any, **kwargs: Any) -> Any:
+        """Return the additive measurement-noise distribution."""
+        raise NotImplementedError
+
+
+__all__ = [
+    "SupportsLikelihood",
+    "SupportsLinearGaussianMeasurement",
+    "SupportsLinearGaussianTransition",
+    "SupportsLogLikelihood",
+    "SupportsPredictedDistribution",
+    "SupportsTransitionDensity",
+    "SupportsTransitionSampling",
+]

--- a/tests/protocols/test_model_protocols.py
+++ b/tests/protocols/test_model_protocols.py
@@ -1,0 +1,73 @@
+"""Tests for public model capability protocols."""
+
+from __future__ import annotations
+
+from pyrecest.backend import array
+from pyrecest.models import (
+    DensityTransitionModel,
+    IdentityGaussianMeasurementModel,
+    IdentityGaussianTransitionModel,
+    LikelihoodMeasurementModel,
+    SampleableTransitionModel,
+    SupportsLikelihood as ModelsSupportsLikelihood,
+    SupportsLinearGaussianMeasurement as ModelsSupportsLinearGaussianMeasurement,
+    SupportsLinearGaussianTransition as ModelsSupportsLinearGaussianTransition,
+    SupportsLogLikelihood as ModelsSupportsLogLikelihood,
+    SupportsPredictedDistribution as ModelsSupportsPredictedDistribution,
+    SupportsTransitionDensity as ModelsSupportsTransitionDensity,
+    SupportsTransitionSampling as ModelsSupportsTransitionSampling,
+)
+from pyrecest.models.likelihood import (
+    SupportsLikelihood as LikelihoodSupportsLikelihood,
+)
+from pyrecest.protocols.models import (
+    SupportsLikelihood,
+    SupportsLinearGaussianMeasurement,
+    SupportsLinearGaussianTransition,
+    SupportsLogLikelihood,
+    SupportsPredictedDistribution,
+    SupportsTransitionDensity,
+    SupportsTransitionSampling,
+)
+
+
+def test_model_protocols_are_reexported_from_existing_model_locations():
+    assert ModelsSupportsLikelihood is SupportsLikelihood
+    assert LikelihoodSupportsLikelihood is SupportsLikelihood
+    assert ModelsSupportsLogLikelihood is SupportsLogLikelihood
+    assert ModelsSupportsTransitionSampling is SupportsTransitionSampling
+    assert ModelsSupportsTransitionDensity is SupportsTransitionDensity
+    assert ModelsSupportsPredictedDistribution is SupportsPredictedDistribution
+    assert ModelsSupportsLinearGaussianTransition is SupportsLinearGaussianTransition
+    assert ModelsSupportsLinearGaussianMeasurement is SupportsLinearGaussianMeasurement
+
+
+def test_likelihood_model_satisfies_likelihood_protocols():
+    model = LikelihoodMeasurementModel(
+        lambda measurement, state: measurement + state,
+        log_likelihood=lambda measurement, state: measurement - state,
+    )
+
+    assert isinstance(model, SupportsLikelihood)
+    assert isinstance(model, SupportsLogLikelihood)
+
+
+def test_transition_models_satisfy_transition_protocols():
+    sampleable = SampleableTransitionModel(lambda state, n=1: state)
+    density_based = DensityTransitionModel(
+        lambda state_next, state_previous: state_next + state_previous
+    )
+
+    assert isinstance(sampleable, SupportsTransitionSampling)
+    assert isinstance(density_based, SupportsTransitionDensity)
+
+
+def test_linear_gaussian_models_satisfy_model_protocols():
+    noise_covariance = array([[1.0, 0.0], [0.0, 1.0]])
+    transition_model = IdentityGaussianTransitionModel(2, noise_covariance)
+    measurement_model = IdentityGaussianMeasurementModel(2, noise_covariance)
+
+    assert isinstance(transition_model, SupportsLinearGaussianTransition)
+    assert isinstance(transition_model, SupportsPredictedDistribution)
+    assert isinstance(measurement_model, SupportsLinearGaussianMeasurement)
+    assert isinstance(measurement_model, SupportsPredictedDistribution)


### PR DESCRIPTION
## Summary

Adds PR3 from the public protocol roadmap by moving model capability contracts into the public protocol namespace:

- adds `pyrecest.protocols.models`
- defines runtime-checkable model protocols for likelihood, log-likelihood, transition sampling, transition density, predicted distributions, and linear-Gaussian transition/measurement models
- keeps existing likelihood/transition protocol imports working through `pyrecest.models.likelihood`
- re-exports the expanded model protocol set from `pyrecest.models`
- adds focused protocol compliance tests
- documents the preferred `pyrecest.protocols.models` import path

## Scope

This is intentionally additive and stacked on PR #1952 (`feature/public-protocol-seed`). It does not change filter behavior or introduce protocol-based adapters yet.

## Notes

An existing branch named `feature/model-protocols` already diverged from PR #1952, so this PR uses a fresh stacked branch: `feature/public-model-protocols`.

## Tests

Prepared locally against the PR0 file state:

```bash
PYTHONPATH=src python -m compileall -q \
  src/pyrecest/protocols \
  src/pyrecest/models/likelihood.py \
  src/pyrecest/models/__init__.py \
  tests/protocols/test_model_protocols.py
```

Result:

```text
OK
```

I could not run the focused pytest locally in the partial workspace because the local synthetic checkout only contained the files needed for the patch and lacked `pyrecest.backend`. CI should run the full repository tests.