### PR TITLE
Fix backend and wrapped distribution edge cases

### DIFF
--- a/src/pyrecest/_backend/jax/__init__.py
+++ b/src/pyrecest/_backend/jax/__init__.py
@@ -214,8 +214,10 @@ def to_ndarray(x, to_ndim, axis=0):
     if not isinstance(x, _jnp.ndarray):
         x = _jnp.array(x)
 
-    # Check if we need to add a dimension
-    if x.ndim == to_ndim - 1:
+    if x.ndim > to_ndim:
+        raise ValueError("The ndim cannot be adapted properly.")
+
+    while x.ndim < to_ndim:
         x = _jnp.expand_dims(x, axis=axis)
 
     return x

--- a/src/pyrecest/_backend/jax/random.py
+++ b/src/pyrecest/_backend/jax/random.py
@@ -86,7 +86,9 @@ def rand(size=None, *args, **kwargs):
 
 def uniform(low=0.0, high=1.0, size=None, *args, **kwargs):
     state, has_state, kwargs = _get_state(**kwargs)
-    if low >= high:
+    low = _jnp.asarray(low)
+    high = _jnp.asarray(high)
+    if bool(_jnp.any(low >= high)):
         raise ValueError("Upper bound must be higher than lower bound")
     state, res = _rand(state, size, *args, minval=low, maxval=high, **kwargs)
     return set_state_return(has_state, state, res)

--- a/src/pyrecest/_backend/pytorch/__init__.py
+++ b/src/pyrecest/_backend/pytorch/__init__.py
@@ -701,7 +701,7 @@ def _contains_slice(indices):
     if isinstance(indices, slice):
         return True
     if isinstance(indices, tuple):
-        return any(isinstance(index, slice) for index in indices)
+        return _builtins.any(isinstance(index, slice) for index in indices)
     return False
 
 

--- a/src/pyrecest/_backend/pytorch/__init__.py
+++ b/src/pyrecest/_backend/pytorch/__init__.py
@@ -276,9 +276,15 @@ def split(x, indices_or_sections, axis=0):
 
 
 def logical_and(x, y):
-    if _torch.is_tensor(x) or _torch.is_tensor(y):
-        return x * y
-    return x and y
+    device = None
+    if _torch.is_tensor(x):
+        device = x.device
+    elif _torch.is_tensor(y):
+        device = y.device
+    return _torch.logical_and(
+        _torch.as_tensor(x, device=device),
+        _torch.as_tensor(y, device=device),
+    )
 
 
 def _normalize_reduction_axes(axis, ndim_):
@@ -649,6 +655,8 @@ def _is_boolean(x):
     if isinstance(x, bool):
         return True
     if isinstance(x, (tuple, list)):
+        if not x:
+            return False
         return _is_boolean(x[0])
     if _torch.is_tensor(x):
         return x.dtype in [_torch.bool, _torch.uint8]
@@ -661,6 +669,74 @@ def _is_iterable(x):
     if _torch.is_tensor(x):
         return ndim(x) > 0
     return False
+
+
+def _as_assignment_values(values, x):
+    if _torch.is_tensor(values):
+        return values.to(device=x.device, dtype=x.dtype)
+    return _torch.as_tensor(values, dtype=x.dtype, device=x.device)
+
+
+def _assignment_value_length(values):
+    return len(values) if _is_iterable(values) else 1
+
+
+def _is_scalar_index(index):
+    return isinstance(index, (int, _np.integer)) or (
+        _torch.is_tensor(index) and index.ndim == 0
+    )
+
+
+def _assignment_index_length(indices, zip_indices):
+    if zip_indices:
+        return len(indices)
+    if isinstance(indices, tuple) and all(
+        _is_scalar_index(index) for index in indices
+    ):
+        return 1
+    return len(indices) if _is_iterable(indices) else 1
+
+
+def _contains_slice(indices):
+    if isinstance(indices, slice):
+        return True
+    if isinstance(indices, tuple):
+        return any(isinstance(index, slice) for index in indices)
+    return False
+
+
+def _as_assignment_index(index, *, device):
+    if _torch.is_tensor(index):
+        if index.dtype in [_torch.bool, _torch.uint8]:
+            return index.to(device=device)
+        return index.to(device=device, dtype=_torch.long)
+    return _torch.as_tensor(index, dtype=_torch.long, device=device)
+
+
+def _normalize_index_put_indices(indices, *, device):
+    index_seq = indices if isinstance(indices, tuple) else (indices,)
+    return tuple(_as_assignment_index(index, device=device) for index in index_seq)
+
+
+def _as_boolean_index(indices, *, device):
+    if _torch.is_tensor(indices):
+        return indices.to(device=device, dtype=_torch.bool)
+    return _torch.as_tensor(indices, dtype=_torch.bool, device=device)
+
+
+def _apply_assignment(x_new, indices, values, *, accumulate):
+    if _contains_slice(indices):
+        if accumulate:
+            x_new[indices] += values
+        else:
+            x_new[indices] = values
+        return x_new
+    x_new.index_put_(
+        _normalize_index_put_indices(indices, device=x_new.device),
+        values,
+        accumulate=accumulate,
+    )
+    return x_new
 
 
 def assignment(x, values, indices, axis=0):
