### PR TITLE
Validate Gauss-von-Mises parameters

### DIFF
--- a/src/pyrecest/distributions/cart_prod/gauss_von_mises_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/gauss_von_mises_distribution.py
@@ -58,6 +58,25 @@ def _validate_positive_sample_count(n) -> int:
     return count_int
 
 
+def _validate_positive_finite_scalar(value, name: str) -> float:
+    scalar_array = np.asarray(value)
+    if scalar_array.shape != ():
+        raise ValueError(f"{name} must be a scalar")
+
+    scalar = scalar_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(f"{name} must be a positive finite scalar")
+
+    try:
+        scalar_float = float(scalar)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a positive finite scalar") from exc
+
+    if not np.isfinite(scalar_float) or scalar_float <= 0.0:
+        raise ValueError(f"{name} must be a positive finite scalar")
+    return scalar_float
+
+
 class GaussVonMisesDistribution(AbstractHypercylindricalDistribution):
     """Gauss von Mises Distribution on R^linD x S^1.
 
@@ -80,14 +99,22 @@ class GaussVonMisesDistribution(AbstractHypercylindricalDistribution):
         n = mu.shape[0]
 
         # Validate parameters
-        assert P.shape == (n, n), "P and mu must have matching size"
-        assert allclose(P, P.T), "P must be symmetric"
-        linalg.cholesky(P)  # raises if not positive definite
+        if P.shape != (n, n):
+            raise ValueError("P and mu must have matching size")
+        if not bool(allclose(P, P.T)):
+            raise ValueError("P must be symmetric")
+        try:
+            cholesky_factor = linalg.cholesky(P)
+        except Exception as exc:
+            raise ValueError("P must be positive definite") from exc
 
-        assert beta.shape == (n,), "size of beta must match size of mu"
-        assert Gamma.shape == (n, n), "Gamma and mu must have matching size"
-        assert allclose(Gamma, Gamma.T), "Gamma must be symmetric"
-        assert float(kappa) > 0, "kappa has to be a positive scalar"
+        if beta.shape != (n,):
+            raise ValueError("size of beta must match size of mu")
+        if Gamma.shape != (n, n):
+            raise ValueError("Gamma and mu must have matching size")
+        if not bool(allclose(Gamma, Gamma.T)):
+            raise ValueError("Gamma must be symmetric")
+        kappa = _validate_positive_finite_scalar(kappa, "kappa")
 
         AbstractHypercylindricalDistribution.__init__(self, bound_dim=1, lin_dim=n)
 
@@ -98,7 +125,7 @@ class GaussVonMisesDistribution(AbstractHypercylindricalDistribution):
         self.Gamma = array(Gamma)
         self.kappa = float(kappa)
         # Lower triangular Cholesky factor of P
-        self.A = linalg.cholesky(P)
+        self.A = cholesky_factor
 
     def get_theta(self, xa):
         """Compute the angle offset theta for each column of xa (linear part).

--- a/src/pyrecest/distributions/cart_prod/gauss_von_mises_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/gauss_von_mises_distribution.py
@@ -2,6 +2,7 @@ import numpy as np
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member,redefined-builtin
+from pyrecest.backend import all as backend_all
 from pyrecest.backend import (
     allclose,
     arccos,
@@ -16,6 +17,7 @@ from pyrecest.backend import (
     full,
     hstack,
     imag,
+    isfinite,
     linalg,
     mod,
     pi,
@@ -107,6 +109,8 @@ class GaussVonMisesDistribution(AbstractHypercylindricalDistribution):
             cholesky_factor = linalg.cholesky(P)
         except Exception as exc:
             raise ValueError("P must be positive definite") from exc
+        if not bool(backend_all(isfinite(cholesky_factor))):
+            raise ValueError("P must be positive definite")
 
         if beta.shape != (n,):
             raise ValueError("size of beta must match size of mu")

--- a/tests/distributions/test_gauss_von_mises_distribution.py
+++ b/tests/distributions/test_gauss_von_mises_distribution.py
@@ -5,6 +5,7 @@ from pyrecest import backend
 from pyrecest.backend import (
     all,
     allclose,
+    array,
     cos,
     exp,
     linalg,
@@ -80,6 +81,57 @@ class GaussVonMisesDistributionTest(unittest.TestCase):
         self.assertIsInstance(gauss, GaussianDistribution)
         self.assertTrue(allclose(gauss.mu, self.g.mode()))
         self.assertTrue(allclose(gauss.C[1:, 1:], self.g.P, atol=1e-10))
+
+    def test_constructor_accepts_numpy_scalar_kappa(self):
+        dist = GaussVonMisesDistribution(2, 1.3, 3, 0, 0.001, np.int64(1))
+
+        self.assertEqual(dist.kappa, 1.0)
+
+    def test_constructor_rejects_invalid_kappa(self):
+        for kappa in (True, 0.0, -1.0, float("nan"), float("inf")):
+            with self.subTest(kappa=kappa), self.assertRaisesRegex(
+                ValueError, "kappa"
+            ):
+                GaussVonMisesDistribution(2, 1.3, 3, 0, 0.001, kappa)
+
+    def test_constructor_rejects_invalid_matrix_parameters(self):
+        valid_mu = array([0.0, 0.0])
+        valid_p = np.eye(2)
+        valid_beta = array([0.0, 0.0])
+        valid_gamma = np.zeros((2, 2))
+
+        invalid_parameters = [
+            (
+                "P and mu",
+                (valid_mu, np.eye(1), 3, valid_beta, valid_gamma, 0.7),
+            ),
+            (
+                "P must be symmetric",
+                (valid_mu, array([[1.0, 2.0], [0.0, 1.0]]), 3, valid_beta, valid_gamma, 0.7),
+            ),
+            (
+                "positive definite",
+                (valid_mu, array([[1.0, 2.0], [2.0, 1.0]]), 3, valid_beta, valid_gamma, 0.7),
+            ),
+            (
+                "beta",
+                (valid_mu, valid_p, 3, array([0.0]), valid_gamma, 0.7),
+            ),
+            (
+                "Gamma and mu",
+                (valid_mu, valid_p, 3, valid_beta, np.zeros((1, 1)), 0.7),
+            ),
+            (
+                "Gamma must be symmetric",
+                (valid_mu, valid_p, 3, valid_beta, array([[0.0, 1.0], [0.0, 0.0]]), 0.7),
+            ),
+        ]
+
+        for message, args in invalid_parameters:
+            with self.subTest(message=message), self.assertRaisesRegex(
+                ValueError, message
+            ):
+                GaussVonMisesDistribution(*args)
 
     @unittest.skipIf(
         backend.__backend_name__ == "jax",


### PR DESCRIPTION
## Summary
- replace assertion-based `GaussVonMisesDistribution` constructor validation with explicit `ValueError`s
- reject invalid covariance, coupling, and concentration parameters before later numerical operations
- accept NumPy scalar `kappa` values while rejecting booleans, non-finite values, and non-positive values

## Tests
- `python -m pytest tests/distributions/test_gauss_von_mises_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/cart_prod/gauss_von_mises_distribution.py tests/distributions/test_gauss_von_mises_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/cart_prod/gauss_von_mises_distribution.py tests/distributions/test_gauss_von_mises_distribution.py`
- `git diff --check`