### PR TITLE
Accept list inputs in wrapped Cauchy distribution

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py
@@ -1,5 +1,5 @@
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import arctan2, cos, cosh, exp, mod, pi, sin, sinh, tanh
+from pyrecest.backend import arctan2, array, cos, cosh, exp, mod, pi, sin, sinh, tanh
 
 from .abstract_circular_distribution import AbstractCircularDistribution
 
@@ -20,6 +20,7 @@ class WrappedCauchyDistribution(AbstractCircularDistribution):
         self.gamma = gamma
 
     def pdf(self, xs):
+        xs = array(xs)
         assert xs.ndim == 1
         xs_centered = mod(xs - self.mu, 2 * pi)
         return 1 / (2 * pi) * sinh(self.gamma) / (cosh(self.gamma) - cos(xs_centered))
@@ -38,9 +39,11 @@ class WrappedCauchyDistribution(AbstractCircularDistribution):
         def coth(x):
             return 1 / tanh(x)
 
+        xs = array(xs)
         assert xs.ndim == 1
 
         def primitive(angles):
+            angles = array(angles)
             angles_centered = mod(angles - self.mu, 2.0 * pi)
             half_angles = angles_centered / 2.0
             return (

--- a/tests/distributions/test_wrapped_cauchy_distribution.py
+++ b/tests/distributions/test_wrapped_cauchy_distribution.py
@@ -42,6 +42,12 @@ class WrappedCauchyDistributionTest(unittest.TestCase):
         dist = WrappedCauchyDistribution(array(1.0), array(0.5))
         npt.assert_array_less(dist.pdf(array([2.0])), dist.pdf(array([1.0])))
 
+    def test_pdf_accepts_list_inputs(self):
+        dist = WrappedCauchyDistribution(self.mu, self.gamma)
+        xs = [0.1, 0.2, 0.3]
+
+        npt.assert_allclose(dist.pdf(xs), dist.pdf(array(xs)))
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
         reason="Not supported on this backend",
@@ -69,6 +75,16 @@ class WrappedCauchyDistributionTest(unittest.TestCase):
         xs = array([0.5, 1.0, 2.0, 4.0])
 
         npt.assert_allclose(dist.cdf(xs), dist.cdf_numerical(xs), atol=1e-8)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
+    def test_cdf_accepts_list_inputs(self):
+        dist = WrappedCauchyDistribution(self.mu, self.gamma)
+        xs = [0.5, 1.0, 2.0]
+
+        npt.assert_allclose(dist.cdf(xs), dist.cdf(array(xs)), atol=1e-8)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Convert wrapped Cauchy `pdf` and `cdf` inputs to backend arrays before dimensionality checks
- Normalize the internal CDF primitive argument so array-like starting points are handled consistently
- Add regression tests for list-valued wrapped Cauchy PDF and CDF inputs

## Tests
- `python -m pytest tests/distributions/test_wrapped_cauchy_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py tests/distributions/test_wrapped_cauchy_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py tests/distributions/test_wrapped_cauchy_distribution.py`
- `git diff --check`