### PR TITLE
Fix backend contract edge cases

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/__init__.py
+++ b/src/pyrecest/_backend/_shared_numpy/__init__.py
@@ -291,7 +291,7 @@ def array_from_sparse(indices, data, target_shape):
 def vec_to_diag(vec):
     """Convert vector to diagonal matrix."""
     d = vec.shape[-1]
-    return _np.squeeze(vec[..., None, :] * eye(d, dtype=vec.dtype)[None, :, :])
+    return vec[..., :, None] * eye(d, dtype=vec.dtype)
 
 
 def tril_to_vec(x, k=0):
@@ -338,8 +338,17 @@ def divide(a, b, ignore_div_zero=False):
     if ignore_div_zero is False:
         return _np.divide(a, b)
 
-    wider_dtype, _ = _get_wider_dtype([a, b])
-    return _np.divide(a, b, out=zeros(a.shape, dtype=wider_dtype), where=b != 0)
+    a_arr, b_arr = _np.asarray(a), _np.asarray(b)
+    a_arr, b_arr = _np.broadcast_arrays(a_arr, b_arr)
+    result_dtype = _np.result_type(a_arr, b_arr)
+    if result_dtype.kind in "biu":
+        result_dtype = get_default_dtype()
+    return _np.divide(
+        a_arr,
+        b_arr,
+        out=zeros(a_arr.shape, dtype=result_dtype),
+        where=b_arr != 0,
+    )
 
 
 def ravel_tril_indices(n, k=0, m=None):

--- a/src/pyrecest/_backend/jax/__init__.py
+++ b/src/pyrecest/_backend/jax/__init__.py
@@ -393,9 +393,49 @@ def is_bool(array):
     return _jnp.issubdtype(array.dtype, _jnp.bool_)
 
 
+def divide(a, b, ignore_div_zero=False):
+    if ignore_div_zero is False:
+        return _jnp.divide(a, b)
+
+    a_arr, b_arr = _jnp.asarray(a), _jnp.asarray(b)
+    quotient = _jnp.divide(a_arr, b_arr)
+    return _jnp.where(b_arr != 0, quotient, _jnp.zeros_like(quotient))
+
+
+def dot(a, b):
+    a = _jnp.asarray(a)
+    b = _jnp.asarray(b)
+
+    if b.ndim == 1:
+        return _jnp.dot(a, b)
+    if a.ndim == 1:
+        return _jnp.dot(a, b.T)
+    return _jnp.einsum("...i,...i->...", a, b)
+
+
+def outer(a, b):
+    a = _jnp.asarray(a)
+    b = _jnp.asarray(b)
+
+    if a.ndim > 1 and b.ndim > 1:
+        return _jnp.einsum("...i,...j->...ij", a, b)
+
+    result = _jnp.multiply.outer(a, b)
+    if b.ndim > 1:
+        result = _jnp.swapaxes(result, 0, -2)
+    return result
+
+
 # Matrix-vector multiplication
 def matvec(matrix, vector):
-    return _jnp.dot(matrix, vector)
+    matrix = _jnp.asarray(matrix)
+    vector = _jnp.asarray(vector)
+
+    if vector.ndim == 1:
+        return _jnp.matmul(matrix, vector)
+    if matrix.ndim == 2:
+        return _jnp.matmul(matrix, vector.T).T
+    return _jnp.einsum("...ij,...j->...i", matrix, vector)
 
 
 # One-hot encoding
@@ -436,9 +476,12 @@ def scatter_add(input, dim, index, src):
     raise NotImplementedError("scatter_add is implemented for dim 0 and dim 1.")
 
 
-# Set diagonal elements of a matrix
 def set_diag(matrix, values):
-    return matrix.at[_jnp.diag_indices_from(matrix)].set(values)
+    matrix = _jnp.asarray(matrix)
+    values = _jnp.asarray(values, dtype=matrix.dtype)
+    diag_len = matrix.shape[-2] if matrix.shape[-2] < matrix.shape[-1] else matrix.shape[-1]
+    diag_indices = _jnp.arange(diag_len)
+    return matrix.at[..., diag_indices, diag_indices].set(values)
 
 
 # Get lower triangle and flatten to vector
@@ -455,14 +498,25 @@ def triu_to_vec(x, k=0):
     return x[..., rows, cols]
 
 
-# Create diagonal matrix from vector
 def vec_to_diag(vector):
