### PR TITLE
Fix robust hypertoroidal scalar/list inputs

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
@@ -24,6 +24,7 @@ from pyrecest.backend import (
 )
 from scipy.special import erf  # pylint: disable=no-name-in-module
 
+from ..hypertorus._input_validation import as_shift_vector
 from ..hypertorus.hypertoroidal_wrapped_normal_distribution import (
     HypertoroidalWrappedNormalDistribution,
 )
@@ -246,8 +247,8 @@ class WrappedNormalDistribution(
         return CircularDiracDistribution(samples, weights)
 
     def shift(self, shift_by):
-        assert shift_by.shape in ((1,), ())
-        return WrappedNormalDistribution(self.scalar_mu + squeeze(shift_by), self.sigma)
+        shift_by = as_shift_vector(shift_by, 1)
+        return WrappedNormalDistribution(self.scalar_mu + shift_by[0], self.sigma)
 
     def to_vm(self) -> VonMisesDistribution:
         # Convert to Von Mises distribution

--- a/src/pyrecest/distributions/hypertorus/_input_validation.py
+++ b/src/pyrecest/distributions/hypertorus/_input_validation.py
@@ -1,0 +1,45 @@
+"""Input-normalization helpers for hypertoroidal distributions."""
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array
+
+
+def as_shift_vector(shift_by, dim: int, *, name: str = "shift_by"):
+    """Return ``shift_by`` as a one-dimensional backend vector of length ``dim``.
+
+    A scalar shift is accepted for one-dimensional hypertoroidal distributions.
+    This keeps public APIs robust for ordinary Python scalar/list inputs before
+    shape validation is performed.
+    """
+    shift_by = array(shift_by)
+    if shift_by.ndim == 0:
+        if dim != 1:
+            raise ValueError(f"{name} must have shape ({dim},), got scalar.")
+        return shift_by.reshape((1,))
+    if shift_by.ndim == 1 and shift_by.shape[0] == dim:
+        return shift_by
+    raise ValueError(f"{name} must have shape ({dim},), got {shift_by.shape}.")
+
+
+def as_hypertoroidal_points(xs, dim: int, *, name: str = "xs"):
+    """Return evaluation points as an array with trailing dimension ``dim``.
+
+    For one-dimensional distributions, a scalar is treated as one query point
+    and a one-dimensional array is treated as a batch of scalar query points.
+    For higher-dimensional distributions, a one-dimensional array of length
+    ``dim`` is treated as a single query point.
+    """
+    xs = array(xs)
+    if xs.ndim == 0:
+        if dim != 1:
+            raise ValueError(f"{name} must have trailing dimension {dim}, got scalar.")
+        return xs.reshape((1, 1))
+    if xs.ndim == 1:
+        if dim == 1:
+            return xs.reshape((-1, 1))
+        if xs.shape[0] == dim:
+            return xs.reshape((1, dim))
+        raise ValueError(f"{name} must have trailing dimension {dim}, got {xs.shape}.")
+    if xs.shape[-1] != dim:
+        raise ValueError(f"{name} must have trailing dimension {dim}, got {xs.shape}.")
+    return xs.reshape((-1, dim))

--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py
@@ -25,6 +25,7 @@ from pyrecest.backend import (
 
 from ..abstract_dirac_distribution import AbstractDiracDistribution
 from ..nonperiodic.linear_dirac_distribution import LinearDiracDistribution
+from ._input_validation import as_shift_vector
 from .abstract_hypertoroidal_distribution import AbstractHypertoroidalDistribution
 
 
@@ -33,6 +34,7 @@ class HypertoroidalDiracDistribution(
 ):
     def __init__(self, d, w=None, dim: int | None = None):
         """Can set dim manually to tell apart number of samples vs dimension for 1-D arrays."""
+        d = array(d)
         if dim is None:
             if d.ndim > 1:
                 dim = d.shape[-1]
@@ -175,9 +177,12 @@ class HypertoroidalDiracDistribution(
         )
 
     def shift(self, shift_by) -> "HypertoroidalDiracDistribution":
-        assert shift_by.shape[-1] == self.dim
+        shift_by = as_shift_vector(shift_by, self.dim)
         hd = copy.copy(self)
-        hd.d = mod(self.d + reshape(shift_by, (1, -1)), 2.0 * pi)
+        if self.dim == 1 and self.d.ndim == 1:
+            hd.d = mod(self.d + shift_by[0], 2.0 * pi)
+        else:
+            hd.d = mod(self.d + reshape(shift_by, (1, -1)), 2.0 * pi)
         return hd
 
     def entropy(self):

--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_wrapped_normal_distribution.py
@@ -7,7 +7,6 @@ from pyrecest.backend import (
     allclose,
     arange,
     array,
-    atleast_2d,
     exp,
     int32,
     int64,
@@ -21,6 +20,7 @@ from pyrecest.backend import (
 )
 from scipy.stats import multivariate_normal
 
+from ._input_validation import as_hypertoroidal_points, as_shift_vector
 from .abstract_hypertoroidal_distribution import AbstractHypertoroidalDistribution
 
 
@@ -82,10 +82,7 @@ class HypertoroidalWrappedNormalDistribution(AbstractHypertoroidalDistribution):
         :param m: Controls the number of terms in the Fourier series approximation.
         :return: PDF values at xs.
         """
-        assert (
-            xs.shape[-1] == self.dim
-        ), "Last dimension of xs must match the distribution dimension"
-        xs = atleast_2d(xs)  # Ensure xs is at least 2-D for approach below
+        xs = as_hypertoroidal_points(xs, self.dim)
         xs = (xs + pi) % (2 * pi) - pi
 
         # Generate all combinations of offsets for each dimension
@@ -112,8 +109,7 @@ class HypertoroidalWrappedNormalDistribution(AbstractHypertoroidalDistribution):
         :raises AssertionError: If shape of shift_by does not match the dimension of the distribution.
         :return: Shifted distribution.
         """
-        assert shift_by.shape == (self.dim,)
-
+        shift_by = as_shift_vector(shift_by, self.dim)
         return self.set_mean(self.mu + shift_by)
 
     def sample(self, n: Union[int, int32, int64]):

--- a/tests/distributions/test_hypertoroidal_dirac_distribution.py
+++ b/tests/distributions/test_hypertoroidal_dirac_distribution.py
@@ -33,6 +33,22 @@ class TestHypertoroidalDiracDistribution(TestAbstractDiracDistribution):
         npt.assert_array_almost_equal(self.twd.d, self.d)
         npt.assert_array_almost_equal(self.twd.w, self.w)
 
+    def test_init_accepts_python_lists_when_dimension_is_inferable(self):
+        d = [[0.1, 0.2], [0.3, 0.4]]
+        w = [0.25, 0.75]
+
+        dist = HypertoroidalDiracDistribution(d, w)
+
+        self.assertEqual(dist.dim, 2)
+        npt.assert_allclose(dist.d, array(d))
+        npt.assert_allclose(dist.w, array(w))
+
+    def test_init_accepts_one_dimensional_python_list_with_explicit_dim(self):
+        dist = HypertoroidalDiracDistribution([0.1, 0.2, 0.3], dim=1)
+
+        self.assertEqual(dist.dim, 1)
+        npt.assert_allclose(dist.d, array([0.1, 0.2, 0.3]))
+
     def test_from_distribution_sampling_1d(self):
         n_particles = 5
         vm = VonMisesDistribution(array(0.2), array(1.5))
@@ -107,6 +123,26 @@ class TestHypertoroidalDiracDistribution(TestAbstractDiracDistribution):
             zeros_like(twd.d),
             atol=1e-6,
         )
+
+    def test_shift_accepts_python_list(self):
+        shifted = self.twd.shift([1.0, -3.0, 6.0])
+
+        npt.assert_allclose(
+            AbstractHypertoroidalDistribution.angular_error(
+                self.twd.d,
+                shifted.d - array([1.0, -3.0, 6.0]),
+            ),
+            zeros_like(self.twd.d),
+            atol=1e-6,
+        )
+
+    def test_shift_accepts_scalar_for_one_dimensional_distribution(self):
+        dist = HypertoroidalDiracDistribution([0.1, 0.2, 0.3], dim=1)
+
+        shifted = dist.shift(0.25)
+
+        self.assertEqual(shifted.dim, 1)
+        npt.assert_allclose(shifted.d, mod(array([0.35, 0.45, 0.55]), 2.0 * pi))
 
     @staticmethod
     def get_pseudorandom_hypertoroidal_wd(dim=2):

--- a/tests/distributions/test_hypertoroidal_wrapped_normal_distribution.py
+++ b/tests/distributions/test_hypertoroidal_wrapped_normal_distribution.py
@@ -22,6 +22,26 @@ class TestHypertoroidalWNDistribution(unittest.TestCase):
         )
         npt.assert_allclose(pdf_values, expected_values, rtol=2e-6)
 
+    def test_pdf_accepts_scalar_and_1d_batch_for_one_dimensional_distribution(self):
+        dist = HypertoroidalWNDistribution(0.3, 0.7)
+
+        scalar_value = dist.pdf(0.3)
+        batch_values = dist.pdf([0.3, 0.4])
+
+        self.assertEqual(scalar_value.shape, (1,))
+        self.assertEqual(batch_values.shape, (2,))
+        npt.assert_allclose(scalar_value, dist.pdf(array([[0.3]])))
+        npt.assert_allclose(batch_values, dist.pdf(array([[0.3], [0.4]])))
+
+    def test_pdf_accepts_list_single_point_for_multidimensional_distribution(self):
+        dist = HypertoroidalWNDistribution([1.0, 2.0], [[0.5, 0.1], [0.1, 0.3]])
+
+        from_list = dist.pdf([1.0, 2.0])
+        from_matrix = dist.pdf([[1.0, 2.0]])
+
+        self.assertEqual(from_list.shape, (1,))
+        npt.assert_allclose(from_list, from_matrix)
+
     def test_scalar_parameters_are_stored_as_vector_and_matrix(self):
         dist = HypertoroidalWNDistribution(array(0.3), array(0.7))
 
@@ -33,6 +53,23 @@ class TestHypertoroidalWNDistribution(unittest.TestCase):
         npt.assert_allclose(
             dist.trigonometric_moment(1), exp(1j * array([0.3]) - 0.7 / 2)
         )
+
+    def test_shift_accepts_scalar_for_one_dimensional_distribution(self):
+        dist = HypertoroidalWNDistribution(0.3, 0.7)
+
+        shifted = dist.shift(0.25)
+
+        self.assertEqual(shifted.dim, 1)
+        npt.assert_allclose(shifted.mu, array([0.55]))
+        npt.assert_allclose(dist.mu, array([0.3]))
+
+    def test_shift_accepts_list_for_multidimensional_distribution(self):
+        dist = HypertoroidalWNDistribution([1.0, 2.0], [[0.5, 0.1], [0.1, 0.6]])
+
+        shifted = dist.shift([0.25, -0.5])
+
+        npt.assert_allclose(shifted.mu, mod(array([1.25, 1.5]), 2.0 * pi))
+        npt.assert_allclose(dist.mu, array([1.0, 2.0]))
 
     def test_shift_returns_copy_without_mutating_original(self):
         mu = array([1.0, 2.0])

--- a/tests/distributions/test_wrapped_normal_distribution.py
+++ b/tests/distributions/test_wrapped_normal_distribution.py
@@ -10,6 +10,7 @@ from pyrecest.backend import (
     array,
     exp,
     isfinite,
+    mod,
     ones_like,
     pi,
     sqrt,
@@ -101,6 +102,16 @@ class WrappedNormalDistributionTest(unittest.TestCase):
 
         self.assertTrue(bool(isfinite(value)))
         self.assertLess(iterations["count"], 10)
+
+    def test_shift_accepts_python_scalar(self):
+        shifted = self.wn.shift(0.25)
+
+        npt.assert_allclose(shifted.mu, array([mod(self.mu + 0.25, 2.0 * pi)]))
+        npt.assert_allclose(self.wn.mu, array([self.mu]))
+
+    def test_shift_rejects_wrong_shape(self):
+        with self.assertRaises(ValueError):
+            self.wn.shift([0.1, 0.2])
 
     def test_multiply_uses_explicit_vm_approximation(self):
         """The product API is a documented VM-based approximation."""


### PR DESCRIPTION
## Summary
- add shared hypertoroidal input-normalization helpers for scalar/list inputs
- accept scalar and list inputs in wrapped-normal PDF/shift paths before shape validation
- accept Python lists in hypertoroidal Dirac construction and scalar/list shifts
- add regression tests for scalar/list wrapped-normal and Dirac inputs

## Testing
- Not run locally: the sandbox could not clone GitHub (`Could not resolve host: github.com`), so this was prepared via the GitHub connector only.