### PR TITLE
Validate Mardia-Sutton sigma

### DIFF
--- a/src/pyrecest/distributions/cart_prod/mardia_sutton_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/mardia_sutton_distribution.py
@@ -1,4 +1,6 @@
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
+import math
+
 from pyrecest.backend import (
     array,
     atleast_2d,
@@ -39,6 +41,10 @@ class MardiaSuttonDistribution(AbstractHypercylindricalDistribution):
         """
         AbstractHypercylindricalDistribution.__init__(self, bound_dim=1, lin_dim=1)
         assert kappa > 0, "kappa must be a positive scalar"
+        sigma_float = float(sigma)
+        assert (
+            math.isfinite(sigma_float) and sigma_float > 0.0
+        ), "sigma must be a positive finite scalar"
         assert (
             float(sqrt(rho1**2 + rho2**2)) < 1.0
         ), "sqrt(rho1^2 + rho2^2) must be strictly less than 1"
@@ -48,7 +54,7 @@ class MardiaSuttonDistribution(AbstractHypercylindricalDistribution):
         self.kappa = kappa
         self.rho1 = rho1
         self.rho2 = rho2
-        self.sigma = sigma
+        self.sigma = sigma_float
 
     def get_mu_sigma(self, xa_circular):
         """Compute the conditional mean and std of the linear variable given circular values.

--- a/tests/distributions/test_mardia_sutton_distribution.py
+++ b/tests/distributions/test_mardia_sutton_distribution.py
@@ -142,6 +142,13 @@ class TestMardiaSuttonDistribution(unittest.TestCase):
                 self.mu, self.mu0, self.kappa, 0.8, 0.8, self.sigma
             )
 
+    def test_invalid_sigma(self):
+        for sigma in (0.0, -1.0, float("nan"), float("inf")):
+            with self.subTest(sigma=sigma), self.assertRaises(AssertionError):
+                MardiaSuttonDistribution(
+                    self.mu, self.mu0, self.kappa, self.rho1, self.rho2, sigma
+                )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Reject invalid `MardiaSuttonDistribution` linear scale parameters during construction.
- Guard against zero, negative, `nan`, and `inf` `sigma` values producing invalid conditional Gaussian scales.
- Add regression coverage for invalid `sigma` values.

## Root Cause
The constructor documented `sigma` as positive but never validated it. Zero, negative, and nonfinite values were accepted and later produced `nan` densities through SciPy's normal pdf.

## Tests
- `PYTHONPATH=src py -3.12 -m pytest tests/distributions/test_mardia_sutton_distribution.py -q`
- `py -3.12 -m ruff check src/pyrecest/distributions/cart_prod/mardia_sutton_distribution.py tests/distributions/test_mardia_sutton_distribution.py`
- `PYTHONPATH=src py -3.12 -m pylint --disable=import-error src/pyrecest/distributions/cart_prod/mardia_sutton_distribution.py tests/distributions/test_mardia_sutton_distribution.py`
- `git diff --check`