### PR TITLE
Accept list inputs in SE2 Bingham construction

### DIFF
--- a/src/pyrecest/distributions/cart_prod/se2_bingham_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/se2_bingham_distribution.py
@@ -94,6 +94,7 @@ class SE2BinghamDistribution(AbstractSE2Distribution):
             C3 is None
         ), "Either both C2 and C3 must be provided, or neither."
 
+        C = array(C, dtype=float)
         if C2 is None:
             assert C.shape == (4, 4), "C must be 4x4 when C2 and C3 are not provided."
             assert allclose(C, C.T, atol=1e-6), "Full C matrix must be symmetric."
@@ -102,6 +103,8 @@ class SE2BinghamDistribution(AbstractSE2Distribution):
             self.C2 = C[2:, :2]
             self.C3 = C[2:, 2:]
         else:
+            C2 = array(C2, dtype=float)
+            C3 = array(C3, dtype=float)
             assert C.shape == (2, 2), "C1 must be 2x2."
             assert C2.shape == (2, 2), "C2 must be 2x2."
             assert C3.shape == (2, 2), "C3 must be 2x2."

--- a/tests/distributions/test_se2_bingham_distribution.py
+++ b/tests/distributions/test_se2_bingham_distribution.py
@@ -23,6 +23,19 @@ class TestSE2BinghamDistribution(unittest.TestCase):
         dist = SE2BinghamDistribution(self.C1, self.C2, self.C3)
         self.assertIsInstance(dist, SE2BinghamDistribution)
 
+    def test_constructor_accepts_list_parts(self):
+        """Distribution can be constructed from array-like C1, C2, C3."""
+        dist = SE2BinghamDistribution(
+            [[-3.0, 0.5], [0.5, -1.0]],
+            [[0.1, 0.2], [-0.1, 0.3]],
+            [[-2.0, 0.1], [0.1, -1.5]],
+        )
+
+        self.assertIsInstance(dist, SE2BinghamDistribution)
+        npt.assert_array_almost_equal(dist.C1, self.C1)
+        npt.assert_array_almost_equal(dist.C2, self.C2)
+        npt.assert_array_almost_equal(dist.C3, self.C3)
+
     def test_constructor_from_full_matrix(self):
         """Distribution can be constructed from the full 4x4 matrix."""
         C_full = self.dist.C
@@ -31,6 +44,15 @@ class TestSE2BinghamDistribution(unittest.TestCase):
         npt.assert_array_almost_equal(dist2.C1, self.dist.C1)
         npt.assert_array_almost_equal(dist2.C2, self.dist.C2)
         npt.assert_array_almost_equal(dist2.C3, self.dist.C3)
+
+    def test_constructor_accepts_list_full_matrix(self):
+        """Distribution can be constructed from an array-like full matrix."""
+        dist = SE2BinghamDistribution(np.asarray(self.dist.C).tolist())
+
+        self.assertIsInstance(dist, SE2BinghamDistribution)
+        npt.assert_array_almost_equal(dist.C1, self.dist.C1)
+        npt.assert_array_almost_equal(dist.C2, self.dist.C2)
+        npt.assert_array_almost_equal(dist.C3, self.dist.C3)
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",


### PR DESCRIPTION
## Summary
- Convert `SE2BinghamDistribution` constructor matrices to backend arrays before shape validation
- Support array-like full-matrix and `(C1, C2, C3)` constructor inputs as documented
- Add regression tests for list-valued SE(2) Bingham constructor matrices

## Tests
- `python -m pytest tests/distributions/test_se2_bingham_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/cart_prod/se2_bingham_distribution.py tests/distributions/test_se2_bingham_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/cart_prod/se2_bingham_distribution.py tests/distributions/test_se2_bingham_distribution.py`
- `git diff --check`