### PR TITLE
Validate block particle weights

### DIFF
--- a/src/pyrecest/filters/block_particle_filter.py
+++ b/src/pyrecest/filters/block_particle_filter.py
@@ -213,6 +213,8 @@ class BlockParticleFilter:
         weights = array(weights, dtype=float)
         if ndim(weights) != 1:
             weights = reshape(weights, (-1,))
+        if not all(isfinite(weights)):
+            raise ValueError("Particle weights must be finite.")
         if not all(weights >= 0.0):
             raise ValueError("Particle weights must be nonnegative.")
         weight_sum = sum(weights)

--- a/tests/filters/test_block_particle_filter.py
+++ b/tests/filters/test_block_particle_filter.py
@@ -86,6 +86,22 @@ class BlockParticleFilterTest(unittest.TestCase):
         npt.assert_allclose(filt.block_weights, array([[1.0, 0.0], [1.0, 0.0]]))
         npt.assert_allclose(filt.weights, array([1.0, 0.0]))
 
+    def test_rejects_nonfinite_weights(self):
+        for invalid_weight in (float("nan"), float("inf"), -float("inf")):
+            with self.subTest(invalid_weight=invalid_weight):
+                with self.assertRaisesRegex(ValueError, "finite"):
+                    DummyBlockParticleFilter(
+                        array([[0.0, 10.0], [1.0, 11.0]]),
+                        weights=array([invalid_weight, 1.0]),
+                    )
+
+                with self.assertRaisesRegex(ValueError, "finite"):
+                    DummyBlockParticleFilter(
+                        array([[0.0, 10.0], [1.0, 11.0]]),
+                        partition="singleton",
+                        block_weights=array([[1.0, invalid_weight], [1.0, 1.0]]),
+                    )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Reject nonfinite block particle weights before normalization
- Add regression coverage for global and per-block nonfinite weights

## Root Cause
`BlockParticleFilter._normalize_weights` checked only nonnegativity and positive total mass. Positive infinity passed those checks, so normalization divided by an infinite sum and produced `nan` weights. The corrupted weights could then propagate into block resampling, ESS calculations, and product-state estimates.

## Tests
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/filters/test_block_particle_filter.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/filters/test_block_particle_filter.py tests/filters/test_partitioned_so3_product_particle_filter.py tests/filters/test_so3_product_block_particle_filter.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/filters/block_particle_filter.py tests/filters/test_block_particle_filter.py`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pylint --persistent=no --disable=import-error src/pyrecest/filters/block_particle_filter.py tests/filters/test_block_particle_filter.py`
- `git diff --check`