### PR TITLE
Validate bias application feature rows

### DIFF
--- a/src/pyrecest/calibration/bias.py
+++ b/src/pyrecest/calibration/bias.py
@@ -95,7 +95,14 @@ class SensorBiasCorrectionModel:
         values = _as_2d(measurements, "measurements")
         if values.shape[1] != self.target_dim:
             raise ValueError("measurements have incompatible target dimension")
-        bias = self.predict(features, n_rows=values.shape[0])
+        try:
+            bias = self.predict(features, n_rows=values.shape[0])
+        except ValueError as exc:
+            if str(exc) == "features rows must match requested row count":
+                raise ValueError(
+                    "features must produce one predicted bias row per measurement"
+                ) from exc
+            raise
         if bias.shape != values.shape:
             raise ValueError(
                 "features must produce one predicted bias row per measurement"

--- a/src/pyrecest/calibration/bias.py
+++ b/src/pyrecest/calibration/bias.py
@@ -11,6 +11,12 @@ import numpy as np
 from .time_offset import nearest_time_indices
 
 
+_FEATURE_ROW_COUNT_ERROR = (
+    "features rows must match requested row count; "
+    "features must produce one predicted bias row per measurement"
+)
+
+
 @dataclass(frozen=True)
 class BiasTrainingExamples:
     """Matched measurement/reference pairs used for bias fitting."""
@@ -99,14 +105,10 @@ class SensorBiasCorrectionModel:
             bias = self.predict(features, n_rows=values.shape[0])
         except ValueError as exc:
             if str(exc) == "features rows must match requested row count":
-                raise ValueError(
-                    "features must produce one predicted bias row per measurement"
-                ) from exc
+                raise ValueError(_FEATURE_ROW_COUNT_ERROR) from exc
             raise
         if bias.shape != values.shape:
-            raise ValueError(
-                "features must produce one predicted bias row per measurement"
-            )
+            raise ValueError(_FEATURE_ROW_COUNT_ERROR)
         corrected = values.copy()
         valid = np.isfinite(values).all(axis=1) & np.isfinite(bias).all(axis=1)
         corrected[valid] = values[valid] - bias[valid]

--- a/src/pyrecest/calibration/bias.py
+++ b/src/pyrecest/calibration/bias.py
@@ -94,6 +94,10 @@ class SensorBiasCorrectionModel:
         if values.shape[1] != self.target_dim:
             raise ValueError("measurements have incompatible target dimension")
         bias = self.predict(features, n_rows=values.shape[0])
+        if bias.shape != values.shape:
+            raise ValueError(
+                "features must produce one predicted bias row per measurement"
+            )
         corrected = values.copy()
         valid = np.isfinite(values).all(axis=1) & np.isfinite(bias).all(axis=1)
         corrected[valid] = values[valid] - bias[valid]

--- a/tests/calibration/test_bias.py
+++ b/tests/calibration/test_bias.py
@@ -1,0 +1,45 @@
+import numpy as np
+import pytest
+
+from pyrecest.calibration.bias import SensorBiasCorrectionModel
+
+
+def test_apply_rejects_feature_row_count_mismatch():
+    model = SensorBiasCorrectionModel(
+        target_dim=1,
+        feature_dim=1,
+        intercept=np.array([0.0]),
+        coefficients=np.array([[1.0]]),
+        feature_mean=np.array([0.0]),
+        feature_scale=np.array([1.0]),
+        residual_std=np.array([0.0]),
+        training_count=2,
+        ridge_alpha=0.0,
+    )
+
+    measurements = np.array([[10.0], [20.0]])
+    features = np.array([[1.0]])
+
+    with pytest.raises(ValueError, match="one predicted bias row per measurement"):
+        model.apply(measurements, features)
+
+
+def test_apply_accepts_matching_feature_rows():
+    model = SensorBiasCorrectionModel(
+        target_dim=1,
+        feature_dim=1,
+        intercept=np.array([0.5]),
+        coefficients=np.array([[2.0]]),
+        feature_mean=np.array([1.0]),
+        feature_scale=np.array([2.0]),
+        residual_std=np.array([0.0]),
+        training_count=3,
+        ridge_alpha=0.0,
+    )
+
+    measurements = np.array([[10.0], [20.0]])
+    features = np.array([[1.0], [3.0]])
+
+    corrected = model.apply(measurements, features)
+
+    np.testing.assert_allclose(corrected, np.array([[9.5], [17.5]]))


### PR DESCRIPTION
## Summary
- Add an explicit `SensorBiasCorrectionModel.apply` shape check after bias prediction.
- Reject feature arrays that do not produce exactly one predicted bias row per measurement.
- Add regression coverage for mismatched and matching feature row counts.

## Bug fixed
For nonconstant bias models, `predict(features, n_rows=...)` returns one bias row per feature row. `apply()` previously proceeded without checking that the predicted bias matrix matched the measurement matrix, so a single feature row could be silently broadcast to multiple measurements, or other row mismatches could fail later via NumPy boolean indexing/broadcasting. The patch fails fast with a clear `ValueError`.

## Validation
- Branch created from current `main` (`acd35ff2fc999a78ae13d2116af1fba85aa0c39e`).
- Compared branch against `main`: 2 commits ahead, 0 behind; only `src/pyrecest/calibration/bias.py` and a focused calibration regression test changed.
- Local pytest was not run because this execution environment cannot clone/install the repository from GitHub; repository CI should run the focused regression tests and full suite.