### PR TITLE
Respect hyperrectangular uniform support

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/hyperrectangular_uniform_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/hyperrectangular_uniform_distribution.py
@@ -1,3 +1,6 @@
+from pyrecest.backend import all as backend_all
+from pyrecest.backend import array, logical_and, ones, reshape, where, zeros
+
 from ..abstract_uniform_distribution import AbstractUniformDistribution
 from .abstract_hyperrectangular_distribution import AbstractHyperrectangularDistribution
 
@@ -11,3 +14,32 @@ class HyperrectangularUniformDistribution(
 
     def get_manifold_size(self):
         return AbstractHyperrectangularDistribution.get_manifold_size(self)
+
+    def pdf(self, xs):
+        """Evaluate the uniform density inside the hyperrectangle and zero outside."""
+        xs, single = self._coerce_points(xs)
+        lower = self.bounds[:, 0]
+        upper = self.bounds[:, 1]
+        inside = backend_all(logical_and(xs >= lower, xs <= upper), axis=1)
+        values = where(
+            inside,
+            ones(xs.shape[0]) / self.get_manifold_size(),
+            zeros(xs.shape[0]),
+        )
+        return values[0] if single else values
+
+    def _coerce_points(self, xs):
+        xs = array(xs)
+        if xs.ndim == 0:
+            if self.dim != 1:
+                raise ValueError("Scalar points are only valid for dim == 1")
+            return reshape(xs, (1, 1)), True
+        if xs.ndim == 1:
+            if self.dim == 1:
+                return reshape(xs, (-1, 1)), False
+            if xs.shape[0] == self.dim:
+                return reshape(xs, (1, self.dim)), True
+            raise ValueError(f"Point dimension {xs.shape[0]} does not match dim {self.dim}")
+        if xs.ndim != 2 or xs.shape[1] != self.dim:
+            raise ValueError(f"xs must have shape (n, {self.dim})")
+        return xs, False

--- a/tests/distributions/test_hyperrectangular_uniform_distribution.py
+++ b/tests/distributions/test_hyperrectangular_uniform_distribution.py
@@ -1,0 +1,42 @@
+import unittest
+
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array
+from pyrecest.distributions.nonperiodic.hyperrectangular_uniform_distribution import (
+    HyperrectangularUniformDistribution,
+)
+
+
+class TestHyperrectangularUniformDistribution(unittest.TestCase):
+    def test_pdf_is_zero_outside_bounds(self):
+        dist = HyperrectangularUniformDistribution(array([[0.0, 1.0], [10.0, 12.0]]))
+
+        pdf_values = dist.pdf(
+            array(
+                [
+                    [0.5, 11.0],
+                    [-0.5, 11.0],
+                    [0.5, 20.0],
+                    [1.0, 10.0],
+                ]
+            )
+        )
+
+        npt.assert_allclose(pdf_values, array([0.5, 0.0, 0.0, 0.5]))
+
+    def test_pdf_accepts_single_multidimensional_point(self):
+        dist = HyperrectangularUniformDistribution(array([[0.0, 1.0], [10.0, 12.0]]))
+
+        npt.assert_allclose(float(dist.pdf(array([0.5, 11.0]))), 0.5)
+
+    def test_pdf_rejects_wrong_point_dimension(self):
+        dist = HyperrectangularUniformDistribution(array([[0.0, 1.0], [10.0, 12.0]]))
+
+        with self.assertRaises(ValueError):
+            dist.pdf(array([0.5, 11.0, 0.0]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Make `HyperrectangularUniformDistribution.pdf` return the uniform density only for points inside the finite hyperrectangle.
- Return zero for points outside any bound.
- Add regression coverage for inside, boundary, outside, single-point, and wrong-dimensional PDF inputs.

## Root Cause
`HyperrectangularUniformDistribution` inherited the generic uniform distribution PDF, which only divides by manifold size and ignores bounded support. As a result, out-of-bounds points received the same positive density as in-bounds points.

## Tests
- `MPLBACKEND=Agg PYTHONPATH=src python -m pytest tests/distributions/test_hyperrectangular_uniform_distribution.py tests/distributions/test_custom_hyperrectangular_distribution.py -q -p no:cacheprovider`
- `python -m ruff check src/pyrecest/distributions/nonperiodic/hyperrectangular_uniform_distribution.py tests/distributions/test_hyperrectangular_uniform_distribution.py`
- `MPLBACKEND=Agg PYTHONPATH=src python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/nonperiodic/hyperrectangular_uniform_distribution.py tests/distributions/test_hyperrectangular_uniform_distribution.py`
- `git diff --check`