### PR TITLE
Normalize PyTorch randint size handling

### DIFF
--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -4,7 +4,6 @@ from numbers import Integral as _Integral
 
 import torch as _torch
 from torch import get_rng_state as get_state  # For PyRecEst
-from torch import randint
 from torch import set_rng_state as set_state  # For PyRecEst
 from torch.distributions.multivariate_normal import (
     MultivariateNormal as _MultivariateNormal,
@@ -25,6 +24,22 @@ def _choice_size(size):
         size = (size,)
     size = tuple(int(dim) for dim in size)
     return size, int(_torch.prod(_torch.tensor(size)).item())
+
+
+def _randint_size(size):
+    if size is None:
+        return ()
+    if not hasattr(size, "__iter__") or isinstance(size, (str, bytes)):
+        return (size,)
+    return tuple(size)
+
+
+def randint(low, high=None, size=None, *args, **kwargs):
+    if high is None:
+        if low is None:
+            raise TypeError("randint() missing required argument 'high'")
+        return _torch.randint(low, _randint_size(size), *args, **kwargs)
+    return _torch.randint(low, high, _randint_size(size), *args, **kwargs)
 
 
 def _normal_size(size):

--- a/tests/test_pytorch_backend.py
+++ b/tests/test_pytorch_backend.py
@@ -179,6 +179,20 @@ class TestPytorchBackendCopy(unittest.TestCase):
 
 @unittest.skipIf(pytorch_backend is None, "PyTorch is not installed")
 class TestPytorchBackendRandom(unittest.TestCase):
+    def test_randint_matches_numpy_scalar_contract(self):
+        sample = pytorch_backend.random.randint(0, 5)
+
+        self.assertEqual(sample.shape, ())
+        self.assertGreaterEqual(int(sample), 0)
+        self.assertLess(int(sample), 5)
+
+    def test_randint_accepts_numpy_style_integer_size(self):
+        samples = pytorch_backend.random.randint(0, 5, size=4)
+
+        self.assertEqual(tuple(samples.shape), (4,))
+        self.assertTrue(pytorch_backend.all(samples >= 0))
+        self.assertTrue(pytorch_backend.all(samples < 5))
+
     def test_choice_accepts_weighted_sampling_without_replacement(self):
         values = pytorch_backend.array([0, 1, 2, 3])
         probabilities = pytorch_backend.array([0.1, 0.2, 0.3, 0.4])


### PR DESCRIPTION
## Summary
- replace the direct `torch.randint` export with a PyRecEst wrapper that accepts the NumPy-style `randint(low, high=None, size=None, ...)` contract
- return scalar tensors for `size=None` and normalize integer `size` values to one-dimensional PyTorch shapes
- add PyTorch regression tests for scalar randint calls and integer `size` handling

## Root cause
The PyTorch backend directly re-exported `torch.randint`. PyTorch requires a shape argument and treats a plain integer third positional value differently from NumPy's `size=`, so calls such as `pyrecest._backend.pytorch.random.randint(0, 5)` and `...randint(0, 5, size=4)` failed even though they are valid for NumPy-style backends.

## Validation
- `python -m py_compile` on the modified random backend and test module
- isolated local wrapper checks with installed PyTorch for scalar, integer-size, tuple-size, and list-size randint calls

Note: I could not run the full repository test suite locally because the sandbox cannot clone/install from GitHub over the container network; CI should provide full coverage.