### PR TITLE
Validate partially wrapped normal parameters

### DIFF
--- a/src/pyrecest/distributions/cart_prod/partially_wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/partially_wrapped_normal_distribution.py
@@ -6,6 +6,7 @@ import numpy as np
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 # pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import all as backend_all
 from pyrecest.backend import (
     allclose,
     arange,
@@ -17,6 +18,7 @@ from pyrecest.backend import (
     hstack,
     int32,
     int64,
+    isfinite,
     linalg,
     meshgrid,
     mod,
@@ -123,9 +125,11 @@ class PartiallyWrappedNormalDistribution(AbstractHypercylindricalDistribution):
         if not bool(allclose(C, C.T)):
             raise ValueError("C must be symmetric")
         try:
-            linalg.cholesky(C)
+            chol = linalg.cholesky(C)
         except Exception as exc:
             raise ValueError("C must be positive definite") from exc
+        if not bool(backend_all(isfinite(chol))):
+            raise ValueError("C must be positive definite")
         mu = where(arange(mu.shape[0]) < bound_dim, mod(mu, 2 * pi), mu)
 
         AbstractHypercylindricalDistribution.__init__(

--- a/src/pyrecest/distributions/cart_prod/partially_wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/partially_wrapped_normal_distribution.py
@@ -1,4 +1,5 @@
 import copy
+from numbers import Integral
 from typing import Union
 
 import numpy as np
@@ -89,6 +90,17 @@ def _validate_positive_sample_count(n) -> int:
     return count_int
 
 
+def _validate_bound_dim(bound_dim, total_dim: int) -> int:
+    if isinstance(bound_dim, bool) or not isinstance(bound_dim, Integral):
+        raise ValueError("bound_dim must be a non-negative integer")
+    bound_dim = int(bound_dim)
+    if bound_dim < 0:
+        raise ValueError("bound_dim must be non-negative")
+    if bound_dim > total_dim:
+        raise ValueError("bound_dim must not exceed the distribution dimension")
+    return bound_dim
+
+
 class PartiallyWrappedNormalDistribution(AbstractHypercylindricalDistribution):
     """Partially wrapped normal distribution on periodic-linear domains.
 
@@ -103,14 +115,17 @@ class PartiallyWrappedNormalDistribution(AbstractHypercylindricalDistribution):
     def __init__(self, mu, C, bound_dim: Union[int, int32, int64]):
         mu = array(mu)
         C = array(C)
-        assert bound_dim >= 0, "bound_dim must be non-negative"
-        assert mu.ndim == 1, "mu must be a 1-dimensional array"
-        assert C.shape == (mu.shape[-1], mu.shape[-1]), "C must match size of mu"
-        assert allclose(C, C.T), "C must be symmetric"
-        assert (
-            len(linalg.cholesky(C)) > 0
-        ), "C must be positive definite"  # Will fail if not positive definite
-        assert bound_dim <= mu.shape[0]
+        if mu.ndim != 1:
+            raise ValueError("mu must be a 1-dimensional array")
+        bound_dim = _validate_bound_dim(bound_dim, mu.shape[0])
+        if C.shape != (mu.shape[-1], mu.shape[-1]):
+            raise ValueError("C must match size of mu")
+        if not bool(allclose(C, C.T)):
+            raise ValueError("C must be symmetric")
+        try:
+            linalg.cholesky(C)
+        except Exception as exc:
+            raise ValueError("C must be positive definite") from exc
         mu = where(arange(mu.shape[0]) < bound_dim, mod(mu, 2 * pi), mu)
 
         AbstractHypercylindricalDistribution.__init__(
@@ -183,9 +198,8 @@ class PartiallyWrappedNormalDistribution(AbstractHypercylindricalDistribution):
         For bounded dimensions, the mean is wrapped into [0, 2*pi) to stay on the manifold.
         """
         new_mean = array(new_mean)
-        assert new_mean.shape == (
-            self.input_dim,
-        ), "new_mean must match distribution dim"
+        if new_mean.shape != (self.input_dim,):
+            raise ValueError("new_mean must match distribution dim")
         new_dist = copy.deepcopy(self)
         wrapped_mean = where(
             arange(new_mean.shape[0]) < self.bound_dim, mod(new_mean, 2 * pi), new_mean

--- a/tests/distributions/test_partially_wrapped_normal_distribution.py
+++ b/tests/distributions/test_partially_wrapped_normal_distribution.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 import scipy.linalg
 
@@ -58,13 +59,38 @@ class TestPartiallyWrappedNormalDistribution(unittest.TestCase):
         npt.assert_allclose(shifted.mu, [7.0 - 2.0 * pi, 3.0])
         npt.assert_allclose(dist.mu, [5.0, 1.0])
 
+    def test_set_mean_rejects_wrong_shape(self):
+        with self.assertRaisesRegex(ValueError, "new_mean"):
+            self.dist_2d.set_mean([1.0])
+
     def test_linear_mean_is_empty_for_fully_periodic_distribution(self):
         dist = PartiallyWrappedNormalDistribution(
-            [0.0, 1.0], [[1.0, 0.1], [0.1, 2.0]], 2
+            [0.0, 1.0], [[1.0, 0.1], [0.1, 2.0]], np.int64(2)
         )
 
         self.assertEqual(dist.linear_mean().shape, (0,))
         self.assertEqual(dist.linear_covariance().shape, (0, 0))
+
+    def test_constructor_rejects_invalid_parameters(self):
+        invalid_parameters = [
+            ("bound_dim", ([0.0, 1.0], [[1.0, 0.0], [0.0, 1.0]], True)),
+            ("bound_dim", ([0.0, 1.0], [[1.0, 0.0], [0.0, 1.0]], 1.5)),
+            ("bound_dim", ([0.0, 1.0], [[1.0, 0.0], [0.0, 1.0]], -1)),
+            ("bound_dim", ([0.0, 1.0], [[1.0, 0.0], [0.0, 1.0]], 3)),
+            ("mu", ([[0.0, 1.0]], [[1.0, 0.0], [0.0, 1.0]], 1)),
+            ("C must match", ([0.0, 1.0], [[1.0]], 1)),
+            ("C must be symmetric", ([0.0, 1.0], [[1.0, 2.0], [0.0, 1.0]], 1)),
+            (
+                "positive definite",
+                ([0.0, 1.0], [[1.0, 2.0], [2.0, 1.0]], 1),
+            ),
+        ]
+
+        for message, args in invalid_parameters:
+            with self.subTest(message=message), self.assertRaisesRegex(
+                ValueError, message
+            ):
+                PartiallyWrappedNormalDistribution(*args)
 
     def test_hybrid_mean_2d(self):
         npt.assert_allclose(self.dist_2d.hybrid_mean(), self.mu)

--- a/tests/distributions/test_partially_wrapped_normal_distribution.py
+++ b/tests/distributions/test_partially_wrapped_normal_distribution.py
@@ -56,7 +56,7 @@ class TestPartiallyWrappedNormalDistribution(unittest.TestCase):
 
         shifted = dist.set_mean([7.0, 3.0])
 
-        npt.assert_allclose(shifted.mu, [7.0 - 2.0 * pi, 3.0])
+        npt.assert_allclose(shifted.mu, [7.0 - 2.0 * pi, 3.0], rtol=5e-7)
         npt.assert_allclose(dist.mu, [5.0, 1.0])
 
     def test_set_mean_rejects_wrong_shape(self):


### PR DESCRIPTION
## Summary
- replace assertion-based `PartiallyWrappedNormalDistribution` constructor validation with explicit `ValueError`s
- validate `bound_dim`, mean dimensionality, covariance shape/symmetry/positive-definiteness, and `set_mean` shape before use
- accept NumPy integer scalar `bound_dim` values while rejecting booleans, non-integers, and out-of-range dimensions

## Tests
- `python -m pytest tests/distributions/test_partially_wrapped_normal_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/cart_prod/partially_wrapped_normal_distribution.py tests/distributions/test_partially_wrapped_normal_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/cart_prod/partially_wrapped_normal_distribution.py tests/distributions/test_partially_wrapped_normal_distribution.py`
- `git diff --check`