### PR TITLE
Add MEM-QKF batch update mode

### DIFF
--- a/src/pyrecest/filters/mem_qkf_tracker.py
+++ b/src/pyrecest/filters/mem_qkf_tracker.py
@@ -31,12 +31,15 @@ class MEMQKFTracker(MEMEKFTracker):
     benchmark helper that reports full ``length`` and ``width`` by doubling its
     internal semi-axis states.
 
-    The update is sequential in target-originated point measurements. For each
-    point, it performs a kinematic Kalman update, a scalar quadratic orientation
-    update, and a two-dimensional quadratic semi-axis update. The reference
-    MEM-QKF equations keep the orientation covariance separate from the two
-    axis-length covariances. Consequently this implementation only retains the
-    block-diagonal terms of ``shape_covariance``:
+    By default, the update is sequential in target-originated point
+    measurements. For each point, it performs a kinematic Kalman update, a
+    scalar quadratic orientation update, and a two-dimensional quadratic
+    semi-axis update. With ``update_mode="batch"``, the kinematics are updated
+    once from the measurement-set centroid, while the extent update remains
+    sequential in the individual points. The reference MEM-QKF equations keep
+    the orientation covariance separate from the two axis-length covariances.
+    Consequently this implementation only retains the block-diagonal terms of
+    ``shape_covariance``:
     ``shape_covariance[0, 0]`` and ``shape_covariance[1:, 1:]``. Cross-covariance
     terms between orientation and axes are ignored and reset to zero after
     initialization, prediction, and update.
@@ -47,6 +50,10 @@ class MEMQKFTracker(MEMEKFTracker):
         Measurement-noise covariance used by :meth:`update` when
         ``meas_noise_cov`` is omitted. This is useful when porting code from
         reference implementations that store ``R`` in the tracker instance.
+    update_mode : {"sequential", "batch"}, default="sequential"
+        Selects whether every measurement performs a kinematic update
+        (``"sequential"``) or whether one centroid-based kinematic update is
+        performed before the sequential extent update (``"batch"``).
     minimum_axis_length : float, default=1e-9
         Lower bound applied to semi-axis lengths after updates.
     minimum_covariance_eigenvalue : float, default=0.0
@@ -74,6 +81,7 @@ class MEMQKFTracker(MEMEKFTracker):
         log_prior_extents=False,
         log_posterior_extents=False,
         default_meas_noise_cov=None,
+        update_mode="sequential",
         minimum_axis_length=1e-9,
         minimum_covariance_eigenvalue=0.0,
     ):
@@ -99,6 +107,7 @@ class MEMQKFTracker(MEMEKFTracker):
 
         self.default_meas_noise_cov = None
         self.set_default_measurement_noise_cov(default_meas_noise_cov)
+        self.update_mode = self._validate_update_mode(update_mode)
         self.shape_covariance = self._decoupled_shape_covariance(
             self._regularize_variance(self.shape_covariance[0, 0]),
             self._project_symmetric_covariance(self.shape_covariance[1:, 1:]),
@@ -113,6 +122,13 @@ class MEMQKFTracker(MEMEKFTracker):
             self.orientation_variance,
             axis_covariance,
         )
+
+    @staticmethod
+    def _validate_update_mode(update_mode):
+        update_mode = str(update_mode).lower()
+        if update_mode not in {"sequential", "batch"}:
+            raise ValueError("update_mode must be 'sequential' or 'batch'")
+        return update_mode
 
     @staticmethod
     def _rotation(angle):
@@ -259,6 +275,17 @@ class MEMQKFTracker(MEMEKFTracker):
             meas_noise_cov + additive_measurement_noise
         )
 
+        if self.update_mode == "batch":
+            self._batch_kinematic_update(
+                measurements,
+                measurement_matrix,
+                meas_noise_cov,
+                multiplicative_noise_cov,
+            )
+            update_kinematics = False
+        else:
+            update_kinematics = True
+
         for measurement_index in range(measurements.shape[1]):
             self._update_single_measurement_qkf(
                 measurements[:, measurement_index],
@@ -267,6 +294,7 @@ class MEMQKFTracker(MEMEKFTracker):
                 meas_noise_cov,
                 multiplicative_noise_cov,
                 shape_measurement_covariance,
+                update_kinematics=update_kinematics,
             )
 
         if self.log_posterior_estimates:
@@ -283,18 +311,22 @@ class MEMQKFTracker(MEMEKFTracker):
         meas_noise_cov,
         multiplicative_noise_cov,
         shape_measurement_covariance,
