### PR TITLE
Keep masked SO3 likelihoods finite

### DIFF
--- a/src/pyrecest/filters/so3_product_particle_filter.py
+++ b/src/pyrecest/filters/so3_product_particle_filter.py
@@ -565,7 +565,12 @@ class SO3ProductParticleFilter(HyperhemisphereCartProdParticleFilter):
             ],
             axis=1,
         )
-        clean_log_likelihood = -0.5 * (distances / sigma) ** 2
+        active_distances = where(
+            component_weights > 0.0,
+            distances,
+            zeros(distances.shape),
+        )
+        clean_log_likelihood = -0.5 * (active_distances / sigma) ** 2
         if eps > 0.0:
             clean_probability = eps if eps < 1.0 - 1e-12 else 1.0 - 1e-12
             outlier_probability = eps if eps > 1e-12 else 1e-12
@@ -575,7 +580,12 @@ class SO3ProductParticleFilter(HyperhemisphereCartProdParticleFilter):
             clean_log_likelihood = normalizer + log(
                 exp(clean_term - normalizer) + exp(outlier_term - normalizer)
             )
-        return component_weights * clean_log_likelihood
+        active_log_likelihood = where(
+            component_weights > 0.0,
+            clean_log_likelihood,
+            zeros(clean_log_likelihood.shape),
+        )
+        return component_weights * active_log_likelihood
 
     def geodesic_log_likelihood(
         self,

--- a/tests/filters/test_so3_product_particle_filter.py
+++ b/tests/filters/test_so3_product_particle_filter.py
@@ -1,9 +1,22 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array, cos, diag, exp, linalg, ones, pi, random, sin, stack
+from pyrecest.backend import (
+    array,
+    cos,
+    diag,
+    exp,
+    linalg,
+    ones,
+    pi,
+    random,
+    sin,
+    stack,
+    to_numpy,
+)
 from pyrecest.filters import (
     HyperhemisphereCartProdParticleFilter,
     SO3ProductParticleFilter,
@@ -146,6 +159,28 @@ class SO3ProductParticleFilterTest(unittest.TestCase):
         )
 
         npt.assert_allclose(filt.weights, array([0.5, 0.5]), atol=ATOL)
+
+    def test_masked_component_stays_finite_with_tiny_noise(self):
+        filt = SO3ProductParticleFilter(n_particles=2, num_rotations=2)
+        filt.set_particles(
+            stack(
+                [
+                    stack([z_quaternion(0.0), z_quaternion(pi)], axis=0),
+                    stack([z_quaternion(0.0), z_quaternion(-pi / 2.0)], axis=0),
+                ],
+                axis=0,
+            )
+        )
+
+        log_likelihoods = filt.component_geodesic_log_likelihood(
+            stack([z_quaternion(0.0), z_quaternion(0.0)], axis=0),
+            noise_std=1e-300,
+            mask=array([1.0, 0.0]),
+        )
+
+        log_likelihoods_np = to_numpy(log_likelihoods)
+        self.assertTrue(np.isfinite(log_likelihoods_np).all())
+        npt.assert_allclose(log_likelihoods[:, 1], array([0.0, 0.0]), atol=ATOL)
 
     def test_log_likelihood_update_supports_zero_likelihoods(self):
         filt = SO3ProductParticleFilter(n_particles=3, num_rotations=1)


### PR DESCRIPTION
## Summary
- avoid `0 * -inf` in masked or zero-confidence SO(3)^K geodesic likelihood components
- zero inactive component distances before the tiny-noise likelihood calculation and zero inactive log-likelihoods before weighting
- add a regression test for masked components with tiny noise that previously produced NaN values

## Validation
- `python -m pytest tests/filters/test_so3_product_particle_filter.py -q`
- `ruff check src/pyrecest/filters/so3_product_particle_filter.py tests/filters/test_so3_product_particle_filter.py`

## Quality impact
This improves numerical robustness for masked SO(3)^K measurement updates. It keeps hidden or zero-confidence components from contaminating particle weights when valid but very small measurement noise is used.