### PR TITLE
Fix wrapped exponential scalar parameter handling

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
@@ -2,7 +2,7 @@
 from typing import Union
 
 # pylint: disable=redefined-builtin
-from pyrecest.backend import exp, int32, int64, log, mod, ndim, pi, random
+from pyrecest.backend import asarray, exp, int32, int64, log, mod, ndim, pi, random
 
 from .abstract_circular_distribution import AbstractCircularDistribution
 
@@ -18,6 +18,7 @@ class WrappedExponentialDistribution(AbstractCircularDistribution):
 
     def __init__(self, lambda_):
         AbstractCircularDistribution.__init__(self)
+        lambda_ = asarray(lambda_)
         assert lambda_.shape in ((1,), ())
         assert lambda_ > 0.0
         self.lambda_ = lambda_

--- a/tests/distributions/test_wrapped_exponential_distribution.py
+++ b/tests/distributions/test_wrapped_exponential_distribution.py
@@ -17,6 +17,11 @@ class WrappedExponentialDistributionTest(unittest.TestCase):
         self.lambda_ = array(2.0)
         self.we = WrappedExponentialDistribution(self.lambda_)
 
+    def test_accepts_python_scalar_parameter(self):
+        we = WrappedExponentialDistribution(2.0)
+
+        npt.assert_allclose(we.pdf(array(1.0)), self.we.pdf(array(1.0)), rtol=5e-7)
+
     def test_pdf(self):
         def pdftemp(x):
             return sum(


### PR DESCRIPTION
## Summary
- coerce `WrappedExponentialDistribution`'s rate parameter through the active backend before shape validation
- restore support for documented Python scalar parameters such as `WrappedExponentialDistribution(2.0)`
- add a regression test comparing Python scalar and backend scalar construction

## Validation
- connector compare confirms the branch only changes `wrapped_exponential_distribution.py` and its focused test
- inspected the resulting branch contents via the GitHub connector
- full local pytest execution was not possible here because direct GitHub checkout is unavailable in the execution sandbox; PR CI should run the backend matrix