### PR TITLE
Fix time-offset calibration aggregation

### DIFF
--- a/src/pyrecest/calibration/time_offset.py
+++ b/src/pyrecest/calibration/time_offset.py
@@ -61,17 +61,21 @@ def apply_time_offset(times_s: np.ndarray, offset_s: float | None) -> np.ndarray
 def nearest_time_indices(
     reference_times_s: np.ndarray, query_times_s: np.ndarray
 ) -> np.ndarray:
-    """Return indices of nearest reference times for each query time."""
+    """Return original indices of nearest reference times for each query time."""
 
     reference = np.asarray(reference_times_s, dtype=float).reshape(-1)
     query = np.asarray(query_times_s, dtype=float).reshape(-1)
     if reference.size == 0:
         raise ValueError("reference_times_s must not be empty")
-    insertion = np.searchsorted(reference, query)
-    right = np.clip(insertion, 0, reference.size - 1)
-    left = np.clip(insertion - 1, 0, reference.size - 1)
-    use_right = np.abs(reference[right] - query) < np.abs(reference[left] - query)
-    return np.where(use_right, right, left)
+    order = np.argsort(reference)
+    sorted_reference = reference[order]
+    insertion = np.searchsorted(sorted_reference, query)
+    right = np.clip(insertion, 0, sorted_reference.size - 1)
+    left = np.clip(insertion - 1, 0, sorted_reference.size - 1)
+    use_right = np.abs(sorted_reference[right] - query) < np.abs(
+        sorted_reference[left] - query
+    )
+    return order[np.where(use_right, right, left)]
 
 
 def interpolate_reference_values(
@@ -227,18 +231,26 @@ def aggregate_time_offset_sweeps(
         )
         total = float(np.sum(counts))
         row = {"time_offset_s": float(offset), "count": total}
-        for key in ("mean", "rmse", "p95", "max", metric):
+        for key in dict.fromkeys(("mean", "rmse", "p95", "max", metric)):
             values = np.array(
                 [float(part.get(key, np.nan)) for part in parts], dtype=float
             )
-            valid = np.isfinite(values) & (counts > 0.0)
-            row[key] = (
-                float(np.average(values[valid], weights=counts[valid]))
-                if valid.any()
-                else float("nan")
-            )
+            row[key] = _aggregate_summary_metric(key, values, counts)
         rows.append(row)
     return rows
+
+
+def _aggregate_summary_metric(
+    key: str, values: np.ndarray, counts: np.ndarray
+) -> float:
+    valid = np.isfinite(values) & (counts > 0.0)
+    if not valid.any():
+        return float("nan")
+    if key == "rmse":
+        return float(np.sqrt(np.average(values[valid] ** 2, weights=counts[valid])))
+    if key == "max":
+        return float(np.max(values[valid]))
+    return float(np.average(values[valid], weights=counts[valid]))
 
 
 def _error_stats(

--- a/tests/calibration/test_time_offset_bias.py
+++ b/tests/calibration/test_time_offset_bias.py
@@ -7,9 +7,11 @@ from pyrecest.calibration.bias import (
     make_bias_training_examples,
 )
 from pyrecest.calibration.time_offset import (
+    aggregate_time_offset_sweeps,
     apply_time_offset,
     fit_time_offset,
     make_offset_grid,
+    nearest_time_indices,
     time_offset_error_summary,
 )
 
@@ -24,6 +26,45 @@ class TimeOffsetCalibrationTest(unittest.TestCase):
         npt.assert_allclose(
             apply_time_offset(np.array([1.0, 2.0]), 0.5), np.array([1.5, 2.5])
         )
+
+    def test_nearest_time_indices_accepts_unsorted_reference_times(self):
+        indices = nearest_time_indices(
+            np.array([10.0, 0.0, 5.0]), np.array([0.2, 7.0, 9.0])
+        )
+
+        npt.assert_array_equal(indices, np.array([1, 2, 0]))
+
+    def test_aggregate_time_offset_sweeps_preserves_rmse_and_max_semantics(self):
+        aggregated = aggregate_time_offset_sweeps(
+            [
+                [
+                    {
+                        "time_offset_s": 0.0,
+                        "count": 1.0,
+                        "mean": 1.0,
+                        "rmse": 3.0,
+                        "p95": 3.0,
+                        "max": 3.0,
+                    }
+                ],
+                [
+                    {
+                        "time_offset_s": 0.0,
+                        "count": 3.0,
+                        "mean": 2.0,
+                        "rmse": 4.0,
+                        "p95": 4.0,
+                        "max": 7.0,
+                    }
+                ],
+            ]
+        )
+
+        self.assertEqual(len(aggregated), 1)
+        self.assertEqual(aggregated[0]["count"], 4.0)
+        self.assertAlmostEqual(aggregated[0]["mean"], 1.75)
+        self.assertAlmostEqual(aggregated[0]["rmse"], np.sqrt(57.0 / 4.0))
+        self.assertEqual(aggregated[0]["max"], 7.0)
 
     def test_fit_time_offset_recovers_known_shift(self):
         reference_times = np.linspace(0.0, 10.0, 101)


### PR DESCRIPTION
## Summary
- make nearest-time lookup robust to unsorted reference timestamps
- preserve RMSE and max semantics when aggregating time-offset sweeps
- add calibration regression coverage for the fixed cases

## Validation
- git diff --check
- conflict marker scan
- python -m py_compile on changed Python files

Full test suites were not run, per request.