### PR TITLE
Fix JAX UKF sigma-point updates

### DIFF
--- a/src/pyrecest/filters/_ukf.py
+++ b/src/pyrecest/filters/_ukf.py
@@ -10,13 +10,12 @@ from copy import deepcopy
 from pyrecest.backend import (
     asarray,
     einsum,
-    empty,
-    empty_like,
     expand_dims,
     eye,
     float64,
     linalg,
     reshape,
+    stack,
     transpose,
     zeros,
 )
@@ -85,11 +84,12 @@ class UnscentedKalmanFilter:
         sigmas = points.sigma_points(self.x, self.P)
         n_sigmas = sigmas.shape[0]
 
-        sigmas_f = empty_like(sigmas)
-        for i in range(n_sigmas):
-            sigmas_f[i] = reshape(
-                asarray(fx(sigmas[i], dt, **fx_args), dtype=float64), (-1,)
-            )
+        sigmas_f = stack(
+            [
+                reshape(asarray(fx(sigmas[i], dt, **fx_args), dtype=float64), (-1,))
+                for i in range(n_sigmas)
+            ]
+        )
 
         Wm = points.Wm
         Wc = points.Wc
@@ -144,19 +144,18 @@ class UnscentedKalmanFilter:
         Wm = self._model.points.Wm
         Wc = self._model.points.Wc
 
-        sigmas_h = None
-        dim_z = None
-        for i in range(sigmas_f.shape[0]):
-            sigma_h = reshape(asarray(hx(sigmas_f[i], **hx_args), dtype=float64), (-1,))
-            if sigmas_h is None:
-                dim_z = sigma_h.shape[0]
-                sigmas_h = empty((sigmas_f.shape[0], dim_z))
-            elif sigma_h.shape[0] != dim_z:
+        sigma_rows = [
+            reshape(asarray(hx(sigmas_f[i], **hx_args), dtype=float64), (-1,))
+            for i in range(sigmas_f.shape[0])
+        ]
+        dim_z = sigma_rows[0].shape[0]
+        for sigma_h in sigma_rows[1:]:
+            if sigma_h.shape[0] != dim_z:
                 raise ValueError(
                     "measurement function must return vectors with consistent "
                     f"dimension; got {sigma_h.shape[0]} and expected {dim_z}"
                 )
