### PR TITLE
Fix GNN pairwise-cost input validation

### DIFF
--- a/src/pyrecest/filters/global_nearest_neighbor.py
+++ b/src/pyrecest/filters/global_nearest_neighbor.py
@@ -5,6 +5,7 @@ import pyrecest.backend
 from pyrecest.backend import (
     all,
     any,
+    asarray,
     empty,
     full,
     linalg,
@@ -72,6 +73,7 @@ class GlobalNearestNeighbor(AbstractNearestNeighborTracker):
     def _validate_pairwise_cost_matrix(pairwise_cost_matrix, n_targets, n_meas):
         if pairwise_cost_matrix is None:
             return None
+        pairwise_cost_matrix = asarray(pairwise_cost_matrix, dtype=float)
         if pairwise_cost_matrix.shape != (n_targets, n_meas):
             raise ValueError(
                 "pairwise_cost_matrix must have shape "
@@ -116,7 +118,11 @@ class GlobalNearestNeighbor(AbstractNearestNeighborTracker):
         n_targets = len(self.filter_bank)
         n_meas = measurements.shape[1]
 
-        if cov_mats_meas.ndim != 2 and cov_mats_meas.shape[2] != n_meas:
+        valid_shared_covariance = cov_mats_meas.ndim == 2
+        valid_per_measurement_covariances = (
+            cov_mats_meas.ndim == 3 and cov_mats_meas.shape[2] == n_meas
+        )
+        if not (valid_shared_covariance or valid_per_measurement_covariances):
             raise ValueError(
                 "cov_mats_meas must be a matrix or contain one covariance per measurement."
             )

--- a/tests/filters/test_global_nearest_neighbor_pairwise_costs.py
+++ b/tests/filters/test_global_nearest_neighbor_pairwise_costs.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-member,duplicate-code
@@ -88,6 +89,30 @@ class GlobalNearestNeighborPairwiseCostTest(unittest.TestCase):
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
         reason="Not supported on this backend",
     )
+    def test_pairwise_cost_matrix_accepts_array_like_input(self):
+        tracker = GlobalNearestNeighbor()
+        tracker.filter_state = self.kfs_init
+        all_gaussians = [kf.filter_state for kf in self.kfs_init]
+        perfect_meas_ordered = self.meas_mat @ column_stack(
+            [gaussian.mu for gaussian in all_gaussians]
+        )
+
+        association = tracker.find_association(
+            perfect_meas_ordered,
+            self.meas_mat,
+            eye(2),
+            pairwise_cost_matrix=[
+                [10.0, -10.0, 10.0],
+                [10.0, 10.0, -10.0],
+                [-10.0, 10.0, 10.0],
+            ],
+        )
+        npt.assert_array_equal(association, [1, 2, 0])
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
     def test_pairwise_cost_matrix_shape_is_validated(self):
         tracker = GlobalNearestNeighbor()
         tracker.filter_state = self.kfs_init
@@ -102,6 +127,25 @@ class GlobalNearestNeighborPairwiseCostTest(unittest.TestCase):
                 self.meas_mat,
                 eye(2),
                 pairwise_cost_matrix=zeros((2, 3)),
+            )
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
+    def test_invalid_measurement_covariance_shape_raises_value_error(self):
+        tracker = GlobalNearestNeighbor()
+        tracker.filter_state = self.kfs_init
+        all_gaussians = [kf.filter_state for kf in self.kfs_init]
+        perfect_meas_ordered = self.meas_mat @ column_stack(
+            [gaussian.mu for gaussian in all_gaussians]
+        )
+
+        with self.assertRaises(ValueError):
+            tracker.find_association(
+                perfect_meas_ordered,
+                self.meas_mat,
+                np.ones((2,)),
             )
 
     @unittest.skipIf(


### PR DESCRIPTION
## Summary
- coerce `pairwise_cost_matrix` through the active backend before validating its shape, so documented array-like inputs such as Python lists work
- tighten measurement-covariance shape validation so malformed 1-D or wrong-depth covariance inputs raise the intended `ValueError` instead of leaking indexing errors
- add focused GNN regression tests for list pairwise costs and invalid covariance shapes

## Rationale
`GlobalNearestNeighbor.find_association()` documents `pairwise_cost_matrix` as array-like, but the validator accessed `.shape` before coercion. Passing a plain nested Python list therefore failed with `AttributeError` before the association logic could use it. The same validation block also accessed `cov_mats_meas.shape[2]` whenever `ndim != 2`, so 1-D malformed covariance input raised `IndexError` rather than the intended validation error.

## Validation
- Connector compare confirms this branch is ahead of current `main` by 2 commits and behind by 0.
- Changes are limited to `src/pyrecest/filters/global_nearest_neighbor.py` and `tests/filters/test_global_nearest_neighbor_pairwise_costs.py`.
- Full local pytest was not run because the sandbox cannot resolve GitHub; PR CI should run the focused GNN tests and full matrix.