### PR TITLE
Fix JAX sparse array flat indexing

### DIFF
--- a/src/pyrecest/_backend/jax/__init__.py
+++ b/src/pyrecest/_backend/jax/__init__.py
@@ -334,16 +334,18 @@ def array_from_sparse(indices, data, target_shape):
     # Convert inputs to JAX arrays if they aren't already
     indices = _jnp.array(indices)
     data = _jnp.array(data)
-    
+
     # Create a dense array of zeros with the appropriate data type
     out = _jnp.zeros(target_shape, dtype=data.dtype)
-    
-    # Compute linear indices from multi-dimensional indices
+
+    # Compute linear indices from multi-dimensional indices and apply them to
+    # the flattened dense array.  Indexing the original n-D array with these
+    # flattened positions would address the first axis instead of the flat
+    # storage order and can therefore put values into the wrong entries or
+    # raise out-of-bounds errors for multidimensional target shapes.
     linear_indices = _jnp.ravel_multi_index(indices.T, target_shape)
-    
-    # Use JAX's indexing to place data into the output array
-    out = out.at[linear_indices].set(data)
-    
+    out = out.reshape(-1).at[linear_indices].set(data).reshape(target_shape)
+
     return out
 
 
@@ -368,11 +370,11 @@ def get_slice(array, start, end):
 
 def as_dtype(array):
     """Change the data type of a given array.
-    
+
     Parameters:
     - array: The array whose data type needs to be changed
     - dtype: The new data type
-    
+
     Returns:
     A new array with the specified data type.
     """

--- a/tests/backend/test_jax_array_from_sparse.py
+++ b/tests/backend/test_jax_array_from_sparse.py
@@ -1,0 +1,28 @@
+import pytest
+
+pytest.importorskip("jax")
+import jax.numpy as jnp  # noqa: E402
+
+from pyrecest._backend.jax import array_from_sparse  # noqa: E402
+
+
+def test_array_from_sparse_uses_flat_indices_for_multidimensional_target():
+    indices = jnp.array([[0, 0], [1, 2]])
+    data = jnp.array([3.0, 5.0])
+
+    dense = array_from_sparse(indices, data, (2, 3))
+
+    expected = jnp.array([[3.0, 0.0, 0.0], [0.0, 0.0, 5.0]])
+    assert jnp.array_equal(dense, expected)
+
+
+def test_array_from_sparse_handles_non_first_axis_flat_positions():
+    indices = jnp.array([[0, 1, 2], [1, 0, 3]])
+    data = jnp.array([7, 11])
+
+    dense = array_from_sparse(indices, data, (2, 2, 4))
+
+    expected = jnp.zeros((2, 2, 4), dtype=data.dtype)
+    expected = expected.at[0, 1, 2].set(7)
+    expected = expected.at[1, 0, 3].set(11)
+    assert jnp.array_equal(dense, expected)


### PR DESCRIPTION
## Summary
- Fix `array_from_sparse` in the JAX backend by applying raveled indices to a flattened dense array before reshaping back to the requested target shape.
- Add regression tests for 2-D and 3-D multidimensional sparse-to-dense conversion.

## Why
The previous implementation computed flat/raveled indices with `jnp.ravel_multi_index`, but then used those positions to index the original n-D output array. For multidimensional target shapes this indexes the first axis rather than the flattened storage order, which can write values to the wrong positions or raise out-of-bounds errors.

## Tests
- Not run locally; change was made through the GitHub connector.
- Added `tests/backend/test_jax_array_from_sparse.py` for CI coverage.