### PR TITLE
Reject undefined hypertoroidal Dirac means

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py
@@ -7,6 +7,8 @@ import matplotlib.pyplot as plt
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    abs,
+    any as backend_any,
     arctan2,
     array,
     atleast_1d,
@@ -106,6 +108,8 @@ class HypertoroidalDiracDistribution(
         :return: Mean direction
         """
         a = self.trigonometric_moment(1)
+        if bool(backend_any(abs(a) < 1e-12)):
+            raise ValueError("Mean direction is undefined for zero resultant moments.")
         m = mod(arctan2(imag(a), real(a)), 2.0 * pi)
         return m
 

--- a/tests/distributions/test_hypertoroidal_dirac_distribution.py
+++ b/tests/distributions/test_hypertoroidal_dirac_distribution.py
@@ -16,6 +16,9 @@ from pyrecest.distributions import (
     ToroidalDiracDistribution,
     VonMisesDistribution,
 )
+from pyrecest.distributions.circle.circular_dirac_distribution import (
+    CircularDiracDistribution,
+)
 
 from .test_abstract_dirac_distribution import TestAbstractDiracDistribution
 
@@ -70,6 +73,17 @@ class TestHypertoroidalDiracDistribution(TestAbstractDiracDistribution):
         npt.assert_almost_equal(m[1], m2, decimal=10)
         npt.assert_almost_equal(m[0], sum(self.w * exp(1j * self.d[:, 0])), decimal=10)
         npt.assert_almost_equal(m[1], sum(self.w * exp(1j * self.d[:, 1])), decimal=10)
+
+    def test_mean_direction_rejects_zero_resultant_moment(self):
+        circular = CircularDiracDistribution(array([0.0, pi]), array([0.5, 0.5]))
+        hypertoroidal = HypertoroidalDiracDistribution(
+            array([[0.0, 0.0], [pi, 0.0]]), array([0.5, 0.5])
+        )
+
+        for dist in (circular, hypertoroidal):
+            with self.subTest(distribution=dist.__class__.__name__):
+                with self.assertRaisesRegex(ValueError, "undefined"):
+                    dist.mean_direction()
 
     def test_sample(self):
         n_samples = 5


### PR DESCRIPTION
## Summary
- Reject zero first trigonometric moments in `HypertoroidalDiracDistribution.mean_direction`.
- Add regression coverage for antipodal circular Dirac particles and mixed hypertoroidal particles with an undefined component mean.

## Root cause
For equally weighted antipodal circular particles, the first trigonometric moment cancels to zero. The previous implementation took `arctan2(imag(moment), real(moment))` anyway, so tiny floating-point roundoff produced an arbitrary angle such as `pi/2` instead of reporting that the mean direction is undefined.

## Tests
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/distributions/test_hypertoroidal_dirac_distribution.py -q -p no:cacheprovider`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/distributions/test_hypertoroidal_dirac_distribution.py tests/distributions/test_circular_dirac_distribution.py tests/distributions/test_hypertoroidal_dirac_marginalize_out.py tests/distributions/test_circular_uniform_distribution.py -q -p no:cacheprovider`
- `python -m ruff check src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py tests/distributions/test_hypertoroidal_dirac_distribution.py`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py tests/distributions/test_hypertoroidal_dirac_distribution.py`
- `git diff --check`