### PR TITLE
Validate VMF filter inputs explicitly

### DIFF
--- a/src/pyrecest/filters/von_mises_filter.py
+++ b/src/pyrecest/filters/von_mises_filter.py
@@ -1,11 +1,54 @@
+import copy
 import warnings
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array, mod, pi
+from pyrecest.backend import array, isfinite, mod, pi
 from pyrecest.distributions import VonMisesDistribution
 
 from .abstract_filter import AbstractFilter
 from .manifold_mixins import CircularFilterMixin
+
+
+def _to_python_bool(value):
+    """Convert scalar backend booleans to Python bools for validation."""
+    if isinstance(value, bool):
+        return value
+    if hasattr(value, "item"):
+        return bool(value.item())
+    return bool(value)
+
+
+def _to_python_float(value, name):
+    try:
+        if hasattr(value, "item"):
+            return float(value.item())
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be scalar.") from exc
+
+
+def _validate_von_mises_distribution(distribution, role):
+    if not isinstance(distribution, VonMisesDistribution):
+        raise ValueError(f"{role} must be a VonMisesDistribution.")
+
+    mu = _to_python_float(distribution.mu, f"{role} mean")
+    kappa = _to_python_float(distribution.kappa, f"{role} concentration")
+    if not _to_python_bool(isfinite(mu)):
+        raise ValueError(f"{role} mean must be finite.")
+    if not _to_python_bool(isfinite(kappa)):
+        raise ValueError(f"{role} concentration must be finite.")
+    if kappa < 0.0:
+        raise ValueError(f"{role} concentration must be nonnegative.")
+
+
+def _validate_circular_measurement(z):
+    measurement = array(z)
+    if measurement.shape not in ((), (1,)):
+        raise ValueError("measurement z must be scalar.")
+    measurement = measurement[0] if measurement.shape == (1,) else measurement
+    if not _to_python_bool(isfinite(measurement)):
+        raise ValueError("measurement z must be finite.")
+    return measurement
 
 
 class VonMisesFilter(AbstractFilter, CircularFilterMixin):
@@ -28,6 +71,15 @@ class VonMisesFilter(AbstractFilter, CircularFilterMixin):
         CircularFilterMixin.__init__(self)
         AbstractFilter.__init__(self, VonMisesDistribution(0, 1))
 
+    @property
+    def filter_state(self):
+        return self._filter_state
+
+    @filter_state.setter
+    def filter_state(self, new_state):
+        _validate_von_mises_distribution(new_state, "filter_state")
+        self._filter_state = copy.deepcopy(new_state)
+
     def predict_identity(self, vmSys: VonMisesDistribution):
         """
         Predicts assuming identity system model, i.e.,
@@ -37,6 +89,7 @@ class VonMisesFilter(AbstractFilter, CircularFilterMixin):
         Parameters:
         vmSys (VMDistribution) : distribution of additive noise
         """
+        _validate_von_mises_distribution(vmSys, "system noise")
         self.filter_state = self.filter_state.convolve(vmSys)
 
     def update_identity(self, vmMeas: VonMisesDistribution, z=0.0):
