### PR TITLE
Validate stacked cart product sample counts

### DIFF
--- a/src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py
@@ -1,8 +1,30 @@
 # pylint: disable=no-name-in-module,no-member
-from beartype import beartype
+import numpy as np
 from pyrecest.backend import concatenate, hstack, prod, stack
 
 from .abstract_cart_prod_distribution import AbstractCartProdDistribution
+
+
+def _validate_positive_sample_count(n) -> int:
+    count_array = np.asarray(n)
+    if count_array.ndim != 0:
+        raise ValueError("n must be a scalar integer")
+
+    count = count_array.item()
+    if isinstance(count, (bool, np.bool_)):
+        raise ValueError("n must be an integer, not a boolean")
+
+    try:
+        count_int = int(count)
+        count_float = float(count)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("n must be an integer") from exc
+
+    if not np.isfinite(count_float) or not count_float.is_integer():
+        raise ValueError("n must be a finite integer")
+    if count_int <= 0:
+        raise ValueError("n must be positive")
+    return count_int
 
 
 class CartProdStackedDistribution(AbstractCartProdDistribution):
@@ -10,9 +32,8 @@ class CartProdStackedDistribution(AbstractCartProdDistribution):
         self.dists = dists
         AbstractCartProdDistribution.__init__(self, sum(dist.dim for dist in dists))
 
-    @beartype
     def sample(self, n: int):
-        assert n > 0, "n must be positive"
+        n = _validate_positive_sample_count(n)
         return hstack([dist.sample(n) for dist in self.dists])
 
     def pdf(self, xs):

--- a/tests/distributions/test_cart_prod_stacked_distribution.py
+++ b/tests/distributions/test_cart_prod_stacked_distribution.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 from pyrecest.backend import allclose, array, eye
 from pyrecest.distributions import GaussianDistribution
 from pyrecest.distributions.cart_prod.cart_prod_stacked_distribution import (
@@ -17,6 +18,43 @@ class ConcreteCartProdStackedDistribution(CartProdStackedDistribution):
 
 
 class TestCartProdStackedDistribution(unittest.TestCase):
+    def test_sample_returns_concatenated_component_samples(self):
+        dist = ConcreteCartProdStackedDistribution(
+            [
+                GaussianDistribution(array([0.0, 0.0]), eye(2)),
+                GaussianDistribution(array([0.0, 0.0, 0.0]), eye(3)),
+            ]
+        )
+
+        samples = dist.sample(5)
+
+        self.assertEqual(samples.shape, (5, 5))
+
+    def test_sample_accepts_integer_like_count(self):
+        dist = ConcreteCartProdStackedDistribution(
+            [
+                GaussianDistribution(array([0.0, 0.0]), eye(2)),
+                GaussianDistribution(array([0.0, 0.0, 0.0]), eye(3)),
+            ]
+        )
+
+        samples = dist.sample(np.array(4.0))
+
+        self.assertEqual(samples.shape, (4, 5))
+
+    def test_sample_rejects_invalid_count(self):
+        dist = ConcreteCartProdStackedDistribution(
+            [
+                GaussianDistribution(array([0.0, 0.0]), eye(2)),
+                GaussianDistribution(array([0.0, 0.0, 0.0]), eye(3)),
+            ]
+        )
+
+        for n in (0, -1, 1.5, True, [3]):
+            with self.subTest(n=n):
+                with self.assertRaises(ValueError):
+                    dist.sample(n)
+
     def test_pdf_slices_component_columns_for_batched_samples(self):
         dist = ConcreteCartProdStackedDistribution(
             [


### PR DESCRIPTION
## Summary
- Validate `CartProdStackedDistribution.sample` counts before sampling component distributions.
- Replace assertion/type-decorator based count checks with consistent `ValueError`s for zero, negative, fractional, boolean, and nonscalar counts.
- Add regression coverage for concatenated sample shapes, scalar-array counts, and invalid sample counts.

## Root Cause
The sampler relied on `beartype` plus `assert n > 0`. That allowed `True` to be treated as one sample, produced assertion/type-decorator exceptions for other invalid inputs, and would lose the assertion check under optimized Python.

## Tests
- `PYTHONPATH=src py -3.12 -m pytest tests/distributions/test_cart_prod_stacked_distribution.py tests/distributions/test_se3_lin_vel_cart_prod_stacked_distribution.py -q`
- `py -3.12 -m ruff check src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py tests/distributions/test_cart_prod_stacked_distribution.py`
- `PYTHONPATH=src py -3.12 -m pylint --disable=import-error src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py tests/distributions/test_cart_prod_stacked_distribution.py`
- `git diff --check`