### PR TITLE
Fix JAX random.randint backend contract

### DIFF
--- a/src/pyrecest/_backend/jax/random.py
+++ b/src/pyrecest/_backend/jax/random.py
@@ -117,7 +117,8 @@ def randint(low=None, high=None, size=None, *args, **kwargs):
 
     The preferred contract is ``randint(low, high=None, size=None, ...)``, which
     matches NumPy and the other PyRecEst backends. The older JAX-backend-only
-    forms ``randint(shape, minval=..., maxval=...)`` and
+    forms ``randint(shape, minval=..., maxval=...)``,
+    ``randint(size=shape, minval=..., maxval=...)``, and
     ``randint(shape, minval, maxval)`` are still accepted for compatibility.
     """
     legacy_minval = kwargs.pop("minval", None)
@@ -131,12 +132,15 @@ def randint(low=None, high=None, size=None, *args, **kwargs):
                 "Specify either NumPy-style 'low, high' or legacy "
                 "'minval, maxval', not both."
             )
-        if size is not None:
-            raise TypeError(
-                "Specify the legacy output shape as the first positional "
-                "argument or use NumPy-style 'size=', not both."
-            )
-        size = low
+        if low is not None:
+            if size is not None:
+                raise TypeError(
+                    "Specify the legacy output shape either as the first "
+                    "positional argument or 'size=', not both."
+                )
+            size = low
+        elif size is None:
+            raise TypeError("randint() missing required argument 'size'")
         low = legacy_minval
         high = legacy_maxval
     elif _looks_like_shape_sequence(low) and high is not None and size is not None:

--- a/src/pyrecest/_backend/jax/random.py
+++ b/src/pyrecest/_backend/jax/random.py
@@ -65,6 +65,12 @@ def _looks_like_shape(value):
     )
 
 
+def _looks_like_shape_sequence(value):
+    return isinstance(value, (list, tuple)) and all(
+        isinstance(dim, (int, _np.integer)) for dim in value
+    )
+
+
 def set_state_return(has_state, state, res):
     if has_state:
         return state, res
@@ -94,14 +100,56 @@ def uniform(low=0.0, high=1.0, size=None, *args, **kwargs):
     return set_state_return(has_state, state, res)
 
 
-def _randint(state, size, *args, **kwargs):
+def _randint(state, size, low, high, *args, **kwargs):
     state, key = jax.random.split(state)
-    return state, jax.random.randint(key, size, *args, **kwargs)
+    return state, jax.random.randint(
+        key,
+        _shape_from_size(size),
+        low,
+        high,
+        *args,
+        **kwargs,
+    )
 
 
-def randint(size, *args, **kwargs):
+def randint(low=None, high=None, size=None, *args, **kwargs):
+    """Draw integer samples using NumPy-compatible arguments.
+
+    The preferred contract is ``randint(low, high=None, size=None, ...)``, which
+    matches NumPy and the other PyRecEst backends. The older JAX-backend-only
+    forms ``randint(shape, minval=..., maxval=...)`` and
+    ``randint(shape, minval, maxval)`` are still accepted for compatibility.
+    """
+    legacy_minval = kwargs.pop("minval", None)
+    legacy_maxval = kwargs.pop("maxval", None)
+
+    if legacy_minval is not None or legacy_maxval is not None:
+        if legacy_minval is None or legacy_maxval is None:
+            raise TypeError("Specify both 'minval' and 'maxval'.")
+        if high is not None:
+            raise TypeError(
+                "Specify either NumPy-style 'low, high' or legacy "
+                "'minval, maxval', not both."
+            )
+        if size is not None:
+            raise TypeError(
+                "Specify the legacy output shape as the first positional "
+                "argument or use NumPy-style 'size=', not both."
+            )
+        size = low
+        low = legacy_minval
+        high = legacy_maxval
+    elif _looks_like_shape_sequence(low) and high is not None and size is not None:
+        # Legacy positional form: randint(shape, minval, maxval)
+        size, low, high = low, high, size
+    elif high is None:
+        if low is None:
+            raise TypeError("randint() missing required argument 'high'")
+        high = low
+        low = 0
+
     state, has_state, kwargs = _get_state(**kwargs)
-    state, res = _randint(state, _shape_from_size(size), *args, **kwargs)
+    state, res = _randint(state, size, low, high, *args, **kwargs)
     return set_state_return(has_state, state, res)
 
 

--- a/tests/backend_support/test_jax_random_integer_contract.py
+++ b/tests/backend_support/test_jax_random_integer_contract.py
@@ -1,0 +1,41 @@
+"""Regression test for JAX random integer argument handling."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+_CHECK = """
+import pyrecest.backend as backend
+from pyrecest.backend import random
+
+samples = random.randint(0, 5, size=(16,))
+high_only = random.randint(5, size=(16,))
+compat = random.randint((16,), minval=2, maxval=7)
+
+assert samples.shape == (16,)
+assert high_only.shape == (16,)
+assert compat.shape == (16,)
+assert bool(backend.all(samples >= 0))
+assert bool(backend.all(samples < 5))
+assert bool(backend.all(high_only >= 0))
+assert bool(backend.all(high_only < 5))
+assert bool(backend.all(compat >= 2))
+assert bool(backend.all(compat < 7))
+print("ok")
+"""
+
+
+@pytest.mark.backend_portable
+def test_jax_randint_argument_styles():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("JAX is not installed")
+
+    result = run_backend_code("jax", _CHECK)
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout

--- a/tests/backend_support/test_jax_random_integer_contract.py
+++ b/tests/backend_support/test_jax_random_integer_contract.py
@@ -15,17 +15,21 @@ from pyrecest.backend import random
 
 samples = random.randint(0, 5, size=(16,))
 high_only = random.randint(5, size=(16,))
-compat = random.randint((16,), minval=2, maxval=7)
+compat_positional_shape = random.randint((16,), minval=2, maxval=7)
+compat_keyword_shape = random.randint(size=(16,), minval=2, maxval=7)
 
 assert samples.shape == (16,)
 assert high_only.shape == (16,)
-assert compat.shape == (16,)
+assert compat_positional_shape.shape == (16,)
+assert compat_keyword_shape.shape == (16,)
 assert bool(backend.all(samples >= 0))
 assert bool(backend.all(samples < 5))
 assert bool(backend.all(high_only >= 0))
 assert bool(backend.all(high_only < 5))
-assert bool(backend.all(compat >= 2))
-assert bool(backend.all(compat < 7))
+assert bool(backend.all(compat_positional_shape >= 2))
+assert bool(backend.all(compat_positional_shape < 7))
+assert bool(backend.all(compat_keyword_shape >= 2))
+assert bool(backend.all(compat_keyword_shape < 7))
 print("ok")
 """
 