-            sigmas_h[i] = sigma_h
+        sigmas_h = stack(sigma_rows)
 
         if z.shape[0] != dim_z:
             raise ValueError(

--- a/src/pyrecest/filters/unscented_kalman_filter.py
+++ b/src/pyrecest/filters/unscented_kalman_filter.py
@@ -14,6 +14,10 @@ from .abstract_filter import AbstractFilter
 from .manifold_mixins import EuclideanFilterMixin
 
 
+def _assert_supported_backend():
+    assert pyrecest.backend.__backend_name__ != "pytorch", "Not supported on this backend"
+
+
 class UnscentedKalmanFilter(AbstractFilter, EuclideanFilterMixin):
     # pylint: disable=too-many-positional-arguments
     def __init__(
@@ -90,19 +94,13 @@ class UnscentedKalmanFilter(AbstractFilter, EuclideanFilterMixin):
         :param fx: Function with signature fx(x, dt, **fx_args)
         :param sys_noise_cov: Process noise matrix Q
         """
-        assert pyrecest.backend.__backend_name__ not in (
-            "pytorch",
-            "jax",
-        ), "Not supported on this backend"
+        _assert_supported_backend()
         self._filter_state.Q = sys_noise_cov
         self._filter_state.predict(dt=dt, fx=fx, **fx_args)
         self._predicted = True
 
     def update_nonlinear(self, measurement, hx, cov_mat_meas, **hx_args):
-        assert pyrecest.backend.__backend_name__ not in (
-            "pytorch",
-            "jax",
-        ), "Not supported on this backend"
+        _assert_supported_backend()
         self._ensure_predicted()
         self._filter_state.update(z=measurement, hx=hx, R=cov_mat_meas, **hx_args)
         self._predicted = False
@@ -155,10 +153,7 @@ class UnscentedKalmanFilter(AbstractFilter, EuclideanFilterMixin):
         )
 
     def predict_identity(self, sys_noise_cov, dt=None):
-        assert pyrecest.backend.__backend_name__ not in (
-            "pytorch",
-            "jax",
-        ), "Not supported on this backend"
+        _assert_supported_backend()
         self._filter_state.Q = sys_noise_cov
 
         def fx(x, _):
@@ -168,10 +163,7 @@ class UnscentedKalmanFilter(AbstractFilter, EuclideanFilterMixin):
         self._predicted = True
 
     def predict_linear(self, system_matrix, sys_noise_cov, sys_input=None, dt=None):
-        assert pyrecest.backend.__backend_name__ not in (
-            "pytorch",
-            "jax",
-        ), "Not supported on this backend"
+        _assert_supported_backend()
         self._filter_state.Q = sys_noise_cov
 
         if sys_input is None:
@@ -203,10 +195,7 @@ class UnscentedKalmanFilter(AbstractFilter, EuclideanFilterMixin):
         keyword aliases, and legacy two-argument positional calls are detected
         when the argument shapes make the old order unambiguous.
         """
-        assert pyrecest.backend.__backend_name__ not in (
-            "pytorch",
-            "jax",
-        ), "Not supported on this backend"
+        _assert_supported_backend()
 
         if meas is not None or meas_cov is not None:
             if measurement is not None or meas_noise is not None:
@@ -241,10 +230,7 @@ class UnscentedKalmanFilter(AbstractFilter, EuclideanFilterMixin):
         self._predicted = False
 
     def update_linear(self, measurement, measurement_matrix, cov_mat_meas):
-        assert pyrecest.backend.__backend_name__ not in (
-            "pytorch",
-            "jax",
-        ), "Not supported on this backend"
+        _assert_supported_backend()
         self._ensure_predicted()
 
         def hx(x):

--- a/src/pyrecest/sampling/sigma_points.py
+++ b/src/pyrecest/sampling/sigma_points.py
@@ -2,12 +2,8 @@
 Sigma-point sampling schemes for unscented transforms.
 """
 
-import pyrecest.backend
-
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import asarray
-from pyrecest.backend import copy as backend_copy
-from pyrecest.backend import empty, float64, full, linalg, reshape
+from pyrecest.backend import asarray, float64, full, hstack, linalg, reshape, stack
 
 
 class MerweScaledSigmaPoints:
@@ -26,10 +22,6 @@ class MerweScaledSigmaPoints:
     """
 
     def __init__(self, n: int, alpha: float, beta: float, kappa: float):
-        if pyrecest.backend.__backend_name__ == "jax":
-            raise NotImplementedError(
-                "MerweScaledSigmaPoints is not supported on the JAX backend"
-            )
         self.n = n
         self.alpha = alpha
         self.beta = beta
@@ -39,12 +31,23 @@ class MerweScaledSigmaPoints:
     def _compute_weights(self):
         n = self.n
         lam = self.alpha**2 * (n + self.kappa) - n
+        scale = n + lam
 
-        self.Wm = full(2 * n + 1, 0.5 / (n + lam))
-        self.Wm[0] = lam / (n + lam)
-
-        self.Wc = backend_copy(self.Wm)
-        self.Wc[0] = lam / (n + lam) + (1.0 - self.alpha**2 + self.beta)
+        self.Wm = hstack(
+            [
+                asarray([lam / scale], dtype=float64),
+                full((2 * n,), 0.5 / scale, dtype=float64),
+            ]
+        )
+        self.Wc = hstack(
+            [
+                asarray(
+                    [lam / scale + (1.0 - self.alpha**2 + self.beta)],
+                    dtype=float64,
+                ),
+                full((2 * n,), 0.5 / scale, dtype=float64),
+            ]
+        )
 
     def sigma_points(self, x, P):
         """Return ``(2n+1, n)`` sigma-point matrix.
@@ -64,12 +67,9 @@ class MerweScaledSigmaPoints:
 
         U = linalg.cholesky((n + lam) * P)  # lower-triangular
 
-        sigmas = empty((2 * n + 1, n))
-        sigmas[0] = x
-        for i in range(n):
-            sigmas[i + 1] = x + U[:, i]
-            sigmas[n + i + 1] = x - U[:, i]
-        return sigmas
+        positive = [x + U[:, i] for i in range(n)]
+        negative = [x - U[:, i] for i in range(n)]
+        return stack([x, *positive, *negative])
 
 
 class JulierSigmaPoints:
@@ -84,10 +84,6 @@ class JulierSigmaPoints:
     """
 
     def __init__(self, n: int, kappa: float = 0.0):
-        if pyrecest.backend.__backend_name__ == "jax":
-            raise NotImplementedError(
-                "JulierSigmaPoints is not supported on the JAX backend"
-            )
         self.n = n
         self.kappa = kappa
         self._compute_weights()
@@ -96,10 +92,18 @@ class JulierSigmaPoints:
         n = self.n
         k = n + self.kappa
 
-        self.Wm = full(2 * n + 1, 0.5 / k)
-        self.Wm[0] = self.kappa / k
-
-        self.Wc = backend_copy(self.Wm)
+        self.Wm = hstack(
+            [
+                asarray([self.kappa / k], dtype=float64),
+                full((2 * n,), 0.5 / k, dtype=float64),
+            ]
+        )
+        self.Wc = hstack(
+            [
+                asarray([self.kappa / k], dtype=float64),
+                full((2 * n,), 0.5 / k, dtype=float64),
+            ]
+        )
 
     def sigma_points(self, x, P):
         """Return ``(2n+1, n)`` sigma-point matrix.
@@ -119,9 +123,6 @@ class JulierSigmaPoints:
 
         U = linalg.cholesky(k * P)  # lower-triangular
 
-        sigmas = empty((2 * n + 1, n))
-        sigmas[0] = x
-        for i in range(n):
-            sigmas[i + 1] = x + U[:, i]
-            sigmas[n + i + 1] = x - U[:, i]
-        return sigmas
+        positive = [x + U[:, i] for i in range(n)]
+        negative = [x - U[:, i] for i in range(n)]
+        return stack([x, *positive, *negative])

--- a/tests/test_sigma_points.py
+++ b/tests/test_sigma_points.py
@@ -2,14 +2,13 @@ import unittest
 
 import numpy as np
 import numpy.testing as npt
-import pyrecest.backend
-from pyrecest.backend import __backend_name__
+from pyrecest.backend import __backend_name__, asarray, to_numpy
 from pyrecest.sampling import JulierSigmaPoints, MerweScaledSigmaPoints
 
 
 @unittest.skipIf(
-    __backend_name__ in ("pytorch", "jax"),
-    reason="Sigma-point tests use NumPy assertions",
+    __backend_name__ == "pytorch",
+    reason="Sigma-point tests use NumPy assertions and the PyTorch backend is unsupported",
 )
 class TestSigmaPoints(unittest.TestCase):
     def test_merwe_scaled_sigma_points_match_moments(self):
@@ -17,39 +16,28 @@ class TestSigmaPoints(unittest.TestCase):
         covariance = np.array([[2.0, 0.4], [0.4, 1.0]])
         points = MerweScaledSigmaPoints(n=2, alpha=0.5, beta=2.0, kappa=0.0)
 
-        sigmas = points.sigma_points(mean, covariance)
+        sigmas = points.sigma_points(asarray(mean), asarray(covariance))
         weighted_mean = points.Wm @ sigmas
         deviations = sigmas - weighted_mean
         weighted_covariance = deviations.T @ (deviations * points.Wc[:, None])
 
         self.assertEqual(sigmas.shape, (5, 2))
-        npt.assert_allclose(weighted_mean, mean)
-        npt.assert_allclose(weighted_covariance, covariance)
-
-    def test_sigma_points_reject_jax_backend_with_not_implemented_error(self):
-        old_backend_name = pyrecest.backend.__backend_name__
-        pyrecest.backend.__backend_name__ = "jax"
-        try:
-            with self.assertRaises(NotImplementedError):
-                MerweScaledSigmaPoints(n=2, alpha=0.5, beta=2.0, kappa=0.0)
-            with self.assertRaises(NotImplementedError):
-                JulierSigmaPoints(n=2, kappa=1.0)
-        finally:
-            pyrecest.backend.__backend_name__ = old_backend_name
+        npt.assert_allclose(to_numpy(weighted_mean), mean)
+        npt.assert_allclose(to_numpy(weighted_covariance), covariance)
 
     def test_julier_sigma_points_match_moments(self):
         mean = np.array([0.5, 1.5])
         covariance = np.array([[1.5, 0.2], [0.2, 0.5]])
         points = JulierSigmaPoints(n=2, kappa=1.0)
 
-        sigmas = points.sigma_points(mean, covariance)
+        sigmas = points.sigma_points(asarray(mean), asarray(covariance))
         weighted_mean = points.Wm @ sigmas
         deviations = sigmas - weighted_mean
         weighted_covariance = deviations.T @ (deviations * points.Wc[:, None])
 
         self.assertEqual(sigmas.shape, (5, 2))
-        npt.assert_allclose(weighted_mean, mean)
-        npt.assert_allclose(weighted_covariance, covariance)
+        npt.assert_allclose(to_numpy(weighted_mean), mean)
+        npt.assert_allclose(to_numpy(weighted_covariance), covariance)
 
 
 if __name__ == "__main__":

--- a/tests/test_ukf_jax_backend.py
+++ b/tests/test_ukf_jax_backend.py
@@ -29,7 +29,7 @@ from pyrecest.sampling.sigma_points import MerweScaledSigmaPoints
 points = MerweScaledSigmaPoints(2, alpha=0.5, beta=2.0, kappa=0.0)
 sigmas = points.sigma_points(backend.asarray([0.0, 0.0]), backend.eye(2))
 assert sigmas.shape == (5, 2)
-assert backend.isclose(backend.sum(points.Wm), 1.0)
+assert bool(backend.to_numpy(backend.isclose(backend.sum(points.Wm), 1.0)))
 
 initial = GaussianDistribution(backend.asarray([0.0, 0.0]), backend.eye(2))
 ukf = UnscentedKalmanFilter(initial)
@@ -37,6 +37,6 @@ ukf.predict_identity(0.1 * backend.eye(2))
 ukf.update_identity(0.1 * backend.eye(2), backend.asarray([1.0, -1.0]))
 estimate = ukf.get_point_estimate()
 assert estimate.shape == (2,)
-assert backend.all(backend.isfinite(estimate))
+assert bool(backend.to_numpy(backend.all(backend.isfinite(estimate))))
 """
     subprocess.run([sys.executable, "-c", code], check=True, env=env)

--- a/tests/test_ukf_jax_backend.py
+++ b/tests/test_ukf_jax_backend.py
@@ -1,0 +1,42 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_jax_euclidean_ukf_predict_update_runs_without_inplace_writes():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("jax is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "jax"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import pyrecest.backend as backend
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.filters.unscented_kalman_filter import UnscentedKalmanFilter
+from pyrecest.sampling.sigma_points import MerweScaledSigmaPoints
+
+points = MerweScaledSigmaPoints(2, alpha=0.5, beta=2.0, kappa=0.0)
+sigmas = points.sigma_points(backend.asarray([0.0, 0.0]), backend.eye(2))
+assert sigmas.shape == (5, 2)
+assert backend.isclose(backend.sum(points.Wm), 1.0)
+
+initial = GaussianDistribution(backend.asarray([0.0, 0.0]), backend.eye(2))
+ukf = UnscentedKalmanFilter(initial)
+ukf.predict_identity(0.1 * backend.eye(2))
+ukf.update_identity(0.1 * backend.eye(2), backend.asarray([1.0, -1.0]))
+estimate = ukf.get_point_estimate()
+assert estimate.shape == (2,)
+assert backend.all(backend.isfinite(estimate))
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- remove the explicit JAX rejection from Julier/Merwe sigma-point constructors
- build sigma-point weights and matrices functionally instead of via in-place array writes
- build UKF propagated/measurement sigma matrices via `stack`, so immutable backends such as JAX do not fail at row assignment
- allow the Euclidean UKF public methods on JAX while keeping the existing PyTorch guard
- add a backend-portable JAX subprocess regression test for sigma-point generation and a predict/update cycle

## Rationale
The JAX backend uses immutable arrays. The existing sigma-point and UKF helper implementations used NumPy-style in-place row assignment, and the public Euclidean UKF additionally rejected JAX before reaching the helper. This made an otherwise backend-expressible UKF path unusable on JAX.

## Validation
- Branch was recreated from current `main` before opening this PR.
- Could not run local pytest in the execution container because direct GitHub checkout/network access is unavailable here; CI should exercise the new `backend_portable` JAX regression and the existing suite.