### PR TITLE
Validate bias calibration fit parameters

### DIFF
--- a/src/pyrecest/calibration/bias.py
+++ b/src/pyrecest/calibration/bias.py
@@ -232,10 +232,8 @@ def fit_sensor_bias_correction_from_examples(
 ) -> SensorBiasCorrectionModel:
     """Fit a ridge-linear bias model from prepared examples."""
 
-    if ridge_alpha < 0.0:
-        raise ValueError("ridge_alpha must be nonnegative")
-    if min_samples < 1:
-        raise ValueError("min_samples must be positive")
+    ridge_alpha = _as_nonnegative_finite_float(ridge_alpha, "ridge_alpha")
+    min_samples = _as_positive_int(min_samples, "min_samples")
     y = _as_2d(examples.residual, "examples.residual")
     x = _as_2d(examples.features, "examples.features")
     if x.shape[0] != y.shape[0]:
@@ -245,7 +243,7 @@ def fit_sensor_bias_correction_from_examples(
     x = x[valid]
     if y.shape[0] == 0:
         raise ValueError("no finite bias training examples")
-    if x.shape[0] < int(min_samples):
+    if x.shape[0] < min_samples:
         x = np.empty((y.shape[0], 0), dtype=float)
 
     feature_mean = _nanmean_or_zero(x)
@@ -255,7 +253,7 @@ def fit_sensor_bias_correction_from_examples(
     )
     standardized = (x - feature_mean) / feature_scale if x.shape[1] else x
     design = np.column_stack([np.ones(y.shape[0]), standardized])
-    regularizer = np.eye(design.shape[1]) * float(ridge_alpha)
+    regularizer = np.eye(design.shape[1]) * ridge_alpha
     regularizer[0, 0] = 0.0
     lhs = design.T @ design + regularizer
     rhs = design.T @ y
@@ -274,7 +272,7 @@ def fit_sensor_bias_correction_from_examples(
         feature_scale=feature_scale,
         residual_std=residual_std,
         training_count=int(y.shape[0]),
-        ridge_alpha=float(ridge_alpha),
+        ridge_alpha=ridge_alpha,
         metadata={} if metadata is None else dict(metadata),
     )
 
@@ -335,6 +333,29 @@ def _as_nonnegative_int(value: Any, name: str) -> int:
         raise ValueError(f"{name} must be a nonnegative integer")
     if result < 0:
         raise ValueError(f"{name} must be a nonnegative integer")
+    return result
+
+
+def _as_positive_int(value: Any, name: str) -> int:
+    result = _as_nonnegative_int(value, name)
+    if result <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return result
+
+
+def _as_nonnegative_finite_float(value: Any, name: str) -> float:
+    arr = np.asarray(value)
+    if arr.ndim != 0 or arr.dtype == np.bool_:
+        raise ValueError(f"{name} must be a nonnegative finite scalar")
+    scalar = arr.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(f"{name} must be a nonnegative finite scalar")
+    try:
+        result = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be a nonnegative finite scalar") from exc
+    if not np.isfinite(result) or result < 0.0:
+        raise ValueError(f"{name} must be a nonnegative finite scalar")
     return result
 
 

--- a/tests/calibration/test_time_offset_bias.py
+++ b/tests/calibration/test_time_offset_bias.py
@@ -330,6 +330,59 @@ class BiasCalibrationTest(unittest.TestCase):
         ):
             fit_sensor_bias_correction_from_examples(examples, min_samples=1)
 
+    def test_fit_sensor_bias_correction_rejects_invalid_fit_parameters(self):
+        examples = BiasTrainingExamples(
+            measured=np.array([[1.0], [2.0]]),
+            reference=np.array([[0.0], [0.0]]),
+            residual=np.array([[1.0], [2.0]]),
+            features=np.array([[0.0], [1.0]]),
+            time_delta_s=np.array([0.0, 0.0]),
+        )
+
+        invalid_ridge_alpha_values = (np.nan, np.inf, -1.0, True, np.array([0.0]))
+        for ridge_alpha in invalid_ridge_alpha_values:
+            with self.subTest(ridge_alpha=ridge_alpha):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "ridge_alpha must be a nonnegative finite scalar",
+                ):
+                    fit_sensor_bias_correction_from_examples(
+                        examples,
+                        ridge_alpha=ridge_alpha,
+                        min_samples=1,
+                    )
+
+        invalid_min_samples_values = (0, 1.5, np.nan, np.inf, False, np.array([1]))
+        for min_samples in invalid_min_samples_values:
+            with self.subTest(min_samples=min_samples):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "min_samples must be",
+                ):
+                    fit_sensor_bias_correction_from_examples(
+                        examples,
+                        ridge_alpha=0.0,
+                        min_samples=min_samples,
+                    )
+
+    def test_fit_sensor_bias_correction_accepts_integer_like_min_samples(self):
+        examples = BiasTrainingExamples(
+            measured=np.array([[1.0], [2.0]]),
+            reference=np.array([[0.0], [0.0]]),
+            residual=np.array([[1.0], [2.0]]),
+            features=np.array([[0.0], [1.0]]),
+            time_delta_s=np.array([0.0, 0.0]),
+        )
+
+        model = fit_sensor_bias_correction_from_examples(
+            examples,
+            ridge_alpha=np.array(0.0),
+            min_samples=np.array(2.0),
+        )
+
+        self.assertEqual(model.feature_dim, 1)
+        self.assertEqual(model.ridge_alpha, 0.0)
+
     def test_fit_sensor_bias_correction_subtracts_predicted_bias(self):
         times = np.arange(8.0)
         reference = np.column_stack([times, -times])


### PR DESCRIPTION
## Summary
- validate `ridge_alpha` as a nonnegative finite scalar before building the ridge system
- validate `min_samples` as a positive integer instead of silently truncating with `int(...)`
- add regression coverage for invalid calibration fit parameters and accepted integer-like scalar inputs

## Root cause
Bias calibration fitting only compared `ridge_alpha < 0` and `min_samples < 1`. `NaN` passes those comparisons by making them false, while fractional `min_samples` values were later truncated through `int(min_samples)`, changing whether feature-based fitting is used.

## Tests
- `py -3.12 -m pytest -q tests\calibration\test_time_offset_bias.py tests\calibration\test_bias.py tests\calibration\test_bias_prediction_row_count.py`
- `py -3.12 -m ruff check src tests`
- `git diff --check`
- `git diff --cached --check`