### PR TITLE
Accept list inputs in custom circular PDFs

### DIFF
--- a/src/pyrecest/distributions/circle/custom_circular_distribution.py
+++ b/src/pyrecest/distributions/circle/custom_circular_distribution.py
@@ -37,6 +37,7 @@ class CustomCircularDistribution(
         Returns:
             : The value of the pdf at xs.
         """
+        xs = array(xs)
         return AbstractCustomDistribution.pdf(self, mod(xs + self.shift_by, 2 * pi))
 
     def integrate(self, integration_boundaries=None) -> float:

--- a/tests/distributions/test_abstract_circular_distribution.py
+++ b/tests/distributions/test_abstract_circular_distribution.py
@@ -136,6 +136,14 @@ class AbstractCircularDistributionTest(unittest.TestCase):
             )
         )
 
+    def test_custom_circular_pdf_accepts_list_inputs(self):
+        dist = CustomCircularDistribution(cos, shift_by=0.2)
+
+        list_pdf = dist.pdf([0.1, 0.2])
+        array_pdf = dist.pdf(array([0.1, 0.2]))
+
+        self.assertTrue(allclose(list_pdf, array_pdf, rtol=1e-12))
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
         reason="Not supported on this backend",


### PR DESCRIPTION
## Summary
- convert `CustomCircularDistribution.pdf` inputs to backend arrays before applying the circular shift
- add regression coverage for Python list inputs matching equivalent array inputs

## Root cause
`CustomCircularDistribution.pdf` applied `xs + shift_by` before normalizing `xs` to a backend array. Plain Python lists therefore used list addition semantics and raised `TypeError`, even though neighboring distribution APIs accept array-like point inputs.

## Impact
Custom circular densities can now be evaluated with Python list inputs as documented array-like values, while existing scalar and array behavior is preserved.

## Tests
- `python -m pytest tests/distributions/test_abstract_circular_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/circle/custom_circular_distribution.py tests/distributions/test_abstract_circular_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/circle/custom_circular_distribution.py tests/distributions/test_abstract_circular_distribution.py`