### PR TITLE
Accept list inputs in custom hyperhemispherical PDFs

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/custom_hyperhemispherical_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/custom_hyperhemispherical_distribution.py
@@ -33,7 +33,9 @@ class CustomHyperhemisphericalDistribution(
         :param xs: points where the pdf will be calculated.
         :return: numpy.ndarray: pdf values at given points.
         """
-        assert xs.shape[-1] == self.dim + 1
+        xs = asarray(xs)
+        if xs.ndim == 0 or xs.shape[-1] != self.dim + 1:
+            raise ValueError("Invalid shape of input data points.")
         p = asarray(self.scale_by * self.f(xs))
         assert p.ndim <= 1, "Output format of pdf is not as expected"
         return p

--- a/tests/distributions/test_custom_hyperhemispherical_distribution.py
+++ b/tests/distributions/test_custom_hyperhemispherical_distribution.py
@@ -6,7 +6,7 @@ import numpy.testing as npt
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array, pi
+from pyrecest.backend import array, ones, pi
 from pyrecest.distributions import (
     CustomHyperhemisphericalDistribution,
     HypersphericalUniformDistribution,
@@ -14,6 +14,21 @@ from pyrecest.distributions import (
 
 
 class CustomHyperhemisphericalDistributionTest(unittest.TestCase):
+    def test_pdf_accepts_list_inputs(self):
+        dist = CustomHyperhemisphericalDistribution(
+            lambda xs: ones(xs.shape[:-1]), 2
+        )
+        points = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]
+
+        npt.assert_allclose(dist.pdf(points[0]), dist.pdf(array(points[0])))
+        npt.assert_allclose(dist.pdf(points), dist.pdf(array(points)))
+
+    def test_pdf_rejects_wrong_dimension(self):
+        dist = CustomHyperhemisphericalDistribution(lambda xs: 1.0, 2)
+
+        with self.assertRaises(ValueError):
+            dist.pdf([1.0, 0.0])
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
         reason="Numerical integration is only supported for the NumPy backend",


### PR DESCRIPTION
## Summary
- Convert custom hyperhemispherical PDF inputs to backend arrays before shape validation
- Raise a clear ValueError for malformed point dimensions
- Add regression tests for list-valued single and batched PDF inputs

## Tests
- `python -m pytest tests/distributions/test_custom_hyperhemispherical_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/hypersphere_subset/custom_hyperhemispherical_distribution.py tests/distributions/test_custom_hyperhemispherical_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/hypersphere_subset/custom_hyperhemispherical_distribution.py tests/distributions/test_custom_hyperhemispherical_distribution.py`
- `git diff --check`