### PR TITLE
Speed up hyperhemispherical grid point estimates

### DIFF
--- a/src/pyrecest/filters/hyperhemispherical_grid_filter.py
+++ b/src/pyrecest/filters/hyperhemispherical_grid_filter.py
@@ -5,10 +5,8 @@ from pyrecest.backend import (
     allclose,
     array,
     exp,
+    linalg,
     sum,
-)
-from pyrecest.distributions.hypersphere_subset.bingham_distribution import (
-    BinghamDistribution,
 )
 from pyrecest.distributions.hypersphere_subset.hyperhemispherical_grid_distribution import (
     HyperhemisphericalGridDistribution,
@@ -251,7 +249,7 @@ class HyperhemisphericalGridFilter(AbstractGridFilter, HyperhemisphericalFilterM
 
     def get_point_estimate(self):
         """
-        Compute a point estimate by fitting a Bingham distribution to the state.
+        Compute a point estimate from the dominant scatter-matrix eigenvector.
 
         Returns
         -------
@@ -262,7 +260,8 @@ class HyperhemisphericalGridFilter(AbstractGridFilter, HyperhemisphericalFilterM
         weights = gd_full.grid_values / sum(gd_full.grid_values)
         S = gd_full.grid.T @ (gd_full.grid * weights[:, None])
         S = 0.5 * (S + S.T)
-        p = BinghamDistribution.fit_to_moment(S).mode()
+        _, eigenvectors = linalg.eigh(S)
+        p = eigenvectors[:, -1]
         if p[-1] < 0:
             p = -p
         return p

--- a/tests/filters/test_hyperhemispherical_grid_filter.py
+++ b/tests/filters/test_hyperhemispherical_grid_filter.py
@@ -95,6 +95,31 @@ class TestHyperhemisphericalGridFilter(unittest.TestCase):
         pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
         reason="Not supported on JAX backend",
     )
+    def test_get_point_estimate_matches_s3_scatter_mode(self):
+        f = HyperhemisphericalGridFilter(8, 3)
+        grid = f.filter_state.get_grid()
+        weights = array([0.3, 0.4, 0.6, 1.1, 1.7, 0.8, 0.5, 1.3])
+        f.filter_state = HyperhemisphericalGridDistribution(grid, weights)
+
+        gd_full = f.filter_state.to_full_sphere()
+        full_weights = gd_full.grid_values / pyrecest.backend.sum(gd_full.grid_values)
+        scatter = gd_full.grid.T @ (gd_full.grid * full_weights[:, None])
+        scatter = 0.5 * (scatter + scatter.T)
+        _, eigenvectors = linalg.eigh(scatter)
+        expected = eigenvectors[:, -1]
+        if expected[-1] < 0:
+            expected = -expected
+
+        p = f.get_point_estimate()
+
+        self.assertAlmostEqual(float(linalg.norm(p)), 1.0, places=5)
+        self.assertGreaterEqual(float(p[-1]), 0.0)
+        self.assertTrue(pyrecest.backend.allclose(p, expected, atol=1e-10))
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on JAX backend",
+    )
     def test_update_identity(self):
         f = HyperhemisphericalGridFilter(self.n_grid, self.dim)
         with warnings.catch_warnings():


### PR DESCRIPTION
## Summary

This speeds up `HyperhemisphericalGridFilter.get_point_estimate()` by returning the dominant eigenvector of the grid scatter matrix directly.

The previous implementation built the same scatter matrix, then fitted a full `BinghamDistribution` via `BinghamDistribution.fit_to_moment(S).mode()`. That fit solves for concentration parameters with repeated numerical normalizing-constant evaluations, even though the returned mode is just the dominant scatter-matrix eigenvector.

## Impact

In a local S3+ 8-cell smoke check, point-estimate runtime dropped from roughly 30 seconds to about 0.0003 seconds.

## Validation

- `PYTHONPATH=src python -m pytest tests\filters\test_hyperhemispherical_grid_filter.py -q --basetemp .pytest-tmp\hyperhemi-point-estimate-local`
- `python -m ruff check src\pyrecest\filters\hyperhemispherical_grid_filter.py tests\filters\test_hyperhemispherical_grid_filter.py`
- `git diff --check`

Added a regression test for the S3+ case verifying that the point estimate matches the dominant scatter-matrix eigenvector.