### PR TITLE
Validate linear update planning scalars

### DIFF
--- a/src/pyrecest/filters/linear_update_planning.py
+++ b/src/pyrecest/filters/linear_update_planning.py
@@ -81,12 +81,10 @@ def chi_square_gate_threshold(
 
     if probability is None:
         return None
-    probability = float(probability)
-    measurement_dim = int(measurement_dim)
+    probability = _as_finite_scalar(probability, "probability")
+    measurement_dim = _as_positive_integer(measurement_dim, "measurement_dim")
     if not 0.0 < probability < 1.0:
         raise ValueError("probability must be in (0, 1)")
-    if measurement_dim <= 0:
-        raise ValueError("measurement_dim must be positive")
     return float(chi2.ppf(probability, measurement_dim))
 
 
@@ -118,6 +116,11 @@ def student_t_covariance_scale(
 ) -> float:
     """Return Student-t covariance inflation from NIS."""
 
+    nis = _as_nonnegative_scalar(nis, "nis")
+    measurement_dim = _as_positive_integer(measurement_dim, "measurement_dim")
+    dof = _as_finite_scalar(degrees_of_freedom, "degrees_of_freedom")
+    if dof <= 2.0:
+        raise ValueError("degrees_of_freedom must be greater than 2")
     if _student_t_covariance_scale is not None:
         return float(
             np.asarray(
@@ -129,12 +132,6 @@ def student_t_covariance_scale(
                 dtype=float,
             )
         )
-    measurement_dim = int(measurement_dim)
-    dof = float(degrees_of_freedom)
-    if measurement_dim <= 0:
-        raise ValueError("measurement_dim must be positive")
-    if dof <= 2.0:
-        raise ValueError("degrees_of_freedom must be greater than 2")
     return float(max(1.0, (dof + float(nis)) / (dof + measurement_dim)))
 
 
@@ -143,15 +140,14 @@ def huber_covariance_scale(
 ) -> float:
     """Return multivariate Huber covariance inflation from NIS."""
 
+    nis = _as_nonnegative_scalar(nis, "nis")
+    threshold = _as_positive_scalar(threshold, "threshold")
     if _huber_covariance_scale is not None:
         return float(
             np.asarray(
                 _huber_covariance_scale(nis, huber_threshold=threshold), dtype=float
             )
         )
-    threshold = float(threshold)
-    if threshold <= 0.0:
-        raise ValueError("threshold must be positive")
     return float(max(1.0, np.sqrt(float(nis)) / threshold))
 
 
@@ -170,10 +166,15 @@ def robust_update_covariance_scale(
     mode = None if robust_update in (None, "none") else str(robust_update)
     if mode is None:
         return 1.0, None
+    nis = _as_nonnegative_scalar(nis, "nis")
     if mode == "nis-inflate":
-        if gate_threshold is None or float(nis) <= float(gate_threshold):
+        inflation_alpha = _as_positive_scalar(inflation_alpha, "inflation_alpha")
+        if gate_threshold is None:
             return 1.0, None
-        scale = max(1.0, (float(nis) / float(gate_threshold)) ** float(inflation_alpha))
+        gate_threshold = _as_positive_scalar(gate_threshold, "gate_threshold")
+        if nis <= gate_threshold:
+            return 1.0, None
+        scale = max(1.0, (nis / gate_threshold) ** inflation_alpha)
         return float(scale), "inflated"
     if mode == "student-t":
         scale = student_t_covariance_scale(nis, measurement_dim, student_t_dof)
@@ -211,9 +212,7 @@ def plan_linear_measurement_update(
     inflation.  ``nis`` is always computed against the nominal covariance.
     """
 
-    alpha = float(inflation_alpha)
-    if alpha <= 0.0:
-        raise ValueError("inflation_alpha must be positive")
+    alpha = _as_positive_scalar(inflation_alpha, "inflation_alpha")
 
     vector = np.asarray(measurement_vector, dtype=float).reshape(-1)
     measurement_dim = vector.size
@@ -246,9 +245,11 @@ def plan_linear_measurement_update(
         measurement_dim,
         "safety_gate",
     )
-    residual_threshold = None if max_residual_norm is None else float(max_residual_norm)
-    if residual_threshold is not None and residual_threshold <= 0.0:
-        raise ValueError("max_residual_norm must be positive or None")
+    residual_threshold = (
+        None
+        if max_residual_norm is None
+        else _as_positive_scalar(max_residual_norm, "max_residual_norm")
+    )
 
     residual = vector - observation @ state_mean
     nominal_innovation_covariance = (
@@ -337,7 +338,7 @@ def gate_threshold_for_measurement(
     source = str(measurement.source)
     if gate_thresholds_by_source and source in gate_thresholds_by_source:
         value = gate_thresholds_by_source[source]
-        return None if value is None else float(value)
+        return None if value is None else _as_positive_scalar(value, "gate_threshold")
     if gate_probabilities_by_source and source in gate_probabilities_by_source:
         probability = gate_probabilities_by_source[source]
         vector = np.asarray(measurement.vector).reshape(-1)
@@ -377,15 +378,49 @@ def _resolve_threshold(
     name: str,
 ) -> float | None:
     if threshold is not None:
-        value = float(threshold)
-        if value <= 0.0:
-            raise ValueError(f"{name}_threshold must be positive or None")
-        return value
+        return _as_positive_scalar(threshold, f"{name}_threshold")
     return chi_square_gate_threshold(probability, measurement_dim)
 
 
 def _symmetrized(matrix: np.ndarray) -> np.ndarray:
     return 0.5 * (matrix + matrix.T)
+
+
+def _as_finite_scalar(value: Any, name: str) -> float:
+    value_array = np.asarray(value)
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError(f"{name} must be a finite scalar")
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(f"{name} must be a finite scalar")
+    try:
+        parsed = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be a finite scalar") from exc
+    if not np.isfinite(parsed):
+        raise ValueError(f"{name} must be a finite scalar")
+    return parsed
+
+
+def _as_positive_scalar(value: Any, name: str) -> float:
+    parsed = _as_finite_scalar(value, name)
+    if parsed <= 0.0:
+        raise ValueError(f"{name} must be positive")
+    return parsed
+
+
+def _as_nonnegative_scalar(value: Any, name: str) -> float:
+    parsed = _as_finite_scalar(value, name)
+    if parsed < 0.0:
+        raise ValueError(f"{name} must be nonnegative")
+    return parsed
+
+
+def _as_positive_integer(value: Any, name: str) -> int:
+    parsed = _as_nonnegative_scalar(value, name)
+    if parsed <= 0.0 or not parsed.is_integer():
+        raise ValueError(f"{name} must be a positive integer")
+    return int(parsed)
 
 
 __all__ = [

--- a/tests/filters/test_linear_update_planning.py
+++ b/tests/filters/test_linear_update_planning.py
@@ -1,8 +1,11 @@
 import numpy as np
+import pytest
+
 from pyrecest.filters.linear_update_planning import (
     chi_square_gate_threshold,
     plan_linear_measurement_update,
     robust_update_covariance_scale,
+    student_t_covariance_scale,
 )
 
 
@@ -51,3 +54,73 @@ def test_nis_inflate_uses_gate_ratio():
     )
     assert action == "inflated"
     assert np.isclose(scale, 2.0)
+
+
+def test_chi_square_gate_threshold_rejects_invalid_measurement_dim():
+    invalid_dimensions = (True, 1.5, np.nan, np.inf, np.array([2]))
+
+    for measurement_dim in invalid_dimensions:
+        with pytest.raises(ValueError, match="measurement_dim"):
+            chi_square_gate_threshold(0.95, measurement_dim)
+
+
+def test_plan_rejects_nonfinite_threshold_parameters():
+    base_kwargs = {
+        "mean": np.zeros(1),
+        "covariance_matrix": np.eye(1),
+        "measurement_vector": np.array([1.0]),
+        "measurement_covariance": np.eye(1),
+        "observation_matrix": np.eye(1),
+    }
+    invalid_overrides = (
+        {"gate_threshold": np.nan},
+        {"safety_gate_threshold": np.inf},
+        {"max_residual_norm": np.nan},
+        {"inflation_alpha": np.nan},
+    )
+
+    for overrides in invalid_overrides:
+        with pytest.raises(ValueError, match=next(iter(overrides))):
+            plan_linear_measurement_update(**base_kwargs, **overrides)
+
+
+def test_robust_scale_rejects_nonfinite_parameters():
+    invalid_cases = (
+        {
+            "robust_update": "nis-inflate",
+            "nis": np.nan,
+            "measurement_dim": 1,
+            "gate_threshold": 1.0,
+            "inflation_alpha": 1.0,
+        },
+        {
+            "robust_update": "nis-inflate",
+            "nis": 2.0,
+            "measurement_dim": 1,
+            "gate_threshold": np.nan,
+            "inflation_alpha": 1.0,
+        },
+        {
+            "robust_update": "nis-inflate",
+            "nis": 2.0,
+            "measurement_dim": 1,
+            "gate_threshold": 1.0,
+            "inflation_alpha": np.inf,
+        },
+        {
+            "robust_update": "huber",
+            "nis": 2.0,
+            "measurement_dim": 1,
+            "gate_threshold": None,
+            "huber_threshold": np.nan,
+        },
+    )
+
+    for kwargs in invalid_cases:
+        with pytest.raises(ValueError):
+            robust_update_covariance_scale(**kwargs)
+
+
+def test_student_t_covariance_scale_rejects_nonfinite_dof():
+    with pytest.raises(ValueError, match="degrees_of_freedom"):
+        student_t_covariance_scale(1.0, measurement_dim=2, degrees_of_freedom=np.nan)


### PR DESCRIPTION
## Summary
- validate linear-update planning scalar inputs before comparisons and robust scale calculations
- reject NaN/inf, booleans, non-scalar arrays, and fractional measurement dimensions in gating and robust update helpers
- add regression coverage for invalid gate thresholds, measurement dimensions, robust scaling inputs, and Student-t degrees of freedom

## Root cause
Several public helpers used bare `float(...)`/`int(...)` conversion and positivity checks. `NaN` values pass `<= 0` checks by making comparisons false, and fractional or boolean dimensions could be coerced into valid-looking chi-square degrees of freedom.

## Tests
- `py -3.12 -m pytest -q tests\filters\test_linear_update_planning.py tests\test_linear_gaussian_robust.py tests\filters\test_robust_linear_gaussian_update.py`
- `py -3.12 -m ruff check src tests`
- `git diff --check`
- `git diff --cached --check`