### PR TITLE
Fix JAX multinomial RNG state handling

### DIFF
--- a/src/pyrecest/_backend/__init__.py
+++ b/src/pyrecest/_backend/__init__.py
@@ -273,6 +273,12 @@ BACKEND_ATTRIBUTES = {
     ],
 }
 
+OPTIONAL_BACKEND_ATTRIBUTES = {
+    "random": [
+        "create_random_state",
+    ],
+}
+
 
 def _deduplicated_attributes(attributes):
     """Return ``attributes`` with duplicates removed while preserving order."""
@@ -348,6 +354,10 @@ class BackendImporter(importlib.abc.MetaPathFinder, importlib.abc.Loader):
                         ) from None
                 else:
                     setattr(new_submodule, attribute_name, attribute)
+
+            for attribute_name in OPTIONAL_BACKEND_ATTRIBUTES.get(module_name, []):
+                if hasattr(submodule, attribute_name):
+                    setattr(new_submodule, attribute_name, getattr(submodule, attribute_name))
 
         return new_module
 

--- a/src/pyrecest/_backend/jax/random.py
+++ b/src/pyrecest/_backend/jax/random.py
@@ -177,12 +177,19 @@ def multivariate_normal(mean, cov, size=None, *args, **kwargs):
     return set_state_return(has_state, state, res)
 
 
-def multinomial(n, pvals):
-    """Sample from a multinomial distribution using JAX."""
-    state, has_state, _ = _get_state()
+def _multinomial(state, n, pvals):
     state, key = jax.random.split(state)
-    backend.jax_global_random_state = state
     pvals = _jnp.asarray(pvals, dtype=_jnp.float32)
     pvals = pvals / pvals.sum()
     samples = jax.random.categorical(key, _jnp.log(pvals), shape=(n,))
-    return _jnp.bincount(samples, minlength=len(pvals))
+    return state, _jnp.bincount(samples, minlength=len(pvals))
+
+
+def multinomial(n, pvals, **kwargs):
+    """Sample from a multinomial distribution using the JAX RNG state contract."""
+    state, has_state, kwargs = _get_state(**kwargs)
+    if kwargs:
+        unexpected = ", ".join(sorted(kwargs))
+        raise TypeError(f"Unexpected keyword argument(s): {unexpected}")
+    state, res = _multinomial(state, n, pvals)
+    return set_state_return(has_state, state, res)

--- a/tests/test_backend_random.py
+++ b/tests/test_backend_random.py
@@ -28,6 +28,31 @@ class TestBackendRandom(unittest.TestCase):
 
         self.assertEqual(sample.shape, (1, 2))
 
+    @unittest.skipIf(pyrecest.backend.__backend_name__ != "jax", "JAX-specific RNG state contract")
+    def test_jax_multinomial_explicit_state_does_not_mutate_global_state(self):
+        state = random.create_random_state(123)
+        original_global_state = random.get_state()
+
+        state_after, sample = random.multinomial(
+            10, pyrecest.backend.array([0.25, 0.75]), state=state
+        )
+
+        self.assertEqual(sample.shape, (2,))
+        self.assertEqual(int(pyrecest.backend.sum(sample)), 10)
+        npt.assert_array_equal(random.get_state(), original_global_state)
+        self.assertFalse(pyrecest.backend.all(random.get_state() == state_after))
+
+    @unittest.skipIf(pyrecest.backend.__backend_name__ != "jax", "JAX-specific RNG state contract")
+    def test_jax_multinomial_uses_and_advances_global_state(self):
+        random.seed(321)
+        initial_state = random.get_state()
+
+        sample = random.multinomial(8, pyrecest.backend.array([0.5, 0.5]))
+
+        self.assertEqual(sample.shape, (2,))
+        self.assertEqual(int(pyrecest.backend.sum(sample)), 8)
+        self.assertFalse(pyrecest.backend.all(random.get_state() == initial_state))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- make the JAX `random.multinomial` helper follow the same explicit/global RNG-state contract as the other JAX random helpers
- reject unexpected keyword arguments instead of silently ignoring them
- add JAX-specific regression tests for explicit-state sampling and global-state advancement

## Validation
- connector compare: branch is 2 commits ahead of current `main`, 0 behind
- local full test execution was not possible because this execution environment cannot resolve `github.com`; PR CI should run the suite