### PR TITLE
Validate Euclidean sampler controls

### DIFF
--- a/src/pyrecest/sampling/euclidean_sampler.py
+++ b/src/pyrecest/sampling/euclidean_sampler.py
@@ -16,6 +16,12 @@ class AbstractEuclideanSampler(AbstractSampler):
 
 class GaussianSampler(AbstractEuclideanSampler):
     def sample_stochastic(self, n_samples: int, dim: int):
+        n_samples = _validate_integral_argument(n_samples, "n_samples")
+        dim = _validate_integral_argument(dim, "dim")
+        if n_samples < 0:
+            raise ValueError("n_samples must be nonnegative")
+        if dim < 1:
+            raise ValueError("dim must be positive")
         return GaussianDistribution(zeros(dim), eye(dim)).sample(n_samples)
 
 
@@ -89,15 +95,14 @@ class FibonacciRejectionSampler(AbstractEuclideanSampler):
     def _validate_rejection_args(n_candidates, dim, max_density, bounding_box):
         n_candidates = _validate_integral_argument(n_candidates, "n_candidates")
         dim = _validate_integral_argument(dim, "dim")
-        max_density = float(max_density)
+        max_density = _validate_positive_finite_scalar_argument(
+            max_density, "max_density"
+        )
 
         if n_candidates < 0:
             raise ValueError("n_candidates must be nonnegative")
         if dim < 1:
             raise ValueError("dim must be positive")
-        if not np.isfinite(max_density) or max_density <= 0:
-            raise ValueError("max_density must be positive and finite")
-
         if bounding_box is None:
             bounding_box = np.column_stack((np.zeros(dim), np.ones(dim)))
         else:
@@ -229,6 +234,26 @@ def _validate_integral_argument(value, name: str) -> int:
             return int(float_value)
 
     raise ValueError(f"{name} must be an integer")
+
+
+def _validate_positive_finite_scalar_argument(value, name: str) -> float:
+    """Return a positive finite scalar float without accepting bools or vectors."""
+    try:
+        array_value = np.asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a positive finite scalar") from exc
+
+    if array_value.ndim != 0:
+        raise ValueError(f"{name} must be a positive finite scalar")
+    if np.issubdtype(array_value.dtype, np.bool_):
+        raise ValueError(f"{name} must be a positive finite scalar")
+    try:
+        float_value = float(array_value.item())
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be a positive finite scalar") from exc
+    if not np.isfinite(float_value) or float_value <= 0.0:
+        raise ValueError(f"{name} must be a positive finite scalar")
+    return float_value
 
 
 def _validate_gaussian_transform_args(d, covariance, mean):

--- a/tests/test_euclidean_sampler.py
+++ b/tests/test_euclidean_sampler.py
@@ -54,6 +54,29 @@ class TestGaussianSampler(unittest.TestCase):
             _, p_value = shapiro(self.samples[:, i])
             self.assertGreater(p_value, 0.05)
 
+    def test_sample_stochastic_validates_integer_arguments(self):
+        invalid_cases = (
+            {"n_samples": -1, "dim": 2, "message": "n_samples"},
+            {"n_samples": 1.5, "dim": 2, "message": "n_samples"},
+            {"n_samples": True, "dim": 2, "message": "n_samples"},
+            {"n_samples": np.array([2]), "dim": 2, "message": "n_samples"},
+            {"n_samples": 2, "dim": 0, "message": "dim"},
+            {"n_samples": 2, "dim": 1.5, "message": "dim"},
+            {"n_samples": 2, "dim": True, "message": "dim"},
+        )
+
+        for case in invalid_cases:
+            kwargs = dict(case)
+            message = kwargs.pop("message")
+            with self.subTest(case=kwargs):
+                with self.assertRaisesRegex(ValueError, message):
+                    self.sampler.sample_stochastic(**kwargs)
+
+    def test_sample_stochastic_accepts_integer_like_scalar_arguments(self):
+        samples = self.sampler.sample_stochastic(np.float64(3.0), np.array(2))
+
+        self.assertEqual(samples.shape, (3, 2))
+
 
 class TestFibonacciGridSampler(unittest.TestCase):
     def setUp(self):
@@ -295,6 +318,18 @@ class TestFibonacciRejectionSampler(unittest.TestCase):
                 dim=1,
                 max_density=0.5,
             )
+
+    def test_rejection_sampler_rejects_invalid_max_density(self):
+        invalid_values = (0.0, -1.0, np.nan, np.inf, True, np.array([1.0]))
+        for max_density in invalid_values:
+            with self.subTest(max_density=max_density):
+                with self.assertRaisesRegex(ValueError, "max_density"):
+                    self.sampler.sample_rejection(
+                        lambda xs: np.ones(xs.shape[0]),
+                        n_candidates=4,
+                        dim=1,
+                        max_density=max_density,
+                    )
 
     def test_invalid_bounding_box(self):
         """Bounding boxes need one lower and one upper value per dimension."""


### PR DESCRIPTION
## Summary
- validate Gaussian sampler counts and dimensions consistently with deterministic grid samplers
- reject boolean, nonscalar, nonfinite, and nonpositive rejection `max_density` values before sampling
- add regression tests for invalid sampler controls and integer-like scalar inputs

## Tests
- `py -3.12 -m pytest -q tests\test_euclidean_sampler.py tests\test_euclidean_sampler_integer_args.py`
- `py -3.12 -m pytest -q tests\test_euclidean_sampler.py tests\test_euclidean_sampler_integer_args.py tests\test_backend_random.py tests\test_backend_contract.py`
- `py -3.12 -m ruff check src tests`
- `git diff --check`