### PR TITLE
Fix PyTorch random.multinomial sequence inputs

### DIFF
--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -120,6 +120,8 @@ def rand(size=None, dtype=None):
 
 
 def multinomial(n, pvals):
+    device = pvals.device if _torch.is_tensor(pvals) else None
+    pvals = _torch.as_tensor(pvals, dtype=_torch.float32, device=device)
     pvals = pvals / pvals.sum()
     return _torch.multinomial(pvals, n, replacement=True).bincount(minlength=len(pvals))
 

--- a/tests/test_backend_random.py
+++ b/tests/test_backend_random.py
@@ -70,6 +70,12 @@ class TestBackendRandom(unittest.TestCase):
         self.assertTrue(set(sample_np[0].tolist()).issubset({0, 1, 2}))
         self.assertTrue(set(sample_np[1].tolist()).issubset({3, 4, 5}))
 
+    def test_multinomial_accepts_python_probability_sequence(self):
+        sample = random.multinomial(12, [0.25, 0.75])
+
+        self.assertEqual(sample.shape, (2,))
+        self.assertEqual(int(pyrecest.backend.sum(sample)), 12)
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ != "jax", "JAX-specific RNG state contract"
     )


### PR DESCRIPTION
## Summary
- coerce PyTorch backend `random.multinomial` probability inputs to tensors before normalization
- preserve tensor device placement when `pvals` is already a tensor
- add backend-random regression coverage for Python probability sequences

## Rationale
The NumPy and JAX random backends accept ordinary Python probability sequences for `random.multinomial`. The PyTorch backend assumed `pvals` was already a tensor and called `.sum()` directly, so portable code such as `random.multinomial(12, [0.25, 0.75])` failed only under `PYRECEST_BACKEND=pytorch`.

## Validation
- connector compare confirms this branch is two commits ahead of current `main` and behind by zero
- changes are limited to `src/pyrecest/_backend/pytorch/random.py` and `tests/test_backend_random.py`
- direct local pytest execution was not available through the GitHub connector; PR CI should run the backend matrix