### PR TITLE
Validate Dirac sample counts

### DIFF
--- a/src/pyrecest/distributions/abstract_dirac_distribution.py
+++ b/src/pyrecest/distributions/abstract_dirac_distribution.py
@@ -1,6 +1,7 @@
 import copy
 import warnings
 from collections.abc import Callable
+from numbers import Integral
 from typing import Union
 
 from beartype import beartype
@@ -109,7 +110,9 @@ class AbstractDiracDistribution(AbstractDistributionType):
         return dist
 
     def sample(self, n: Union[int, int32, int64]):
-        indices = random.choice(arange(self.d.shape[0]), n, p=self.w)
+        if isinstance(n, bool) or not isinstance(n, Integral) or int(n) <= 0:
+            raise ValueError("n must be a positive integer.")
+        indices = random.choice(arange(self.d.shape[0]), int(n), p=self.w)
         samples = self.d[indices]
         return samples
 

--- a/tests/distributions/test_abstract_dirac_distribution.py
+++ b/tests/distributions/test_abstract_dirac_distribution.py
@@ -41,6 +41,17 @@ class TestAbstractDiracDistribution(unittest.TestCase):
             ),
         )
 
+    def test_sample_rejects_invalid_count(self):
+        dist = LinearDiracDistribution(
+            array([[0.0], [1.0]]),
+            array([0.25, 0.75]),
+        )
+
+        for n in (0, -1, 1.5, True):
+            with self.subTest(n=n):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
+                    dist.sample(n)
+
     def test_mode_returns_highest_weighted_dirac(self):
         dist = LinearDiracDistribution(
             array(


### PR DESCRIPTION
## Summary
- reject non-positive, non-integral, and boolean sample counts in the base Dirac sampler
- convert validated integer-like counts before backend random choice
- add regression coverage for invalid LinearDiracDistribution sample counts

## Tests
- `PYTHONPATH=src py -3.12 -m pytest tests/distributions/test_abstract_dirac_distribution.py tests/distributions/test_linear_dirac_distribution.py -q`
- `PYTHONPATH=src py -3.12 -m pytest @files -q` with `files` enumerating `tests/distributions/test_*dirac*.py`
- `py -3.12 -m ruff check src/pyrecest/distributions/abstract_dirac_distribution.py tests/distributions/test_abstract_dirac_distribution.py`
- `git diff --check`

Pylint was not run locally because it is not installed in this workspace (`No module named pylint`).