### PR TITLE
Fix tracklet Viterbi multisession assignment edge cases

### DIFF
--- a/src/pyrecest/filters/tracklet_viterbi.py
+++ b/src/pyrecest/filters/tracklet_viterbi.py
@@ -274,7 +274,12 @@ def solve_fixed_lag_tracklet_viterbi(
         )
         selected = local.path[1 if prefix_added else 0]
         path.append(selected)
-        total_cost += float(local.total_cost)
+        total_cost += _fixed_lag_committed_step_cost(
+            previous_committed,
+            selected,
+            config,
+            transition_cost,
+        )
         if selected is not None:
             previous_committed = selected
 
@@ -413,6 +418,39 @@ def _nodes_for_frame(
     if include_missed_detection:
         nodes.append(_Node(None, 0.0))
     return nodes
+
+
+def _fixed_lag_committed_step_cost(
+    previous_committed: TrackletAssociationCandidate | None,
+    selected: TrackletAssociationCandidate | None,
+    config: TrackletViterbiConfig,
+    transition_cost: TransitionCost | None,
+) -> float:
+    """Score only the newly committed fixed-lag decision.
+
+    ``solve_fixed_lag_tracklet_viterbi`` solves overlapping look-ahead windows.
+    The local window total includes uncommitted future decisions, so accumulating
+    those window totals double-counts costs. This helper mirrors the solver's
+    prefix-memory semantics while charging only the decision committed at the
+    current frame.
+    """
+
+    unary_cost = 0.0 if selected is None else float(selected.unary_cost)
+    if previous_committed is None:
+        return float(
+            unary_cost
+            + (float(config.missed_detection_cost) if selected is None else 0.0)
+        )
+
+    transition = transition_cost or (
+        lambda previous, current, miss_streak: default_tracklet_transition_cost(
+            previous,
+            current,
+            miss_streak,
+            config,
+        )
+    )
+    return float(unary_cost + transition(previous_committed, selected, 0))
 
 
 def _reconstruct_path(

--- a/src/pyrecest/utils/multisession_assignment.py
+++ b/src/pyrecest/utils/multisession_assignment.py
@@ -319,6 +319,7 @@ def tracks_to_session_labels(
     inferred_sizes, max_session_index = _validate_track_session_sizes(
         tracks,
         session_sizes,
+        require_unique_sessions=True,
     )
 
     labels = [

--- a/tests/filters/test_tracklet_viterbi.py
+++ b/tests/filters/test_tracklet_viterbi.py
@@ -53,6 +53,21 @@ def test_fixed_lag_solver_uses_prefix_memory():
     assert [candidate.candidate_id for candidate in result.path] == ["a0", "a1"]
 
 
+def test_fixed_lag_total_cost_scores_committed_path_once():
+    frames = [
+        [TrackletAssociationCandidate("a0", unary_cost=1.0, time_s=0.0)],
+        [TrackletAssociationCandidate("a1", unary_cost=2.0, time_s=1.0)],
+    ]
+    result = solve_fixed_lag_tracklet_viterbi(
+        frames,
+        lag_s=10.0,
+        config=TrackletViterbiConfig(missed_detection_cost=100.0),
+    )
+
+    assert [candidate.candidate_id for candidate in result.path] == ["a0", "a1"]
+    assert result.total_cost == 3.0
+
+
 def test_retention_keeps_track_representative_outside_top_k():
     candidates = [
         TrackletAssociationCandidate("best", unary_cost=0.0, track_id="A"),

--- a/tests/test_multisession_assignment.py
+++ b/tests/test_multisession_assignment.py
@@ -148,6 +148,17 @@ class TestMultiSessionAssignment(unittest.TestCase):
         __backend_name__ == "jax",
         reason="Not supported on this backend",
     )
+    def test_tracks_to_session_labels_rejects_duplicate_sessions_in_one_track(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Each track can only contain one detection per session",
+        ):
+            tracks_to_session_labels([[(0, 0), (0, 1)]], session_sizes=[2])
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
     def test_rejects_inconsistent_session_sizes(self):
         pairwise_costs = {
             (0, 1): array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]),


### PR DESCRIPTION
## Summary
- fix tracklet Viterbi edge cases in multisession assignment utilities
- add focused coverage for tracklet and multisession assignment behavior

## Validation
- `git diff --check`
- conflict-marker search
- `python -m py_compile` on changed Python files