### PR TITLE
Fix empty assignment-index backend handling

### DIFF
--- a/src/pyrecest/_backend/__init__.py
+++ b/src/pyrecest/_backend/__init__.py
@@ -215,6 +215,7 @@ BACKEND_ATTRIBUTES = {
         "jacobian_vec",
         "jacobian_and_hessian",
         "value_and_grad",
+        "value_and_jacobian",
         "value_jacobian_and_hessian",
     ],
     "linalg": [

--- a/src/pyrecest/_backend/__init__.py
+++ b/src/pyrecest/_backend/__init__.py
@@ -351,8 +351,10 @@ def _mean_with_numpy_signature(mean_func, asarray_func, reshape_func):
 
 def _is_empty_assignment_index(indices):
     """Return whether ``indices`` selects no elements for assignment helpers."""
-    if isinstance(indices, (list, tuple)):
+    if isinstance(indices, list):
         return len(indices) == 0
+    if isinstance(indices, tuple):
+        return False
 
     ndim = getattr(indices, "ndim", None)
     shape = getattr(indices, "shape", None)

--- a/src/pyrecest/_backend/__init__.py
+++ b/src/pyrecest/_backend/__init__.py
@@ -215,7 +215,6 @@ BACKEND_ATTRIBUTES = {
         "jacobian_vec",
         "jacobian_and_hessian",
         "value_and_grad",
-        "value_and_jacobian",
         "value_jacobian_and_hessian",
     ],
     "linalg": [
@@ -349,6 +348,28 @@ def _mean_with_numpy_signature(mean_func, asarray_func, reshape_func):
     return mean
 
 
+def _is_empty_assignment_index(indices):
+    """Return whether ``indices`` selects no elements for assignment helpers."""
+    if isinstance(indices, (list, tuple)):
+        return len(indices) == 0
+
+    ndim = getattr(indices, "ndim", None)
+    shape = getattr(indices, "shape", None)
+    return ndim is not None and ndim > 0 and shape is not None and shape[0] == 0
+
+
+def _assignment_with_empty_indices_noop(assignment_func, copy_func):
+    """Return an assignment wrapper that treats empty indices as a no-op."""
+
+    @wraps(assignment_func)
+    def assignment(x, values, indices, axis=0):
+        if _is_empty_assignment_index(indices):
+            return copy_func(x)
+        return assignment_func(x, values, indices, axis=axis)
+
+    return assignment
+
+
 class BackendImporter(importlib.abc.MetaPathFinder, importlib.abc.Loader):
     """
     Meta path finder and loader for dynamically creating backend modules.
@@ -441,6 +462,14 @@ class BackendImporter(importlib.abc.MetaPathFinder, importlib.abc.Loader):
                         attribute = _quantile_with_numpy_axis(
                             attribute,
                             getattr(backend, "asarray"),
+                        )
+                    if (
+                        module_name == ""
+                        and attribute_name in {"assignment", "assignment_by_sum"}
+                    ):
+                        attribute = _assignment_with_empty_indices_noop(
+                            attribute,
+                            getattr(backend, "copy"),
                         )
                     setattr(new_submodule, attribute_name, attribute)
 

--- a/tests/test_backend_contract.py
+++ b/tests/test_backend_contract.py
@@ -27,6 +27,15 @@ class BackendContractTest(unittest.TestCase):
         self.assertEqual(to_numpy(first).dtype, np.dtype("bool"))
         self.assertEqual(to_numpy(second).dtype, np.dtype("bool"))
 
+    def test_assignment_with_empty_indices_is_a_noop(self):
+        original = array([1.0, 2.0, 3.0])
+
+        assigned = backend.assignment(original, 99.0, [])
+        added = backend.assignment_by_sum(original, 99.0, [])
+
+        npt.assert_allclose(to_numpy(assigned), [1.0, 2.0, 3.0])
+        npt.assert_allclose(to_numpy(added), [1.0, 2.0, 3.0])
+
     def test_choice_supports_numpy_like_size_replace_and_probabilities(self):
         values = array([0, 1, 2, 3])
         weights = array([0.1, 0.2, 0.3, 0.4])


### PR DESCRIPTION
## Summary
- Treat empty assignment index collections as no-op updates in the public backend facade.
- Keep empty tuple assignment semantics unchanged.
- Add a backend-contract regression test covering `assignment` and `assignment_by_sum` with empty list indices.

## Testing
- Not run locally: container GitHub DNS resolution failed, so validation is deferred to repository CI.