### PR TITLE
Validate multisession integer inputs

### DIFF
--- a/src/pyrecest/utils/multisession_assignment.py
+++ b/src/pyrecest/utils/multisession_assignment.py
@@ -26,6 +26,8 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
+import numpy as np
+
 from pyrecest.backend import (
     __backend_name__,
     arange,
@@ -378,11 +380,59 @@ def _validate_scalar_cost(name: str, value: float) -> None:
         raise ValueError(f"{name} must be finite.")
 
 
+def _normalize_nonnegative_integer(
+    value: Any,
+    name: str,
+    *,
+    negative_message: str | None = None,
+) -> int:
+    value_array = np.asarray(value)
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError(f"{name} must be a non-negative integer.")
+
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(f"{name} must be a non-negative integer.")
+    if isinstance(scalar, (int, np.integer)):
+        integer_value = int(scalar)
+    else:
+        try:
+            scalar_float = float(scalar)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(f"{name} must be a non-negative integer.") from exc
+        if not math.isfinite(scalar_float) or not scalar_float.is_integer():
+            raise ValueError(f"{name} must be a non-negative integer.")
+        integer_value = int(scalar_float)
+
+    if integer_value < 0:
+        if negative_message is not None:
+            raise ValueError(negative_message.format(value=integer_value))
+        raise ValueError(f"{name} must be a non-negative integer.")
+    return integer_value
+
+
 def _normalize_session_index(session_idx: Any) -> int:
-    session_idx = int(session_idx)
-    if session_idx < 0:
-        raise ValueError(f"Session indices must be non-negative, got {session_idx}.")
-    return session_idx
+    return _normalize_nonnegative_integer(
+        session_idx,
+        "Session indices",
+        negative_message="Session indices must be non-negative, got {value}.",
+    )
+
+
+def _normalize_detection_index(detection_idx: Any) -> int:
+    return _normalize_nonnegative_integer(
+        detection_idx,
+        "Detection indices",
+        negative_message="Detection indices must be non-negative, got {value}.",
+    )
+
+
+def _normalize_session_size(size: Any, session_idx: int) -> int:
+    return _normalize_nonnegative_integer(
+        size,
+        f"Session {session_idx} detection count",
+        negative_message=f"Session {session_idx} has a negative detection count.",
+    )
 
 
 def _normalize_pairwise_costs(
@@ -424,14 +474,16 @@ def _normalize_session_sizes(
     if isinstance(session_sizes, Mapping):
         normalized = {}
         for session_idx, size in session_sizes.items():
-            normalized[_normalize_session_index(session_idx)] = int(size)
+            normalized_session_idx = _normalize_session_index(session_idx)
+            normalized[normalized_session_idx] = _normalize_session_size(
+                size,
+                normalized_session_idx,
+            )
     else:
         normalized = {
-            session_idx: int(size) for session_idx, size in enumerate(session_sizes)
+            session_idx: _normalize_session_size(size, session_idx)
+            for session_idx, size in enumerate(session_sizes)
         }
-    for session_idx, size in normalized.items():
-        if size < 0:
-            raise ValueError(f"Session {session_idx} has a negative detection count.")
     return normalized
 
 
@@ -729,7 +781,10 @@ def _iter_track_items(track: TrackInput) -> list[Observation]:
     else:
         items = list(track)
     items = [
-        (_normalize_session_index(session_idx), int(detection_idx))
+        (
+            _normalize_session_index(session_idx),
+            _normalize_detection_index(detection_idx),
+        )
         for session_idx, detection_idx in items
     ]
     items.sort(key=lambda item: item[0])

--- a/tests/test_multisession_assignment_validation.py
+++ b/tests/test_multisession_assignment_validation.py
@@ -1,0 +1,91 @@
+"""Input validation tests for multi-session assignment."""
+
+import unittest
+
+import numpy as np
+
+from pyrecest.backend import __backend_name__, array
+from pyrecest.utils import solve_multisession_assignment, tracks_to_session_labels
+
+
+class TestMultiSessionAssignmentValidation(unittest.TestCase):
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_accepts_scalar_integer_like_session_sizes(self):
+        result = solve_multisession_assignment(
+            {},
+            session_sizes=[np.array(1.0), 0],
+            start_cost=1.0,
+            end_cost=1.0,
+        )
+
+        self.assertEqual(result.tracks, [{0: 0}])
+        self.assertAlmostEqual(result.total_cost, 2.0)
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_rejects_non_integer_session_sizes(self):
+        invalid_session_sizes = (
+            [True],
+            [1.5],
+            [np.nan],
+            [np.inf],
+            [-1],
+            [np.array([1])],
+            {True: 1},
+            {0: True},
+        )
+
+        for session_sizes in invalid_session_sizes:
+            with self.subTest(session_sizes=session_sizes):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "must be a non-negative integer|negative detection count",
+                ):
+                    solve_multisession_assignment({}, session_sizes=session_sizes)
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_rejects_non_integer_pairwise_session_indices(self):
+        invalid_pairwise_costs = (
+            {(True, 2): array([[0.1]], dtype=float)},
+            {(0, 1.5): array([[0.1]], dtype=float)},
+            {(np.nan, 1): array([[0.1]], dtype=float)},
+        )
+
+        for pairwise_costs in invalid_pairwise_costs:
+            with self.subTest(pairwise_costs=pairwise_costs):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "Session indices must be a non-negative integer",
+                ):
+                    solve_multisession_assignment(pairwise_costs)
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_rejects_non_integer_track_indices(self):
+        invalid_tracks = (
+            [{1.5: 0}],
+            [{0: True}],
+            [[(0, 1.5)]],
+        )
+
+        for tracks in invalid_tracks:
+            with self.subTest(tracks=tracks):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "must be a non-negative integer",
+                ):
+                    tracks_to_session_labels(tracks)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reject boolean, fractional, non-finite, and shaped-array values for multisession session indices, detection indices, and session sizes
- preserve the existing negative-index and negative-size error messages
- add regression coverage for invalid normalized integer inputs while keeping scalar integer-like values accepted

## Root cause
The multisession assignment normalizers used bare `int(...)` conversions. That silently truncated values such as `1.5` to `1` and treated `True` as `1`, allowing invalid dimensions or indices to produce plausible assignments.

## Tests
- `py -3.12 -m pytest -q tests\test_multisession_assignment.py tests\test_multisession_assignment_validation.py tests\test_multisession_assignment_observation_costs.py`
- `py -3.12 -m ruff check src tests`
- `git diff --check`
- `git diff --cached --check`