### PR TITLE
Accept list inputs in von Mises-Fisher distribution

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/von_mises_fisher_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/von_mises_fisher_distribution.py
@@ -63,7 +63,7 @@ class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
             mass around ``mu``. ``kappa == 0`` is the uniform distribution on the
             hypersphere.
         """
-        AbstractHypersphericalDistribution.__init__(self, dim=mu.shape[0] - 1)
+        mu = array(mu)
         epsilon = 1e-6
         assert mu.ndim == 1, "mu must be a vector"
         assert (
@@ -71,6 +71,7 @@ class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
         ), "mu must be at least two-dimensional for the circular case"
         assert kappa >= 0, "kappa must be a nonnegative scalar"
         assert abs(linalg.norm(mu) - 1.0) < epsilon, "mu must be a normalized"
+        AbstractHypersphericalDistribution.__init__(self, dim=mu.shape[0] - 1)
 
         self.mu = mu
         self.kappa = kappa
@@ -93,7 +94,11 @@ class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
             Unit-vector evaluation point or batch of points in the embedding
             space.
         """
-        assert xs.shape[-1] == self.input_dim
+        xs = array(xs)
+        if xs.ndim == 0 or xs.shape[-1] != self.input_dim:
+            raise ValueError(
+                f"xs must have trailing dimension {self.input_dim}, got {xs.shape}."
+            )
 
         return self.C * exp(self.kappa * xs @ self.mu)
 
@@ -218,6 +223,7 @@ class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
             inverted to estimate ``kappa``. A zero vector represents the uniform
             distribution and therefore receives an arbitrary stored direction.
         """
+        m = array(m)
         assert ndim(m) == 1, "mu must be a vector"
         assert len(m) >= 2, "mu must be at least 2 for the circular case"
 
@@ -239,6 +245,7 @@ class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
 
     def set_mean(self, new_mean):
         """Replace the mean direction and return the distribution."""
+        new_mean = array(new_mean)
         assert new_mean.shape == self.mu.shape
         dist = copy.deepcopy(self)
         dist.mu = copy.deepcopy(new_mean)
@@ -246,6 +253,7 @@ class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
 
     def set_mode(self, new_mode):
         """Replace the modal direction and return the distribution."""
+        new_mode = array(new_mode)
         assert new_mode.shape == self.mu.shape
         dist = copy.deepcopy(self)
         dist.mu = copy.deepcopy(new_mode)

--- a/tests/distributions/test_von_mises_fisher_distribution.py
+++ b/tests/distributions/test_von_mises_fisher_distribution.py
@@ -73,6 +73,11 @@ class TestVonMisesFisherDistribution(
         self.assertEqual(self.vmf.kappa, self.kappa)
         self.assertEqual(self.vmf.dim + 1, len(self.mu))
 
+    def test_constructor_accepts_list_mu(self):
+        vmf = VonMisesFisherDistribution([float(v) for v in self.mu], self.kappa)
+
+        npt.assert_allclose(vmf.mu, self.mu)
+
     def test_zero_kappa_is_uniform_density(self):
         vmf = VonMisesFisherDistribution(array([1.0, 0.0, 0.0]), 0.0)
         points = array(
@@ -99,6 +104,15 @@ class TestVonMisesFisherDistribution(
         npt.assert_allclose(self.vmf.mu, self.mu)
         npt.assert_allclose(shifted.mu, new_mu)
 
+    def test_set_mean_accepts_list_input(self):
+        new_mu = [0.0, 0.0, 1.0]
+
+        shifted = self.vmf.set_mean(new_mu)
+
+        self.assertIsNot(shifted, self.vmf)
+        npt.assert_allclose(self.vmf.mu, self.mu)
+        npt.assert_allclose(shifted.mu, array(new_mu))
+
     def test_set_mode_returns_new_distribution(self):
         new_mu = array([0.0, 0.0, 1.0])
 
@@ -107,6 +121,15 @@ class TestVonMisesFisherDistribution(
         self.assertIsNot(shifted, self.vmf)
         npt.assert_allclose(self.vmf.mu, self.mu)
         npt.assert_allclose(shifted.mu, new_mu)
+
+    def test_set_mode_accepts_list_input(self):
+        new_mu = [0.0, 0.0, 1.0]
+
+        shifted = self.vmf.set_mode(new_mu)
+
+        self.assertIsNot(shifted, self.vmf)
+        npt.assert_allclose(self.vmf.mu, self.mu)
+        npt.assert_allclose(shifted.mu, array(new_mu))
 
     def test_from_zero_mean_resultant_vector_returns_uniform(self):
         vmf = VonMisesFisherDistribution.from_mean_resultant_vector(
@@ -117,6 +140,12 @@ class TestVonMisesFisherDistribution(
         self.assertAlmostEqual(
             _as_float(vmf.pdf(array([0.0, 0.0, 1.0]))), 1.0 / (4.0 * pi)
         )
+
+    def test_from_mean_resultant_vector_accepts_list_input(self):
+        vmf = VonMisesFisherDistribution.from_mean_resultant_vector([0.2, 0.0, 0.0])
+
+        npt.assert_allclose(vmf.mu, array([1.0, 0.0, 0.0]))
+        self.assertGreater(_as_float(vmf.kappa), 0.0)
 
     def test_opposite_equal_vmf_product_is_uniform(self):
         mu = array([1.0, 0.0, 0.0])
@@ -210,6 +239,19 @@ class TestVonMisesFisherDistribution(
                 ],
             ),
         )
+
+    def test_pdf_accepts_list_inputs(self):
+        x = [
+            [float(v) for v in vectors_to_test_2d[0]],
+            [float(v) for v in vectors_to_test_2d[1]],
+        ]
+
+        npt.assert_allclose(self.vmf.pdf(x), self.vmf.pdf(array(x)))
+        npt.assert_allclose(self.vmf.pdf(x[0]), self.vmf.pdf(array(x[0])))
+
+    def test_pdf_rejects_wrong_dimension(self):
+        with self.assertRaises(ValueError):
+            self.vmf.pdf([1.0, 0.0])
 
     def test_pdf_3d(self):
         mu = array([1.0, 1.0, 2.0, -3.0])


### PR DESCRIPTION
## Summary
- normalize vMF mean directions before constructor shape validation
- accept list-like `pdf` evaluation points while keeping wrong trailing dimensions rejected
- accept list-like `set_mean`, `set_mode`, and mean-resultant-vector inputs

## Tests
- `python -m pytest tests/distributions/test_von_mises_fisher_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/hypersphere_subset/von_mises_fisher_distribution.py tests/distributions/test_von_mises_fisher_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/hypersphere_subset/von_mises_fisher_distribution.py tests/distributions/test_von_mises_fisher_distribution.py`
- `git diff --check`