### PR TITLE
Validate non-assignment costs

### DIFF
--- a/src/pyrecest/utils/assignment.py
+++ b/src/pyrecest/utils/assignment.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from heapq import heappop, heappush
+from math import isfinite as _is_scalar_finite
 
 import pyrecest.backend
 from pyrecest.backend import abs as _abs
@@ -36,7 +37,7 @@ def _coerce_non_assignment_costs(costs, size: int, name: str):
     costs_array = _asarray(costs, dtype=float)
     if costs_array.ndim == 0:
         cost = float(costs_array)
-        if not _isfinite(cost):
+        if not _is_scalar_finite(cost):
             raise ValueError(f"{name} must be finite")
         return _full((size,), cost, dtype=float)
 

--- a/src/pyrecest/utils/assignment.py
+++ b/src/pyrecest/utils/assignment.py
@@ -35,11 +35,16 @@ def _coerce_non_assignment_costs(costs, size: int, name: str):
 
     costs_array = _asarray(costs, dtype=float)
     if costs_array.ndim == 0:
-        return _full((size,), float(costs_array), dtype=float)
+        cost = float(costs_array)
+        if not _isfinite(cost):
+            raise ValueError(f"{name} must be finite")
+        return _full((size,), cost, dtype=float)
 
     costs = costs_array.reshape(-1)
     if costs.shape[0] != size:
         raise ValueError(f"{name} must be scalar or have length {size}")
+    if _any(~_isfinite(costs)):
+        raise ValueError(f"{name} must be finite")
     return costs
 
 

--- a/tests/utils/test_assignment.py
+++ b/tests/utils/test_assignment.py
@@ -178,6 +178,31 @@ class MurtyAssignmentTest(unittest.TestCase):
         npt.assert_array_equal(solutions[0]["unassigned_cols"], np.array([], dtype=int))
         self.assertAlmostEqual(solutions[0]["cost"], 2.0)
 
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on the JAX backend",
+    )
+    def test_nonfinite_non_assignment_costs_are_rejected(self):
+        cost_matrix = np.array([[1.0]])
+
+        for invalid_cost in (np.nan, np.inf, -np.inf):
+            with self.subTest(kind="row", invalid_cost=invalid_cost):
+                with self.assertRaisesRegex(
+                    ValueError, "row_non_assignment_costs must be finite"
+                ):
+                    murty_k_best_assignments(
+                        cost_matrix,
+                        row_non_assignment_costs=invalid_cost,
+                    )
+            with self.subTest(kind="column", invalid_cost=invalid_cost):
+                with self.assertRaisesRegex(
+                    ValueError, "col_non_assignment_costs must be finite"
+                ):
+                    murty_k_best_assignments(
+                        cost_matrix,
+                        col_non_assignment_costs=np.array([invalid_cost]),
+                    )
+
     def test_non_positive_k_returns_empty_list(self):
         self.assertEqual(murty_k_best_assignments(np.eye(2), k=0), [])
 


### PR DESCRIPTION
## Summary
- Reject non-finite row and column non-assignment costs in `murty_k_best_assignments`.
- Add regression coverage for scalar and vector `NaN`/`inf` non-assignment costs.

## Root Cause
Forbidden pairwise assignments can be encoded with `inf`, but non-assignment costs are inserted directly into the augmented finite assignment matrix. `NaN` or `inf` values there can produce invalid large-cost sentinels or fail later in SciPy instead of reporting invalid caller input clearly.

## Validation
- `py -3.12 -m pytest -q tests\utils\test_assignment.py`
- `py -3.12 -m ruff check src tests`
- `git diff --check`