### PR TITLE
Fix cart product PDF component slicing

### DIFF
--- a/src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py
@@ -1,6 +1,6 @@
 # pylint: disable=no-name-in-module,no-member
 from beartype import beartype
-from pyrecest.backend import concatenate, empty, hstack, prod
+from pyrecest.backend import concatenate, hstack, prod, stack
 
 from .abstract_cart_prod_distribution import AbstractCartProdDistribution
 
@@ -16,12 +16,17 @@ class CartProdStackedDistribution(AbstractCartProdDistribution):
         return hstack([dist.sample(n) for dist in self.dists])
 
     def pdf(self, xs):
-        ps = empty((len(self.dists), xs.shape[1]))
+        ps = []
         next_dim = 0
-        for i, dist in enumerate(self.dists):
-            ps[i, :] = dist.pdf(xs[next_dim : next_dim + dist.dim, :])  # noqa: E203
-            next_dim += dist.dim
-        return prod(ps, axis=0)
+        for dist in self.dists:
+            next_input_dim = next_dim + dist.input_dim
+            if xs.ndim == 1:
+                xs_curr = xs[next_dim:next_input_dim]
+            else:
+                xs_curr = xs[:, next_dim:next_input_dim]
+            ps.append(dist.pdf(xs_curr))
+            next_dim = next_input_dim
+        return prod(stack(ps), axis=0)
 
     def shift(self, shift_by):
         assert len(shift_by) == self.dim, "Incorrect number of offsets"

--- a/tests/distributions/test_cart_prod_stacked_distribution.py
+++ b/tests/distributions/test_cart_prod_stacked_distribution.py
@@ -17,6 +17,35 @@ class ConcreteCartProdStackedDistribution(CartProdStackedDistribution):
 
 
 class TestCartProdStackedDistribution(unittest.TestCase):
+    def test_pdf_slices_component_columns_for_batched_samples(self):
+        dist = ConcreteCartProdStackedDistribution(
+            [
+                GaussianDistribution(array([0.0, 0.0]), eye(2)),
+                GaussianDistribution(array([0.0, 0.0, 0.0]), eye(3)),
+            ]
+        )
+        xs = array([[1.0, 2.0, 3.0, 4.0, 5.0], [0.5, 1.5, 2.5, 3.5, 4.5]])
+
+        pdf_values = dist.pdf(xs)
+        expected = dist.dists[0].pdf(xs[:, :2]) * dist.dists[1].pdf(xs[:, 2:])
+
+        self.assertEqual(pdf_values.shape, (2,))
+        self.assertTrue(allclose(pdf_values, expected))
+
+    def test_pdf_slices_component_entries_for_single_sample(self):
+        dist = ConcreteCartProdStackedDistribution(
+            [
+                GaussianDistribution(array([0.0, 0.0]), eye(2)),
+                GaussianDistribution(array([0.0, 0.0, 0.0]), eye(3)),
+            ]
+        )
+        x = array([1.0, 2.0, 3.0, 4.0, 5.0])
+
+        pdf_value = dist.pdf(x)
+        expected = dist.dists[0].pdf(x[:2]) * dist.dists[1].pdf(x[2:])
+
+        self.assertTrue(allclose(pdf_value, expected))
+
     def test_shift_uses_cumulative_component_dimensions(self):
         dist = ConcreteCartProdStackedDistribution(
             [


### PR DESCRIPTION
## Summary
- slice Cartesian product PDF inputs along the trailing component dimension
- use component `input_dim` widths so embedded manifolds are handled correctly
- add batched and single-sample regression coverage for stacked Cartesian product PDFs

## Tests
- `PYTHONPATH=src py -3.12 -m pytest tests/distributions/test_cart_prod_stacked_distribution.py tests/distributions/test_se3_lin_vel_cart_prod_stacked_distribution.py -q`
- `py -3.12 -m ruff check src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py tests/distributions/test_cart_prod_stacked_distribution.py`
- `git diff --check`

Pylint was not run locally because it is not installed in this workspace (`No module named pylint`).