### PR TITLE
Validate piecewise constant sample counts

### DIFF
--- a/src/pyrecest/distributions/circle/piecewise_constant_distribution.py
+++ b/src/pyrecest/distributions/circle/piecewise_constant_distribution.py
@@ -1,4 +1,5 @@
 # pylint: disable=no-name-in-module,no-member,redefined-builtin
+import numpy as np
 import pyrecest.backend
 from pyrecest.backend import (
     arange,
@@ -15,6 +16,28 @@ from pyrecest.backend import (
 )
 
 from .abstract_circular_distribution import AbstractCircularDistribution
+
+
+def _validate_positive_sample_count(n) -> int:
+    count_array = np.asarray(n)
+    if count_array.ndim != 0:
+        raise ValueError("n must be a scalar integer")
+
+    count = count_array.item()
+    if isinstance(count, (bool, np.bool_)):
+        raise ValueError("n must be an integer, not a boolean")
+
+    try:
+        count_int = int(count)
+        count_float = float(count)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("n must be an integer") from exc
+
+    if not np.isfinite(count_float) or not count_float.is_integer():
+        raise ValueError("n must be a finite integer")
+    if count_int <= 0:
+        raise ValueError("n must be positive")
+    return count_int
 
 
 class PiecewiseConstantDistribution(AbstractCircularDistribution):
@@ -122,6 +145,7 @@ class PiecewiseConstantDistribution(AbstractCircularDistribution):
         """
         if pyrecest.backend.__backend_name__ == "jax":  # pylint: disable=no-member
             raise NotImplementedError("sample is not supported on the JAX backend.")
+        n = _validate_positive_sample_count(n)
         num_intervals = len(self.w)
         interval_width = 2.0 * pi / num_intervals
         # Each interval has probability w[j] * interval_width, which sums to 1 by

--- a/tests/distributions/test_piecewise_constant_distribution.py
+++ b/tests/distributions/test_piecewise_constant_distribution.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 import pyrecest.backend
 
@@ -121,6 +122,25 @@ class PiecewiseConstantDistributionTest(unittest.TestCase):
         self.assertEqual(len(samples), 100)
         self.assertTrue(all(samples >= 0.0))
         self.assertTrue(all(samples < 2.0 * pi))
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on JAX backend",
+    )
+    def test_sample_accepts_integer_like_count(self):
+        samples = self.dist.sample(np.array(4.0))
+
+        self.assertEqual(samples.shape, (4,))
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on JAX backend",
+    )
+    def test_sample_rejects_invalid_count(self):
+        for n in (0, -1, 1.5, True, [3]):
+            with self.subTest(n=n):
+                with self.assertRaises(ValueError):
+                    self.dist.sample(n)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Validate `PiecewiseConstantDistribution.sample` counts before passing them into backend random shape arguments.
- Preserve scalar integer-like inputs such as backend scalar arrays.
- Add regression coverage for valid scalar-array counts and invalid zero, negative, fractional, boolean, and nonscalar counts.

## Root Cause
`PiecewiseConstantDistribution.sample` used `n` directly in `size=(n,)`. That let `sample(0)` silently return an empty vector and caused other invalid counts to fail with backend-specific shape errors instead of a consistent distribution API error.

## Tests
- `PYTHONPATH=src py -3.12 -m pytest tests/distributions/test_piecewise_constant_distribution.py -q`
- `py -3.12 -m ruff check src/pyrecest/distributions/circle/piecewise_constant_distribution.py tests/distributions/test_piecewise_constant_distribution.py`
- `PYTHONPATH=src py -3.12 -m pylint --disable=import-error src/pyrecest/distributions/circle/piecewise_constant_distribution.py tests/distributions/test_piecewise_constant_distribution.py`
- `git diff --check`