### PR TITLE
Fix infinite log-weight normalization

### DIFF
--- a/src/pyrecest/filters/gaussian_hypothesis_mixture.py
+++ b/src/pyrecest/filters/gaussian_hypothesis_mixture.py
@@ -59,6 +59,13 @@ def normalize_log_weights(log_weights: list[float] | np.ndarray) -> np.ndarray:
     values = np.asarray(log_weights, dtype=float).reshape(-1)
     if values.size == 0:
         raise ValueError("log_weights must not be empty")
+
+    positive_infinite = np.isposinf(values)
+    if np.any(positive_infinite):
+        weights = np.zeros(values.size, dtype=float)
+        weights[positive_infinite] = 1.0 / np.count_nonzero(positive_infinite)
+        return weights
+
     maximum = float(np.max(values))
     if not np.isfinite(maximum):
         return np.full(values.size, 1.0 / values.size)

--- a/tests/filters/test_gaussian_hypothesis_mixture.py
+++ b/tests/filters/test_gaussian_hypothesis_mixture.py
@@ -14,6 +14,32 @@ class GaussianHypothesisMixtureTest(unittest.TestCase):
 
         self.assertTrue(np.allclose(weights, np.array([0.5, 0.5])))
 
+    def test_positive_infinite_log_weights_dominate(self):
+        weights = normalize_log_weights(np.array([0.0, np.inf, -np.inf]))
+
+        self.assertTrue(np.allclose(weights, np.array([0.0, 1.0, 0.0])))
+
+    def test_multiple_positive_infinite_log_weights_share_mass(self):
+        weights = normalize_log_weights(np.array([np.inf, 5.0, np.inf]))
+
+        self.assertTrue(np.allclose(weights, np.array([0.5, 0.0, 0.5])))
+
+    def test_moment_matching_respects_dominant_infinite_weight(self):
+        mean, covariance, weights = moment_match_gaussian_hypotheses(
+            [
+                WeightedGaussianHypothesis(
+                    np.array([0.0]), np.array([[1.0]]), log_weight=0.0
+                ),
+                WeightedGaussianHypothesis(
+                    np.array([3.0]), np.array([[2.0]]), log_weight=np.inf
+                ),
+            ]
+        )
+
+        self.assertTrue(np.allclose(weights, np.array([0.0, 1.0])))
+        self.assertTrue(np.allclose(mean, np.array([3.0])))
+        self.assertTrue(np.allclose(covariance, np.array([[2.0]])))
+
     def test_moment_matching_includes_between_hypothesis_spread(self):
         mean, covariance, weights = moment_match_gaussian_hypotheses(
             [


### PR DESCRIPTION
## Summary
- Treat positive infinite log weights as dominant support instead of falling back to a uniform distribution.
- Split probability mass uniformly only among hypotheses with `+inf` log weight.
- Add regression coverage for single and multiple `+inf` weights and moment matching with a dominant infinite-weight hypothesis.

## Bug fixed
`normalize_log_weights` previously used `not np.isfinite(maximum)` as a generic fallback to uniform weights. That is appropriate when all weights collapse to `-inf`/non-finite support, but it is mathematically wrong when one or more hypotheses have `+inf` log weights: those hypotheses should receive all probability mass. The old behavior could make `moment_match_gaussian_hypotheses` average incompatible hypotheses even when one hypothesis has an infinite log-score advantage.

## Validation
- Branch created from current `main` (`5c989c29fa1d937e3b4b117610f69c7dba018a3d`).
- Compared branch against `main`: 2 commits ahead, 0 behind; only `gaussian_hypothesis_mixture.py` and its focused tests changed.
- Local pytest was not run because this execution container cannot resolve `github.com`; repository CI should run the focused regression tests and full matrix.