### PR TITLE
Accept array-like custom linear inputs

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/custom_linear_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/custom_linear_distribution.py
@@ -1,12 +1,23 @@
 import copy
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import ndim, reshape, zeros
+from pyrecest.backend import array, ndim, reshape, zeros
 
 from ..abstract_custom_nonperiodic_distribution import (
     AbstractCustomNonPeriodicDistribution,
 )
 from .abstract_linear_distribution import AbstractLinearDistribution
+
+
+def _as_shift_vector(shift_by, dim: int, *, name: str = "shift_by"):
+    shift_by = array(shift_by)
+    if shift_by.ndim == 0:
+        if dim != 1:
+            raise ValueError(f"{name} must have shape ({dim},), got scalar.")
+        return reshape(shift_by, (1,))
+    if shift_by.ndim == 1 and shift_by.shape[0] == dim:
+        return shift_by
+    raise ValueError(f"{name} must have shape ({dim},), got {shift_by.shape}.")
 
 
 class CustomLinearDistribution(
@@ -30,24 +41,31 @@ class CustomLinearDistribution(
         AbstractLinearDistribution.__init__(self, dim=dim)
         AbstractCustomNonPeriodicDistribution.__init__(self, f, scale_by=scale_by)
         if shift_by is not None:
-            self.shift_by = shift_by
+            self.shift_by = _as_shift_vector(shift_by, dim)
         else:
             self.shift_by = zeros(dim)
 
     def shift(self, shift_by):
-        assert self.dim == 1 or self.dim == shift_by.shape[0] and shift_by.ndim == 1
+        shift_by = _as_shift_vector(shift_by, self.dim)
         cd = copy.deepcopy(self)
         cd.shift_by = self.shift_by + shift_by
         return cd
 
     def set_mean(self, new_mean):
+        new_mean = _as_shift_vector(new_mean, self.dim, name="new_mean")
         mean_offset = new_mean - self.mean()
         self.shift_by = self.shift_by + mean_offset
         if self._mean_numerical is not None:
             self._mean_numerical = new_mean
 
     def pdf(self, xs):
-        assert self.dim == 1 and xs.ndim <= 1 or xs.shape[-1] == self.dim
+        xs = array(xs)
+        if xs.ndim == 0 and self.dim != 1:
+            raise ValueError(f"xs must have trailing dimension {self.dim}")
+        if xs.ndim != 0 and not (
+            self.dim == 1 and xs.ndim <= 1 or xs.shape[-1] == self.dim
+        ):
+            raise ValueError(f"xs must have trailing dimension {self.dim}")
         p = self.scale_by * self.f(
             # To ensure 2-d for broadcasting
             reshape(xs, (-1, self.dim))

--- a/tests/distributions/test_custom_linear_distribution.py
+++ b/tests/distributions/test_custom_linear_distribution.py
@@ -37,6 +37,39 @@ class CustomLinearDistributionTest(unittest.TestCase):
         npt.assert_allclose(cld.shift_by, array([2.0]))
         npt.assert_allclose(cld.pdf(array([3.0])), g.pdf(array([1.0])))
 
+    def test_pdf_accepts_scalar_and_list_inputs(self):
+        cld = CustomLinearDistribution(
+            lambda xs: xs[:, 0] * 0.0 + 1.0, 1, shift_by=[0.2]
+        )
+
+        scalar_pdf = cld.pdf(0.3)
+        list_pdf = cld.pdf([0.3, 0.4])
+        array_pdf = cld.pdf(array([0.3, 0.4]))
+
+        self.assertEqual(scalar_pdf.shape, (1,))
+        npt.assert_allclose(list_pdf, array_pdf)
+
+    def test_pdf_accepts_multidimensional_list_inputs(self):
+        cld = CustomLinearDistribution(
+            lambda xs: xs[:, 0], 2, shift_by=[0.2, -0.1]
+        )
+
+        list_pdf = cld.pdf([[1.0, 2.0], [3.0, 4.0]])
+        array_pdf = cld.pdf(array([[1.0, 2.0], [3.0, 4.0]]))
+
+        npt.assert_allclose(list_pdf, array_pdf)
+
+    def test_constructor_rejects_wrong_shift_shape(self):
+        with self.assertRaisesRegex(ValueError, "shift_by"):
+            CustomLinearDistribution(lambda xs: xs[:, 0], 2, shift_by=[0.2])
+
+    def test_shift_accepts_list_offset(self):
+        cld = CustomLinearDistribution(lambda xs: xs[:, 0], 2)
+
+        shifted = cld.shift([0.2, -0.1])
+
+        npt.assert_allclose(shifted.shift_by, array([0.2, -0.1]))
+
     @staticmethod
     def verify_pdf_equal(dist1, dist2, tol):
         x, y = meshgrid(


### PR DESCRIPTION
## Summary
- normalize `CustomLinearDistribution` query inputs before shape checks
- validate `shift_by` and `new_mean` as dimension-matching vectors
- let `shift` accept ordinary Python list offsets
- add regression tests for scalar, list, multidimensional list, and invalid shift inputs

## Root cause
`CustomLinearDistribution.pdf` read `.ndim` and `.shape` on raw caller inputs before converting them to backend arrays. Plain Python scalars and lists therefore raised `AttributeError` even though the distribution later reshapes inputs for vectorized evaluation. Shift inputs had the same raw-list issue in the constructor and `shift`.

## Impact
Custom linear densities now accept ordinary array-like scalar, vector, and matrix inputs consistently, while malformed shifts fail with clear `ValueError`s.

## Tests
- `python -m pytest tests/distributions/test_custom_linear_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/nonperiodic/custom_linear_distribution.py tests/distributions/test_custom_linear_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/nonperiodic/custom_linear_distribution.py tests/distributions/test_custom_linear_distribution.py`