### PR TITLE
Validate SO3 product particle weights

### DIFF
--- a/src/pyrecest/filters/so3_product_particle_filter.py
+++ b/src/pyrecest/filters/so3_product_particle_filter.py
@@ -131,6 +131,8 @@ class SO3ProductParticleFilter(HyperhemisphereCartProdParticleFilter):
         weights = array(weights, dtype=float)
         if ndim(weights) != 1:
             weights = reshape(weights, (-1,))
+        if not all(isfinite(weights)):
+            raise ValueError("Particle weights must be finite.")
         if not all(weights >= 0.0):
             raise ValueError("Particle weights must be nonnegative.")
         weight_sum = sum(weights)

--- a/tests/filters/test_so3_product_particle_filter.py
+++ b/tests/filters/test_so3_product_particle_filter.py
@@ -49,6 +49,25 @@ class SO3ProductParticleFilterTest(unittest.TestCase):
         self.assertGreaterEqual(float(filt.particles[1, 1, -1]), 0.0)
         npt.assert_allclose(filt.weights, array([0.25, 0.75]))
 
+    def test_rejects_nonfinite_weights(self):
+        particles = array([[[0.0, 0.0, 0.0, 1.0]], [z_quaternion(pi / 2.0)]])
+
+        for invalid_weight in (float("nan"), float("inf"), -float("inf")):
+            with self.subTest(invalid_weight=invalid_weight):
+                with self.assertRaisesRegex(ValueError, "finite"):
+                    SO3ProductParticleFilter(
+                        n_particles=2,
+                        num_rotations=1,
+                        weights=array([invalid_weight, 1.0]),
+                    )
+
+                filt = SO3ProductParticleFilter(n_particles=2, num_rotations=1)
+                with self.assertRaisesRegex(ValueError, "finite"):
+                    filt.set_particles(
+                        particles,
+                        weights=array([1.0, invalid_weight]),
+                    )
+
     def test_predict_with_tangent_delta_rotates_each_component(self):
         filt = SO3ProductParticleFilter(n_particles=3, num_rotations=2)
         tangent_delta = array([0.0, 0.0, pi / 2.0, pi / 4.0, 0.0, 0.0])


### PR DESCRIPTION
## Summary
- Reject nonfinite SO(3) product particle weights before normalization
- Add regression coverage for constructor and `set_particles` weight validation

## Root Cause
`SO3ProductParticleFilter._normalize_weights` checked only nonnegativity and positive total mass. Positive infinity could pass those checks, trigger invalid division during normalization, and only fail later with a misleading nonnegative-weight error after producing `nan` internally.

## Tests
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/filters/test_so3_product_particle_filter.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/filters/test_so3_product_particle_filter.py tests/filters/test_partitioned_so3_product_particle_filter.py tests/filters/test_so3_product_block_particle_filter.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/filters/so3_product_particle_filter.py tests/filters/test_so3_product_particle_filter.py`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pylint --persistent=no --disable=import-error src/pyrecest/filters/so3_product_particle_filter.py tests/filters/test_so3_product_particle_filter.py`
- `git diff --check`