### PR TITLE
Accept scalar and list mixture shifts

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_mixture.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_mixture.py
@@ -6,6 +6,7 @@ from typing import Union
 from pyrecest.backend import complex128, int32, int64, zeros
 
 from ..abstract_mixture import AbstractMixture
+from ._input_validation import as_shift_vector
 from .abstract_hypertoroidal_distribution import AbstractHypertoroidalDistribution
 
 
@@ -51,7 +52,7 @@ class HypertoroidalMixture(AbstractMixture, AbstractHypertoroidalDistribution):
         :param shift_by: angles to shift by
         :returns: shifted distribution
         """
-        assert shift_by.shape == (self.dim,)
+        shift_by = as_shift_vector(shift_by, self.dim)
         hd_shifted = copy.deepcopy(self)
         hd_shifted.dists = [dist.shift(shift_by) for dist in hd_shifted.dists]
         return hd_shifted

--- a/tests/distributions/test_abstract_mixture.py
+++ b/tests/distributions/test_abstract_mixture.py
@@ -13,6 +13,9 @@ from pyrecest.distributions.hypersphere_subset.hyperspherical_mixture import (
     HypersphericalMixture,
 )
 from pyrecest.distributions.hypertorus.hypertoroidal_mixture import HypertoroidalMixture
+from pyrecest.distributions.hypertorus.hypertoroidal_wrapped_normal_distribution import (
+    HypertoroidalWrappedNormalDistribution,
+)
 from pyrecest.distributions.hypertorus.toroidal_wrapped_normal_distribution import (
     ToroidalWrappedNormalDistribution,
 )
@@ -55,6 +58,37 @@ class AbstractMixtureTest(unittest.TestCase):
             [vmf, vmf.shift(array([1.0, 1.0]))], array([0.5, 0.5])
         )
         self._test_sample(mix, 10)
+
+    def test_hypertoroidal_mixture_shift_accepts_list_input(self):
+        vmf = ToroidalWrappedNormalDistribution(array([1.0, 0.0]), eye(2))
+        mix = HypertoroidalMixture(
+            [vmf, vmf.shift(array([1.0, 1.0]))], array([0.5, 0.5])
+        )
+
+        shifted_list = mix.shift([0.5, 1.0])
+        shifted_array = mix.shift(array([0.5, 1.0]))
+
+        for dist_list, dist_array in zip(shifted_list.dists, shifted_array.dists):
+            self.assertTrue(allclose(dist_list.mu, dist_array.mu))
+
+    def test_hypertoroidal_mixture_shift_accepts_scalar_for_one_dimensional_mix(self):
+        hwn = HypertoroidalWrappedNormalDistribution(array([1.0]), array([[1.0]]))
+        mix = HypertoroidalMixture([hwn, hwn.shift(1.0)], array([0.5, 0.5]))
+
+        shifted_scalar = mix.shift(0.5)
+        shifted_array = mix.shift(array([0.5]))
+
+        for dist_scalar, dist_array in zip(shifted_scalar.dists, shifted_array.dists):
+            self.assertTrue(allclose(dist_scalar.mu, dist_array.mu))
+
+    def test_hypertoroidal_mixture_shift_rejects_wrong_dimension(self):
+        vmf = ToroidalWrappedNormalDistribution(array([1.0, 0.0]), eye(2))
+        mix = HypertoroidalMixture(
+            [vmf, vmf.shift(array([1.0, 1.0]))], array([0.5, 0.5])
+        )
+
+        with self.assertRaises(ValueError):
+            mix.shift([0.5])
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch",),


### PR DESCRIPTION
## Summary
- normalize `HypertoroidalMixture.shift` inputs through the shared hypertoroidal shift validator
- accept list-like shifts for multidimensional mixtures
- accept scalar shifts for one-dimensional hypertoroidal mixtures and keep wrong-dimensional inputs rejected

## Tests
- `python -m pytest tests/distributions/test_abstract_mixture.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/hypertorus/hypertoroidal_mixture.py tests/distributions/test_abstract_mixture.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/hypertorus/hypertoroidal_mixture.py tests/distributions/test_abstract_mixture.py`
- `git diff --check`