### PR TITLE
Harden PyPI release asset verification

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -294,14 +294,14 @@ jobs:
           metadata_dir = pathlib.Path("release-metadata")
           distribution_name = re.sub(r"[^\w\d.]+", "_", package_name).lower()
           expected_sdist = f"{distribution_name}-{package_version}.tar.gz"
-          expected_wheel_prefix = f"{distribution_name}-{package_version}-"
+          expected_wheel = f"{distribution_name}-{package_version}-py3-none-any.whl"
           wanted = []
 
           for asset in release["assets"]:
               name = asset["name"]
               if (
                   name == expected_sdist
-                  or (name.startswith(expected_wheel_prefix) and name.endswith(".whl"))
+                  or name == expected_wheel
                   or name == "SHA256SUMS.txt"
               ):
                   wanted.append(asset)

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -335,12 +335,29 @@ jobs:
           checksum_path = pathlib.Path("release-metadata/SHA256SUMS.txt")
           for line in checksum_path.read_text(encoding="utf-8").splitlines():
               digest, filename = line.split(maxsplit=1)
+              if "/" in filename or "\\" in filename:
+                  raise SystemExit(f"Unexpected path in SHA256SUMS.txt: {filename}")
+              if filename in hashes:
+                  raise SystemExit(f"Duplicate distribution file listed in SHA256SUMS.txt: {filename}")
               hashes[filename] = digest
+
+          distribution_files = {
+              path.name
+              for path in dist_dir.iterdir()
+              if path.suffix == ".whl" or path.name.endswith(".tar.gz")
+          }
+          checksum_files = set(hashes)
+          if checksum_files != distribution_files:
+              missing = sorted(distribution_files - checksum_files)
+              extra = sorted(checksum_files - distribution_files)
+              raise SystemExit(
+                  "SHA256SUMS.txt does not match downloaded distributions. "
+                  f"Missing checksums: {missing or 'none'}; "
+                  f"unexpected checksums: {extra or 'none'}"
+              )
 
           for filename, expected_digest in hashes.items():
               path = dist_dir / filename
-              if not path.exists():
-                  raise SystemExit(f"Missing distribution file listed in SHA256SUMS.txt: {filename}")
               actual_digest = hashlib.sha256(path.read_bytes()).hexdigest()
               if actual_digest != expected_digest:
                   raise SystemExit(f"Hash mismatch for {filename}: expected {expected_digest}, got {actual_digest}")

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -260,17 +260,22 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
+          PACKAGE_NAME: ${{ needs.resolve.outputs.package_name }}
+          PACKAGE_VERSION: ${{ needs.resolve.outputs.version }}
         run: |
           python - <<'PY'
           import json
           import os
           import pathlib
+          import re
           import urllib.parse
           import urllib.request
 
           owner = os.environ["OWNER"]
           repo = os.environ["REPO"]
           release_tag = os.environ["RELEASE_TAG"]
+          package_name = os.environ["PACKAGE_NAME"]
+          package_version = os.environ["PACKAGE_VERSION"]
           token = os.environ["GITHUB_TOKEN"]
           encoded_release_tag = urllib.parse.quote(release_tag, safe="")
 
@@ -287,12 +292,31 @@ jobs:
 
           dist_dir = pathlib.Path("dist")
           metadata_dir = pathlib.Path("release-metadata")
+          distribution_name = re.sub(r"[^\w\d.]+", "_", package_name).lower()
+          expected_sdist = f"{distribution_name}-{package_version}.tar.gz"
+          expected_wheel_prefix = f"{distribution_name}-{package_version}-"
           wanted = []
 
           for asset in release["assets"]:
               name = asset["name"]
-              if name.endswith(".whl") or name.endswith(".tar.gz") or name == "SHA256SUMS.txt":
+              if (
+                  name == expected_sdist
+                  or (name.startswith(expected_wheel_prefix) and name.endswith(".whl"))
+                  or name == "SHA256SUMS.txt"
+              ):
                   wanted.append(asset)
+
+          unexpected_distribution_assets = sorted(
+              asset["name"]
+              for asset in release["assets"]
+              if (asset["name"].endswith(".whl") or asset["name"].endswith(".tar.gz"))
+              and asset not in wanted
+          )
+          if unexpected_distribution_assets:
+              raise SystemExit(
+                  f"Unexpected distribution assets on release {release_tag}: "
+                  f"{unexpected_distribution_assets}"
+              )
 
           wheel_assets = [asset for asset in wanted if asset["name"].endswith(".whl")]
           sdist_assets = [asset for asset in wanted if asset["name"].endswith(".tar.gz")]

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -294,14 +294,12 @@ jobs:
               if name.endswith(".whl") or name.endswith(".tar.gz") or name == "SHA256SUMS.txt":
                   wanted.append(asset)
 
-          distribution_assets = [
-              asset for asset in wanted
-              if asset["name"].endswith(".whl") or asset["name"].endswith(".tar.gz")
-          ]
-          if not distribution_assets:
-              raise SystemExit(
-                  f"No wheel or source distribution assets found on release {release_tag}."
-              )
+          wheel_assets = [asset for asset in wanted if asset["name"].endswith(".whl")]
+          sdist_assets = [asset for asset in wanted if asset["name"].endswith(".tar.gz")]
+          if not wheel_assets:
+              raise SystemExit(f"No wheel asset found on release {release_tag}.")
+          if not sdist_assets:
+              raise SystemExit(f"No source distribution asset found on release {release_tag}.")
           if not any(asset["name"] == "SHA256SUMS.txt" for asset in wanted):
               raise SystemExit(f"No SHA256SUMS.txt asset found on release {release_tag}.")
 


### PR DESCRIPTION
## Summary
- rebase onto current `main`
- only accept release distribution assets matching the exact wheel and sdist filenames produced by the release workflow
- require GitHub Releases to include both a wheel and source distribution before publishing
- require `SHA256SUMS.txt` to cover exactly the downloaded wheel and sdist files
- reject duplicate checksum entries and path-like checksum filenames before reading from `dist/`

## Verification
- `git diff --check`
- parsed `.github/workflows/publish-to-pypi.yml` with PyYAML
- locally simulated accepted and rejected asset-list/name cases, including wrong-version and platform wheel assets
- validated the stricter asset selection against the real `2.2.3` GitHub Release assets
- locally simulated accepted and rejected checksum-manifest cases