### PR TITLE
Fix PyTorch mean integer backend inputs

### DIFF
--- a/src/pyrecest/_backend/__init__.py
+++ b/src/pyrecest/_backend/__init__.py
@@ -215,6 +215,7 @@ BACKEND_ATTRIBUTES = {
         "jacobian_vec",
         "jacobian_and_hessian",
         "value_and_grad",
+        "value_jacobian_and_hessian",
         "value_and_jacobian",
         "value_jacobian_and_hessian",
     ],
@@ -328,12 +329,26 @@ def _meshgrid_with_arraylike_axes(meshgrid_func, asarray_func, atleast_1d_func):
     return meshgrid
 
 
-def _mean_with_numpy_signature(mean_func, asarray_func, reshape_func):
+def _mean_with_numpy_signature(
+    mean_func,
+    asarray_func,
+    reshape_func,
+    cast_func,
+    get_default_dtype_func,
+    is_complex_func,
+    is_floating_func,
+):
     """Return a NumPy-compatible mean wrapper for stricter backends."""
 
     @wraps(mean_func)
     def mean(a, axis=None, dtype=None, out=None, keepdims=False):
-        a = asarray_func(a, dtype=dtype) if dtype is not None else asarray_func(a)
+        if dtype is not None:
+            a = asarray_func(a, dtype=dtype)
+        else:
+            a = asarray_func(a)
+            if not is_floating_func(a) and not is_complex_func(a):
+                a = cast_func(a, dtype=get_default_dtype_func())
+
         if axis is None:
             result = mean_func(a)
             if keepdims:
@@ -614,6 +629,10 @@ class BackendImporter(importlib.abc.MetaPathFinder, importlib.abc.Loader):
                             attribute,
                             getattr(backend, "asarray"),
                             getattr(backend, "reshape"),
+                            getattr(backend, "cast"),
+                            getattr(backend, "get_default_dtype"),
+                            getattr(backend, "is_complex"),
+                            getattr(backend, "is_floating"),
                         )
                     if (
                         module_name == ""

--- a/tests/test_backend_mean_contract.py
+++ b/tests/test_backend_mean_contract.py
@@ -1,4 +1,8 @@
+import importlib.util
+
 import pyrecest.backend as backend
+import pytest
+from tests.support.backend_runner import run_backend_code
 
 
 def _to_python(value):
@@ -27,3 +31,26 @@ def test_mean_accepts_tuple_axis():
     result = backend.mean(values, axis=(0, 2))
 
     assert _to_python(result) == [3.5, 5.5]
+
+
+@pytest.mark.backend_portable
+def test_pytorch_mean_accepts_integer_array_like_inputs():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import pyrecest.backend as backend
+
+result = backend.mean([[1, 2, 3], [4, 5, 6]], axis=0, keepdims=True)
+expected = backend.array([[2.5, 3.5, 4.5]])
+assert tuple(result.shape) == (1, 3)
+assert result.dtype == backend.float64
+assert backend.allclose(result, expected)
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- Promote non-floating/non-complex PyTorch backend `mean` inputs to the configured default floating dtype before reduction.
- Preserve explicit `dtype` handling and NumPy-style `axis`/`keepdims` semantics.
- Add a forced-PyTorch regression test for integer Python-list inputs.

## Rationale
The public backend facade generally accepts NumPy-style array-like inputs. For the PyTorch backend, `backend.mean([[1, 2, 3], [4, 5, 6]], axis=0, keepdims=True)` previously converted the list to an integer tensor and forwarded it to `torch.mean`, which rejects integer tensors. NumPy returns a floating result for the same input.

## Validation
- Added `tests/test_backend_mean_contract.py::test_pytorch_mean_accepts_integer_array_like_inputs`.
- Full local pytest could not be run from this execution environment; repository CI should run the focused regression and full matrix.