### PR TITLE
Validate generalized von Mises inputs explicitly

### DIFF
--- a/src/pyrecest/distributions/circle/generalized_von_mises_distribution.py
+++ b/src/pyrecest/distributions/circle/generalized_von_mises_distribution.py
@@ -1,7 +1,32 @@
 # pylint: disable=no-name-in-module,no-member,redefined-builtin
-from pyrecest.backend import arange, array, atleast_1d, cos, exp, sum
+from pyrecest.backend import all, arange, array, atleast_1d, cos, exp, isfinite, sum
 
 from .abstract_circular_distribution import AbstractCircularDistribution
+
+
+def _validate_parameters(mu, kappa):
+    mu = array(mu, dtype=float)
+    kappa = array(kappa, dtype=float)
+    if mu.ndim != 1:
+        raise ValueError("mu must be a one-dimensional array.")
+    if kappa.ndim != 1:
+        raise ValueError("kappa must be a one-dimensional array.")
+    if mu.shape != kappa.shape:
+        raise ValueError("mu and kappa must have the same shape.")
+    if not bool(all(isfinite(mu))):
+        raise ValueError("mu must be finite.")
+    if not bool(all(isfinite(kappa))):
+        raise ValueError("kappa must be finite.")
+    if not bool(all(kappa > 0.0)):
+        raise ValueError("all kappa values must be positive.")
+    return mu, kappa
+
+
+def _as_1d_input(xs):
+    xs = atleast_1d(array(xs))
+    if xs.ndim != 1:
+        raise ValueError("xs must be a scalar or one-dimensional array.")
+    return xs
 
 
 class GvMDistribution(AbstractCircularDistribution):
@@ -21,11 +46,7 @@ class GvMDistribution(AbstractCircularDistribution):
     """
 
     def __init__(self, mu, kappa):
-        mu = array(mu, dtype=float)
-        kappa = array(kappa, dtype=float)
-        assert mu.ndim == 1, "mu must be a 1D array"
-        assert mu.shape == kappa.shape, "mu and kappa must have the same shape"
-        assert (kappa > 0).all(), "all kappa values must be positive"
+        mu, kappa = _validate_parameters(mu, kappa)
         AbstractCircularDistribution.__init__(self)
         self.mu = mu
         self.kappa = kappa
@@ -34,9 +55,7 @@ class GvMDistribution(AbstractCircularDistribution):
     @property
     def norm_const(self):
         if self._norm_const is None:
-            self._norm_const = self.integrate_fun_over_domain(
-                lambda *args: self.pdf_unnormalized(array(args)), self.dim
-            )
+            self._norm_const = self.integrate_fun_over_domain(lambda *args: self.pdf_unnormalized(array(args)), self.dim)
         return self._norm_const
 
     def pdf_unnormalized(self, xs):
@@ -53,7 +72,7 @@ class GvMDistribution(AbstractCircularDistribution):
         p : array, shape (n,)
             Unnormalized pdf values.
         """
-        xs = atleast_1d(array(xs))
+        xs = _as_1d_input(xs)
         # j = [1, 2, ..., k], shape (k,)
         j = arange(1, self.mu.shape[0] + 1, dtype=float)
         # Broadcast: (k, 1) * ((1, n) - (k, 1)) → (k, n)

--- a/tests/distributions/test_generalized_von_mises_distribution.py
+++ b/tests/distributions/test_generalized_von_mises_distribution.py
@@ -14,12 +14,21 @@ class TestGvMDistribution(unittest.TestCase):
         self.assertEqual(dist.kappa.shape, (1,))
 
     def test_init_invalid_kappa(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(ValueError, "kappa"):
             GvMDistribution(array([2.0]), array([-1.0]))
 
     def test_init_shape_mismatch(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(ValueError, "same shape"):
             GvMDistribution(array([1.0, 2.0]), array([1.0]))
+
+    def test_init_rejects_nonfinite_parameters(self):
+        for mu, kappa, pattern in (
+            (array([float("nan")]), array([1.0]), "mu"),
+            (array([1.0]), array([float("inf")]), "kappa"),
+        ):
+            with self.subTest(mu=mu, kappa=kappa):
+                with self.assertRaisesRegex(ValueError, pattern):
+                    GvMDistribution(mu, kappa)
 
     def test_pdf_order1_matches_von_mises(self):
         """Order-1 GvM with a single mu and kappa should match the von Mises PDF."""
@@ -40,6 +49,12 @@ class TestGvMDistribution(unittest.TestCase):
         gvm = GvMDistribution(array([1.0]), array([2.0]))
 
         npt.assert_allclose(gvm.pdf(0.5), gvm.pdf(array([0.5])))
+
+    def test_pdf_rejects_matrix_input(self):
+        gvm = GvMDistribution(array([1.0]), array([2.0]))
+
+        with self.assertRaisesRegex(ValueError, "one-dimensional"):
+            gvm.pdf(array([[0.5, 1.0]]))
 
     def test_pdf_integrates_to_one(self):
         """PDF should integrate to 1 over [0, 2*pi]."""


### PR DESCRIPTION
## Summary
- replace assertion-based GvMDistribution parameter validation with explicit ValueError checks
- reject non-finite parameters and matrix-valued pdf inputs explicitly
- update tests to cover invalid parameters and optimized Python behavior

## Validation
- `$env:MPLBACKEND='Agg'; ..\.poetry-2.4.1\Scripts\python.exe -m poetry run python -m pytest tests/distributions/test_generalized_von_mises_distribution.py -q`
- `$env:MPLBACKEND='Agg'; ..\.poetry-2.4.1\Scripts\python.exe -m poetry run python -O -m pytest tests/distributions/test_generalized_von_mises_distribution.py -q`
- `..\.poetry-2.4.1\Scripts\python.exe -m poetry run ruff check src/pyrecest/distributions/circle/generalized_von_mises_distribution.py tests/distributions/test_generalized_von_mises_distribution.py`
- `..\.poetry-2.4.1\Scripts\python.exe -m poetry run ruff format --check src/pyrecest/distributions/circle/generalized_von_mises_distribution.py tests/distributions/test_generalized_von_mises_distribution.py`
- `git diff --check`

Note: local test runs used `MPLBACKEND=Agg` to avoid the host Tk backend issue during import.