--- a/tests/test_backend_random.py
+++ b/tests/test_backend_random.py
@@ -9,12 +9,7 @@ from pyrecest.backend import random
 
 class TestBackendRandom(unittest.TestCase):
     def test_randint_returns_integer_samples_in_bounds(self):
-        if pyrecest.backend.__backend_name__ == "jax":
-            samples = random.randint((64,), minval=0, maxval=5)
-        elif pyrecest.backend.__backend_name__ == "pytorch":
-            samples = random.randint(0, 5, (64,))
-        else:
-            samples = random.randint(0, 5, size=(64,))
+        samples = random.randint(0, 5, size=(64,))
 
         npt.assert_equal(samples.shape, (64,))
         self.assertIn(samples.dtype, (pyrecest.backend.int32, pyrecest.backend.int64))


### PR DESCRIPTION
## Summary

- Fix the JAX random backend so `random.randint(0, high, size=...)` and `random.randint(low, high, size=...)` follow the NumPy/PyTorch-style PyRecEst backend contract.
- Preserve the existing JAX-backend legacy forms using `minval`/`maxval`, including positional and keyword shape variants.
- Remove the backend-specific branch from the generic random backend test and add a focused JAX subprocess regression test.

## Tests

- Added `tests/backend_support/test_jax_random_integer_contract.py`.
- Updated `tests/test_backend_random.py` to exercise the portable randint contract.
- Locally validated the patched JAX call forms in isolation because the execution container could not resolve github.com for a full repository clone/test run.