### PR TITLE
Accept scalar sine-skewed shifts

### DIFF
--- a/src/pyrecest/distributions/circle/sine_skewed_distributions.py
+++ b/src/pyrecest/distributions/circle/sine_skewed_distributions.py
@@ -17,6 +17,13 @@ def _validate_sine_power(value, name):
     return int(value)
 
 
+def _validate_scalar_angle(value):
+    angle = array(value)
+    if ndim(angle) != 0:
+        raise ValueError("angle must be a scalar")
+    return angle
+
+
 class GeneralizedKSineSkewedVonMisesDistribution(AbstractCircularDistribution):
     """
     See Bekker, A., Nakhaei Rad, N., Arashi, M., Ley, C. (2020). Generalized Skew-Symmetric Circular and
@@ -74,8 +81,7 @@ class GeneralizedKSineSkewedVonMisesDistribution(AbstractCircularDistribution):
         return norm_const * vm_pdf * skew_factor
 
     def shift(self, shift_by):
-        if ndim(shift_by) != 0:
-            raise ValueError("angle must be a scalar")
+        shift_by = _validate_scalar_angle(shift_by)
         new_dist = GeneralizedKSineSkewedVonMisesDistribution(
             self.mu + shift_by, self.kappa, self.lambda_, self.k, self.m
         )
@@ -109,8 +115,7 @@ class GSSVMDistribution(GeneralizedKSineSkewedVonMisesDistribution):
         return self.m
 
     def shift(self, shift_by):
-        if ndim(shift_by) != 0:
-            raise ValueError("angle must be a scalar")
+        shift_by = _validate_scalar_angle(shift_by)
         return GSSVMDistribution(self.mu + shift_by, self.kappa, self.lambda_, self.n)
 
 
@@ -258,8 +263,7 @@ class GeneralizedKSineSkewedWrappedCauchyDistribution(AbstractCircularDistributi
         return norm_const * wc_pdf_vals * skew_factor
 
     def shift(self, shift_by):
-        if ndim(shift_by) != 0:
-            raise ValueError("angle must be a scalar")
+        shift_by = _validate_scalar_angle(shift_by)
         return GeneralizedKSineSkewedWrappedCauchyDistribution(
             self.mu + shift_by, self.gamma, self.lambda_, self.k, self.m
         )

--- a/tests/distributions/test_sine_skewed_distributions.py
+++ b/tests/distributions/test_sine_skewed_distributions.py
@@ -5,6 +5,7 @@ import numpy.testing as npt
 import pyrecest.backend
 from pyrecest.backend import array, pi
 from pyrecest.distributions.circle.sine_skewed_distributions import (
+    GSSVMDistribution,
     GeneralizedKSineSkewedVonMisesDistribution,
     GeneralizedKSineSkewedWrappedCauchyDistribution,
     SineSkewedWrappedCauchyDistribution,
@@ -56,6 +57,30 @@ class TestGeneralizedKSineSkewedVonMisesDistribution(unittest.TestCase):
         self.assertEqual(
             new_dist.mu, pi / 2, "Shift method did not update mu correctly."
         )
+
+    def test_shift_accepts_python_scalar(self):
+        dist = GeneralizedKSineSkewedVonMisesDistribution(
+            mu=0, kappa=1, lambda_=0.5, k=1, m=1
+        )
+
+        new_dist = dist.shift(0.25)
+
+        npt.assert_allclose(float(new_dist.mu), 0.25, atol=1e-12)
+
+    def test_shift_rejects_non_scalar(self):
+        dist = GeneralizedKSineSkewedVonMisesDistribution(
+            mu=0, kappa=1, lambda_=0.5, k=1, m=1
+        )
+
+        with self.assertRaisesRegex(ValueError, "angle must be a scalar"):
+            dist.shift([0.25])
+
+    def test_gssvm_shift_accepts_python_scalar(self):
+        dist = GSSVMDistribution(mu=0, kappa=1, lambda_=0.5, n=1)
+
+        new_dist = dist.shift(0.25)
+
+        npt.assert_allclose(float(new_dist.mu), 0.25, atol=1e-12)
 
     @unittest.skipIf(
         # pylint: disable=no-member
@@ -249,6 +274,23 @@ class TestGeneralizedKSineSkewedWrappedCauchyDistribution(unittest.TestCase):
         new_dist = dist.shift(array(pi / 2))
 
         npt.assert_allclose(float(new_dist.mu), pi / 2, atol=1e-10)
+
+    def test_shift_accepts_python_scalar(self):
+        dist = GeneralizedKSineSkewedWrappedCauchyDistribution(
+            mu=0, gamma=0.5, lambda_=0.4, k=1, m=1
+        )
+
+        new_dist = dist.shift(0.25)
+
+        npt.assert_allclose(float(new_dist.mu), 0.25, atol=1e-12)
+
+    def test_shift_rejects_non_scalar(self):
+        dist = GeneralizedKSineSkewedWrappedCauchyDistribution(
+            mu=0, gamma=0.5, lambda_=0.4, k=1, m=1
+        )
+
+        with self.assertRaisesRegex(ValueError, "angle must be a scalar"):
+            dist.shift([0.25])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Coerce generalized sine-skewed shift angles before scalar validation
- Cover Python scalar shifts for GSSVM, generalized sine-skewed von Mises, and generalized sine-skewed wrapped Cauchy distributions
- Ensure non-scalar shift inputs raise the intended `ValueError` instead of leaking `AttributeError`

## Root cause
The affected `shift` methods called backend `ndim` directly on raw `shift_by` values. Python floats and lists do not provide `.ndim`, so ordinary scalar shifts raised `AttributeError` before validation could run.

## Validation
- `PYTHONPATH=src python -m pytest tests/distributions/test_sine_skewed_distributions.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/circle/sine_skewed_distributions.py tests/distributions/test_sine_skewed_distributions.py`
- `PYTHONPATH=src python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/circle/sine_skewed_distributions.py tests/distributions/test_sine_skewed_distributions.py`
- `git diff --check`