### PR TITLE
Fix backend meshgrid array-like coercion

### DIFF
--- a/src/pyrecest/_backend/__init__.py
+++ b/src/pyrecest/_backend/__init__.py
@@ -10,6 +10,7 @@ import logging
 import os
 import sys
 import types
+from functools import wraps
 
 import pyrecest._backend._common as common
 
@@ -283,6 +284,17 @@ for _module_name, _attributes in BACKEND_ATTRIBUTES.items():
     BACKEND_ATTRIBUTES[_module_name] = _deduplicated_attributes(_attributes)
 
 
+def _meshgrid_with_arraylike_axes(meshgrid_func, asarray_func, atleast_1d_func):
+    """Return a NumPy-compatible meshgrid wrapper for stricter backends."""
+
+    @wraps(meshgrid_func)
+    def meshgrid(*axes, **kwargs):
+        coerced_axes = [atleast_1d_func(asarray_func(axis)) for axis in axes]
+        return meshgrid_func(*coerced_axes, **kwargs)
+
+    return meshgrid
+
+
 class BackendImporter(importlib.abc.MetaPathFinder, importlib.abc.Loader):
     """
     Meta path finder and loader for dynamically creating backend modules.
@@ -347,6 +359,16 @@ class BackendImporter(importlib.abc.MetaPathFinder, importlib.abc.Loader):
                             f"attribute '{attribute_name}'."
                         ) from None
                 else:
+                    if (
+                        module_name == ""
+                        and attribute_name == "meshgrid"
+                        and backend_name in {"jax", "pytorch"}
+                    ):
+                        attribute = _meshgrid_with_arraylike_axes(
+                            attribute,
+                            getattr(backend, "asarray"),
+                            getattr(backend, "atleast_1d"),
+                        )
                     setattr(new_submodule, attribute_name, attribute)
 
         return new_module

--- a/tests/test_backend_meshgrid_contract.py
+++ b/tests/test_backend_meshgrid_contract.py
@@ -1,0 +1,22 @@
+import pyrecest.backend as backend
+
+
+def _to_python(value):
+    value = backend.to_numpy(value)
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    return value
+
+
+def test_meshgrid_accepts_numpy_style_array_like_axes():
+    rows, cols = backend.meshgrid([0, 1], range(2), indexing="ij")
+
+    assert _to_python(rows) == [[0, 0], [1, 1]]
+    assert _to_python(cols) == [[0, 1], [0, 1]]
+
+
+def test_meshgrid_accepts_scalar_axes():
+    rows, cols = backend.meshgrid(1, [2, 3], indexing="ij")
+
+    assert _to_python(rows) == [[1, 1]]
+    assert _to_python(cols) == [[2, 3]]


### PR DESCRIPTION
## Summary
- wrap the backend facade `meshgrid` for JAX and PyTorch so array-like and scalar axes are coerced via `asarray` + `atleast_1d`
- keep NumPy behavior unchanged while making stricter backends match NumPy's permissive `meshgrid` contract
- add focused regression coverage for list/range/scalar meshgrid axes

## Validation
- reproduced the raw JAX/PyTorch failures locally with `meshgrid([0, 1], range(2), indexing="ij")`
- compared branch against `main`: 2 commits ahead, 0 behind

Full project tests were not run because this execution environment cannot resolve `github.com` to clone the repository.