### PR TITLE
Add PyRecEst fusion utility candidates

### DIFF
--- a/src/pyrecest/calibration/__init__.py
+++ b/src/pyrecest/calibration/__init__.py
@@ -1,0 +1,37 @@
+"""Calibration helpers for asynchronous sensor-fusion workflows."""
+
+from .bias import (
+    BiasTrainingExamples,
+    SensorBiasCorrectionModel,
+    fit_sensor_bias_correction,
+    fit_sensor_bias_correction_from_examples,
+    make_bias_training_examples,
+)
+from .time_offset import (
+    TimeOffsetFitResult,
+    aggregate_time_offset_sweeps,
+    apply_time_offset,
+    fit_time_offset,
+    interpolate_reference_values,
+    make_offset_grid,
+    nearest_time_indices,
+    time_offset_error_summary,
+    time_offset_sweep,
+)
+
+__all__ = [
+    "BiasTrainingExamples",
+    "SensorBiasCorrectionModel",
+    "TimeOffsetFitResult",
+    "aggregate_time_offset_sweeps",
+    "apply_time_offset",
+    "fit_sensor_bias_correction",
+    "fit_sensor_bias_correction_from_examples",
+    "fit_time_offset",
+    "interpolate_reference_values",
+    "make_bias_training_examples",
+    "make_offset_grid",
+    "nearest_time_indices",
+    "time_offset_error_summary",
+    "time_offset_sweep",
+]

