### PR TITLE
Fix PyTorch backend take and pad contracts

### DIFF
--- a/src/pyrecest/_backend/pytorch/__init__.py
+++ b/src/pyrecest/_backend/pytorch/__init__.py
@@ -1,7 +1,6 @@
 """Pytorch based computation backend."""
 
 import builtins as _builtins
-from collections.abc import Iterable as _Iterable
 
 import numpy as _np
 import torch as _torch
@@ -1124,35 +1123,83 @@ def min(a, axis=None):
 amin = min
 
 
-def take(a, indices, axis=0):
+def _normalize_take_axis(axis, ndim_):
+    if axis is None:
+        return None
+    axis = int(axis)
+    if axis < 0:
+        axis += ndim_
+    if axis < 0 or axis >= ndim_:
+        raise IndexError(f"axis {axis} is out of bounds for array of dimension {ndim_}")
+    return axis
+
+
+def _normalize_take_indices(indices, axis_size, mode):
+    if mode is None:
+        mode = "raise"
+    if mode == "raise":
+        if _torch.any((indices >= axis_size) | (indices < -axis_size)):
+            raise IndexError("index out of bounds")
+        return _torch.remainder(indices, axis_size)
+    if mode == "wrap":
+        if axis_size == 0 and indices.numel():
+            raise IndexError("cannot do a non-empty take from an empty axis")
+        return _torch.remainder(indices, axis_size) if axis_size else indices
+    if mode == "clip":
+        if axis_size == 0 and indices.numel():
+            raise IndexError("cannot do a non-empty take from an empty axis")
+        return _torch.clamp(indices, 0, axis_size - 1) if axis_size else indices
+    raise ValueError("mode must be one of 'raise', 'wrap', or 'clip'")
+
+
+def take(a, indices, axis=None, out=None, mode=None):
     a = array(a)
+    axis = _normalize_take_axis(axis, a.ndim)
+    if axis is None:
+        a = _torch.flatten(a)
+        axis = 0
+
     if not _torch.is_tensor(indices):
         indices = _torch.as_tensor(indices, dtype=_torch.long, device=a.device)
     else:
         indices = indices.to(device=a.device, dtype=_torch.long)
 
     scalar_index = indices.ndim == 0
+    indices_shape = tuple(indices.shape)
+    flat_indices = indices.reshape(-1)
+    flat_indices = _normalize_take_indices(flat_indices, a.shape[axis], mode)
+
+    result = _torch.index_select(a, axis, flat_indices)
     if scalar_index:
-        indices = indices.reshape(1)
-
-    result = _torch.index_select(a, axis, indices)
-    return _torch.squeeze(result, dim=axis) if scalar_index else result
-
-
-def _unnest_iterable(ls):
-    out = []
-    if isinstance(ls, _Iterable):
-        for inner_ls in ls:
-            out.extend(_unnest_iterable(inner_ls))
+        result = _torch.squeeze(result, dim=axis)
     else:
-        out.append(ls)
+        result = result.reshape(
+            tuple(a.shape[:axis]) + indices_shape + tuple(a.shape[axis + 1 :])
+        )
 
-    return out
+    if out is not None:
+        out.copy_(result)
+        return out
+    return result
+
+
+def _torch_pad_width(pad_width, ndim_):
+    try:
+        pad_pairs = _np.broadcast_to(_np.asarray(pad_width), (ndim_, 2))
+    except ValueError as exc:
+        raise ValueError(f"pad_width must be broadcastable to shape ({ndim_}, 2)") from exc
+
+    if _np.any(pad_pairs < 0):
+        raise ValueError("index can't contain negative values")
+
+    return [int(value) for pair in reversed(pad_pairs.tolist()) for value in pair]
 
 
 def pad(a, pad_width, mode="constant", constant_values=0.0):
+    a = array(a)
+    torch_pad_width = _torch_pad_width(pad_width, a.ndim)
     return _torch.nn.functional.pad(
-        a, _unnest_iterable(reversed(pad_width)), mode=mode, value=constant_values
+        a, torch_pad_width, mode=mode, value=constant_values
     )
 
 

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -129,6 +129,86 @@ def test_take_removes_axis_for_scalar_indices():
     assert _to_python(result) == [[1.0, 2.0, 3.0]]
 
 
+def test_take_defaults_to_flattened_input():
+    values = array([[0, 1, 2], [3, 4, 5]])
+
+    result = backend.take(values, [[0, 2], [5, 1]])
+
+    assert result.shape == (2, 2)
+    assert _to_python(result) == [[0, 2], [5, 1]]
+
+
+def test_take_preserves_multidimensional_index_shape():
+    values = array([[0, 1, 2], [3, 4, 5]])
+
+    result = backend.take(values, [[0, 2], [1, 0]], axis=1)
+
+    assert result.shape == (2, 2, 2)
+    assert _to_python(result) == [[[0, 2], [1, 0]], [[3, 5], [4, 3]]]
+
+
+def test_take_wraps_negative_indices_in_raise_mode():
+    values = array([[0, 1, 2], [3, 4, 5]])
+
+    result = backend.take(values, [-1, 0], axis=1)
+
+    assert result.shape == (2, 2)
+    assert _to_python(result) == [[2, 0], [5, 3]]
+
+
+def test_pytorch_take_raises_for_out_of_bounds_indices():
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific take bounds regression test")
+
+    values = array([0, 1, 2])
+
+    with pytest.raises(IndexError):
+        backend.take(values, [3])
+
+
+def test_pad_accepts_scalar_pad_width():
+    result = backend.pad(array([1, 2, 3]), 1)
+
+    assert result.shape == (5,)
+    assert _to_python(result) == [0, 1, 2, 3, 0]
+
+
+def test_pad_treats_length_two_pad_width_as_before_after_for_each_axis():
+    result = backend.pad(array([1, 2, 3]), (1, 2))
+
+    assert result.shape == (6,)
+    assert _to_python(result) == [0, 1, 2, 3, 0, 0]
+
+
+def test_pad_broadcasts_single_axis_pair_to_all_axes():
+    result = backend.pad(array([[1, 2], [3, 4]]), ((1, 2),))
+
+    assert result.shape == (5, 5)
+    assert _to_python(result) == [
+        [0, 0, 0, 0, 0],
+        [0, 1, 2, 0, 0],
+        [0, 3, 4, 0, 0],
+        [0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0],
+    ]
+
+
+def test_pad_uses_per_axis_pad_pairs_in_numpy_order():
+    result = backend.pad(array([[1, 2], [3, 4]]), ((1, 0), (0, 2)))
+
+    assert result.shape == (3, 4)
+    assert _to_python(result) == [
+        [0, 0, 0, 0],
+        [1, 2, 0, 0],
+        [3, 4, 0, 0],
+    ]
+
+
+def test_pad_rejects_negative_widths():
+    with pytest.raises(ValueError):
+        backend.pad(array([1, 2, 3]), (-1, 0))
+
+
 def test_cross_uses_trailing_vector_axis_for_batched_vectors():
     first = array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
     second = array([[0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])


### PR DESCRIPTION
## Summary
- align the PyTorch backend `take` wrapper with NumPy defaults, index shape handling, modes, and `out`
- normalize `pad_width` for PyTorch padding using NumPy-compatible broadcasting and validation
- add backend contract regression coverage for take and pad edge cases

## Validation
- Not run, per request.