### PR TITLE
Validate track manager integer inputs

### DIFF
--- a/src/pyrecest/filters/track_manager.py
+++ b/src/pyrecest/filters/track_manager.py
@@ -173,17 +173,15 @@ class TrackManager(
             log_prior_estimates=log_prior_estimates,
             log_posterior_estimates=log_posterior_estimates,
         )
-        if n_init < 1:
-            raise ValueError("n_init must be at least 1")
-        if max_misses < 0:
-            raise ValueError("max_misses must be non-negative")
+        n_init = _as_positive_integer(n_init, "n_init")
+        max_misses = _as_nonnegative_integer(max_misses, "max_misses")
 
         self.predictor = predictor
         self.updater = updater
         self.initiator = initiator
         self.associator = associator
-        self.n_init = int(n_init)
-        self.max_misses = int(max_misses)
+        self.n_init = n_init
+        self.max_misses = max_misses
         self.allow_births = bool(allow_births)
         self.confirm_condition = confirm_condition
         self.delete_condition = delete_condition
@@ -620,8 +618,11 @@ class TrackManager(
         matches: List[Tuple[int, int]] = []
 
         for track_index, measurement_index in association.matches:
-            track_index = int(track_index)
-            measurement_index = int(measurement_index)
+            track_index = _as_nonnegative_integer(track_index, "Track index")
+            measurement_index = _as_nonnegative_integer(
+                measurement_index,
+                "Measurement index",
+            )
             if track_index < 0 or track_index >= num_tracks:
                 raise ValueError("Track index in association is out of range")
             if measurement_index < 0 or measurement_index >= num_measurements:
@@ -642,7 +643,10 @@ class TrackManager(
             )
         else:
             unmatched_track_indices = sorted(
-                {int(index) for index in association.unmatched_track_indices}
+                {
+                    _as_nonnegative_integer(index, "Unmatched track index")
+                    for index in association.unmatched_track_indices
+                }
             )
 
         if association.unmatched_measurement_indices is None:
@@ -651,7 +655,10 @@ class TrackManager(
             )
         else:
             unmatched_measurement_indices = sorted(
-                {int(index) for index in association.unmatched_measurement_indices}
+                {
+                    _as_nonnegative_integer(index, "Unmatched measurement index")
+                    for index in association.unmatched_measurement_indices
+                }
             )
 
         if used_track_indices.intersection(unmatched_track_indices):
@@ -977,6 +984,37 @@ def _coerce_cost_vector(cost: Any, length: int, name: str) -> np.ndarray:
     if vector.size != length:
         raise ValueError(f"{name} must be scalar or have length {length}")
     return vector
+
+
+def _as_nonnegative_integer(value: Any, name: str) -> int:
+    value_array = np.asarray(value)
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError(f"{name} must be a non-negative integer")
+
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(f"{name} must be a non-negative integer")
+    if isinstance(scalar, (int, np.integer)):
+        integer_value = int(scalar)
+    else:
+        try:
+            scalar_float = float(scalar)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(f"{name} must be a non-negative integer") from exc
+        if not np.isfinite(scalar_float) or not scalar_float.is_integer():
+            raise ValueError(f"{name} must be a non-negative integer")
+        integer_value = int(scalar_float)
+
+    if integer_value < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+    return integer_value
+
+
+def _as_positive_integer(value: Any, name: str) -> int:
+    integer_value = _as_nonnegative_integer(value, name)
+    if integer_value <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return integer_value
 
 
 # pylint: disable=duplicate-code

--- a/tests/filters/test_track_manager.py
+++ b/tests/filters/test_track_manager.py
@@ -9,6 +9,25 @@ from pyrecest.filters.track_manager import (
 
 
 class TrackManagerAssociationTest(unittest.TestCase):
+    def test_lifecycle_thresholds_accept_integer_like_values(self):
+        manager = TrackManager(n_init=np.array(2.0), max_misses=np.array(1.0))
+
+        self.assertEqual(manager.n_init, 2)
+        self.assertEqual(manager.max_misses, 1)
+
+    def test_lifecycle_thresholds_reject_invalid_integer_values(self):
+        invalid_n_init_values = (0, 1.5, np.nan, np.inf, True, np.array([1]))
+        for n_init in invalid_n_init_values:
+            with self.subTest(n_init=n_init):
+                with self.assertRaisesRegex(ValueError, "n_init must be"):
+                    TrackManager(n_init=n_init)
+
+        invalid_max_misses_values = (-1, 1.5, np.nan, np.inf, False, np.array([1]))
+        for max_misses in invalid_max_misses_values:
+            with self.subTest(max_misses=max_misses):
+                with self.assertRaisesRegex(ValueError, "max_misses must be"):
+                    TrackManager(max_misses=max_misses)
+
     def test_normalize_association_result_requires_track_coverage(self):
         with self.assertRaisesRegex(ValueError, "track"):
             TrackManager._normalize_association_result(
@@ -32,6 +51,43 @@ class TrackManagerAssociationTest(unittest.TestCase):
                 num_tracks=1,
                 num_measurements=1,
             )
+
+    def test_normalize_association_result_rejects_noninteger_match_indices(self):
+        invalid_associations = (
+            (
+                AssociationResult(matches=[(0.5, 0)]),
+                "Track index must be a non-negative integer",
+            ),
+            (
+                AssociationResult(matches=[(0, True)]),
+                "Measurement index must be a non-negative integer",
+            ),
+            (
+                AssociationResult(
+                    matches=[],
+                    unmatched_track_indices=[0.5],
+                    unmatched_measurement_indices=[0],
+                ),
+                "Unmatched track index must be a non-negative integer",
+            ),
+            (
+                AssociationResult(
+                    matches=[],
+                    unmatched_track_indices=[0],
+                    unmatched_measurement_indices=[np.array([0])],
+                ),
+                "Unmatched measurement index must be a non-negative integer",
+            ),
+        )
+
+        for association, message in invalid_associations:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(ValueError, message):
+                    TrackManager._normalize_association_result(
+                        association,
+                        num_tracks=1,
+                        num_measurements=1,
+                    )
 
     def test_solver_does_not_return_nonfinite_pair_as_match(self):
         association = solve_global_nearest_neighbor(


### PR DESCRIPTION
## Summary
- validate `TrackManager` lifecycle thresholds as integer scalars before storing them
- reject fractional, boolean, non-finite, and shaped-array association indices before normalization
- add regression coverage for lifecycle threshold and association-index validation

## Root cause
`TrackManager` and association normalization used bare `int(...)` conversions. That silently truncated fractional values like `1.5` and treated booleans as `0`/`1`, which can change track confirmation/deletion timing or normalize associations to the wrong track/measurement.

## Tests
- `py -3.12 -m pytest -q tests\filters\test_track_manager.py`
- `py -3.12 -m ruff check src tests`
- `git diff --check`
- `git diff --cached --check`