### PR TITLE
Reject undefined hyperspherical particle means

### DIFF
--- a/src/pyrecest/filters/hyperspherical_particle_filter.py
+++ b/src/pyrecest/filters/hyperspherical_particle_filter.py
@@ -1,7 +1,7 @@
 import copy
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
-from pyrecest.backend import eye, linalg, sum, tile
+from pyrecest.backend import eye, tile
 from pyrecest.distributions import AbstractHypersphericalDistribution
 from pyrecest.distributions.hypersphere_subset.hyperspherical_dirac_distribution import (
     HypersphericalDiracDistribution,
@@ -57,10 +57,4 @@ class HypersphericalParticleFilter(AbstractParticleFilter, HypersphericalFilterM
             self.filter_state = self.filter_state.reweigh(lambda x: likelihood(z, x))
 
     def get_estimate_mean(self):
-        vec_sum = sum(
-            self.filter_state.d
-            * tile(self.filter_state.w, (self.filter_state.input_dim, 1)).T,
-            axis=0,
-        )
-        mean = vec_sum / linalg.norm(vec_sum)
-        return mean
+        return self.filter_state.mean_direction()

--- a/tests/filters/test_hyperspherical_particle_filter.py
+++ b/tests/filters/test_hyperspherical_particle_filter.py
@@ -74,3 +74,14 @@ class HypersphericalParticleFilterTest(unittest.TestCase):
         est = hpf.get_point_estimate()
         npt.assert_allclose(linalg.norm(est), 1, atol=1e-10)
         self.assertFalse(allclose(est, vmf_init_mean, atol=1e-2))
+
+    def test_get_estimate_mean_rejects_zero_resultant(self):
+        hpf = HypersphericalParticleFilter(2, 3)
+        hpf.filter_state = HypersphericalDiracDistribution(
+            array([[1.0, 0.0, 0.0], [-1.0, 0.0, 0.0]]),
+            array([0.5, 0.5]),
+        )
+
+        with self.assertWarnsRegex(UserWarning, "Mean direction is undefined"):
+            with self.assertRaisesRegex(ValueError, "Mean direction is undefined"):
+                hpf.get_estimate_mean()


### PR DESCRIPTION
## Summary
- Route hyperspherical particle-filter mean estimates through the Dirac distribution mean-direction guard
- Add regression coverage for symmetric particle states with zero resultant vectors

## Root cause
`HypersphericalParticleFilter.get_estimate_mean()` normalized the weighted resultant directly. Symmetric particle states with a zero resultant therefore returned NaNs instead of reporting that the mean direction is undefined.

## Tests
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/filters/test_hyperspherical_particle_filter.py -q -p no:cacheprovider`
- `python -m ruff check src/pyrecest/filters/hyperspherical_particle_filter.py tests/filters/test_hyperspherical_particle_filter.py`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pylint --persistent=no --disable=import-error src/pyrecest/filters/hyperspherical_particle_filter.py tests/filters/test_hyperspherical_particle_filter.py`
- `git diff --check`