### PR TITLE
Apply MegaLinter formatting fixes

### DIFF
--- a/docs/protocol-capability-matrix.md
+++ b/docs/protocol-capability-matrix.md
@@ -17,12 +17,12 @@ class intentionally gains or loses one of these capabilities.
 
 ## Distribution capabilities
 
-| Class | `dim` | `input_dim` | `pdf` | `ln_pdf` | `sample` | `mean` | `covariance` | `convert_to` | `approximate_as` | `from_distribution` |
-| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| `GaussianDistribution` | yes | yes | yes | yes | yes | yes | yes | yes | yes | yes |
-| `LinearDiracDistribution` | yes | yes | no | no | yes | yes | yes | yes | yes | yes |
-| `VonMisesDistribution` | yes | yes | yes | yes | yes | yes | no | yes | yes | no |
-| `CircularUniformDistribution` | yes | yes | yes | yes | yes | no | no | yes | yes | no |
+| Class                         | `dim` | `input_dim` | `pdf` | `ln_pdf` | `sample` | `mean` | `covariance` | `convert_to` | `approximate_as` | `from_distribution` |
+|-------------------------------|------:|------------:|------:|---------:|---------:|-------:|-------------:|-------------:|-----------------:|--------------------:|
+| `GaussianDistribution`        |   yes |         yes |   yes |      yes |      yes |    yes |          yes |          yes |              yes |                 yes |
+| `LinearDiracDistribution`     |   yes |         yes |    no |       no |      yes |    yes |          yes |          yes |              yes |                 yes |
+| `VonMisesDistribution`        |   yes |         yes |   yes |      yes |      yes |    yes |           no |          yes |              yes |                  no |
+| `CircularUniformDistribution` |   yes |         yes |   yes |      yes |      yes |     no |           no |          yes |              yes |                  no |
 
 Notes:
 
@@ -37,11 +37,11 @@ Notes:
 
 ## Filter capabilities
 
-| Class | `dim` | `filter_state` | `get_point_estimate` | `predict_linear` | `update_linear` | `predict_nonlinear` | `update_nonlinear` | `predict_model` | `update_model` | `update_nonlinear_using_likelihood` | history recording |
-| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| `KalmanFilter` | yes | yes | yes | yes | yes | no | no | yes | yes | no | yes |
-| `UnscentedKalmanFilter` | yes | yes | yes | yes | yes | yes | yes | yes | yes | no | yes |
-| `CircularParticleFilter` | yes | yes | yes | no | no | yes | no | yes | yes | yes | yes |
+| Class                    | `dim` | `filter_state` | `get_point_estimate` | `predict_linear` | `update_linear` | `predict_nonlinear` | `update_nonlinear` | `predict_model` | `update_model` | `update_nonlinear_using_likelihood` | history recording |
+|--------------------------|------:|---------------:|---------------------:|-----------------:|----------------:|--------------------:|-------------------:|----------------:|---------------:|------------------------------------:|------------------:|
+| `KalmanFilter`           |   yes |            yes |                  yes |              yes |             yes |                  no |                 no |             yes |            yes |                                  no |               yes |
+| `UnscentedKalmanFilter`  |   yes |            yes |                  yes |              yes |             yes |                 yes |                yes |             yes |            yes |                                  no |               yes |
+| `CircularParticleFilter` |   yes |            yes |                  yes |               no |              no |                 yes |                 no |             yes |            yes |                                 yes |               yes |
 
 Notes:
 

--- a/docs/representation-conversion.md
+++ b/docs/representation-conversion.md
@@ -122,25 +122,25 @@ gateway. A route is supported when the alias resolver can select a target class
 and that target class either implements `from_distribution(...)`, is already the
 source type, or has an explicitly registered converter.
 
-| Source representation | Target / alias | Concrete target selected | Required parameters | Method | Exact? |
-| --- | --- | --- | --- | --- | --- |
-| Any distribution | same concrete class | requested class | none | identity conversion | yes |
-| Any registered source type | registered target class | registered target class | converter-specific | registered converter | converter-specific |
-| Any distribution accepted by a registered alias | registered alias | alias target or resolver result | alias/converter-specific | registered converter or target `from_distribution(...)` | converter-specific |
-| `AbstractLinearDistribution` | `"particles"`, `"dirac"`, `"samples"`, `"linear_dirac"` | `LinearDiracDistribution` | `n_particles` | sampling through `from_distribution(...)` | no |
-| distribution exposing `mean()` and `covariance()` | `"gaussian"`, `"normal"`, `"moment_matched_gaussian"` | `GaussianDistribution` | none | moment matching through `GaussianDistribution.from_distribution(...)` | no, except identity |
-| `GaussianDistribution` | `LinearDiracDistribution` or linear particle aliases | `LinearDiracDistribution` | `n_particles` | Gaussian sampling | no |
-| `LinearDiracDistribution` | Gaussian aliases | `GaussianDistribution` | none | weighted empirical mean/covariance | no |
-| `AbstractCircularDistribution` | `"particles"`, `"dirac"`, `"samples"`, `"circular_dirac"` | `CircularDiracDistribution` | `n_particles` | circular sampling | no |
-| `AbstractCircularDistribution` | `"grid"`, `"circular_grid"` | `CircularGridDistribution` | `no_of_gridpoints` | evaluate density on circular grid | no |
-| `AbstractCircularDistribution` | `"fourier"`, `"circular_fourier"` | `CircularFourierDistribution` | `n` | Fourier approximation | no |
-| `AbstractHypertoroidalDistribution` | `"particles"`, `"dirac"`, `"samples"`, `"hypertoroidal_dirac"` | `HypertoroidalDiracDistribution` | `n_particles` | hypertoroidal sampling | no |
-| `AbstractHypertoroidalDistribution` | `"grid"`, `"hypertoroidal_grid"` | `HypertoroidalGridDistribution` | `n_grid_points` | evaluate density on hypertoroidal grid | no |
-| `AbstractHypertoroidalDistribution` | `"fourier"`, `"hypertoroidal_fourier"` | `HypertoroidalFourierDistribution` | target-specific Fourier parameters | Fourier approximation | no |
-| `AbstractHypersphericalDistribution` | `"particles"`, `"dirac"`, `"samples"`, `"hyperspherical_dirac"` | `HypersphericalDiracDistribution` | `n_particles` | hyperspherical sampling | no |
-| `AbstractHypersphericalDistribution` | `"grid"`, `"hyperspherical_grid"` | `HypersphericalGridDistribution` | `no_of_grid_points`, `grid_type` | evaluate density on hyperspherical grid | no |
-| `AbstractHyperhemisphericalDistribution` | `"particles"`, `"dirac"`, `"samples"`, `"hyperhemispherical_dirac"` | `HyperhemisphericalDiracDistribution` | `n_particles` | hyperhemispherical sampling | no |
-| `AbstractHyperhemisphericalDistribution` | `"grid"`, `"hyperhemispherical_grid"` | `HyperhemisphericalGridDistribution` | `no_of_grid_points`, `grid_type` | evaluate density on hyperhemispherical grid | no |
+| Source representation                             | Target / alias                                                      | Concrete target selected              | Required parameters                | Method                                                                | Exact?              |
+|---------------------------------------------------|---------------------------------------------------------------------|---------------------------------------|------------------------------------|-----------------------------------------------------------------------|---------------------|
+| Any distribution                                  | same concrete class                                                 | requested class                       | none                               | identity conversion                                                   | yes                 |
+| Any registered source type                        | registered target class                                             | registered target class               | converter-specific                 | registered converter                                                  | converter-specific  |
+| Any distribution accepted by a registered alias   | registered alias                                                    | alias target or resolver result       | alias/converter-specific           | registered converter or target `from_distribution(...)`               | converter-specific  |
+| `AbstractLinearDistribution`                      | `"particles"`, `"dirac"`, `"samples"`, `"linear_dirac"`             | `LinearDiracDistribution`             | `n_particles`                      | sampling through `from_distribution(...)`                             | no                  |
+| distribution exposing `mean()` and `covariance()` | `"gaussian"`, `"normal"`, `"moment_matched_gaussian"`               | `GaussianDistribution`                | none                               | moment matching through `GaussianDistribution.from_distribution(...)` | no, except identity |
+| `GaussianDistribution`                            | `LinearDiracDistribution` or linear particle aliases                | `LinearDiracDistribution`             | `n_particles`                      | Gaussian sampling                                                     | no                  |
+| `LinearDiracDistribution`                         | Gaussian aliases                                                    | `GaussianDistribution`                | none                               | weighted empirical mean/covariance                                    | no                  |
+| `AbstractCircularDistribution`                    | `"particles"`, `"dirac"`, `"samples"`, `"circular_dirac"`           | `CircularDiracDistribution`           | `n_particles`                      | circular sampling                                                     | no                  |
+| `AbstractCircularDistribution`                    | `"grid"`, `"circular_grid"`                                         | `CircularGridDistribution`            | `no_of_gridpoints`                 | evaluate density on circular grid                                     | no                  |
+| `AbstractCircularDistribution`                    | `"fourier"`, `"circular_fourier"`                                   | `CircularFourierDistribution`         | `n`                                | Fourier approximation                                                 | no                  |
+| `AbstractHypertoroidalDistribution`               | `"particles"`, `"dirac"`, `"samples"`, `"hypertoroidal_dirac"`      | `HypertoroidalDiracDistribution`      | `n_particles`                      | hypertoroidal sampling                                                | no                  |
+| `AbstractHypertoroidalDistribution`               | `"grid"`, `"hypertoroidal_grid"`                                    | `HypertoroidalGridDistribution`       | `n_grid_points`                    | evaluate density on hypertoroidal grid                                | no                  |
+| `AbstractHypertoroidalDistribution`               | `"fourier"`, `"hypertoroidal_fourier"`                              | `HypertoroidalFourierDistribution`    | target-specific Fourier parameters | Fourier approximation                                                 | no                  |
+| `AbstractHypersphericalDistribution`              | `"particles"`, `"dirac"`, `"samples"`, `"hyperspherical_dirac"`     | `HypersphericalDiracDistribution`     | `n_particles`                      | hyperspherical sampling                                               | no                  |
+| `AbstractHypersphericalDistribution`              | `"grid"`, `"hyperspherical_grid"`                                   | `HypersphericalGridDistribution`      | `no_of_grid_points`, `grid_type`   | evaluate density on hyperspherical grid                               | no                  |
+| `AbstractHyperhemisphericalDistribution`          | `"particles"`, `"dirac"`, `"samples"`, `"hyperhemispherical_dirac"` | `HyperhemisphericalDiracDistribution` | `n_particles`                      | hyperhemispherical sampling                                           | no                  |
+| `AbstractHyperhemisphericalDistribution`          | `"grid"`, `"hyperhemispherical_grid"`                               | `HyperhemisphericalGridDistribution`  | `no_of_grid_points`, `grid_type`   | evaluate density on hyperhemispherical grid                           | no                  |
 
 The `"samples"` alias currently follows the same route as `"particles"` and
 returns a weighted Dirac representation, not a raw unweighted sample array. Use
