### PR TITLE
Fix PyTorch tuple reductions

### DIFF
--- a/src/pyrecest/_backend/pytorch/__init__.py
+++ b/src/pyrecest/_backend/pytorch/__init__.py
@@ -281,21 +281,37 @@ def logical_and(x, y):
     return x and y
 
 
+def _normalize_reduction_axes(axis, ndim_):
+    if isinstance(axis, (int, _np.integer)):
+        axis = (axis,)
+    else:
+        axis = tuple(axis)
+
+    normalized_axes = tuple(one_axis + ndim_ if one_axis < 0 else one_axis for one_axis in axis)
+    if len(set(normalized_axes)) != len(normalized_axes):
+        raise ValueError("duplicate value in 'axis'")
+
+    for one_axis, normalized_axis in zip(axis, normalized_axes):
+        if normalized_axis < 0 or normalized_axis >= ndim_:
+            raise IndexError(f"axis {one_axis} is out of bounds for array of dimension {ndim_}")
+
+    return normalized_axes
+
+
+def _reduce_over_axes(x, axis, reducer):
+    result = x
+    for one_axis in sorted(_normalize_reduction_axes(axis, x.ndim), reverse=True):
+        result = reducer(result, one_axis)
+    return result
+
+
 def any(x, axis=None):
     if not _torch.is_tensor(x):
         x = _torch.tensor(x)
+    x = x.bool()
     if axis is None:
         return _torch.any(x)
-    if isinstance(axis, int):
-        return _torch.any(x.bool(), axis)
-    if len(axis) == 1:
-        return _torch.any(x, *axis)
-    axis = list(axis)
-    for i_axis, one_axis in enumerate(axis):
-        if one_axis < 0:
-            axis[i_axis] = ndim(x) + one_axis
-    new_axis = tuple(k - 1 if k >= 0 else k for k in axis[1:])
-    return any(_torch.any(x.bool(), axis[0]), new_axis)
+    return _reduce_over_axes(x, axis, lambda values, one_axis: _torch.any(values, dim=one_axis))
 
 
 def flip(x, axis):
@@ -314,18 +330,10 @@ def concatenate(seq, axis=0, out=None):
 def all(x, axis=None):
     if not _torch.is_tensor(x):
         x = _torch.tensor(x)
+    x = x.bool()
     if axis is None:
-        return x.bool().all()
-    if isinstance(axis, int):
-        return _torch.all(x.bool(), axis)
-    if len(axis) == 1:
-        return _torch.all(x, *axis)
-    axis = list(axis)
-    for i_axis, one_axis in enumerate(axis):
-        if one_axis < 0:
-            axis[i_axis] = ndim(x) + one_axis
-    new_axis = tuple(k - 1 if k >= 0 else k for k in axis[1:])
-    return all(_torch.all(x.bool(), axis[0]), new_axis)
+        return _torch.all(x)
+    return _reduce_over_axes(x, axis, lambda values, one_axis: _torch.all(values, dim=one_axis))
 
 
 def get_slice(x, indices):
@@ -397,9 +405,12 @@ def shape(val):
 
 
 def max(a, axis=None):
+    a = array(a)
     if axis is None:
-        return _torch.max(array(a))
-    return _torch.max(array(a), dim=axis).values
+        return _torch.max(a)
+    return _reduce_over_axes(
+        a, axis, lambda values, one_axis: _torch.max(values, dim=one_axis).values
+    )
 
 
 amax = max

--- a/tests/test_pytorch_backend.py
+++ b/tests/test_pytorch_backend.py
@@ -70,6 +70,49 @@ class TestPytorchBackendCov(unittest.TestCase):
 
 
 @unittest.skipIf(pytorch_backend is None, "PyTorch is not installed")
+class TestPytorchBackendReductions(unittest.TestCase):
+    def test_max_accepts_tuple_axis_in_any_order(self):
+        values = pytorch_backend.array(list(range(24))).reshape(2, 3, 4)
+
+        for axis in ((2, 0), (-1, 0)):
+            with self.subTest(axis=axis):
+                result = pytorch_backend.max(values, axis=axis)
+
+                self.assertEqual(tuple(result.shape), (3,))
+                self.assertEqual(result.tolist(), [15, 19, 23])
+
+    def test_any_accepts_tuple_axis_in_any_order(self):
+        values = pytorch_backend.array(
+            [
+                [[False, False], [True, False], [False, False]],
+                [[False, True], [False, False], [False, False]],
+            ]
+        )
+
+        for axis in ((2, 0), (-1, 0)):
+            with self.subTest(axis=axis):
+                result = pytorch_backend.any(values, axis=axis)
+
+                self.assertEqual(tuple(result.shape), (3,))
+                self.assertEqual(result.tolist(), [True, True, False])
+
+    def test_all_accepts_tuple_axis_in_any_order(self):
+        values = pytorch_backend.array(
+            [
+                [[True, True], [False, True], [True, True]],
+                [[True, False], [True, True], [True, True]],
+            ]
+        )
+
+        for axis in ((2, 0), (-1, 0)):
+            with self.subTest(axis=axis):
+                result = pytorch_backend.all(values, axis=axis)
+
+                self.assertEqual(tuple(result.shape), (3,))
+                self.assertEqual(result.tolist(), [False, False, True])
+
+
+@unittest.skipIf(pytorch_backend is None, "PyTorch is not installed")
 class TestPytorchBackendRandom(unittest.TestCase):
     def test_choice_accepts_weighted_sampling_without_replacement(self):
         values = pytorch_backend.array([0, 1, 2, 3])


### PR DESCRIPTION
## Summary
- normalize PyTorch backend tuple-axis reductions
- align tuple-axis behavior for boolean reductions and max-like reductions
- add focused backend coverage

## Validation
- `git diff --check`
- conflict-marker search
- `python -m py_compile` on changed Python files