### PR TITLE
Reject malformed TDOA sensor positions

### DIFF
--- a/src/pyrecest/models/sensor_models.py
+++ b/src/pyrecest/models/sensor_models.py
@@ -110,6 +110,18 @@ def _as_vector(value, length: int, name: str):
     return vector
 
 
+def _as_sensor_positions(value, position_dim: int = 2):
+    sensors = asarray(value)
+    sensor_shape = tuple(sensors.shape)
+    if len(sensor_shape) != 2 or sensor_shape[1] != position_dim:
+        raise ValueError(
+            f"sensor_positions must have shape (n_sensors, {position_dim})"
+        )
+    if sensor_shape[0] < 2:
+        raise ValueError("sensor_positions must contain at least two sensors")
+    return sensors
+
+
 def _validate_positive_range_squared(range_sq, name="range"):
     range_sq_value = _as_scalar_float(range_sq, name)
     if range_sq_value <= 0.0:
@@ -232,7 +244,7 @@ def tdoa_measurement(
     """Return TDOA range-difference measurements relative to one sensor."""
     propagation_speed = _as_positive_float(propagation_speed, "propagation_speed")
     position = _select(state, position_indices, 2, "position_indices")
-    sensors = asarray(sensor_positions)
+    sensors = _as_sensor_positions(sensor_positions)
     reference_sensor = _normalize_reference_sensor(
         reference_sensor,
         int(sensors.shape[0]),
@@ -262,7 +274,7 @@ def fdoa_measurement(
     propagation_speed = _as_positive_float(propagation_speed, "propagation_speed")
     position = _select(state, position_indices, 2, "position_indices")
     velocity = _select(state, velocity_indices, 2, "velocity_indices")
-    sensors = asarray(sensor_positions)
+    sensors = _as_sensor_positions(sensor_positions)
     if sensor_velocities is None:
         sensor_velocities = zeros(tuple(sensors.shape))
     sensor_velocities = asarray(sensor_velocities)

--- a/tests/test_dynamic_models.py
+++ b/tests/test_dynamic_models.py
@@ -75,18 +75,16 @@ class TestMotionModelCatalog(unittest.TestCase):
 
     def test_kinematic_models_validate_integer_parameters(self):
         invalid_cases = [
-            {"spatial_dim": 0, "message": "spatial_dim"},
-            {"spatial_dim": 1.5, "message": "spatial_dim"},
-            {"spatial_dim": True, "message": "spatial_dim"},
-            {"spatial_dim": np.array([2]), "message": "spatial_dim"},
-            {"derivative_order": -1, "message": "derivative_order"},
-            {"derivative_order": 1.5, "message": "derivative_order"},
-            {"derivative_order": True, "message": "derivative_order"},
+            ({"spatial_dim": 0}, "spatial_dim"),
+            ({"spatial_dim": 1.5}, "spatial_dim"),
+            ({"spatial_dim": True}, "spatial_dim"),
+            ({"spatial_dim": np.array([2])}, "spatial_dim"),
+            ({"derivative_order": -1}, "derivative_order"),
+            ({"derivative_order": 1.5}, "derivative_order"),
+            ({"derivative_order": True}, "derivative_order"),
         ]
 
-        for case in invalid_cases:
-            kwargs = dict(case)
-            message = kwargs.pop("message")
+        for kwargs, message in invalid_cases:
             with self.subTest(case=kwargs):
                 with self.assertRaisesRegex(ValueError, message):
                     kinematic_transition_matrix(1.0, **kwargs)
@@ -309,6 +307,18 @@ class TestSensorModelCatalog(unittest.TestCase):
                         sensors,
                         reference_sensor=reference_sensor,
                     )
+
+        invalid_sensor_positions = (
+            array([0.0, 0.0]),
+            array([[0.0, 0.0]]),
+            array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]),
+        )
+        for sensor_positions in invalid_sensor_positions:
+            with self.subTest(sensor_positions=sensor_positions):
+                with self.assertRaisesRegex(ValueError, "sensor_positions"):
+                    tdoa_measurement(state, sensor_positions)
+                with self.assertRaisesRegex(ValueError, "sensor_positions"):
+                    fdoa_measurement(state, sensor_positions)
 
         with self.assertRaisesRegex(ValueError, "sensor_velocities"):
             fdoa_measurement(


### PR DESCRIPTION
## Summary
- Validate that TDOA/FDOA `sensor_positions` has shape `(n_sensors, 2)` with at least two sensors
- Add regression coverage for one-dimensional, single-sensor, and wrong-width sensor position inputs
- Reshape one existing dynamic-model invalid-argument test to keep Pylint from seeing stale `message` keys in `**kwargs`

## Root cause
`tdoa_measurement()` and `fdoa_measurement()` converted `sensor_positions` directly with `asarray()` and then used `sensors.shape[0]` as the sensor count. A single 2-D sensor position written as `[x, y]` was therefore treated as two scalar sensors and could return a bogus zero range/range-rate difference instead of rejecting invalid input.

## Tests
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/test_dynamic_models.py -q -p no:cacheprovider`
- `python -m ruff check src/pyrecest/models/sensor_models.py tests/test_dynamic_models.py`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pylint --persistent=no --disable=import-error src/pyrecest/models/sensor_models.py tests/test_dynamic_models.py`
- `git diff --check`