### PR TITLE
Fix MegaLinter auto-fix PR creation

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -108,10 +108,13 @@ jobs:
         if: github.ref == 'refs/heads/main' && steps.ml.outputs.has_updated_sources == 1 && (env.APPLY_FIXES_EVENT == 'all' || env.APPLY_FIXES_EVENT == github.event_name) && env.APPLY_FIXES_MODE == 'pull_request' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && !contains(github.event.head_commit.message, 'skip fix')
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+          # Prefer the scoped workflow token over a user PAT. In the failing run,
+          # the auto-fix PR push failed with a 403 despite job-level write permissions.
+          token: ${{ github.token }}
           commit-message: "[MegaLinter] Apply linters automatic fixes"
           title: "[MegaLinter] Apply linters automatic fixes"
-          branch: megalinter-fixes
+          # Avoid force-updating a stale or diverged auto-fix branch.
+          branch: megalinter-fixes-${{ github.run_id }}
           labels: bot
           base: main
 


### PR DESCRIPTION
## Summary

- Use the workflow-scoped `${{ github.token }}` for the MegaLinter auto-fix PR step instead of preferring a repository PAT.
- Generate a run-specific MegaLinter fix branch (`megalinter-fixes-${{ github.run_id }}`) to avoid force-updating a stale/diverged `megalinter-fixes` branch.
- Document the reason in the workflow: the failing run linted successfully, but `peter-evans/create-pull-request` failed while pushing the generated fixes with HTTP 403.

## Context

The referenced MegaLinter run successfully linted all files and generated four auto-formatting fixes, then failed only when pushing the auto-fix PR branch. The log showed:

```text
remote: Permission to FlorianPfaff/PyRecEst.git denied to FlorianPfaff.
fatal: unable to access 'https://github.com/FlorianPfaff/PyRecEst/': The requested URL returned error: 403
```

Using the job token with explicit job-level `contents: write` / `pull-requests: write` permissions avoids a misconfigured PAT overriding the workflow token, and the unique branch name avoids branch divergence problems from reusing `megalinter-fixes`.

## Testing

Not run locally. This is a GitHub Actions workflow-only change.