### PR TITLE
Allow degenerate uniform intervals across backends

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/random.py
+++ b/src/pyrecest/_backend/_shared_numpy/random.py
@@ -9,8 +9,17 @@ rand = _modify_func_default_dtype(
     copy=False, kw_only=True, target=_allow_complex_dtype(target=_np.random.rand)
 )
 
+
+def _uniform(low=0.0, high=1.0, size=None):
+    low_array = _np.asarray(low)
+    high_array = _np.asarray(high)
+    if _np.any(low_array > high_array):
+        raise ValueError("Upper bound must be greater than or equal to lower bound")
+    return _np.random.uniform(low, high, size)
+
+
 uniform = _modify_func_default_dtype(
-    copy=False, kw_only=True, target=_allow_complex_dtype(target=_np.random.uniform)
+    copy=False, kw_only=True, target=_allow_complex_dtype(target=_uniform)
 )
 
 

--- a/src/pyrecest/_backend/jax/random.py
+++ b/src/pyrecest/_backend/jax/random.py
@@ -94,8 +94,8 @@ def uniform(low=0.0, high=1.0, size=None, *args, **kwargs):
     state, has_state, kwargs = _get_state(**kwargs)
     low = _jnp.asarray(low)
     high = _jnp.asarray(high)
-    if bool(_jnp.any(low >= high)):
-        raise ValueError("Upper bound must be higher than lower bound")
+    if bool(_jnp.any(low > high)):
+        raise ValueError("Upper bound must be greater than or equal to lower bound")
     state, res = _rand(state, size, *args, minval=low, maxval=high, **kwargs)
     return set_state_return(has_state, state, res)
 

--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -190,8 +190,8 @@ def uniform(low=0.0, high=1.0, size=None, dtype=None):
 
     low = _torch.as_tensor(low, dtype=dtype, device=device)
     high = _torch.as_tensor(high, dtype=dtype, device=device)
-    if bool(_torch.any(low >= high)):
-        raise ValueError("Upper bound must be higher than lower bound")
+    if bool(_torch.any(low > high)):
+        raise ValueError("Upper bound must be greater than or equal to lower bound")
     if size is None:
         size = ()
     elif not hasattr(size, "__iter__"):

--- a/tests/test_backend_random.py
+++ b/tests/test_backend_random.py
@@ -16,6 +16,16 @@ class TestBackendRandom(unittest.TestCase):
         npt.assert_array_less(-1, samples)
         npt.assert_array_less(samples, 5)
 
+    def test_uniform_allows_degenerate_interval(self):
+        samples = random.uniform(2.5, 2.5, size=(4,))
+
+        self.assertEqual(tuple(pyrecest.backend.shape(samples)), (4,))
+        npt.assert_allclose(pyrecest.backend.to_numpy(samples), [2.5, 2.5, 2.5, 2.5])
+
+    def test_uniform_rejects_descending_interval(self):
+        with self.assertRaises(ValueError):
+            random.uniform(2.0, 1.0, size=(3,))
+
     def test_choice_single_sample_preserves_sample_axis(self):
         values = pyrecest.backend.array([[0, 1], [2, 3], [4, 5]])
 


### PR DESCRIPTION
Closed as stale duplicate after applying the same backend uniform-interval fix directly on main.