### PR TITLE
Validate hypertoroidal uniform sample counts

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_uniform_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_uniform_distribution.py
@@ -1,10 +1,34 @@
 from typing import Union
 
 # pylint: disable=no-name-in-module,no-member
+import numpy as np
+
 from pyrecest.backend import int32, int64, log, ndim, ones, pi, prod, random, zeros
 
 from ..abstract_uniform_distribution import AbstractUniformDistribution
 from .abstract_hypertoroidal_distribution import AbstractHypertoroidalDistribution
+
+
+def _validate_positive_sample_count(n) -> int:
+    count_array = np.asarray(n)
+    if count_array.ndim != 0:
+        raise ValueError("n must be a scalar integer")
+
+    count = count_array.item()
+    if isinstance(count, (bool, np.bool_)):
+        raise ValueError("n must be an integer, not a boolean")
+
+    try:
+        count_int = int(count)
+        count_float = float(count)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("n must be an integer") from exc
+
+    if not np.isfinite(count_float) or not count_float.is_integer():
+        raise ValueError("n must be a finite integer")
+    if count_int <= 0:
+        raise ValueError("n must be positive")
+    return count_int
 
 
 class HypertoroidalUniformDistribution(
@@ -68,6 +92,7 @@ class HypertoroidalUniformDistribution(
         :param n: Sample size
         :returns: Sample of size n
         """
+        n = _validate_positive_sample_count(n)
         return 2.0 * pi * random.uniform(size=(n, self.dim))
 
     def get_manifold_size(self):

--- a/tests/distributions/test_circular_uniform_distribution.py
+++ b/tests/distributions/test_circular_uniform_distribution.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
@@ -112,3 +113,18 @@ class CircularUniformDistributionTest(unittest.TestCase):
         n = 10
         s = cu.sample(n)
         npt.assert_allclose(s.shape[0], n)
+
+    def test_sampling_accepts_numpy_integer_count(self):
+        cu = CircularUniformDistribution()
+
+        samples = cu.sample(np.int64(4))
+
+        npt.assert_allclose(samples.shape[0], 4)
+
+    def test_sampling_rejects_invalid_count(self):
+        cu = CircularUniformDistribution()
+
+        for n in (0, -1, 2.5, True, [3]):
+            with self.subTest(n=n):
+                with self.assertRaises(ValueError):
+                    cu.sample(n)

--- a/tests/distributions/test_toroidal_uniform_distribution.py
+++ b/tests/distributions/test_toroidal_uniform_distribution.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 # pylint: disable=no-name-in-module,no-member
 import pyrecest.backend
 
@@ -78,6 +79,17 @@ class TestToroidalUniformDistribution(unittest.TestCase):
         self.assertEqual(s.shape, (n, 2))
         self.assertTrue(all(s >= 0))
         self.assertTrue(all(s < 2 * pi))
+
+    def test_sampling_accepts_numpy_integer_count(self):
+        samples = self.tud.sample(np.int64(4))
+
+        self.assertEqual(samples.shape, (4, 2))
+
+    def test_sampling_rejects_invalid_count(self):
+        for n in (0, -1, 2.5, True, [3]):
+            with self.subTest(n=n):
+                with self.assertRaises(ValueError):
+                    self.tud.sample(n)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- validate hypertoroidal uniform sample counts before delegating to backend random shape handling
- reject zero, negative, boolean, fractional, nonfinite, and nonscalar counts with `ValueError`
- keep scalar NumPy integer counts accepted for circular and toroidal uniform sampling
- add regression tests for circular and toroidal uniform distributions

## Tests
- `PYTHONPATH=src py -3.12 -m pytest -q tests\distributions\test_circular_uniform_distribution.py tests\distributions\test_toroidal_uniform_distribution.py`
- `PYTHONPATH=src py -3.12 -m pytest -q tests\distributions\test_circular_uniform_distribution.py tests\distributions\test_toroidal_uniform_distribution.py tests\distributions\test_hypertoroidal_wrapped_normal_distribution.py tests\distributions\test_hypertoroidal_dirac_distribution.py`
- `py -3.12 -m ruff check src tests`
- `git diff --check`

Note: local `pylint` is not installed in this Python environment (`No module named pylint`).