### PR TITLE
Validate hypertoroidal Dirac particle counts

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py
@@ -1,5 +1,6 @@
 import copy
 from collections.abc import Callable
+from numbers import Integral
 from typing import Union
 
 import matplotlib.pyplot as plt
@@ -73,13 +74,24 @@ class HypertoroidalDiracDistribution(
 
         if n_particles is None:
             raise ValueError("n_particles is required for sampling-based conversion.")
-        if n_particles <= 0:
-            raise ValueError("n_particles must be a positive integer.")
+        n_particles = HypertoroidalDiracDistribution._validate_particle_count(
+            n_particles
+        )
         return HypertoroidalDiracDistribution(
             distribution.sample(n_particles),
             ones(n_particles) / n_particles,
             dim=distribution.dim,
         )
+
+    @staticmethod
+    def _validate_particle_count(n_particles):
+        if (
+            isinstance(n_particles, bool)
+            or not isinstance(n_particles, Integral)
+            or int(n_particles) <= 0
+        ):
+            raise ValueError("n_particles must be a positive integer.")
+        return int(n_particles)
 
     def plot(self, resolution=128, **kwargs):
         _ = resolution

--- a/tests/distributions/test_hypertoroidal_dirac_distribution.py
+++ b/tests/distributions/test_hypertoroidal_dirac_distribution.py
@@ -1,6 +1,7 @@
 import copy
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
@@ -21,6 +22,17 @@ from pyrecest.distributions.circle.circular_dirac_distribution import (
 )
 
 from .test_abstract_dirac_distribution import TestAbstractDiracDistribution
+
+
+class LenientHypertoroidalDistribution(AbstractHypertoroidalDistribution):
+    def __init__(self):
+        super().__init__(1)
+
+    def pdf(self, xs):
+        return zeros_like(xs)
+
+    def sample(self, n):
+        return array([0.0] * int(n))
 
 
 class TestHypertoroidalDiracDistribution(TestAbstractDiracDistribution):
@@ -64,6 +76,21 @@ class TestHypertoroidalDiracDistribution(TestAbstractDiracDistribution):
         self.assertEqual(wd.w.shape, (n_particles,))
         npt.assert_array_almost_equal(wd.w, array([1.0 / n_particles] * n_particles))
         npt.assert_array_almost_equal(wd.d, mod(wd.d, 2.0 * pi))
+
+    def test_from_distribution_validates_sampling_particle_count(self):
+        dist = LenientHypertoroidalDistribution()
+
+        wd = HypertoroidalDiracDistribution.from_distribution(dist, np.int64(3))
+
+        self.assertEqual(wd.d.shape, (3,))
+        self.assertEqual(wd.w.shape, (3,))
+
+        for n_particles in (True, 1.5, 0, -1):
+            with self.subTest(n_particles=n_particles):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
+                    HypertoroidalDiracDistribution.from_distribution(
+                        dist, n_particles
+                    )
 
     def test_trigonometric_moment(self):
         m = self.twd.trigonometric_moment(1)


### PR DESCRIPTION
## Summary
- validate `HypertoroidalDiracDistribution.from_distribution` particle counts before sampling
- reject booleans, fractional counts, and non-positive values at the conversion boundary
- add regression coverage with a lenient hypertoroidal distribution to prove invalid counts cannot be silently coerced

## Tests
- `$env:PYTHONPATH='src'; $env:MPLBACKEND='Agg'; python -m pytest tests/distributions/test_hypertoroidal_dirac_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py tests/distributions/test_hypertoroidal_dirac_distribution.py`
- `$env:PYTHONPATH='src'; $env:MPLBACKEND='Agg'; python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py tests/distributions/test_hypertoroidal_dirac_distribution.py`
- `git diff --check`