### PR TITLE
Fix PyTorch Sylvester mixed dtype inputs

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -66,6 +66,16 @@ def _as_linalg_tensor(value):
     return tensor
 
 
+def _common_linalg_dtype(*tensors):
+    """Return a common floating/complex dtype for torch.linalg operations."""
+    dtype = tensors[0].dtype
+    for tensor in tensors[1:]:
+        dtype = _torch.promote_types(dtype, tensor.dtype)
+    if dtype.is_floating_point or dtype.is_complex:
+        return dtype
+    return get_default_dtype()
+
+
 class _Logm(_torch.autograd.Function):
     """Torch autograd function for matrix logarithm.
 
@@ -160,6 +170,10 @@ def solve_sylvester(a, b, q):
     a = _as_linalg_tensor(a)
     b = _as_linalg_tensor(b)
     q = _as_linalg_tensor(q)
+    common_dtype = _common_linalg_dtype(a, b, q)
+    a = a.to(dtype=common_dtype)
+    b = b.to(dtype=common_dtype)
+    q = q.to(dtype=common_dtype)
     if (
         a.shape == b.shape
         and _torch.all(a == b)

--- a/tests/test_pytorch_backend.py
+++ b/tests/test_pytorch_backend.py
@@ -22,8 +22,7 @@ class TestPytorchBackendStd(unittest.TestCase):
                 pytorch_backend.array([1.632993161855452, 1.632993161855452]),
             )
         )
-        self.assertTrue(
-            pytorch_backend.allclose(sample_std, pytorch_backend.array([2.0, 2.0]))
+        self.assertTrue(pytorch_backend.allclose(sample_std, pytorch_backend.array([2.0, 2.0]))
         )
 
     def test_std_accepts_keepdims_and_dtype(self):
@@ -205,6 +204,19 @@ class TestPytorchBackendLinalg(unittest.TestCase):
                 pytorch_backend.array([1.0, 0.0], dtype=pytorch_backend.float64),
             )
         )
+
+    def test_solve_sylvester_promotes_mixed_dtypes(self):
+        a = pytorch_backend.array([[2.0, 0.0], [0.0, 3.0]], dtype=pytorch_backend.float32)
+        b = pytorch_backend.array([[2.0, 0.0], [0.0, 3.0]], dtype=pytorch_backend.float32)
+        q = pytorch_backend.array([[8.0, 10.0], [10.0, 12.0]], dtype=pytorch_backend.float64)
+
+        result = pytorch_backend.linalg.solve_sylvester(a, b, q)
+
+        expected = pytorch_backend.array(
+            [[2.0, 2.0], [2.0, 2.0]], dtype=pytorch_backend.float64
+        )
+        self.assertEqual(result.dtype, pytorch_backend.float64)
+        self.assertTrue(pytorch_backend.allclose(result, expected))
 
     def test_sqrtm_complex_result_uses_matching_complex_precision(self):
         dtype_pairs = (


### PR DESCRIPTION
## Summary
- Promote PyTorch `solve_sylvester` inputs to a common floating/complex dtype before the optimized symmetric path.
- Add regression coverage for mixed `float32`/`float64` Sylvester inputs.

## Rationale
The PyTorch linalg backend now accepts array-like inputs, but `solve_sylvester` still coerced each input independently. In the optimized symmetric path, eigenvectors from `a`/`b` are multiplied with `q`; if `a`/`b` are `float32` and `q` is `float64`, PyTorch raises a dtype mismatch. Promoting all inputs to a common dtype keeps the optimized path and SciPy fallback on compatible tensors.

## Validation
- Connector compare confirms this branch is 2 commits ahead of `main` and 0 behind.
- Added focused regression coverage in `tests/test_pytorch_backend.py`.
- Full local pytest could not be run because the execution container cannot resolve `github.com`; PR CI should run the focused PyTorch backend test and full suite.