### PR TITLE
Preserve custom hypertoroidal scale and shift on conversion

### DIFF
--- a/src/pyrecest/distributions/hypertorus/custom_hypertoroidal_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/custom_hypertoroidal_distribution.py
@@ -10,7 +10,7 @@ from .abstract_hypertoroidal_distribution import AbstractHypertoroidalDistributi
 class CustomHypertoroidalDistribution(
     AbstractHypertoroidalDistribution, AbstractCustomDistribution
 ):
-    def __init__(self, f, dim, shift_by=None):
+    def __init__(self, f, dim, shift_by=None, scale_by=1):
         # Constructor, it is the user's responsibility to ensure that f is a valid
         # hypertoroidal density and takes arguments of the same form as
         # .pdf, i.e., it needs to be vectorized.
@@ -20,7 +20,7 @@ class CustomHypertoroidalDistribution(
         #       pdf of the distribution
         #   dim (scalar)
         #       dimension of the hypertorus
-        AbstractCustomDistribution.__init__(self, f)
+        AbstractCustomDistribution.__init__(self, f, scale_by)
         AbstractHypertoroidalDistribution.__init__(self, dim)
         if shift_by is None:
             self.shift_by = zeros(dim)
@@ -38,7 +38,9 @@ class CustomHypertoroidalDistribution(
         #   ccd (CustomCircularDistribution)
         #       CustomCircularDistribution with same parameters
         assert self.dim == 1
-        ccd = CustomCircularDistribution(self.f)
+        ccd = CustomCircularDistribution(
+            self.f, scale_by=self.scale_by, shift_by=self.shift_by[0]
+        )
         return ccd
 
     def to_custom_toroidal(self):
@@ -50,5 +52,7 @@ class CustomHypertoroidalDistribution(
         from .custom_toroidal_distribution import CustomToroidalDistribution
 
         assert self.dim == 2
-        ctd = CustomToroidalDistribution(self.f)
+        ctd = CustomToroidalDistribution(
+            self.f, scale_by=self.scale_by, shift_by=self.shift_by
+        )
         return ctd

--- a/src/pyrecest/distributions/hypertorus/custom_toroidal_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/custom_toroidal_distribution.py
@@ -5,6 +5,8 @@ from .custom_hypertoroidal_distribution import CustomHypertoroidalDistribution
 class CustomToroidalDistribution(
     CustomHypertoroidalDistribution, AbstractToroidalDistribution
 ):
-    def __init__(self, f):
+    def __init__(self, f, scale_by=1, shift_by=None):
         AbstractToroidalDistribution.__init__(self)
-        CustomHypertoroidalDistribution.__init__(self, f, 2)
+        CustomHypertoroidalDistribution.__init__(
+            self, f, 2, shift_by=shift_by, scale_by=scale_by
+        )

--- a/tests/distributions/test_custom_hypertoroidal_distribution.py
+++ b/tests/distributions/test_custom_hypertoroidal_distribution.py
@@ -4,7 +4,7 @@ import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import array
-from pyrecest.distributions import CustomHypertoroidalDistribution
+from pyrecest.distributions import CustomHypertoroidalDistribution, CustomToroidalDistribution
 
 
 class CustomHypertoroidalDistributionTest(unittest.TestCase):
@@ -32,6 +32,30 @@ class CustomHypertoroidalDistributionTest(unittest.TestCase):
     def test_constructor_rejects_wrong_shift_shape(self):
         with self.assertRaisesRegex(ValueError, "shift_by"):
             CustomHypertoroidalDistribution(lambda xs: xs, 2, shift_by=[0.1])
+
+    def test_to_custom_circular_preserves_scale_and_shift(self):
+        dist = CustomHypertoroidalDistribution(
+            lambda xs: xs, 1, shift_by=[0.4], scale_by=2.5
+        )
+
+        circular = dist.to_custom_circular()
+        xs = array([0.1, 0.2, 0.3])
+
+        npt.assert_allclose(circular.pdf(xs), dist.pdf(xs))
+
+    def test_to_custom_toroidal_preserves_scale_and_shift(self):
+        dist = CustomHypertoroidalDistribution(
+            lambda xs: xs[:, 0] + 2.0 * xs[:, 1],
+            2,
+            shift_by=[0.3, 0.4],
+            scale_by=0.5,
+        )
+
+        toroidal = dist.to_custom_toroidal()
+        xs = array([[0.1, 0.2], [0.5, 0.6]])
+
+        self.assertIsInstance(toroidal, CustomToroidalDistribution)
+        npt.assert_allclose(toroidal.pdf(xs), dist.pdf(xs))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- preserve `scale_by` and `shift_by` when converting `CustomHypertoroidalDistribution` to custom circular or toroidal distributions
- allow `CustomToroidalDistribution` to receive optional `scale_by` and `shift_by` parameters so converted toroidal PDFs retain the source distribution behavior
- extend `test_custom_hypertoroidal_distribution.py` with regression checks that converted PDFs match the original distribution

## Root cause
`CustomHypertoroidalDistribution.to_custom_circular()` and `.to_custom_toroidal()` instantiated the target custom distributions with only `self.f`. That discarded the inherited custom-density scale factor and the hypertoroidal shift vector, so the converted distribution could evaluate a different PDF than the source distribution.

## Tests
- Added regression coverage in `tests/distributions/test_custom_hypertoroidal_distribution.py`
- Syntax sanity checked the modified files with `python -m py_compile`
- Not run locally: full pytest suite was unavailable in the sandbox because cloning/installing the repository dependencies failed due DNS resolution issues