### PR TITLE
Validate Euclidean box filter sizes

### DIFF
--- a/src/pyrecest/filters/euclidean_box_particle_filter.py
+++ b/src/pyrecest/filters/euclidean_box_particle_filter.py
@@ -4,6 +4,7 @@ import copy
 from collections import Counter, defaultdict
 from collections.abc import Callable
 from itertools import product
+from numbers import Integral
 from typing import Union
 
 import numpy as _np
@@ -65,12 +66,8 @@ class EuclideanBoxParticleFilter(AbstractParticleFilter, EuclideanFilterMixin):
         resampling_criterion: Callable | None = None,
         split_resampled_boxes: bool = True,
     ):
-        n_particles = int(n_particles)
-        dim = int(dim)
-        if n_particles <= 0:
-            raise ValueError("n_particles must be a positive integer")
-        if dim <= 0:
-            raise ValueError("dim must be a positive integer")
+        n_particles = self._validate_positive_int(n_particles, "n_particles")
+        dim = self._validate_positive_int(dim, "dim")
 
         self.default_box_half_width = LinearBoxParticleDistribution._coerce_half_width(
             box_half_width, dim
@@ -468,6 +465,16 @@ class EuclideanBoxParticleFilter(AbstractParticleFilter, EuclideanFilterMixin):
         if value.shape[0] != dim:
             raise ValueError(f"{name} must have dimension {dim}")
         return value
+
+    @staticmethod
+    def _validate_positive_int(value, name: str):
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, Integral)
+            or int(value) <= 0
+        ):
+            raise ValueError(f"{name} must be a positive integer")
+        return int(value)
 
 
 BoxParticleFilter = EuclideanBoxParticleFilter

--- a/tests/filters/test_euclidean_box_particle_filter.py
+++ b/tests/filters/test_euclidean_box_particle_filter.py
@@ -11,6 +11,21 @@ from pyrecest.filters.euclidean_box_particle_filter import EuclideanBoxParticleF
 
 
 class EuclideanBoxParticleFilterTest(unittest.TestCase):
+    def test_constructor_rejects_invalid_particle_count_and_dimension(self):
+        invalid_arguments = (
+            ("bool-n-particles", True, 1, "n_particles"),
+            ("fractional-n-particles", 1.5, 1, "n_particles"),
+            ("zero-n-particles", 0, 1, "n_particles"),
+            ("bool-dim", 1, True, "dim"),
+            ("fractional-dim", 1, 1.5, "dim"),
+            ("zero-dim", 1, 0, "dim"),
+        )
+
+        for name, n_particles, dim, message in invalid_arguments:
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(ValueError, message):
+                    EuclideanBoxParticleFilter(n_particles, dim)
+
     def test_identity_box_update_uses_contracted_volume_ratio(self):
         pf = EuclideanBoxParticleFilter(2, 1)
         pf.filter_state = LinearBoxParticleDistribution(


### PR DESCRIPTION
## Summary
- validate `EuclideanBoxParticleFilter` particle count and dimension before coercion
- reject booleans, fractional sizes, and non-positive values instead of silently turning them into integers
- add regression coverage for invalid constructor sizes

## Tests
- `$env:PYTHONPATH='src'; $env:MPLBACKEND='Agg'; python -m pytest tests/filters/test_euclidean_box_particle_filter.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/filters/euclidean_box_particle_filter.py tests/filters/test_euclidean_box_particle_filter.py`
- `$env:PYTHONPATH='src'; $env:MPLBACKEND='Agg'; python -m pylint --persistent=no --disable=import-error src/pyrecest/filters/euclidean_box_particle_filter.py tests/filters/test_euclidean_box_particle_filter.py`
- `git diff --check`