### PR TITLE
Support scalar wrapped normal likelihood callbacks

### DIFF
--- a/src/pyrecest/filters/wrapped_normal_filter.py
+++ b/src/pyrecest/filters/wrapped_normal_filter.py
@@ -49,7 +49,13 @@ class WrappedNormalFilter(AbstractFilter, CircularFilterMixin):
         try:
             values = array(likelihood(z, points) ** power)
             values_flat = values.reshape((-1,))
-            if values_flat.shape == (points.shape[0],):
+            try:
+                point_count = points.shape[0]
+            except (AttributeError, IndexError):
+                point_count = None
+            if point_count is None:
+                return values_flat[0]
+            if values_flat.shape == (point_count,):
                 return values_flat
         except (TypeError, ValueError):
             pass

--- a/src/pyrecest/filters/wrapped_normal_filter.py
+++ b/src/pyrecest/filters/wrapped_normal_filter.py
@@ -1,5 +1,4 @@
 from collections.abc import Callable
-from functools import partial
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 from pyrecest.backend import array, log, max, maximum, min, minimum, mod, pi
@@ -38,11 +37,32 @@ class WrappedNormalFilter(AbstractFilter, CircularFilterMixin):
         wn_meas_shifted = WrappedNormalDistribution(mu_w_new, wn_meas.sigma)
         self.filter_state = self.filter_state.multiply_vm_approximation(wn_meas_shifted)
 
+    @staticmethod
+    def _evaluate_likelihood_values(likelihood: Callable, z, points, *, power=1.0):
+        """Evaluate a likelihood callback for each Dirac support point.
+
+        Historically, wrapped-normal updates accepted callbacks with the scalar
+        signature ``likelihood(z, x)``.  Some callbacks also support vectorized
+        evaluation over all support points; keep that fast path when it returns
+        one value per point, and otherwise fall back to pointwise evaluation.
+        """
+        try:
+            values = array(likelihood(z, points) ** power)
+            values_flat = values.reshape((-1,))
+            if values_flat.shape == (points.shape[0],):
+                return values_flat
+        except (TypeError, ValueError):
+            pass
+
+        return array([likelihood(z, point) ** power for point in points])
+
     def update_nonlinear_particle(self, likelihood, z):
         n = 100
         samples = self.filter_state.sample(n)
         wd = CircularDiracDistribution(samples)
-        wd_new = wd.reweigh(partial(likelihood, z))
+        wd_new = wd.reweigh(
+            lambda points: self._evaluate_likelihood_values(likelihood, z, points)
+        )
         self.filter_state = wd_new.to_wn()
 
     def update_nonlinear_progressive(
@@ -57,7 +77,7 @@ class WrappedNormalFilter(AbstractFilter, CircularFilterMixin):
 
         while lambda_ > 0:
             wd = self.filter_state.to_dirac5()
-            likelihood_vals = array([likelihood(z, x) for x in wd.d])
+            likelihood_vals = self._evaluate_likelihood_values(likelihood, z, wd.d)
             likelihood_vals_min = min(likelihood_vals)
             likelihood_vals_max = max(likelihood_vals)
 
@@ -83,7 +103,11 @@ class WrappedNormalFilter(AbstractFilter, CircularFilterMixin):
 
             current_lambda = maximum(current_lambda, MINIMUM_LAMBDA)
             current_lambda = minimum(current_lambda, lambda_)
-            wd_new = wd.reweigh(lambda x: likelihood(z, x) ** current_lambda)
+            wd_new = wd.reweigh(
+                lambda points, power=current_lambda: self._evaluate_likelihood_values(
+                    likelihood, z, points, power=power
+                )
+            )
             self.filter_state = wd_new.to_wn()
             lambda_ = lambda_ - current_lambda
             steps += 1

--- a/src/pyrecest/filters/wrapped_normal_filter.py
+++ b/src/pyrecest/filters/wrapped_normal_filter.py
@@ -57,7 +57,7 @@ class WrappedNormalFilter(AbstractFilter, CircularFilterMixin):
                 return values_flat[0]
             if values_flat.shape == (point_count,):
                 return values_flat
-        except (TypeError, ValueError):
+        except (RuntimeError, TypeError, ValueError):
             pass
 
         return array([likelihood(z, point) ** power for point in points])

--- a/tests/filters/test_wrapped_normal_filter_likelihood_callbacks.py
+++ b/tests/filters/test_wrapped_normal_filter_likelihood_callbacks.py
@@ -1,0 +1,34 @@
+import math
+
+import numpy as np
+
+from pyrecest.backend import array, random
+from pyrecest.distributions import WrappedNormalDistribution
+from pyrecest.filters import WrappedNormalFilter
+
+
+def _scalar_only_likelihood(z, x):
+    return math.exp(math.cos(float(z) - float(x)))
+
+
+def _make_filter():
+    return WrappedNormalFilter(WrappedNormalDistribution(array(0.0), array(0.5)))
+
+
+def test_update_nonlinear_particle_accepts_scalar_likelihood_callback():
+    random.seed(0)
+    filt = _make_filter()
+
+    filt.update_nonlinear_particle(_scalar_only_likelihood, 0.1)
+
+    assert isinstance(filt.filter_state, WrappedNormalDistribution)
+    assert np.isfinite(float(filt.filter_state.sigma))
+
+
+def test_update_nonlinear_progressive_accepts_scalar_likelihood_callback():
+    filt = _make_filter()
+
+    filt.update_nonlinear_progressive(_scalar_only_likelihood, 0.1)
+
+    assert isinstance(filt.filter_state, WrappedNormalDistribution)
+    assert np.isfinite(float(filt.filter_state.sigma))


### PR DESCRIPTION
## Summary
- keep vectorized wrapped-normal likelihood evaluation when available
- fall back to scalar pointwise callbacks for nonlinear particle/progressive updates
- add focused callback coverage

## Validation
- git diff --check
- conflict marker scan
- python -m py_compile on changed Python files

No test suites were run per request.