### PR TITLE
Accept list inputs in custom hyperspherical PDFs

### DIFF
--- a/src/pyrecest/distributions/abstract_custom_distribution.py
+++ b/src/pyrecest/distributions/abstract_custom_distribution.py
@@ -42,9 +42,9 @@ class AbstractCustomDistribution(AbstractDistributionType):
         :returns: PDF values at given points.
         """
         # Shifting is something for subclasses
-        assert (
-            self.dim == 1 or self.input_dim == xs.shape[-1]
-        ), "Input dimension of pdf is not as expected"
+        xs = pyrecest.backend.asarray(xs)
+        if self.dim != 1 and (xs.ndim == 0 or self.input_dim != xs.shape[-1]):
+            raise ValueError("Input dimension of pdf is not as expected.")
         return self.scale_by * self.f(xs)
 
     @abstractmethod

--- a/tests/distributions/test_custom_hyperspherical_distribution.py
+++ b/tests/distributions/test_custom_hyperspherical_distribution.py
@@ -3,7 +3,7 @@ import unittest
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import allclose, array, linalg, random
+from pyrecest.backend import allclose, array, linalg, ones, random
 from pyrecest.distributions import VonMisesFisherDistribution
 from pyrecest.distributions.hypersphere_subset.custom_hyperspherical_distribution import (
     CustomHypersphericalDistribution,
@@ -35,6 +35,21 @@ class CustomHypersphericalDistributionTest(unittest.TestCase):
             ),
             "PDF values do not match.",
         )
+
+    def test_pdf_accepts_list_inputs(self):
+        dist = CustomHypersphericalDistribution(
+            lambda xs: ones(xs.shape[:-1]), dim=2
+        )
+        points = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]
+
+        self.assertTrue(allclose(dist.pdf(points[0]), dist.pdf(array(points[0]))))
+        self.assertTrue(allclose(dist.pdf(points), dist.pdf(array(points))))
+
+    def test_pdf_rejects_wrong_dimension(self):
+        dist = CustomHypersphericalDistribution(lambda xs: 1.0, dim=2)
+
+        with self.assertRaises(ValueError):
+            dist.pdf([1.0, 0.0])
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",


### PR DESCRIPTION
## Summary
- Convert abstract custom distribution PDF inputs to backend arrays before dimension validation
- Raise a clear `ValueError` for malformed custom hyperspherical point dimensions instead of failing on missing `.shape`
- Add regression tests for list-valued single and batched custom hyperspherical PDF inputs

## Tests
- `python -m pytest tests/distributions/test_custom_hyperspherical_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m pytest tests/distributions/test_custom_hyperspherical_distribution.py tests/distributions/test_abstract_hyperspherical_distribution.py tests/distributions/test_zero_density_entropy.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/abstract_custom_distribution.py tests/distributions/test_custom_hyperspherical_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/abstract_custom_distribution.py tests/distributions/test_custom_hyperspherical_distribution.py`
- `git diff --check`