### PR TITLE
Validate wrapped exponential inputs explicitly

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
@@ -3,9 +3,32 @@ from numbers import Integral
 from typing import Union
 
 # pylint: disable=redefined-builtin
-from pyrecest.backend import asarray, exp, int32, int64, log, mod, ndim, pi, random
+from pyrecest.backend import (
+    all,
+    asarray,
+    exp,
+    int32,
+    int64,
+    isfinite,
+    log,
+    mod,
+    ndim,
+    pi,
+    random,
+)
 
 from .abstract_circular_distribution import AbstractCircularDistribution
+
+
+def _validate_positive_scalar(value, name):
+    value = asarray(value)
+    if value.shape not in ((), (1,)):
+        raise ValueError(f"{name} must be a positive scalar.")
+    if not bool(all(isfinite(value))):
+        raise ValueError(f"{name} must be finite.")
+    if not bool(all(value > 0.0)):
+        raise ValueError(f"{name} must be positive.")
+    return value
 
 
 class WrappedExponentialDistribution(AbstractCircularDistribution):
@@ -19,15 +42,14 @@ class WrappedExponentialDistribution(AbstractCircularDistribution):
 
     def __init__(self, lambda_):
         AbstractCircularDistribution.__init__(self)
-        lambda_ = asarray(lambda_)
-        assert lambda_.shape in ((1,), ())
-        assert lambda_ > 0.0
+        lambda_ = _validate_positive_scalar(lambda_, "lambda_")
         self.lambda_ = lambda_
         self._normalization_const = 1.0 / (1.0 - exp(-2.0 * pi * lambda_))
 
     def pdf(self, xs):
         xs = asarray(xs)
-        assert ndim(xs) <= 1
+        if ndim(xs) > 1:
+            raise ValueError("xs must be a scalar or one-dimensional array.")
         xs = mod(xs, 2.0 * pi)
         return self.lambda_ * exp(-self.lambda_ * xs) * self._normalization_const
 

--- a/tests/distributions/test_wrapped_exponential_distribution.py
+++ b/tests/distributions/test_wrapped_exponential_distribution.py
@@ -25,11 +25,7 @@ class WrappedExponentialDistributionTest(unittest.TestCase):
 
     def test_pdf(self):
         def pdftemp(x):
-            return sum(
-                self.lambda_ * exp(-self.lambda_ * (x + 2.0 * pi * k))
-                for k in arange(-20, 21)
-                if x + 2.0 * pi * k >= 0
-            )
+            return sum(self.lambda_ * exp(-self.lambda_ * (x + 2.0 * pi * k)) for k in arange(-20, 21) if x + 2.0 * pi * k >= 0)
 
         for x in [0.0, 1.0, 2.0, 3.0, 4.0]:
             npt.assert_allclose(self.we.pdf(array(x)), pdftemp(array(x)), rtol=5e-7)
@@ -42,6 +38,16 @@ class WrappedExponentialDistributionTest(unittest.TestCase):
             rtol=5e-7,
         )
 
+    def test_rejects_invalid_lambda(self):
+        for lambda_ in (0.0, -0.5, float("inf"), array([1.0, 2.0])):
+            with self.subTest(lambda_=lambda_):
+                with self.assertRaisesRegex(ValueError, "lambda_"):
+                    WrappedExponentialDistribution(lambda_)
+
+    def test_pdf_rejects_matrix_inputs(self):
+        with self.assertRaisesRegex(ValueError, "one-dimensional"):
+            self.we.pdf(array([[0.0, 1.0]]))
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
         reason="Not supported on this backend",
@@ -50,8 +56,7 @@ class WrappedExponentialDistributionTest(unittest.TestCase):
         npt.assert_allclose(self.we.integrate(), 1.0, rtol=5e-7)
         npt.assert_allclose(self.we.integrate_numerically(), 1.0, rtol=5e-7)
         npt.assert_allclose(
-            self.we.integrate(array([0.0, pi]))
-            + self.we.integrate(array([pi, 2.0 * pi])),
+            self.we.integrate(array([0.0, pi])) + self.we.integrate(array([pi, 2.0 * pi])),
             1.0,
             rtol=5e-7,
         )
@@ -69,9 +74,7 @@ class WrappedExponentialDistributionTest(unittest.TestCase):
             )
 
     def test_circular_mean(self):
-        npt.assert_allclose(
-            self.we.mean_direction(), float(arctan(1.0 / self.lambda_)), rtol=5e-7
-        )
+        npt.assert_allclose(self.we.mean_direction(), float(arctan(1.0 / self.lambda_)), rtol=5e-7)
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",


### PR DESCRIPTION
## Summary
- replace assertion-based WrappedExponentialDistribution parameter validation with explicit ValueError checks
- reject non-finite, non-positive, and non-scalar rate parameters before normalization is computed
- replace the assertion-based pdf rank check with an explicit scalar-or-one-dimensional input validation

## Validation
- `..\.poetry-2.4.1\Scripts\python.exe -m poetry run python -m pytest tests/distributions/test_wrapped_exponential_distribution.py -q`
- `..\.poetry-2.4.1\Scripts\python.exe -m poetry run python -O -m pytest tests/distributions/test_wrapped_exponential_distribution.py -q`
- `..\.poetry-2.4.1\Scripts\python.exe -m poetry run ruff check src/pyrecest/distributions/circle/wrapped_exponential_distribution.py tests/distributions/test_wrapped_exponential_distribution.py`
- `..\.poetry-2.4.1\Scripts\python.exe -m poetry run ruff format --check src/pyrecest/distributions/circle/wrapped_exponential_distribution.py tests/distributions/test_wrapped_exponential_distribution.py`
- `git diff --check`