### PR TITLE
Accept scalar and list Fourier PDF inputs

### DIFF
--- a/src/pyrecest/distributions/circle/circular_fourier_distribution.py
+++ b/src/pyrecest/distributions/circle/circular_fourier_distribution.py
@@ -128,6 +128,7 @@ class CircularFourierDistribution(AbstractCircularDistribution):
         return fdNew
 
     def pdf(self, xs):
+        xs = array(xs)
         assert xs.ndim <= 2, "xs should have at most 2 dimensions."
         xs = xs.reshape(-1, 1)
         a, b = self.get_a_b()

--- a/tests/distributions/test_circular_fourier_distribution.py
+++ b/tests/distributions/test_circular_fourier_distribution.py
@@ -89,6 +89,17 @@ class TestCircularFourierDistribution(unittest.TestCase):
         fd_real = fd.to_real_fd()
         npt.assert_array_almost_equal(dist.pdf(xs), fd_real.pdf(xs))
 
+    def test_pdf_accepts_scalar_and_list_inputs(self):
+        fd = CircularFourierDistribution(
+            c=array([1.0]),
+            n=1,
+            transformation="identity",
+            multiplied_by_n=False,
+        )
+
+        npt.assert_allclose(fd.pdf(0.5), fd.pdf(array([0.5])))
+        npt.assert_allclose(fd.pdf([0.5, 1.0]), fd.pdf(array([0.5, 1.0])))
+
     def test_even_number_of_grid_values_is_rejected(self):
         dist = VonMisesDistribution(2.5, 1.5)
 


### PR DESCRIPTION
## Summary
- Convert `CircularFourierDistribution.pdf` query points to backend arrays before dimensionality checks
- Fix scalar and list PDF inputs that previously failed before evaluation
- Add regression coverage comparing scalar/list inputs with equivalent backend arrays

## Tests
- `python -m pytest tests/distributions/test_circular_fourier_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/circle/circular_fourier_distribution.py tests/distributions/test_circular_fourier_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/circle/circular_fourier_distribution.py tests/distributions/test_circular_fourier_distribution.py`
- `git diff --check`