### PR TITLE
Fix scalar process noise in random matrix tracker

### DIFF
--- a/src/pyrecest/filters/random_matrix_tracker.py
+++ b/src/pyrecest/filters/random_matrix_tracker.py
@@ -1,6 +1,7 @@
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
     array,
+    asarray,
     concatenate,
     cos,
     exp,
@@ -60,6 +61,7 @@ class RandomMatrixTracker(AbstractExtendedObjectTracker):
         x_rows = self.kinematic_state.shape[0]
         y_rows = x_rows // 2
 
+        Cw = asarray(Cw)
         if Cw.shape in ((), (1,)):
             Cw = Cw * eye(x_rows)
 

--- a/tests/filters/test_random_matrix_tracker.py
+++ b/tests/filters/test_random_matrix_tracker.py
@@ -72,6 +72,21 @@ class TestRandomMatrixTracker(unittest.TestCase):
         )
         npt.assert_array_almost_equal(self.tracker.extent, expected_extent, decimal=5)
 
+    def test_predict_accepts_scalar_process_noise(self):
+        dt = 0.1
+        tau = 1.0
+        system_matrix = eye(2)
+
+        self.tracker.predict(dt, 0.05, tau, system_matrix)
+
+        expected_covariance = self.initial_covariance + 0.05 * eye(2)
+        npt.assert_array_almost_equal(
+            self.tracker.kinematic_state, self.initial_state, decimal=5
+        )
+        npt.assert_array_almost_equal(
+            self.tracker.covariance, expected_covariance, decimal=5
+        )
+
     @parameterized.expand(
         [
             (


### PR DESCRIPTION
## Summary
- normalize `RandomMatrixTracker.predict()` process noise through the active backend before inspecting its shape
- restore support for Python scalar process-noise inputs by expanding them to isotropic covariance matrices
- add a focused regression test for scalar `Cw`

## Rationale
`RandomMatrixTracker.predict()` already intended to accept scalar process noise via the `Cw.shape in ((), (1,))` branch. However, unlike the factorized GIW random-matrix tracker, it inspected `Cw.shape` before coercing `Cw` into a backend array. Passing a natural Python scalar such as `0.05` therefore raised `AttributeError` instead of producing `0.05 * eye(state_dim)`.

## Validation
- connector compare confirms this branch is ahead of `main` by two commits and behind by zero
- changes are limited to `src/pyrecest/filters/random_matrix_tracker.py` and `tests/filters/test_random_matrix_tracker.py`
- direct local pytest execution was not possible in this environment; PR CI should run the focused and full test matrix