### PR TITLE
Preserve cart product distribution type on updates

### DIFF
--- a/src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py
@@ -25,11 +25,14 @@ class CartProdStackedDistribution(AbstractCartProdDistribution):
 
     def shift(self, shift_by):
         assert len(shift_by) == self.dim, "Incorrect number of offsets"
-        shifted_dists = [
-            dist.shift(shift_by[curr_dim : curr_dim + dist.dim])  # noqa: E203
-            for curr_dim, dist in enumerate(self.dists)
-        ]
-        return CartProdStackedDistribution(shifted_dists)
+        shifted_dists = []
+        curr_dim = 0
+        for dist in self.dists:
+            shifted_dists.append(
+                dist.shift(shift_by[curr_dim : curr_dim + dist.dim])  # noqa: E203
+            )
+            curr_dim += dist.dim
+        return self.__class__(shifted_dists)
 
     def set_mode(self, new_mode):
         new_dists = []
@@ -39,7 +42,7 @@ class CartProdStackedDistribution(AbstractCartProdDistribution):
                 dist.set_mode(new_mode[curr_ind : curr_ind + dist.dim])  # noqa: E203
             )
             curr_ind += dist.dim
-        return CartProdStackedDistribution(new_dists)
+        return self.__class__(new_dists)
 
     def hybrid_mean(self):
         return concatenate([dist.mean() for dist in self.dists])

--- a/tests/distributions/test_cart_prod_stacked_distribution.py
+++ b/tests/distributions/test_cart_prod_stacked_distribution.py
@@ -1,0 +1,50 @@
+import unittest
+
+from pyrecest.backend import allclose, array, eye
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.distributions.cart_prod.cart_prod_stacked_distribution import (
+    CartProdStackedDistribution,
+)
+
+
+class ConcreteCartProdStackedDistribution(CartProdStackedDistribution):
+    @property
+    def input_dim(self):
+        return sum(dist.input_dim for dist in self.dists)
+
+    def get_manifold_size(self):
+        return float("inf")
+
+
+class TestCartProdStackedDistribution(unittest.TestCase):
+    def test_shift_uses_cumulative_component_dimensions(self):
+        dist = ConcreteCartProdStackedDistribution(
+            [
+                GaussianDistribution(array([1.0, 2.0]), eye(2)),
+                GaussianDistribution(array([3.0, 4.0, 5.0]), eye(3)),
+            ]
+        )
+
+        shifted = dist.shift(array([10.0, 20.0, 30.0, 40.0, 50.0]))
+
+        self.assertIsInstance(shifted, ConcreteCartProdStackedDistribution)
+        self.assertTrue(allclose(shifted.dists[0].mu, array([11.0, 22.0])))
+        self.assertTrue(allclose(shifted.dists[1].mu, array([33.0, 44.0, 55.0])))
+
+    def test_set_mode_preserves_concrete_distribution_type(self):
+        dist = ConcreteCartProdStackedDistribution(
+            [
+                GaussianDistribution(array([1.0, 2.0]), eye(2)),
+                GaussianDistribution(array([3.0, 4.0, 5.0]), eye(3)),
+            ]
+        )
+
+        shifted = dist.set_mode(array([10.0, 20.0, 30.0, 40.0, 50.0]))
+
+        self.assertIsInstance(shifted, ConcreteCartProdStackedDistribution)
+        self.assertTrue(allclose(shifted.dists[0].mu, array([10.0, 20.0])))
+        self.assertTrue(allclose(shifted.dists[1].mu, array([30.0, 40.0, 50.0])))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- preserve the concrete Cartesian product distribution subclass from `shift()` and `set_mode()`
- use cumulative component dimensions when slicing `shift_by` offsets
- add regression coverage for stacked Cartesian product updates

## Tests
- `PYTHONPATH=src py -3.12 -m pytest tests/distributions/test_cart_prod_stacked_distribution.py tests/distributions/test_se3_lin_vel_cart_prod_stacked_distribution.py -q`
- `py -3.12 -m ruff check src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py tests/distributions/test_cart_prod_stacked_distribution.py`
- `git diff --check`

Pylint was not run locally because it is not installed in this workspace (`No module named pylint`).