### PR TITLE
Add max-cardinality assignment helper

### DIFF
--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -174,6 +174,7 @@ pairwise features, and point-set registration.
 Common starting points include:
 
 - `murty_k_best_assignments`;
+- `min_cost_max_cardinality_assignment`;
 - `LogisticPairwiseAssociationModel`;
 - `pairwise_mahalanobis_distances`;
 - `pairwise_covariance_shape_components`;

--- a/src/pyrecest/filters/global_nearest_neighbor.py
+++ b/src/pyrecest/filters/global_nearest_neighbor.py
@@ -2,7 +2,18 @@
 import warnings
 
 import pyrecest.backend
-from pyrecest.backend import all, any, empty, full, linalg, repeat, squeeze, stack
+from pyrecest.backend import (
+    all,
+    any,
+    empty,
+    full,
+    linalg,
+    repeat,
+    squeeze,
+    stack,
+    where,
+)
+from pyrecest.utils.assignment import min_cost_max_cardinality_assignment
 from scipy.optimize import linear_sum_assignment
 from scipy.spatial.distance import cdist
 from scipy.stats import chi2
@@ -19,6 +30,12 @@ class GlobalNearestNeighbor(AbstractNearestNeighborTracker):
     calcium-imaging cell tracking where association should depend on arbitrary
     pairwise cues like ROI overlap, footprint correlation, or appearance
     embeddings in addition to centroid distance.
