### PR TITLE
Add PyTorch arg reduction backend wrapper

### DIFF
--- a/src/pyrecest/_backend/__init__.py
+++ b/src/pyrecest/_backend/__init__.py
@@ -370,6 +370,54 @@ def _sum_with_numpy_signature(sum_func, asarray_func, reshape_func):
     return sum
 
 
+def _arg_reduction_with_numpy_signature(arg_func, asarray_func, reshape_func):
+    """Return a NumPy-compatible argmin/argmax wrapper for stricter backends."""
+
+    @wraps(arg_func)
+    def arg_reduction(
+        a,
+        axis=None,
+        out=None,
+        keepdims=False,
+        *,
+        dim=None,
+        keepdim=None,
+    ):
+        if dim is not None:
+            if axis is not None and axis != dim:
+                raise TypeError(f"{arg_func.__name__}() got both 'axis' and 'dim'")
+            axis = dim
+        if keepdim is not None:
+            if keepdims is not False and keepdims != keepdim:
+                raise TypeError(
+                    f"{arg_func.__name__}() got both 'keepdims' and 'keepdim'"
+                )
+            keepdims = keepdim
+
+        a = asarray_func(a)
+        try:
+            import torch as _torch
+        except ModuleNotFoundError:  # pragma: no cover - only relevant for PyTorch
+            pass
+        else:
+            if _torch.is_tensor(a) and a.dtype == _torch.bool:
+                a = a.to(dtype=_torch.uint8)
+
+        if axis is None:
+            result = arg_func(a)
+            if keepdims:
+                result = reshape_func(result, (1,) * a.ndim)
+        else:
+            result = arg_func(a, dim=axis, keepdim=keepdims)
+
+        if out is not None:
+            out[...] = result
+            return out
+        return result
+
+    return arg_reduction
+
+
 def _is_empty_assignment_index(indices):
     """Return whether ``indices`` selects no elements for assignment helpers."""
     if isinstance(indices, list):
@@ -474,6 +522,16 @@ class BackendImporter(importlib.abc.MetaPathFinder, importlib.abc.Loader):
                         and backend_name == "pytorch"
                     ):
                         attribute = _sum_with_numpy_signature(
+                            attribute,
+                            getattr(backend, "asarray"),
+                            getattr(backend, "reshape"),
+                        )
+                    if (
+                        module_name == ""
+                        and attribute_name in {"argmax", "argmin"}
+                        and backend_name == "pytorch"
+                    ):
+                        attribute = _arg_reduction_with_numpy_signature(
                             attribute,
                             getattr(backend, "asarray"),
                             getattr(backend, "reshape"),

--- a/tests/backend_support/test_pytorch_arg_reduction_contract.py
+++ b/tests/backend_support/test_pytorch_arg_reduction_contract.py
@@ -1,0 +1,38 @@
+"""Regression tests for PyTorch backend arg reduction keyword compatibility."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_pytorch_arg_reductions_accept_numpy_axis_and_keepdims_keywords():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import pyrecest.backend as backend
+
+values = backend.asarray([[1.0, 5.0, 0.0], [4.0, 2.0, 3.0], [-1.0, 3.0, 6.0]])
+assert backend.to_numpy(backend.argmax(values, axis=1)).tolist() == [1, 0, 2]
+assert backend.to_numpy(backend.argmin(values, axis=0, keepdims=True)).tolist() == [
+    [2, 1, 0]
+]
+assert backend.to_numpy(backend.argmax(values, dim=0, keepdim=True)).tolist() == [
+    [1, 0, 2]
+]
+
+flags = backend.asarray([[False, True, True], [True, True, False]])
+assert backend.to_numpy(backend.argmax(flags, axis=1)).tolist() == [1, 0]
+assert backend.to_numpy(backend.argmin(flags, axis=1)).tolist() == [0, 2]
+assert backend.to_numpy(backend.argmax(flags, keepdims=True)).tolist() == [[1]]
+""",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- wrap PyTorch argmin/argmax with NumPy-style axis/keepdims keyword support
- handle PyTorch boolean tensors before arg reductions
- add a backend portability regression for axis, dim, keepdims, and boolean reductions

## Validation
- `git diff --check`
- `git diff --cached --check`
- Tests not run per request.