### PR TITLE
Add optional Kalman update diagnostics

### DIFF
--- a/src/pyrecest/filters/_linear_gaussian.py
+++ b/src/pyrecest/filters/_linear_gaussian.py
@@ -28,6 +28,22 @@ def _as_matrix(x, name):
     return x
 
 
+def normalized_innovation_squared(innovation, innovation_covariance):
+    """Return innovation.T @ inv(innovation_covariance) @ innovation."""
+    innovation = _as_vector(innovation, "innovation")
+    innovation_covariance = _as_matrix(
+        innovation_covariance,
+        "innovation_covariance",
+    )
+    innovation_dim = innovation.shape[0]
+    if innovation_covariance.shape != (innovation_dim, innovation_dim):
+        raise ValueError(
+            "innovation_covariance must have shape "
+            "(innovation_dim, innovation_dim)"
+        )
+    return transpose(innovation) @ linalg.solve(innovation_covariance, innovation)
+
+
 def huber_covariance_scale(normalized_innovation_squared, huber_threshold=2.0):
     """Return measurement-covariance scaling for a Huber robust update.
 
@@ -139,9 +155,23 @@ def linear_gaussian_predict(
 
 
 def linear_gaussian_update(
-    mean, covariance, measurement, measurement_matrix, meas_noise
+    mean,
+    covariance,
+    measurement,
+    measurement_matrix,
+    meas_noise,
+    *,
+    return_diagnostics=False,
+    scale=1.0,
+    action="updated",
 ):
-    """Update step for z_k = H x_k + v with v ~ N(0, R)."""
+    """Update step for z_k = H x_k + v with v ~ N(0, R).
+
+    If ``return_diagnostics`` is true, return a third value containing the
+    normalized innovation squared (NIS), residual, covariance scale, and action.
+    ``scale`` multiplies ``meas_noise`` for the update but diagnostics report
+    the pre-scaled NIS, matching the usual gating/robust-update convention.
+    """
     mean = _as_vector(mean, "mean")
     covariance = _as_matrix(covariance, "covariance")
     measurement = _as_vector(measurement, "measurement")
@@ -160,9 +190,18 @@ def linear_gaussian_update(
     if meas_noise.shape != (meas_dim, meas_dim):
         raise ValueError("meas_noise must have shape (meas_dim, meas_dim)")
 
+    scale = float(scale)
+    if scale <= 0.0:
+        raise ValueError("scale must be positive")
+
     innovation = measurement - measurement_matrix @ mean
-    innovation_cov = (
+    nominal_innovation_cov = (
         measurement_matrix @ covariance @ transpose(measurement_matrix) + meas_noise
+    )
+    scaled_meas_noise = meas_noise * scale
+    innovation_cov = (
+        measurement_matrix @ covariance @ transpose(measurement_matrix)
+        + scaled_meas_noise
     )
     cross_cov = covariance @ transpose(measurement_matrix)
 
@@ -175,9 +214,18 @@ def linear_gaussian_update(
     identity = eye(state_dim)
     correction = identity - kalman_gain @ measurement_matrix
     updated_covariance = correction @ covariance @ transpose(correction)
-    updated_covariance = updated_covariance + kalman_gain @ meas_noise @ transpose(
+    updated_covariance = updated_covariance + kalman_gain @ scaled_meas_noise @ transpose(
         kalman_gain
     )
     updated_covariance = 0.5 * (updated_covariance + transpose(updated_covariance))
+
+    if return_diagnostics:
+        diagnostics = {
+            "nis": normalized_innovation_squared(innovation, nominal_innovation_cov),
+            "residual": innovation,
+            "scale": scale,
+            "action": action,
+        }
+        return updated_mean, updated_covariance, diagnostics
 
     return updated_mean, updated_covariance

--- a/src/pyrecest/filters/kalman_filter.py
+++ b/src/pyrecest/filters/kalman_filter.py
@@ -174,7 +174,15 @@ class KalmanFilter(AbstractFilter, EuclideanFilterMixin):
         )
         self.predict_linear(system_matrix, sys_noise_cov, sys_input)
 
-    def update_identity(self, meas_noise, measurement):
+    def update_identity(
+        self,
+        meas_noise,
+        measurement,
+        *,
+        return_diagnostics=False,
+        scale=1.0,
+        action="updated",
+    ):
         """Update with a measurement matrix equal to the identity.
 
         Parameters
