### PR TITLE
Fix PyRecEst runtime edge cases

### DIFF
--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -25,14 +25,14 @@ def choice(a, size=None, replace=True, p=None):
     size, num_samples = _choice_size(size)
     if p is not None:
         assert _torch.is_tensor(p), "p must be a tensor"
-        if not replace:
+        if not replace and num_samples > len(a):
             raise ValueError(
-                "Sampling without replacement is not supported with PyTorch when probabilities are given."
+                "Cannot take a larger sample than population when 'replace=False'."
             )
 
         p = _torch.as_tensor(p, dtype=_torch.float32, device=a.device)
         p = p / p.sum()  # Normalize probabilities
-        indices = _torch.multinomial(p, num_samples=num_samples, replacement=True)
+        indices = _torch.multinomial(p, num_samples=num_samples, replacement=replace)
         if size is not None:
             indices = indices.reshape(size)
     elif replace:

--- a/src/pyrecest/cli.py
+++ b/src/pyrecest/cli.py
@@ -102,11 +102,17 @@ def _cmd_run_scenario(args: argparse.Namespace) -> int:
         failures: list[str] = []
         expected_estimate = expected.get("final_estimate")
         if expected_estimate is not None:
-            max_error = _max_abs_error(result.final_estimate, expected_estimate)
-            if max_error > tolerance:
+            if len(result.final_estimate) != len(expected_estimate):
                 failures.append(
-                    f"final_estimate mismatch: max_abs_error={max_error:.6g} > tolerance={tolerance:.6g}"
+                    "final_estimate length mismatch: "
+                    f"expected {len(expected_estimate)}, got {len(result.final_estimate)}"
                 )
+            else:
+                max_error = _max_abs_error(result.final_estimate, expected_estimate)
+                if max_error > tolerance:
+                    failures.append(
+                        f"final_estimate mismatch: max_abs_error={max_error:.6g} > tolerance={tolerance:.6g}"
+                    )
         if isinstance(expected.get("metrics"), dict):
             failures.extend(
                 _check_expected_mapping(

--- a/src/pyrecest/diagnostics.py
+++ b/src/pyrecest/diagnostics.py
@@ -107,11 +107,12 @@ class ParticleDiagnostics(_DiagnosticsMappingMixin):
     ) -> "ParticleDiagnostics":
         """Build particle diagnostics from normalized or unnormalized weights."""
         values = _coerce_weight_values(weights)
-        total = sum(values)
+        nonnegative_values = [max(0.0, value) for value in values]
+        total = sum(nonnegative_values)
         if total <= 0.0:
-            normalized = [0.0 for _ in values]
+            normalized = [0.0 for _ in nonnegative_values]
         else:
-            normalized = [max(0.0, value / total) for value in values]
+            normalized = [value / total for value in nonnegative_values]
         squared_sum = sum(weight * weight for weight in normalized)
         effective_sample_size = 1.0 / squared_sum if squared_sum > 0.0 else 0.0
         entropy = -sum(weight * log(weight) for weight in normalized if weight > 0.0)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 from pyrecest.cli import main
 
@@ -24,3 +25,28 @@ def test_cli_run_scenario_with_expected(capsys):
     )
     payload = json.loads(capsys.readouterr().out)
     assert payload["name"] == "linear_gaussian_cv_1d"
+
+
+def test_cli_run_scenario_rejects_final_estimate_length_mismatch(tmp_path, capsys):
+    expected = json.loads(
+        Path("scenarios/linear_gaussian_cv_1d/expected.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    expected["final_estimate"] = [*expected["final_estimate"], 0.0]
+    expected_path = tmp_path / "expected_length_mismatch.json"
+    expected_path.write_text(json.dumps(expected), encoding="utf-8")
+
+    assert (
+        main(
+            [
+                "run-scenario",
+                "scenarios/linear_gaussian_cv_1d/config.toml",
+                "--expected",
+                str(expected_path),
+            ]
+        )
+        == 1
+    )
+    captured = capsys.readouterr()
+    assert "final_estimate length mismatch" in captured.err

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,3 +1,5 @@
+from math import isclose, log
+
 from pyrecest.diagnostics import (
     AssociationDiagnostics,
     FilterDiagnostics,
@@ -13,3 +15,10 @@ def test_diagnostics_are_dict_serializable_containers():
     assert filter_diag.to_dict()["nis"] == 1.5
     assert particle_diag.to_dict()["resampled"] is True
     assert association_diag.to_dict()["selected_assignments"] == [(0, 1)]
+
+
+def test_particle_diagnostics_clips_negative_weights_before_normalizing():
+    diagnostics = ParticleDiagnostics.from_weights([2.0, -1.0, 2.0])
+
+    assert isclose(diagnostics.effective_sample_size, 2.0)
+    assert isclose(diagnostics.weight_entropy, log(2.0))

--- a/tests/test_pytorch_backend.py
+++ b/tests/test_pytorch_backend.py
@@ -70,6 +70,20 @@ class TestPytorchBackendCov(unittest.TestCase):
 
 
 @unittest.skipIf(pytorch_backend is None, "PyTorch is not installed")
+class TestPytorchBackendRandom(unittest.TestCase):
+    def test_choice_accepts_weighted_sampling_without_replacement(self):
+        values = pytorch_backend.array([0, 1, 2, 3])
+        probabilities = pytorch_backend.array([0.1, 0.2, 0.3, 0.4])
+
+        sample = pytorch_backend.random.choice(
+            values, size=2, replace=False, p=probabilities
+        )
+
+        self.assertEqual(sample.shape, (2,))
+        self.assertEqual(int(pytorch_backend.unique(sample).shape[0]), 2)
+
+
+@unittest.skipIf(pytorch_backend is None, "PyTorch is not installed")
 class TestPytorchBackendLinalg(unittest.TestCase):
     def test_sqrtm_complex_result_uses_matching_complex_precision(self):
         dtype_pairs = (


### PR DESCRIPTION
## Summary
- allow weighted PyTorch sampling without replacement when sample size permits
- report final-estimate length mismatches cleanly in the scenario CLI
- normalize particle diagnostics after clipping negative weights

## Validation
- `git diff --check`
- conflict-marker scan with `rg`
- `python -m py_compile src\pyrecest\_backend\pytorch\random.py src\pyrecest\cli.py src\pyrecest\diagnostics.py tests\test_cli.py tests\test_diagnostics.py tests\test_pytorch_backend.py`

Tests were not run per request.