@@ -691,22 +767,26 @@ def assignment(x, values, indices, axis=0):
     If a list is given, it must have the same length as indices.
     """
     x_new = copy(x)
+    values = _as_assignment_values(values, x_new)
 
     use_vectorization = hasattr(indices, "__len__") and len(indices) < ndim(x)
     if _is_boolean(indices):
+        indices = _as_boolean_index(indices, device=x_new.device)
         x_new[indices] = values
         return x_new
-    zip_indices = _is_iterable(indices) and _is_iterable(indices[0])
-    len_indices = len(indices) if _is_iterable(indices) else 1
+    zip_indices = (
+        _is_iterable(indices)
+        and len(indices) > 0
+        and _is_iterable(indices[0])
+    )
+    len_indices = _assignment_index_length(indices, zip_indices)
     if zip_indices:
         indices = tuple(zip(*indices))
     if not use_vectorization:
-        if not zip_indices:
-            len_indices = len(indices) if _is_iterable(indices) else 1
-        len_values = len(values) if _is_iterable(values) else 1
+        len_values = _assignment_value_length(values)
         if len_values > 1 and len_values != len_indices:
             raise ValueError("Either one value or as many values as indices")
-        x_new[indices] = values
+        _apply_assignment(x_new, indices, values, accumulate=False)
     else:
         indices = tuple(list(indices[:axis]) + [slice(None)] + list(indices[axis:]))
         x_new[indices] = values
@@ -741,20 +821,25 @@ def assignment_by_sum(x, values, indices, axis=0):
     If a list is given, it must have the same length as indices.
     """
     x_new = copy(x)
-    values = array(values)
+    values = _as_assignment_values(values, x_new)
     use_vectorization = hasattr(indices, "__len__") and len(indices) < ndim(x)
     if _is_boolean(indices):
+        indices = _as_boolean_index(indices, device=x_new.device)
         x_new[indices] += values
         return x_new
-    zip_indices = _is_iterable(indices) and _is_iterable(indices[0])
+    zip_indices = (
+        _is_iterable(indices)
+        and len(indices) > 0
+        and _is_iterable(indices[0])
+    )
+    len_indices = _assignment_index_length(indices, zip_indices)
     if zip_indices:
-        indices = list(zip(*indices))
+        indices = tuple(zip(*indices))
     if not use_vectorization:
-        len_indices = len(indices) if _is_iterable(indices) else 1
-        len_values = len(values) if _is_iterable(values) else 1
+        len_values = _assignment_value_length(values)
         if len_values > 1 and len_values != len_indices:
             raise ValueError("Either one value or as many values as indices")
-        x_new[indices] += values
+        _apply_assignment(x_new, indices, values, accumulate=True)
     else:
         indices = tuple(list(indices[:axis]) + [slice(None)] + list(indices[axis:]))
         x_new[indices] += values

--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -80,9 +80,21 @@ def normal(loc=0.0, scale=1.0, size=None):
 
 
 def uniform(low=0.0, high=1.0, size=None, dtype=None):
-    if low >= high:
+    device = None
+    if _torch.is_tensor(low):
+        device = low.device
+    elif _torch.is_tensor(high):
+        device = high.device
+
+    low = _torch.as_tensor(low, dtype=dtype, device=device)
+    high = _torch.as_tensor(high, dtype=dtype, device=device)
+    if bool(_torch.any(low >= high)):
         raise ValueError("Upper bound must be higher than lower bound")
-    return (high - low) * rand(size, dtype=dtype) + low
+    if size is None:
+        size = ()
+    elif not hasattr(size, "__iter__"):
+        size = (size,)
+    return (high - low) * _torch.rand(size, dtype=dtype, device=device) + low
 
 
 @_modify_func_default_dtype(copy=False, kw_only=True)

