### PR TITLE
Reject nonfinite association weights

### DIFF
--- a/src/pyrecest/utils/association_models.py
+++ b/src/pyrecest/utils/association_models.py
@@ -230,8 +230,13 @@ class LogisticPairwiseAssociationModel:  # pylint: disable=too-many-instance-att
             )
         negative_weight = float(self.class_weight[0])
         positive_weight = float(self.class_weight[1])
-        if negative_weight <= 0.0 or positive_weight <= 0.0:
-            raise ValueError("class weights must be positive")
+        if (
+            not _numpy.isfinite(negative_weight)
+            or not _numpy.isfinite(positive_weight)
+            or negative_weight <= 0.0
+            or positive_weight <= 0.0
+        ):
+            raise ValueError("class weights must be finite and positive")
         return _BinaryClassWeights(negative=negative_weight, positive=positive_weight)
 
     @staticmethod
@@ -242,6 +247,8 @@ class LogisticPairwiseAssociationModel:  # pylint: disable=too-many-instance-att
         flattened_sample_weight = asarray(sample_weight, dtype=float64).reshape(-1)
         if flattened_sample_weight.shape[0] != labels.shape[0]:
             raise ValueError("sample_weight must match the number of flattened labels")
+        if not all(isfinite(flattened_sample_weight)):
+            raise ValueError("sample_weight must be finite")
         return flattened_sample_weight
 
     def _build_effective_sample_weights(

--- a/tests/test_association_models.py
+++ b/tests/test_association_models.py
@@ -167,6 +167,32 @@ class TestLogisticPairwiseAssociationModel(unittest.TestCase):
                 self.training_features, zeros(self.training_labels.shape, dtype=int) + 2
             )
 
+    def test_nonfinite_sample_weights_raise(self):
+        for invalid_weight in (float("nan"), float("inf"), -float("inf")):
+            with self.subTest(invalid_weight=invalid_weight):
+                sample_weight = ones(self.training_labels.shape)
+                sample_weight[0] = invalid_weight
+                model = LogisticPairwiseAssociationModel()
+
+                with self.assertRaisesRegex(ValueError, "sample_weight must be finite"):
+                    model.fit(
+                        self.training_features,
+                        self.training_labels,
+                        sample_weight=sample_weight,
+                    )
+
+    def test_nonfinite_class_weights_raise(self):
+        for invalid_weight in (float("nan"), float("inf"), -float("inf")):
+            with self.subTest(invalid_weight=invalid_weight):
+                model = LogisticPairwiseAssociationModel(
+                    class_weight={0: 1.0, 1: invalid_weight}
+                )
+
+                with self.assertRaisesRegex(
+                    ValueError, "class weights must be finite and positive"
+                ):
+                    model.fit(self.training_features, self.training_labels)
+
     def test_pairwise_feature_tensor_stacks_named_components_and_sanitizes(self):
         components = {
             "distance": array([[0.0, float("inf")], [float("nan"), -float("inf")]]),

--- a/tests/test_association_models.py
+++ b/tests/test_association_models.py
@@ -171,7 +171,10 @@ class TestLogisticPairwiseAssociationModel(unittest.TestCase):
         for invalid_weight in (float("nan"), float("inf"), -float("inf")):
             with self.subTest(invalid_weight=invalid_weight):
                 sample_weight = ones(self.training_labels.shape)
-                sample_weight[0] = invalid_weight
+                if hasattr(sample_weight, "at"):
+                    sample_weight = sample_weight.at[0].set(invalid_weight)
+                else:
+                    sample_weight[0] = invalid_weight
                 model = LogisticPairwiseAssociationModel()
 
                 with self.assertRaisesRegex(ValueError, "sample_weight must be finite"):


### PR DESCRIPTION
## Summary
- Reject non-finite `sample_weight` values before fitting `LogisticPairwiseAssociationModel`.
- Reject non-finite class-weight dictionary entries.
- Add regression coverage for `NaN`, `inf`, and `-inf` weights.

## Root Cause
The association model validated negative weights, but `NaN` and positive infinity pass comparisons like `weight <= 0.0`. Those values could enter the effective weights and poison the Newton system with non-finite gradients or Hessians instead of failing clearly at input validation.

## Validation
- `py -3.12 -m pytest -q tests\test_association_models.py`
- `py -3.12 -m ruff check src tests`
- `git diff --check`