### PR TITLE
Reject NaN time delta cutoffs

### DIFF
--- a/src/pyrecest/calibration/bias.py
+++ b/src/pyrecest/calibration/bias.py
@@ -158,7 +158,8 @@ def make_bias_training_examples(
 ) -> BiasTrainingExamples:
     """Match measurements to nearest reference values and compute residual bias."""
 
-    if max_time_delta_s < 0.0:
+    max_time_delta = float(max_time_delta_s)
+    if max_time_delta < 0.0 or np.isnan(max_time_delta):
         raise ValueError("max_time_delta_s must be nonnegative")
     measurement_times = np.asarray(measurement_times_s, dtype=float).reshape(-1)
     measurements = _as_2d(measurement_values, "measurement_values")
@@ -208,7 +209,7 @@ def make_bias_training_examples(
     valid = (
         np.isfinite(measurement_times)
         & np.isfinite(measurements).all(axis=1)
-        & (delta_s <= float(max_time_delta_s))
+        & (delta_s <= max_time_delta)
     )
     valid &= np.isfinite(features).all(axis=1)
     measured = measurements[valid]

--- a/src/pyrecest/calibration/time_offset.py
+++ b/src/pyrecest/calibration/time_offset.py
@@ -90,7 +90,10 @@ def apply_time_offset(times_s: np.ndarray, offset_s: float | None) -> np.ndarray
 
 
 def _validate_max_time_delta(max_time_delta_s: float | None) -> None:
-    if max_time_delta_s is not None and float(max_time_delta_s) < 0.0:
+    if max_time_delta_s is None:
+        return
+    max_time_delta = float(max_time_delta_s)
+    if max_time_delta < 0.0 or np.isnan(max_time_delta):
         raise ValueError("max_time_delta_s must be nonnegative")
 
 

--- a/tests/calibration/test_time_offset_bias.py
+++ b/tests/calibration/test_time_offset_bias.py
@@ -140,6 +140,31 @@ class TimeOffsetCalibrationTest(unittest.TestCase):
                 max_time_delta_s=-1.0,
             )
 
+    def test_interpolation_rejects_nan_max_time_delta(self):
+        for max_time_delta_s in (np.nan, -np.inf):
+            with self.subTest(max_time_delta_s=max_time_delta_s):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "max_time_delta_s must be nonnegative",
+                ):
+                    interpolate_reference_values(
+                        np.array([0.0, 1.0]),
+                        np.array([[0.0], [1.0]]),
+                        np.array([0.5]),
+                        max_time_delta_s=max_time_delta_s,
+                    )
+
+    def test_interpolation_accepts_infinite_max_time_delta_as_unbounded(self):
+        interpolated, valid = interpolate_reference_values(
+            np.array([0.0, 10.0]),
+            np.array([[0.0], [10.0]]),
+            np.array([5.0]),
+            max_time_delta_s=np.inf,
+        )
+
+        npt.assert_allclose(interpolated, np.array([[5.0]]))
+        npt.assert_array_equal(valid, np.array([True]))
+
     def test_interpolation_skips_nonfinite_reference_rows(self):
         interpolated, valid = interpolate_reference_values(
             np.array([0.0, 1.0, 2.0, np.nan, 3.0]),
@@ -234,6 +259,32 @@ class BiasCalibrationTest(unittest.TestCase):
         npt.assert_allclose(examples.reference, np.array([[0.0], [4.0]]))
         npt.assert_allclose(examples.residual, np.array([[1.0], [1.0]]))
         npt.assert_allclose(examples.time_delta_s, np.array([0.0, 0.0]))
+
+    def test_make_bias_training_examples_rejects_nan_max_time_delta(self):
+        for max_time_delta_s in (np.nan, -np.inf):
+            with self.subTest(max_time_delta_s=max_time_delta_s):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "max_time_delta_s must be nonnegative",
+                ):
+                    make_bias_training_examples(
+                        np.array([0.0]),
+                        np.array([[1.0]]),
+                        np.array([0.0]),
+                        np.array([[0.0]]),
+                        max_time_delta_s=max_time_delta_s,
+                    )
+
+    def test_make_bias_training_examples_accepts_infinite_max_time_delta(self):
+        examples = make_bias_training_examples(
+            np.array([5.0]),
+            np.array([[8.0]]),
+            np.array([0.0]),
+            np.array([[1.0]]),
+            max_time_delta_s=np.inf,
+        )
+
+        npt.assert_allclose(examples.residual, np.array([[7.0]]))
 
     def test_make_bias_training_examples_returns_empty_without_finite_reference_rows(
         self,


### PR DESCRIPTION
## Summary
- Reject `NaN` values for calibration `max_time_delta_s` cutoffs before matching/interpolation.
- Preserve `np.inf` as an accepted unbounded cutoff.
- Add regression coverage for timestamp interpolation and bias training examples.

## Root Cause
The calibration code only rejected negative maximum time deltas. `NaN` is not less than zero, so it could flow into comparisons like `delta_s <= NaN`, silently marking every candidate invalid and producing empty calibration matches instead of reporting bad input.

## Validation
- `py -3.12 -m pytest -q tests\calibration\test_time_offset_bias.py tests\calibration\test_bias.py tests\calibration\test_bias_prediction_row_count.py`
- `py -3.12 -m ruff check src tests`
- `git diff --check`