### PR TITLE
Validate linear box particle counts

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/linear_box_particle_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/linear_box_particle_distribution.py
@@ -2,6 +2,7 @@
 
 import copy
 import warnings
+from numbers import Integral
 from typing import Union
 
 # pylint: disable=no-name-in-module,no-member,redefined-builtin
@@ -168,7 +169,7 @@ class LinearBoxParticleDistribution(AbstractLinearDistribution):
 
     def sample(self, n: Union[int, int32, int64]):
         """Draw point samples from the represented box mixture."""
-        n = int(n)
+        n = self._validate_particle_count(n)
         indices = random.choice(arange(self.w.shape[0]), n, p=self.w)
         lower = self.lower[indices]
         upper = self.upper[indices]
@@ -295,16 +296,27 @@ class LinearBoxParticleDistribution(AbstractLinearDistribution):
                 "LinearBoxParticleDistribution.from_distribution requires "
                 "n_particles, n_samples, or n."
             )
-        particle_counts = [int(value) for value in specified_counts]
+        particle_counts = [
+            LinearBoxParticleDistribution._validate_particle_count(value)
+            for value in specified_counts
+        ]
         if len(set(particle_counts)) != 1:
             raise ValueError(
                 "n_particles, n_samples, and n must agree when more than one "
                 "particle-count alias is supplied."
             )
         particle_count = particle_counts[0]
-        if particle_count <= 0:
-            raise ValueError("Number of particles must be positive.")
         return particle_count
+
+    @staticmethod
+    def _validate_particle_count(value):
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, Integral)
+            or int(value) <= 0
+        ):
+            raise ValueError("Number of particles must be a positive integer.")
+        return int(value)
 
     @staticmethod
     def _coerce_half_width(box_half_width, dim):

--- a/tests/distributions/test_linear_box_particle_distribution.py
+++ b/tests/distributions/test_linear_box_particle_distribution.py
@@ -25,10 +25,26 @@ class LinearBoxParticleDistributionTest(unittest.TestCase):
             dist.pdf(array([-1.0, 0.5, 1.5, 3.0])), array([0.0, 0.5, 0.5, 0.0])
         )
 
+    def test_sample_rejects_invalid_count(self):
+        dist = LinearBoxParticleDistribution(array([[0.0]]), array([[2.0]]))
+
+        for n in (0, -1, 1.5, True):
+            with self.subTest(n=n):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
+                    dist.sample(n)
+
     def test_integrate_query_box(self):
         dist = LinearBoxParticleDistribution(array([[0.0]]), array([[4.0]]), ones(1))
 
         npt.assert_allclose(dist.integrate(array([1.0]), array([3.0])), 0.5)
+
+    def test_from_distribution_rejects_invalid_particle_count_aliases(self):
+        for n_particles in (0, -1, 1.5, True):
+            with self.subTest(n_particles=n_particles):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
+                    LinearBoxParticleDistribution.from_distribution(
+                        object(), n_particles=n_particles
+                    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- reject non-positive, non-integral, and boolean sample counts in `LinearBoxParticleDistribution.sample`
- apply the same validation to `from_distribution` particle-count aliases before sampling
- add regression coverage for invalid direct and aliased particle counts

## Tests
- `PYTHONPATH=src py -3.12 -m pytest tests/distributions/test_linear_box_particle_distribution.py tests/filters/test_euclidean_box_particle_filter.py -q`
- `py -3.12 -m ruff check src/pyrecest/distributions/nonperiodic/linear_box_particle_distribution.py tests/distributions/test_linear_box_particle_distribution.py`
- `git diff --check`

Pylint was not run locally because it is not installed in this workspace (`No module named pylint`).