### PR TITLE
Validate SO3 product tangent Gaussian covariance

### DIFF
--- a/src/pyrecest/distributions/so3_product_tangent_gaussian_distribution.py
+++ b/src/pyrecest/distributions/so3_product_tangent_gaussian_distribution.py
@@ -5,10 +5,12 @@ import numpy as np
 from pyrecest.backend import (
     abs,
     all,
+    allclose,
     amax,
     array,
     diag,
     exp,
+    isfinite,
     linalg,
     log,
     matmul,
@@ -60,6 +62,14 @@ def _validate_positive_sample_count(n) -> int:
     return count_int
 
 
+def _to_python_bool(value) -> bool:
+    if isinstance(value, bool):
+        return value
+    if hasattr(value, "item"):
+        return bool(value.item())
+    return bool(value)
+
+
 class SO3ProductTangentGaussianDistribution(AbstractBoundedDomainDistribution):
     """Log-Gaussian approximation on Cartesian products of SO(3).
 
@@ -81,9 +91,15 @@ class SO3ProductTangentGaussianDistribution(AbstractBoundedDomainDistribution):
 
         C = array(C, dtype=float)
         expected_shape = (self.dim, self.dim)
-        assert C.shape == expected_shape, f"C must have shape {expected_shape}."
+        if C.shape != expected_shape:
+            raise ValueError(f"C must have shape {expected_shape}.")
         if check_validity:
-            linalg.cholesky(C)
+            if not _to_python_bool(all(isfinite(C))):
+                raise ValueError("C must contain only finite values.")
+            if not _to_python_bool(allclose(C, transpose(C))):
+                raise ValueError("C must be symmetric.")
+            if not _to_python_bool(all(linalg.eigvalsh(C) > 0.0)):
+                raise ValueError("C must be positive definite.")
         self.C = C
 
     @property

--- a/tests/distributions/test_so3_product_tangent_gaussian_distribution.py
+++ b/tests/distributions/test_so3_product_tangent_gaussian_distribution.py
@@ -39,6 +39,40 @@ class SO3ProductTangentGaussianDistributionTest(unittest.TestCase):
         npt.assert_allclose(dist.get_manifold_size(), pi**4, atol=ATOL)
         self.assertTrue(dist.is_valid())
 
+    def test_constructor_rejects_invalid_covariance(self):
+        mean = array([z_quaternion(0.0), x_quaternion(0.0)])
+
+        invalid_cases = [
+            (diag(array([0.1, 0.2, 0.3])), "shape"),
+            (
+                diag(
+                    array(
+                        [0.1, 0.2, 0.3, float("nan"), 0.5, 0.6]
+                    )
+                ),
+                "finite",
+            ),
+            (
+                array(
+                    [
+                        [0.1, 0.2, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.2, 0.0, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 0.3, 0.0, 0.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.4, 0.0, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.5, 0.0],
+                        [0.0, 0.0, 0.0, 0.0, 0.0, 0.6],
+                    ]
+                ),
+                "symmetric",
+            ),
+            (diag(array([0.1, 0.2, 0.3, 0.0, 0.5, 0.6])), "positive definite"),
+        ]
+
+        for covariance, message in invalid_cases:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(ValueError, message):
+                    SO3ProductTangentGaussianDistribution(mean, covariance)
+
     def test_exp_log_roundtrip_with_base_product_rotation(self):
         base = array(
             [


### PR DESCRIPTION
## Summary
- replace assertion/Cholesky-only covariance checks in `SO3ProductTangentGaussianDistribution` with explicit `ValueError` validation
- reject wrong-shape, non-finite, non-symmetric, and non-positive-definite product tangent covariance matrices
- add focused regression tests for the invalid covariance cases

## Validation
- `python -m pytest tests/distributions/test_so3_product_tangent_gaussian_distribution.py -q`
- `ruff check src/pyrecest/distributions/so3_product_tangent_gaussian_distribution.py tests/distributions/test_so3_product_tangent_gaussian_distribution.py`

## Quality impact
This makes SO(3)^K tangent Gaussian construction fail early with clear validation errors instead of backend assertions or ambiguous linear-algebra failures.