@@ -183,11 +191,20 @@ class KalmanFilter(AbstractFilter, EuclideanFilterMixin):
             Measurement-noise covariance.
         measurement : array-like, shape (n,)
             Measurement vector.
+        return_diagnostics : bool, optional
+            If true, return update diagnostics after updating the filter state.
+        scale : float, optional
+            Multiplicative measurement-noise scale used for the update.
+        action : str, optional
+            Caller-defined diagnostic label for the update action.
         """
-        self.update_linear(
+        return self.update_linear(
             measurement=measurement,
             measurement_matrix=eye(self.dim),
             meas_noise=meas_noise,
+            return_diagnostics=return_diagnostics,
+            scale=scale,
+            action=action,
         )
 
     def update_linear(
@@ -195,6 +212,10 @@ class KalmanFilter(AbstractFilter, EuclideanFilterMixin):
         measurement,
         measurement_matrix,
         meas_noise,
+        *,
+        return_diagnostics=False,
+        scale=1.0,
+        action="updated",
     ):
         """Update the state with a linear Gaussian measurement model.
 
@@ -207,21 +228,46 @@ class KalmanFilter(AbstractFilter, EuclideanFilterMixin):
             vectors.
         meas_noise : array-like, shape (m, m)
             Measurement-noise covariance ``R``.
+        return_diagnostics : bool, optional
+            If true, return a diagnostics dictionary after updating the filter
+            state. The dictionary contains ``nis``, ``residual``, ``scale``,
+            and ``action``.
+        scale : float, optional
+            Multiplicative measurement-noise scale used for the update.
+        action : str, optional
+            Caller-defined diagnostic label for the update action.
         """
-        new_mean, new_covariance = linear_gaussian_update(
+        result = linear_gaussian_update(
             mean=self._filter_state.mu,
             covariance=self._filter_state.C,
             measurement=measurement,
             measurement_matrix=measurement_matrix,
             meas_noise=meas_noise,
+            return_diagnostics=return_diagnostics,
+            scale=scale,
+            action=action,
         )
+        if return_diagnostics:
+            new_mean, new_covariance, diagnostics = result
+        else:
+            new_mean, new_covariance = result
+            diagnostics = None
         self._filter_state = GaussianDistribution(
             new_mean,
             new_covariance,
             check_validity=False,
         )
+        return diagnostics
 
-    def update_model(self, measurement_model, measurement):
+    def update_model(
+        self,
+        measurement_model,
+        measurement,
+        *,
+        return_diagnostics=False,
+        scale=1.0,
+        action="updated",
+    ):
         """Update the state with a linear Gaussian measurement model object.
 
         The model object is consumed structurally. It must expose a
@@ -235,6 +281,12 @@ class KalmanFilter(AbstractFilter, EuclideanFilterMixin):
             :meth:`update_linear`.
         measurement : array-like, shape (m,)
             Measurement vector ``z``.
