### PR TITLE
Validate complex Watson sample counts

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/complex_watson_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/complex_watson_distribution.py
@@ -1,5 +1,6 @@
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 import mpmath
+import numpy as np
 import pyrecest.backend
 from pyrecest.backend import (
     abs,
@@ -31,6 +32,28 @@ from pyrecest.backend import (
     zeros_like,
 )
 from scipy.optimize import brentq
+
+
+def _validate_positive_sample_count(n) -> int:
+    count_array = np.asarray(n)
+    if count_array.ndim != 0:
+        raise ValueError("n must be a scalar integer")
+
+    count = count_array.item()
+    if isinstance(count, (bool, np.bool_)):
+        raise ValueError("n must be an integer, not a boolean")
+
+    try:
+        count_int = int(count)
+        count_float = float(count)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("n must be an integer") from exc
+
+    if not np.isfinite(count_float) or not count_float.is_integer():
+        raise ValueError("n must be a finite integer")
+    if count_int <= 0:
+        raise ValueError("n must be positive")
+    return count_int
 
 
 class ComplexWatsonDistribution:
@@ -101,6 +124,8 @@ class ComplexWatsonDistribution:
         assert (
             pyrecest.backend.__backend_name__ != "jax"  # pylint: disable=no-member
         ), "sample() uses in-place array assignment which is incompatible with JAX. Use numpy or pytorch backend instead."
+        n = _validate_positive_sample_count(n)
+
         D = self.dim
 
         # Compute B = -kappa * (I - mu * mu^H)

--- a/tests/distributions/test_complex_watson_distribution.py
+++ b/tests/distributions/test_complex_watson_distribution.py
@@ -1,6 +1,7 @@
 # pylint: disable=no-name-in-module,no-member,redefined-builtin
 import unittest
 
+import numpy as np
 import pyrecest.backend
 from pyrecest.backend import (
     all,
@@ -157,6 +158,27 @@ class TestComplexWatsonDistribution(unittest.TestCase):
         cw = ComplexWatsonDistribution(self.mu2, self.kappa2)
         samples = cw.sample(50)
         self.assertEqual(samples.shape, (50, 2))
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on JAX backend",
+    )
+    def test_sample_accepts_integer_like_count(self):
+        """Scalar integer-like counts should be normalized before sampling."""
+        cw = ComplexWatsonDistribution(self.mu2, self.kappa2)
+        samples = cw.sample(np.array(4.0))
+        self.assertEqual(samples.shape, (4, 2))
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on JAX backend",
+    )
+    def test_sample_rejects_invalid_count(self):
+        """Invalid counts should fail before backend random shape handling."""
+        cw = ComplexWatsonDistribution(self.mu2, self.kappa2)
+        for invalid_n in (0, -1, 1.5, True, [3]):
+            with self.subTest(n=invalid_n), self.assertRaises(ValueError):
+                cw.sample(invalid_n)
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member


### PR DESCRIPTION
## Summary
- Validate `ComplexWatsonDistribution.sample` counts before allocation and backend random shape handling.
- Reject zero, negative, fractional, boolean, and nonscalar counts with consistent `ValueError`s.
- Add regression coverage for scalar-array counts and invalid sample counts.

## Root Cause
The sampler used `n` directly as the sample matrix dimension and loop bound. That let `sample(0)` return an empty `(0, D)` sample matrix and leaked backend-specific errors for other invalid counts.

## Tests
- `PYTHONPATH=src py -3.12 -m pytest tests/distributions/test_complex_watson_distribution.py -q`
- `py -3.12 -m ruff check src/pyrecest/distributions/hypersphere_subset/complex_watson_distribution.py tests/distributions/test_complex_watson_distribution.py`
- `PYTHONPATH=src py -3.12 -m pylint --disable=import-error src/pyrecest/distributions/hypersphere_subset/complex_watson_distribution.py tests/distributions/test_complex_watson_distribution.py`
- `git diff --check`