### PR TITLE
Add named pairwise association feature schema

### DIFF
--- a/src/pyrecest/distributions/conditional/sd_half_cond_sd_half_grid_distribution.py
+++ b/src/pyrecest/distributions/conditional/sd_half_cond_sd_half_grid_distribution.py
@@ -57,8 +57,8 @@ class SdHalfCondSdHalfGridDistribution(AbstractConditionalDistribution):
 
     def _check_normalization(self, tol=0.01):
         """Warn if any column is not normalized to 1 over the hemisphere."""
-        # Match HyperhemisphericalGridDistribution.get_manifold_size(): for a
-        # hemisphere embedded in R^d, the represented manifold is S^(d-1).
+        # Match HyperhemisphericalGridDistribution.get_manifold_size(): a grid
+        # in R^d represents S^{d-1}, so the quadrature surface uses d - 1.
         hemisphere_surface = 0.5 * (
             AbstractHypersphereSubsetDistribution.compute_unit_hypersphere_surface(
                 self.grid.shape[1] - 1

--- a/src/pyrecest/distributions/conditional/sd_half_cond_sd_half_grid_distribution.py
+++ b/src/pyrecest/distributions/conditional/sd_half_cond_sd_half_grid_distribution.py
@@ -57,11 +57,11 @@ class SdHalfCondSdHalfGridDistribution(AbstractConditionalDistribution):
 
     def _check_normalization(self, tol=0.01):
         """Warn if any column is not normalized to 1 over the hemisphere."""
-        # Match HyperhemisphericalGridDistribution.get_manifold_size(), which
-        # uses the grid embedding dimension for the existing quadrature rule.
+        # Match HyperhemisphericalGridDistribution.get_manifold_size(): for a
+        # hemisphere embedded in R^d, the represented manifold is S^(d-1).
         hemisphere_surface = 0.5 * (
             AbstractHypersphereSubsetDistribution.compute_unit_hypersphere_surface(
-                self.grid.shape[1]
+                self.grid.shape[1] - 1
             )
         )
         ints = mean(self.grid_values, axis=0) * hemisphere_surface

--- a/src/pyrecest/filters/so3_grid_transition.py
+++ b/src/pyrecest/filters/so3_grid_transition.py
@@ -88,10 +88,10 @@ def so3_right_multiplication_grid_transition(
     column_maxima = reshape(amax(exponents, axis=0), (1, exponents.shape[1]))
     scores = exp(exponents - column_maxima)
 
-    manifold_size = (
-        0.5
-        * AbstractHypersphereSubsetDistribution.compute_unit_hypersphere_surface(
-            quaternion_grid.shape[1] - 1
+    manifold_dim = quaternion_grid.shape[1] - 1
+    manifold_size = 0.5 * (
+        AbstractHypersphereSubsetDistribution.compute_unit_hypersphere_surface(
+            manifold_dim
         )
     )
     column_integrals = sum(scores, axis=0, keepdims=True) / scores.shape[0]

--- a/src/pyrecest/filters/so3_grid_transition.py
+++ b/src/pyrecest/filters/so3_grid_transition.py
@@ -91,7 +91,7 @@ def so3_right_multiplication_grid_transition(
     manifold_size = (
         0.5
         * AbstractHypersphereSubsetDistribution.compute_unit_hypersphere_surface(
-            quaternion_grid.shape[1]
+            quaternion_grid.shape[1] - 1
         )
     )
     column_integrals = sum(scores, axis=0, keepdims=True) / scores.shape[0]

--- a/src/pyrecest/utils/__init__.py
+++ b/src/pyrecest/utils/__init__.py
@@ -1,6 +1,11 @@
 """Utility helpers for :mod:`pyrecest`."""
 
 from .assignment import murty_k_best_assignments
+from .association_features import (
+    CalibratedPairwiseAssociationModel,
+    NamedPairwiseFeatureSchema,
+    pairwise_feature_tensor,
+)
 from .association_models import LogisticPairwiseAssociationModel
 from .history_recorder import HistoryRecorder
 from .multisession_assignment import (
@@ -49,7 +54,10 @@ __all__ = [
     "stitch_tracks_from_pairwise_scores",
     "tracks_to_index_matrix",
     "tracks_to_session_labels",
+    "CalibratedPairwiseAssociationModel",
     "LogisticPairwiseAssociationModel",
+    "NamedPairwiseFeatureSchema",
+    "pairwise_feature_tensor",
     "HistoryRecorder",
     "ThinPlateSplineRegistrationResult",
     "ThinPlateSplineTransform",

--- a/src/pyrecest/utils/association_features.py
+++ b/src/pyrecest/utils/association_features.py
@@ -1,0 +1,300 @@
+"""Named pairwise feature helpers for probabilistic association models."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Literal
+
+# pylint: disable=no-name-in-module,no-member,redefined-builtin
+from pyrecest.backend import (
+    asarray,
+    clip,
+    exp,
+    float64,
+    isinf,
+    isnan,
+    log,
+    stack,
+    where,
+)
+
+_COST_MODE = Literal["negative_log_probability", "one_minus_probability"]
+FeatureTransform = Callable[[Mapping[str, Any]], Any]
+
+
+@dataclass(frozen=True, init=False)
+class NamedPairwiseFeatureSchema:
+    """Named schema for building pairwise feature tensors from components.
+
+    Parameters
+    ----------
+    feature_names:
+        Ordered names of the feature planes to stack on the final tensor axis.
+        If no transform is registered for a name, the same key is looked up in
+        ``components`` when building a tensor.
+    transforms:
+        Optional mapping from feature name to a callable receiving the full
+        component mapping and returning the feature plane. This keeps derived
+        features domain-specific without baking their semantics into PyRecEst.
+    """
+
+    feature_names: tuple[str, ...]
+    transforms: Mapping[str, FeatureTransform]
+
+    def __init__(
+        self,
+        feature_names: Sequence[str],
+        *,
+        transforms: Mapping[str, FeatureTransform] | None = None,
+    ) -> None:
+        normalized_names = _normalize_feature_names(feature_names)
+        normalized_transforms = _normalize_feature_transforms(
+            normalized_names, transforms
+        )
+        object.__setattr__(self, "feature_names", normalized_names)
+        object.__setattr__(
+            self, "transforms", MappingProxyType(normalized_transforms)
+        )
+
+    def __len__(self) -> int:
+        return len(self.feature_names)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.feature_names)
+
+    def feature_index(self, feature_name: str) -> int:
+        """Return the last-axis index of a named feature."""
+        try:
+            return self.feature_names.index(feature_name)
+        except ValueError as exc:
+            raise KeyError(f"Unknown feature name {feature_name!r}") from exc
+
+    def build_tensor(self, components: Mapping[str, Any]) -> Any:
+        """Build a ``(..., n_features)`` tensor from named pairwise components."""
+        return pairwise_feature_tensor(
+            components, self.feature_names, transforms=self.transforms
+        )
+
+
+def pairwise_feature_tensor(
+    components: Mapping[str, Any],
+    feature_names: Sequence[str] | NamedPairwiseFeatureSchema,
+    transforms: Mapping[str, FeatureTransform] | None = None,
+) -> Any:
+    """Build a pairwise feature tensor from named component planes.
+
+    All feature planes must have the same shape. Non-finite values are converted
+    to finite sentinels: ``nan -> 0``, ``+inf -> 1e6``, and ``-inf -> -1e6``.
+    """
+    if isinstance(feature_names, NamedPairwiseFeatureSchema):
+        if transforms is not None:
+            raise ValueError(
+                "transforms must be omitted when feature_names is a schema"
+            )
+        return pairwise_feature_tensor(
+            components, feature_names.feature_names, transforms=feature_names.transforms
+        )
+
+    normalized_names = _normalize_feature_names(feature_names)
+    normalized_transforms = _normalize_feature_transforms(
+        normalized_names, transforms
+    )
+    feature_planes = [
+        _component_feature(components, feature_name, normalized_transforms)
+        for feature_name in normalized_names
+    ]
+    reference_shape = feature_planes[0].shape
+    for feature_name, feature_plane in zip(normalized_names, feature_planes):
+        if feature_plane.shape != reference_shape:
+            raise ValueError(
+                f"Feature {feature_name!r} has shape {feature_plane.shape}, expected {reference_shape}"
+            )
+    return stack(feature_planes, axis=-1)
+
+
+@dataclass(frozen=True, init=False)
+class CalibratedPairwiseAssociationModel:
+    """Association model wrapper that keeps a named pairwise feature schema.
+
+    The wrapped model may expose ``predict_match_probability``,
+    ``predict_proba``, or ``pairwise_cost_matrix``. Component mappings are first
+    converted to tensors via ``schema`` before being passed to the model.
+    """
+
+    model: Any
+    schema: NamedPairwiseFeatureSchema
+    probability_clip: float
+
+    def __init__(
+        self,
+        model: Any,
+        feature_names: Sequence[str] | None = None,
+        *,
+        schema: NamedPairwiseFeatureSchema | None = None,
+        transforms: Mapping[str, FeatureTransform] | None = None,
+        probability_clip: float = 1.0e-12,
+    ) -> None:
+        if schema is not None and feature_names is not None:
+            raise ValueError("Provide either schema or feature_names, not both")
+        if schema is not None and transforms is not None:
+            raise ValueError("transforms must be attached to the provided schema")
+        if schema is None:
+            if feature_names is None:
+                raise ValueError("feature_names or schema is required")
+            schema = NamedPairwiseFeatureSchema(
+                feature_names, transforms=transforms
+            )
+        if not 0.0 < probability_clip < 0.5:
+            raise ValueError("probability_clip must lie in (0, 0.5)")
+
+        object.__setattr__(self, "model", model)
+        object.__setattr__(self, "schema", schema)
+        object.__setattr__(self, "probability_clip", float(probability_clip))
+
+    @property
+    def feature_names(self) -> tuple[str, ...]:
+        """Ordered feature names expected by the wrapped model."""
+        return self.schema.feature_names
+
+    def build_feature_tensor(self, components: Mapping[str, Any]) -> Any:
+        """Build a feature tensor using this model's schema."""
+        return self.schema.build_tensor(components)
+
+    def predict_match_probability(self, features_or_components: Any) -> Any:
+        """Return calibrated match probabilities for tensors or components."""
+        features = self._features_from_components_or_tensor(features_or_components)
+        if hasattr(self.model, "predict_match_probability"):
+            probabilities = self.model.predict_match_probability(features)
+        elif hasattr(self.model, "predict_proba"):
+            probabilities = self._predict_proba_probability(features)
+        elif hasattr(self.model, "pairwise_cost_matrix"):
+            costs = asarray(self.model.pairwise_cost_matrix(features), dtype=float64)
+            probabilities = exp(-costs)
+        else:
+            raise TypeError(
+                "model must expose predict_match_probability, predict_proba, or pairwise_cost_matrix"
+            )
+        return clip(asarray(probabilities, dtype=float64), 0.0, 1.0)
+
+    def pairwise_probability_matrix_from_components(
+        self, components: Mapping[str, Any]
+    ) -> Any:
+        """Convert components into calibrated pairwise probabilities."""
+        return self.predict_match_probability(components)
+
+    def pairwise_cost_matrix_from_components(
+        self,
+        components: Mapping[str, Any],
+        *,
+        mode: _COST_MODE = "negative_log_probability",
+    ) -> Any:
+        """Convert components into calibrated assignment costs."""
+        return self.pairwise_cost_matrix(components, mode=mode)
+
+    def pairwise_cost_matrix(
+        self,
+        features_or_components: Any,
+        *,
+        mode: _COST_MODE = "negative_log_probability",
+    ) -> Any:
+        """Convert features or components into an assignment cost matrix."""
+        probabilities = clip(
+            self.predict_match_probability(features_or_components),
+            self.probability_clip,
+            1.0 - self.probability_clip,
+        )
+        if mode == "negative_log_probability":
+            return -log(probabilities)
+        if mode == "one_minus_probability":
+            return 1.0 - probabilities
+        raise ValueError(f"Unsupported cost mode: {mode}")
+
+    def _features_from_components_or_tensor(self, features_or_components: Any) -> Any:
+        if isinstance(features_or_components, Mapping):
+            return self.build_feature_tensor(features_or_components)
+        return features_or_components
+
+    def _predict_proba_probability(self, features: Any) -> Any:
+        flattened_features, original_shape = _flatten_prediction_features(features)
+        probabilities = asarray(
+            self.model.predict_proba(flattened_features), dtype=float64
+        )
+        if probabilities.ndim >= 2 and probabilities.shape[-1] == 2:
+            probabilities = probabilities[..., 1]
+        elif probabilities.ndim != 1:
+            raise ValueError(
+                "predict_proba must return probabilities with shape (n_samples,) or (n_samples, 2)"
+            )
+        if original_shape == ():
+            return asarray(probabilities[0], dtype=float64)
+        return probabilities.reshape(original_shape)
+
+
+def _normalize_feature_names(feature_names: Sequence[str]) -> tuple[str, ...]:
+    if isinstance(feature_names, str):
+        raise ValueError("feature_names must be a sequence of names, not a string")
+    normalized_names = tuple(feature_names)
+    if not normalized_names:
+        raise ValueError("At least one feature is required")
+    for feature_name in normalized_names:
+        if not isinstance(feature_name, str) or not feature_name:
+            raise ValueError("feature_names must contain non-empty strings")
+    if len(set(normalized_names)) != len(normalized_names):
+        raise ValueError("feature_names must not contain duplicates")
+    return normalized_names
+
+
+def _normalize_feature_transforms(
+    feature_names: tuple[str, ...],
+    transforms: Mapping[str, FeatureTransform] | None,
+) -> dict[str, FeatureTransform]:
+    if transforms is None:
+        return {}
+    normalized_transforms = dict(transforms)
+    unknown_transforms = set(normalized_transforms) - set(feature_names)
+    if unknown_transforms:
+        raise KeyError(
+            f"Transforms supplied for unknown features: {sorted(unknown_transforms)!r}"
+        )
+    for feature_name, transform in normalized_transforms.items():
+        if not callable(transform):
+            raise TypeError(f"Transform for feature {feature_name!r} must be callable")
+    return normalized_transforms
+
+
+def _component_feature(
+    components: Mapping[str, Any],
+    feature_name: str,
+    transforms: Mapping[str, FeatureTransform],
+) -> Any:
+    if feature_name in transforms:
+        values = transforms[feature_name](components)
+    else:
+        if feature_name not in components:
+            raise KeyError(f"Pairwise components do not contain {feature_name!r}")
+        values = components[feature_name]
+    return _finite_feature_plane(values, feature_name)
+
+
+def _finite_feature_plane(values: Any, feature_name: str) -> Any:
+    values = asarray(values, dtype=float64)
+    if values.ndim == 0:
+        raise ValueError(f"Feature {feature_name!r} must be at least one-dimensional")
+    finite_values = where(isnan(values), 0.0, values)
+    finite_values = where(
+        isinf(finite_values),
+        where(finite_values > 0.0, 1.0e6, -1.0e6),
+        finite_values,
+    )
+    return finite_values
+
+
+def _flatten_prediction_features(features: Any) -> tuple[Any, tuple[int, ...]]:
+    features = asarray(features, dtype=float64)
+    if features.ndim == 0:
+        raise ValueError("features must be at least one-dimensional")
+    if features.ndim == 1:
+        return features[None, :], ()
+    return features.reshape(-1, features.shape[-1]), features.shape[:-1]

--- a/tests/test_association_models.py
+++ b/tests/test_association_models.py
@@ -19,7 +19,12 @@ from pyrecest.backend import (
     vstack,
     zeros,
 )
-from pyrecest.utils import LogisticPairwiseAssociationModel
+from pyrecest.utils import (
+    CalibratedPairwiseAssociationModel,
+    LogisticPairwiseAssociationModel,
+    NamedPairwiseFeatureSchema,
+    pairwise_feature_tensor,
+)
 
 
 class TestLogisticPairwiseAssociationModel(unittest.TestCase):
@@ -127,6 +132,60 @@ class TestLogisticPairwiseAssociationModel(unittest.TestCase):
             model.fit(
                 self.training_features, zeros(self.training_labels.shape, dtype=int) + 2
             )
+
+    def test_pairwise_feature_tensor_stacks_named_components_and_sanitizes(self):
+        components = {
+            "distance": array([[0.0, float("inf")], [float("nan"), -float("inf")]]),
+            "overlap": array([[0.9, 0.2], [0.1, 0.8]]),
+        }
+
+        features = pairwise_feature_tensor(
+            components,
+            ("distance", "one_minus_overlap"),
+            transforms={"one_minus_overlap": lambda item: 1.0 - item["overlap"]},
+        )
+
+        self.assertEqual(features.shape, (2, 2, 2))
+        npt.assert_allclose(
+            features[:, :, 0], array([[0.0, 1.0e6], [0.0, -1.0e6]])
+        )
+        npt.assert_allclose(features[:, :, 1], array([[0.1, 0.8], [0.9, 0.2]]))
+
+    def test_named_pairwise_feature_schema_validates_feature_layout(self):
+        schema = NamedPairwiseFeatureSchema(("distance", "similarity"))
+        self.assertEqual(schema.feature_index("similarity"), 1)
+
+        with self.assertRaises(KeyError):
+            schema.build_tensor({"distance": array([[1.0]])})
+        with self.assertRaises(ValueError):
+            pairwise_feature_tensor(
+                {
+                    "distance": array([[1.0, 2.0]]),
+                    "similarity": array([[1.0], [2.0]]),
+                },
+                ("distance", "similarity"),
+            )
+
+    def test_calibrated_pairwise_association_model_uses_named_components(self):
+        model = LogisticPairwiseAssociationModel(class_weight="balanced")
+        model.fit(self.training_features, self.training_labels)
+        calibrated_model = CalibratedPairwiseAssociationModel(
+            model, feature_names=("distance", "similarity")
+        )
+        components = {
+            "distance": array([[0.15, 2.2], [2.6, 0.18]]),
+            "similarity": array([[0.92, 0.15], [0.08, 0.88]]),
+        }
+
+        probabilities = calibrated_model.pairwise_probability_matrix_from_components(
+            components
+        )
+        costs = calibrated_model.pairwise_cost_matrix_from_components(components)
+
+        self.assertEqual(probabilities.shape, (2, 2))
+        self.assertEqual(costs.shape, (2, 2))
+        npt.assert_array_equal(argmax(probabilities, axis=1), array([0, 1]))
+        npt.assert_array_equal(argmin(costs, axis=1), array([0, 1]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a generic named-feature convenience layer around the existing LogisticPairwiseAssociationModel.

Changes:
- Adds NamedPairwiseFeatureSchema, pairwise_feature_tensor, and CalibratedPairwiseAssociationModel.
- Keeps derived feature semantics generic via explicit transforms.
- Exports the new helpers from pyrecest.utils.
- Adds tests for tensor construction, finite-value sanitization, schema validation, and calibrated probability/cost conversion.

This intentionally keeps Track2p/Suite2p/ROI-specific defaults and feature semantics downstream in BayesCaTrack.