### PR TITLE
Reuse MegaLinter autofix PR branch

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -113,8 +113,8 @@ jobs:
           token: ${{ github.token }}
           commit-message: "[MegaLinter] Apply linters automatic fixes"
           title: "[MegaLinter] Apply linters automatic fixes"
-          # Avoid force-updating a stale or diverged auto-fix branch.
-          branch: megalinter-fixes-${{ github.run_id }}
+          # Keep one open auto-fix PR and update it on subsequent runs.
+          branch: megalinter-fixes
           labels: bot
           base: main
 


### PR DESCRIPTION
## Summary
- change the MegaLinter auto-fix PR branch from `megalinter-fixes-${{ github.run_id }}` to the stable `megalinter-fixes`
- align the created branch with the existing bot-auto-merge workflow condition

With a stable branch, `peter-evans/create-pull-request` updates the existing open auto-fix PR for that branch instead of creating a new PR for every workflow run.

## Verification
- `python -c "import yaml, pathlib; [yaml.safe_load(pathlib.Path(p).read_text()) for p in ['.github/workflows/mega-linter.yml', '.github/workflows/bot-auto-merge.yml']]; print('yaml ok')"`
- `git diff --check`