### PR TITLE
Accept list inputs in linear Dirac construction

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/linear_dirac_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/linear_dirac_distribution.py
@@ -14,6 +14,7 @@ from .abstract_linear_distribution import AbstractLinearDistribution
 
 class LinearDiracDistribution(AbstractDiracDistribution, AbstractLinearDistribution):
     def __init__(self, d, w=None):
+        d = asarray(d)
         dim = d.shape[1] if d.ndim > 1 else 1
         AbstractLinearDistribution.__init__(self, dim)
         AbstractDiracDistribution.__init__(self, d, w)

--- a/tests/distributions/test_linear_dirac_distribution.py
+++ b/tests/distributions/test_linear_dirac_distribution.py
@@ -19,6 +19,18 @@ from .test_abstract_dirac_distribution import TestAbstractDiracDistribution
 
 
 class LinearDiracDistributionTest(TestAbstractDiracDistribution):
+    def test_constructor_accepts_list_inputs(self):
+        one_dimensional = LinearDiracDistribution([1.0, 2.0, 3.0])
+        multidimensional = LinearDiracDistribution(
+            [[1.0, 2.0], [3.0, 4.0]], [0.25, 0.75]
+        )
+
+        self.assertEqual(one_dimensional.dim, 1)
+        npt.assert_allclose(one_dimensional.d, array([1.0, 2.0, 3.0]))
+        self.assertEqual(multidimensional.dim, 2)
+        npt.assert_allclose(multidimensional.d, array([[1.0, 2.0], [3.0, 4.0]]))
+        npt.assert_allclose(multidimensional.w, array([0.25, 0.75]))
+
     def test_from_distribution(self):
         random.seed(0)
         C = wishart.rvs(3, eye(3))


### PR DESCRIPTION
## Summary
- Convert linear Dirac sample locations to backend arrays before dimension inference
- Fix one-dimensional and multidimensional list-valued Dirac constructor inputs that previously raised `AttributeError`
- Add regression coverage for list-valued locations and weights

## Tests
- `python -m pytest tests/distributions/test_linear_dirac_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/nonperiodic/linear_dirac_distribution.py tests/distributions/test_linear_dirac_distribution.py`
- `python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/nonperiodic/linear_dirac_distribution.py`
- `python -m pylint --persistent=no --disable=import-error tests/distributions/test_linear_dirac_distribution.py`
- `git diff --check`