### PR TITLE
Fix JAX meshgrid input coercion

### DIFF
--- a/src/pyrecest/_backend/jax/__init__.py
+++ b/src/pyrecest/_backend/jax/__init__.py
@@ -92,7 +92,6 @@ from jax.numpy import (  # For pyrecest; For Riemannian score-based SDE
     max,
     maximum,
     mean,
-    meshgrid,
     min,
     minimum,
     mod,
@@ -155,6 +154,19 @@ def has_autodiff():
 
 def isscalar(x):
     return _jnp.isscalar(x) and not isinstance(x, _jnp.ndarray)
+
+
+def meshgrid(*xi, copy=True, sparse=False, indexing="xy"):
+    """Return coordinate matrices with NumPy-style axis coercion.
+
+    The PyRecEst backend contract follows NumPy semantics: callers may pass
+    lists, ranges, and scalar axes. JAX's native ``meshgrid`` requires array or
+    scalar arguments and then rejects 0-D array axes. Coercing every axis to at
+    least one-dimensional JAX arrays preserves NumPy-compatible behavior while
+    keeping the returned arrays in the JAX backend.
+    """
+    axes = tuple(_jnp.atleast_1d(_jnp.asarray(axis)) for axis in xi)
+    return _jnp.meshgrid(*axes, copy=copy, sparse=sparse, indexing=indexing)
 
 
 from jax import device_get as to_numpy

--- a/tests/test_backend_meshgrid_contract.py
+++ b/tests/test_backend_meshgrid_contract.py
@@ -1,4 +1,10 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
 import pyrecest.backend as backend
+import pytest
 
 
 def _to_python(value):
@@ -20,3 +26,29 @@ def test_meshgrid_accepts_scalar_axes():
 
     assert _to_python(rows) == [[1, 1]]
     assert _to_python(cols) == [[2, 3]]
+
+
+@pytest.mark.backend_portable
+def test_jax_meshgrid_accepts_numpy_style_axes():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("jax is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "jax"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import pyrecest.backend as backend
+rows, cols = backend.meshgrid([0, 1], range(2), indexing='ij')
+assert backend.to_numpy(rows).tolist() == [[0, 0], [1, 1]]
+assert backend.to_numpy(cols).tolist() == [[0, 1], [0, 1]]
+rows, cols = backend.meshgrid(1, [2, 3], indexing='ij')
+assert backend.to_numpy(rows).tolist() == [[1, 1]]
+assert backend.to_numpy(cols).tolist() == [[2, 3]]
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- replace the direct JAX `meshgrid` export with a small backend wrapper that coerces lists, ranges, and scalar axes to one-dimensional JAX arrays
- preserve NumPy-style backend semantics while returning JAX arrays
- add an explicit subprocess regression test for `PYRECEST_BACKEND=jax`

## Bug fixed
The shared backend contract accepts NumPy-style `meshgrid` axes such as lists, `range` objects, and scalar axes. `jax.numpy.meshgrid` rejects list/range axes and also rejects 0-D array axes, so the JAX backend could fail even though the NumPy backend passed the same contract tests.

## Validation
- Local focused JAX smoke check confirmed native `jax.numpy.meshgrid([0, 1], range(2), indexing="ij")` raises `TypeError` and the wrapper produces the expected coordinate grids.
- `compare_commits` reports this branch is ahead of `main` by 2 commits and behind by 0, changing only `src/pyrecest/_backend/jax/__init__.py` and `tests/test_backend_meshgrid_contract.py`.
- Full local pytest was not run because the execution container cannot clone from GitHub; PR CI should run the backend-portability test and full matrix.