### PR TITLE
Update MEM-QKF robustness

### DIFF
--- a/src/pyrecest/filters/mem_qkf_tracker.py
+++ b/src/pyrecest/filters/mem_qkf_tracker.py
@@ -1,28 +1,63 @@
 from __future__ import annotations
 
+from typing import Any
+
 # pylint: disable=no-name-in-module,no-member,duplicate-code,too-many-locals
-from pyrecest.backend import array, cos, eye, kron, linalg, mean, sin, zeros
+from pyrecest.backend import abs as backend_abs
+from pyrecest.backend import (
+    array,
+    cos,
+    diag,
+    eye,
+    kron,
+    linalg,
+    maximum,
+    mean,
+    sin,
+    where,
+    zeros,
+)
 
 from .mem_ekf_tracker import MEMEKFTracker
 
 
 class MEMQKFTracker(MEMEKFTracker):
-    """Quadratic Kalman-filter MEM tracker for one 2-D elliptical object.
+    """Sequential decoupled MEM-QKF tracker for one 2-D elliptical object.
 
     This filter ports the MEM-QKF update used in the quadratic extended-object
     tracking benchmark to PyRecEst's MEM tracker convention. The state is split
     into a Euclidean kinematic state and a shape state
-    ``[orientation, semi_axis_1, semi_axis_2]``. The update is sequential in the
-    point measurements and decomposes the shape update into an orientation
-    update and an axis-length update.
+    ``[orientation, semi_axis_1, semi_axis_2]``. This differs from the reference
+    benchmark helper that reports full ``length`` and ``width`` by doubling its
+    internal semi-axis states.
 
-    The reference MEM-QKF equations keep the orientation covariance separate
-    from the two axis-length covariances. Consequently this implementation only
-    retains the block-diagonal terms of ``shape_covariance``:
+    The update is sequential in target-originated point measurements. For each
+    point, it performs a kinematic Kalman update, a scalar quadratic orientation
+    update, and a two-dimensional quadratic semi-axis update. The reference
+    MEM-QKF equations keep the orientation covariance separate from the two
+    axis-length covariances. Consequently this implementation only retains the
+    block-diagonal terms of ``shape_covariance``:
     ``shape_covariance[0, 0]`` and ``shape_covariance[1:, 1:]``. Cross-covariance
     terms between orientation and axes are ignored and reset to zero after
     initialization, prediction, and update.
