### PR TITLE
Validate bias prediction row counts

### DIFF
--- a/src/pyrecest/calibration/bias.py
+++ b/src/pyrecest/calibration/bias.py
@@ -75,14 +75,18 @@ class SensorBiasCorrectionModel:
         """Predict residual bias for feature rows."""
 
         if self.feature_dim == 0:
-            rows = 1 if n_rows is None else int(n_rows)
+            rows = (
+                1 if n_rows is None else _as_nonnegative_int(n_rows, "n_rows")
+            )
             return np.repeat(self.intercept.reshape(1, -1), rows, axis=0)
         if features is None:
             raise ValueError("features are required for a nonconstant bias model")
         x = _as_2d(features, "features")
         if x.shape[1] != self.feature_dim:
             raise ValueError("features have incompatible feature dimension")
-        if n_rows is not None and x.shape[0] != int(n_rows):
+        if n_rows is not None and x.shape[0] != _as_nonnegative_int(
+            n_rows, "n_rows"
+        ):
             raise ValueError("features rows must match requested row count")
         standardized = (x - self.feature_mean) / self.feature_scale
         return self.intercept.reshape(1, -1) + standardized @ self.coefficients
@@ -303,6 +307,26 @@ def _as_2d(values: np.ndarray, name: str) -> np.ndarray:
     if out.ndim != 2:
         raise ValueError(f"{name} must be one- or two-dimensional")
     return out
+
+
+def _as_nonnegative_int(value: Any, name: str) -> int:
+    arr = np.asarray(value)
+    if arr.ndim != 0 or arr.dtype == np.bool_:
+        raise ValueError(f"{name} must be a nonnegative integer")
+    scalar = arr.item()
+    if isinstance(scalar, (int, np.integer)) and not isinstance(scalar, bool):
+        result = int(scalar)
+    elif (
+        isinstance(scalar, (float, np.floating))
+        and np.isfinite(scalar)
+        and float(scalar).is_integer()
+    ):
+        result = int(scalar)
+    else:
+        raise ValueError(f"{name} must be a nonnegative integer")
+    if result < 0:
+        raise ValueError(f"{name} must be a nonnegative integer")
+    return result
 
 
 def _nanmean_or_zero(values: np.ndarray) -> np.ndarray:

--- a/tests/calibration/test_bias_prediction_row_count.py
+++ b/tests/calibration/test_bias_prediction_row_count.py
@@ -1,0 +1,56 @@
+import numpy as np
+import pytest
+from pyrecest.calibration.bias import SensorBiasCorrectionModel
+
+
+def _constant_bias_model():
+    return SensorBiasCorrectionModel(
+        target_dim=1,
+        feature_dim=0,
+        intercept=np.array([2.0]),
+        coefficients=np.empty((0, 1)),
+        feature_mean=np.empty(0),
+        feature_scale=np.empty(0),
+        residual_std=np.array([0.0]),
+        training_count=3,
+        ridge_alpha=0.0,
+    )
+
+
+def _feature_bias_model():
+    return SensorBiasCorrectionModel(
+        target_dim=1,
+        feature_dim=1,
+        intercept=np.array([0.0]),
+        coefficients=np.array([[1.0]]),
+        feature_mean=np.array([0.0]),
+        feature_scale=np.array([1.0]),
+        residual_std=np.array([0.0]),
+        training_count=3,
+        ridge_alpha=0.0,
+    )
+
+
+@pytest.mark.parametrize("n_rows", [-1, 1.5, np.nan, np.inf, True, np.array([1])])
+def test_constant_bias_predict_rejects_invalid_n_rows(n_rows):
+    model = _constant_bias_model()
+
+    with pytest.raises(ValueError, match="n_rows must be a nonnegative integer"):
+        model.predict(n_rows=n_rows)
+
+
+def test_constant_bias_predict_accepts_integer_like_n_rows():
+    model = _constant_bias_model()
+
+    prediction = model.predict(n_rows=np.array(2.0))
+
+    assert prediction.shape == (2, 1)
+    np.testing.assert_allclose(prediction, np.array([[2.0], [2.0]]))
+
+
+@pytest.mark.parametrize("n_rows", [0.5, np.nan, np.inf, False])
+def test_feature_bias_predict_validates_explicit_n_rows_before_row_comparison(n_rows):
+    model = _feature_bias_model()
+
+    with pytest.raises(ValueError, match="n_rows must be a nonnegative integer"):
+        model.predict(np.array([[1.0]]), n_rows=n_rows)


### PR DESCRIPTION
## Summary
- validate `SensorBiasCorrectionModel.predict(..., n_rows=...)` as a nonnegative integer-like scalar
- reject non-integral floats, booleans, arrays, NaN/inf, and negative row counts before prediction
- add focused regression coverage for constant and feature-based bias models

## Bug fixed
`predict(..., n_rows=...)` previously used `int(n_rows)` directly. That silently truncated values such as `1.5`, accepted boolean row counts, and could let invalid row-count controls produce misleading predictions or low-level `np.repeat` errors. The patch fails fast with a clear `ValueError` while preserving valid integer-like scalar inputs.

## Validation
- Added focused tests in `tests/calibration/test_bias_prediction_row_count.py`.
- Full local pytest was not run in this execution environment; repository CI should run the focused tests and full suite.