### PR TITLE
Validate SE2 Dirac conversion inputs

### DIFF
--- a/src/pyrecest/distributions/se2_dirac_distribution.py
+++ b/src/pyrecest/distributions/se2_dirac_distribution.py
@@ -1,4 +1,6 @@
 # pylint: disable=no-name-in-module,no-member
+from numbers import Integral
+
 from pyrecest.backend import ones
 
 from .abstract_se2_distribution import AbstractSE2Distribution
@@ -94,17 +96,25 @@ class SE2DiracDistribution(HypercylindricalDiracDistribution, AbstractSE2Distrib
             AbstractHypercylindricalDistribution,
         )
 
-        assert isinstance(
-            distribution, AbstractHypercylindricalDistribution
-        ), "distribution must be an instance of AbstractHypercylindricalDistribution"
-        assert (
-            distribution.bound_dim == 1 and distribution.lin_dim == 2
-        ), "distribution must have bound_dim=1 and lin_dim=2"
-        assert (
-            isinstance(n_particles, int) and n_particles > 0
-        ), "n_particles must be a positive integer"
+        if not isinstance(distribution, AbstractHypercylindricalDistribution):
+            raise TypeError(
+                "distribution must be an instance of AbstractHypercylindricalDistribution"
+            )
+        if distribution.bound_dim != 1 or distribution.lin_dim != 2:
+            raise ValueError("distribution must have bound_dim=1 and lin_dim=2")
+        n_particles = SE2DiracDistribution._validate_particle_count(n_particles)
 
         return SE2DiracDistribution(
             distribution.sample(n_particles),
             ones(n_particles) / n_particles,
         )
+
+    @staticmethod
+    def _validate_particle_count(n_particles):
+        if (
+            isinstance(n_particles, bool)
+            or not isinstance(n_particles, Integral)
+            or int(n_particles) <= 0
+        ):
+            raise ValueError("n_particles must be a positive integer")
+        return int(n_particles)

--- a/tests/distributions/test_se2_dirac_distribution.py
+++ b/tests/distributions/test_se2_dirac_distribution.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member,duplicate-code
@@ -61,11 +62,9 @@ class TestSE2DiracDistribution(unittest.TestCase):
         npt.assert_allclose(C, C.T, atol=1e-7)
 
     def test_covariance_4d_positive_semidefinite(self):
-        import numpy as _np  # pylint: disable=import-outside-toplevel
-
-        C = _np.array(self.dist.covariance_4d())
-        eigvals = _np.linalg.eigvalsh(C)
-        self.assertTrue(_np.all(eigvals >= -1e-12))
+        C = np.array(self.dist.covariance_4d())
+        eigvals = np.linalg.eigvalsh(C)
+        self.assertTrue(np.all(eigvals >= -1e-12))
 
     def test_mean_delegates_to_hybrid_mean(self):
         npt.assert_array_equal(self.dist.mean(), self.dist.hybrid_mean())
@@ -84,15 +83,23 @@ class TestSE2DiracDistribution(unittest.TestCase):
         npt.assert_allclose(ddist.hybrid_mean(), pwn.hybrid_mean(), atol=0.05)
 
     def test_from_distribution_type_error(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(TypeError):
             SE2DiracDistribution.from_distribution("not_a_distribution", 10)
 
     def test_from_distribution_particles_error(self):
         mu = array([1.0, 2.0, 3.0])
         C = array([[0.5, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
         pwn = PartiallyWrappedNormalDistribution(mu, C, bound_dim=1)
-        with self.assertRaises(AssertionError):
-            SE2DiracDistribution.from_distribution(pwn, 0)
+
+        ddist = SE2DiracDistribution.from_distribution(pwn, np.int64(3))
+
+        self.assertEqual(ddist.d.shape, (3, 3))
+        self.assertEqual(ddist.w.shape, (3,))
+
+        for n_particles in (True, 1.5, 0, -1):
+            with self.subTest(n_particles=n_particles):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
+                    SE2DiracDistribution.from_distribution(pwn, n_particles)
 
     def test_marginalize_linear(self):
         from pyrecest.distributions.hypertorus.hypertoroidal_dirac_distribution import (  # pylint: disable=import-outside-toplevel


### PR DESCRIPTION
## Summary
- replace `SE2DiracDistribution.from_distribution` assertions with explicit runtime validation
- reject invalid source distribution types, incompatible dimensions, booleans, fractional counts, and non-positive particle counts with clear exceptions
- keep integral scalar particle counts such as NumPy integers accepted

## Tests
- `$env:PYTHONPATH='src'; $env:MPLBACKEND='Agg'; python -m pytest tests/distributions/test_se2_dirac_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/se2_dirac_distribution.py tests/distributions/test_se2_dirac_distribution.py`
- `$env:PYTHONPATH='src'; $env:MPLBACKEND='Agg'; python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/se2_dirac_distribution.py tests/distributions/test_se2_dirac_distribution.py`
- `git diff --check`