### PR TITLE
Validate piecewise constant weights

### DIFF
--- a/src/pyrecest/distributions/circle/piecewise_constant_distribution.py
+++ b/src/pyrecest/distributions/circle/piecewise_constant_distribution.py
@@ -5,6 +5,7 @@ from pyrecest.backend import (
     array,
     exp,
     floor,
+    isfinite,
     log,
     mean,
     mod,
@@ -41,7 +42,16 @@ class PiecewiseConstantDistribution(AbstractCircularDistribution):
         AbstractCircularDistribution.__init__(self)
         w = array(w, dtype=float).ravel()
         assert w.ndim == 1 and w.shape[0] > 0
-        self.w = w / (mean(w) * 2.0 * pi)
+        if any(not bool(isfinite(weight)) for weight in w):
+            raise ValueError("Weights must be finite")
+        if any(bool(weight < 0.0) for weight in w):
+            raise ValueError("Weights must be nonnegative")
+
+        mean_weight = mean(w)
+        if not bool(mean_weight > 0.0):
+            raise ValueError("Weights must have positive total mass")
+
+        self.w = w / (mean_weight * 2.0 * pi)
 
     def pdf(self, xs):
         """Evaluate the pdf at each point in xs.

--- a/tests/distributions/test_piecewise_constant_distribution.py
+++ b/tests/distributions/test_piecewise_constant_distribution.py
@@ -30,6 +30,18 @@ class PiecewiseConstantDistributionTest(unittest.TestCase):
             self.dist.pdf(array([10.9])), array([4 * self.normal]), rtol=1e-10
         )
 
+    def test_constructor_rejects_invalid_weights(self):
+        for invalid_weights, message in [
+            (array([1.0, -0.5, 1.0]), "nonnegative"),
+            (array([0.0, 0.0]), "positive total mass"),
+            (array([float("nan"), 1.0]), "finite"),
+            (array([float("inf"), 1.0]), "finite"),
+        ]:
+            with self.subTest(weights=invalid_weights), self.assertRaisesRegex(
+                ValueError, message
+            ):
+                PiecewiseConstantDistribution(invalid_weights)
+
     def test_integral_normalized(self):
         """Verify the distribution integrates to 1 via the exact sum."""
         n = len(self.dist.w)


### PR DESCRIPTION
## Summary
- Reject invalid `PiecewiseConstantDistribution` interval weights before normalization.
- Guard against negative, all-zero, `nan`, and `inf` weights producing invalid densities.
- Add regression coverage for constructor validation.

## Root Cause
The constructor normalized the weight vector by its mean without validating that the weights formed a finite nonnegative measure with positive total mass. Negative weights produced negative pdf values, and zero/nonfinite weights produced `nan` densities.

## Tests
- `PYTHONPATH=src py -3.12 -m pytest tests/distributions/test_piecewise_constant_distribution.py -q`
- `py -3.12 -m ruff check src/pyrecest/distributions/circle/piecewise_constant_distribution.py tests/distributions/test_piecewise_constant_distribution.py`
- `PYTHONPATH=src py -3.12 -m pylint --disable=import-error src/pyrecest/distributions/circle/piecewise_constant_distribution.py tests/distributions/test_piecewise_constant_distribution.py`
- `git diff --check`