### PR TITLE
Validate custom hypertoroidal shift inputs

### DIFF
--- a/src/pyrecest/distributions/hypertorus/custom_hypertoroidal_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/custom_hypertoroidal_distribution.py
@@ -1,8 +1,9 @@
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import mod, pi, zeros
+from pyrecest.backend import array, mod, pi, zeros
 
 from ..abstract_custom_distribution import AbstractCustomDistribution
 from ..circle.custom_circular_distribution import CustomCircularDistribution
+from ._input_validation import as_shift_vector
 from .abstract_hypertoroidal_distribution import AbstractHypertoroidalDistribution
 
 
@@ -24,9 +25,10 @@ class CustomHypertoroidalDistribution(
         if shift_by is None:
             self.shift_by = zeros(dim)
         else:
-            self.shift_by = shift_by
+            self.shift_by = as_shift_vector(shift_by, dim)
 
     def pdf(self, xs):
+        xs = array(xs)
         return AbstractCustomDistribution.pdf(self, mod(xs + self.shift_by, 2 * pi))
 
     def to_custom_circular(self):

--- a/tests/distributions/test_custom_hypertoroidal_distribution.py
+++ b/tests/distributions/test_custom_hypertoroidal_distribution.py
@@ -1,0 +1,38 @@
+import unittest
+
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array
+from pyrecest.distributions import CustomHypertoroidalDistribution
+
+
+class CustomHypertoroidalDistributionTest(unittest.TestCase):
+    def test_pdf_accepts_list_inputs_with_list_shift(self):
+        dist = CustomHypertoroidalDistribution(
+            lambda xs: xs * 0.0 + 1.0, 1, shift_by=[0.1]
+        )
+
+        list_pdf = dist.pdf([0.1, 0.2])
+        array_pdf = dist.pdf(array([0.1, 0.2]))
+
+        self.assertEqual(list_pdf.shape, (2,))
+        npt.assert_allclose(list_pdf, array_pdf)
+
+    def test_pdf_accepts_multidimensional_list_inputs_with_list_shift(self):
+        dist = CustomHypertoroidalDistribution(
+            lambda xs: xs[:, 0], 2, shift_by=[0.1, 0.2]
+        )
+
+        list_pdf = dist.pdf([[0.1, 0.2], [0.3, 0.4]])
+        array_pdf = dist.pdf(array([[0.1, 0.2], [0.3, 0.4]]))
+
+        npt.assert_allclose(list_pdf, array_pdf)
+
+    def test_constructor_rejects_wrong_shift_shape(self):
+        with self.assertRaisesRegex(ValueError, "shift_by"):
+            CustomHypertoroidalDistribution(lambda xs: xs, 2, shift_by=[0.1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- normalize `CustomHypertoroidalDistribution` query inputs to backend arrays before applying shifts
- validate `shift_by` as a vector matching the hypertorus dimension
- add focused regression tests for Python list inputs with list shifts and invalid shift shapes

## Root cause
`CustomHypertoroidalDistribution.pdf` applied `xs + shift_by` before normalizing either side. When both were Python lists, Python concatenated them instead of performing numeric addition; in 1-D this could return the wrong number of density evaluations, and in higher dimensions it could fail with a shape error.

## Impact
Custom hypertoroidal densities now handle Python list inputs and list shifts numerically and reject malformed shifts at construction with a clear `ValueError`.

## Tests
- `python -m pytest tests/distributions/test_custom_hypertoroidal_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m pytest tests/distributions/test_zero_density_entropy.py tests/distributions/test_custom_hypertoroidal_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/hypertorus/custom_hypertoroidal_distribution.py tests/distributions/test_custom_hypertoroidal_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/hypertorus/custom_hypertoroidal_distribution.py tests/distributions/test_custom_hypertoroidal_distribution.py`