### PR TITLE
Validate time-offset reference value rank

### DIFF
--- a/src/pyrecest/calibration/time_offset.py
+++ b/src/pyrecest/calibration/time_offset.py
@@ -127,12 +127,14 @@ def interpolate_reference_values(
     reference_times = np.asarray(reference_times_s, dtype=float).reshape(-1)
     reference_values = np.asarray(reference_values, dtype=float)
     query_times = np.asarray(query_times_s, dtype=float).reshape(-1)
+    if reference_values.ndim not in (1, 2):
+        raise ValueError("reference_values must be one- or two-dimensional")
+    if reference_values.ndim == 1:
+        reference_values = reference_values.reshape(-1, 1)
     if reference_times.size != reference_values.shape[0]:
         raise ValueError("reference_times_s length must match reference_values rows")
     if reference_times.size < 2:
         raise ValueError("at least two reference times are required for interpolation")
-    if reference_values.ndim == 1:
-        reference_values = reference_values.reshape(-1, 1)
     order = np.argsort(reference_times)
     reference_times = reference_times[order]
     reference_values = reference_values[order]

--- a/tests/calibration/test_time_offset_bias.py
+++ b/tests/calibration/test_time_offset_bias.py
@@ -133,6 +133,28 @@ class TimeOffsetCalibrationTest(unittest.TestCase):
                 max_time_delta_s=-1.0,
             )
 
+    def test_interpolation_rejects_scalar_reference_values(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "reference_values must be one- or two-dimensional",
+        ):
+            interpolate_reference_values(
+                np.array([0.0, 1.0]),
+                np.array(1.0),
+                np.array([0.5]),
+            )
+
+    def test_interpolation_rejects_higher_rank_reference_values(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "reference_values must be one- or two-dimensional",
+        ):
+            interpolate_reference_values(
+                np.array([0.0, 1.0]),
+                np.zeros((2, 1, 1)),
+                np.array([0.5]),
+            )
+
     def test_time_offset_summary_rejects_mismatched_measurement_lengths(self):
         with self.assertRaisesRegex(
             ValueError,


### PR DESCRIPTION
## Summary
- Validate `reference_values` rank before time-offset interpolation.
- Convert one-dimensional reference trajectories before checking row counts.
- Add regression tests for scalar and higher-rank `reference_values` inputs.

## Rationale
`interpolate_reference_values` accepted invalid scalar or higher-rank `reference_values` until later array indexing/interpolation logic failed with unclear low-level errors. The function now rejects such inputs with the same explicit one-/two-dimensional contract already used for measurement values.

## Validation
- Connector compare confirms the branch is 2 commits ahead of `main` and 0 behind.
- Added focused regression coverage in `tests/calibration/test_time_offset_bias.py`.
- I could not run local pytest because this execution environment cannot clone/fetch from `github.com`; repository CI should run the focused calibration tests and full suite.