@@ -151,17 +151,17 @@ needed.
 
 Common conversion parameters depend on the target representation:
 
-| Parameter | Used by | Meaning |
-| --- | --- | --- |
-| `n_particles` | Dirac/particle targets | Number of samples used to form the weighted Dirac approximation. |
-| `no_of_gridpoints` | `CircularGridDistribution` | Number of circular grid points. |
-| `n_grid_points` | `HypertoroidalGridDistribution` | Number of grid points per toroidal dimension. |
-| `no_of_grid_points` | hypersphere-subset grid targets | Number of hyperspherical or hyperhemispherical grid points. |
-| `grid_type` | hypersphere-subset grid targets | Grid construction method, such as a Leopardi-style grid where supported. |
-| `n` | Fourier targets | Fourier truncation/order parameter used by the target representation. |
-| `covariance_regularization` | SO(3) tangent-Gaussian targets | Optional diagonal regularization when fitting tangent-Gaussian approximations from few Dirac particles. |
-| `return_info` | conversion gateway | Return a `ConversionResult` instead of only the converted distribution. |
-| `copy_if_same` | conversion gateway | Return a deep copy for identity conversion instead of the original object. |
+| Parameter                   | Used by                         | Meaning                                                                                                 |
+|-----------------------------|---------------------------------|---------------------------------------------------------------------------------------------------------|
+| `n_particles`               | Dirac/particle targets          | Number of samples used to form the weighted Dirac approximation.                                        |
+| `no_of_gridpoints`          | `CircularGridDistribution`      | Number of circular grid points.                                                                         |
+| `n_grid_points`             | `HypertoroidalGridDistribution` | Number of grid points per toroidal dimension.                                                           |
+| `no_of_grid_points`         | hypersphere-subset grid targets | Number of hyperspherical or hyperhemispherical grid points.                                             |
+| `grid_type`                 | hypersphere-subset grid targets | Grid construction method, such as a Leopardi-style grid where supported.                                |
+| `n`                         | Fourier targets                 | Fourier truncation/order parameter used by the target representation.                                   |
+| `covariance_regularization` | SO(3) tangent-Gaussian targets  | Optional diagonal regularization when fitting tangent-Gaussian approximations from few Dirac particles. |
+| `return_info`               | conversion gateway              | Return a `ConversionResult` instead of only the converted distribution.                                 |
+| `copy_if_same`              | conversion gateway              | Return a deep copy for identity conversion instead of the original object.                              |
 
 ## Error messages
 

--- a/examples/basic/kalman_filter_with_models.py
+++ b/examples/basic/kalman_filter_with_models.py
@@ -1,14 +1,13 @@
 """Kalman filter example using reusable linear-Gaussian model objects."""
 
 # pylint: disable=import-error,no-name-in-module,no-member
+from _filter_example_output import print_position_velocity_estimates
 from pyrecest.backend import array, diag
 from pyrecest.filters import KalmanFilter
 from pyrecest.models import (
     LinearGaussianMeasurementModel,
     LinearGaussianTransitionModel,
 )
-
-from _filter_example_output import print_position_velocity_estimates
 
 
 def run_filter():

--- a/examples/basic/particle_filter_with_models.py
+++ b/examples/basic/particle_filter_with_models.py
@@ -1,6 +1,7 @@
 """Particle filter example using reusable transition and likelihood models."""
 
 # pylint: disable=import-error,no-name-in-module,no-member
+from _filter_example_output import print_position_velocity_estimates
 from pyrecest.backend import array, diag
 from pyrecest.distributions import GaussianDistribution
 from pyrecest.filters import EuclideanParticleFilter
@@ -8,8 +9,6 @@ from pyrecest.models import (
     LikelihoodMeasurementModel,
     SampleableTransitionModel,
 )
-
-from _filter_example_output import print_position_velocity_estimates
 
 
 def make_constant_velocity_sampler(dt, process_noise):

--- a/examples/basic/representation_conversion.py
+++ b/examples/basic/representation_conversion.py
@@ -105,7 +105,9 @@ def print_linear_example():
 
 def print_circular_example():
     """Print the circular grid/Fourier conversion workflow."""
-    distribution, grid_result, fourier_result, evaluation_points = run_circular_example()
+    distribution, grid_result, fourier_result, evaluation_points = (
+        run_circular_example()
+    )
     grid = grid_result.distribution
     fourier = fourier_result.distribution
 

--- a/examples/basic/ukf_with_models.py
+++ b/examples/basic/ukf_with_models.py
@@ -1,14 +1,13 @@
 """Unscented Kalman filter example using additive-noise model objects."""
 
 # pylint: disable=import-error,no-name-in-module,no-member
+from _filter_example_output import print_position_velocity_estimates
 from pyrecest.backend import array, diag
 from pyrecest.filters import UnscentedKalmanFilter
 from pyrecest.models import (
     AdditiveNoiseMeasurementModel,
     AdditiveNoiseTransitionModel,
 )
-
-from _filter_example_output import print_position_velocity_estimates
 
 
 def constant_velocity_transition(state, dt):

--- a/src/pyrecest/distributions/__init__.py
+++ b/src/pyrecest/distributions/__init__.py
@@ -22,16 +22,6 @@ from .abstract_periodic_grid_distribution import AbstractPeriodicGridDistributio
 from .abstract_se2_distribution import AbstractSE2Distribution
 from .abstract_se3_distribution import AbstractSE3Distribution
 from .abstract_uniform_distribution import AbstractUniformDistribution
