### PR TITLE
Fix hypertoroidal wrapped-normal input edge cases

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_wrapped_normal_distribution.py
@@ -7,7 +7,6 @@ from pyrecest.backend import (
     allclose,
     arange,
     array,
-    atleast_2d,
     exp,
     int32,
     int64,
@@ -37,6 +36,30 @@ def _as_2d_covariance(C):
     if C.ndim == 0:
         C = C.reshape((1, 1))
     return C
+
+
+def _as_2d_points(xs, dim):
+    """Return evaluation points as an ``(n, dim)`` array.
+
+    A one-dimensional wrapped normal is often called with scalar values or with
+    a plain one-dimensional list of sample locations.  Those inputs previously
+    reached ``xs.shape[-1]`` before array coercion and therefore failed with an
+    ``AttributeError`` or ``IndexError`` instead of being evaluated.
+    """
+    xs = array(xs)
+    if xs.ndim == 0:
+        if dim != 1:
+            raise ValueError(f"Scalar evaluation points are only valid for dim=1, got dim={dim}.")
+        return xs.reshape((1, 1))
+    if xs.ndim == 1:
+        if dim == 1:
+            return xs.reshape((-1, 1))
+        if xs.shape[0] != dim:
+            raise ValueError(f"One-dimensional point input must have shape ({dim},), got {xs.shape}.")
+        return xs.reshape((1, dim))
+    if xs.ndim != 2 or xs.shape[-1] != dim:
+        raise ValueError(f"Evaluation points must have shape (n, {dim}), got {xs.shape}.")
+    return xs
 
 
 class HypertoroidalWrappedNormalDistribution(AbstractHypertoroidalDistribution):
@@ -82,11 +105,8 @@ class HypertoroidalWrappedNormalDistribution(AbstractHypertoroidalDistribution):
         :param m: Controls the number of terms in the Fourier series approximation.
         :return: PDF values at xs.
         """
-        assert (
-            xs.shape[-1] == self.dim
-        ), "Last dimension of xs must match the distribution dimension"
-        xs = atleast_2d(xs)  # Ensure xs is at least 2-D for approach below
-        xs = (xs + pi) % (2 * pi) - pi
+        xs = _as_2d_points(xs, self.dim)
+        xs = mod(xs + pi, 2 * pi) - pi
 
         # Generate all combinations of offsets for each dimension
         offsets = [arange(-m, m + 1) * 2.0 * pi for _ in range(self.dim)]
@@ -112,6 +132,7 @@ class HypertoroidalWrappedNormalDistribution(AbstractHypertoroidalDistribution):
         :raises AssertionError: If shape of shift_by does not match the dimension of the distribution.
         :return: Shifted distribution.
         """
+        shift_by = _as_1d_mu(shift_by)
         assert shift_by.shape == (self.dim,)
 
         return self.set_mean(self.mu + shift_by)
@@ -144,7 +165,7 @@ class HypertoroidalWrappedNormalDistribution(AbstractHypertoroidalDistribution):
         m = _as_1d_mu(m)
         assert m.shape == (self.dim,), "m must be of shape (dim,)"
         dist = copy.deepcopy(self)
-        dist.mu = m
+        dist.mu = mod(m, 2.0 * pi)
         return dist
 
     def trigonometric_moment(self, n):

--- a/tests/distributions/test_hypertoroidal_wrapped_normal_distribution.py
+++ b/tests/distributions/test_hypertoroidal_wrapped_normal_distribution.py
@@ -34,6 +34,27 @@ class TestHypertoroidalWNDistribution(unittest.TestCase):
             dist.trigonometric_moment(1), exp(1j * array([0.3]) - 0.7 / 2)
         )
 
+    def test_scalar_pdf_accepts_scalar_and_plain_sequence_inputs(self):
+        dist = HypertoroidalWNDistribution(0.3, 0.7)
+
+        scalar_pdf = dist.pdf(0.2)
+        list_pdf = dist.pdf([0.2, 0.4])
+        matrix_pdf = dist.pdf(array([[0.2], [0.4]]))
+
+        self.assertEqual(scalar_pdf.shape, (1,))
+        self.assertEqual(list_pdf.shape, (2,))
+        npt.assert_allclose(list_pdf, matrix_pdf)
+        npt.assert_allclose(scalar_pdf, matrix_pdf[:1])
+
+    def test_vector_pdf_accepts_single_point_sequence(self):
+        dist = HypertoroidalWNDistribution(array([0.3, 0.4]), array([[0.7, 0.0], [0.0, 0.5]]))
+
+        one_point_pdf = dist.pdf([0.2, 0.5])
+        matrix_pdf = dist.pdf(array([[0.2, 0.5]]))
+
+        self.assertEqual(one_point_pdf.shape, (1,))
+        npt.assert_allclose(one_point_pdf, matrix_pdf)
+
     def test_shift_returns_copy_without_mutating_original(self):
         mu = array([1.0, 2.0])
         C = array([[0.5, 0.1], [0.1, 0.6]])
@@ -46,6 +67,22 @@ class TestHypertoroidalWNDistribution(unittest.TestCase):
         npt.assert_allclose(dist.mu, mu)
         npt.assert_allclose(shifted.mu, mod(mu + shift_by, 2.0 * pi))
         npt.assert_allclose(shifted.C, dist.C)
+
+    def test_scalar_shift_accepts_python_scalar(self):
+        dist = HypertoroidalWNDistribution(0.3, 0.7)
+
+        shifted = dist.shift(0.5)
+
+        npt.assert_allclose(shifted.mu, array([0.8]))
+        npt.assert_allclose(dist.mu, array([0.3]))
+
+    def test_set_mode_wraps_to_fundamental_domain(self):
+        dist = HypertoroidalWNDistribution(array([0.3, 0.4]), array([[0.7, 0.0], [0.0, 0.5]]))
+
+        updated = dist.set_mode(array([2.0 * pi + 0.1, -0.2]))
+
+        npt.assert_allclose(updated.mu, mod(array([0.1, -0.2]), 2.0 * pi))
+        npt.assert_allclose(dist.mu, array([0.3, 0.4]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- coerce hypertoroidal wrapped-normal PDF inputs before shape validation so scalar/list inputs work for 1-D distributions
- allow scalar `shift_by` values for 1-D wrapped-normal shifts
- wrap `set_mode` results into the fundamental domain, matching constructor and `set_mean` behavior
- add regression coverage for scalar/list PDF inputs, single vector points, scalar shifts, and mode wrapping

## Validation
- connector compare: branch is ahead of `main` by 2 commits and modifies only the distribution plus focused tests
- full local test execution was not possible because the execution sandbox cannot clone GitHub; PR CI should run the suite