### PR TITLE
Fix PyTorch random choice backend behavior

### DIFF
--- a/src/pyrecest/_backend/pytorch/__init__.py
+++ b/src/pyrecest/_backend/pytorch/__init__.py
@@ -634,7 +634,9 @@ def prod(x, axis=None):
     x = array(x)
     if axis is None:
         return _torch.prod(x)
-    return _torch.prod(x, dim=axis)
+    return _reduce_over_axes(
+        x, axis, lambda values, one_axis: _torch.prod(values, dim=one_axis)
+    )
 
 
 def where(condition, x=None, y=None):

--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -1,5 +1,7 @@
 """Torch based random backend."""
 
+from numbers import Integral as _Integral
+
 import torch as _torch
 from torch import get_rng_state as get_state  # For PyRecEst
 from torch import randint
@@ -20,48 +22,84 @@ def _choice_size(size):
     return size, int(_torch.prod(_torch.tensor(size)).item())
 
 
-def _choice_population(a, p=None):
-    """Normalize NumPy-compatible ``choice`` populations to a tensor."""
-    device = p.device if _torch.is_tensor(p) else None
-    if isinstance(a, int):
-        if a <= 0:
-            raise ValueError("a must be greater than 0 unless no samples are taken")
-        return _torch.arange(a, device=device)
-    if _torch.is_tensor(a):
-        return a
-    return _torch.as_tensor(a, device=device)
+def _integer_population_size(a):
+    if isinstance(a, _Integral):
+        return int(a)
+    if (
+        _torch.is_tensor(a)
+        and a.ndim == 0
+        and not _torch.is_floating_point(a)
+        and not _torch.is_complex(a)
+    ):
+        return int(a.item())
+    return None
 
 
-def choice(a, size=None, replace=True, p=None):
-    a = _choice_population(a, p=p)
-    size, num_samples = _choice_size(size)
+def _choice_indices(population_size, size, num_samples, replace, p, device):
+    if population_size <= 0:
+        if num_samples == 0:
+            return _torch.empty(size or (0,), dtype=_torch.long, device=device)
+        raise ValueError("a must be greater than 0 unless no samples are taken")
+
     if p is not None:
-        if not replace and num_samples > len(a):
+        if not replace and num_samples > population_size:
             raise ValueError(
                 "Cannot take a larger sample than population when 'replace=False'."
             )
 
-        p = _torch.as_tensor(p, dtype=_torch.float32, device=a.device)
+        p = _torch.as_tensor(p, dtype=_torch.float32, device=device)
+        if p.ndim != 1 or p.shape[0] != population_size:
+            raise ValueError("p must be 1-dimensional with one entry per population item")
+
         p = p / p.sum()  # Normalize probabilities
         indices = _torch.multinomial(p, num_samples=num_samples, replacement=replace)
         if size is None:
-            indices = indices[0]
-        else:
-            indices = indices.reshape(size)
-    elif replace:
-        indices = _torch.randint(0, len(a), size or (), device=a.device)
-    else:
-        if num_samples > len(a):
-            raise ValueError(
-                "Cannot take a larger sample than population when 'replace=False'."
-            )
-        indices = _torch.randperm(len(a), device=a.device)[:num_samples]
-        if size is None:
-            indices = indices[0]
-        else:
-            indices = indices.reshape(size)
+            return indices[0]
+        return indices.reshape(size)
 
-    return a[indices]
+    if replace:
+        return _torch.randint(0, population_size, size or (), device=device)
+
+    if num_samples > population_size:
+        raise ValueError(
+            "Cannot take a larger sample than population when 'replace=False'."
+        )
+
+    indices = _torch.randperm(population_size, device=device)[:num_samples]
+    if size is None:
+        return indices[0]
+    return indices.reshape(size)
+
+
+def _take_choice(a, indices, axis):
+    axis = axis % a.ndim
+    if indices.ndim == 0:
+        return a.select(axis, int(indices.item()))
+
+    flattened_indices = indices.reshape(-1)
+    selected = _torch.index_select(a, dim=axis, index=flattened_indices)
+    return selected.reshape((*a.shape[:axis], *indices.shape, *a.shape[axis + 1 :]))
+
+
+def choice(a, size=None, replace=True, p=None, axis=0, shuffle=True):
+    del shuffle
+
+    size, num_samples = _choice_size(size)
+    population_size = _integer_population_size(a)
+    if population_size is not None:
+        device = p.device if _torch.is_tensor(p) else None
+        return _choice_indices(population_size, size, num_samples, replace, p, device)
+
+    if not _torch.is_tensor(a):
+        a = _torch.as_tensor(a)
+    if a.ndim == 0:
+        raise ValueError(
+            "a must be a positive integer or an array with at least one dimension"
+        )
+
+    axis = axis % a.ndim
+    indices = _choice_indices(a.shape[axis], size, num_samples, replace, p, a.device)
+    return _take_choice(a, indices, axis)
 
 
 def seed(*args, **kwargs):

