### PR TITLE
Accept list inputs in circular uniform CDF

### DIFF
--- a/src/pyrecest/distributions/circle/circular_uniform_distribution.py
+++ b/src/pyrecest/distributions/circle/circular_uniform_distribution.py
@@ -1,4 +1,4 @@
-from pyrecest.backend import pi, where
+from pyrecest.backend import array, pi, where
 
 from ..hypertorus.hypertoroidal_uniform_distribution import (
     HypertoroidalUniformDistribution,
@@ -41,6 +41,7 @@ class CircularUniformDistribution(
             cdf evaluated at columns of xa
         """
 
+        xa = array(xa)
         val = (xa - starting_point) / (2 * pi)
         val = where(val < 0, val + 1, val)
 

--- a/tests/distributions/test_circular_uniform_distribution.py
+++ b/tests/distributions/test_circular_uniform_distribution.py
@@ -36,6 +36,12 @@ class CircularUniformDistributionTest(unittest.TestCase):
         x = array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
         npt.assert_allclose(cu.cdf(x), cu.cdf_numerical(x))
 
+    def test_cdf_accepts_list_inputs(self):
+        cu = CircularUniformDistribution()
+        x = [1.0, 2.0, 3.0]
+
+        npt.assert_allclose(cu.cdf(x), cu.cdf(array(x)))
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
         reason="Not supported on this backend",


### PR DESCRIPTION
## Summary
- Convert circular uniform CDF query points to backend arrays before arithmetic
- Fix list-valued CDF inputs that previously raised `TypeError`
- Add regression coverage comparing list inputs with equivalent backend arrays

## Tests
- `python -m pytest tests/distributions/test_circular_uniform_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/circle/circular_uniform_distribution.py tests/distributions/test_circular_uniform_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/circle/circular_uniform_distribution.py tests/distributions/test_circular_uniform_distribution.py`
- `git diff --check`