### PR TITLE
Validate box particle weights

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/linear_box_particle_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/linear_box_particle_distribution.py
@@ -17,6 +17,7 @@ from pyrecest.backend import (
     int32,
     int64,
     isclose,
+    isfinite,
     logical_and,
     maximum,
     minimum,
@@ -68,8 +69,6 @@ class LinearBoxParticleDistribution(AbstractLinearDistribution):
                 weights = reshape(weights, (-1,))
             if weights.shape[0] != n_boxes:
                 raise ValueError("Number of weights and boxes must match")
-            if bool(any(weights < 0)):
-                raise ValueError("Weights must be nonnegative")
             self.w = copy.copy(weights)
         self.normalize_in_place()
 
@@ -114,9 +113,7 @@ class LinearBoxParticleDistribution(AbstractLinearDistribution):
 
     def normalize_in_place(self):
         """Normalize weights in-place."""
-        total_weight = sum(self.w)
-        if bool(total_weight <= 0):
-            raise ValueError("At least one box particle must have positive weight")
+        total_weight = self._validate_weights(self.w, "Weights")
         if not bool(isclose(total_weight, 1.0, atol=1e-10)):
             warnings.warn("Weights are not normalized.", RuntimeWarning)
             self.w = self.w / total_weight
@@ -217,15 +214,15 @@ class LinearBoxParticleDistribution(AbstractLinearDistribution):
     def reweigh(self, f):
         """Return a copy with weights multiplied by ``f`` evaluated at centers."""
         dist = copy.deepcopy(self)
-        weights_update = f(dist.centers())
+        weights_update = array(f(dist.centers()))
         if weights_update.shape != dist.w.shape:
             raise ValueError("Function returned wrong output dimensions")
-        if bool(any(weights_update < 0)):
-            raise ValueError("All weight updates must be nonnegative")
+        self._validate_weights(weights_update, "Weight updates")
         new_weights = dist.w * weights_update
-        if bool(sum(new_weights) <= 0):
-            raise ValueError("The sum of all weights must be positive")
-        dist.w = new_weights / sum(new_weights)
+        total_weight = self._validate_weights(
+            new_weights, "Updated box particle weights"
+        )
+        dist.w = new_weights / total_weight
         return dist
 
     def integrate(self, left=None, right=None):
@@ -317,6 +314,17 @@ class LinearBoxParticleDistribution(AbstractLinearDistribution):
         ):
             raise ValueError("Number of particles must be a positive integer.")
         return int(value)
+
+    @staticmethod
+    def _validate_weights(weights, name):
+        if not bool(all(isfinite(weights))):
+            raise ValueError(f"{name} must be finite")
+        if bool(any(weights < 0)):
+            raise ValueError(f"{name} must be nonnegative")
+        total_weight = sum(weights)
+        if not bool(isfinite(total_weight)) or not bool(total_weight > 0):
+            raise ValueError(f"{name} must have positive finite total mass")
+        return total_weight
 
     @staticmethod
     def _coerce_half_width(box_half_width, dim):

--- a/tests/distributions/test_linear_box_particle_distribution.py
+++ b/tests/distributions/test_linear_box_particle_distribution.py
@@ -1,9 +1,10 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array, ones
+from pyrecest.backend import array, ones, to_numpy
 from pyrecest.distributions.nonperiodic.linear_box_particle_distribution import (
     LinearBoxParticleDistribution,
 )
@@ -37,6 +38,42 @@ class LinearBoxParticleDistributionTest(unittest.TestCase):
         dist = LinearBoxParticleDistribution(array([[0.0]]), array([[4.0]]), ones(1))
 
         npt.assert_allclose(dist.integrate(array([1.0]), array([3.0])), 0.5)
+
+    def test_constructor_rejects_nonfinite_weights(self):
+        invalid_weights = (
+            ("nan", array([np.nan, 1.0])),
+            ("inf", array([np.inf, 1.0])),
+        )
+
+        for name, weights in invalid_weights:
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(ValueError, "finite"):
+                    LinearBoxParticleDistribution(
+                        array([[0.0], [1.0]]), array([[1.0], [2.0]]), weights
+                    )
+
+    def test_reweigh_rejects_invalid_weight_updates(self):
+        invalid_updates = (
+            ("nan", lambda _centers: array([1.0, np.nan]), "finite"),
+            ("inf", lambda _centers: array([1.0, np.inf]), "finite"),
+            ("negative", lambda _centers: array([1.0, -0.5]), "nonnegative"),
+            (
+                "zero-mass",
+                lambda _centers: array([0.0, 0.0]),
+                "positive finite total mass",
+            ),
+        )
+
+        for name, update, message in invalid_updates:
+            with self.subTest(name=name):
+                dist = LinearBoxParticleDistribution(
+                    array([[0.0], [1.0]]), array([[1.0], [2.0]])
+                )
+
+                with self.assertRaisesRegex(ValueError, message):
+                    dist.reweigh(update)
+
+                npt.assert_allclose(to_numpy(dist.w), [0.5, 0.5])
 
     def test_from_distribution_rejects_invalid_particle_count_aliases(self):
         for n_particles in (0, -1, 1.5, True):


### PR DESCRIPTION
## Summary
- validate box-particle distribution weights before normalization
- reject non-finite, negative, and zero-mass reweight updates before storing normalized weights
- add regression coverage for invalid constructor weights and invalid reweight outputs

## Tests
- `$env:PYTHONPATH='src'; $env:MPLBACKEND='Agg'; python -m pytest tests/distributions/test_linear_box_particle_distribution.py tests/filters/test_euclidean_box_particle_filter.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/nonperiodic/linear_box_particle_distribution.py tests/distributions/test_linear_box_particle_distribution.py`
- `$env:PYTHONPATH='src'; $env:MPLBACKEND='Agg'; python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/nonperiodic/linear_box_particle_distribution.py tests/distributions/test_linear_box_particle_distribution.py`
- `git diff --check`