### PR TITLE
Validate filter state assignments explicitly

### DIFF
--- a/src/pyrecest/filters/abstract_filter.py
+++ b/src/pyrecest/filters/abstract_filter.py
@@ -20,9 +20,16 @@ class AbstractFilter(ABC):
 
     @filter_state.setter
     def filter_state(self, new_state):
-        assert self._filter_state is None or isinstance(
-            new_state, type(self.filter_state)
-        ), "New distribution has to be of the same class as (or inherit from) the previous density."
+        if self._filter_state is not None and not isinstance(
+            new_state, type(self._filter_state)
+        ):
+            expected = type(self._filter_state).__name__
+            actual = type(new_state).__name__
+            raise ValueError(
+                "New distribution has to be of the same class as "
+                "(or inherit from) the previous density: "
+                f"expected {expected}, got {actual}."
+            )
         self._filter_state = copy.deepcopy(new_state)
 
     def get_point_estimate(self):

--- a/tests/test_history_recorder.py
+++ b/tests/test_history_recorder.py
@@ -104,6 +104,14 @@ class HistoryRecorderTest(unittest.TestCase):
             filter_obj.history["point_estimate"], array([[1.0, 3.0], [2.0, 4.0]])
         )
 
+    def test_filter_state_rejects_wrong_type_with_explicit_error(self):
+        filter_obj = _DummyFilter(_DummyBelief([1.0, 2.0]))
+
+        with self.assertRaisesRegex(ValueError, "expected _DummyBelief"):
+            filter_obj.filter_state = {"mean": [3.0, 4.0]}
+
+        npt.assert_array_equal(filter_obj.filter_state.mean(), array([1.0, 2.0]))
+
     def test_multitarget_tracker_logging_is_mirrored_in_history(self):
         tracker = _DummyMultitargetTracker()
         tracker.estimate = array([1.0, 2.0])


### PR DESCRIPTION
## Summary
- replace the assertion-only `AbstractFilter.filter_state` type guard with an explicit `ValueError`
- keep the previous filter state unchanged when an invalid replacement is rejected
- add a regression test for the shared filter-state setter

## Why
The previous assertion is skipped under optimized Python, which can let an invalid state object enter a filter and fail later in less obvious ways. The new guard preserves valid behavior while making invalid assignments fail consistently.

## Validation
- `python -m pytest tests/test_history_recorder.py -q` -> `6 passed`
- `python -O -m pytest tests/test_history_recorder.py -q` -> `6 passed, 1 warning`
- `python -m pytest tests/filters/test_wrapped_normal_filter.py tests/filters/test_toroidal_wrapped_normal_filter.py -q` -> `8 passed`
- `ruff check src/pyrecest/filters/abstract_filter.py tests/test_history_recorder.py` -> Passed