### PR TITLE
Implement JAX positive-definite matrix check

### DIFF
--- a/src/pyrecest/_backend/capabilities.py
+++ b/src/pyrecest/_backend/capabilities.py
@@ -56,7 +56,6 @@ BACKEND_CAPABILITIES: Final = {
             ),
             "linalg": (
                 "fractional_matrix_power",
-                "is_single_matrix_pd",
                 "logm",
                 "quadratic_assignment",
                 "solve_sylvester",

--- a/src/pyrecest/_backend/jax/linalg.py
+++ b/src/pyrecest/_backend/jax/linalg.py
@@ -1,5 +1,6 @@
 """JAX-based linear algebra backend."""
 
+import jax.numpy as _jnp
 from jax.numpy.linalg import (  # NOQA
     cholesky,
     det,
@@ -22,9 +23,10 @@ from jax.scipy.linalg import (
     sqrtm,
 )
 
+from .._backend_config import jax_atol as atol
+
 unsupported_functions = [
     "fractional_matrix_power",
-    "is_single_matrix_pd",
     "logm",
     "quadratic_assignment",
     "solve_sylvester",
@@ -33,6 +35,23 @@ unsupported_functions = [
 
 def _raise_unsupported(*args, **kwargs):
     raise NotImplementedError("This function is not supported in this JAX backend.")
+
+
+def is_single_matrix_pd(mat):
+    """Check if a 2D square matrix is positive definite."""
+    mat = _jnp.asarray(mat)
+    if mat.ndim != 2 or mat.shape[0] != mat.shape[1]:
+        return False
+
+    if mat.dtype in (_jnp.complex64, _jnp.complex128):
+        is_hermitian = _jnp.all(
+            _jnp.abs(mat - _jnp.conj(_jnp.transpose(mat))) < atol
+        )
+        eigvals = _jnp.linalg.eigvalsh(mat)
+        return _jnp.logical_and(is_hermitian, _jnp.min(_jnp.real(eigvals)) > 0)
+
+    factor = _jnp.linalg.cholesky(mat)
+    return _jnp.all(_jnp.isfinite(factor))
 
 
 for func_name in unsupported_functions:

--- a/tests/backend_support/test_jax_linalg_contract.py
+++ b/tests/backend_support/test_jax_linalg_contract.py
@@ -1,0 +1,38 @@
+"""Regression tests for JAX backend linear-algebra helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_jax_is_single_matrix_pd_is_supported():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("JAX is not installed")
+
+    result = run_backend_code(
+        "jax",
+        """
+import pyrecest.backend as backend
+
+real_pd = backend.array([[2.0, 0.0], [0.0, 1.0]])
+real_indefinite = backend.array([[1.0, 2.0], [2.0, 1.0]])
+non_square = backend.ones((2, 3))
+complex_hermitian_pd = backend.array([[2.0 + 0.0j, 0.5j], [-0.5j, 2.0 + 0.0j]])
+complex_non_hermitian = backend.array([[1.0 + 0.0j, 1.0j], [1.0j, 1.0 + 0.0j]])
+
+assert bool(backend.linalg.is_single_matrix_pd(real_pd)) is True
+assert bool(backend.linalg.is_single_matrix_pd(real_indefinite)) is False
+assert backend.linalg.is_single_matrix_pd(non_square) is False
+assert bool(backend.linalg.is_single_matrix_pd(complex_hermitian_pd)) is True
+assert bool(backend.linalg.is_single_matrix_pd(complex_non_hermitian)) is False
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- implement a JAX-native `backend.linalg.is_single_matrix_pd` instead of routing it to `NotImplementedError`
- remove `is_single_matrix_pd` from the JAX linalg unsupported-capability metadata
- add subprocess regression coverage for real, complex Hermitian, indefinite, non-square, and non-Hermitian inputs under the JAX backend

## Validation
- connector compare shows the changes are limited to `src/pyrecest/_backend/jax/linalg.py`, `src/pyrecest/_backend/capabilities.py`, and `tests/backend_support/test_jax_linalg_contract.py`
- local checkout/test execution was not possible in this sandbox because DNS resolution for `github.com` fails; PR CI should run the full matrix