### PR TITLE
Fix S2 coordinate conversion validation

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/abstract_sphere_subset_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/abstract_sphere_subset_distribution.py
@@ -82,7 +82,9 @@ class AbstractSphereSubsetDistribution(AbstractHypersphereSubsetDistribution):
         Returns:
             tuple: Spherical coordinates.
         """
-        assert ndim(x) == 1 and ndim(y) == 1 and ndim(z), "Inputs must be 1-dimensional"
+        assert (
+            ndim(x) == 1 and ndim(y) == 1 and ndim(z) == 1
+        ), "Inputs must be 1-dimensional"
         if mode == "inclination":
             phi, theta = AbstractSphereSubsetDistribution._cart_to_sph_inclination(
                 x, y, z
@@ -108,8 +110,8 @@ class AbstractSphereSubsetDistribution(AbstractHypersphereSubsetDistribution):
     def _sph_to_cart_inclination(theta_inc, phi_az_right) -> tuple:
         # Conversion for the (r, θ_inc, φ_az,right) convention. Used by many textbooks.
         # Downside is that it does not generalize well to higher dimensions.
-        assert ndim(theta_inc) == 1 and ndim(
-            phi_az_right
+        assert (
+            ndim(theta_inc) == 1 and ndim(phi_az_right) == 1
         ), "Inputs must be 1-dimensional"
         x = sin(phi_az_right) * cos(theta_inc)
         y = sin(phi_az_right) * sin(theta_inc)
@@ -136,7 +138,7 @@ class AbstractSphereSubsetDistribution(AbstractHypersphereSubsetDistribution):
         if map_to_inclination:
             inclination = pi / 2 - elevation
             return AbstractSphereSubsetDistribution._sph_to_cart_inclination(
-                inclination, elevation
+                azimuth, inclination
             )
 
         x = cos(elevation) * cos(azimuth)
@@ -146,7 +148,7 @@ class AbstractSphereSubsetDistribution(AbstractHypersphereSubsetDistribution):
 
     @staticmethod
     def _cart_to_sph_inclination(x, y, z) -> tuple:
-        assert ndim(x) == 1 and ndim(y) == 1 and ndim(z)
+        assert ndim(x) == 1 and ndim(y) == 1 and ndim(z) == 1
         azimuth = arctan2(y, x)
         azimuth = where(azimuth < 0, azimuth + 2 * pi, azimuth)
         colatitude = arccos(z)

--- a/tests/distributions/test_abstract_sphere_subset_distribution.py
+++ b/tests/distributions/test_abstract_sphere_subset_distribution.py
@@ -86,3 +86,39 @@ class TestAbstractSphereSubsetDistribution(unittest.TestCase):
         # The new spherical coordinates should be close to the original ones
         npt.assert_allclose(azimuth_new, array([0, 0, 0]), atol=1e-15)
         npt.assert_allclose(theta_new, theta, atol=1e-15)
+
+    def test_cart_to_sph_rejects_matrix_z_in_inclination_mode(self):
+        x = array([1.0, 0.0])
+        y = array([0.0, 1.0])
+        z = array([[0.0, 0.0]])
+
+        with self.assertRaises(AssertionError):
+            AbstractSphereSubsetDistribution.cart_to_sph(x, y, z)
+
+    def test_inclination_helpers_reject_matrix_inputs(self):
+        azimuth = array([0.0, 0.5])
+        colatitude = array([[0.1, 0.2]])
+        x = array([1.0, 0.0])
+        y = array([0.0, 1.0])
+        z = array([[0.0, 0.0]])
+
+        with self.assertRaises(AssertionError):
+            AbstractSphereSubsetDistribution._sph_to_cart_inclination(
+                azimuth, colatitude
+            )
+        with self.assertRaises(AssertionError):
+            AbstractSphereSubsetDistribution._cart_to_sph_inclination(x, y, z)
+
+    def test_elevation_map_to_inclination_matches_direct_formula(self):
+        azimuth = array([0.25, 1.25, 2.25])
+        elevation = array([-0.4, 0.0, 0.4])
+
+        direct = AbstractSphereSubsetDistribution._sph_to_cart_elevation(
+            azimuth, elevation
+        )
+        mapped = AbstractSphereSubsetDistribution._sph_to_cart_elevation(
+            azimuth, elevation, map_to_inclination=True
+        )
+
+        for direct_component, mapped_component in zip(direct, mapped):
+            npt.assert_allclose(mapped_component, direct_component, atol=1e-12)


### PR DESCRIPTION
## Summary
- tighten S² coordinate conversion dimensionality assertions so all Cartesian/spherical inputs must actually be 1-D
- fix the optional elevation-to-inclination conversion path to pass azimuth and computed colatitude in the correct order
- add regression coverage for rejected matrix inputs and the elevation `map_to_inclination=True` path

## Validation
- `python -m py_compile` on the changed implementation and test files in a local scratch copy
- connector compare confirms the PR is limited to `src/pyrecest/distributions/hypersphere_subset/abstract_sphere_subset_distribution.py` and `tests/distributions/test_abstract_sphere_subset_distribution.py`

Note: full pytest execution was not possible in the execution sandbox because direct GitHub checkout/install is unavailable; PR CI should run the repository suite.