### PR TITLE
Validate sine-skewed distribution parameters

### DIFF
--- a/src/pyrecest/distributions/circle/sine_skewed_distributions.py
+++ b/src/pyrecest/distributions/circle/sine_skewed_distributions.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+from numbers import Integral
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import array, cos, cosh, exp, mod, ndim, pi, sin, sinh
@@ -8,6 +9,12 @@ from .abstract_circular_distribution import AbstractCircularDistribution
 from .von_mises_distribution import VonMisesDistribution
 from .wrapped_cauchy_distribution import WrappedCauchyDistribution
 from .wrapped_normal_distribution import WrappedNormalDistribution
+
+
+def _validate_sine_power(value, name):
+    if isinstance(value, bool) or not isinstance(value, Integral) or int(value) < 1:
+        raise ValueError(f"{name} must be a positive integer")
+    return int(value)
 
 
 class GeneralizedKSineSkewedVonMisesDistribution(AbstractCircularDistribution):
@@ -34,8 +41,9 @@ class GeneralizedKSineSkewedVonMisesDistribution(AbstractCircularDistribution):
         self.validate_parameters()
 
     def validate_parameters(self):
-        assert -1.0 <= self.lambda_ and self.lambda_ <= 1.0
-        assert isinstance(self.m, int) and self.m >= 1
+        if not (-1.0 <= self.lambda_ <= 1.0):
+            raise ValueError("lambda_ must be between -1 and 1 inclusive")
+        self.m = _validate_sine_power(self.m, "m")
 
     def pdf(self, xs):
         # Evaluate the von Mises distribution and multiply by (1 + lambda_ * sin(xa - mu))
