### PR TITLE
Add robust linear Gaussian update

### DIFF
--- a/src/pyrecest/filters/_linear_gaussian.py
+++ b/src/pyrecest/filters/_linear_gaussian.py
@@ -9,6 +9,7 @@ from pyrecest.backend import (
     float64,
     linalg,
     maximum,
+    power,
     sqrt,
     transpose,
 )
@@ -114,6 +115,55 @@ def student_t_covariance_scale(
     nis = asarray(normalized_innovation_squared, dtype=float64)
     scale = (dof + nis) / (dof + measurement_dim)
     return maximum(min_scale, scale)
+
+
+def nis_inflation_covariance_scale(nis, gate_threshold, inflation_alpha=1.0):
+    """Return thresholded NIS-inflation measurement-covariance scaling."""
+    gate_threshold = float(gate_threshold)
+    if gate_threshold <= 0.0:
+        raise ValueError("gate_threshold must be positive")
+
+    inflation_alpha = float(inflation_alpha)
+    if inflation_alpha <= 0.0:
+        raise ValueError("inflation_alpha must be positive")
+
+    nis = asarray(nis, dtype=float64)
+    return maximum(1.0, power(nis / gate_threshold, inflation_alpha))
+
+
+def robust_measurement_covariance_scale(
+    normalized_innovation_squared,
+    measurement_dim,
+    robust_method="student-t",
+    *,
+    student_t_dof=4.0,
+    huber_threshold=2.0,
+    gate_threshold=None,
+    inflation_alpha=1.0,
+):
+    """Return covariance scaling for a robust linear-Gaussian update."""
+    if robust_method in (None, "none"):
+        return asarray(1.0, dtype=float64)
+    if robust_method == "student-t":
+        return student_t_covariance_scale(
+            normalized_innovation_squared,
+            measurement_dim,
+            dof=student_t_dof,
+        )
+    if robust_method == "huber":
+        return huber_covariance_scale(
+            normalized_innovation_squared,
+            huber_threshold=huber_threshold,
+        )
+    if robust_method == "nis-inflate":
+        if gate_threshold is None:
+            raise ValueError("gate_threshold is required for nis-inflate")
+        return nis_inflation_covariance_scale(
+            normalized_innovation_squared,
+            gate_threshold,
+            inflation_alpha,
+        )
+    raise ValueError(f"unknown robust_method {robust_method!r}")
 
 
 def linear_gaussian_predict(
@@ -229,3 +279,77 @@ def linear_gaussian_update(
         return updated_mean, updated_covariance, diagnostics
 
     return updated_mean, updated_covariance
+
+
+def linear_gaussian_innovation_statistics(
+    mean, covariance, measurement, measurement_matrix, meas_noise
+):
+    """Return innovation, innovation covariance, and NIS for a linear update."""
+    _, _, diagnostics = linear_gaussian_update(
+        mean,
+        covariance,
+        measurement,
+        measurement_matrix,
+        meas_noise,
+        return_diagnostics=True,
+    )
+    return (
+        diagnostics["residual"],
+        measurement_matrix @ _as_matrix(covariance, "covariance") @ transpose(
+            _as_matrix(measurement_matrix, "measurement_matrix")
+        )
+        + _as_matrix(meas_noise, "meas_noise"),
+        diagnostics["nis"],
+    )
+
+
+def linear_gaussian_update_robust(
+    mean,
+    covariance,
+    measurement,
+    measurement_matrix,
+    meas_noise,
+    robust_method="student-t",
+    *,
+    student_t_dof=4.0,
+    huber_threshold=2.0,
+    gate_threshold=None,
+    inflation_alpha=1.0,
+    return_diagnostics=False,
+):
+    """Robust linear-Gaussian update via adaptive measurement covariance."""
+    _, _, diagnostics = linear_gaussian_update(
+        mean,
+        covariance,
+        measurement,
+        measurement_matrix,
+        meas_noise,
+        return_diagnostics=True,
+    )
+    meas_dim = _as_matrix(measurement_matrix, "measurement_matrix").shape[0]
+    scale = robust_measurement_covariance_scale(
+        diagnostics["nis"],
+        meas_dim,
+        robust_method,
+        student_t_dof=student_t_dof,
+        huber_threshold=huber_threshold,
+        gate_threshold=gate_threshold,
+        inflation_alpha=inflation_alpha,
+    )
+    action = "updated" if robust_method in (None, "none") else str(robust_method)
+    result = linear_gaussian_update(
+        mean,
+        covariance,
+        measurement,
+        measurement_matrix,
+        meas_noise,
+        return_diagnostics=return_diagnostics,
+        scale=scale,
+        action=action,
+    )
+    if not return_diagnostics:
+        return result
+
+    updated_mean, updated_covariance, robust_diagnostics = result
+    robust_diagnostics["scaled_meas_noise"] = _as_matrix(meas_noise, "meas_noise") * scale
+    return updated_mean, updated_covariance, robust_diagnostics

--- a/src/pyrecest/filters/kalman_filter.py
+++ b/src/pyrecest/filters/kalman_filter.py
@@ -3,7 +3,11 @@
 from pyrecest.backend import atleast_1d, atleast_2d, eye
 from pyrecest.distributions import GaussianDistribution
 
-from ._linear_gaussian import linear_gaussian_predict, linear_gaussian_update
+from ._linear_gaussian import (
+    linear_gaussian_predict,
+    linear_gaussian_update,
+    linear_gaussian_update_robust,
+)
 from .abstract_filter import AbstractFilter
 from .manifold_mixins import EuclideanFilterMixin
 
@@ -258,6 +262,77 @@ class KalmanFilter(AbstractFilter, EuclideanFilterMixin):
             check_validity=False,
         )
         return diagnostics
+
+    def update_linear_robust(
+        self,
+        measurement,
+        measurement_matrix,
+        meas_noise,
+        robust_method="student-t",
+        *,
+        student_t_dof=4.0,
+        huber_threshold=2.0,
+        gate_threshold=None,
+        inflation_alpha=1.0,
+        return_diagnostics=False,
+    ):
+        """Update with a robust linear Gaussian measurement model.
+
+        This method preserves the standard Kalman update behavior when
+        ``robust_method`` is ``None`` or ``"none"``. For ``"student-t"`` and
+        ``"huber"``, the measurement covariance is adaptively inflated based on
+        the innovation's normalized squared Mahalanobis distance before the
+        Joseph-form update is applied.
+        """
+        result = linear_gaussian_update_robust(
+            mean=self._filter_state.mu,
+            covariance=self._filter_state.C,
+            measurement=measurement,
+            measurement_matrix=measurement_matrix,
+            meas_noise=meas_noise,
+            robust_method=robust_method,
+            student_t_dof=student_t_dof,
+            huber_threshold=huber_threshold,
+            gate_threshold=gate_threshold,
+            inflation_alpha=inflation_alpha,
+            return_diagnostics=return_diagnostics,
+        )
+        if return_diagnostics:
+            new_mean, new_covariance, diagnostics = result
+        else:
+            new_mean, new_covariance = result
+            diagnostics = None
+        self._filter_state = GaussianDistribution(
+            new_mean,
+            new_covariance,
+            check_validity=False,
+        )
+        return diagnostics
+
+    def update_model_robust(
+        self,
+        measurement_model,
+        measurement,
+        robust_method="student-t",
+        **kwargs,
+    ):
+        """Robustly update using a structural linear Gaussian model object."""
+        measurement_matrix = _get_required_model_attribute(
+            measurement_model,
+            "measurement_matrix",
+        )
+        meas_noise = _get_required_model_attribute(
+            measurement_model,
+            "meas_noise",
+            "measurement_noise_cov",
+        )
+        return self.update_linear_robust(
+            measurement,
+            measurement_matrix,
+            meas_noise,
+            robust_method=robust_method,
+            **kwargs,
+        )
 
     def update_model(
         self,

--- a/tests/filters/test_robust_linear_gaussian_update.py
+++ b/tests/filters/test_robust_linear_gaussian_update.py
@@ -1,0 +1,140 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+import pyrecest.backend
+from pyrecest.backend import array, eye, to_numpy
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.filters import KalmanFilter
+from pyrecest.filters._linear_gaussian import (
+    huber_covariance_scale,
+    linear_gaussian_update,
+    linear_gaussian_update_robust,
+    normalized_innovation_squared,
+    student_t_covariance_scale,
+)
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+    reason="tests compare backend scalars with NumPy helpers",
+)
+class RobustLinearGaussianUpdateTest(unittest.TestCase):
+    def setUp(self):
+        self.mean = array([0.0, 0.0])
+        self.covariance = eye(2)
+        self.measurement_matrix = eye(2)
+        self.meas_noise = eye(2)
+
+    def test_normalized_innovation_squared_matches_mahalanobis_norm(self):
+        innovation = array([2.0, 0.0])
+        innovation_covariance = eye(2) * 2.0
+
+        nis = normalized_innovation_squared(innovation, innovation_covariance)
+
+        self.assertAlmostEqual(float(nis), 2.0)
+
+    def test_student_t_scale_is_monotonic(self):
+        small = student_t_covariance_scale(2.0, measurement_dim=2, dof=4.0)
+        large = student_t_covariance_scale(100.0, measurement_dim=2, dof=4.0)
+
+        self.assertEqual(float(small), 1.0)
+        self.assertGreater(float(large), float(small))
+
+    def test_huber_scale_uses_mahalanobis_threshold(self):
+        inlier = huber_covariance_scale(4.0, huber_threshold=2.0)
+        outlier = huber_covariance_scale(100.0, huber_threshold=2.0)
+
+        self.assertEqual(float(inlier), 1.0)
+        self.assertGreater(float(outlier), 1.0)
+
+    def test_student_t_update_downweights_outlier(self):
+        measurement = array([100.0, 100.0])
+        plain_mean, _ = linear_gaussian_update(
+            self.mean,
+            self.covariance,
+            measurement,
+            self.measurement_matrix,
+            self.meas_noise,
+        )
+        robust_mean, _, diagnostics = linear_gaussian_update_robust(
+            self.mean,
+            self.covariance,
+            measurement,
+            self.measurement_matrix,
+            self.meas_noise,
+            robust_method="student-t",
+            student_t_dof=4.0,
+            return_diagnostics=True,
+        )
+
+        self.assertGreater(float(diagnostics["scale"]), 1.0)
+        self.assertLess(
+            np.linalg.norm(to_numpy(robust_mean)),
+            np.linalg.norm(to_numpy(plain_mean)),
+        )
+
+    def test_huber_update_downweights_outlier(self):
+        measurement = array([100.0, 100.0])
+        plain_mean, _ = linear_gaussian_update(
+            self.mean,
+            self.covariance,
+            measurement,
+            self.measurement_matrix,
+            self.meas_noise,
+        )
+        robust_mean, _, diagnostics = linear_gaussian_update_robust(
+            self.mean,
+            self.covariance,
+            measurement,
+            self.measurement_matrix,
+            self.meas_noise,
+            robust_method="huber",
+            huber_threshold=2.0,
+            return_diagnostics=True,
+        )
+
+        self.assertGreater(float(diagnostics["scale"]), 1.0)
+        self.assertLess(
+            np.linalg.norm(to_numpy(robust_mean)),
+            np.linalg.norm(to_numpy(plain_mean)),
+        )
+
+    def test_none_method_matches_standard_update(self):
+        measurement = array([1.0, -1.0])
+        plain_mean, plain_covariance = linear_gaussian_update(
+            self.mean,
+            self.covariance,
+            measurement,
+            self.measurement_matrix,
+            self.meas_noise,
+        )
+        robust_mean, robust_covariance = linear_gaussian_update_robust(
+            self.mean,
+            self.covariance,
+            measurement,
+            self.measurement_matrix,
+            self.meas_noise,
+            robust_method="none",
+        )
+
+        npt.assert_allclose(to_numpy(robust_mean), to_numpy(plain_mean))
+        npt.assert_allclose(to_numpy(robust_covariance), to_numpy(plain_covariance))
+
+    def test_kalman_filter_update_linear_robust_returns_diagnostics(self):
+        kf = KalmanFilter(GaussianDistribution(self.mean, self.covariance))
+        diagnostics = kf.update_linear_robust(
+            array([100.0, 100.0]),
+            self.measurement_matrix,
+            self.meas_noise,
+            robust_method="student-t",
+            return_diagnostics=True,
+        )
+
+        self.assertIn("nis", diagnostics)
+        self.assertGreater(float(diagnostics["scale"]), 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Conflict-resolved replacement for the closed PR #1994.

This builds on the current `main` implementation, which already contains plain linear-update diagnostics and Student-t/Huber scale helpers, and adds the remaining reusable robust update API:

- `nis_inflation_covariance_scale(...)`
- `robust_measurement_covariance_scale(...)`
- `linear_gaussian_innovation_statistics(...)`
- `linear_gaussian_update_robust(...)`
- `KalmanFilter.update_linear_robust(...)`
- `KalmanFilter.update_model_robust(...)`
- regression tests for scale behavior, outlier downweighting, and the class wrapper

The standard `linear_gaussian_update(...)` and `KalmanFilter.update_linear(...)` behavior remain unchanged.

## Validation

Not run in this environment.