### PR TITLE
Validate ellipsoidal ball inputs explicitly

### DIFF
--- a/src/pyrecest/distributions/abstract_ellipsoidal_ball_distribution.py
+++ b/src/pyrecest/distributions/abstract_ellipsoidal_ball_distribution.py
@@ -9,6 +9,7 @@ from pyrecest.backend import (
     sqrt,
     transpose,
 )
+from pyrecest.exceptions import ShapeError, ValidationError
 from scipy.special import gamma
 
 from .abstract_bounded_nonperiodic_distribution import (
@@ -31,25 +32,30 @@ class AbstractEllipsoidalBallDistribution(AbstractBoundedNonPeriodicDistribution
         center = array(center)
         shape_matrix = array(shape_matrix)
 
-        assert center.ndim == 1, "center must be a 1-dimensional array"
+        if center.ndim != 1:
+            raise ShapeError("center", center.shape, expected="(dim,)")
         AbstractBoundedNonPeriodicDistribution.__init__(self, center.shape[-1])
-        assert shape_matrix.ndim == 2, "shape_matrix must be a 2-dimensional array"
-        assert shape_matrix.shape == (
-            self.dim,
-            self.dim,
-        ), "shape_matrix must match the center dimension"
-        assert bool(
-            backend_all(isfinite(center))
-        ), "center must contain only finite values"
-        assert bool(
-            backend_all(isfinite(shape_matrix))
-        ), "shape_matrix must contain only finite values"
-        assert allclose(
-            shape_matrix, transpose(shape_matrix)
-        ), "shape_matrix must be symmetric"
-        assert bool(
-            backend_all(linalg.eigvalsh(shape_matrix) > 0.0)
-        ), "shape_matrix must be positive definite"
+        if shape_matrix.ndim != 2:
+            raise ShapeError(
+                "shape_matrix",
+                shape_matrix.shape,
+                expected=f"({self.dim}, {self.dim})",
+            )
+        if shape_matrix.shape != (self.dim, self.dim):
+            raise ShapeError(
+                "shape_matrix",
+                shape_matrix.shape,
+                expected=f"({self.dim}, {self.dim})",
+                reason="shape_matrix must match the center dimension",
+            )
+        if not bool(backend_all(isfinite(center))):
+            raise ValidationError("center must contain only finite values")
+        if not bool(backend_all(isfinite(shape_matrix))):
+            raise ValidationError("shape_matrix must contain only finite values")
+        if not bool(allclose(shape_matrix, transpose(shape_matrix))):
+            raise ValidationError("shape_matrix must be symmetric")
+        if not bool(backend_all(linalg.eigvalsh(shape_matrix) > 0.0)):
+            raise ValidationError("shape_matrix must be positive definite")
 
         self.center = center
         self.shape_matrix = shape_matrix

--- a/src/pyrecest/distributions/ellipsoidal_ball_uniform_distribution.py
+++ b/src/pyrecest/distributions/ellipsoidal_ball_uniform_distribution.py
@@ -50,7 +50,7 @@ class EllipsoidalBallUniformDistribution(
         :returns: PDF values at given points.
         """
         xs = array(xs)
-        if xs.ndim == 0 or xs.shape[-1] != self.dim:
+        if xs.ndim not in (1, 2) or xs.shape[-1] != self.dim:
             raise ShapeError(
                 "xs",
                 xs.shape,

--- a/src/pyrecest/distributions/ellipsoidal_ball_uniform_distribution.py
+++ b/src/pyrecest/distributions/ellipsoidal_ball_uniform_distribution.py
@@ -2,7 +2,8 @@ from numbers import Integral
 from typing import Union
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import int32, int64, linalg, random, where, zeros
+from pyrecest.backend import array, int32, int64, linalg, random, where, zeros
+from pyrecest.exceptions import ShapeError
 
 from .abstract_ellipsoidal_ball_distribution import AbstractEllipsoidalBallDistribution
 from .abstract_uniform_distribution import AbstractUniformDistribution
@@ -48,7 +49,13 @@ class EllipsoidalBallUniformDistribution(
         :param xs: Points at which to compute the PDF.
         :returns: PDF values at given points.
         """
-        assert xs.shape[-1] == self.dim
+        xs = array(xs)
+        if xs.ndim == 0 or xs.shape[-1] != self.dim:
+            raise ShapeError(
+                "xs",
+                xs.shape,
+                expected=f"({self.dim},) or (n, {self.dim})",
+            )
 
         reciprocal_volume = 1 / self.get_manifold_size()
 

--- a/tests/distributions/test_ellipsoidal_ball_uniform_distribution.py
+++ b/tests/distributions/test_ellipsoidal_ball_uniform_distribution.py
@@ -1,3 +1,6 @@
+import os
+import subprocess
+import sys
 import unittest
 
 import numpy as np
@@ -6,6 +9,7 @@ import numpy.testing as npt
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import array, diag
 from pyrecest.distributions import EllipsoidalBallUniformDistribution
+from pyrecest.exceptions import ShapeError, ValidationError
 
 
 class TestEllipsoidalBallUniformDistribution(unittest.TestCase):
@@ -15,6 +19,14 @@ class TestEllipsoidalBallUniformDistribution(unittest.TestCase):
         )
         npt.assert_allclose(dist.pdf(array([0.0, 0.0, 0.0])), 1 / 100.53096491)
 
+    def test_pdf_rejects_dimension_mismatch(self):
+        dist = EllipsoidalBallUniformDistribution(
+            array([0.0, 0.0]), diag(array([1.0, 1.0]))
+        )
+
+        with self.assertRaisesRegex(ShapeError, "xs"):
+            dist.pdf(array([0.0]))
+
     def test_mean_and_covariance(self):
         center = array([2.0, 3.0])
         shape_matrix = array([[4.0, 3.0], [3.0, 9.0]])
@@ -22,6 +34,17 @@ class TestEllipsoidalBallUniformDistribution(unittest.TestCase):
 
         npt.assert_allclose(dist.mean(), center)
         npt.assert_allclose(dist.covariance(), shape_matrix / (dist.dim + 2))
+
+    def test_rejects_invalid_shapes(self):
+        with self.assertRaisesRegex(ShapeError, "center"):
+            EllipsoidalBallUniformDistribution(
+                array([[0.0, 0.0]]), diag(array([1.0, 1.0]))
+            )
+
+        with self.assertRaisesRegex(ShapeError, "shape_matrix"):
+            EllipsoidalBallUniformDistribution(
+                array([0.0, 0.0]), array([[1.0, 0.0, 0.0]])
+            )
 
     def test_rejects_invalid_shape_matrix(self):
         center = array([0.0, 0.0])
@@ -34,8 +57,39 @@ class TestEllipsoidalBallUniformDistribution(unittest.TestCase):
 
         for shape_matrix in invalid_shape_matrices:
             with self.subTest(shape_matrix=shape_matrix):
-                with self.assertRaises(AssertionError):
+                with self.assertRaises(ValidationError):
                     EllipsoidalBallUniformDistribution(center, shape_matrix)
+
+    def test_validation_survives_optimized_python(self):
+        env = os.environ.copy()
+        src_path = os.path.abspath("src")
+        env["PYTHONPATH"] = (
+            src_path
+            if not env.get("PYTHONPATH")
+            else os.pathsep.join([src_path, env["PYTHONPATH"]])
+        )
+
+        code = """
+from pyrecest.backend import array, diag
+from pyrecest.distributions import EllipsoidalBallUniformDistribution
+from pyrecest.exceptions import ShapeError, ValidationError
+
+valid = EllipsoidalBallUniformDistribution(array([0.0, 0.0]), diag(array([1.0, 1.0])))
+cases = (
+    lambda: EllipsoidalBallUniformDistribution(array([[0.0, 0.0]]), diag(array([1.0, 1.0]))),
+    lambda: EllipsoidalBallUniformDistribution(array([0.0, 0.0]), array([[1.0, 0.0, 0.0]])),
+    lambda: EllipsoidalBallUniformDistribution(array([0.0, 0.0]), array([[1.0, 2.0], [0.0, 1.0]])),
+    lambda: valid.pdf(array([0.0])),
+)
+for case in cases:
+    try:
+        case()
+    except (ShapeError, ValidationError):
+        pass
+    else:
+        raise AssertionError("invalid ellipsoidal ball input was accepted under optimized Python")
+"""
+        subprocess.run([sys.executable, "-O", "-c", code], check=True, env=env)
 
     def test_sampling(self):
         dist = EllipsoidalBallUniformDistribution(


### PR DESCRIPTION
## Summary
- replace assertion-based ellipsoidal ball parameter validation with explicit `ShapeError` / `ValidationError` exceptions
- validate `EllipsoidalBallUniformDistribution.pdf` input dimensions before evaluating the quadratic form
- add regression coverage for invalid shapes, invalid shape matrices, PDF dimension mismatches, and optimized Python (`-O`) validation

## Root cause
Ellipsoidal ball constructors and PDF evaluation used `assert` for user-input validation. Python removes asserts under optimized execution, so malformed centers, shape matrices, or PDF inputs could bypass checks and fail later with less predictable backend errors.

## Tests
- Added regression coverage in `tests/distributions/test_ellipsoidal_ball_uniform_distribution.py`
- Syntax sanity checked the modified files locally with `python -m py_compile`
- Not run locally: full repository tests were unavailable in the sandbox because cloning/installing from GitHub over the container network failed due DNS resolution issues