### PR TITLE
Validate numerical repair helper parameters

### DIFF
--- a/src/pyrecest/numerics.py
+++ b/src/pyrecest/numerics.py
@@ -67,6 +67,9 @@ def nearest_symmetric_psd(matrix, *, min_eigenvalue: float = 0.0):
     should not silently replace validation in algorithms where invalid covariance
     matrices indicate a modeling error.
     """
+    if not np.isfinite(min_eigenvalue) or min_eigenvalue < 0.0:
+        raise ValueError("min_eigenvalue must be finite and nonnegative.")
+
     arr = _to_numpy_array(matrix)
     if arr.ndim != 2 or arr.shape[0] != arr.shape[1]:
         raise ShapeError(f"Expected a square matrix, got shape {arr.shape}.")
@@ -84,6 +87,11 @@ def jittered_cholesky(matrix, *, initial_jitter: float = 1e-12, max_attempts: in
     jitter. It raises :class:`NumericalStabilityError` if no factorization is
     found within ``max_attempts``.
     """
+    if not np.isfinite(initial_jitter) or initial_jitter <= 0.0:
+        raise ValueError("initial_jitter must be finite and positive.")
+    if not isinstance(max_attempts, (int, np.integer)) or max_attempts < 0:
+        raise ValueError("max_attempts must be a nonnegative integer.")
+
     arr = _to_numpy_array(matrix)
     if arr.ndim != 2 or arr.shape[0] != arr.shape[1]:
         raise ShapeError(f"Expected a square matrix, got shape {arr.shape}.")

--- a/tests/test_numerics.py
+++ b/tests/test_numerics.py
@@ -21,11 +21,31 @@ def test_symmetrize_matrix_and_psd_projection():
     assert is_positive_semidefinite(repaired)
 
 
+def test_nearest_symmetric_psd_rejects_invalid_min_eigenvalue():
+    matrix = np.eye(2)
+
+    for min_eigenvalue in (-1.0, np.nan, np.inf):
+        with pytest.raises(ValueError, match="min_eigenvalue"):
+            nearest_symmetric_psd(matrix, min_eigenvalue=min_eigenvalue)
+
+
 def test_jittered_cholesky_reports_jitter():
     matrix = np.array([[1.0, 0.0], [0.0, 0.0]])
     factor, jitter = jittered_cholesky(matrix)
     assert np.asarray(factor).shape == (2, 2)
     assert jitter > 0.0
+
+
+def test_jittered_cholesky_rejects_invalid_retry_controls():
+    matrix = np.eye(2)
+
+    for initial_jitter in (0.0, -1e-12, np.nan, np.inf):
+        with pytest.raises(ValueError, match="initial_jitter"):
+            jittered_cholesky(matrix, initial_jitter=initial_jitter)
+
+    for max_attempts in (-1, 1.5):
+        with pytest.raises(ValueError, match="max_attempts"):
+            jittered_cholesky(matrix, max_attempts=max_attempts)
 
 
 def test_assert_covariance_matrix_rejects_non_psd():


### PR DESCRIPTION
## Summary
- Reject invalid `min_eigenvalue` values in `nearest_symmetric_psd` before eigenvalue clipping can produce non-PSD/NaN repairs.
- Reject invalid `initial_jitter` and `max_attempts` controls in `jittered_cholesky` before retry logic can silently fail to progress or raise low-level type errors.
- Add focused regression coverage for these numerical helper contracts.

## Rationale
The numerical repair helpers are intended for controlled diagnostics/repair. Passing negative, non-finite, or otherwise invalid repair parameters previously allowed misleading outputs or unclear downstream errors. The new validation keeps valid behavior unchanged while failing fast for invalid controls.

## Validation
- Fresh branch created from current `main`.
- Added focused tests in `tests/test_numerics.py`.
- Full local pytest could not be run because this execution container cannot resolve `github.com`; repository CI should run the focused numerics tests and full matrix.