### PR TITLE
Accept SO3 likelihood value vectors

### DIFF
--- a/src/pyrecest/filters/so3_product_particle_filter.py
+++ b/src/pyrecest/filters/so3_product_particle_filter.py
@@ -465,13 +465,18 @@ class SO3ProductParticleFilter(HyperhemisphereCartProdParticleFilter):
         ess_threshold=None,
     ):
         """Update weights from a likelihood evaluated on product particles."""
-        if measurement is None:
-            likelihood_values = likelihood(self.particles)
+        if callable(likelihood):
+            if measurement is None:
+                likelihood_values = likelihood(self.particles)
+            else:
+                likelihood_values = likelihood(measurement, self.particles)
         else:
-            likelihood_values = likelihood(measurement, self.particles)
+            likelihood_values = likelihood
         likelihood_values = array(likelihood_values, dtype=float)
         if likelihood_values.shape != self.weights.shape:
             raise ValueError("likelihood must return one value per particle.")
+        if not all(isfinite(likelihood_values)):
+            raise ValueError("likelihood values must be finite.")
         if not all(likelihood_values >= 0.0):
             raise ValueError("likelihood values must be nonnegative.")
 

--- a/tests/filters/test_so3_product_particle_filter.py
+++ b/tests/filters/test_so3_product_particle_filter.py
@@ -119,6 +119,28 @@ class SO3ProductParticleFilterTest(unittest.TestCase):
 
         npt.assert_allclose(log_likelihood_filter.weights, likelihood_filter.weights)
 
+    def test_update_with_likelihood_accepts_direct_values(self):
+        callable_filter = SO3ProductParticleFilter(n_particles=2, num_rotations=1)
+        direct_filter = SO3ProductParticleFilter(n_particles=2, num_rotations=1)
+        likelihood_values = array([0.25, 1.0])
+
+        callable_filter.update_with_likelihood(
+            lambda _: likelihood_values, resample=False
+        )
+        direct_filter.update_with_likelihood(likelihood_values, resample=False)
+
+        npt.assert_allclose(direct_filter.weights, callable_filter.weights)
+
+    def test_update_with_likelihood_rejects_nonfinite_values(self):
+        filt = SO3ProductParticleFilter(n_particles=2, num_rotations=1)
+
+        for invalid_value in (float("nan"), float("inf"), -float("inf")):
+            with self.subTest(invalid_value=invalid_value):
+                with self.assertRaisesRegex(ValueError, "finite"):
+                    filt.update_with_likelihood(
+                        array([1.0, invalid_value]), resample=False
+                    )
+
     def test_update_with_log_likelihood_is_underflow_safe(self):
         filt = SO3ProductParticleFilter(n_particles=2, num_rotations=1)
 


### PR DESCRIPTION
## Summary
- let `SO3ProductParticleFilter.update_with_likelihood` accept direct likelihood vectors, matching the direct-vector support already present in `update_with_log_likelihood`
- reject non-finite likelihood values before converting them to log weights
- add focused regression tests for direct likelihood vectors and NaN/Inf likelihood values

## Validation
- `python -m pytest tests/filters/test_so3_product_particle_filter.py -q`
- `ruff check src/pyrecest/filters/so3_product_particle_filter.py tests/filters/test_so3_product_particle_filter.py`

## Quality impact
This improves SO(3)^K filter API consistency and input hygiene. It makes simple precomputed likelihood updates usable without wrapping them in a callback, while still failing fast on invalid likelihood values.