--- a/src/pyrecest/calibration/bias.py
+++ b/src/pyrecest/calibration/bias.py
@@ -1,0 +1,294 @@
+"""Generic measurement-bias calibration utilities."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from .time_offset import nearest_time_indices
+
+
+@dataclass(frozen=True)
+class BiasTrainingExamples:
+    """Matched measurement/reference pairs used for bias fitting."""
+
+    measured: np.ndarray
+    reference: np.ndarray
+    residual: np.ndarray
+    features: np.ndarray
+    time_delta_s: np.ndarray
+
+
+@dataclass(frozen=True)
+class SensorBiasCorrectionModel:
+    """Ridge-linear model for measurement residual bias.
+
+    The model predicts ``bias = measured - reference`` from optional feature
+    vectors.  Applying the model subtracts the predicted bias from measurements.
+    """
+
+    target_dim: int
+    feature_dim: int
+    intercept: np.ndarray
+    coefficients: np.ndarray
+    feature_mean: np.ndarray
+    feature_scale: np.ndarray
+    residual_std: np.ndarray
+    training_count: int
+    ridge_alpha: float
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        target_dim = int(self.target_dim)
+        feature_dim = int(self.feature_dim)
+        if target_dim <= 0:
+            raise ValueError("target_dim must be positive")
+        if feature_dim < 0:
+            raise ValueError("feature_dim must be nonnegative")
+        intercept = np.asarray(self.intercept, dtype=float).reshape(target_dim)
+        coefficients = np.asarray(self.coefficients, dtype=float).reshape(feature_dim, target_dim)
+        feature_mean = np.asarray(self.feature_mean, dtype=float).reshape(feature_dim)
+        feature_scale = np.asarray(self.feature_scale, dtype=float).reshape(feature_dim)
+        residual_std = np.asarray(self.residual_std, dtype=float).reshape(target_dim)
+        feature_scale = np.where(np.isfinite(feature_scale) & (feature_scale > 0.0), feature_scale, 1.0)
+        object.__setattr__(self, "target_dim", target_dim)
+        object.__setattr__(self, "feature_dim", feature_dim)
+        object.__setattr__(self, "intercept", intercept)
+        object.__setattr__(self, "coefficients", coefficients)
+        object.__setattr__(self, "feature_mean", feature_mean)
+        object.__setattr__(self, "feature_scale", feature_scale)
+        object.__setattr__(self, "residual_std", residual_std)
+        object.__setattr__(self, "training_count", int(self.training_count))
+        object.__setattr__(self, "ridge_alpha", float(self.ridge_alpha))
+        object.__setattr__(self, "metadata", dict(self.metadata))
+
+    def predict(self, features: np.ndarray | None = None, *, n_rows: int | None = None) -> np.ndarray:
+        """Predict residual bias for feature rows."""
+
+        if self.feature_dim == 0:
+            rows = 1 if n_rows is None else int(n_rows)
+            return np.repeat(self.intercept.reshape(1, -1), rows, axis=0)
+        if features is None:
+            raise ValueError("features are required for a nonconstant bias model")
+        x = _as_2d(features, "features")
+        if x.shape[1] != self.feature_dim:
+            raise ValueError("features have incompatible feature dimension")
+        standardized = (x - self.feature_mean) / self.feature_scale
+        return self.intercept.reshape(1, -1) + standardized @ self.coefficients
+
+    def apply(self, measurements: np.ndarray, features: np.ndarray | None = None) -> np.ndarray:
+        """Return measurements with predicted bias subtracted."""
+
+        values = _as_2d(measurements, "measurements")
+        if values.shape[1] != self.target_dim:
+            raise ValueError("measurements have incompatible target dimension")
+        bias = self.predict(features, n_rows=values.shape[0])
+        corrected = values.copy()
+        valid = np.isfinite(values).all(axis=1) & np.isfinite(bias).all(axis=1)
+        corrected[valid] = values[valid] - bias[valid]
+        return corrected
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the model to a JSON-compatible mapping."""
+
+        return {
+            "target_dim": int(self.target_dim),
+            "feature_dim": int(self.feature_dim),
+            "intercept": self.intercept.tolist(),
+            "coefficients": self.coefficients.tolist(),
+            "feature_mean": self.feature_mean.tolist(),
+            "feature_scale": self.feature_scale.tolist(),
+            "residual_std": self.residual_std.tolist(),
+            "training_count": int(self.training_count),
+            "ridge_alpha": float(self.ridge_alpha),
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "SensorBiasCorrectionModel":
+        """Deserialize a model produced by :meth:`to_dict`."""
+
+        return cls(
+            target_dim=int(payload["target_dim"]),
+            feature_dim=int(payload["feature_dim"]),
+            intercept=np.asarray(payload["intercept"], dtype=float),
+            coefficients=np.asarray(payload["coefficients"], dtype=float),
+            feature_mean=np.asarray(payload["feature_mean"], dtype=float),
+            feature_scale=np.asarray(payload["feature_scale"], dtype=float),
+            residual_std=np.asarray(payload["residual_std"], dtype=float),
+            training_count=int(payload["training_count"]),
+            ridge_alpha=float(payload.get("ridge_alpha", 0.0)),
+            metadata=payload.get("metadata", {}),
+        )
+
+
+def make_bias_training_examples(
+    measurement_times_s: np.ndarray,
+    measurement_values: np.ndarray,
+    reference_times_s: np.ndarray,
+    reference_values: np.ndarray,
+    *,
+    feature_values: np.ndarray | None = None,
+    max_time_delta_s: float = 2.0,
+) -> BiasTrainingExamples:
+    """Match measurements to nearest reference values and compute residual bias."""
+
+    if max_time_delta_s < 0.0:
+        raise ValueError("max_time_delta_s must be nonnegative")
+    measurement_times = np.asarray(measurement_times_s, dtype=float).reshape(-1)
+    measurements = _as_2d(measurement_values, "measurement_values")
+    reference_times = np.asarray(reference_times_s, dtype=float).reshape(-1)
+    references = _as_2d(reference_values, "reference_values")
+    if measurement_times.size != measurements.shape[0]:
+        raise ValueError("measurement_times_s length must match measurement_values rows")
+    if reference_times.size != references.shape[0]:
+        raise ValueError("reference_times_s length must match reference_values rows")
+    if measurements.shape[1] != references.shape[1]:
+        raise ValueError("measurement_values and reference_values must have the same target dimension")
+    if reference_times.size == 0:
+        return BiasTrainingExamples(
+            measured=np.empty((0, measurements.shape[1])),
+            reference=np.empty((0, measurements.shape[1])),
+            residual=np.empty((0, measurements.shape[1])),
+            features=np.empty((0, 0 if feature_values is None else _as_2d(feature_values, "feature_values").shape[1])),
+            time_delta_s=np.empty(0),
+        )
+
+    order = np.argsort(reference_times)
+    reference_times = reference_times[order]
+    references = references[order]
+    nearest = nearest_time_indices(reference_times, measurement_times)
+    delta_s = np.abs(reference_times[nearest] - measurement_times)
+    valid = (
+        np.isfinite(measurement_times)
+        & np.isfinite(measurements).all(axis=1)
+        & np.isfinite(references[nearest]).all(axis=1)
+        & (delta_s <= float(max_time_delta_s))
+    )
+    if feature_values is None:
+        features = np.empty((measurements.shape[0], 0), dtype=float)
+    else:
+        features = _as_2d(feature_values, "feature_values")
+        if features.shape[0] != measurements.shape[0]:
+            raise ValueError("feature_values rows must match measurement_values rows")
+        valid &= np.isfinite(features).all(axis=1)
+    measured = measurements[valid]
+    reference = references[nearest[valid]]
+    return BiasTrainingExamples(
+        measured=measured,
+        reference=reference,
+        residual=measured - reference,
+        features=features[valid],
+        time_delta_s=delta_s[valid],
+    )
+
+
+def fit_sensor_bias_correction_from_examples(
+    examples: BiasTrainingExamples,
+    *,
+    ridge_alpha: float = 1.0e-2,
+    min_samples: int = 4,
+    metadata: Mapping[str, Any] | None = None,
+) -> SensorBiasCorrectionModel:
+    """Fit a ridge-linear bias model from prepared examples."""
+
+    if ridge_alpha < 0.0:
+        raise ValueError("ridge_alpha must be nonnegative")
+    if min_samples < 1:
+        raise ValueError("min_samples must be positive")
+    y = _as_2d(examples.residual, "examples.residual")
+    x = _as_2d(examples.features, "examples.features")
+    valid = np.isfinite(y).all(axis=1) & np.isfinite(x).all(axis=1)
+    y = y[valid]
+    x = x[valid]
+    if y.shape[0] == 0:
+        raise ValueError("no finite bias training examples")
+    if x.shape[0] < int(min_samples):
+        x = np.empty((y.shape[0], 0), dtype=float)
+
+    feature_mean = _nanmean_or_zero(x)
+    feature_scale = np.nanstd(x, axis=0) if x.shape[1] else np.empty(0, dtype=float)
+    feature_scale = np.where(np.isfinite(feature_scale) & (feature_scale > 1.0e-12), feature_scale, 1.0)
+    standardized = (x - feature_mean) / feature_scale if x.shape[1] else x
+    design = np.column_stack([np.ones(y.shape[0]), standardized])
+    regularizer = np.eye(design.shape[1]) * float(ridge_alpha)
+    regularizer[0, 0] = 0.0
+    lhs = design.T @ design + regularizer
+    rhs = design.T @ y
+    try:
+        beta = np.linalg.solve(lhs, rhs)
+    except np.linalg.LinAlgError:
+        beta = np.linalg.pinv(lhs) @ rhs
+    residual = y - design @ beta
+    residual_std = np.std(residual, axis=0) if residual.size else np.zeros(y.shape[1])
+    return SensorBiasCorrectionModel(
+        target_dim=y.shape[1],
+        feature_dim=x.shape[1],
+        intercept=beta[0],
+        coefficients=beta[1:],
+        feature_mean=feature_mean,
+        feature_scale=feature_scale,
+        residual_std=residual_std,
+        training_count=int(y.shape[0]),
+        ridge_alpha=float(ridge_alpha),
+        metadata={} if metadata is None else dict(metadata),
+    )
+
+
+def fit_sensor_bias_correction(
+    measurement_times_s: np.ndarray,
+    measurement_values: np.ndarray,
+    reference_times_s: np.ndarray,
+    reference_values: np.ndarray,
+    *,
+    feature_values: np.ndarray | None = None,
+    max_time_delta_s: float = 2.0,
+    ridge_alpha: float = 1.0e-2,
+    min_samples: int = 4,
+    metadata: Mapping[str, Any] | None = None,
+) -> SensorBiasCorrectionModel:
+    """Fit a bias correction model directly from timestamped measurements."""
+
+    examples = make_bias_training_examples(
+        measurement_times_s,
+        measurement_values,
+        reference_times_s,
+        reference_values,
+        feature_values=feature_values,
+        max_time_delta_s=max_time_delta_s,
+    )
+    return fit_sensor_bias_correction_from_examples(
+        examples,
+        ridge_alpha=ridge_alpha,
+        min_samples=min_samples,
+        metadata=metadata,
+    )
+
+
+def _as_2d(values: np.ndarray, name: str) -> np.ndarray:
+    out = np.asarray(values, dtype=float)
+    if out.ndim == 1:
+        return out.reshape(-1, 1)
+    if out.ndim != 2:
+        raise ValueError(f"{name} must be one- or two-dimensional")
+    return out
+
+
+def _nanmean_or_zero(values: np.ndarray) -> np.ndarray:
+    if values.shape[1] == 0:
+        return np.empty(0, dtype=float)
+    with np.errstate(invalid="ignore"):
+        mean = np.nanmean(values, axis=0)
+    return np.where(np.isfinite(mean), mean, 0.0)
+
+
+__all__ = [
+    "BiasTrainingExamples",
+    "SensorBiasCorrectionModel",
+    "fit_sensor_bias_correction",
+    "fit_sensor_bias_correction_from_examples",
+    "make_bias_training_examples",
+]

--- a/src/pyrecest/calibration/time_offset.py
+++ b/src/pyrecest/calibration/time_offset.py
@@ -1,0 +1,257 @@
+"""Generic timestamp-offset calibration utilities."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class TimeOffsetFitResult:
+    """Best timestamp correction selected from an offset sweep."""
+
+    best_offset_s: float | None
+    metric: str
+    offsets_s: np.ndarray
+    metric_values: np.ndarray
+    counts: np.ndarray
+    summaries: list[dict[str, float]] = field(default_factory=list)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def summary(self) -> dict[str, Any]:
+        """Return a compact JSON-serializable summary."""
+
+        out: dict[str, Any] = {
+            "metric": self.metric,
+            "best_offset_s": self.best_offset_s,
+            "evaluated_offsets": int(len(self.offsets_s)),
+        }
+        if self.best_offset_s is not None and len(self.metric_values):
+            best_index = int(np.nanargmin(self.metric_values))
+            out["best_metric_value"] = float(self.metric_values[best_index])
+            out["best_count"] = int(self.counts[best_index])
+        out.update(dict(self.metadata))
+        return out
+
+
+def make_offset_grid(min_s: float, max_s: float, step_s: float) -> np.ndarray:
+    """Return an inclusive offset grid rounded to nanosecond precision."""
+
+    if step_s <= 0.0:
+        raise ValueError("step_s must be positive")
+    if max_s < min_s:
+        raise ValueError("max_s must be greater than or equal to min_s")
+    count = int(np.floor((float(max_s) - float(min_s)) / float(step_s))) + 1
+    offsets = float(min_s) + np.arange(count, dtype=float) * float(step_s)
+    if offsets.size == 0 or offsets[-1] < float(max_s) - 1.0e-12:
+        offsets = np.append(offsets, float(max_s))
+    return np.round(offsets, decimals=9)
+
+
+def apply_time_offset(times_s: np.ndarray, offset_s: float | None) -> np.ndarray:
+    """Return a copy of ``times_s`` shifted by ``offset_s`` seconds."""
+
+    offset = 0.0 if offset_s is None else float(offset_s)
+    return np.asarray(times_s, dtype=float) + offset
+
+
+def nearest_time_indices(reference_times_s: np.ndarray, query_times_s: np.ndarray) -> np.ndarray:
+    """Return indices of nearest reference times for each query time."""
+
+    reference = np.asarray(reference_times_s, dtype=float).reshape(-1)
+    query = np.asarray(query_times_s, dtype=float).reshape(-1)
+    if reference.size == 0:
+        raise ValueError("reference_times_s must not be empty")
+    insertion = np.searchsorted(reference, query)
+    right = np.clip(insertion, 0, reference.size - 1)
+    left = np.clip(insertion - 1, 0, reference.size - 1)
+    use_right = np.abs(reference[right] - query) < np.abs(reference[left] - query)
+    return np.where(use_right, right, left)
+
+
+def interpolate_reference_values(
+    reference_times_s: np.ndarray,
+    reference_values: np.ndarray,
+    query_times_s: np.ndarray,
+    *,
+    max_time_delta_s: float | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Interpolate reference values at query times and return a validity mask."""
+
+    reference_times = np.asarray(reference_times_s, dtype=float).reshape(-1)
+    reference_values = np.asarray(reference_values, dtype=float)
+    query_times = np.asarray(query_times_s, dtype=float).reshape(-1)
+    if reference_times.size != reference_values.shape[0]:
+        raise ValueError("reference_times_s length must match reference_values rows")
+    if reference_times.size < 2:
+        raise ValueError("at least two reference times are required for interpolation")
+    if reference_values.ndim == 1:
+        reference_values = reference_values.reshape(-1, 1)
+    order = np.argsort(reference_times)
+    reference_times = reference_times[order]
+    reference_values = reference_values[order]
+
+    interpolated = np.column_stack(
+        [np.interp(query_times, reference_times, reference_values[:, dim]) for dim in range(reference_values.shape[1])]
+    )
+    valid = (query_times >= reference_times[0]) & (query_times <= reference_times[-1])
+    if max_time_delta_s is not None:
+        nearest = nearest_time_indices(reference_times, query_times)
+        valid &= np.abs(reference_times[nearest] - query_times) <= float(max_time_delta_s)
+    valid &= np.isfinite(interpolated).all(axis=1)
+    return interpolated, valid
+
+
+def time_offset_error_summary(
+    measurement_times_s: np.ndarray,
+    measurement_values: np.ndarray,
+    reference_times_s: np.ndarray,
+    reference_values: np.ndarray,
+    offset_s: float,
+    *,
+    max_time_delta_s: float | None = None,
+) -> dict[str, float]:
+    """Evaluate one candidate offset against a reference trajectory."""
+
+    measurement_values = np.asarray(measurement_values, dtype=float)
+    if measurement_values.ndim == 1:
+        measurement_values = measurement_values.reshape(-1, 1)
+    query_times = apply_time_offset(measurement_times_s, offset_s)
+    reference_at_query, valid = interpolate_reference_values(
+        reference_times_s,
+        reference_values,
+        query_times,
+        max_time_delta_s=max_time_delta_s,
+    )
+    if reference_at_query.shape[1] != measurement_values.shape[1]:
+        raise ValueError("measurement_values and reference_values must have the same value dimension")
+    valid &= np.isfinite(measurement_values).all(axis=1)
+    errors = np.linalg.norm(measurement_values[valid] - reference_at_query[valid], axis=1)
+    return _error_stats(float(offset_s), errors, total_count=len(measurement_values))
+
+
+def time_offset_sweep(
+    measurement_times_s: np.ndarray,
+    measurement_values: np.ndarray,
+    reference_times_s: np.ndarray,
+    reference_values: np.ndarray,
+    offsets_s: Iterable[float],
+    *,
+    max_time_delta_s: float | None = None,
+) -> list[dict[str, float]]:
+    """Return error summaries for each candidate timestamp offset."""
+
+    return [
+        time_offset_error_summary(
+            measurement_times_s,
+            measurement_values,
+            reference_times_s,
+            reference_values,
+            float(offset),
+            max_time_delta_s=max_time_delta_s,
+        )
+        for offset in offsets_s
+    ]
+
+
+def fit_time_offset(
+    measurement_times_s: np.ndarray,
+    measurement_values: np.ndarray,
+    reference_times_s: np.ndarray,
+    reference_values: np.ndarray,
+    offsets_s: Iterable[float],
+    *,
+    metric: str = "rmse",
+    max_time_delta_s: float | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> TimeOffsetFitResult:
+    """Fit a timestamp offset by minimizing a sweep metric."""
+
+    summaries = time_offset_sweep(
+        measurement_times_s,
+        measurement_values,
+        reference_times_s,
+        reference_values,
+        offsets_s,
+        max_time_delta_s=max_time_delta_s,
+    )
+    offsets = np.array([row["time_offset_s"] for row in summaries], dtype=float)
+    values = np.array([row.get(metric, np.nan) for row in summaries], dtype=float)
+    counts = np.array([row.get("count", 0.0) for row in summaries], dtype=float)
+    finite = np.isfinite(values) & (counts > 0)
+    best = None if not finite.any() else float(offsets[np.where(finite)[0][int(np.nanargmin(values[finite]))]])
+    return TimeOffsetFitResult(
+        best_offset_s=best,
+        metric=str(metric),
+        offsets_s=offsets,
+        metric_values=values,
+        counts=counts.astype(int),
+        summaries=summaries,
+        metadata={} if metadata is None else dict(metadata),
+    )
+
+
+def aggregate_time_offset_sweeps(
+    sweeps: Iterable[Iterable[Mapping[str, float]]],
+    *,
+    metric: str = "rmse",
+) -> list[dict[str, float]]:
+    """Aggregate same-offset sweeps with count weighting."""
+
+    by_offset: dict[float, list[Mapping[str, float]]] = {}
+    for sweep in sweeps:
+        for row in sweep:
+            by_offset.setdefault(float(row["time_offset_s"]), []).append(row)
+    rows: list[dict[str, float]] = []
+    for offset, parts in sorted(by_offset.items()):
+        counts = np.array([float(part.get("count", 0.0)) for part in parts], dtype=float)
+        total = float(np.sum(counts))
+        row = {"time_offset_s": float(offset), "count": total}
+        for key in ("mean", "rmse", "p95", "max", metric):
+            values = np.array([float(part.get(key, np.nan)) for part in parts], dtype=float)
+            valid = np.isfinite(values) & (counts > 0.0)
+            row[key] = float(np.average(values[valid], weights=counts[valid])) if valid.any() else float("nan")
+        rows.append(row)
+    return rows
+
+
+def _error_stats(offset_s: float, errors: np.ndarray, *, total_count: int) -> dict[str, float]:
+    errors = np.asarray(errors, dtype=float).reshape(-1)
+    errors = errors[np.isfinite(errors)]
+    if errors.size == 0:
+        return {
+            "time_offset_s": float(offset_s),
+            "count": 0.0,
+            "coverage": 0.0 if total_count else float("nan"),
+            "mean": float("nan"),
+            "std": float("nan"),
+            "rmse": float("nan"),
+            "p95": float("nan"),
+            "max": float("nan"),
+        }
+    return {
+        "time_offset_s": float(offset_s),
+        "count": float(errors.size),
+        "coverage": float(errors.size / total_count) if total_count > 0 else float("nan"),
+        "mean": float(np.mean(errors)),
+        "std": float(np.std(errors)),
+        "rmse": float(np.sqrt(np.mean(errors**2))),
+        "p95": float(np.percentile(errors, 95)),
+        "max": float(np.max(errors)),
+    }
+
+
+__all__ = [
+    "TimeOffsetFitResult",
+    "aggregate_time_offset_sweeps",
+    "apply_time_offset",
+    "fit_time_offset",
+    "interpolate_reference_values",
+    "make_offset_grid",
+    "nearest_time_indices",
+    "time_offset_error_summary",
+    "time_offset_sweep",
+]

--- a/src/pyrecest/evaluation/diagnostic_summaries.py
+++ b/src/pyrecest/evaluation/diagnostic_summaries.py
@@ -1,0 +1,276 @@
+"""Compact diagnostic summaries for filter and tracker record streams."""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import numpy as np
+
+Record = Mapping[str, Any]
+
+
+def build_diagnostic_summary(
+    records: Sequence[Record],
+    *,
+    top_n: int = 20,
+    window_s: float = 30.0,
+    time_key: str = "time_s",
+    residual_key: str = "residual_norm",
+    error_key: str = "error",
+    source_key: str = "source",
+    track_id_key: str = "track_id",
+    covariance_scale_key: str = "covariance_scale",
+) -> dict[str, Any]:
+    """Build a JSON-serializable diagnostic summary from mapping records."""
+
+    if top_n < 1:
+        raise ValueError("top_n must be positive")
+    if window_s <= 0.0:
+        raise ValueError("window_s must be positive")
+    return {
+        "schema_version": 1,
+        "top_n": int(top_n),
+        "window_s": float(window_s),
+        "top_residuals": top_residuals(records, residual_key=residual_key, top_n=top_n),
+        "track_switches": track_switch_summary(records, time_key=time_key, track_id_key=track_id_key, top_n=top_n),
+        "covariance_inflation": covariance_inflation_summary(
+            records,
+            scale_key=covariance_scale_key,
+            source_key=source_key,
+            top_n=top_n,
+        ),
+        "worst_time_windows": worst_time_windows(
+            records,
+            time_key=time_key,
+            error_key=error_key,
+            residual_key=residual_key,
+            scale_key=covariance_scale_key,
+            track_id_key=track_id_key,
+            window_s=window_s,
+            top_n=top_n,
+        ),
+    }
+
+
+def top_residuals(
+    records: Sequence[Record],
+    *,
+    residual_key: str = "residual_norm",
+    top_n: int = 20,
+) -> list[dict[str, Any]]:
+    """Return records with the largest finite residual values."""
+
+    scored = []
+    for index, record in enumerate(records):
+        value = _optional_float(record.get(residual_key))
+        if value is not None:
+            scored.append((value, index, record))
+    scored.sort(key=lambda item: item[0], reverse=True)
+    return [_json_record(record) for _, _, record in scored[:top_n]]
+
+
+def track_switch_summary(
+    records: Sequence[Record],
+    *,
+    time_key: str = "time_s",
+    track_id_key: str = "track_id",
+    top_n: int = 20,
+) -> dict[str, Any]:
+    """Summarize changes in finite track id over time."""
+
+    ordered = _sort_by_time(records, time_key)
+    finite: list[tuple[Any, Record]] = []
+    for record in ordered:
+        track_id = record.get(track_id_key)
+        if track_id is not None and not _is_nan(track_id):
+            finite.append((track_id, record))
+    if not finite:
+        return _empty_track_switch_summary()
+
+    events: list[dict[str, Any]] = []
+    transitions: Counter[tuple[Any, Any]] = Counter()
+    previous_id: Any | None = None
+    for current_id, record in finite:
+        if previous_id is not None and current_id != previous_id:
+            transitions[(previous_id, current_id)] += 1
+            event = {"from_track_id": previous_id, "to_track_id": current_id}
+            time_value = _optional_float(record.get(time_key))
+            if time_value is not None:
+                event["time_s"] = time_value
+            events.append(_json_record(event))
+        previous_id = current_id
+
+    unique_ids = {track_id for track_id, _ in finite}
+    return {
+        "count": int(sum(transitions.values())),
+        "updates_with_track_id": int(len(finite)),
+        "unique_track_ids": int(len(unique_ids)),
+        "first_track_id": _json_value(finite[0][0]),
+        "last_track_id": _json_value(finite[-1][0]),
+        "top_transitions": [
+            {"from_track_id": _json_value(src), "to_track_id": _json_value(dst), "count": int(count)}
+            for (src, dst), count in transitions.most_common(top_n)
+        ],
+        "events": events[:top_n],
+    }
+
+
+def covariance_inflation_summary(
+    records: Sequence[Record],
+    *,
+    scale_key: str = "covariance_scale",
+    source_key: str = "source",
+    top_n: int = 20,
+) -> dict[str, Any]:
+    """Summarize updates whose covariance scale is greater than one."""
+
+    inflated: list[tuple[float, Record]] = []
+    by_source: Counter[str] = Counter()
+    for record in records:
+        scale = _optional_float(record.get(scale_key))
+        if scale is not None and scale > 1.0:
+            inflated.append((scale, record))
+            by_source[str(record.get(source_key, "unknown"))] += 1
+    if not inflated:
+        return {
+            "count": 0,
+            "by_source": {},
+            "mean_scale": None,
+            "p95_scale": None,
+            "max_scale": None,
+            "top_scaled_updates": [],
+        }
+    scales = np.array([scale for scale, _ in inflated], dtype=float)
+    inflated.sort(key=lambda item: item[0], reverse=True)
+    return {
+        "count": int(len(inflated)),
+        "by_source": dict(sorted(by_source.items())),
+        "mean_scale": float(np.mean(scales)),
+        "p95_scale": float(np.percentile(scales, 95)),
+        "max_scale": float(np.max(scales)),
+        "top_scaled_updates": [_json_record(record) for _, record in inflated[:top_n]],
+    }
+
+
+def worst_time_windows(
+    records: Sequence[Record],
+    *,
+    time_key: str = "time_s",
+    error_key: str = "error",
+    residual_key: str = "residual_norm",
+    scale_key: str = "covariance_scale",
+    track_id_key: str = "track_id",
+    window_s: float = 30.0,
+    top_n: int = 20,
+) -> list[dict[str, Any]]:
+    """Return windows with the largest RMSE for a supplied scalar error key."""
+
+    if window_s <= 0.0:
+        raise ValueError("window_s must be positive")
+    grouped: dict[float, list[Record]] = {}
+    for record in records:
+        time_value = _optional_float(record.get(time_key))
+        error = _optional_float(record.get(error_key))
+        if time_value is None or error is None:
+            continue
+        start = math.floor(time_value / window_s) * window_s
+        grouped.setdefault(float(start), []).append(record)
+
+    rows: list[dict[str, Any]] = []
+    for start, group in grouped.items():
+        errors = np.array([_optional_float(record.get(error_key)) for record in group], dtype=float)
+        errors = errors[np.isfinite(errors)]
+        if errors.size == 0:
+            continue
+        residuals = np.array(
+            [value for value in (_optional_float(record.get(residual_key)) for record in group) if value is not None],
+            dtype=float,
+        )
+        scales = np.array(
+            [value for value in (_optional_float(record.get(scale_key)) for record in group) if value is not None],
+            dtype=float,
+        )
+        rows.append(
+            {
+                "time_start_s": float(start),
+                "time_end_s": float(start + window_s),
+                "count": int(errors.size),
+                "rmse": float(np.sqrt(np.mean(errors**2))),
+                "mae": float(np.mean(np.abs(errors))),
+                "p95": float(np.percentile(errors, 95)),
+                "max": float(np.max(errors)),
+                "mean_residual": None if residuals.size == 0 else float(np.mean(residuals)),
+                "covariance_inflation_count": int(np.sum(scales > 1.0)) if scales.size else 0,
+                "track_switch_count": track_switch_summary(group, time_key=time_key, track_id_key=track_id_key, top_n=1)["count"],
+            }
+        )
+    rows.sort(key=lambda item: item["rmse"], reverse=True)
+    return rows[:top_n]
+
+
+def _empty_track_switch_summary() -> dict[str, Any]:
+    return {
+        "count": 0,
+        "updates_with_track_id": 0,
+        "unique_track_ids": 0,
+        "first_track_id": None,
+        "last_track_id": None,
+        "top_transitions": [],
+        "events": [],
+    }
+
+
+def _sort_by_time(records: Sequence[Record], time_key: str) -> list[Record]:
+    return sorted(
+        records,
+        key=lambda record: (
+            float("inf") if _optional_float(record.get(time_key)) is None else float(record.get(time_key)),
+        ),
+    )
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        out = float(value)
+    except (TypeError, ValueError):
+        return None
+    return out if math.isfinite(out) else None
+
+
+def _is_nan(value: Any) -> bool:
+    try:
+        return bool(math.isnan(float(value)))
+    except (TypeError, ValueError):
+        return False
+
+
+def _json_record(record: Mapping[str, Any]) -> dict[str, Any]:
+    return {str(key): _json_value(value) for key, value in record.items()}
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, np.integer):
+        return int(value)
+    if isinstance(value, np.floating):
+        value = float(value)
+    if isinstance(value, float):
+        return None if not math.isfinite(value) else value
+    if isinstance(value, np.bool_):
+        return bool(value)
+    if isinstance(value, np.ndarray):
+        return [_json_value(item) for item in value.tolist()]
+    return value
+
+
+__all__ = [
+    "build_diagnostic_summary",
+    "covariance_inflation_summary",
+    "top_residuals",
+    "track_switch_summary",
+    "worst_time_windows",
+]

--- a/src/pyrecest/filters/adaptive_process_noise.py
+++ b/src/pyrecest/filters/adaptive_process_noise.py
@@ -1,0 +1,122 @@
+"""Adaptive process-noise scaling from innovation statistics."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class AdaptiveProcessNoiseConfig:
+    """Parameters for bounded NIS-ratio process-noise adaptation.
+
+    ``base_scale`` is the nominal multiplier applied when the observed NIS per
+    measurement dimension is near one.  The rolling ratio is mapped to a bounded
+    scale using ``low_nis_ratio``, ``high_nis_ratio``, and ``scale_gain``.
+    """
+
+    base_scale: float = 1.0
+    min_scale: float = 0.35
+    max_scale: float = 4.0
+    ewma_alpha: float = 0.05
+    high_nis_ratio: float = 1.5
+    low_nis_ratio: float = 0.6
+    scale_gain: float = 0.5
+
+    def __post_init__(self) -> None:
+        if self.base_scale <= 0.0:
+            raise ValueError("base_scale must be positive")
+        if self.min_scale <= 0.0 or self.max_scale < self.min_scale:
+            raise ValueError("scale bounds must be positive and ordered")
+        if not 0.0 < self.ewma_alpha <= 1.0:
+            raise ValueError("ewma_alpha must be in (0, 1]")
+        if self.high_nis_ratio < self.low_nis_ratio:
+            raise ValueError("high_nis_ratio must be at least low_nis_ratio")
+        if self.scale_gain < 0.0:
+            raise ValueError("scale_gain must be nonnegative")
+
+
+@dataclass
+class RollingNISProcessNoiseAdapter:
+    """Maintain EWMA NIS ratios and return process-noise scale factors."""
+
+    config: AdaptiveProcessNoiseConfig = field(default_factory=AdaptiveProcessNoiseConfig)
+    ratios_by_source: dict[str, float] = field(default_factory=dict)
+    updates_by_source: dict[str, int] = field(default_factory=dict)
+
+    def observe(
+        self,
+        *,
+        source: str = "default",
+        measurement_dim: int,
+        nis: float,
+        accepted: bool = True,
+    ) -> float:
+        """Ingest one innovation and return the updated source NIS ratio."""
+
+        source = str(source)
+        measurement_dim = int(measurement_dim)
+        nis = float(nis)
+        if not accepted or measurement_dim <= 0 or not np.isfinite(nis):
+            return self.ratios_by_source.get(source, 1.0)
+        ratio = max(nis / float(measurement_dim), 0.0)
+        previous = self.ratios_by_source.get(source, 1.0)
+        alpha = float(self.config.ewma_alpha)
+        updated = (1.0 - alpha) * previous + alpha * ratio
+        self.ratios_by_source[source] = float(updated)
+        self.updates_by_source[source] = self.updates_by_source.get(source, 0) + 1
+        return float(updated)
+
+    def ratio(self, source_weights: Mapping[str, float] | None = None) -> float:
+        """Return a weighted aggregate NIS ratio across observed sources."""
+
+        if not self.ratios_by_source:
+            return 1.0
+        if source_weights:
+            numerator = 0.0
+            denominator = 0.0
+            for source, ratio in self.ratios_by_source.items():
+                weight = float(source_weights.get(source, 0.0))
+                if weight > 0.0:
+                    numerator += weight * ratio
+                    denominator += weight
+            if denominator > 0.0:
+                return float(numerator / denominator)
+        return float(np.mean(list(self.ratios_by_source.values())))
+
+    def scale(self, source_weights: Mapping[str, float] | None = None) -> float:
+        """Return the adapted process-noise multiplier."""
+
+        return float(self.config.base_scale * adaptive_scale_from_ratio(self.ratio(source_weights), self.config))
+
+    def scaled_covariance(
+        self,
+        process_noise_covariance: np.ndarray,
+        source_weights: Mapping[str, float] | None = None,
+    ) -> np.ndarray:
+        """Return ``process_noise_covariance`` multiplied by the adapted scale."""
+
+        return np.asarray(process_noise_covariance, dtype=float) * self.scale(source_weights)
+
+
+def adaptive_scale_from_ratio(ratio: float, config: AdaptiveProcessNoiseConfig | None = None) -> float:
+    """Map a normalized NIS ratio to a bounded process-noise scale."""
+
+    config = AdaptiveProcessNoiseConfig() if config is None else config
+    ratio = float(ratio)
+    if ratio > float(config.high_nis_ratio):
+        scale = 1.0 + float(config.scale_gain) * (ratio - float(config.high_nis_ratio))
+    elif ratio < float(config.low_nis_ratio):
+        scale = 1.0 - float(config.scale_gain) * (float(config.low_nis_ratio) - ratio)
+    else:
+        scale = 1.0
+    return float(np.clip(scale, float(config.min_scale), float(config.max_scale)))
+
+
+__all__ = [
+    "AdaptiveProcessNoiseConfig",
+    "RollingNISProcessNoiseAdapter",
+    "adaptive_scale_from_ratio",
+]

--- a/src/pyrecest/filters/linear_update_planning.py
+++ b/src/pyrecest/filters/linear_update_planning.py
@@ -1,0 +1,371 @@
+"""Planning utilities for robust linear-Gaussian measurement updates.
+
+The helpers in this module compute the quantities needed before a Kalman-style
+linear measurement update: innovation, normalized innovation squared (NIS),
+chi-square gating thresholds, hard-rejection decisions, and robust covariance
+inflation scales.  They deliberately stop short of mutating a filter state so
+that trackers, out-of-sequence updaters, and evaluation code can share the same
+pre-update policy logic.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+import numpy as np
+from scipy.stats import chi2
+
+try:  # Prefer PyRecEst's backend-aware primitives when the full package exists.
+    from ._linear_gaussian import (
+        huber_covariance_scale as _huber_covariance_scale,
+        normalized_innovation_squared as _normalized_innovation_squared,
+        student_t_covariance_scale as _student_t_covariance_scale,
+    )
+except Exception:  # pragma: no cover - only used by standalone downstream copies
+    _huber_covariance_scale = None
+    _normalized_innovation_squared = None
+    _student_t_covariance_scale = None
+
+ROBUST_UPDATE_MODES = ("nis-inflate", "student-t", "huber")
+DEFAULT_STUDENT_T_DOF = 4.0
+DEFAULT_HUBER_THRESHOLD = 2.0
+
+
+class MeasurementLike(Protocol):
+    """Structural protocol for source-specific update-policy lookup."""
+
+    source: str
+    vector: Any
+
+
+@dataclass(frozen=True)
+class LinearUpdatePlan:
+    """Precomputed decision and diagnostics for one linear measurement update."""
+
+    vector: np.ndarray
+    covariance: np.ndarray
+    observation: np.ndarray
+    residual: np.ndarray
+    nominal_innovation_covariance: np.ndarray
+    innovation_covariance: np.ndarray
+    nis: float
+    residual_norm: float
+    gate_threshold: float | None
+    safety_gate_threshold: float | None
+    residual_threshold: float | None
+    covariance_scale: float
+    action: str
+    accepted: bool
+    inflation_alpha: float
+    robust_update: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def chi_square_gate_threshold(probability: float | None, measurement_dim: int) -> float | None:
+    """Return the chi-square NIS gate for a measurement probability.
+
+    Parameters
+    ----------
+    probability : float or None
+        Gate probability in ``(0, 1)``.  ``None`` disables the gate and returns
+        ``None``.
+    measurement_dim : int
+        Measurement dimension, i.e. the chi-square degrees of freedom.
+    """
+
+    if probability is None:
+        return None
+    probability = float(probability)
+    measurement_dim = int(measurement_dim)
+    if not 0.0 < probability < 1.0:
+        raise ValueError("probability must be in (0, 1)")
+    if measurement_dim <= 0:
+        raise ValueError("measurement_dim must be positive")
+    return float(chi2.ppf(probability, measurement_dim))
+
+
+def normalized_innovation_squared(residual: np.ndarray, innovation_covariance: np.ndarray) -> float:
+    """Return ``residual.T @ inv(innovation_covariance) @ residual`` as a float."""
+
+    residual = np.asarray(residual, dtype=float).reshape(-1)
+    innovation_covariance = np.asarray(innovation_covariance, dtype=float)
+    if innovation_covariance.shape != (residual.size, residual.size):
+        raise ValueError("innovation_covariance must have shape (residual_dim, residual_dim)")
+    if _normalized_innovation_squared is not None:
+        return float(np.asarray(_normalized_innovation_squared(residual, innovation_covariance), dtype=float))
+    return float(residual.T @ np.linalg.solve(innovation_covariance, residual))
+
+
+def student_t_covariance_scale(
+    nis: float,
+    measurement_dim: int,
+    degrees_of_freedom: float = DEFAULT_STUDENT_T_DOF,
+) -> float:
+    """Return Student-t covariance inflation from NIS."""
+
+    if _student_t_covariance_scale is not None:
+        return float(
+            np.asarray(
+                _student_t_covariance_scale(
+                    nis,
+                    measurement_dim,
+                    dof=degrees_of_freedom,
+                ),
+                dtype=float,
+            )
+        )
+    measurement_dim = int(measurement_dim)
+    dof = float(degrees_of_freedom)
+    if measurement_dim <= 0:
+        raise ValueError("measurement_dim must be positive")
+    if dof <= 2.0:
+        raise ValueError("degrees_of_freedom must be greater than 2")
+    return float(max(1.0, (dof + float(nis)) / (dof + measurement_dim)))
+
+
+def huber_covariance_scale(nis: float, threshold: float = DEFAULT_HUBER_THRESHOLD) -> float:
+    """Return multivariate Huber covariance inflation from NIS."""
+
+    if _huber_covariance_scale is not None:
+        return float(np.asarray(_huber_covariance_scale(nis, huber_threshold=threshold), dtype=float))
+    threshold = float(threshold)
+    if threshold <= 0.0:
+        raise ValueError("threshold must be positive")
+    return float(max(1.0, np.sqrt(float(nis)) / threshold))
+
+
+def robust_update_covariance_scale(
+    robust_update: str | None,
+    *,
+    nis: float,
+    measurement_dim: int,
+    gate_threshold: float | None,
+    inflation_alpha: float = 1.0,
+    student_t_dof: float = DEFAULT_STUDENT_T_DOF,
+    huber_threshold: float = DEFAULT_HUBER_THRESHOLD,
+) -> tuple[float, str | None]:
+    """Return covariance scale and diagnostic action for a robust update mode."""
+
+    mode = None if robust_update in (None, "none") else str(robust_update)
+    if mode is None:
+        return 1.0, None
+    if mode == "nis-inflate":
+        if gate_threshold is None or float(nis) <= float(gate_threshold):
+            return 1.0, None
+        scale = max(1.0, (float(nis) / float(gate_threshold)) ** float(inflation_alpha))
+        return float(scale), "inflated"
+    if mode == "student-t":
+        scale = student_t_covariance_scale(nis, measurement_dim, student_t_dof)
+        return scale, "student_t" if scale > 1.0 else None
+    if mode == "huber":
+        scale = huber_covariance_scale(nis, huber_threshold)
+        return scale, "huberized" if scale > 1.0 else None
+    raise ValueError(f"unknown robust update mode {robust_update!r}")
+
+
+def plan_linear_measurement_update(
+    *,
+    mean: np.ndarray,
+    covariance_matrix: np.ndarray,
+    measurement_vector: np.ndarray,
+    measurement_covariance: np.ndarray,
+    observation_matrix: np.ndarray,
+    gate_threshold: float | None = None,
+    gate_probability: float | None = None,
+    safety_gate_threshold: float | None = None,
+    safety_gate_probability: float | None = None,
+    max_residual_norm: float | None = None,
+    robust_update: str | None = None,
+    inflation_alpha: float = 1.0,
+    student_t_dof: float = DEFAULT_STUDENT_T_DOF,
+    huber_threshold: float = DEFAULT_HUBER_THRESHOLD,
+    metadata: Mapping[str, Any] | None = None,
+) -> LinearUpdatePlan:
+    """Prepare shared NIS gating and robust-inflation quantities.
+
+    ``gate_threshold`` and ``safety_gate_threshold`` are NIS thresholds.  Their
+    probability counterparts are converted with a chi-square inverse CDF when a
+    threshold is not supplied explicitly.  The returned covariance and
+    ``innovation_covariance`` are the effective values after any accepted robust
+    inflation.  ``nis`` is always computed against the nominal covariance.
+    """
+
+    alpha = float(inflation_alpha)
+    if alpha <= 0.0:
+        raise ValueError("inflation_alpha must be positive")
+
+    vector = np.asarray(measurement_vector, dtype=float).reshape(-1)
+    measurement_dim = vector.size
+    covariance = np.asarray(measurement_covariance, dtype=float)
+    observation = np.asarray(observation_matrix, dtype=float)
+    state_mean = np.asarray(mean, dtype=float).reshape(-1)
+    state_covariance = np.asarray(covariance_matrix, dtype=float)
+
+    if measurement_dim <= 0:
+        raise ValueError("measurement_vector must contain at least one element")
+    if observation.ndim != 2 or observation.shape[0] != measurement_dim:
+        raise ValueError("observation_matrix must have shape (measurement_dim, state_dim)")
+    if observation.shape[1] != state_mean.size:
+        raise ValueError("observation_matrix and mean have incompatible shapes")
+    if state_covariance.shape != (state_mean.size, state_mean.size):
+        raise ValueError("covariance_matrix must have shape (state_dim, state_dim)")
+    if covariance.shape != (measurement_dim, measurement_dim):
+        raise ValueError("measurement_covariance must have shape (measurement_dim, measurement_dim)")
+
+    resolved_gate_threshold = _resolve_threshold(gate_threshold, gate_probability, measurement_dim, "gate")
+    resolved_safety_threshold = _resolve_threshold(
+        safety_gate_threshold,
+        safety_gate_probability,
+        measurement_dim,
+        "safety_gate",
+    )
+    residual_threshold = None if max_residual_norm is None else float(max_residual_norm)
+    if residual_threshold is not None and residual_threshold <= 0.0:
+        raise ValueError("max_residual_norm must be positive or None")
+
+    residual = vector - observation @ state_mean
+    nominal_innovation_covariance = observation @ state_covariance @ observation.T + covariance
+    nominal_innovation_covariance = _symmetrized(nominal_innovation_covariance)
+    nis = normalized_innovation_squared(residual, nominal_innovation_covariance)
+    residual_norm = float(np.linalg.norm(residual))
+
+    accepted = True
+    action = "updated"
+    covariance_scale = 1.0
+    effective_covariance = covariance.copy()
+    effective_innovation_covariance = nominal_innovation_covariance.copy()
+
+    residual_over_threshold = residual_threshold is not None and residual_norm > residual_threshold
+    safety_over_threshold = resolved_safety_threshold is not None and nis > resolved_safety_threshold
+    reject_by_residual = residual_over_threshold and (
+        resolved_safety_threshold is None or safety_over_threshold
+    )
+
+    if reject_by_residual:
+        accepted = False
+        action = "residual_rejected"
+    elif safety_over_threshold:
+        accepted = False
+        action = "safety_rejected"
+    elif resolved_gate_threshold is not None and nis > resolved_gate_threshold and robust_update in (None, "none"):
+        accepted = False
+        action = "rejected"
+    else:
+        covariance_scale, robust_action = robust_update_covariance_scale(
+            robust_update,
+            nis=nis,
+            measurement_dim=measurement_dim,
+            gate_threshold=resolved_gate_threshold,
+            inflation_alpha=alpha,
+            student_t_dof=student_t_dof,
+            huber_threshold=huber_threshold,
+        )
+        if covariance_scale > 1.0:
+            effective_covariance = covariance * covariance_scale
+            effective_innovation_covariance = _symmetrized(
+                observation @ state_covariance @ observation.T + effective_covariance
+            )
+        if robust_action is not None:
+            action = robust_action
+
+    return LinearUpdatePlan(
+        vector=vector,
+        covariance=effective_covariance,
+        observation=observation,
+        residual=residual,
+        nominal_innovation_covariance=nominal_innovation_covariance,
+        innovation_covariance=effective_innovation_covariance,
+        nis=float(nis),
+        residual_norm=residual_norm,
+        gate_threshold=resolved_gate_threshold,
+        safety_gate_threshold=resolved_safety_threshold,
+        residual_threshold=residual_threshold,
+        covariance_scale=float(covariance_scale),
+        action=action,
+        accepted=bool(accepted),
+        inflation_alpha=alpha,
+        robust_update=robust_update,
+        metadata={} if metadata is None else dict(metadata),
+    )
+
+
+def gate_threshold_for_measurement(
+    measurement: MeasurementLike,
+    *,
+    gate_probabilities_by_source: Mapping[str, float | None] | None = None,
+    gate_thresholds_by_source: Mapping[str, float | None] | None = None,
+) -> float | None:
+    """Resolve a source-specific NIS gate threshold for a measurement object."""
+
+    source = str(measurement.source)
+    if gate_thresholds_by_source and source in gate_thresholds_by_source:
+        value = gate_thresholds_by_source[source]
+        return None if value is None else float(value)
+    if gate_probabilities_by_source and source in gate_probabilities_by_source:
+        probability = gate_probabilities_by_source[source]
+        vector = np.asarray(measurement.vector).reshape(-1)
+        return chi_square_gate_threshold(probability, vector.size)
+    return None
+
+
+def robust_update_for_measurement(
+    measurement: MeasurementLike,
+    *,
+    robust_update_by_source: Mapping[str, str | None] | None = None,
+) -> str | None:
+    """Resolve a source-specific robust update mode for a measurement object."""
+
+    if robust_update_by_source and str(measurement.source) in robust_update_by_source:
+        return robust_update_by_source[str(measurement.source)]
+    return None
+
+
+def source_float_value(
+    measurement: MeasurementLike,
+    values_by_source: Mapping[str, float | None] | None,
+    default: float | None = None,
+) -> float | None:
+    """Return a source-specific scalar value, falling back to ``default``."""
+
+    if values_by_source and str(measurement.source) in values_by_source:
+        value = values_by_source[str(measurement.source)]
+        return None if value is None else float(value)
+    return default
+
+
+def _resolve_threshold(
+    threshold: float | None,
+    probability: float | None,
+    measurement_dim: int,
+    name: str,
+) -> float | None:
+    if threshold is not None:
+        value = float(threshold)
+        if value <= 0.0:
+            raise ValueError(f"{name}_threshold must be positive or None")
+        return value
+    return chi_square_gate_threshold(probability, measurement_dim)
+
+
+def _symmetrized(matrix: np.ndarray) -> np.ndarray:
+    return 0.5 * (matrix + matrix.T)
+
+
+__all__ = [
+    "DEFAULT_HUBER_THRESHOLD",
+    "DEFAULT_STUDENT_T_DOF",
+    "LinearUpdatePlan",
+    "MeasurementLike",
+    "ROBUST_UPDATE_MODES",
+    "chi_square_gate_threshold",
+    "gate_threshold_for_measurement",
+    "huber_covariance_scale",
+    "normalized_innovation_squared",
+    "plan_linear_measurement_update",
+    "robust_update_covariance_scale",
+    "robust_update_for_measurement",
+    "source_float_value",
+    "student_t_covariance_scale",
+]

--- a/src/pyrecest/filters/tracklet_viterbi.py
+++ b/src/pyrecest/filters/tracklet_viterbi.py
@@ -1,0 +1,459 @@
+"""Generic fixed-lag Viterbi association for single-target tracklets."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Hashable, Mapping, Sequence
+from dataclasses import dataclass, field, replace
+from typing import Any
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class TrackletAssociationCandidate:
+    """One association candidate for one scan/frame.
+
+    Parameters
+    ----------
+    candidate_id : Hashable
+        Identifier that is unique enough for diagnostics within a frame.
+    unary_cost : float
+        Per-candidate negative log-cost or any additive score to minimize.
+    time_s : float, optional
+        Candidate timestamp.  When omitted, frame indices are used for fixed-lag
+        windows and motion costs.
+    track_id : Hashable, optional
+        External tracklet identifier used for switch-cost penalties.
+    position : array-like, optional
+        Position vector used by the default constant-velocity transition cost
+        when ``config.motion_weight`` is positive.
+    velocity : array-like, optional
+        Velocity vector used for default motion prediction when available.
+    metadata : mapping, optional
+        User-defined payload copied through to results.
+    """
+
+    candidate_id: Hashable
+    unary_cost: float = 0.0
+    time_s: float | None = None
+    track_id: Hashable | None = None
+    position: Any | None = None
+    velocity: Any | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class TrackletViterbiConfig:
+    """Configuration for generic tracklet Viterbi association."""
+
+    max_candidates_per_frame: int | None = None
+    missed_detection_cost: float = 7.0
+    consecutive_miss_cost: float = 1.0
+    switch_cost: float = 8.0
+    missing_track_id_cost: float = 1.0
+    motion_weight: float = 0.0
+    transition_position_std: float = 1.0
+    transition_velocity_std: float | None = None
+    max_speed: float | None = None
+    max_speed_penalty: float = 0.0
+    max_candidate_pool_per_frame: int | None = None
+    max_candidates_per_track_id: int = 1
+
+    def __post_init__(self) -> None:
+        if self.max_candidates_per_frame is not None and self.max_candidates_per_frame < 1:
+            raise ValueError("max_candidates_per_frame must be positive or None")
+        if self.max_candidate_pool_per_frame is not None and self.max_candidate_pool_per_frame < 1:
+            raise ValueError("max_candidate_pool_per_frame must be positive or None")
+        if self.max_candidates_per_track_id < 0:
+            raise ValueError("max_candidates_per_track_id must be nonnegative")
+        for name in (
+            "missed_detection_cost",
+            "consecutive_miss_cost",
+            "switch_cost",
+            "missing_track_id_cost",
+            "motion_weight",
+            "max_speed_penalty",
+        ):
+            if float(getattr(self, name)) < 0.0:
+                raise ValueError(f"{name} must be nonnegative")
+        if self.transition_position_std <= 0.0:
+            raise ValueError("transition_position_std must be positive")
+        if self.transition_velocity_std is not None and self.transition_velocity_std <= 0.0:
+            raise ValueError("transition_velocity_std must be positive or None")
+        if self.max_speed is not None and self.max_speed <= 0.0:
+            raise ValueError("max_speed must be positive or None")
+
+
+@dataclass(frozen=True)
+class TrackletViterbiResult:
+    """Result of a Viterbi association solve."""
+
+    path: list[TrackletAssociationCandidate | None]
+    total_cost: float
+    costs_by_frame: list[np.ndarray] = field(default_factory=list)
+    parent_indices_by_frame: list[np.ndarray] = field(default_factory=list)
+    miss_streaks_by_frame: list[np.ndarray] = field(default_factory=list)
+
+    @property
+    def selected_candidates(self) -> list[TrackletAssociationCandidate]:
+        """Return non-missed candidates in path order."""
+
+        return [candidate for candidate in self.path if candidate is not None]
+
+    @property
+    def missed_detection_count(self) -> int:
+        """Return the number of missed detections in the selected path."""
+
+        return sum(candidate is None for candidate in self.path)
+
+
+@dataclass(frozen=True)
+class TrackSupport:
+    """Prefix-only support statistics for a candidate track id."""
+
+    count: int
+    span_s: float
+    continuity: float
+    score: float
+
+
+@dataclass(frozen=True)
+class _Node:
+    candidate: TrackletAssociationCandidate | None
+    unary_cost: float
+
+    @property
+    def is_miss(self) -> bool:
+        return self.candidate is None
+
+
+TransitionCost = Callable[
+    [TrackletAssociationCandidate | None, TrackletAssociationCandidate | None, int],
+    float,
+]
+
+
+def solve_tracklet_viterbi(
+    frames: Sequence[Sequence[TrackletAssociationCandidate]],
+    *,
+    config: TrackletViterbiConfig | None = None,
+    transition_cost: TransitionCost | None = None,
+    include_missed_detection: bool = True,
+    return_tables: bool = False,
+) -> TrackletViterbiResult:
+    """Select a minimum-cost single-target path through candidate frames.
+
+    The path contains one entry per input frame.  ``None`` denotes the missed
+    detection branch for that frame.
+    """
+
+    config = TrackletViterbiConfig() if config is None else config
+    nodes_by_frame = [_nodes_for_frame(frame, config, include_missed_detection) for frame in frames]
+    if not nodes_by_frame:
+        return TrackletViterbiResult([], 0.0)
+    if any(not nodes for nodes in nodes_by_frame):
+        raise ValueError("each frame must contain at least one candidate or allow missed detection")
+
+    transition = transition_cost or (lambda previous, current, miss_streak: default_tracklet_transition_cost(previous, current, miss_streak, config))
+    first_costs = np.array(
+        [node.unary_cost + (config.missed_detection_cost if node.is_miss else 0.0) for node in nodes_by_frame[0]],
+        dtype=float,
+    )
+    costs = [first_costs]
+    miss_streaks = [np.array([1 if node.is_miss else 0 for node in nodes_by_frame[0]], dtype=int)]
+    parents = [np.full(len(nodes_by_frame[0]), -1, dtype=int)]
+
+    for frame_index in range(1, len(nodes_by_frame)):
+        previous_nodes = nodes_by_frame[frame_index - 1]
+        current_nodes = nodes_by_frame[frame_index]
+        current_costs = np.empty(len(current_nodes), dtype=float)
+        current_miss_streaks = np.empty(len(current_nodes), dtype=int)
+        current_parents = np.empty(len(current_nodes), dtype=int)
+        for current_index, current_node in enumerate(current_nodes):
+            alternatives = np.array(
+                [
+                    costs[-1][previous_index]
+                    + float(
+                        transition(
+                            previous_node.candidate,
+                            current_node.candidate,
+                            int(miss_streaks[-1][previous_index]),
+                        )
+                    )
+                    for previous_index, previous_node in enumerate(previous_nodes)
+                ],
+                dtype=float,
+            )
+            parent = int(np.argmin(alternatives))
+            current_parents[current_index] = parent
+            current_costs[current_index] = current_node.unary_cost + alternatives[parent]
+            current_miss_streaks[current_index] = (
+                int(miss_streaks[-1][parent]) + 1 if current_node.is_miss else 0
+            )
+        costs.append(current_costs)
+        miss_streaks.append(current_miss_streaks)
+        parents.append(current_parents)
+
+    terminal = int(np.argmin(costs[-1]))
+    path_nodes = _reconstruct_path(nodes_by_frame, parents, terminal)
+    result = TrackletViterbiResult(
+        path=[node.candidate for node in path_nodes],
+        total_cost=float(costs[-1][terminal]),
+        costs_by_frame=costs if return_tables else [],
+        parent_indices_by_frame=parents if return_tables else [],
+        miss_streaks_by_frame=miss_streaks if return_tables else [],
+    )
+    return result
+
+
+def solve_fixed_lag_tracklet_viterbi(
+    frames: Sequence[Sequence[TrackletAssociationCandidate]],
+    *,
+    lag_s: float,
+    config: TrackletViterbiConfig | None = None,
+    transition_cost: TransitionCost | None = None,
+    include_missed_detection: bool = True,
+) -> TrackletViterbiResult:
+    """Commit Viterbi decisions using at most ``lag_s`` future context.
+
+    Each frame is solved on a local look-ahead window.  The previous non-missed
+    committed candidate is prepended as a zero-cost prefix candidate, preserving
+    dynamic consistency without using unbounded future information.
+    """
+
+    if lag_s <= 0.0:
+        raise ValueError("lag_s must be positive")
+    config = TrackletViterbiConfig() if config is None else config
+    if not frames:
+        return TrackletViterbiResult([], 0.0)
+
+    frame_times = [_frame_time(frame, index) for index, frame in enumerate(frames)]
+    path: list[TrackletAssociationCandidate | None] = []
+    previous_committed: TrackletAssociationCandidate | None = None
+    total_cost = 0.0
+
+    for frame_index, start_time in enumerate(frame_times):
+        end_time = start_time + float(lag_s)
+        window_end = frame_index
+        while window_end + 1 < len(frames) and frame_times[window_end + 1] <= end_time:
+            window_end += 1
+        window_frames = [list(frame) for frame in frames[frame_index : window_end + 1]]
+        prefix_added = previous_committed is not None
+        if prefix_added:
+            assert previous_committed is not None
+            window_frames.insert(0, [replace(previous_committed, unary_cost=0.0)])
+        local = solve_tracklet_viterbi(
+            window_frames,
+            config=config,
+            transition_cost=transition_cost,
+            include_missed_detection=include_missed_detection,
+        )
+        selected = local.path[1 if prefix_added else 0]
+        path.append(selected)
+        total_cost += float(local.total_cost)
+        if selected is not None:
+            previous_committed = selected
+
+    return TrackletViterbiResult(path=path, total_cost=total_cost)
+
+
+def default_tracklet_transition_cost(
+    previous: TrackletAssociationCandidate | None,
+    current: TrackletAssociationCandidate | None,
+    previous_miss_streak: int,
+    config: TrackletViterbiConfig | None = None,
+) -> float:
+    """Default transition cost with missed detections, switches, and motion."""
+
+    config = TrackletViterbiConfig() if config is None else config
+    if current is None:
+        return float(config.missed_detection_cost) + (
+            float(config.consecutive_miss_cost) if previous is None else 0.0
+        )
+    if previous is None:
+        return 0.0
+
+    cost = _track_switch_cost(previous.track_id, current.track_id, config)
+    if config.motion_weight > 0.0:
+        cost += float(config.motion_weight) * _motion_cost(previous, current, config)
+    return float(cost)
+
+
+def retain_top_and_track_representatives(
+    candidates: Sequence[TrackletAssociationCandidate],
+    *,
+    config: TrackletViterbiConfig | None = None,
+) -> list[TrackletAssociationCandidate]:
+    """Retain top unary candidates plus best representatives per track id."""
+
+    config = TrackletViterbiConfig() if config is None else config
+    if not candidates:
+        return []
+    ordered = sorted(enumerate(candidates), key=lambda item: (float(item[1].unary_cost), item[0]))
+    top_k = config.max_candidates_per_frame or len(ordered)
+    max_pool = config.max_candidate_pool_per_frame or max(top_k, top_k + 8)
+    keep: set[int] = {index for index, _ in ordered[:top_k]}
+
+    if config.max_candidates_per_track_id > 0:
+        kept_by_track: dict[Hashable, int] = {}
+        for index, candidate in ordered:
+            if candidate.track_id is None:
+                continue
+            kept_count = kept_by_track.get(candidate.track_id, 0)
+            if kept_count >= config.max_candidates_per_track_id:
+                continue
+            keep.add(index)
+            kept_by_track[candidate.track_id] = kept_count + 1
+            if len(keep) >= max_pool:
+                break
+    return [candidate for index, candidate in ordered if index in keep][:max_pool]
+
+
+def prefix_track_support(
+    frames: Sequence[Sequence[TrackletAssociationCandidate]],
+) -> dict[int, dict[Hashable, TrackSupport]]:
+    """Return prefix-only track support statistics for each frame."""
+
+    support_by_frame: dict[int, dict[Hashable, TrackSupport]] = {}
+    previous: list[TrackletAssociationCandidate] = []
+    for frame_index, frame in enumerate(frames):
+        support_by_frame[frame_index] = track_support_by_id(previous)
+        previous.extend(candidate for candidate in frame if candidate.track_id is not None)
+    return support_by_frame
+
+
+def track_support_by_id(candidates: Sequence[TrackletAssociationCandidate]) -> dict[Hashable, TrackSupport]:
+    """Return support statistics for finite/non-null track ids."""
+
+    grouped: dict[Hashable, list[TrackletAssociationCandidate]] = {}
+    for candidate in candidates:
+        if candidate.track_id is not None:
+            grouped.setdefault(candidate.track_id, []).append(candidate)
+    support: dict[Hashable, TrackSupport] = {}
+    for track_id, group in grouped.items():
+        times = [float(candidate.time_s) for candidate in group if candidate.time_s is not None]
+        span_s = max(times) - min(times) if len(times) >= 2 else 0.0
+        count = len(group)
+        if times:
+            frame_span = max(float(count), span_s + 1.0)
+        else:
+            frame_span = float(count)
+        continuity = float(np.clip(count / max(frame_span, 1.0), 0.0, 1.0))
+        score = float(np.log1p(count) + 0.5 * np.log1p(max(span_s, 0.0)) + 0.5 * continuity)
+        support[track_id] = TrackSupport(count=count, span_s=float(span_s), continuity=continuity, score=score)
+    return support
+
+
+def track_support_cost(
+    candidate: TrackletAssociationCandidate,
+    support_by_id: Mapping[Hashable, TrackSupport],
+    *,
+    weight: float = 0.45,
+    max_reward: float = 4.0,
+) -> float:
+    """Return a bounded negative cost for candidates with supported track ids."""
+
+    if candidate.track_id is None:
+        return 0.0
+    support = support_by_id.get(candidate.track_id)
+    if support is None:
+        return 0.0
+    weight = max(0.0, float(weight))
+    max_reward = max(0.0, float(max_reward))
+    if weight <= 0.0 or max_reward <= 0.0:
+        return 0.0
+    return -float(min(max_reward, weight * max(0.0, support.score)))
+
+
+def _nodes_for_frame(
+    frame: Sequence[TrackletAssociationCandidate],
+    config: TrackletViterbiConfig,
+    include_missed_detection: bool,
+) -> list[_Node]:
+    candidates = retain_top_and_track_representatives(frame, config=config)
+    nodes = [_Node(candidate, float(candidate.unary_cost)) for candidate in candidates]
+    if include_missed_detection:
+        nodes.append(_Node(None, 0.0))
+    return nodes
+
+
+def _reconstruct_path(
+    nodes_by_frame: list[list[_Node]],
+    parents: list[np.ndarray],
+    terminal_index: int,
+) -> list[_Node]:
+    best = int(terminal_index)
+    path: list[_Node] = []
+    for frame_index in range(len(nodes_by_frame) - 1, -1, -1):
+        path.append(nodes_by_frame[frame_index][best])
+        best = int(parents[frame_index][best])
+        if best < 0:
+            break
+    path.reverse()
+    return path
+
+
+def _track_switch_cost(
+    previous_track_id: Hashable | None,
+    current_track_id: Hashable | None,
+    config: TrackletViterbiConfig,
+) -> float:
+    if previous_track_id is None:
+        return 0.0
+    if current_track_id is None:
+        return float(config.missing_track_id_cost)
+    return 0.0 if previous_track_id == current_track_id else float(config.switch_cost)
+
+
+def _motion_cost(
+    previous: TrackletAssociationCandidate,
+    current: TrackletAssociationCandidate,
+    config: TrackletViterbiConfig,
+) -> float:
+    if previous.position is None or current.position is None:
+        return 0.0
+    previous_position = np.asarray(previous.position, dtype=float).reshape(-1)
+    current_position = np.asarray(current.position, dtype=float).reshape(-1)
+    if previous_position.shape != current_position.shape:
+        raise ValueError("candidate positions must have matching shapes")
+    dt_s = max(_candidate_time(current, 1.0) - _candidate_time(previous, 0.0), 1.0e-9)
+    if previous.velocity is None:
+        predicted = previous_position
+    else:
+        predicted = previous_position + np.asarray(previous.velocity, dtype=float).reshape(previous_position.shape) * dt_s
+    position_cost = float(np.sum(((current_position - predicted) / float(config.transition_position_std)) ** 2))
+    speed_cost = 0.0
+    displacement_velocity = (current_position - previous_position) / dt_s
+    if config.max_speed is not None:
+        speed_excess = max(0.0, float(np.linalg.norm(displacement_velocity)) - float(config.max_speed))
+        if speed_excess > 0.0:
+            speed_cost = float(config.max_speed_penalty) * speed_excess**2
+    velocity_cost = 0.0
+    if config.transition_velocity_std is not None and current.velocity is not None:
+        velocity = np.asarray(current.velocity, dtype=float).reshape(displacement_velocity.shape)
+        velocity_cost = float(np.sum(((velocity - displacement_velocity) / float(config.transition_velocity_std)) ** 2))
+    return position_cost + speed_cost + velocity_cost
+
+
+def _candidate_time(candidate: TrackletAssociationCandidate, fallback: float) -> float:
+    return fallback if candidate.time_s is None else float(candidate.time_s)
+
+
+def _frame_time(frame: Sequence[TrackletAssociationCandidate], frame_index: int) -> float:
+    times = [float(candidate.time_s) for candidate in frame if candidate.time_s is not None]
+    return float(np.median(times)) if times else float(frame_index)
+
+
+__all__ = [
+    "TrackSupport",
+    "TrackletAssociationCandidate",
+    "TrackletViterbiConfig",
+    "TrackletViterbiResult",
+    "default_tracklet_transition_cost",
+    "prefix_track_support",
+    "retain_top_and_track_representatives",
+    "solve_fixed_lag_tracklet_viterbi",
+    "solve_tracklet_viterbi",
+    "track_support_by_id",
+    "track_support_cost",
+]

--- a/tests/calibration/test_time_offset_bias.py
+++ b/tests/calibration/test_time_offset_bias.py
@@ -1,0 +1,107 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+from pyrecest.calibration.bias import (
+    fit_sensor_bias_correction,
+    make_bias_training_examples,
+)
+from pyrecest.calibration.time_offset import (
+    apply_time_offset,
+    fit_time_offset,
+    make_offset_grid,
+    time_offset_error_summary,
+)
+
+
+class TimeOffsetCalibrationTest(unittest.TestCase):
+    def test_offset_grid_is_inclusive(self):
+        grid = make_offset_grid(-0.5, 0.5, 0.25)
+
+        npt.assert_allclose(grid, np.array([-0.5, -0.25, 0.0, 0.25, 0.5]))
+
+    def test_apply_time_offset_shifts_times(self):
+        npt.assert_allclose(apply_time_offset(np.array([1.0, 2.0]), 0.5), np.array([1.5, 2.5]))
+
+    def test_fit_time_offset_recovers_known_shift(self):
+        reference_times = np.linspace(0.0, 10.0, 101)
+        reference_values = np.column_stack([reference_times, reference_times**2])
+        measurement_times = np.linspace(1.0, 8.0, 15)
+        true_offset = 0.4
+        measurement_values = np.column_stack([
+            measurement_times + true_offset,
+            (measurement_times + true_offset) ** 2,
+        ])
+        offsets = make_offset_grid(-1.0, 1.0, 0.1)
+
+        result = fit_time_offset(
+            measurement_times,
+            measurement_values,
+            reference_times,
+            reference_values,
+            offsets,
+            max_time_delta_s=0.25,
+        )
+
+        self.assertAlmostEqual(result.best_offset_s, true_offset, places=9)
+        self.assertEqual(result.summary()["best_count"], len(measurement_times))
+
+    def test_time_offset_summary_reports_empty_when_no_overlap(self):
+        summary = time_offset_error_summary(
+            np.array([100.0]),
+            np.array([[1.0]]),
+            np.array([0.0, 1.0]),
+            np.array([[0.0], [1.0]]),
+            0.0,
+        )
+
+        self.assertEqual(summary["count"], 0.0)
+
+
+class BiasCalibrationTest(unittest.TestCase):
+    def test_make_bias_training_examples_uses_nearest_reference(self):
+        examples = make_bias_training_examples(
+            np.array([0.0, 1.0]),
+            np.array([[1.0], [3.0]]),
+            np.array([0.0, 1.0]),
+            np.array([[0.0], [2.0]]),
+        )
+
+        npt.assert_allclose(examples.residual, np.array([[1.0], [1.0]]))
+
+    def test_fit_sensor_bias_correction_subtracts_predicted_bias(self):
+        times = np.arange(8.0)
+        reference = np.column_stack([times, -times])
+        feature = times.reshape(-1, 1)
+        bias = np.column_stack([2.0 + 0.5 * times, -1.0 + 0.25 * times])
+        measurements = reference + bias
+
+        model = fit_sensor_bias_correction(
+            times,
+            measurements,
+            times,
+            reference,
+            feature_values=feature,
+            ridge_alpha=0.0,
+            min_samples=2,
+        )
+        corrected = model.apply(measurements, feature)
+
+        npt.assert_allclose(corrected, reference, atol=1e-10)
+        self.assertEqual(model.training_count, len(times))
+
+    def test_constant_bias_model_when_features_are_unavailable(self):
+        times = np.arange(5.0)
+        reference = times.reshape(-1, 1)
+        measurements = reference + 3.0
+
+        model = fit_sensor_bias_correction(times, measurements, times, reference, min_samples=2)
+        corrected = model.apply(measurements)
+
+        self.assertEqual(model.feature_dim, 0)
+        npt.assert_allclose(corrected, reference, atol=1e-10)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/evaluation/test_diagnostic_summaries.py
+++ b/tests/evaluation/test_diagnostic_summaries.py
@@ -1,0 +1,57 @@
+import math
+import unittest
+
+from pyrecest.evaluation.diagnostic_summaries import (
+    build_diagnostic_summary,
+    covariance_inflation_summary,
+    top_residuals,
+    track_switch_summary,
+    worst_time_windows,
+)
+
+
+class DiagnosticSummariesTest(unittest.TestCase):
+    def setUp(self):
+        self.records = [
+            {"time_s": 0.0, "track_id": "A", "source": "rf", "residual_norm": 1.0, "covariance_scale": 1.0, "error": 1.0},
+            {"time_s": 1.0, "track_id": "A", "source": "rf", "residual_norm": 4.0, "covariance_scale": 2.0, "error": 2.0},
+            {"time_s": 2.0, "track_id": "B", "source": "radar", "residual_norm": 3.0, "covariance_scale": 3.0, "error": 10.0},
+            {"time_s": 7.0, "track_id": "B", "source": "radar", "residual_norm": 2.0, "covariance_scale": 1.0, "error": 3.0},
+        ]
+
+    def test_top_residuals_returns_largest_first(self):
+        rows = top_residuals(self.records, top_n=2)
+
+        self.assertEqual([row["residual_norm"] for row in rows], [4.0, 3.0])
+
+    def test_track_switch_summary_counts_transitions(self):
+        summary = track_switch_summary(self.records)
+
+        self.assertEqual(summary["count"], 1)
+        self.assertEqual(summary["top_transitions"][0]["from_track_id"], "A")
+        self.assertEqual(summary["top_transitions"][0]["to_track_id"], "B")
+
+    def test_covariance_inflation_summary_counts_by_source(self):
+        summary = covariance_inflation_summary(self.records)
+
+        self.assertEqual(summary["count"], 2)
+        self.assertEqual(summary["by_source"], {"radar": 1, "rf": 1})
+        self.assertEqual(summary["max_scale"], 3.0)
+
+    def test_worst_windows_sort_by_rmse(self):
+        rows = worst_time_windows(self.records, window_s=5.0, top_n=2)
+
+        self.assertEqual(rows[0]["time_start_s"], 0.0)
+        self.assertTrue(math.isclose(rows[0]["rmse"], math.sqrt((1 + 4 + 100) / 3)))
+        self.assertEqual(rows[0]["track_switch_count"], 1)
+
+    def test_build_diagnostic_summary(self):
+        summary = build_diagnostic_summary(self.records, top_n=2, window_s=5.0)
+
+        self.assertEqual(summary["schema_version"], 1)
+        self.assertEqual(len(summary["top_residuals"]), 2)
+        self.assertEqual(summary["covariance_inflation"]["count"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/filters/test_adaptive_process_noise.py
+++ b/tests/filters/test_adaptive_process_noise.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+from pyrecest.filters.adaptive_process_noise import (
+    AdaptiveProcessNoiseConfig,
+    RollingNISProcessNoiseAdapter,
+    adaptive_scale_from_ratio,
+)
+
+
+def test_scale_increases_for_high_nis_ratio_and_decreases_for_low_ratio():
+    config = AdaptiveProcessNoiseConfig(min_scale=0.5, max_scale=3.0, high_nis_ratio=1.5, low_nis_ratio=0.5, scale_gain=1.0)
+    assert adaptive_scale_from_ratio(2.0, config) > 1.0
+    assert adaptive_scale_from_ratio(0.0, config) < 1.0
+
+
+def test_rolling_adapter_updates_source_ratio_and_scales_covariance():
+    adapter = RollingNISProcessNoiseAdapter(AdaptiveProcessNoiseConfig(ewma_alpha=1.0, high_nis_ratio=1.1))
+    ratio = adapter.observe(source="radar", measurement_dim=2, nis=6.0)
+    assert np.isclose(ratio, 3.0)
+    scaled = adapter.scaled_covariance(np.eye(2), {"radar": 1.0})
+    assert np.allclose(scaled, np.eye(2) * adapter.scale({"radar": 1.0}))

--- a/tests/filters/test_linear_update_planning.py
+++ b/tests/filters/test_linear_update_planning.py
@@ -1,0 +1,54 @@
+import numpy as np
+
+from pyrecest.filters.linear_update_planning import (
+    chi_square_gate_threshold,
+    plan_linear_measurement_update,
+    robust_update_covariance_scale,
+)
+
+
+def test_chi_square_gate_threshold_matches_known_2d_95_percent_gate():
+    assert np.isclose(chi_square_gate_threshold(0.95, 2), 5.991464547107979)
+
+
+def test_hard_gate_rejects_without_changing_effective_covariance():
+    plan = plan_linear_measurement_update(
+        mean=np.zeros(2),
+        covariance_matrix=np.eye(2),
+        measurement_vector=np.array([10.0, 0.0]),
+        measurement_covariance=np.eye(2),
+        observation_matrix=np.eye(2),
+        gate_threshold=1.0,
+        robust_update="none",
+    )
+    assert not plan.accepted
+    assert plan.action == "rejected"
+    assert plan.covariance_scale == 1.0
+
+
+def test_student_t_plan_inflates_outlier_covariance():
+    plan = plan_linear_measurement_update(
+        mean=np.zeros(2),
+        covariance_matrix=np.eye(2),
+        measurement_vector=np.array([100.0, 100.0]),
+        measurement_covariance=np.eye(2),
+        observation_matrix=np.eye(2),
+        robust_update="student-t",
+        student_t_dof=4.0,
+    )
+    assert plan.accepted
+    assert plan.action == "student_t"
+    assert plan.covariance_scale > 1.0
+    assert np.allclose(plan.covariance, np.eye(2) * plan.covariance_scale)
+
+
+def test_nis_inflate_uses_gate_ratio():
+    scale, action = robust_update_covariance_scale(
+        "nis-inflate",
+        nis=10.0,
+        measurement_dim=2,
+        gate_threshold=2.5,
+        inflation_alpha=0.5,
+    )
+    assert action == "inflated"
+    assert np.isclose(scale, 2.0)

--- a/tests/filters/test_tracklet_viterbi.py
+++ b/tests/filters/test_tracklet_viterbi.py
@@ -1,0 +1,62 @@
+from pyrecest.filters.tracklet_viterbi import (
+    TrackletAssociationCandidate,
+    TrackletViterbiConfig,
+    prefix_track_support,
+    retain_top_and_track_representatives,
+    solve_fixed_lag_tracklet_viterbi,
+    solve_tracklet_viterbi,
+    track_support_cost,
+)
+
+
+def test_switch_cost_prefers_coherent_tracklet():
+    frames = [
+        [TrackletAssociationCandidate("a0", unary_cost=0.0, track_id="A")],
+        [
+            TrackletAssociationCandidate("b1", unary_cost=0.0, track_id="B"),
+            TrackletAssociationCandidate("a1", unary_cost=2.0, track_id="A"),
+        ],
+    ]
+    result = solve_tracklet_viterbi(frames, config=TrackletViterbiConfig(switch_cost=10.0, missed_detection_cost=100.0))
+    assert [candidate.candidate_id for candidate in result.path] == ["a0", "a1"]
+
+
+def test_missed_detection_branch_is_selected_when_candidates_are_expensive():
+    result = solve_tracklet_viterbi(
+        [[TrackletAssociationCandidate("bad", unary_cost=100.0)]],
+        config=TrackletViterbiConfig(missed_detection_cost=1.0),
+    )
+    assert result.path == [None]
+    assert result.missed_detection_count == 1
+
+
+def test_fixed_lag_solver_uses_prefix_memory():
+    frames = [
+        [TrackletAssociationCandidate("a0", unary_cost=0.0, track_id="A", time_s=0.0)],
+        [
+            TrackletAssociationCandidate("b1", unary_cost=0.0, track_id="B", time_s=1.0),
+            TrackletAssociationCandidate("a1", unary_cost=2.0, track_id="A", time_s=1.0),
+        ],
+    ]
+    result = solve_fixed_lag_tracklet_viterbi(frames, lag_s=0.1, config=TrackletViterbiConfig(switch_cost=10.0, missed_detection_cost=100.0))
+    assert [candidate.candidate_id for candidate in result.path] == ["a0", "a1"]
+
+
+def test_retention_keeps_track_representative_outside_top_k():
+    candidates = [
+        TrackletAssociationCandidate("best", unary_cost=0.0, track_id="A"),
+        TrackletAssociationCandidate("second", unary_cost=1.0, track_id="A"),
+        TrackletAssociationCandidate("track-b", unary_cost=5.0, track_id="B"),
+    ]
+    kept = retain_top_and_track_representatives(candidates, config=TrackletViterbiConfig(max_candidates_per_frame=1, max_candidate_pool_per_frame=3))
+    assert {candidate.candidate_id for candidate in kept} == {"best", "track-b"}
+
+
+def test_prefix_track_support_yields_bounded_reward():
+    frames = [
+        [TrackletAssociationCandidate("a0", track_id="A", time_s=0.0)],
+        [TrackletAssociationCandidate("a1", track_id="A", time_s=1.0)],
+    ]
+    support = prefix_track_support(frames)
+    candidate = TrackletAssociationCandidate("a1", track_id="A", time_s=1.0)
+    assert track_support_cost(candidate, support[1]) < 0.0


### PR DESCRIPTION
Summary:
- Add calibration helpers for sensor bias and time-offset estimation.
- Add diagnostic summary utilities and reusable filter planning/adaptive-noise/tracklet Viterbi helpers.
- Add regression coverage for the new utility modules.

Validation:
- Checked for reject files and conflict markers.
- Ran git diff --check on the staged diff.
- Tests were not run per request.