### PR TITLE
Validate JAX random size arguments

### DIFF
--- a/src/pyrecest/_backend/jax/random.py
+++ b/src/pyrecest/_backend/jax/random.py
@@ -6,6 +6,7 @@ who says he was in inspired by https://github.com/wesselb/lab/blob/master/lab/ja
 """
 
 import sys
+from numbers import Integral as _Integral
 
 import jax
 import jax.numpy as _jnp
@@ -50,17 +51,33 @@ def _get_state(**kwargs):
     return state, has_state, kwargs
 
 
+def _shape_dimension_from_size(dim, name="size"):
+    if isinstance(dim, (bool, _np.bool_)):
+        raise TypeError(f"{name} entries must be integers, not booleans")
+    if not isinstance(dim, _Integral):
+        raise TypeError(f"{name} must be None, an integer, or a tuple/list of integers")
+
+    dim = int(dim)
+    if dim < 0:
+        raise ValueError(f"{name} entries must be non-negative")
+    return dim
+
+
 def _shape_from_size(size):
     """Convert a NumPy-style ``size`` argument to JAX's shape argument."""
     if size is None:
         return ()
-    if hasattr(size, "__iter__"):
-        return tuple(int(dim) for dim in size)
-    return (int(size),)
+    if isinstance(size, (bool, _np.bool_)):
+        raise TypeError("size must be an integer or a tuple/list of integers, not boolean")
+    if isinstance(size, _Integral):
+        return (_shape_dimension_from_size(size),)
+    if isinstance(size, (tuple, list)):
+        return tuple(_shape_dimension_from_size(dim) for dim in size)
+    raise TypeError("size must be None, an integer, or a tuple/list of integers")
 
 
 def _looks_like_integer_dimension(value):
-    return isinstance(value, (int, _np.integer))
+    return isinstance(value, _Integral) and not isinstance(value, (bool, _np.bool_))
 
 
 def _looks_like_shape(value):

--- a/tests/test_backend_random.py
+++ b/tests/test_backend_random.py
@@ -94,6 +94,26 @@ class TestBackendRandom(unittest.TestCase):
         self.assertEqual(int(pyrecest.backend.sum(sample)), 12)
 
     @unittest.skipIf(
+        pyrecest.backend.__backend_name__ != "jax", "JAX-specific size validation"
+    )
+    def test_jax_random_rejects_invalid_size_arguments(self):
+        invalid_sizes = (True, (2, True), 1.5, (2, 1.5), "3", -1, (2, -1))
+        random_calls = (
+            lambda size: random.rand(size=size),
+            lambda size: random.uniform(size=size),
+            lambda size: random.randint(0, 5, size=size),
+            lambda size: random.normal(size=size),
+            lambda size: random.choice(5, size=size),
+            lambda size: random.multivariate_normal([0.0], [[1.0]], size=size),
+        )
+
+        for invalid_size in invalid_sizes:
+            for random_call in random_calls:
+                with self.subTest(size=invalid_size, random_call=random_call):
+                    with self.assertRaises((TypeError, ValueError)):
+                        random_call(invalid_size)
+
+    @unittest.skipIf(
         pyrecest.backend.__backend_name__ != "jax", "JAX-specific RNG state contract"
     )
     def test_jax_multinomial_explicit_state_does_not_mutate_global_state(self):


### PR DESCRIPTION
## Summary
- validate JAX random `size` arguments before converting them to JAX shape tuples
- reject booleans, floats, strings, negative dimensions, and non-list/tuple shape containers instead of silently coercing them with `int(...)`
- add a JAX-specific regression test across `rand`, `uniform`, `randint`, `normal`, `choice`, and `multivariate_normal`

## Notes
- This is intentionally scoped to JAX because NumPy/Torch currently rely on their native size handling in this test module.
- I could not run the repository test suite locally because the sandbox cannot clone/install from GitHub; validation is left to CI.
