### PR TITLE
Validate piecewise numerical interval counts

### DIFF
--- a/src/pyrecest/distributions/circle/piecewise_constant_distribution.py
+++ b/src/pyrecest/distributions/circle/piecewise_constant_distribution.py
@@ -250,7 +250,7 @@ class PiecewiseConstantDistribution(AbstractCircularDistribution):
                 "calculate_parameters_numerically is not supported on the JAX backend."
             )
 
-        assert n >= 1
+        n = _validate_positive_sample_count(n)
         w = zeros(n)
         for j in range(1, n + 1):
             left = PiecewiseConstantDistribution.left_border(j, n)

--- a/src/pyrecest/distributions/circle/piecewise_constant_distribution.py
+++ b/src/pyrecest/distributions/circle/piecewise_constant_distribution.py
@@ -250,10 +250,13 @@ class PiecewiseConstantDistribution(AbstractCircularDistribution):
                 "calculate_parameters_numerically is not supported on the JAX backend."
             )
 
+        def _evaluate_pdf(x):
+            return float(array(pdf_func(array([x]))).reshape(-1)[0])
+
         n = _validate_positive_sample_count(n)
         w = zeros(n)
         for j in range(1, n + 1):
             left = PiecewiseConstantDistribution.left_border(j, n)
             r = PiecewiseConstantDistribution.right_border(j, n)
-            w[j - 1] = quad(lambda x: float(pdf_func(array([x]))), left, r)[0]
+            w[j - 1] = quad(_evaluate_pdf, left, r)[0]
         return w

--- a/tests/distributions/test_piecewise_constant_distribution.py
+++ b/tests/distributions/test_piecewise_constant_distribution.py
@@ -118,6 +118,29 @@ class PiecewiseConstantDistributionTest(unittest.TestCase):
         self.assertLessEqual(delta2, delta1)
         self.assertLessEqual(delta3, delta2)
 
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on JAX backend",
+    )
+    def test_calculate_parameters_numerically_accepts_integer_like_count(self):
+        weights = PiecewiseConstantDistribution.calculate_parameters_numerically(
+            lambda _xs: array([1.0 / (2.0 * pi)]), np.array(4.0)
+        )
+
+        npt.assert_allclose(weights, array([0.25, 0.25, 0.25, 0.25]), rtol=1e-12)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on JAX backend",
+    )
+    def test_calculate_parameters_numerically_rejects_invalid_count(self):
+        for n in (0, -1, 1.5, True, [3], float("nan"), float("inf")):
+            with self.subTest(n=n):
+                with self.assertRaises(ValueError):
+                    PiecewiseConstantDistribution.calculate_parameters_numerically(
+                        lambda _xs: array([1.0 / (2.0 * pi)]), n
+                    )
+
     def test_entropy(self):
         """Verify analytical entropy against the direct formula."""
         w = self.dist.w


### PR DESCRIPTION
## Summary
- validate `PiecewiseConstantDistribution.calculate_parameters_numerically` interval counts with the same scalar positive-integer helper used by sampling
- reject booleans, fractional counts, non-scalar inputs, and non-finite values before allocating arrays or iterating intervals
- keep scalar integer-like inputs such as NumPy scalar arrays working, and avoid NumPy array-to-scalar conversion warnings in the quadrature callback

## Tests
- focused standalone Python validation of the count-validation and uniform-density quadrature path (`np.array(4.0)` -> four 0.25 weights; invalid counts raise `ValueError`)

Full repository pytest was not run in this environment.