### PR TITLE
Validate hyperspherical uniform sample counts

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/hyperspherical_uniform_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/hyperspherical_uniform_distribution.py
@@ -1,6 +1,8 @@
 from typing import Union
 
 # pylint: disable=no-name-in-module,no-member
+import numpy as np
+
 from pyrecest.backend import (
     cos,
     empty,
@@ -21,6 +23,28 @@ from .abstract_hypersphere_subset_uniform_distribution import (
 from .abstract_hyperspherical_distribution import AbstractHypersphericalDistribution
 
 
+def _validate_positive_sample_count(n) -> int:
+    count_array = np.asarray(n)
+    if count_array.ndim != 0:
+        raise ValueError("n must be a scalar integer")
+
+    count = count_array.item()
+    if isinstance(count, (bool, np.bool_)):
+        raise ValueError("n must be an integer, not a boolean")
+
+    try:
+        count_int = int(count)
+        count_float = float(count)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("n must be an integer") from exc
+
+    if not np.isfinite(count_float) or not count_float.is_integer():
+        raise ValueError("n must be a finite integer")
+    if count_int <= 0:
+        raise ValueError("n must be positive")
+    return count_int
+
+
 class HypersphericalUniformDistribution(
     AbstractHypersphericalDistribution, AbstractHypersphereSubsetUniformDistribution
 ):
@@ -35,7 +59,7 @@ class HypersphericalUniformDistribution(
         return log_density * ones(xs.shape[0]) if xs.ndim > 1 else log_density
 
     def sample(self, n: Union[int, int32, int64]):
-        assert isinstance(n, int) and n > 0, "n must be a positive integer"
+        n = _validate_positive_sample_count(n)
 
         if self.dim == 2:
             s = empty(

--- a/tests/distributions/test_hyperspherical_uniform_distribution.py
+++ b/tests/distributions/test_hyperspherical_uniform_distribution.py
@@ -3,6 +3,7 @@
 # pylint: disable=no-name-in-module,no-member
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 import pyrecest.backend
 from pyrecest.backend import linalg, log, ones, random
@@ -51,6 +52,22 @@ class HypersphericalUniformDistributionTest(unittest.TestCase):
             samples = hud.sample(n)
             self.assertEqual(samples.shape, (n, hud.dim + 1))
             npt.assert_allclose(linalg.norm(samples, axis=1), ones(n), rtol=5e-7)
+
+    def test_sample_accepts_numpy_integer_count(self):
+        hud = HypersphericalUniformDistribution(2)
+
+        samples = hud.sample(np.int64(4))
+
+        self.assertEqual(samples.shape, (4, hud.dim + 1))
+        npt.assert_allclose(linalg.norm(samples, axis=1), ones(4), rtol=5e-7)
+
+    def test_sample_rejects_invalid_count(self):
+        hud = HypersphericalUniformDistribution(2)
+
+        for n in (0, -1, 2.5, True, [3]):
+            with self.subTest(n=n):
+                with self.assertRaises(ValueError):
+                    hud.sample(n)
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",


### PR DESCRIPTION
## Summary
- replace assertion-only hyperspherical uniform sample count validation with explicit `ValueError`s
- accept scalar NumPy integer counts as advertised by the type annotation
- reject boolean, nonscalar, nonfinite, fractional, and nonpositive sample counts before sampling
- add regression tests for NumPy integer counts and invalid count inputs

## Tests
- `PYTHONPATH=src py -3.12 -m pytest -q tests\distributions\test_hyperspherical_uniform_distribution.py`
- `PYTHONPATH=src py -3.12 -m pytest -q tests\distributions\test_hyperspherical_uniform_distribution.py tests\distributions\test_hyperspherical_mixture.py tests\distributions\test_hyperspherical_grid_distribution.py`
- `py -3.12 -m ruff check src tests`
- `git diff --check`

Note: local `pylint` is not installed in this Python environment (`No module named pylint`).