### PR TITLE
Complete MHT tracker and backend fixes

### DIFF
--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -108,8 +108,8 @@ Common starting points include:
 - `EuclideanParticleFilter` and manifold-specific particle filters;
 - `VonMisesFilter`, `VonMisesFisherFilter`, and Fourier or grid filters for
   directional estimation;
-- `MultiBernoulliTracker`, `GlobalNearestNeighbor`, `JPDAF`, and
-  `TrackManager` for tracking workflows.
+- `MultiBernoulliTracker`, `MultiHypothesisTracker`, `GlobalNearestNeighbor`,
+  `JPDAF`, and `TrackManager` for tracking workflows.
 - `FullSCGPTracker` for star-convex Gaussian-process extended-object tracking,
   including optional per-measurement covariance, reliability weights, and
   active-measurement masks.

--- a/src/pyrecest/_backend/_shared_numpy/__init__.py
+++ b/src/pyrecest/_backend/_shared_numpy/__init__.py
@@ -255,7 +255,9 @@ def set_diag(x, new_diag):
     1-D array, but modifies x instead of creating a copy.
     """
     arr_shape = x.shape
-    x[..., range(arr_shape[-2]), range(arr_shape[-1])] = new_diag
+    diag_len = min(arr_shape[-2], arr_shape[-1])
+    diag_indices = range(diag_len)
+    x[..., diag_indices, diag_indices] = new_diag
     return x
 
 
@@ -371,11 +373,11 @@ def outer(a, b):
     if a.ndim > 1 and b.ndim > 1:
         return _np.einsum("...i,...j->...ij", a, b)
 
-    out = _np.multiply.outer(a, b)
-    if b.ndim > 1:
-        out = out.swapaxes(0, -2)
-
-    return out
+    if a.ndim == 1 and b.ndim > 1:
+        return _np.einsum("i,...j->...ij", a, b)
+    if a.ndim > 1 and b.ndim == 1:
+        return _np.einsum("...i,j->...ij", a, b)
+    return _np.multiply.outer(a, b)
 
 
 def matvec(A, b):
@@ -388,10 +390,10 @@ def matvec(A, b):
 
 def dot(a, b):
     if b.ndim == 1:
-        return _np.dot(a, b)
+        return _np.einsum("...i,i->...", a, b)
 
     if a.ndim == 1:
-        return _np.dot(a, b.T)
+        return _np.einsum("i,...i->...", a, b)
 
     return _np.einsum("...i,...i->...", a, b)
 

--- a/src/pyrecest/_backend/jax/__init__.py
+++ b/src/pyrecest/_backend/jax/__init__.py
@@ -3,6 +3,8 @@ based on implementation by Emile Mathieu
 for Riemannian Score-based SDE
 """
 
