### PR TITLE
Validate SO3 product conversion counts

### DIFF
--- a/src/pyrecest/distributions/so3_conversion.py
+++ b/src/pyrecest/distributions/so3_conversion.py
@@ -1,6 +1,8 @@
 """Conversion registrations for SO(3) distribution representations."""
 
 # pylint: disable=no-name-in-module,no-member
+from numbers import Integral
+
 from pyrecest.backend import array, diag, matmul, reshape, sum, transpose
 
 from .conversion import register_conversion
@@ -14,9 +16,18 @@ from .so3_tangent_gaussian_distribution import SO3TangentGaussianDistribution
 
 def _sample_so3_product_dirac(distribution, n_particles):
     """Create an SO(3)^K Dirac approximation by sampling a source distribution."""
-    if not isinstance(n_particles, int) or n_particles <= 0:
-        raise ValueError("n_particles must be a positive integer")
+    n_particles = _validate_particle_count(n_particles)
     return SO3ProductDiracDistribution(distribution.sample(n_particles))
+
+
+def _validate_particle_count(n_particles):
+    if (
+        isinstance(n_particles, bool)
+        or not isinstance(n_particles, Integral)
+        or int(n_particles) <= 0
+    ):
+        raise ValueError("n_particles must be a positive integer")
+    return int(n_particles)
 
 
 def _so3_tangent_gaussian_from_dirac(

--- a/tests/distributions/test_conversion.py
+++ b/tests/distributions/test_conversion.py
@@ -1,5 +1,7 @@
 import unittest
 
+import numpy as np
+
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import allclose, array, eye, random
 from pyrecest.distributions import (
@@ -222,12 +224,21 @@ class ConversionTest(unittest.TestCase):
         mean = array([[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.0, 1.0]])
         distribution = SO3ProductTangentGaussianDistribution(mean, 0.01 * eye(6))
 
-        particles = convert_distribution(distribution, "particles", n_particles=8)
+        particles = convert_distribution(
+            distribution, "particles", n_particles=np.int64(8)
+        )
 
         self.assertIsInstance(particles, SO3ProductDiracDistribution)
         self.assertEqual(particles.d.shape, (8, 2, 4))
         self.assertEqual(particles.num_rotations, 2)
         self.assertTrue(particles.is_valid())
+
+        for n_particles in (True, 1.5, 0, -1, None):
+            with self.subTest(n_particles=n_particles):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
+                    convert_distribution(
+                        distribution, "particles", n_particles=n_particles
+                    )
 
     def test_so3_product_dirac_to_tangent_gaussian_alias(self):
         mean = array([[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.0, 1.0]])


### PR DESCRIPTION
## Summary
- validate `n_particles` in the registered SO(3)^K Dirac sampling conversion with integral-scalar semantics
- accept NumPy integer scalar particle counts while rejecting booleans, non-integers, missing values, and non-positive counts
- cover SO(3)^K conversion count validation in the existing conversion tests

## Tests
- `python -m pytest tests/distributions/test_conversion.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/so3_conversion.py tests/distributions/test_conversion.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/so3_conversion.py tests/distributions/test_conversion.py`
- `git diff --check`