### PR TITLE
Fix MEM-RBPF FFBSi tuple record handling

### DIFF
--- a/src/pyrecest/smoothers/mem_rbpf_ffbsi_smoother.py
+++ b/src/pyrecest/smoothers/mem_rbpf_ffbsi_smoother.py
@@ -170,6 +170,13 @@ class MEMRBPFFFBSiSmoother(AbstractSmoother):
         self.angle_wrap_terms = int(angle_wrap_terms)
         self.axis_floor = float(axis_floor)
 
+    @staticmethod
+    def _uniform_weights_from_theta(theta):
+        theta = np.asarray(theta).reshape(-1)
+        if theta.size == 0:
+            raise ValueError("tuple records must contain at least one theta particle")
+        return np.full(theta.shape, 1.0 / theta.size, dtype=float)
+
     @classmethod
     def _as_record(cls, record) -> MEMRBPFForwardRecord:
         if isinstance(record, MEMRBPFForwardRecord):
@@ -178,10 +185,22 @@ class MEMRBPFFFBSiSmoother(AbstractSmoother):
             return MEMRBPFForwardRecord.from_tracker(record)
         if isinstance(record, Mapping):
             return MEMRBPFForwardRecord.from_mapping(record)
-        if isinstance(record, tuple) and len(record) in (5, 6):
-            kwargs = {} if len(record) == 5 else dict(record[5])
+        if isinstance(record, tuple) and len(record) in (5, 6, 7):
+            kwargs = {}
+            weights = None
+            if len(record) == 5:
+                weights = cls._uniform_weights_from_theta(record[2])
+            elif len(record) == 6:
+                if isinstance(record[5], Mapping):
+                    kwargs = dict(record[5])
+                    weights = cls._uniform_weights_from_theta(record[2])
+                else:
+                    weights = record[5]
+            else:
+                weights = record[5]
+                kwargs = dict(record[6])
             return MEMRBPFForwardRecord(
-                record[0], record[1], record[2], record[3], record[4], **kwargs
+                record[0], record[1], record[2], record[3], record[4], weights, **kwargs
             )
         raise ValueError(
             "record must be a MEMRBPFForwardRecord, MEMRBPFTracker, mapping, or tuple"

--- a/tests/smoothers/test_mem_rbpf_ffbsi_smoother.py
+++ b/tests/smoothers/test_mem_rbpf_ffbsi_smoother.py
@@ -181,3 +181,48 @@ def test_smooth_accepts_mapping_records():
 
     assert result.states.shape == (1, 4)
     assert np.all(np.isfinite(result.states))
+
+
+def test_smooth_accepts_legacy_five_tuple_records_with_uniform_weights():
+    axis_cov = np.repeat(np.eye(2)[np.newaxis, :, :] * 0.2, 2, axis=0)
+    tuple_record = (
+        np.array([0.0]),
+        np.array([[1.0]]),
+        np.array([0.0, 0.2]),
+        np.array([[2.0, 1.0], [1.8, 0.8]]),
+        axis_cov,
+    )
+
+    normalized = MEMRBPFFFBSiSmoother._as_record(tuple_record)
+    npt.assert_allclose(normalized.weights, np.array([0.5, 0.5]))
+
+    result = MEMRBPFFFBSiSmoother(n_trajectories=4, sample_axis=False).smooth(
+        [tuple_record], rng=2, full_axis_lengths=False
+    )
+
+    assert result.states.shape == (1, 4)
+    assert np.all(np.isfinite(result.states))
+
+
+def test_smooth_accepts_tuple_records_with_weights_and_kwargs():
+    axis_cov = np.repeat(np.eye(2)[np.newaxis, :, :] * 0.2, 2, axis=0)
+    tuple_record = (
+        np.array([0.0]),
+        np.array([[1.0]]),
+        np.array([0.0, 0.2]),
+        np.array([[2.0, 1.0], [1.8, 0.8]]),
+        axis_cov,
+        np.array([0.8, 0.2]),
+        {"orientation_process_variance": 0.05},
+    )
+
+    normalized = MEMRBPFFFBSiSmoother._as_record(tuple_record)
+    npt.assert_allclose(normalized.weights, np.array([0.8, 0.2]))
+    assert normalized.orientation_process_variance == 0.05
+
+    result = MEMRBPFFFBSiSmoother(n_trajectories=4, sample_axis=False).smooth(
+        [tuple_record], rng=2, full_axis_lengths=False
+    )
+
+    assert result.states.shape == (1, 4)
+    assert np.all(np.isfinite(result.states))


### PR DESCRIPTION
## Summary
- fix `MEMRBPFFFBSiSmoother` legacy tuple-record handling so documented 5-tuples no longer omit the required particle weights
- infer uniform weights for legacy 5-tuples and 6-tuples whose last element is the kwargs mapping
- support explicit `(x, P, theta, axis, axis_covariance, weights, kwargs)` tuple records without breaking the existing mapping and object paths
- add regression tests for legacy uniform-weight tuple records and explicit weights plus kwargs

## Rationale
`_as_record` advertised tuple records of length 5 or 6, but a 5-tuple was forwarded directly into `MEMRBPFForwardRecord` without the required `weights` argument. That made the legacy tuple compatibility path unusable. A 6-tuple was also ambiguous because it was always treated as `(five fields, kwargs)`, leaving no way to provide explicit weights together with keyword metadata.

## Validation
- Verified the branch is based on current `main` via connector compare: 2 commits ahead, 0 behind.
- Reviewed the connector diff: 2 files changed (`src/pyrecest/smoothers/mem_rbpf_ffbsi_smoother.py`, `tests/smoothers/test_mem_rbpf_ffbsi_smoother.py`).
- Direct local pytest execution was not possible from this environment because the sandbox cannot clone/resolve GitHub; PR CI should run the focused smoother tests and full matrix.