### PR TITLE
Validate finite sequence association costs

### DIFF
--- a/src/pyrecest/filters/sequence_association.py
+++ b/src/pyrecest/filters/sequence_association.py
@@ -284,6 +284,6 @@ def _reconstruct_path(
 
 def _validate_cost(value: object, name: str) -> float:
     cost = float(value)
-    if np.isnan(cost):
-        raise ValueError(f"{name} must not be NaN")
+    if not np.isfinite(cost):
+        raise ValueError(f"{name} must be finite")
     return cost

--- a/tests/filters/test_sequence_association.py
+++ b/tests/filters/test_sequence_association.py
@@ -1,5 +1,7 @@
 import unittest
 
+import numpy as np
+
 from pyrecest.filters import (
     SequenceAssociationNode,
     solve_top_k_viterbi_sequence_associations,
@@ -86,6 +88,22 @@ class SequenceAssociationTest(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             SequenceAssociationNode(0, None)
+
+    def test_validation_rejects_nonfinite_unary_costs(self):
+        for invalid_cost in (np.nan, np.inf, -np.inf):
+            with self.subTest(invalid_cost=invalid_cost):
+                with self.assertRaises(ValueError):
+                    _node(0, 0, "A", invalid_cost)
+
+    def test_validation_rejects_nonfinite_transition_costs(self):
+        frames = [[_node(0, 0, "A", 0.0)], [_node(1, 0, "A", 0.0)]]
+
+        for invalid_cost in (np.nan, np.inf, -np.inf):
+            with self.subTest(invalid_cost=invalid_cost):
+                with self.assertRaises(ValueError):
+                    solve_viterbi_sequence_association(
+                        frames, lambda _a, _b, _c: invalid_cost
+                    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Reject non-finite unary and transition costs in sequence-association Viterbi helpers.
- Replace the previous NaN-only guard with a finite-value check.
- Add regression coverage for NaN, +inf, and -inf unary/transition costs.

## Bug fixed
`SequenceAssociationNode` and transition callbacks were validated only against `NaN`. `+inf` and `-inf` could enter the dynamic-programming tables, producing invalid or meaningless terminal rankings and paths. The solver now fails fast with a clear `ValueError` for all non-finite costs.

## Validation
- Added focused tests in `tests/filters/test_sequence_association.py`.
- I could not run pytest locally because the execution container cannot resolve `github.com` for repository checkout/install; CI should run the focused test and full suite.