### PR TITLE
Validate Bingham sample counts

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/bingham_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/bingham_distribution.py
@@ -36,6 +36,28 @@ def _cache_key(values):
     return tuple(float(value) for value in _as_numpy_vector(values))
 
 
+def _validate_positive_sample_count(n) -> int:
+    count_array = _np.asarray(n)
+    if count_array.ndim != 0:
+        raise ValueError("n must be a scalar integer")
+
+    count = count_array.item()
+    if isinstance(count, (bool, _np.bool_)):
+        raise ValueError("n must be an integer, not a boolean")
+
+    try:
+        count_int = int(count)
+        count_float = float(count)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("n must be an integer") from exc
+
+    if not _np.isfinite(count_float) or not count_float.is_integer():
+        raise ValueError("n must be a finite integer")
+    if count_int <= 0:
+        raise ValueError("n must be positive")
+    return count_int
+
+
 @lru_cache(maxsize=4096)
 def _calculate_F_and_dF_cached(Z_key):
     Z = _np.asarray(Z_key, dtype=float)
@@ -223,6 +245,7 @@ class BinghamDistribution(AbstractHypersphericalDistribution):
         return BinghamDistribution(Z_, M_)
 
     def sample(self, n):
+        n = _validate_positive_sample_count(n)
         return self.sample_metropolis_hastings(n)
 
     @property

--- a/tests/distributions/test_bingham_distribution.py
+++ b/tests/distributions/test_bingham_distribution.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 import pyrecest.backend
 
@@ -74,6 +75,25 @@ class TestBinghamDistribution(unittest.TestCase):
         samples, weights = self.bd.sample_deterministic()
         self.assertEqual(samples.shape, (3, 6))
         npt.assert_allclose(to_numpy(weights).sum(), 1.0, rtol=0, atol=1e-7)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_sample_accepts_integer_like_count(self):
+        """Scalar integer-like counts should be normalized before sampling."""
+        samples = self.bd.sample(np.array(4.0))
+        self.assertEqual(samples.shape, (4, 3))
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_sample_rejects_invalid_count(self):
+        """Invalid counts should fail before Metropolis-Hastings allocation."""
+        for invalid_n in (0, -1, 1.5, True, [3]):
+            with self.subTest(n=invalid_n), self.assertRaises(ValueError):
+                self.bd.sample(invalid_n)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Validate `BinghamDistribution.sample` counts before Metropolis-Hastings allocation.
- Reject zero, negative, fractional, boolean, and nonscalar counts with consistent `ValueError`s.
- Add regression coverage for scalar-array counts and invalid sample counts.

## Root Cause
The Bingham sampler delegated `n` directly into Metropolis-Hastings loop/allocation math. That let `sample(0)`, `sample(-1)`, and `sample(False)` return empty sample matrices through SO(3) wrappers and leaked backend-specific errors for other invalid counts.

## Tests
- `PYTHONPATH=src py -3.12 -m pytest tests/distributions/test_bingham_distribution.py tests/distributions/test_so3_bingham_distribution.py -q`
- `py -3.12 -m ruff check src/pyrecest/distributions/hypersphere_subset/bingham_distribution.py tests/distributions/test_bingham_distribution.py`
- `PYTHONPATH=src py -3.12 -m pylint --disable=import-error src/pyrecest/distributions/hypersphere_subset/bingham_distribution.py tests/distributions/test_bingham_distribution.py`
- `git diff --check`