### PR TITLE
Validate hypertoroidal grid resolutions

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_grid_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_grid_distribution.py
@@ -32,11 +32,15 @@ from .hypertoroidal_dirac_distribution import HypertoroidalDiracDistribution
 
 def _normalize_hypertoroidal_resolution(value, dim: int, name: str) -> tuple[int, ...]:
     """Normalize scalar or per-dimension hypertoroidal resolutions."""
+    if isinstance(value, bool):
+        raise ValueError(f"{name} entries must be positive integers.")
     if isinstance(value, Integral):
         resolution = (int(value),) * dim
     else:
         try:
-            resolution = tuple(int(v) for v in value)
+            resolution = tuple(
+                _validate_hypertoroidal_resolution_entry(v, name) for v in value
+            )
         except TypeError as exc:
             raise TypeError(
                 f"{name} must be an integer or a sequence of integers."
@@ -50,6 +54,12 @@ def _normalize_hypertoroidal_resolution(value, dim: int, name: str) -> tuple[int
     if builtins.any(v <= 0 for v in resolution):
         raise ValueError(f"{name} entries must be positive integers.")
     return resolution
+
+
+def _validate_hypertoroidal_resolution_entry(value, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError(f"{name} entries must be positive integers.")
+    return int(value)
 
 
 class HypertoroidalGridDistribution(

--- a/tests/distributions/test_hypertoroidal_grid_distribution.py
+++ b/tests/distributions/test_hypertoroidal_grid_distribution.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
@@ -119,6 +120,31 @@ class HypertoroidalGridDistributionTest(unittest.TestCase):
             max(hgd.get_grid(), 0), array([30 / 31 * 2 * pi, 30 / 31 * 2 * pi])
         )
         self.assertEqual(hgd.grid_type, "cartesian_prod")
+
+    def test_from_distribution_rejects_invalid_grid_resolution_counts(self):
+        dist = HypertoroidalWrappedNormalDistribution(
+            array([0.0, 0.0]), array([[1.0, 0.0], [0.0, 1.0]])
+        )
+
+        valid = HypertoroidalGridDistribution.from_distribution(
+            dist, (np.int64(3), np.int64(4))
+        )
+
+        self.assertEqual(valid.grid_values.shape, (3, 4))
+
+        invalid_resolutions = (
+            True,
+            (True, 3),
+            (1.5, 3),
+            (0, 3),
+            (3, -1),
+        )
+        for n_grid_points in invalid_resolutions:
+            with self.subTest(n_grid_points=n_grid_points):
+                with self.assertRaisesRegex(ValueError, "positive integers"):
+                    HypertoroidalGridDistribution.from_distribution(
+                        dist, n_grid_points
+                    )
 
     def test_from_function_3D(self):
         random.seed(0)


### PR DESCRIPTION
## Summary
- validate hypertoroidal grid resolution entries before normalizing them
- reject booleans, fractional entries, and non-positive counts instead of silently coercing them with `int()`
- add regression coverage for invalid grid resolutions while keeping NumPy integer entries accepted

## Tests
- `$env:PYTHONPATH='src'; $env:MPLBACKEND='Agg'; python -m pytest tests/distributions/test_hypertoroidal_grid_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/hypertorus/hypertoroidal_grid_distribution.py tests/distributions/test_hypertoroidal_grid_distribution.py`
- `$env:PYTHONPATH='src'; $env:MPLBACKEND='Agg'; python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/hypertorus/hypertoroidal_grid_distribution.py tests/distributions/test_hypertoroidal_grid_distribution.py`
- `git diff --check`