### PR TITLE
Validate circular mixture sample counts

### DIFF
--- a/src/pyrecest/distributions/circle/circular_mixture.py
+++ b/src/pyrecest/distributions/circle/circular_mixture.py
@@ -1,4 +1,5 @@
 import collections
+from numbers import Integral
 import warnings
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
@@ -102,6 +103,10 @@ class CircularMixture(AbstractCircularDistribution, HypertoroidalMixture):
         Returning a flat vector here preserves that circular API and avoids
         assigning ``(k,)`` component samples into ``(k, 1)`` slices.
         """
+        if isinstance(n, bool) or not isinstance(n, Integral) or int(n) <= 0:
+            raise ValueError("n must be a positive integer.")
+        n = int(n)
+
         occurrences = random.multinomial(n, self.w)
         samples = []
 

--- a/tests/distributions/test_circular_mixture.py
+++ b/tests/distributions/test_circular_mixture.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
@@ -54,6 +55,19 @@ class TestCircularMixture(unittest.TestCase):
         samples = mixture.sample(5)
 
         self.assertEqual(samples.shape, (5,))
+
+    def test_sample_accepts_integer_like_count(self):
+        mixture = CircularMixture([self.dist1], array([1.0]))
+
+        samples = mixture.sample(np.int64(4))
+
+        self.assertEqual(samples.shape, (4,))
+
+    def test_sample_rejects_invalid_count(self):
+        for n in (0, -1, 1.5, True):
+            with self.subTest(n=n):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
+                    self.mixture.sample(n)
 
     def test_init_accepts_list_weights_and_keeps_parent_normalization(self):
         with self.assertWarns(UserWarning):


### PR DESCRIPTION
## Summary
- Validate `CircularMixture.sample` counts before dispatching to backend multinomial sampling.
- Reject zero, negative, floating-point, and boolean counts with a clear `ValueError`.
- Add regression coverage for invalid counts and integer-like NumPy counts.

## Root Cause
`CircularMixture.sample` passed `n` directly to `random.multinomial`, so values such as `1.5` and `True` were silently interpreted as one draw while `False` returned an empty sample vector.

## Tests
- `PYTHONPATH=src py -3.12 -m pytest tests/distributions/test_circular_mixture.py -q`
- `py -3.12 -m ruff check src/pyrecest/distributions/circle/circular_mixture.py tests/distributions/test_circular_mixture.py`
- `git diff --check`
- `PYTHONPATH=src py -3.12 -m pylint --disable=import-error src/pyrecest/distributions/circle/circular_mixture.py tests/distributions/test_circular_mixture.py`