### PR TITLE
Fix time-offset summary best-row reporting

### DIFF
--- a/src/pyrecest/calibration/time_offset.py
+++ b/src/pyrecest/calibration/time_offset.py
@@ -29,12 +29,43 @@ class TimeOffsetFitResult:
             "best_offset_s": self.best_offset_s,
             "evaluated_offsets": int(len(self.offsets_s)),
         }
-        if self.best_offset_s is not None and len(self.metric_values):
-            best_index = int(np.nanargmin(self.metric_values))
+        best_index = _best_metric_index(
+            self.offsets_s,
+            self.metric_values,
+            self.counts,
+            self.best_offset_s,
+        )
+        if best_index is not None:
             out["best_metric_value"] = float(self.metric_values[best_index])
             out["best_count"] = int(self.counts[best_index])
         out.update(dict(self.metadata))
         return out
+
+
+def _best_metric_index(
+    offsets_s: np.ndarray,
+    metric_values: np.ndarray,
+    counts: np.ndarray,
+    best_offset_s: float | None,
+) -> int | None:
+    """Return the finite, non-empty row corresponding to ``best_offset_s``."""
+
+    if best_offset_s is None:
+        return None
+    offsets = np.asarray(offsets_s, dtype=float).reshape(-1)
+    values = np.asarray(metric_values, dtype=float).reshape(-1)
+    counts = np.asarray(counts, dtype=float).reshape(-1)
+    if not (offsets.size == values.size == counts.size):
+        return None
+    finite = np.isfinite(values) & (counts > 0.0)
+    if not finite.any():
+        return None
+    matching = finite & np.isclose(offsets, float(best_offset_s), rtol=0.0, atol=1e-12)
+    if matching.any():
+        candidates = np.flatnonzero(matching)
+        return int(candidates[int(np.nanargmin(values[candidates]))])
+    candidates = np.flatnonzero(finite)
+    return int(candidates[int(np.nanargmin(values[candidates]))])
 
 
 def make_offset_grid(min_s: float, max_s: float, step_s: float) -> np.ndarray:

--- a/tests/calibration/test_time_offset_bias.py
+++ b/tests/calibration/test_time_offset_bias.py
@@ -9,6 +9,7 @@ from pyrecest.calibration.bias import (
     make_bias_training_examples,
 )
 from pyrecest.calibration.time_offset import (
+    TimeOffsetFitResult,
     aggregate_time_offset_sweeps,
     apply_time_offset,
     fit_time_offset,
@@ -92,6 +93,21 @@ class TimeOffsetCalibrationTest(unittest.TestCase):
 
         self.assertAlmostEqual(result.best_offset_s, true_offset, places=9)
         self.assertEqual(result.summary()["best_count"], len(measurement_times))
+
+    def test_fit_result_summary_uses_best_nonempty_offset_row(self):
+        result = TimeOffsetFitResult(
+            best_offset_s=0.5,
+            metric="rmse",
+            offsets_s=np.array([0.0, 0.5]),
+            metric_values=np.array([0.0, 1.25]),
+            counts=np.array([0, 7]),
+        )
+
+        summary = result.summary()
+
+        self.assertEqual(summary["best_offset_s"], 0.5)
+        self.assertEqual(summary["best_metric_value"], 1.25)
+        self.assertEqual(summary["best_count"], 7)
 
     def test_time_offset_summary_reports_empty_when_no_overlap(self):
         summary = time_offset_error_summary(


### PR DESCRIPTION
## Summary
- Fix `TimeOffsetFitResult.summary()` so `best_metric_value` and `best_count` are taken from the same finite, non-empty offset row that corresponds to `best_offset_s`.
- Ignore zero-count rows when producing best-row summary fields.
- Add a regression test covering a zero-count row with an artificially lower finite metric.

## Testing
- Not run locally; repository inspection and patching were performed through the GitHub connector because the execution container cannot resolve `github.com`.