### PR TITLE
Fix pylint issues in recent filter utilities

### DIFF
--- a/src/pyrecest/filters/_linear_gaussian.py
+++ b/src/pyrecest/filters/_linear_gaussian.py
@@ -51,7 +51,10 @@ def normalized_innovation_squared(innovation, innovation_covariance):
     return transpose(innovation) @ linalg.solve(innovation_covariance, innovation)
 
 
-def huber_covariance_scale(normalized_innovation_squared, huber_threshold=2.0):
+def huber_covariance_scale(  # pylint: disable=redefined-outer-name
+    normalized_innovation_squared,
+    huber_threshold=2.0,
+):
     """Return measurement-covariance scaling for a Huber robust update.
 
     The Huber weight is one for Mahalanobis innovation norm below ``k`` and
@@ -75,7 +78,7 @@ def huber_covariance_scale(normalized_innovation_squared, huber_threshold=2.0):
     return maximum(1.0, sqrt(nis) / huber_threshold)
 
 
-def student_t_covariance_scale(
+def student_t_covariance_scale(  # pylint: disable=redefined-outer-name
     normalized_innovation_squared,
     measurement_dim,
     dof=4.0,
@@ -126,6 +129,7 @@ def student_t_covariance_scale(
 def _robust_update_decision(
     normalized_innovation_squared_value,
     measurement_dim,
+    *,
     robust_update,
     gate_threshold,
     student_t_dof,
@@ -314,11 +318,11 @@ def linear_gaussian_update_robust(
     accepted, action, scale = _robust_update_decision(
         nis,
         meas_dim,
-        robust_update,
-        gate_threshold,
-        student_t_dof,
-        huber_threshold,
-        inflation_alpha,
+        robust_update=robust_update,
+        gate_threshold=gate_threshold,
+        student_t_dof=student_t_dof,
+        huber_threshold=huber_threshold,
+        inflation_alpha=inflation_alpha,
     )
 
     if not accepted:

--- a/src/pyrecest/filters/relaxed_s3f_so3.py
+++ b/src/pyrecest/filters/relaxed_s3f_so3.py
@@ -45,7 +45,7 @@ SUPPORTED_RELAXED_S3F_SO3_VARIANTS = ("baseline", "r1", "r1_r2")
 SUPPORTED_S3R3_CELL_METHODS = ("local_tangent_samples",)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True)  # pylint: disable=too-many-instance-attributes
 class S3R3CellStatistics:
     """Numerical R1/R2 statistics for local tangent cells around S3+ points.
 

--- a/src/pyrecest/utils/track_evaluation.py
+++ b/src/pyrecest/utils/track_evaluation.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-positional-arguments
 """Generic evaluation helpers for multi-session track matrices."""
 
 from __future__ import annotations

--- a/tests/filters/test_relaxed_s3f_so3.py
+++ b/tests/filters/test_relaxed_s3f_so3.py
@@ -1,3 +1,4 @@
+# pylint: disable=no-value-for-parameter
 import unittest
 
 from pyrecest.backend import allclose, array, eye, linalg, ones, zeros


### PR DESCRIPTION
## Summary

- Fix `_robust_update_decision(...)` to avoid the too-many-positional-arguments lint warning by making configuration arguments keyword-only.
- Add narrow pylint suppressions for public NIS scale-helper parameter names, the relaxed S3F statistics dataclass, Track2p-style track-evaluation helper arity, and the lru_cache wrapper false positive in the relaxed S3F test.

## Notes

The changes are intended to preserve behavior and only address the reported MegaLinter/pylint failures.

## Validation

Not run locally in this environment.