### PR TITLE
Fix non-vectorized Dirac transforms across backends

### DIFF
--- a/src/pyrecest/distributions/abstract_dirac_distribution.py
+++ b/src/pyrecest/distributions/abstract_dirac_distribution.py
@@ -8,7 +8,6 @@ from beartype import beartype
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 from pyrecest.backend import (
     all,
-    apply_along_axis,
     arange,
     argmax,
     asarray,
@@ -19,6 +18,7 @@ from pyrecest.backend import (
     log,
     ones,
     random,
+    stack,
     sum,
 )
 
@@ -91,7 +91,7 @@ class AbstractDiracDistribution(AbstractDistributionType):
         if function_is_vectorized:
             dist.d = f(dist.d)
         else:
-            dist.d = apply_along_axis(f, 1, dist.d)
+            dist.d = stack([asarray(f(point)) for point in dist.d])
         return dist
 
     def reweigh(self, f: Callable) -> "AbstractDiracDistribution":

--- a/tests/distributions/test_abstract_dirac_distribution.py
+++ b/tests/distributions/test_abstract_dirac_distribution.py
@@ -1,8 +1,13 @@
+import importlib.util
+import os
+import subprocess
+import sys
 import unittest
 import warnings
 
 import matplotlib
 import numpy.testing as npt
+import pytest
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import array, random
@@ -53,6 +58,32 @@ class TestAbstractDiracDistribution(unittest.TestCase):
             mode = dist.mode()
 
         npt.assert_allclose(mode, array([1.0, 2.0]))
+
+    def test_apply_function_non_vectorized_maps_complete_diracs(self):
+        dist = LinearDiracDistribution(
+            array(
+                [
+                    [0.0, 1.0],
+                    [2.0, 3.0],
+                ]
+            ),
+            array([0.5, 0.5]),
+        )
+
+        mapped = dist.apply_function(
+            lambda point: array([point[1], point[0] + point[1]]),
+            function_is_vectorized=False,
+        )
+
+        npt.assert_allclose(
+            mapped.d,
+            array(
+                [
+                    [1.0, 1.0],
+                    [3.0, 5.0],
+                ]
+            ),
+        )
 
     def test_rejects_negative_weights(self):
         with self.assertRaisesRegex(ValueError, "nonnegative"):
@@ -157,3 +188,35 @@ class TestAbstractDiracDistribution(unittest.TestCase):
             ddist.plot()
         except (ValueError, RuntimeError) as e:
             self.fail(f"{name}: Plotting failed for dimension {dim} with error: {e}")
+
+
+@pytest.mark.backend_portable
+def test_pytorch_non_vectorized_dirac_transform_maps_particles_not_coordinates():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import numpy.testing as npt
+from pyrecest.backend import array, to_numpy
+from pyrecest.distributions import LinearDiracDistribution
+
+dist = LinearDiracDistribution(
+    array([[0.0, 1.0], [2.0, 3.0]]),
+    array([0.5, 0.5]),
+)
+mapped = dist.apply_function(
+    lambda point: array([point[1], point[0] + point[1]]),
+    function_is_vectorized=False,
+)
+npt.assert_allclose(to_numpy(mapped.d), [[1.0, 1.0], [3.0, 5.0]])
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- Map non-vectorized Dirac transforms over complete Dirac particles instead of delegating to backend `apply_along_axis`.
- Remove the fragile `apply_along_axis(..., axis=1, ...)` dependency from `AbstractDiracDistribution.apply_function`.
- Add default-backend and optional PyTorch-backend regression coverage.

## Bug fixed
`AbstractDiracDistribution.apply_function(..., function_is_vectorized=False)` intended to call the provided function once per Dirac particle. The previous implementation used `backend.apply_along_axis(f, 1, dist.d)`, which is backend-sensitive and, under the PyTorch backend, iterates over coordinate columns rather than particle rows and stacks the result along the wrong axis. This can silently produce invalid transformed particles.

## Validation
- Compared branch against current `main`: 2 commits ahead, 0 behind.
- Added focused regression coverage in `tests/distributions/test_abstract_dirac_distribution.py`.
- Full local pytest was not run because the execution sandbox cannot resolve `github.com`; repository CI should run the focused tests and full matrix.