### PR TITLE
Validate particle scenario weights

### DIFF
--- a/src/pyrecest/scenarios.py
+++ b/src/pyrecest/scenarios.py
@@ -91,7 +91,7 @@ def _to_float_list(value: Any) -> list[float]:
         from pyrecest.backend import to_numpy
 
         value = to_numpy(value)
-    except Exception:  # pragma: no cover - fallback for backend-specific values
+    except Exception:  # pragma: no cover  # pylint: disable=broad-exception-caught
         pass
 
     if hasattr(value, "tolist"):
@@ -99,6 +99,32 @@ def _to_float_list(value: Any) -> list[float]:
     if isinstance(value, int | float):
         return [float(value)]
     return [float(item) for item in value]
+
+
+def _normalized_particle_weights(raw_weights: Any, particle_count: int, backend):
+    if particle_count <= 0:
+        raise ValueError("particle_resampling scenarios require at least one particle")
+
+    if raw_weights is None:
+        weight_values = [1.0 for _ in range(particle_count)]
+    else:
+        weight_values = _to_float_list(raw_weights)
+
+    if len(weight_values) != particle_count:
+        raise ValueError("weights must contain one entry per particle")
+    if any(not math.isfinite(weight) for weight in weight_values):
+        raise ValueError("weights must be finite")
+    if any(weight < 0.0 for weight in weight_values):
+        raise ValueError("weights must be nonnegative")
+
+    weight_total = sum(weight_values)
+    if weight_total <= 0.0:
+        raise ValueError("weights must have positive total mass")
+
+    return backend.asarray(
+        [weight / weight_total for weight in weight_values],
+        dtype=backend.float64,
+    )
 
 
 @scenario_runner("linear_gaussian")
@@ -117,7 +143,7 @@ def run_linear_gaussian_scenario(path: str | Path) -> ScenarioResult:
     seed = _apply_scenario_seed(config)
 
     from pyrecest import backend as be
-    from pyrecest.filters import KalmanFilter
+    from pyrecest.filters.kalman_filter import KalmanFilter
 
     model = config["model"]
     measurement = config["measurement"]
@@ -197,13 +223,11 @@ def run_particle_resampling_scenario(path: str | Path) -> ScenarioResult:
 
     data = config["data"]
     particles = be.asarray(data["particles"], dtype=be.float64)
-    raw_weights = data.get("weights")
-    if raw_weights is None:
-        raw_weights = [
-            1.0 / int(particles.shape[0]) for _ in range(int(particles.shape[0]))
-        ]
-    weights = be.asarray(raw_weights, dtype=be.float64)
-    weights = weights / be.sum(weights)
+    weights = _normalized_particle_weights(
+        data.get("weights"),
+        int(particles.shape[0]),
+        be,
+    )
     num_samples = int(data.get("num_samples", int(particles.shape[0])))
 
     indices = be.random.choice(

--- a/tests/test_scenario_registry_and_reproducibility.py
+++ b/tests/test_scenario_registry_and_reproducibility.py
@@ -1,6 +1,25 @@
 from pathlib import Path
 
+import pytest
+
 from pyrecest.scenarios import available_scenario_types, run_scenario
+
+
+def _write_particle_scenario(path: Path, weights: str) -> None:
+    path.write_text(
+        f"""
+[scenario]
+type = "particle_resampling"
+name = "particle-resampling"
+seed = 7
+
+[data]
+particles = [[0.0, 0.0], [1.0, 0.0]]
+weights = {weights}
+num_samples = 4
+""".strip(),
+        encoding="utf-8",
+    )
 
 
 def test_particle_resampling_scenario_is_seed_reproducible(tmp_path: Path):
@@ -30,3 +49,19 @@ num_samples = 8
         == second.diagnostics["metadata"]["indices"]
     )
     assert first.metrics["effective_sample_size"] > 0.0
+
+
+def test_particle_resampling_scenario_rejects_zero_weight_mass(tmp_path: Path):
+    scenario = tmp_path / "zero_weights.toml"
+    _write_particle_scenario(scenario, "[0.0, 0.0]")
+
+    with pytest.raises(ValueError, match="weights must have positive total mass"):
+        run_scenario(scenario)
+
+
+def test_particle_resampling_scenario_rejects_negative_weights(tmp_path: Path):
+    scenario = tmp_path / "negative_weights.toml"
+    _write_particle_scenario(scenario, "[1.0, -0.5]")
+
+    with pytest.raises(ValueError, match="weights must be nonnegative"):
+        run_scenario(scenario)


### PR DESCRIPTION
## Summary
- Validate particle-resampling scenario weights before normalization and sampling
- Reject mismatched, nonfinite, negative, zero-mass, and empty-particle configurations with clear errors
- Add regression coverage for zero-total and negative scenario weights
- Import `KalmanFilter` from its concrete module so the touched scenario module passes Pylint cleanly

## Root cause
`run_particle_resampling_scenario()` normalized `data.weights` with `weights / sum(weights)` without validating the vector first. A zero-total weight vector produced NaN probabilities and then failed later inside backend random sampling with an opaque `probabilities contain NaN` error.

## Tests
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/test_scenario_registry_and_reproducibility.py tests/test_scenarios.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/scenarios.py tests/test_scenario_registry_and_reproducibility.py tests/test_scenarios.py`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pylint --persistent=no --disable=import-error src/pyrecest/scenarios.py tests/test_scenario_registry_and_reproducibility.py tests/test_scenarios.py`
- `git diff --check`