### PR TITLE
Validate adaptive process noise config

### DIFF
--- a/src/pyrecest/filters/adaptive_process_noise.py
+++ b/src/pyrecest/filters/adaptive_process_noise.py
@@ -26,16 +26,54 @@ class AdaptiveProcessNoiseConfig:
     scale_gain: float = 0.5
 
     def __post_init__(self) -> None:
-        if self.base_scale <= 0.0:
+        base_scale = _normalize_finite_scalar(self.base_scale, "base_scale")
+        min_scale = _normalize_finite_scalar(self.min_scale, "min_scale")
+        max_scale = _normalize_finite_scalar(self.max_scale, "max_scale")
+        ewma_alpha = _normalize_finite_scalar(self.ewma_alpha, "ewma_alpha")
+        high_nis_ratio = _normalize_finite_scalar(
+            self.high_nis_ratio,
+            "high_nis_ratio",
+        )
+        low_nis_ratio = _normalize_finite_scalar(
+            self.low_nis_ratio,
+            "low_nis_ratio",
+        )
+        scale_gain = _normalize_finite_scalar(self.scale_gain, "scale_gain")
+
+        if base_scale <= 0.0:
             raise ValueError("base_scale must be positive")
-        if self.min_scale <= 0.0 or self.max_scale < self.min_scale:
+        if min_scale <= 0.0 or max_scale < min_scale:
             raise ValueError("scale bounds must be positive and ordered")
-        if not 0.0 < self.ewma_alpha <= 1.0:
+        if not 0.0 < ewma_alpha <= 1.0:
             raise ValueError("ewma_alpha must be in (0, 1]")
-        if self.high_nis_ratio < self.low_nis_ratio:
+        if high_nis_ratio < low_nis_ratio:
             raise ValueError("high_nis_ratio must be at least low_nis_ratio")
-        if self.scale_gain < 0.0:
+        if scale_gain < 0.0:
             raise ValueError("scale_gain must be nonnegative")
+
+        object.__setattr__(self, "base_scale", base_scale)
+        object.__setattr__(self, "min_scale", min_scale)
+        object.__setattr__(self, "max_scale", max_scale)
+        object.__setattr__(self, "ewma_alpha", ewma_alpha)
+        object.__setattr__(self, "high_nis_ratio", high_nis_ratio)
+        object.__setattr__(self, "low_nis_ratio", low_nis_ratio)
+        object.__setattr__(self, "scale_gain", scale_gain)
+
+
+def _normalize_finite_scalar(value: float, name: str) -> float:
+    value_array = np.asarray(value)
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError(f"{name} must be a finite scalar")
+    value_scalar = value_array.item()
+    if isinstance(value_scalar, (bool, np.bool_)):
+        raise ValueError(f"{name} must be a finite scalar")
+    try:
+        value_float = float(value_scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be a finite scalar") from exc
+    if not np.isfinite(value_float):
+        raise ValueError(f"{name} must be a finite scalar")
+    return value_float
 
 
 @dataclass

--- a/tests/filters/test_adaptive_process_noise.py
+++ b/tests/filters/test_adaptive_process_noise.py
@@ -1,4 +1,6 @@
 import numpy as np
+import pytest
+
 from pyrecest.filters.adaptive_process_noise import (
     AdaptiveProcessNoiseConfig,
     RollingNISProcessNoiseAdapter,
@@ -26,3 +28,40 @@ def test_rolling_adapter_updates_source_ratio_and_scales_covariance():
     assert np.isclose(ratio, 3.0)
     scaled = adapter.scaled_covariance(np.eye(2), {"radar": 1.0})
     assert np.allclose(scaled, np.eye(2) * adapter.scale({"radar": 1.0}))
+
+
+def test_config_normalizes_scalar_numeric_values():
+    config = AdaptiveProcessNoiseConfig(
+        base_scale=np.array(1.25),
+        min_scale=np.array(0.5),
+        max_scale=np.array(2.5),
+        ewma_alpha=np.array(0.25),
+        high_nis_ratio=np.array(1.5),
+        low_nis_ratio=np.array(0.5),
+        scale_gain=np.array(0.75),
+    )
+
+    assert config.base_scale == 1.25
+    assert config.min_scale == 0.5
+    assert config.max_scale == 2.5
+    assert config.ewma_alpha == 0.25
+    assert config.high_nis_ratio == 1.5
+    assert config.low_nis_ratio == 0.5
+    assert config.scale_gain == 0.75
+
+
+def test_config_rejects_nonfinite_or_nonscalar_values():
+    invalid_values = (np.nan, np.inf, -np.inf, True, np.array([1.0]))
+
+    for field_name in (
+        "base_scale",
+        "min_scale",
+        "max_scale",
+        "ewma_alpha",
+        "high_nis_ratio",
+        "low_nis_ratio",
+        "scale_gain",
+    ):
+        for value in invalid_values:
+            with pytest.raises(ValueError, match=f"{field_name} must be a finite scalar"):
+                AdaptiveProcessNoiseConfig(**{field_name: value})


### PR DESCRIPTION
## Summary
- normalize adaptive process-noise config values to finite scalar floats during construction
- reject NaN, infinite, boolean, and shaped-array config inputs before they can affect EWMA updates or scale bounds
- add regression coverage for valid scalar array inputs and invalid nonfinite/nonscalar values

## Root cause
`AdaptiveProcessNoiseConfig` only used range comparisons in `__post_init__`. Comparisons with `NaN` are false and infinities can satisfy the existing inequalities, so invalid configuration values were accepted and could propagate into process-noise scaling.

## Tests
- `py -3.12 -m pytest -q tests\filters\test_adaptive_process_noise.py`
- `py -3.12 -m ruff check src tests`
- `git diff --check`
- `git diff --cached --check`