### PR TITLE
Validate complex ACG parameter matrix

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/complex_angular_central_gaussian_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/complex_angular_central_gaussian_distribution.py
@@ -1,6 +1,7 @@
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 from pyrecest.backend import (
     abs,
+    all as backend_all,
     allclose,
     array,
     complex128,
@@ -17,6 +18,15 @@ from pyrecest.backend import (
     sum,
     transpose,
 )
+
+
+def _to_python_bool(value):
+    """Convert scalar backend boolean values to Python ``bool``."""
+    if isinstance(value, bool):
+        return value
+    if hasattr(value, "item"):
+        return bool(value.item())
+    return bool(value)
 
 
 class ComplexAngularCentralGaussianDistribution:
@@ -38,7 +48,12 @@ class ComplexAngularCentralGaussianDistribution:
         C : array-like of shape (d, d)
             Hermitian positive definite parameter matrix.
         """
-        assert allclose(C, conj(transpose(C))), "C must be Hermitian"
+        C = array(C)
+        assert C.ndim == 2 and C.shape[0] == C.shape[1], "C must be a square matrix"
+        assert _to_python_bool(allclose(C, conj(transpose(C)))), "C must be Hermitian"
+        assert _to_python_bool(
+            backend_all(linalg.eigvalsh(C) > 0.0)
+        ), "C must be positive definite"
         self.C = C
         self.dim = C.shape[0]
 

--- a/tests/distributions/test_complex_angular_central_gaussian_distribution.py
+++ b/tests/distributions/test_complex_angular_central_gaussian_distribution.py
@@ -46,6 +46,16 @@ class TestComplexAngularCentralGaussianDistribution(unittest.TestCase):
         with self.assertRaises(AssertionError):
             ComplexAngularCentralGaussianDistribution(C_bad)
 
+    def test_constructor_rejects_non_positive_definite_matrix(self):
+        """Hermitian parameter matrices must be positive definite."""
+        invalid_matrices = [
+            array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, 0.0 + 0j]]),
+            array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, -1.0 + 0j]]),
+        ]
+        for C_bad in invalid_matrices:
+            with self.subTest(C=C_bad), self.assertRaises(AssertionError):
+                ComplexAngularCentralGaussianDistribution(C_bad)
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",
         reason="Not supported on JAX backend",


### PR DESCRIPTION
## Summary
- Validate `ComplexAngularCentralGaussianDistribution` matrices as square, Hermitian, and positive definite during construction.
- Convert the parameter matrix to the active backend array before storing it.
- Add regression coverage for singular and indefinite Hermitian matrices.

## Root Cause
The constructor documented `C` as Hermitian positive definite but only checked the Hermitian part. Invalid matrices were accepted and then failed later in `pdf`/`sample`, or could produce mathematically invalid density values.

## Tests
- `PYTHONPATH=src py -3.12 -m pytest tests/distributions/test_complex_angular_central_gaussian_distribution.py -q`
- `py -3.12 -m ruff check src/pyrecest/distributions/hypersphere_subset/complex_angular_central_gaussian_distribution.py tests/distributions/test_complex_angular_central_gaussian_distribution.py`
- `PYTHONPATH=src py -3.12 -m pylint --disable=import-error src/pyrecest/distributions/hypersphere_subset/complex_angular_central_gaussian_distribution.py tests/distributions/test_complex_angular_central_gaussian_distribution.py`
- `git diff --check`