### PR TITLE
Accept list inputs in Watson distribution

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/watson_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/watson_distribution.py
@@ -36,9 +36,10 @@ class WatsonDistribution(AbstractHypersphericalDistribution):
             mu (): The mean direction of the distribution.
             kappa (float): The concentration parameter of the distribution.
         """
-        AbstractHypersphericalDistribution.__init__(self, dim=mu.shape[0] - 1)
+        mu = array(mu)
         assert mu.ndim == 1, "mu must be a 1-D vector"
         assert abs(linalg.norm(mu) - 1.0) < self.EPSILON, "mu is unnormalized"
+        AbstractHypersphericalDistribution.__init__(self, dim=mu.shape[0] - 1)
 
         self.mu = mu
         self.kappa = kappa
@@ -79,11 +80,20 @@ class WatsonDistribution(AbstractHypersphericalDistribution):
         Returns:
             np.generic: The value of the pdf at xs.
         """
-        assert xs.shape[-1] == self.input_dim, "Last dimension of xs must be dim + 1"
+        xs = array(xs)
+        if xs.ndim == 0 or xs.shape[-1] != self.input_dim:
+            raise ValueError(
+                f"xs must have trailing dimension {self.input_dim}, got {xs.shape}."
+            )
         p = self.norm_const * exp(self.kappa * (xs @ self.mu) ** 2)
         return p
 
     def ln_pdf(self, xs):
+        xs = array(xs)
+        if xs.ndim == 0 or xs.shape[-1] != self.input_dim:
+            raise ValueError(
+                f"xs must have trailing dimension {self.input_dim}, got {xs.shape}."
+            )
         return self.ln_norm_const + self.kappa * (xs @ self.mu) ** 2
 
     def to_bingham(self) -> BinghamDistribution:
@@ -113,6 +123,7 @@ class WatsonDistribution(AbstractHypersphericalDistribution):
         return self.mode_numerical()
 
     def set_mode(self, new_mode):
+        new_mode = array(new_mode)
         assert new_mode.shape == self.mu.shape
         dist = copy.deepcopy(self)
         dist.mu = copy.deepcopy(new_mode)

--- a/tests/distributions/test_watson_distribution.py
+++ b/tests/distributions/test_watson_distribution.py
@@ -38,6 +38,13 @@ class TestWatsonDistribution(unittest.TestCase):
         self.assertEqual(w.kappa, kappa)
         self.assertEqual(w.input_dim, mu.shape[0])
 
+    def test_constructor_accepts_list_mu(self):
+        mu = array([1.0, 2.0, 3.0])
+        mu = mu / linalg.norm(mu)
+        w = WatsonDistribution([float(v) for v in mu], 2.0)
+
+        npt.assert_allclose(w.mu, mu)
+
     def test_pdf(self):
         mu = array([1.0, 2.0, 3.0])
         mu = mu / linalg.norm(mu)
@@ -57,6 +64,21 @@ class TestWatsonDistribution(unittest.TestCase):
 
         pdf_values = w.pdf(self.xs)
         npt.assert_array_almost_equal(pdf_values, expected_pdf_values, decimal=5)
+
+    def test_pdf_accepts_list_inputs(self):
+        mu = array([1.0, 2.0, 3.0])
+        mu = mu / linalg.norm(mu)
+        w = WatsonDistribution(mu, 2.0)
+        xs = [[float(v) for v in self.xs[0]], [float(v) for v in self.xs[1]]]
+
+        npt.assert_allclose(w.pdf(xs), w.pdf(array(xs)))
+        npt.assert_allclose(w.pdf(xs[0]), w.pdf(array(xs[0])))
+
+    def test_pdf_rejects_wrong_dimension(self):
+        dist = WatsonDistribution(array([1.0, 0.0, 0.0]), 2.0)
+
+        with self.assertRaises(ValueError):
+            dist.pdf([1.0, 0.0])
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",
@@ -118,6 +140,12 @@ class TestWatsonDistribution(unittest.TestCase):
             err_msg="ln_pdf does not return correct log probabilities.",
         )
 
+    def test_ln_pdf_rejects_wrong_dimension(self):
+        dist = WatsonDistribution(array([1.0, 0.0, 0.0]), 2.0)
+
+        with self.assertRaises(ValueError):
+            dist.ln_pdf([1.0, 0.0])
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",
         "JAX proposals use an explicit PRNG-key signature",
@@ -155,6 +183,17 @@ class TestWatsonDistribution(unittest.TestCase):
         dist = WatsonDistribution(mu, 2.0)
 
         shifted = dist.shift(new_mode)
+
+        self.assertIsNot(shifted, dist)
+        npt.assert_allclose(dist.mu, mu)
+        npt.assert_allclose(shifted.mu, new_mode)
+
+    def test_shift_accepts_list_mode(self):
+        mu = array([0.0, 0.0, 1.0])
+        new_mode = array([1.0, 0.0, 0.0])
+        dist = WatsonDistribution([0.0, 0.0, 1.0], 2.0)
+
+        shifted = dist.shift([1.0, 0.0, 0.0])
 
         self.assertIsNot(shifted, dist)
         npt.assert_allclose(dist.mu, mu)


### PR DESCRIPTION
## Summary
- normalize Watson mean directions before constructor shape validation
- accept list-like `pdf` and `ln_pdf` evaluation points while keeping wrong trailing dimensions rejected
- accept list-like mode vectors through `set_mode` and `shift`

## Tests
- `python -m pytest tests/distributions/test_watson_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/hypersphere_subset/watson_distribution.py tests/distributions/test_watson_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/hypersphere_subset/watson_distribution.py tests/distributions/test_watson_distribution.py`
- `git diff --check`