### PR TITLE
Accept list inputs in von Mises distribution

### DIFF
--- a/src/pyrecest/distributions/circle/von_mises_distribution.py
+++ b/src/pyrecest/distributions/circle/von_mises_distribution.py
@@ -59,6 +59,7 @@ class VonMisesDistribution(AbstractCircularDistribution):
         return self._norm_const
 
     def pdf(self, xs):
+        xs = array(xs)
         p = exp(self.kappa * cos(xs - self.mu)) / self.norm_const
         return p
 
@@ -101,6 +102,7 @@ class VonMisesDistribution(AbstractCircularDistribution):
         val : (n)
             cdf evaluated at columns of xs
         """
+        xs = array(xs)
         assert xs.ndim <= 1
 
         r = zeros_like(xs)

--- a/tests/distributions/test_von_mises_distribution.py
+++ b/tests/distributions/test_von_mises_distribution.py
@@ -6,6 +6,7 @@ import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
+import pyrecest.backend
 from pyrecest.backend import abs, allclose, array, linspace
 from pyrecest.distributions import VonMisesDistribution
 
@@ -34,6 +35,23 @@ class TestVonMisesDistribution(unittest.TestCase):
                 ],
             ),
         )
+
+    def test_pdf_accepts_list_inputs(self):
+        dist = VonMisesDistribution(0.3, 1.2)
+        xs = [0.5, 1.0]
+
+        npt.assert_allclose(dist.pdf(xs), dist.pdf(array(xs)))
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
+    def test_cdf_accepts_scalar_and_list_inputs(self):
+        dist = VonMisesDistribution(0.3, 1.2)
+        xs = [0.5, 1.0]
+
+        npt.assert_allclose(dist.cdf(0.5), dist.cdf(array(0.5)))
+        npt.assert_allclose(dist.cdf(xs), dist.cdf(array(xs)))
 
     def test_uniform_trigonometric_moments(self):
         dist = VonMisesDistribution(2, 0)


### PR DESCRIPTION
## Summary
- Convert von Mises PDF and CDF query points to backend arrays before arithmetic and dimensionality checks
- Fix list-valued PDF/CDF inputs and scalar CDF inputs that previously failed before evaluation
- Add regression coverage comparing scalar/list inputs with equivalent backend arrays

## Tests
- `python -m pytest tests/distributions/test_von_mises_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/circle/von_mises_distribution.py tests/distributions/test_von_mises_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/circle/von_mises_distribution.py tests/distributions/test_von_mises_distribution.py`
- `git diff --check`