### PR TITLE
Fix documentation examples checkout

### DIFF
--- a/.github/workflows/docs-examples.yml
+++ b/.github/workflows/docs-examples.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
## Summary
- pin the Documentation examples workflow checkout step back to `actions/checkout@v4`
- avoid the observed checkout failure where `actions/checkout@v6` could not fetch the pull-request merge ref before README examples ran

## Rationale
The current documentation examples workflow failed during checkout with:

```text
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

That prevents the README/documentation example checks from exercising the package at all. Other workflows are still successfully checking out with their current configuration, so this patch limits the compatibility fallback to the failing workflow.

## Validation
- Inspected the failing GitHub Actions job logs for the Documentation examples workflow.
- The change is restricted to `.github/workflows/docs-examples.yml`.
- PR CI should validate the workflow behavior.