### PR TITLE
Fix scalar non-assignment costs in Murty assignments

### DIFF
--- a/src/pyrecest/utils/assignment.py
+++ b/src/pyrecest/utils/assignment.py
@@ -35,7 +35,7 @@ def _coerce_non_assignment_costs(costs, size: int, name: str):
 
     costs_array = _asarray(costs, dtype=float)
     if costs_array.ndim == 0:
-        return _full(size, float(costs_array), dtype=float)
+        return _full((size,), float(costs_array), dtype=float)
 
     costs = costs_array.reshape(-1)
     if costs.shape[0] != size:

--- a/src/pyrecest/utils/assignment.py
+++ b/src/pyrecest/utils/assignment.py
@@ -33,9 +33,13 @@ def _coerce_non_assignment_costs(costs, size: int, name: str):
     if costs is None:
         return _zeros(size, dtype=float)
 
-    costs = _asarray(costs, dtype=float).reshape(-1)
+    costs_array = _asarray(costs, dtype=float)
+    if costs_array.ndim == 0:
+        return _full(size, float(costs_array), dtype=float)
+
+    costs = costs_array.reshape(-1)
     if costs.shape[0] != size:
-        raise ValueError(f"{name} must have length {size}")
+        raise ValueError(f"{name} must be scalar or have length {size}")
     return costs
 
 

--- a/tests/utils/test_assignment.py
+++ b/tests/utils/test_assignment.py
@@ -160,6 +160,24 @@ class MurtyAssignmentTest(unittest.TestCase):
         npt.assert_array_equal(solutions[0]["unassigned_cols"], np.array([], dtype=int))
         self.assertAlmostEqual(solutions[0]["cost"], 3.0)
 
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on the JAX backend",
+    )
+    def test_scalar_non_assignment_costs_are_broadcast(self):
+        solutions = murty_k_best_assignments(
+            np.array([[1.0, 100.0], [100.0, 1.0]]),
+            k=1,
+            row_non_assignment_costs=5.0,
+            col_non_assignment_costs=np.array(6.0),
+        )
+
+        self.assertEqual(len(solutions), 1)
+        npt.assert_array_equal(solutions[0]["assignment"], np.array([0, 1]))
+        npt.assert_array_equal(solutions[0]["unassigned_rows"], np.array([], dtype=int))
+        npt.assert_array_equal(solutions[0]["unassigned_cols"], np.array([], dtype=int))
+        self.assertAlmostEqual(solutions[0]["cost"], 2.0)
+
     def test_non_positive_k_returns_empty_list(self):
         self.assertEqual(murty_k_best_assignments(np.eye(2), k=0), [])
 


### PR DESCRIPTION
## Summary
- Broadcast scalar and zero-dimensional array non-assignment costs to the required row/column length in `murty_k_best_assignments`.
- Keep vector-valued non-assignment costs unchanged, with a clearer validation message.
- Add regression coverage for Python scalar row costs and 0-D NumPy array column costs.

## Rationale
`row_non_assignment_costs=5.0` or `col_non_assignment_costs=np.array(6.0)` should behave as scalar broadcast costs. The old code reshaped scalar-like inputs to a length-one vector and rejected them whenever the corresponding problem dimension was not one.

## Testing
- Added `tests/utils/test_assignment.py::MurtyAssignmentTest::test_scalar_non_assignment_costs_are_broadcast`.
- Full local pytest was not run because the execution container cannot resolve `github.com`; repository CI should run the focused assignment tests and full matrix.