### PR TITLE
Validate numerics scalar controls

### DIFF
--- a/src/pyrecest/numerics.py
+++ b/src/pyrecest/numerics.py
@@ -31,9 +31,40 @@ def _from_numpy_array(value: np.ndarray):
 
 
 def _validate_nonnegative_finite(name: str, value: float) -> float:
-    value = float(value)
+    try:
+        value_array = np.asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a scalar number.") from exc
+    if value_array.shape != () or np.issubdtype(value_array.dtype, np.bool_):
+        raise ValueError(f"{name} must be a scalar number.")
+    try:
+        value = float(value_array.item())
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be a scalar number.") from exc
     if not np.isfinite(value) or value < 0.0:
         raise ValueError(f"{name} must be finite and non-negative.")
+    return value
+
+
+def _validate_positive_finite(name: str, value: float) -> float:
+    value = _validate_nonnegative_finite(name, value)
+    if value <= 0.0:
+        raise ValueError(f"{name} must be finite and positive.")
+    return value
+
+
+def _validate_nonnegative_integer(name: str, value: int) -> int:
+    try:
+        value_array = np.asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a nonnegative integer.") from exc
+    if value_array.shape != () or not np.issubdtype(value_array.dtype, np.integer):
+        raise ValueError(f"{name} must be a nonnegative integer.")
+    if np.issubdtype(value_array.dtype, np.bool_):
+        raise ValueError(f"{name} must be a nonnegative integer.")
+    value = int(value_array.item())
+    if value < 0:
+        raise ValueError(f"{name} must be a nonnegative integer.")
     return value
 
 
@@ -76,8 +107,7 @@ def nearest_symmetric_psd(matrix, *, min_eigenvalue: float = 0.0):
     should not silently replace validation in algorithms where invalid covariance
     matrices indicate a modeling error.
     """
-    if not np.isfinite(min_eigenvalue) or min_eigenvalue < 0.0:
-        raise ValueError("min_eigenvalue must be finite and nonnegative.")
+    min_eigenvalue = _validate_nonnegative_finite("min_eigenvalue", min_eigenvalue)
 
     arr = _to_numpy_array(matrix)
     if arr.ndim != 2 or arr.shape[0] != arr.shape[1]:
@@ -96,10 +126,8 @@ def jittered_cholesky(matrix, *, initial_jitter: float = 1e-12, max_attempts: in
     jitter. It raises :class:`NumericalStabilityError` if no factorization is
     found within ``max_attempts``.
     """
-    if not np.isfinite(initial_jitter) or initial_jitter <= 0.0:
-        raise ValueError("initial_jitter must be finite and positive.")
-    if not isinstance(max_attempts, (int, np.integer)) or max_attempts < 0:
-        raise ValueError("max_attempts must be a nonnegative integer.")
+    initial_jitter = _validate_positive_finite("initial_jitter", initial_jitter)
+    max_attempts = _validate_nonnegative_integer("max_attempts", max_attempts)
 
     arr = _to_numpy_array(matrix)
     if arr.ndim != 2 or arr.shape[0] != arr.shape[1]:

--- a/tests/test_numerics.py
+++ b/tests/test_numerics.py
@@ -24,7 +24,7 @@ def test_symmetrize_matrix_and_psd_projection():
 def test_nearest_symmetric_psd_rejects_invalid_min_eigenvalue():
     matrix = np.eye(2)
 
-    for min_eigenvalue in (-1.0, np.nan, np.inf):
+    for min_eigenvalue in (-1.0, np.nan, np.inf, True, np.array([0.0])):
         with pytest.raises(ValueError, match="min_eigenvalue"):
             nearest_symmetric_psd(matrix, min_eigenvalue=min_eigenvalue)
 
@@ -39,13 +39,20 @@ def test_jittered_cholesky_reports_jitter():
 def test_jittered_cholesky_rejects_invalid_retry_controls():
     matrix = np.eye(2)
 
-    for initial_jitter in (0.0, -1e-12, np.nan, np.inf):
+    for initial_jitter in (0.0, -1e-12, np.nan, np.inf, True, np.array([1e-12])):
         with pytest.raises(ValueError, match="initial_jitter"):
             jittered_cholesky(matrix, initial_jitter=initial_jitter)
 
-    for max_attempts in (-1, 1.5):
+    for max_attempts in (-1, 1.5, True, np.array([1])):
         with pytest.raises(ValueError, match="max_attempts"):
             jittered_cholesky(matrix, max_attempts=max_attempts)
+
+
+def test_jittered_cholesky_accepts_numpy_integer_retry_count():
+    matrix = np.array([[1.0, 0.0], [0.0, 0.0]])
+    _, jitter = jittered_cholesky(matrix, max_attempts=np.int64(3))
+
+    assert jitter > 0.0
 
 
 def test_assert_covariance_matrix_rejects_non_psd():

--- a/tests/test_numerics_atol_contract.py
+++ b/tests/test_numerics_atol_contract.py
@@ -7,14 +7,14 @@ from pyrecest.numerics import (
 )
 
 
-@pytest.mark.parametrize("atol", [-1.0, np.nan, np.inf])
+@pytest.mark.parametrize("atol", [-1.0, np.nan, np.inf, True, np.array([1e-10])])
 @pytest.mark.parametrize("validator", [is_symmetric, is_positive_semidefinite])
 def test_matrix_predicates_reject_invalid_atol(atol, validator):
-    with pytest.raises(ValueError, match="atol must be finite and non-negative"):
+    with pytest.raises(ValueError, match="atol"):
         validator(np.eye(2), atol=atol)
 
 
-@pytest.mark.parametrize("atol", [-1.0, np.nan, np.inf])
+@pytest.mark.parametrize("atol", [-1.0, np.nan, np.inf, True, np.array([1e-10])])
 def test_assert_covariance_matrix_rejects_invalid_atol(atol):
-    with pytest.raises(ValueError, match="atol must be finite and non-negative"):
+    with pytest.raises(ValueError, match="atol"):
         assert_covariance_matrix(np.eye(2), atol=atol)


### PR DESCRIPTION
## Summary
- reject boolean and nonscalar numeric tolerance/jitter controls instead of coercing them through `float(...)`
- validate `max_attempts` as a scalar nonnegative integer before retrying Cholesky factorization
- add regression coverage for invalid `atol`, `min_eigenvalue`, `initial_jitter`, and `max_attempts` values

## Tests
- `py -3.12 -m pytest -q tests\test_numerics.py tests\test_numerics_atol_contract.py`
- `py -3.12 -m ruff check src tests`
- `git diff --check`