### PR TITLE
Accept list inputs in toroidal matrix distribution

### DIFF
--- a/src/pyrecest/distributions/hypertorus/toroidal_vm_matrix_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/toroidal_vm_matrix_distribution.py
@@ -19,6 +19,7 @@ from scipy.integrate import dblquad
 from scipy.special import iv
 
 from ..circle.custom_circular_distribution import CustomCircularDistribution
+from ._input_validation import as_shift_vector
 from .abstract_toroidal_distribution import AbstractToroidalDistribution
 
 _2pi = 2.0 * pi
@@ -42,6 +43,9 @@ class ToroidalVMMatrixDistribution(AbstractToroidalDistribution):
 
     def __init__(self, mu, kappa, A):
         AbstractToroidalDistribution.__init__(self)
+        mu = array(mu)
+        kappa = array(kappa)
+        A = array(A)
         assert mu.shape == (2,)
         assert kappa.shape == (2,)
         assert A.shape == (2, 2)
@@ -68,7 +72,17 @@ class ToroidalVMMatrixDistribution(AbstractToroidalDistribution):
             self.C = self._norm_const_approx()
 
     def pdf(self, xs):
-        assert xs.shape[-1] == 2
+        xs = array(xs)
+        if xs.ndim == 1:
+            if xs.shape[0] != self.dim:
+                raise ValueError(
+                    f"xs must have trailing dimension {self.dim}, got {xs.shape}."
+                )
+            xs = xs.reshape((1, self.dim))
+        elif xs.ndim == 0 or xs.shape[-1] != self.dim:
+            raise ValueError(
+                f"xs must have trailing dimension {self.dim}, got {xs.shape}."
+            )
         x1_mm = xs[..., 0] - self.mu[0]
         x2_mm = xs[..., 1] - self.mu[1]
         exponent = (
@@ -328,7 +342,7 @@ class ToroidalVMMatrixDistribution(AbstractToroidalDistribution):
 
     def shift(self, shift_by):
         """Return a copy of this distribution shifted by shift_by."""
-        assert shift_by.shape == (2,)
+        shift_by = as_shift_vector(shift_by, self.dim)
         result = copy.copy(self)
         result.mu = mod(self.mu + shift_by, _2pi)
         return result

--- a/tests/distributions/test_toroidal_vm_matrix_distribution.py
+++ b/tests/distributions/test_toroidal_vm_matrix_distribution.py
@@ -25,11 +25,32 @@ class TestToroidalVMMatrixDistribution(unittest.TestCase):
         npt.assert_allclose(self.tvm.kappa, self.kappa, atol=1e-10)
         npt.assert_allclose(self.tvm.A, self.A, atol=1e-10)
 
+    def test_constructor_accepts_list_inputs(self):
+        tvm = ToroidalVMMatrixDistribution(
+            [1.0, 2.0], [0.5, 0.7], [[0.3, 0.1], [-0.2, 0.4]]
+        )
+        npt.assert_allclose(tvm.mu, self.mu, atol=1e-10)
+        npt.assert_allclose(tvm.kappa, self.kappa, atol=1e-10)
+        npt.assert_allclose(tvm.A, self.A, atol=1e-10)
+
     def test_pdf_positive(self):
         xs = array([[0.5, 1.0], [1.0, 2.0], [3.0, 4.0]])
         vals = self.tvm.pdf(xs)
         for v in vals.ravel():
             self.assertGreater(float(v), 0.0)
+
+    def test_pdf_accepts_list_inputs(self):
+        array_vals = self.tvm.pdf(array([[0.5, 1.0], [1.0, 2.0]]))
+        list_vals = self.tvm.pdf([[0.5, 1.0], [1.0, 2.0]])
+        npt.assert_allclose(list_vals, array_vals, atol=1e-10)
+
+        single_val = self.tvm.pdf([1.0, 2.0])
+        self.assertEqual(single_val.shape, (1,))
+        npt.assert_allclose(single_val, self.tvm.pdf(array([[1.0, 2.0]])), atol=1e-10)
+
+    def test_pdf_rejects_wrong_dimension(self):
+        with self.assertRaises(ValueError):
+            self.tvm.pdf([1.0, 2.0, 3.0])
 
     def test_mu_wrapped(self):
         mu_unwrapped = array([1.0 + 2 * float(pi), 2.0])
@@ -90,6 +111,11 @@ class TestToroidalVMMatrixDistribution(unittest.TestCase):
         # A and kappa unchanged
         npt.assert_allclose(shifted.kappa, self.tvm.kappa, atol=1e-10)
         npt.assert_allclose(shifted.A, self.tvm.A, atol=1e-10)
+
+    def test_shift_accepts_list_input(self):
+        shifted = self.tvm.shift([0.5, -0.3])
+        expected_mu = mod(self.mu + array([0.5, -0.3]), 2.0 * float(pi))
+        npt.assert_allclose(shifted.mu, expected_mu, atol=1e-10)
 
     def test_shift_does_not_modify_original(self):
         original_mu = array(self.tvm.mu)


### PR DESCRIPTION
## Summary
- normalize toroidal matrix distribution constructor arguments before shape validation
- accept list-like PDF evaluation points while preserving existing batched output shapes
- accept list-like shift vectors via the shared hypertoroidal input validator

## Tests
- `python -m pytest tests/distributions/test_toroidal_vm_matrix_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/hypertorus/toroidal_vm_matrix_distribution.py tests/distributions/test_toroidal_vm_matrix_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/hypertorus/toroidal_vm_matrix_distribution.py tests/distributions/test_toroidal_vm_matrix_distribution.py`
- `git diff --check`