### PR TITLE
Clamp Hopf quaternion conversion

### DIFF
--- a/src/pyrecest/sampling/hyperspherical_sampler.py
+++ b/src/pyrecest/sampling/hyperspherical_sampler.py
@@ -10,6 +10,7 @@ from pyrecest.backend import (
     arccos,
     arctan2,
     array,
+    clip,
     column_stack,
     cos,
     deg2rad,
@@ -393,7 +394,7 @@ class AbstractHopfBasedS3Sampler(AbstractHypersphericalUniformSampler):
 
     @staticmethod
     def quaternion_to_hopf_yershova(q):
-        θ = 2 * arccos(sqrt(q[:, 0] ** 2 + q[:, 1] ** 2))
+        θ = 2 * arccos(clip(sqrt(q[:, 0] ** 2 + q[:, 1] ** 2), 0.0, 1.0))
         ϕ = arctan2(q[:, 3], q[:, 2]) - arctan2(q[:, 1], q[:, 0])
         ψ = 2 * arctan2(q[:, 1], q[:, 0])
         return θ, ϕ, ψ

--- a/tests/test_hyperspherical_sampler.py
+++ b/tests/test_hyperspherical_sampler.py
@@ -441,6 +441,15 @@ class TestHopfConversion(unittest.TestCase):
             recovered_quaternions, recovered_quaternions_via_legacy_alias
         )
 
+    def test_quaternion_to_hopf_clips_theta_roundoff(self):
+        quaternion = array([[1.0 + 1e-12, 0.0, 0.0, 0.0]])
+
+        theta, _, _ = AbstractHopfBasedS3Sampler.quaternion_to_hopf_yershova(
+            quaternion
+        )
+
+        npt.assert_allclose(theta, array([0.0]), atol=1e-12)
+
 
 class TestSymmetricLeopardiSampler(unittest.TestCase):
     @unittest.skipIf(


### PR DESCRIPTION
## Summary
- Clamp the Hopf quaternion conversion input before `arccos`
- Add regression coverage for tiny roundoff overshoots near the identity quaternion

## Root Cause
`quaternion_to_hopf_yershova` derived `theta` from `sqrt(q0^2 + q1^2)` and passed it directly to `arccos`. A unit quaternion with a tiny floating-point overshoot can make that value slightly larger than `1`, producing `nan` instead of a zero Hopf polar angle.

## Tests
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/test_hyperspherical_sampler.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/sampling/hyperspherical_sampler.py tests/test_hyperspherical_sampler.py`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pylint --persistent=no --disable=import-error src/pyrecest/sampling/hyperspherical_sampler.py tests/test_hyperspherical_sampler.py`
- `git diff --check`