### PR TITLE
Accept list inputs in bivariate von Mises distributions

### DIFF
--- a/src/pyrecest/distributions/hypertorus/abstract_toroidal_bivar_vm_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/abstract_toroidal_bivar_vm_distribution.py
@@ -1,5 +1,5 @@
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
-from pyrecest.backend import all, cos, exp, mod, pi
+from pyrecest.backend import all, array, cos, exp, mod, pi
 
 from .abstract_toroidal_distribution import AbstractToroidalDistribution
 
@@ -16,6 +16,8 @@ class AbstractToroidalBivarVMDistribution(AbstractToroidalDistribution):
 
     def __init__(self, mu, kappa):
         AbstractToroidalDistribution.__init__(self)
+        mu = array(mu)
+        kappa = array(kappa)
         assert mu.shape == (2,)
         assert kappa.shape == (2,)
         assert all(kappa >= 0.0)
@@ -27,7 +29,11 @@ class AbstractToroidalBivarVMDistribution(AbstractToroidalDistribution):
         raise NotImplementedError
 
     def pdf(self, xs):
-        assert xs.shape[-1] == 2
+        xs = array(xs)
+        if xs.ndim == 0 or xs.shape[-1] != self.dim:
+            raise ValueError(
+                f"xs must have trailing dimension {self.dim}, got {xs.shape}."
+            )
         return self.C * exp(
             self.kappa[0] * cos(xs[..., 0] - self.mu[0])
             + self.kappa[1] * cos(xs[..., 1] - self.mu[1])

--- a/src/pyrecest/distributions/hypertorus/toroidal_von_mises_cosine_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/toroidal_von_mises_cosine_distribution.py
@@ -5,6 +5,7 @@ import numpy as np
 from pyrecest.backend import asarray, cos, mod, pi
 from scipy.special import iv
 
+from ._input_validation import as_shift_vector
 from .abstract_toroidal_bivar_vm_distribution import AbstractToroidalBivarVMDistribution
 
 _SERIES_RTOL = 1e-14
@@ -114,7 +115,7 @@ class ToroidalVonMisesCosineDistribution(AbstractToroidalBivarVMDistribution):
         return self.trigonometric_moment_numerical(n)
 
     def shift(self, shift_by):
-        assert shift_by.shape == (self.dim,)
+        shift_by = as_shift_vector(shift_by, self.dim)
         tvm = ToroidalVonMisesCosineDistribution(
             mod(self.mu + shift_by, 2.0 * pi), self.kappa, self.kappa3
         )

--- a/tests/distributions/test_toroidal_von_mises_cosine_distribution.py
+++ b/tests/distributions/test_toroidal_von_mises_cosine_distribution.py
@@ -80,6 +80,13 @@ class ToroidalVMCosineDistributionTest(ToroidalBivarVMTestMixin, unittest.TestCa
         npt.assert_allclose(self.tvm.kappa, self.kappa)
         self.assertEqual(self.tvm.kappa3, self.kappa3)
 
+    def test_accepts_list_parameters(self):
+        tvm = ToroidalVonMisesCosineDistribution([1.0, 2.0], [0.7, 1.4], 0.5)
+
+        npt.assert_allclose(tvm.mu, self.mu)
+        npt.assert_allclose(tvm.kappa, self.kappa)
+        npt.assert_allclose(tvm.kappa3, self.kappa3)
+
     def test_accepts_python_scalar_coupling_parameter(self):
         tvm = ToroidalVonMisesCosineDistribution(self.mu, self.kappa, 0.5)
         x = array([1.3, 2.4])
@@ -145,6 +152,10 @@ class ToroidalVMCosineDistributionTest(ToroidalBivarVMTestMixin, unittest.TestCa
             atol=1e-10,
             rtol=1e-6,
         )
+
+    def test_shift_accepts_list_input(self):
+        shifted = self.tvm.shift([4.0, 2.0])
+        npt.assert_allclose(shifted.mu, self.tvm.shift(array([4.0, 2.0])).mu)
 
 
 if __name__ == "__main__":

--- a/tests/distributions/test_toroidal_von_mises_sine_distribution.py
+++ b/tests/distributions/test_toroidal_von_mises_sine_distribution.py
@@ -68,6 +68,16 @@ class ToroidalBivarVMTestMixin:
 
         npt.assert_allclose(self.tvm.pdf(x), expected)
 
+    def test_pdf_accepts_list_inputs(self):
+        x = [[1.0, 2.0], [1.3, 2.4]]
+
+        npt.assert_allclose(self.tvm.pdf(x), self.tvm.pdf(array(x)))
+        npt.assert_allclose(self.tvm.pdf([1.3, 2.4]), self.tvm.pdf(array([1.3, 2.4])))
+
+    def test_pdf_rejects_wrong_dimension(self):
+        with self.assertRaises(ValueError):
+            self.tvm.pdf([1.0, 2.0, 3.0])
+
 
 class ToroidalVMSineDistributionTest(ToroidalBivarVMTestMixin, unittest.TestCase):
     def setUp(self):
@@ -84,6 +94,13 @@ class ToroidalVMSineDistributionTest(ToroidalBivarVMTestMixin, unittest.TestCase
         npt.assert_allclose(self.tvm.mu, self.mu)
         npt.assert_allclose(self.tvm.kappa, self.kappa)
         self.assertEqual(self.tvm.lambda_, self.lambda_)
+
+    def test_accepts_list_parameters(self):
+        tvm = ToroidalVonMisesSineDistribution([1.0, 2.0], [0.7, 1.4], 0.5)
+
+        npt.assert_allclose(tvm.mu, self.mu)
+        npt.assert_allclose(tvm.kappa, self.kappa)
+        npt.assert_allclose(tvm.lambda_, self.lambda_)
 
     def test_accepts_python_scalar_lambda(self):
         tvm = ToroidalVonMisesSineDistribution(self.mu, self.kappa, 0.5)


### PR DESCRIPTION
## Summary
- normalize shared bivariate toroidal von Mises `mu` and `kappa` inputs before shape validation
- accept list-like PDF evaluation points for the sine and cosine models with explicit `ValueError` on wrong trailing dimensions
- accept list-like shifts for the cosine model through the shared hypertoroidal shift validator

## Tests
- `python -m pytest tests/distributions/test_toroidal_von_mises_sine_distribution.py tests/distributions/test_toroidal_von_mises_cosine_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/hypertorus/abstract_toroidal_bivar_vm_distribution.py src/pyrecest/distributions/hypertorus/toroidal_von_mises_cosine_distribution.py tests/distributions/test_toroidal_von_mises_sine_distribution.py tests/distributions/test_toroidal_von_mises_cosine_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/hypertorus/abstract_toroidal_bivar_vm_distribution.py src/pyrecest/distributions/hypertorus/toroidal_von_mises_cosine_distribution.py tests/distributions/test_toroidal_von_mises_sine_distribution.py tests/distributions/test_toroidal_von_mises_cosine_distribution.py`
- `git diff --check`