### PR TITLE
Reduce S3 grid sweep in hyperhemispherical tests

### DIFF
--- a/tests/distributions/test_hyperhemispherical_grid_distribution.py
+++ b/tests/distributions/test_hyperhemispherical_grid_distribution.py
@@ -237,7 +237,9 @@ class HyperhemisphericalGridDistributionTest(unittest.TestCase):
         reason="Not supported on this backend",
     )
     def test_multiply_vmf_mixture_s3(self):
-        kappas = [0.1 + 0.3 * i for i in range(14)]  # 0.1:0.3:4
+        # Representative low/medium/high concentrations from the original
+        # 0.1:0.3:4 sweep keep the coverage while avoiding a 14x14 grid loop.
+        kappas = [0.1, 2.2, 4.0]
 
         for kappa1 in kappas:
             for kappa2 in kappas:


### PR DESCRIPTION
## Summary

Reduces the expensive S3 VMF-mixture multiply test from the full 14x14 kappa grid to representative low, medium, and high concentration values. This keeps the hemisphere/full-sphere comparison logic intact while cutting the loop from 196 grid comparisons to 9.

## Validation

- `PYRECEST_BACKEND=numpy python -m pytest --rootdir . -q tests/distributions/test_hyperhemispherical_grid_distribution.py::HyperhemisphericalGridDistributionTest::test_multiply_vmf_mixture_s3`
- `PYRECEST_BACKEND=pytorch python -m pytest --rootdir . -q tests/distributions/test_hyperhemispherical_grid_distribution.py::HyperhemisphericalGridDistributionTest::test_multiply_vmf_mixture_s3`