### PR TITLE
Validate candidate pruning top-k

### DIFF
--- a/src/pyrecest/utils/candidate_pruning.py
+++ b/src/pyrecest/utils/candidate_pruning.py
@@ -37,9 +37,7 @@ class CandidatePruningConfig:
             value = getattr(self, name)
             if value is None:
                 continue
-            parsed = int(value)
-            if parsed <= 0:
-                raise ValueError(f"{name} must be positive or None")
+            parsed = _normalize_positive_integer(value, name)
             object.__setattr__(self, name, parsed)
 
         if self.probability_threshold is not None:
@@ -76,6 +74,31 @@ def candidate_pruning_config_from_mapping(
     if isinstance(value, CandidatePruningConfig):
         return value
     return CandidatePruningConfig(**dict(value))
+
+
+def _normalize_positive_integer(value: Any, name: str) -> int:
+    value_array = np.asarray(value)
+    message = f"{name} must be a positive integer or None"
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError(message)
+
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(message)
+    if isinstance(scalar, (int, np.integer)):
+        parsed = int(scalar)
+    else:
+        try:
+            scalar_float = float(scalar)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(message) from exc
+        if not np.isfinite(scalar_float) or not scalar_float.is_integer():
+            raise ValueError(message)
+        parsed = int(scalar_float)
+
+    if parsed <= 0:
+        raise ValueError(message)
+    return parsed
 
 
 def candidate_mask_from_costs(

--- a/tests/test_candidate_pruning.py
+++ b/tests/test_candidate_pruning.py
@@ -82,7 +82,7 @@ class TestCandidatePruning(unittest.TestCase):
         npt.assert_array_equal(mask, np.array([[True, True], [True, False]]))
 
     def test_mapping_config_normalization_and_validation(self):
-        cfg = candidate_pruning_config_from_mapping({"row_top_k": 2})
+        cfg = candidate_pruning_config_from_mapping({"row_top_k": np.array(2.0)})
         self.assertIsInstance(cfg, CandidatePruningConfig)
         self.assertEqual(cfg.row_top_k, 2)
 
@@ -98,6 +98,18 @@ class TestCandidatePruning(unittest.TestCase):
                 probability_matrix=np.array([[0.5, 0.5]]),
                 config=CandidatePruningConfig(probability_threshold=0.4),
             )
+
+    def test_top_k_rejects_non_integer_values(self):
+        invalid_top_k_values = (True, 1.5, np.nan, np.inf, np.array([1]))
+
+        for field_name in ("row_top_k", "column_top_k"):
+            for value in invalid_top_k_values:
+                with self.subTest(field_name=field_name, value=value):
+                    with self.assertRaisesRegex(
+                        ValueError,
+                        f"{field_name} must be a positive integer or None",
+                    ):
+                        CandidatePruningConfig(**{field_name: value})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- reject boolean, fractional, non-finite, and shaped-array values for candidate pruning `row_top_k` and `column_top_k`
- keep scalar integer-like top-k values accepted through config normalization
- add regression coverage for invalid top-k inputs

## Root cause
`CandidatePruningConfig` normalized top-k values with bare `int(...)`, so inputs such as `True` and `1.5` were silently converted to `1`. That can change the pruning graph while appearing to be a valid configuration.

## Tests
- `py -3.12 -m pytest -q tests\test_candidate_pruning.py`
- `py -3.12 -m ruff check src tests`
- `git diff --check`
- `git diff --cached --check`