### PR TITLE
Validate tracklet Viterbi config parameters

### DIFF
--- a/src/pyrecest/filters/tracklet_viterbi.py
+++ b/src/pyrecest/filters/tracklet_viterbi.py
@@ -9,6 +9,56 @@ from typing import Any
 import numpy as np
 
 
+def _as_scalar_float(value: Any, name: str) -> float:
+    value_array = np.asarray(value)
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError(f"{name} must be a scalar number")
+    try:
+        scalar = float(value_array.item())
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be a scalar number") from exc
+    if not np.isfinite(scalar):
+        raise ValueError(f"{name} must be finite")
+    return scalar
+
+
+def _as_nonnegative_float(value: Any, name: str) -> float:
+    scalar = _as_scalar_float(value, name)
+    if scalar < 0.0:
+        raise ValueError(f"{name} must be nonnegative")
+    return scalar
+
+
+def _as_positive_float(value: Any, name: str) -> float:
+    scalar = _as_scalar_float(value, name)
+    if scalar <= 0.0:
+        raise ValueError(f"{name} must be positive")
+    return scalar
+
+
+def _as_integer(value: Any, name: str) -> int:
+    scalar = _as_scalar_float(value, name)
+    if not scalar.is_integer():
+        raise ValueError(f"{name} must be an integer")
+    return int(scalar)
+
+
+def _as_optional_positive_integer(value: Any | None, name: str) -> int | None:
+    if value is None:
+        return None
+    integer = _as_integer(value, name)
+    if integer < 1:
+        raise ValueError(f"{name} must be positive or None")
+    return integer
+
+
+def _as_nonnegative_integer(value: Any, name: str) -> int:
+    integer = _as_integer(value, name)
+    if integer < 0:
+        raise ValueError(f"{name} must be nonnegative")
+    return integer
+
+
 @dataclass(frozen=True)
 class TrackletAssociationCandidate:
     """One association candidate for one scan/frame.
@@ -60,18 +110,30 @@ class TrackletViterbiConfig:
     max_candidates_per_track_id: int = 1
 
     def __post_init__(self) -> None:
-        if (
-            self.max_candidates_per_frame is not None
-            and self.max_candidates_per_frame < 1
-        ):
-            raise ValueError("max_candidates_per_frame must be positive or None")
-        if (
-            self.max_candidate_pool_per_frame is not None
-            and self.max_candidate_pool_per_frame < 1
-        ):
-            raise ValueError("max_candidate_pool_per_frame must be positive or None")
-        if self.max_candidates_per_track_id < 0:
-            raise ValueError("max_candidates_per_track_id must be nonnegative")
+        object.__setattr__(
+            self,
+            "max_candidates_per_frame",
+            _as_optional_positive_integer(
+                self.max_candidates_per_frame,
+                "max_candidates_per_frame",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "max_candidate_pool_per_frame",
+            _as_optional_positive_integer(
+                self.max_candidate_pool_per_frame,
+                "max_candidate_pool_per_frame",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "max_candidates_per_track_id",
+            _as_nonnegative_integer(
+                self.max_candidates_per_track_id,
+                "max_candidates_per_track_id",
+            ),
+        )
         for name in (
             "missed_detection_cost",
             "consecutive_miss_cost",
@@ -80,17 +142,34 @@ class TrackletViterbiConfig:
             "motion_weight",
             "max_speed_penalty",
         ):
-            if float(getattr(self, name)) < 0.0:
-                raise ValueError(f"{name} must be nonnegative")
-        if self.transition_position_std <= 0.0:
-            raise ValueError("transition_position_std must be positive")
-        if (
-            self.transition_velocity_std is not None
-            and self.transition_velocity_std <= 0.0
-        ):
-            raise ValueError("transition_velocity_std must be positive or None")
-        if self.max_speed is not None and self.max_speed <= 0.0:
-            raise ValueError("max_speed must be positive or None")
+            object.__setattr__(
+                self,
+                name,
+                _as_nonnegative_float(getattr(self, name), name),
+            )
+        object.__setattr__(
+            self,
+            "transition_position_std",
+            _as_positive_float(
+                self.transition_position_std,
+                "transition_position_std",
+            ),
+        )
+        if self.transition_velocity_std is not None:
+            object.__setattr__(
+                self,
+                "transition_velocity_std",
+                _as_positive_float(
+                    self.transition_velocity_std,
+                    "transition_velocity_std",
+                ),
+            )
+        if self.max_speed is not None:
+            object.__setattr__(
+                self,
+                "max_speed",
+                _as_positive_float(self.max_speed, "max_speed"),
+            )
 
 
 @dataclass(frozen=True)

--- a/tests/filters/test_tracklet_viterbi.py
+++ b/tests/filters/test_tracklet_viterbi.py
@@ -1,3 +1,6 @@
+import numpy as np
+import pytest
+
 from pyrecest.filters.tracklet_viterbi import (
     TrackletAssociationCandidate,
     TrackletViterbiConfig,
@@ -7,6 +10,42 @@ from pyrecest.filters.tracklet_viterbi import (
     solve_tracklet_viterbi,
     track_support_cost,
 )
+
+
+def test_config_validates_candidate_limits():
+    for name in ("max_candidates_per_frame", "max_candidate_pool_per_frame"):
+        for value in (0, 1.5, np.nan, True, np.array([1])):
+            with pytest.raises(ValueError, match=name):
+                TrackletViterbiConfig(**{name: value})
+
+    for value in (-1, 1.5, np.nan, True, np.array([1])):
+        with pytest.raises(ValueError, match="max_candidates_per_track_id"):
+            TrackletViterbiConfig(max_candidates_per_track_id=value)
+
+
+def test_config_normalizes_integer_like_candidate_limits():
+    config = TrackletViterbiConfig(
+        max_candidates_per_frame=np.array(2.0),
+        max_candidate_pool_per_frame=3.0,
+        max_candidates_per_track_id=np.int64(1),
+    )
+
+    assert config.max_candidates_per_frame == 2
+    assert config.max_candidate_pool_per_frame == 3
+    assert config.max_candidates_per_track_id == 1
+
+
+def test_config_rejects_nonfinite_float_parameters():
+    invalid_cases = {
+        "missed_detection_cost": np.nan,
+        "max_speed_penalty": np.inf,
+        "transition_position_std": np.nan,
+        "transition_velocity_std": np.inf,
+        "max_speed": np.nan,
+    }
+    for name, value in invalid_cases.items():
+        with pytest.raises(ValueError, match=name):
+            TrackletViterbiConfig(**{name: value})
 
 
 def test_switch_cost_prefers_coherent_tracklet():


### PR DESCRIPTION
## Summary
- normalize candidate retention limits to validated integer values
- reject NaN, infinite, boolean, nonscalar, and fractional values before they reach Viterbi retention and cost logic
- add regression tests for invalid limits and nonfinite float parameters

## Tests
- `py -3.12 -m pytest -q tests\filters\test_tracklet_viterbi.py`
- `py -3.12 -m pytest -q tests\filters`
- `py -3.12 -m ruff check src tests`
- `git diff --check`