### PR TITLE
Fix association model solve fallback

### DIFF
--- a/src/pyrecest/utils/association_models.py
+++ b/src/pyrecest/utils/association_models.py
@@ -44,6 +44,7 @@ from pyrecest.backend import (
 )
 
 _COST_MODE = Literal["negative_log_probability", "one_minus_probability"]
+_SOLVE_FALLBACK_EXCEPTIONS = (LinAlgError, RuntimeError, ValueError)
 
 
 @dataclass(frozen=True)
@@ -331,6 +332,22 @@ class LogisticPairwiseAssociationModel:  # pylint: disable=too-many-instance-att
             else requested_tolerance
         )
 
+    @staticmethod
+    def _solve_newton_step(hessian: Any, gradient: Any) -> Any:
+        """Solve an IRLS Newton system with backend-neutral fallback semantics."""
+        try:
+            step = linalg.solve(hessian, gradient)
+        except _SOLVE_FALLBACK_EXCEPTIONS:
+            step = linalg.pinv(hessian) @ gradient
+
+        if not all(isfinite(step)):
+            step = linalg.pinv(hessian) @ gradient
+        if not all(isfinite(step)):
+            raise FloatingPointError(
+                "Newton step is not finite even after pseudoinverse fallback"
+            )
+        return step
+
     def _store_fitted_parameters(self, parameter_vector: Any) -> None:
         if self.fit_intercept:
             self.intercept_ = float(parameter_vector[0])
@@ -375,10 +392,7 @@ class LogisticPairwiseAssociationModel:  # pylint: disable=too-many-instance-att
             if self.l2_regularization > 0.0:
                 hessian = hessian + self.l2_regularization * diag(regularization_mask)
 
-            try:
-                step = linalg.solve(hessian, gradient)
-            except LinAlgError:
-                step = linalg.pinv(hessian) @ gradient
+            step = self._solve_newton_step(hessian, gradient)
 
             parameter_vector = parameter_vector - step
             self.n_iter_ = iteration

--- a/tests/test_association_models.py
+++ b/tests/test_association_models.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 import numpy.testing as npt
 
@@ -125,6 +126,39 @@ class TestLogisticPairwiseAssociationModel(unittest.TestCase):
         self.assertTrue(all(isfinite(probabilities)))
         self.assertGreater(mean(probabilities[:80]), 0.9)
         self.assertLess(mean(probabilities[80:]), 0.1)
+
+    def test_fit_uses_pinv_fallback_for_backend_runtime_solve_errors(self):
+        model = LogisticPairwiseAssociationModel(
+            class_weight="balanced", max_iterations=3
+        )
+
+        with patch(
+            "pyrecest.utils.association_models.linalg.solve",
+            side_effect=RuntimeError("singular linear system"),
+        ):
+            model.fit(self.training_features, self.training_labels)
+
+        probabilities = model.predict_match_probability(self.training_features)
+        self.assertGreater(model.n_iter_, 0)
+        self.assertTrue(all(isfinite(probabilities)))
+
+    def test_fit_uses_pinv_fallback_for_nonfinite_backend_solve_results(self):
+        model = LogisticPairwiseAssociationModel(
+            class_weight="balanced", max_iterations=3
+        )
+
+        def nonfinite_solve(_hessian, gradient):
+            return zeros(gradient.shape) + float("nan")
+
+        with patch(
+            "pyrecest.utils.association_models.linalg.solve",
+            side_effect=nonfinite_solve,
+        ):
+            model.fit(self.training_features, self.training_labels)
+
+        probabilities = model.predict_match_probability(self.training_features)
+        self.assertGreater(model.n_iter_, 0)
+        self.assertTrue(all(isfinite(probabilities)))
 
     def test_invalid_labels_raise(self):
         model = LogisticPairwiseAssociationModel()


### PR DESCRIPTION
## Summary
- make `LogisticPairwiseAssociationModel`'s Newton solve fallback backend-neutral by retrying with `pinv` for backend runtime/value errors as well as NumPy `LinAlgError`
- retry with `pinv` when a backend solve returns non-finite steps, and fail explicitly if the fallback is also non-finite
- add focused regressions for raised backend solve errors and non-finite solve results

## Rationale
The association model fit loop uses the active backend's `linalg.solve`, but previously only caught `numpy.linalg.LinAlgError`. Non-NumPy backends may signal singular or unsupported linear solves with different exception types, and some backend solve implementations can return non-finite values instead of raising. In both cases, the existing pseudoinverse fallback was bypassed and bad Newton steps could propagate into fitted parameters.

## Validation
- Syntax-compiled the modified source and test file in the sandbox.
- Reviewed the branch diff through the GitHub connector: 2 files changed (`src/pyrecest/utils/association_models.py`, `tests/test_association_models.py`).
- Direct repository checkout and pytest execution were not possible here because the sandbox could not resolve `github.com`; PR CI should run the focused and full test matrix.