### PR TITLE
Validate SO3 product Dirac sample count

### DIFF
--- a/src/pyrecest/distributions/so3_product_dirac_distribution.py
+++ b/src/pyrecest/distributions/so3_product_dirac_distribution.py
@@ -2,6 +2,7 @@
 
 # pylint: disable=no-name-in-module,no-member,arguments-renamed
 from math import prod
+from numbers import Integral
 
 from pyrecest.backend import (
     abs,
@@ -155,9 +156,12 @@ class SO3ProductDiracDistribution(HyperhemisphereCartProdDiracDistribution):
         return self.as_flat_array()
 
     def sample(self, n):
-        indices = random.choice(arange(self.d.shape[0]), n, p=self.w)
+        if isinstance(n, bool) or not isinstance(n, Integral) or int(n) <= 0:
+            raise ValueError("n must be a positive integer.")
+        sample_count = int(n)
+        indices = random.choice(arange(self.d.shape[0]), sample_count, p=self.w)
         samples = self.d[indices]
-        if int(n) == 1 and samples.shape == (self.num_rotations, 4):
+        if sample_count == 1 and samples.shape == (self.num_rotations, 4):
             return reshape(samples, (1, self.num_rotations, 4))
         return samples
 

--- a/tests/distributions/test_so3_product_dirac_distribution.py
+++ b/tests/distributions/test_so3_product_dirac_distribution.py
@@ -222,6 +222,14 @@ class SO3ProductDiracDistributionTest(unittest.TestCase):
         npt.assert_allclose(linalg.norm(single_sample, axis=-1), ones((1, 2)))
         npt.assert_allclose(sum(dist.w), 1.0)
 
+    def test_sampling_rejects_invalid_count(self):
+        dist = SO3ProductDiracDistribution(array([[self.identity, self.z_ninety]]))
+
+        for n in (0, -1, 1.5, True):
+            with self.subTest(n=n):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
+                    dist.sample(n)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- reject non-positive and non-integral sample counts before SO3 product Dirac sampling
- preserve existing single-sample output shape after validation
- add regression coverage for invalid sample counts

## Tests
- `PYTHONPATH=src py -3.12 -m pytest tests/distributions/test_so3_product_dirac_distribution.py -q`
- `py -3.12 -m ruff check src/pyrecest/distributions/so3_product_dirac_distribution.py tests/distributions/test_so3_product_dirac_distribution.py`
- `git diff --check`

Pylint was not run locally because it is not installed in this workspace (`No module named pylint`).