### PR TITLE
Reject nonfinite SO3 product Dirac inputs

### DIFF
--- a/src/pyrecest/distributions/so3_product_dirac_distribution.py
+++ b/src/pyrecest/distributions/so3_product_dirac_distribution.py
@@ -12,6 +12,7 @@ from pyrecest.backend import (
     array,
     asarray,
     clip,
+    isfinite,
     linalg,
     ndim,
     pi,
@@ -103,6 +104,10 @@ class SO3ProductDiracDistribution(HyperhemisphereCartProdDiracDistribution):
     @staticmethod
     def _normalize_quaternions(quaternions):
         norms = linalg.norm(quaternions, axis=-1)
+        if not all(isfinite(quaternions)):
+            raise ValueError("SO(3) quaternions must be finite.")
+        if not all(isfinite(norms)):
+            raise ValueError("SO(3) quaternion norms must be finite.")
         if not all(norms > 0.0):
             raise ValueError("SO(3) quaternions must be nonzero.")
         return quaternions / reshape(norms, tuple(norms.shape) + (1,))

--- a/tests/distributions/test_so3_product_dirac_distribution.py
+++ b/tests/distributions/test_so3_product_dirac_distribution.py
@@ -1,5 +1,5 @@
 import unittest
-from math import sqrt
+from math import inf, nan, sqrt
 
 import numpy.testing as npt
 import pyrecest.backend
@@ -96,6 +96,18 @@ class SO3ProductDiracDistributionTest(unittest.TestCase):
 
         self.assertEqual(dist.d.shape, (1, 2, 4))
         npt.assert_allclose(dist.as_quaternions()[0], locations)
+
+    def test_constructor_rejects_nonfinite_quaternions(self):
+        invalid_locations = [
+            array([[[inf, 0.0, 0.0, 1.0]]]),
+            array([[[nan, 0.0, 0.0, 1.0]]]),
+            array([[[0.0, 0.0, 0.0, 1.0], [0.0, inf, 0.0, 1.0]]]),
+        ]
+
+        for locations in invalid_locations:
+            with self.subTest(locations=locations):
+                with self.assertRaisesRegex(ValueError, "finite"):
+                    SO3ProductDiracDistribution(locations)
 
     def test_marginalize_rotations(self):
         dist = SO3ProductDiracDistribution(


### PR DESCRIPTION
## Summary
- Reject non-finite quaternion entries and non-finite norms before normalizing SO(3)^K Dirac particles.
- Add regression coverage for `inf` and `nan` constructor inputs, including multi-rotation product particles.

## Root cause
`SO3ProductDiracDistribution._normalize_quaternions` only checked for positive norms. An input containing `inf` has an infinite norm, passes the nonzero check, and divides `inf / inf`, creating `nan` particle locations.

## Tests
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/distributions/test_so3_product_dirac_distribution.py -q -p no:cacheprovider`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/distributions/test_so3_product_dirac_distribution.py tests/distributions/test_so3_product_tangent_gaussian_distribution.py tests/filters/test_so3_product_particle_filter.py -q -p no:cacheprovider`
- `python -m ruff check src/pyrecest/distributions/so3_product_dirac_distribution.py tests/distributions/test_so3_product_dirac_distribution.py`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/so3_product_dirac_distribution.py tests/distributions/test_so3_product_dirac_distribution.py`
- `git diff --check`