### PR TITLE
Validate Euclidean sampler integer arguments

### DIFF
--- a/src/pyrecest/sampling/euclidean_sampler.py
+++ b/src/pyrecest/sampling/euclidean_sampler.py
@@ -87,8 +87,8 @@ class FibonacciRejectionSampler(AbstractEuclideanSampler):
 
     @staticmethod
     def _validate_rejection_args(n_candidates, dim, max_density, bounding_box):
-        n_candidates = int(n_candidates)
-        dim = int(dim)
+        n_candidates = _validate_integral_argument(n_candidates, "n_candidates")
+        dim = _validate_integral_argument(dim, "dim")
         max_density = float(max_density)
 
         if n_candidates < 0:
@@ -175,8 +175,8 @@ class _QMCProposalGridSampler(AbstractEuclideanSampler):
 
     @staticmethod
     def _validate_grid_args(n_samples: int, dim: int):
-        n_samples = int(n_samples)
-        dim = int(dim)
+        n_samples = _validate_integral_argument(n_samples, "n_samples")
+        dim = _validate_integral_argument(dim, "dim")
         if n_samples < 0:
             raise ValueError("n_samples must be nonnegative")
         if dim < 1:
@@ -208,6 +208,27 @@ def _is_prime(n):
         if n % i == 0:
             return False
     return True
+
+
+def _validate_integral_argument(value, name: str) -> int:
+    """Return a scalar integer argument without silently truncating floats."""
+    try:
+        array_value = np.asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+
+    if array_value.ndim != 0:
+        raise ValueError(f"{name} must be a scalar integer")
+    if np.issubdtype(array_value.dtype, np.bool_):
+        raise ValueError(f"{name} must be an integer")
+    if np.issubdtype(array_value.dtype, np.integer):
+        return int(array_value)
+    if np.issubdtype(array_value.dtype, np.floating):
+        float_value = float(array_value)
+        if np.isfinite(float_value) and float_value.is_integer():
+            return int(float_value)
+
+    raise ValueError(f"{name} must be an integer")
 
 
 def _validate_gaussian_transform_args(d, covariance, mean):
@@ -393,8 +414,8 @@ class FibonacciGridSampler(AbstractEuclideanSampler):
         xy_gauss : np.ndarray of shape (d, n_points)
             Gaussian grid on R^d with the given covariance and mean.
         """
-        d = int(d)
-        n_points = int(n_points)
+        d = _validate_integral_argument(d, "d")
+        n_points = _validate_integral_argument(n_points, "n_points")
         if d < 1:
             raise ValueError("d must be positive")
         if n_points < 0:

--- a/tests/test_euclidean_sampler_integer_args.py
+++ b/tests/test_euclidean_sampler_integer_args.py
@@ -1,0 +1,68 @@
+import numpy as np
+import pytest
+
+from pyrecest.sampling.euclidean_sampler import (
+    FibonacciGridSampler,
+    FibonacciRejectionSampler,
+    HaltonGridSampler,
+    SobolGridSampler,
+)
+
+
+@pytest.mark.parametrize("sampler", [SobolGridSampler(), HaltonGridSampler()])
+def test_qmc_grid_samplers_reject_non_integral_grid_arguments(sampler):
+    with pytest.raises(ValueError, match="n_samples"):
+        sampler.get_uniform_samples(2.5, 2)
+    with pytest.raises(ValueError, match="dim"):
+        sampler.get_uniform_samples(4, 1.5)
+
+
+@pytest.mark.parametrize("sampler", [SobolGridSampler(), HaltonGridSampler()])
+def test_qmc_grid_samplers_accept_integer_like_scalar_arguments(sampler):
+    samples = sampler.get_uniform_samples(np.array(4), np.float64(2.0))
+    assert samples.shape == (4, 2)
+
+
+def test_fibonacci_grid_sampler_rejects_non_integral_grid_arguments():
+    sampler = FibonacciGridSampler()
+
+    with pytest.raises(ValueError, match="n_points"):
+        sampler.get_uniform_samples(2.5, 2)
+    with pytest.raises(ValueError, match="d"):
+        sampler.get_uniform_samples(4, 1.5)
+
+
+def test_fibonacci_grid_sampler_accepts_integer_like_scalar_arguments():
+    samples = FibonacciGridSampler().get_uniform_samples(np.float64(4.0), np.array(2))
+    assert samples.shape == (4, 2)
+
+
+def test_fibonacci_rejection_sampler_rejects_non_integral_rejection_arguments():
+    sampler = FibonacciRejectionSampler()
+
+    with pytest.raises(ValueError, match="n_candidates"):
+        sampler.sample_rejection(
+            lambda xs: np.ones(xs.shape[0]),
+            n_candidates=2.5,
+            dim=2,
+            max_density=1.0,
+        )
+    with pytest.raises(ValueError, match="dim"):
+        sampler.sample_rejection(
+            lambda xs: np.ones(xs.shape[0]),
+            n_candidates=4,
+            dim=1.5,
+            max_density=1.0,
+        )
+
+
+def test_fibonacci_rejection_sampler_accepts_integer_like_scalar_arguments():
+    samples, info = FibonacciRejectionSampler().sample_rejection(
+        lambda xs: np.ones(xs.shape[0]),
+        n_candidates=np.float64(4.0),
+        dim=np.array(2),
+        max_density=1.0,
+    )
+
+    assert samples.shape == (4, 2)
+    assert info["n_candidates"] == 4


### PR DESCRIPTION
## Summary
- Reject non-integral `n_samples`, `n_candidates`, `n_points`, and dimension arguments in the Euclidean deterministic samplers instead of silently truncating them with `int(...)`.
- Preserve integer-like scalar values such as 0-D NumPy integer arrays and finite floating scalars with exact integer value.
- Add focused regression coverage for Fibonacci, Sobol, Halton, and rejection-sampler argument validation.

## Rationale
The deterministic sampler APIs treat counts and dimensions as discrete quantities. Before this change, calls such as `get_uniform_samples(2.5, 2)` or `sample_rejection(..., dim=1.5)` were accepted and silently truncated to different problems, which can mask configuration errors and produce misleading sample sets.

## Validation
- Connector compare confirms this branch is 2 commits ahead of `main` and 0 behind.
- Added `tests/test_euclidean_sampler_integer_args.py`.
- Full local pytest could not be run because this execution environment cannot clone/fetch from `github.com`; repository CI should run the focused sampler tests and full suite.