### PR TITLE
Validate Euclidean particle filter sizes

### DIFF
--- a/src/pyrecest/filters/euclidean_particle_filter.py
+++ b/src/pyrecest/filters/euclidean_particle_filter.py
@@ -1,5 +1,6 @@
 import copy
 from collections.abc import Callable
+from numbers import Integral
 from typing import Union
 
 # pylint: disable=no-name-in-module,no-member
@@ -23,10 +24,8 @@ class EuclideanParticleFilter(AbstractParticleFilter, EuclideanFilterMixin):
         n_particles: Union[int, int32, int64],
         dim: Union[int, int32, int64],
     ):
-        if not (isinstance(n_particles, int) and n_particles > 0):
-            raise ValueError("n_particles must be a positive integer")
-        if not (isinstance(dim, int) and dim > 0):
-            raise ValueError("dim must be a positive integer")
+        n_particles = self._validate_positive_int(n_particles, "n_particles")
+        dim = self._validate_positive_int(dim, "dim")
 
         initial_distribution = LinearDiracDistribution(zeros((n_particles, dim)))
         EuclideanFilterMixin.__init__(self)
@@ -67,3 +66,13 @@ class EuclideanParticleFilter(AbstractParticleFilter, EuclideanFilterMixin):
         AbstractParticleFilter.predict_nonlinear(
             self, f, noise_distribution, function_is_vectorized, shift_instead_of_add
         )
+
+    @staticmethod
+    def _validate_positive_int(value, name: str):
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, Integral)
+            or int(value) <= 0
+        ):
+            raise ValueError(f"{name} must be a positive integer")
+        return int(value)

--- a/tests/filters/test_euclidean_particle_filter.py
+++ b/tests/filters/test_euclidean_particle_filter.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
@@ -20,6 +21,25 @@ class EuclideanParticleFilterTest(unittest.TestCase):
         self.pf = EuclideanParticleFilter(n_particles=1000, dim=3)
         self.forced_mean = array([1.0, 2.0, 3.0])
         self.pf.filter_state = self.prior
+
+    def test_constructor_validates_particle_count_and_dimension(self):
+        valid = EuclideanParticleFilter(n_particles=np.int64(3), dim=np.int64(2))
+
+        self.assertEqual(valid.filter_state.d.shape, (3, 2))
+
+        invalid_arguments = (
+            ("bool-n-particles", True, 1, "n_particles"),
+            ("fractional-n-particles", 1.5, 1, "n_particles"),
+            ("zero-n-particles", 0, 1, "n_particles"),
+            ("bool-dim", 1, True, "dim"),
+            ("fractional-dim", 1, 1.5, "dim"),
+            ("zero-dim", 1, 0, "dim"),
+        )
+
+        for name, n_particles, dim, message in invalid_arguments:
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(ValueError, message):
+                    EuclideanParticleFilter(n_particles, dim)
 
     def test_prediction_accepts_in_place_set_mean_noise(self):
         pf = EuclideanParticleFilter(n_particles=3, dim=3)


### PR DESCRIPTION
## Summary
- validate `EuclideanParticleFilter` particle count and dimension before creating the initial state
- reject booleans, fractional sizes, and non-positive values with clear `ValueError`s
- accept integral scalar sizes such as NumPy integers consistently with the type contract

## Tests
- `$env:PYTHONPATH='src'; $env:MPLBACKEND='Agg'; python -m pytest tests/filters/test_euclidean_particle_filter.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/filters/euclidean_particle_filter.py tests/filters/test_euclidean_particle_filter.py`
- `$env:PYTHONPATH='src'; $env:MPLBACKEND='Agg'; python -m pylint --persistent=no --disable=import-error src/pyrecest/filters/euclidean_particle_filter.py tests/filters/test_euclidean_particle_filter.py`
- `git diff --check`