### PR TITLE
Fix backend contract shape handling

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/__init__.py
+++ b/src/pyrecest/_backend/_shared_numpy/__init__.py
@@ -255,7 +255,9 @@ def set_diag(x, new_diag):
     1-D array, but modifies x instead of creating a copy.
     """
     arr_shape = x.shape
-    x[..., range(arr_shape[-2]), range(arr_shape[-1])] = new_diag
+    diag_len = min(arr_shape[-2], arr_shape[-1])
+    diag_indices = range(diag_len)
+    x[..., diag_indices, diag_indices] = new_diag
     return x
 
 
@@ -371,11 +373,11 @@ def outer(a, b):
     if a.ndim > 1 and b.ndim > 1:
         return _np.einsum("...i,...j->...ij", a, b)
 
-    out = _np.multiply.outer(a, b)
-    if b.ndim > 1:
-        out = out.swapaxes(0, -2)
-
-    return out
+    if a.ndim == 1 and b.ndim > 1:
+        return _np.einsum("i,...j->...ij", a, b)
+    if a.ndim > 1 and b.ndim == 1:
+        return _np.einsum("...i,j->...ij", a, b)
+    return _np.multiply.outer(a, b)
 
 
 def matvec(A, b):
@@ -388,10 +390,10 @@ def matvec(A, b):
 
 def dot(a, b):
     if b.ndim == 1:
-        return _np.dot(a, b)
+        return _np.einsum("...i,i->...", a, b)
 
     if a.ndim == 1:
-        return _np.dot(a, b.T)
+        return _np.einsum("i,...i->...", a, b)
 
     return _np.einsum("...i,...i->...", a, b)
 

--- a/src/pyrecest/_backend/jax/__init__.py
+++ b/src/pyrecest/_backend/jax/__init__.py
@@ -3,6 +3,8 @@ based on implementation by Emile Mathieu
 for Riemannian Score-based SDE
 """
 
