### PR TITLE
Validate ellipsoidal ball sample counts

### DIFF
--- a/src/pyrecest/distributions/ellipsoidal_ball_uniform_distribution.py
+++ b/src/pyrecest/distributions/ellipsoidal_ball_uniform_distribution.py
@@ -1,3 +1,4 @@
+from numbers import Integral
 from typing import Union
 
 # pylint: disable=no-name-in-module,no-member
@@ -80,6 +81,9 @@ class EllipsoidalBallUniformDistribution(
         :param n: Number of samples to generate.
         :returns: Generated samples.
         """
+        if isinstance(n, bool) or not isinstance(n, Integral) or int(n) <= 0:
+            raise ValueError("n must be a positive integer.")
+        n = int(n)
         random_points = random.normal(size=(n, self.dim))
         random_points /= linalg.norm(random_points, axis=1).reshape(-1, 1)
 

--- a/tests/distributions/test_ellipsoidal_ball_uniform_distribution.py
+++ b/tests/distributions/test_ellipsoidal_ball_uniform_distribution.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
@@ -31,6 +32,25 @@ class TestEllipsoidalBallUniformDistribution(unittest.TestCase):
         self.assertEqual(samples.shape[0], 10.0)
         p = dist.pdf(samples)
         self.assertTrue(all(p == p[0]))
+
+    def test_sampling_accepts_integer_like_count(self):
+        dist = EllipsoidalBallUniformDistribution(
+            array([2.0, 3.0]), array([[4.0, 3.0], [3.0, 9.0]])
+        )
+
+        samples = dist.sample(np.int64(4))
+
+        self.assertEqual(samples.shape, (4, dist.dim))
+
+    def test_sampling_rejects_invalid_count(self):
+        dist = EllipsoidalBallUniformDistribution(
+            array([2.0, 3.0]), array([[4.0, 3.0], [3.0, 9.0]])
+        )
+
+        for n in (0, -1, 1.5, True):
+            with self.subTest(n=n):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
+                    dist.sample(n)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- reject non-positive, non-integral, and boolean sample counts in ellipsoidal-ball uniform sampling
- convert validated integer-like counts before building backend random sample shapes
- add regression coverage for invalid counts and `np.int64` counts

## Tests
- `PYTHONPATH=src py -3.12 -m pytest tests/distributions/test_ellipsoidal_ball_uniform_distribution.py -q`
- `py -3.12 -m ruff check src/pyrecest/distributions/ellipsoidal_ball_uniform_distribution.py tests/distributions/test_ellipsoidal_ball_uniform_distribution.py`
- `git diff --check`

Pylint was not run locally because it is not installed in this workspace (`No module named pylint`).