### PR TITLE
Validate circular sampler inputs

### DIFF
--- a/src/pyrecest/sampling/hypertoroidal_sampler.py
+++ b/src/pyrecest/sampling/hypertoroidal_sampler.py
@@ -1,8 +1,38 @@
 # pylint: disable=no-name-in-module,no-member
+import numpy as np
+
 from pyrecest.backend import linspace, pi
 from pyrecest.distributions import CircularUniformDistribution
 
 from .abstract_sampler import AbstractSampler
+
+
+def _validate_integral_scalar(value, name: str, *, minimum: int) -> int:
+    scalar = np.asarray(value)
+    if scalar.ndim != 0:
+        raise ValueError(f"{name} must be a scalar integer")
+
+    scalar_value = scalar.item()
+    if isinstance(scalar_value, (bool, np.bool_)):
+        raise ValueError(f"{name} must be an integer, not a boolean")
+
+    try:
+        integer_value = int(scalar_value)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+
+    try:
+        float_value = float(scalar_value)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+
+    if not np.isfinite(float_value) or not float_value.is_integer():
+        raise ValueError(f"{name} must be a finite integer")
+    if integer_value < minimum:
+        if minimum == 0:
+            raise ValueError(f"{name} must be nonnegative")
+        raise ValueError(f"{name} must be positive")
+    return integer_value
 
 
 class AbstractHypertoroidalSampler(AbstractSampler):
@@ -15,18 +45,22 @@ class AbstractCircularSampler(AbstractHypertoroidalSampler):
 
 class CircularUniformSampler(AbstractCircularSampler):
     def sample_stochastic(self, n_samples: int, dim: int = 1):
-        assert (
-            dim == 1
-        ), "CircularUniformSampler is supposed to be used for the circle (which is one-dimensional) only."
+        n_samples = _validate_integral_scalar(n_samples, "n_samples", minimum=0)
+        dim = _validate_integral_scalar(dim, "dim", minimum=1)
+        if dim != 1:
+            raise ValueError(
+                "CircularUniformSampler is supposed to be used for the circle "
+                "(which is one-dimensional) only."
+            )
         return CircularUniformDistribution().sample(n_samples)
 
     def get_grid(self, grid_density_parameter: int):
         """
         Returns an equidistant grid of points on the circle [0,2*pi).
         """
-        grid_density_parameter = int(grid_density_parameter)
-        if grid_density_parameter <= 0:
-            raise ValueError("grid_density_parameter must be positive")
+        grid_density_parameter = _validate_integral_scalar(
+            grid_density_parameter, "grid_density_parameter", minimum=1
+        )
         points = linspace(0.0, 2.0 * pi, grid_density_parameter, endpoint=False)
         # Set it to the middle of the interval instead of the start
         points += (2.0 * pi / grid_density_parameter) / 2.0

--- a/tests/test_hypertoroidal_sampler.py
+++ b/tests/test_hypertoroidal_sampler.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
@@ -23,6 +24,24 @@ class TestCircularUniformSampler(unittest.TestCase):
         self.assertTrue(all(samples >= 0.0))
         self.assertTrue(all(samples < 2.0 * pi))
 
+    def test_sample_stochastic_accepts_integer_like_scalars(self):
+        samples = self.sampler.sample_stochastic(np.array(3.0), dim=np.array(1.0))
+
+        self.assertEqual(samples.shape, (3, 1))
+
+    def test_sample_stochastic_rejects_invalid_controls(self):
+        invalid_sample_counts = (-1, 1.5, True, [2])
+        for n_samples in invalid_sample_counts:
+            with self.subTest(n_samples=n_samples):
+                with self.assertRaises(ValueError):
+                    self.sampler.sample_stochastic(n_samples)
+
+        invalid_dims = (0, 1.5, 2, True, [1])
+        for dim in invalid_dims:
+            with self.subTest(dim=dim):
+                with self.assertRaises(ValueError):
+                    self.sampler.sample_stochastic(2, dim=dim)
+
     def test_get_grid(self):
         grid_density_parameter = 100
         grid_points = self.sampler.get_grid(grid_density_parameter)
@@ -42,6 +61,17 @@ class TestCircularUniformSampler(unittest.TestCase):
             self.sampler.get_grid(0)
         with self.assertRaises(ValueError):
             self.sampler.get_grid(-1)
+
+    def test_get_grid_accepts_integer_like_scalar_density(self):
+        grid_points = self.sampler.get_grid(np.array(4.0))
+
+        self.assertEqual(grid_points.shape[0], 4)
+
+    def test_get_grid_rejects_noninteger_density(self):
+        for density in (2.5, True, [3]):
+            with self.subTest(density=density):
+                with self.assertRaises(ValueError):
+                    self.sampler.get_grid(density)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace assertion-based circular sampler dimension validation with explicit `ValueError`s
- reject boolean, nonscalar, fractional, nonfinite, and nonpositive grid density inputs before constructing grids
- add regression tests for integer-like scalar inputs and invalid sampler controls

## Tests
- `PYTHONPATH=src py -3.12 -m pytest -q tests\test_hypertoroidal_sampler.py`
- `PYTHONPATH=src py -3.12 -m pytest -q tests\test_hyperspherical_sampler.py`
- `py -3.12 -m ruff check src tests`
- `git diff --check`

Note: local `pylint` is not installed in this Python environment (`No module named pylint`).