### PR TITLE
Validate SE2 UKF inputs explicitly

### DIFF
--- a/src/pyrecest/filters/se2_ukf.py
+++ b/src/pyrecest/filters/se2_ukf.py
@@ -17,13 +17,17 @@ Reference:
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
+    allclose,
     array,
     asarray,
     column_stack,
     concatenate,
     isclose,
+    isfinite,
     linalg,
     mean,
+    transpose,
     vstack,
     zeros,
 )
@@ -31,6 +35,57 @@ from pyrecest.distributions import GaussianDistribution
 
 from .abstract_filter import AbstractFilter
 from .manifold_mixins import SE2FilterMixin
+
+
+def _to_python_bool(value):
+    """Convert scalar backend booleans to Python bools for validation."""
+    if isinstance(value, bool):
+        return value
+    if hasattr(value, "item"):
+        return bool(value.item())
+    return bool(value)
+
+
+def _validate_se2_gaussian(distribution, role):
+    if not isinstance(distribution, GaussianDistribution):
+        raise ValueError(f"{role} must be a GaussianDistribution.")
+
+    mu = asarray(distribution.mu)
+    covariance = asarray(distribution.C)
+    if mu.shape != (4,):
+        raise ValueError(f"{role} mean must be a 4-D vector.")
+    if covariance.shape != (4, 4):
+        raise ValueError(f"{role} covariance must be 4x4.")
+    if not _to_python_bool(backend_all(isfinite(mu))):
+        raise ValueError(f"{role} mean must be finite.")
+    if not _to_python_bool(backend_all(isfinite(covariance))):
+        raise ValueError(f"{role} covariance must be finite.")
+
+    rotation_norm = linalg.norm(mu[0:2])
+    if not _to_python_bool(isfinite(rotation_norm)):
+        raise ValueError(f"{role} rotation part must have a finite norm.")
+    if not _to_python_bool(isclose(rotation_norm, 1.0)):
+        raise ValueError(f"{role} rotation part must be normalised.")
+    if not _to_python_bool(allclose(covariance, transpose(covariance))):
+        raise ValueError(f"{role} covariance must be symmetric.")
+    if not _to_python_bool(backend_all(linalg.eigvalsh(covariance) > 0.0)):
+        raise ValueError(f"{role} covariance must be positive definite.")
+    return mu, covariance
+
+
+def _validate_se2_measurement(z):
+    measurement = asarray(z).ravel()
+    if measurement.shape != (4,):
+        raise ValueError("measurement z must be a 4-D vector.")
+    if not _to_python_bool(backend_all(isfinite(measurement))):
+        raise ValueError("measurement z must be finite.")
+
+    rotation_norm = linalg.norm(measurement[0:2])
+    if not _to_python_bool(isfinite(rotation_norm)):
+        raise ValueError("measurement z rotation part must have a finite norm.")
+    if not _to_python_bool(isclose(rotation_norm, 1.0)):
+        raise ValueError("measurement z rotation part must be normalised.")
+    return measurement
 
 
 def _dual_quaternion_multiply(dq1, dq2):
@@ -117,18 +172,7 @@ class SE2UKF(AbstractFilter, SE2FilterMixin):
 
     @filter_state.setter
     def filter_state(self, new_state: GaussianDistribution):
-        assert isinstance(
-            new_state, GaussianDistribution
-        ), "filter_state must be a GaussianDistribution"
-        mu = asarray(new_state.mu)
-        assert mu.shape == (4,), "Mean must be a 4-D vector."
-        assert isclose(
-            linalg.norm(mu[0:2]), 1.0
-        ), "First two entries of the mean must be normalised."
-        assert asarray(new_state.C).shape == (
-            4,
-            4,
-        ), "Covariance must be 4×4."
+        _validate_se2_gaussian(new_state, "filter_state")
         self._filter_state = new_state
 
     # ------------------------------------------------------------------
@@ -153,14 +197,7 @@ class SE2UKF(AbstractFilter, SE2FilterMixin):
             two entries normalised) and a 4×4 covariance.
         """
         # pylint: disable=too-many-locals
-        assert isinstance(gauss_sys, GaussianDistribution)
-        mu_sys = asarray(gauss_sys.mu)
-        C_sys = asarray(gauss_sys.C)
-        assert mu_sys.shape == (4,), "System noise mean must be 4-D."
-        assert C_sys.shape == (4, 4), "System noise covariance must be 4×4."
-        assert isclose(
-            linalg.norm(mu_sys[0:2]), 1.0
-        ), "First two entries of the system noise mean must be normalised."
+        mu_sys, C_sys = _validate_se2_gaussian(gauss_sys, "system noise")
 
         mu = asarray(self._filter_state.mu)
         C = asarray(self._filter_state.C)
@@ -241,17 +278,8 @@ class SE2UKF(AbstractFilter, SE2FilterMixin):
             Measurement in dual-quaternion representation.
         """
         # pylint: disable=too-many-locals
-        assert isinstance(gauss_meas, GaussianDistribution)
-        mu_meas = asarray(gauss_meas.mu)
-        C_meas = asarray(gauss_meas.C)
-        assert mu_meas.shape == (4,), "Measurement noise mean must be 4-D."
-        assert C_meas.shape == (4, 4), "Measurement noise covariance must be 4×4."
-        assert isclose(
-            linalg.norm(mu_meas[0:2]), 1.0
-        ), "First two entries of the measurement noise mean must be normalised."
-
-        z = asarray(z).ravel()
-        assert z.shape == (4,), "Measurement z must be a 4-D vector."
+        mu_meas, C_meas = _validate_se2_gaussian(gauss_meas, "measurement noise")
+        z = _validate_se2_measurement(z)
 
         mu = asarray(self._filter_state.mu)
         C = asarray(self._filter_state.C)

