### PR TITLE
Fix min_length denominators in track metrics

### DIFF
--- a/src/pyrecest/utils/track_metrics.py
+++ b/src/pyrecest/utils/track_metrics.py
@@ -120,9 +120,9 @@ def score_false_tracks(
     unreferenced_observations = 0
     total_observations = 0
     for observations in _observations_by_track(predicted):
-        total_observations += len(observations)
         if len(observations) < int(min_length):
             continue
+        total_observations += len(observations)
         evaluated_tracks += 1
         matched = sum(
             1 for observation in observations if observation in reference_lookup
@@ -172,9 +172,9 @@ def score_missed_tracks(
     missed_observations = 0
     total_observations = 0
     for observations in _observations_by_track(reference):
-        total_observations += len(observations)
         if len(observations) < int(min_length):
             continue
+        total_observations += len(observations)
         evaluated_tracks += 1
         recovered = sum(
             1 for observation in observations if observation in predicted_lookup

--- a/tests/test_track_metrics.py
+++ b/tests/test_track_metrics.py
@@ -62,6 +62,32 @@ class TestTrackMetrics(unittest.TestCase):
         self.assertEqual(scores["false_tracks"], 1)
         npt.assert_allclose(scores["observation_weighted_track_purity"], 6.0 / 7.0)
 
+    def test_min_length_limits_false_track_observation_rate_denominator(self):
+        predicted = [
+            [99, None, None],
+            [10, 11, None],
+        ]
+        reference = [[10, 10, None]]
+
+        scores = score_false_tracks(predicted, reference, min_length=2)
+
+        self.assertEqual(scores["false_track_evaluated_tracks"], 1)
+        self.assertEqual(scores["unreferenced_predicted_observations"], 1)
+        npt.assert_allclose(scores["unreferenced_predicted_observation_rate"], 0.5)
+
+    def test_min_length_limits_missed_track_observation_rate_denominator(self):
+        predicted = [[10, 10, None]]
+        reference = [
+            [99, None, None],
+            [10, 10, 10],
+        ]
+
+        scores = score_missed_tracks(predicted, reference, min_length=2)
+
+        self.assertEqual(scores["missed_track_evaluated_reference_tracks"], 1)
+        self.assertEqual(scores["missed_reference_observations"], 1)
+        npt.assert_allclose(scores["missed_reference_observation_rate"], 1.0 / 3.0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- restrict false-track observation-rate denominators to tracks that pass `min_length`
- restrict missed-track observation-rate denominators to reference tracks that pass `min_length`
- add regressions covering skipped short tracks for both metrics

## Rationale
When `min_length > 1`, short tracks are excluded from the evaluated-track counts and from the numerator of the observation-rate metrics. The denominator still included their observations, which biased the reported observation rates downward.

## Validation
- connector compare confirms the patch is limited to `src/pyrecest/utils/track_metrics.py` and `tests/test_track_metrics.py`
- local test execution was not possible here because direct repository checkout is unavailable in the execution sandbox; PR CI should run the focused and full test suites