### PR TITLE
Validate wrapped exponential sample counts

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
@@ -1,4 +1,5 @@
 # pylint: disable=no-name-in-module,no-member
+from numbers import Integral
 from typing import Union
 
 # pylint: disable=redefined-builtin
@@ -33,6 +34,9 @@ class WrappedExponentialDistribution(AbstractCircularDistribution):
         return 1.0 / (1.0 - 1j * n / self.lambda_)
 
     def sample(self, n: Union[int, int32, int64]):
+        if isinstance(n, bool) or not isinstance(n, Integral) or int(n) <= 0:
+            raise ValueError("n must be a positive integer.")
+        n = int(n)
         # Use inverse CDF method: X = -ln(U)/lambda ~ Exp(lambda), then wrap
         u = random.uniform(size=(n,))
         return mod(-log(u) / self.lambda_, 2.0 * pi)

--- a/tests/distributions/test_wrapped_exponential_distribution.py
+++ b/tests/distributions/test_wrapped_exponential_distribution.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
@@ -84,6 +85,17 @@ class WrappedExponentialDistributionTest(unittest.TestCase):
         self.assertEqual(s.shape, (n,))
         self.assertTrue((s >= 0).all())
         self.assertTrue((s < 2.0 * pi).all())
+
+    def test_sample_accepts_integer_like_count(self):
+        samples = self.we.sample(np.int64(4))
+
+        self.assertEqual(samples.shape, (4,))
+
+    def test_sample_rejects_invalid_count(self):
+        for n in (0, -1, 1.5, True):
+            with self.subTest(n=n):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
+                    self.we.sample(n)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- reject non-positive, non-integral, and boolean sample counts in wrapped-exponential sampling
- convert validated integer-like counts before building backend random sample shapes
- add regression coverage for invalid counts and `np.int64` counts

## Tests
- `PYTHONPATH=src py -3.12 -m pytest tests/distributions/test_wrapped_exponential_distribution.py tests/distributions/test_wrapped_laplace_distribution.py -q`
- `py -3.12 -m ruff check src/pyrecest/distributions/circle/wrapped_exponential_distribution.py tests/distributions/test_wrapped_exponential_distribution.py`
- `git diff --check`

Pylint was not run locally because it is not installed in this workspace (`No module named pylint`).