### PR TITLE
Validate numerical tolerance inputs

### DIFF
--- a/src/pyrecest/numerics.py
+++ b/src/pyrecest/numerics.py
@@ -30,6 +30,13 @@ def _from_numpy_array(value: np.ndarray):
         return value
 
 
+def _validate_nonnegative_finite(name: str, value: float) -> float:
+    value = float(value)
+    if not np.isfinite(value) or value < 0.0:
+        raise ValueError(f"{name} must be finite and non-negative.")
+    return value
+
+
 def symmetrize_matrix(matrix):
     """Return ``0.5 * (matrix + matrix.T)`` in the active backend representation."""
     arr = _to_numpy_array(matrix)
@@ -40,6 +47,7 @@ def symmetrize_matrix(matrix):
 
 def is_symmetric(matrix, *, atol: float = 1e-10) -> bool:
     """Return whether a matrix is symmetric within an absolute tolerance."""
+    atol = _validate_nonnegative_finite("atol", atol)
     arr = _to_numpy_array(matrix)
     return bool(
         arr.ndim == 2
@@ -50,6 +58,7 @@ def is_symmetric(matrix, *, atol: float = 1e-10) -> bool:
 
 def is_positive_semidefinite(matrix, *, atol: float = 1e-10) -> bool:
     """Return whether a symmetric matrix is positive semidefinite within tolerance."""
+    atol = _validate_nonnegative_finite("atol", atol)
     arr = _to_numpy_array(matrix)
     if (
         arr.ndim != 2
@@ -113,6 +122,7 @@ def assert_covariance_matrix(
     matrix, *, name: str = "covariance", dim: int | None = None, atol: float = 1e-10
 ):
     """Validate a covariance matrix and return it in the active backend representation."""
+    atol = _validate_nonnegative_finite("atol", atol)
     arr = _to_numpy_array(matrix)
     if arr.ndim != 2 or arr.shape[0] != arr.shape[1]:
         raise ShapeError(f"{name} must be a square matrix, got shape {arr.shape}.")

--- a/tests/test_numerics_atol_contract.py
+++ b/tests/test_numerics_atol_contract.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pytest
+from pyrecest.numerics import (
+    assert_covariance_matrix,
+    is_positive_semidefinite,
+    is_symmetric,
+)
+
+
+@pytest.mark.parametrize("atol", [-1.0, np.nan, np.inf])
+@pytest.mark.parametrize("validator", [is_symmetric, is_positive_semidefinite])
+def test_matrix_predicates_reject_invalid_atol(atol, validator):
+    with pytest.raises(ValueError, match="atol must be finite and non-negative"):
+        validator(np.eye(2), atol=atol)
+
+
+@pytest.mark.parametrize("atol", [-1.0, np.nan, np.inf])
+def test_assert_covariance_matrix_rejects_invalid_atol(atol):
+    with pytest.raises(ValueError, match="atol must be finite and non-negative"):
+        assert_covariance_matrix(np.eye(2), atol=atol)


### PR DESCRIPTION
## Summary
- Reject negative, NaN, and infinite `atol` values in numerical matrix validators.
- Apply the tolerance validation consistently in `is_symmetric`, `is_positive_semidefinite`, and `assert_covariance_matrix`.
- Add focused regression tests in `tests/test_numerics_atol_contract.py`.

## Bug fixed
`np.allclose` does not reliably fail on invalid absolute tolerances such as negative or NaN `atol` values. Because the numerical validators forwarded `atol` directly, callers could accidentally use invalid tolerance controls and receive misleading validation results. The patch fails fast with a clear `ValueError` before symmetry or PSD checks are evaluated.

## Validation
- Rebased onto current `main` and compared branch against `main`: 2 commits ahead, 0 behind.
- Added focused invalid-`atol` regression tests.
- Full local pytest was not run because this execution container cannot resolve `github.com`; repository CI should run the focused tests and full matrix.