### PR TITLE
Validate JAX random size arguments

### DIFF
--- a/src/pyrecest/_backend/jax/random.py
+++ b/src/pyrecest/_backend/jax/random.py
@@ -50,17 +50,32 @@ def _get_state(**kwargs):
     return state, has_state, kwargs
 
 
+def _looks_like_integer_dimension(value):
+    return isinstance(value, (int, _np.integer)) and not isinstance(value, (bool, _np.bool_))
+
+
+def _size_type_error():
+    return TypeError("size must be None, an integer, or a sequence of integers")
+
+
+def _integer_dimension(value):
+    if not _looks_like_integer_dimension(value):
+        raise _size_type_error()
+    value = int(value)
+    if value < 0:
+        raise ValueError("size dimensions must be non-negative")
+    return value
+
+
 def _shape_from_size(size):
     """Convert a NumPy-style ``size`` argument to JAX's shape argument."""
     if size is None:
         return ()
-    if hasattr(size, "__iter__"):
-        return tuple(int(dim) for dim in size)
-    return (int(size),)
-
-
-def _looks_like_integer_dimension(value):
-    return isinstance(value, (int, _np.integer))
+    if _looks_like_integer_dimension(size):
+        return (_integer_dimension(size),)
+    if isinstance(size, (str, bytes)) or not hasattr(size, "__iter__"):
+        raise _size_type_error()
+    return tuple(_integer_dimension(dim) for dim in size)
 
 
 def _looks_like_shape(value):

--- a/tests/backend/test_jax_random_backend.py
+++ b/tests/backend/test_jax_random_backend.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 jax = pytest.importorskip("jax")
@@ -24,3 +25,47 @@ def test_multivariate_normal_accepts_shape_keyword():
 
     with pytest.raises(TypeError):
         random.multivariate_normal(mean, cov, size=(1,), shape=(2,))
+
+
+def _size_aware_samplers():
+    values = jnp.array([0, 1, 2])
+    mean = jnp.array([0.0])
+    cov = jnp.eye(1)
+    return (
+        lambda size: random.rand(size=size),
+        lambda size: random.uniform(size=size),
+        lambda size: random.normal(size=size),
+        lambda size: random.randint(0, 3, size=size),
+        lambda size: random.choice(values, size=size),
+        lambda size: random.multivariate_normal(mean, cov, size=size),
+    )
+
+
+@pytest.mark.parametrize(
+    "bad_size",
+    [True, False, np.bool_(True), (True,), [np.bool_(False), 2], 1.5, (2.0,), "3"],
+)
+def test_size_arguments_reject_bool_and_non_integral_dimensions(bad_size):
+    for sampler in _size_aware_samplers():
+        with pytest.raises(TypeError):
+            sampler(bad_size)
+
+
+@pytest.mark.parametrize("bad_size", [-1, (2, -1)])
+def test_size_arguments_reject_negative_dimensions(bad_size):
+    for sampler in _size_aware_samplers():
+        with pytest.raises(ValueError):
+            sampler(bad_size)
+
+
+def test_normal_legacy_shape_detection_accepts_numpy_integer_dimensions():
+    random.seed(0)
+
+    assert random.normal(np.int64(3)).shape == (3,)
+    assert random.normal((np.int64(2), 3)).shape == (2, 3)
+
+
+def test_normal_bool_location_is_not_interpreted_as_legacy_shape():
+    random.seed(0)
+
+    assert random.normal(True).shape == ()


### PR DESCRIPTION
## Summary
- validate JAX random `size` dimensions before converting them to backend shapes
- reject boolean, non-integral, string, and negative dimensions with explicit exceptions instead of silently coercing them through `int(...)`
- keep NumPy integer dimensions supported for legacy `random.normal(size)` dispatch and add regression coverage for boolean locations

## Tests
- isolated local JAX regression check covering `rand`, `uniform`, `normal`, `randint`, `choice`, and `multivariate_normal` with invalid and valid size inputs

## Notes
- I could not run the full repository test suite in this environment because the repository could not be cloned from GitHub over the container network.