### PR TITLE
Validate complex Bingham sample counts

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/complex_bingham_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/complex_bingham_distribution.py
@@ -9,6 +9,7 @@ Reference:
   Journal of the Royal Statistical Society. Series B (Methodological), 1994, 285-299.
 """
 
+import numpy as np
 import pyrecest.backend
 from pyrecest.backend import (
     abs,
@@ -48,6 +49,28 @@ from scipy.optimize import least_squares
 from .abstract_complex_hyperspherical_distribution import (
     AbstractComplexHypersphericalDistribution,
 )
+
+
+def _validate_positive_sample_count(n) -> int:
+    count_array = np.asarray(n)
+    if count_array.ndim != 0:
+        raise ValueError("n must be a scalar integer")
+
+    count = count_array.item()
+    if isinstance(count, (bool, np.bool_)):
+        raise ValueError("n must be an integer, not a boolean")
+
+    try:
+        count_int = int(count)
+        count_float = float(count)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("n must be an integer") from exc
+
+    if not np.isfinite(count_float) or not count_float.is_integer():
+        raise ValueError("n must be a finite integer")
+    if count_int <= 0:
+        raise ValueError("n must be positive")
+    return count_int
 
 
 class ComplexBinghamDistribution(AbstractComplexHypersphericalDistribution):
@@ -132,6 +155,8 @@ class ComplexBinghamDistribution(AbstractComplexHypersphericalDistribution):
         array, shape (d, n), dtype complex128
             Sampled unit vectors (each column has unit norm).
         """
+        n = _validate_positive_sample_count(n)
+
         d = self.complex_dim
         if d < 2:
             raise ValueError("Sampling requires d >= 2.")

--- a/tests/distributions/test_complex_bingham_distribution.py
+++ b/tests/distributions/test_complex_bingham_distribution.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 import pyrecest.backend
 
@@ -127,6 +128,25 @@ class TestComplexBinghamDistribution(unittest.TestCase):
         random.seed(42)
         S = self.cB2.sample(50)
         self.assertEqual(S.shape, (2, 50))
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on JAX backend",
+    )
+    def test_sample_accepts_integer_like_count(self):
+        """Scalar integer-like counts should be normalized before sampling."""
+        S = self.cB2.sample(np.array(4.0))
+        self.assertEqual(S.shape, (2, 4))
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on JAX backend",
+    )
+    def test_sample_rejects_invalid_count(self):
+        """Invalid counts should fail before backend random shape handling."""
+        for invalid_n in (0, -1, 1.5, True, [3]):
+            with self.subTest(n=invalid_n), self.assertRaises(ValueError):
+                self.cB2.sample(invalid_n)
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member


### PR DESCRIPTION
## Summary
- Validate `ComplexBinghamDistribution.sample` counts before allocation and backend random shape handling.
- Reject zero, negative, fractional, boolean, and nonscalar counts with consistent `ValueError`s.
- Add regression coverage for scalar-array counts and invalid sample counts.

## Root Cause
The sampler used `n` directly as the sample matrix dimension and loop bound. That let `sample(0)` return an empty `(d, 0)` sample matrix and leaked backend-specific errors for other invalid counts.

## Tests
- `PYTHONPATH=src py -3.12 -m pytest tests/distributions/test_complex_bingham_distribution.py -q`
- `py -3.12 -m ruff check src/pyrecest/distributions/hypersphere_subset/complex_bingham_distribution.py tests/distributions/test_complex_bingham_distribution.py`
- `PYTHONPATH=src py -3.12 -m pylint --disable=import-error src/pyrecest/distributions/hypersphere_subset/complex_bingham_distribution.py tests/distributions/test_complex_bingham_distribution.py`
- `git diff --check`