### PR TITLE
Fix PD matrix shape guards for NumPy and PyTorch backends

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/linalg.py
+++ b/src/pyrecest/_backend/_shared_numpy/linalg.py
@@ -77,7 +77,7 @@ def qr(*args, **kwargs):
 
 def is_single_matrix_pd(mat):
     """Check if 2D square matrix is positive definite."""
-    if mat.shape[0] != mat.shape[1]:
+    if mat.ndim != 2 or mat.shape[0] != mat.shape[1]:
         return False
     if mat.dtype in [_np.complex64, _np.complex128]:
         if not _is_hermitian(mat):

--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -165,7 +165,7 @@ def solve_sylvester(a, b, q):
 # (TODO) (sait) _torch.linalg.cholesky_ex for even faster way
 def is_single_matrix_pd(mat):
     """Check if 2D square matrix is positive definite."""
-    if mat.shape[0] != mat.shape[1]:
+    if mat.ndim != 2 or mat.shape[0] != mat.shape[1]:
         return False
     if mat.dtype in [_torch.complex64, _torch.complex128]:
         is_hermitian = _torch.all(

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -16,6 +16,11 @@ def _linalg_call_args(name):
     }[name]
 
 
+def _skip_if_linalg_function_unsupported(name):
+    if name in get_unsupported_functions(backend.__backend_name__, "linalg"):
+        pytest.skip(f"{name} is unsupported on the active backend")
+
+
 def test_declared_linalg_unsupported_functions_raise_not_implemented():
     unsupported = get_unsupported_functions(backend.__backend_name__, "linalg")
     if not unsupported:
@@ -24,6 +29,25 @@ def test_declared_linalg_unsupported_functions_raise_not_implemented():
     for name in unsupported:
         with pytest.raises(NotImplementedError):
             getattr(linalg, name)(*_linalg_call_args(name))
+
+
+def test_is_single_matrix_pd_rejects_vector_inputs():
+    _skip_if_linalg_function_unsupported("is_single_matrix_pd")
+
+    assert linalg.is_single_matrix_pd(array([1.0, 2.0])) is False
+
+
+def test_is_single_matrix_pd_rejects_batched_inputs():
+    _skip_if_linalg_function_unsupported("is_single_matrix_pd")
+
+    batched_identity = array(
+        [
+            [[1.0, 0.0], [0.0, 1.0]],
+            [[2.0, 0.0], [0.0, 2.0]],
+        ]
+    )
+
+    assert linalg.is_single_matrix_pd(batched_identity) is False
 
 
 def test_pytorch_to_numpy_detaches_tensors_requiring_grad():


### PR DESCRIPTION
## Summary
- reject vector and batched inputs in NumPy/PyTorch `linalg.is_single_matrix_pd()`
- align those backends with the single 2-D matrix contract used by the JAX implementation
- add backend regression tests for vector and batched inputs

## Validation
- connector compare shows changes limited to NumPy/PyTorch linalg guards and backend contract tests
- local checkout/test execution was not possible here because this environment previously could not resolve GitHub directly; PR CI should run the backend matrix