### PR TITLE
Fix JAX random.normal NumPy integer shape handling

### DIFF
--- a/src/pyrecest/_backend/jax/random.py
+++ b/src/pyrecest/_backend/jax/random.py
@@ -59,15 +59,19 @@ def _shape_from_size(size):
     return (int(size),)
 
 
+def _looks_like_integer_dimension(value):
+    return isinstance(value, (int, _np.integer))
+
+
 def _looks_like_shape(value):
-    return isinstance(value, int) or (
-        isinstance(value, tuple) and all(isinstance(dim, int) for dim in value)
+    return _looks_like_integer_dimension(value) or (
+        isinstance(value, tuple) and all(_looks_like_integer_dimension(dim) for dim in value)
     )
 
 
 def _looks_like_shape_sequence(value):
     return isinstance(value, (list, tuple)) and all(
-        isinstance(dim, (int, _np.integer)) for dim in value
+        _looks_like_integer_dimension(dim) for dim in value
     )
 
 

--- a/tests/backend_support/test_jax_random_normal_contract.py
+++ b/tests/backend_support/test_jax_random_normal_contract.py
@@ -1,0 +1,34 @@
+"""Regression test for JAX random.normal shape argument handling."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+_CHECK = """
+import numpy as np
+import pyrecest.backend as backend
+from pyrecest.backend import random
+
+samples_from_numpy_scalar = random.normal(np.int64(3))
+samples_from_numpy_tuple = random.normal((np.int64(2), 3))
+samples_from_python_tuple = random.normal((2, 3))
+
+assert tuple(backend.shape(samples_from_numpy_scalar)) == (3,)
+assert tuple(backend.shape(samples_from_numpy_tuple)) == (2, 3)
+assert tuple(backend.shape(samples_from_python_tuple)) == (2, 3)
+print("ok")
+"""
+
+
+@pytest.mark.backend_portable
+def test_jax_normal_accepts_numpy_integer_shape_arguments():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("JAX is not installed")
+
+    result = run_backend_code("jax", _CHECK)
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- Accept NumPy integer scalar and tuple dimensions in the JAX backend's legacy `random.normal(size)` call form.
- Reuse the same integer-dimension predicate for legacy JAX random shape detection.
- Add a JAX backend regression test covering `np.int64(3)`, `(np.int64(2), 3)`, and a regular Python tuple shape.

## Bug fixed
`random.normal(np.int64(3))` was interpreted as `loc=np.int64(3)` instead of as a legacy shape argument because `_looks_like_shape` only accepted Python `int`. Tuple shapes containing NumPy integer dimensions, such as `(np.int64(2), 3)`, were similarly not recognized as shapes and could fail during arithmetic with JAX arrays.

## Validation
- Locally reproduced the old dispatch behavior with JAX 0.9.0.1: `np.int64(3)` produced a scalar-shaped sample and tuple shapes with NumPy integer dimensions failed.
- Verified the updated predicate maps these arguments to shapes `(3,)` and `(2, 3)` respectively.