-from .conversion import (
-    ConversionError,
-    ConversionResult,
-    can_convert,
-    convert_distribution,
-    register_conversion,
-    register_conversion_alias,
-    registered_conversion_aliases,
-    registered_conversions,
-)
 from .cart_prod.abstract_cart_prod_distribution import AbstractCartProdDistribution
 from .cart_prod.abstract_custom_lin_bounded_cart_prod_distribution import (
     AbstractCustomLinBoundedCartProdDistribution,
@@ -123,6 +113,16 @@ from .conditional.sd_half_cond_sd_half_grid_distribution import (
     SdHalfCondSdHalfGridDistribution,
 )
 from .conditional.td_cond_td_grid_distribution import TdCondTdGridDistribution
+from .conversion import (
+    ConversionError,
+    ConversionResult,
+    can_convert,
+    convert_distribution,
+    register_conversion,
+    register_conversion_alias,
+    registered_conversion_aliases,
+    registered_conversions,
+)
 from .custom_hyperrectangular_distribution import CustomHyperrectangularDistribution
 from .disk_uniform_distribution import DiskUniformDistribution
 from .ellipsoidal_ball_uniform_distribution import EllipsoidalBallUniformDistribution

--- a/src/pyrecest/distributions/abstract_distribution_type.py
+++ b/src/pyrecest/distributions/abstract_distribution_type.py
@@ -31,6 +31,4 @@ class AbstractDistributionType(ABC):
 
     def approximate_as(self, target_type, /, *, return_info: bool = False, **kwargs):
         """Alias for :meth:`convert_to` emphasizing approximate conversions."""
-        return self.convert_to(
-            target_type, return_info=return_info, **kwargs
-        )
+        return self.convert_to(target_type, return_info=return_info, **kwargs)

--- a/src/pyrecest/distributions/circle/circular_fourier_distribution.py
+++ b/src/pyrecest/distributions/circle/circular_fourier_distribution.py
@@ -318,8 +318,7 @@ class CircularFourierDistribution(AbstractCircularDistribution):
                 transformation = "identity"
             coeffs = array(
                 [
-                    conj(distribution.trigonometric_moment(k).squeeze())
-                    / (2.0 * pi)
+                    conj(distribution.trigonometric_moment(k).squeeze()) / (2.0 * pi)
                     for k in range(int(n) // 2 + 1)
                 ]
             )

--- a/src/pyrecest/distributions/conversion.py
+++ b/src/pyrecest/distributions/conversion.py
@@ -797,9 +797,9 @@ def _validate_conversion_arguments(
         )
 
 
-from . import (
+from . import (  # noqa: F401,E402  pylint: disable=wrong-import-position,unused-import
     so3_conversion as _so3_conversion,
-)  # noqa: F401,E402  pylint: disable=wrong-import-position,unused-import
+)
 
 __all__ = [
     "ConversionError",

--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_grid_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_grid_distribution.py
@@ -1,7 +1,7 @@
 import builtins
 import math
-from numbers import Integral
 import warnings
+from numbers import Integral
 
 from beartype import beartype
 
@@ -323,9 +323,7 @@ class HypertoroidalGridDistribution(
         """Return a weighted Dirac distribution on the grid points."""
         weights = reshape(self.grid_values, (-1,))
         weights = weights / sum(weights)
-        return HypertoroidalDiracDistribution(
-            self.get_grid(), weights, dim=self.dim
-        )
+        return HypertoroidalDiracDistribution(self.get_grid(), weights, dim=self.dim)
 
     def plot(self, *args, **kwargs):
         return self.to_dirac_distribution().plot(*args, **kwargs)

--- a/src/pyrecest/distributions/nonperiodic/linear_dirac_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/linear_dirac_distribution.py
@@ -4,7 +4,9 @@ import matplotlib.pyplot as plt
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import cov, ones, reshape, sum as backend_sum, zeros
+from pyrecest.backend import cov, ones, reshape
+from pyrecest.backend import sum as backend_sum
+from pyrecest.backend import zeros
 
 from ..abstract_dirac_distribution import AbstractDiracDistribution
 from .abstract_linear_distribution import AbstractLinearDistribution
@@ -76,9 +78,7 @@ class LinearDiracDistribution(AbstractDiracDistribution, AbstractLinearDistribut
             n=n,
         )
         samples = distribution.sample(particle_count)
-        return LinearDiracDistribution(
-            samples, ones(particle_count) / particle_count
-        )
+        return LinearDiracDistribution(samples, ones(particle_count) / particle_count)
 
     @staticmethod
     def _resolve_particle_count(n_particles=None, n_samples=None, n=None):

--- a/src/pyrecest/distributions/so3_conversion.py
+++ b/src/pyrecest/distributions/so3_conversion.py
@@ -58,9 +58,7 @@ def _so3_tangent_gaussian_from_dirac(
         tangent_mean, base=initial_mean
     )[0]
 
-    residuals = SO3TangentGaussianDistribution.log_map(
-        rotations, base=refined_mean
-    )
+    residuals = SO3TangentGaussianDistribution.log_map(rotations, base=refined_mean)
     residual_mean = sum(weights * residuals, axis=0)
     centered = residuals - residual_mean
     covariance = matmul(transpose(weights * centered), centered)

--- a/src/pyrecest/filters/abstract_particle_filter.py
+++ b/src/pyrecest/filters/abstract_particle_filter.py
@@ -29,12 +29,16 @@ class AbstractParticleFilter(AbstractFilter):
             )
 
         sample_next = transition_model.sample_next
-        function_is_vectorized = getattr(transition_model, "function_is_vectorized", True)
+        function_is_vectorized = getattr(
+            transition_model, "function_is_vectorized", True
+        )
 
         if function_is_vectorized:
             updated_particles = sample_next(self.filter_state.d)
         else:
-            updated_particles = [sample_next(particle) for particle in self.filter_state.d]
+            updated_particles = [
+                sample_next(particle) for particle in self.filter_state.d
+            ]
             if self.filter_state.dim == 1:
                 updated_particles = hstack(updated_particles)
             else:

--- a/src/pyrecest/filters/goal_conditioned_replay_particle_filter.py
+++ b/src/pyrecest/filters/goal_conditioned_replay_particle_filter.py
@@ -346,9 +346,7 @@ class GoalConditionedReplayParticleFilter(EuclideanParticleFilter):
 
     @property
     def last_position_proposal_fraction(self) -> float:
-        proposal_mask = self._last_transition_diagnostics.get(
-            "position_proposal_mask"
-        )
+        proposal_mask = self._last_transition_diagnostics.get("position_proposal_mask")
         if proposal_mask is None:
             return 0.0
         return float(sum(proposal_mask) / proposal_mask.shape[0])

--- a/src/pyrecest/filters/kalman_filter.py
+++ b/src/pyrecest/filters/kalman_filter.py
@@ -7,7 +7,6 @@ from ._linear_gaussian import linear_gaussian_predict, linear_gaussian_update
 from .abstract_filter import AbstractFilter
 from .manifold_mixins import EuclideanFilterMixin
 
-
 _MODEL_ATTRIBUTE_SENTINEL = object()
 
 

--- a/src/pyrecest/filters/state_space_subdivision_filter.py
+++ b/src/pyrecest/filters/state_space_subdivision_filter.py
@@ -2,9 +2,22 @@ import copy
 import warnings
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array, asarray, concatenate, einsum, exp, less_equal, linalg, log, stack, transpose
 from pyrecest.backend import any as backend_any
+from pyrecest.backend import (
+    array,
+    asarray,
+    concatenate,
+    einsum,
+    exp,
+    less_equal,
+    linalg,
+    log,
+    stack,
+)
 from pyrecest.backend import sum as backend_sum
+from pyrecest.backend import (
+    transpose,
+)
 
 from ..distributions.cart_prod.state_space_subdivision_gaussian_distribution import (
     StateSpaceSubdivisionGaussianDistribution,
@@ -294,12 +307,16 @@ class StateSpaceSubdivisionFilter(AbstractFilter, HypercylindricalFilterMixin):
                 pdf_values = []
                 for i in range(n_areas):
                     j = i if n_likelihoods > 1 else 0
-                    combined_cov = state.linear_distributions[i].C + likelihoods_linear[j].C
+                    combined_cov = (
+                        state.linear_distributions[i].C + likelihoods_linear[j].C
+                    )
                     temp_g = GaussianDistribution(
                         likelihoods_linear[j].mu, combined_cov, check_validity=False
                     )
                     pdf_values.append(
-                        asarray(temp_g.pdf(state.linear_distributions[i].mu)).reshape((1,))
+                        asarray(temp_g.pdf(state.linear_distributions[i].mu)).reshape(
+                            (1,)
+                        )
                     )
                 factors = concatenate(pdf_values)  # shape (n_areas,)
                 state.gd.grid_values = state.gd.grid_values * factors
@@ -322,7 +339,9 @@ class StateSpaceSubdivisionFilter(AbstractFilter, HypercylindricalFilterMixin):
 
         state.gd.normalize_in_place(warn_unnorm=False)
 
-    def _update_single_linear_likelihood(self, likelihood):  # pylint: disable=too-many-locals
+    def _update_single_linear_likelihood(
+        self, likelihood
+    ):  # pylint: disable=too-many-locals
         """Vectorized update for one linear Gaussian likelihood."""
 
         state = self._filter_state

--- a/src/pyrecest/models/__init__.py
+++ b/src/pyrecest/models/__init__.py
@@ -35,10 +35,12 @@ from .likelihood import (
     SupportsTransitionDensity,
     SupportsTransitionSampling,
 )
-from .linear_gaussian import IdentityGaussianMeasurementModel
-from .linear_gaussian import IdentityGaussianTransitionModel
-from .linear_gaussian import LinearGaussianMeasurementModel
-from .linear_gaussian import LinearGaussianTransitionModel
+from .linear_gaussian import (
+    IdentityGaussianMeasurementModel,
+    IdentityGaussianTransitionModel,
+    LinearGaussianMeasurementModel,
+    LinearGaussianTransitionModel,
+)
 from .validation import (
     infer_state_dim_from_distribution,
     validate_covariance_matrix,

--- a/src/pyrecest/models/adapters.py
+++ b/src/pyrecest/models/adapters.py
@@ -108,7 +108,9 @@ def as_density_transition_model(
 
     if isinstance(model_or_density, SupportsTransitionDensity):
         if _metadata_was_requested(name=name, extra=sample_next):
-            raise ValueError("sample_next and name are only used when wrapping a callable.")
+            raise ValueError(
+                "sample_next and name are only used when wrapping a callable."
+            )
         return model_or_density
 
     if callable(model_or_density):
@@ -135,7 +137,9 @@ def evaluate_log_likelihood(
 ) -> Any:
     """Evaluate ``log p(measurement | state)`` on a compatible model."""
 
-    _require_capability(model, SupportsLogLikelihood, "log_likelihood(measurement, state)")
+    _require_capability(
+        model, SupportsLogLikelihood, "log_likelihood(measurement, state)"
+    )
     return model.log_likelihood(measurement, state)
 
 
@@ -169,7 +173,9 @@ def predict_distribution_from_model(
 ) -> Any:
     """Propagate ``state_distribution`` with a distribution-aware model."""
 
-    _require_capability(model, SupportsPredictedDistribution, "predict_distribution(state_distribution)")
+    _require_capability(
+        model, SupportsPredictedDistribution, "predict_distribution(state_distribution)"
+    )
     return model.predict_distribution(state_distribution, *args, **kwargs)
 
 
@@ -190,7 +196,9 @@ def require_model_attribute(model: object, *names: str) -> Any:
     )
 
 
-def get_optional_model_attribute(model: object, *names: str, default: Any = None) -> Any:
+def get_optional_model_attribute(
+    model: object, *names: str, default: Any = None
+) -> Any:
     """Return the first available optional model attribute from ``names``."""
 
     for name in names:
@@ -206,7 +214,9 @@ def linear_transition_arguments(model: object) -> LinearTransitionArguments:
 
     return LinearTransitionArguments(
         system_matrix=require_model_attribute(model, "system_matrix"),
-        sys_noise_cov=require_model_attribute(model, "system_noise_cov", "sys_noise_cov"),
+        sys_noise_cov=require_model_attribute(
+            model, "system_noise_cov", "sys_noise_cov"
+        ),
         sys_input=get_optional_model_attribute(model, "sys_input", "system_input"),
     )
 
@@ -216,7 +226,9 @@ def linear_measurement_arguments(model: object) -> LinearMeasurementArguments:
 
     return LinearMeasurementArguments(
         measurement_matrix=require_model_attribute(model, "measurement_matrix"),
-        meas_noise=require_model_attribute(model, "meas_noise", "measurement_noise_cov"),
+        meas_noise=require_model_attribute(
+            model, "meas_noise", "measurement_noise_cov"
+        ),
     )
 
 

--- a/src/pyrecest/models/likelihood.py
+++ b/src/pyrecest/models/likelihood.py
@@ -66,7 +66,9 @@ def _accepts_sample_count(callback: Callable[..., Any]) -> bool:
     return any(parameter.name == "n" for parameter in parameters)
 
 
-def _evaluate_distribution_method(distribution: Any, method_name: str, *args: Any) -> Any:
+def _evaluate_distribution_method(
+    distribution: Any, method_name: str, *args: Any
+) -> Any:
     method = getattr(distribution, method_name, None)
     if method is None or not callable(method):
         raise AttributeError(
@@ -117,7 +119,9 @@ class LikelihoodMeasurementModel:
 
             def log_likelihood(measurement: Any, state: Any) -> Any:
                 distribution = distribution_factory(state)
-                return _evaluate_distribution_method(distribution, log_pdf_method, measurement)
+                return _evaluate_distribution_method(
+                    distribution, log_pdf_method, measurement
+                )
 
         return cls(likelihood, log_likelihood=log_likelihood, name=name)
 

--- a/src/pyrecest/models/linear_gaussian.py
+++ b/src/pyrecest/models/linear_gaussian.py
@@ -1,6 +1,15 @@
 """Reusable linear Gaussian transition and measurement models."""
 
-from pyrecest.backend import asarray, eye, matmul, matvec, ndim, reshape, transpose, zeros
+from pyrecest.backend import (
+    asarray,
+    eye,
+    matmul,
+    matvec,
+    ndim,
+    reshape,
+    transpose,
+    zeros,
+)
 from pyrecest.distributions import GaussianDistribution
 
 
@@ -91,7 +100,10 @@ class LinearGaussianTransitionModel:
         state_covariance = _as_square(state_covariance, "state_covariance")
         if _shape(state_covariance) != (self.state_dim, self.state_dim):
             raise ValueError("state_covariance has incompatible shape")
-        return matmul(matmul(self.matrix, state_covariance), transpose(self.matrix)) + self.noise_cov
+        return (
+            matmul(matmul(self.matrix, state_covariance), transpose(self.matrix))
+            + self.noise_cov
+        )
 
     def predict_distribution(self, state_distribution, check_validity=False):
         return GaussianDistribution(
@@ -101,7 +113,9 @@ class LinearGaussianTransitionModel:
         )
 
     def noise_distribution(self, check_validity=False):
-        return GaussianDistribution(zeros((self.predicted_dim,)), self.noise_cov, check_validity=check_validity)
+        return GaussianDistribution(
+            zeros((self.predicted_dim,)), self.noise_cov, check_validity=check_validity
+        )
 
 
 class IdentityGaussianTransitionModel(LinearGaussianTransitionModel):
@@ -141,7 +155,10 @@ class LinearGaussianMeasurementModel:
         state_covariance = _as_square(state_covariance, "state_covariance")
         if _shape(state_covariance) != (self.state_dim, self.state_dim):
             raise ValueError("state_covariance has incompatible shape")
-        return matmul(matmul(self.matrix, state_covariance), transpose(self.matrix)) + self.noise_cov
+        return (
+            matmul(matmul(self.matrix, state_covariance), transpose(self.matrix))
+            + self.noise_cov
+        )
 
     def predict_distribution(self, state_distribution, check_validity=False):
         return GaussianDistribution(
@@ -151,7 +168,11 @@ class LinearGaussianMeasurementModel:
         )
 
     def noise_distribution(self, check_validity=False):
-        return GaussianDistribution(zeros((self.measurement_dim,)), self.noise_cov, check_validity=check_validity)
+        return GaussianDistribution(
+            zeros((self.measurement_dim,)),
+            self.noise_cov,
+            check_validity=check_validity,
+        )
 
 
 class IdentityGaussianMeasurementModel(LinearGaussianMeasurementModel):

--- a/src/pyrecest/models/validation.py
+++ b/src/pyrecest/models/validation.py
@@ -33,7 +33,9 @@ def _format_shape(shape: tuple[int, ...]) -> str:
     return str(shape)
 
 
-def _validate_expected_dim(actual_dim: int, expected_dim: int | None, name: str, dim_name: str) -> None:
+def _validate_expected_dim(
+    actual_dim: int, expected_dim: int | None, name: str, dim_name: str
+) -> None:
     if expected_dim is None:
         return
     if not isinstance(expected_dim, Integral):
@@ -41,7 +43,9 @@ def _validate_expected_dim(actual_dim: int, expected_dim: int | None, name: str,
     if int(expected_dim) <= 0:
         raise ValueError(f"{dim_name} must be positive.")
     if actual_dim != int(expected_dim):
-        raise ValueError(f"{name} has dimension {actual_dim}, expected {int(expected_dim)}.")
+        raise ValueError(
+            f"{name} has dimension {actual_dim}, expected {int(expected_dim)}."
+        )
 
 
 def _to_python_bool(value: Any) -> bool:
@@ -53,7 +57,13 @@ def _to_python_bool(value: Any) -> bool:
     return bool(value)
 
 
-def validate_vector(vector: Any, *, name: str = "vector", dim: int | None = None, allow_scalar: bool = False):
+def validate_vector(
+    vector: Any,
+    *,
+    name: str = "vector",
+    dim: int | None = None,
+    allow_scalar: bool = False,
+):
     """Validate and return a one-dimensional backend array.
 
     Parameters
@@ -80,14 +90,22 @@ def validate_vector(vector: Any, *, name: str = "vector", dim: int | None = None
         vector_ndim = 1
 
     if vector_ndim != 1:
-        raise ValueError(f"{name} must be one-dimensional with shape (dim,), got shape {_format_shape(_shape_tuple(vector))}.")
+        raise ValueError(
+            f"{name} must be one-dimensional with shape (dim,), got shape {_format_shape(_shape_tuple(vector))}."
+        )
 
     actual_dim = _shape_tuple(vector)[0]
     _validate_expected_dim(actual_dim, dim, name, "dim")
     return vector
 
 
-def validate_state_vector(state: Any, *, name: str = "state", state_dim: int | None = None, allow_scalar: bool = False):
+def validate_state_vector(
+    state: Any,
+    *,
+    name: str = "state",
+    state_dim: int | None = None,
+    allow_scalar: bool = False,
+):
     """Validate a state vector with shape ``(state_dim,)``.
 
     Scalar state vectors are rejected by default.  Set ``allow_scalar=True`` for
@@ -96,12 +114,26 @@ def validate_state_vector(state: Any, *, name: str = "state", state_dim: int | N
     return validate_vector(state, name=name, dim=state_dim, allow_scalar=allow_scalar)
 
 
-def validate_measurement_vector(measurement: Any, *, name: str = "measurement", meas_dim: int | None = None, allow_scalar: bool = False):
+def validate_measurement_vector(
+    measurement: Any,
+    *,
+    name: str = "measurement",
+    meas_dim: int | None = None,
+    allow_scalar: bool = False,
+):
     """Validate a single-target measurement vector with shape ``(meas_dim,)``."""
-    return validate_vector(measurement, name=name, dim=meas_dim, allow_scalar=allow_scalar)
+    return validate_vector(
+        measurement, name=name, dim=meas_dim, allow_scalar=allow_scalar
+    )
 
 
-def validate_matrix(matrix: Any, *, name: str = "matrix", rows: int | None = None, cols: int | None = None):
+def validate_matrix(
+    matrix: Any,
+    *,
+    name: str = "matrix",
+    rows: int | None = None,
+    cols: int | None = None,
+):
     """Validate and return a two-dimensional backend array.
 
     Parameters
@@ -118,7 +150,9 @@ def validate_matrix(matrix: Any, *, name: str = "matrix", rows: int | None = Non
     matrix = _as_backend_array(matrix, name)
 
     if backend.ndim(matrix) != 2:
-        raise ValueError(f"{name} must be two-dimensional, got shape {_format_shape(_shape_tuple(matrix))}.")
+        raise ValueError(
+            f"{name} must be two-dimensional, got shape {_format_shape(_shape_tuple(matrix))}."
+        )
 
     actual_rows, actual_cols = _shape_tuple(matrix)
     _validate_expected_dim(actual_rows, rows, name, "rows")
@@ -151,11 +185,20 @@ def validate_covariance_matrix(
     covariance = validate_matrix(covariance, name=name)
     rows, cols = _shape_tuple(covariance)
     if rows != cols:
-        raise ValueError(f"{name} must be square, got shape {_format_shape((rows, cols))}.")
+        raise ValueError(
+            f"{name} must be square, got shape {_format_shape((rows, cols))}."
+        )
 
     _validate_expected_dim(rows, dim, name, "dim")
 
-    if check_symmetric and not _to_python_bool(backend.allclose(covariance, backend.transpose(covariance), rtol=symmetric_rtol, atol=symmetric_atol)):
+    if check_symmetric and not _to_python_bool(
+        backend.allclose(
+            covariance,
+            backend.transpose(covariance),
+            rtol=symmetric_rtol,
+            atol=symmetric_atol,
+        )
+    ):
         raise ValueError(f"{name} must be symmetric.")
 
     return covariance
@@ -192,13 +235,21 @@ def validate_noise_covariance(
     check_symmetric: bool = False,
 ):
     """Validate a process- or measurement-noise covariance with shape ``(dim, dim)``."""
-    return validate_covariance_matrix(noise_covariance, name=name, dim=dim, allow_scalar=allow_scalar, check_symmetric=check_symmetric)
+    return validate_covariance_matrix(
+        noise_covariance,
+        name=name,
+        dim=dim,
+        allow_scalar=allow_scalar,
+        check_symmetric=check_symmetric,
+    )
 
 
 def _maybe_call(value: Any, *, allow_methods: bool) -> Any:
     if callable(value):
         if not allow_methods:
-            raise ValueError("Callable distribution attributes are disabled for this inference attempt.")
+            raise ValueError(
+                "Callable distribution attributes are disabled for this inference attempt."
+            )
         return value()
     return value
 
@@ -209,7 +260,9 @@ def _positive_int_or_none(value: Any) -> int | None:
     return None
 
 
-def infer_state_dim_from_distribution(distribution: Any, *, allow_methods: bool = True) -> int:
+def infer_state_dim_from_distribution(
+    distribution: Any, *, allow_methods: bool = True
+) -> int:
     """Infer a state dimension from common PyRecEst distribution attributes.
 
     The helper first checks explicit dimension attributes such as ``dim`` and
@@ -221,7 +274,9 @@ def infer_state_dim_from_distribution(distribution: Any, *, allow_methods: bool 
     """
     for attr_name in ("dim", "input_dim"):
         if hasattr(distribution, attr_name):
-            attr_value = _maybe_call(getattr(distribution, attr_name), allow_methods=allow_methods)
+            attr_value = _maybe_call(
+                getattr(distribution, attr_name), allow_methods=allow_methods
+            )
             inferred_dim = _positive_int_or_none(attr_value)
             if inferred_dim is not None:
                 return inferred_dim
@@ -229,16 +284,26 @@ def infer_state_dim_from_distribution(distribution: Any, *, allow_methods: bool 
     for attr_name in ("mu", "m", "mean"):
         if hasattr(distribution, attr_name):
             try:
-                mean = _maybe_call(getattr(distribution, attr_name), allow_methods=allow_methods)
-                return _shape_tuple(validate_state_vector(mean, name=f"distribution.{attr_name}"))[0]
+                mean = _maybe_call(
+                    getattr(distribution, attr_name), allow_methods=allow_methods
+                )
+                return _shape_tuple(
+                    validate_state_vector(mean, name=f"distribution.{attr_name}")
+                )[0]
             except (TypeError, ValueError):
                 pass
 
     for attr_name in ("C", "covariance"):
         if hasattr(distribution, attr_name):
             try:
-                covariance = _maybe_call(getattr(distribution, attr_name), allow_methods=allow_methods)
-                return _shape_tuple(validate_covariance_matrix(covariance, name=f"distribution.{attr_name}"))[0]
+                covariance = _maybe_call(
+                    getattr(distribution, attr_name), allow_methods=allow_methods
+                )
+                return _shape_tuple(
+                    validate_covariance_matrix(
+                        covariance, name=f"distribution.{attr_name}"
+                    )
+                )[0]
             except (TypeError, ValueError):
                 pass
 
@@ -249,7 +314,9 @@ def infer_state_dim_from_distribution(distribution: Any, *, allow_methods: bool 
         except (TypeError, ValueError):
             pass
 
-    raise ValueError("Could not infer a positive state dimension from the distribution.")
+    raise ValueError(
+        "Could not infer a positive state dimension from the distribution."
+    )
 
 
 __all__ = [

--- a/src/pyrecest/protocols/testing.py
+++ b/src/pyrecest/protocols/testing.py
@@ -24,7 +24,9 @@ def _normalise_shape(shape: Iterable[int], value_name: str) -> tuple[int, ...]:
     try:
         return tuple(int(axis) for axis in shape)
     except TypeError as exc:
-        raise ProtocolAssertionError(f"{value_name} must be an iterable shape.") from exc
+        raise ProtocolAssertionError(
+            f"{value_name} must be an iterable shape."
+        ) from exc
 
 
 def _shape_of(value: object, value_name: str) -> tuple[int, ...]:
@@ -43,12 +45,16 @@ def _nonnegative_integer(value: object, value_name: str) -> int:
     return int_value
 
 
-def assert_protocol_instance(obj: object, protocol: type[Any], *, protocol_name: str | None = None) -> None:
+def assert_protocol_instance(
+    obj: object, protocol: type[Any], *, protocol_name: str | None = None
+) -> None:
     name = protocol_name or getattr(protocol, "__name__", repr(protocol))
     try:
         conforms = isinstance(obj, protocol)
     except TypeError as exc:
-        raise ProtocolAssertionError(f"{name} cannot be used for runtime checks.") from exc
+        raise ProtocolAssertionError(
+            f"{name} cannot be used for runtime checks."
+        ) from exc
     if not conforms:
         raise ProtocolAssertionError(f"{_type_name(obj)} does not satisfy {name}.")
 
@@ -56,14 +62,18 @@ def assert_protocol_instance(obj: object, protocol: type[Any], *, protocol_name:
 def assert_has_attribute(obj: object, attribute_name: str) -> Any:
     value = getattr(obj, attribute_name, _MISSING)
     if value is _MISSING:
-        raise ProtocolAssertionError(f"{_type_name(obj)} must provide {attribute_name!r}.")
+        raise ProtocolAssertionError(
+            f"{_type_name(obj)} must provide {attribute_name!r}."
+        )
     return value
 
 
 def assert_callable_attribute(obj: object, attribute_name: str) -> Callable[..., Any]:
     value = assert_has_attribute(obj, attribute_name)
     if not callable(value):
-        raise ProtocolAssertionError(f"{_type_name(obj)}.{attribute_name} must be callable.")
+        raise ProtocolAssertionError(
+            f"{_type_name(obj)}.{attribute_name} must be callable."
+        )
     return cast(Callable[..., Any], value)
 
 
@@ -73,32 +83,48 @@ def assert_value_is_not_none(value: T | None, *, value_name: str = "value") -> T
     return value
 
 
-def assert_method_returns_non_none(obj: object, method_name: str, *args: Any, **kwargs: Any) -> Any:
+def assert_method_returns_non_none(
+    obj: object, method_name: str, *args: Any, **kwargs: Any
+) -> Any:
     method = assert_callable_attribute(obj, method_name)
-    return assert_value_is_not_none(method(*args, **kwargs), value_name=f"{method_name} result")
+    return assert_value_is_not_none(
+        method(*args, **kwargs), value_name=f"{method_name} result"
+    )
 
 
-def assert_shape(value: object, expected_shape: Iterable[int], *, value_name: str = "value") -> tuple[int, ...]:
+def assert_shape(
+    value: object, expected_shape: Iterable[int], *, value_name: str = "value"
+) -> tuple[int, ...]:
     actual = _shape_of(value, value_name)
     expected = _normalise_shape(expected_shape, "expected_shape")
     if actual != expected:
-        raise ProtocolAssertionError(f"{value_name} must have shape {expected}, got {actual}.")
+        raise ProtocolAssertionError(
+            f"{value_name} must have shape {expected}, got {actual}."
+        )
     return actual
 
 
-def assert_shape_prefix(value: object, expected_prefix: Iterable[int], *, value_name: str = "value") -> tuple[int, ...]:
+def assert_shape_prefix(
+    value: object, expected_prefix: Iterable[int], *, value_name: str = "value"
+) -> tuple[int, ...]:
     actual = _shape_of(value, value_name)
     expected = _normalise_shape(expected_prefix, "expected_prefix")
     if actual[: len(expected)] != expected:
-        raise ProtocolAssertionError(f"{value_name} shape must start with {expected}, got {actual}.")
+        raise ProtocolAssertionError(
+            f"{value_name} shape must start with {expected}, got {actual}."
+        )
     return actual
 
 
-def assert_trailing_dimension(value: object, expected_dim: int, *, value_name: str = "value") -> tuple[int, ...]:
+def assert_trailing_dimension(
+    value: object, expected_dim: int, *, value_name: str = "value"
+) -> tuple[int, ...]:
     actual = _shape_of(value, value_name)
     dim = _nonnegative_integer(expected_dim, "expected_dim")
     if not actual or actual[-1] != dim:
-        raise ProtocolAssertionError(f"{value_name} trailing dimension must be {dim}, got {actual}.")
+        raise ProtocolAssertionError(
+            f"{value_name} trailing dimension must be {dim}, got {actual}."
+        )
     return actual
 
 
@@ -152,8 +178,14 @@ def assert_supports_transition_sampling(model: object, state: Any, n: int = 1) -
     return assert_method_returns_non_none(model, "sample_next", state, n)
 
 
-def assert_supports_transition_density(model: object, state_next: Any, state_previous: Any) -> Any:
-    return assert_method_returns_non_none(model, "transition_density", state_next, state_previous)
+def assert_supports_transition_density(
+    model: object, state_next: Any, state_previous: Any
+) -> Any:
+    return assert_method_returns_non_none(
+        model, "transition_density", state_next, state_previous
+    )
 
 
-__all__ = [name for name in globals() if name.startswith("assert_")] + ["ProtocolAssertionError"]
+__all__ = [name for name in globals() if name.startswith("assert_")] + [
+    "ProtocolAssertionError"
+]

--- a/tests/distributions/test_conversion_backend_compatibility.py
+++ b/tests/distributions/test_conversion_backend_compatibility.py
@@ -2,10 +2,23 @@ import unittest
 
 # pylint: disable=no-name-in-module,no-member,redefined-builtin
 from pyrecest import backend
-from pyrecest.backend import allclose, array, diag, is_array, random, sum as backend_sum, to_numpy
+from pyrecest.backend import (
+    allclose,
+    array,
+    diag,
+    is_array,
+    random,
+)
+from pyrecest.backend import sum as backend_sum
+from pyrecest.backend import (
+    to_numpy,
+)
 from pyrecest.distributions import GaussianDistribution, LinearDiracDistribution
-from pyrecest.distributions.conversion import ConversionError, can_convert, convert_distribution
-
+from pyrecest.distributions.conversion import (
+    ConversionError,
+    can_convert,
+    convert_distribution,
+)
 
 SUPPORTED_BACKENDS = ("numpy", "pytorch", "jax")
 
@@ -82,7 +95,9 @@ class ConversionBackendCompatibilityTest(unittest.TestCase):
         self.assertTrue(is_array(gaussian.mean()), self.backend_name)
         self.assertTrue(is_array(gaussian.covariance()), self.backend_name)
         self.assertTrue(_as_bool(allclose(gaussian.mean(), particles.mean())))
-        self.assertTrue(_as_bool(allclose(gaussian.covariance(), particles.covariance())))
+        self.assertTrue(
+            _as_bool(allclose(gaussian.covariance(), particles.covariance()))
+        )
 
     def test_class_and_alias_targets_are_consistent_on_active_backend(self):
         random.seed(7)

--- a/tests/distributions/test_conversion_exports.py
+++ b/tests/distributions/test_conversion_exports.py
@@ -2,7 +2,6 @@ import unittest
 
 from pyrecest import distributions
 
-
 CONVERSION_EXPORTS = (
     "ConversionError",
     "ConversionResult",

--- a/tests/filters/test_goal_conditioned_replay_particle_imm_filter.py
+++ b/tests/filters/test_goal_conditioned_replay_particle_imm_filter.py
@@ -11,7 +11,9 @@ from pyrecest.backend import (
     isnan,
     ones,
     random,
-    sum as backend_sum,
+)
+from pyrecest.backend import sum as backend_sum
+from pyrecest.backend import (
     zeros,
 )
 from pyrecest.distributions import GaussianDistribution

--- a/tests/filters/test_grid_filter_model_adapters.py
+++ b/tests/filters/test_grid_filter_model_adapters.py
@@ -66,8 +66,10 @@ class TestGridFilterModelAdapters(unittest.TestCase):
     def test_predict_model_matches_transition_density_prediction(self):
         reference_filter = self._initialized_filter()
         model_filter = self._initialized_filter()
-        transition_density = HyperhemisphericalGridFilter.sys_noise_to_transition_density(
-            self.system_noise, self.n_grid
+        transition_density = (
+            HyperhemisphericalGridFilter.sys_noise_to_transition_density(
+                self.system_noise, self.n_grid
+            )
         )
 
         reference_filter.predict_nonlinear_via_transition_density(transition_density)
@@ -90,8 +92,10 @@ class TestGridFilterModelAdapters(unittest.TestCase):
         reference_filter = self._initialized_filter()
         model_filter = self._initialized_filter()
 
-        transition_density = HyperhemisphericalGridFilter.sys_noise_to_transition_density(
-            self.system_noise, self.n_grid
+        transition_density = (
+            HyperhemisphericalGridFilter.sys_noise_to_transition_density(
+                self.system_noise, self.n_grid
+            )
         )
         reference_filter.predict_nonlinear_via_transition_density(transition_density)
 

--- a/tests/filters/test_kalman_filter.py
+++ b/tests/filters/test_kalman_filter.py
@@ -79,9 +79,13 @@ class KalmanFilterTest(unittest.TestCase):
         filter_model.update_model(measurement_model, measurement)
 
         self.assertTrue(
-            allclose(filter_linear.get_point_estimate(), filter_model.get_point_estimate())
+            allclose(
+                filter_linear.get_point_estimate(), filter_model.get_point_estimate()
+            )
         )
-        self.assertTrue(allclose(filter_linear.filter_state.C, filter_model.filter_state.C))
+        self.assertTrue(
+            allclose(filter_linear.filter_state.C, filter_model.filter_state.C)
+        )
 
     def test_predict_identity_1d(self):
         kf = KalmanFilter((array([0]), array([[1]])))
@@ -116,9 +120,13 @@ class KalmanFilterTest(unittest.TestCase):
         filter_model.predict_model(transition_model)
 
         self.assertTrue(
-            allclose(filter_linear.get_point_estimate(), filter_model.get_point_estimate())
+            allclose(
+                filter_linear.get_point_estimate(), filter_model.get_point_estimate()
+            )
         )
-        self.assertTrue(allclose(filter_linear.filter_state.C, filter_model.filter_state.C))
+        self.assertTrue(
+            allclose(filter_linear.filter_state.C, filter_model.filter_state.C)
+        )
 
     def test_predict_model_accepts_existing_noise_and_input_aliases(self):
         initial_state = (array([0.0, 1.0]), diag(array([1.0, 2.0])))
@@ -138,9 +146,13 @@ class KalmanFilterTest(unittest.TestCase):
         filter_model.predict_model(transition_model)
 
         self.assertTrue(
-            allclose(filter_linear.get_point_estimate(), filter_model.get_point_estimate())
+            allclose(
+                filter_linear.get_point_estimate(), filter_model.get_point_estimate()
+            )
         )
-        self.assertTrue(allclose(filter_linear.filter_state.C, filter_model.filter_state.C))
+        self.assertTrue(
+            allclose(filter_linear.filter_state.C, filter_model.filter_state.C)
+        )
 
 
 if __name__ == "__main__":

--- a/tests/filters/test_unscented_kalman_filter.py
+++ b/tests/filters/test_unscented_kalman_filter.py
@@ -99,9 +99,7 @@ class UnscentedKalmanFilterTest(unittest.TestCase):
         direct.predict_nonlinear(fx, sys_noise_cov, dt=0.25, bias=0.1)
         transition_model = AdditiveNoiseTransitionModel(
             transition_function=fx,
-            noise_distribution=GaussianDistribution(
-                array([0.0, 0.0]), sys_noise_cov
-            ),
+            noise_distribution=GaussianDistribution(array([0.0, 0.0]), sys_noise_cov),
             dt=0.25,
             function_args={"bias": 0.1},
         )
@@ -135,9 +133,7 @@ class UnscentedKalmanFilterTest(unittest.TestCase):
         direct.update_nonlinear(measurement, hx, meas_noise_cov, offset=0.1)
         measurement_model = AdditiveNoiseMeasurementModel(
             measurement_function=hx,
-            noise_distribution=GaussianDistribution(
-                array([0.0, 0.0]), meas_noise_cov
-            ),
+            noise_distribution=GaussianDistribution(array([0.0, 0.0]), meas_noise_cov),
             function_args={"offset": 0.1},
         )
         via_model.update_model(measurement_model, measurement)

--- a/tests/models/test_additive_noise_models.py
+++ b/tests/models/test_additive_noise_models.py
@@ -51,7 +51,9 @@ class AdditiveNoiseTransitionModelTest(unittest.TestCase):
 
         state = array([2.0, 3.0])
 
-        assert_backend_allclose(self, model.transition_function(state), array([3.0, 6.0]))
+        assert_backend_allclose(
+            self, model.transition_function(state), array([3.0, 6.0])
+        )
         assert_backend_allclose(self, model.mean(state), array([3.1, 5.8]))
         assert_backend_allclose(self, model.noise_covariance, diag(array([1.0, 2.0])))
         assert_backend_allclose(self, model.jacobian(state), diag(array([1.0, 2.0])))
@@ -68,7 +70,9 @@ class AdditiveNoiseTransitionModelTest(unittest.TestCase):
             covariance=array([[1.0]]),
             pdf_value=array(7.0),
         )
-        model = AdditiveNoiseTransitionModel(lambda x: array([x[0] + 1.0]), noise_distribution=noise)
+        model = AdditiveNoiseTransitionModel(
+            lambda x: array([x[0] + 1.0]), noise_distribution=noise
+        )
 
         likelihood = model.transition_density(array([4.5]), array([2.0]))
 
@@ -116,7 +120,9 @@ class AdditiveNoiseMeasurementModelTest(unittest.TestCase):
         assert_backend_allclose(self, model.mean(state), array([4.5]))
         assert_backend_allclose(self, model.noise_covariance, array([[2.0]]))
         assert_backend_allclose(self, model.jacobian(state), array([[4.0]]))
-        assert_backend_allclose(self, model.sample_measurement(state, n=2), array([[4.5], [3.5]]))
+        assert_backend_allclose(
+            self, model.sample_measurement(state, n=2), array([[4.5], [3.5]])
+        )
         self.assertTrue(model.has_jacobian())
 
     def test_likelihood_uses_measurement_residual(self):
@@ -125,12 +131,16 @@ class AdditiveNoiseMeasurementModelTest(unittest.TestCase):
             covariance=array([[1.0]]),
             pdf_value=array(11.0),
         )
-        model = AdditiveNoiseMeasurementModel(lambda x: array([x[0] * x[0]]), noise_distribution=noise)
+        model = AdditiveNoiseMeasurementModel(
+            lambda x: array([x[0] * x[0]]), noise_distribution=noise
+        )
 
         likelihood = model.likelihood(array([5.0]), array([2.0]))
 
         assert_backend_allclose(self, likelihood, array(11.0))
-        assert_backend_allclose(self, model.measurement_residual(array([5.0]), array([2.0])), array([1.0]))
+        assert_backend_allclose(
+            self, model.measurement_residual(array([5.0]), array([2.0])), array([1.0])
+        )
         assert_backend_allclose(self, noise.last_pdf_arg, array([1.0]))
 
     def test_missing_measurement_capabilities_raise(self):

--- a/tests/models/test_likelihood_sampleable_models.py
+++ b/tests/models/test_likelihood_sampleable_models.py
@@ -2,7 +2,6 @@ import unittest
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import allclose, arange, array, exp, reshape
-
 from pyrecest.models import (
     DensityTransitionModel,
     LikelihoodMeasurementModel,
@@ -49,10 +48,14 @@ class LikelihoodMeasurementModelTest(unittest.TestCase):
 
         self.assertIsInstance(model, SupportsLogLikelihood)
         self.assertTrue(model.has_log_likelihood)
-        self.assertTrue(allclose(model.log_likelihood(array([3.0]), array([1.0])), array([2.0])))
+        self.assertTrue(
+            allclose(model.log_likelihood(array([3.0]), array([1.0])), array([2.0]))
+        )
 
     def test_missing_log_likelihood_raises(self):
-        model = LikelihoodMeasurementModel(lambda measurement, state: measurement + state)
+        model = LikelihoodMeasurementModel(
+            lambda measurement, state: measurement + state
+        )
 
         self.assertFalse(model.has_log_likelihood)
         with self.assertRaises(NotImplementedError):
@@ -64,8 +67,12 @@ class LikelihoodMeasurementModelTest(unittest.TestCase):
             log_pdf_method="log_pdf",
         )
 
-        self.assertTrue(allclose(model.likelihood(array([2.0]), array([3.0])), array([5.0])))
-        self.assertTrue(allclose(model.log_likelihood(array([2.0]), array([3.0])), array([-1.0])))
+        self.assertTrue(
+            allclose(model.likelihood(array([2.0]), array([3.0])), array([5.0]))
+        )
+        self.assertTrue(
+            allclose(model.log_likelihood(array([2.0]), array([3.0])), array([-1.0]))
+        )
 
     def test_non_callable_likelihood_rejected(self):
         with self.assertRaises(TypeError):
@@ -82,7 +89,11 @@ class SampleableTransitionModelTest(unittest.TestCase):
         self.assertIsInstance(model, SupportsTransitionSampling)
         self.assertEqual(model.name, "unit-test-transition")
         self.assertFalse(model.has_transition_density)
-        self.assertTrue(allclose(model.sample_next(array([10.0]), n=3), array([[10.0], [11.0], [12.0]])))
+        self.assertTrue(
+            allclose(
+                model.sample_next(array([10.0]), n=3), array([[10.0], [11.0], [12.0]])
+            )
+        )
 
     def test_unary_sample_next_callback(self):
         def shift_state(state):
@@ -95,11 +106,15 @@ class SampleableTransitionModelTest(unittest.TestCase):
     def test_optional_transition_density(self):
         model = SampleableTransitionModel(
             lambda state, n=1: state + reshape(arange(n), (n, 1)),
-            transition_density=lambda state_next, state_previous: exp(-0.5 * (state_next - state_previous) ** 2),
+            transition_density=lambda state_next, state_previous: exp(
+                -0.5 * (state_next - state_previous) ** 2
+            ),
         )
 
         self.assertTrue(model.has_transition_density)
-        self.assertTrue(allclose(model.transition_density(array([1.0]), array([1.0])), array([1.0])))
+        self.assertTrue(
+            allclose(model.transition_density(array([1.0]), array([1.0])), array([1.0]))
+        )
 
     def test_missing_transition_density_raises(self):
         model = SampleableTransitionModel(lambda state, n=1: state)
@@ -122,27 +137,37 @@ class SampleableTransitionModelTest(unittest.TestCase):
 class DensityTransitionModelTest(unittest.TestCase):
     def test_transition_density_callback(self):
         model = DensityTransitionModel(
-            lambda state_next, state_previous: exp(-0.5 * (state_next - state_previous) ** 2)
+            lambda state_next, state_previous: exp(
+                -0.5 * (state_next - state_previous) ** 2
+            )
         )
 
         self.assertIsInstance(model, SupportsTransitionDensity)
         self.assertFalse(model.has_sampler)
-        self.assertTrue(allclose(model.transition_density(array([2.0]), array([2.0])), array([1.0])))
+        self.assertTrue(
+            allclose(model.transition_density(array([2.0]), array([2.0])), array([1.0]))
+        )
 
     def test_optional_sampler(self):
         def sample_next(state, n=1):
             return state + reshape(arange(n), (n, 1))
 
         model = DensityTransitionModel(
-            lambda state_next, state_previous: exp(-0.5 * (state_next - state_previous) ** 2),
+            lambda state_next, state_previous: exp(
+                -0.5 * (state_next - state_previous) ** 2
+            ),
             sample_next=sample_next,
         )
 
         self.assertTrue(model.has_sampler)
-        self.assertTrue(allclose(model.sample_next(array([4.0]), n=2), array([[4.0], [5.0]])))
+        self.assertTrue(
+            allclose(model.sample_next(array([4.0]), n=2), array([[4.0], [5.0]]))
+        )
 
     def test_missing_sampler_raises(self):
-        model = DensityTransitionModel(lambda state_next, state_previous: state_next + state_previous)
+        model = DensityTransitionModel(
+            lambda state_next, state_previous: state_next + state_previous
+        )
 
         with self.assertRaises(NotImplementedError):
             model.sample_next(array([1.0]))

--- a/tests/models/test_linear_gaussian_models.py
+++ b/tests/models/test_linear_gaussian_models.py
@@ -3,10 +3,12 @@ import unittest
 import numpy.testing as npt
 from pyrecest.backend import array, diag, eye, to_numpy
 from pyrecest.distributions import GaussianDistribution
-from pyrecest.models import IdentityGaussianMeasurementModel
-from pyrecest.models import IdentityGaussianTransitionModel
-from pyrecest.models import LinearGaussianMeasurementModel
-from pyrecest.models import LinearGaussianTransitionModel
+from pyrecest.models import (
+    IdentityGaussianMeasurementModel,
+    IdentityGaussianTransitionModel,
+    LinearGaussianMeasurementModel,
+    LinearGaussianTransitionModel,
+)
 
 
 class LinearGaussianModelsTest(unittest.TestCase):
@@ -19,8 +21,12 @@ class LinearGaussianModelsTest(unittest.TestCase):
         state = GaussianDistribution(array([2.0, 0.5]), diag(array([1.0, 2.0])))
         predicted = model.predict_distribution(state)
 
-        npt.assert_allclose(to_numpy(predicted.mu), to_numpy(array([3.0, 0.25])), atol=1e-12)
-        npt.assert_allclose(to_numpy(predicted.C), to_numpy(array([[3.1, 2.0], [2.0, 2.2]])), atol=1e-12)
+        npt.assert_allclose(
+            to_numpy(predicted.mu), to_numpy(array([3.0, 0.25])), atol=1e-12
+        )
+        npt.assert_allclose(
+            to_numpy(predicted.C), to_numpy(array([[3.1, 2.0], [2.0, 2.2]])), atol=1e-12
+        )
 
     def test_transition_noise_distribution_and_alias(self):
         noise_cov = diag(array([0.1, 0.2]))
@@ -38,7 +44,9 @@ class LinearGaussianModelsTest(unittest.TestCase):
         predicted = model.predict_distribution(state)
 
         npt.assert_allclose(to_numpy(predicted.mu), to_numpy(array([2.0])), atol=1e-12)
-        npt.assert_allclose(to_numpy(predicted.C), to_numpy(array([[1.25]])), atol=1e-12)
+        npt.assert_allclose(
+            to_numpy(predicted.C), to_numpy(array([[1.25]])), atol=1e-12
+        )
 
     def test_measurement_noise_distribution_and_alias(self):
         noise_cov = array([[0.25]])
@@ -54,8 +62,12 @@ class LinearGaussianModelsTest(unittest.TestCase):
         transition_model = IdentityGaussianTransitionModel(2, diag(array([0.1, 0.2])))
         measurement_model = IdentityGaussianMeasurementModel(2, diag(array([0.3, 0.4])))
 
-        npt.assert_allclose(to_numpy(transition_model.system_matrix), to_numpy(eye(2)), atol=1e-12)
-        npt.assert_allclose(to_numpy(measurement_model.measurement_matrix), to_numpy(eye(2)), atol=1e-12)
+        npt.assert_allclose(
+            to_numpy(transition_model.system_matrix), to_numpy(eye(2)), atol=1e-12
+        )
+        npt.assert_allclose(
+            to_numpy(measurement_model.measurement_matrix), to_numpy(eye(2)), atol=1e-12
+        )
 
     def test_rejects_incompatible_shapes(self):
         with self.assertRaises(ValueError):
@@ -63,11 +75,15 @@ class LinearGaussianModelsTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             LinearGaussianMeasurementModel(array([[1.0, 0.0]]), diag(array([0.1, 0.2])))
 
-        transition_model = LinearGaussianTransitionModel(eye(2), diag(array([0.1, 0.2])))
+        transition_model = LinearGaussianTransitionModel(
+            eye(2), diag(array([0.1, 0.2]))
+        )
         with self.assertRaises(ValueError):
             transition_model.predict_mean(array([1.0, 2.0, 3.0]))
 
-        measurement_model = LinearGaussianMeasurementModel(array([[1.0, 0.0]]), array([[0.25]]))
+        measurement_model = LinearGaussianMeasurementModel(
+            array([[1.0, 0.0]]), array([[0.25]])
+        )
         with self.assertRaises(ValueError):
             measurement_model.predict_mean(array([1.0, 2.0, 3.0]))
 

--- a/tests/models/test_model_adapters.py
+++ b/tests/models/test_model_adapters.py
@@ -89,10 +89,10 @@ class ModelAdapterTest(unittest.TestCase):
 
     def test_evaluate_log_likelihood(self):
         def likelihood(measurement, state):
-            return exp(-(measurement - state) ** 2)
+            return exp(-((measurement - state) ** 2))
 
         def log_likelihood(measurement, state):
-            return -(measurement - state) ** 2
+            return -((measurement - state) ** 2)
 
         model = as_likelihood_model(
             likelihood,

--- a/tests/models/test_validation.py
+++ b/tests/models/test_validation.py
@@ -51,15 +51,21 @@ class TestModelValidation(unittest.TestCase):
 
     def test_validate_covariance_matrix_can_check_symmetry(self):
         with self.assertRaisesRegex(ValueError, "symmetric"):
-            validate_covariance_matrix(array([[1.0, 2.0], [0.0, 1.0]]), check_symmetric=True)
+            validate_covariance_matrix(
+                array([[1.0, 2.0], [0.0, 1.0]]), check_symmetric=True
+            )
 
     def test_validate_noise_covariance_uses_covariance_rules(self):
-        noise_covariance = validate_noise_covariance(array(0.5), dim=1, allow_scalar=True)
+        noise_covariance = validate_noise_covariance(
+            array(0.5), dim=1, allow_scalar=True
+        )
 
         self.assertEqual(noise_covariance.shape, (1, 1))
 
     def test_validate_transition_matrix_accepts_pred_by_state_shape(self):
-        system_matrix = validate_transition_matrix(zeros((3, 2)), state_dim=2, pred_dim=3)
+        system_matrix = validate_transition_matrix(
+            zeros((3, 2)), state_dim=2, pred_dim=3
+        )
 
         self.assertEqual(system_matrix.shape, (3, 2))
 
@@ -68,7 +74,9 @@ class TestModelValidation(unittest.TestCase):
             validate_transition_matrix(zeros((2, 2)), state_dim=3)
 
     def test_validate_measurement_matrix_accepts_meas_by_state_shape(self):
-        measurement_matrix = validate_measurement_matrix(zeros((1, 2)), state_dim=2, meas_dim=1)
+        measurement_matrix = validate_measurement_matrix(
+            zeros((1, 2)), state_dim=2, meas_dim=1
+        )
 
         self.assertEqual(measurement_matrix.shape, (1, 2))
 
@@ -93,7 +101,9 @@ class TestModelValidation(unittest.TestCase):
             def covariance(self):
                 return eye(5)
 
-        self.assertEqual(infer_state_dim_from_distribution(DistributionWithCovariance()), 5)
+        self.assertEqual(
+            infer_state_dim_from_distribution(DistributionWithCovariance()), 5
+        )
 
     def test_infer_state_dim_from_dirac_locations(self):
         class DistributionWithDiracs:

--- a/tests/protocols/test_existing_distribution_capabilities.py
+++ b/tests/protocols/test_existing_distribution_capabilities.py
@@ -162,9 +162,7 @@ def _observed_capabilities(row: DistributionCapabilityRow) -> frozenset[str]:
         "from_distribution": lambda: _class_callable(distribution, "from_distribution"),
     }
 
-    return frozenset(
-        capability for capability, check in checks.items() if check()
-    )
+    return frozenset(capability for capability, check in checks.items() if check())
 
 
 @pytest.mark.parametrize("row", DISTRIBUTION_ROWS, ids=lambda row: row.name)

--- a/tests/protocols/test_existing_filter_capabilities.py
+++ b/tests/protocols/test_existing_filter_capabilities.py
@@ -47,7 +47,9 @@ FILTER_CAPABILITIES = (
     ClassCapability("update_nonlinear", "update_nonlinear"),
     ClassCapability("predict_model", "predict_model"),
     ClassCapability("update_model", "update_model"),
-    ClassCapability("update_nonlinear_using_likelihood", "update_nonlinear_using_likelihood"),
+    ClassCapability(
+        "update_nonlinear_using_likelihood", "update_nonlinear_using_likelihood"
+    ),
     ClassCapability("record_filter_state", "record_filter_state"),
     ClassCapability("record_point_estimate", "record_point_estimate"),
 )

--- a/tests/protocols/test_protocol_import_compatibility.py
+++ b/tests/protocols/test_protocol_import_compatibility.py
@@ -2,16 +2,22 @@
 
 from __future__ import annotations
 
+from pyrecest.models import SupportsLikelihood as ModelSupportsLikelihood
+from pyrecest.models import SupportsLogLikelihood as ModelSupportsLogLikelihood
+from pyrecest.models import SupportsTransitionDensity as ModelSupportsTransitionDensity
 from pyrecest.models import (
-    SupportsLikelihood as ModelSupportsLikelihood,
-    SupportsLogLikelihood as ModelSupportsLogLikelihood,
-    SupportsTransitionDensity as ModelSupportsTransitionDensity,
     SupportsTransitionSampling as ModelSupportsTransitionSampling,
 )
 from pyrecest.models.likelihood import (
     SupportsLikelihood as LikelihoodSupportsLikelihood,
+)
+from pyrecest.models.likelihood import (
     SupportsLogLikelihood as LikelihoodSupportsLogLikelihood,
+)
+from pyrecest.models.likelihood import (
     SupportsTransitionDensity as LikelihoodSupportsTransitionDensity,
+)
+from pyrecest.models.likelihood import (
     SupportsTransitionSampling as LikelihoodSupportsTransitionSampling,
 )
 from pyrecest.protocols import SupportsDim as PackageSupportsDim

--- a/tests/protocols/test_protocol_testing_helpers.py
+++ b/tests/protocols/test_protocol_testing_helpers.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-
 from pyrecest.protocols.common import SupportsDim
 from pyrecest.protocols.testing import (
     ProtocolAssertionError,
@@ -188,7 +187,19 @@ def test_model_helpers_return_method_results():
     likelihood_model = DemoLikelihoodModel()
     transition_model = DemoTransitionModel()
 
-    assert assert_supports_likelihood(likelihood_model, measurement, state) == (measurement, state)
-    assert assert_supports_log_likelihood(likelihood_model, measurement, state) == (measurement, state, "log")
-    assert_shape(assert_supports_transition_sampling(transition_model, state, 3), (3, 2))
-    assert assert_supports_transition_density(transition_model, next_state, state) == (next_state, state)
+    assert assert_supports_likelihood(likelihood_model, measurement, state) == (
+        measurement,
+        state,
+    )
+    assert assert_supports_log_likelihood(likelihood_model, measurement, state) == (
+        measurement,
+        state,
+        "log",
+    )
+    assert_shape(
+        assert_supports_transition_sampling(transition_model, state, 3), (3, 2)
+    )
+    assert assert_supports_transition_density(transition_model, next_state, state) == (
+        next_state,
+        state,
+    )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -32,11 +32,15 @@ class ModelObjectTest(unittest.TestCase):
             return array([x[0] + offset, x[1] - offset])
 
         model = AdditiveNoiseMeasurementModel(
-            measurement_function=hx, noise_distribution=noise_cov, function_args={"offset": 0.25}
+            measurement_function=hx,
+            noise_distribution=noise_cov,
+            function_args={"offset": 0.25},
         )
 
         self.assertTrue(allclose(model.noise_covariance, noise_cov))
-        self.assertTrue(allclose(model.evaluate(array([1.0, 2.0])), array([1.25, 1.75])))
+        self.assertTrue(
+            allclose(model.evaluate(array([1.0, 2.0])), array([1.25, 1.75]))
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Applies the `updated_sources` contents from the MegaLinter report artifact generated by Actions run 25292476492 / job 74205183462.

The artifact reformatted Python, docs, examples, and tests using the configured MegaLinter fixers, including Black, isort, Ruff, and markdown table formatting.

## Validation

- `git diff --check`
- `python -m compileall -q src tests examples/basic`
- `PYTHONPATH=src python -m pytest tests/distributions/test_conversion_backend_compatibility.py tests/distributions/test_conversion_exports.py tests/filters/test_goal_conditioned_replay_particle_imm_filter.py tests/filters/test_grid_filter_model_adapters.py tests/filters/test_kalman_filter.py tests/filters/test_unscented_kalman_filter.py tests/models/test_additive_noise_models.py tests/models/test_likelihood_sampleable_models.py tests/models/test_linear_gaussian_models.py tests/models/test_model_adapters.py tests/models/test_validation.py tests/protocols/test_existing_distribution_capabilities.py tests/protocols/test_existing_filter_capabilities.py tests/protocols/test_protocol_import_compatibility.py tests/protocols/test_protocol_testing_helpers.py tests/test_models.py -q`