### PR TITLE
Validate ROI assignment thresholds

### DIFF
--- a/src/pyrecest/utils/roi_assignment.py
+++ b/src/pyrecest/utils/roi_assignment.py
@@ -9,6 +9,7 @@ boolean masks or as sparse pixel lists such as Suite2p ``stat.npy`` entries with
 
 from __future__ import annotations
 
+import math
 import sys
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -307,8 +308,12 @@ def pairwise_iou_masks(
     """Compute a dense pairwise IoU matrix for two ROI collections."""
 
     _backend_not_supported("pairwise_iou_masks")
-    if centroid_distance_threshold is not None and centroid_distance_threshold < 0:
-        raise ValueError("centroid_distance_threshold must be non-negative.")
+    if centroid_distance_threshold is not None:
+        centroid_distance_threshold = float(centroid_distance_threshold)
+        if centroid_distance_threshold < 0.0 or math.isnan(
+            centroid_distance_threshold
+        ):
+            raise ValueError("centroid_distance_threshold must be non-negative.")
 
     prepared_reference = _prepare_rois(reference_rois)
     prepared_query = _prepare_rois(query_rois)
@@ -504,6 +509,9 @@ def assign_by_similarity_matrix(
     similarities = asarray(similarity_matrix, dtype=float64)
     if similarities.ndim != 2:
         raise ValueError("similarity_matrix must be two-dimensional.")
+    min_similarity = float(min_similarity)
+    if not math.isfinite(min_similarity):
+        raise ValueError("min_similarity must be finite.")
 
     n_rows, n_cols = similarities.shape
     if n_rows == 0:
@@ -542,7 +550,7 @@ def assign_by_similarity_matrix(
         raise ValueError("num_dummy must be non-negative.")
 
     max_similarity = float(amax(similarities[finite_mask]))
-    threshold_cost = max_similarity - float(min_similarity)
+    threshold_cost = max_similarity - min_similarity
     dummy_penalty = max(
         1e-12,
         sys.float_info.epsilon * max(1.0, abs(max_similarity), abs(min_similarity)),

--- a/tests/test_roi_assignment.py
+++ b/tests/test_roi_assignment.py
@@ -162,6 +162,21 @@ class TestSimilarityAssignment(unittest.TestCase):
         npt.assert_array_equal(result.matched_row_indices, array([0]))
         npt.assert_array_equal(result.unmatched_row_indices, array([1]))
 
+    @unittest.skipIf(
+        backend.__backend_name__ == "jax",
+        reason="Not supported on the jax backend",
+    )
+    def test_assignment_rejects_nonfinite_min_similarity(self):
+        similarity_matrix = array([[1.0]])
+
+        for min_similarity in (float("nan"), float("inf"), -float("inf")):
+            with self.subTest(min_similarity=min_similarity):
+                with self.assertRaisesRegex(ValueError, "min_similarity must be finite"):
+                    assign_by_similarity_matrix(
+                        similarity_matrix,
+                        min_similarity=min_similarity,
+                    )
+
 
 class TestRoiAssociation(unittest.TestCase):
     @unittest.skipIf(
@@ -267,6 +282,19 @@ class TestRoiAssociation(unittest.TestCase):
         )
         npt.assert_array_equal(result.assignment, array([-1]))
         self.assertGreater(result.centroid_distance_matrix[0, 0], 1.0)
+
+    @unittest.skipIf(
+        backend.__backend_name__ == "jax",
+        reason="Not supported on the jax backend",
+    )
+    def test_pairwise_iou_masks_rejects_nan_centroid_threshold(self):
+        roi = array([[1]], dtype=bool)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "centroid_distance_threshold must be non-negative",
+        ):
+            pairwise_iou_masks([roi], [roi], centroid_distance_threshold=float("nan"))
 
     @unittest.skipIf(
         backend.__backend_name__ == "jax",


### PR DESCRIPTION
## Summary
- Reject non-finite `min_similarity` values before building ROI assignment costs.
- Reject `NaN` centroid-distance thresholds so ROI gating cannot be silently disabled.
- Add regression tests for both threshold validation paths.

## Root Cause
`NaN` thresholds pass comparisons such as `threshold < 0` and make later comparisons false. That could silently disable centroid gating or produce no similarity matches; infinities in `min_similarity` could also create invalid SciPy assignment costs.

## Validation
- `py -3.12 -m pytest -q tests\test_roi_assignment.py`
- `py -3.12 -m ruff check src tests`
- `git diff --check`