### PR TITLE
Validate SO3 grid transition finiteness

### DIFF
--- a/src/pyrecest/filters/so3_grid_transition.py
+++ b/src/pyrecest/filters/so3_grid_transition.py
@@ -1,5 +1,7 @@
 """Transition-density helpers for grid filters on SO(3)."""
 
+import math
+
 # pylint: disable=no-name-in-module,no-member,redefined-builtin
 from pyrecest.backend import (
     abs,
@@ -8,6 +10,7 @@ from pyrecest.backend import (
     array,
     clip,
     exp,
+    isfinite,
     linalg,
     ndim,
     reshape,
@@ -73,8 +76,9 @@ def so3_right_multiplication_grid_transition(
     ``mean(grid_values[:, j]) * manifold_size == 1`` for every column.
     """
 
-    if kappa <= 0.0:
-        raise ValueError("kappa must be positive.")
+    kappa = float(kappa)
+    if not math.isfinite(kappa) or kappa <= 0.0:
+        raise ValueError("kappa must be positive and finite.")
 
     quaternion_grid = _as_quaternion_grid(grid)
     delta_quaternion = _as_so3_increment(orientation_increment)
@@ -130,6 +134,8 @@ def _as_quaternion_grid(grid):
         )
     if quaternion_grid.shape[0] == 0:
         raise ValueError("grid must contain at least one quaternion.")
+    if not all(isfinite(quaternion_grid)):
+        raise ValueError("grid quaternions must be finite.")
     if not all(linalg.norm(quaternion_grid, axis=1) > 0.0):
         raise ValueError("grid quaternions must be nonzero.")
 
@@ -138,6 +144,8 @@ def _as_quaternion_grid(grid):
 
 def _as_so3_increment(orientation_increment):
     values = array(orientation_increment, dtype=float)
+    if not all(isfinite(values)):
+        raise ValueError("orientation_increment must be finite.")
     if ndim(values) == 1:
         if values.shape[0] == 3:
             return exp_map_identity(values)[0]

--- a/tests/filters/test_so3_grid_transition.py
+++ b/tests/filters/test_so3_grid_transition.py
@@ -171,6 +171,32 @@ class TestSO3GridTransition(unittest.TestCase):
                 1.0,
             )
 
+    def test_rejects_nonfinite_inputs(self):
+        for invalid_kappa in (float("nan"), float("inf"), -float("inf")):
+            with self.subTest(invalid_kappa=invalid_kappa):
+                with self.assertRaisesRegex(ValueError, "kappa"):
+                    so3_right_multiplication_grid_transition(
+                        self.grid,
+                        array([0.0, 0.0, 0.0]),
+                        invalid_kappa,
+                    )
+
+        invalid_grid = array(self.grid)
+        invalid_grid[0, 0] = float("nan")
+        with self.assertRaisesRegex(ValueError, "grid quaternions"):
+            so3_right_multiplication_grid_transition(
+                invalid_grid,
+                array([0.0, 0.0, 0.0]),
+                1.0,
+            )
+
+        with self.assertRaisesRegex(ValueError, "orientation_increment"):
+            so3_right_multiplication_grid_transition(
+                self.grid,
+                array([float("inf"), 0.0, 0.0]),
+                1.0,
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- reject non-finite SO(3) grid-transition concentration values before transition-density normalization
- turn non-finite quaternion-grid and orientation-increment inputs into explicit `ValueError`s
- add focused regression coverage for NaN/Inf kappa, grid, and increment inputs

## Validation
- `python -m pytest tests/filters/test_so3_grid_transition.py -q`
- `ruff check src/pyrecest/filters/so3_grid_transition.py tests/filters/test_so3_grid_transition.py`

## Quality impact
This hardens the SO(3) grid-transition path against invalid numerical inputs that can otherwise reach exponentiation or quaternion normalization and produce less clear failures.