### PR TITLE
Validate multisession max gap

### DIFF
--- a/src/pyrecest/utils/multisession_assignment_score.py
+++ b/src/pyrecest/utils/multisession_assignment_score.py
@@ -6,6 +6,8 @@ import math
 from collections.abc import Callable
 from typing import Any
 
+import numpy as np
+
 from pyrecest.backend import (
     __backend_name__,
 )
@@ -36,6 +38,33 @@ from .multisession_assignment import (
 
 def _default_score_to_cost(scores: Any) -> Any:
     return -asarray(scores, dtype=float)
+
+
+def _normalize_max_gap(max_gap: Any) -> int:
+    max_gap_array = np.asarray(max_gap)
+    if max_gap_array.shape != () or max_gap_array.dtype == np.bool_:
+        raise ValueError("max_gap must be a non-negative integer.")
+
+    max_gap_value = max_gap_array.item()
+    if isinstance(max_gap_value, (bool, np.bool_)):
+        raise ValueError("max_gap must be a non-negative integer.")
+
+    if isinstance(max_gap_value, (int, np.integer)):
+        if max_gap_value < 0:
+            raise ValueError("max_gap must be a non-negative integer.")
+        return int(max_gap_value)
+
+    try:
+        max_gap_float = float(max_gap_value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("max_gap must be a non-negative integer.") from exc
+    if (
+        not math.isfinite(max_gap_float)
+        or max_gap_float < 0
+        or not max_gap_float.is_integer()
+    ):
+        raise ValueError("max_gap must be a non-negative integer.")
+    return int(max_gap_float)
 
 
 def tracks_to_index_matrix(
@@ -77,12 +106,7 @@ def solve_multisession_assignment_from_similarity(  # pylint: disable=R0913,R091
     if min_score is not None and not math.isfinite(min_score):
         raise ValueError("min_score must be finite.")
     if max_gap is not None:
-        original_max_gap = max_gap
-        max_gap = int(max_gap)
-        if max_gap != original_max_gap:
-            raise ValueError("max_gap must be an integer.")
-        if max_gap < 0:
-            raise ValueError("max_gap must be non-negative.")
+        max_gap = _normalize_max_gap(max_gap)
 
     normalized_pairwise_scores = _normalize_pairwise_costs(pairwise_scores)
     normalized_session_sizes = _normalize_session_sizes(session_sizes)

--- a/tests/test_multisession_assignment.py
+++ b/tests/test_multisession_assignment.py
@@ -3,13 +3,19 @@
 import unittest
 from unittest.mock import patch
 
+import numpy as np
+
 from pyrecest.backend import (  # pylint: disable=no-name-in-module
     __backend_name__,
     array,
     array_equal,
 )
 from pyrecest.utils import multisession_assignment as multisession_assignment_module
-from pyrecest.utils import solve_multisession_assignment, tracks_to_session_labels
+from pyrecest.utils import (
+    solve_multisession_assignment,
+    solve_multisession_assignment_from_similarity,
+    tracks_to_session_labels,
+)
 
 
 class TestMultiSessionAssignment(unittest.TestCase):
@@ -96,6 +102,44 @@ class TestMultiSessionAssignment(unittest.TestCase):
         self.assertEqual(self._canonical_tracks(result.tracks), expected_tracks)
         self.assertAlmostEqual(result.total_cost, 8.8)
         self.assertEqual(result.matched_edges, [((0, 0), (2, 0), 0.8)])
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_similarity_wrapper_accepts_scalar_integer_like_max_gap(self):
+        result = solve_multisession_assignment_from_similarity(
+            {(0, 2): array([[0.9]], dtype=float)},
+            session_sizes=[1, 0, 1],
+            max_gap=np.array(1.0),
+            start_cost=1.0,
+            end_cost=1.0,
+        )
+
+        self.assertEqual(
+            self._canonical_tracks(result.tracks),
+            [((0, 0), (2, 0))],
+        )
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_similarity_wrapper_rejects_invalid_max_gap(self):
+        pairwise_scores = {(0, 2): array([[0.9]], dtype=float)}
+
+        invalid_max_gaps = (True, 1.5, np.nan, np.inf, -1, np.array([1]))
+        for max_gap in invalid_max_gaps:
+            with self.subTest(max_gap=max_gap):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "max_gap must be a non-negative integer",
+                ):
+                    solve_multisession_assignment_from_similarity(
+                        pairwise_scores,
+                        session_sizes=[1, 0, 1],
+                        max_gap=max_gap,
+                    )
 
     @unittest.skipIf(
         __backend_name__ == "jax",


### PR DESCRIPTION
## Summary
- reject boolean, non-scalar, non-finite, fractional, and negative `max_gap` values in the score-native multisession assignment wrapper
- keep scalar integer-like values accepted before filtering cross-session edges
- add regression coverage for valid and invalid `max_gap` inputs

## Tests
- `py -3.12 -m pytest -q tests\test_multisession_assignment.py`
- `py -3.12 -m ruff check src tests`
- `git diff --check`