+
+    Parameters added by this subclass
+    ---------------------------------
+    default_meas_noise_cov : array-like, optional
+        Measurement-noise covariance used by :meth:`update` when
+        ``meas_noise_cov`` is omitted. This is useful when porting code from
+        reference implementations that store ``R`` in the tracker instance.
+    minimum_axis_length : float, default=1e-9
+        Lower bound applied to semi-axis lengths after updates.
+    minimum_covariance_eigenvalue : float, default=0.0
+        Lower bound used when projecting updated covariance matrices back to the
+        positive-semidefinite cone.
     """
+
+    kinematic_state: Any
+    covariance: Any
+    shape_state: Any
+    shape_covariance: Any
 
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     def __init__(
@@ -38,6 +73,9 @@ class MEMQKFTracker(MEMEKFTracker):
         log_posterior_estimates=False,
         log_prior_extents=False,
         log_posterior_extents=False,
+        default_meas_noise_cov=None,
+        minimum_axis_length=1e-9,
+        minimum_covariance_eigenvalue=0.0,
     ):
         super().__init__(
             kinematic_state,
@@ -52,9 +90,28 @@ class MEMQKFTracker(MEMEKFTracker):
             log_prior_extents=log_prior_extents,
             log_posterior_extents=log_posterior_extents,
         )
+        self.minimum_axis_length = float(minimum_axis_length)
+        if self.minimum_axis_length <= 0.0:
+            raise ValueError("minimum_axis_length must be positive")
+        self.minimum_covariance_eigenvalue = float(minimum_covariance_eigenvalue)
+        if self.minimum_covariance_eigenvalue < 0.0:
+            raise ValueError("minimum_covariance_eigenvalue must be non-negative")
+
+        self.default_meas_noise_cov = None
+        self.set_default_measurement_noise_cov(default_meas_noise_cov)
         self.shape_covariance = self._decoupled_shape_covariance(
-            self.shape_covariance[0, 0],
-            self.shape_covariance[1:, 1:],
+            self._regularize_variance(self.shape_covariance[0, 0]),
+            self._project_symmetric_covariance(self.shape_covariance[1:, 1:]),
+        )
+        orientation = self.shape_state[0]
+        axes, axis_covariance = self._canonicalize_axes_and_axis_covariance(
+            self.shape_state[1:],
+            self.axis_covariance,
+        )
+        self.shape_state = array([orientation, axes[0], axes[1]])
+        self.shape_covariance = self._decoupled_shape_covariance(
+            self.orientation_variance,
+            axis_covariance,
         )
 
     @staticmethod
@@ -80,13 +137,34 @@ class MEMQKFTracker(MEMEKFTracker):
             linalg.block_diag(array([[orientation_variance]]), axis_covariance)
         )
 
+    def _regularize_variance(self, variance):
+        if float(variance) < self.minimum_covariance_eigenvalue:
+            return array(self.minimum_covariance_eigenvalue)
+        return variance
+
+    def _project_symmetric_covariance(self, covariance):
+        covariance = self._symmetrize(covariance)
+        eigenvalues, eigenvectors = linalg.eigh(covariance)
+        if float(eigenvalues[0]) >= self.minimum_covariance_eigenvalue:
+            return covariance
+        eigenvalues = maximum(eigenvalues, self.minimum_covariance_eigenvalue)
+        return self._symmetrize((eigenvectors * eigenvalues) @ eigenvectors.T)
+
+    def _canonicalize_axes_and_axis_covariance(self, axes, axis_covariance):
+        axes = array(axes)
+        signs = where(axes < 0.0, -1.0, 1.0)
+        sign_matrix = diag(signs)
+        axis_covariance = sign_matrix @ axis_covariance @ sign_matrix.T
+        axes = maximum(backend_abs(axes), self.minimum_axis_length)
+        return axes, self._project_symmetric_covariance(axis_covariance)
+
     def _regularize_covariance(self, covariance):
         covariance = self._symmetrize(covariance)
         if self.covariance_regularization > 0.0:
             covariance = covariance + self.covariance_regularization * eye(
                 covariance.shape[0]
             )
-        return self._symmetrize(covariance)
+        return self._project_symmetric_covariance(covariance)
 
     @staticmethod
     def _gain_from_cross_covariance(cross_covariance, innovation_covariance):
@@ -100,6 +178,22 @@ class MEMQKFTracker(MEMEKFTracker):
     @property
     def axis_covariance(self):
         return self.shape_covariance[1:, 1:]
+
+    def set_default_measurement_noise_cov(self, meas_noise_cov):
+        """Set the measurement-noise covariance used by default in updates."""
+        if meas_noise_cov is None:
+            self.default_meas_noise_cov = None
+            return
+        self.default_meas_noise_cov = self._get_measurement_noise(meas_noise_cov)
+
+    def set_R(self, meas_noise_cov):
+        """Compatibility alias for setting the default measurement covariance."""
+        self.set_default_measurement_noise_cov(meas_noise_cov)
+
+    def _get_update_measurement_noise(self, meas_noise_cov):
+        if meas_noise_cov is None and self.default_meas_noise_cov is not None:
+            return self.default_meas_noise_cov
+        return self._get_measurement_noise(meas_noise_cov)
 
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     def predict_linear(
@@ -118,9 +212,14 @@ class MEMQKFTracker(MEMEKFTracker):
             shape_system_matrix=shape_system_matrix,
             shape_sys_noise=shape_sys_noise,
         )
-        self.shape_covariance = self._decoupled_shape_covariance(
-            self.shape_covariance[0, 0],
+        axes, axis_covariance = self._canonicalize_axes_and_axis_covariance(
+            self.shape_state[1:],
             self.shape_covariance[1:, 1:],
+        )
+        self.shape_state = array([self.shape_state[0], axes[0], axes[1]])
+        self.shape_covariance = self._decoupled_shape_covariance(
+            self._regularize_variance(self.shape_covariance[0, 0]),
+            axis_covariance,
         )
 
     def predict(self, *args, **kwargs):
@@ -140,7 +239,7 @@ class MEMQKFTracker(MEMEKFTracker):
             return
 
         measurement_matrix = self._get_measurement_matrix(meas_mat)
-        meas_noise_cov = self._get_measurement_noise(meas_noise_cov)
+        meas_noise_cov = self._get_update_measurement_noise(meas_noise_cov)
         multiplicative_noise_cov = self._get_multiplicative_noise_cov(
             multiplicative_noise_cov
         )
@@ -214,12 +313,16 @@ class MEMQKFTracker(MEMEKFTracker):
             multiplicative_noise_cov,
             shape_measurement_covariance,
         )
+        semi_axes, axis_covariance = self._canonicalize_axes_and_axis_covariance(
+            semi_axes,
+            axis_covariance,
+        )
 
         self.kinematic_state = kinematic_state
-        self.covariance = self._symmetrize(covariance)
+        self.covariance = self._project_symmetric_covariance(covariance)
         self.shape_state = array([orientation, semi_axes[0], semi_axes[1]])
         self.shape_covariance = self._decoupled_shape_covariance(
-            orientation_variance,
+            self._regularize_variance(orientation_variance),
             axis_covariance,
         )
 
@@ -321,8 +424,8 @@ class MEMQKFTracker(MEMEKFTracker):
                 shifted_measurement[0] * shifted_measurement[1],
             ]
         )
-        expected_pseudo_measurement = (
-            selection_matrix @ self._vectorize_columns(quadratic_covariance)
+        expected_pseudo_measurement = selection_matrix @ self._vectorize_columns(
+            quadratic_covariance
         )
         pseudo_covariance = self._regularize_covariance(
             selection_matrix
@@ -356,9 +459,10 @@ class MEMQKFTracker(MEMEKFTracker):
         )
         innovation = pseudo_measurement - expected_pseudo_measurement
         posterior_orientation = orientation + (orientation_gain @ innovation)[0]
-        posterior_orientation_variance = orientation_variance - (
-            orientation_gain @ orientation_cross_covariance.T
-        )[0, 0]
+        posterior_orientation_variance = (
+            orientation_variance
+            - (orientation_gain @ orientation_cross_covariance.T)[0, 0]
+        )
         return posterior_orientation, posterior_orientation_variance
 
     # pylint: disable=too-many-arguments

--- a/tests/filters/test_mem_qkf_tracker.py
+++ b/tests/filters/test_mem_qkf_tracker.py
@@ -1,11 +1,21 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member,protected-access,duplicate-code
 import pyrecest.backend
 from pyrecest.backend import all, array, diag, eye, linalg
 from pyrecest.filters import MEMQKFTracker, MemQkfTracker
+
+
+def _rot(angle):
+    return array(
+        [
+            [np.cos(angle), -np.sin(angle)],
+            [np.sin(angle), np.cos(angle)],
+        ]
+    )
 
 
 @unittest.skipIf(
@@ -124,6 +134,223 @@ class TestMEMQKFTracker(unittest.TestCase):
 
         npt.assert_allclose(self.tracker.kinematic_state, prior_kinematic_state)
         npt.assert_allclose(self.tracker.shape_state, prior_shape_state)
+
+    def test_default_measurement_noise_matches_explicit_noise(self):
+        R = _rot(0.35) @ diag(array([0.5, 1.3])) @ _rot(0.35).T
+        explicit_tracker = MEMQKFTracker(
+            self.kinematic_state,
+            self.covariance,
+            self.shape_state,
+            self.shape_covariance,
+            measurement_matrix=self.measurement_matrix,
+        )
+        default_tracker = MEMQKFTracker(
+            self.kinematic_state,
+            self.covariance,
+            self.shape_state,
+            self.shape_covariance,
+            measurement_matrix=self.measurement_matrix,
+            default_meas_noise_cov=R,
+        )
+
+        explicit_tracker.update(array([2.0, -0.5]), meas_noise_cov=R)
+        default_tracker.update(array([2.0, -0.5]))
+
+        npt.assert_allclose(
+            default_tracker.kinematic_state, explicit_tracker.kinematic_state
+        )
+        npt.assert_allclose(default_tracker.covariance, explicit_tracker.covariance)
+        npt.assert_allclose(default_tracker.shape_state, explicit_tracker.shape_state)
+        npt.assert_allclose(
+            default_tracker.shape_covariance, explicit_tracker.shape_covariance
+        )
+
+    def test_set_r_updates_default_measurement_noise(self):
+        R = _rot(0.2) @ diag(array([0.3, 0.9])) @ _rot(0.2).T
+        tracker_via_setter = MEMQKFTracker(
+            self.kinematic_state,
+            self.covariance,
+            self.shape_state,
+            self.shape_covariance,
+            measurement_matrix=self.measurement_matrix,
+        )
+        tracker_via_constructor = MEMQKFTracker(
+            self.kinematic_state,
+            self.covariance,
+            self.shape_state,
+            self.shape_covariance,
+            measurement_matrix=self.measurement_matrix,
+            default_meas_noise_cov=R,
+        )
+
+        tracker_via_setter.set_R(R)
+        tracker_via_setter.update(array([1.5, -0.2]))
+        tracker_via_constructor.update(array([1.5, -0.2]))
+
+        npt.assert_allclose(
+            tracker_via_setter.get_point_estimate(),
+            tracker_via_constructor.get_point_estimate(),
+        )
+        npt.assert_allclose(
+            tracker_via_setter.shape_covariance,
+            tracker_via_constructor.shape_covariance,
+        )
+
+    def test_canonicalizes_negative_axes_and_axis_covariance(self):
+        tracker = MEMQKFTracker(
+            self.kinematic_state,
+            self.covariance,
+            self.shape_state,
+            self.shape_covariance,
+            measurement_matrix=self.measurement_matrix,
+        )
+
+        axes, axis_covariance = tracker._canonicalize_axes_and_axis_covariance(
+            array([-2.0, 3.0]),
+            array([[4.0, 1.5], [1.5, 9.0]]),
+        )
+
+        npt.assert_allclose(axes, array([2.0, 3.0]))
+        npt.assert_allclose(axis_covariance, array([[4.0, -1.5], [-1.5, 9.0]]))
+
+    def test_projects_covariance_to_positive_semidefinite_cone(self):
+        tracker = MEMQKFTracker(
+            self.kinematic_state,
+            self.covariance,
+            self.shape_state,
+            self.shape_covariance,
+            measurement_matrix=self.measurement_matrix,
+        )
+
+        projected = tracker._project_symmetric_covariance(
+            array([[1.0, 2.0], [2.0, 1.0]])
+        )
+
+        self.assertTrue(all(linalg.eigvalsh(projected) >= -1e-12))
+        npt.assert_allclose(projected, projected.T)
+
+    def test_matches_reference_single_measurement_with_rotated_noise(self):
+        R = _rot(0.35) @ diag(array([0.5, 1.3])) @ _rot(0.35).T
+        tracker = MEMQKFTracker(
+            array([1.0, -2.0, 0.5, -0.25]),
+            diag(array([0.7, 0.5, 0.2, 0.15])),
+            array([0.4, 3.0, 1.5]),
+            array(
+                [
+                    [0.12, 0.03, -0.02],
+                    [0.03, 0.4, 0.05],
+                    [-0.02, 0.05, 0.3],
+                ]
+            ),
+            measurement_matrix=self.measurement_matrix,
+            default_meas_noise_cov=R,
+        )
+
+        tracker.update(array([4.2, -0.3]))
+
+        npt.assert_allclose(
+            tracker.kinematic_state,
+            array([1.640726536537, -1.726294883847, 0.5, -0.25]),
+            rtol=1e-11,
+            atol=1e-11,
+        )
+        npt.assert_allclose(
+            tracker.covariance,
+            array(
+                [
+                    [0.548779436205, 0.014872785112, 0.0, 0.0],
+                    [0.014872785112, 0.39950147325, 0.0, 0.0],
+                    [0.0, 0.0, 0.2, 0.0],
+                    [0.0, 0.0, 0.0, 0.15],
+                ]
+            ),
+            rtol=1e-11,
+            atol=1e-11,
+        )
+        npt.assert_allclose(
+            tracker.shape_state,
+            array([0.421699822463, 3.175376001946, 1.460534411964]),
+            rtol=1e-11,
+            atol=1e-11,
+        )
+        npt.assert_allclose(
+            tracker.shape_covariance,
+            array(
+                [
+                    [0.116431846933, 0.0, 0.0],
+                    [0.0, 0.388418700999, 0.050000621341],
+                    [0.0, 0.050000621341, 0.296641000868],
+                ]
+            ),
+            rtol=1e-11,
+            atol=1e-11,
+        )
+
+    def test_matches_reference_multiple_measurements_with_axis_covariance(self):
+        R = _rot(0.75) @ diag(array([0.8, 0.25])) @ _rot(0.75).T
+        tracker = MEMQKFTracker(
+            array([-1.0, 0.7, 0.4, 0.2]),
+            array(
+                [
+                    [0.8, 0.1, 0.0, 0.02],
+                    [0.1, 0.6, 0.01, 0.0],
+                    [0.0, 0.01, 0.2, 0.03],
+                    [0.02, 0.0, 0.03, 0.25],
+                ]
+            ),
+            array([-0.7, 2.5, 0.9]),
+            array(
+                [
+                    [0.18, 0.02, 0.01],
+                    [0.02, 0.35, -0.04],
+                    [0.01, -0.04, 0.22],
+                ]
+            ),
+            measurement_matrix=self.measurement_matrix,
+        )
+
+        tracker.update(
+            array([[0.6, -1.2], [1.4, 0.1], [-0.8, 1.6], [2.1, -0.4]]),
+            meas_noise_cov=R,
+        )
+
+        npt.assert_allclose(
+            tracker.kinematic_state,
+            array([0.169678397452, 0.432365872634, 0.39295584805, 0.231002997924]),
+            rtol=1e-11,
+            atol=1e-11,
+        )
+        npt.assert_allclose(
+            tracker.covariance,
+            array(
+                [
+                    [0.237025136168, -0.030283754173, -0.001019776956, 0.006180572643],
+                    [-0.030283754173, 0.202133177335, 0.00350499824, -0.001633343414],
+                    [-0.001019776956, 0.00350499824, 0.199891616517, 0.030001601447],
+                    [0.006180572643, -0.001633343414, 0.030001601447, 0.249654113954],
+                ]
+            ),
+            rtol=1e-11,
+            atol=1e-11,
+        )
+        npt.assert_allclose(
+            tracker.shape_state,
+            array([-0.710280286611, 2.503516324213, 0.796103049888]),
+            rtol=1e-11,
+            atol=1e-11,
+        )
+        npt.assert_allclose(
+            tracker.shape_covariance,
+            array(
+                [
+                    [0.109712822241, 0.0, 0.0],
+                    [0.0, 0.261238659416, -0.039961799629],
+                    [0.0, -0.039961799629, 0.20388307481],
+                ]
+            ),
+            rtol=1e-11,
+            atol=1e-11,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- apply the provided MEM-QKF next-version robustness update
- add default measurement-noise support via constructor and `set_R`
- canonicalize semi-axis signs and project covariance updates back to the positive-semidefinite cone
- extend MEM-QKF regression coverage with rotated-noise/reference-value cases

## Verification
- `$env:PYTHONPATH='src'; python -m pytest tests\filters\test_mem_qkf_tracker.py`
- `python -m pylint src\pyrecest\filters\mem_qkf_tracker.py tests\filters\test_mem_qkf_tracker.py`
- `python -m flake8 src\pyrecest\filters\mem_qkf_tracker.py tests\filters\test_mem_qkf_tracker.py`
- `$env:PYTHONPATH='src'; python -m mypy --ignore-missing-imports --follow-imports=skip src\pyrecest\filters\mem_qkf_tracker.py tests\filters\test_mem_qkf_tracker.py`
- `python -m black --check src\pyrecest\filters\mem_qkf_tracker.py tests\filters\test_mem_qkf_tracker.py`
- `python -m isort --check-only --profile black src\pyrecest\filters\mem_qkf_tracker.py tests\filters\test_mem_qkf_tracker.py`
- `$env:PYTHONPATH='src'; python -m pytest tests\filters\test_mem_ekf_tracker.py tests\filters\test_mem_ekf_star_tracker.py tests\filters\test_mem_soekf_tracker.py tests\filters\test_mem_qkf_tracker.py`