-    return _jnp.diag(vector)
+    vector = _jnp.asarray(vector)
+    return vector[..., :, None] * _jnp.eye(vector.shape[-1], dtype=vector.dtype)
 
 
-# Create matrix from diagonal, upper triangular, and lower triangular parts
-def mat_from_diag_triu_tril(diag, triu, tril):
-    matrix = _jnp.diag(diag)
-    matrix = matrix.at[_jnp.triu_indices_from(matrix, k=1)].set(triu)
-    matrix = matrix.at[_jnp.tril_indices_from(matrix, k=-1)].set(tril)
+def mat_from_diag_triu_tril(diag, tri_upp, tri_low):
+    diag = _jnp.asarray(diag)
+    tri_upp = _jnp.asarray(tri_upp)
+    tri_low = _jnp.asarray(tri_low)
+    dtype = _jnp.result_type(diag, tri_upp, tri_low)
+    diag = diag.astype(dtype)
+    tri_upp = tri_upp.astype(dtype)
+    tri_low = tri_low.astype(dtype)
+
+    n = diag.shape[-1]
+    i = _jnp.arange(n)
+    j, k = _jnp.triu_indices(n, k=1)
+    matrix = _jnp.zeros(diag.shape + (n,), dtype=dtype)
+    matrix = matrix.at[..., i, i].set(diag)
+    matrix = matrix.at[..., j, k].set(tri_upp)
+    matrix = matrix.at[..., k, j].set(tri_low)
     return matrix

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -150,3 +150,81 @@ def test_triangular_matrix_helpers_preserve_batch_dimensions():
 
     assert _to_python(backend.tril_to_vec(values)) == [[1, 3, 4], [5, 7, 8]]
     assert _to_python(backend.triu_to_vec(values)) == [[1, 2, 4], [5, 6, 8]]
+
+
+def test_divide_ignore_div_zero_accepts_scalars_and_integer_inputs():
+    assert _to_python(backend.divide(array([1.0, 2.0]), 0.0, ignore_div_zero=True)) == [0.0, 0.0]
+    assert _to_python(backend.divide(1.0, array([0.0, 2.0]), ignore_div_zero=True)) == [0.0, 0.5]
+
+    numerator = backend.asarray([1, 2], dtype=backend.int32)
+    denominator = backend.asarray([1, 0], dtype=backend.int32)
+
+    assert _to_python(backend.divide(numerator, denominator, ignore_div_zero=True)) == [1.0, 0.0]
+
+
+def test_vec_to_diag_preserves_leading_singleton_batch_dimension():
+    result = backend.vec_to_diag(array([[1.0, 2.0]]))
+
+    assert result.shape == (1, 2, 2)
+    assert _to_python(result) == [[[1.0, 0.0], [0.0, 2.0]]]
+
+
+def test_tril_and_triu_to_vec_skip_masked_entries():
+    values = array([[1.0, 2.0], [3.0, 4.0]])
+
+    assert _to_python(backend.tril_to_vec(values)) == [1.0, 3.0, 4.0]
+    assert _to_python(backend.triu_to_vec(values)) == [1.0, 2.0, 4.0]
+
+
+def test_set_diag_preserves_leading_batch_dimensions():
+    result = backend.set_diag(backend.zeros((1, 2, 2)), array([[1.0, 2.0]]))
+
+    assert result.shape == (1, 2, 2)
+    assert _to_python(result) == [[[1.0, 0.0], [0.0, 2.0]]]
+
+
+def test_batched_mat_from_diag_triu_tril_preserves_leading_dimensions():
+    result = backend.mat_from_diag_triu_tril(
+        array([[1.0, 2.0], [5.0, 6.0]]),
+        array([[3.0], [7.0]]),
+        array([[4.0], [8.0]]),
+    )
+
+    assert result.shape == (2, 2, 2)
+    assert _to_python(result) == [
+        [[1.0, 3.0], [4.0, 2.0]],
+        [[5.0, 7.0], [8.0, 6.0]],
+    ]
+
+
+def test_batched_matvec_pairs_leading_dimensions():
+    matrix = array([[[1.0, 0.0], [0.0, 1.0]], [[2.0, 0.0], [0.0, 3.0]]])
+    vector = array([[1.0, 2.0], [3.0, 4.0]])
+
+    result = backend.matvec(matrix, vector)
+
+    assert result.shape == (2, 2)
+    assert _to_python(result) == [[1.0, 2.0], [6.0, 12.0]]
+
+
+def test_batched_dot_uses_last_axis_inner_product():
+    first = array([[1.0, 2.0], [3.0, 4.0]])
+    second = array([[5.0, 6.0], [7.0, 8.0]])
+
+    result = backend.dot(first, second)
+
+    assert result.shape == (2,)
+    assert _to_python(result) == [17.0, 53.0]
+
+
+def test_batched_outer_pairs_leading_dimensions():
+    first = array([[1.0, 2.0], [3.0, 4.0]])
+    second = array([[5.0, 6.0], [7.0, 8.0]])
+
+    result = backend.outer(first, second)
+
+    assert result.shape == (2, 2, 2)
+    assert _to_python(result) == [
+        [[5.0, 6.0], [10.0, 12.0]],
+        [[21.0, 24.0], [28.0, 32.0]],
+    ]


### PR DESCRIPTION
## Summary
- make NumPy divide-with-zero handling work with scalars, broadcasting, and integer inputs
- add JAX backend implementations for divide, dot, outer, batched matvec, set_diag, vec_to_diag, and triangular matrix reconstruction edge cases
- extend backend contract coverage for these shape and dtype cases

## Validation
- `git diff --check`
- conflict-marker scan with `rg`
- `python -m py_compile src\pyrecest\_backend\_shared_numpy\__init__.py src\pyrecest\_backend\jax\__init__.py tests\test_backend_contracts.py`

Tests were not run per request.