### PR TITLE
Validate linear Dirac particle counts

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/linear_dirac_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/linear_dirac_distribution.py
@@ -1,3 +1,5 @@
+from numbers import Integral
+
 import matplotlib.pyplot as plt
 
 # pylint: disable=no-name-in-module,no-member
@@ -93,17 +95,29 @@ class LinearDiracDistribution(AbstractDiracDistribution, AbstractLinearDistribut
                 "n_particles, n_samples, or n."
             )
 
-        particle_counts = [int(value) for value in specified_counts]
+        particle_counts = [
+            LinearDiracDistribution._validate_particle_count(value)
+            for value in specified_counts
+        ]
         if len(set(particle_counts)) != 1:
             raise ConversionError(
                 "n_particles, n_samples, and n must agree when more than one "
                 "particle-count alias is supplied."
             )
 
-        particle_count = particle_counts[0]
-        if particle_count <= 0:
-            raise ConversionError("Number of particles must be positive.")
-        return particle_count
+        return particle_counts[0]
+
+    @staticmethod
+    def _validate_particle_count(value):
+        from ..conversion import ConversionError
+
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, Integral)
+            or int(value) <= 0
+        ):
+            raise ConversionError("Number of particles must be a positive integer.")
+        return int(value)
 
     @staticmethod
     def weighted_samples_to_mean_and_cov(samples, weights=None):

--- a/tests/distributions/test_conversion.py
+++ b/tests/distributions/test_conversion.py
@@ -266,7 +266,7 @@ class ConversionTest(unittest.TestCase):
         self.assertIsInstance(particles, LinearDiracDistribution)
         self.assertEqual(particles.d.shape[0], 25)
 
-    def test_linear_dirac_rejects_conflicting_particle_count_aliases(self):
+    def test_linear_dirac_rejects_invalid_particle_count_aliases(self):
         gaussian = GaussianDistribution(array([0.0, 0.0]), eye(2))
 
         with self.assertRaises(ConversionError):
@@ -276,6 +276,22 @@ class ConversionTest(unittest.TestCase):
                 n_particles=5,
                 n_samples=6,
             )
+
+        invalid_alias_values = (
+            ("n_particles", 0),
+            ("n_samples", -1),
+            ("n", 1.5),
+            ("n_particles", True),
+        )
+
+        for alias, value in invalid_alias_values:
+            with self.subTest(alias=alias, value=value):
+                with self.assertRaisesRegex(ConversionError, "positive integer"):
+                    convert_distribution(
+                        gaussian,
+                        LinearDiracDistribution,
+                        **{alias: value},
+                    )
 
     def test_linear_dirac_set_mean_uses_current_mean_method(self):
         particles = LinearDiracDistribution(


### PR DESCRIPTION
## Summary
- reject invalid `LinearDiracDistribution.from_distribution` particle-count aliases before sampling
- prevent booleans, fractional counts, and non-positive values from being silently coerced with `int()`
- extend conversion coverage for invalid LinearDirac particle-count aliases

## Tests
- `$env:PYTHONPATH='src'; $env:MPLBACKEND='Agg'; python -m pytest tests/distributions/test_conversion.py tests/distributions/test_linear_dirac_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/nonperiodic/linear_dirac_distribution.py tests/distributions/test_conversion.py`
- `$env:PYTHONPATH='src'; $env:MPLBACKEND='Agg'; python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/nonperiodic/linear_dirac_distribution.py tests/distributions/test_conversion.py`
- `git diff --check`