### PR TITLE
Validate hypertoroidal PDF series order

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_wrapped_normal_distribution.py
@@ -40,6 +40,15 @@ def _as_2d_covariance(C):
     return C
 
 
+def _validate_series_order(m) -> int:
+    if isinstance(m, bool) or not isinstance(m, Integral):
+        raise ValueError("m must be a non-negative integer")
+    m = int(m)
+    if m < 0:
+        raise ValueError("m must be a non-negative integer")
+    return m
+
+
 class HypertoroidalWrappedNormalDistribution(AbstractHypertoroidalDistribution):
     def __init__(self, mu, C):
         """
@@ -83,6 +92,7 @@ class HypertoroidalWrappedNormalDistribution(AbstractHypertoroidalDistribution):
         :param m: Controls the number of terms in the Fourier series approximation.
         :return: PDF values at xs.
         """
+        m = _validate_series_order(m)
         xs = as_hypertoroidal_points(xs, self.dim)
         xs = (xs + pi) % (2 * pi) - pi
 

--- a/tests/distributions/test_hypertoroidal_wrapped_normal_distribution.py
+++ b/tests/distributions/test_hypertoroidal_wrapped_normal_distribution.py
@@ -73,6 +73,22 @@ class TestHypertoroidalWNDistribution(unittest.TestCase):
         npt.assert_allclose(list_pdf, matrix_pdf)
         npt.assert_allclose(scalar_pdf, matrix_pdf[:1])
 
+    def test_pdf_accepts_numpy_integer_series_order(self):
+        dist = HypertoroidalWNDistribution(0.3, 0.7)
+
+        values = dist.pdf(0.2, m=np.int64(2))
+
+        self.assertEqual(values.shape, (1,))
+        self.assertGreater(float(values[0]), 0.0)
+
+    def test_pdf_rejects_invalid_series_order(self):
+        dist = HypertoroidalWNDistribution(0.3, 0.7)
+
+        for m in (True, -1, 1.5, [1]):
+            with self.subTest(m=m):
+                with self.assertRaisesRegex(ValueError, "non-negative integer"):
+                    dist.pdf(0.2, m=m)
+
     def test_vector_pdf_accepts_single_point_sequence(self):
         dist = HypertoroidalWNDistribution(
             array([0.3, 0.4]), array([[0.7, 0.0], [0.0, 0.5]])


### PR DESCRIPTION
## Summary
- validate the hypertoroidal wrapped normal PDF truncation order before building offset grids
- reject boolean, negative, fractional, and non-scalar values instead of producing invalid densities
- add regression tests for valid NumPy integer orders and invalid orders

## Root cause
`HypertoroidalWrappedNormalDistribution.pdf` passed `m` directly into `arange`. Negative values could produce an empty offset grid and zero density, while boolean or fractional values silently changed the Fourier approximation.

## Tests
- `python -m pytest tests/distributions/test_hypertoroidal_wrapped_normal_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/hypertorus/hypertoroidal_wrapped_normal_distribution.py tests/distributions/test_hypertoroidal_wrapped_normal_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/hypertorus/hypertoroidal_wrapped_normal_distribution.py tests/distributions/test_hypertoroidal_wrapped_normal_distribution.py`