### PR TITLE
Validate association gate parameters

### DIFF
--- a/src/pyrecest/filters/association_hypotheses.py
+++ b/src/pyrecest/filters/association_hypotheses.py
@@ -148,6 +148,40 @@ def hypothesis_cost(
     return float(missing_cost)
 
 
+def _as_scalar_float(value: Any, name: str) -> float:
+    value_array = np.asarray(value)
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError(f"{name} must be a scalar number")
+    try:
+        scalar = float(value_array.item())
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be a scalar number") from exc
+    if np.isnan(scalar):
+        raise ValueError(f"{name} must not be NaN")
+    return scalar
+
+
+def _as_finite_scalar(value: Any, name: str) -> float:
+    scalar = _as_scalar_float(value, name)
+    if not np.isfinite(scalar):
+        raise ValueError(f"{name} must be finite")
+    return scalar
+
+
+def _as_nonnegative_scalar(value: Any, name: str) -> float:
+    scalar = _as_scalar_float(value, name)
+    if scalar < 0.0:
+        raise ValueError(f"{name} must be nonnegative")
+    return scalar
+
+
+def _as_positive_integer(value: Any, name: str) -> int:
+    scalar = _as_finite_scalar(value, name)
+    if scalar <= 0.0 or not scalar.is_integer():
+        raise ValueError(f"{name} must be a positive integer")
+    return int(scalar)
+
+
 class NISGate:
     """Gate association hypotheses by normalized innovation squared."""
 
@@ -163,10 +197,12 @@ class NISGate:
                 raise ValueError(
                     "Either threshold or both measurement_dim and confidence must be provided."
                 )
-            threshold = chi2.ppf(float(confidence), int(measurement_dim))
-        self.threshold = float(threshold)
-        if self.threshold < 0.0:
-            raise ValueError("threshold must be nonnegative")
+            confidence = _as_finite_scalar(confidence, "confidence")
+            if not 0.0 < confidence < 1.0:
+                raise ValueError("confidence must be in (0, 1)")
+            measurement_dim = _as_positive_integer(measurement_dim, "measurement_dim")
+            threshold = chi2.ppf(confidence, measurement_dim)
+        self.threshold = _as_nonnegative_scalar(threshold, "threshold")
 
     def accepts(self, hypothesis: AssociationHypothesis) -> bool:
         """Return whether ``hypothesis`` is accepted by the NIS threshold."""
@@ -184,7 +220,7 @@ class CostThresholdGate:
     """Gate hypotheses by maximum minimization cost."""
 
     def __init__(self, threshold: float, *, missing_cost: float = np.inf):
-        self.threshold = float(threshold)
+        self.threshold = _as_scalar_float(threshold, "threshold")
         self.missing_cost = float(missing_cost)
 
     def accepts(self, hypothesis: AssociationHypothesis) -> bool:
@@ -203,7 +239,7 @@ class ProbabilityThresholdGate:
     """Gate hypotheses by minimum probability or likelihood."""
 
     def __init__(self, threshold: float, *, use_likelihood: bool = False):
-        self.threshold = float(threshold)
+        self.threshold = _as_scalar_float(threshold, "threshold")
         self.use_likelihood = bool(use_likelihood)
         if self.use_likelihood:
             if self.threshold <= 0.0:
@@ -232,9 +268,7 @@ class TopKGate:
     def __init__(
         self, k: int, *, mode: GateMode = "track", missing_cost: float = np.inf
     ):
-        self.k = int(k)
-        if self.k <= 0:
-            raise ValueError("k must be positive")
+        self.k = _as_positive_integer(k, "k")
         if mode not in ("track", "measurement"):
             raise ValueError("mode must be 'track' or 'measurement'")
         self.mode = mode

--- a/tests/filters/test_association_hypotheses.py
+++ b/tests/filters/test_association_hypotheses.py
@@ -1,5 +1,7 @@
 import unittest
 
+import numpy as np
+
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import allclose, array
 from pyrecest.filters import (
@@ -60,6 +62,32 @@ class AssociationHypothesesTest(unittest.TestCase):
         self.assertEqual(cost_matrix[1, 0], 99.0)
         self.assertAlmostEqual(cost_matrix[1, 1], 0.5)
 
+    def test_nis_gate_rejects_invalid_threshold(self):
+        for threshold in (np.nan, True, np.array([1.0])):
+            with self.subTest(threshold=threshold):
+                with self.assertRaisesRegex(ValueError, "threshold"):
+                    NISGate(threshold=threshold)
+
+    def test_nis_gate_validates_confidence_and_measurement_dimension(self):
+        invalid_cases = [
+            {"measurement_dim": 1, "confidence": np.nan, "message": "confidence"},
+            {"measurement_dim": 1, "confidence": 1.0, "message": "confidence"},
+            {"measurement_dim": True, "confidence": 0.95, "message": "measurement_dim"},
+            {"measurement_dim": 1.5, "confidence": 0.95, "message": "measurement_dim"},
+            {
+                "measurement_dim": np.array([1]),
+                "confidence": 0.95,
+                "message": "measurement_dim",
+            },
+        ]
+        for case in invalid_cases:
+            with self.subTest(case=case):
+                with self.assertRaisesRegex(ValueError, case["message"]):
+                    NISGate(
+                        measurement_dim=case["measurement_dim"],
+                        confidence=case["confidence"],
+                    )
+
     def test_cost_threshold_and_top_k_gates_are_generic(self):
         hypotheses = [
             AssociationHypothesis(0, 0, cost=1.0),
@@ -79,6 +107,26 @@ class AssociationHypothesesTest(unittest.TestCase):
             [(hyp.track_index, hyp.measurement_index) for hyp in top_per_track],
             [(0, 0), (1, 1)],
         )
+
+    def test_cost_and_probability_gates_reject_nan_thresholds(self):
+        for gate_factory in (CostThresholdGate, ProbabilityThresholdGate):
+            with self.subTest(gate_factory=gate_factory):
+                with self.assertRaisesRegex(ValueError, "threshold"):
+                    gate_factory(np.nan)
+
+        with self.assertRaisesRegex(ValueError, "threshold"):
+            ProbabilityThresholdGate(np.nan, use_likelihood=True)
+
+    def test_top_k_gate_rejects_invalid_k(self):
+        for k in (True, 1.5, np.nan, np.inf, np.array([1])):
+            with self.subTest(k=k):
+                with self.assertRaisesRegex(ValueError, "k must"):
+                    TopKGate(k)
+
+    def test_top_k_gate_accepts_integer_scalar_k(self):
+        gate = TopKGate(np.array(2.0))
+
+        self.assertEqual(gate.k, 2)
 
     def test_probability_likelihood_gate_rejects_zero_threshold(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Summary
- reject NaN and nonscalar thresholds in association gates
- validate NIS confidence and measurement dimension before deriving chi-square thresholds
- require TopKGate k to be a real positive integer instead of silently truncating values

## Tests
- `py -3.12 -m pytest -q tests\filters\test_association_hypotheses.py`
- `py -3.12 -m pytest -q tests\filters`
- `py -3.12 -m ruff check src tests`
- `git diff --check`