### PR TITLE
Fix time-offset input shape validation

### DIFF
--- a/src/pyrecest/calibration/time_offset.py
+++ b/src/pyrecest/calibration/time_offset.py
@@ -130,7 +130,11 @@ def time_offset_error_summary(
     measurement_values = np.asarray(measurement_values, dtype=float)
     if measurement_values.ndim == 1:
         measurement_values = measurement_values.reshape(-1, 1)
+    elif measurement_values.ndim != 2:
+        raise ValueError("measurement_values must be one- or two-dimensional")
     query_times = apply_time_offset(measurement_times_s, offset_s)
+    if query_times.size != measurement_values.shape[0]:
+        raise ValueError("measurement_times_s length must match measurement_values rows")
     reference_at_query, valid = interpolate_reference_values(
         reference_times_s,
         reference_values,

--- a/tests/calibration/test_time_offset_bias.py
+++ b/tests/calibration/test_time_offset_bias.py
@@ -102,6 +102,32 @@ class TimeOffsetCalibrationTest(unittest.TestCase):
 
         self.assertEqual(summary["count"], 0.0)
 
+    def test_time_offset_summary_rejects_mismatched_measurement_lengths(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "measurement_times_s length must match measurement_values rows",
+        ):
+            time_offset_error_summary(
+                np.array([0.0, 1.0]),
+                np.array([[0.0]]),
+                np.array([0.0, 1.0]),
+                np.array([[0.0], [1.0]]),
+                0.0,
+            )
+
+    def test_time_offset_summary_rejects_higher_rank_measurements(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "measurement_values must be one- or two-dimensional",
+        ):
+            time_offset_error_summary(
+                np.array([0.0]),
+                np.zeros((1, 1, 1)),
+                np.array([0.0, 1.0]),
+                np.array([[0.0], [1.0]]),
+                0.0,
+            )
+
 
 class BiasCalibrationTest(unittest.TestCase):
     def test_make_bias_training_examples_uses_nearest_reference(self):


### PR DESCRIPTION
## Summary
- validate `measurement_values` rank before time-offset error evaluation
- reject `measurement_times_s` / `measurement_values` row-count mismatches with an explicit `ValueError`
- add regression tests for mismatched lengths and higher-rank measurements

## Validation
- compared branch against `main`: 2 commits ahead, 0 behind
- not run locally: this execution environment cannot resolve `github.com` to clone/install the repository