### PR TITLE
Clamp angular distance inner products

### DIFF
--- a/src/pyrecest/evaluation/get_distance_function.py
+++ b/src/pyrecest/evaluation/get_distance_function.py
@@ -5,7 +5,7 @@ from math import pi
 from typing import Any
 
 import numpy as np
-from pyrecest.backend import arccos, asarray, dot, linalg, to_numpy
+from pyrecest.backend import arccos, asarray, clip, dot, linalg, to_numpy
 from pyrecest.distributions import AbstractHypertoroidalDistribution
 from scipy.optimize import linear_sum_assignment
 
@@ -99,6 +99,10 @@ def _euclidean_mtt_distance(x1, x2, *, cutoff_distance: float) -> float:
     return matched_cost + float(cutoff_distance) * missed_count
 
 
+def _angular_distance_from_inner_product(inner_product):
+    return arccos(clip(inner_product, -1.0, 1.0))
+
+
 def get_distance_function(
     manifold_name, additional_params=None, nSymm=None, symmetryOffsets=None
 ):
@@ -122,12 +126,15 @@ def get_distance_function(
     elif _is_hypersphere_symmetric_name(normalized_name):
 
         def distance_function(x1, x2):
-            return min(arccos(dot(x1, x2)), arccos(dot(x1, -x2)))
+            return min(
+                _angular_distance_from_inner_product(dot(x1, x2)),
+                _angular_distance_from_inner_product(dot(x1, -x2)),
+            )
 
     elif "hypersphere" in normalized_name:
 
         def distance_function(x1, x2):
-            return arccos(dot(x1, x2))
+            return _angular_distance_from_inner_product(dot(x1, x2))
 
     elif "se2bounded" in normalized_name:
 
@@ -144,7 +151,10 @@ def get_distance_function(
     elif "se3bounded" in normalized_name:
 
         def distance_function(x1, x2):
-            return min(arccos(dot(x1[:4], x2[:4])), arccos(dot(x1[:4], -x2[:4])))
+            return min(
+                _angular_distance_from_inner_product(dot(x1[:4], x2[:4])),
+                _angular_distance_from_inner_product(dot(x1[:4], -x2[:4])),
+            )
 
     elif "se3" in normalized_name or "se3linear" in normalized_name:
 

--- a/tests/evaluation/test_evaluation_registries.py
+++ b/tests/evaluation/test_evaluation_registries.py
@@ -35,6 +35,23 @@ def test_underscored_symmetric_hypersphere_distance_is_antipodal_invariant():
     )
 
 
+def test_angular_distances_clip_inner_product_roundoff():
+    cases = (
+        ("hypersphere", array([1.0, 0.0]), array([1.0 + 1e-12, 0.0])),
+        ("hypersphere_symmetric", array([1.0, 0.0]), array([1.0 + 1e-12, 0.0])),
+        (
+            "se3bounded",
+            array([1.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0]),
+            array([1.0 + 1e-12, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0]),
+        ),
+    )
+
+    for manifold_name, estimate, truth in cases:
+        distance = get_distance_function(manifold_name)
+
+        assert _as_float(distance(estimate, truth)) == pytest.approx(0.0)
+
+
 def test_se2bounded_distance_uses_angular_component_before_linear_dispatch():
     distance = get_distance_function("se2bounded")
 


### PR DESCRIPTION
## Summary
- Clamp inner products before angular-distance `arccos` calls
- Apply the fix to hypersphere, antipodal hypersphere, and SE(3)-bounded distance functions
- Add regression coverage for tiny inner-product roundoff above 1

## Root cause
`get_distance_function()` passed raw dot products directly to `arccos` for several angular distance paths. A dot product of `1 + eps`, which can happen from floating-point roundoff, produced `nan` distances instead of zero.

## Tests
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/evaluation/test_evaluation_registries.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/test_evaluation_basic.py::TestEvalationBasics::test_get_distance_function -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/evaluation/get_distance_function.py tests/evaluation/test_evaluation_registries.py`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pylint --persistent=no --disable=import-error src/pyrecest/evaluation/get_distance_function.py tests/evaluation/test_evaluation_registries.py`
- `git diff --check`