### PR TITLE
Fix PyTorch random.choice population handling

### DIFF
--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -20,11 +20,22 @@ def _choice_size(size):
     return size, int(_torch.prod(_torch.tensor(size)).item())
 
 
+def _choice_population(a, p=None):
+    """Normalize NumPy-compatible ``choice`` populations to a tensor."""
+    device = p.device if _torch.is_tensor(p) else None
+    if isinstance(a, int):
+        if a <= 0:
+            raise ValueError("a must be greater than 0 unless no samples are taken")
+        return _torch.arange(a, device=device)
+    if _torch.is_tensor(a):
+        return a
+    return _torch.as_tensor(a, device=device)
+
+
 def choice(a, size=None, replace=True, p=None):
-    assert _torch.is_tensor(a), "a must be a tensor"
+    a = _choice_population(a, p=p)
     size, num_samples = _choice_size(size)
     if p is not None:
-        assert _torch.is_tensor(p), "p must be a tensor"
         if not replace and num_samples > len(a):
             raise ValueError(
                 "Cannot take a larger sample than population when 'replace=False'."

--- a/tests/test_backend_random.py
+++ b/tests/test_backend_random.py
@@ -28,6 +28,22 @@ class TestBackendRandom(unittest.TestCase):
 
         self.assertEqual(sample.shape, (1, 2))
 
+    def test_choice_accepts_python_list_population(self):
+        samples = random.choice([10, 20, 30], size=(32,))
+
+        self.assertEqual(samples.shape, (32,))
+        npt.assert_array_less(9, samples)
+        npt.assert_array_less(samples, 31)
+        for sample in pyrecest.backend.to_numpy(samples).tolist():
+            self.assertIn(sample, (10, 20, 30))
+
+    def test_choice_accepts_integer_population(self):
+        samples = random.choice(5, size=(32,))
+
+        self.assertEqual(samples.shape, (32,))
+        npt.assert_array_less(-1, samples)
+        npt.assert_array_less(samples, 5)
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ != "jax", "JAX-specific RNG state contract"
     )


### PR DESCRIPTION
## Summary
- normalize PyTorch `random.choice` populations so Python integer and list inputs match the NumPy/JAX backend contract
- continue supporting tensor populations and tensor/list probabilities by moving probability inputs to the sampled tensor device
- add backend-random regression coverage for Python list and integer populations

## Rationale
The NumPy and JAX backend `random.choice` helpers accept NumPy-compatible populations such as `5` and `[10, 20, 30]`. The PyTorch backend previously asserted that `a` was already a tensor, so otherwise portable code failed only under PyTorch.

## Validation
- connector compare confirms the branch is ahead of `main` by two commits, behind by zero, and changes only `src/pyrecest/_backend/pytorch/random.py` and `tests/test_backend_random.py`
- local PyTorch smoke test of the patched `choice` logic with list, integer, and tensor populations
- local repository checkout/pytest execution was not possible here because the execution sandbox could not resolve `github.com`; PR CI should run the backend test matrix