### PR TITLE
Accept array-like ellipsoidal ball PDF inputs

### DIFF
--- a/src/pyrecest/distributions/ellipsoidal_ball_uniform_distribution.py
+++ b/src/pyrecest/distributions/ellipsoidal_ball_uniform_distribution.py
@@ -2,7 +2,7 @@ from numbers import Integral
 from typing import Union
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import int32, int64, linalg, random, where, zeros
+from pyrecest.backend import array, int32, int64, linalg, random, reshape, where, zeros
 
 from .abstract_ellipsoidal_ball_distribution import AbstractEllipsoidalBallDistribution
 from .abstract_uniform_distribution import AbstractUniformDistribution
@@ -48,14 +48,9 @@ class EllipsoidalBallUniformDistribution(
         :param xs: Points at which to compute the PDF.
         :returns: PDF values at given points.
         """
-        assert xs.shape[-1] == self.dim
+        xs, single = self._coerce_points(xs)
 
         reciprocal_volume = 1 / self.get_manifold_size()
-
-        # Make xs always 2D for uniform handling
-        single = xs.ndim == 1
-        if single:
-            xs = xs[None, :]
 
         # (n, dim)
         diff = xs - self.center[None, :]
@@ -73,6 +68,24 @@ class EllipsoidalBallUniformDistribution(
         pdf_values = where(inside, reciprocal_volume, zeros(quad.shape[0]))
 
         return pdf_values[0] if single else pdf_values
+
+    def _coerce_points(self, xs):
+        xs = array(xs)
+        if xs.ndim == 0:
+            if self.dim != 1:
+                raise ValueError("Scalar points are only valid for dim == 1")
+            return reshape(xs, (1, 1)), True
+        if xs.ndim == 1:
+            if self.dim == 1:
+                return reshape(xs, (-1, 1)), False
+            if xs.shape[0] == self.dim:
+                return reshape(xs, (1, self.dim)), True
+            raise ValueError(
+                f"Point dimension {xs.shape[0]} does not match dim {self.dim}"
+            )
+        if xs.ndim != 2 or xs.shape[1] != self.dim:
+            raise ValueError(f"xs must have shape (n, {self.dim})")
+        return xs, False
 
     def sample(self, n: Union[int, int32, int64]):
         """

--- a/tests/distributions/test_ellipsoidal_ball_uniform_distribution.py
+++ b/tests/distributions/test_ellipsoidal_ball_uniform_distribution.py
@@ -15,6 +15,34 @@ class TestEllipsoidalBallUniformDistribution(unittest.TestCase):
         )
         npt.assert_allclose(dist.pdf(array([0.0, 0.0, 0.0])), 1 / 100.53096491)
 
+    def test_pdf_accepts_scalar_and_list_inputs_for_one_dimensional_ball(self):
+        dist = EllipsoidalBallUniformDistribution(array([0.0]), diag(array([1.0])))
+
+        scalar_pdf = dist.pdf(0.0)
+        list_pdf = dist.pdf([0.0, 0.5, 2.0])
+        array_pdf = dist.pdf(array([0.0, 0.5, 2.0]))
+
+        npt.assert_allclose(scalar_pdf, array_pdf[0])
+        npt.assert_allclose(list_pdf, array_pdf)
+        npt.assert_allclose(array_pdf[-1], 0.0)
+
+    def test_pdf_accepts_list_inputs_for_multidimensional_ball(self):
+        dist = EllipsoidalBallUniformDistribution(array([0.0, 0.0]), diag(array([1.0, 1.0])))
+
+        single_pdf = dist.pdf([0.0, 0.0])
+        batch_pdf = dist.pdf([[0.0, 0.0], [2.0, 0.0]])
+        array_pdf = dist.pdf(array([[0.0, 0.0], [2.0, 0.0]]))
+
+        npt.assert_allclose(single_pdf, array_pdf[0])
+        npt.assert_allclose(batch_pdf, array_pdf)
+        npt.assert_allclose(batch_pdf[-1], 0.0)
+
+    def test_pdf_rejects_wrong_point_dimension(self):
+        dist = EllipsoidalBallUniformDistribution(array([0.0, 0.0]), diag(array([1.0, 1.0])))
+
+        with self.assertRaisesRegex(ValueError, "Point dimension"):
+            dist.pdf([0.0, 0.0, 0.0])
+
     def test_mean_and_covariance(self):
         center = array([2.0, 3.0])
         shape_matrix = array([[4.0, 3.0], [3.0, 9.0]])


### PR DESCRIPTION
## Summary
- normalize `EllipsoidalBallUniformDistribution.pdf` query points before shape checks
- accept scalar and Python list inputs for one-dimensional ellipsoidal balls
- accept list single points and batches for multidimensional ellipsoidal balls
- raise explicit `ValueError`s for malformed point dimensions

## Root cause
`EllipsoidalBallUniformDistribution.pdf` read `.shape` and `.ndim` from raw caller inputs before converting them to backend arrays. Plain Python scalars and lists therefore raised `AttributeError`, and one-dimensional vector batches asserted instead of being evaluated as scalar query points.

## Impact
Ellipsoidal ball uniform densities now follow the same scalar/list point handling used by nearby bounded nonperiodic distributions such as hyperrectangular uniform and linear box-particle distributions.

## Tests
- `python -m pytest tests/distributions/test_ellipsoidal_ball_uniform_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m pytest tests/distributions/test_ellipsoidal_ball_uniform_distribution.py tests/distributions/test_disk_uniform_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/ellipsoidal_ball_uniform_distribution.py tests/distributions/test_ellipsoidal_ball_uniform_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/ellipsoidal_ball_uniform_distribution.py tests/distributions/test_ellipsoidal_ball_uniform_distribution.py`