### PR TITLE
Fix PyTorch sum keepdims contract

### DIFF
--- a/src/pyrecest/_backend/__init__.py
+++ b/src/pyrecest/_backend/__init__.py
@@ -349,6 +349,27 @@ def _mean_with_numpy_signature(mean_func, asarray_func, reshape_func):
     return mean
 
 
+def _sum_with_numpy_signature(sum_func, asarray_func, reshape_func):
+    """Return a NumPy-compatible sum wrapper for stricter backends."""
+
+    @wraps(sum_func)
+    def sum(a, axis=None, dtype=None, out=None, keepdims=False):
+        a = asarray_func(a, dtype=dtype) if dtype is not None else asarray_func(a)
+        if axis is None:
+            result = sum_func(a, dtype=dtype)
+            if keepdims:
+                result = reshape_func(result, (1,) * a.ndim)
+        else:
+            result = sum_func(a, axis=axis, keepdims=keepdims, dtype=dtype)
+
+        if out is not None:
+            out[...] = result
+            return out
+        return result
+
+    return sum
+
+
 def _is_empty_assignment_index(indices):
     """Return whether ``indices`` selects no elements for assignment helpers."""
     if isinstance(indices, list):
@@ -443,6 +464,16 @@ class BackendImporter(importlib.abc.MetaPathFinder, importlib.abc.Loader):
                         and backend_name == "pytorch"
                     ):
                         attribute = _mean_with_numpy_signature(
+                            attribute,
+                            getattr(backend, "asarray"),
+                            getattr(backend, "reshape"),
+                        )
+                    if (
+                        module_name == ""
+                        and attribute_name == "sum"
+                        and backend_name == "pytorch"
+                    ):
+                        attribute = _sum_with_numpy_signature(
                             attribute,
                             getattr(backend, "asarray"),
                             getattr(backend, "reshape"),

--- a/tests/test_backend_sum_contract.py
+++ b/tests/test_backend_sum_contract.py
@@ -1,0 +1,68 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pyrecest.backend as backend
+import pytest
+
+
+def _to_python(value):
+    value = backend.to_numpy(value)
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    return value
+
+
+def test_sum_accepts_axis_and_keepdims_keywords():
+    values = backend.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+
+    result = backend.sum(values, axis=1, keepdims=True)
+
+    assert _to_python(result) == [[6.0], [15.0]]
+
+
+def test_sum_accepts_axis_none_with_keepdims():
+    values = backend.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+
+    result = backend.sum(values, keepdims=True)
+
+    assert _to_python(result) == [[21.0]]
+
+
+def test_sum_accepts_tuple_axis():
+    values = backend.array(
+        [
+            [[1.0, 2.0], [3.0, 4.0]],
+            [[5.0, 6.0], [7.0, 8.0]],
+        ]
+    )
+
+    result = backend.sum(values, axis=(0, 2))
+
+    assert _to_python(result) == [14.0, 22.0]
+
+
+@pytest.mark.backend_portable
+def test_pytorch_sum_accepts_axis_none_with_keepdims():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import pyrecest.backend as backend
+values = backend.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+total = backend.sum(values, keepdims=True)
+assert backend.to_numpy(total).tolist() == [[21.0]]
+row_sums = backend.sum(values, axis=1, keepdims=True)
+assert backend.to_numpy(row_sums).tolist() == [[6.0], [15.0]]
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- wrap the PyTorch backend `sum` export with a NumPy-compatible signature
- preserve `axis=None, keepdims=True` by reducing first and reshaping to singleton dimensions
- add backend-contract regression tests, including a subprocess test that forces `PYRECEST_BACKEND=pytorch`

## Rationale
The PyTorch backend implementation accepted `keepdims` but, for `axis=None`, forwarded it as `torch.sum(x, keepdim=...)`. PyTorch rejects `keepdim` unless a reduction dimension is supplied, while NumPy-compatible code expects `sum(values, keepdims=True)` to preserve singleton dimensions.

## Validation
- local PyTorch smoke check confirmed `torch.sum(x, keepdim=True)` raises the failing signature and that reducing first then reshaping reproduces NumPy-style output
- connector compare after rebasing shows this branch is ahead of current `main` by 2 commits and behind by 0
- changed files are limited to `src/pyrecest/_backend/__init__.py` and `tests/test_backend_sum_contract.py`
- full pytest was not run locally because the execution container cannot resolve `github.com`; PR CI should run the full backend matrix