### PR TITLE
Add generic candidate pruning utilities

### DIFF
--- a/src/pyrecest/utils/__init__.py
+++ b/src/pyrecest/utils/__init__.py
@@ -7,6 +7,12 @@ from .association_features import (
     pairwise_feature_tensor,
 )
 from .association_models import LogisticPairwiseAssociationModel
+from .candidate_pruning import (
+    CandidatePruningConfig,
+    candidate_mask_from_costs,
+    candidate_pruning_config_from_mapping,
+    prune_pairwise_cost_matrix,
+)
 from .history_recorder import HistoryRecorder
 from .metrics import (
     anees,
@@ -136,6 +142,10 @@ __all__ = [
     "LogisticPairwiseAssociationModel",
     "NamedPairwiseFeatureSchema",
     "pairwise_feature_tensor",
+    "CandidatePruningConfig",
+    "candidate_mask_from_costs",
+    "candidate_pruning_config_from_mapping",
+    "prune_pairwise_cost_matrix",
     "HistoryRecorder",
     "ThinPlateSplineRegistrationResult",
     "ThinPlateSplineTransform",

--- a/src/pyrecest/utils/candidate_pruning.py
+++ b/src/pyrecest/utils/candidate_pruning.py
@@ -1,0 +1,213 @@
+"""Candidate pruning helpers for pairwise association matrices.
+
+These utilities reduce dense pairwise association matrices to high-recall
+candidate graphs before downstream assignment.  Pruning is expressed as a boolean
+mask over a rectangular cost matrix; callers that need to preserve matrix shape
+can replace pruned entries by a large finite cost.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class CandidatePruningConfig:
+    """Configuration for pairwise cost/probability candidate pruning.
+
+    The enabled criteria are combined by union: a candidate is kept when any
+    active row/column top-k, probability-threshold, cost-threshold, or percentile
+    criterion selects it.  If no criterion is enabled, all finite costs are kept.
+    """
+
+    row_top_k: int | None = None
+    column_top_k: int | None = None
+    probability_threshold: float | None = None
+    max_cost: float | None = None
+    max_cost_percentile: float | None = None
+    always_keep_finite: bool = False
+    large_cost: float = 1.0e6
+
+    def __post_init__(self) -> None:
+        for name in ("row_top_k", "column_top_k"):
+            value = getattr(self, name)
+            if value is None:
+                continue
+            parsed = int(value)
+            if parsed <= 0:
+                raise ValueError(f"{name} must be positive or None")
+            object.__setattr__(self, name, parsed)
+
+        if self.probability_threshold is not None:
+            threshold = float(self.probability_threshold)
+            if not 0.0 <= threshold <= 1.0:
+                raise ValueError("probability_threshold must lie in [0, 1]")
+            object.__setattr__(self, "probability_threshold", threshold)
+
+        if self.max_cost is not None:
+            max_cost = float(self.max_cost)
+            if not np.isfinite(max_cost):
+                raise ValueError("max_cost must be finite or None")
+            object.__setattr__(self, "max_cost", max_cost)
+
+        if self.max_cost_percentile is not None:
+            percentile = float(self.max_cost_percentile)
+            if not 0.0 <= percentile <= 100.0:
+                raise ValueError("max_cost_percentile must lie in [0, 100]")
+            object.__setattr__(self, "max_cost_percentile", percentile)
+
+        large_cost = float(self.large_cost)
+        if not np.isfinite(large_cost) or large_cost <= 0.0:
+            raise ValueError("large_cost must be finite and positive")
+        object.__setattr__(self, "large_cost", large_cost)
+
+
+def candidate_pruning_config_from_mapping(
+    value: CandidatePruningConfig | Mapping[str, Any] | None,
+) -> CandidatePruningConfig | None:
+    """Normalize optional pruning config inputs."""
+
+    if value is None:
+        return None
+    if isinstance(value, CandidatePruningConfig):
+        return value
+    return CandidatePruningConfig(**dict(value))
+
+
+def candidate_mask_from_costs(
+    cost_matrix: Any,
+    *,
+    probability_matrix: Any | None = None,
+    config: CandidatePruningConfig | Mapping[str, Any] | None = None,
+) -> np.ndarray:
+    """Return a boolean candidate mask for a pairwise association matrix."""
+
+    costs = _as_cost_matrix(cost_matrix)
+    finite_costs = np.isfinite(costs)
+    cfg = candidate_pruning_config_from_mapping(config)
+    if cfg is None:
+        return finite_costs
+
+    keep = np.zeros(costs.shape, dtype=bool)
+    any_rule = False
+
+    if cfg.always_keep_finite:
+        keep |= finite_costs
+        any_rule = True
+    if cfg.row_top_k is not None:
+        keep |= _row_top_k_mask(costs, cfg.row_top_k)
+        any_rule = True
+    if cfg.column_top_k is not None:
+        keep |= _column_top_k_mask(costs, cfg.column_top_k)
+        any_rule = True
+    if cfg.probability_threshold is not None and probability_matrix is not None:
+        probabilities = _as_probability_matrix(probability_matrix, costs.shape)
+        keep |= np.isfinite(probabilities) & (
+            probabilities >= cfg.probability_threshold
+        )
+        any_rule = True
+    if cfg.max_cost is not None:
+        keep |= finite_costs & (costs <= cfg.max_cost)
+        any_rule = True
+    if cfg.max_cost_percentile is not None:
+        threshold = _finite_percentile(costs, cfg.max_cost_percentile)
+        if threshold is not None:
+            keep |= finite_costs & (costs <= threshold)
+            any_rule = True
+
+    if not any_rule:
+        keep = finite_costs
+    return keep & finite_costs
+
+
+def prune_pairwise_cost_matrix(
+    cost_matrix: Any,
+    *,
+    probability_matrix: Any | None = None,
+    config: CandidatePruningConfig | Mapping[str, Any] | None = None,
+    large_cost: float | None = None,
+) -> np.ndarray:
+    """Replace pruned candidate entries by a large finite cost."""
+
+    costs = _as_cost_matrix(cost_matrix)
+    cfg = candidate_pruning_config_from_mapping(config)
+    if cfg is None:
+        return costs
+
+    penalty = cfg.large_cost if large_cost is None else float(large_cost)
+    if not np.isfinite(penalty) or penalty <= 0.0:
+        raise ValueError("large_cost must be finite and positive")
+
+    mask = candidate_mask_from_costs(
+        costs,
+        probability_matrix=probability_matrix,
+        config=cfg,
+    )
+    return np.where(mask, costs, penalty)
+
+
+def _row_top_k_mask(costs: np.ndarray, top_k: int) -> np.ndarray:
+    mask = np.zeros(costs.shape, dtype=bool)
+    if costs.shape[1] == 0:
+        return mask
+
+    k = min(int(top_k), costs.shape[1])
+    for row_index, row in enumerate(costs):
+        finite_columns = np.flatnonzero(np.isfinite(row))
+        if finite_columns.size == 0:
+            continue
+        ordered = finite_columns[np.argsort(row[finite_columns], kind="stable")]
+        mask[row_index, ordered[:k]] = True
+    return mask
+
+
+def _column_top_k_mask(costs: np.ndarray, top_k: int) -> np.ndarray:
+    mask = np.zeros(costs.shape, dtype=bool)
+    if costs.shape[0] == 0:
+        return mask
+
+    k = min(int(top_k), costs.shape[0])
+    for column_index in range(costs.shape[1]):
+        column = costs[:, column_index]
+        finite_rows = np.flatnonzero(np.isfinite(column))
+        if finite_rows.size == 0:
+            continue
+        ordered = finite_rows[np.argsort(column[finite_rows], kind="stable")]
+        mask[ordered[:k], column_index] = True
+    return mask
+
+
+def _finite_percentile(costs: np.ndarray, percentile: float) -> float | None:
+    finite = np.asarray(costs, dtype=float)[np.isfinite(costs)]
+    if finite.size == 0:
+        return None
+    return float(np.percentile(finite, float(percentile)))
+
+
+def _as_cost_matrix(cost_matrix: Any) -> np.ndarray:
+    costs = np.asarray(cost_matrix, dtype=float)
+    if costs.ndim != 2:
+        raise ValueError("cost_matrix must be two-dimensional")
+    return np.nan_to_num(costs, nan=np.inf, posinf=np.inf, neginf=np.inf)
+
+
+def _as_probability_matrix(
+    probability_matrix: Any,
+    shape: tuple[int, int],
+) -> np.ndarray:
+    probabilities = np.asarray(probability_matrix, dtype=float)
+    if probabilities.shape != shape:
+        raise ValueError("probability_matrix must match cost_matrix shape")
+    return probabilities
+
+
+__all__ = (
+    "CandidatePruningConfig",
+    "candidate_mask_from_costs",
+    "candidate_pruning_config_from_mapping",
+    "prune_pairwise_cost_matrix",
+)

--- a/tests/test_candidate_pruning.py
+++ b/tests/test_candidate_pruning.py
@@ -1,0 +1,105 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+from pyrecest.utils import (
+    CandidatePruningConfig,
+    candidate_mask_from_costs,
+    candidate_pruning_config_from_mapping,
+    prune_pairwise_cost_matrix,
+)
+
+
+class TestCandidatePruning(unittest.TestCase):
+    def test_none_config_keeps_all_finite_costs(self):
+        costs = np.array([[1.0, np.inf], [np.nan, 2.0]])
+
+        mask = candidate_mask_from_costs(costs)
+        pruned = prune_pairwise_cost_matrix(costs)
+
+        npt.assert_array_equal(mask, np.array([[True, False], [False, True]]))
+        npt.assert_allclose(pruned, np.array([[1.0, np.inf], [np.inf, 2.0]]))
+
+    def test_row_and_column_top_k_rules_are_unioned(self):
+        costs = np.array(
+            [
+                [4.0, 1.0, 3.0],
+                [2.0, 5.0, 0.5],
+                [7.0, 0.2, 6.0],
+            ]
+        )
+
+        mask = candidate_mask_from_costs(
+            costs,
+            config=CandidatePruningConfig(row_top_k=1, column_top_k=1),
+        )
+
+        expected = np.array(
+            [
+                [False, True, False],
+                [True, False, True],
+                [False, True, False],
+            ]
+        )
+        npt.assert_array_equal(mask, expected)
+
+    def test_probability_and_cost_threshold_rules_are_unioned(self):
+        costs = np.array([[1.0, 3.0], [4.0, 0.8]])
+        probabilities = np.array([[0.1, 0.95], [0.2, 0.3]])
+
+        mask = candidate_mask_from_costs(
+            costs,
+            probability_matrix=probabilities,
+            config={"probability_threshold": 0.9, "max_cost": 1.0},
+        )
+
+        npt.assert_array_equal(mask, np.array([[True, True], [False, True]]))
+
+    def test_percentile_rule_and_large_cost_replacement(self):
+        costs = np.array([[1.0, 2.0, 100.0], [3.0, 4.0, 5.0]])
+
+        pruned = prune_pairwise_cost_matrix(
+            costs,
+            config=CandidatePruningConfig(max_cost_percentile=50.0, large_cost=999.0),
+        )
+
+        npt.assert_allclose(
+            pruned,
+            np.array([[1.0, 2.0, 999.0], [3.0, 999.0, 999.0]]),
+        )
+
+    def test_always_keep_finite_overrides_selective_rules(self):
+        costs = np.array([[1.0, 10.0], [3.0, np.inf]])
+
+        mask = candidate_mask_from_costs(
+            costs,
+            config=CandidatePruningConfig(
+                row_top_k=1,
+                always_keep_finite=True,
+            ),
+        )
+
+        npt.assert_array_equal(mask, np.array([[True, True], [True, False]]))
+
+    def test_mapping_config_normalization_and_validation(self):
+        cfg = candidate_pruning_config_from_mapping({"row_top_k": 2})
+        self.assertIsInstance(cfg, CandidatePruningConfig)
+        self.assertEqual(cfg.row_top_k, 2)
+
+        with self.assertRaises(ValueError):
+            CandidatePruningConfig(row_top_k=0)
+        with self.assertRaises(ValueError):
+            CandidatePruningConfig(probability_threshold=1.1)
+        with self.assertRaises(ValueError):
+            candidate_mask_from_costs(np.array([1.0, 2.0]))
+        with self.assertRaises(ValueError):
+            candidate_mask_from_costs(
+                np.array([[1.0]]),
+                probability_matrix=np.array([[0.5, 0.5]]),
+                config=CandidatePruningConfig(probability_threshold=0.4),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add reusable candidate-pruning helpers for pairwise association cost matrices
- export `CandidatePruningConfig`, `candidate_mask_from_costs`, `candidate_pruning_config_from_mapping`, and `prune_pairwise_cost_matrix` from `pyrecest.utils`
- cover row/column top-k, probability thresholds, cost thresholds, percentile pruning, null-config behavior, and validation

## Context
This ports the generic candidate-pruning piece out of BayesCaTrack so downstream tracking code can rely on PyRecEst for assignment/backend utilities while keeping BayesCaTrack focused on calcium-imaging semantics.

## Tests
- Added `tests/test_candidate_pruning.py`