### PR TITLE
Validate Mardia-Sutton distribution parameters

### DIFF
--- a/src/pyrecest/distributions/cart_prod/mardia_sutton_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/mardia_sutton_distribution.py
@@ -42,6 +42,25 @@ def _validate_positive_sample_count(n) -> int:
     return count_int
 
 
+def _validate_positive_finite_scalar(value, name: str) -> float:
+    scalar_array = np.asarray(value)
+    if scalar_array.shape != ():
+        raise ValueError(f"{name} must be a scalar")
+
+    scalar = scalar_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(f"{name} must be a positive finite scalar")
+
+    try:
+        scalar_float = float(scalar)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a positive finite scalar") from exc
+
+    if not math.isfinite(scalar_float) or scalar_float <= 0.0:
+        raise ValueError(f"{name} must be a positive finite scalar")
+    return scalar_float
+
+
 class MardiaSuttonDistribution(AbstractHypercylindricalDistribution):
     """Gauss-von Mises distribution for cylindrical data (1 circular + 1 linear dimension).
 
@@ -63,18 +82,15 @@ class MardiaSuttonDistribution(AbstractHypercylindricalDistribution):
             sigma (positive scalar): linear standard deviation
         """
         AbstractHypercylindricalDistribution.__init__(self, bound_dim=1, lin_dim=1)
-        assert kappa > 0, "kappa must be a positive scalar"
-        sigma_float = float(sigma)
-        assert (
-            math.isfinite(sigma_float) and sigma_float > 0.0
-        ), "sigma must be a positive finite scalar"
-        assert (
-            float(sqrt(rho1**2 + rho2**2)) < 1.0
-        ), "sqrt(rho1^2 + rho2^2) must be strictly less than 1"
+        kappa_float = _validate_positive_finite_scalar(kappa, "kappa")
+        sigma_float = _validate_positive_finite_scalar(sigma, "sigma")
+        rho_norm = float(sqrt(rho1**2 + rho2**2))
+        if not math.isfinite(rho_norm) or rho_norm >= 1.0:
+            raise ValueError("sqrt(rho1^2 + rho2^2) must be strictly less than 1")
 
         self.mu = mu
         self.mu0 = mod(mu0, 2.0 * pi)
-        self.kappa = kappa
+        self.kappa = kappa_float
         self.rho1 = rho1
         self.rho2 = rho2
         self.sigma = sigma_float

--- a/tests/distributions/test_mardia_sutton_distribution.py
+++ b/tests/distributions/test_mardia_sutton_distribution.py
@@ -39,12 +39,13 @@ class TestMardiaSuttonDistribution(unittest.TestCase):
         dist2 = MardiaSuttonDistribution(
             self.mu,
             self.mu0 + 2.0 * float(pi),
-            self.kappa,
+            np.int64(1),
             self.rho1,
             self.rho2,
             self.sigma,
         )
         npt.assert_allclose(dist2.mu0, self.dist.mu0, atol=1e-10)
+        npt.assert_allclose(dist2.kappa, 1.0)
 
     def test_pdf_positive(self):
         xs = array([[0.0, 0.0], [1.0, 2.0], [3.0, -1.0]])
@@ -143,20 +144,28 @@ class TestMardiaSuttonDistribution(unittest.TestCase):
                     self.dist.sample(n)
 
     def test_invalid_kappa(self):
-        with self.assertRaises(AssertionError):
-            MardiaSuttonDistribution(
-                self.mu, self.mu0, 0.0, self.rho1, self.rho2, self.sigma
-            )
+        for kappa in (True, 0.0, -1.0, float("nan"), float("inf")):
+            with self.subTest(kappa=kappa), self.assertRaisesRegex(
+                ValueError, "kappa"
+            ):
+                MardiaSuttonDistribution(
+                    self.mu, self.mu0, kappa, self.rho1, self.rho2, self.sigma
+                )
 
     def test_invalid_rho(self):
-        with self.assertRaises(AssertionError):
-            MardiaSuttonDistribution(
-                self.mu, self.mu0, self.kappa, 0.8, 0.8, self.sigma
-            )
+        for rho1, rho2 in ((0.8, 0.8), (float("nan"), 0.0), (float("inf"), 0.0)):
+            with self.subTest(rho1=rho1, rho2=rho2), self.assertRaisesRegex(
+                ValueError, "rho"
+            ):
+                MardiaSuttonDistribution(
+                    self.mu, self.mu0, self.kappa, rho1, rho2, self.sigma
+                )
 
     def test_invalid_sigma(self):
-        for sigma in (0.0, -1.0, float("nan"), float("inf")):
-            with self.subTest(sigma=sigma), self.assertRaises(AssertionError):
+        for sigma in (True, 0.0, -1.0, float("nan"), float("inf")):
+            with self.subTest(sigma=sigma), self.assertRaisesRegex(
+                ValueError, "sigma"
+            ):
                 MardiaSuttonDistribution(
                     self.mu, self.mu0, self.kappa, self.rho1, self.rho2, sigma
                 )


### PR DESCRIPTION
## Summary
- replace assertion-based `MardiaSuttonDistribution` constructor validation with explicit `ValueError`s
- reject boolean, non-finite, and non-positive scalar values for `kappa` and `sigma`
- reject non-finite or out-of-range correlation radius values and cover the behavior in tests

## Tests
- `python -m pytest tests/distributions/test_mardia_sutton_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/cart_prod/mardia_sutton_distribution.py tests/distributions/test_mardia_sutton_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/cart_prod/mardia_sutton_distribution.py tests/distributions/test_mardia_sutton_distribution.py`
- `git diff --check`