### PR TITLE
Accept list inputs in toroidal Rivest distribution

### DIFF
--- a/src/pyrecest/distributions/hypertorus/toroidal_vm_rivest_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/toroidal_vm_rivest_distribution.py
@@ -2,6 +2,7 @@
 from pyrecest.backend import all, array, asarray, cos, exp, mod, pi, sin, sqrt
 from scipy.special import iv
 
+from ._input_validation import as_shift_vector
 from .abstract_toroidal_distribution import AbstractToroidalDistribution
 
 
@@ -17,6 +18,8 @@ class ToroidalVMRivestDistribution(AbstractToroidalDistribution):
 
     def __init__(self, mu, kappa, alpha, beta):
         AbstractToroidalDistribution.__init__(self)
+        mu = array(mu)
+        kappa = array(kappa)
         assert mu.shape == (2,)
         assert kappa.shape == (2,)
         alpha = asarray(alpha)
@@ -48,7 +51,11 @@ class ToroidalVMRivestDistribution(AbstractToroidalDistribution):
         return 4.0 * pi**2 * total
 
     def pdf(self, xs):
-        assert xs.shape[-1] == 2
+        xs = array(xs)
+        if xs.ndim == 0 or xs.shape[-1] != self.dim:
+            raise ValueError(
+                f"xs must have trailing dimension {self.dim}, got {xs.shape}."
+            )
         p = self.C * exp(
             self.kappa[0] * cos(xs[..., 0] - self.mu[0])
             + self.kappa[1] * cos(xs[..., 1] - self.mu[1])
@@ -139,7 +146,7 @@ class ToroidalVMRivestDistribution(AbstractToroidalDistribution):
         return e_sin_a_sin_b / sqrt(e_sin_a_sq * e_sin_b_sq)
 
     def shift(self, shift_by):
-        assert shift_by.shape == (self.dim,)
+        shift_by = as_shift_vector(shift_by, self.dim)
         return ToroidalVMRivestDistribution(
             mod(self.mu + shift_by, 2.0 * pi),
             self.kappa,

--- a/tests/distributions/test_toroidal_vm_rivest_distribution.py
+++ b/tests/distributions/test_toroidal_vm_rivest_distribution.py
@@ -36,6 +36,14 @@ class ToroidalVMRivestDistributionTest(unittest.TestCase):
         self.assertEqual(self.dist.alpha, self.alpha)
         self.assertEqual(self.dist.beta, self.beta)
 
+    def test_accepts_list_parameters(self):
+        dist = ToroidalVMRivestDistribution([1.0, 2.0], [0.7, 1.4], 0.5, 0.3)
+
+        npt.assert_allclose(dist.mu, self.mu)
+        npt.assert_allclose(dist.kappa, self.kappa)
+        npt.assert_allclose(dist.alpha, self.alpha)
+        npt.assert_allclose(dist.beta, self.beta)
+
     def test_accepts_python_scalar_correlation_parameters(self):
         dist = ToroidalVMRivestDistribution(self.mu, self.kappa, 0.5, 0.3)
         x = array([1.3, 2.4])
@@ -80,6 +88,10 @@ class ToroidalVMRivestDistributionTest(unittest.TestCase):
         self.assertEqual(shifted.alpha, self.dist.alpha)
         self.assertEqual(shifted.beta, self.dist.beta)
 
+    def test_shift_accepts_list_input(self):
+        shifted = self.dist.shift([0.5, 1.0])
+        npt.assert_allclose(shifted.mu, self.dist.shift(array([0.5, 1.0])).mu)
+
     # jscpd:ignore-start
     # pylint: disable=R0801
     def _unnormalized_pdf(self, xs):
@@ -114,6 +126,16 @@ class ToroidalVMRivestDistributionTest(unittest.TestCase):
 
         expected = pdf(x)
         npt.assert_allclose(self.dist.pdf(x), expected)
+
+    def test_pdf_accepts_list_inputs(self):
+        x = [[1.0, 2.0], [1.3, 2.4]]
+
+        npt.assert_allclose(self.dist.pdf(x), self.dist.pdf(array(x)))
+        npt.assert_allclose(self.dist.pdf([1.3, 2.4]), self.dist.pdf(array([1.3, 2.4])))
+
+    def test_pdf_rejects_wrong_dimension(self):
+        with self.assertRaises(ValueError):
+            self.dist.pdf([1.0, 2.0, 3.0])
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),


### PR DESCRIPTION
## Summary
- normalize toroidal Rivest `mu` and `kappa` constructor inputs before shape validation
- accept list-like `pdf` evaluation points and raise `ValueError` for wrong trailing dimensions
- accept list-like shift vectors through the shared hypertoroidal shift validator

## Tests
- `python -m pytest tests/distributions/test_toroidal_vm_rivest_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/hypertorus/toroidal_vm_rivest_distribution.py tests/distributions/test_toroidal_vm_rivest_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/hypertorus/toroidal_vm_rivest_distribution.py tests/distributions/test_toroidal_vm_rivest_distribution.py`
- `git diff --check`