### PR TITLE
Reject nonfinite SO3 tangent updates

### DIFF
--- a/src/pyrecest/filters/so3_product_particle_filter.py
+++ b/src/pyrecest/filters/so3_product_particle_filter.py
@@ -295,6 +295,8 @@ class SO3ProductParticleFilter(HyperhemisphereCartProdParticleFilter):
             )
         if tangent_vectors.shape[0] != n_particles:
             raise ValueError("Tangent vector batch size must match particle count.")
+        if not all(isfinite(tangent_vectors)):
+            raise ValueError("SO(3)^K tangent vectors must be finite.")
 
         return tangent_vectors
 

--- a/tests/filters/test_so3_product_particle_filter.py
+++ b/tests/filters/test_so3_product_particle_filter.py
@@ -78,6 +78,14 @@ class SO3ProductParticleFilterTest(unittest.TestCase):
         npt.assert_allclose(filt.particles[0], expected, atol=ATOL)
         npt.assert_allclose(filt.particles[1], expected, atol=ATOL)
 
+    def test_rejects_nonfinite_tangent_delta(self):
+        filt = SO3ProductParticleFilter(n_particles=2, num_rotations=1)
+
+        for invalid_value in (float("nan"), float("inf"), -float("inf")):
+            with self.subTest(invalid_value=invalid_value):
+                with self.assertRaisesRegex(ValueError, "finite"):
+                    filt.predict_with_tangent_delta(array([invalid_value, 0.0, 0.0]))
+
     def test_predict_identity_with_full_tangent_noise_covariance(self):
         random.seed(0)
         filt = SO3ProductParticleFilter(n_particles=4, num_rotations=2)


### PR DESCRIPTION
## Summary
- reject NaN and infinite SO(3)^K tangent update vectors before applying the exponential map
- add a focused regression test covering NaN, +Inf, and -Inf tangent deltas

## Validation
- `python -m pytest tests/filters/test_so3_product_particle_filter.py -q`
- `ruff check src/pyrecest/filters/so3_product_particle_filter.py tests/filters/test_so3_product_particle_filter.py`

## Quality impact
This is a defensive robustness improvement for SO(3)^K prediction paths. It prevents invalid numeric inputs from silently contaminating particles and later diagnostics.