### PR TITLE
Add delayed-decision MHT utilities

### DIFF
--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -109,7 +109,9 @@ Common starting points include:
 - `VonMisesFilter`, `VonMisesFisherFilter`, and Fourier or grid filters for
   directional estimation;
 - `MultiBernoulliTracker`, `MultiHypothesisTracker`, `GlobalNearestNeighbor`,
-  `JPDAF`, and `TrackManager` for tracking workflows.
+  `JPDAF`, and `TrackManager` for tracking workflows. `MultiHypothesisTracker`
+  supports top-K hypothesis inspection, delayed assignment commitments, reranker
+  callbacks, score-temperature calibration, and diversity-aware pruning.
 - `FullSCGPTracker` for star-convex Gaussian-process extended-object tracking,
   including optional per-measurement covariance, reliability weights, and
   active-measurement masks.

--- a/src/pyrecest/filters/multi_hypothesis_tracker.py
+++ b/src/pyrecest/filters/multi_hypothesis_tracker.py
@@ -39,6 +39,14 @@ class MultiHypothesisTracker(AbstractMultitargetTracker):
     It keeps a fixed number of tracks and maintains several competing global
     hypotheses, each represented by a complete bank of single-target filters.
 
+    The tracker can be used as a top-K hypothesis generator rather than only as
+    a top-1 estimator.  In addition to the usual best-hypothesis accessors, it
+    exposes assignment-history marginals, lagged assignment commitments, optional
+    whole-hypothesis reranking, score-temperature calibration, and a
+    diversity-aware pruning mode. These utilities are useful when the true
+    association sequence tends to remain inside the retained beam but is not
+    consistently the highest-scoring branch at the current scan.
+
     Notes
     -----
     * The implementation currently supports linear-Gaussian measurement updates.
@@ -47,6 +55,9 @@ class MultiHypothesisTracker(AbstractMultitargetTracker):
       are many ambiguous measurements.
     * New-track initiation and track deletion are not included. Unassigned
       measurements are interpreted as clutter.
+    * If ``hypothesis_reranker`` is supplied, it should be a callable or an
+      object with a ``score(filter_bank, assignment_history, base_log_weight)``
+      method returning an additive log score for the complete hypothesis.
     """
 
     def __init__(
@@ -55,6 +66,8 @@ class MultiHypothesisTracker(AbstractMultitargetTracker):
         association_param=None,
         log_prior_estimates=True,
         log_posterior_estimates=True,
+        hypothesis_reranker=None,
+        hypothesis_diversity_key=None,
     ):
         super().__init__(
             log_prior_estimates=log_prior_estimates,
@@ -72,15 +85,27 @@ class MultiHypothesisTracker(AbstractMultitargetTracker):
             "max_hypotheses_per_global_hypothesis": 5,
             "max_measurements_per_track": 5,
             "prune_log_weight_delta": 20.0,
+            "measurement_log_likelihood_weight": 1.0,
+            "detection_log_weight": 1.0,
+            "missed_detection_log_weight": 1.0,
+            "clutter_log_weight": 1.0,
+            "score_temperature": 1.0,
+            "pruning_strategy": "top_k",
+            "diversity_history_length": 3,
+            "max_hypotheses_per_signature": 1,
         }
 
         self.association_param = default_association_param
         if association_param is not None:
             self.association_param.update(association_param)
 
+        self.hypothesis_reranker = hypothesis_reranker
+        self.hypothesis_diversity_key = hypothesis_diversity_key
         self._global_hypotheses = []
+        self._global_base_log_weights = array([])
         self._global_log_weights = array([])
         self._global_hypothesis_histories = []
+        self._global_filter_bank_histories = []
 
         if initial_prior is not None:
             self.filter_state = initial_prior
@@ -98,6 +123,10 @@ class MultiHypothesisTracker(AbstractMultitargetTracker):
     @property
     def global_hypothesis_histories(self):
         return self._global_hypothesis_histories
+
+    @property
+    def global_filter_bank_histories(self):
+        return self._global_filter_bank_histories
 
     @property
     def filter_bank(self):
@@ -135,15 +164,19 @@ class MultiHypothesisTracker(AbstractMultitargetTracker):
             Gaussian states, which are wrapped in Kalman filters.
         log_weights : array-like, optional
             Log-weights of the global hypotheses. If omitted, a uniform prior
-            over the supplied hypotheses is assumed.
+            over the supplied hypotheses is assumed. These are interpreted as
+            base model scores; optional reranker scores are added separately
+            when effective hypothesis weights are computed.
         """
         if not isinstance(hypotheses, list):
             raise ValueError("hypotheses must be provided as a list")
 
         if len(hypotheses) == 0:
             self._global_hypotheses = []