+import builtins as _builtins
+
 import jax.numpy as _jnp
 from jax import vmap
 from jax.numpy import (  # For pyrecest; For Riemannian score-based SDE
@@ -479,7 +481,7 @@ def scatter_add(input, dim, index, src):
 def set_diag(matrix, values):
     matrix = _jnp.asarray(matrix)
     values = _jnp.asarray(values, dtype=matrix.dtype)
-    diag_len = min(matrix.shape[-2], matrix.shape[-1])
+    diag_len = _builtins.min(matrix.shape[-2], matrix.shape[-1])
     diag_indices = _jnp.arange(diag_len)
     return matrix.at[..., diag_indices, diag_indices].set(values)
 

--- a/src/pyrecest/_backend/jax/__init__.py
+++ b/src/pyrecest/_backend/jax/__init__.py
@@ -407,9 +407,9 @@ def dot(a, b):
     b = _jnp.asarray(b)
 
     if b.ndim == 1:
-        return _jnp.dot(a, b)
+        return _jnp.einsum("...i,i->...", a, b)
     if a.ndim == 1:
-        return _jnp.dot(a, b.T)
+        return _jnp.einsum("i,...i->...", a, b)
     return _jnp.einsum("...i,...i->...", a, b)
 
 
@@ -419,11 +419,11 @@ def outer(a, b):
 
     if a.ndim > 1 and b.ndim > 1:
         return _jnp.einsum("...i,...j->...ij", a, b)
-
-    result = _jnp.multiply.outer(a, b)
-    if b.ndim > 1:
-        result = _jnp.swapaxes(result, 0, -2)
-    return result
+    if a.ndim == 1 and b.ndim > 1:
+        return _jnp.einsum("i,...j->...ij", a, b)
+    if a.ndim > 1 and b.ndim == 1:
+        return _jnp.einsum("...i,j->...ij", a, b)
+    return _jnp.multiply.outer(a, b)
 
 
 # Matrix-vector multiplication
@@ -479,7 +479,7 @@ def scatter_add(input, dim, index, src):
 def set_diag(matrix, values):
     matrix = _jnp.asarray(matrix)
     values = _jnp.asarray(values, dtype=matrix.dtype)
-    diag_len = matrix.shape[-2] if matrix.shape[-2] < matrix.shape[-1] else matrix.shape[-1]
+    diag_len = min(matrix.shape[-2], matrix.shape[-1])
     diag_indices = _jnp.arange(diag_len)
     return matrix.at[..., diag_indices, diag_indices].set(values)
 

--- a/src/pyrecest/_backend/pytorch/__init__.py
+++ b/src/pyrecest/_backend/pytorch/__init__.py
@@ -1,5 +1,6 @@
 """Pytorch based computation backend."""
 
+import builtins as _builtins
 from collections.abc import Iterable as _Iterable
 
 import numpy as _np
@@ -596,7 +597,7 @@ def set_diag(x, new_diag):
     This mimics tensorflow.linalg.set_diag(x, new_diag), when new_diag is a
     1-D array, but modifies x instead of creating a copy.
     """
-    diag_len = min(x.shape[-2], x.shape[-1])
+    diag_len = _builtins.min(x.shape[-2], x.shape[-1])
     result = x.clone()
     diag_indices = _torch.arange(diag_len, device=x.device)
     values = _torch.as_tensor(new_diag, dtype=x.dtype, device=x.device)

--- a/src/pyrecest/_backend/pytorch/__init__.py
+++ b/src/pyrecest/_backend/pytorch/__init__.py
@@ -596,10 +596,12 @@ def set_diag(x, new_diag):
     This mimics tensorflow.linalg.set_diag(x, new_diag), when new_diag is a
     1-D array, but modifies x instead of creating a copy.
     """
-    arr_shape = x.shape
-    off_diag = (1 - _torch.eye(arr_shape[-1])) * x
-    diag = _torch.einsum("ij,...i->...ij", _torch.eye(new_diag.shape[-1]), new_diag)
-    return diag + off_diag
+    diag_len = min(x.shape[-2], x.shape[-1])
+    result = x.clone()
+    diag_indices = _torch.arange(diag_len, device=x.device)
+    values = _torch.as_tensor(new_diag, dtype=x.dtype, device=x.device)
+    result[..., diag_indices, diag_indices] = values
+    return result
 
 
 def prod(x, axis=None):
@@ -929,10 +931,10 @@ def dot(a, b):
         return _torch.dot(a, b)
 
     if b.ndim == 1:
-        return _torch.tensordot(a, b, dims=1)
+        return _torch.einsum("...i,i->...", a, b)
 
     if a.ndim == 1:
-        return _torch.tensordot(a, b.T, dims=1)
+        return _torch.einsum("i,...i->...", a, b)
 
     return _torch.einsum("...i,...i->...", a, b)
 

--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -33,7 +33,9 @@ def choice(a, size=None, replace=True, p=None):
         p = _torch.as_tensor(p, dtype=_torch.float32, device=a.device)
         p = p / p.sum()  # Normalize probabilities
         indices = _torch.multinomial(p, num_samples=num_samples, replacement=replace)
-        if size is not None:
+        if size is None:
+            indices = indices[0]
+        else:
             indices = indices.reshape(size)
     elif replace:
         indices = _torch.randint(0, len(a), size or (), device=a.device)

--- a/src/pyrecest/filters/__init__.py
+++ b/src/pyrecest/filters/__init__.py
@@ -118,6 +118,7 @@ _FILTER_EXPORTS: Final[dict[str, str]] = {
     "MeasurementRecord": ".out_of_sequence",
     "MeasurementTimeBuffer": ".out_of_sequence",
     "MultiBernoulliTracker": ".multi_bernoulli_tracker",
+    "MultiHypothesisTracker": ".multi_hypothesis_tracker",
     "MultipleExtendedObjectStepResult": ".abstract_multiple_extended_object_tracker",
     "LinPeriodicParticleFilter": ".lin_periodic_particle_filter",
     "MEMEKFStarTracker": ".mem_ekf_star_tracker",

--- a/src/pyrecest/filters/multi_hypothesis_tracker.py
+++ b/src/pyrecest/filters/multi_hypothesis_tracker.py
@@ -1,10 +1,11 @@
 # pylint: disable=no-name-in-module,no-member,duplicate-code,redefined-builtin
 import warnings
+from builtins import all as builtin_all
 from copy import deepcopy
 from math import log
 
 from pyrecest.backend import (
-    all,
+    all as backend_all,
     argmax,
     array,
     asarray,
@@ -153,7 +154,9 @@ class MultiHypothesisTracker(AbstractMultitargetTracker):
         ]
 
         n_targets = len(filter_banks[0])
-        if not all(len(filter_bank) == n_targets for filter_bank in filter_banks):
+        if not builtin_all(
+            len(filter_bank) == n_targets for filter_bank in filter_banks
+        ):
             raise ValueError(
                 "All global hypotheses must have the same number of tracks"
             )
@@ -236,7 +239,7 @@ class MultiHypothesisTracker(AbstractMultitargetTracker):
             return
 
         if isinstance(sys_noises, GaussianDistribution):
-            if not all(asarray(sys_noises.mu) == 0.0):
+            if not backend_all(asarray(sys_noises.mu) == 0.0):
                 raise ValueError("System noise mean is expected to be zero")
             sys_noises = sys_noises.C
 
@@ -324,9 +327,9 @@ class MultiHypothesisTracker(AbstractMultitargetTracker):
                 updated_filter_bank = self._apply_assignment(
                     parent_filter_bank,
                     assignment,
-                    measurements,
-                    measurement_matrix,
-                    cov_mats_meas,
+                    measurements_np,
+                    measurement_matrix_np,
+                    cov_mats_meas_np,
                 )
                 new_hypotheses.append(updated_filter_bank)
                 new_log_weights.append(
@@ -581,12 +584,12 @@ class MultiHypothesisTracker(AbstractMultitargetTracker):
         if len(hypothesis) == 0:
             return []
 
-        if all(isinstance(item, EuclideanFilterMixin) for item in hypothesis):
+        if builtin_all(isinstance(item, EuclideanFilterMixin) for item in hypothesis):
             filter_bank = deepcopy(hypothesis)
         else:
             filter_bank = [KalmanFilter(filter_state) for filter_state in hypothesis]
 
-        if not all(
+        if not builtin_all(
             id(filter_bank[i]) != id(filter_bank[j])
             for i in range(len(filter_bank))
             for j in range(i + 1, len(filter_bank))

--- a/tests/distributions/test_multi_hypothesis_tracker.py
+++ b/tests/distributions/test_multi_hypothesis_tracker.py
@@ -6,8 +6,7 @@ import numpy.testing as npt
 import pyrecest.backend
 from pyrecest.backend import array, eye, log
 from pyrecest.distributions import GaussianDistribution
-from pyrecest.filters import KalmanFilter
-from pyrecest.filters.multi_hypothesis_tracker import MultiHypothesisTracker
+from pyrecest.filters import KalmanFilter, MultiHypothesisTracker
 
 
 @unittest.skipIf(
@@ -43,6 +42,61 @@ class MultiHypothesisTrackerTest(unittest.TestCase):
         self.assertEqual(tracker.get_number_of_global_hypotheses(), 1)
         self.assertEqual(tracker.get_point_estimate().shape, (2, 2))
         self.assertEqual(tracker.get_point_estimate(True).shape, (4,))
+
+    def test_setting_gaussian_states_wraps_them_in_kalman_filters(self):
+        tracker = MultiHypothesisTracker(
+            association_param=self.association_param,
+            log_prior_estimates=False,
+            log_posterior_estimates=False,
+        )
+        tracker.filter_state = [
+            GaussianDistribution(array([0.0, 0.0]), eye(2)),
+            GaussianDistribution(array([1.0, 0.0]), eye(2)),
+        ]
+
+        self.assertTrue(
+            all(
+                isinstance(filter_obj, KalmanFilter)
+                for filter_obj in tracker.filter_bank
+            )
+        )
+        npt.assert_allclose(
+            tracker.get_point_estimate(),
+            array([[0.0, 1.0], [0.0, 0.0]]),
+        )
+
+    def test_rejects_global_hypotheses_with_inconsistent_track_counts(self):
+        tracker = MultiHypothesisTracker(
+            log_prior_estimates=False,
+            log_posterior_estimates=False,
+        )
+
+        with self.assertRaises(ValueError):
+            tracker.set_global_hypotheses(
+                [
+                    [KalmanFilter(GaussianDistribution(array([0.0, 0.0]), eye(2)))],
+                    [
+                        KalmanFilter(GaussianDistribution(array([1.0, 0.0]), eye(2))),
+                        KalmanFilter(GaussianDistribution(array([2.0, 0.0]), eye(2))),
+                    ],
+                ]
+            )
+
+    def test_update_linear_accepts_array_like_inputs(self):
+        tracker = MultiHypothesisTracker(
+            association_param=self.association_param,
+            log_prior_estimates=False,
+            log_posterior_estimates=False,
+        )
+        tracker.filter_state = [GaussianDistribution(array([0.0, 0.0]), eye(2))]
+
+        tracker.update_linear([[0.2], [-0.2]], [[1.0, 0.0], [0.0, 1.0]], eye(2))
+
+        npt.assert_allclose(
+            tracker.get_point_estimate(),
+            array([[0.1], [-0.1]]),
+            atol=1.0e-12,
+        )
 
     def test_setting_multiple_global_hypotheses_and_weighted_estimate(self):
         tracker = MultiHypothesisTracker(

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -183,6 +183,13 @@ def test_set_diag_preserves_leading_batch_dimensions():
     assert _to_python(result) == [[[1.0, 0.0], [0.0, 2.0]]]
 
 
+def test_set_diag_accepts_rectangular_matrices():
+    result = backend.set_diag(backend.ones((2, 3)), array([5.0, 6.0]))
+
+    assert result.shape == (2, 3)
+    assert _to_python(result) == [[5.0, 1.0, 1.0], [1.0, 6.0, 1.0]]
+
+
 def test_batched_mat_from_diag_triu_tril_preserves_leading_dimensions():
     result = backend.mat_from_diag_triu_tril(
         array([[1.0, 2.0], [5.0, 6.0]]),
@@ -217,6 +224,21 @@ def test_batched_dot_uses_last_axis_inner_product():
     assert _to_python(result) == [17.0, 53.0]
 
 
+def test_batched_dot_accepts_high_rank_right_operand():
+    first = array([1.0, 2.0])
+    second = array(
+        [
+            [[0.0, 1.0], [2.0, 3.0], [4.0, 5.0]],
+            [[6.0, 7.0], [8.0, 9.0], [10.0, 11.0]],
+        ]
+    )
+
+    result = backend.dot(first, second)
+
+    assert result.shape == (2, 3)
+    assert _to_python(result) == [[2.0, 8.0, 14.0], [20.0, 26.0, 32.0]]
+
+
 def test_batched_outer_pairs_leading_dimensions():
     first = array([[1.0, 2.0], [3.0, 4.0]])
     second = array([[5.0, 6.0], [7.0, 8.0]])
@@ -227,4 +249,30 @@ def test_batched_outer_pairs_leading_dimensions():
     assert _to_python(result) == [
         [[5.0, 6.0], [10.0, 12.0]],
         [[21.0, 24.0], [28.0, 32.0]],
+    ]
+
+
+def test_outer_accepts_high_rank_right_operand():
+    first = array([1.0, 2.0])
+    second = array(
+        [
+            [[0.0, 1.0], [2.0, 3.0], [4.0, 5.0]],
+            [[6.0, 7.0], [8.0, 9.0], [10.0, 11.0]],
+        ]
+    )
+
+    result = backend.outer(first, second)
+
+    assert result.shape == (2, 3, 2, 2)
+    assert _to_python(result) == [
+        [
+            [[0.0, 1.0], [0.0, 2.0]],
+            [[2.0, 3.0], [4.0, 6.0]],
+            [[4.0, 5.0], [8.0, 10.0]],
+        ],
+        [
+            [[6.0, 7.0], [12.0, 14.0]],
+            [[8.0, 9.0], [16.0, 18.0]],
+            [[10.0, 11.0], [20.0, 22.0]],
+        ],
     ]

--- a/tests/test_pytorch_backend.py
+++ b/tests/test_pytorch_backend.py
@@ -82,6 +82,14 @@ class TestPytorchBackendRandom(unittest.TestCase):
         self.assertEqual(sample.shape, (2,))
         self.assertEqual(int(pytorch_backend.unique(sample).shape[0]), 2)
 
+    def test_choice_returns_scalar_for_weighted_size_none(self):
+        values = pytorch_backend.array([0, 1, 2, 3])
+        probabilities = pytorch_backend.array([0.1, 0.2, 0.3, 0.4])
+
+        sample = pytorch_backend.random.choice(values, p=probabilities)
+
+        self.assertEqual(sample.shape, ())
+
 
 @unittest.skipIf(pytorch_backend is None, "PyTorch is not installed")
 class TestPytorchBackendLinalg(unittest.TestCase):


### PR DESCRIPTION
## Summary
- complete and export the multi-hypothesis tracker implementation
- document the tracker in the API overview
- add backend contract fixes for high-rank operations and diagonal handling
- preserve remaining PyTorch random scalar behavior from the bugfix patch

## Notes
- Some CLI and diagnostics hunks from `pyrecest_bugfixes.patch` were already present on current `main`; only the remaining missing changes were applied.

## Verification
- `git diff --check`
- conflict-marker scan
- `python -m py_compile` on changed Python files