### PR TITLE
Validate partially wrapped normal sample counts

### DIFF
--- a/src/pyrecest/distributions/cart_prod/partially_wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/partially_wrapped_normal_distribution.py
@@ -1,6 +1,7 @@
 import copy
 from typing import Union
 
+import numpy as np
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
@@ -63,6 +64,28 @@ def _as_2d_query_points(xs, dim: int):
             f"{dim}, got shape {xs.shape}."
         )
     return reshape(xs, (-1, dim))
+
+
+def _validate_positive_sample_count(n) -> int:
+    count_array = np.asarray(n)
+    if count_array.ndim != 0:
+        raise ValueError("n must be a scalar integer")
+
+    count = count_array.item()
+    if isinstance(count, (bool, np.bool_)):
+        raise ValueError("n must be an integer, not a boolean")
+
+    try:
+        count_int = int(count)
+        count_float = float(count)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("n must be an integer") from exc
+
+    if not np.isfinite(count_float) or not count_float.is_integer():
+        raise ValueError("n must be a finite integer")
+    if count_int <= 0:
+        raise ValueError("n must be positive")
+    return count_int
 
 
 class PartiallyWrappedNormalDistribution(AbstractHypercylindricalDistribution):
@@ -206,7 +229,7 @@ class PartiallyWrappedNormalDistribution(AbstractHypercylindricalDistribution):
         Parameters:
             n (int): number of points to sample
         """
-        assert n > 0, "n must be positive"
+        n = _validate_positive_sample_count(n)
         s = random.multivariate_normal(mean=self.mu, cov=self.C, size=(n,))
         wrapped_values = mod(s[:, : self.bound_dim], 2.0 * pi)
         unbounded_values = s[:, self.bound_dim :]  # noqa: E203

--- a/tests/distributions/test_partially_wrapped_normal_distribution.py
+++ b/tests/distributions/test_partially_wrapped_normal_distribution.py
@@ -88,6 +88,17 @@ class TestPartiallyWrappedNormalDistribution(unittest.TestCase):
             rtol=5e-7,
         )
 
+    def test_sample_accepts_integer_like_count(self):
+        samples = self.dist_2d.sample(array(4))
+
+        self.assertEqual(samples.shape, (4, 2))
+
+    def test_sample_rejects_invalid_count(self):
+        for n in (0, -1, 1.5, True, [3]):
+            with self.subTest(n=n):
+                with self.assertRaises(ValueError):
+                    self.dist_2d.sample(n)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Validate `PartiallyWrappedNormalDistribution.sample` counts before using them as backend random shape arguments.
- Replace assertion-based validation with consistent `ValueError`s for zero, negative, fractional, boolean, and nonscalar counts.
- Add regression coverage for valid backend scalar counts and invalid sample counts.

## Root Cause
The sampler relied on `assert n > 0` and then passed `n` directly into `size=(n,)`. That made validation disappear under optimized Python and also leaked backend-specific shape/type errors for invalid counts.

## Tests
- `PYTHONPATH=src py -3.12 -m pytest tests/distributions/test_partially_wrapped_normal_distribution.py -q`
- `py -3.12 -m ruff check src/pyrecest/distributions/cart_prod/partially_wrapped_normal_distribution.py tests/distributions/test_partially_wrapped_normal_distribution.py`
- `PYTHONPATH=src py -3.12 -m pylint --disable=import-error src/pyrecest/distributions/cart_prod/partially_wrapped_normal_distribution.py tests/distributions/test_partially_wrapped_normal_distribution.py`
- `git diff --check`