### PR TITLE
Accept scalar inputs in wrapped PDFs

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
@@ -26,6 +26,7 @@ class WrappedExponentialDistribution(AbstractCircularDistribution):
         self._normalization_const = 1.0 / (1.0 - exp(-2.0 * pi * lambda_))
 
     def pdf(self, xs):
+        xs = asarray(xs)
         assert ndim(xs) <= 1
         xs = mod(xs, 2.0 * pi)
         return self.lambda_ * exp(-self.lambda_ * xs) * self._normalization_const

--- a/src/pyrecest/distributions/circle/wrapped_laplace_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_laplace_distribution.py
@@ -33,6 +33,7 @@ class WrappedLaplaceDistribution(AbstractCircularDistribution):
         )
 
     def pdf(self, xs):
+        xs = asarray(xs)
         assert ndim(xs) <= 1
         xs = mod(xs, 2.0 * pi)
         p = (

--- a/tests/distributions/test_wrapped_exponential_distribution.py
+++ b/tests/distributions/test_wrapped_exponential_distribution.py
@@ -34,6 +34,14 @@ class WrappedExponentialDistributionTest(unittest.TestCase):
         for x in [0.0, 1.0, 2.0, 3.0, 4.0]:
             npt.assert_allclose(self.we.pdf(array(x)), pdftemp(array(x)), rtol=5e-7)
 
+    def test_pdf_accepts_scalar_and_list_inputs(self):
+        npt.assert_allclose(self.we.pdf(1.0), self.we.pdf(array(1.0)), rtol=5e-7)
+        npt.assert_allclose(
+            self.we.pdf([0.0, 1.0, 2.0]),
+            self.we.pdf(array([0.0, 1.0, 2.0])),
+            rtol=5e-7,
+        )
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
         reason="Not supported on this backend",

--- a/tests/distributions/test_wrapped_laplace_distribution.py
+++ b/tests/distributions/test_wrapped_laplace_distribution.py
@@ -43,6 +43,14 @@ class WrappedLaplaceDistributionTest(unittest.TestCase):
         for x in [0.0, 1.0, 2.0, 3.0, 4.0]:
             npt.assert_allclose(self.wl.pdf(array(x)), pdftemp(array(x)), rtol=1e-6)
 
+    def test_pdf_accepts_scalar_and_list_inputs(self):
+        npt.assert_allclose(self.wl.pdf(1.0), self.wl.pdf(array(1.0)), rtol=1e-6)
+        npt.assert_allclose(
+            self.wl.pdf([0.0, 1.0, 2.0]),
+            self.wl.pdf(array([0.0, 1.0, 2.0])),
+            rtol=1e-6,
+        )
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
         reason="Not supported on this backend",


### PR DESCRIPTION
## Summary
- Normalize wrapped exponential and wrapped Laplace PDF query inputs before dimensionality checks
- Add regression coverage for Python scalar and list inputs

## Root cause
Both PDF methods called backend `ndim` on raw user input. Python scalars and lists do not expose `.ndim`, so otherwise valid query inputs raised `AttributeError` before the backend could coerce them.

## Validation
- `PYTHONPATH=src python -m pytest tests/distributions/test_wrapped_exponential_distribution.py tests/distributions/test_wrapped_laplace_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/circle/wrapped_exponential_distribution.py src/pyrecest/distributions/circle/wrapped_laplace_distribution.py tests/distributions/test_wrapped_exponential_distribution.py tests/distributions/test_wrapped_laplace_distribution.py`
- `PYTHONPATH=src python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/circle/wrapped_exponential_distribution.py src/pyrecest/distributions/circle/wrapped_laplace_distribution.py tests/distributions/test_wrapped_exponential_distribution.py tests/distributions/test_wrapped_laplace_distribution.py`
- `git diff --check`