### PR TITLE
Fix PyTorch backend mean axis handling

### DIFF
--- a/src/pyrecest/_backend/__init__.py
+++ b/src/pyrecest/_backend/__init__.py
@@ -301,6 +301,27 @@ def _meshgrid_with_arraylike_axes(meshgrid_func, asarray_func, atleast_1d_func):
     return meshgrid
 
 
+def _mean_with_numpy_signature(mean_func, asarray_func, reshape_func):
+    """Return a NumPy-compatible mean wrapper for stricter backends."""
+
+    @wraps(mean_func)
+    def mean(a, axis=None, dtype=None, out=None, keepdims=False):
+        a = asarray_func(a, dtype=dtype) if dtype is not None else asarray_func(a)
+        if axis is None:
+            result = mean_func(a)
+            if keepdims:
+                result = reshape_func(result, (1,) * a.ndim)
+        else:
+            result = mean_func(a, dim=axis, keepdim=keepdims)
+
+        if out is not None:
+            out[...] = result
+            return out
+        return result
+
+    return mean
+
+
 class BackendImporter(importlib.abc.MetaPathFinder, importlib.abc.Loader):
     """
     Meta path finder and loader for dynamically creating backend modules.
@@ -365,6 +386,16 @@ class BackendImporter(importlib.abc.MetaPathFinder, importlib.abc.Loader):
                             f"attribute '{attribute_name}'."
                         ) from None
                 else:
+                    if (
+                        module_name == ""
+                        and attribute_name == "mean"
+                        and backend_name == "pytorch"
+                    ):
+                        attribute = _mean_with_numpy_signature(
+                            attribute,
+                            getattr(backend, "asarray"),
+                            getattr(backend, "reshape"),
+                        )
                     if (
                         module_name == ""
                         and attribute_name == "meshgrid"

--- a/tests/test_backend_mean_contract.py
+++ b/tests/test_backend_mean_contract.py
@@ -1,0 +1,29 @@
+import pyrecest.backend as backend
+
+
+def _to_python(value):
+    value = backend.to_numpy(value)
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    return value
+
+
+def test_mean_accepts_axis_and_keepdims_keywords():
+    values = backend.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+
+    result = backend.mean(values, axis=1, keepdims=True)
+
+    assert _to_python(result) == [[2.0], [5.0]]
+
+
+def test_mean_accepts_tuple_axis():
+    values = backend.array(
+        [
+            [[1.0, 2.0], [3.0, 4.0]],
+            [[5.0, 6.0], [7.0, 8.0]],
+        ]
+    )
+
+    result = backend.mean(values, axis=(0, 2))
+
+    assert _to_python(result) == [3.5, 5.5]


### PR DESCRIPTION
## Summary
- wrap the exposed PyTorch backend `mean` with a NumPy-compatible signature
- support `axis`, `keepdims`, `dtype`, and `out` arguments for the PyTorch backend export
- add backend contract tests for `axis`/`keepdims` and tuple axes

## Rationale
`pyrecest.backend` exposes NumPy-style APIs across backends. The PyTorch backend currently exports raw `torch.mean`, which does not accept NumPy-style `axis=` or `keepdims=` keyword arguments. Portable code using `backend.mean(..., axis=..., keepdims=...)` therefore succeeds with NumPy/JAX but fails with PyTorch.

## Validation
- Connector compare confirms the branch changes only `src/pyrecest/_backend/__init__.py` and `tests/test_backend_mean_contract.py`.
- Direct local checkout/pytest execution was not possible because the execution sandbox cannot resolve `github.com`; PR CI should run the backend matrix.