### PR TITLE
Accept scalar inputs in numerical circular CDFs

### DIFF
--- a/src/pyrecest/distributions/circle/abstract_circular_distribution.py
+++ b/src/pyrecest/distributions/circle/abstract_circular_distribution.py
@@ -1,7 +1,7 @@
 import matplotlib.pyplot as plt
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array, cos, linspace, log, mod, pi, sin
+from pyrecest.backend import array, atleast_1d, cos, linspace, log, mod, pi, sin
 
 from ..hypertorus.abstract_hypertoroidal_distribution import (
     AbstractHypertoroidalDistribution,
@@ -23,6 +23,7 @@ class AbstractCircularDistribution(AbstractHypertoroidalDistribution):
         Returns:
             : The computed CDF as a numpy array.
         """
+        xs = atleast_1d(array(xs))
         assert xs.ndim == 1, "xs must be a 1D array"
 
         return array([self._cdf_numerical_single(x, starting_point) for x in xs])

--- a/tests/distributions/test_abstract_circular_distribution.py
+++ b/tests/distributions/test_abstract_circular_distribution.py
@@ -43,6 +43,21 @@ class AbstractCircularDistributionTest(unittest.TestCase):
                 )
 
     @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
+    def test_cdf_numerical_accepts_scalar_and_list_inputs(self):
+        dist = WrappedNormalDistribution(array(0.3), array(0.8))
+        xs = [0.5, 1.0]
+
+        self.assertTrue(
+            allclose(dist.cdf_numerical(0.5), dist.cdf_numerical(array([0.5])))
+        )
+        self.assertTrue(
+            allclose(dist.cdf_numerical(xs), dist.cdf_numerical(array(xs)))
+        )
+
+    @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",
         reason="Not supported on jax backend",
     )


### PR DESCRIPTION
## Summary
- Normalize numerical circular CDF query points with `atleast_1d(array(...))`
- Fix scalar and list-valued `cdf_numerical` inputs that previously failed before integration
- Add regression coverage comparing scalar/list inputs with equivalent backend arrays

## Tests
- `python -m pytest tests/distributions/test_abstract_circular_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/circle/abstract_circular_distribution.py tests/distributions/test_abstract_circular_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/circle/abstract_circular_distribution.py tests/distributions/test_abstract_circular_distribution.py`
- `git diff --check`