### PR TITLE
Accept scalar inputs in generalized von Mises PDFs

### DIFF
--- a/src/pyrecest/distributions/circle/generalized_von_mises_distribution.py
+++ b/src/pyrecest/distributions/circle/generalized_von_mises_distribution.py
@@ -1,5 +1,5 @@
 # pylint: disable=no-name-in-module,no-member,redefined-builtin
-from pyrecest.backend import arange, array, cos, exp, sum
+from pyrecest.backend import arange, array, atleast_1d, cos, exp, sum
 
 from .abstract_circular_distribution import AbstractCircularDistribution
 
@@ -53,7 +53,7 @@ class GvMDistribution(AbstractCircularDistribution):
         p : array, shape (n,)
             Unnormalized pdf values.
         """
-        xs = array(xs)
+        xs = atleast_1d(array(xs))
         # j = [1, 2, ..., k], shape (k,)
         j = arange(1, self.mu.shape[0] + 1, dtype=float)
         # Broadcast: (k, 1) * ((1, n) - (k, 1)) → (k, n)

--- a/tests/distributions/test_generalized_von_mises_distribution.py
+++ b/tests/distributions/test_generalized_von_mises_distribution.py
@@ -36,6 +36,11 @@ class TestGvMDistribution(unittest.TestCase):
         xs = linspace(0.0, 2.0 * pi, 50)
         self.assertTrue((gvm.pdf(xs) >= 0).all())
 
+    def test_pdf_accepts_scalar_input(self):
+        gvm = GvMDistribution(array([1.0]), array([2.0]))
+
+        npt.assert_allclose(gvm.pdf(0.5), gvm.pdf(array([0.5])))
+
     def test_pdf_integrates_to_one(self):
         """PDF should integrate to 1 over [0, 2*pi]."""
         from scipy.integrate import quad


### PR DESCRIPTION
## Summary
- Normalize generalized von Mises PDF inputs with `atleast_1d` before vectorized indexing
- Fix scalar PDF evaluation that previously raised an `IndexError`
- Add a regression test comparing scalar and one-element array evaluations

## Tests
- `python -m pytest tests/distributions/test_generalized_von_mises_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/circle/generalized_von_mises_distribution.py tests/distributions/test_generalized_von_mises_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/circle/generalized_von_mises_distribution.py tests/distributions/test_generalized_von_mises_distribution.py`
- `git diff --check`