### PR TITLE
Validate mixture sample counts

### DIFF
--- a/src/pyrecest/distributions/abstract_mixture.py
+++ b/src/pyrecest/distributions/abstract_mixture.py
@@ -3,6 +3,7 @@ import copy
 import warnings
 from typing import Union
 
+import numpy as np
 import pyrecest.backend
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
@@ -24,6 +25,28 @@ from .abstract_distribution_type import AbstractDistributionType
 from .abstract_manifold_specific_distribution import (
     AbstractManifoldSpecificDistribution,
 )
+
+
+def _validate_positive_sample_count(n) -> int:
+    count_array = np.asarray(n)
+    if count_array.ndim != 0:
+        raise ValueError("n must be a scalar integer")
+
+    count = count_array.item()
+    if isinstance(count, (bool, np.bool_)):
+        raise ValueError("n must be an integer, not a boolean")
+
+    try:
+        count_int = int(count)
+        count_float = float(count)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("n must be an integer") from exc
+
+    if not np.isfinite(count_float) or not count_float.is_integer():
+        raise ValueError("n must be a finite integer")
+    if count_int <= 0:
+        raise ValueError("n must be positive")
+    return count_int
 
 
 class AbstractMixture(AbstractDistributionType):
@@ -99,6 +122,7 @@ class AbstractMixture(AbstractDistributionType):
         return pyrecest.backend.atleast_2d(samples)
 
     def sample(self, n: Union[int, int32, int64]):
+        n = _validate_positive_sample_count(n)
         occurrences = random.multinomial(n, self.w)
         if pyrecest.backend.__backend_name__ == "jax":
             samples = []

--- a/tests/distributions/test_linear_mixture.py
+++ b/tests/distributions/test_linear_mixture.py
@@ -1,6 +1,7 @@
 import unittest
 from warnings import catch_warnings, simplefilter
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
@@ -99,6 +100,33 @@ class LinearMixtureTest(unittest.TestCase):
         samples = lm.sample(5)
 
         self.assertEqual(samples.shape, (5, 1))
+
+    def test_sample_accepts_integer_like_count(self):
+        mixture = GaussianMixture(
+            [
+                GaussianDistribution(array([0.0, 0.0]), diag(array([1.0, 1.0]))),
+                GaussianDistribution(array([1.0, 1.0]), diag(array([1.0, 1.0]))),
+            ],
+            array([0.25, 0.75]),
+        )
+
+        samples = mixture.sample(np.array(4.0))
+
+        self.assertEqual(samples.shape, (4, 2))
+
+    def test_sample_rejects_invalid_count(self):
+        mixture = GaussianMixture(
+            [
+                GaussianDistribution(array([0.0, 0.0]), diag(array([1.0, 1.0]))),
+                GaussianDistribution(array([1.0, 1.0]), diag(array([1.0, 1.0]))),
+            ],
+            array([0.25, 0.75]),
+        )
+
+        for n in (0, -1, 1.5, True, [3]):
+            with self.subTest(n=n):
+                with self.assertRaises(ValueError):
+                    mixture.sample(n)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Validate `AbstractMixture.sample` counts before backend multinomial sampling.
- Reject zero, negative, non-integer, boolean, and nonscalar counts with consistent `ValueError`s.
- Add regression coverage through `GaussianMixture`, which uses the generic mixture sampler.

## Root Cause
The generic mixture sampler passed `n` directly to `random.multinomial` and then used it for allocation. That let `sample(0)` silently return an empty sample array and left floats/booleans to fail with backend-specific errors instead of the distribution API rejecting invalid sample counts consistently.

## Tests
- `PYTHONPATH=src py -3.12 -m pytest tests/distributions/test_linear_mixture.py tests/distributions/test_abstract_mixture.py -q`
- `py -3.12 -m ruff check src/pyrecest/distributions/abstract_mixture.py tests/distributions/test_linear_mixture.py`
- `PYTHONPATH=src py -3.12 -m pylint --disable=import-error src/pyrecest/distributions/abstract_mixture.py tests/distributions/test_linear_mixture.py`
- `git diff --check`