### PR TITLE
Fix association gate monotonicity

### DIFF
--- a/src/pyrecest/filters/association_hypotheses.py
+++ b/src/pyrecest/filters/association_hypotheses.py
@@ -296,6 +296,29 @@ class TopKGate:
         return self.filter(hypotheses)
 
 
+def _merge_active_gate_results(
+    hypotheses: Sequence[AssociationHypothesis],
+    gated_active: Sequence[AssociationHypothesis],
+) -> list[AssociationHypothesis]:
+    """Merge active gate output while preserving prior rejections."""
+    gated_active = list(gated_active)
+    active_count = sum(1 for hypothesis in hypotheses if hypothesis.accepted)
+    if len(gated_active) != active_count:
+        return [
+            *gated_active,
+            *(hypothesis for hypothesis in hypotheses if not hypothesis.accepted),
+        ]
+
+    gated_iter = iter(gated_active)
+    result = []
+    for hypothesis in hypotheses:
+        if hypothesis.accepted:
+            result.append(next(gated_iter))
+        else:
+            result.append(hypothesis)
+    return result
+
+
 def gate_hypotheses(
     hypotheses: Sequence[AssociationHypothesis],
     gate,
@@ -303,15 +326,24 @@ def gate_hypotheses(
     reject_reason: str | None = None,
 ) -> list[AssociationHypothesis]:
     """Apply one gate to hypotheses and preserve rejected diagnostics."""
+    active_hypotheses = [hypothesis for hypothesis in hypotheses if hypothesis.accepted]
+    if not active_hypotheses:
+        return list(hypotheses)
+
     if isinstance(gate, TopKGate):
-        return gate.filter(hypotheses)
+        return _merge_active_gate_results(
+            hypotheses, gate.filter(active_hypotheses)
+        )
     if hasattr(gate, "filter"):
-        filtered = gate.filter(hypotheses)
+        filtered = gate.filter(active_hypotheses)
         if filtered is not None:
-            return list(filtered)
+            return _merge_active_gate_results(hypotheses, filtered)
 
     result = []
     for hypothesis in hypotheses:
+        if not hypothesis.accepted:
+            result.append(hypothesis)
+            continue
         accepted = bool(
             gate(hypothesis) if callable(gate) else gate.accepts(hypothesis)
         )

--- a/tests/filters/test_association_gate_monotonicity.py
+++ b/tests/filters/test_association_gate_monotonicity.py
@@ -1,0 +1,47 @@
+import unittest
+
+from pyrecest.filters import (
+    AssociationHypothesis,
+    CostThresholdGate,
+    ProbabilityThresholdGate,
+    TopKGate,
+    filter_hypotheses,
+)
+
+
+class AssociationGateMonotonicityTest(unittest.TestCase):
+    def test_later_scalar_gate_does_not_reaccept_prior_rejection(self):
+        hypotheses = [
+            AssociationHypothesis(0, 0, cost=1.0, probability=0.0),
+            AssociationHypothesis(0, 1, cost=2.0, probability=1.0),
+        ]
+
+        gated = filter_hypotheses(
+            hypotheses,
+            [ProbabilityThresholdGate(0.5), CostThresholdGate(3.0)],
+            accepted_only=False,
+        )
+
+        self.assertFalse(gated[0].accepted)
+        self.assertEqual(gated[0].reason, "ProbabilityThresholdGate")
+        self.assertTrue(gated[1].accepted)
+
+    def test_later_top_k_gate_only_ranks_active_hypotheses(self):
+        hypotheses = [
+            AssociationHypothesis(0, 0, cost=1.0, probability=0.0),
+            AssociationHypothesis(0, 1, cost=10.0, probability=1.0),
+        ]
+
+        accepted = filter_hypotheses(
+            hypotheses,
+            [ProbabilityThresholdGate(0.5), TopKGate(1, mode="track")],
+        )
+
+        self.assertEqual(
+            [(hypothesis.track_index, hypothesis.measurement_index) for hypothesis in accepted],
+            [(0, 1)],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Apply subsequent association gates only to hypotheses that are still accepted by earlier gates.
- Preserve prior rejection state and diagnostic reasons when scalar gates or collection gates such as `TopKGate` run later in a gate chain.
- Add regression coverage for scalar-gate and TopK-gate reacceptance cases.

## Rationale
`filter_hypotheses` chains gates, but `gate_hypotheses` previously re-evaluated every hypothesis for every later gate. This allowed a hypothesis rejected by `ProbabilityThresholdGate` to become accepted again by `CostThresholdGate`, and allowed a later `TopKGate` to rank/select a previously rejected low-cost hypothesis over a still-active hypothesis.

## Validation
- Connector compare confirms this branch is ahead of `main` by 2 commits and behind by 0.
- Added focused regression coverage in `tests/filters/test_association_gate_monotonicity.py`.
- Full local pytest could not be run because this sandbox cannot resolve `github.com`; repository CI should run the focused association tests and full suite.