### PR TITLE
Validate wrapped-normal moments

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
@@ -1,3 +1,4 @@
+from math import isfinite
 from numbers import Integral
 from typing import Union
 
@@ -45,6 +46,7 @@ class WrappedNormalDistribution(
     """
 
     MAX_SIGMA_BEFORE_UNIFORM = 10
+    _MOMENT_NORM_TOL = 1e-12
 
     def __init__(
         self,
@@ -261,8 +263,24 @@ class WrappedNormalDistribution(
 
     @staticmethod
     def from_moment(m) -> "WrappedNormalDistribution":
-        mu = mod(angle(m.squeeze()), 2.0 * pi)
-        sigma = sqrt(-2 * log(abs(m.squeeze())))
+        moment = m.squeeze()
+        moment_abs = float(abs(moment))
+        if not isfinite(moment_abs):
+            raise ValueError("First trigonometric moment must be finite.")
+        if moment_abs > 1.0 + WrappedNormalDistribution._MOMENT_NORM_TOL:
+            raise ValueError(
+                "First trigonometric moment must have magnitude at most 1."
+            )
+
+        moment_abs = min(moment_abs, 1.0)
+        if moment_abs == 1.0:
+            raise ValueError(
+                "First trigonometric moment with |m| = 1 cannot be moment-matched "
+                "to a wrapped normal with positive variance."
+            )
+
+        mu = mod(angle(moment), 2.0 * pi)
+        sigma = sqrt(-2 * log(moment_abs))
         return WrappedNormalDistribution(mu, sigma)
 
     @staticmethod

--- a/tests/distributions/test_wrapped_normal_distribution.py
+++ b/tests/distributions/test_wrapped_normal_distribution.py
@@ -159,6 +159,24 @@ class WrappedNormalDistributionTest(unittest.TestCase):
         self.assertTrue(allclose(convolved.C, array(13.0), atol=1e-12))
         self.assertTrue(allclose(convolved.sigma, sqrt(array(13.0)), atol=1e-12))
 
+    def test_from_moment_recovers_parameters(self):
+        reconstructed = WrappedNormalDistribution.from_moment(
+            self.wn.trigonometric_moment(1)
+        )
+
+        self.assertTrue(allclose(reconstructed.scalar_mu, self.mu, atol=1e-12))
+        self.assertTrue(allclose(reconstructed.sigma, self.sigma, atol=1e-12))
+
+    def test_from_moment_rejects_invalid_magnitudes(self):
+        for moment in (
+            array(1.0 + 0.0j),
+            array(1.0 + 1e-13 + 0.0j),
+            array(1.01 + 0.0j),
+        ):
+            with self.subTest(moment=moment):
+                with self.assertRaisesRegex(ValueError, "First trigonometric moment"):
+                    WrappedNormalDistribution.from_moment(moment)
+
     def test_sample_accepts_integer_like_count(self):
         samples = self.wn.sample(np.int64(4))
 


### PR DESCRIPTION
## Summary
- Validate first trigonometric moments before converting them to a wrapped normal
- Reject nonfinite, impossible, and degenerate moment magnitudes with clear `ValueError`s
- Add regression coverage for valid moment recovery and invalid magnitude handling

## Root Cause
`WrappedNormalDistribution.from_moment` computed `sqrt(-2 * log(abs(m)))` before checking whether the first moment magnitude was valid. Inputs with magnitude above one produced `nan` variance and then failed later with unrelated covariance assertions; `|m| = 1` reached the positive-definite covariance check even though it implies zero variance.

## Tests
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/distributions/test_wrapped_normal_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/circle/wrapped_normal_distribution.py tests/distributions/test_wrapped_normal_distribution.py`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/circle/wrapped_normal_distribution.py tests/distributions/test_wrapped_normal_distribution.py`
- `git diff --check`