### PR TITLE
Accept scalar and list Fourier shifts

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_fourier_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_fourier_distribution.py
@@ -37,6 +37,7 @@ from pyrecest.backend import (
 )
 
 from ..abstract_orthogonal_basis_distribution import AbstractOrthogonalBasisDistribution
+from ._input_validation import as_shift_vector
 from .abstract_hypertoroidal_distribution import AbstractHypertoroidalDistribution
 from .hypertoroidal_uniform_distribution import HypertoroidalUniformDistribution
 
@@ -720,11 +721,7 @@ class HypertoroidalFourierDistribution(
         shift_by : array_like, shape (dim,)
             Shift in radians for each angular dimension.
         """
-        assert ndim(shift_by) <= 1
-        if shift_by.shape[0] != self.dim:
-            raise ValueError(
-                f"shift: expected {self.dim} shift angles, got {shift_by.shape[0]}"
-            )
+        shift_by = as_shift_vector(shift_by, self.dim)
 
         # All angles are zero, return unchanged copy
         if all(shift_by == 0):

--- a/tests/distributions/test_hypertoroidal_fourier_distribution.py
+++ b/tests/distributions/test_hypertoroidal_fourier_distribution.py
@@ -478,6 +478,40 @@ class HypertoroidalFourierDistributionTest(unittest.TestCase):
         self.assertAlmostEqual(integrate2d(hfd_conv_id), 1.0, places=5)
         self.assertAlmostEqual(integrate2d(hfd_conv_sqrt), 1.0, places=5)
 
+    def test_shift_accepts_scalar_and_list_inputs(self):
+        hfd_1d = HypertoroidalFourierDistribution(
+            array([0.0, 1.0 / sqrt(2 * pi), 0.0]), "sqrt"
+        )
+        npt.assert_allclose(
+            hfd_1d.shift(0.5).coeff_mat,
+            hfd_1d.shift(array([0.5])).coeff_mat,
+        )
+        npt.assert_allclose(
+            hfd_1d.shift([0.5]).coeff_mat,
+            hfd_1d.shift(array([0.5])).coeff_mat,
+        )
+
+        coeffs_2d = array(
+            [
+                [0.0, 0.0, 0.0],
+                [0.0, 1.0 / (sqrt(2 * pi) ** 2), 0.0],
+                [0.0, 0.0, 0.0],
+            ]
+        )
+        hfd_2d = HypertoroidalFourierDistribution(coeffs_2d, "sqrt")
+        npt.assert_allclose(
+            hfd_2d.shift([0.5, 1.0]).coeff_mat,
+            hfd_2d.shift(array([0.5, 1.0])).coeff_mat,
+        )
+
+    def test_shift_rejects_wrong_dimension(self):
+        hfd = HypertoroidalFourierDistribution(
+            array([0.0, 1.0 / sqrt(2 * pi), 0.0]), "sqrt"
+        )
+
+        with self.assertRaises(ValueError):
+            hfd.shift([0.5, 1.0])
+
     # pylint: disable=too-many-locals
     def test_shift(self):
         C_list = [


### PR DESCRIPTION
## Summary
- normalize `HypertoroidalFourierDistribution.shift` inputs through the shared hypertoroidal shift validator
- accept scalar shifts for one-dimensional Fourier distributions and list-like vectors for higher dimensions
- add regression coverage for scalar, list, and wrong-dimensional shift inputs

## Tests
- `python -m pytest tests/distributions/test_hypertoroidal_fourier_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/hypertorus/hypertoroidal_fourier_distribution.py tests/distributions/test_hypertoroidal_fourier_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/hypertorus/hypertoroidal_fourier_distribution.py tests/distributions/test_hypertoroidal_fourier_distribution.py`
- `git diff --check`