### PR TITLE
Accept list inputs in SE3 Dirac construction

### DIFF
--- a/src/pyrecest/distributions/cart_prod/lin_hypersphere_cart_prod_dirac_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/lin_hypersphere_cart_prod_dirac_distribution.py
@@ -1,5 +1,5 @@
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
-from pyrecest.backend import abs, amax, linalg
+from pyrecest.backend import abs, amax, asarray, linalg
 
 from ..abstract_se3_distribution import AbstractSE3Distribution
 from .lin_bounded_cart_prod_dirac_distribution import (
@@ -11,6 +11,7 @@ class LinHypersphereCartProdDiracDistribution(
     LinBoundedCartProdDiracDistribution, AbstractSE3Distribution
 ):
     def __init__(self, bound_dim, d, w=None):
+        d = asarray(d)
         assert (
             amax(abs(linalg.norm(d[:, : (bound_dim + 1)], None, -1) - 1), 0) < 1e-5
         ), "The hypersphere ssubset part of d must be normalized"

--- a/tests/distributions/test_se3_dirac_distribution.py
+++ b/tests/distributions/test_se3_dirac_distribution.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy as np
+import numpy.testing as npt
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 # pylint: disable=no-name-in-module,no-member
@@ -30,6 +31,19 @@ class SE3DiracDistributionTest(unittest.TestCase):
         w = array([1.0, 2.0, 3.0, 1.0, 2.0, 3.0])
         w = w / sum(w)
         SE3DiracDistribution(concatenate((dSph, dLin), axis=-1), w)
+
+    def test_constructor_accepts_list_inputs(self):
+        particles = [
+            [1.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0],
+            [0.0, 1.0, 0.0, 0.0, 4.0, 5.0, 6.0],
+        ]
+        weights = [0.25, 0.75]
+
+        dist = SE3DiracDistribution(particles, weights)
+
+        npt.assert_allclose(dist.d, array(particles))
+        npt.assert_allclose(dist.w, array(weights))
+        self.assertEqual(dist.d.shape, (2, 7))
 
     def test_from_distribution(self):
         cpsd = SE3CartProdStackedDistribution(


### PR DESCRIPTION
## Summary
- Coerce SE(3) Dirac particles to a backend array before hypersphere normalization checks
- Add regression coverage for Python list particles and weights

## Tests
- `PYTHONPATH=src python -m pytest tests/distributions/test_se3_dirac_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/cart_prod/lin_hypersphere_cart_prod_dirac_distribution.py tests/distributions/test_se3_dirac_distribution.py`
- `PYTHONPATH=src python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/cart_prod/lin_hypersphere_cart_prod_dirac_distribution.py tests/distributions/test_se3_dirac_distribution.py`
- `git diff --check`