### PR TITLE
Validate chi-square dimensions

### DIFF
--- a/src/pyrecest/utils/metrics.py
+++ b/src/pyrecest/utils/metrics.py
@@ -224,16 +224,17 @@ def chi_square_confidence_bounds(
     degrees_of_freedom: int, *, n_samples: int = 1, confidence: float = 0.95
 ) -> tuple[float, float]:
     """Return two-sided chi-square bounds for an averaged NEES/NIS statistic."""
-    if int(degrees_of_freedom) <= 0:
-        raise ValueError("degrees_of_freedom must be positive")
-    if int(n_samples) <= 0:
-        raise ValueError("n_samples must be positive")
+    degrees_of_freedom = _as_positive_int(
+        degrees_of_freedom,
+        "degrees_of_freedom",
+    )
+    n_samples = _as_positive_int(n_samples, "n_samples")
     if not 0.0 < float(confidence) < 1.0:
         raise ValueError("confidence must be in the open interval (0, 1)")
     alpha = 1.0 - float(confidence)
-    aggregate_dof = int(degrees_of_freedom) * int(n_samples)
-    lower = chi2.ppf(alpha / 2.0, aggregate_dof) / float(n_samples)
-    upper = chi2.ppf(1.0 - alpha / 2.0, aggregate_dof) / float(n_samples)
+    aggregate_dof = degrees_of_freedom * n_samples
+    lower = chi2.ppf(alpha / 2.0, aggregate_dof) / n_samples
+    upper = chi2.ppf(1.0 - alpha / 2.0, aggregate_dof) / n_samples
     return float(lower), float(upper)
 
 
@@ -578,6 +579,26 @@ def _as_covariance_stack(
             raise ValueError(f"{name} must have shape ({n_samples}, {dim}, {dim})")
         return covariance_array
     raise ValueError(f"{name} must have shape (dim, dim) or (n, dim, dim)")
+
+
+def _as_positive_int(value: Any, name: str) -> int:
+    array = np.asarray(value)
+    if array.ndim != 0 or array.dtype == np.bool_:
+        raise ValueError(f"{name} must be a positive integer")
+    scalar = array.item()
+    if isinstance(scalar, (int, np.integer)) and not isinstance(scalar, bool):
+        result = int(scalar)
+    elif (
+        isinstance(scalar, (float, np.floating))
+        and np.isfinite(scalar)
+        and float(scalar).is_integer()
+    ):
+        result = int(scalar)
+    else:
+        raise ValueError(f"{name} must be a positive integer")
+    if result <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return result
 
 
 def _quadratic_forms(vectors: np.ndarray, matrices: np.ndarray) -> np.ndarray:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -9,6 +9,7 @@ from pyrecest.evaluation.eot_shape_database import Cross, Star
 from pyrecest.utils.metrics import (
     anees,
     anis,
+    chi_square_confidence_bounds,
     consistency_fraction,
     eot_shape_iou,
     extent_error,
@@ -118,6 +119,29 @@ class TestANEES(unittest.TestCase):
             consistency_fraction([lower - 1.0, 2.0, upper + 1.0], lower, upper),
             1.0 / 3.0,
         )
+
+    def test_chi_square_bounds_reject_noninteger_dimensions(self):
+        invalid_values = (1.5, np.nan, np.inf, True, np.array([2]))
+
+        for value in invalid_values:
+            with self.subTest(parameter="degrees_of_freedom", value=value):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "degrees_of_freedom must be a positive integer",
+                ):
+                    chi_square_confidence_bounds(value)
+            with self.subTest(parameter="n_samples", value=value):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "n_samples must be a positive integer",
+                ):
+                    chi_square_confidence_bounds(2, n_samples=value)
+
+    def test_chi_square_bounds_accept_integer_like_scalars(self):
+        direct = chi_square_confidence_bounds(2, n_samples=3)
+        integer_like = chi_square_confidence_bounds(np.array(2.0), n_samples=3.0)
+
+        self.assertEqual(direct, integer_like)
 
 
 class TestSetDistances(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Reject non-integer, non-scalar, boolean, and non-finite dimensions in chi-square confidence bounds.
- Preserve support for integer-like scalar inputs such as `np.array(2.0)`.
- Add regression coverage so fractional dimensions and sample counts are not silently truncated.

## Root Cause
`chi_square_confidence_bounds` used `int(...)` directly for `degrees_of_freedom` and `n_samples`. Inputs such as `1.5` were silently truncated to `1`, producing confidence bounds for the wrong number of degrees of freedom or samples.

## Validation
- `py -3.12 -m pytest -q tests\test_metrics.py`
- `py -3.12 -m ruff check src tests`
- `git diff --check`