### PR TITLE
Add JAX triangular vector helpers

### DIFF
--- a/src/pyrecest/_backend/jax/__init__.py
+++ b/src/pyrecest/_backend/jax/__init__.py
@@ -442,13 +442,17 @@ def set_diag(matrix, values):
 
 
 # Get lower triangle and flatten to vector
-def tril_to_vec(matrix):
-    return _jnp.tril(matrix).ravel()
+def tril_to_vec(x, k=0):
+    n = x.shape[-1]
+    rows, cols = _jnp.tril_indices(n, k=k)
+    return x[..., rows, cols]
 
 
 # Get upper triangle and flatten to vector
-def triu_to_vec(matrix):
-    return _jnp.triu(matrix).ravel()
+def triu_to_vec(x, k=0):
+    n = x.shape[-1]
+    rows, cols = _jnp.triu_indices(n, k=k)
+    return x[..., rows, cols]
 
 
 # Create diagonal matrix from vector

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -135,3 +135,18 @@ def test_as_dtype_string_lookup_is_available():
 
 def test_ravel_tril_indices_returns_flat_indices():
     assert _to_python(backend.ravel_tril_indices(3)) == [0, 3, 4, 6, 7, 8]
+
+
+def test_triangular_matrix_helpers_return_compact_vectors():
+    values = array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+
+    assert _to_python(backend.tril_to_vec(values)) == [1, 4, 5, 7, 8, 9]
+    assert _to_python(backend.triu_to_vec(values)) == [1, 2, 3, 5, 6, 9]
+    assert _to_python(backend.triu_to_vec(values, k=1)) == [2, 3, 6]
+
+
+def test_triangular_matrix_helpers_preserve_batch_dimensions():
+    values = array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
+
+    assert _to_python(backend.tril_to_vec(values)) == [[1, 3, 4], [5, 7, 8]]
+    assert _to_python(backend.triu_to_vec(values)) == [[1, 2, 4], [5, 6, 8]]


### PR DESCRIPTION
## Summary
- expose JAX backend triangular-vector helper support
- add backend contract coverage for triangular vector helpers

## Validation
- `git apply --recount --check --index C:\Users\emper\Downloads\patches\pyrecest-jax-triangular-vector-helpers.patch`
- `git diff --cached --check`
- conflict-marker scan with `rg`

Per request, I did not run tests.