### PR TITLE
Propagate additive model arguments to Jacobians

### DIFF
--- a/src/pyrecest/models/additive_noise.py
+++ b/src/pyrecest/models/additive_noise.py
@@ -101,6 +101,21 @@ def _dt_call_mode(function: Callable[..., Any]) -> str | None:
     return "positional" if len(positional) >= 2 else None
 
 
+def _supported_kwargs(function: Callable[..., Any], kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Return kwargs accepted by ``function``, preserving opaque callables."""
+    if not kwargs:
+        return {}
+    try:
+        signature = inspect.signature(function)
+    except (TypeError, ValueError):
+        return kwargs
+
+    parameters = signature.parameters
+    if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters.values()):
+        return kwargs
+    return {key: value for key, value in kwargs.items() if key in parameters}
+
+
 def _call_transition_function(
     function: Callable[..., Any],
     state: Any,
@@ -121,6 +136,26 @@ def _call_transition_function(
     return function(state, **call_kwargs)
 
 
+def _call_transition_jacobian(
+    function: Callable[..., Any],
+    state: Any,
+    dt: Any,
+    function_args: dict[str, Any],
+    kwargs: dict[str, Any],
+) -> Any:
+    """Call a transition Jacobian with arguments it explicitly accepts."""
+    call_kwargs = _supported_kwargs(function, {**function_args, **kwargs})
+    if dt is None:
+        return function(state, **call_kwargs)
+
+    dt_mode = _dt_call_mode(function)
+    if dt_mode == "keyword" and "dt" not in call_kwargs:
+        return function(state, dt=dt, **call_kwargs)
+    if dt_mode == "positional":
+        return function(state, dt, **call_kwargs)
+    return function(state, **call_kwargs)
+
+
 def _call_measurement_function(
     function: Callable[..., Any],
     state: Any,
@@ -129,6 +164,16 @@ def _call_measurement_function(
 ) -> Any:
     """Call a measurement function with default and per-call arguments."""
     return function(state, **{**function_args, **kwargs})
+
+
+def _call_measurement_jacobian(
+    function: Callable[..., Any],
+    state: Any,
+    function_args: dict[str, Any],
+    kwargs: dict[str, Any],
+) -> Any:
+    """Call a measurement Jacobian with arguments it explicitly accepts."""
+    return function(state, **_supported_kwargs(function, {**function_args, **kwargs}))
 
 
 class AdditiveNoiseTransitionModel:
@@ -225,12 +270,15 @@ class AdditiveNoiseTransitionModel:
         noise_mean = self.noise_mean
         return propagated if noise_mean is None else propagated + noise_mean
 
-    def jacobian(self, state):
+    def jacobian(self, state, dt=None, **kwargs):
         """Return the transition Jacobian evaluated at ``state``."""
         jacobian = self._jacobian
         if jacobian is None:
             raise NotImplementedError("No transition Jacobian callback was supplied")
-        return jacobian(state)
+        effective_dt = self.dt if dt is None else dt
+        return _call_transition_jacobian(
+            jacobian, state, effective_dt, self.function_args, kwargs
+        )
 
     def has_jacobian(self):
         """Return whether this model can provide transition Jacobians."""
@@ -324,12 +372,14 @@ class AdditiveNoiseMeasurementModel:
             else _distribution_covariance(self.noise_distribution)
         )
 
-    def jacobian(self, state):
+    def jacobian(self, state, **kwargs):
         """Return the measurement Jacobian evaluated at ``state``."""
         jacobian = self._jacobian
         if jacobian is None:
             raise NotImplementedError("No measurement Jacobian callback was supplied")
-        return jacobian(state)
+        return _call_measurement_jacobian(
+            jacobian, state, self.function_args, kwargs
+        )
 
     def has_jacobian(self):
         """Return whether this model can provide measurement Jacobians."""

--- a/tests/models/test_additive_noise_models.py
+++ b/tests/models/test_additive_noise_models.py
@@ -89,6 +89,50 @@ class AdditiveNoiseTransitionModelTest(unittest.TestCase):
         assert_backend_allclose(self, likelihood, array(7.0))
         assert_backend_allclose(self, noise.last_pdf_arg, array([1.5]))
 
+    def test_transition_jacobian_receives_dt_and_function_arguments(self):
+        calls = []
+
+        def transition_function(x, dt, scale):
+            return array([x[0] + dt * scale * x[1], x[1]])
+
+        def jacobian(_x, dt, scale):
+            calls.append((dt, scale))
+            return array([[1.0, dt * scale], [0.0, 1.0]])
+
+        model = AdditiveNoiseTransitionModel(
+            transition_function,
+            jacobian=jacobian,
+            dt=0.5,
+            function_args={"scale": 4.0},
+        )
+
+        state = array([1.0, 2.0])
+
+        assert_backend_allclose(
+            self, model.transition_function(state), array([5.0, 2.0])
+        )
+        assert_backend_allclose(
+            self, model.jacobian(state), array([[1.0, 2.0], [0.0, 1.0]])
+        )
+        assert_backend_allclose(
+            self,
+            model.jacobian(state, dt=0.25, scale=8.0),
+            array([[1.0, 2.0], [0.0, 1.0]]),
+        )
+        self.assertEqual(calls, [(0.5, 4.0), (0.25, 8.0)])
+
+    def test_transition_jacobian_ignores_function_args_it_does_not_accept(self):
+        model = AdditiveNoiseTransitionModel(
+            lambda x, scale: x * scale,
+            jacobian=lambda _x: eye(2),
+            function_args={"scale": 2.0},
+        )
+
+        assert_backend_allclose(
+            self, model.transition_function(array([1.0, 2.0])), array([2.0, 4.0])
+        )
+        assert_backend_allclose(self, model.jacobian(array([1.0, 2.0])), eye(2))
+
     def test_explicit_noise_statistics_work_without_distribution(self):
         model = AdditiveNoiseTransitionModel(
             lambda x: x,
@@ -152,6 +196,45 @@ class AdditiveNoiseMeasurementModelTest(unittest.TestCase):
             self, model.measurement_residual(array([5.0]), array([2.0])), array([1.0])
         )
         assert_backend_allclose(self, noise.last_pdf_arg, array([1.0]))
+
+    def test_measurement_jacobian_receives_function_arguments(self):
+        calls = []
+
+        def measurement_function(x, scale, offset):
+            return array([scale * x[0] + offset])
+
+        def jacobian(_x, scale, offset):
+            calls.append((scale, offset))
+            return array([[scale + offset]])
+
+        model = AdditiveNoiseMeasurementModel(
+            measurement_function,
+            jacobian=jacobian,
+            function_args={"scale": 2.0, "offset": 0.5},
+        )
+
+        state = array([3.0])
+
+        assert_backend_allclose(
+            self, model.measurement_function(state), array([6.5])
+        )
+        assert_backend_allclose(self, model.jacobian(state), array([[2.5]]))
+        assert_backend_allclose(
+            self, model.jacobian(state, scale=4.0), array([[4.5]])
+        )
+        self.assertEqual(calls, [(2.0, 0.5), (4.0, 0.5)])
+
+    def test_measurement_jacobian_ignores_function_args_it_does_not_accept(self):
+        model = AdditiveNoiseMeasurementModel(
+            lambda x, scale: x * scale,
+            jacobian=lambda _x: array([[1.0]]),
+            function_args={"scale": 2.0},
+        )
+
+        assert_backend_allclose(
+            self, model.measurement_function(array([3.0])), array([6.0])
+        )
+        assert_backend_allclose(self, model.jacobian(array([3.0])), array([[1.0]]))
 
     def test_missing_measurement_capabilities_raise(self):
         model = AdditiveNoiseMeasurementModel(lambda x: x)


### PR DESCRIPTION
## Summary
- pass stored `dt` and `function_args` through additive transition Jacobian callbacks
- pass stored and call-time `function_args` through additive measurement Jacobian callbacks
- add regression tests for parameterized transition and measurement Jacobians, including call-time overrides

## Root cause
`AdditiveNoiseTransitionModel.evaluate()` and `AdditiveNoiseMeasurementModel.evaluate()` already apply stored model parameters, but `jacobian()` called the supplied callback with only the state. This can make EKF-style linearizations inconsistent with the nonlinear model whenever `dt` or model parameters are configured on the additive model object.

## Tests
- Not run locally: this environment could not clone GitHub directly (`Could not resolve host: github.com`). The branch was created through the connected GitHub API.

Suggested validation:
- `PYTHONPATH=src python -m pytest tests/models/test_additive_noise_models.py -q`
- `python -m ruff check src/pyrecest/models/additive_noise.py tests/models/test_additive_noise_models.py`