+            self._global_base_log_weights = array([])
             self._global_log_weights = array([])
             self._global_hypothesis_histories = []
+            self._global_filter_bank_histories = []
             return
 
         if self._looks_like_single_hypothesis(hypotheses):
@@ -165,9 +198,10 @@ class MultiHypothesisTracker(AbstractMultitargetTracker):
             deepcopy(filter_bank) for filter_bank in filter_banks
         ]
         self._global_hypothesis_histories = [[] for _ in self._global_hypotheses]
+        self._global_filter_bank_histories = [[] for _ in self._global_hypotheses]
 
         if log_weights is None:
-            self._global_log_weights = array(
+            self._global_base_log_weights = array(
                 [0.0 for _ in range(len(self._global_hypotheses))]
             )
         else:
@@ -175,9 +209,10 @@ class MultiHypothesisTracker(AbstractMultitargetTracker):
                 raise ValueError(
                     "The number of log-weights must match the number of hypotheses"
                 )
-            self._global_log_weights = array(log_weights)
+            self._global_base_log_weights = array(log_weights)
 
-        self._normalize_log_weights()
+        self._normalize_base_log_weights()
+        self._refresh_effective_log_weights()
 
         if self.log_prior_estimates and self.get_number_of_targets() > 0:
             self.store_prior_estimates()
@@ -199,9 +234,229 @@ class MultiHypothesisTracker(AbstractMultitargetTracker):
         return self._global_hypotheses[self.get_best_hypothesis_index()]
 
     def get_global_hypothesis_weights(self):
+        """Return normalized effective weights used for ranking hypotheses."""
         if self.get_number_of_global_hypotheses() == 0:
             return array([])
         return exp(self._global_log_weights)
+
+    def get_global_hypothesis_log_weights(self):
+        """Return normalized effective log weights used for ranking hypotheses."""
+        if self.get_number_of_global_hypotheses() == 0:
+            return array([])
+        return array(self._global_log_weights)
+
+    def get_global_hypothesis_base_log_weights(self):
+        """Return relative base-model log weights before optional reranking."""
+        if self.get_number_of_global_hypotheses() == 0:
+            return array([])
+        return array(self._global_base_log_weights)
+
+    def refresh_hypothesis_scores(self):
+        """Recompute effective weights after changing a stateful reranker."""
+        self._refresh_effective_log_weights()
+
+    def get_top_hypotheses(
+        self,
+        k=None,
+        copy_hypotheses=True,
+        include_weights=False,
+        include_histories=False,
+    ):
+        """Return the top hypotheses sorted by effective log weight.
+
+        Parameters
+        ----------
+        k : int, optional
+            Maximum number of hypotheses to return. If omitted, all retained
+            hypotheses are returned.
+        copy_hypotheses : bool, default=True
+            Whether to deep-copy the filter banks before returning them.
+        include_weights : bool, default=False
+            If true, return dictionaries with ``weight`` and ``log_weight``.
+        include_histories : bool, default=False
+            If true, include a copy of each hypothesis assignment history.
+        """
+        n_hypotheses = self.get_number_of_global_hypotheses()
+        if n_hypotheses == 0:
+            return []
+        if k is None:
+            k = n_hypotheses
+        order = sorted(
+            range(n_hypotheses),
+            key=lambda index: float(self._global_log_weights[index]),
+            reverse=True,
+        )[: int(k)]
+
+        top_hypotheses = []
+        for index in order:
+            hypothesis = self._global_hypotheses[index]
+            if copy_hypotheses:
+                hypothesis = deepcopy(hypothesis)
+
+            if include_weights or include_histories:
+                record = {"index": index, "hypothesis": hypothesis}
+                if include_weights:
+                    record["weight"] = float(exp(self._global_log_weights[index]))
+                    record["log_weight"] = float(self._global_log_weights[index])
+                    record["base_log_weight"] = float(
+                        self._global_base_log_weights[index]
+                    )
+                if include_histories:
+                    record["history"] = list(
+                        self._global_hypothesis_histories[index]
+                    )
+                top_hypotheses.append(record)
+            else:
+                top_hypotheses.append(hypothesis)
+
+        return top_hypotheses
+
+    def get_best_hypothesis_margin(self):
+        """Return the log-weight gap between the best and second hypothesis."""
+        n_hypotheses = self.get_number_of_global_hypotheses()
+        if n_hypotheses == 0:
+            raise ValueError("Currently, there are zero global hypotheses.")
+        if n_hypotheses == 1:
+            return float("inf")
+        sorted_log_weights = sorted(
+            (float(log_weight) for log_weight in self._global_log_weights),
+            reverse=True,
+        )
+        return sorted_log_weights[0] - sorted_log_weights[1]
+
+    def get_hypothesis_entropy(self):
+        """Return the entropy of the retained effective hypothesis weights."""
+        if self.get_number_of_global_hypotheses() == 0:
+            return 0.0
+        weights = self.get_global_hypothesis_weights()
+        return float(-backend_sum(weights * self._global_log_weights))
+
+    def get_assignment_distribution(self, time_index=None, lag=None):
+        """Return a probability mass function over global assignments.
+
+        Parameters
+        ----------
+        time_index : int, optional
+            Assignment-history index to inspect. Negative values follow Python
+            indexing. If omitted, the latest assignment is used.
+        lag : int, optional
+            Number of scans to look back from the latest assignment. ``lag=0``
+            is the current scan, ``lag=1`` is the previous scan, and so on.
+        """
+        history_index = self._resolve_history_index(time_index=time_index, lag=lag)
+        distribution = {}
+        normalizer = 0.0
+        for weight, history in zip(
+            self.get_global_hypothesis_weights(), self._global_hypothesis_histories
+        ):
+            assignment = tuple(int(value) for value in history[history_index])
+            probability = float(weight)
+            distribution[assignment] = distribution.get(assignment, 0.0) + probability
+            normalizer += probability
+
+        if normalizer > 0.0:
+            distribution = {
+                assignment: probability / normalizer
+                for assignment, probability in distribution.items()
+            }
+        return distribution
+
+    def get_assignment_marginals(self, time_index=None, lag=None):
+        """Return per-track assignment marginals at a history index.
+
+        The result is a list of dictionaries. Entry ``i`` maps measurement
+        indices to probabilities for track ``i``; missed detections use ``-1``.
+        """
+        distribution = self.get_assignment_distribution(time_index=time_index, lag=lag)
+        if not distribution:
+            return []
+
+        n_tracks = len(next(iter(distribution)))
+        marginals = [dict() for _ in range(n_tracks)]
+        for assignment, probability in distribution.items():
+            for track_index, measurement_index in enumerate(assignment):
+                track_marginal = marginals[track_index]
+                track_marginal[measurement_index] = (
+                    track_marginal.get(measurement_index, 0.0) + probability
+                )
+        return marginals
+
+    def get_lagged_assignment_commitment(self, lag=0, mass_threshold=0.9):
+        """Return a delayed whole-assignment commitment if enough mass agrees.
+
+        The returned dictionary always contains the most likely assignment and
+        its probability. The ``assignment`` field is set to that assignment only
+        when its probability is at least ``mass_threshold``; otherwise it is
+        ``None``.
+        """
+        distribution = self.get_assignment_distribution(lag=lag)
+        best_assignment, best_probability = max(
+            distribution.items(), key=lambda item: item[1]
+        )
+        committed_assignment = (
+            best_assignment if best_probability >= mass_threshold else None
+        )
+        return {
+            "assignment": committed_assignment,
+            "best_assignment": best_assignment,
+            "probability": best_probability,
+            "distribution": distribution,
+        }
+
+    def get_track_assignment_commitments(self, lag=0, mass_threshold=0.9):
+        """Return delayed per-track commitments from assignment marginals."""
+        marginals = self.get_assignment_marginals(lag=lag)
+        committed_assignments = []
+        committed_probabilities = []
+        for track_marginal in marginals:
+            best_assignment, best_probability = max(
+                track_marginal.items(), key=lambda item: item[1]
+            )
+            committed_assignments.append(
+                best_assignment if best_probability >= mass_threshold else None
+            )
+            committed_probabilities.append(best_probability)
+        return {
+            "assignments": tuple(committed_assignments),
+            "probabilities": tuple(committed_probabilities),
+            "marginals": marginals,
+        }
+
+    def get_lagged_point_estimate(
+        self, lag=0, hypothesis_index=None, flatten_vector=False, weighted_average=False
+    ):
+        """Return a delayed filtered point estimate selected using current weights.
+
+        The stored filter-bank snapshot at ``lag`` is used, while the hypothesis
+        selection or averaging weights are the current effective hypothesis
+        weights. This provides delayed-decision estimates without forcing an
+        immediate top-1 commitment.
+        """
+        history_index = self._resolve_history_index(lag=lag)
+
+        if weighted_average:
+            all_point_estimates = stack(
+                [
+                    self._point_estimate_from_filter_bank(
+                        filter_bank_history[history_index]
+                    )
+                    for filter_bank_history in self._global_filter_bank_histories
+                ],
+                axis=2,
+            )
+            weights = self.get_global_hypothesis_weights().reshape(1, 1, -1)
+            point_estimate = backend_sum(all_point_estimates * weights, axis=2)
+        else:
+            if hypothesis_index is None:
+                hypothesis_index = self.get_best_hypothesis_index()
+            filter_bank = self._global_filter_bank_histories[int(hypothesis_index)][
+                history_index
+            ]
+            point_estimate = self._point_estimate_from_filter_bank(filter_bank)
+
+        if flatten_vector:
+            point_estimate = point_estimate.flatten()
+        return point_estimate
 
     def get_point_estimate(self, flatten_vector=False, weighted_average=False):
         num_targets = self.get_number_of_targets()
@@ -308,8 +563,9 @@ class MultiHypothesisTracker(AbstractMultitargetTracker):
         base_log_score = self._get_base_log_score(n_meas)
 
         new_hypotheses = []
-        new_log_weights = []
+        new_base_log_weights = []
         new_histories = []
+        new_filter_bank_histories = []
 
         for parent_index, parent_filter_bank in enumerate(self._global_hypotheses):
             candidate_measurements = self._build_candidate_measurements(
@@ -332,16 +588,21 @@ class MultiHypothesisTracker(AbstractMultitargetTracker):
                     cov_mats_meas_np,
                 )
                 new_hypotheses.append(updated_filter_bank)
-                new_log_weights.append(
-                    self._global_log_weights[parent_index] + assignment_log_score
+                new_base_log_weights.append(
+                    self._global_base_log_weights[parent_index] + assignment_log_score
                 )
                 new_histories.append(
                     self._global_hypothesis_histories[parent_index] + [assignment]
                 )
+                new_filter_bank_histories.append(
+                    self._global_filter_bank_histories[parent_index]
+                    + [deepcopy(updated_filter_bank)]
+                )
 
         self._global_hypotheses = new_hypotheses
-        self._global_log_weights = array(new_log_weights)
+        self._global_base_log_weights = array(new_base_log_weights)
         self._global_hypothesis_histories = new_histories
+        self._global_filter_bank_histories = new_filter_bank_histories
 
         self.prune_hypotheses()
 
@@ -352,6 +613,26 @@ class MultiHypothesisTracker(AbstractMultitargetTracker):
         if self.get_number_of_global_hypotheses() == 0:
             return
 
+        self._normalize_base_log_weights()
+        self._refresh_effective_log_weights()
+        surviving_indices = self._select_surviving_indices()
+
+        self._global_hypotheses = [
+            self._global_hypotheses[i] for i in surviving_indices
+        ]
+        self._global_base_log_weights = array(
+            [self._global_base_log_weights[i] for i in surviving_indices]
+        )
+        self._global_hypothesis_histories = [
+            self._global_hypothesis_histories[i] for i in surviving_indices
+        ]
+        self._global_filter_bank_histories = [
+            self._global_filter_bank_histories[i] for i in surviving_indices
+        ]
+        self._normalize_base_log_weights()
+        self._refresh_effective_log_weights()
+
+    def _select_surviving_indices(self):
         max_global_hypotheses = int(self.association_param["max_global_hypotheses"])
         prune_log_weight_delta = float(self.association_param["prune_log_weight_delta"])
 
@@ -368,18 +649,74 @@ class MultiHypothesisTracker(AbstractMultitargetTracker):
         surviving_indices.sort(
             key=lambda i: float(self._global_log_weights[i]), reverse=True
         )
-        surviving_indices = surviving_indices[:max_global_hypotheses]
+        pruning_strategy = str(
+            self.association_param.get("pruning_strategy", "top_k")
+        ).lower()
+        if pruning_strategy in ("diverse", "diverse_top_k"):
+            surviving_indices = self._select_diverse_surviving_indices(
+                surviving_indices, max_global_hypotheses
+            )
+        else:
+            surviving_indices = surviving_indices[:max_global_hypotheses]
 
-        self._global_hypotheses = [
-            self._global_hypotheses[i] for i in surviving_indices
-        ]
-        self._global_log_weights = array(
-            [self._global_log_weights[i] for i in surviving_indices]
+        return surviving_indices
+
+    def _select_diverse_surviving_indices(self, candidate_indices, max_hypotheses):
+        history_length = int(self.association_param.get("diversity_history_length", 3))
+        max_per_signature = self.association_param.get(
+            "max_hypotheses_per_signature", 1
         )
-        self._global_hypothesis_histories = [
-            self._global_hypothesis_histories[i] for i in surviving_indices
-        ]
-        self._normalize_log_weights()
+        if max_per_signature is None:
+            max_per_signature = max_hypotheses
+        max_per_signature = int(max_per_signature)
+        if max_per_signature <= 0:
+            raise ValueError("max_hypotheses_per_signature must be positive")
+
+        selected_indices = []
+        signature_counts = {}
+        for index in candidate_indices:
+            signature = self._hypothesis_signature(index, history_length)
+            signature_counts.setdefault(signature, 0)
+            if signature_counts[signature] >= max_per_signature:
+                continue
+            selected_indices.append(index)
+            signature_counts[signature] += 1
+            if len(selected_indices) >= max_hypotheses:
+                break
+        return selected_indices
+
+    def _hypothesis_signature(self, index, history_length):
+        if self.hypothesis_diversity_key is not None:
+            signature = self.hypothesis_diversity_key(
+                self._global_hypotheses[index],
+                self._global_hypothesis_histories[index],
+            )
+        else:
+            history = self._global_hypothesis_histories[index]
+            if history_length <= 0:
+                signature = tuple(history)
+            else:
+                signature = tuple(history[-history_length:])
+
+        try:
+            hash(signature)
+        except TypeError:
+            signature = repr(signature)
+        return signature
+
+    @staticmethod
+    def _point_estimate_from_filter_bank(filter_bank):
+        return stack(
+            [filter_obj.get_point_estimate() for filter_obj in filter_bank],
+            axis=1,
+        )
+
+    def _normalize_base_log_weights(self):
+        if len(self._global_base_log_weights) == 0:
+            return
+        self._global_base_log_weights = (
+            self._global_base_log_weights - backend_max(self._global_base_log_weights)
+        )
 
     def _normalize_log_weights(self):
         if len(self._global_log_weights) == 0:
@@ -392,6 +729,80 @@ class MultiHypothesisTracker(AbstractMultitargetTracker):
             - backend_log(backend_sum(shifted_weights))
         )
 
+    def _refresh_effective_log_weights(self):
+        if len(self._global_base_log_weights) == 0:
+            self._global_log_weights = array([])
+            return
+
+        score_temperature = float(self.association_param.get("score_temperature", 1.0))
+        if score_temperature <= 0.0:
+            raise ValueError("score_temperature must be positive")
+
+        effective_log_weights = []
+        for index, base_log_weight in enumerate(self._global_base_log_weights):
+            reranker_score = self._score_hypothesis_with_reranker(
+                self._global_hypotheses[index],
+                self._global_hypothesis_histories[index],
+                float(base_log_weight),
+            )
+            effective_log_weights.append(float(base_log_weight) + reranker_score)
+
+        self._global_log_weights = array(effective_log_weights) / score_temperature
+        self._normalize_log_weights()
+
+    def _score_hypothesis_with_reranker(
+        self, filter_bank, assignment_history, base_log_weight
+    ):
+        if self.hypothesis_reranker is None:
+            return 0.0
+        if hasattr(self.hypothesis_reranker, "score"):
+            score = self.hypothesis_reranker.score(
+                filter_bank,
+                assignment_history,
+                base_log_weight,
+            )
+        elif callable(self.hypothesis_reranker):
+            score = self.hypothesis_reranker(
+                filter_bank,
+                assignment_history,
+                base_log_weight,
+            )
+        else:
+            raise ValueError(
+                "hypothesis_reranker must be callable or expose a score method"
+            )
+        return float(score)
+
+    def _resolve_history_index(self, time_index=None, lag=None):
+        if self.get_number_of_global_hypotheses() == 0:
+            raise ValueError("Currently, there are zero global hypotheses.")
+        if not self._global_hypothesis_histories or len(
+            self._global_hypothesis_histories[0]
+        ) == 0:
+            raise ValueError("No assignment history is available yet.")
+
+        history_length = len(self._global_hypothesis_histories[0])
+        if not builtins.all(
+            len(history) == history_length
+            for history in self._global_hypothesis_histories
+        ):
+            raise ValueError("All hypotheses must have assignment histories of equal length")
+
+        if lag is not None:
+            if time_index is not None:
+                raise ValueError("Specify either time_index or lag, not both")
+            if lag < 0:
+                raise ValueError("lag must be non-negative")
+            resolved_index = history_length - 1 - int(lag)
+        else:
+            resolved_index = -1 if time_index is None else int(time_index)
+            if resolved_index < 0:
+                resolved_index += history_length
+
+        if resolved_index < 0 or resolved_index >= history_length:
+            raise IndexError("Requested assignment history index is out of range")
+        return resolved_index
+
     def _get_base_log_score(self, n_meas):
         eps = 1.0e-12
         detection_probability = min(
@@ -400,10 +811,14 @@ class MultiHypothesisTracker(AbstractMultitargetTracker):
         )
         clutter_intensity = max(float(self.association_param["clutter_intensity"]), eps)
         missed_detection_probability = 1.0 - detection_probability
+        missed_detection_weight = float(
+            self.association_param.get("missed_detection_log_weight", 1.0)
+        )
+        clutter_weight = float(self.association_param.get("clutter_log_weight", 1.0))
 
         n_tracks = self.get_number_of_targets()
-        return n_meas * log(clutter_intensity) + n_tracks * log(
-            missed_detection_probability
+        return n_meas * clutter_weight * log(clutter_intensity) + n_tracks * (
+            missed_detection_weight * log(missed_detection_probability)
         )
 
     def _build_candidate_measurements(  # pylint: disable=too-many-locals
@@ -424,6 +839,16 @@ class MultiHypothesisTracker(AbstractMultitargetTracker):
         )
         clutter_intensity = max(float(self.association_param["clutter_intensity"]), eps)
         missed_detection_probability = 1.0 - detection_probability
+        measurement_weight = float(
+            self.association_param.get("measurement_log_likelihood_weight", 1.0)
+        )
+        detection_weight = float(
+            self.association_param.get("detection_log_weight", 1.0)
+        )
+        missed_detection_weight = float(
+            self.association_param.get("missed_detection_log_weight", 1.0)
+        )
+        clutter_weight = float(self.association_param.get("clutter_log_weight", 1.0))
 
         gating_distance_threshold = self.association_param["gating_distance_threshold"]
         if gating_distance_threshold is None:
@@ -459,10 +884,10 @@ class MultiHypothesisTracker(AbstractMultitargetTracker):
                     gating_distance = sqrt(gating_distance)
                 if gating_distance <= gating_distance_threshold:
                     gain = (
-                        log(detection_probability)
-                        + log_likelihood
-                        - log(missed_detection_probability)
-                        - log(clutter_intensity)
+                        detection_weight * log(detection_probability)
+                        + measurement_weight * log_likelihood
+                        - missed_detection_weight * log(missed_detection_probability)
+                        - clutter_weight * log(clutter_intensity)
                     )
                     track_candidates.append((j, gain))
 

--- a/src/pyrecest/filters/multi_hypothesis_tracker.py
+++ b/src/pyrecest/filters/multi_hypothesis_tracker.py
@@ -782,7 +782,7 @@ class MultiHypothesisTracker(AbstractMultitargetTracker):
             raise ValueError("No assignment history is available yet.")
 
         history_length = len(self._global_hypothesis_histories[0])
-        if not builtins.all(
+        if not builtin_all(
             len(history) == history_length
             for history in self._global_hypothesis_histories
         ):

--- a/tests/distributions/test_multi_hypothesis_tracker.py
+++ b/tests/distributions/test_multi_hypothesis_tracker.py
@@ -6,7 +6,9 @@ import numpy.testing as npt
 import pyrecest.backend
 from pyrecest.backend import array, eye, log
 from pyrecest.distributions import GaussianDistribution
-from pyrecest.filters import KalmanFilter, MultiHypothesisTracker
+from pyrecest.filters import KalmanFilter
+from pyrecest.filters import MultiHypothesisTracker as ExportedMultiHypothesisTracker
+from pyrecest.filters.multi_hypothesis_tracker import MultiHypothesisTracker
 
 
 @unittest.skipIf(
@@ -30,6 +32,9 @@ class MultiHypothesisTrackerTest(unittest.TestCase):
             "clutter_intensity": 1.0e-6,
         }
 
+    def test_filter_namespace_exports_multi_hypothesis_tracker(self):
+        self.assertIs(ExportedMultiHypothesisTracker, MultiHypothesisTracker)
+
     def test_setting_state_sets_single_global_hypothesis(self):
         tracker = MultiHypothesisTracker(
             association_param=self.association_param,
@@ -43,7 +48,7 @@ class MultiHypothesisTrackerTest(unittest.TestCase):
         self.assertEqual(tracker.get_point_estimate().shape, (2, 2))
         self.assertEqual(tracker.get_point_estimate(True).shape, (4,))
 
-    def test_setting_gaussian_states_wraps_them_in_kalman_filters(self):
+    def test_setting_gaussian_states_wraps_kalman_filters(self):
         tracker = MultiHypothesisTracker(
             association_param=self.association_param,
             log_prior_estimates=False,
@@ -51,33 +56,27 @@ class MultiHypothesisTrackerTest(unittest.TestCase):
         )
         tracker.filter_state = [
             GaussianDistribution(array([0.0, 0.0]), eye(2)),
-            GaussianDistribution(array([1.0, 0.0]), eye(2)),
+            GaussianDistribution(array([10.0, 0.0]), eye(2)),
         ]
 
-        self.assertTrue(
-            all(
-                isinstance(filter_obj, KalmanFilter)
-                for filter_obj in tracker.filter_bank
-            )
-        )
+        self.assertEqual(tracker.get_number_of_targets(), 2)
+        self.assertIsInstance(tracker.filter_bank[0], KalmanFilter)
         npt.assert_allclose(
-            tracker.get_point_estimate(),
-            array([[0.0, 1.0], [0.0, 0.0]]),
+            tracker.get_point_estimate(), array([[0.0, 10.0], [0.0, 0.0]])
         )
 
-    def test_rejects_global_hypotheses_with_inconsistent_track_counts(self):
+    def test_setting_inconsistent_global_hypotheses_raises(self):
         tracker = MultiHypothesisTracker(
             log_prior_estimates=False,
             log_posterior_estimates=False,
         )
-
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "same number of tracks"):
             tracker.set_global_hypotheses(
                 [
                     [KalmanFilter(GaussianDistribution(array([0.0, 0.0]), eye(2)))],
                     [
+                        KalmanFilter(GaussianDistribution(array([0.0, 0.0]), eye(2))),
                         KalmanFilter(GaussianDistribution(array([1.0, 0.0]), eye(2))),
-                        KalmanFilter(GaussianDistribution(array([2.0, 0.0]), eye(2))),
                     ],
                 ]
             )
@@ -142,6 +141,25 @@ class MultiHypothesisTrackerTest(unittest.TestCase):
         for filter_state in tracker.filter_state:
             npt.assert_allclose(filter_state.C, 0.5 * eye(2), atol=1.0e-12)
 
+    def test_update_accepts_array_like_inputs(self):
+        tracker = MultiHypothesisTracker(
+            association_param=self.association_param,
+            log_prior_estimates=False,
+            log_posterior_estimates=False,
+        )
+        tracker.filter_state = self.kfs_init
+
+        tracker.update_linear(
+            [[9.9, 0.1], [0.2, -0.1]],
+            [[1.0, 0.0], [0.0, 1.0]],
+            [[1.0, 0.0], [0.0, 1.0]],
+        )
+
+        best_history = tracker.global_hypothesis_histories[
+            tracker.get_best_hypothesis_index()
+        ][-1]
+        self.assertEqual(best_history, (1, 0))
+
     def test_update_with_no_measurements_keeps_state(self):
         tracker = MultiHypothesisTracker(
             association_param=self.association_param,
@@ -162,6 +180,112 @@ class MultiHypothesisTrackerTest(unittest.TestCase):
         )
         for filter_state in tracker.filter_state:
             npt.assert_allclose(filter_state.C, eye(2), atol=1.0e-12)
+
+    def test_assignment_marginals_and_lagged_commitment(self):
+        tracker = MultiHypothesisTracker(
+            association_param=self.association_param,
+            log_prior_estimates=False,
+            log_posterior_estimates=False,
+        )
+        tracker.filter_state = self.kfs_init
+        tracker.update_linear(array([[9.9, 0.1], [0.2, -0.1]]), self.meas_mat, self.meas_noise)
+
+        distribution = tracker.get_assignment_distribution(lag=0)
+        self.assertAlmostEqual(sum(distribution.values()), 1.0)
+        self.assertGreater(distribution[(1, 0)], 0.99)
+
+        marginals = tracker.get_assignment_marginals(lag=0)
+        self.assertGreater(marginals[0][1], 0.99)
+        self.assertGreater(marginals[1][0], 0.99)
+
+        commitment = tracker.get_lagged_assignment_commitment(lag=0, mass_threshold=0.9)
+        self.assertEqual(commitment["assignment"], (1, 0))
+        self.assertGreater(commitment["probability"], 0.99)
+
+        track_commitment = tracker.get_track_assignment_commitments(
+            lag=0, mass_threshold=0.9
+        )
+        self.assertEqual(track_commitment["assignments"], (1, 0))
+        npt.assert_allclose(
+            tracker.get_lagged_point_estimate(lag=0),
+            tracker.get_point_estimate(),
+        )
+        self.assertGreater(tracker.get_best_hypothesis_margin(), 0.0)
+        self.assertGreaterEqual(tracker.get_hypothesis_entropy(), 0.0)
+
+    def test_hypothesis_reranker_can_lift_non_top_branch(self):
+        def prefer_identity_assignment(_filter_bank, assignment_history, _base_log_weight):
+            if assignment_history and assignment_history[-1] == (0, 1):
+                return 100.0
+            return 0.0
+
+        tracker = MultiHypothesisTracker(
+            association_param={
+                **self.association_param,
+                "max_hypotheses_per_global_hypothesis": 10,
+            },
+            log_prior_estimates=False,
+            log_posterior_estimates=False,
+            hypothesis_reranker=prefer_identity_assignment,
+        )
+        tracker.filter_state = self.kfs_init
+        tracker.update_linear(array([[9.9, 0.1], [0.2, -0.1]]), self.meas_mat, self.meas_noise)
+
+        best_history = tracker.global_hypothesis_histories[
+            tracker.get_best_hypothesis_index()
+        ][-1]
+        self.assertEqual(best_history, (0, 1))
+        self.assertEqual(
+            tracker.get_top_hypotheses(1, include_weights=True, include_histories=True)[0][
+                "history"
+            ][-1],
+            (0, 1),
+        )
+
+    def test_score_temperature_softens_effective_weights(self):
+        tracker_cold = MultiHypothesisTracker(
+            association_param={**self.association_param, "score_temperature": 1.0},
+            log_prior_estimates=False,
+            log_posterior_estimates=False,
+        )
+        tracker_warm = MultiHypothesisTracker(
+            association_param={**self.association_param, "score_temperature": 5.0},
+            log_prior_estimates=False,
+            log_posterior_estimates=False,
+        )
+        for tracker in (tracker_cold, tracker_warm):
+            tracker.filter_state = self.kfs_init
+            tracker.update_linear(
+                array([[9.9, 0.1], [0.2, -0.1]]),
+                self.meas_mat,
+                self.meas_noise,
+            )
+
+        self.assertGreater(
+            tracker_warm.get_hypothesis_entropy(),
+            tracker_cold.get_hypothesis_entropy(),
+        )
+
+    def test_diverse_pruning_keeps_distinct_recent_assignment_signatures(self):
+        tracker = MultiHypothesisTracker(
+            association_param={
+                **self.association_param,
+                "max_global_hypotheses": 2,
+                "pruning_strategy": "diverse_top_k",
+                "diversity_history_length": 1,
+                "max_hypotheses_per_signature": 1,
+            },
+            log_prior_estimates=False,
+            log_posterior_estimates=False,
+        )
+        tracker.filter_state = self.kfs_init
+        tracker.update_linear(array([[9.9, 0.1], [0.2, -0.1]]), self.meas_mat, self.meas_noise)
+
+        signatures = {
+            tuple(history[-1:]) for history in tracker.global_hypothesis_histories
+        }
+        self.assertEqual(len(signatures), tracker.get_number_of_global_hypotheses())
+        self.assertLessEqual(tracker.get_number_of_global_hypotheses(), 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add delayed-decision and marginal-history utilities to the multi-hypothesis tracker
- expose the tracker through the lazy filters API
- document the tracker API and add focused MHT regression coverage

## Validation
- `git diff --check`
- conflict-marker scan with `rg`
- `python -m py_compile` on changed Python files

Note: full test suites were not run per request.