### PR TITLE
Validate hypertoroidal wrapped normal sample counts

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_wrapped_normal_distribution.py
@@ -1,4 +1,5 @@
 import copy
+from numbers import Integral
 from typing import Union
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
@@ -113,8 +114,9 @@ class HypertoroidalWrappedNormalDistribution(AbstractHypertoroidalDistribution):
         return self.set_mean(self.mu + shift_by)
 
     def sample(self, n: Union[int, int32, int64]):
-        if n <= 0:
+        if isinstance(n, bool) or not isinstance(n, Integral) or int(n) <= 0:
             raise ValueError("n must be a positive integer")
+        n = int(n)
 
         s = random.multivariate_normal(self.mu, self.C, (n,))
         s = mod(s, 2.0 * pi)  # wrap the samples

--- a/tests/distributions/test_hypertoroidal_wrapped_normal_distribution.py
+++ b/tests/distributions/test_hypertoroidal_wrapped_normal_distribution.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
@@ -94,6 +95,18 @@ class TestHypertoroidalWNDistribution(unittest.TestCase):
         npt.assert_allclose(
             dist.trigonometric_moment(1), exp(1j * array([0.3]) - 0.7 / 2)
         )
+
+    def test_sample_validates_count_before_backend_call(self):
+        dist = HypertoroidalWNDistribution([0.0, 0.0], [[1.0, 0.0], [0.0, 1.0]])
+
+        samples = dist.sample(np.int64(3))
+
+        self.assertEqual(samples.shape, (3, 2))
+
+        for n in (True, 1.5, 0, -1):
+            with self.subTest(n=n):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
+                    dist.sample(n)
 
     def test_shift_accepts_scalar_for_one_dimensional_distribution(self):
         dist = HypertoroidalWNDistribution(0.3, 0.7)


### PR DESCRIPTION
## Summary
- validate `HypertoroidalWrappedNormalDistribution.sample` counts before calling the backend sampler
- reject booleans, fractional counts, and non-positive values with a clear `ValueError`
- keep integral scalar counts such as NumPy integers working

## Tests
- `$env:PYTHONPATH='src'; $env:MPLBACKEND='Agg'; python -m pytest tests/distributions/test_hypertoroidal_wrapped_normal_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/hypertorus/hypertoroidal_wrapped_normal_distribution.py tests/distributions/test_hypertoroidal_wrapped_normal_distribution.py`
- `$env:PYTHONPATH='src'; $env:MPLBACKEND='Agg'; python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/hypertorus/hypertoroidal_wrapped_normal_distribution.py tests/distributions/test_hypertoroidal_wrapped_normal_distribution.py`
- `git diff --check`