### PR TITLE
Fix hypertoroidal custom grid dimension inference

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_grid_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_grid_distribution.py
@@ -73,7 +73,18 @@ class HypertoroidalGridDistribution(
         enforce_pdf_nonnegative: bool = True,
         dim: int | None = None,
     ):
-        dim = grid_values.ndim
+        if dim is None:
+            if grid_type == "custom" and grid is not None:
+                # For custom grids, grid_values may be flat with one value per
+                # grid row, so grid_values.ndim is not a reliable manifold
+                # dimension. Infer the dimension from the grid coordinates.
+                dim = 1 if grid.ndim <= 1 else grid.shape[1]
+            else:
+                # Cartesian-product grid values are stored as an array whose
+                # number of axes is the hypertorus dimension.
+                dim = grid_values.ndim
+        elif dim <= 0:
+            raise ValueError("dim must be a positive integer.")
 
         # Initialize hypertoroidal base class
         AbstractHypertoroidalDistribution.__init__(self, dim)

--- a/tests/distributions/test_hypertoroidal_grid_distribution.py
+++ b/tests/distributions/test_hypertoroidal_grid_distribution.py
@@ -26,6 +26,24 @@ class HypertoroidalGridDistributionTest(unittest.TestCase):
         npt.assert_allclose(hgd.get_grid(), grid)
         npt.assert_allclose(hgd.get_grid().shape, (4, 2))
 
+    def test_custom_flat_grid_honors_explicit_dim(self):
+        grid = array([[0.0, 0.0], [pi, 0.0], [0.0, pi], [pi, pi]])
+        grid_values = array([1.0, 1.0, 1.0, 1.0]) / ((2.0 * pi) ** 2)
+
+        hgd = HypertoroidalGridDistribution(grid_values, grid=grid, dim=2)
+
+        self.assertEqual(hgd.dim, 2)
+        npt.assert_allclose(hgd.get_grid(), grid)
+
+    def test_custom_flat_grid_infers_dim_from_grid(self):
+        grid = array([[0.0, 0.0], [pi, 0.0], [0.0, pi], [pi, pi]])
+        grid_values = array([1.0, 1.0, 1.0, 1.0]) / ((2.0 * pi) ** 2)
+
+        hgd = HypertoroidalGridDistribution(grid_values, grid=grid)
+
+        self.assertEqual(hgd.dim, 2)
+        npt.assert_allclose(hgd.get_grid(), grid)
+
     def test_pdf_custom_grid_flattens_grid_values_for_nearest_neighbor(self):
         grid = array(
             [


### PR DESCRIPTION
## Summary
- preserve explicit `dim` for custom hypertoroidal grids
- infer custom-grid dimension from grid coordinates when `dim` is omitted
- add regression tests for flat custom `grid_values` with 2-D grid coordinates

## Notes
This intentionally focuses on the dimension-inference bug; concurrent custom-grid nearest-neighbor fixes already present on `main` are preserved.