--- a/tests/filters/test_se2_ukf.py
+++ b/tests/filters/test_se2_ukf.py
@@ -89,8 +89,65 @@ class TestSE2UKF(unittest.TestCase):
     def test_set_state_unnormalised_raises(self):
         mu = array([1.0, 1.0, 0.0, 0.0])  # not unit-norm in first 2 entries
         C = eye(4) * 0.1
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             self.filter.filter_state = GaussianDistribution(mu, C)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on JAX backend",
+    )
+    def test_set_state_validation_errors_are_explicit(self):
+        with self.assertRaisesRegex(ValueError, "GaussianDistribution"):
+            self.filter.filter_state = object()
+        with self.assertRaisesRegex(ValueError, "4-D vector"):
+            self.filter.filter_state = GaussianDistribution(
+                array([1.0, 0.0, 0.0]), eye(3)
+            )
+        with self.assertRaisesRegex(ValueError, "finite"):
+            self.filter.filter_state = GaussianDistribution(
+                array([float("nan"), 0.0, 0.0, 1.0]),
+                eye(4),
+                check_validity=False,
+            )
+        with self.assertRaisesRegex(ValueError, "finite"):
+            self.filter.filter_state = GaussianDistribution(
+                array([1.0, 0.0, 0.0, 0.0]),
+                array(
+                    [
+                        [1.0, 0.0, 0.0, 0.0],
+                        [0.0, float("inf"), 0.0, 0.0],
+                        [0.0, 0.0, 1.0, 0.0],
+                        [0.0, 0.0, 0.0, 1.0],
+                    ]
+                ),
+                check_validity=False,
+            )
+        with self.assertRaisesRegex(ValueError, "symmetric"):
+            self.filter.filter_state = GaussianDistribution(
+                array([1.0, 0.0, 0.0, 0.0]),
+                array(
+                    [
+                        [1.0, 0.5, 0.0, 0.0],
+                        [0.0, 1.0, 0.0, 0.0],
+                        [0.0, 0.0, 1.0, 0.0],
+                        [0.0, 0.0, 0.0, 1.0],
+                    ]
+                ),
+                check_validity=False,
+            )
+        with self.assertRaisesRegex(ValueError, "positive definite"):
+            self.filter.filter_state = GaussianDistribution(
+                array([1.0, 0.0, 0.0, 0.0]),
+                array(
+                    [
+                        [1.0, 0.0, 0.0, 0.0],
+                        [0.0, 1.0, 0.0, 0.0],
+                        [0.0, 0.0, 1.0, 0.0],
+                        [0.0, 0.0, 0.0, -1.0],
+                    ]
+                ),
+                check_validity=False,
+            )
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",
@@ -101,6 +158,19 @@ class TestSE2UKF(unittest.TestCase):
         noise = _make_noise()
         self.filter.predict_identity(noise)
         self.assertIsInstance(self.filter.filter_state, GaussianDistribution)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on JAX backend",
+    )
+    def test_predict_identity_rejects_invalid_noise(self):
+        self.filter.filter_state = _make_identity_state()
+        with self.assertRaisesRegex(ValueError, "system noise"):
+            self.filter.predict_identity(object())
+        with self.assertRaisesRegex(ValueError, "system noise"):
+            self.filter.predict_identity(
+                GaussianDistribution(array([2.0, 0.0, 0.0, 0.0]), eye(4))
+            )
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",
@@ -213,6 +283,34 @@ class TestSE2UKF(unittest.TestCase):
         z = array([1.0, 0.0, 0.0, 0.0])
         self.filter.update_identity(_make_noise(), z)
         self.assertIsInstance(self.filter.filter_state, GaussianDistribution)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on JAX backend",
+    )
+    def test_update_identity_accepts_array_like_measurement(self):
+        self.filter.filter_state = _make_identity_state()
+
+        self.filter.update_identity(_make_noise(), [1.0, 0.0, 0.0, 0.0])
+
+        npt.assert_allclose(linalg.norm(self.filter.filter_state.mu[0:2]), 1.0)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on JAX backend",
+    )
+    def test_update_identity_rejects_invalid_inputs(self):
+        self.filter.filter_state = _make_identity_state()
+        with self.assertRaisesRegex(ValueError, "measurement noise"):
+            self.filter.update_identity(object(), [1.0, 0.0, 0.0, 0.0])
+        with self.assertRaisesRegex(ValueError, "4-D vector"):
+            self.filter.update_identity(_make_noise(), [1.0, 0.0, 0.0])
+        with self.assertRaisesRegex(ValueError, "finite"):
+            self.filter.update_identity(
+                _make_noise(), [float("nan"), 0.0, 0.0, 0.0]
+            )
+        with self.assertRaisesRegex(ValueError, "normalised"):
+            self.filter.update_identity(_make_noise(), [2.0, 0.0, 0.0, 0.0])
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",


### PR DESCRIPTION
## Summary
- replace SE2 UKF assertion-only input checks with explicit `ValueError` validation
- validate state, system-noise, measurement-noise, and measurement dual-quaternion inputs for shape, finiteness, normalization, covariance symmetry, and positive definiteness
- add focused regression coverage, including an optimized-Python `-O` validation run

## Impact
Invalid SE(2) UKF inputs now fail before sigma-point construction or linear algebra, including when Python assertions are disabled. Valid SE(2) UKF state propagation and update behavior is unchanged.

## Validation
- `python -m pytest tests/filters/test_se2_ukf.py -q` -> `24 passed`
- `python -O -m pytest tests/filters/test_se2_ukf.py -q` -> `24 passed, 1 warning`
- `ruff check src/pyrecest/filters/se2_ukf.py tests/filters/test_se2_ukf.py` -> passed