### PR TITLE
Accept scalar hypertoroidal shifts

### DIFF
--- a/src/pyrecest/distributions/hypertorus/abstract_hypertoroidal_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/abstract_hypertoroidal_distribution.py
@@ -67,13 +67,12 @@ class AbstractHypertoroidalDistribution(AbstractPeriodicDistribution):
         :return: The shifted distribution.
         :rtype: CustomHypertoroidalDistribution
 
-        :raises AssertionError: If the shift vector is not of the same dimension as the distribution.
+        :raises ValueError: If the shift vector is not of the same dimension as the distribution.
         """
         from .custom_hypertoroidal_distribution import CustomHypertoroidalDistribution
+        from ._input_validation import as_shift_vector
 
-        assert shift_by.shape == (
-            self.dim,
-        ), "Shift vector must be of the same dimension as the distribution."
+        shift_by = as_shift_vector(shift_by, self.dim)
 
         # Define the shifted PDF. A positive shift moves mass forward on the
         # hypertorus, hence the shifted density evaluates the original density

--- a/tests/distributions/test_custom_hypertoroidal_distribution.py
+++ b/tests/distributions/test_custom_hypertoroidal_distribution.py
@@ -3,7 +3,7 @@ import unittest
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array
+from pyrecest.backend import array, cos
 from pyrecest.distributions import (
     CustomHypertoroidalDistribution,
     CustomToroidalDistribution,
@@ -35,6 +35,28 @@ class CustomHypertoroidalDistributionTest(unittest.TestCase):
     def test_constructor_rejects_wrong_shift_shape(self):
         with self.assertRaisesRegex(ValueError, "shift_by"):
             CustomHypertoroidalDistribution(lambda xs: xs, 2, shift_by=[0.1])
+
+    def test_shift_accepts_scalar_for_one_dimension(self):
+        dist = CustomHypertoroidalDistribution(cos, 1)
+
+        shifted = dist.shift(0.1)
+
+        npt.assert_allclose(shifted.pdf(array([0.3])), dist.pdf(array([0.2])))
+
+    def test_shift_accepts_list_vector(self):
+        dist = CustomHypertoroidalDistribution(lambda xs: xs[:, 0] + xs[:, 1], 2)
+
+        shifted = dist.shift([0.1, 0.2])
+
+        npt.assert_allclose(
+            shifted.pdf(array([[0.4, 0.6]])), dist.pdf(array([[0.3, 0.4]]))
+        )
+
+    def test_shift_rejects_wrong_shape(self):
+        dist = CustomHypertoroidalDistribution(lambda xs: xs[:, 0], 2)
+
+        with self.assertRaisesRegex(ValueError, "shift_by"):
+            dist.shift([0.1])
 
     def test_to_custom_circular_preserves_scale_and_shift(self):
         dist = CustomHypertoroidalDistribution(


### PR DESCRIPTION
## Summary
- Normalize inherited hypertoroidal `shift_by` inputs with the existing shift-vector helper
- Allow one-dimensional scalar shifts and list vector shifts for distributions using the default hypertoroidal `shift`
- Add regression coverage through `CustomHypertoroidalDistribution`

## Root cause
`AbstractHypertoroidalDistribution.shift` read `shift_by.shape` directly. Python floats and lists do not expose `.shape`, so valid public inputs failed with `AttributeError` before shape validation could run.

## Validation
- `PYTHONPATH=src python -m pytest tests/distributions/test_custom_hypertoroidal_distribution.py tests/distributions/test_abstract_hypertoroidal_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/hypertorus/abstract_hypertoroidal_distribution.py tests/distributions/test_custom_hypertoroidal_distribution.py`
- `PYTHONPATH=src python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/hypertorus/abstract_hypertoroidal_distribution.py tests/distributions/test_custom_hypertoroidal_distribution.py`
- `git diff --check`