### PR TITLE
Reject undefined hypertoroidal base means

### DIFF
--- a/src/pyrecest/distributions/hypertorus/abstract_hypertoroidal_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/abstract_hypertoroidal_distribution.py
@@ -11,6 +11,7 @@ import pyrecest.backend
 from pyrecest.backend import (
     abs,
     angle,
+    any as backend_any,
     arange,
     array,
     atleast_2d,
@@ -244,6 +245,8 @@ class AbstractHypertoroidalDistribution(AbstractPeriodicDistribution):
 
     def mean_direction(self):
         a = self.trigonometric_moment(1)
+        if bool(backend_any(abs(a) < 1e-12)):
+            raise ValueError("Mean direction is undefined for zero resultant moments.")
         m = mod(angle(a), 2.0 * pi)
         return m
 

--- a/tests/distributions/test_abstract_hypertoroidal_distribution.py
+++ b/tests/distributions/test_abstract_hypertoroidal_distribution.py
@@ -4,7 +4,7 @@ import matplotlib
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array, pi
+from pyrecest.backend import array, ones, pi
 from pyrecest.distributions import AbstractHypertoroidalDistribution
 from pyrecest.distributions.hypertorus.toroidal_wrapped_normal_distribution import (
     ToroidalWrappedNormalDistribution,
@@ -12,6 +12,17 @@ from pyrecest.distributions.hypertorus.toroidal_wrapped_normal_distribution impo
 
 matplotlib.pyplot.close("all")
 matplotlib.use("Agg")
+
+
+class ZeroMomentHypertoroidalDistribution(AbstractHypertoroidalDistribution):
+    def __init__(self):
+        super().__init__(dim=2)
+
+    def pdf(self, xs):
+        return ones(xs.shape[0])
+
+    def trigonometric_moment(self, _):
+        return array([0.0 + 0.0j, 1.0 + 0.0j])
 
 
 class TestAbstractHypertoroidalDistribution(unittest.TestCase):
@@ -29,6 +40,12 @@ class TestAbstractHypertoroidalDistribution(unittest.TestCase):
             pi / 2,
             rtol=2e-07,
         )
+
+    def test_mean_direction_rejects_zero_resultant_moment(self):
+        dist = ZeroMomentHypertoroidalDistribution()
+
+        with self.assertRaisesRegex(ValueError, "undefined"):
+            dist.mean_direction()
 
     def test_plot_2d(self):
         mu = array([0.0, 1.0])


### PR DESCRIPTION
## Summary
- Reject zero first trigonometric moments in `AbstractHypertoroidalDistribution.mean_direction`.
- Add regression coverage for a hypertoroidal distribution with one undefined component mean.

## Root cause
The base hypertoroidal `mean_direction()` converted the first trigonometric moment to an angle without checking whether the moment magnitude was zero. For symmetric or uniform-like custom distributions, the moment cancels to zero and numerical integration roundoff can produce an arbitrary angle instead of reporting that the mean direction is undefined.

## Tests
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/distributions/test_abstract_hypertoroidal_distribution.py -q -p no:cacheprovider`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/distributions/test_abstract_hypertoroidal_distribution.py tests/distributions/test_circular_uniform_distribution.py tests/distributions/test_toroidal_uniform_distribution.py tests/distributions/test_toroidal_fourier_distribution.py -q -p no:cacheprovider`
- `python -m ruff check src/pyrecest/distributions/hypertorus/abstract_hypertoroidal_distribution.py tests/distributions/test_abstract_hypertoroidal_distribution.py`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/hypertorus/abstract_hypertoroidal_distribution.py tests/distributions/test_abstract_hypertoroidal_distribution.py`
- `git diff --check`