--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -51,7 +51,10 @@ def _choice_indices(population_size, size, num_samples, replace, p, device):
         if p.ndim != 1 or p.shape[0] != population_size:
             raise ValueError("p must be 1-dimensional with one entry per population item")
 
-        p = p / p.sum()  # Normalize probabilities
+        p_sum = p.sum()
+        if not bool(_torch.isfinite(p_sum)) or bool(p_sum <= 0):
+            raise ValueError("probabilities do not sum to a positive value")
+        p = p / p_sum
         indices = _torch.multinomial(p, num_samples=num_samples, replacement=replace)
         if size is None:
             return indices[0]

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -86,6 +86,17 @@ def test_default_reductions_reduce_all_elements():
     assert float(_to_python(backend.prod(values))) == 120.0
 
 
+def test_prod_accepts_tuple_axis():
+    values = array(
+        [[[2.0, 3.0], [4.0, 5.0]], [[6.0, 7.0], [8.0, 9.0]]]
+    )
+
+    result = backend.prod(values, axis=(0, 2))
+
+    assert result.shape == (2,)
+    assert _to_python(result) == [252.0, 1440.0]
+
+
 def test_default_cumprod_flattens_all_elements():
     values = array([[2.0, 3.0], [4.0, 5.0]])
 

--- a/tests/test_backend_random.py
+++ b/tests/test_backend_random.py
@@ -44,6 +44,23 @@ class TestBackendRandom(unittest.TestCase):
         npt.assert_array_less(-1, samples)
         npt.assert_array_less(samples, 5)
 
+        no_replacement = random.choice(5, size=5, replace=False)
+
+        self.assertEqual(tuple(pyrecest.backend.shape(no_replacement)), (5,))
+        self.assertEqual(
+            len(set(pyrecest.backend.to_numpy(no_replacement).tolist())), 5
+        )
+
+    def test_choice_samples_matrix_values_along_requested_axis(self):
+        values = pyrecest.backend.array([[0, 1, 2], [3, 4, 5]])
+
+        sample = random.choice(values, size=2, replace=False, axis=1)
+
+        self.assertEqual(tuple(pyrecest.backend.shape(sample)), (2, 2))
+        sample_np = pyrecest.backend.to_numpy(sample)
+        self.assertTrue(set(sample_np[0].tolist()).issubset({0, 1, 2}))
+        self.assertTrue(set(sample_np[1].tolist()).issubset({3, 4, 5}))
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ != "jax", "JAX-specific RNG state contract"
     )

--- a/tests/test_backend_random.py
+++ b/tests/test_backend_random.py
@@ -51,6 +51,20 @@ class TestBackendRandom(unittest.TestCase):
             len(set(pyrecest.backend.to_numpy(no_replacement).tolist())), 5
         )
 
+    def test_choice_accepts_python_probability_sequence(self):
+        values = pyrecest.backend.array([10, 20, 30])
+
+        samples = random.choice(values, size=(32,), p=[0.2, 0.3, 0.5])
+
+        self.assertEqual(samples.shape, (32,))
+        for sample in pyrecest.backend.to_numpy(samples).tolist():
+            self.assertIn(sample, (10, 20, 30))
+
+    def test_choice_accepts_zero_sized_integer_population_sample(self):
+        samples = random.choice(0, size=(0,))
+
+        self.assertEqual(samples.shape, (0,))
+
     def test_choice_samples_matrix_values_along_requested_axis(self):
         values = pyrecest.backend.array([[0, 1, 2], [3, 4, 5]])
 


### PR DESCRIPTION
## Summary
- support tuple-axis PyTorch product reductions
- extend PyTorch random choice to support integer populations and axis selection
- add backend contract coverage for these behaviors

## Validation
- `git diff --check`

Tests were not run per request.