### PR TITLE
Validate SO3 quaternion inputs explicitly

### DIFF
--- a/src/pyrecest/distributions/_so3_helpers.py
+++ b/src/pyrecest/distributions/_so3_helpers.py
@@ -38,15 +38,22 @@ def normalize_quaternions(quaternions):
     """Return canonical scalar-last unit quaternions."""
     quaternions = array(quaternions, dtype=float)
     if ndim(quaternions) == 1:
-        assert quaternions.shape[0] == 4, "SO(3) quaternions must have length 4."
+        if quaternions.shape[0] != 4:
+            raise ValueError("SO(3) quaternions must have length 4.")
         quaternions = reshape(quaternions, (1, 4))
+    elif ndim(quaternions) >= 2:
+        if quaternions.shape[-1] != 4:
+            raise ValueError("SO(3) quaternions must have length 4.")
     else:
-        assert quaternions.shape[-1] == 4, "SO(3) quaternions must have length 4."
+        raise ValueError("SO(3) quaternions must have length 4.")
 
     norms = linalg.norm(quaternions, axis=-1)
-    assert all(isfinite(quaternions)), "SO(3) quaternions must be finite."
-    assert all(isfinite(norms)), "SO(3) quaternion norms must be finite."
-    assert all(norms > 0.0), "SO(3) quaternions must be nonzero."
+    if not bool(all(isfinite(quaternions))):
+        raise ValueError("SO(3) quaternions must be finite.")
+    if not bool(all(isfinite(norms))):
+        raise ValueError("SO(3) quaternion norms must be finite.")
+    if not bool(all(norms > 0.0)):
+        raise ValueError("SO(3) quaternions must be nonzero.")
 
     normalized = quaternions / reshape(norms, tuple(norms.shape) + (1,))
     return where(normalized[..., -1:] < 0.0, -normalized, normalized)

--- a/tests/distributions/test_so3_helpers.py
+++ b/tests/distributions/test_so3_helpers.py
@@ -31,6 +31,23 @@ class SO3HelpersTest(unittest.TestCase):
             atol=ATOL,
         )
 
+    def test_normalize_quaternions_rejects_invalid_inputs(self):
+        invalid_cases = [
+            (array(1.0), "length 4"),
+            (array([1.0, 0.0, 0.0]), "length 4"),
+            (array([[1.0, 0.0, 0.0]]), "length 4"),
+            (array([math.inf, 0.0, 0.0, 1.0]), "finite"),
+            (array([math.nan, 0.0, 0.0, 1.0]), "finite"),
+            (array([0.0, 0.0, 0.0, 0.0]), "nonzero"),
+        ]
+
+        for quaternions, message in invalid_cases:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(ValueError, message):
+                    so3_helpers.normalize_quaternions(quaternions)
+                with self.assertRaisesRegex(ValueError, message):
+                    private_normalize_quaternions(quaternions)
+
     def test_exp_log_roundtrip_with_base_rotation(self):
         base = z_quaternion(pi / 3.0)
         tangent_vectors = array([[0.1, -0.2, 0.05], [0.0, 0.0, 0.0]])

--- a/tests/distributions/test_so3_uniform_distribution.py
+++ b/tests/distributions/test_so3_uniform_distribution.py
@@ -55,7 +55,7 @@ class SO3UniformDistributionTest(unittest.TestCase):
 
         for rotation in invalid_rotations:
             with self.subTest(rotation=rotation):
-                with self.assertRaises(AssertionError):
+                with self.assertRaisesRegex(ValueError, "finite"):
                     dist.pdf(rotation)
 
     def test_sample_returns_canonical_unit_quaternions(self):


### PR DESCRIPTION
## Summary
- replace assertion-based validation in the shared SO(3) quaternion normalizer with explicit `ValueError`s
- reject scalar, wrong-width, non-finite, and zero quaternion inputs deterministically
- update SO(3) helper and uniform-distribution regression coverage for the new failure mode

## Validation
- `python -m pytest tests/distributions/test_so3_helpers.py tests/distributions/test_so3_uniform_distribution.py -q`
- `python -m pytest tests/distributions/test_so3_*.py tests/filters/test_so3_*.py -q` using PowerShell-expanded test paths
- `ruff check src/pyrecest/distributions/_so3_helpers.py tests/distributions/test_so3_helpers.py tests/distributions/test_so3_uniform_distribution.py`

## Quality impact
This removes assertion-dependent public SO(3) quaternion validation, so invalid quaternion inputs fail consistently even when Python assertions are optimized away.