### PR TITLE
Revert unrelated MegaLinter token change

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -93,7 +93,7 @@ jobs:
           # https://megalinter.io/latest/configuration/#shared-variables
           # ADD YOUR CUSTOM ENV VARIABLES HERE OR DEFINE THEM IN A FILE .mega-linter.yml AT THE ROOT OF YOUR REPOSITORY
           VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }} # Validates all source when push on main, else just the git diff with main.
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EMAIL_REPORTER_SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
 
       # Upload MegaLinter artifacts


### PR DESCRIPTION
## Summary
- restore the MegaLinter environment `GITHUB_TOKEN` line to `secrets.GITHUB_TOKEN`
- keep PR #2184's `HistoryRecorder` bug fix intact

## Validation
- inspected current `main` and confirmed the unrelated token-line change was present after the merged bug-fix PR
- this PR only reverts that workflow-line drift