### PR TITLE
Fix wrapped-normal input edge cases

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
@@ -119,29 +119,29 @@ class WrappedNormalDistribution(
             tmp = -1.0 / (2.0 * sigma**2)
             nc = 1.0 / (sqrt(2.0 * pi) * sigma)
 
-            def wrapped_addendum(i):
+            def body_fun(val):
+                i, result, _last_increment = val
                 xp = x + 2 * pi * i
                 xm = x - 2 * pi * i
                 tp = xp * xp * tmp
                 tm = xm * xm * tmp
-                return exp(tp) + exp(tm)
-
-            def body_fun(val):
-                i, result = val
-                return (i + 1, result + wrapped_addendum(i))
+                increment = exp(tp) + exp(tm)
+                new_result = result + increment
+                return (i + 1, new_result, increment)
 
             def cond_fun(val):
-                i, result = val
-                # Continue while the next pair of wrapped terms would change
-                # at least one accumulated density value.
-                new_result = result + wrapped_addendum(i)
-                return logical_and(any(new_result != result), i <= max_iterations)
+                i, _result, last_increment = val
+                # The accumulated density is positive and may keep changing by
+                # tiny floating-point amounts for a long time. Stop based on the
+                # latest wrapped contribution instead.
+                return logical_and(any(last_increment > 1e-10), i <= max_iterations)
 
             initial_val = (
                 1,
                 exp(x * x * tmp),
+                ones(x.shape) * float("inf"),
             )
-            _, result = lax.while_loop(cond_fun, body_fun, initial_val)
+            _, result, _last_increment = lax.while_loop(cond_fun, body_fun, initial_val)
 
             result *= nc
 
@@ -246,6 +246,7 @@ class WrappedNormalDistribution(
         return CircularDiracDistribution(samples, weights)
 
     def shift(self, shift_by):
+        shift_by = array(shift_by)
         assert shift_by.shape in ((1,), ())
         return WrappedNormalDistribution(self.scalar_mu + squeeze(shift_by), self.sigma)
 

--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_wrapped_normal_distribution.py
@@ -7,7 +7,6 @@ from pyrecest.backend import (
     allclose,
     arange,
     array,
-    atleast_2d,
     exp,
     int32,
     int64,
@@ -16,6 +15,7 @@ from pyrecest.backend import (
     mod,
     pi,
     random,
+    reshape,
     stack,
     zeros,
 )
@@ -37,6 +37,28 @@ def _as_2d_covariance(C):
     if C.ndim == 0:
         C = C.reshape((1, 1))
     return C
+
+
+def _as_2d_query_points(xs, dim: int):
+    """Normalize scalar/vector/matrix query inputs to shape ``(n_eval, dim)``."""
+    xs = array(xs)
+    if xs.ndim == 0:
+        if dim != 1:
+            raise ValueError(
+                f"Scalar query points are only valid for one-dimensional distributions, got dim={dim}."
+            )
+        return reshape(xs, (1, 1))
+
+    if xs.ndim == 1:
+        if dim == 1:
+            return reshape(xs, (-1, 1))
+        if xs.shape[0] == dim:
+            return reshape(xs, (1, dim))
+        raise ValueError(f"Last dimension of xs must match the distribution dimension {dim}, got shape {xs.shape}.")
+
+    if xs.shape[-1] != dim:
+        raise ValueError(f"Last dimension of xs must match the distribution dimension {dim}, got shape {xs.shape}.")
+    return reshape(xs, (-1, dim))
 
 
 class HypertoroidalWrappedNormalDistribution(AbstractHypertoroidalDistribution):
@@ -82,10 +104,7 @@ class HypertoroidalWrappedNormalDistribution(AbstractHypertoroidalDistribution):
         :param m: Controls the number of terms in the Fourier series approximation.
         :return: PDF values at xs.
         """
-        assert (
-            xs.shape[-1] == self.dim
-        ), "Last dimension of xs must match the distribution dimension"
-        xs = atleast_2d(xs)  # Ensure xs is at least 2-D for approach below
+        xs = _as_2d_query_points(xs, self.dim)
         xs = (xs + pi) % (2 * pi) - pi
 
         # Generate all combinations of offsets for each dimension
@@ -112,6 +131,7 @@ class HypertoroidalWrappedNormalDistribution(AbstractHypertoroidalDistribution):
         :raises AssertionError: If shape of shift_by does not match the dimension of the distribution.
         :return: Shifted distribution.
         """
+        shift_by = _as_1d_mu(shift_by)
         assert shift_by.shape == (self.dim,)
 
         return self.set_mean(self.mu + shift_by)

--- a/tests/distributions/test_hypertoroidal_wrapped_normal_distribution.py
+++ b/tests/distributions/test_hypertoroidal_wrapped_normal_distribution.py
@@ -22,6 +22,24 @@ class TestHypertoroidalWNDistribution(unittest.TestCase):
         )
         npt.assert_allclose(pdf_values, expected_values, rtol=2e-6)
 
+    def test_pdf_accepts_python_sequence_parameters_and_query_points(self):
+        dist = HypertoroidalWNDistribution([1.0, 2.0], [[0.5, 0.1], [0.1, 0.3]])
+
+        query_points = [[1.0, 2.0], [1.1, 2.1]]
+
+        npt.assert_allclose(dist.pdf(query_points), dist.pdf(array(query_points)))
+
+    def test_pdf_interprets_one_dimensional_sequences_as_multiple_scalar_points(self):
+        dist = HypertoroidalWNDistribution(0.3, 0.7)
+
+        query_points = [0.1, 0.2, 0.3]
+        expected_points = array([[0.1], [0.2], [0.3]])
+
+        values = dist.pdf(query_points)
+
+        self.assertEqual(values.shape, (3,))
+        npt.assert_allclose(values, dist.pdf(expected_points))
+
     def test_scalar_parameters_are_stored_as_vector_and_matrix(self):
         dist = HypertoroidalWNDistribution(array(0.3), array(0.7))
 
@@ -46,6 +64,16 @@ class TestHypertoroidalWNDistribution(unittest.TestCase):
         npt.assert_allclose(dist.mu, mu)
         npt.assert_allclose(shifted.mu, mod(mu + shift_by, 2.0 * pi))
         npt.assert_allclose(shifted.C, dist.C)
+
+    def test_shift_accepts_plain_python_sequences(self):
+        mu = array([1.0, 2.0])
+        C = array([[0.5, 0.1], [0.1, 0.6]])
+        dist = HypertoroidalWNDistribution(mu, C)
+
+        shifted = dist.shift([0.25, -0.5])
+
+        npt.assert_allclose(shifted.mu, mod(mu + array([0.25, -0.5]), 2.0 * pi))
+        npt.assert_allclose(dist.mu, mu)
 
 
 if __name__ == "__main__":

--- a/tests/distributions/test_wrapped_normal_distribution.py
+++ b/tests/distributions/test_wrapped_normal_distribution.py
@@ -147,6 +147,16 @@ class WrappedNormalDistributionTest(unittest.TestCase):
         self.assertTrue(allclose(convolved.C, array(13.0), atol=1e-12))
         self.assertTrue(allclose(convolved.sigma, sqrt(array(13.0)), atol=1e-12))
 
+    def test_shift_accepts_scalar_and_singleton_sequence_inputs(self):
+        dist = WrappedNormalDistribution(array(0.3), array(0.4))
+
+        scalar_shifted = dist.shift(0.2)
+        sequence_shifted = dist.shift([0.2])
+
+        self.assertTrue(allclose(scalar_shifted.scalar_mu, array(0.5), atol=1e-12))
+        self.assertTrue(allclose(sequence_shifted.scalar_mu, array(0.5), atol=1e-12))
+        self.assertTrue(allclose(scalar_shifted.sigma, dist.sigma, atol=1e-12))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- normalize hypertoroidal wrapped-normal query points before checking shape, so Python sequences and scalar 1-D queries are accepted consistently
- coerce hypertoroidal and circular `shift()` inputs before inspecting `.shape`
- stop the circular wrapped-normal JAX PDF loop based on the latest wrapped contribution instead of accumulated density changes
- add regression tests for sequence/scalar inputs and scalar shifts

## Validation
- connector diff check: branch is 4 commits ahead of `main`, 0 behind, with changes limited to the two wrapped-normal implementations and their tests

Note: I could not run the full local test suite in this sandbox because direct GitHub checkout failed due DNS resolution, so validation was limited to connector diff inspection.