### PR TITLE
Validate hypercylindrical subdivision sample counts

### DIFF
--- a/src/pyrecest/distributions/cart_prod/hypercylindrical_state_space_subdivision_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/hypercylindrical_state_space_subdivision_distribution.py
@@ -1,5 +1,7 @@
 import copy
 
+import numpy as np
+
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 from pyrecest.backend import __backend_name__ as backend_name
 from pyrecest.backend import (
@@ -37,6 +39,28 @@ from pyrecest.distributions.nonperiodic.custom_linear_distribution import (
     CustomLinearDistribution,
 )
 from pyrecest.distributions.nonperiodic.linear_mixture import LinearMixture
+
+
+def _validate_positive_sample_count(n) -> int:
+    count_array = np.asarray(n)
+    if count_array.ndim != 0:
+        raise ValueError("n must be a scalar integer")
+
+    count = count_array.item()
+    if isinstance(count, (bool, np.bool_)):
+        raise ValueError("n must be an integer, not a boolean")
+
+    try:
+        count_int = int(count)
+        count_float = float(count)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("n must be an integer") from exc
+
+    if not np.isfinite(count_float) or not count_float.is_integer():
+        raise ValueError("n must be a finite integer")
+    if count_int <= 0:
+        raise ValueError("n must be positive")
+    return count_int
 
 
 class HypercylindricalStateSpaceSubdivisionDistribution(
@@ -160,6 +184,7 @@ class HypercylindricalStateSpaceSubdivisionDistribution(
         s : array, shape (n, bound_dim + lin_dim)
         """
         assert backend_name == "numpy", "Only supported for numpy backend"
+        n = _validate_positive_sample_count(n)
         # Sample indices from the grid distribution weighted by grid_values
         weights = reshape(self.gd.grid_values, (-1,))
         weights = weights / backend_sum(weights)

--- a/tests/distributions/test_hypercylindrical_state_space_subdivision_distribution.py
+++ b/tests/distributions/test_hypercylindrical_state_space_subdivision_distribution.py
@@ -1,6 +1,7 @@
 import unittest
 from math import pi
 
+import numpy as np
 import numpy.testing as npt
 from pyrecest.backend import __backend_name__ as backend_name
 from pyrecest.backend import all as backend_all
@@ -141,6 +142,57 @@ class HypercylindricalStateSpaceSubdivisionDistributionTest(unittest.TestCase):
         hcrbd = HypercylindricalStateSpaceSubdivisionDistribution(gd, lin_dists)
         samples = hcrbd.sample(50)
         self.assertEqual(array(samples).shape, (50, 2))
+
+    @unittest.skipIf(
+        backend_name != "numpy",
+        reason="Not supported on this backend",
+    )
+    def test_sample_accepts_integer_like_count(self):
+        from pyrecest.distributions.circle.circular_uniform_distribution import (
+            CircularUniformDistribution,
+        )
+        from pyrecest.distributions.hypertorus.hypertoroidal_grid_distribution import (
+            HypertoroidalGridDistribution,
+        )
+
+        n_grid = 10
+        gd = HypertoroidalGridDistribution.from_distribution(
+            CircularUniformDistribution(), (n_grid,)
+        )
+        lin_dists = [
+            GaussianDistribution(array([0.0]), array([[1.0]])) for _ in range(n_grid)
+        ]
+        hcrbd = HypercylindricalStateSpaceSubdivisionDistribution(gd, lin_dists)
+
+        samples = hcrbd.sample(np.array(4.0))
+
+        self.assertEqual(array(samples).shape, (4, 2))
+
+    @unittest.skipIf(
+        backend_name != "numpy",
+        reason="Not supported on this backend",
+    )
+    def test_sample_rejects_invalid_count(self):
+        from pyrecest.distributions.circle.circular_uniform_distribution import (
+            CircularUniformDistribution,
+        )
+        from pyrecest.distributions.hypertorus.hypertoroidal_grid_distribution import (
+            HypertoroidalGridDistribution,
+        )
+
+        n_grid = 10
+        gd = HypertoroidalGridDistribution.from_distribution(
+            CircularUniformDistribution(), (n_grid,)
+        )
+        lin_dists = [
+            GaussianDistribution(array([0.0]), array([[1.0]])) for _ in range(n_grid)
+        ]
+        hcrbd = HypercylindricalStateSpaceSubdivisionDistribution(gd, lin_dists)
+
+        for n in (0, -1, 1.5, True, [3]):
+            with self.subTest(n=n):
+                with self.assertRaises(ValueError):
+                    hcrbd.sample(n)
 
     @unittest.skipIf(
         backend_name != "numpy",


### PR DESCRIPTION
## Summary
- Validate `HypercylindricalStateSpaceSubdivisionDistribution.sample` counts before backend grid sampling.
- Reject zero, negative, fractional, boolean, and nonscalar counts with consistent `ValueError`s.
- Add regression coverage for valid scalar-array counts and invalid sample counts.

## Root Cause
The sampler passed `n` directly into backend random shape arguments. That let `sample(0)` return an empty sample matrix and leaked backend-specific type/shape errors for invalid counts.

## Tests
- `PYTHONPATH=src py -3.12 -m pytest tests/distributions/test_hypercylindrical_state_space_subdivision_distribution.py -q`
- `py -3.12 -m ruff check src/pyrecest/distributions/cart_prod/hypercylindrical_state_space_subdivision_distribution.py tests/distributions/test_hypercylindrical_state_space_subdivision_distribution.py`
- `PYTHONPATH=src py -3.12 -m pylint --disable=import-error src/pyrecest/distributions/cart_prod/hypercylindrical_state_space_subdivision_distribution.py tests/distributions/test_hypercylindrical_state_space_subdivision_distribution.py`
- `git diff --check`