### PR TITLE
Accept scalar inputs in wrapped Cauchy distribution

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py
@@ -1,5 +1,17 @@
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import arctan2, array, cos, cosh, exp, mod, pi, sin, sinh, tanh
+from pyrecest.backend import (
+    arctan2,
+    array,
+    atleast_1d,
+    cos,
+    cosh,
+    exp,
+    mod,
+    pi,
+    sin,
+    sinh,
+    tanh,
+)
 
 from .abstract_circular_distribution import AbstractCircularDistribution
 
@@ -20,7 +32,7 @@ class WrappedCauchyDistribution(AbstractCircularDistribution):
         self.gamma = gamma
 
     def pdf(self, xs):
-        xs = array(xs)
+        xs = atleast_1d(array(xs))
         assert xs.ndim == 1
         xs_centered = mod(xs - self.mu, 2 * pi)
         return 1 / (2 * pi) * sinh(self.gamma) / (cosh(self.gamma) - cos(xs_centered))
@@ -39,7 +51,7 @@ class WrappedCauchyDistribution(AbstractCircularDistribution):
         def coth(x):
             return 1 / tanh(x)
 
-        xs = array(xs)
+        xs = atleast_1d(array(xs))
         assert xs.ndim == 1
 
         def primitive(angles):

--- a/tests/distributions/test_wrapped_cauchy_distribution.py
+++ b/tests/distributions/test_wrapped_cauchy_distribution.py
@@ -48,6 +48,12 @@ class WrappedCauchyDistributionTest(unittest.TestCase):
 
         npt.assert_allclose(dist.pdf(xs), dist.pdf(array(xs)))
 
+    def test_pdf_accepts_scalar_inputs(self):
+        dist = WrappedCauchyDistribution(self.mu, self.gamma)
+
+        npt.assert_allclose(dist.pdf(0.5), dist.pdf(array([0.5])))
+        npt.assert_allclose(dist.pdf(array(0.5)), dist.pdf(array([0.5])))
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
         reason="Not supported on this backend",
@@ -85,6 +91,18 @@ class WrappedCauchyDistributionTest(unittest.TestCase):
         xs = [0.5, 1.0, 2.0]
 
         npt.assert_allclose(dist.cdf(xs), dist.cdf(array(xs)), atol=1e-8)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
+    def test_cdf_accepts_scalar_inputs(self):
+        dist = WrappedCauchyDistribution(self.mu, self.gamma)
+
+        npt.assert_allclose(dist.cdf(0.5), dist.cdf(array([0.5])), atol=1e-8)
+        npt.assert_allclose(
+            dist.cdf(array(0.5)), dist.cdf(array([0.5])), atol=1e-8
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Normalize wrapped Cauchy `pdf` and `cdf` query points with `atleast_1d`
- Fix scalar Python and backend-array PDF/CDF inputs that previously raised `AssertionError`
- Add regression tests for scalar wrapped Cauchy PDF and CDF evaluations

## Tests
- `python -m pytest tests/distributions/test_wrapped_cauchy_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py tests/distributions/test_wrapped_cauchy_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py tests/distributions/test_wrapped_cauchy_distribution.py`
- `git diff --check`