### PR TITLE
Accept list inputs in hypercylindrical Dirac construction

### DIFF
--- a/src/pyrecest/distributions/cart_prod/hypercylindrical_dirac_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/hypercylindrical_dirac_distribution.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import column_stack, cos, int32, int64, pi, sin
+from pyrecest.backend import asarray, column_stack, cos, int32, int64, pi, sin
 
 from ..hypertorus.hypertoroidal_dirac_distribution import HypertoroidalDiracDistribution
 from ..nonperiodic.linear_dirac_distribution import LinearDiracDistribution
@@ -18,6 +18,7 @@ class HypercylindricalDiracDistribution(
     LinBoundedCartProdDiracDistribution, AbstractHypercylindricalDistribution
 ):
     def __init__(self, bound_dim: Union[int, int32, int64], d, w=None):
+        d = asarray(d)
         AbstractHypercylindricalDistribution.__init__(
             self, bound_dim, d.shape[-1] - bound_dim
         )

--- a/tests/distributions/test_hypercylindrical_dirac_distribution.py
+++ b/tests/distributions/test_hypercylindrical_dirac_distribution.py
@@ -55,6 +55,16 @@ class TestHypercylindricalDiracDistribution(TestAbstractDiracDistribution):
         clin = self.pwd.linear_covariance()
         assert clin.shape == (self.pwd.lin_dim, self.pwd.lin_dim)
 
+    def test_constructor_accepts_list_inputs(self):
+        dist = HypercylindricalDiracDistribution(
+            1, [[0.1, 1.0], [0.2, 2.0]], [0.25, 0.75]
+        )
+
+        npt.assert_allclose(dist.d, array([[0.1, 1.0], [0.2, 2.0]]))
+        npt.assert_allclose(dist.w, array([0.25, 0.75]))
+        self.assertEqual(dist.bound_dim, 1)
+        self.assertEqual(dist.lin_dim, 1)
+
     def test_apply_function_identity(self):
         same = self.pwd.apply_function(lambda x: x)
         npt.assert_array_equal(self.pwd.d, same.d)


### PR DESCRIPTION
## Summary
- Coerce hypercylindrical Dirac particles before deriving linear dimension
- Add regression coverage for list-valued particles and list weights

## Root cause
`HypercylindricalDiracDistribution.__init__` read `d.shape` before `AbstractDiracDistribution` converted `d` to a backend array. Python list inputs therefore raised `AttributeError` even though the base Dirac constructor accepts array-like particles and weights.

## Validation
- `PYTHONPATH=src python -m pytest tests/distributions/test_hypercylindrical_dirac_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/cart_prod/hypercylindrical_dirac_distribution.py tests/distributions/test_hypercylindrical_dirac_distribution.py`
- `PYTHONPATH=src python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/cart_prod/hypercylindrical_dirac_distribution.py tests/distributions/test_hypercylindrical_dirac_distribution.py`
- `git diff --check`