### PR TITLE
Accept list starting points in linear modes

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/abstract_linear_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/abstract_linear_distribution.py
@@ -20,7 +20,6 @@ from pyrecest.backend import (
     int64,
     linspace,
     meshgrid,
-    ndim,
     ones,
     random,
     reshape,
@@ -83,10 +82,14 @@ class AbstractLinearDistribution(AbstractManifoldSpecificDistribution):
         def neg_pdf(x):
             return -self.pdf(x)
 
-        assert ndim(starting_point) <= 1, "Starting point must be a 1D array"
-        starting_point = atleast_1d(
-            starting_point
-        )  # Avoid numpy warning "DeprecationWarning: Use of `minimize` with `x0.ndim != 1` is deprecated"
+        starting_point = atleast_1d(array(starting_point))
+        if starting_point.ndim != 1:
+            raise ValueError("Starting point must be a 1D array")
+        if starting_point.shape[0] != self.dim:
+            raise ValueError(
+                f"Starting point must have dimension {self.dim}, "
+                f"got {starting_point.shape[0]}"
+            )
 
         result = minimize(neg_pdf, starting_point, method="L-BFGS-B")
         return result.x

--- a/tests/distributions/test_abstract_linear_distribution.py
+++ b/tests/distributions/test_abstract_linear_distribution.py
@@ -84,6 +84,36 @@ class TestAbstractLinearDistribution(unittest.TestCase):
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
         reason="Not supported on this backend",
     )
+    def test_mode_numerical_accepts_scalar_starting_point_for_1d(self):
+        g = GaussianDistribution(array([1.0]), array([[0.7]]))
+
+        npt.assert_allclose(g.mode_numerical(0.0), array([1.0]), atol=2e-4)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
+    def test_mode_numerical_accepts_list_starting_point(self):
+        mu = array([5.0, 10.0])
+        C = array([[2.0, 1.0], [1.0, 1.0]])
+        g = GaussianDistribution(mu, C)
+
+        npt.assert_allclose(g.mode_numerical([5.0, 10.0]), mu, atol=2e-4)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
+    def test_mode_numerical_rejects_non_vector_starting_point(self):
+        g = GaussianDistribution(array([1.0, 2.0]), array([[1.0, 0.0], [0.0, 1.0]]))
+
+        with self.assertRaisesRegex(ValueError, "1D array"):
+            g.mode_numerical([[1.0, 2.0]])
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
     def test_mode_numerical_gaussian_3D(self):
         npt.assert_allclose(self.g_3D.mode_numerical(), self.mu_3D, atol=5e-4)
 


### PR DESCRIPTION
## Summary
- Normalize `mode_numerical` starting points before dimensionality checks
- Accept Python scalar starting points for one-dimensional linear distributions and Python list vectors for multidimensional modes
- Add explicit malformed-starting-point validation and regression coverage

## Root cause
`AbstractLinearDistribution.mode_numerical` called backend `ndim` on raw `starting_point` inputs. Python floats and lists do not expose `.ndim`, so valid public inputs raised `AttributeError` before `scipy.optimize.minimize` could run.

## Validation
- `PYTHONPATH=src python -m pytest tests/distributions/test_abstract_linear_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/nonperiodic/abstract_linear_distribution.py tests/distributions/test_abstract_linear_distribution.py`
- `PYTHONPATH=src python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/nonperiodic/abstract_linear_distribution.py tests/distributions/test_abstract_linear_distribution.py`
- `git diff --check`