### PR TITLE
Reject nonfinite particle diagnostic weights

### DIFF
--- a/src/pyrecest/diagnostics.py
+++ b/src/pyrecest/diagnostics.py
@@ -7,8 +7,8 @@ dependency on pandas, plotting libraries, or backend-specific array types.
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
-from math import log
+from dataclasses import asdict, dataclass, field, fields
+from math import isfinite, log
 from typing import Any
 
 
@@ -18,7 +18,7 @@ def _coerce_weight_values(weights: Any) -> list[float]:
         from pyrecest.backend import to_numpy
 
         weights = to_numpy(weights)
-    except Exception:  # pragma: no cover - best-effort fallback for foreign arrays
+    except Exception:  # pragma: no cover  # pylint: disable=broad-exception-caught
         pass
 
     if hasattr(weights, "tolist"):
@@ -76,7 +76,7 @@ class FilterDiagnostics(_DiagnosticsMappingMixin):
 
     @classmethod
     def from_mapping(cls, mapping: dict[str, Any]) -> "FilterDiagnostics":
-        known = {field_name for field_name in cls.__dataclass_fields__}
+        known = {dataclass_field.name for dataclass_field in fields(cls)}
         values = {key: value for key, value in mapping.items() if key in known}
         metadata = dict(mapping.get("metadata", {}))
         metadata.update(
@@ -107,6 +107,8 @@ class ParticleDiagnostics(_DiagnosticsMappingMixin):
     ) -> "ParticleDiagnostics":
         """Build particle diagnostics from normalized or unnormalized weights."""
         values = _coerce_weight_values(weights)
+        if any(not isfinite(value) for value in values):
+            raise ValueError("Particle weights must be finite.")
         nonnegative_values = [max(0.0, value) for value in values]
         total = sum(nonnegative_values)
         if total <= 0.0:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,5 +1,7 @@
 from math import isclose, log
 
+import pytest
+
 from pyrecest.diagnostics import (
     AssociationDiagnostics,
     FilterDiagnostics,
@@ -22,3 +24,9 @@ def test_particle_diagnostics_clips_negative_weights_before_normalizing():
 
     assert isclose(diagnostics.effective_sample_size, 2.0)
     assert isclose(diagnostics.weight_entropy, log(2.0))
+
+
+def test_particle_diagnostics_rejects_nonfinite_weights():
+    for weights in ([float("nan"), 1.0], [float("inf"), 1.0]):
+        with pytest.raises(ValueError, match="Particle weights must be finite"):
+            ParticleDiagnostics.from_weights(weights)


### PR DESCRIPTION
## Summary
- Reject NaN and infinite particle weights when building `ParticleDiagnostics`
- Add regression coverage for nonfinite diagnostic weights
- Replace direct `__dataclass_fields__` access with `dataclasses.fields()` so the touched diagnostics module passes Pylint cleanly

## Root cause
`ParticleDiagnostics.from_weights()` clipped negative weights but never checked whether the input weights were finite. As a result, nonfinite weights could be converted into finite-looking ESS and entropy values, hiding invalid particle filter state in diagnostics.

## Tests
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/test_diagnostics.py tests/test_diagnostics_integration.py -q -p no:cacheprovider`
- `python -m ruff check src/pyrecest/diagnostics.py tests/test_diagnostics.py tests/test_diagnostics_integration.py`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pylint --persistent=no --disable=import-error src/pyrecest/diagnostics.py tests/test_diagnostics.py`
- `git diff --check`