### PR TITLE
Validate Mardia Sutton sample counts

### DIFF
--- a/src/pyrecest/distributions/cart_prod/mardia_sutton_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/mardia_sutton_distribution.py
@@ -1,4 +1,5 @@
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
+import numpy as np
 from pyrecest.backend import (
     array,
     atleast_2d,
@@ -15,6 +16,28 @@ from scipy.stats import norm, vonmises
 
 from ..circle.von_mises_distribution import VonMisesDistribution
 from .abstract_hypercylindrical_distribution import AbstractHypercylindricalDistribution
+
+
+def _validate_positive_sample_count(n) -> int:
+    count_array = np.asarray(n)
+    if count_array.ndim != 0:
+        raise ValueError("n must be a scalar integer")
+
+    count = count_array.item()
+    if isinstance(count, (bool, np.bool_)):
+        raise ValueError("n must be an integer, not a boolean")
+
+    try:
+        count_int = int(count)
+        count_float = float(count)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("n must be an integer") from exc
+
+    if not np.isfinite(count_float) or not count_float.is_integer():
+        raise ValueError("n must be a finite integer")
+    if count_int <= 0:
+        raise ValueError("n must be positive")
+    return count_int
 
 
 class MardiaSuttonDistribution(AbstractHypercylindricalDistribution):
@@ -110,7 +133,7 @@ class MardiaSuttonDistribution(AbstractHypercylindricalDistribution):
         Returns:
             s (n, 2): n samples on [0, 2π) × R (circular first, then linear)
         """
-        assert n > 0, "n must be positive"
+        n = _validate_positive_sample_count(n)
         s_vm = array(
             vonmises.rvs(kappa=float(self.kappa), loc=float(self.mu0), size=n)
             % (2.0 * float(pi))

--- a/tests/distributions/test_mardia_sutton_distribution.py
+++ b/tests/distributions/test_mardia_sutton_distribution.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
@@ -129,6 +130,17 @@ class TestMardiaSuttonDistribution(unittest.TestCase):
         s = self.dist.sample(n)
         self.assertTrue((s[:, 0] >= 0).all())
         self.assertTrue((s[:, 0] < 2.0 * float(pi)).all())
+
+    def test_sample_accepts_integer_like_count(self):
+        s = self.dist.sample(np.array(4.0))
+
+        self.assertEqual(s.shape, (4, 2))
+
+    def test_sample_rejects_invalid_count(self):
+        for n in (0, -1, 1.5, True, [3]):
+            with self.subTest(n=n):
+                with self.assertRaises(ValueError):
+                    self.dist.sample(n)
 
     def test_invalid_kappa(self):
         with self.assertRaises(AssertionError):


### PR DESCRIPTION
## Summary
- Validate `MardiaSuttonDistribution.sample` counts before passing them into SciPy random samplers.
- Replace assertion-based count checks with consistent `ValueError`s for zero, negative, fractional, boolean, and nonscalar counts.
- Add regression coverage for valid scalar-array counts and invalid sample counts.

## Root Cause
The sampler relied on `assert n > 0` and then passed `n` directly into SciPy `vonmises` and `norm` sampling. Invalid counts therefore produced assertion/backend errors instead of stable distribution API validation.

## Tests
- `PYTHONPATH=src py -3.12 -m pytest tests/distributions/test_mardia_sutton_distribution.py -q`
- `py -3.12 -m ruff check src/pyrecest/distributions/cart_prod/mardia_sutton_distribution.py tests/distributions/test_mardia_sutton_distribution.py`
- `PYTHONPATH=src py -3.12 -m pylint --disable=import-error src/pyrecest/distributions/cart_prod/mardia_sutton_distribution.py tests/distributions/test_mardia_sutton_distribution.py`
- `git diff --check`