### PR TITLE
Accept array-like custom hyperrectangular inputs

### DIFF
--- a/src/pyrecest/distributions/custom_hyperrectangular_distribution.py
+++ b/src/pyrecest/distributions/custom_hyperrectangular_distribution.py
@@ -1,5 +1,8 @@
 from collections.abc import Callable
 
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array, reshape
+
 from .abstract_custom_nonperiodic_distribution import (
     AbstractCustomNonPeriodicDistribution,
 )
@@ -16,4 +19,23 @@ class CustomHyperrectangularDistribution(
         AbstractCustomNonPeriodicDistribution.__init__(self, f)
 
     def pdf(self, xs):
+        xs = self._coerce_points(xs)
         return AbstractCustomNonPeriodicDistribution.pdf(self, xs)
+
+    def _coerce_points(self, xs):
+        xs = array(xs)
+        if xs.ndim == 0:
+            if self.dim != 1:
+                raise ValueError("Scalar points are only valid for dim == 1")
+            return reshape(xs, (1, 1))
+        if xs.ndim == 1:
+            if self.dim == 1:
+                return reshape(xs, (-1, 1))
+            if xs.shape[0] == self.dim:
+                return reshape(xs, (1, self.dim))
+            raise ValueError(
+                f"Point dimension {xs.shape[0]} does not match dim {self.dim}"
+            )
+        if xs.ndim != 2 or xs.shape[1] != self.dim:
+            raise ValueError(f"xs must have shape (n, {self.dim})")
+        return xs

--- a/tests/distributions/test_custom_hyperrectangular_distribution.py
+++ b/tests/distributions/test_custom_hyperrectangular_distribution.py
@@ -52,6 +52,39 @@ class TestCustomHyperrectangularDistribution(unittest.TestCase):
         self.assertAlmostEqual(float(cd.get_manifold_size()), 2.0)
         self.assertAlmostEqual(cd.integrate(), 1.0)
 
+    def test_pdf_accepts_scalar_and_list_inputs_for_one_dimensional_bounds(self):
+        cd = CustomHyperrectangularDistribution(
+            lambda xs: xs[:, 0] * 0.0 + 0.5, array([0.0, 2.0])
+        )
+
+        scalar_pdf = cd.pdf(0.5)
+        list_pdf = cd.pdf([0.5, 1.5])
+        array_pdf = cd.pdf(array([0.5, 1.5]))
+
+        self.assertEqual(scalar_pdf.shape, (1,))
+        self.assertTrue(allclose(list_pdf, array_pdf))
+
+    def test_pdf_accepts_list_inputs_for_multidimensional_bounds(self):
+        cd = CustomHyperrectangularDistribution(
+            lambda xs: xs[:, 0] * 0.0 + 1.0,
+            array([[0.0, 1.0], [10.0, 12.0]]),
+        )
+
+        single_pdf = cd.pdf([0.5, 11.0])
+        batch_pdf = cd.pdf([[0.5, 11.0], [1.5, 11.0]])
+        array_pdf = cd.pdf(array([[0.5, 11.0], [1.5, 11.0]]))
+
+        self.assertEqual(single_pdf.shape, (1,))
+        self.assertTrue(allclose(batch_pdf, array_pdf))
+
+    def test_pdf_rejects_wrong_point_dimension(self):
+        cd = CustomHyperrectangularDistribution(
+            lambda xs: xs[:, 0], array([[0.0, 1.0], [10.0, 12.0]])
+        )
+
+        with self.assertRaisesRegex(ValueError, "Point dimension"):
+            cd.pdf([0.5, 11.0, 3.0])
+
     def test_bounds_must_be_finite_and_strictly_increasing(self):
         invalid_bounds = [
             array([2.0, 1.0]),


### PR DESCRIPTION
## Summary
- normalize `CustomHyperrectangularDistribution.pdf` query points before delegating to the custom density callable
- accept scalar/list inputs for one-dimensional bounds and list single points or batches for multidimensional bounds
- raise explicit `ValueError`s for malformed point dimensions
- add focused regression tests for scalar, list, batch, and invalid point inputs

## Root cause
`CustomHyperrectangularDistribution.pdf` forwarded raw caller inputs directly to `AbstractCustomNonPeriodicDistribution.pdf` and then to the custom callable. Plain Python scalars and lists therefore failed in vectorized custom density functions before they were normalized to the row-wise point shape used by the rest of the hyperrectangular API.

## Impact
Custom hyperrectangular densities now accept ordinary array-like query points consistently with `HyperrectangularUniformDistribution`.

## Tests
- `python -m pytest tests/distributions/test_custom_hyperrectangular_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/custom_hyperrectangular_distribution.py tests/distributions/test_custom_hyperrectangular_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/custom_hyperrectangular_distribution.py tests/distributions/test_custom_hyperrectangular_distribution.py`