### PR TITLE
Validate nonadditive noise weights

### DIFF
--- a/src/pyrecest/filters/abstract_particle_filter.py
+++ b/src/pyrecest/filters/abstract_particle_filter.py
@@ -3,7 +3,18 @@ import inspect
 from collections.abc import Callable
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
-from pyrecest.backend import hstack, ndim, ones_like, random, sum, vmap, vstack
+from pyrecest.backend import (
+    all,
+    array,
+    hstack,
+    isfinite,
+    ndim,
+    ones_like,
+    random,
+    sum,
+    vmap,
+    vstack,
+)
 from pyrecest.diagnostics import ParticleDiagnostics
 from pyrecest.distributions.abstract_manifold_specific_distribution import (
     AbstractManifoldSpecificDistribution,
@@ -194,11 +205,19 @@ class AbstractParticleFilter(AbstractFilter):
         self._filter_state.d = updated_particles
 
     def predict_nonlinear_nonadditive(self, f, samples, weights):
+        weights = array(weights, dtype=float)
         assert (
             samples.shape[0] == weights.shape[0]
         ), "samples and weights must match in size"
 
-        weights = weights / sum(weights)
+        if not bool(all(isfinite(weights))):
+            raise ValueError("Noise weights must be finite.")
+        if not bool(all(weights >= 0.0)):
+            raise ValueError("Noise weights must be nonnegative.")
+        weight_sum = sum(weights)
+        if not bool(isfinite(weight_sum)) or not bool(weight_sum > 0.0):
+            raise ValueError("Noise weights must have positive finite total mass.")
+        weights = weights / weight_sum
         n_particles = self.filter_state.w.shape[0]
         noise_samples = random.choice(samples, n_particles, p=weights)
 

--- a/tests/filters/test_euclidean_particle_filter.py
+++ b/tests/filters/test_euclidean_particle_filter.py
@@ -58,6 +58,24 @@ class EuclideanParticleFilterTest(unittest.TestCase):
         self.assertEqual(self.pf.get_point_estimate().shape, (3,))
         npt.assert_allclose(est, self.prior.mu + mean(samples, axis=0), atol=0.1)
 
+    def test_predict_nonlinear_nonadditive_rejects_invalid_weights(self):
+        samples = array([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
+
+        def f(x, w):
+            return x + w
+
+        invalid_cases = (
+            (array([float("nan"), 1.0]), "finite"),
+            (array([float("inf"), 1.0]), "finite"),
+            (array([-float("inf"), 1.0]), "finite"),
+            (array([-1.0, 2.0]), "nonnegative"),
+            (array([0.0, 0.0]), "positive finite total mass"),
+        )
+        for weights, message in invalid_cases:
+            with self.subTest(weights=weights):
+                with self.assertRaisesRegex(ValueError, message):
+                    self.pf.predict_nonlinear_nonadditive(f, samples, weights)
+
     def test_predict_update_cycle_3d_forced_particle_pos_no_pred(self):
         force_first_particle_pos = array([1.1, 2.0, 3.0])
         self.pf.filter_state.d = vstack(


### PR DESCRIPTION
## Summary
- Validate nonadditive particle-prediction noise weights before normalization
- Reject nonfinite, negative, and zero-mass weights with clear `ValueError`s
- Add Euclidean particle-filter regression coverage for invalid nonadditive noise weights

## Root Cause
`AbstractParticleFilter.predict_nonlinear_nonadditive` normalized caller-provided noise weights before checking whether they were valid. Inputs such as `inf`, `nan`, negative weights, or all-zero weights produced `nan` probabilities and failed later inside random sampling with a less useful backend error.

## Tests
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/filters/test_euclidean_particle_filter.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/filters/test_euclidean_particle_filter.py tests/filters/test_hypertoroidal_particle_filter.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/filters/abstract_particle_filter.py tests/filters/test_euclidean_particle_filter.py`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pylint --persistent=no --disable=import-error src/pyrecest/filters/abstract_particle_filter.py tests/filters/test_euclidean_particle_filter.py`
- `git diff --check`