+        update_kinematics=True,
     ):
         orientation = self.shape_state[0]
         semi_axes = self.shape_state[1:]
         orientation_variance = self.orientation_variance
         axis_covariance = self.axis_covariance
 
-        kinematic_state, covariance = self._kinematic_update(
-            measurement,
-            measurement_matrix,
-            meas_noise_cov,
-            multiplicative_noise_cov,
-        )
+        kinematic_state = self.kinematic_state
+        covariance = self.covariance
+        if update_kinematics:
+            kinematic_state, covariance = self._kinematic_update(
+                measurement,
+                measurement_matrix,
+                meas_noise_cov,
+                multiplicative_noise_cov,
+            )
         orientation, orientation_variance = self._orientation_update(
             measurement,
             center_estimate,
@@ -350,6 +382,39 @@ class MEMQKFTracker(MEMEKFTracker):
             kinematic_gain @ innovation_covariance @ kinematic_gain.T
         )
         return kinematic_state, covariance
+
+    def _batch_kinematic_update(
+        self,
+        measurements,
+        measurement_matrix,
+        meas_noise_cov,
+        multiplicative_noise_cov,
+    ):
+        n_measurements = measurements.shape[1]
+        centroid = mean(measurements, axis=1)
+        extent_transform = self._extent_transform()
+        centroid_covariance = self._symmetrize(
+            (
+                extent_transform @ multiplicative_noise_cov @ extent_transform.T
+                + meas_noise_cov
+            )
+            / n_measurements
+        )
+        innovation_covariance = self._regularize_covariance(
+            measurement_matrix @ self.covariance @ measurement_matrix.T
+            + centroid_covariance
+        )
+        kinematic_cross_covariance = self.covariance @ measurement_matrix.T
+        kinematic_gain = self._gain_from_cross_covariance(
+            kinematic_cross_covariance,
+            innovation_covariance,
+        )
+        innovation = centroid - measurement_matrix @ self.kinematic_state
+        self.kinematic_state = self.kinematic_state + kinematic_gain @ innovation
+        self.covariance = self._project_symmetric_covariance(
+            self.covariance
+            - kinematic_gain @ innovation_covariance @ kinematic_gain.T
+        )
 
     # pylint: disable=too-many-arguments
     def _orientation_update(

--- a/src/pyrecest/filters/mem_qkf_tracker.py
+++ b/src/pyrecest/filters/mem_qkf_tracker.py
@@ -412,8 +412,7 @@ class MEMQKFTracker(MEMEKFTracker):
         innovation = centroid - measurement_matrix @ self.kinematic_state
         self.kinematic_state = self.kinematic_state + kinematic_gain @ innovation
         self.covariance = self._project_symmetric_covariance(
-            self.covariance
-            - kinematic_gain @ innovation_covariance @ kinematic_gain.T
+            self.covariance - kinematic_gain @ innovation_covariance @ kinematic_gain.T
         )
 
     # pylint: disable=too-many-arguments

--- a/src/pyrecest/filters/velocity_locked_mem_qkf_tracker.py
+++ b/src/pyrecest/filters/velocity_locked_mem_qkf_tracker.py
@@ -103,8 +103,7 @@ class VelocityLockedMEMQKFTracker(MEMQKFTracker):
         jacobian_entries[velocity_y_index] = velocity_x / speed_squared
         heading_jacobian = array(jacobian_entries)
         orientation_variance = (
-            heading_jacobian @ covariance @ heading_jacobian.T
-            + self.sideslip_variance
+            heading_jacobian @ covariance @ heading_jacobian.T + self.sideslip_variance
         )
         orientation_variance = maximum(
             orientation_variance,
@@ -174,6 +173,7 @@ class VelocityLockedMEMQKFTracker(MEMQKFTracker):
         meas_noise_cov,
         multiplicative_noise_cov,
         shape_measurement_covariance,
+        update_kinematics=True,
     ):
         # Stationary/near-stationary fallback: keep the full MEM-QKF orientation
         # update so the filter remains usable for fixed targets.
@@ -185,18 +185,22 @@ class VelocityLockedMEMQKFTracker(MEMQKFTracker):
                 meas_noise_cov,
                 multiplicative_noise_cov,
                 shape_measurement_covariance,
+                update_kinematics=update_kinematics,
             )
             return
 
         semi_axes = self.shape_state[1:]
         axis_covariance = self.axis_covariance
 
