### PR TITLE
Validate hypertoroidal Dirac conversion counts

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py
@@ -1,5 +1,6 @@
 import copy
 from collections.abc import Callable
+from numbers import Integral
 from typing import Union
 
 import matplotlib.pyplot as plt
@@ -75,13 +76,24 @@ class HypertoroidalDiracDistribution(
 
         if n_particles is None:
             raise ValueError("n_particles is required for sampling-based conversion.")
-        if n_particles <= 0:
-            raise ValueError("n_particles must be a positive integer.")
+        n_particles = HypertoroidalDiracDistribution._validate_particle_count(
+            n_particles
+        )
         return HypertoroidalDiracDistribution(
             distribution.sample(n_particles),
             ones(n_particles) / n_particles,
             dim=distribution.dim,
         )
+
+    @staticmethod
+    def _validate_particle_count(n_particles):
+        if (
+            isinstance(n_particles, bool)
+            or not isinstance(n_particles, Integral)
+            or int(n_particles) <= 0
+        ):
+            raise ValueError("n_particles must be a positive integer.")
+        return int(n_particles)
 
     def plot(self, resolution=128, **kwargs):
         _ = resolution

--- a/tests/distributions/test_hypertoroidal_dirac_distribution.py
+++ b/tests/distributions/test_hypertoroidal_dirac_distribution.py
@@ -1,6 +1,7 @@
 import copy
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
@@ -53,17 +54,27 @@ class TestHypertoroidalDiracDistribution(TestAbstractDiracDistribution):
         npt.assert_allclose(dist.d, array([0.1, 0.2, 0.3]))
 
     def test_from_distribution_sampling_1d(self):
-        n_particles = 5
+        n_particles = np.int64(5)
         vm = VonMisesDistribution(array(0.2), array(1.5))
 
         wd = HypertoroidalDiracDistribution.from_distribution(vm, n_particles)
 
         self.assertIsInstance(wd, HypertoroidalDiracDistribution)
         self.assertEqual(wd.dim, 1)
-        self.assertEqual(wd.d.shape, (n_particles,))
-        self.assertEqual(wd.w.shape, (n_particles,))
-        npt.assert_array_almost_equal(wd.w, array([1.0 / n_particles] * n_particles))
+        self.assertEqual(wd.d.shape, (int(n_particles),))
+        self.assertEqual(wd.w.shape, (int(n_particles),))
+        npt.assert_array_almost_equal(
+            wd.w, array([1.0 / n_particles] * int(n_particles))
+        )
         npt.assert_array_almost_equal(wd.d, mod(wd.d, 2.0 * pi))
+
+    def test_from_distribution_rejects_invalid_particle_counts(self):
+        vm = VonMisesDistribution(array(0.2), array(1.5))
+
+        for n_particles in (True, 1.5, 0, -1):
+            with self.subTest(n_particles=n_particles):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
+                    HypertoroidalDiracDistribution.from_distribution(vm, n_particles)
 
     def test_trigonometric_moment(self):
         m = self.twd.trigonometric_moment(1)


### PR DESCRIPTION
## Summary
- validate `n_particles` before sampling in `HypertoroidalDiracDistribution.from_distribution`
- accept NumPy integer scalar particle counts while rejecting booleans, non-integers, and non-positive counts
- cover valid and invalid hypertoroidal Dirac conversion counts in the existing distribution tests

## Tests
- `python -m pytest tests/distributions/test_hypertoroidal_dirac_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py tests/distributions/test_hypertoroidal_dirac_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py tests/distributions/test_hypertoroidal_dirac_distribution.py`
- `git diff --check`