### PR TITLE
Validate UKF backend support explicitly

### DIFF
--- a/src/pyrecest/filters/unscented_kalman_filter.py
+++ b/src/pyrecest/filters/unscented_kalman_filter.py
@@ -14,10 +14,11 @@ from .abstract_filter import AbstractFilter
 from .manifold_mixins import EuclideanFilterMixin
 
 
-def _assert_supported_backend():
-    assert (
-        pyrecest.backend.__backend_name__ != "pytorch"
-    ), "Not supported on this backend"
+def _validate_supported_backend():
+    if pyrecest.backend.__backend_name__ == "pytorch":
+        raise NotImplementedError(
+            "UnscentedKalmanFilter is not supported on the PyTorch backend."
+        )
 
 
 class UnscentedKalmanFilter(AbstractFilter, EuclideanFilterMixin):
@@ -96,13 +97,13 @@ class UnscentedKalmanFilter(AbstractFilter, EuclideanFilterMixin):
         :param fx: Function with signature fx(x, dt, **fx_args)
         :param sys_noise_cov: Process noise matrix Q
         """
-        _assert_supported_backend()
+        _validate_supported_backend()
         self._filter_state.Q = sys_noise_cov
         self._filter_state.predict(dt=dt, fx=fx, **fx_args)
         self._predicted = True
 
     def update_nonlinear(self, measurement, hx, cov_mat_meas, **hx_args):
-        _assert_supported_backend()
+        _validate_supported_backend()
         self._ensure_predicted()
         self._filter_state.update(z=measurement, hx=hx, R=cov_mat_meas, **hx_args)
         self._predicted = False
@@ -155,7 +156,7 @@ class UnscentedKalmanFilter(AbstractFilter, EuclideanFilterMixin):
         )
 
     def predict_identity(self, sys_noise_cov, dt=None):
-        _assert_supported_backend()
+        _validate_supported_backend()
         self._filter_state.Q = sys_noise_cov
 
         def fx(x, _):
@@ -165,7 +166,7 @@ class UnscentedKalmanFilter(AbstractFilter, EuclideanFilterMixin):
         self._predicted = True
 
     def predict_linear(self, system_matrix, sys_noise_cov, sys_input=None, dt=None):
-        _assert_supported_backend()
+        _validate_supported_backend()
         self._filter_state.Q = sys_noise_cov
 
         if sys_input is None:
@@ -197,7 +198,7 @@ class UnscentedKalmanFilter(AbstractFilter, EuclideanFilterMixin):
         keyword aliases, and legacy two-argument positional calls are detected
         when the argument shapes make the old order unambiguous.
         """
-        _assert_supported_backend()
+        _validate_supported_backend()
 
         if meas is not None or meas_cov is not None:
             if measurement is not None or meas_noise is not None:
@@ -232,7 +233,7 @@ class UnscentedKalmanFilter(AbstractFilter, EuclideanFilterMixin):
         self._predicted = False
 
     def update_linear(self, measurement, measurement_matrix, cov_mat_meas):
-        _assert_supported_backend()
+        _validate_supported_backend()
         self._ensure_predicted()
 
         def hx(x):

--- a/tests/filters/test_unscented_kalman_filter.py
+++ b/tests/filters/test_unscented_kalman_filter.py
@@ -1,5 +1,6 @@
 import copy
 import unittest
+from unittest.mock import patch
 
 import numpy.testing as npt
 
@@ -67,6 +68,19 @@ class UnscentedKalmanFilterTest(unittest.TestCase):
             kf._filter_state.update(  # pylint: disable=protected-access
                 z=array([1.0]), hx=hx
             )
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
+    def test_unsupported_pytorch_backend_raises_not_implemented(self):
+        kf = UnscentedKalmanFilter(
+            GaussianDistribution(array([0.0]), array([[1.0]]))
+        )
+
+        with patch.object(pyrecest.backend, "__backend_name__", "pytorch"):
+            with self.assertRaisesRegex(NotImplementedError, "PyTorch backend"):
+                kf.predict_identity(array([[1.0]]))
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),


### PR DESCRIPTION
## Summary
- replace the assertion-only Euclidean UKF PyTorch backend guard with an explicit `NotImplementedError`
- update all UKF prediction/update entry points to use the explicit guard
- add a regression test that simulates the PyTorch backend

## Why
The previous backend guard used `assert`, so optimized Python could skip the unsupported-backend check and let UKF execution proceed into unsupported code paths. The new guard preserves valid NumPy behavior while failing consistently for unsupported PyTorch execution.

## Validation
- `python -m pytest tests/filters/test_unscented_kalman_filter.py -q` -> `14 passed`
- `python -O -m pytest tests/filters/test_unscented_kalman_filter.py -q` -> `14 passed, 1 warning`
- `ruff check src/pyrecest/filters/unscented_kalman_filter.py tests/filters/test_unscented_kalman_filter.py` -> Passed