### PR TITLE
Fix sampler edge cases

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/spherical_grid_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/spherical_grid_distribution.py
@@ -166,10 +166,12 @@ class SphericalGridDistribution(
                 "not be valid).",
                 UserWarning,
             )
-            a = -6.0
-            b = 36.0 - 8.0 * (4.0 - no_of_grid_points)
-            degree = (-a + sqrt(b)) / 4.0
-            grid = get_grid_hypersphere(
+            degree = int(
+                round(float((-22.0 + sqrt(32.0 * no_of_grid_points + 4.0)) / 16.0))
+            )
+            if degree < 0:
+                raise ValueError("no_of_grid_points is too small for a Driscoll-Healy grid")
+            grid, _ = get_grid_hypersphere(
                 "driscoll_healy", grid_density_parameter=degree, dim=2
             )
         else:

--- a/src/pyrecest/sampling/euclidean_sampler.py
+++ b/src/pyrecest/sampling/euclidean_sampler.py
@@ -364,6 +364,13 @@ class FibonacciGridSampler(AbstractEuclideanSampler):
         xy_gauss : np.ndarray of shape (d, n_points)
             Gaussian grid on R^d with the given covariance and mean.
         """
+        d = int(d)
+        n_points = int(n_points)
+        if d < 1:
+            raise ValueError("d must be positive")
+        if n_points < 0:
+            raise ValueError("n_points must be nonnegative")
+
         if covariance is None:
             covariance = np.eye(d)
         if mean is None:
@@ -373,6 +380,11 @@ class FibonacciGridSampler(AbstractEuclideanSampler):
         if n_points == 0:
             empty_arr = np.empty((d, 0))
             return empty_arr.copy(), empty_arr.copy(), empty_arr.copy()
+        if n_points == 1:
+            xy_equal = np.full((d, 1), 0.5)
+            xy_stdMM = np.zeros((d, 1))
+            xy_gauss = mean.reshape(-1, 1).copy()
+            return xy_equal, xy_stdMM, xy_gauss
 
         V, _ = _fibonacci_eigen(d)
 

--- a/src/pyrecest/sampling/hyperspherical_sampler.py
+++ b/src/pyrecest/sampling/hyperspherical_sampler.py
@@ -1,5 +1,6 @@
 import itertools
 from abc import abstractmethod
+from math import ceil
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest import backend
@@ -183,8 +184,13 @@ class SphericalCoordinatesBasedFixedResolutionSampler(
             ) from exc
         res_lon = int(res_lon)
         res_lat = int(res_lat)
-        phi = linspace(0.0, 2 * pi, num=res_lon, endpoint=False)
-        theta = linspace(pi / (res_lat + 1), pi, num=res_lat, endpoint=False)
+        if res_lon <= 0 or res_lat <= 0:
+            raise ValueError("grid resolution entries must be positive")
+        phi_values = linspace(0.0, 2 * pi, num=res_lon, endpoint=False)
+        theta_values = linspace(pi / (res_lat + 1), pi, num=res_lat, endpoint=False)
+        phi_theta_stacked = array(list(itertools.product(phi_values, theta_values)))
+        phi = phi_theta_stacked[:, 0]
+        theta = phi_theta_stacked[:, 1]
         return phi, theta, {"res_lat": res_lat, "res_lon": res_lon}
 
 
@@ -418,9 +424,9 @@ class FibonacciHopfSampler(AbstractHopfBasedS3Sampler):
         # Step 2: Discretize the unit circle using the circular grid
         circular_sampler = CircularUniformSampler()
         if len(grid_density_parameter) == 2:
-            n_sample_circle = grid_density_parameter[1]
+            n_sample_circle = int(grid_density_parameter[1])
         else:
-            n_sample_circle = sqrt(grid_density_parameter[0])
+            n_sample_circle = int(ceil(float(grid_density_parameter[0]) ** 0.5))
         psi_points = circular_sampler.get_grid(n_sample_circle)
 
         # Step 3: Combine the two grids to generate a grid for S3

--- a/src/pyrecest/sampling/hypertoroidal_sampler.py
+++ b/src/pyrecest/sampling/hypertoroidal_sampler.py
@@ -24,6 +24,9 @@ class CircularUniformSampler(AbstractCircularSampler):
         """
         Returns an equidistant grid of points on the circle [0,2*pi).
         """
+        grid_density_parameter = int(grid_density_parameter)
+        if grid_density_parameter <= 0:
+            raise ValueError("grid_density_parameter must be positive")
         points = linspace(0.0, 2.0 * pi, grid_density_parameter, endpoint=False)
         # Set it to the middle of the interval instead of the start
         points += (2.0 * pi / grid_density_parameter) / 2.0

--- a/tests/distributions/test_spherical_grid_distribution_driscoll_healy.py
+++ b/tests/distributions/test_spherical_grid_distribution_driscoll_healy.py
@@ -4,7 +4,7 @@ import warnings
 
 import numpy.testing as npt
 
-# pylint: disable=no-name-in-module,no-member
+# pylint: disable=redefined-builtin,no-name-in-module,no-member
 from pyrecest.backend import all, array, ones
 from pyrecest.distributions.hypersphere_subset.spherical_grid_distribution import (
     SphericalGridDistribution,

--- a/tests/distributions/test_spherical_grid_distribution_driscoll_healy.py
+++ b/tests/distributions/test_spherical_grid_distribution_driscoll_healy.py
@@ -32,8 +32,12 @@ class TestSphericalGridDistributionDriscollHealy(unittest.TestCase):
         self.assertEqual(distribution.grid_type, "driscoll_healy")
         self.assertEqual(distribution.grid.shape, (91, 3))
         self.assertEqual(distribution.grid_values.shape, (91,))
-        self.assertTrue(all(distribution.grid_values == 1.0))
-        npt.assert_allclose(distribution.pdf(array([0.0, 0.0, 1.0])), 1.0)
+        self.assertTrue(all(distribution.grid_values == distribution.grid_values[0]))
+        npt.assert_allclose(distribution.integrate(), 1.0)
+        npt.assert_allclose(
+            distribution.pdf(array([0.0, 0.0, 1.0])),
+            distribution.grid_values[0],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/distributions/test_spherical_grid_distribution_driscoll_healy.py
+++ b/tests/distributions/test_spherical_grid_distribution_driscoll_healy.py
@@ -1,0 +1,40 @@
+import importlib.util
+import unittest
+import warnings
+
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import all, array, ones
+from pyrecest.distributions.hypersphere_subset.spherical_grid_distribution import (
+    SphericalGridDistribution,
+)
+
+pyshtools_installed = importlib.util.find_spec("pyshtools") is not None
+
+
+class TestSphericalGridDistributionDriscollHealy(unittest.TestCase):
+    @unittest.skipIf(not pyshtools_installed, "pyshtools is not installed")
+    def test_from_function_driscoll_healy_unpacks_grid_and_uses_integer_degree(self):
+        """Driscoll-Healy construction should produce a valid S² grid distribution."""
+
+        def constant_density(xs):
+            return ones(xs.shape[0])
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            distribution = SphericalGridDistribution.from_function(
+                constant_density,
+                no_of_grid_points=91,
+                grid_type="driscoll_healy",
+            )
+
+        self.assertEqual(distribution.grid_type, "driscoll_healy")
+        self.assertEqual(distribution.grid.shape, (91, 3))
+        self.assertEqual(distribution.grid_values.shape, (91,))
+        self.assertTrue(all(distribution.grid_values == 1.0))
+        npt.assert_allclose(distribution.pdf(array([0.0, 0.0, 1.0])), 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_euclidean_sampler.py
+++ b/tests/test_euclidean_sampler.py
@@ -69,6 +69,28 @@ class TestFibonacciGridSampler(unittest.TestCase):
         samples = self.sampler.sample_stochastic(50, 3)
         self.assertEqual(samples.shape, (50, 3))
 
+    def test_sample_stochastic_singleton_is_finite_origin(self):
+        """A singleton moment-matched Gaussian grid should be finite and centered."""
+        samples = self.sampler.sample_stochastic(1, 2)
+        self.assertEqual(samples.shape, (1, 2))
+        self.assertTrue(np.all(np.isfinite(samples)))
+        npt.assert_allclose(samples, np.zeros((1, 2)))
+
+    def test_get_gaussian_samples_singleton_returns_requested_mean(self):
+        """A singleton transformed Gaussian grid should represent the requested mean."""
+        mu = np.array([3.0, -2.0])
+        cov = np.array([[2.0, 0.5], [0.5, 1.0]])
+        samples = self.sampler.get_gaussian_samples(1, 2, covariance=cov, mean=mu)
+        self.assertEqual(samples.shape, (1, 2))
+        self.assertTrue(np.all(np.isfinite(samples)))
+        npt.assert_allclose(samples[0], mu)
+
+    def test_get_uniform_samples_singleton_is_center(self):
+        """A singleton uniform Fibonacci grid should be the center of the unit cube."""
+        samples = self.sampler.get_uniform_samples(1, 3)
+        self.assertEqual(samples.shape, (1, 3))
+        npt.assert_allclose(samples, np.full((1, 3), 0.5))
+
     def test_sample_stochastic_mean_close_to_zero(self):
         """Marginal means of the moment-matched samples should be ~0."""
         samples = self.sampler.sample_stochastic(200, 2)
@@ -109,6 +131,13 @@ class TestFibonacciGridSampler(unittest.TestCase):
         """Requesting zero samples should return an empty (0, dim) array."""
         samples = self.sampler.sample_stochastic(0, 2)
         self.assertEqual(samples.shape, (0, 2))
+
+    def test_invalid_grid_arguments(self):
+        """Fibonacci grid generation should reject invalid dimensions and counts."""
+        with self.assertRaises(ValueError):
+            self.sampler.sample_stochastic(-1, 2)
+        with self.assertRaises(ValueError):
+            self.sampler.sample_stochastic(1, 0)
 
     def test_fibonacci_eigen_d4(self):
         """fibonacci_eigen for D=4 should return orthonormal V."""

--- a/tests/test_hyperspherical_sampler.py
+++ b/tests/test_hyperspherical_sampler.py
@@ -1,5 +1,6 @@
 import importlib.util
 import unittest
+from math import ceil
 
 import numpy.testing as npt
 
@@ -191,6 +192,16 @@ class TestHypersphericalSampler(unittest.TestCase):
             f"Expected 4-dimensional-output but got {grid.shape[1]}-dimensional output",
         )
 
+    def test_fibonacci_hopf_sampler_accepts_integer_density(self):
+        sampler = FibonacciHopfSampler()
+        grid_density_parameter = 10
+        grid, grid_description = sampler.get_grid(grid_density_parameter)
+
+        expected_circle_points = ceil(grid_density_parameter**0.5)
+        expected_points = grid_density_parameter * expected_circle_points
+        self.assertEqual(grid.shape, (expected_points, 4))
+        self.assertEqual(grid_description["layer-parameter"], [grid_density_parameter])
+
     @parameterized.expand(
         [
             ("test_2d_12_n_only", 12, 2, (12, 3)),
@@ -297,29 +308,26 @@ class TestHypersphericalSampler(unittest.TestCase):
 
 class TestSphericalCoordinatesBasedFixedResolutionSampler(unittest.TestCase):
     def test_get_grid_spherical_coordinates(self):
-        # Create an instance of the sampler
         sampler = SphericalCoordinatesBasedFixedResolutionSampler()
+        res_lon = 10
+        res_lat = 20
 
-        # Define the resolution parameters for latitude and longitude
-        grid_density_parameter = array(
-            [10, 20]
-        )  # 10 latitude lines, 20 longitude lines
+        phi, theta, _ = sampler.get_grid_spherical_coordinates((res_lon, res_lat))
 
-        # Call the method
-        phi, theta, _ = sampler.get_grid_spherical_coordinates(grid_density_parameter)
-
-        expected_phi = linspace(
-            0.0, 2 * pi, num=grid_density_parameter[0], endpoint=False
-        )
-        expected_theta = linspace(
-            pi / (grid_density_parameter[1] + 1),
+        expected_phi_values = linspace(0.0, 2 * pi, num=res_lon, endpoint=False)
+        expected_theta_values = linspace(
+            pi / (res_lat + 1),
             pi,
-            num=grid_density_parameter[1],
+            num=res_lat,
             endpoint=False,
         )
+        expected_phi = array(
+            [phi_value for phi_value in expected_phi_values for _ in expected_theta_values]
+        )
+        expected_theta = array(
+            [theta_value for _ in expected_phi_values for theta_value in expected_theta_values]
+        )
 
-        # Check if the first and last values of the generated phi and theta are as expected
-        # This assumes that you have access to phi and theta which might not be the case here
         npt.assert_allclose(phi, expected_phi)
         npt.assert_allclose(theta, expected_theta)
 
@@ -327,9 +335,26 @@ class TestSphericalCoordinatesBasedFixedResolutionSampler(unittest.TestCase):
         sampler = SphericalCoordinatesBasedFixedResolutionSampler()
 
         phi, theta, grid_description = sampler.get_grid_spherical_coordinates((10, 20))
-        npt.assert_equal(phi.shape[0], 10)
-        npt.assert_equal(theta.shape[0], 20)
+        npt.assert_equal(phi.shape[0], 200)
+        npt.assert_equal(theta.shape[0], 200)
         self.assertEqual(grid_description, {"res_lat": 20, "res_lon": 10})
+
+    def test_get_grid_returns_full_tensor_product(self):
+        sampler = SphericalCoordinatesBasedFixedResolutionSampler()
+
+        grid, grid_description = sampler.get_grid((4, 3))
+
+        self.assertEqual(grid.shape, (12, 3))
+        self.assertEqual(grid_description, {"res_lat": 3, "res_lon": 4})
+        npt.assert_allclose(linalg.norm(grid, axis=1), 1.0, atol=1e-12)
+
+    def test_get_grid_rejects_nonpositive_resolution(self):
+        sampler = SphericalCoordinatesBasedFixedResolutionSampler()
+
+        with self.assertRaises(ValueError):
+            sampler.get_grid((0, 3))
+        with self.assertRaises(ValueError):
+            sampler.get_grid((4, 0))
 
 
 class TestHopfConversion(unittest.TestCase):

--- a/tests/test_hypertoroidal_sampler.py
+++ b/tests/test_hypertoroidal_sampler.py
@@ -37,6 +37,12 @@ class TestCircularUniformSampler(unittest.TestCase):
         # Check that the grid points are equidistant
         npt.assert_array_almost_equal(std(diff(grid_points)), 0.0)
 
+    def test_get_grid_rejects_nonpositive_density(self):
+        with self.assertRaises(ValueError):
+            self.sampler.get_grid(0)
+        with self.assertRaises(ValueError):
+            self.sampler.get_grid(-1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- fix singleton Fibonacci Gaussian/grid samples so they no longer divide by zero and return finite centered representatives
- make fixed-resolution spherical grids return the full longitude/latitude tensor product and validate positive resolutions
- make Fibonacci-Hopf integer-density grids choose an integer circle count and validate circular grid density
- fix `SphericalGridDistribution.from_function(..., grid_type="driscoll_healy")` so it unpacks the generated grid and uses an integer Driscoll-Healy degree
- add regression coverage for the affected Euclidean, spherical/Hopf, circular, and Driscoll-Healy spherical-grid edge cases

## Validation
- Added focused regression tests in `tests/test_euclidean_sampler.py`, `tests/test_hyperspherical_sampler.py`, `tests/test_hypertoroidal_sampler.py`, and `tests/distributions/test_spherical_grid_distribution_driscoll_healy.py`
- Did not run the full test suite locally in this environment