### PR TITLE
Restore velocity locked MEM-QKF aliases

### DIFF
--- a/src/pyrecest/filters/velocity_aligned_mem_qkf_tracker.py
+++ b/src/pyrecest/filters/velocity_aligned_mem_qkf_tracker.py
@@ -247,3 +247,5 @@ class VelocityAlignedMEMQKFTracker(MEMQKFTracker):
 
 
 VelocityAlignedMemQkfTracker = VelocityAlignedMEMQKFTracker
+VelocityLockedMEMQKFTracker = VelocityAlignedMEMQKFTracker
+VelocityLockedMemQkfTracker = VelocityAlignedMEMQKFTracker


### PR DESCRIPTION
## Summary
- Restore `VelocityLockedMEMQKFTracker` and `VelocityLockedMemQkfTracker` compatibility aliases
- Fix `from pyrecest.filters import ...` after the velocity-aligned tracker rename

## Validation
- `PYTHONPATH=src python -` import smoke test for `FullSCGPTracker` and `VelocityLockedMEMQKFTracker`