### PR TITLE
Reject undefined hyperspherical Dirac means

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/hyperspherical_dirac_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/hyperspherical_dirac_distribution.py
@@ -2,7 +2,7 @@ import matplotlib.pyplot as plt
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import arctan2, linalg, reshape, sum
+from pyrecest.backend import arctan2, reshape, sum
 
 from ..circle.circular_dirac_distribution import CircularDiracDistribution
 from .abstract_hypersphere_subset_dirac_distribution import (
@@ -38,8 +38,7 @@ class HypersphericalDiracDistribution(
 
     def mean_direction(self):
         mean_res_vec = self.mean_resultant_vector()
-        mu = mean_res_vec / linalg.norm(mean_res_vec)
-        return mu
+        return self._normalize_mean_direction(mean_res_vec)
 
     def mean_resultant_vector(self):
         return sum(self.d * reshape(self.w, (-1, 1)), axis=0)

--- a/tests/distributions/test_hyperspherical_dirac_distribution.py
+++ b/tests/distributions/test_hyperspherical_dirac_distribution.py
@@ -114,6 +114,19 @@ class HypersphericalDiracDistributionTest(unittest.TestCase):
         dot = float(axis @ v)
         assert abs(dot) > 1.0 - 1e-6
 
+    def test_mean_direction_rejects_symmetric_zero_resultant(self):
+        d = array(
+            [
+                [1.0, 0.0, 0.0],
+                [-1.0, 0.0, 0.0],
+            ]
+        )
+        dist = HypersphericalDiracDistribution(d, array([0.5, 0.5]))
+
+        with self.assertWarnsRegex(UserWarning, "Mean direction is undefined"):
+            with self.assertRaisesRegex(ValueError, "Mean direction is undefined"):
+                dist.mean_direction()
+
     def test_to_circular_dirac_distribution_uses_rowwise_s1_samples(self):
         d = array(
             [


### PR DESCRIPTION
## Summary
- Use the shared hypersphere mean-direction validator for `HypersphericalDiracDistribution.mean_direction`.
- Add regression coverage for symmetric antipodal particles whose weighted resultant is zero.

## Root cause
`HypersphericalDiracDistribution.mean_direction` divided by `linalg.norm(mean_resultant_vector)` directly. For symmetric Dirac sets, such as equally weighted antipodal points, the resultant norm is zero and the method returned `nan` values instead of reporting that the mean direction is undefined.

## Tests
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/distributions/test_hyperspherical_dirac_distribution.py -q -p no:cacheprovider`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/distributions/test_hyperspherical_dirac_distribution.py tests/distributions/test_abstract_hyperspherical_distribution.py tests/distributions/test_abstract_hyperhemispherical_distribution.py -q -p no:cacheprovider`
- `python -m ruff check src/pyrecest/distributions/hypersphere_subset/hyperspherical_dirac_distribution.py tests/distributions/test_hyperspherical_dirac_distribution.py`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/hypersphere_subset/hyperspherical_dirac_distribution.py tests/distributions/test_hyperspherical_dirac_distribution.py`
- `git diff --check`