### PR TITLE
Validate numerical tolerance inputs

### DIFF
--- a/src/pyrecest/numerics.py
+++ b/src/pyrecest/numerics.py
@@ -30,6 +30,13 @@ def _from_numpy_array(value: np.ndarray):
         return value
 
 
+def _validate_nonnegative_finite(name: str, value: float) -> float:
+    value = float(value)
+    if not np.isfinite(value) or value < 0.0:
+        raise ValueError(f"{name} must be finite and non-negative.")
+    return value
+
+
 def symmetrize_matrix(matrix):
     """Return ``0.5 * (matrix + matrix.T)`` in the active backend representation."""
     arr = _to_numpy_array(matrix)
@@ -40,6 +47,7 @@ def symmetrize_matrix(matrix):
 
 def is_symmetric(matrix, *, atol: float = 1e-10) -> bool:
     """Return whether a matrix is symmetric within an absolute tolerance."""
+    atol = _validate_nonnegative_finite("atol", atol)
     arr = _to_numpy_array(matrix)
     return bool(
         arr.ndim == 2
@@ -50,6 +58,7 @@ def is_symmetric(matrix, *, atol: float = 1e-10) -> bool:
 
 def is_positive_semidefinite(matrix, *, atol: float = 1e-10) -> bool:
     """Return whether a symmetric matrix is positive semidefinite within tolerance."""
+    atol = _validate_nonnegative_finite("atol", atol)
     arr = _to_numpy_array(matrix)
     if (
         arr.ndim != 2
@@ -105,6 +114,7 @@ def assert_covariance_matrix(
     matrix, *, name: str = "covariance", dim: int | None = None, atol: float = 1e-10
 ):
     """Validate a covariance matrix and return it in the active backend representation."""
+    atol = _validate_nonnegative_finite("atol", atol)
     arr = _to_numpy_array(matrix)
     if arr.ndim != 2 or arr.shape[0] != arr.shape[1]:
         raise ShapeError(f"{name} must be a square matrix, got shape {arr.shape}.")

--- a/tests/test_numerics.py
+++ b/tests/test_numerics.py
@@ -31,3 +31,16 @@ def test_jittered_cholesky_reports_jitter():
 def test_assert_covariance_matrix_rejects_non_psd():
     with pytest.raises(NumericalStabilityError):
         assert_covariance_matrix(np.array([[1.0, 0.0], [0.0, -1.0]]))
+
+
+@pytest.mark.parametrize("atol", [-1.0, float("nan"), float("inf")])
+@pytest.mark.parametrize("validator", [is_symmetric, is_positive_semidefinite])
+def test_matrix_predicates_reject_invalid_atol(atol, validator):
+    with pytest.raises(ValueError, match="atol must be finite and non-negative"):
+        validator(np.eye(2), atol=atol)
+
+
+@pytest.mark.parametrize("atol", [-1.0, float("nan"), float("inf")])
+def test_assert_covariance_matrix_rejects_invalid_atol(atol):
+    with pytest.raises(ValueError, match="atol must be finite and non-negative"):
+        assert_covariance_matrix(np.eye(2), atol=atol)


### PR DESCRIPTION
Superseded by a rebased branch because `main` advanced while this PR was being opened. The same fix is being reopened from the current `main` head.