### PR TITLE
Validate wrapped Laplace inputs explicitly

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_laplace_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_laplace_distribution.py
@@ -1,7 +1,18 @@
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import asarray, exp, mod, ndim, pi
+from pyrecest.backend import all, asarray, exp, isfinite, mod, ndim, pi
 
 from .abstract_circular_distribution import AbstractCircularDistribution
+
+
+def _validate_positive_scalar(value, name):
+    value = asarray(value)
+    if value.shape not in ((), (1,)):
+        raise ValueError(f"{name} must be a positive scalar.")
+    if not bool(all(isfinite(value))):
+        raise ValueError(f"{name} must be finite.")
+    if not bool(all(value > 0.0)):
+        raise ValueError(f"{name} must be positive.")
+    return value
 
 
 class WrappedLaplaceDistribution(AbstractCircularDistribution):
@@ -16,35 +27,26 @@ class WrappedLaplaceDistribution(AbstractCircularDistribution):
 
     def __init__(self, lambda_, kappa_):
         AbstractCircularDistribution.__init__(self)
-        lambda_ = asarray(lambda_)
-        kappa_ = asarray(kappa_)
-        assert lambda_.shape in ((1,), ())
-        assert kappa_.shape in ((1,), ())
-        assert lambda_ > 0.0
-        assert kappa_ > 0.0
+        lambda_ = _validate_positive_scalar(lambda_, "lambda_")
+        kappa_ = _validate_positive_scalar(kappa_, "kappa_")
         self.lambda_ = lambda_
         self.kappa = kappa_
 
     def trigonometric_moment(self, n):
-        return (
-            1
-            / (1 - 1j * n / self.lambda_ / self.kappa)
-            / (1 + 1j * n / (self.lambda_ / self.kappa))
-        )
+        return 1 / (1 - 1j * n / self.lambda_ / self.kappa) / (1 + 1j * n / (self.lambda_ / self.kappa))
 
     def pdf(self, xs):
         xs = asarray(xs)
-        assert ndim(xs) <= 1
+        if ndim(xs) > 1:
+            raise ValueError("xs must be a scalar or one-dimensional array.")
         xs = mod(xs, 2.0 * pi)
         p = (
             self.lambda_
             * self.kappa
             / (1 + self.kappa**2)
             * (
-                exp(-self.lambda_ * self.kappa * xs)
-                / (1 - exp(-2.0 * pi * self.lambda_ * self.kappa))
-                + exp(self.lambda_ / self.kappa * xs)
-                / (exp(2.0 * pi * self.lambda_ / self.kappa) - 1.0)
+                exp(-self.lambda_ * self.kappa * xs) / (1 - exp(-2.0 * pi * self.lambda_ * self.kappa))
+                + exp(self.lambda_ / self.kappa * xs) / (exp(2.0 * pi * self.lambda_ / self.kappa) - 1.0)
             )
         )
         return p

--- a/tests/distributions/test_wrapped_laplace_distribution.py
+++ b/tests/distributions/test_wrapped_laplace_distribution.py
@@ -25,17 +25,7 @@ class WrappedLaplaceDistributionTest(unittest.TestCase):
 
     def test_pdf(self):
         def laplace(x):
-            return (
-                self.lambda_
-                / (1 / self.kappa + self.kappa)
-                * exp(
-                    -(
-                        abs(x)
-                        * self.lambda_
-                        * (self.kappa if x >= 0 else 1 / self.kappa)
-                    )
-                )
-            )
+            return self.lambda_ / (1 / self.kappa + self.kappa) * exp(-(abs(x) * self.lambda_ * (self.kappa if x >= 0 else 1 / self.kappa)))
 
         def pdftemp(x):
             return sum(laplace(z) for z in x + 2.0 * pi * arange(-20, 21))
@@ -51,6 +41,22 @@ class WrappedLaplaceDistributionTest(unittest.TestCase):
             rtol=1e-6,
         )
 
+    def test_rejects_invalid_lambda(self):
+        for lambda_ in (0.0, -0.5, float("inf"), array([1.0, 2.0])):
+            with self.subTest(lambda_=lambda_):
+                with self.assertRaisesRegex(ValueError, "lambda_"):
+                    WrappedLaplaceDistribution(lambda_, self.kappa)
+
+    def test_rejects_invalid_kappa(self):
+        for kappa in (0.0, -0.5, float("inf"), array([1.0, 2.0])):
+            with self.subTest(kappa=kappa):
+                with self.assertRaisesRegex(ValueError, "kappa_"):
+                    WrappedLaplaceDistribution(self.lambda_, kappa)
+
+    def test_pdf_rejects_matrix_inputs(self):
+        with self.assertRaisesRegex(ValueError, "one-dimensional"):
+            self.wl.pdf(array([[0.0, 1.0]]))
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
         reason="Not supported on this backend",
@@ -59,8 +65,7 @@ class WrappedLaplaceDistributionTest(unittest.TestCase):
         npt.assert_allclose(self.wl.integrate(), 1.0, rtol=1e-10)
         npt.assert_allclose(self.wl.integrate_numerically(), 1.0, rtol=1e-10)
         npt.assert_allclose(
-            self.wl.integrate(array([0.0, pi]))
-            + self.wl.integrate(array([pi, 2.0 * pi])),
+            self.wl.integrate(array([0.0, pi])) + self.wl.integrate(array([pi, 2.0 * pi])),
             1.0,
             rtol=1e-10,
         )


### PR DESCRIPTION
## Summary
- replace assertion-based WrappedLaplaceDistribution parameter validation with explicit ValueError checks
- reject non-finite, non-positive, and non-scalar lambda_/kappa_ parameters before density evaluation
- replace the assertion-based pdf rank check with explicit scalar-or-one-dimensional input validation

## Validation
- `..\.poetry-2.4.1\Scripts\python.exe -m poetry run python -m pytest tests/distributions/test_wrapped_laplace_distribution.py -q`
- `..\.poetry-2.4.1\Scripts\python.exe -m poetry run python -O -m pytest tests/distributions/test_wrapped_laplace_distribution.py -q`
- `..\.poetry-2.4.1\Scripts\python.exe -m poetry run ruff check src/pyrecest/distributions/circle/wrapped_laplace_distribution.py tests/distributions/test_wrapped_laplace_distribution.py`
- `..\.poetry-2.4.1\Scripts\python.exe -m poetry run ruff format --check src/pyrecest/distributions/circle/wrapped_laplace_distribution.py tests/distributions/test_wrapped_laplace_distribution.py`
- `git diff --check`