### PR TITLE
Validate hyperspherical grid densities

### DIFF
--- a/src/pyrecest/sampling/hyperspherical_sampler.py
+++ b/src/pyrecest/sampling/hyperspherical_sampler.py
@@ -3,6 +3,8 @@ from abc import abstractmethod
 from math import ceil
 
 # pylint: disable=no-name-in-module,no-member
+import numpy as np
+
 from pyrecest import backend
 from pyrecest.backend import (
     arange,
@@ -33,6 +35,56 @@ from ..distributions.hypersphere_subset.hyperspherical_uniform_distribution impo
 from .abstract_sampler import AbstractSampler
 from .hypertoroidal_sampler import CircularUniformSampler
 from .leopardi_sampler import get_partition_points_cartesian
+
+
+def _validate_positive_integral_scalar(value, name: str) -> int:
+    scalar = np.asarray(value)
+    if scalar.ndim != 0:
+        raise ValueError(f"{name} must be a scalar integer")
+
+    scalar_value = scalar.item()
+    if isinstance(scalar_value, (bool, np.bool_)):
+        raise ValueError(f"{name} must be an integer, not a boolean")
+
+    try:
+        integer_value = int(scalar_value)
+        float_value = float(scalar_value)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+
+    if not np.isfinite(float_value) or not float_value.is_integer():
+        raise ValueError(f"{name} must be a finite integer")
+    if integer_value <= 0:
+        raise ValueError(f"{name} must be positive")
+    return integer_value
+
+
+def _normalize_fibonacci_hopf_grid_density_parameter(grid_density_parameter):
+    if np.asarray(grid_density_parameter).ndim == 0:
+        return [
+            _validate_positive_integral_scalar(
+                grid_density_parameter, "grid_density_parameter"
+            )
+        ]
+
+    try:
+        grid_density_values = list(grid_density_parameter)
+    except TypeError as exc:
+        raise ValueError(
+            "grid_density_parameter must be a scalar or contain one or two entries"
+        ) from exc
+
+    if len(grid_density_values) not in (1, 2):
+        raise ValueError(
+            "grid_density_parameter must be a scalar or contain one or two entries"
+        )
+
+    return [
+        _validate_positive_integral_scalar(
+            value, f"grid_density_parameter[{index}]"
+        )
+        for index, value in enumerate(grid_density_values)
+    ]
 
 
 def _validate_grid_dim(name: str, dim: int, expected_dim: int) -> None:
@@ -182,10 +234,8 @@ class SphericalCoordinatesBasedFixedResolutionSampler(
             raise ValueError(
                 "grid_density_parameter must contain exactly two entries"
             ) from exc
-        res_lon = int(res_lon)
-        res_lat = int(res_lat)
-        if res_lon <= 0 or res_lat <= 0:
-            raise ValueError("grid resolution entries must be positive")
+        res_lon = _validate_positive_integral_scalar(res_lon, "res_lon")
+        res_lat = _validate_positive_integral_scalar(res_lat, "res_lat")
         phi_values = linspace(0.0, 2 * pi, num=res_lon, endpoint=False)
         theta_values = linspace(pi / (res_lat + 1), pi, num=res_lat, endpoint=False)
         phi_theta_stacked = array(list(itertools.product(phi_values, theta_values)))
@@ -300,12 +350,15 @@ class DriscollHealySampler(AbstractSphericalCoordinatesBasedSampler):
 
 class SphericalFibonacciSampler(AbstractSphericalCoordinatesBasedSampler):
     def get_grid_spherical_coordinates(self, grid_density_parameter: int):
-        indices = arange(0, grid_density_parameter, dtype=float) + 0.5
+        n_samples = _validate_positive_integral_scalar(
+            grid_density_parameter, "grid_density_parameter"
+        )
+        indices = arange(0, n_samples, dtype=float) + 0.5
         phi = pi * (1 + 5**0.5) * indices
-        theta = arccos(1 - 2 * indices / grid_density_parameter)
+        theta = arccos(1 - 2 * indices / n_samples)
         grid_specific_description = {
             "scheme": "spherical_fibonacci",
-            "n_samples": grid_density_parameter,
+            "n_samples": n_samples,
         }
         return phi, theta, grid_specific_description
 
@@ -409,8 +462,9 @@ class FibonacciHopfSampler(AbstractHopfBasedS3Sampler):
         First parameter is the number of points on the sphere, second parameter is the number of points on the circle.
         """
         _validate_grid_dim("FibonacciHopfSampler", dim, 3)
-        if isinstance(grid_density_parameter, int):
-            grid_density_parameter = [grid_density_parameter]
+        grid_density_parameter = _normalize_fibonacci_hopf_grid_density_parameter(
+            grid_density_parameter
+        )
 
         s3_points_list = []
 
@@ -424,9 +478,9 @@ class FibonacciHopfSampler(AbstractHopfBasedS3Sampler):
         # Step 2: Discretize the unit circle using the circular grid
         circular_sampler = CircularUniformSampler()
         if len(grid_density_parameter) == 2:
-            n_sample_circle = int(grid_density_parameter[1])
+            n_sample_circle = grid_density_parameter[1]
         else:
-            n_sample_circle = int(ceil(float(grid_density_parameter[0]) ** 0.5))
+            n_sample_circle = int(ceil(grid_density_parameter[0] ** 0.5))
         psi_points = circular_sampler.get_grid(n_sample_circle)
 
         # Step 3: Combine the two grids to generate a grid for S3

--- a/tests/test_hyperspherical_sampler.py
+++ b/tests/test_hyperspherical_sampler.py
@@ -2,6 +2,7 @@ import importlib.util
 import unittest
 from math import ceil
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module
@@ -202,6 +203,31 @@ class TestHypersphericalSampler(unittest.TestCase):
         self.assertEqual(grid.shape, (expected_points, 4))
         self.assertEqual(grid_description["layer-parameter"], [grid_density_parameter])
 
+    def test_fibonacci_hopf_sampler_accepts_integer_like_density(self):
+        sampler = FibonacciHopfSampler()
+        grid, grid_description = sampler.get_grid((np.array(4.0), np.array(3.0)))
+
+        self.assertEqual(grid.shape, (12, 4))
+        self.assertEqual(grid_description["layer-parameter"], [4, 3])
+
+    def test_fibonacci_hopf_sampler_rejects_invalid_density(self):
+        sampler = FibonacciHopfSampler()
+
+        invalid_density_parameters = (
+            0,
+            -3,
+            2.5,
+            True,
+            [],
+            [4, 2.5],
+            [4, True],
+            [4, 2, 1],
+        )
+        for grid_density_parameter in invalid_density_parameters:
+            with self.subTest(grid_density_parameter=grid_density_parameter):
+                with self.assertRaises(ValueError):
+                    sampler.get_grid(grid_density_parameter)
+
     @parameterized.expand(
         [
             ("test_2d_12_n_only", 12, 2, (12, 3)),
@@ -363,6 +389,33 @@ class TestSphericalCoordinatesBasedFixedResolutionSampler(unittest.TestCase):
             sampler.get_grid((0, 3))
         with self.assertRaises(ValueError):
             sampler.get_grid((4, 0))
+
+    def test_get_grid_rejects_noninteger_resolution(self):
+        sampler = SphericalCoordinatesBasedFixedResolutionSampler()
+
+        invalid_density_parameters = ((2.5, 3), (4, 3.5), (True, 3), ([4], 3))
+        for grid_density_parameter in invalid_density_parameters:
+            with self.subTest(grid_density_parameter=grid_density_parameter):
+                with self.assertRaises(ValueError):
+                    sampler.get_grid(grid_density_parameter)
+
+
+class TestSphericalFibonacciSampler(unittest.TestCase):
+    def test_get_grid_accepts_integer_like_density(self):
+        sampler = SphericalFibonacciSampler()
+
+        grid, grid_description = sampler.get_grid(np.array(5.0))
+
+        self.assertEqual(grid.shape, (5, 3))
+        self.assertEqual(grid_description["n_samples"], 5)
+
+    def test_get_grid_rejects_invalid_density(self):
+        sampler = SphericalFibonacciSampler()
+
+        for grid_density_parameter in (0, -1, 2.5, True, [3]):
+            with self.subTest(grid_density_parameter=grid_density_parameter):
+                with self.assertRaises(ValueError):
+                    sampler.get_grid(grid_density_parameter)
 
 
 class TestHopfConversion(unittest.TestCase):


### PR DESCRIPTION
## Summary
- reject nonpositive, boolean, nonscalar, and fractional spherical Fibonacci grid densities before building grids
- validate Fibonacci-Hopf one/two-entry density controls instead of silently truncating the circle count
- validate fixed-resolution spherical grid entries before passing them to tensor-product grid generation
- add regression tests for invalid controls and integer-like scalar inputs

## Tests
- `PYTHONPATH=src py -3.12 -m pytest -q tests\test_hyperspherical_sampler.py`
- `PYTHONPATH=src py -3.12 -m pytest -q tests\test_hyperspherical_sampler.py tests\test_hypertoroidal_sampler.py`
- `py -3.12 -m ruff check src tests`
- `git diff --check`

Note: local `pylint` is not installed in this Python environment (`No module named pylint`).