### PR TITLE
Fix MegaLinter PR validation mode

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -97,6 +97,7 @@ jobs:
           # Validate the checked-out codebase directly on PRs and on main pushes.
           VALIDATE_ALL_CODEBASE: true
           GITHUB_TOKEN: ${{ github.token }}
+          EMAIL_REPORTER_SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
 
       # Upload MegaLinter artifacts
       - name: Archive production artifacts

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -92,9 +92,11 @@ jobs:
           # All available variables are described in documentation
           # https://megalinter.io/latest/configuration/#shared-variables
           # ADD YOUR CUSTOM ENV VARIABLES HERE OR DEFINE THEM IN A FILE .mega-linter.yml AT THE ROOT OF YOUR REPOSITORY
-          VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }} # Validates all source when push on main, else just the git diff with main.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          EMAIL_REPORTER_SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+          # Diff mode currently fails in the MegaLinter container before any linter
+          # runs because its internal fetch cannot reuse checkout credentials.
+          # Validate the checked-out codebase directly on PRs and on main pushes.
+          VALIDATE_ALL_CODEBASE: true
+          GITHUB_TOKEN: ${{ github.token }}
 
       # Upload MegaLinter artifacts
       - name: Archive production artifacts


### PR DESCRIPTION
## Summary
- run MegaLinter against the checked-out codebase on pull requests instead of using diff-mode file collection
- use the workflow-scoped `github.token` for the MegaLinter step
- avoid the current pre-lint failure where MegaLinter's internal diff fetch cannot authenticate before any linter runs

## Rationale
The MegaLinter job currently fails during file collection on pull requests, before it reaches the actual linters. The failing run attempted `git fetch origin HEAD:refs/remotes/origin/HEAD` inside the MegaLinter container and failed with a GitHub credential error. Since `VALIDATE_ALL_CODEBASE` is false for PRs, MegaLinter enters this diff-collection path. Validating the checked-out codebase avoids that unauthenticated internal fetch path.

This is important because focused bug-fix PRs, including the open track-metric fix, are otherwise blocked by infrastructure before tests/lint can provide useful signal.

## Validation
- inspected the failed MegaLinter job logs from the open track-metric bug-fix PR
- connector compare confirms the patch changes only `.github/workflows/mega-linter.yml`
- direct local checkout/test execution was not possible here because the execution sandbox cannot resolve `github.com`; PR CI should validate the workflow behavior