### PR TITLE
Fix hypercylindrical conditioning input handling

### DIFF
--- a/src/pyrecest/distributions/cart_prod/abstract_hypercylindrical_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/abstract_hypercylindrical_distribution.py
@@ -14,6 +14,7 @@ from pyrecest.backend import (
     any,
     arange,
     array,
+    asarray,
     column_stack,
     concatenate,
     cos,
@@ -186,6 +187,7 @@ class AbstractHypercylindricalDistribution(AbstractLinPeriodicCartProdDistributi
         dist : CustomHypertoroidalDistribution
             The distribution after conditioning.
         """
+        input_lin = asarray(input_lin)
         assert (
             input_lin.ndim == 0
             and self.lin_dim == 1
@@ -229,11 +231,13 @@ class AbstractHypercylindricalDistribution(AbstractLinPeriodicCartProdDistributi
             dist: CustomLinearDistribution
                 CustomLinearDistribution instance
         """
+        input_periodic = asarray(input_periodic)
         assert (
             input_periodic.ndim == 0
-            or input_periodic.shape[0] == self.bound_dim
-            and ndim(input_periodic) == 2
-        ), "Input should be of size (lin_dim,)."
+            and self.bound_dim == 1
+            or ndim(input_periodic) == 1
+            and input_periodic.shape[0] == self.bound_dim
+        ), "Input should be a scalar for bound_dim == 1 or of size (bound_dim,)."
 
         input_periodic = mod(input_periodic, 2.0 * pi)
 

--- a/tests/distributions/test_abstract_hypercylindrical_distribution.py
+++ b/tests/distributions/test_abstract_hypercylindrical_distribution.py
@@ -87,6 +87,50 @@ class AbstractHypercylindricalDistributionTest(unittest.TestCase):
             atol=1e-10,
         )
 
+    def test_condition_on_periodic_accepts_periodic_vectors(self):
+        hwn = PartiallyWrappedNormalDistribution(
+            array([1.0, 2.0, 3.0]),
+            array([[2.0, 0.3, 0.1], [0.3, 1.5, 0.2], [0.1, 0.2, 1.0]]),
+            2,
+        )
+        input_periodic = array([1.5, 2.5])
+        input_linear = arange(-2, 3)
+
+        dist_cond = hwn.condition_on_periodic(input_periodic, normalize=False)
+
+        npt.assert_allclose(
+            dist_cond.pdf(input_linear),
+            hwn.pdf(
+                column_stack(
+                    [
+                        input_periodic[0] * ones(input_linear.shape[0]),
+                        input_periodic[1] * ones(input_linear.shape[0]),
+                        input_linear,
+                    ]
+                )
+            ),
+        )
+
+    def test_condition_helpers_accept_python_lists(self):
+        hwn = PartiallyWrappedNormalDistribution(
+            array([1.0, 2.0]), array([[2.0, 0.3], [0.3, 1.0]]), 1
+        )
+        input_periodic = [1.5]
+        input_linear = [2.5]
+        query_points = arange(-2, 3)
+
+        periodic_cond = hwn.condition_on_periodic(input_periodic, normalize=False)
+        linear_cond = hwn.condition_on_linear(input_linear, normalize=False)
+
+        npt.assert_allclose(
+            periodic_cond.pdf(query_points),
+            hwn.pdf(column_stack([input_periodic[0] * ones(5), query_points])),
+        )
+        npt.assert_allclose(
+            linear_cond.pdf(query_points),
+            hwn.pdf(column_stack([query_points, input_linear[0] * ones(5)])),
+        )
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
         reason="Not supported on this backend",


### PR DESCRIPTION
## Summary
- coerce hypercylindrical conditioning inputs before inspecting `.ndim`/`.shape`, so Python lists are accepted consistently
- fix `condition_on_periodic()` to accept the documented 1-D periodic vector input for `bound_dim > 1`
- add regression coverage for multi-periodic conditioning vectors and Python-list inputs for both conditioning helpers

## Validation
- connector compare: branch changes are limited to `abstract_hypercylindrical_distribution.py` and focused regression tests
- local full test execution was not possible because this execution environment cannot directly check out GitHub; PR CI should run the suite

Supersedes the no-diff closed PR #2185, which was closed after the branch was reset while `main` was advancing.