### PR TITLE
Clamp sphere coordinate conversion

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/abstract_sphere_subset_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/abstract_sphere_subset_distribution.py
@@ -3,6 +3,7 @@ from pyrecest.backend import (
     arccos,
     arctan2,
     atleast_2d,
+    clip,
     column_stack,
     cos,
     ndim,
@@ -151,7 +152,7 @@ class AbstractSphereSubsetDistribution(AbstractHypersphereSubsetDistribution):
         assert ndim(x) == 1 and ndim(y) == 1 and ndim(z) == 1
         azimuth = arctan2(y, x)
         azimuth = where(azimuth < 0, azimuth + 2 * pi, azimuth)
-        colatitude = arccos(z)
+        colatitude = arccos(clip(z, -1.0, 1.0))
         return azimuth, colatitude
 
     @staticmethod
@@ -159,5 +160,5 @@ class AbstractSphereSubsetDistribution(AbstractHypersphereSubsetDistribution):
         assert ndim(x) == 1 and ndim(y) == 1 and ndim(z) == 1
         azimuth = arctan2(y, x)
         azimuth = where(azimuth < 0, azimuth + 2 * pi, azimuth)
-        elevation = pi / 2 - arccos(z)  # elevation is π/2 - colatitude
+        elevation = pi / 2 - arccos(clip(z, -1.0, 1.0))
         return azimuth, elevation

--- a/tests/distributions/test_abstract_sphere_subset_distribution.py
+++ b/tests/distributions/test_abstract_sphere_subset_distribution.py
@@ -1,3 +1,4 @@
+# pylint: disable=protected-access
 import unittest
 
 import numpy.testing as npt
@@ -37,6 +38,25 @@ class TestAbstractSphereSubsetDistribution(unittest.TestCase):
         npt.assert_allclose(x_new, x, atol=1e-7)
         npt.assert_allclose(y_new, y, atol=1e-7)
         npt.assert_allclose(z_new, z, atol=1e-7)
+
+    @parameterized.expand(
+        [
+            ("inclination_north", "inclination", 1.0 + 1e-12, 0.0),
+            ("inclination_south", "inclination", -1.0 - 1e-12, pi),
+            ("elevation_north", "elevation", 1.0 + 1e-12, pi / 2),
+            ("elevation_south", "elevation", -1.0 - 1e-12, -pi / 2),
+        ]
+    )
+    def test_cart_to_sph_clips_roundoff_at_poles(
+        self, _case, mode, z_value, expected_theta
+    ):
+        x = array([0.0])
+        y = array([0.0])
+        z = array([z_value])
+
+        _, theta = AbstractSphereSubsetDistribution.cart_to_sph(x, y, z, mode=mode)
+
+        npt.assert_allclose(theta, array([expected_theta]), atol=1e-12)
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Summary
- Clamp sphere `cart_to_sph` inverse-trig inputs to `[-1, 1]` for inclination and elevation modes
- Add regression coverage for tiny near-pole floating-point overshoots
- Suppress protected-access in the existing helper-test module so targeted pylint stays clean

## Tests
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/distributions/test_abstract_sphere_subset_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/hypersphere_subset/abstract_sphere_subset_distribution.py tests/distributions/test_abstract_sphere_subset_distribution.py`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/hypersphere_subset/abstract_sphere_subset_distribution.py tests/distributions/test_abstract_sphere_subset_distribution.py`
- `git diff --check`