### PR TITLE
Validate boxed particle weight updates

### DIFF
--- a/src/pyrecest/filters/euclidean_boxed_particle_filter.py
+++ b/src/pyrecest/filters/euclidean_boxed_particle_filter.py
@@ -18,6 +18,7 @@ from pyrecest.backend import (
     array,
     int32,
     int64,
+    isfinite,
     logical_and,
     ones,
     random,
@@ -208,6 +209,8 @@ class EuclideanBoxedParticleFilter(EuclideanParticleFilter):
         weight_update = where(
             inside, self.filter_state.w, zeros_like(self.filter_state.w)
         )
+        if not bool(any(inside)):
+            raise ValueError("No particle lies inside the requested box")
 
         if likelihood is not None:
             if isinstance(likelihood, AbstractManifoldSpecificDistribution):
@@ -217,10 +220,8 @@ class EuclideanBoxedParticleFilter(EuclideanParticleFilter):
                 raise ValueError("likelihood must return one value per particle")
             weight_update = weight_update * likelihood_values
 
-        if bool(sum(weight_update) <= 0):
-            raise ValueError("No particle lies inside the requested box")
         new_state = copy.deepcopy(self.filter_state)
-        new_state.w = weight_update / sum(weight_update)
+        new_state.w = self._normalize_weight_update(weight_update)
         self._filter_state = new_state
         self.resample_if_needed()
         return self
@@ -439,6 +440,19 @@ class EuclideanBoxedParticleFilter(EuclideanParticleFilter):
                 "proposal_distribution must be callable or expose a sample(n) method"
             )
         return self._coerce_points(samples)
+
+    @staticmethod
+    def _normalize_weight_update(weight_update):
+        if not bool(all(isfinite(weight_update))):
+            raise ValueError("Particle weight updates must be finite")
+        if not bool(all(weight_update >= 0)):
+            raise ValueError("Particle weight updates must be nonnegative")
+        total_weight = sum(weight_update)
+        if not bool(isfinite(total_weight)) or not bool(total_weight > 0):
+            raise ValueError(
+                "Particle weight updates must have positive finite total mass"
+            )
+        return weight_update / total_weight
 
     def _coerce_points(self, points):
         points = array(points)

--- a/tests/filters/test_euclidean_boxed_particle_filter.py
+++ b/tests/filters/test_euclidean_boxed_particle_filter.py
@@ -83,6 +83,40 @@ class EuclideanBoxedParticleFilterTest(unittest.TestCase):
         npt.assert_allclose(to_numpy(pf.filter_state.d), [[0.0], [1.0], [3.0]])
         npt.assert_allclose(to_numpy(pf.filter_state.w), [0.4, 0.6, 0.0])
 
+    def test_reweight_constraint_rejects_invalid_likelihood_weights(self):
+        invalid_likelihoods = (
+            ("nan", lambda _particles: array([1.0, np.nan, 1.0]), "finite"),
+            ("inf", lambda _particles: array([1.0, np.inf, 1.0]), "finite"),
+            (
+                "negative",
+                lambda _particles: array([1.0, -0.5, 1.0]),
+                "nonnegative",
+            ),
+            (
+                "zero-mass",
+                lambda _particles: array([0.0, 0.0, 0.0]),
+                "positive finite total mass",
+            ),
+        )
+
+        for name, likelihood, message in invalid_likelihoods:
+            with self.subTest(name=name):
+                pf = EuclideanBoxedParticleFilter(3, 1)
+                pf.filter_state = LinearDiracDistribution(
+                    array([[0.0], [1.0], [2.0]]),
+                    array([1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0]),
+                )
+
+                with self.assertRaisesRegex(ValueError, message):
+                    pf.reweight_by_box(
+                        array([0.0]), array([2.0]), likelihood=likelihood
+                    )
+
+                npt.assert_allclose(
+                    to_numpy(pf.filter_state.w),
+                    [1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0],
+                )
+
     def test_upsample_generation_accepts_proposal_samples_in_box(self):
         proposal = DeterministicProposal()
         pf = EuclideanBoxedParticleFilter(3, 1)


### PR DESCRIPTION
## Summary
- validate boxed particle weight updates before assigning them to the filter state
- reject non-finite, negative, and zero-mass likelihood updates instead of leaving invalid particle weights
- add regression coverage for invalid likelihood outputs

## Tests
- `PYTHONPATH=src MPLBACKEND=Agg python -m pytest tests/filters/test_euclidean_boxed_particle_filter.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/filters/euclidean_boxed_particle_filter.py tests/filters/test_euclidean_boxed_particle_filter.py`
- `PYTHONPATH=src MPLBACKEND=Agg python -m pylint --persistent=no --disable=import-error src/pyrecest/filters/euclidean_boxed_particle_filter.py tests/filters/test_euclidean_boxed_particle_filter.py`
- `git diff --check`