### PR TITLE
Bump urllib3 requirements to 2.7.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -71,5 +71,5 @@ tqdm==4.67.3 ; python_version >= "3.11" and python_version < "3.15"
 triton==3.6.0 ; python_version >= "3.11" and python_version < "3.15" and platform_system == "Linux"
 typing-extensions==4.15.0 ; python_version >= "3.11" and python_version < "3.15"
 tzdata==2026.1 ; python_version >= "3.11" and python_version < "3.15" and (sys_platform == "win32" or sys_platform == "emscripten")
-urllib3==2.6.3 ; python_version >= "3.11" and python_version < "3.15"
+urllib3==2.7.0 ; python_version >= "3.11" and python_version < "3.15"
 xarray==2026.4.0 ; python_version >= "3.11" and python_version < "3.15"

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,5 +59,5 @@ tqdm==4.67.3 ; python_version >= "3.11" and python_version < "3.15"
 triton==3.6.0 ; python_version >= "3.11" and python_version < "3.15" and platform_system == "Linux"
 typing-extensions==4.15.0 ; python_version >= "3.11" and python_version < "3.15"
 tzdata==2026.1 ; python_version >= "3.11" and python_version < "3.15" and (sys_platform == "win32" or sys_platform == "emscripten")
-urllib3==2.6.3 ; python_version >= "3.11" and python_version < "3.15"
+urllib3==2.7.0 ; python_version >= "3.11" and python_version < "3.15"
 xarray==2026.4.0 ; python_version >= "3.11" and python_version < "3.15"


### PR DESCRIPTION
## Summary
- update exported runtime and development requirements from urllib3 2.6.3 to 2.7.0
- align requirements files with the existing poetry.lock urllib3 2.7.0 entry

## Verification
- `rg "urllib3==|name = \"urllib3\"|urllib3-2\.7\.0" -n requirements.txt requirements-dev.txt poetry.lock`
- `git diff --check`