### PR TITLE
Accept array-like piecewise PDF inputs

### DIFF
--- a/src/pyrecest/distributions/circle/piecewise_constant_distribution.py
+++ b/src/pyrecest/distributions/circle/piecewise_constant_distribution.py
@@ -89,9 +89,13 @@ class PiecewiseConstantDistribution(AbstractCircularDistribution):
         p : ndarray, shape (n,)
             Pdf values at each point.
         """
-        assert xs.ndim == 1
+        xs = array(xs, dtype=float)
+        if xs.ndim == 0:
+            xs = xs.reshape((1,))
+        if xs.ndim != 1:
+            raise ValueError("xs must be a scalar or one-dimensional array")
         n_intervals = len(self.w)
-        xs_mod = array(mod(xs, 2.0 * pi), dtype=float)
+        xs_mod = mod(xs, 2.0 * pi)
         idx = array(
             [
                 min(int(floor(x / (2.0 * pi) * n_intervals)), n_intervals - 1)

--- a/tests/distributions/test_piecewise_constant_distribution.py
+++ b/tests/distributions/test_piecewise_constant_distribution.py
@@ -31,6 +31,19 @@ class PiecewiseConstantDistributionTest(unittest.TestCase):
             self.dist.pdf(array([10.9])), array([4 * self.normal]), rtol=1e-10
         )
 
+    def test_pdf_accepts_scalar_and_list_inputs(self):
+        scalar_pdf = self.dist.pdf(0.0)
+        list_pdf = self.dist.pdf([0.0, 4.2])
+        array_pdf = self.dist.pdf(array([0.0, 4.2]))
+
+        self.assertEqual(scalar_pdf.shape, (1,))
+        npt.assert_allclose(scalar_pdf, array([1 * self.normal]), rtol=1e-10)
+        npt.assert_allclose(list_pdf, array_pdf, rtol=1e-10)
+
+    def test_pdf_rejects_matrix_input(self):
+        with self.assertRaisesRegex(ValueError, "one-dimensional"):
+            self.dist.pdf(array([[0.0, 1.0]]))
+
     def test_constructor_rejects_invalid_weights(self):
         for invalid_weights, message in [
             (array([1.0, -0.5, 1.0]), "nonnegative"),


### PR DESCRIPTION
## Summary
- convert `PiecewiseConstantDistribution.pdf` inputs before inspecting dimensions
- accept documented scalar and Python sequence inputs instead of raising `AttributeError`
- raise a clear `ValueError` for matrix inputs
- add regression tests for scalar, list, and matrix inputs

## Root cause
`PiecewiseConstantDistribution.pdf` checked `xs.ndim` before converting `xs` to a backend array. Plain Python scalars and lists are documented as array-like inputs but do not expose `.ndim`, so they failed before density evaluation.

## Impact
Callers can now evaluate piecewise-constant circular densities with the same scalar/list input shapes accepted by neighboring distribution APIs, while invalid higher-rank inputs get an explicit validation error.

## Tests
- `python -m pytest tests/distributions/test_piecewise_constant_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/circle/piecewise_constant_distribution.py tests/distributions/test_piecewise_constant_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/circle/piecewise_constant_distribution.py tests/distributions/test_piecewise_constant_distribution.py`