### PR TITLE
Validate grid filter likelihood shapes explicitly

### DIFF
--- a/src/pyrecest/filters/abstract_grid_filter.py
+++ b/src/pyrecest/filters/abstract_grid_filter.py
@@ -1,6 +1,7 @@
 import warnings
 
 from beartype import beartype
+from pyrecest.backend import array, ones_like
 from pyrecest.distributions.abstract_grid_distribution import AbstractGridDistribution
 from pyrecest.distributions.abstract_manifold_specific_distribution import (
     AbstractManifoldSpecificDistribution,
@@ -33,18 +34,22 @@ class AbstractGridFilter(AbstractFilter):
                 self.filter_state.enforce_pdf_nonnegative,
             )
         elif self.filter_state.grid_values.shape != new_state.grid_values.shape:
-            warnings.warn(
-                "New grid has a different number of grid points.", RuntimeWarning
-            )
+            warnings.warn("New grid has a different number of grid points.", RuntimeWarning)
 
         self._filter_state = new_state
 
-    def update_nonlinear(self, likelihood, z):
-        grid_vals_new = self.filter_state.grid_values * likelihood(
-            z, self.filter_state.get_grid()
-        )
-        assert grid_vals_new.shape == self.filter_state.grid_values.shape
+    def _grid_likelihood_values(self, likelihood, z):
+        likelihood_values = array(likelihood(z, self.filter_state.get_grid()))
+        expected_shape = self.filter_state.grid_values.shape
+        if likelihood_values.shape == ():
+            return ones_like(self.filter_state.grid_values) * likelihood_values
+        if likelihood_values.shape != expected_shape:
+            raise ValueError(f"likelihood must return a scalar or one value per grid point with shape {expected_shape}, got {likelihood_values.shape}.")
+        return likelihood_values
 
+    def update_nonlinear(self, likelihood, z):
+        likelihood_values = self._grid_likelihood_values(likelihood, z)
+        grid_vals_new = self.filter_state.grid_values * likelihood_values
         self.filter_state.grid_values = grid_vals_new
         self.filter_state.normalize_in_place(warn_unnorm=False)
 
@@ -68,15 +73,10 @@ class AbstractGridFilter(AbstractFilter):
         """
         if hasattr(measurement_model, "likelihood_values"):
             likelihood = measurement_model.likelihood_values
-        elif hasattr(measurement_model, "likelihood") and callable(
-            measurement_model.likelihood
-        ):
+        elif hasattr(measurement_model, "likelihood") and callable(measurement_model.likelihood):
             likelihood = measurement_model.likelihood
         else:
-            raise TypeError(
-                "measurement_model must expose likelihood_values(z, grid) "
-                "or a callable likelihood(z, grid) attribute."
-            )
+            raise TypeError("measurement_model must expose likelihood_values(z, grid) or a callable likelihood(z, grid) attribute.")
         self.update_nonlinear(likelihood, z)
 
     def predict_model(self, transition_model):
@@ -96,24 +96,16 @@ class AbstractGridFilter(AbstractFilter):
         filter does not expose ``predict_nonlinear_via_transition_density``, a
         clear ``NotImplementedError`` is raised.
         """
-        predict_via_density = getattr(
-            self, "predict_nonlinear_via_transition_density", None
-        )
+        predict_via_density = getattr(self, "predict_nonlinear_via_transition_density", None)
         if not callable(predict_via_density):
-            raise NotImplementedError(
-                f"{type(self).__name__} does not implement "
-                "predict_nonlinear_via_transition_density."
-            )
+            raise NotImplementedError(f"{type(self).__name__} does not implement predict_nonlinear_via_transition_density.")
 
         if hasattr(transition_model, "transition_density_for_filter"):
             transition_density = transition_model.transition_density_for_filter(self)
         elif hasattr(transition_model, "transition_density"):
             transition_density = transition_model.transition_density
         else:
-            raise TypeError(
-                "transition_model must expose transition_density_for_filter(filter) "
-                "or a transition_density attribute."
-            )
+            raise TypeError("transition_model must expose transition_density_for_filter(filter) or a transition_density attribute.")
         predict_via_density(transition_density)  # pylint: disable=not-callable
 
     def plot_filter_state(self):

--- a/tests/filters/test_grid_filter_model_adapters.py
+++ b/tests/filters/test_grid_filter_model_adapters.py
@@ -2,7 +2,7 @@ import unittest
 import warnings
 
 import pyrecest.backend
