### PR TITLE
Validate wrapped normal sigma

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
@@ -62,9 +62,12 @@ class WrappedNormalDistribution(
             raise ValueError(f"mu must be a scalar, but got shape {mu.shape}.")
         if ndim(sigma) > 1 or (ndim(sigma) == 1 and sigma.shape[0] != 1):
             raise ValueError(f"sigma must be a scalar, but got shape {sigma.shape}.")
+        sigma_scalar = squeeze(sigma)
+        if not bool(isfinite(sigma_scalar)) or not bool(sigma_scalar > 0):
+            raise ValueError(f"sigma must be a positive finite scalar, got {sigma}.")
         AbstractCircularDistribution.__init__(self)
         HypertoroidalWrappedNormalDistribution.__init__(
-            self, squeeze(mu), squeeze(sigma) ** 2
+            self, squeeze(mu), sigma_scalar**2
         )
 
     @property

--- a/tests/distributions/test_wrapped_normal_distribution.py
+++ b/tests/distributions/test_wrapped_normal_distribution.py
@@ -52,6 +52,12 @@ class WrappedNormalDistributionTest(unittest.TestCase):
             )
         )
 
+    def test_constructor_rejects_invalid_sigma(self):
+        for sigma in (-1.0, 0.0, float("nan"), float("inf")):
+            with self.subTest(sigma=sigma):
+                with self.assertRaisesRegex(ValueError, "positive finite scalar"):
+                    WrappedNormalDistribution(array(0.0), array(sigma))
+
     def test_pdf_is_periodic_when_central_term_underflows(self):
         """The pdf must still add wrapped terms near the 0 / 2π boundary."""
         wn = WrappedNormalDistribution(array(0.0), array(0.1))


### PR DESCRIPTION
## Summary
- reject non-positive and non-finite `sigma` values in `WrappedNormalDistribution`
- reuse the validated scalar value when passing covariance to the hypertoroidal base class
- add regression coverage for negative, zero, NaN, and infinite standard deviations

## Root cause
`WrappedNormalDistribution.__init__` squared `sigma` before base covariance validation. A negative standard deviation therefore became a positive covariance and was silently accepted as its absolute value.

## Impact
Invalid wrapped-normal parameters now fail at construction with a clear `ValueError` instead of producing a distribution with different semantics than the caller requested.

## Tests
- `python -m pytest tests/distributions/test_wrapped_normal_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/circle/wrapped_normal_distribution.py tests/distributions/test_wrapped_normal_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/circle/wrapped_normal_distribution.py tests/distributions/test_wrapped_normal_distribution.py`