### PR TITLE
Validate ellipsoidal ball shape matrix

### DIFF
--- a/src/pyrecest/distributions/abstract_ellipsoidal_ball_distribution.py
+++ b/src/pyrecest/distributions/abstract_ellipsoidal_ball_distribution.py
@@ -1,5 +1,14 @@
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import linalg, pi, sqrt
+from pyrecest.backend import (
+    all as backend_all,
+    allclose,
+    array,
+    isfinite,
+    linalg,
+    pi,
+    sqrt,
+    transpose,
+)
 from scipy.special import gamma
 
 from .abstract_bounded_nonperiodic_distribution import (
@@ -19,11 +28,31 @@ class AbstractEllipsoidalBallDistribution(AbstractBoundedNonPeriodicDistribution
         :param center: The center of the ellipsoidal ball.
         :param shape_matrix: The shape matrix of the ellipsoidal ball.
         """
+        center = array(center)
+        shape_matrix = array(shape_matrix)
+
+        assert center.ndim == 1, "center must be a 1-dimensional array"
         AbstractBoundedNonPeriodicDistribution.__init__(self, center.shape[-1])
+        assert shape_matrix.ndim == 2, "shape_matrix must be a 2-dimensional array"
+        assert shape_matrix.shape == (
+            self.dim,
+            self.dim,
+        ), "shape_matrix must match the center dimension"
+        assert bool(
+            backend_all(isfinite(center))
+        ), "center must contain only finite values"
+        assert bool(
+            backend_all(isfinite(shape_matrix))
+        ), "shape_matrix must contain only finite values"
+        assert allclose(
+            shape_matrix, transpose(shape_matrix)
+        ), "shape_matrix must be symmetric"
+        assert bool(
+            backend_all(linalg.eigvalsh(shape_matrix) > 0.0)
+        ), "shape_matrix must be positive definite"
+
         self.center = center
         self.shape_matrix = shape_matrix
-        assert center.ndim == 1 and shape_matrix.ndim == 2
-        assert shape_matrix.shape[0] == self.dim and shape_matrix.shape[1] == self.dim
 
     def get_manifold_size(self):
         """

--- a/tests/distributions/test_ellipsoidal_ball_uniform_distribution.py
+++ b/tests/distributions/test_ellipsoidal_ball_uniform_distribution.py
@@ -23,6 +23,20 @@ class TestEllipsoidalBallUniformDistribution(unittest.TestCase):
         npt.assert_allclose(dist.mean(), center)
         npt.assert_allclose(dist.covariance(), shape_matrix / (dist.dim + 2))
 
+    def test_rejects_invalid_shape_matrix(self):
+        center = array([0.0, 0.0])
+        invalid_shape_matrices = [
+            array([[1.0, 2.0], [0.0, 1.0]]),
+            array([[1.0, 0.0], [0.0, 0.0]]),
+            array([[1.0, 0.0], [0.0, -1.0]]),
+            array([[1.0, 0.0], [0.0, float("nan")]]),
+        ]
+
+        for shape_matrix in invalid_shape_matrices:
+            with self.subTest(shape_matrix=shape_matrix):
+                with self.assertRaises(AssertionError):
+                    EllipsoidalBallUniformDistribution(center, shape_matrix)
+
     def test_sampling(self):
         dist = EllipsoidalBallUniformDistribution(
             array([2.0, 3.0]), array([[4.0, 3.0], [3.0, 9.0]])


### PR DESCRIPTION
## Summary
- Validate ellipsoidal-ball centers and shape matrices during construction.
- Reject nonfinite centers, nonfinite shape matrices, non-symmetric matrices, and non-positive-definite shape matrices before they can produce invalid geometry.
- Add regression coverage for invalid ellipsoidal shape matrices.

## Root Cause
`AbstractEllipsoidalBallDistribution` only checked the array dimensions. Non-symmetric, singular, and indefinite shape matrices could be constructed, producing zero or `nan` manifold sizes or failing later during sampling.

## Tests
- `MPLBACKEND=Agg PYTHONPATH=src python -m pytest tests/distributions/test_ellipsoidal_ball_uniform_distribution.py -q -p no:cacheprovider`
- `python -m ruff check src/pyrecest/distributions/abstract_ellipsoidal_ball_distribution.py tests/distributions/test_ellipsoidal_ball_uniform_distribution.py`
- `MPLBACKEND=Agg PYTHONPATH=src python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/abstract_ellipsoidal_ball_distribution.py tests/distributions/test_ellipsoidal_ball_uniform_distribution.py`
- `git diff --check`