+
+    Set ``association_param["maximize_cardinality"]`` to ``True`` when the
+    association step should keep as many gated track/measurement pairs as
+    possible before minimizing assignment cost. This matches frame-to-frame
+    object linking use cases where track birth/death is handled outside the
+    GNN update.
     """
 
     def __init__(
@@ -34,6 +51,7 @@ class GlobalNearestNeighbor(AbstractNearestNeighborTracker):
             "max_new_tracks": 10,
             "gating_distance_threshold": chi2.ppf(0.999, 2),
             "pairwise_cost_weight": 1.0,
+            "maximize_cardinality": False,
         }
         if association_param is None:
             association_param = default_association_param
@@ -199,17 +217,30 @@ class GlobalNearestNeighbor(AbstractNearestNeighborTracker):
         )
         dists = self._apply_pairwise_cost_matrix(dists, pairwise_cost_matrix)
 
-        # Pad to square and add max_new_tracks rows and columns
-        pad_to = max(n_targets, n_meas) + self.association_param["max_new_tracks"]
-        association_matrix = full(
-            (pad_to, pad_to), self.association_param["gating_distance_threshold"]
-        )
-        association_matrix[: dists.shape[0], : dists.shape[1]] = dists
+        if self.association_param.get("maximize_cardinality", False):
+            gated_dists = where(
+                dists <= self.association_param["gating_distance_threshold"],
+                dists,
+                float("inf"),
+            )
+            assignment_result = min_cost_max_cardinality_assignment(gated_dists)
+            association = assignment_result["assignment"]
+            association = where(association < 0, n_meas, association)
+        else:
+            # Pad to square and add max_new_tracks rows and columns
+            pad_to = (
+                max(n_targets, n_meas)
+                + self.association_param["max_new_tracks"]
+            )
+            association_matrix = full(
+                (pad_to, pad_to), self.association_param["gating_distance_threshold"]
+            )
+            association_matrix[: dists.shape[0], : dists.shape[1]] = dists
 
-        # Use the Hungarian algorithm to find the optimal assignment
-        _, col_ind = linear_sum_assignment(association_matrix)
+            # Use the Hungarian algorithm to find the optimal assignment
+            _, col_ind = linear_sum_assignment(association_matrix)
 
-        association = col_ind[:n_targets]
+            association = col_ind[:n_targets]
 
         if warn_on_no_meas_for_track and any(association >= n_meas):
             warnings.warn(

--- a/src/pyrecest/utils/__init__.py
+++ b/src/pyrecest/utils/__init__.py
@@ -1,6 +1,6 @@
 """Utility helpers for :mod:`pyrecest`."""
 
-from .assignment import murty_k_best_assignments
+from .assignment import min_cost_max_cardinality_assignment, murty_k_best_assignments
 from .association_features import (
     CalibratedPairwiseAssociationModel,
     NamedPairwiseFeatureSchema,
@@ -151,6 +151,7 @@ __all__ = [
     "ThinPlateSplineTransform",
     "estimate_thin_plate_spline",
     "joint_tps_registration_assignment",
+    "min_cost_max_cardinality_assignment",
     "murty_k_best_assignments",
     "pairwise_covariance_shape_components",
     "pairwise_mahalanobis_distances",

--- a/src/pyrecest/utils/assignment.py
+++ b/src/pyrecest/utils/assignment.py
@@ -274,4 +274,80 @@ def murty_k_best_assignments(  # pylint: disable=too-many-locals
     return ranked_solutions
 
 
-__all__ = ["murty_k_best_assignments"]
+def min_cost_max_cardinality_assignment(cost_matrix):
+    """Compute the cheapest assignment among maximum-cardinality matchings.
+
+    Parameters
+    ----------
+    cost_matrix : array_like, shape (n_rows, n_cols)
+        Matrix containing the cost of assigning each row to each column.
+        Forbidden assignments can be encoded as ``numpy.inf``.
+
+    Returns
+    -------
+    dict
+        Assignment solution with the same keys as ``murty_k_best_assignments``:
+        ``assignment`` contains the matched column per row or ``-1``;
+        ``unassigned_rows`` and ``unassigned_cols`` list unmatched indices; and
+        ``cost`` is the sum of selected finite assignment costs, excluding the
+        artificial priority penalties used internally.
+
+    Notes
+    -----
+    This helper is useful for tracking-by-detection steps where track
+    birth/death is handled elsewhere and the association stage should first use
+    as many gated detections as possible, then minimize the association cost
+    among those maximum-cardinality solutions.
+    """
+    if pyrecest.backend.__backend_name__ == "jax":  # pylint: disable=no-member
+        raise NotImplementedError(
+            "min_cost_max_cardinality_assignment is not supported on the JAX backend."
+        )
+
+    cost_matrix = _asarray(cost_matrix, dtype=float)
+    if cost_matrix.ndim != 2:
+        raise ValueError("cost_matrix must be a two-dimensional array")
+
+    n_rows, n_cols = cost_matrix.shape
+    assignment = _full((n_rows,), -1, dtype=_int64)
+    finite_costs = cost_matrix[_isfinite(cost_matrix)]
+    if finite_costs.shape[0] == 0:
+        return {
+            "assignment": assignment,
+            "unassigned_rows": _asarray(list(range(n_rows)), dtype=_int64),
+            "unassigned_cols": _asarray(list(range(n_cols)), dtype=_int64),
+            "cost": 0.0,
+        }
+
+    cardinality_priority_cost = 2.0 * (float(_sum(_abs(finite_costs))) + 1.0)
+    solutions = murty_k_best_assignments(
+        cost_matrix,
+        k=1,
+        row_non_assignment_costs=_full(
+            (n_rows,), cardinality_priority_cost, dtype=float
+        ),
+        col_non_assignment_costs=_zeros(n_cols, dtype=float),
+    )
+    if not solutions:
+        return {
+            "assignment": assignment,
+            "unassigned_rows": _asarray(list(range(n_rows)), dtype=_int64),
+            "unassigned_cols": _asarray(list(range(n_cols)), dtype=_int64),
+            "cost": 0.0,
+        }
+
+    solution = solutions[0]
+    assignment = solution["assignment"]
+    assigned_rows = _where(assignment >= 0)[0]
+    total_cost = 0.0
+    if assigned_rows.shape[0] > 0:
+        total_cost = float(_sum(cost_matrix[assigned_rows, assignment[assigned_rows]]))
+    return {
+        "assignment": assignment,
+        "unassigned_rows": solution["unassigned_rows"],
+        "unassigned_cols": solution["unassigned_cols"],
+        "cost": total_cost,
+    }
+
+
+__all__ = ["min_cost_max_cardinality_assignment", "murty_k_best_assignments"]

--- a/tests/filters/test_global_nearest_neighbor.py
+++ b/tests/filters/test_global_nearest_neighbor.py
@@ -296,6 +296,38 @@ class GlobalNearestNeighborTest(unittest.TestCase):
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
         reason="Not supported on this backend",
     )
+    def test_maximize_cardinality_prefers_more_feasible_matches(self):
+        tracker = GlobalNearestNeighbor(
+            association_param={
+                "distance_metric_pos": "Euclidean",
+                "square_dist": False,
+                "gating_distance_threshold": 2.05,
+                "max_new_tracks": 2,
+                "maximize_cardinality": True,
+            }
+        )
+        tracker.filter_state = [
+            KalmanFilter(
+                GaussianDistribution(array([0.0, 0.0]), eye(2))
+            ),
+            KalmanFilter(
+                GaussianDistribution(array([0.0, -0.1]), eye(2))
+            ),
+        ]
+
+        association = tracker.find_association(
+            array([[0.0, 0.0], [1.0, 2.0]]),
+            eye(2),
+            eye(2),
+            warn_on_no_meas_for_track=False,
+        )
+
+        npt.assert_array_equal(association, array([1, 0]))
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
     def test_association_with_clutter(self):
         tracker = GlobalNearestNeighbor()
         tracker.filter_state = self.kfs_init

--- a/tests/utils/test_assignment.py
+++ b/tests/utils/test_assignment.py
@@ -3,7 +3,10 @@ import unittest
 import numpy as np
 import numpy.testing as npt
 import pyrecest.backend
-from pyrecest.utils import murty_k_best_assignments
+from pyrecest.utils import (
+    min_cost_max_cardinality_assignment,
+    murty_k_best_assignments,
+)
 
 
 class MurtyAssignmentTest(unittest.TestCase):
@@ -159,6 +162,57 @@ class MurtyAssignmentTest(unittest.TestCase):
 
     def test_non_positive_k_returns_empty_list(self):
         self.assertEqual(murty_k_best_assignments(np.eye(2), k=0), [])
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on the JAX backend",
+    )
+    def test_min_cost_max_cardinality_prefers_more_matches(self):
+        cost_matrix = np.array(
+            [
+                [1.0, 2.0],
+                [1.1, np.inf],
+            ]
+        )
+
+        solution = min_cost_max_cardinality_assignment(cost_matrix)
+
+        npt.assert_array_equal(solution["assignment"], np.array([1, 0]))
+        npt.assert_array_equal(solution["unassigned_rows"], np.array([], dtype=int))
+        npt.assert_array_equal(solution["unassigned_cols"], np.array([], dtype=int))
+        self.assertAlmostEqual(solution["cost"], 3.1)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on the JAX backend",
+    )
+    def test_min_cost_max_cardinality_reports_unassigned_entries(self):
+        solution = min_cost_max_cardinality_assignment(
+            np.array(
+                [
+                    [np.inf, np.inf],
+                    [4.0, np.inf],
+                    [np.inf, 1.0],
+                ]
+            )
+        )
+
+        npt.assert_array_equal(solution["assignment"], np.array([-1, 0, 1]))
+        npt.assert_array_equal(solution["unassigned_rows"], np.array([0]))
+        npt.assert_array_equal(solution["unassigned_cols"], np.array([], dtype=int))
+        self.assertAlmostEqual(solution["cost"], 5.0)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on the JAX backend",
+    )
+    def test_min_cost_max_cardinality_handles_no_feasible_edges(self):
+        solution = min_cost_max_cardinality_assignment(np.full((2, 3), np.inf))
+
+        npt.assert_array_equal(solution["assignment"], np.array([-1, -1]))
+        npt.assert_array_equal(solution["unassigned_rows"], np.array([0, 1]))
+        npt.assert_array_equal(solution["unassigned_cols"], np.array([0, 1, 2]))
+        self.assertAlmostEqual(solution["cost"], 0.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a min-cost max-cardinality assignment helper
- use the helper in global nearest-neighbor assignment when requested
- document the new utility and add focused coverage

## Validation
- Applied patch with one import hunk resolved manually
- Checked for conflict markers and `.rej` files
- Ran `git diff --check` and `git diff --cached --check`

Tests were not run per request.