### PR TITLE
Validate toroidal wrapped normal inputs explicitly

### DIFF
--- a/src/pyrecest/filters/toroidal_wrapped_normal_filter.py
+++ b/src/pyrecest/filters/toroidal_wrapped_normal_filter.py
@@ -30,5 +30,8 @@ class ToroidalWrappedNormalFilter(AbstractFilter, ToroidalFilterMixin):
         )
 
     def predict_identity(self, twn_sys):
-        assert isinstance(twn_sys, ToroidalWrappedNormalDistribution)
+        if not isinstance(twn_sys, ToroidalWrappedNormalDistribution):
+            raise ValueError(
+                "twn_sys must be a ToroidalWrappedNormalDistribution."
+            )
         self.filter_state = self.filter_state.convolve(twn_sys)

--- a/tests/filters/test_toroidal_wrapped_normal_filter.py
+++ b/tests/filters/test_toroidal_wrapped_normal_filter.py
@@ -37,3 +37,13 @@ class ToroidalWrappedNormalFilterTest(unittest.TestCase):
             dist_result.mu, mod(self.twn.mu + self.twn.mu, 2 * pi)
         )
         npt.assert_array_almost_equal(dist_result.C, self.twn.C + self.twn.C)
+
+    def test_predict_identity_rejects_invalid_noise_explicitly(self):
+        curr_filter = ToroidalWrappedNormalFilter()
+        curr_filter.filter_state = self.twn
+
+        with self.assertRaisesRegex(ValueError, "ToroidalWrappedNormalDistribution"):
+            curr_filter.predict_identity(object())
+
+        npt.assert_array_almost_equal(curr_filter.filter_state.mu, self.twn.mu)
+        npt.assert_array_almost_equal(curr_filter.filter_state.C, self.twn.C)


### PR DESCRIPTION
## Summary
- replace the assertion-only toroidal wrapped-normal identity-prediction type check with an explicit `ValueError`
- add a regression test that invalid prediction noise leaves the prior state unchanged

## Why
The old assertion is skipped under optimized Python, so invalid system-noise objects could reach convolution and fail later with less clear errors. The new check keeps the valid prediction path unchanged while making invalid inputs fail consistently.

## Validation
- `python -m pytest tests/filters/test_toroidal_wrapped_normal_filter.py -q` -> `3 passed`
- `python -O -m pytest tests/filters/test_toroidal_wrapped_normal_filter.py -q` -> `3 passed, 1 warning`
- `ruff check src/pyrecest/filters/toroidal_wrapped_normal_filter.py tests/filters/test_toroidal_wrapped_normal_filter.py` -> Passed