### PR TITLE
Preserve dtype in PyTorch sqrtm

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -44,6 +44,14 @@ def _torch_as_like(value, like):
     return _torch.from_numpy(_np.asarray(value))
 
 
+_COMPLEX_DTYPE_FOR_TENSOR_DTYPE = {
+    _torch.float32: _np.complex64,
+    _torch.float64: _np.complex128,
+    _torch.complex64: _np.complex64,
+    _torch.complex128: _np.complex128,
+}
+
+
 class _Logm(_torch.autograd.Function):
     """Torch autograd function for matrix logarithm.
 
@@ -87,7 +95,13 @@ def sqrtm(x):
     x_np = _as_numpy_no_grad(x)
     np_sqrtm = _np.vectorize(_scipy.linalg.sqrtm, signature="(n,m)->(n,m)")(x_np)
     if np_sqrtm.dtype.kind == "c":
-        np_sqrtm = np_sqrtm.astype(f"complex{int(np_sqrtm.dtype.name[7:]) // 2}")
+        target_complex_dtype = (
+            _COMPLEX_DTYPE_FOR_TENSOR_DTYPE.get(x.dtype)
+            if isinstance(x, _torch.Tensor)
+            else None
+        )
+        if target_complex_dtype is not None:
+            np_sqrtm = np_sqrtm.astype(target_complex_dtype, copy=False)
 
     return _torch_as_like(np_sqrtm, x)
 

--- a/tests/test_pytorch_backend.py
+++ b/tests/test_pytorch_backend.py
@@ -69,5 +69,31 @@ class TestPytorchBackendCov(unittest.TestCase):
         self.assertTrue(pytorch_backend.allclose(aweights, original_aweights))
 
 
+@unittest.skipIf(pytorch_backend is None, "PyTorch is not installed")
+class TestPytorchBackendLinalg(unittest.TestCase):
+    def test_sqrtm_complex_result_uses_matching_complex_precision(self):
+        dtype_pairs = (
+            (pytorch_backend.float32, pytorch_backend.complex64),
+            (pytorch_backend.float64, pytorch_backend.complex128),
+        )
+
+        for real_dtype, complex_dtype in dtype_pairs:
+            with self.subTest(real_dtype=real_dtype):
+                value = pytorch_backend.array(
+                    [[-1.0, 0.0], [0.0, 1.0]], dtype=real_dtype
+                )
+
+                result = pytorch_backend.linalg.sqrtm(value)
+
+                expected = pytorch_backend.array(
+                    [[0.0 + 1.0j, 0.0 + 0.0j], [0.0 + 0.0j, 1.0 + 0.0j]],
+                    dtype=complex_dtype,
+                )
+                self.assertEqual(result.dtype, complex_dtype)
+                self.assertTrue(
+                    pytorch_backend.allclose(result, expected, atol=1e-6, rtol=1e-6)
+                )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- preserve input dtype through the PyTorch backend matrix square root path
- add focused dtype coverage for the PyTorch backend

## Validation
- Applied malformed patch with `git apply --recount`
- Checked for conflict markers and `.rej` files
- Ran `git diff --cached --check`

Tests were not run per request.