### PR TITLE
Validate SO3 Dirac rotation matrix inputs

### DIFF
--- a/src/pyrecest/distributions/so3_dirac_distribution.py
+++ b/src/pyrecest/distributions/so3_dirac_distribution.py
@@ -10,6 +10,7 @@ from pyrecest.backend import (
     array,
     asarray,
     clip,
+    isfinite,
     linalg,
     ndim,
     spatial,
@@ -51,15 +52,17 @@ class SO3DiracDistribution(HyperhemisphericalDiracDistribution):
         cls._require_rotation_method("from_matrix")
         rotation_matrices = asarray(rotation_matrices)
         if ndim(rotation_matrices) == 2:
-            assert rotation_matrices.shape == (
-                3,
-                3,
-            ), "A single rotation matrix must have shape (3, 3)."
+            if rotation_matrices.shape != (3, 3):
+                raise ValueError("A single rotation matrix must have shape (3, 3).")
+        elif ndim(rotation_matrices) >= 3:
+            if rotation_matrices.shape[-2:] != (3, 3):
+                raise ValueError("Rotation matrices must have shape (..., 3, 3).")
         else:
-            assert rotation_matrices.shape[-2:] == (
-                3,
-                3,
-            ), "Rotation matrices must have shape (..., 3, 3)."
+            raise ValueError(
+                "Rotation matrices must have shape (3, 3) or (..., 3, 3)."
+            )
+        if not bool(all(isfinite(rotation_matrices))):
+            raise ValueError("Rotation matrices must be finite.")
 
         quaternions = spatial.Rotation.from_matrix(rotation_matrices).as_quat()
         return cls(quaternions, w=w)

--- a/src/pyrecest/distributions/so3_product_dirac_distribution.py
+++ b/src/pyrecest/distributions/so3_product_dirac_distribution.py
@@ -130,6 +130,8 @@ class SO3ProductDiracDistribution(HyperhemisphereCartProdDiracDistribution):
         rotation_matrices = asarray(rotation_matrices)
         if ndim(rotation_matrices) < 2 or rotation_matrices.shape[-2:] != (3, 3):
             raise ValueError("Rotation matrices must have shape (..., 3, 3).")
+        if not bool(all(isfinite(rotation_matrices))):
+            raise ValueError("Rotation matrices must be finite.")
 
         if ndim(rotation_matrices) == 2:
             quaternions = array(

--- a/tests/distributions/test_so3_dirac_distribution.py
+++ b/tests/distributions/test_so3_dirac_distribution.py
@@ -50,6 +50,31 @@ class SO3DiracDistributionTest(unittest.TestCase):
 
         npt.assert_allclose(dist.as_rotation_matrices(), rotations, atol=ATOL)
 
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "pytorch",
+        reason="Rotation matrix conversion is not supported on the PyTorch backend.",
+    )
+    def test_from_rotation_matrices_rejects_invalid_inputs(self):
+        invalid_cases = [
+            (array([1.0, 0.0, 0.0]), "shape"),
+            (array([[1.0, 0.0], [0.0, 1.0]]), "shape"),
+            (
+                array(
+                    [
+                        [1.0, 0.0, 0.0],
+                        [0.0, float("nan"), 0.0],
+                        [0.0, 0.0, 1.0],
+                    ]
+                ),
+                "finite",
+            ),
+        ]
+
+        for rotation_matrices, message in invalid_cases:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(ValueError, message):
+                    SO3DiracDistribution.from_rotation_matrices(rotation_matrices)
+
     def test_from_distribution_validates_particle_count(self):
         source = SO3UniformDistribution()
 

--- a/tests/distributions/test_so3_product_dirac_distribution.py
+++ b/tests/distributions/test_so3_product_dirac_distribution.py
@@ -214,6 +214,33 @@ class SO3ProductDiracDistributionTest(unittest.TestCase):
             atol=1e-6,
         )
 
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "pytorch",
+        reason="Rotation matrix conversion is not supported on the PyTorch backend.",
+    )
+    def test_from_rotation_matrices_rejects_invalid_inputs(self):
+        invalid_cases = [
+            (array([1.0, 0.0, 0.0]), "shape"),
+            (array([[1.0, 0.0], [0.0, 1.0]]), "shape"),
+            (
+                array(
+                    [
+                        [1.0, 0.0, 0.0],
+                        [0.0, nan, 0.0],
+                        [0.0, 0.0, 1.0],
+                    ]
+                ),
+                "finite",
+            ),
+        ]
+
+        for rotation_matrices, message in invalid_cases:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(ValueError, message):
+                    SO3ProductDiracDistribution.from_rotation_matrices(
+                        rotation_matrices
+                    )
+
     def test_sampling(self):
         random.seed(0)
         dist = SO3ProductDiracDistribution(


### PR DESCRIPTION
## Summary
- replace assertion-based SO(3) Dirac rotation-matrix shape checks with explicit `ValueError` validation
- reject non-finite rotation matrices before backend conversion in both SO(3) and SO(3)^K Dirac constructors
- add focused regression coverage for malformed and non-finite rotation-matrix inputs

## Validation
- `python -m pytest tests/distributions/test_so3_dirac_distribution.py tests/distributions/test_so3_product_dirac_distribution.py -q`
- `ruff check src/pyrecest/distributions/so3_dirac_distribution.py src/pyrecest/distributions/so3_product_dirac_distribution.py tests/distributions/test_so3_dirac_distribution.py tests/distributions/test_so3_product_dirac_distribution.py`

## Quality impact
This makes Dirac initialization from SO(3) rotation matrices fail early with clear validation errors instead of assertion failures or backend-specific conversion errors.