### PR TITLE
Validate SO3 Dirac conversion inputs

### DIFF
--- a/src/pyrecest/distributions/so3_dirac_distribution.py
+++ b/src/pyrecest/distributions/so3_dirac_distribution.py
@@ -1,6 +1,8 @@
 """Dirac distribution on SO(3)."""
 
 # pylint: disable=no-name-in-module,no-member
+from numbers import Integral
+
 from pyrecest.backend import (
     abs,
     all,
@@ -97,10 +99,18 @@ class SO3DiracDistribution(HyperhemisphericalDiracDistribution):
     @classmethod
     def from_distribution(cls, distribution, n_particles=None):
         """Create an SO(3) Dirac distribution by sampling another distribution."""
-        assert (
-            isinstance(n_particles, int) and n_particles > 0
-        ), "n_particles must be a positive integer"
+        n_particles = cls._validate_particle_count(n_particles)
         return cls(distribution.sample(n_particles))
+
+    @staticmethod
+    def _validate_particle_count(n_particles):
+        if (
+            isinstance(n_particles, bool)
+            or not isinstance(n_particles, Integral)
+            or int(n_particles) <= 0
+        ):
+            raise ValueError("n_particles must be a positive integer")
+        return int(n_particles)
 
     def angular_error_mean(self, rotation):
         """Return the weighted mean angular error to ``rotation`` in radians."""

--- a/tests/distributions/test_so3_dirac_distribution.py
+++ b/tests/distributions/test_so3_dirac_distribution.py
@@ -1,11 +1,12 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import array, cos, eye, linalg, pi, sin, sqrt, stack
-from pyrecest.distributions import SO3DiracDistribution
+from pyrecest.distributions import SO3DiracDistribution, SO3UniformDistribution
 from pyrecest.distributions.hypersphere_subset.hyperhemispherical_dirac_distribution import (
     HyperhemisphericalDiracDistribution,
 )
@@ -48,6 +49,20 @@ class SO3DiracDistributionTest(unittest.TestCase):
         dist = SO3DiracDistribution.from_rotation_matrices(rotations)
 
         npt.assert_allclose(dist.as_rotation_matrices(), rotations, atol=ATOL)
+
+    def test_from_distribution_validates_particle_count(self):
+        source = SO3UniformDistribution()
+
+        dist = SO3DiracDistribution.from_distribution(source, np.int64(3))
+
+        self.assertEqual(dist.d.shape, (3, 4))
+        self.assertEqual(dist.w.shape, (3,))
+        self.assertTrue(dist.is_valid())
+
+        for n_particles in (True, 1.5, 0, -1, None):
+            with self.subTest(n_particles=n_particles):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
+                    SO3DiracDistribution.from_distribution(source, n_particles)
 
     def test_geodesic_distance_respects_antipodal_equivalence(self):
         identity = array([0.0, 0.0, 0.0, 1.0])


### PR DESCRIPTION
## Summary
- replace assertion-based particle-count validation in `SO3DiracDistribution.from_distribution` with explicit exceptions
- accept NumPy integer scalar particle counts while rejecting booleans, non-integers, missing values, and non-positive counts
- cover valid and invalid SO3 Dirac conversion counts in the existing distribution tests

## Tests
- `python -m pytest tests/distributions/test_so3_dirac_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/so3_dirac_distribution.py tests/distributions/test_so3_dirac_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/so3_dirac_distribution.py tests/distributions/test_so3_dirac_distribution.py`
- `git diff --check`