### PR TITLE
Validate negative time-offset max delta

### DIFF
--- a/src/pyrecest/calibration/time_offset.py
+++ b/src/pyrecest/calibration/time_offset.py
@@ -89,6 +89,11 @@ def apply_time_offset(times_s: np.ndarray, offset_s: float | None) -> np.ndarray
     return np.asarray(times_s, dtype=float) + offset
 
 
+def _validate_max_time_delta(max_time_delta_s: float | None) -> None:
+    if max_time_delta_s is not None and float(max_time_delta_s) < 0.0:
+        raise ValueError("max_time_delta_s must be nonnegative")
+
+
 def nearest_time_indices(
     reference_times_s: np.ndarray, query_times_s: np.ndarray
 ) -> np.ndarray:
@@ -118,6 +123,7 @@ def interpolate_reference_values(
 ) -> tuple[np.ndarray, np.ndarray]:
     """Interpolate reference values at query times and return a validity mask."""
 
+    _validate_max_time_delta(max_time_delta_s)
     reference_times = np.asarray(reference_times_s, dtype=float).reshape(-1)
     reference_values = np.asarray(reference_values, dtype=float)
     query_times = np.asarray(query_times_s, dtype=float).reshape(-1)

--- a/tests/calibration/test_time_offset_bias.py
+++ b/tests/calibration/test_time_offset_bias.py
@@ -13,6 +13,7 @@ from pyrecest.calibration.time_offset import (
     aggregate_time_offset_sweeps,
     apply_time_offset,
     fit_time_offset,
+    interpolate_reference_values,
     make_offset_grid,
     nearest_time_indices,
     time_offset_error_summary,
@@ -119,6 +120,18 @@ class TimeOffsetCalibrationTest(unittest.TestCase):
         )
 
         self.assertEqual(summary["count"], 0.0)
+
+    def test_interpolation_rejects_negative_max_time_delta(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "max_time_delta_s must be nonnegative",
+        ):
+            interpolate_reference_values(
+                np.array([0.0, 1.0]),
+                np.array([[0.0], [1.0]]),
+                np.array([0.5]),
+                max_time_delta_s=-1.0,
+            )
 
     def test_time_offset_summary_rejects_mismatched_measurement_lengths(self):
         with self.assertRaisesRegex(


### PR DESCRIPTION
## Summary
- reject negative `max_time_delta_s` values in time-offset interpolation
- add regression coverage for invalid negative tolerance input

## Rationale
Negative maximum time-delta tolerances cannot have physical meaning. Before this change, time-offset calibration paths accepted them and silently marked all candidate rows invalid/empty instead of surfacing a configuration error. This now matches the bias-calibration helper’s nonnegative tolerance validation.

## Testing
- Added `tests/calibration/test_time_offset_bias.py::TimeOffsetCalibrationTest::test_interpolation_rejects_negative_max_time_delta`
- Local full pytest could not be run because the execution container cannot resolve `github.com`; PR CI should run the focused calibration test and full matrix.