### PR TITLE
Fix positive-definite checks for non-symmetric matrices

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/linalg.py
+++ b/src/pyrecest/_backend/_shared_numpy/linalg.py
@@ -84,6 +84,8 @@ def is_single_matrix_pd(mat):
             return False
         eigvals = _np.linalg.eigvalsh(mat)
         return _np.min(_np.real(eigvals)) > 0
+    if not _is_symmetric(mat):
+        return False
     try:
         _np.linalg.cholesky(mat)
         return True

--- a/src/pyrecest/_backend/jax/linalg.py
+++ b/src/pyrecest/_backend/jax/linalg.py
@@ -48,8 +48,9 @@ def is_single_matrix_pd(mat):
         eigvals = _jnp.linalg.eigvalsh(mat)
         return _jnp.logical_and(is_hermitian, _jnp.min(_jnp.real(eigvals)) > 0)
 
+    is_symmetric = _jnp.all(_jnp.abs(mat - _jnp.transpose(mat)) < atol)
     factor = _jnp.linalg.cholesky(mat)
-    return _jnp.all(_jnp.isfinite(factor))
+    return _jnp.logical_and(is_symmetric, _jnp.all(_jnp.isfinite(factor)))
 
 
 for func_name in unsupported_functions:

--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -185,6 +185,8 @@ def is_single_matrix_pd(mat):
             return False
         eigvals = _torch.linalg.eigvalsh(mat)
         return _torch.min(_torch.real(eigvals)) > 0
+    if not _torch.all(_torch.abs(mat - mat.transpose(-2, -1)) < atol):
+        return False
     try:
         _torch.linalg.cholesky(mat)
         return True

--- a/tests/backend_support/test_linalg_pd_symmetry_contract.py
+++ b/tests/backend_support/test_linalg_pd_symmetry_contract.py
@@ -1,0 +1,68 @@
+"""Regression tests for positive-definite matrix predicates."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+import pyrecest.backend as backend
+from tests.support.backend_runner import run_backend_code
+
+
+_NONSYMMETRIC_CHOLESKY_ACCEPTED = [[1.0, 100.0], [0.0, 1.0]]
+
+
+def _as_bool(value) -> bool:
+    value = backend.to_numpy(value)
+    if hasattr(value, "item"):
+        return bool(value.item())
+    return bool(value)
+
+
+@pytest.mark.backend_portable
+def test_is_single_matrix_pd_rejects_real_nonsymmetric_matrix():
+    """PD predicates must reject real matrices outside the symmetric cone."""
+    matrix = backend.array(_NONSYMMETRIC_CHOLESKY_ACCEPTED)
+
+    assert _as_bool(backend.linalg.is_single_matrix_pd(matrix)) is False
+
+
+@pytest.mark.backend_portable
+def test_jax_is_single_matrix_pd_rejects_real_nonsymmetric_matrix():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("JAX is not installed")
+
+    result = run_backend_code(
+        "jax",
+        """
+import pyrecest.backend as backend
+
+matrix = backend.array([[1.0, 100.0], [0.0, 1.0]])
+assert bool(backend.linalg.is_single_matrix_pd(matrix)) is False
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+@pytest.mark.backend_portable
+def test_pytorch_is_single_matrix_pd_rejects_real_nonsymmetric_matrix():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import pyrecest.backend as backend
+
+matrix = backend.array([[1.0, 100.0], [0.0, 1.0]])
+assert bool(backend.linalg.is_single_matrix_pd(matrix)) is False
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
Superseded by #2238, which is based on the newer `main` commit after #2233 merged.