+import builtins as _builtins
+
 import jax.numpy as _jnp
 from jax import vmap
 from jax.numpy import (  # For pyrecest; For Riemannian score-based SDE
@@ -479,7 +481,7 @@ def scatter_add(input, dim, index, src):
 def set_diag(matrix, values):
     matrix = _jnp.asarray(matrix)
     values = _jnp.asarray(values, dtype=matrix.dtype)
-    diag_len = min(matrix.shape[-2], matrix.shape[-1])
+    diag_len = _builtins.min(matrix.shape[-2], matrix.shape[-1])
     diag_indices = _jnp.arange(diag_len)
     return matrix.at[..., diag_indices, diag_indices].set(values)
 

--- a/src/pyrecest/_backend/jax/__init__.py
+++ b/src/pyrecest/_backend/jax/__init__.py
@@ -407,9 +407,9 @@ def dot(a, b):
     b = _jnp.asarray(b)
 
     if b.ndim == 1:
-        return _jnp.dot(a, b)
+        return _jnp.einsum("...i,i->...", a, b)
     if a.ndim == 1:
-        return _jnp.dot(a, b.T)
+        return _jnp.einsum("i,...i->...", a, b)
     return _jnp.einsum("...i,...i->...", a, b)
 
 
@@ -419,11 +419,11 @@ def outer(a, b):
 
     if a.ndim > 1 and b.ndim > 1:
         return _jnp.einsum("...i,...j->...ij", a, b)
-
-    result = _jnp.multiply.outer(a, b)
-    if b.ndim > 1:
-        result = _jnp.swapaxes(result, 0, -2)
-    return result
+    if a.ndim == 1 and b.ndim > 1:
+        return _jnp.einsum("i,...j->...ij", a, b)
+    if a.ndim > 1 and b.ndim == 1:
+        return _jnp.einsum("...i,j->...ij", a, b)
+    return _jnp.multiply.outer(a, b)
 
 
 # Matrix-vector multiplication
@@ -479,7 +479,7 @@ def scatter_add(input, dim, index, src):
 def set_diag(matrix, values):
     matrix = _jnp.asarray(matrix)
     values = _jnp.asarray(values, dtype=matrix.dtype)
-    diag_len = matrix.shape[-2] if matrix.shape[-2] < matrix.shape[-1] else matrix.shape[-1]
+    diag_len = min(matrix.shape[-2], matrix.shape[-1])
     diag_indices = _jnp.arange(diag_len)
     return matrix.at[..., diag_indices, diag_indices].set(values)
 

--- a/src/pyrecest/_backend/pytorch/__init__.py
+++ b/src/pyrecest/_backend/pytorch/__init__.py
@@ -1,5 +1,6 @@
 """Pytorch based computation backend."""
 
+import builtins as _builtins
 from collections.abc import Iterable as _Iterable
 
 import numpy as _np
@@ -596,7 +597,7 @@ def set_diag(x, new_diag):
     This mimics tensorflow.linalg.set_diag(x, new_diag), when new_diag is a
     1-D array, but modifies x instead of creating a copy.
     """
-    diag_len = min(x.shape[-2], x.shape[-1])
+    diag_len = _builtins.min(x.shape[-2], x.shape[-1])
     result = x.clone()
     diag_indices = _torch.arange(diag_len, device=x.device)
     values = _torch.as_tensor(new_diag, dtype=x.dtype, device=x.device)

--- a/src/pyrecest/_backend/pytorch/__init__.py
+++ b/src/pyrecest/_backend/pytorch/__init__.py
@@ -596,10 +596,12 @@ def set_diag(x, new_diag):
     This mimics tensorflow.linalg.set_diag(x, new_diag), when new_diag is a
     1-D array, but modifies x instead of creating a copy.
     """
-    arr_shape = x.shape
-    off_diag = (1 - _torch.eye(arr_shape[-1])) * x
-    diag = _torch.einsum("ij,...i->...ij", _torch.eye(new_diag.shape[-1]), new_diag)
-    return diag + off_diag
+    diag_len = min(x.shape[-2], x.shape[-1])
+    result = x.clone()
+    diag_indices = _torch.arange(diag_len, device=x.device)
+    values = _torch.as_tensor(new_diag, dtype=x.dtype, device=x.device)
+    result[..., diag_indices, diag_indices] = values
+    return result
 
 
 def prod(x, axis=None):
@@ -929,10 +931,10 @@ def dot(a, b):
         return _torch.dot(a, b)
 
     if b.ndim == 1:
-        return _torch.tensordot(a, b, dims=1)
+        return _torch.einsum("...i,i->...", a, b)
 
     if a.ndim == 1:
-        return _torch.tensordot(a, b.T, dims=1)
+        return _torch.einsum("i,...i->...", a, b)
 
     return _torch.einsum("...i,...i->...", a, b)
 

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -183,6 +183,13 @@ def test_set_diag_preserves_leading_batch_dimensions():
     assert _to_python(result) == [[[1.0, 0.0], [0.0, 2.0]]]
 
 
+def test_set_diag_accepts_rectangular_matrices():
+    result = backend.set_diag(backend.ones((2, 3)), array([5.0, 6.0]))
+
+    assert result.shape == (2, 3)
+    assert _to_python(result) == [[5.0, 1.0, 1.0], [1.0, 6.0, 1.0]]
+
+
 def test_batched_mat_from_diag_triu_tril_preserves_leading_dimensions():
     result = backend.mat_from_diag_triu_tril(
         array([[1.0, 2.0], [5.0, 6.0]]),
@@ -217,6 +224,21 @@ def test_batched_dot_uses_last_axis_inner_product():
     assert _to_python(result) == [17.0, 53.0]
 
 
+def test_batched_dot_accepts_high_rank_right_operand():
+    first = array([1.0, 2.0])
+    second = array(
+        [
+            [[0.0, 1.0], [2.0, 3.0], [4.0, 5.0]],
+            [[6.0, 7.0], [8.0, 9.0], [10.0, 11.0]],
+        ]
+    )
+
+    result = backend.dot(first, second)
+
+    assert result.shape == (2, 3)
+    assert _to_python(result) == [[2.0, 8.0, 14.0], [20.0, 26.0, 32.0]]
+
+
 def test_batched_outer_pairs_leading_dimensions():
     first = array([[1.0, 2.0], [3.0, 4.0]])
     second = array([[5.0, 6.0], [7.0, 8.0]])
@@ -227,4 +249,30 @@ def test_batched_outer_pairs_leading_dimensions():
     assert _to_python(result) == [
         [[5.0, 6.0], [10.0, 12.0]],
         [[21.0, 24.0], [28.0, 32.0]],
+    ]
+
+
+def test_outer_accepts_high_rank_right_operand():
+    first = array([1.0, 2.0])
+    second = array(
+        [
+            [[0.0, 1.0], [2.0, 3.0], [4.0, 5.0]],
+            [[6.0, 7.0], [8.0, 9.0], [10.0, 11.0]],
+        ]
+    )
+
+    result = backend.outer(first, second)
+
+    assert result.shape == (2, 3, 2, 2)
+    assert _to_python(result) == [
+        [
+            [[0.0, 1.0], [0.0, 2.0]],
+            [[2.0, 3.0], [4.0, 6.0]],
+            [[4.0, 5.0], [8.0, 10.0]],
+        ],
+        [
+            [[6.0, 7.0], [12.0, 14.0]],
+            [[8.0, 9.0], [16.0, 18.0]],
+            [[10.0, 11.0], [20.0, 22.0]],
+        ],
     ]


### PR DESCRIPTION
## Summary
- make backend `set_diag` handle rectangular matrices consistently
- align NumPy, JAX, and PyTorch dot/outer behavior for higher-rank operands
- add backend contract tests for rectangular diagonal and high-rank shape cases

## Validation
- `git diff --check`
- conflict-marker scan with `rg`
- `python -m py_compile src\pyrecest\_backend\_shared_numpy\__init__.py src\pyrecest\_backend\jax\__init__.py src\pyrecest\_backend\pytorch\__init__.py tests\test_backend_contracts.py`

Tests were not run per request.