-from pyrecest.backend import allclose, array
+from pyrecest.backend import allclose, array, ones
 from pyrecest.distributions import HyperhemisphericalWatsonDistribution
 from pyrecest.distributions.hypersphere_subset.watson_distribution import (
     WatsonDistribution,
@@ -21,9 +21,7 @@ class TestGridFilterModelAdapters(unittest.TestCase):
     def setUp(self):
         self.n_grid = 50
         self.dim = 2
-        self.initial_distribution = HyperhemisphericalWatsonDistribution(
-            array([0.0, 0.0, 1.0]), 5.0
-        )
+        self.initial_distribution = HyperhemisphericalWatsonDistribution(array([0.0, 0.0, 1.0]), 5.0)
         self.measurement = array([0.0, 0.0, 1.0])
         self.system_noise = WatsonDistribution(array([0.0, 0.0, 1.0]), 3.0)
 
@@ -46,9 +44,7 @@ class TestGridFilterModelAdapters(unittest.TestCase):
             return HyperhemisphericalWatsonDistribution(measurement, 2.0).pdf(grid)
 
         reference_filter.update_nonlinear(likelihood, self.measurement)
-        model_filter.update_model(
-            GridLikelihoodMeasurementModel(likelihood), self.measurement
-        )
+        model_filter.update_model(GridLikelihoodMeasurementModel(likelihood), self.measurement)
 
         self.assertTrue(
             bool(
@@ -63,14 +59,39 @@ class TestGridFilterModelAdapters(unittest.TestCase):
         pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
         reason="Not supported on JAX backend",
     )
+    def test_update_nonlinear_accepts_scalar_likelihood(self):
+        filter_instance = self._initialized_filter()
+        expected_grid_values = array(filter_instance.filter_state.grid_values)
+
+        filter_instance.update_nonlinear(lambda _measurement, _grid: 1.0, self.measurement)
+
+        self.assertTrue(bool(allclose(filter_instance.filter_state.grid_values, expected_grid_values)))
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on JAX backend",
+    )
+    def test_update_nonlinear_rejects_wrong_likelihood_shape(self):
+        filter_instance = self._initialized_filter()
+        original_grid_values = array(filter_instance.filter_state.grid_values)
+        bad_likelihood_values = ones((filter_instance.filter_state.grid_values.shape[0], 1))
+
+        with self.assertRaisesRegex(ValueError, "one value per grid point"):
+            filter_instance.update_nonlinear(
+                lambda _measurement, _grid: bad_likelihood_values,
+                self.measurement,
+            )
+
+        self.assertTrue(bool(allclose(filter_instance.filter_state.grid_values, original_grid_values)))
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on JAX backend",
+    )
     def test_predict_model_matches_transition_density_prediction(self):
         reference_filter = self._initialized_filter()
         model_filter = self._initialized_filter()
-        transition_density = (
-            HyperhemisphericalGridFilter.sys_noise_to_transition_density(
-                self.system_noise, self.n_grid
-            )
-        )
+        transition_density = HyperhemisphericalGridFilter.sys_noise_to_transition_density(self.system_noise, self.n_grid)
 
         reference_filter.predict_nonlinear_via_transition_density(transition_density)
         model_filter.predict_model(GridTransitionDensityModel(transition_density))
@@ -92,11 +113,7 @@ class TestGridFilterModelAdapters(unittest.TestCase):
         reference_filter = self._initialized_filter()
         model_filter = self._initialized_filter()
 
-        transition_density = (
-            HyperhemisphericalGridFilter.sys_noise_to_transition_density(
-                self.system_noise, self.n_grid
-            )
-        )
+        transition_density = HyperhemisphericalGridFilter.sys_noise_to_transition_density(self.system_noise, self.n_grid)
         reference_filter.predict_nonlinear_via_transition_density(transition_density)
 
         def transition_density_factory(filter_instance):
@@ -105,9 +122,7 @@ class TestGridFilterModelAdapters(unittest.TestCase):
                 filter_instance.filter_state.grid_values.shape[0],
             )
 
-        model_filter.predict_model(
-            GridTransitionDensityFactoryModel(transition_density_factory)
-        )
+        model_filter.predict_model(GridTransitionDensityFactoryModel(transition_density_factory))
 
         self.assertTrue(
             bool(


### PR DESCRIPTION
## Summary
- replace the post-multiplication grid likelihood shape assertion with explicit validation
- allow scalar likelihoods by expanding them across the current grid
- add regression coverage for scalar likelihoods and wrong-shaped likelihood outputs, including optimized Python behavior

## Validation
- `..\.poetry-2.4.1\Scripts\python.exe -m poetry run python -m pytest tests/filters/test_grid_filter_model_adapters.py -q`
- `..\.poetry-2.4.1\Scripts\python.exe -m poetry run python -O -m pytest tests/filters/test_grid_filter_model_adapters.py -q`
- `..\.poetry-2.4.1\Scripts\python.exe -m poetry run ruff check src/pyrecest/filters/abstract_grid_filter.py tests/filters/test_grid_filter_model_adapters.py`
- `..\.poetry-2.4.1\Scripts\python.exe -m poetry run ruff format --check src/pyrecest/filters/abstract_grid_filter.py tests/filters/test_grid_filter_model_adapters.py`
- `git diff --check`