### PR TITLE
Validate Fibonacci Gaussian sampler inputs

### DIFF
--- a/src/pyrecest/sampling/euclidean_sampler.py
+++ b/src/pyrecest/sampling/euclidean_sampler.py
@@ -210,6 +210,35 @@ def _is_prime(n):
     return True
 
 
+def _validate_gaussian_transform_args(d, covariance, mean):
+    if covariance is None:
+        covariance = np.eye(d)
+    else:
+        covariance = np.asarray(covariance, dtype=float)
+
+    if covariance.shape != (d, d):
+        raise ValueError("covariance must have shape (dim, dim)")
+    if not np.all(np.isfinite(covariance)):
+        raise ValueError("covariance must be finite")
+    if not np.allclose(covariance, covariance.T):
+        raise ValueError("covariance must be symmetric")
+
+    covariance_scale = max(1.0, float(np.max(np.abs(covariance))))
+    tolerance = 100.0 * np.finfo(float).eps * covariance_scale
+    if np.min(np.linalg.eigvalsh(covariance)) < -tolerance:
+        raise ValueError("covariance must be positive semidefinite")
+
+    if mean is None:
+        mean = np.zeros(d)
+    mean = np.asarray(mean, dtype=float).ravel()
+    if mean.shape != (d,):
+        raise ValueError("mean must have shape (dim,)")
+    if not np.all(np.isfinite(mean)):
+        raise ValueError("mean must be finite")
+
+    return covariance, mean
+
+
 def _fibonacci_eigen(d):  # pylint: disable=too-many-locals
     """Compute the eigenvector basis V and eigenvalues R of the Fibonacci matrix.
 
@@ -371,11 +400,7 @@ class FibonacciGridSampler(AbstractEuclideanSampler):
         if n_points < 0:
             raise ValueError("n_points must be nonnegative")
 
-        if covariance is None:
-            covariance = np.eye(d)
-        if mean is None:
-            mean = np.zeros(d)
-        mean = np.asarray(mean, dtype=float).ravel()
+        covariance, mean = _validate_gaussian_transform_args(d, covariance, mean)
 
         if n_points == 0:
             empty_arr = np.empty((d, 0))
@@ -482,6 +507,7 @@ class FibonacciGridSampler(AbstractEuclideanSampler):
 
         # Transform to a Gaussian with the requested covariance and mean
         C_vals, C_vecs = np.linalg.eigh(covariance)
+        C_vals = np.maximum(C_vals, 0.0)
         xy_gauss = C_vecs @ np.diag(np.sqrt(C_vals)) @ xy_stdMM + mean.reshape(-1, 1)
 
         return xy_equal, xy_stdMM, xy_gauss

--- a/tests/test_euclidean_sampler.py
+++ b/tests/test_euclidean_sampler.py
@@ -127,6 +127,39 @@ class TestFibonacciGridSampler(unittest.TestCase):
         samples = self.sampler.get_gaussian_samples(200, 2, mean=mu)
         npt.assert_allclose(samples.mean(axis=0), mu, atol=0.5)
 
+    def test_get_gaussian_samples_rejects_invalid_covariance(self):
+        """Invalid covariance matrices should fail before producing NaN samples."""
+        invalid_covariances = [
+            np.array([[1.0, 2.0], [2.0, 1.0]]),
+            np.array([[1.0, np.nan], [np.nan, 1.0]]),
+            np.array([[1.0, 0.2], [0.1, 1.0]]),
+            np.array([1.0, 2.0]),
+        ]
+        for covariance in invalid_covariances:
+            with self.subTest(covariance=covariance):
+                with self.assertRaises(ValueError):
+                    self.sampler.get_gaussian_samples(
+                        10, 2, covariance=covariance, mean=np.zeros(2)
+                    )
+
+    def test_get_gaussian_samples_accepts_semidefinite_covariance(self):
+        """Positive-semidefinite covariances are valid Gaussian transforms."""
+        covariance = np.array([[1.0, 1.0], [1.0, 1.0]])
+        samples = self.sampler.get_gaussian_samples(
+            20, 2, covariance=covariance, mean=np.zeros(2)
+        )
+
+        self.assertEqual(samples.shape, (20, 2))
+        self.assertTrue(np.all(np.isfinite(samples)))
+        npt.assert_allclose(samples[:, 0], samples[:, 1], atol=1e-12)
+
+    def test_get_gaussian_samples_rejects_invalid_mean(self):
+        """The Gaussian transform mean must match the requested dimension."""
+        with self.assertRaises(ValueError):
+            self.sampler.get_gaussian_samples(10, 2, mean=np.array([1.0, 2.0, 3.0]))
+        with self.assertRaises(ValueError):
+            self.sampler.get_gaussian_samples(10, 2, mean=np.array([1.0, np.nan]))
+
     def test_zero_samples(self):
         """Requesting zero samples should return an empty (0, dim) array."""
         samples = self.sampler.sample_stochastic(0, 2)


### PR DESCRIPTION
## Summary
- Add validation for Fibonacci Gaussian transform covariance and mean inputs.
- Reject malformed, non-finite, non-symmetric, and non-positive-semidefinite covariance matrices before the Gaussian transform can produce NaN samples.
- Clamp tiny negative eigenvalues after validation so numerically semidefinite matrices remain usable.
- Add regression tests for invalid covariances, invalid means, and valid semidefinite covariance matrices.

## Rationale
`FibonacciGridSampler.get_gaussian_samples` previously passed user-provided covariance matrices directly to `np.linalg.eigh` and then took `np.sqrt` of the eigenvalues. A symmetric covariance with a negative eigenvalue could silently produce NaN samples instead of failing with a clear validation error. It also accepted malformed or non-finite mean/covariance inputs until later numerical code failed less clearly.

## Validation
- Connector compare confirms this branch is 2 commits ahead of `main` and 0 behind.
- Added focused unit coverage in `tests/test_euclidean_sampler.py`.
- Full local pytest could not be run because the execution container cannot resolve `github.com`; PR CI should run the focused sampler tests and full suite.