### PR TITLE
Fix evaluation control-flow regressions

### DIFF
--- a/src/pyrecest/evaluation/check_and_fix_config.py
+++ b/src/pyrecest/evaluation/check_and_fix_config.py
@@ -32,6 +32,8 @@ def check_and_fix_config(simulation_param):
     # Initialize default values if they are not present
     simulation_param.setdefault("use_transition", False)
     simulation_param.setdefault("use_likelihood", False)
+    simulation_param.setdefault("eot", False)
+    simulation_param.setdefault("mtt", False)
     simulation_param.setdefault("n_targets", 1)
     simulation_param.setdefault(
         "apply_sys_noise_times",

--- a/src/pyrecest/evaluation/check_and_fix_config.py
+++ b/src/pyrecest/evaluation/check_and_fix_config.py
@@ -1,6 +1,33 @@
 from pyrecest.distributions import AbstractManifoldSpecificDistribution
 
 
+def _expand_meas_per_step(simulation_param):
+    if "n_meas_at_individual_time_step" in simulation_param:
+        return
+    if "meas_per_step" not in simulation_param:
+        return
+
+    assert isinstance(
+        simulation_param["meas_per_step"], int
+    ), "meas_per_step must be an integer"
+    assert simulation_param["meas_per_step"] > 0, "meas_per_step must be positive"
+
+    simulation_param["n_meas_at_individual_time_step"] = [
+        simulation_param["meas_per_step"]
+    ] * simulation_param["n_timesteps"]
+    del simulation_param["meas_per_step"]
+
+
+def _validate_measurement_counts(simulation_param):
+    assert all(
+        x > 0 for x in simulation_param["n_meas_at_individual_time_step"]
+    ), "n_meas_at_individual_time_step must contain positive values"
+    assert all(
+        isinstance(x, int)
+        for x in simulation_param["n_meas_at_individual_time_step"]
+    ), "n_meas_at_individual_time_step must contain integer values"
+
+
 def check_and_fix_config(simulation_param):
     # Initialize default values if they are not present
     simulation_param.setdefault("use_transition", False)
@@ -28,17 +55,26 @@ def check_and_fix_config(simulation_param):
         raise ValueError("MTT and EOT cannot be used together at the moment.")
 
     if simulation_param["eot"]:
+        if (
+            "n_meas_at_individual_time_step" in simulation_param
+            and "meas_per_step" in simulation_param
+        ):
+            raise ValueError(
+                "Do not provide n_meas_at_individual_time_step and meas_per_step at the same time."
+            )
+        _expand_meas_per_step(simulation_param)
         assert (
             sum(
                 key in simulation_param
                 for key in [
-                    "meas_per_step",
                     "n_meas_at_individual_time_step",
                     "intensity_lambda",
                 ]
             )
             == 1
-        ), "Must use precisely one parameter to modulate the number of measurements (meas_per_step, n_meas_at_individual_time_step, or lambda_intensity)"
+        ), "Must use precisely one parameter to modulate the number of measurements (n_meas_at_individual_time_step or lambda_intensity)"
+        if "n_meas_at_individual_time_step" in simulation_param:
+            _validate_measurement_counts(simulation_param)
     elif simulation_param["mtt"]:
         assert (
             "n_meas_at_individual_time_step" not in simulation_param
@@ -75,23 +111,8 @@ def check_and_fix_config(simulation_param):
         "n_meas_at_individual_time_step" not in simulation_param
         and "meas_per_step" in simulation_param
     ):
