### PR TITLE
Validate weighted sample moments

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/linear_dirac_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/linear_dirac_distribution.py
@@ -4,8 +4,7 @@ import matplotlib.pyplot as plt
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import cov, ones, reshape
-from pyrecest.backend import sum as backend_sum
+from pyrecest.backend import asarray, cov, ones, reshape
 from pyrecest.backend import zeros
 
 from ..abstract_dirac_distribution import AbstractDiracDistribution
@@ -107,12 +106,21 @@ class LinearDiracDistribution(AbstractDiracDistribution, AbstractLinearDistribut
 
     @staticmethod
     def weighted_samples_to_mean_and_cov(samples, weights=None):
+        samples = asarray(samples)
         sample_matrix = reshape(samples, (-1, 1)) if samples.ndim == 1 else samples
+        if sample_matrix.ndim != 2:
+            raise ValueError("samples must be a 1D or 2D array")
+        if sample_matrix.shape[0] == 0:
+            raise ValueError("samples must contain at least one sample")
 
         if weights is None:
             weights = ones(sample_matrix.shape[0]) / sample_matrix.shape[0]
         else:
-            weights = weights / backend_sum(weights)
+            weights = reshape(asarray(weights), (-1,))
+            if weights.shape[0] != sample_matrix.shape[0]:
+                raise ValueError("Number of weights and samples must match")
+            total_weight = AbstractDiracDistribution._validate_weights(weights)
+            weights = weights / total_weight
 
         mean = weights @ sample_matrix
         deviation = sample_matrix - mean

--- a/tests/distributions/test_linear_dirac_distribution.py
+++ b/tests/distributions/test_linear_dirac_distribution.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
@@ -32,6 +33,22 @@ class LinearDiracDistributionTest(TestAbstractDiracDistribution):
         ddist = LinearDiracDistribution(gd.sample(15000))
         self.assertTrue(allclose(ddist.mean(), gd.mean(), atol=0.05))
         self.assertTrue(allclose(ddist.covariance(), gd.covariance(), atol=0.05))
+
+    def test_weighted_samples_to_mean_and_cov_rejects_invalid_weights(self):
+        samples = array([[0.0], [2.0]])
+        invalid_weights = (
+            ("nan", array([1.0, np.nan]), "finite"),
+            ("inf", array([1.0, np.inf]), "finite"),
+            ("negative", array([1.5, -0.5]), "nonnegative"),
+            ("zero-mass", array([0.0, 0.0]), "positive finite total mass"),
+        )
+
+        for name, weights, message in invalid_weights:
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(ValueError, message):
+                    LinearDiracDistribution.weighted_samples_to_mean_and_cov(
+                        samples, weights
+                    )
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Summary
- validate sample and weight inputs before computing weighted Dirac moments
- reject non-finite, negative, zero-mass, and mismatched weights before normalization
- add regression coverage for invalid weighted moment inputs

## Tests
- `$env:PYTHONPATH='src'; $env:MPLBACKEND='Agg'; python -m pytest tests/distributions/test_linear_dirac_distribution.py tests/distributions/test_conversion.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/nonperiodic/linear_dirac_distribution.py tests/distributions/test_linear_dirac_distribution.py`
- `$env:PYTHONPATH='src'; $env:MPLBACKEND='Agg'; python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/nonperiodic/linear_dirac_distribution.py tests/distributions/test_linear_dirac_distribution.py`
- `git diff --check`