+        return_diagnostics : bool, optional
+            If true, return update diagnostics after updating the filter state.
+        scale : float, optional
+            Multiplicative measurement-noise scale used for the update.
+        action : str, optional
+            Caller-defined diagnostic label for the update action.
         """
         measurement_matrix = _get_required_model_attribute(
             measurement_model,
@@ -245,7 +297,14 @@ class KalmanFilter(AbstractFilter, EuclideanFilterMixin):
             "meas_noise",
             "measurement_noise_cov",
         )
-        self.update_linear(measurement, measurement_matrix, meas_noise)
+        return self.update_linear(
+            measurement,
+            measurement_matrix,
+            meas_noise,
+            return_diagnostics=return_diagnostics,
+            scale=scale,
+            action=action,
+        )
 
     def get_point_estimate(self):
         """Return the posterior mean vector with shape ``(n,)``."""

--- a/tests/filters/test_kalman_filter.py
+++ b/tests/filters/test_kalman_filter.py
@@ -87,6 +87,70 @@ class KalmanFilterTest(unittest.TestCase):
             allclose(filter_linear.filter_state.C, filter_model.filter_state.C)
         )
 
+    def test_update_linear_default_return_stays_none(self):
+        kf = KalmanFilter((array([0.0]), array([[1.0]])))
+        result = kf.update_linear(array([2.0]), array([[1.0]]), array([[1.0]]))
+        self.assertIsNone(result)
+
+    def test_update_linear_can_return_diagnostics(self):
+        kf = KalmanFilter((array([0.0, 1.0]), diag(array([1.0, 2.0]))))
+        diagnostics = kf.update_linear(
+            array([2.0, 0.0]),
+            eye(2),
+            diag(array([2.0, 1.0])),
+            return_diagnostics=True,
+        )
+
+        self.assertEqual(diagnostics["action"], "updated")
+        self.assertEqual(diagnostics["scale"], 1.0)
+        self.assertTrue(allclose(diagnostics["residual"], array([2.0, -1.0])))
+        self.assertTrue(allclose(diagnostics["nis"], array(5.0 / 3.0)))
+
+    def test_update_linear_scale_is_applied_and_reported(self):
+        kf = KalmanFilter((array([0.0]), array([[1.0]])))
+        diagnostics = kf.update_linear(
+            array([4.0]),
+            array([[1.0]]),
+            array([[1.0]]),
+            return_diagnostics=True,
+            scale=4.0,
+            action="huberized",
+        )
+
+        self.assertEqual(diagnostics["action"], "huberized")
+        self.assertEqual(diagnostics["scale"], 4.0)
+        self.assertTrue(allclose(diagnostics["nis"], array(8.0)))
+        self.assertTrue(allclose(kf.get_point_estimate(), array([0.8])))
+        self.assertTrue(allclose(kf.filter_state.C, array([[0.8]])))
+
+    def test_update_identity_forwards_diagnostics(self):
+        kf = KalmanFilter((array([0.0]), array([[1.0]])))
+        diagnostics = kf.update_identity(
+            array([[1.0]]),
+            array([2.0]),
+            return_diagnostics=True,
+            action="accepted",
+        )
+
+        self.assertEqual(diagnostics["action"], "accepted")
+        self.assertTrue(allclose(diagnostics["residual"], array([2.0])))
+
+    def test_update_model_forwards_diagnostics(self):
+        kf = KalmanFilter((array([0.0]), array([[1.0]])))
+        measurement_model = _LinearGaussianMeasurementModel(
+            array([[1.0]]),
+            array([[1.0]]),
+        )
+        diagnostics = kf.update_model(
+            measurement_model,
+            array([2.0]),
+            return_diagnostics=True,
+            action="accepted",
+        )
+
+        self.assertEqual(diagnostics["action"], "accepted")
+        self.assertTrue(allclose(diagnostics["residual"], array([2.0])))
+
     def test_predict_identity_1d(self):
         kf = KalmanFilter((array([0]), array([[1]])))
         kf.predict_identity(array([[3]]), array([1]))


### PR DESCRIPTION
## Summary
- add normalized innovation squared diagnostics to the backend-native linear-Gaussian update primitive
- allow optional diagnostics return with residual, NIS, measurement-noise scale, and action label
- forward diagnostics through `KalmanFilter.update_linear`, `update_identity`, and `update_model` without changing default return behavior
- add Kalman filter regression tests for diagnostics and scaled measurement noise

## Testing
- `python -m py_compile src/pyrecest/filters/_linear_gaussian.py src/pyrecest/filters/kalman_filter.py tests/filters/test_kalman_filter.py` locally on the generated files
- full pytest not run locally because the container cannot clone/install GitHub dependencies