### PR TITLE
Validate complex ACG sample counts

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/complex_angular_central_gaussian_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/complex_angular_central_gaussian_distribution.py
@@ -1,4 +1,5 @@
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
+import numpy as np
 from pyrecest.backend import (
     abs,
     allclose,
@@ -17,6 +18,28 @@ from pyrecest.backend import (
     sum,
     transpose,
 )
+
+
+def _validate_positive_sample_count(n) -> int:
+    count_array = np.asarray(n)
+    if count_array.ndim != 0:
+        raise ValueError("n must be a scalar integer")
+
+    count = count_array.item()
+    if isinstance(count, (bool, np.bool_)):
+        raise ValueError("n must be an integer, not a boolean")
+
+    try:
+        count_int = int(count)
+        count_float = float(count)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("n must be an integer") from exc
+
+    if not np.isfinite(count_float) or not count_float.is_integer():
+        raise ValueError("n must be a finite integer")
+    if count_int <= 0:
+        raise ValueError("n must be positive")
+    return count_int
 
 
 class ComplexAngularCentralGaussianDistribution:
@@ -86,6 +109,8 @@ class ComplexAngularCentralGaussianDistribution:
         Z : array-like of shape (n, d)
             Complex unit vectors sampled from the distribution.
         """
+        n = _validate_positive_sample_count(n)
+
         # Lower Cholesky factor: C = L @ L^H
         L = linalg.cholesky(self.C)
         a = random.normal(size=(n, self.dim))

--- a/tests/distributions/test_complex_angular_central_gaussian_distribution.py
+++ b/tests/distributions/test_complex_angular_central_gaussian_distribution.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 import pyrecest.backend
 
@@ -133,6 +134,25 @@ class TestComplexAngularCentralGaussianDistribution(unittest.TestCase):
         Z = self.dist_identity_2d.sample(n)
         self.assertEqual(Z.shape[0], n)
         self.assertEqual(Z.shape[1], 2)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on JAX backend",
+    )  # pylint: disable=no-member
+    def test_sample_accepts_integer_like_count(self):
+        """Scalar integer-like counts should be normalized before sampling."""
+        Z = self.dist_identity_2d.sample(np.array(4.0))
+        self.assertEqual(Z.shape, (4, 2))
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on JAX backend",
+    )  # pylint: disable=no-member
+    def test_sample_rejects_invalid_count(self):
+        """Invalid counts should fail before backend random shape handling."""
+        for invalid_n in (0, -1, 1.5, True, [3]):
+            with self.subTest(n=invalid_n), self.assertRaises(ValueError):
+                self.dist_identity_2d.sample(invalid_n)
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",


### PR DESCRIPTION
## Summary
- Validate `ComplexAngularCentralGaussianDistribution.sample` counts before backend random shape handling.
- Reject zero, negative, fractional, boolean, and nonscalar counts with consistent `ValueError`s.
- Add regression coverage for scalar-array counts and invalid sample counts.

## Root Cause
The sampler passed `n` directly into backend random shape arguments. That let `sample(0)` return an empty `(0, d)` sample matrix and leaked backend-specific errors for other invalid counts.

## Tests
- `PYTHONPATH=src py -3.12 -m pytest tests/distributions/test_complex_angular_central_gaussian_distribution.py -q`
- `py -3.12 -m ruff check src/pyrecest/distributions/hypersphere_subset/complex_angular_central_gaussian_distribution.py tests/distributions/test_complex_angular_central_gaussian_distribution.py`
- `PYTHONPATH=src py -3.12 -m pylint --disable=import-error src/pyrecest/distributions/hypersphere_subset/complex_angular_central_gaussian_distribution.py tests/distributions/test_complex_angular_central_gaussian_distribution.py`
- `git diff --check`