### PR TITLE
Fix PyTorch backend copy for scalar inputs

### DIFF
--- a/src/pyrecest/_backend/pytorch/__init__.py
+++ b/src/pyrecest/_backend/pytorch/__init__.py
@@ -997,7 +997,9 @@ def assignment_by_sum(x, values, indices, axis=0):
 
 
 def copy(x):
-    return x.clone()
+    if _torch.is_tensor(x):
+        return x.clone()
+    return _np.copy(x)
 
 
 def cumsum(x, axis=None, dtype=None):

--- a/tests/test_pytorch_backend.py
+++ b/tests/test_pytorch_backend.py
@@ -153,6 +153,31 @@ class TestPytorchBackendReductions(unittest.TestCase):
 
 
 @unittest.skipIf(pytorch_backend is None, "PyTorch is not installed")
+class TestPytorchBackendCopy(unittest.TestCase):
+    def test_copy_accepts_python_scalar(self):
+        copied = pytorch_backend.copy(1.5)
+
+        self.assertEqual(copied.shape, ())
+        self.assertEqual(float(copied), 1.5)
+
+    def test_copy_accepts_python_sequence_without_aliasing(self):
+        values = [[1.0, 2.0], [3.0, 4.0]]
+
+        copied = pytorch_backend.copy(values)
+        values[0][0] = 99.0
+
+        self.assertEqual(copied.tolist(), [[1.0, 2.0], [3.0, 4.0]])
+
+    def test_copy_clones_tensor(self):
+        values = pytorch_backend.array([1.0, 2.0])
+
+        copied = pytorch_backend.copy(values)
+        values[0] = 99.0
+
+        self.assertEqual(copied.tolist(), [1.0, 2.0])
+
+
+@unittest.skipIf(pytorch_backend is None, "PyTorch is not installed")
 class TestPytorchBackendRandom(unittest.TestCase):
     def test_choice_accepts_weighted_sampling_without_replacement(self):
         values = pytorch_backend.array([0, 1, 2, 3])


### PR DESCRIPTION
## Summary
- make `pyrecest._backend.pytorch.copy` accept non-tensor inputs using NumPy-compatible copy semantics
- preserve tensor clone semantics for existing tensor callers
- add regression coverage for Python scalars, Python sequences, and tensor aliasing

## Rationale
The PyTorch backend exposes a NumPy-like `copy` helper, but the implementation unconditionally called `.clone()`. This fails for scalar/list inputs even though the rest of the backend often accepts Python and NumPy-style inputs before converting them.

## Tests
- Not run locally: sandbox cannot clone from github.com directly in this environment.