-        kinematic_state, covariance = self._kinematic_update(
-            measurement,
-            measurement_matrix,
-            meas_noise_cov,
-            multiplicative_noise_cov,
-        )
+        kinematic_state = self.kinematic_state
+        covariance = self.covariance
+        if update_kinematics:
+            kinematic_state, covariance = self._kinematic_update(
+                measurement,
+                measurement_matrix,
+                meas_noise_cov,
+                multiplicative_noise_cov,
+            )
         covariance = self._project_symmetric_covariance(covariance)
         heading_moments = self._heading_moments_from_velocity(
             kinematic_state,

--- a/tests/filters/test_mem_qkf_tracker.py
+++ b/tests/filters/test_mem_qkf_tracker.py
@@ -154,8 +154,7 @@ class TestMEMQKFTracker(unittest.TestCase):
         centroid = np.mean(normalized_measurements, axis=1)
         extent_transform = tracker._extent_transform()
         centroid_covariance = (
-            extent_transform @ tracker.multiplicative_noise_cov @ extent_transform.T
-            + R
+            extent_transform @ tracker.multiplicative_noise_cov @ extent_transform.T + R
         ) / normalized_measurements.shape[1]
         innovation_covariance = (
             self.measurement_matrix @ self.covariance @ self.measurement_matrix.T

--- a/tests/filters/test_mem_qkf_tracker.py
+++ b/tests/filters/test_mem_qkf_tracker.py
@@ -44,6 +44,7 @@ class TestMEMQKFTracker(unittest.TestCase):
 
     def test_initialization_and_alias(self):
         self.assertIs(MemQkfTracker, MEMQKFTracker)
+        self.assertEqual(self.tracker.update_mode, "sequential")
         npt.assert_allclose(self.tracker.kinematic_state, self.kinematic_state)
         npt.assert_allclose(self.tracker.shape_state, self.shape_state)
         npt.assert_allclose(
@@ -51,6 +52,17 @@ class TestMEMQKFTracker(unittest.TestCase):
             diag(array([4.0, 1.0])),
         )
         self.assertEqual(self.tracker.get_point_estimate().shape[0], 7)
+
+    def test_rejects_unknown_update_mode(self):
+        with self.assertRaises(ValueError):
+            MEMQKFTracker(
+                self.kinematic_state,
+                self.covariance,
+                self.shape_state,
+                self.shape_covariance,
+                measurement_matrix=self.measurement_matrix,
+                update_mode="unsupported",
+            )
 
     def test_initialization_drops_orientation_axis_cross_covariances(self):
         shape_covariance = array(
@@ -125,6 +137,76 @@ class TestMEMQKFTracker(unittest.TestCase):
 
         self.assertGreater(tracker.kinematic_state[0], 0.0)
         self.assertGreater(tracker.shape_state[1], 1.0)
+
+    def test_batch_update_uses_single_centroid_kinematic_update(self):
+        R = _rot(0.4) @ diag(array([0.4, 1.1])) @ _rot(0.4).T
+        measurements = array([[1.7, -0.4], [2.3, 0.8], [0.6, -1.1], [1.1, 0.2]])
+        tracker = MEMQKFTracker(
+            self.kinematic_state,
+            self.covariance,
+            self.shape_state,
+            self.shape_covariance,
+            measurement_matrix=self.measurement_matrix,
+            update_mode="batch",
+        )
+
+        normalized_measurements = tracker._normalize_measurements(measurements)
+        centroid = np.mean(normalized_measurements, axis=1)
+        extent_transform = tracker._extent_transform()
+        centroid_covariance = (
+            extent_transform @ tracker.multiplicative_noise_cov @ extent_transform.T
+            + R
+        ) / normalized_measurements.shape[1]
+        innovation_covariance = (
+            self.measurement_matrix @ self.covariance @ self.measurement_matrix.T
+            + centroid_covariance
+        )
+        kinematic_gain = tracker._gain_from_cross_covariance(
+            self.covariance @ self.measurement_matrix.T,
+            innovation_covariance,
+        )
+        expected_state = self.kinematic_state + kinematic_gain @ (
+            centroid - self.measurement_matrix @ self.kinematic_state
+        )
+        expected_covariance = self.covariance - (
+            kinematic_gain @ innovation_covariance @ kinematic_gain.T
+        )
+
+        tracker.update(measurements, meas_noise_cov=R)
+
+        npt.assert_allclose(tracker.kinematic_state, expected_state)
+        npt.assert_allclose(tracker.covariance, expected_covariance)
+        self.assertTrue(all(linalg.eigvalsh(tracker.shape_covariance) > -1e-12))
+
+    def test_batch_update_differs_from_sequential_on_measurement_sets(self):
+        R = _rot(0.5) @ diag(array([0.7, 0.2])) @ _rot(0.5).T
+        measurements = array([[1.5, -0.3], [2.0, 0.6], [-0.2, 1.4], [0.8, -1.0]])
+        sequential_tracker = MEMQKFTracker(
+            self.kinematic_state,
+            self.covariance,
+            self.shape_state,
+            self.shape_covariance,
+            measurement_matrix=self.measurement_matrix,
+        )
+        batch_tracker = MEMQKFTracker(
+            self.kinematic_state,
+            self.covariance,
+            self.shape_state,
+            self.shape_covariance,
+            measurement_matrix=self.measurement_matrix,
+            update_mode="batch",
+        )
+
+        sequential_tracker.update(measurements, meas_noise_cov=R)
+        batch_tracker.update(measurements, meas_noise_cov=R)
+
+        self.assertFalse(
+            np.allclose(
+                batch_tracker.kinematic_state,
+                sequential_tracker.kinematic_state,
+            )
+        )
+        self.assertTrue(all(linalg.eigvalsh(batch_tracker.covariance) > 0.0))
 
     def test_update_without_measurements_is_noop(self):
         prior_kinematic_state = self.tracker.kinematic_state.copy()

--- a/tests/filters/test_velocity_locked_mem_qkf_tracker.py
+++ b/tests/filters/test_velocity_locked_mem_qkf_tracker.py
@@ -4,7 +4,7 @@ from pyrecest.backend import array, diag, eye
 from pyrecest.filters.velocity_locked_mem_qkf_tracker import VelocityLockedMEMQKFTracker
 
 
-def _make_tracker(speed_threshold=1e-9):
+def _make_tracker(speed_threshold=1e-9, **kwargs):
     return VelocityLockedMEMQKFTracker(
         kinematic_state=array([0.0, 0.0, 3.0, 4.0]),
         covariance=diag(array([1.0, 1.0, 0.04, 0.04])),
@@ -12,6 +12,7 @@ def _make_tracker(speed_threshold=1e-9):
         shape_covariance=diag(array([0.5, 0.2, 0.2])),
         default_meas_noise_cov=0.05 * eye(2),
         speed_threshold=speed_threshold,
+        **kwargs,
     )
 
 
@@ -40,6 +41,24 @@ def test_velocity_locked_orientation_tracks_prediction_heading():
 
 def test_velocity_locked_update_keeps_orientation_coupled_to_velocity():
     tracker = _make_tracker()
+    measurements = array(
+        [
+            [1.0, 0.2],
+            [-0.1, 0.7],
+            [0.4, -0.2],
+        ]
+    )
+    tracker.update(measurements)
+
+    vx, vy = tracker.kinematic_state[2], tracker.kinematic_state[3]
+    expected_heading = np.arctan2(float(vy), float(vx))
+    assert np.isclose(float(tracker.shape_state[0]), expected_heading)
+    assert tracker.shape_state[1] > 0.0
+    assert tracker.shape_state[2] > 0.0
+
+
+def test_velocity_locked_batch_update_keeps_orientation_coupled_to_velocity():
+    tracker = _make_tracker(update_mode="batch")
     measurements = array(
         [
             [1.0, 0.2],


### PR DESCRIPTION
﻿## Summary
- Adds `update_mode="sequential"|"batch"` to `MEMQKFTracker`.
- Keeps sequential updates as the default to preserve existing behavior.
- Adds a batch mode that performs one centroid-based kinematic update and then reuses the existing sequential quadratic extent updates.
- Adds focused tests for invalid modes, centroid kinematic behavior, and multi-measurement behavior differences.

## Validation
- `PYTHONPATH=src python -m pytest tests\filters\test_mem_qkf_tracker.py` -> 15 passed
- `python -m ruff check src\pyrecest\filters\mem_qkf_tracker.py tests\filters\test_mem_qkf_tracker.py` -> passed
- `git diff --check` -> passed

## Note
- Full `poetry install --with dev` on Windows still fails on optional `healpy` native build dependencies (`cfitsio`/pkg-config), unrelated to this MEM-QKF change.
