### PR TITLE
Validate SE3 Dirac conversion inputs

### DIFF
--- a/src/pyrecest/distributions/se3_dirac_distribution.py
+++ b/src/pyrecest/distributions/se3_dirac_distribution.py
@@ -1,4 +1,6 @@
 # pylint: disable=no-name-in-module,no-member
+from numbers import Integral
+
 from pyrecest.backend import ones
 
 from .abstract_se3_distribution import AbstractSE3Distribution
@@ -34,15 +36,25 @@ class SE3DiracDistribution(
 
     @staticmethod
     def from_distribution(distribution, n_particles):
-        assert isinstance(
-            distribution, AbstractSE3Distribution
-        ), "dist must be an instance of AbstractSE3Distribution"
-        assert (
-            isinstance(n_particles, int) and n_particles > 0
-        ), "n_particles must be a positive integer"
+        if not isinstance(distribution, AbstractSE3Distribution):
+            raise TypeError(
+                "distribution must be an instance of AbstractSE3Distribution"
+            )
+
+        n_particles = SE3DiracDistribution._validate_particle_count(n_particles)
 
         ddist = SE3DiracDistribution(
             distribution.sample(n_particles),
             1 / n_particles * ones(n_particles),
         )
         return ddist
+
+    @staticmethod
+    def _validate_particle_count(n_particles):
+        if (
+            isinstance(n_particles, bool)
+            or not isinstance(n_particles, Integral)
+            or int(n_particles) <= 0
+        ):
+            raise ValueError("n_particles must be a positive integer")
+        return int(n_particles)

--- a/tests/distributions/test_se3_dirac_distribution.py
+++ b/tests/distributions/test_se3_dirac_distribution.py
@@ -1,5 +1,7 @@
 import unittest
 
+import numpy as np
+
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import array, concatenate, diag, linalg, sum, tile
@@ -38,7 +40,17 @@ class SE3DiracDistributionTest(unittest.TestCase):
                 ),
             ]
         )
-        SE3DiracDistribution.from_distribution(cpsd, 100)
+        ddist = SE3DiracDistribution.from_distribution(cpsd, np.int64(3))
+        self.assertEqual(ddist.d.shape, (3, 7))
+        self.assertEqual(ddist.w.shape, (3,))
+
+        for n_particles in (True, 1.5, 0, -1):
+            with self.subTest(n_particles=n_particles):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
+                    SE3DiracDistribution.from_distribution(cpsd, n_particles)
+
+        with self.assertRaises(TypeError):
+            SE3DiracDistribution.from_distribution("not a distribution", 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace assertion-based validation in `SE3DiracDistribution.from_distribution` with explicit exceptions
- accept NumPy integer scalar particle counts while rejecting booleans, non-integers, and non-positive counts
- cover valid and invalid conversion inputs in the SE3 Dirac distribution tests

## Tests
- `python -m pytest tests/distributions/test_se3_dirac_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/se3_dirac_distribution.py tests/distributions/test_se3_dirac_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/se3_dirac_distribution.py tests/distributions/test_se3_dirac_distribution.py`
- `git diff --check`