### PR TITLE
Fix to_hemisphere invalid grid validation

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/hyperspherical_grid_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/hyperspherical_grid_distribution.py
@@ -202,7 +202,13 @@ class HypersphericalGridDistribution(
                 candidates = self.grid[same_xy, :]
 
                 # Among those, at least one must have opposite z
-                self.assertTrue(any(isclose(candidates[:, -1], -v[-1], atol=5 * tol)))
+                if not any(isclose(candidates[:, -1], -v[-1], atol=5 * tol)):
+                    raise ValueError(
+                        "ToHemisphere:AsymmetricGrid: "
+                        "Can only use to_hemisphere for antipodally symmetric grids. "
+                        "Use grid_type 'leopardi_symm_antipodal' or 'leopardi_symm_plane'"
+                        "when calling from_distribution or from_function."
+                    )
 
             raise ValueError(
                 "ToHemisphere:AsymmetricGrid: "

--- a/tests/distributions/test_hyperspherical_grid_to_hemisphere_validation.py
+++ b/tests/distributions/test_hyperspherical_grid_to_hemisphere_validation.py
@@ -1,0 +1,35 @@
+import unittest
+
+import pyrecest
+from pyrecest.backend import array
+from pyrecest.distributions.hypersphere_subset.hyperspherical_grid_distribution import (
+    HypersphericalGridDistribution,
+)
+
+
+class HypersphericalGridToHemisphereValidationTest(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on this backend",
+    )
+    def test_invalid_even_grid_raises_valueerror_not_attributeerror(self):
+        """Invalid even grids should fail with the documented validation error."""
+        grid = array(
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+                [0.0, 0.0, -1.0],
+            ]
+        )
+        grid_values = array([1.0, 1.0, 1.0, 1.0])
+        dist = HypersphericalGridDistribution(grid, grid_values)
+
+        with self.assertRaises(ValueError) as cm:
+            dist.to_hemisphere()
+
+        self.assertIn("ToHemisphere:AsymmetricGrid", str(cm.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- replace the stray `self.assertTrue(...)` call in `HypersphericalGridDistribution.to_hemisphere()` with production-code validation that raises `ValueError`
- add a regression test for invalid even-sized grids so the method no longer fails with `AttributeError`

## Testing
- Not run locally; changes were made via the GitHub connector.