### PR TITLE
Reject boolean model dimensions

### DIFF
--- a/src/pyrecest/models/validation.py
+++ b/src/pyrecest/models/validation.py
@@ -38,7 +38,7 @@ def _validate_expected_dim(
 ) -> None:
     if expected_dim is None:
         return
-    if not isinstance(expected_dim, Integral):
+    if isinstance(expected_dim, bool) or not isinstance(expected_dim, Integral):
         raise TypeError(f"{dim_name} must be an integer or None.")
     if int(expected_dim) <= 0:
         raise ValueError(f"{dim_name} must be positive.")
@@ -255,6 +255,8 @@ def _maybe_call(value: Any, *, allow_methods: bool) -> Any:
 
 
 def _positive_int_or_none(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
     if isinstance(value, Integral) and int(value) > 0:
         return int(value)
     return None

--- a/tests/models/test_validation.py
+++ b/tests/models/test_validation.py
@@ -31,6 +31,23 @@ class TestModelValidation(unittest.TestCase):
 
         self.assertEqual(state.shape, (1,))
 
+    def test_validate_expected_dimensions_reject_boolean_values(self):
+        invalid_calls = [
+            lambda: validate_state_vector(array([1.0]), state_dim=True),
+            lambda: validate_measurement_vector(array([1.0]), meas_dim=True),
+            lambda: validate_covariance_matrix(eye(1), dim=True),
+            lambda: validate_noise_covariance(array(0.5), dim=True, allow_scalar=True),
+            lambda: validate_transition_matrix(zeros((1, 1)), state_dim=True),
+            lambda: validate_transition_matrix(zeros((1, 1)), pred_dim=True),
+            lambda: validate_measurement_matrix(zeros((1, 1)), state_dim=True),
+            lambda: validate_measurement_matrix(zeros((1, 1)), meas_dim=True),
+        ]
+
+        for call in invalid_calls:
+            with self.subTest(call=call):
+                with self.assertRaisesRegex(TypeError, "integer or None"):
+                    call()
+
     def test_validate_measurement_vector_accepts_expected_shape(self):
         measurement = validate_measurement_vector(array([1.0]), meas_dim=1)
 
@@ -89,6 +106,13 @@ class TestModelValidation(unittest.TestCase):
             dim = 4
 
         self.assertEqual(infer_state_dim_from_distribution(DistributionWithDim()), 4)
+
+    def test_infer_state_dim_rejects_boolean_dim_attribute(self):
+        class DistributionWithBooleanDim:
+            dim = True
+
+        with self.assertRaisesRegex(ValueError, "Could not infer"):
+            infer_state_dim_from_distribution(DistributionWithBooleanDim())
 
     def test_infer_state_dim_from_mean_attribute(self):
         class DistributionWithMean:


### PR DESCRIPTION
## Summary
- reject boolean expected dimensions in shared model validators instead of treating `True` as dimension 1
- ignore boolean distribution `dim` attributes during state-dimension inference
- add regression coverage across validation entry points

## Tests
- `py -3.12 -m pytest -q tests\models\test_validation.py`
- `py -3.12 -m pytest -q tests\models`
- `py -3.12 -m ruff check src tests`
- `git diff --check`