### PR TITLE
Validate SO3 product tangent sample counts

### DIFF
--- a/src/pyrecest/distributions/so3_product_tangent_gaussian_distribution.py
+++ b/src/pyrecest/distributions/so3_product_tangent_gaussian_distribution.py
@@ -1,6 +1,8 @@
 """Tangent-space Gaussian distribution on Cartesian products of SO(3)."""
 
 # pylint: disable=no-name-in-module,no-member
+import numpy as np
+
 from pyrecest.backend import (
     abs,
     all,
@@ -35,6 +37,28 @@ from ._so3_helpers import (
     so3_exp_map_volume_log_jacobian,
 )
 from .abstract_bounded_domain_distribution import AbstractBoundedDomainDistribution
+
+
+def _validate_positive_sample_count(n) -> int:
+    count_array = np.asarray(n)
+    if count_array.ndim != 0:
+        raise ValueError("n must be a scalar integer")
+
+    count = count_array.item()
+    if isinstance(count, (bool, np.bool_)):
+        raise ValueError("n must be an integer, not a boolean")
+
+    try:
+        count_int = int(count)
+        count_float = float(count)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("n must be an integer") from exc
+
+    if not np.isfinite(count_float) or not count_float.is_integer():
+        raise ValueError("n must be a finite integer")
+    if count_int <= 0:
+        raise ValueError("n must be positive")
+    return count_int
 
 
 class SO3ProductTangentGaussianDistribution(AbstractBoundedDomainDistribution):
@@ -322,6 +346,7 @@ class SO3ProductTangentGaussianDistribution(AbstractBoundedDomainDistribution):
 
     def sample_tangent(self, n):
         """Draw tangent-space Gaussian samples with shape ``(n, 3 * K)``."""
+        n = _validate_positive_sample_count(n)
         samples = random.multivariate_normal(mean=zeros(self.dim), cov=self.C, size=n)
         if ndim(samples) == 1:
             return reshape(samples, (1, self.dim))

--- a/tests/distributions/test_so3_product_tangent_gaussian_distribution.py
+++ b/tests/distributions/test_so3_product_tangent_gaussian_distribution.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
@@ -87,6 +88,31 @@ class SO3ProductTangentGaussianDistributionTest(unittest.TestCase):
         npt.assert_allclose(
             linalg.norm(single_sample, axis=-1), ones((1, 2)), atol=ATOL
         )
+
+    def test_sampling_accepts_integer_like_count(self):
+        dist = SO3ProductTangentGaussianDistribution.from_covariance_diagonal(
+            array([z_quaternion(0.0), x_quaternion(0.0)]),
+            array([0.01, 0.01, 0.01, 0.02, 0.02, 0.02]),
+        )
+
+        samples = dist.sample(np.array(3.0))
+        tangent_samples = dist.sample_tangent(np.int64(3))
+
+        self.assertEqual(samples.shape, (3, 2, 4))
+        self.assertEqual(tangent_samples.shape, (3, 6))
+
+    def test_sampling_rejects_invalid_count(self):
+        dist = SO3ProductTangentGaussianDistribution.from_covariance_diagonal(
+            array([z_quaternion(0.0), x_quaternion(0.0)]),
+            array([0.01, 0.01, 0.01, 0.02, 0.02, 0.02]),
+        )
+
+        for n in (0, -1, 2.5, True, [3]):
+            with self.subTest(n=n):
+                with self.assertRaises(ValueError):
+                    dist.sample(n)
+                with self.assertRaises(ValueError):
+                    dist.sample_tangent(n)
 
     def test_geodesic_distance_component_and_sum(self):
         identity_product = array([z_quaternion(0.0), x_quaternion(0.0)])


### PR DESCRIPTION
## Summary
- validate SO(3) product tangent Gaussian sample counts before backend random sampling
- reject zero, negative, boolean, fractional, nonfinite, and nonscalar counts with `ValueError`
- keep scalar NumPy integer and integer-like scalar counts accepted for `sample` and `sample_tangent`
- add regression tests for valid and invalid sample-count inputs

## Tests
- `PYTHONPATH=src py -3.12 -m pytest -q tests\distributions\test_so3_product_tangent_gaussian_distribution.py`
- `PYTHONPATH=src py -3.12 -m pytest -q tests\distributions\test_so3_product_tangent_gaussian_distribution.py tests\distributions\test_so3_product_dirac_distribution.py tests\filters\test_partitioned_so3_product_particle_filter.py tests\filters\test_so3_product_particle_filter.py`
- `py -3.12 -m ruff check src tests`
- `git diff --check`

Note: local `pylint` is not installed in this Python environment (`No module named pylint`).