### PR TITLE
Allow manual requirements workflow runs

### DIFF
--- a/.github/workflows/update-requirements.yml
+++ b/.github/workflows/update-requirements.yml
@@ -19,12 +19,6 @@ on: # yamllint disable-line rule:truthy
       - "pyproject.toml"
       - "poetry.lock"
   workflow_dispatch:
-    inputs:
-      create_pull_request:
-        description: "Create or update the update-requirements PR when changes are found"
-        required: false
-        default: true
-        type: boolean
 
 env: # Comment env block if you do not want to apply fixes
   # Apply linter fixes configuration
@@ -106,7 +100,6 @@ jobs:
           (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name || github.event_name == 'workflow_dispatch') &&
           env.APPLY_FIXES_MODE == 'pull_request' &&
           (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) &&
-          (github.event_name != 'workflow_dispatch' || inputs.create_pull_request) &&
           (github.event_name != 'push' || !contains(github.event.head_commit.message, 'skip fix'))
         uses: peter-evans/create-pull-request@v8
         with:
@@ -125,7 +118,6 @@ jobs:
           (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name || github.event_name == 'workflow_dispatch') &&
           env.APPLY_FIXES_MODE == 'pull_request' &&
           (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) &&
-          (github.event_name != 'workflow_dispatch' || inputs.create_pull_request) &&
           (github.event_name != 'push' || !contains(github.event.head_commit.message, 'skip fix'))
         run: |
           echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"

--- a/.github/workflows/update-requirements.yml
+++ b/.github/workflows/update-requirements.yml
@@ -18,6 +18,13 @@ on: # yamllint disable-line rule:truthy
     paths:
       - "pyproject.toml"
       - "poetry.lock"
+  workflow_dispatch:
+    inputs:
+      create_pull_request:
+        description: "Create or update the update-requirements PR when changes are found"
+        required: false
+        default: true
+        type: boolean
 
 env: # Comment env block if you do not want to apply fixes
   # Apply linter fixes configuration
@@ -44,7 +51,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.head_ref || github.ref_name }}
           fetch-depth: 0
 
       - name: Set up Python
@@ -93,10 +100,17 @@ jobs:
       # Create Pull Request step
       - name: Create Pull Request with applied fixes
         id: cpr
-        if: github.ref == 'refs/heads/main' && env.changes_made == 'true' && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'pull_request' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.head_commit.message, 'skip fix')
+        if: >-
+          github.ref == 'refs/heads/main' &&
+          env.changes_made == 'true' &&
+          (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name || github.event_name == 'workflow_dispatch') &&
+          env.APPLY_FIXES_MODE == 'pull_request' &&
+          (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) &&
+          (github.event_name != 'workflow_dispatch' || inputs.create_pull_request) &&
+          (github.event_name != 'push' || !contains(github.event.head_commit.message, 'skip fix'))
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT }}
           commit-message: "Update requirements"
           title: "Update requirements"
           branch: update-requirements
@@ -105,7 +119,14 @@ jobs:
 
       # Output PR details
       - name: Create PR output
-        if: github.ref == 'refs/heads/main' && env.changes_made == 'true' && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'pull_request' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.head_commit.message, 'skip fix')
+        if: >-
+          github.ref == 'refs/heads/main' &&
+          env.changes_made == 'true' &&
+          (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name || github.event_name == 'workflow_dispatch') &&
+          env.APPLY_FIXES_MODE == 'pull_request' &&
+          (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) &&
+          (github.event_name != 'workflow_dispatch' || inputs.create_pull_request) &&
+          (github.event_name != 'push' || !contains(github.event.head_commit.message, 'skip fix'))
         run: |
           echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
           echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/src/pyrecest/filters/hyperhemispherical_grid_filter.py
+++ b/src/pyrecest/filters/hyperhemispherical_grid_filter.py
@@ -204,10 +204,6 @@ class HyperhemisphericalGridFilter(AbstractGridFilter, HyperhemisphericalFilterM
         if isinstance(meas_noise, HyperhemisphericalWatsonDistribution):
             meas_noise = meas_noise.set_mode(z)
         elif isinstance(meas_noise, WatsonDistribution):
-            from pyrecest.backend import (  # pylint: disable=import-outside-toplevel
-                linalg,
-            )
-
             standard_pole = array([*([0.0] * (self.dim - 1)), 1.0])
             if linalg.norm(meas_noise.mu - standard_pole) > 1e-6:
                 raise ValueError(
@@ -215,10 +211,6 @@ class HyperhemisphericalGridFilter(AbstractGridFilter, HyperhemisphericalFilterM
                 )
             meas_noise = WatsonDistribution(z, meas_noise.kappa)
         elif isinstance(meas_noise, VonMisesFisherDistribution) and z[-1] == 0:
-            from pyrecest.backend import (  # pylint: disable=import-outside-toplevel
-                linalg,
-            )
-
             standard_pole = array([*([0.0] * (self.dim - 1)), 1.0])
             if linalg.norm(meas_noise.mu - standard_pole) > 1e-6:
                 raise ValueError(

--- a/tests/filters/test_hyperhemispherical_grid_filter.py
+++ b/tests/filters/test_hyperhemispherical_grid_filter.py
@@ -2,7 +2,8 @@ import unittest
 import warnings
 
 import pyrecest.backend
-from pyrecest.backend import array, linalg
+from pyrecest.backend import allclose, array, linalg
+from pyrecest.backend import sum as backend_sum
 from pyrecest.distributions import (
     HyperhemisphericalWatsonDistribution,
     SdHalfCondSdHalfGridDistribution,
@@ -102,7 +103,7 @@ class TestHyperhemisphericalGridFilter(unittest.TestCase):
         f.filter_state = HyperhemisphericalGridDistribution(grid, weights)
 
         gd_full = f.filter_state.to_full_sphere()
-        full_weights = gd_full.grid_values / pyrecest.backend.sum(gd_full.grid_values)
+        full_weights = gd_full.grid_values / backend_sum(gd_full.grid_values)
         scatter = gd_full.grid.T @ (gd_full.grid * full_weights[:, None])
         scatter = 0.5 * (scatter + scatter.T)
         _, eigenvectors = linalg.eigh(scatter)
@@ -114,7 +115,7 @@ class TestHyperhemisphericalGridFilter(unittest.TestCase):
 
         self.assertAlmostEqual(float(linalg.norm(p)), 1.0, places=5)
         self.assertGreaterEqual(float(p[-1]), 0.0)
-        self.assertTrue(pyrecest.backend.allclose(p, expected, atol=1e-10))
+        self.assertTrue(allclose(p, expected, atol=1e-10))
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member


### PR DESCRIPTION
## Summary
- add a manual `workflow_dispatch` trigger for the requirements update workflow
- use `secrets.PAT` explicitly for `peter-evans/create-pull-request`
- allow manual runs through the PR creation condition while keeping the `skip fix` guard safe for push events

## Validation
- `git diff --check`
- parsed `.github/workflows/update-requirements.yml` as YAML

After this lands on `main`, the workflow can be tested from Actions > Update requirements.txt > Run workflow.