### PR TITLE
Fix PyTorch random.normal array parameters

### DIFF
--- a/.checkov.yml
+++ b/.checkov.yml
@@ -1,0 +1,2 @@
+skip-path:
+  - megalinter-reports/

--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -22,6 +22,38 @@ def _choice_size(size):
     return size, int(_torch.prod(_torch.tensor(size)).item())
 
 
+def _normal_size(size):
+    if size is None:
+        return None
+    if not hasattr(size, "__iter__"):
+        return (size,)
+    return tuple(int(dim) for dim in size)
+
+
+def _normal_device(*values):
+    for value in values:
+        if _torch.is_tensor(value):
+            return value.device
+    return None
+
+
+def _is_array_parameter(value):
+    return _torch.is_tensor(value) or isinstance(value, (list, tuple)) or (
+        not isinstance(value, (str, bytes)) and hasattr(value, "__array__")
+    )
+
+
+def _normal_array_parameters(loc, scale):
+    device = _normal_device(loc, scale)
+    loc = _torch.as_tensor(loc, device=device)
+    scale = _torch.as_tensor(scale, device=device)
+    dtype = _torch.promote_types(
+        _torch.result_type(loc, scale),
+        _torch.get_default_dtype(),
+    )
+    return loc.to(dtype=dtype), scale.to(dtype=dtype)
+
+
 def _integer_population_size(a):
     if isinstance(a, _Integral):
         return int(a)
@@ -126,11 +158,18 @@ def multinomial(n, pvals):
 
 @_allow_complex_dtype
 def normal(loc=0.0, scale=1.0, size=None):
+    size = _normal_size(size)
+    if not (_is_array_parameter(loc) or _is_array_parameter(scale)):
+        return _torch.normal(mean=loc, std=scale, size=size or ())
+
+    loc, scale = _normal_array_parameters(loc, scale)
     if size is None:
-        size = ()
-    elif not hasattr(size, "__iter__"):
-        size = (size,)
-    return _torch.normal(mean=loc, std=scale, size=size)
+        return _torch.normal(mean=loc, std=scale)
+
+    if bool(_torch.any(scale < 0)):
+        raise ValueError("scale must be non-negative")
+    dtype = _torch.result_type(loc, scale)
+    return _torch.empty(size, dtype=dtype, device=loc.device).normal_() * scale + loc
 
 
 def uniform(low=0.0, high=1.0, size=None, dtype=None):

--- a/tests/backend_support/test_pytorch_random_normal_contract.py
+++ b/tests/backend_support/test_pytorch_random_normal_contract.py
@@ -1,0 +1,63 @@
+"""Regression tests for PyTorch backend random.normal keyword compatibility."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+_ARRAY_PARAMETER_CHECK = """
+import pyrecest.backend as backend
+from pyrecest.backend import random
+
+backend.random.seed(7)
+loc = backend.asarray([1.0, 2.0])
+scale = backend.asarray([0.1, 0.2])
+
+sample = random.normal(loc=loc, scale=scale)
+list_sample = random.normal(loc=[1.0, 2.0], scale=0.1, size=(3, 2))
+
+assert sample.shape == (2,)
+assert list_sample.shape == (3, 2)
+assert backend.to_numpy(sample).dtype.kind == "f"
+assert backend.to_numpy(list_sample).dtype.kind == "f"
+print("ok")
+"""
+
+
+_ARRAY_PARAMETER_NEGATIVE_SCALE_CHECK = """
+from pyrecest.backend import random
+
+try:
+    random.normal(loc=[1.0, 2.0], scale=-1.0, size=(2,))
+except ValueError as exc:
+    assert "scale" in str(exc)
+else:
+    raise AssertionError("array-valued normal accepted a negative scale")
+
+print("ok")
+"""
+
+
+@pytest.mark.backend_portable
+def test_pytorch_normal_accepts_array_valued_parameters():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code("pytorch", _ARRAY_PARAMETER_CHECK)
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+@pytest.mark.backend_portable
+def test_pytorch_normal_rejects_negative_array_scale_with_size():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code("pytorch", _ARRAY_PARAMETER_NEGATIVE_SCALE_CHECK)
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- handle NumPy-style array-valued `loc`/`scale` in the PyTorch `random.normal` backend wrapper
- preserve scalar fast-path behavior while avoiding the invalid `torch.normal(..., size=())` tensor-parameter signature
- add PyTorch backend regression tests for array-valued parameters, explicit output size broadcasting, and negative scale rejection

## Validation
- Local behavioral smoke test of the new PyTorch sampling helper paths passed.
- `compare_commits` shows the branch is cleanly ahead of `main` by two commits.
- Full local pytest was not run because the execution container cannot resolve `github.com`; PR CI should run the focused backend-portability test and full matrix.