### PR TITLE
Add robust linear Kalman update

### DIFF
--- a/src/pyrecest/filters/_linear_gaussian.py
+++ b/src/pyrecest/filters/_linear_gaussian.py
@@ -28,6 +28,13 @@ def _as_matrix(x, name):
     return x
 
 
+def _as_positive_float(x, name):
+    x = float(x)
+    if x <= 0.0:
+        raise ValueError(f"{name} must be positive")
+    return x
+
+
 def normalized_innovation_squared(innovation, innovation_covariance):
     """Return innovation.T @ inv(innovation_covariance) @ innovation."""
     innovation = _as_vector(innovation, "innovation")
@@ -114,6 +121,46 @@ def student_t_covariance_scale(
     nis = asarray(normalized_innovation_squared, dtype=float64)
     scale = (dof + nis) / (dof + measurement_dim)
     return maximum(min_scale, scale)
+
+
+def _robust_update_decision(
+    normalized_innovation_squared_value,
+    measurement_dim,
+    robust_update,
+    gate_threshold,
+    student_t_dof,
+    huber_threshold,
+    inflation_alpha,
+):
+    robust_update = None if robust_update in (None, "none") else robust_update
+    nis = float(normalized_innovation_squared_value)
+
+    if robust_update is None:
+        if gate_threshold is not None:
+            gate_threshold = _as_positive_float(gate_threshold, "gate_threshold")
+            if nis > gate_threshold:
+                return False, "rejected", 1.0
+        return True, "updated", 1.0
+
+    if robust_update == "nis-inflate":
+        inflation_alpha = _as_positive_float(inflation_alpha, "inflation_alpha")
+        if gate_threshold is None:
+            return True, "updated", 1.0
+        gate_threshold = _as_positive_float(gate_threshold, "gate_threshold")
+        scale = max(1.0, (nis / gate_threshold) ** inflation_alpha)
+        return True, "inflated" if scale > 1.0 else "updated", scale
+
+    if robust_update == "student-t":
+        scale = float(
+            student_t_covariance_scale(nis, measurement_dim, dof=student_t_dof)
+        )
+        return True, "student_t" if scale > 1.0 else "updated", scale
+
+    if robust_update == "huber":
+        scale = float(huber_covariance_scale(nis, huber_threshold=huber_threshold))
+        return True, "huberized" if scale > 1.0 else "updated", scale
+
+    raise ValueError(f"unknown robust update mode {robust_update!r}")
 
 
 def linear_gaussian_predict(
@@ -229,3 +276,79 @@ def linear_gaussian_update(
         return updated_mean, updated_covariance, diagnostics
 
     return updated_mean, updated_covariance
+
+
+def linear_gaussian_update_robust(
+    mean,
+    covariance,
+    measurement,
+    measurement_matrix,
+    meas_noise,
+    *,
+    robust_update="student-t",
+    gate_threshold=None,
+    student_t_dof=4.0,
+    huber_threshold=2.0,
+    inflation_alpha=1.0,
+    return_diagnostics=False,
+):
+    """Robust linear-Gaussian update with adaptive measurement covariance.
+
+    Supported modes are ``None``/``"none"`` for ordinary Gaussian updates with
+    optional NIS rejection, ``"student-t"`` for Student-t down-weighting,
+    ``"huber"`` for Huber down-weighting, and ``"nis-inflate"`` for
+    threshold-based covariance inflation.
+    """
+    mean = _as_vector(mean, "mean")
+    covariance = _as_matrix(covariance, "covariance")
+    measurement = _as_vector(measurement, "measurement")
+    measurement_matrix = _as_matrix(measurement_matrix, "measurement_matrix")
+    meas_noise = _as_matrix(meas_noise, "meas_noise")
+
+    meas_dim = measurement_matrix.shape[0]
+    innovation = measurement - measurement_matrix @ mean
+    nominal_innovation_cov = (
+        measurement_matrix @ covariance @ transpose(measurement_matrix) + meas_noise
+    )
+    nis = normalized_innovation_squared(innovation, nominal_innovation_cov)
+    accepted, action, scale = _robust_update_decision(
+        nis,
+        meas_dim,
+        robust_update,
+        gate_threshold,
+        student_t_dof,
+        huber_threshold,
+        inflation_alpha,
+    )
+
+    if not accepted:
+        diagnostics = {
+            "nis": nis,
+            "residual": innovation,
+            "scale": scale,
+            "action": action,
+            "accepted": False,
+            "robust_update": robust_update,
+        }
+        if return_diagnostics:
+            return mean, covariance, diagnostics
+        return mean, covariance
+
+    result = linear_gaussian_update(
+        mean,
+        covariance,
+        measurement,
+        measurement_matrix,
+        meas_noise,
+        return_diagnostics=return_diagnostics,
+        scale=scale,
+        action=action,
+    )
+
+    if return_diagnostics:
+        updated_mean, updated_covariance, diagnostics = result
+        diagnostics["accepted"] = True
+        diagnostics["robust_update"] = robust_update
+        return updated_mean, updated_covariance, diagnostics
+
+    return result

--- a/src/pyrecest/filters/kalman_filter.py
+++ b/src/pyrecest/filters/kalman_filter.py
@@ -3,7 +3,11 @@
 from pyrecest.backend import atleast_1d, atleast_2d, eye
 from pyrecest.distributions import GaussianDistribution
 
-from ._linear_gaussian import linear_gaussian_predict, linear_gaussian_update
+from ._linear_gaussian import (
+    linear_gaussian_predict,
+    linear_gaussian_update,
+    linear_gaussian_update_robust,
+)
 from .abstract_filter import AbstractFilter
 from .manifold_mixins import EuclideanFilterMixin
 
@@ -258,6 +262,50 @@ class KalmanFilter(AbstractFilter, EuclideanFilterMixin):
             check_validity=False,
         )
         return diagnostics
+
+    def update_linear_robust(
+        self,
+        measurement,
+        measurement_matrix,
+        meas_noise,
+        *,
+        robust_update="student-t",
+        gate_threshold=None,
+        student_t_dof=4.0,
+        huber_threshold=2.0,
+        inflation_alpha=1.0,
+        return_diagnostics=False,
+    ):
+        """Robustly update the state with a linear measurement model.
+
+        The Gaussian measurement covariance is adaptively inflated according to
+        the normalized innovation squared. Supported modes are
+        ``"student-t"``, ``"huber"``, ``"nis-inflate"``, and ``None``/
+        ``"none"``. With ``robust_update=None`` and ``gate_threshold`` set,
+        measurements above the gate are rejected and the prior state is kept.
+        """
+        result = linear_gaussian_update_robust(
+            mean=self._filter_state.mu,
+            covariance=self._filter_state.C,
+            measurement=measurement,
+            measurement_matrix=measurement_matrix,
+            meas_noise=meas_noise,
+            robust_update=robust_update,
+            gate_threshold=gate_threshold,
+            student_t_dof=student_t_dof,
+            huber_threshold=huber_threshold,
+            inflation_alpha=inflation_alpha,
+            return_diagnostics=True,
+        )
+        new_mean, new_covariance, diagnostics = result
+        self._filter_state = GaussianDistribution(
+            new_mean,
+            new_covariance,
+            check_validity=False,
+        )
+        if return_diagnostics:
+            return diagnostics
+        return None
 
     def update_model(
         self,

--- a/tests/filters/test_kalman_filter.py
+++ b/tests/filters/test_kalman_filter.py
@@ -151,6 +151,105 @@ class KalmanFilterTest(unittest.TestCase):
         self.assertEqual(diagnostics["action"], "accepted")
         self.assertTrue(allclose(diagnostics["residual"], array([2.0])))
 
+    def test_update_linear_robust_none_matches_update_linear_2d(self):
+        initial_state = (array([0.0, 1.0]), diag(array([1.0, 2.0])))
+        filter_linear = KalmanFilter(initial_state)
+        filter_robust = KalmanFilter(initial_state)
+
+        measurement = array([1.0, 0.0])
+        measurement_matrix = eye(2)
+        meas_noise = diag(array([2.0, 1.0]))
+
+        filter_linear.update_linear(measurement, measurement_matrix, meas_noise)
+        diagnostics = filter_robust.update_linear_robust(
+            measurement,
+            measurement_matrix,
+            meas_noise,
+            robust_update=None,
+            return_diagnostics=True,
+        )
+
+        self.assertTrue(diagnostics["accepted"])
+        self.assertEqual(diagnostics["action"], "updated")
+        self.assertEqual(diagnostics["scale"], 1.0)
+        self.assertTrue(
+            allclose(
+                filter_linear.get_point_estimate(), filter_robust.get_point_estimate()
+            )
+        )
+        self.assertTrue(
+            allclose(filter_linear.filter_state.C, filter_robust.filter_state.C)
+        )
+
+    def test_update_linear_robust_rejects_when_gated(self):
+        kf = KalmanFilter((array([0.0]), array([[1.0]])))
+
+        diagnostics = kf.update_linear_robust(
+            array([10.0]),
+            array([[1.0]]),
+            array([[1.0]]),
+            robust_update=None,
+            gate_threshold=1.0,
+            return_diagnostics=True,
+        )
+
+        self.assertFalse(diagnostics["accepted"])
+        self.assertEqual(diagnostics["action"], "rejected")
+        self.assertTrue(allclose(kf.get_point_estimate(), array([0.0])))
+        self.assertTrue(allclose(kf.filter_state.C, array([[1.0]])))
+
+    def test_student_t_robust_update_downweights_outlier(self):
+        filter_linear = KalmanFilter((array([0.0]), array([[1.0]])))
+        filter_robust = KalmanFilter((array([0.0]), array([[1.0]])))
+
+        measurement = array([100.0])
+        measurement_matrix = array([[1.0]])
+        meas_noise = array([[1.0]])
+
+        filter_linear.update_linear(measurement, measurement_matrix, meas_noise)
+        diagnostics = filter_robust.update_linear_robust(
+            measurement,
+            measurement_matrix,
+            meas_noise,
+            robust_update="student-t",
+            student_t_dof=4.0,
+            return_diagnostics=True,
+        )
+
+        self.assertTrue(diagnostics["accepted"])
+        self.assertEqual(diagnostics["action"], "student_t")
+        self.assertGreater(diagnostics["scale"], 1.0)
+        self.assertLess(
+            float(filter_robust.get_point_estimate()[0]),
+            float(filter_linear.get_point_estimate()[0]),
+        )
+
+    def test_huber_robust_update_downweights_outlier(self):
+        filter_linear = KalmanFilter((array([0.0]), array([[1.0]])))
+        filter_robust = KalmanFilter((array([0.0]), array([[1.0]])))
+
+        measurement = array([100.0])
+        measurement_matrix = array([[1.0]])
+        meas_noise = array([[1.0]])
+
+        filter_linear.update_linear(measurement, measurement_matrix, meas_noise)
+        diagnostics = filter_robust.update_linear_robust(
+            measurement,
+            measurement_matrix,
+            meas_noise,
+            robust_update="huber",
+            huber_threshold=2.0,
+            return_diagnostics=True,
+        )
+
+        self.assertTrue(diagnostics["accepted"])
+        self.assertEqual(diagnostics["action"], "huberized")
+        self.assertGreater(diagnostics["scale"], 1.0)
+        self.assertLess(
+            float(filter_robust.get_point_estimate()[0]),
+            float(filter_linear.get_point_estimate()[0]),
+        )
+
     def test_predict_identity_1d(self):
         kf = KalmanFilter((array([0]), array([[1]])))
         kf.predict_identity(array([[3]]), array([1]))


### PR DESCRIPTION
Adds a robust linear Kalman update API for generic heavy-tailed and gated measurement updates.

Changes:
- Add normalized innovation squared diagnostics to the linear-Gaussian update module.
- Add `linear_gaussian_update_robust(...)` with support for `None`/ordinary gated update, `student-t`, `huber`, and `nis-inflate` covariance scaling.
- Add `KalmanFilter.update_linear_robust(...)` as a class-level convenience wrapper with optional diagnostics.
- Add regression tests for ordinary equivalence, NIS-gate rejection, Student-t outlier downweighting, and Huber outlier downweighting.

This is intended as the PyRecEst-side reusable primitive needed by downstream projects such as RaFT-UAV, without adding any RaFT-UAV-specific source or CLI policy.