### PR TITLE
Accept list inputs in stacked product PDFs

### DIFF
--- a/src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py
@@ -1,6 +1,6 @@
 # pylint: disable=no-name-in-module,no-member
 import numpy as np
-from pyrecest.backend import concatenate, hstack, prod, stack
+from pyrecest.backend import asarray, concatenate, hstack, prod, stack
 
 from .abstract_cart_prod_distribution import AbstractCartProdDistribution
 
@@ -37,6 +37,7 @@ class CartProdStackedDistribution(AbstractCartProdDistribution):
         return hstack([dist.sample(n) for dist in self.dists])
 
     def pdf(self, xs):
+        xs = asarray(xs)
         ps = []
         next_dim = 0
         for dist in self.dists:

--- a/src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py
@@ -1,6 +1,6 @@
 # pylint: disable=no-name-in-module,no-member
 import numpy as np
-from pyrecest.backend import asarray, concatenate, hstack, prod, stack
+from pyrecest.backend import asarray, concatenate, hstack, prod, reshape, stack
 
 from .abstract_cart_prod_distribution import AbstractCartProdDistribution
 
@@ -46,7 +46,10 @@ class CartProdStackedDistribution(AbstractCartProdDistribution):
                 xs_curr = xs[next_dim:next_input_dim]
             else:
                 xs_curr = xs[:, next_dim:next_input_dim]
-            ps.append(dist.pdf(xs_curr))
+            pdf_value = asarray(dist.pdf(xs_curr))
+            if xs.ndim == 1:
+                pdf_value = reshape(pdf_value, ())
+            ps.append(pdf_value)
             next_dim = next_input_dim
         return prod(stack(ps), axis=0)
 

--- a/src/pyrecest/distributions/cart_prod/se3_lin_vel_cart_prod_stacked_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/se3_lin_vel_cart_prod_stacked_distribution.py
@@ -1,4 +1,4 @@
-from pyrecest.backend import prod, stack
+from pyrecest.backend import asarray, prod, stack
 
 from ..hypersphere_subset.abstract_hyperhemispherical_distribution import (
     AbstractHyperhemisphericalDistribution,
@@ -39,6 +39,7 @@ class SE3LinVelCartProdStackedDistribution(CartProdStackedDistribution):
         return self.dists[0]
 
     def pdf(self, xs):
+        xs = asarray(xs)
         ps = []
         next_dim = 0
         for dist in self.dists:

--- a/tests/distributions/test_cart_prod_stacked_distribution.py
+++ b/tests/distributions/test_cart_prod_stacked_distribution.py
@@ -84,6 +84,19 @@ class TestCartProdStackedDistribution(unittest.TestCase):
 
         self.assertTrue(allclose(pdf_value, expected))
 
+    def test_pdf_accepts_list_inputs(self):
+        dist = ConcreteCartProdStackedDistribution(
+            [
+                GaussianDistribution(array([0.0, 0.0]), eye(2)),
+                GaussianDistribution(array([0.0]), eye(1)),
+            ]
+        )
+        single = [1.0, 2.0, 3.0]
+        batched = [[1.0, 2.0, 3.0], [0.0, 0.0, 0.0]]
+
+        self.assertTrue(allclose(dist.pdf(single), dist.pdf(array(single))))
+        self.assertTrue(allclose(dist.pdf(batched), dist.pdf(array(batched))))
+
     def test_shift_uses_cumulative_component_dimensions(self):
         dist = ConcreteCartProdStackedDistribution(
             [

--- a/tests/distributions/test_se3_lin_vel_cart_prod_stacked_distribution.py
+++ b/tests/distributions/test_se3_lin_vel_cart_prod_stacked_distribution.py
@@ -61,6 +61,23 @@ class TestSE3LinVelCartProdStackedDistribution(unittest.TestCase):
         pdf_values = cpd.pdf(ones((100, 10)))
         self.assertTrue(allclose(diff(pdf_values), zeros(99)))
 
+    def test_pdf_accepts_list_inputs(self):
+        cpd = SE3LinVelCartProdStackedDistribution(
+            [
+                HyperhemisphericalUniformDistribution(3),
+                GaussianDistribution(
+                    array([1.0, 2.0, 0.0, -2.0, -1.0, 3.0]),
+                    diag(array([3.0, 2.0, 3.0, 3.0, 4.0, 5.0])),
+                ),
+            ]
+        )
+        points = [
+            [1.0, 0.0, 0.0, 0.0, 1.0, 2.0, 0.0, -2.0, -1.0, 3.0],
+            [0.0, 1.0, 0.0, 0.0, 2.0, 3.0, 1.0, -1.0, 0.0, 4.0],
+        ]
+
+        self.assertTrue(allclose(cpd.pdf(points), cpd.pdf(array(points))))
+
     def test_mode(self):
         mu = array([2.0, 1.0, 3.0, 1.0])
         watson = HyperhemisphericalWatsonDistribution(mu / linalg.norm(mu), 2)


### PR DESCRIPTION
## Summary
- Coerce stacked product `pdf()` inputs to backend arrays before slicing component coordinates
- Apply the same list-input handling to the SE(3) linear-velocity stacked override
- Add regression coverage for generic and SE(3)-velocity stacked PDF list inputs

## Root cause
The stacked product PDF implementations accessed `xs.ndim` and NumPy-style slices before converting caller input. Valid Python lists therefore failed with `AttributeError` before the component distributions could evaluate them.

## Tests
- `PYTHONPATH=src python -m pytest tests/distributions/test_cart_prod_stacked_distribution.py tests/distributions/test_se3_lin_vel_cart_prod_stacked_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py src/pyrecest/distributions/cart_prod/se3_lin_vel_cart_prod_stacked_distribution.py tests/distributions/test_cart_prod_stacked_distribution.py tests/distributions/test_se3_lin_vel_cart_prod_stacked_distribution.py`
- `PYTHONPATH=src python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py src/pyrecest/distributions/cart_prod/se3_lin_vel_cart_prod_stacked_distribution.py tests/distributions/test_cart_prod_stacked_distribution.py tests/distributions/test_se3_lin_vel_cart_prod_stacked_distribution.py`
- `git diff --check`