### PR TITLE
Validate SO3 tangent Gaussian covariance

### DIFF
--- a/src/pyrecest/distributions/so3_tangent_gaussian_distribution.py
+++ b/src/pyrecest/distributions/so3_tangent_gaussian_distribution.py
@@ -4,10 +4,13 @@
 import numpy as np
 from pyrecest.backend import (
     abs,
+    all,
+    allclose,
     amax,
     array,
     diag,
     exp,
+    isfinite,
     linalg,
     log,
     matmul,
@@ -55,6 +58,14 @@ def _validate_positive_sample_count(n) -> int:
     return count_int
 
 
+def _to_python_bool(value) -> bool:
+    if isinstance(value, bool):
+        return value
+    if hasattr(value, "item"):
+        return bool(value.item())
+    return bool(value)
+
+
 class SO3TangentGaussianDistribution(AbstractBoundedDomainDistribution):
     """Log-Gaussian approximation on SO(3).
 
@@ -76,9 +87,15 @@ class SO3TangentGaussianDistribution(AbstractBoundedDomainDistribution):
         self.mu = self._normalize_quaternions(mu)[0]
 
         C = array(C, dtype=float)
-        assert ndim(C) == 2 and C.shape == (3, 3), "C must have shape (3, 3)."
+        if ndim(C) != 2 or C.shape != (3, 3):
+            raise ValueError("C must have shape (3, 3).")
         if check_validity:
-            linalg.cholesky(C)
+            if not _to_python_bool(all(isfinite(C))):
+                raise ValueError("C must contain only finite values.")
+            if not _to_python_bool(allclose(C, transpose(C))):
+                raise ValueError("C must be symmetric.")
+            if not _to_python_bool(all(linalg.eigvalsh(C) > 0.0)):
+                raise ValueError("C must be positive definite.")
         self.C = C
 
     @property

--- a/tests/distributions/test_so3_tangent_gaussian_distribution.py
+++ b/tests/distributions/test_so3_tangent_gaussian_distribution.py
@@ -23,6 +23,21 @@ class SO3TangentGaussianDistributionTest(unittest.TestCase):
         npt.assert_allclose(dist.covariance(), covariance, atol=ATOL)
         self.assertTrue(dist.is_valid())
 
+    def test_constructor_rejects_invalid_covariance(self):
+        mean = array([0.0, 0.0, 0.0, 1.0])
+
+        invalid_cases = [
+            (array([0.1, 0.2, 0.3]), "shape"),
+            (array([[0.1, 0.0, 0.0], [0.0, float("nan"), 0.0], [0.0, 0.0, 0.3]]), "finite"),
+            (array([[0.1, 0.2, 0.0], [0.0, 0.2, 0.0], [0.0, 0.0, 0.3]]), "symmetric"),
+            (diag(array([0.1, 0.0, 0.3])), "positive definite"),
+        ]
+
+        for covariance, message in invalid_cases:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(ValueError, message):
+                    SO3TangentGaussianDistribution(mean, covariance)
+
     def test_exp_log_roundtrip_with_base_rotation(self):
         base = z_quaternion(pi / 3.0)
         tangent_vectors = array([[0.1, -0.2, 0.05], [0.0, 0.0, 0.0]])


### PR DESCRIPTION
## Summary
- replace assertion/Cholesky-only covariance checks in `SO3TangentGaussianDistribution` with explicit `ValueError` validation
- reject wrong-shape, non-finite, non-symmetric, and non-positive-definite tangent covariance matrices
- add focused regression tests for the invalid covariance cases

## Validation
- `python -m pytest tests/distributions/test_so3_tangent_gaussian_distribution.py -q`
- `ruff check src/pyrecest/distributions/so3_tangent_gaussian_distribution.py tests/distributions/test_so3_tangent_gaussian_distribution.py`

## Quality impact
This makes SO(3) tangent Gaussian construction fail early with clear errors instead of backend assertions or ambiguous linear-algebra failures.