### PR TITLE
Validate track metric min length

### DIFF
--- a/src/pyrecest/utils/track_metrics.py
+++ b/src/pyrecest/utils/track_metrics.py
@@ -107,8 +107,7 @@ def score_false_tracks(
     predicted_track_matrix: Any, reference_track_matrix: Any, *, min_length: int = 1
 ) -> dict[str, float | int]:
     """Return metrics for predicted tracks that contain no reference observation."""
-    if int(min_length) <= 0:
-        raise ValueError("min_length must be positive")
+    min_length = _as_positive_int(min_length, "min_length")
     predicted, reference = _normalized_pair(
         predicted_track_matrix, reference_track_matrix
     )
@@ -120,7 +119,7 @@ def score_false_tracks(
     unreferenced_observations = 0
     total_observations = 0
     for observations in _observations_by_track(predicted):
-        if len(observations) < int(min_length):
+        if len(observations) < min_length:
             continue
         total_observations += len(observations)
         evaluated_tracks += 1
@@ -159,8 +158,7 @@ def score_missed_tracks(
     predicted_track_matrix: Any, reference_track_matrix: Any, *, min_length: int = 1
 ) -> dict[str, float | int]:
     """Return metrics for reference tracks with no predicted observation support."""
-    if int(min_length) <= 0:
-        raise ValueError("min_length must be positive")
+    min_length = _as_positive_int(min_length, "min_length")
     predicted, reference = _normalized_pair(
         predicted_track_matrix, reference_track_matrix
     )
@@ -172,7 +170,7 @@ def score_missed_tracks(
     missed_observations = 0
     total_observations = 0
     for observations in _observations_by_track(reference):
-        if len(observations) < int(min_length):
+        if len(observations) < min_length:
             continue
         total_observations += len(observations)
         evaluated_tracks += 1
@@ -331,6 +329,26 @@ def _session_times(
             "session_times must have length equal to the number of sessions"
         )
     return times
+
+
+def _as_positive_int(value: Any, name: str) -> int:
+    array = np.asarray(value)
+    if array.ndim != 0 or array.dtype == np.bool_:
+        raise ValueError(f"{name} must be a positive integer")
+    scalar = array.item()
+    if isinstance(scalar, (int, np.integer)) and not isinstance(scalar, bool):
+        result = int(scalar)
+    elif (
+        isinstance(scalar, (float, np.floating))
+        and np.isfinite(scalar)
+        and float(scalar).is_integer()
+    ):
+        result = int(scalar)
+    else:
+        raise ValueError(f"{name} must be a positive integer")
+    if result <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return result
 
 
 def _zero_ratio(numerator: float, denominator: float) -> float:

--- a/tests/test_track_metrics.py
+++ b/tests/test_track_metrics.py
@@ -88,6 +88,46 @@ class TestTrackMetrics(unittest.TestCase):
         self.assertEqual(scores["missed_reference_observations"], 1)
         npt.assert_allclose(scores["missed_reference_observation_rate"], 1.0 / 3.0)
 
+    def test_min_length_rejects_noninteger_values(self):
+        invalid_values = (0, -1, 1.5, np.nan, np.inf, True, np.array([1]))
+
+        for min_length in invalid_values:
+            with self.subTest(function="score_false_tracks", min_length=min_length):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "min_length must be a positive integer",
+                ):
+                    score_false_tracks(
+                        self.predicted,
+                        self.reference,
+                        min_length=min_length,
+                    )
+            with self.subTest(function="score_missed_tracks", min_length=min_length):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "min_length must be a positive integer",
+                ):
+                    score_missed_tracks(
+                        self.predicted,
+                        self.reference,
+                        min_length=min_length,
+                    )
+
+    def test_min_length_accepts_integer_like_scalars(self):
+        false_scores = score_false_tracks(
+            self.predicted,
+            self.reference,
+            min_length=np.array(2.0),
+        )
+        missed_scores = score_missed_tracks(
+            self.predicted,
+            self.reference,
+            min_length=2.0,
+        )
+
+        self.assertEqual(false_scores["false_track_evaluated_tracks"], 2)
+        self.assertEqual(missed_scores["missed_track_evaluated_reference_tracks"], 2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Reject non-positive, non-integer, boolean, non-scalar, and non-finite `min_length` values in track outcome metrics.
- Preserve support for integer-like scalar inputs such as `np.array(2.0)`.
- Add regression coverage for false-track and missed-track metric entry points.

## Root Cause
`score_false_tracks` and `score_missed_tracks` used `int(min_length)` directly. That silently truncated values such as `1.5` to `1` and accepted `True` as `1`, causing the metrics to evaluate a different track-length threshold than requested.

## Validation
- `py -3.12 -m pytest -q tests\test_track_metrics.py`
- `py -3.12 -m ruff check src tests`
- `git diff --check`