### PR TITLE
Add Student-t covariance scaling helper

### DIFF
--- a/src/pyrecest/filters/__init__.py
+++ b/src/pyrecest/filters/__init__.py
@@ -1,3 +1,4 @@
+from ._linear_gaussian import student_t_covariance_scale
 from .abstract_axial_filter import AbstractAxialFilter
 from .abstract_dummy_filter import AbstractDummyFilter
 from .abstract_extended_object_tracker import AbstractExtendedObjectTracker
@@ -195,6 +196,7 @@ __all__ = [
     "build_linear_gaussian_predictor",
     "build_linear_gaussian_updater",
     "solve_global_nearest_neighbor",
+    "student_t_covariance_scale",
     "SE2FilterMixin",
     "SE2UKF",
     "SO3ProductParticleFilter",

--- a/src/pyrecest/filters/_linear_gaussian.py
+++ b/src/pyrecest/filters/_linear_gaussian.py
@@ -52,6 +52,54 @@ def huber_covariance_scale(normalized_innovation_squared, huber_threshold=2.0):
     return maximum(1.0, sqrt(nis) / huber_threshold)
 
 
+def student_t_covariance_scale(
+    normalized_innovation_squared,
+    measurement_dim,
+    dof=4.0,
+    min_scale=1.0,
+):
+    """Return Student-t measurement-covariance scaling from innovation NIS.
+
+    This helper implements the scale-mixture weight used for an approximate
+    Student-t Kalman measurement update. For normalized innovation squared
+    ``nis``, measurement dimension ``d``, and degrees of freedom ``nu``, the
+    Student-t IRLS/EM weight is
+
+    ``w = (nu + d) / (nu + nis)``.
+
+    A Gaussian update can therefore be made heavy-tailed by replacing the
+    measurement covariance ``R`` with ``R * scale``, where ``scale = 1 / w``.
+    The default ``min_scale=1`` prevents inliers from becoming more confident
+    than the supplied Gaussian measurement model.
+
+    Parameters
+    ----------
+    normalized_innovation_squared : scalar or array-like
+        Squared Mahalanobis innovation, i.e. NIS.
+    measurement_dim : int
+        Dimension ``d`` of the measurement vector. Must be positive.
+    dof : float, optional
+        Student-t degrees of freedom ``nu``. Must be greater than two.
+    min_scale : float, optional
+        Lower bound on the returned covariance scale. Must be nonnegative.
+    """
+    measurement_dim = int(measurement_dim)
+    if measurement_dim <= 0:
+        raise ValueError("measurement_dim must be positive")
+
+    dof = float(dof)
+    if dof <= 2.0:
+        raise ValueError("dof must be greater than 2")
+
+    min_scale = float(min_scale)
+    if min_scale < 0.0:
+        raise ValueError("min_scale must be nonnegative")
+
+    nis = asarray(normalized_innovation_squared, dtype=float64)
+    scale = (dof + nis) / (dof + measurement_dim)
+    return maximum(min_scale, scale)
+
+
 def linear_gaussian_predict(
     mean, covariance, system_matrix, sys_noise_cov, sys_input=None
 ):

--- a/tests/test_linear_gaussian_robust.py
+++ b/tests/test_linear_gaussian_robust.py
@@ -1,0 +1,69 @@
+import pytest
+
+from pyrecest.backend import allclose, array
+from pyrecest.filters import student_t_covariance_scale
+
+
+def test_student_t_covariance_scale_matches_formula():
+    scale = student_t_covariance_scale(
+        normalized_innovation_squared=14.0,
+        measurement_dim=2,
+        dof=4.0,
+    )
+
+    assert allclose(scale, (4.0 + 14.0) / (4.0 + 2.0))
+
+
+def test_student_t_covariance_scale_clamps_inliers_to_one_by_default():
+    scale = student_t_covariance_scale(
+        normalized_innovation_squared=0.5,
+        measurement_dim=2,
+        dof=4.0,
+    )
+
+    assert allclose(scale, 1.0)
+
+
+def test_student_t_covariance_scale_can_return_subunit_inlier_scale():
+    scale = student_t_covariance_scale(
+        normalized_innovation_squared=0.5,
+        measurement_dim=2,
+        dof=4.0,
+        min_scale=0.0,
+    )
+
+    assert allclose(scale, (4.0 + 0.5) / (4.0 + 2.0))
+
+
+def test_student_t_covariance_scale_vectorizes_over_nis():
+    nis = array([0.0, 6.0, 20.0])
+    scale = student_t_covariance_scale(nis, measurement_dim=2, dof=4.0)
+    expected = array(
+        [
+            1.0,
+            (4.0 + 6.0) / (4.0 + 2.0),
+            (4.0 + 20.0) / (4.0 + 2.0),
+        ]
+    )
+
+    assert allclose(scale, expected)
+
+
+def test_student_t_covariance_scale_validates_arguments():
+    with pytest.raises(ValueError, match="measurement_dim"):
+        student_t_covariance_scale(
+            normalized_innovation_squared=1.0,
+            measurement_dim=0,
+        )
+    with pytest.raises(ValueError, match="dof"):
+        student_t_covariance_scale(
+            normalized_innovation_squared=1.0,
+            measurement_dim=2,
+            dof=2.0,
+        )
+    with pytest.raises(ValueError, match="min_scale"):
+        student_t_covariance_scale(
+            normalized_innovation_squared=1.0,
+            measurement_dim=2,
+            min_scale=-1.0,
+        )


### PR DESCRIPTION
## Summary
- add `student_t_covariance_scale(...)` next to the existing Huber covariance scaling helper
- export the helper from `pyrecest.filters`
- add focused tests for formula agreement, inlier clamping, vectorized NIS inputs, and argument validation

## Notes
- this is the minimal PyRecEst backport of the reusable Student-t covariance scaling used by the RaFT-UAV robust-update work
- no RaFT-UAV-specific tracking, CLI, or experiment code is included

## Tests
- not run here; container DNS cannot reach GitHub to install/clone dependencies
- intended targeted test: `python -m pytest tests/test_linear_gaussian_robust.py`