### PR TITLE
Validate hyperrectangular bounds

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/abstract_hyperrectangular_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/abstract_hyperrectangular_distribution.py
@@ -1,5 +1,6 @@
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array, diff, prod, reshape, to_numpy
+from pyrecest.backend import all as backend_all
+from pyrecest.backend import array, diff, isfinite, prod, reshape, to_numpy
 from scipy.integrate import nquad
 
 from ..abstract_bounded_nonperiodic_distribution import (
@@ -16,6 +17,11 @@ class AbstractHyperrectangularDistribution(AbstractBoundedNonPeriodicDistributio
             bounds = reshape(bounds, (1, 2))
         if bounds.ndim != 2 or bounds.shape[1] != 2:
             raise ValueError("bounds must have shape (dim, 2)")
+        if not bool(backend_all(isfinite(bounds))):
+            raise ValueError("bounds must contain only finite values")
+        widths = diff(bounds, axis=1)
+        if not bool(backend_all(widths > 0.0)):
+            raise ValueError("bounds must be strictly increasing in every dimension")
         AbstractBoundedNonPeriodicDistribution.__init__(self, int(bounds.shape[0]))
         self.bounds = bounds
 

--- a/tests/distributions/test_custom_hyperrectangular_distribution.py
+++ b/tests/distributions/test_custom_hyperrectangular_distribution.py
@@ -1,7 +1,7 @@
 import unittest
 
 # pylint: disable=no-name-in-module,no-member
-import pyrecest.backend as backend
+from pyrecest import backend
 from pyrecest.backend import allclose, array, column_stack, linspace, meshgrid, ones
 from pyrecest.distributions.custom_hyperrectangular_distribution import (
     CustomHyperrectangularDistribution,
@@ -51,6 +51,19 @@ class TestCustomHyperrectangularDistribution(unittest.TestCase):
         self.assertEqual(tuple(cd.bounds.shape), (1, 2))
         self.assertAlmostEqual(float(cd.get_manifold_size()), 2.0)
         self.assertAlmostEqual(cd.integrate(), 1.0)
+
+    def test_bounds_must_be_finite_and_strictly_increasing(self):
+        invalid_bounds = [
+            array([2.0, 1.0]),
+            array([1.0, 1.0]),
+            array([0.0, float("nan")]),
+            array([0.0, float("inf")]),
+        ]
+
+        for bounds in invalid_bounds:
+            with self.subTest(bounds=bounds):
+                with self.assertRaises(ValueError):
+                    HyperrectangularUniformDistribution(bounds)
 
     def test_bounds_rows_define_integration_intervals(self):
         cd = CustomHyperrectangularDistribution(


### PR DESCRIPTION
## Summary
- Reject nonfinite hyperrectangular bounds during construction.
- Reject zero-width and reversed intervals so uniform hyperrectangular distributions cannot produce infinite or negative densities.
- Add regression coverage for invalid one-dimensional bounds.

## Root Cause
`AbstractHyperrectangularDistribution` only validated the shape of the bounds array. Bounds such as `[2, 1]`, `[1, 1]`, `nan`, or `inf` were accepted, which led to negative, infinite, or `nan` manifold sizes and PDF values.

## Tests
- `MPLBACKEND=Agg PYTHONPATH=src python -m pytest tests/distributions/test_custom_hyperrectangular_distribution.py -q -p no:cacheprovider`
- `python -m ruff check src/pyrecest/distributions/nonperiodic/abstract_hyperrectangular_distribution.py tests/distributions/test_custom_hyperrectangular_distribution.py`
- `MPLBACKEND=Agg PYTHONPATH=src python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/nonperiodic/abstract_hyperrectangular_distribution.py tests/distributions/test_custom_hyperrectangular_distribution.py`
- `git diff --check`