### PR TITLE
Validate dummy filter inputs explicitly

### DIFF
--- a/src/pyrecest/filters/abstract_dummy_filter.py
+++ b/src/pyrecest/filters/abstract_dummy_filter.py
@@ -24,7 +24,12 @@ class AbstractDummyFilter(AbstractFilter):
         pass
 
     def set_state(self, dist):
-        assert dist.dim == self.dim
+        if not hasattr(dist, "dim"):
+            raise ValueError("dist must expose a dim attribute.")
+        if dist.dim != self.dim:
+            raise ValueError(
+                f"dist must have dimension {self.dim}, got {dist.dim}."
+            )
         # Do nothing
 
     def predict_identity(self, noise_distribution):

--- a/src/pyrecest/filters/hyperspherical_dummy_filter.py
+++ b/src/pyrecest/filters/hyperspherical_dummy_filter.py
@@ -1,3 +1,5 @@
+from numbers import Integral
+
 from pyrecest.distributions.hypersphere_subset.hyperspherical_uniform_distribution import (
     HypersphericalUniformDistribution,
 )
@@ -19,7 +21,11 @@ class HypersphericalDummyFilter(AbstractDummyFilter, HypersphericalFilterMixin):
         Parameters:
             dim (int >= 2): Manifold dimension of the hypersphere (e.g. 2 for S^2).
         """
-        assert dim >= 2, "dim must be at least 2"
+        if isinstance(dim, bool) or not isinstance(dim, Integral):
+            raise ValueError("dim must be an integer at least 2.")
+        dim = int(dim)
+        if dim < 2:
+            raise ValueError("dim must be an integer at least 2.")
         HypersphericalFilterMixin.__init__(self)
         AbstractDummyFilter.__init__(self, HypersphericalUniformDistribution(dim))
 

--- a/src/pyrecest/filters/hypertoroidal_dummy_filter.py
+++ b/src/pyrecest/filters/hypertoroidal_dummy_filter.py
@@ -1,3 +1,5 @@
+from numbers import Integral
+
 from pyrecest.distributions.hypertorus.hypertoroidal_uniform_distribution import (
     HypertoroidalUniformDistribution,
 )
@@ -19,7 +21,11 @@ class HypertoroidalDummyFilter(AbstractDummyFilter, HypertoroidalFilterMixin):
         Parameters:
             dim (int >= 1): Manifold dimension of the hypertorus (e.g. 1 for T^1).
         """
-        assert dim >= 1, "dim must be at least 1"
+        if isinstance(dim, bool) or not isinstance(dim, Integral):
+            raise ValueError("dim must be an integer at least 1.")
+        dim = int(dim)
+        if dim < 1:
+            raise ValueError("dim must be an integer at least 1.")
         HypertoroidalFilterMixin.__init__(self)
         AbstractDummyFilter.__init__(self, HypertoroidalUniformDistribution(dim))
 

--- a/tests/filters/test_hyperspherical_dummy_filter.py
+++ b/tests/filters/test_hyperspherical_dummy_filter.py
@@ -22,9 +22,11 @@ class HypersphericalDummyFilterTest(unittest.TestCase):
     def test_dim_s3(self):
         self.assertEqual(self.filter_s3.dim, 3)
 
-    def test_assert_dim_too_small(self):
-        with self.assertRaises(AssertionError):
-            HypersphericalDummyFilter(1)
+    def test_invalid_dim_raises_explicit_error(self):
+        for invalid_dim in (1, 2.5, True):
+            with self.subTest(invalid_dim=invalid_dim):
+                with self.assertRaisesRegex(ValueError, "integer at least 2"):
+                    HypersphericalDummyFilter(invalid_dim)
 
     def test_filter_state_is_uniform(self):
         self.assertIsInstance(
@@ -74,6 +76,14 @@ class HypersphericalDummyFilterTest(unittest.TestCase):
         original_state = self.filter_s2.filter_state
         new_dist = HypersphericalUniformDistribution(2)
         self.filter_s2.set_state(new_dist)
+        self.assertIs(self.filter_s2.filter_state, original_state)
+
+    def test_set_state_rejects_invalid_dimension_explicitly(self):
+        original_state = self.filter_s2.filter_state
+
+        with self.assertRaisesRegex(ValueError, "dimension 2"):
+            self.filter_s2.set_state(HypersphericalUniformDistribution(3))
+
         self.assertIs(self.filter_s2.filter_state, original_state)
 
     def test_get_estimate_returns_distribution(self):

--- a/tests/filters/test_hypertoroidal_dummy_filter.py
+++ b/tests/filters/test_hypertoroidal_dummy_filter.py
@@ -22,9 +22,11 @@ class HypertoroidalDummyFilterTest(unittest.TestCase):
     def test_dim_t2(self):
         self.assertEqual(self.filter_t2.dim, 2)
 
-    def test_assert_dim_too_small(self):
-        with self.assertRaises(AssertionError):
-            HypertoroidalDummyFilter(0)
+    def test_invalid_dim_raises_explicit_error(self):
+        for invalid_dim in (0, 1.5, True):
+            with self.subTest(invalid_dim=invalid_dim):
+                with self.assertRaisesRegex(ValueError, "integer at least 1"):
+                    HypertoroidalDummyFilter(invalid_dim)
 
     def test_filter_state_is_uniform(self):
         self.assertIsInstance(
@@ -72,6 +74,14 @@ class HypertoroidalDummyFilterTest(unittest.TestCase):
         original_state = self.filter_t2.filter_state
         new_dist = HypertoroidalUniformDistribution(2)
         self.filter_t2.set_state(new_dist)
+        self.assertIs(self.filter_t2.filter_state, original_state)
+
+    def test_set_state_rejects_invalid_dimension_explicitly(self):
+        original_state = self.filter_t2.filter_state
+
+        with self.assertRaisesRegex(ValueError, "dimension 2"):
+            self.filter_t2.set_state(HypertoroidalUniformDistribution(1))
+
         self.assertIs(self.filter_t2.filter_state, original_state)
 
     def test_get_estimate_returns_distribution(self):


### PR DESCRIPTION
## Summary
- replace assertion-only dummy-filter `set_state` dimension checks with explicit `ValueError`s
- replace assertion-only hypertoroidal and hyperspherical dummy-filter constructor dimension checks with explicit integer validation
- add regression tests for invalid constructor dimensions and invalid `set_state` dimensions

## Why
Dummy filters intentionally ignore valid state updates, but assertion-only checks can be skipped under optimized Python. The new checks make invalid dimensions fail consistently before the no-op behavior can hide a bad input.

## Validation
- `python -m pytest tests/filters/test_hypertoroidal_dummy_filter.py tests/filters/test_hyperspherical_dummy_filter.py -q` -> `28 passed, 6 subtests passed`
- `python -O -m pytest tests/filters/test_hypertoroidal_dummy_filter.py tests/filters/test_hyperspherical_dummy_filter.py -q` -> `28 passed, 1 warning, 6 subtests passed`
- `ruff check src/pyrecest/filters/abstract_dummy_filter.py src/pyrecest/filters/hypertoroidal_dummy_filter.py src/pyrecest/filters/hyperspherical_dummy_filter.py tests/filters/test_hypertoroidal_dummy_filter.py tests/filters/test_hyperspherical_dummy_filter.py` -> Passed