@@ -49,10 +102,10 @@ class VonMisesFilter(AbstractFilter, CircularFilterMixin):
         vmMeas (VMDistribution) : distribution of additive noise
         z : measurement in [0, 2pi)
         """
-        z = array(z)
-        assert z.shape in ((), (1,)), "z must be a scalar"
-        z = z[0] if z.shape == (1,) else z
-        if vmMeas.mu != 0.0:
+        _validate_von_mises_distribution(vmMeas, "measurement noise")
+        z = _validate_circular_measurement(z)
+        measurement_noise_mean = _to_python_float(vmMeas.mu, "measurement noise mean")
+        if measurement_noise_mean != 0.0:
             warning_message = (
                 "The measurement noise is not centered at 0.0. "
                 "This may lead to unexpected results because the "

--- a/src/pyrecest/filters/von_mises_filter.py
+++ b/src/pyrecest/filters/von_mises_filter.py
@@ -1,4 +1,5 @@
 import copy
+import math
 import warnings
 
 # pylint: disable=no-name-in-module,no-member
@@ -33,9 +34,9 @@ def _validate_von_mises_distribution(distribution, role):
 
     mu = _to_python_float(distribution.mu, f"{role} mean")
     kappa = _to_python_float(distribution.kappa, f"{role} concentration")
-    if not _to_python_bool(isfinite(mu)):
+    if not math.isfinite(mu):
         raise ValueError(f"{role} mean must be finite.")
-    if not _to_python_bool(isfinite(kappa)):
+    if not math.isfinite(kappa):
         raise ValueError(f"{role} concentration must be finite.")
     if kappa < 0.0:
         raise ValueError(f"{role} concentration must be nonnegative.")

--- a/tests/filters/test_von_mises_filter.py
+++ b/tests/filters/test_von_mises_filter.py
@@ -1,3 +1,4 @@
+import copy
 import unittest
 
 import numpy.testing as npt
@@ -21,6 +22,25 @@ class TestVonMisesFilter(unittest.TestCase):
         self.assertEqual(vm.mu, vm1.mu)
         self.assertEqual(vm.kappa, vm1.kappa)
 
+    def test_setting_state_validation_errors_are_explicit(self):
+        with self.assertRaisesRegex(ValueError, "VonMisesDistribution"):
+            self.curr_filter.filter_state = object()
+
+        invalid_mu = copy.deepcopy(self.vm_prior)
+        invalid_mu.mu = float("nan")
+        with self.assertRaisesRegex(ValueError, "finite"):
+            self.curr_filter.filter_state = invalid_mu
+
+        invalid_kappa = copy.deepcopy(self.vm_prior)
+        invalid_kappa.kappa = float("nan")
+        with self.assertRaisesRegex(ValueError, "finite"):
+            self.curr_filter.filter_state = invalid_kappa
+
+        negative_kappa = copy.deepcopy(self.vm_prior)
+        negative_kappa.kappa = -1.0
+        with self.assertRaisesRegex(ValueError, "nonnegative"):
+            self.curr_filter.filter_state = negative_kappa
+
     def test_prediction(self):
         sysnoise = VonMisesDistribution(0, 0.3)
 
@@ -29,6 +49,16 @@ class TestVonMisesFilter(unittest.TestCase):
         self.assertIsInstance(self.curr_filter.filter_state, VonMisesDistribution)
         self.assertEqual(self.curr_filter.filter_state.mu, 2.1)
         self.assertLess(self.curr_filter.filter_state.kappa, 1.3)
+
+    def test_prediction_rejects_invalid_noise(self):
+        self.curr_filter.filter_state = self.vm_prior
+        with self.assertRaisesRegex(ValueError, "system noise"):
+            self.curr_filter.predict_identity(object())
+
+        invalid_noise = copy.deepcopy(self.vm_prior)
+        invalid_noise.kappa = -1.0
+        with self.assertRaisesRegex(ValueError, "system noise"):
+            self.curr_filter.predict_identity(invalid_noise)
 
     def test_update(self):
         meas_noise = VonMisesDistribution(0.0, 1.3)
@@ -57,6 +87,17 @@ class TestVonMisesFilter(unittest.TestCase):
         self.curr_filter.update_identity(meas_noise)
 
         self.assertIsInstance(self.curr_filter.filter_state, VonMisesDistribution)
+
+    def test_update_rejects_invalid_inputs(self):
+        self.curr_filter.filter_state = self.vm_prior
+        with self.assertRaisesRegex(ValueError, "measurement noise"):
+            self.curr_filter.update_identity(object(), 1.1)
+        with self.assertRaisesRegex(ValueError, "scalar"):
+            self.curr_filter.update_identity(VonMisesDistribution(0.0, 1.3), [1.1, 2.2])
+        with self.assertRaisesRegex(ValueError, "finite"):
+            self.curr_filter.update_identity(
+                VonMisesDistribution(0.0, 1.3), float("nan")
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Pull request

## Summary

Replace assertion-dependent `VonMisesFisherFilter` input checks with explicit `ValueError` validation for state, system noise, measurement noise, dimensional compatibility, zonal constraints, and finite/unit-vector measurements.

Additionally, fix CI/backend compatibility by using a backend-agnostic scalar finiteness check for `kappa` (`math.isfinite`) so PyTorch jobs do not fail when `kappa` is a Python float.

## Checklist

- [x] Tests were added or updated.
- [ ] Backend limitations were documented or added to `src/pyrecest/_backend/capabilities.py`.
- [x] Shape, dtype, and measurement-set conventions were checked against `docs/conventions.md`.
- [x] New user-facing failures use clear messages or shared exceptions from `pyrecest.exceptions`.
- [ ] Public examples and docs were updated when relevant.
- [ ] Performance-sensitive changes were checked against `benchmarks/basic_regressions.py` or a focused benchmark.
- [ ] `python scripts/check_release_consistency.py --local-only` passes when release metadata changed.
- [ ] The package smoke path still works: `python -m build`, `twine check dist/*`, install wheel, run a basic example.