-        assert isinstance(
-            simulation_param["meas_per_step"], int
-        ), "meas_per_step must be an integer"
-        assert simulation_param["meas_per_step"] > 0, "meas_per_step must be positive"
-
-        simulation_param["n_meas_at_individual_time_step"] = [
-            simulation_param["meas_per_step"]
-        ] * simulation_param["n_timesteps"]
-        del simulation_param["meas_per_step"]
-
-        assert all(
-            x > 0 for x in simulation_param["n_meas_at_individual_time_step"]
-        ), "n_meas_at_individual_time_step must contain positive values"
-        assert all(
-            isinstance(x, int)
-            for x in simulation_param["n_meas_at_individual_time_step"]
-        ), "n_meas_at_individual_time_step must contain integer values"
+        _expand_meas_per_step(simulation_param)
+        _validate_measurement_counts(simulation_param)
 
     elif "n_meas_at_individual_time_step" not in simulation_param:
         simulation_param["n_meas_at_individual_time_step"] = [1] * simulation_param[

--- a/src/pyrecest/evaluation/configure_for_filter.py
+++ b/src/pyrecest/evaluation/configure_for_filter.py
@@ -53,7 +53,6 @@ def configure_for_filter(filter_config, scenario_config, precalculated_params=No
     if registered_factory is not None:
         return registered_factory(filter_config, scenario_config, precalculated_params)
 
-
     if filter_name == "kf":
         # Implement your KalmanFilter class and its methods
         filter_obj = KalmanFilter(scenario_config["initial_prior"])
@@ -69,7 +68,7 @@ def configure_for_filter(filter_config, scenario_config, precalculated_params=No
 
             def prediction_routine(curr_input):  # type: ignore
                 return filter_obj.predict_identity(
-                    scenario_config["sys_noise"], curr_input
+                    scenario_config["sys_noise"].covariance(), curr_input
                 )
 
     elif filter_name == "twn":

--- a/src/pyrecest/evaluation/generate_measurements.py
+++ b/src/pyrecest/evaluation/generate_measurements.py
@@ -28,6 +28,21 @@ def _as_shapely_scalar(value):
     return float(np.asarray(value).reshape(-1)[0])
 
 
+def _mtt_state_at(groundtruth, t, target_no, n_targets):
+    """Return one target state from dense or per-step object ground truth."""
+    state_at_t = np.asarray(groundtruth[t])
+    if n_targets == 1 and state_at_t.ndim == 1:
+        if target_no != 0:
+            raise IndexError("target_no out of bounds for single-target ground truth")
+        return state_at_t
+    if state_at_t.ndim != 2:
+        raise ValueError(
+            "MTT groundtruth entries must have shape (n_targets, dim); "
+            f"got {state_at_t.shape}."
+        )
+    return state_at_t[target_no, :]
+
+
 # pylint: disable=too-many-branches,too-many-locals,too-many-statements
 def generate_measurements(groundtruth, simulation_config):
     """
@@ -150,9 +165,15 @@ def generate_measurements(groundtruth, simulation_config):
             for target_no in range(simulation_config["n_targets"]):
                 if n_observations[t, target_no] == 1:
                     meas_no += 1
+                    target_state = _mtt_state_at(
+                        groundtruth,
+                        t,
+                        target_no,
+                        simulation_config["n_targets"],
+                    )
                     measurements[t][meas_no - 1, :] = dot(
                         simulation_config["meas_matrix_for_each_target"],
-                        array(groundtruth[t, target_no, :]),
+                        array(target_state),
                     ) + squeeze(simulation_config["meas_noise"].sample(1))
                 else:
                     if n_observations[t, target_no] != 0:

--- a/src/pyrecest/evaluation/perform_predict_update_cycles.py
+++ b/src/pyrecest/evaluation/perform_predict_update_cycles.py
@@ -6,6 +6,25 @@ from pyrecest.backend import any, array, atleast_2d, empty_like, squeeze
 from .configure_for_filter import configure_for_filter
 
 
+def _update_with_likelihood(filter_obj, likelihood_for_filter, measurement):
+    """Apply a measurement-specific likelihood update to a compatible filter."""
+    if likelihood_for_filter is None:
+        raise ValueError(
+            "use_likelihood=True requires scenario_config['likelihood'] to be set."
+        )
+
+    update_likelihood = getattr(filter_obj, "update_nonlinear_using_likelihood", None)
+    if update_likelihood is None:
+        raise NotImplementedError(
+            f"{type(filter_obj).__name__} does not support likelihood-based updates."
+        )
+
+    if hasattr(likelihood_for_filter, "pdf"):
+        update_likelihood(likelihood_for_filter)
+    else:
+        update_likelihood(likelihood_for_filter, measurement=squeeze(measurement))
+
+
 # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-positional-arguments
 def perform_predict_update_cycles(
     scenario_config,
@@ -22,8 +41,8 @@ def perform_predict_update_cycles(
         all_estimates = None
 
     # Configure filter
-    filter_obj, prediction_routine, _, meas_noise_for_filter = configure_for_filter(
-        filter_config, scenario_config, precalculated_params
+    filter_obj, prediction_routine, likelihood_for_filter, meas_noise_for_filter = (
+        configure_for_filter(filter_config, scenario_config, precalculated_params)
     )
 
     # Check conditions for cumulative updates
@@ -61,7 +80,11 @@ def perform_predict_update_cycles(
             for m in range(n_updates):
                 curr_meas = all_meas_curr_time_step[m, :]
 
-                if not scenario_config.get("use_likelihood", False):
+                if scenario_config.get("use_likelihood", False):
+                    _update_with_likelihood(
+                        filter_obj, likelihood_for_filter, curr_meas
+                    )
+                else:
                     filter_obj.update_identity(
                         meas_noise=meas_noise_for_filter, measurement=squeeze(curr_meas)
                     )

--- a/src/pyrecest/evaluation/perform_predict_update_cycles.py
+++ b/src/pyrecest/evaluation/perform_predict_update_cycles.py
@@ -105,7 +105,10 @@ def perform_predict_update_cycles(
                 prediction_routine(scenario_config["inputs"][:, t])
 
             # If plotting is required
-            if scenario_config.get("plot", False) and t != scenario_config["timesteps"]:
+            if (
+                scenario_config.get("plot", False)
+                and t != scenario_config["n_timesteps"] - 1
+            ):
                 raise NotImplementedError("Plotting is not implemented yet.")
 
     # End timer

--- a/src/pyrecest/evaluation/perform_predict_update_cycles.py
+++ b/src/pyrecest/evaluation/perform_predict_update_cycles.py
@@ -68,7 +68,7 @@ def perform_predict_update_cycles(
         if perform_cumulative_updates:
             raise NotImplementedError("Cumulative updates not implemented yet.")
 
-        all_meas_curr_time_step = atleast_2d(measurements[t])
+        all_meas_curr_time_step = atleast_2d(array(measurements[t]))
         n_updates = all_meas_curr_time_step.shape[0]
 
         if scenario_config.get("eot", False):

--- a/tests/test_evaluation_control_flow_regressions.py
+++ b/tests/test_evaluation_control_flow_regressions.py
@@ -1,0 +1,130 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+# pylint: disable=redefined-builtin,no-name-in-module,no-member
+from pyrecest.backend import array, eye, get_backend_name, zeros
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.evaluation import (
+    configure_for_filter,
+    generate_simulated_scenarios,
+    perform_predict_update_cycles,
+)
+from pyrecest.evaluation.configure_for_filter import register_filter_factory
+
+IS_JAX_BACKEND = get_backend_name() == "jax"
+
+
+class _LikelihoodRecordingFilter:
+    def __init__(self):
+        self.applied_likelihood_values = []
+
+    @property
+    def filter_state(self):
+        return self
+
+    def update_nonlinear_using_likelihood(self, likelihood, measurement=None):
+        likelihood_values = likelihood(measurement, array([[0.0]]))
+        self.applied_likelihood_values.append(likelihood_values)
+
+    def get_point_estimate(self):
+        if not self.applied_likelihood_values:
+            return zeros(1)
+        return array([self.applied_likelihood_values[-1][0]])
+
+
+def _likelihood_test_factory(_filter_config, scenario_config, _precalculated_params):
+    filter_obj = _LikelihoodRecordingFilter()
+
+    def prediction_routine():
+        return None
+
+    return (
+        filter_obj,
+        prediction_routine,
+        scenario_config.get("likelihood"),
+        scenario_config.get("meas_noise"),
+    )
+
+
+class TestEvaluationControlFlowRegressions(unittest.TestCase):
+    def test_configured_kf_with_inputs_passes_process_covariance(self):
+        scenario_config = {
+            "initial_prior": GaussianDistribution(array([0.0]), eye(1)),
+            "sys_noise": GaussianDistribution(array([0.0]), 0.5 * eye(1)),
+            "meas_noise": GaussianDistribution(array([0.0]), eye(1)),
+            "inputs": array([[2.0]]),
+        }
+
+        filter_obj, prediction_routine, _, _ = configure_for_filter(
+            {"name": "kf", "parameter": None},
+            scenario_config,
+        )
+
+        prediction_routine(array([2.0]))
+
+        npt.assert_allclose(filter_obj.filter_state.mean(), array([2.0]))
+        npt.assert_allclose(filter_obj.filter_state.covariance(), 1.5 * eye(1))
+
+    def test_perform_cycles_honors_callable_likelihood_updates(self):
+        filter_name = "likelihood_control_flow_regression"
+        register_filter_factory(filter_name, _likelihood_test_factory)
+        calls = []
+
+        def likelihood(measurement, particles):
+            calls.append((measurement, particles))
+            return array([float(measurement) + 1.0])
+
+        scenario_config = {
+            "n_timesteps": 1,
+            "n_meas_at_individual_time_step": [1],
+            "apply_sys_noise_times": [False],
+            "use_likelihood": True,
+            "likelihood": likelihood,
+            "mtt": False,
+            "eot": False,
+        }
+        groundtruth = np.array([[0.0]])
+        measurements = np.empty(1, dtype=object)
+        measurements[0] = np.array([[2.0]])
+
+        _, _, last_estimate, _ = perform_predict_update_cycles(
+            scenario_config,
+            {"name": filter_name, "parameter": None},
+            groundtruth,
+            measurements,
+        )
+
+        self.assertEqual(len(calls), 1)
+        npt.assert_allclose(last_estimate, array([3.0]))
+
+    @pytest.mark.skipif(
+        IS_JAX_BACKEND, reason="MTT measurement generation is unsupported with JAX."
+    )
+    def test_simulated_single_target_mtt_measurements_accept_object_groundtruth(self):
+        simulation_config = {
+            "mtt": True,
+            "eot": False,
+            "all_seeds": [1],
+            "n_timesteps": 2,
+            "n_targets": 1,
+            "initial_prior": GaussianDistribution(array([0.0, 0.0]), eye(2)),
+            "sys_noise": GaussianDistribution(array([0.0, 0.0]), 1.0e-6 * eye(2)),
+            "meas_matrix_for_each_target": eye(2),
+            "meas_noise": GaussianDistribution(array([0.0, 0.0]), 1.0e-6 * eye(2)),
+            "detection_probability": 1,
+            "clutter_rate": 0,
+        }
+
+        groundtruths, measurements = generate_simulated_scenarios(simulation_config)
+
+        self.assertEqual(groundtruths.shape, (1, 2))
+        self.assertEqual(measurements.shape, (1, 2))
+        self.assertEqual(measurements[0, 0].shape, (1, 2))
+        self.assertEqual(measurements[0, 1].shape, (1, 2))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_evaluation_control_flow_regressions.py
+++ b/tests/test_evaluation_control_flow_regressions.py
@@ -35,6 +35,18 @@ class _LikelihoodRecordingFilter:
         return array([self.applied_likelihood_values[-1][0]])
 
 
+class _PredictOnlyFilter:
+    def __init__(self):
+        self.predicted = False
+
+    @property
+    def filter_state(self):
+        return self
+
+    def get_point_estimate(self):
+        return array([1.0 if self.predicted else 0.0])
+
+
 def _likelihood_test_factory(_filter_config, scenario_config, _precalculated_params):
     filter_obj = _LikelihoodRecordingFilter()
 
@@ -47,6 +59,15 @@ def _likelihood_test_factory(_filter_config, scenario_config, _precalculated_par
         scenario_config.get("likelihood"),
         scenario_config.get("meas_noise"),
     )
+
+
+def _predict_only_test_factory(_filter_config, _scenario_config, _precalculated_params):
+    filter_obj = _PredictOnlyFilter()
+
+    def prediction_routine():
+        filter_obj.predicted = True
+
+    return filter_obj, prediction_routine, None, None
 
 
 class TestEvaluationControlFlowRegressions(unittest.TestCase):
@@ -99,6 +120,30 @@ class TestEvaluationControlFlowRegressions(unittest.TestCase):
 
         self.assertEqual(len(calls), 1)
         npt.assert_allclose(last_estimate, array([3.0]))
+
+    def test_plotting_prediction_guard_uses_n_timesteps_key(self):
+        filter_name = "plotting_timestep_guard_regression"
+        register_filter_factory(filter_name, _predict_only_test_factory)
+        scenario_config = {
+            "n_timesteps": 1,
+            "n_meas_at_individual_time_step": [0],
+            "apply_sys_noise_times": [True],
+            "plot": True,
+            "mtt": False,
+            "eot": False,
+        }
+        groundtruth = np.array([[0.0]])
+        measurements = np.empty(1, dtype=object)
+        measurements[0] = np.empty((0, 1))
+
+        _, _, last_estimate, _ = perform_predict_update_cycles(
+            scenario_config,
+            {"name": filter_name, "parameter": None},
+            groundtruth,
+            measurements,
+        )
+
+        npt.assert_allclose(last_estimate, array([1.0]))
 
     @pytest.mark.skipif(
         IS_JAX_BACKEND, reason="MTT measurement generation is unsupported with JAX."

--- a/tests/test_evaluation_control_flow_regressions.py
+++ b/tests/test_evaluation_control_flow_regressions.py
@@ -8,6 +8,7 @@ import pytest
 from pyrecest.backend import array, eye, get_backend_name, zeros
 from pyrecest.distributions import GaussianDistribution
 from pyrecest.evaluation import (
+    check_and_fix_config,
     configure_for_filter,
     generate_simulated_scenarios,
     perform_predict_update_cycles,
@@ -144,6 +145,20 @@ class TestEvaluationControlFlowRegressions(unittest.TestCase):
         )
 
         npt.assert_allclose(last_estimate, array([1.0]))
+
+    def test_eot_meas_per_step_is_normalized_to_per_step_counts(self):
+        config = check_and_fix_config(
+            {
+                "mtt": False,
+                "eot": True,
+                "n_timesteps": 3,
+                "meas_per_step": 2,
+                "initial_prior": GaussianDistribution(array([0.0, 0.0]), eye(2)),
+            }
+        )
+
+        self.assertNotIn("meas_per_step", config)
+        self.assertEqual(config["n_meas_at_individual_time_step"], [2, 2, 2])
 
     @pytest.mark.skipif(
         IS_JAX_BACKEND, reason="MTT measurement generation is unsupported with JAX."

--- a/tests/test_evaluation_control_flow_regressions.py
+++ b/tests/test_evaluation_control_flow_regressions.py
@@ -146,6 +146,18 @@ class TestEvaluationControlFlowRegressions(unittest.TestCase):
 
         npt.assert_allclose(last_estimate, array([1.0]))
 
+    def test_plain_config_defaults_to_non_mtt_non_eot(self):
+        config = check_and_fix_config(
+            {
+                "n_timesteps": 2,
+                "initial_prior": GaussianDistribution(array([0.0]), eye(1)),
+            }
+        )
+
+        self.assertFalse(config["mtt"])
+        self.assertFalse(config["eot"])
+        self.assertEqual(config["n_meas_at_individual_time_step"], [1, 1])
+
     def test_eot_meas_per_step_is_normalized_to_per_step_counts(self):
         config = check_and_fix_config(
             {


### PR DESCRIPTION
## Summary
- fix Kalman-filter evaluation prediction with inputs so the process covariance matrix is passed instead of the noise distribution object
- honor `use_likelihood=True` in `perform_predict_update_cycles` by dispatching to likelihood-capable filters
- make MTT measurement generation accept the per-step/object-array ground-truth representation produced by `generate_simulated_scenarios`
- fix the plotting prediction guard to use `n_timesteps` instead of the nonexistent `timesteps` key
- normalize EOT `meas_per_step` configs to `n_meas_at_individual_time_step` so checked configs match measurement generation
- default missing `mtt`/`eot` flags in plain custom configs before accessing them
- add focused regression tests for the evaluation control-flow bugs

## Validation
- Added `tests/test_evaluation_control_flow_regressions.py`
- MegaLinter passed on prior PR heads; latest checks are still running/pending after the newest regression commit
- Package/docs jobs passed on prior PR heads
- Did not run the full suite locally in this environment