### PR TITLE
Validate SE2 Bingham sample counts

### DIFF
--- a/src/pyrecest/distributions/cart_prod/se2_bingham_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/se2_bingham_distribution.py
@@ -26,6 +26,28 @@ from ..hypersphere_subset.bingham_distribution import BinghamDistribution
 from ..nonperiodic.custom_linear_distribution import CustomLinearDistribution
 
 
+def _validate_positive_sample_count(n) -> int:
+    count_array = np.asarray(n)
+    if count_array.ndim != 0:
+        raise ValueError("n must be a scalar integer")
+
+    count = count_array.item()
+    if isinstance(count, (bool, np.bool_)):
+        raise ValueError("n must be an integer, not a boolean")
+
+    try:
+        count_int = int(count)
+        count_float = float(count)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("n must be an integer") from exc
+
+    if not np.isfinite(count_float) or not count_float.is_integer():
+        raise ValueError("n must be a finite integer")
+    if count_int <= 0:
+        raise ValueError("n must be positive")
+    return count_int
+
+
 class SE2BinghamDistribution(AbstractSE2Distribution):
     """
     Distribution on SE(2) = S^1 x R^2.
@@ -191,7 +213,7 @@ class SE2BinghamDistribution(AbstractSE2Distribution):
         s : array, shape (n, 4)
             Samples in dual quaternion representation.
         """
-        assert n > 0, "n must be positive."
+        n = _validate_positive_sample_count(n)
         C3_inv = linalg.inv(array(self.C3, dtype=float))
 
         # Step 1: sample Bingham marginal via Schur complement eigendecomp

--- a/tests/distributions/test_se2_bingham_distribution.py
+++ b/tests/distributions/test_se2_bingham_distribution.py
@@ -129,6 +129,25 @@ class TestSE2BinghamDistribution(unittest.TestCase):
         pyrecest.backend.__backend_name__ == "jax",
         reason="Not supported on JAX backend",
     )
+    def test_sample_accepts_integer_like_count(self):
+        samples = self.dist.sample(np.array(4.0))
+
+        self.assertEqual(samples.shape, (4, 4))
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on JAX backend",
+    )
+    def test_sample_rejects_invalid_count(self):
+        for n in (0, -1, 1.5, True, [3]):
+            with self.subTest(n=n):
+                with self.assertRaises(ValueError):
+                    self.dist.sample(n)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on JAX backend",
+    )
     def test_fit_returns_instance(self):
         """fit() should return a valid SE2BinghamDistribution."""
         samples = self.dist.sample(500)


### PR DESCRIPTION
## Summary
- Validate `SE2BinghamDistribution.sample` counts before nested Bingham and Gaussian sampling.
- Replace assertion-based count checks with consistent `ValueError`s for zero, negative, fractional, boolean, and nonscalar counts.
- Add regression coverage for valid scalar-array counts and invalid sample counts.

## Root Cause
The sampler relied on `assert n > 0` and then passed `n` to nested sampling and backend random shape arguments. Invalid counts therefore produced assertion/backend errors instead of stable distribution API validation, and assertions can be disabled with optimized Python.

## Tests
- `PYTHONPATH=src py -3.12 -m pytest tests/distributions/test_se2_bingham_distribution.py -q`
- `py -3.12 -m ruff check src/pyrecest/distributions/cart_prod/se2_bingham_distribution.py tests/distributions/test_se2_bingham_distribution.py`
- `PYTHONPATH=src py -3.12 -m pylint --disable=import-error src/pyrecest/distributions/cart_prod/se2_bingham_distribution.py tests/distributions/test_se2_bingham_distribution.py`
- `git diff --check`