### PR TITLE
Reject undefined hyperspherical grid means

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/hyperspherical_grid_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/hyperspherical_grid_distribution.py
@@ -74,18 +74,7 @@ class HypersphericalGridDistribution(
         Mean direction on the hypersphere.
         """
         mu = (self.grid.T @ self.grid_values).reshape((-1,))  # (dim,)
-        norm_mu = linalg.norm(mu)
-
-        if norm_mu < 1e-8:
-            warnings.warn(
-                "Density may not actually have a mean direction because "
-                "formula yields a point very close to the origin.",
-                UserWarning,
-            )
-            if norm_mu == 0.0:
-                return mu
-
-        return mu / norm_mu
+        return self._normalize_mean_direction(mu)
 
     # ------------------------------------------------------------------
     # PDF (nearest-neighbour / piecewise constant interpolation)

--- a/tests/distributions/test_hyperspherical_grid_distribution.py
+++ b/tests/distributions/test_hyperspherical_grid_distribution.py
@@ -72,6 +72,21 @@ class HypersphericalGridDistributionTest(unittest.TestCase):
 
         npt.assert_allclose(p1, p2, atol=tol, rtol=0.1)
 
+    def test_mean_direction_rejects_symmetric_zero_resultant(self):
+        grid = array(
+            [
+                [1.0, 0.0, 0.0],
+                [-1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, -1.0, 0.0],
+            ]
+        )
+        dist = HypersphericalGridDistribution(grid, array([1.0, 1.0, 1.0, 1.0]))
+
+        with self.assertWarnsRegex(UserWarning, "Mean direction is undefined"):
+            with self.assertRaisesRegex(ValueError, "Mean direction is undefined"):
+                dist.mean_direction()
+
     # --------------------------------------------------------------
     # Approximation tests
     # --------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Use the shared hypersphere mean-direction validator in `HypersphericalGridDistribution.mean_direction`.
- Add regression coverage for symmetric grid densities whose first moment cancels to zero.

## Root cause
`HypersphericalGridDistribution.mean_direction` warned when the weighted grid resultant was near zero, but returned the exact zero vector when the norm was zero. A zero vector is not a valid mean direction on the hypersphere and can silently propagate invalid downstream state.

## Tests
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/distributions/test_hyperspherical_grid_distribution.py -q -p no:cacheprovider`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/distributions/test_hyperspherical_grid_distribution.py tests/distributions/test_hyperhemispherical_grid_distribution.py tests/distributions/test_hypersphere_grid_intrinsic_dimension.py -q -p no:cacheprovider`
- `python -m ruff check src/pyrecest/distributions/hypersphere_subset/hyperspherical_grid_distribution.py tests/distributions/test_hyperspherical_grid_distribution.py`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/hypersphere_subset/hyperspherical_grid_distribution.py tests/distributions/test_hyperspherical_grid_distribution.py`
- `git diff --check`