### PR TITLE
Reject invalid replay particle weights

### DIFF
--- a/src/pyrecest/filters/replay_grid_likelihood.py
+++ b/src/pyrecest/filters/replay_grid_likelihood.py
@@ -214,7 +214,7 @@ def update_position_grid_likelihood(
 def effective_sample_size_fraction(weights) -> float:
     """Return ESS divided by the number of weights."""
 
-    weights = np.asarray(weights, dtype=float)
+    weights = _coerce_particle_weights(weights)
     if weights.size == 0:
         return 0.0
     total = float(np.sum(weights))
@@ -276,7 +276,7 @@ def particle_position_log_posterior(
 
     bin_centers = _coerce_bin_centers(bin_centers)
     positions = _coerce_positions(positions, bin_centers.shape[1], "positions")
-    weights = np.asarray(weights, dtype=float)
+    weights = _coerce_particle_weights(weights)
     if weights.shape != (positions.shape[0],):
         raise ValueError("weights must contain one entry per position particle")
     total = float(np.sum(weights))
@@ -296,6 +296,15 @@ def particle_position_log_posterior(
     positive = masses > 0.0
     log_posterior[positive] = np.log(masses[positive])
     return log_posterior - float(logsumexp(log_posterior))
+
+
+def _coerce_particle_weights(weights) -> np.ndarray:
+    weights = np.asarray(weights, dtype=float)
+    if not np.all(np.isfinite(weights)):
+        raise ValueError("particle weights must be finite")
+    if np.any(weights < 0.0):
+        raise ValueError("particle weights must be nonnegative")
+    return weights
 
 
 def _coerce_bin_centers(bin_centers) -> np.ndarray:

--- a/tests/filters/test_replay_grid_likelihood.py
+++ b/tests/filters/test_replay_grid_likelihood.py
@@ -2,6 +2,8 @@ import types
 import unittest
 
 import numpy as np
+
+# pylint: disable=no-name-in-module
 from pyrecest.filters import (
     adaptive_position_proposal_probability,
     build_replay_grid_likelihood_lookup,
@@ -87,6 +89,12 @@ class TestReplayGridLikelihood(unittest.TestCase):
         self.assertAlmostEqual(probability, 0.5)
         self.assertAlmostEqual(ess_fraction, 0.25)
 
+    def test_effective_sample_size_rejects_invalid_weights(self):
+        for weights in ([1.0, -0.1], [1.0, np.nan], [1.0, np.inf]):
+            with self.subTest(weights=weights):
+                with self.assertRaisesRegex(ValueError, "particle weights"):
+                    effective_sample_size_fraction(weights)
+
     def test_update_position_grid_likelihood_interpolates_particle_positions(self):
         centers = np.array(
             [
@@ -140,6 +148,14 @@ class TestReplayGridLikelihood(unittest.TestCase):
         log_posterior = particle_position_log_posterior(positions, weights, bin_centers)
 
         self.assertTrue(np.allclose(np.exp(log_posterior), [0.5, 0.5]))
+
+    def test_particle_position_log_posterior_rejects_negative_weights(self):
+        positions = np.asarray([[0.0, 0.0], [1.0, 0.0]])
+        weights = np.asarray([-0.25, 1.25])
+        bin_centers = np.asarray([[0.0, 0.0], [1.0, 0.0]])
+
+        with self.assertRaisesRegex(ValueError, "particle weights must be nonnegative"):
+            particle_position_log_posterior(positions, weights, bin_centers)
 
 
 class _DummyFilter:


### PR DESCRIPTION
## Summary
- Validate replay-grid particle weights before ESS and posterior normalization
- Reject nonfinite and negative weights instead of normalizing them into misleading diagnostics or grid posterior mass
- Add regression coverage for invalid ESS weights and negative posterior weights

## Root cause
`particle_position_log_posterior()` only checked the total particle weight. Negative weights with a positive total could accumulate negative grid mass, which was then ignored when constructing the log posterior. `effective_sample_size_fraction()` had the same missing per-weight validation and could report an ESS for invalid particle weights.

## Tests
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/filters/test_replay_grid_likelihood.py -q -p no:cacheprovider`
- `python -m ruff check src/pyrecest/filters/replay_grid_likelihood.py tests/filters/test_replay_grid_likelihood.py`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pylint --persistent=no --disable=import-error src/pyrecest/filters/replay_grid_likelihood.py tests/filters/test_replay_grid_likelihood.py`
- `git diff --check`