### PR TITLE
Validate VMF filter inputs explicitly and fix backend-safe kappa validation

### DIFF
--- a/src/pyrecest/filters/von_mises_fisher_filter.py
+++ b/src/pyrecest/filters/von_mises_fisher_filter.py
@@ -1,4 +1,6 @@
 # pylint: disable=no-name-in-module,no-member
+from math import isfinite as python_isfinite
+
 from pyrecest.backend import (
     all as backend_all,
     allclose,
@@ -44,7 +46,7 @@ def _validate_vmf_distribution(distribution, role):
         raise ValueError(f"{role} mean direction must be normalized.")
 
     kappa = _to_python_float(distribution.kappa)
-    if not _to_python_bool(isfinite(kappa)):
+    if not python_isfinite(kappa):
         raise ValueError(f"{role} concentration must be finite.")
     if kappa < 0.0:
         raise ValueError(f"{role} concentration must be nonnegative.")

--- a/src/pyrecest/filters/von_mises_fisher_filter.py
+++ b/src/pyrecest/filters/von_mises_fisher_filter.py
@@ -1,9 +1,77 @@
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array, ndim
+from pyrecest.backend import (
+    all as backend_all,
+    allclose,
+    array,
+    asarray,
+    isfinite,
+    linalg,
+    ndim,
+)
 from pyrecest.distributions import VonMisesFisherDistribution
 
 from .abstract_filter import AbstractFilter
 from .manifold_mixins import HypersphericalFilterMixin
+
+
+def _to_python_bool(value):
+    """Convert scalar backend booleans to Python bools for validation."""
+    if isinstance(value, bool):
+        return value
+    if hasattr(value, "item"):
+        return bool(value.item())
+    return bool(value)
+
+
+def _to_python_float(value):
+    if hasattr(value, "item"):
+        return float(value.item())
+    return float(value)
+
+
+def _validate_vmf_distribution(distribution, role):
+    if not isinstance(distribution, VonMisesFisherDistribution):
+        raise ValueError(f"{role} must be a VonMisesFisherDistribution.")
+
+    mu = asarray(distribution.mu)
+    if ndim(mu) != 1:
+        raise ValueError(f"{role} mean direction must be a vector.")
+    if mu.shape[0] < 2:
+        raise ValueError(f"{role} mean direction must be at least two-dimensional.")
+    if not _to_python_bool(backend_all(isfinite(mu))):
+        raise ValueError(f"{role} mean direction must be finite.")
+    if not _to_python_bool(allclose(linalg.norm(mu), 1.0)):
+        raise ValueError(f"{role} mean direction must be normalized.")
+
+    kappa = _to_python_float(distribution.kappa)
+    if not _to_python_bool(isfinite(kappa)):
+        raise ValueError(f"{role} concentration must be finite.")
+    if kappa < 0.0:
+        raise ValueError(f"{role} concentration must be nonnegative.")
+
+
+def _validate_compatible_vmf(distribution, reference, role):
+    _validate_vmf_distribution(distribution, role)
+    if distribution.input_dim != reference.input_dim:
+        raise ValueError(f"{role} dimension must match the filter state dimension.")
+
+
+def _validate_zonal_vmf(distribution, role):
+    if not _to_python_bool(allclose(distribution.mu[-1], 1.0)):
+        raise ValueError(
+            f"{role} mean direction must be zonal with final coordinate 1."
+        )
+
+
+def _validate_vmf_measurement(z, input_dim):
+    measurement = asarray(z).ravel()
+    if measurement.shape != (input_dim,):
+        raise ValueError(f"measurement z must have shape ({input_dim},).")
+    if not _to_python_bool(backend_all(isfinite(measurement))):
+        raise ValueError("measurement z must be finite.")
+    if not _to_python_bool(allclose(linalg.norm(measurement), 1.0)):
+        raise ValueError("measurement z must be a unit vector.")
+    return measurement
 
 
 class VonMisesFisherFilter(AbstractFilter, HypersphericalFilterMixin):
@@ -27,9 +95,7 @@ class VonMisesFisherFilter(AbstractFilter, HypersphericalFilterMixin):
 
     @filter_state.setter
     def filter_state(self, filter_state):
-        assert isinstance(
-            filter_state, VonMisesFisherDistribution
-        ), "filter_state must be an instance of VonMisesFisherDistribution."
+        _validate_vmf_distribution(filter_state, "filter_state")
         self._filter_state = filter_state
 
     def set_state(self, state):
@@ -45,9 +111,8 @@ class VonMisesFisherFilter(AbstractFilter, HypersphericalFilterMixin):
         State prediction via mulitiplication. Provide zonal density for update
         Could add support for a rotation Q
         """
-        assert isinstance(
-            sys_noise, VonMisesFisherDistribution
-        ), "sys_noise must be an instance of VonMisesFisherDistribution."
+        _validate_compatible_vmf(sys_noise, self.filter_state, "system noise")
+        _validate_zonal_vmf(sys_noise, "system noise")
         self.filter_state = self.filter_state.convolve(sys_noise)
 
     def update_identity(self, meas_noise, z):
@@ -55,15 +120,8 @@ class VonMisesFisherFilter(AbstractFilter, HypersphericalFilterMixin):
         State update via mulitiplication. Provide zonal density for update
         Could add support for a rotation Q
         """
-        assert isinstance(
-            meas_noise, VonMisesFisherDistribution
-        ), "meas_noise must be an instance of VonMisesFisherDistribution."
-        assert (
-            meas_noise.mu[-1] == 1
-        ), "Set mu of meas_noise to [0,0,...,1] to acknowledge that the mean is discarded."
-        assert (
-            z.shape[0] == self.filter_state.input_dim
-        ), "Dimension mismatch between measurement and state."
-        assert ndim(z) == 1, "z should be a vector."
-        meas_noise.mu = z
-        self.filter_state = self.filter_state.multiply(meas_noise)
+        _validate_compatible_vmf(meas_noise, self.filter_state, "measurement noise")
+        _validate_zonal_vmf(meas_noise, "measurement noise")
+        z = _validate_vmf_measurement(z, self.filter_state.input_dim)
+        shifted_meas_noise = VonMisesFisherDistribution(z, meas_noise.kappa)
+        self.filter_state = self.filter_state.multiply(shifted_meas_noise)

--- a/tests/filters/test_von_mises_fisher_filter.py
+++ b/tests/filters/test_von_mises_fisher_filter.py
@@ -1,3 +1,4 @@
+import copy
 import unittest
 
 import numpy.testing as npt
@@ -25,6 +26,30 @@ class VMFFilterTest(unittest.TestCase):
         self.assertTrue(allclose(self.vmf.mu, vmf_result.mu))
         self.assertEqual(self.vmf.kappa, vmf_result.kappa)
 
+    def test_set_state_validation_errors_are_explicit(self):
+        with self.assertRaisesRegex(ValueError, "VonMisesFisherDistribution"):
+            self.filter.filter_state = object()
+
+        invalid_mu = copy.deepcopy(self.vmf)
+        invalid_mu.mu = array([float("nan"), 0.0])
+        with self.assertRaisesRegex(ValueError, "finite"):
+            self.filter.filter_state = invalid_mu
+
+        nonunit_mu = copy.deepcopy(self.vmf)
+        nonunit_mu.mu = array([2.0, 0.0])
+        with self.assertRaisesRegex(ValueError, "normalized"):
+            self.filter.filter_state = nonunit_mu
+
+        invalid_kappa = copy.deepcopy(self.vmf)
+        invalid_kappa.kappa = float("nan")
+        with self.assertRaisesRegex(ValueError, "finite"):
+            self.filter.filter_state = invalid_kappa
+
+        negative_kappa = copy.deepcopy(self.vmf)
+        negative_kappa.kappa = -1.0
+        with self.assertRaisesRegex(ValueError, "nonnegative"):
+            self.filter.filter_state = negative_kappa
+
     def test_prediction_identity(self):
         """Test prediction identity."""
         self.filter.filter_state = self.vmf
@@ -32,6 +57,19 @@ class VMFFilterTest(unittest.TestCase):
         self.filter.predict_identity(noise_distribution)
         self.assertLess(self.filter.filter_state.kappa, 0.5)
         # Add other assertions and logic here
+
+    def test_predict_identity_rejects_invalid_noise(self):
+        self.filter.filter_state = self.vmf
+        with self.assertRaisesRegex(ValueError, "system noise"):
+            self.filter.predict_identity(object())
+        with self.assertRaisesRegex(ValueError, "dimension"):
+            self.filter.predict_identity(
+                VonMisesFisherDistribution(array([0.0, 0.0, 1.0]), 0.9)
+            )
+        with self.assertRaisesRegex(ValueError, "zonal"):
+            self.filter.predict_identity(
+                VonMisesFisherDistribution(array([1.0, 0.0]), 0.9)
+            )
 
     def test_update_identity(self):
         """Test update identity."""
@@ -42,6 +80,49 @@ class VMFFilterTest(unittest.TestCase):
         self.assertIsInstance(vmf_updated_identity, VonMisesFisherDistribution)
         npt.assert_allclose(self.vmf.mu, vmf_updated_identity.mu, rtol=5e-7)
         self.assertGreaterEqual(vmf_updated_identity.kappa, self.vmf.kappa)
+
+    def test_update_identity_accepts_array_like_measurement_without_mutating_noise(self):
+        self.filter.filter_state = self.vmf
+        noise_distribution = VonMisesFisherDistribution(array([0.0, 1.0]), 0.9)
+        original_noise_mu = copy.deepcopy(noise_distribution.mu)
+
+        self.filter.update_identity(
+            noise_distribution,
+            [float(cos(self.phi)), float(sin(self.phi))],
+        )
+
+        npt.assert_allclose(noise_distribution.mu, original_noise_mu)
+        npt.assert_allclose(self.filter.filter_state.mu, self.vmf.mu, rtol=5e-7)
+
+    def test_update_identity_rejects_invalid_inputs(self):
+        self.filter.filter_state = self.vmf
+        with self.assertRaisesRegex(ValueError, "measurement noise"):
+            self.filter.update_identity(object(), [1.0, 0.0])
+        with self.assertRaisesRegex(ValueError, "dimension"):
+            self.filter.update_identity(
+                VonMisesFisherDistribution(array([0.0, 0.0, 1.0]), 0.9),
+                [1.0, 0.0],
+            )
+        with self.assertRaisesRegex(ValueError, "zonal"):
+            self.filter.update_identity(
+                VonMisesFisherDistribution(array([1.0, 0.0]), 0.9),
+                [1.0, 0.0],
+            )
+        with self.assertRaisesRegex(ValueError, "shape"):
+            self.filter.update_identity(
+                VonMisesFisherDistribution(array([0.0, 1.0]), 0.9),
+                [1.0, 0.0, 0.0],
+            )
+        with self.assertRaisesRegex(ValueError, "finite"):
+            self.filter.update_identity(
+                VonMisesFisherDistribution(array([0.0, 1.0]), 0.9),
+                [float("nan"), 0.0],
+            )
+        with self.assertRaisesRegex(ValueError, "unit vector"):
+            self.filter.update_identity(
+                VonMisesFisherDistribution(array([0.0, 1.0]), 0.9),
+                [2.0, 0.0],
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Pull request

## Summary

This PR replaces assertion-only checks in `VonMisesFisherFilter` with explicit `ValueError` validation and hardens validation behavior across backends.

Changes included:

- replaced assertion-only validation with explicit runtime checks
- validated state, system noise, measurement noise, dimensional compatibility, zonal noise, and finite unit-vector measurements
- avoided mutating the supplied measurement-noise distribution during updates
- fixed CI/backend compatibility by validating scalar `kappa` finiteness with Python `math.isfinite` after scalar conversion (avoids pytorch backend `isfinite` type errors on Python floats)

User-facing impact:

- invalid vMF filter inputs now fail early with clear errors, including under `python -O`
- valid behavior remains unchanged
- pytorch backend CI failures caused by scalar finiteness checking are resolved

Validation performed:

- `PYRECEST_BACKEND=numpy python -m pytest tests/filters/test_von_mises_fisher_filter.py -q` → `7 passed`
- `PYRECEST_BACKEND=numpy python -O -m pytest tests/filters/test_von_mises_fisher_filter.py -q` → `7 passed, 1 warning`
- `ruff check src/pyrecest/filters/von_mises_fisher_filter.py tests/filters/test_von_mises_fisher_filter.py` → passed
- GitHub Actions failing run inspected; failure was pytorch `isfinite` type mismatch on scalar `kappa`

## Checklist

- [x] Tests were added or updated.
- [ ] Backend limitations were documented or added to `src/pyrecest/_backend/capabilities.py`.
- [x] Shape, dtype, and measurement-set conventions were checked against `docs/conventions.md`.
- [x] New user-facing failures use clear messages or shared exceptions from `pyrecest.exceptions`.
- [ ] Public examples and docs were updated when relevant.
- [ ] Performance-sensitive changes were checked against `benchmarks/basic_regressions.py` or a focused benchmark.
- [ ] `python scripts/check_release_consistency.py --local-only` passes when release metadata changed.
- [ ] The package smoke path still works: `python -m build`, `twine check dist/*`, install wheel, run a basic example.