### PR TITLE
Validate Gauss von Mises sample counts

### DIFF
--- a/src/pyrecest/distributions/cart_prod/gauss_von_mises_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/gauss_von_mises_distribution.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member,redefined-builtin
@@ -33,6 +34,28 @@ from scipy.stats import vonmises as _vonmises
 
 from ..nonperiodic.gaussian_distribution import GaussianDistribution
 from .abstract_hypercylindrical_distribution import AbstractHypercylindricalDistribution
+
+
+def _validate_positive_sample_count(n) -> int:
+    count_array = np.asarray(n)
+    if count_array.ndim != 0:
+        raise ValueError("n must be a scalar integer")
+
+    count = count_array.item()
+    if isinstance(count, (bool, np.bool_)):
+        raise ValueError("n must be an integer, not a boolean")
+
+    try:
+        count_int = int(count)
+        count_float = float(count)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("n must be an integer") from exc
+
+    if not np.isfinite(count_float) or not count_float.is_integer():
+        raise ValueError("n must be a finite integer")
+    if count_int <= 0:
+        raise ValueError("n must be positive")
+    return count_int
 
 
 class GaussVonMisesDistribution(AbstractHypercylindricalDistribution):
@@ -193,6 +216,7 @@ class GaussVonMisesDistribution(AbstractHypercylindricalDistribution):
         s : array of shape (lin_dim + 1, n)
             First row is periodic (angle), remaining rows are linear.
         """
+        n = _validate_positive_sample_count(n)
         s_gauss = random.multivariate_normal(
             mean=self.mu, cov=self.P, size=n
         ).T  # (linD, n)

--- a/tests/distributions/test_gauss_von_mises_distribution.py
+++ b/tests/distributions/test_gauss_von_mises_distribution.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 from pyrecest import backend
 from pyrecest.backend import (
     all,
@@ -104,6 +105,25 @@ class GaussVonMisesDistributionTest(unittest.TestCase):
             2.0 * float(pi),
         ) - float(pi)
         self.assertTrue(allclose(angle_error, zeros(expected_n - 3), atol=1e-10))
+
+    @unittest.skipIf(
+        backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_sample_accepts_integer_like_count(self):
+        samples = self.g.sample(np.array(4.0))
+
+        self.assertEqual(samples.shape, (self.g.lin_dim + self.g.bound_dim, 4))
+
+    @unittest.skipIf(
+        backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_sample_rejects_invalid_count(self):
+        for n in (0, -1, 1.5, True, [3]):
+            with self.subTest(n=n):
+                with self.assertRaises(ValueError):
+                    self.g.sample(n)
 
     def test_hybrid_moment(self):
         hm = self.g.hybrid_moment()


### PR DESCRIPTION
## Summary
- Validate `GaussVonMisesDistribution.sample` counts before calling backend and SciPy random samplers.
- Reject zero, negative, fractional, boolean, and nonscalar counts with consistent `ValueError`s.
- Add regression coverage for valid scalar-array counts and invalid sample counts.

## Root Cause
The sampler passed `n` directly into `random.multivariate_normal` and `scipy.stats.vonmises.rvs`. This let `sample(0)` return an empty sample matrix, accepted list-shaped counts such as `[3]`, and leaked backend-specific errors for other invalid counts.

## Tests
- `PYTHONPATH=src py -3.12 -m pytest tests/distributions/test_gauss_von_mises_distribution.py -q`
- `py -3.12 -m ruff check src/pyrecest/distributions/cart_prod/gauss_von_mises_distribution.py tests/distributions/test_gauss_von_mises_distribution.py`
- `PYTHONPATH=src py -3.12 -m pylint --disable=import-error src/pyrecest/distributions/cart_prod/gauss_von_mises_distribution.py tests/distributions/test_gauss_von_mises_distribution.py`
- `git diff --check`