### PR TITLE
Accept list inputs in Bingham distribution

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/bingham_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/bingham_distribution.py
@@ -154,6 +154,8 @@ class BinghamDistribution(AbstractHypersphericalDistribution):
     """
 
     def __init__(self, Z, M):
+        Z = array(Z)
+        M = array(M)
         AbstractHypersphericalDistribution.__init__(self, M.shape[0] - 1)
 
         assert M.shape[1] == self.input_dim, "M is not square"
@@ -193,7 +195,11 @@ class BinghamDistribution(AbstractHypersphericalDistribution):
         return _calculate_F_cached(_cache_key(Z))
 
     def pdf(self, xs):
-        assert xs.shape[-1] == self.dim + 1
+        xs = array(xs)
+        if xs.ndim == 0 or xs.shape[-1] != self.input_dim:
+            raise ValueError(
+                f"xs must have trailing dimension {self.input_dim}, got {xs.shape}."
+            )
 
         C = self.M @ diag(self.Z) @ self.M.T
         p = 1 / self.F * exp(sum(xs * (xs @ C), axis=-1))

--- a/tests/distributions/test_bingham_distribution.py
+++ b/tests/distributions/test_bingham_distribution.py
@@ -20,6 +20,20 @@ class TestBinghamDistribution(unittest.TestCase):
         Z = array([-5.0, -3.0, 0.0])
         self.bd = BinghamDistribution(Z, M)
 
+    def test_constructor_accepts_list_inputs(self):
+        """Z and M can be supplied as ordinary Python lists."""
+        M = [
+            [1 / 3, 2 / 3, -2 / 3],
+            [-2 / 3, 2 / 3, 1 / 3],
+            [2 / 3, 1 / 3, 2 / 3],
+        ]
+        Z = [-5.0, -3.0, 0.0]
+
+        bd = BinghamDistribution(Z, M)
+
+        npt.assert_allclose(bd.Z, array(Z))
+        npt.assert_allclose(bd.M, array(M))
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",
         reason="Not supported on this backend",
@@ -42,6 +56,24 @@ class TestBinghamDistribution(unittest.TestCase):
             expected_values,
             err_msg="Expected and computed pdf values do not match.",
         )
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_pdf_accepts_list_inputs(self):
+        """PDF evaluation points can be supplied as ordinary Python lists."""
+        x = [
+            [float(v) for v in vectors_to_test_2d[0]],
+            [float(v) for v in vectors_to_test_2d[1]],
+        ]
+
+        npt.assert_allclose(self.bd.pdf(x), self.bd.pdf(array(x)))
+        npt.assert_allclose(self.bd.pdf(x[0]), self.bd.pdf(array(x[0])))
+
+    def test_pdf_rejects_wrong_dimension(self):
+        with self.assertRaises(ValueError):
+            self.bd.pdf([1.0, 0.0])
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",


### PR DESCRIPTION
## Summary
- normalize generic Bingham `Z` and `M` constructor inputs before shape validation
- accept list-like `pdf` evaluation points while keeping wrong trailing dimensions rejected
- add focused regression coverage for list constructor and PDF inputs

## Tests
- `python -m pytest tests/distributions/test_bingham_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/hypersphere_subset/bingham_distribution.py tests/distributions/test_bingham_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/hypersphere_subset/bingham_distribution.py tests/distributions/test_bingham_distribution.py`
- `git diff --check`