### PR TITLE
Validate wrapped Cauchy inputs explicitly

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py
@@ -1,11 +1,13 @@
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all,
     arctan2,
     array,
     atleast_1d,
     cos,
     cosh,
     exp,
+    isfinite,
     mod,
     pi,
     sin,
@@ -14,6 +16,24 @@ from pyrecest.backend import (
 )
 
 from .abstract_circular_distribution import AbstractCircularDistribution
+
+
+def _validate_positive_scalar(value, name):
+    value = array(value)
+    if value.shape not in ((), (1,)):
+        raise ValueError(f"{name} must be a positive scalar.")
+    if not bool(all(isfinite(value))):
+        raise ValueError(f"{name} must be finite.")
+    if not bool(all(value > 0.0)):
+        raise ValueError(f"{name} must be positive.")
+    return value
+
+
+def _as_1d_input(xs):
+    xs = atleast_1d(array(xs))
+    if xs.ndim != 1:
+        raise ValueError("xs must be a one-dimensional array.")
+    return xs
 
 
 class WrappedCauchyDistribution(AbstractCircularDistribution):
@@ -28,12 +48,10 @@ class WrappedCauchyDistribution(AbstractCircularDistribution):
     def __init__(self, mu, gamma):
         AbstractCircularDistribution.__init__(self)
         self.mu = mod(mu, 2 * pi)
-        assert gamma > 0
-        self.gamma = gamma
+        self.gamma = _validate_positive_scalar(gamma, "gamma")
 
     def pdf(self, xs):
-        xs = atleast_1d(array(xs))
-        assert xs.ndim == 1
+        xs = _as_1d_input(xs)
         xs_centered = mod(xs - self.mu, 2 * pi)
         return 1 / (2 * pi) * sinh(self.gamma) / (cosh(self.gamma) - cos(xs_centered))
 
@@ -51,17 +69,13 @@ class WrappedCauchyDistribution(AbstractCircularDistribution):
         def coth(x):
             return 1 / tanh(x)
 
-        xs = atleast_1d(array(xs))
-        assert xs.ndim == 1
+        xs = _as_1d_input(xs)
 
         def primitive(angles):
             angles = array(angles)
             angles_centered = mod(angles - self.mu, 2.0 * pi)
             half_angles = angles_centered / 2.0
-            return (
-                arctan2(coth(self.gamma / 2.0) * sin(half_angles), cos(half_angles))
-                / pi
-            )
+            return arctan2(coth(self.gamma / 2.0) * sin(half_angles), cos(half_angles)) / pi
 
         return mod(primitive(xs) - primitive(starting_point), 1.0)
 

--- a/tests/distributions/test_wrapped_cauchy_distribution.py
+++ b/tests/distributions/test_wrapped_cauchy_distribution.py
@@ -30,13 +30,9 @@ class WrappedCauchyDistributionTest(unittest.TestCase):
                 summation += gamma / (pi * (gamma**2 + (x - mu + 2.0 * pi * k) ** 2))
             return summation
 
-        custom_wrapped = CustomCircularDistribution(
-            lambda xs: array([pdf_wrapped(x, self.mu, self.gamma) for x in xs])
-        )
+        custom_wrapped = CustomCircularDistribution(lambda xs: array([pdf_wrapped(x, self.mu, self.gamma) for x in xs]))
 
-        npt.assert_allclose(
-            dist.pdf(xs=self.xs), custom_wrapped.pdf(xs=self.xs), atol=0.0001
-        )
+        npt.assert_allclose(dist.pdf(xs=self.xs), custom_wrapped.pdf(xs=self.xs), atol=0.0001)
 
     def test_pdf_mode_for_nonzero_mean(self):
         dist = WrappedCauchyDistribution(array(1.0), array(0.5))
@@ -53,6 +49,24 @@ class WrappedCauchyDistributionTest(unittest.TestCase):
 
         npt.assert_allclose(dist.pdf(0.5), dist.pdf(array([0.5])))
         npt.assert_allclose(dist.pdf(array(0.5)), dist.pdf(array([0.5])))
+
+    def test_rejects_invalid_gamma(self):
+        for gamma in (0.0, -0.5, float("inf"), array([0.5, 1.0])):
+            with self.subTest(gamma=gamma):
+                with self.assertRaisesRegex(ValueError, "gamma"):
+                    WrappedCauchyDistribution(self.mu, gamma)
+
+    def test_pdf_rejects_matrix_inputs(self):
+        dist = WrappedCauchyDistribution(self.mu, self.gamma)
+
+        with self.assertRaisesRegex(ValueError, "one-dimensional"):
+            dist.pdf(array([[0.1, 0.2]]))
+
+    def test_cdf_rejects_matrix_inputs(self):
+        dist = WrappedCauchyDistribution(self.mu, self.gamma)
+
+        with self.assertRaisesRegex(ValueError, "one-dimensional"):
+            dist.cdf(array([[0.1, 0.2]]))
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),


### PR DESCRIPTION
## Summary
- replace assertion-based WrappedCauchyDistribution gamma validation with explicit ValueError checks
- replace assertion-based pdf/cdf input-rank checks with explicit one-dimensional input validation
- add regression coverage for invalid concentration parameters and matrix-valued pdf/cdf inputs

## Validation
- `..\.poetry-2.4.1\Scripts\python.exe -m poetry run python -m pytest tests/distributions/test_wrapped_cauchy_distribution.py -q`
- `..\.poetry-2.4.1\Scripts\python.exe -m poetry run python -O -m pytest tests/distributions/test_wrapped_cauchy_distribution.py -q`
- `..\.poetry-2.4.1\Scripts\python.exe -m poetry run python -m pytest tests/distributions/test_sine_skewed_distributions.py -q`
- `..\.poetry-2.4.1\Scripts\python.exe -m poetry run python -O -m pytest tests/distributions/test_sine_skewed_distributions.py -q`
- `..\.poetry-2.4.1\Scripts\python.exe -m poetry run ruff check src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py tests/distributions/test_wrapped_cauchy_distribution.py`
- `..\.poetry-2.4.1\Scripts\python.exe -m poetry run ruff format --check src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py tests/distributions/test_wrapped_cauchy_distribution.py`
- `git diff --check`