### PR TITLE
Validate SO3 Bingham inputs explicitly

### DIFF
--- a/src/pyrecest/distributions/so3_bingham_distribution.py
+++ b/src/pyrecest/distributions/so3_bingham_distribution.py
@@ -1,6 +1,8 @@
 """Bingham distribution on SO(3)."""
 
 # pylint: disable=no-name-in-module,no-member
+from math import isfinite as scalar_isfinite
+
 from pyrecest.backend import (
     abs,
     all,
@@ -11,6 +13,7 @@ from pyrecest.backend import (
     diag,
     dot,
     eye,
+    isfinite,
     linalg,
     log,
     ndim,
@@ -43,17 +46,36 @@ class SO3BinghamDistribution(HyperhemisphericalBinghamDistribution):
     def __init__(self, Z, M):
         Z = array(Z, dtype=float)
         M = array(M, dtype=float)
-        assert ndim(Z) == 1 and Z.shape[0] == 4, "Z must have shape (4,)."
-        assert M.shape == (4, 4), "M must have shape (4, 4)."
+        self._validate_parameters(Z, M)
 
         super().__init__(Z, M)
         self.distFullSphere.F = array(self.calculate_normalization_constant(Z))
 
     @staticmethod
+    def _validate_parameters(Z, M):
+        if ndim(Z) != 1 or Z.shape[0] != 4:
+            raise ValueError("Z must have shape (4,).")
+        if M.shape != (4, 4):
+            raise ValueError("M must have shape (4, 4).")
+        if not bool(all(isfinite(Z))):
+            raise ValueError("Z must be finite.")
+        if not bool(all(isfinite(M))):
+            raise ValueError("M must be finite.")
+        if not bool(abs(Z[-1]) <= 1e-12):
+            raise ValueError("The last entry of Z must be zero.")
+        if not bool(all(Z[:-1] <= Z[1:])):
+            raise ValueError("Values in Z must be ascending.")
+        if not bool(amax(abs(M @ transpose(M) - eye(4))) < 0.001):
+            raise ValueError("M must be orthogonal.")
+
+    @staticmethod
     def calculate_normalization_constant(Z):
         """Return the 4-D Bingham normalizing constant."""
         Z = array(Z, dtype=float)
-        assert Z.shape == (4,), "Z must have shape (4,)."
+        if Z.shape != (4,):
+            raise ValueError("Z must have shape (4,).")
+        if not bool(all(isfinite(Z))):
+            raise ValueError("Z must be finite.")
         return BinghamDistribution.calculate_F(Z)
 
     @staticmethod
@@ -98,7 +120,9 @@ class SO3BinghamDistribution(HyperhemisphericalBinghamDistribution):
     @classmethod
     def from_mode_and_concentration(cls, mode, concentration):
         """Create an isotropic Bingham distribution around ``mode``."""
-        assert concentration >= 0.0, "concentration must be nonnegative."
+        concentration = float(concentration)
+        if not scalar_isfinite(concentration) or concentration < 0.0:
+            raise ValueError("concentration must be finite and nonnegative.")
         Z = array([-concentration, -concentration, -concentration, 0.0])
         M = cls._orthogonal_completion(mode)
         return cls(Z, M)
@@ -107,10 +131,10 @@ class SO3BinghamDistribution(HyperhemisphericalBinghamDistribution):
     def from_concentration_matrix(cls, concentration_matrix):
         """Create from a symmetric 4-by-4 exponent matrix."""
         concentration_matrix = array(concentration_matrix, dtype=float)
-        assert concentration_matrix.shape == (
-            4,
-            4,
-        ), "concentration_matrix must have shape (4, 4)."
+        if concentration_matrix.shape != (4, 4):
+            raise ValueError("concentration_matrix must have shape (4, 4).")
+        if not bool(all(isfinite(concentration_matrix))):
+            raise ValueError("concentration_matrix must be finite.")
         concentration_matrix = 0.5 * (
             concentration_matrix + transpose(concentration_matrix)
         )
@@ -126,10 +150,10 @@ class SO3BinghamDistribution(HyperhemisphericalBinghamDistribution):
     @classmethod
     def from_bingham_distribution(cls, distribution):
         """Create from a 4-D hyperspherical Bingham distribution."""
-        assert isinstance(
-            distribution, BinghamDistribution
-        ), "distribution must be a BinghamDistribution."
-        assert distribution.input_dim == 4, "distribution must be 4-D."
+        if not isinstance(distribution, BinghamDistribution):
+            raise ValueError("distribution must be a BinghamDistribution.")
+        if distribution.input_dim != 4:
+            raise ValueError("distribution must be 4-D.")
         return cls(distribution.Z, distribution.M)
 
     def pdf(self, xs):
@@ -190,17 +214,15 @@ class SO3BinghamDistribution(HyperhemisphericalBinghamDistribution):
 
     def multiply(self, B2):
         """Multiply two SO(3) Bingham densities."""
-        assert isinstance(
-            B2, SO3BinghamDistribution
-        ), "B2 must be an SO3BinghamDistribution."
+        if not isinstance(B2, SO3BinghamDistribution):
+            raise ValueError("B2 must be an SO3BinghamDistribution.")
         product = self.distFullSphere.multiply(B2.distFullSphere)
         return SO3BinghamDistribution(product.Z, product.M)
 
     def compose(self, B2):
         """Approximate the distribution of the composed rotation ``self * other``."""
-        assert isinstance(
-            B2, SO3BinghamDistribution
-        ), "B2 must be an SO3BinghamDistribution."
+        if not isinstance(B2, SO3BinghamDistribution):
+            raise ValueError("B2 must be an SO3BinghamDistribution.")
 
         weights = B2.moment_weights()
         first_moment = self.moment()

--- a/tests/distributions/test_so3_bingham_distribution.py
+++ b/tests/distributions/test_so3_bingham_distribution.py
@@ -3,7 +3,7 @@ import unittest
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array, diag, isfinite, pi
+from pyrecest.backend import array, diag, eye, isfinite, pi
 from pyrecest.distributions import SO3BinghamDistribution
 from pyrecest.distributions.hypersphere_subset.hyperhemispherical_bingham_distribution import (
     HyperhemisphericalBinghamDistribution,
@@ -34,6 +34,53 @@ class SO3BinghamDistributionTest(unittest.TestCase):
         npt.assert_allclose(
             dist.distFullSphere.Z, array([-5.0, -5.0, -5.0, 0.0]), atol=ATOL
         )
+
+    def test_constructor_rejects_invalid_parameters(self):
+        valid_z = array([-1.0, -1.0, -1.0, 0.0])
+        valid_m = eye(4)
+        invalid_cases = [
+            (array([0.0, 0.0, 0.0]), valid_m, "shape"),
+            (valid_z, eye(3), "shape"),
+            (array([-1.0, -1.0, float("nan"), 0.0]), valid_m, "finite"),
+            (
+                valid_z,
+                diag(array([1.0, 1.0, 1.0, float("inf")])),
+                "finite",
+            ),
+            (array([-1.0, 0.0, -0.5, 0.0]), valid_m, "ascending"),
+            (array([-1.0, -1.0, -1.0, 1.0]), valid_m, "zero"),
+            (valid_z, diag(array([1.0, 1.0, 1.0, 2.0])), "orthogonal"),
+        ]
+
+        for z, m, message in invalid_cases:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(ValueError, message):
+                    SO3BinghamDistribution(z, m)
+
+    def test_factories_reject_invalid_parameters(self):
+        for concentration in (-1.0, float("inf"), float("nan")):
+            with self.subTest(concentration=concentration):
+                with self.assertRaisesRegex(ValueError, "finite and nonnegative"):
+                    SO3BinghamDistribution.from_mode_and_concentration(
+                        array([0.0, 0.0, 0.0, 1.0]), concentration
+                    )
+
+        with self.assertRaisesRegex(ValueError, "shape"):
+            SO3BinghamDistribution.calculate_normalization_constant(
+                array([0.0, 0.0, 0.0])
+            )
+        with self.assertRaisesRegex(ValueError, "finite"):
+            SO3BinghamDistribution.calculate_normalization_constant(
+                array([0.0, 0.0, float("nan"), 0.0])
+            )
+        with self.assertRaisesRegex(ValueError, "shape"):
+            SO3BinghamDistribution.from_concentration_matrix(eye(3))
+        with self.assertRaisesRegex(ValueError, "finite"):
+            SO3BinghamDistribution.from_concentration_matrix(
+                diag(array([0.0, 0.0, float("inf"), 0.0]))
+            )
+        with self.assertRaisesRegex(ValueError, "BinghamDistribution"):
+            SO3BinghamDistribution.from_bingham_distribution(object())
 
     def test_pdf_is_antipodally_symmetric_and_peaks_at_mode(self):
         dist = SO3BinghamDistribution.from_mode_and_concentration(
@@ -98,6 +145,11 @@ class SO3BinghamDistributionTest(unittest.TestCase):
         npt.assert_allclose(
             product.distFullSphere.Z, array([-5.0, -5.0, -5.0, 0.0]), atol=ATOL
         )
+
+        with self.assertRaisesRegex(ValueError, "SO3BinghamDistribution"):
+            first.multiply(object())
+        with self.assertRaisesRegex(ValueError, "SO3BinghamDistribution"):
+            first.compose(object())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace assertion-based SO(3) Bingham public input checks with explicit `ValueError` validation
- reject malformed, non-finite, unsorted, nonzero-offset, and non-orthogonal constructor parameters before parent Bingham construction
- add regression coverage for invalid constructor, factory, multiply, and compose inputs

## Validation
- `python -m pytest tests/distributions/test_so3_bingham_distribution.py -q`
- `python -m pytest tests/distributions/test_so3_*.py tests/filters/test_so3_*.py -q` using PowerShell-expanded test paths
- `ruff check src/pyrecest/distributions/so3_bingham_distribution.py tests/distributions/test_so3_bingham_distribution.py`

## Quality impact
This makes SO(3) Bingham invalid-parameter failures deterministic and independent of Python assertion settings, reducing the chance that bad experiment parameters reach lower-level Bingham normalization or composition paths.