### PR TITLE
Fix PyTorch sum keepdims contract

### DIFF
--- a/src/pyrecest/_backend/__init__.py
+++ b/src/pyrecest/_backend/__init__.py
@@ -349,6 +349,27 @@ def _mean_with_numpy_signature(mean_func, asarray_func, reshape_func):
     return mean
 
 
+def _sum_with_numpy_signature(sum_func, asarray_func, reshape_func):
+    """Return a NumPy-compatible sum wrapper for stricter backends."""
+
+    @wraps(sum_func)
+    def sum(a, axis=None, dtype=None, out=None, keepdims=False):
+        a = asarray_func(a)
+        if axis is None:
+            result = sum_func(a, dtype=dtype)
+            if keepdims:
+                result = reshape_func(result, (1,) * a.ndim)
+        else:
+            result = sum_func(a, axis=axis, keepdims=keepdims, dtype=dtype)
+
+        if out is not None:
+            out[...] = result
+            return out
+        return result
+
+    return sum
+
+
 def _is_empty_assignment_index(indices):
     """Return whether ``indices`` selects no elements for assignment helpers."""
     if isinstance(indices, list):
@@ -443,6 +464,16 @@ class BackendImporter(importlib.abc.MetaPathFinder, importlib.abc.Loader):
                         and backend_name == "pytorch"
                     ):
                         attribute = _mean_with_numpy_signature(
+                            attribute,
+                            getattr(backend, "asarray"),
+                            getattr(backend, "reshape"),
+                        )
+                    if (
+                        module_name == ""
+                        and attribute_name == "sum"
+                        and backend_name == "pytorch"
+                    ):
+                        attribute = _sum_with_numpy_signature(
                             attribute,
                             getattr(backend, "asarray"),
                             getattr(backend, "reshape"),

--- a/tests/test_backend_sum_contract.py
+++ b/tests/test_backend_sum_contract.py
@@ -1,0 +1,54 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pyrecest.backend as backend
+import pytest
+
+
+def _shape(value):
+    return tuple(backend.shape(value))
+
+
+def _to_python(value):
+    value = backend.to_numpy(value)
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    return value
+
+
+def test_sum_axis_none_keepdims_matches_numpy_contract():
+    values = backend.reshape(backend.arange(6), (2, 3))
+
+    result = backend.sum(values, keepdims=True)
+
+    assert _shape(result) == (1, 1)
+    assert _to_python(result) == [[15]]
+
+
+@pytest.mark.backend_portable
+def test_pytorch_sum_axis_none_keepdims_matches_numpy_contract():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import pyrecest.backend as backend
+values = backend.reshape(backend.arange(6), (2, 3))
+result = backend.sum(values, keepdims=True)
+assert tuple(backend.shape(result)) == (1, 1)
+assert backend.to_numpy(result).tolist() == [[15]]
+axis_result = backend.sum(values, axis=1, keepdims=True)
+assert tuple(backend.shape(axis_result)) == (2, 1)
+assert backend.to_numpy(axis_result).tolist() == [[3], [12]]
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- Add a NumPy-compatible facade wrapper for PyTorch `backend.sum`.
- Make `axis=None, keepdims=True` reduce first and reshape the result to singleton dimensions.
- Add regression coverage for the default backend and a forced PyTorch subprocess.

## Validation
- Compared branch against `main`: 2 commits ahead, 0 behind.
- Local PyTorch smoke check reproduced the raw failing `torch.sum(..., keepdim=True)` signature and verified the reduce-then-reshape behavior.