### PR TITLE
Reject boolean Gaussian sample counts

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
@@ -8,7 +8,6 @@ import pyrecest.backend
 from pyrecest.backend import all as backend_all
 from pyrecest.backend import (
     allclose,
-    asarray,
     exp,
     eye,
     linalg,
@@ -296,7 +295,7 @@ class GaussianDistribution(AbstractLinearDistribution):
 
     def sample(self, n):
         """Draw ``n`` random samples with shape ``(n, dim)``."""
-        if not isinstance(n, Integral) or int(n) <= 0:
+        if isinstance(n, bool) or not isinstance(n, Integral) or int(n) <= 0:
             raise ValueError("n must be a positive integer.")
         return random.multivariate_normal(mean=self.mu, cov=self.C, size=int(n))
 

--- a/tests/distributions/test_gaussian_distribution.py
+++ b/tests/distributions/test_gaussian_distribution.py
@@ -79,6 +79,14 @@ class GaussianDistributionTest(unittest.TestCase):
             ),
         )
 
+    def test_sample_rejects_invalid_count(self):
+        g = GaussianDistribution(array([1.0, 2.0, 3.0]), diag(array([1.0, 1.0, 1.0])))
+
+        for n in (0, -1, 1.5, True):
+            with self.subTest(n=n):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
+                    g.sample(n)
+
     def test_rejects_nonsymmetric_2d_covariance(self):
         mu = array([0.0, 0.0])
         C = array([[1.0, 10.0], [0.0, 1.0]])


### PR DESCRIPTION
## Summary
- Reject boolean values in `GaussianDistribution.sample` instead of treating `True` as one sample.
- Add regression coverage for invalid Gaussian sample counts.
- Remove a dead backend import from the touched module so Pylint stays clean.

## Root Cause
`bool` is a subclass of `numbers.Integral`, so the sampler's existing integer guard allowed `True` through and passed `size=1` to backend normal sampling.

## Tests
- `PYTHONPATH=src py -3.12 -m pytest tests/distributions/test_gaussian_distribution.py -q`
- `py -3.12 -m ruff check src/pyrecest/distributions/nonperiodic/gaussian_distribution.py tests/distributions/test_gaussian_distribution.py`
- `PYTHONPATH=src py -3.12 -m pylint --disable=import-error src/pyrecest/distributions/nonperiodic/gaussian_distribution.py tests/distributions/test_gaussian_distribution.py`
- `git diff --check`