### PR TITLE
Reject nonfinite SO3 quaternions

### DIFF
--- a/src/pyrecest/distributions/_so3_helpers.py
+++ b/src/pyrecest/distributions/_so3_helpers.py
@@ -10,6 +10,7 @@ from pyrecest.backend import (
     clip,
     concatenate,
     cos,
+    isfinite,
     linalg,
     log,
     ndim,
@@ -43,6 +44,8 @@ def normalize_quaternions(quaternions):
         assert quaternions.shape[-1] == 4, "SO(3) quaternions must have length 4."
 
     norms = linalg.norm(quaternions, axis=-1)
+    assert all(isfinite(quaternions)), "SO(3) quaternions must be finite."
+    assert all(isfinite(norms)), "SO(3) quaternion norms must be finite."
     assert all(norms > 0.0), "SO(3) quaternions must be nonzero."
 
     normalized = quaternions / reshape(norms, tuple(norms.shape) + (1,))

--- a/tests/distributions/test_so3_uniform_distribution.py
+++ b/tests/distributions/test_so3_uniform_distribution.py
@@ -45,6 +45,19 @@ class SO3UniformDistributionTest(unittest.TestCase):
         npt.assert_allclose(dist.ln_pdf(rotations), log(expected_pdf), atol=ATOL)
         self.assertAlmostEqual(dist.get_manifold_size(), math.pi**2, places=12)
 
+    def test_pdf_rejects_nonfinite_quaternions(self):
+        dist = SO3UniformDistribution()
+        invalid_rotations = [
+            array([math.inf, 0.0, 0.0, 1.0]),
+            array([math.nan, 0.0, 0.0, 1.0]),
+            array([[0.0, 0.0, 0.0, 1.0], [0.0, math.inf, 0.0, 1.0]]),
+        ]
+
+        for rotation in invalid_rotations:
+            with self.subTest(rotation=rotation):
+                with self.assertRaises(AssertionError):
+                    dist.pdf(rotation)
+
     def test_sample_returns_canonical_unit_quaternions(self):
         dist = SO3UniformDistribution()
 


### PR DESCRIPTION
## Summary
- Reject non-finite SO(3) quaternion entries and infinite norms before normalization.
- Add regression coverage so `SO3UniformDistribution.pdf` rejects `inf`/`nan` quaternion inputs instead of returning the constant density.

## Tests
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/distributions/test_so3_uniform_distribution.py -q -p no:cacheprovider`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/distributions/test_so3_helpers.py tests/distributions/test_so3_dirac_distribution.py tests/distributions/test_so3_product_dirac_distribution.py tests/distributions/test_so3_tangent_gaussian_distribution.py tests/distributions/test_so3_product_tangent_gaussian_distribution.py tests/distributions/test_so3_uniform_distribution.py tests/distributions/test_so3_bingham_distribution.py -q -p no:cacheprovider`
- `python -m ruff check src/pyrecest/distributions/_so3_helpers.py tests/distributions/test_so3_uniform_distribution.py`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/_so3_helpers.py tests/distributions/test_so3_uniform_distribution.py`
- `git diff --check`