@@ -216,9 +224,11 @@ class GeneralizedKSineSkewedWrappedCauchyDistribution(AbstractCircularDistributi
         self.validate_parameters()
 
     def validate_parameters(self):
-        assert self.gamma > 0
-        assert -1.0 <= self.lambda_ and self.lambda_ <= 1.0
-        assert isinstance(self.m, int) and self.m >= 1
+        if self.gamma <= 0:
+            raise ValueError("gamma must be positive")
+        if not (-1.0 <= self.lambda_ <= 1.0):
+            raise ValueError("lambda_ must be between -1 and 1 inclusive")
+        self.m = _validate_sine_power(self.m, "m")
 
     def pdf(self, xs):
         assert self.k == 1, "Currently, only k=1 is supported"

--- a/tests/distributions/test_gssvm_distribution.py
+++ b/tests/distributions/test_gssvm_distribution.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 from pyrecest.backend import array, pi
 from pyrecest.distributions.circle.sine_skewed_distributions import (
@@ -11,7 +12,7 @@ from pyrecest.distributions.circle.sine_skewed_distributions import (
 class TestGSSVMDistribution(unittest.TestCase):
     def test_initialization(self):
         """Test initialization with valid and invalid parameters."""
-        dist = GSSVMDistribution(mu=pi, kappa=1.0, lambda_=0.5, n=1)
+        dist = GSSVMDistribution(mu=pi, kappa=1.0, lambda_=0.5, n=np.int64(1))
         npt.assert_allclose(dist.mu, pi, rtol=5e-7)
         npt.assert_allclose(dist.kappa, 1.0, rtol=1e-7)
         npt.assert_allclose(dist.lambda_, 0.5, rtol=1e-7)
@@ -20,13 +21,15 @@ class TestGSSVMDistribution(unittest.TestCase):
 
     def test_invalid_lambda(self):
         """lambda_ must be in [-1, 1]."""
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             GSSVMDistribution(mu=0.0, kappa=1.0, lambda_=1.5, n=1)
 
     def test_invalid_n_zero(self):
         """n must be a positive integer."""
-        with self.assertRaises(AssertionError):
-            GSSVMDistribution(mu=0.0, kappa=1.0, lambda_=0.5, n=0)
+        for n in (True, 1.5, 0, -1):
+            with self.subTest(n=n):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
+                    GSSVMDistribution(mu=0.0, kappa=1.0, lambda_=0.5, n=n)
 
     def test_n_maps_to_m(self):
         """n property must equal the internal m parameter."""

--- a/tests/distributions/test_sine_skewed_distributions.py
+++ b/tests/distributions/test_sine_skewed_distributions.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 import pyrecest.backend
 from pyrecest.backend import array, pi
@@ -17,22 +18,24 @@ class TestGeneralizedKSineSkewedVonMisesDistribution(unittest.TestCase):
         # Test with valid parameters
         try:
             GeneralizedKSineSkewedVonMisesDistribution(
-                mu=pi, kappa=1, lambda_=0.5, k=1, m=1
+                mu=pi, kappa=1, lambda_=0.5, k=1, m=np.int64(1)
             )
         except NotImplementedError as e:
             self.fail(f"Initialization with valid parameters failed: {e}")
 
         # Test with invalid lambda_
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             GeneralizedKSineSkewedVonMisesDistribution(
                 mu=pi, kappa=1, lambda_=1.5, k=1, m=1
             )
 
         # Test with invalid m
-        with self.assertRaises(AssertionError):
-            GeneralizedKSineSkewedVonMisesDistribution(
-                mu=pi, kappa=1, lambda_=0.5, k=1, m=0
-            )
+        for m in (True, 1.5, 0, -1):
+            with self.subTest(m=m):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
+                    GeneralizedKSineSkewedVonMisesDistribution(
+                        mu=pi, kappa=1, lambda_=0.5, k=1, m=m
+                    )
 
     def test_pdf(self):
         """Test the pdf method for expected behavior."""
@@ -151,21 +154,24 @@ def test_sine_skewed_effect():
 class TestGeneralizedKSineSkewedWrappedCauchyDistribution(unittest.TestCase):
     def test_initialization(self):
         """Test initialization with valid and invalid parameters."""
-        GeneralizedKSineSkewedWrappedCauchyDistribution(
-            mu=pi, gamma=0.5, lambda_=0.5, k=1, m=1
+        dist = GeneralizedKSineSkewedWrappedCauchyDistribution(
+            mu=pi, gamma=0.5, lambda_=0.5, k=1, m=np.int64(1)
         )
+        self.assertEqual(dist.m, 1)
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             GeneralizedKSineSkewedWrappedCauchyDistribution(
                 mu=pi, gamma=0.5, lambda_=1.5, k=1, m=1
             )
 
-        with self.assertRaises(AssertionError):
-            GeneralizedKSineSkewedWrappedCauchyDistribution(
-                mu=pi, gamma=0.5, lambda_=0.5, k=1, m=0
-            )
+        for m in (True, 1.5, 0, -1):
+            with self.subTest(m=m):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
+                    GeneralizedKSineSkewedWrappedCauchyDistribution(
+                        mu=pi, gamma=0.5, lambda_=0.5, k=1, m=m
+                    )
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             GeneralizedKSineSkewedWrappedCauchyDistribution(
                 mu=pi, gamma=-0.1, lambda_=0.5, k=1, m=1
             )


### PR DESCRIPTION
## Summary
- replace assertion-based generalized sine-skewed parameter validation with explicit `ValueError`s
- accept NumPy integer scalar sine powers while rejecting booleans, non-integers, and non-positive powers
- update GSSVM and generalized sine-skewed distribution tests for the explicit validation behavior

## Tests
- `python -m pytest tests/distributions/test_sine_skewed_distributions.py tests/distributions/test_gssvm_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/circle/sine_skewed_distributions.py tests/distributions/test_sine_skewed_distributions.py tests/distributions/test_gssvm_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/circle/sine_skewed_distributions.py tests/distributions/test_sine_skewed_distributions.py tests/distributions/test_gssvm_distribution.py`
- `git diff --check`