### PR TITLE
Validate wrapped normal sample counts

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
@@ -1,3 +1,4 @@
+from numbers import Integral
 from typing import Union
 
 import pyrecest.backend
@@ -236,6 +237,9 @@ class WrappedNormalDistribution(
         )
 
     def sample(self, n: Union[int, int32, int64]):
+        if isinstance(n, bool) or not isinstance(n, Integral) or int(n) <= 0:
+            raise ValueError("n must be a positive integer.")
+        n = int(n)
         return mod(self.scalar_mu + self.sigma * random.normal(size=(n,)), 2.0 * pi)
 
     def to_dirac5(self):

--- a/tests/distributions/test_wrapped_normal_distribution.py
+++ b/tests/distributions/test_wrapped_normal_distribution.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 import pyrecest.backend
 
@@ -157,6 +158,17 @@ class WrappedNormalDistributionTest(unittest.TestCase):
         self.assertTrue(allclose(convolved.mu, array(0.7), atol=1e-12))
         self.assertTrue(allclose(convolved.C, array(13.0), atol=1e-12))
         self.assertTrue(allclose(convolved.sigma, sqrt(array(13.0)), atol=1e-12))
+
+    def test_sample_accepts_integer_like_count(self):
+        samples = self.wn.sample(np.int64(4))
+
+        self.assertEqual(samples.shape, (4,))
+
+    def test_sample_rejects_invalid_count(self):
+        for n in (0, -1, 1.5, True):
+            with self.subTest(n=n):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
+                    self.wn.sample(n)
 
     def test_shift_accepts_scalar_and_singleton_sequence_inputs(self):
         dist = WrappedNormalDistribution(array(0.3), array(0.4))


### PR DESCRIPTION
## Summary
- reject non-positive, non-integral, and boolean sample counts in wrapped-normal sampling
- convert validated integer-like counts before building backend random sample shapes
- add regression coverage for invalid counts and `np.int64` counts

## Tests
- `PYTHONPATH=src py -3.12 -m pytest tests/distributions/test_wrapped_normal_distribution.py tests/distributions/test_circular_grid_distribution.py -q`
- `py -3.12 -m ruff check src/pyrecest/distributions/circle/wrapped_normal_distribution.py tests/distributions/test_wrapped_normal_distribution.py`
- `git diff --check`

Pylint was not run locally because it is not installed in this workspace (`No module named pylint`).