### PR TITLE
Validate von Mises sample counts

### DIFF
--- a/src/pyrecest/distributions/circle/von_mises_distribution.py
+++ b/src/pyrecest/distributions/circle/von_mises_distribution.py
@@ -1,5 +1,6 @@
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 from math import isfinite
+from numbers import Integral
 
 from pyrecest.backend import (
     abs,
@@ -63,9 +64,12 @@ class VonMisesDistribution(AbstractCircularDistribution):
 
     def sample(self, n):
         """Draw samples from the von Mises distribution."""
+        if isinstance(n, bool) or not isinstance(n, Integral) or int(n) <= 0:
+            raise ValueError("n must be a positive integer.")
+        n = int(n)
         return mod(
             array(
-                vonmises.rvs(kappa=float(self.kappa), loc=float(self.mu), size=int(n))
+                vonmises.rvs(kappa=float(self.kappa), loc=float(self.mu), size=n)
             ),
             2.0 * pi,
         )

--- a/tests/distributions/test_von_mises_distribution.py
+++ b/tests/distributions/test_von_mises_distribution.py
@@ -2,6 +2,7 @@ import unittest
 
 import matplotlib
 import matplotlib.pyplot as plt
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
@@ -75,6 +76,21 @@ class TestVonMisesDistribution(unittest.TestCase):
 
         self.assertTrue(allclose(convolved.kappa, array(0.0), atol=1e-14))
         self.assertTrue(allclose(abs(convolved.trigonometric_moment(1)), array(0.0)))
+
+    def test_sample_accepts_integer_like_count(self):
+        dist = VonMisesDistribution(array(0.3), array(1.0))
+
+        samples = dist.sample(np.int64(4))
+
+        self.assertEqual(samples.shape, (4,))
+
+    def test_sample_rejects_invalid_count(self):
+        dist = VonMisesDistribution(array(0.3), array(1.0))
+
+        for n in (0, -1, 1.5, True):
+            with self.subTest(n=n):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
+                    dist.sample(n)
 
     def test_plot(self):
         matplotlib.pyplot.close("all")


### PR DESCRIPTION
## Summary
- reject non-positive, non-integral, and boolean sample counts in von Mises sampling
- convert validated integer-like counts before passing size to scipy
- add regression coverage for invalid counts and `np.int64` counts

## Tests
- `PYTHONPATH=src py -3.12 -m pytest tests/distributions/test_von_mises_distribution.py tests/filters/test_von_mises_filter.py tests/distributions/test_circular_mixture.py -q`
- `py -3.12 -m ruff check src/pyrecest/distributions/circle/von_mises_distribution.py tests/distributions/test_von_mises_distribution.py`
- `git diff --check`

Pylint was not run locally because it is not installed in this workspace (`No module named pylint`).