### PR TITLE
Fix hypertoroidal Dirac marginalization typing

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py
@@ -137,10 +137,10 @@ class HypertoroidalDiracDistribution(
     def marginalize_out(self, dimensions: int | list[int]):
         from ..circle.circular_dirac_distribution import CircularDiracDistribution
 
-        try:
-            dimensions = list(dimensions)
-        except TypeError:
+        if isinstance(dimensions, int):
             dimensions = [dimensions]
+        else:
+            dimensions = list(dimensions)
 
         dimensions = [int(dim) for dim in dimensions]
         dimensions_to_remove = set(dimensions)


### PR DESCRIPTION
## Summary
- Replaces exception-based normalization in `HypertoroidalDiracDistribution.marginalize_out` with explicit `int` vs list type narrowing.
- Keeps existing runtime behavior while allowing mypy to infer that the normalized dimensions are `list[int]`.

## Validation
- `PYTHONPATH=src python -m pytest tests\distributions\test_hypertoroidal_dirac_marginalize_out.py tests\distributions\test_hypertoroidal_dirac_distribution.py -q`
- `PYTHONPATH=src python -m mypy --ignore-missing-imports --follow-imports=skip src\pyrecest\distributions\hypertorus\hypertoroidal_dirac_distribution.py`
- `python -m ruff check src\pyrecest\distributions\hypertorus\hypertoroidal_dirac_distribution.py tests\distributions\test_hypertoroidal_dirac_marginalize_out.py tests\distributions\test_hypertoroidal_dirac_distribution.py`
- `python -m black --check src\pyrecest\distributions\hypertorus\hypertoroidal_dirac_distribution.py tests\distributions\test_hypertoroidal_dirac_marginalize_out.py tests\distributions\test_hypertoroidal_dirac_distribution.py`
- `python -m isort --check-only --profile black src\pyrecest\distributions\hypertorus\hypertoroidal_dirac_distribution.py`
- `python -m pylint src\pyrecest\distributions\hypertorus\hypertoroidal_dirac_distribution.py`
- `git diff --check`