### PR TITLE
Accept list inputs in hypersphere uniform distributions

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/abstract_hypersphere_subset_uniform_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/abstract_hypersphere_subset_uniform_distribution.py
@@ -1,5 +1,5 @@
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import ones
+from pyrecest.backend import array, ones
 
 from ..abstract_uniform_distribution import AbstractUniformDistribution
 from .abstract_hypersphere_subset_distribution import (
@@ -24,6 +24,7 @@ class AbstractHypersphereSubsetUniformDistribution(
         Returns:
             : Probability density at the given data points.
         """
+        xs = array(xs)
         if xs.shape[-1] != self.input_dim:
             raise ValueError("Invalid shape of input data points.")
         manifold_size = self.get_manifold_size()

--- a/src/pyrecest/distributions/hypersphere_subset/hyperspherical_uniform_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/hyperspherical_uniform_distribution.py
@@ -3,6 +3,7 @@ from typing import Union
 # pylint: disable=no-name-in-module,no-member
 import numpy as np
 from pyrecest.backend import (
+    array,
     cos,
     empty,
     int32,
@@ -54,6 +55,9 @@ class HypersphericalUniformDistribution(
         return AbstractHypersphereSubsetUniformDistribution.pdf(self, xs)
 
     def ln_pdf(self, xs):
+        xs = array(xs)
+        if xs.shape[-1] != self.input_dim:
+            raise ValueError("Invalid shape of input data points.")
         log_density = -self.get_ln_manifold_size()
         return log_density * ones(xs.shape[0]) if xs.ndim > 1 else log_density
 

--- a/tests/distributions/test_hyperhemispherical_uniform_distribution.py
+++ b/tests/distributions/test_hyperhemispherical_uniform_distribution.py
@@ -41,6 +41,38 @@ class TestHyperhemisphericalUniformDistribution(unittest.TestCase):
             allclose(hhud.pdf(points), ones(points.shape[0]) / (2 * pi), atol=1e-6)
         )
 
+    def test_pdf_accepts_list_inputs(self):
+        hhud = HyperhemisphericalUniformDistribution(2)
+        points = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]
+
+        npt.assert_allclose(
+            to_numpy(hhud.pdf(points)),
+            to_numpy(hhud.pdf(array(points))),
+        )
+        npt.assert_allclose(
+            to_numpy(hhud.pdf(points[0])),
+            to_numpy(hhud.pdf(array(points[0]))),
+        )
+
+    def test_pdf_rejects_wrong_dimension(self):
+        hhud = HyperhemisphericalUniformDistribution(2)
+
+        with self.assertRaises(ValueError):
+            hhud.pdf([1.0, 0.0])
+
+    def test_ln_pdf_accepts_list_inputs(self):
+        hhud = HyperhemisphericalUniformDistribution(2)
+        points = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]
+
+        npt.assert_allclose(
+            to_numpy(hhud.ln_pdf(points)),
+            to_numpy(hhud.ln_pdf(array(points))),
+        )
+        npt.assert_allclose(
+            to_numpy(hhud.ln_pdf(points[0])),
+            to_numpy(hhud.ln_pdf(array(points[0]))),
+        )
+
     def test_pdf_3d(self):
         hhud = HyperhemisphericalUniformDistribution(3)
 

--- a/tests/distributions/test_hyperspherical_uniform_distribution.py
+++ b/tests/distributions/test_hyperspherical_uniform_distribution.py
@@ -1,12 +1,13 @@
 """Test for uniform distribution on the hypersphere"""
 
 # pylint: disable=no-name-in-module,no-member
+import math
 import unittest
 
 import numpy as np
 import numpy.testing as npt
 import pyrecest.backend
-from pyrecest.backend import linalg, log, ones, random
+from pyrecest.backend import array, linalg, log, ones, random
 from pyrecest.distributions import (
     AbstractHypersphericalDistribution,
     HypersphericalUniformDistribution,
@@ -44,6 +45,19 @@ class HypersphericalUniformDistributionTest(unittest.TestCase):
                 ),
                 atol=1e-10,
             )
+
+    def test_pdf_accepts_list_inputs(self):
+        hud = HypersphericalUniformDistribution(2)
+        points = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]
+
+        npt.assert_allclose(hud.pdf(points), hud.pdf(array(points)))
+        npt.assert_allclose(hud.pdf(points[0]), hud.pdf(array(points[0])))
+
+    def test_pdf_rejects_wrong_dimension(self):
+        hud = HypersphericalUniformDistribution(2)
+
+        with self.assertRaises(ValueError):
+            hud.pdf([1.0, 0.0])
 
     def test_sample(self):
         for dim in range(2, 5):
@@ -92,6 +106,22 @@ class HypersphericalUniformDistributionTest(unittest.TestCase):
             decimal=10,
             err_msg="ln_pdf does not return correct log probabilities.",
         )
+
+    def test_ln_pdf_accepts_list_inputs(self):
+        hud = HypersphericalUniformDistribution(2)
+        points = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]
+
+        npt.assert_allclose(hud.ln_pdf(points), log(hud.pdf(array(points))))
+        npt.assert_allclose(
+            float(hud.ln_pdf(points[0])),
+            math.log(float(hud.pdf(array(points[0])))),
+        )
+
+    def test_ln_pdf_rejects_wrong_dimension(self):
+        hud = HypersphericalUniformDistribution(2)
+
+        with self.assertRaises(ValueError):
+            hud.ln_pdf([1.0, 0.0])
 
     def test_ln_pdf_single_point_matches_pdf(self):
         """Single-point ln_pdf should be scalar-like and match log(pdf)."""


### PR DESCRIPTION
## Summary
- normalize hypersphere-subset uniform PDF inputs before shape validation
- accept list-like hyperspherical uniform `ln_pdf` inputs while keeping wrong dimensions rejected
- add focused regression coverage for hyperspherical and hyperhemispherical uniform list inputs

## Tests
- `python -m pytest tests/distributions/test_hyperspherical_uniform_distribution.py tests/distributions/test_hyperhemispherical_uniform_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/hypersphere_subset/abstract_hypersphere_subset_uniform_distribution.py src/pyrecest/distributions/hypersphere_subset/hyperspherical_uniform_distribution.py tests/distributions/test_hyperspherical_uniform_distribution.py tests/distributions/test_hyperhemispherical_uniform_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/hypersphere_subset/abstract_hypersphere_subset_uniform_distribution.py src/pyrecest/distributions/hypersphere_subset/hyperspherical_uniform_distribution.py tests/distributions/test_hyperspherical_uniform_distribution.py tests/distributions/test_hyperhemispherical_uniform_distribution.py`
- `git diff --check`