--- a/src/pyrecest/distributions/circle/wrapped_laplace_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_laplace_distribution.py
@@ -1,5 +1,5 @@
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import exp, mod, ndim, pi
+from pyrecest.backend import asarray, exp, mod, ndim, pi
 
 from .abstract_circular_distribution import AbstractCircularDistribution
 
@@ -16,6 +16,8 @@ class WrappedLaplaceDistribution(AbstractCircularDistribution):
 
     def __init__(self, lambda_, kappa_):
         AbstractCircularDistribution.__init__(self)
+        lambda_ = asarray(lambda_)
+        kappa_ = asarray(kappa_)
         assert lambda_.shape in ((1,), ())
         assert kappa_.shape in ((1,), ())
         assert lambda_ > 0.0

--- a/tests/backend_support/test_jax_to_ndarray_contract.py
+++ b/tests/backend_support/test_jax_to_ndarray_contract.py
@@ -1,0 +1,33 @@
+"""Regression tests for the JAX backend ``to_ndarray`` helper."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_jax_to_ndarray_adds_all_missing_dimensions_and_rejects_too_many():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("JAX is not installed")
+
+    result = run_backend_code(
+        "jax",
+        """
+import pyrecest.backend as backend
+
+expanded = backend.to_ndarray(backend.asarray([1.0, 2.0]), 3)
+assert expanded.shape == (1, 1, 2)
+
+try:
+    backend.to_ndarray(backend.zeros((1, 2, 3)), 2)
+except ValueError as exc:
+    assert "ndim" in str(exc)
+else:
+    raise AssertionError("expected ValueError for reducing ndim")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/tests/backend_support/test_pytorch_assignment_contract.py
+++ b/tests/backend_support/test_pytorch_assignment_contract.py
@@ -1,0 +1,83 @@
+"""Regression tests for PyTorch backend assignment and logical helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_pytorch_assignment_accepts_numpy_style_advanced_indices():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import pyrecest.backend as backend
+
+x = backend.zeros((3, 3))
+assigned = backend.assignment(x, [5.0, 7.0], [(0, 1), (1, 2)])
+summed = backend.assignment_by_sum(
+    backend.ones((3, 3)),
+    [5.0, 7.0],
+    [(0, 1), (1, 2)],
+)
+duplicate_sum = backend.assignment_by_sum(backend.zeros(3), [1.0, 2.0], [0, 0])
+
+assert backend.to_numpy(assigned).tolist() == [
+    [0.0, 5.0, 0.0],
+    [0.0, 0.0, 7.0],
+    [0.0, 0.0, 0.0],
+]
+assert backend.to_numpy(summed).tolist() == [
+    [1.0, 6.0, 1.0],
+    [1.0, 1.0, 8.0],
+    [1.0, 1.0, 1.0],
+]
+assert backend.to_numpy(duplicate_sum).tolist() == [3.0, 0.0, 0.0]
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.backend_portable
+def test_pytorch_assignment_accepts_list_and_boolean_indices():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import pyrecest.backend as backend
+
+vector = backend.zeros(3)
+by_list = backend.assignment(vector, [4.0, 5.0], [0, 2])
+
+matrix = backend.zeros((3, 3))
+by_mask = backend.assignment(
+    matrix,
+    [1.0, 2.0],
+    [
+        [True, False, False],
+        [False, True, False],
+        [False, False, False],
+    ],
+)
+
+logical = backend.logical_and(backend.asarray([1, 0]), backend.asarray([2, 3]))
+
+assert backend.to_numpy(by_list).tolist() == [4.0, 0.0, 5.0]
+assert backend.to_numpy(by_mask).tolist() == [
+    [1.0, 0.0, 0.0],
+    [0.0, 2.0, 0.0],
+    [0.0, 0.0, 0.0],
+]
+assert backend.to_numpy(logical).tolist() == [True, False]
+""",
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/tests/backend_support/test_random_uniform_contract.py
+++ b/tests/backend_support/test_random_uniform_contract.py
@@ -1,0 +1,79 @@
+"""Regression tests for backend random.uniform bounds handling."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+_UNIFORM_ARRAY_BOUNDS_CHECK = """
+import pyrecest.backend as backend
+from pyrecest.backend import random
+
+low = backend.array([0.0, 10.0])
+high = backend.array([1.0, 20.0])
+
+sample = random.uniform(low=low, high=high, size=(2,))
+
+assert sample.shape == (2,)
+assert bool(backend.all(sample >= low))
+assert bool(backend.all(sample <= high))
+print("ok")
+"""
+
+
+_UNIFORM_ARRAY_BOUNDS_REJECTION_CHECK = """
+import pyrecest.backend as backend
+from pyrecest.backend import random
+
+low = backend.array([0.0, 2.0])
+high = backend.array([1.0, 1.0])
+
+try:
+    random.uniform(low=low, high=high, size=(2,))
+except ValueError as exc:
+    assert "Upper bound" in str(exc)
+else:
+    raise AssertionError("array-valued invalid uniform bounds were accepted")
+
+print("ok")
+"""
+
+
+@pytest.mark.backend_portable
+@pytest.mark.parametrize(
+    "backend,required_module",
+    [
+        ("jax", "jax"),
+        ("pytorch", "torch"),
+    ],
+)
+def test_uniform_accepts_array_valued_bounds(backend, required_module):
+    if importlib.util.find_spec(required_module) is None:
+        pytest.skip(f"{backend} backend dependency is not installed")
+
+    result = run_backend_code(backend, _UNIFORM_ARRAY_BOUNDS_CHECK)
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+@pytest.mark.backend_portable
+@pytest.mark.parametrize(
+    "backend,required_module",
+    [
+        ("jax", "jax"),
+        ("pytorch", "torch"),
+    ],
+)
+def test_uniform_rejects_array_valued_invalid_bounds(backend, required_module):
+    if importlib.util.find_spec(required_module) is None:
+        pytest.skip(f"{backend} backend dependency is not installed")
+
+    result = run_backend_code(backend, _UNIFORM_ARRAY_BOUNDS_REJECTION_CHECK)
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout

--- a/tests/distributions/test_wrapped_laplace_distribution.py
+++ b/tests/distributions/test_wrapped_laplace_distribution.py
@@ -18,6 +18,11 @@ class WrappedLaplaceDistributionTest(unittest.TestCase):
         self.kappa = array(1.3)
         self.wl = WrappedLaplaceDistribution(self.lambda_, self.kappa)
 
+    def test_accepts_python_scalar_parameters(self):
+        wl = WrappedLaplaceDistribution(2.0, 1.3)
+
+        npt.assert_allclose(wl.pdf(array(1.0)), self.wl.pdf(array(1.0)), rtol=1e-6)
+
     def test_pdf(self):
         def laplace(x):
             return (

--- a/tests/filters/test_wrapped_normal_filter.py
+++ b/tests/filters/test_wrapped_normal_filter.py
@@ -1,12 +1,17 @@
+import math
 import unittest
 from unittest.mock import patch
 
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array
+from pyrecest.backend import array, random
 from pyrecest.distributions import WrappedNormalDistribution
 from pyrecest.filters.wrapped_normal_filter import WrappedNormalFilter
+
+
+def _scalar_only_likelihood(z, x):
+    return math.exp(math.cos(float(z) - float(x)))
 
 
 class WrappedNormalFilterTest(unittest.TestCase):
@@ -48,6 +53,23 @@ class WrappedNormalFilterTest(unittest.TestCase):
         self.assertIsInstance(wn_identity2, WrappedNormalDistribution)
         self.assertLess(self.wn.mu, wn_identity2.mu)
         self.assertGreater(self.wn.sigma, wn_identity2.sigma)
+
+    def test_update_nonlinear_particle_accepts_scalar_likelihood_callback(self):
+        random.seed(0)
+        self.wn_filter.filter_state = WrappedNormalDistribution(array(0.0), array(0.5))
+
+        self.wn_filter.update_nonlinear_particle(_scalar_only_likelihood, 0.1)
+
+        self.assertIsInstance(self.wn_filter.filter_state, WrappedNormalDistribution)
+        self.assertTrue(math.isfinite(float(self.wn_filter.filter_state.sigma)))
+
+    def test_update_nonlinear_progressive_accepts_scalar_likelihood_callback(self):
+        self.wn_filter.filter_state = WrappedNormalDistribution(array(0.0), array(0.5))
+
+        self.wn_filter.update_nonlinear_progressive(_scalar_only_likelihood, 0.1)
+
+        self.assertIsInstance(self.wn_filter.filter_state, WrappedNormalDistribution)
+        self.assertTrue(math.isfinite(float(self.wn_filter.filter_state.sigma)))
 
     def test_update_nonlinear_progressive_uses_adaptive_lambda(self):
         class FakeDiracDistribution:


### PR DESCRIPTION
## Summary
- fix JAX/PyTorch backend conversion and assignment edge cases
- allow array bounds in backend random uniform helpers
- accept scalar wrapped Laplace parameters and cover scalar likelihood callbacks

## Validation
- Ran `git diff --check` only.
- Tests not run per request.