### PR TITLE
Fix vMF deterministic sigma-point sampler

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/von_mises_fisher_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/von_mises_fisher_distribution.py
@@ -11,6 +11,7 @@ from pyrecest.backend import (
     all,
     arccos,
     array,
+    clip,
     cos,
     exp,
     int32,
@@ -23,7 +24,7 @@ from pyrecest.backend import (
     sinh,
     zeros,
 )
-from scipy.special import iv
+from scipy.special import iv, ive
 
 from .abstract_hyperspherical_distribution import AbstractHypersphericalDistribution
 
@@ -123,15 +124,25 @@ class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
 
     def sample_deterministic(self):
         """Return deterministic sigma points matched to the mean direction."""
-        samples = zeros((self.dim + 1, self.dim * 2 + 1))
-        samples[0, 0] = 1
-        m1 = iv(self.dim / 2, self.kappa, 1) / iv(self.dim / 2 + 1, self.kappa, 1)
+        n_samples = self.dim * 2 + 1
+        samples = zeros((self.input_dim, n_samples))
+        samples[0, 0] = 1.0
+
+        mean_res_length = self.a_d(self.input_dim, self.kappa)
+        cos_alpha = clip(
+            (n_samples * mean_res_length - 1.0) / (n_samples - 1),
+            -1.0,
+            1.0,
+        )
+        alpha = arccos(cos_alpha)
         for i in range(self.dim):
-            alpha = arccos(((self.dim * 2 + 1) * m1 - 1) / (self.dim * 2))
-            samples[2 * i, 0] = cos(alpha)
-            samples[2 * i + 1, 0] = cos(alpha)
-            samples[2 * i, i + 1] = sin(alpha)
-            samples[2 * i + 1, i + 1] = -sin(alpha)
+            positive_col = 2 * i + 1
+            negative_col = positive_col + 1
+            tangent_row = i + 1
+            samples[0, positive_col] = cos(alpha)
+            samples[0, negative_col] = cos(alpha)
+            samples[tangent_row, positive_col] = sin(alpha)
+            samples[tangent_row, negative_col] = -sin(alpha)
 
         Q = self.get_rotation_matrix()
         samples = Q @ samples
@@ -226,8 +237,8 @@ class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
     @staticmethod
     def a_d(d: Union[int, int32, int64], kappa):
         """Return the ratio of modified Bessel functions used by vMF moments."""
-        bessel1 = array(iv(d / 2, kappa))
-        bessel2 = array(iv(d / 2 - 1, kappa))
+        bessel1 = array(ive(d / 2, kappa))
+        bessel2 = array(ive(d / 2 - 1, kappa))
         if isnan(bessel1) or isnan(bessel2):
             print(f"Bessel functions returned NaN for d={d}, kappa={kappa}")
         return bessel1 / bessel2

--- a/tests/distributions/test_von_mises_fisher_distribution.py
+++ b/tests/distributions/test_von_mises_fisher_distribution.py
@@ -5,7 +5,7 @@ import pyrecest.backend
 from parameterized import parameterized
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import allclose, array, linalg, sqrt
+from pyrecest.backend import allclose, array, linalg, ones, sqrt
 from pyrecest.distributions import VonMisesFisherDistribution
 from pyrecest.distributions.hypersphere_subset.hyperspherical_dirac_distribution import (
     HypersphericalDiracDistribution,
@@ -235,6 +235,35 @@ class TestVonMisesFisherDistribution(unittest.TestCase):
         vmf = VonMisesFisherDistribution.from_distribution(dirac_dist)
 
         npt.assert_allclose(dirac_dist.mean(), vmf.mean())
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        "Test not supported for this backend",
+    )
+    @parameterized.expand(
+        [
+            ("s2", array([1.0, 2.0, 3.0]), 2.0),
+            ("s3", array([1.0, 2.0, 3.0, 4.0]), 0.5),
+        ]
+    )
+    def test_sample_deterministic_matches_mean_resultant_vector(self, _, mu, kappa):
+        mu = mu / linalg.norm(mu)
+        vmf = VonMisesFisherDistribution(mu, kappa)
+
+        samples = vmf.sample_deterministic()
+
+        expected_n_samples = 2 * vmf.dim + 1
+        weights = ones(expected_n_samples) / expected_n_samples
+        self.assertEqual(samples.shape, (vmf.input_dim, expected_n_samples))
+        npt.assert_allclose(
+            linalg.norm(samples, axis=0), ones(expected_n_samples), atol=1e-12
+        )
+        npt.assert_allclose(
+            samples @ weights, vmf.mean_resultant_vector(), atol=1e-12
+        )
+
+    def test_a_d_uses_scaled_bessel_ratio_for_large_kappa(self):
+        npt.assert_allclose(VonMisesFisherDistribution.a_d(3, 1000.0), 0.999)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Fix the von Mises-Fisher deterministic sigma-point sampler to use the embedding-dimension mean resultant length `a_d(input_dim, kappa)`.
- Replace the invalid `iv(..., 1)` usage in the sampler path by the existing `a_d` helper and make `a_d` use the scaled Bessel ratio `ive` for large-kappa stability.
- Correct the sigma-point layout so columns are samples in embedding coordinates.
- Add regression tests for deterministic-sample shape, unit norm, and equal-weight mean-resultant matching.

## Notes
I could not run the full repository test suite in this environment because GitHub/network checkout is unavailable here. The changed Python files were syntax-checked locally before pushing through the connector.