### PR TITLE
Avoid creating hypertoroidal plot axes at import

### DIFF
--- a/src/pyrecest/distributions/hypertorus/abstract_hypertoroidal_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/abstract_hypertoroidal_distribution.py
@@ -315,7 +315,9 @@ class AbstractHypertoroidalDistribution(AbstractPeriodicDistribution):
         return s
 
     @staticmethod
-    def setup_axis_circular(axis_name: str = "x", ax=plt.gca()) -> None:
+    def setup_axis_circular(axis_name: str = "x", ax=None) -> None:
+        if ax is None:
+            ax = plt.gca()
         ticks = [0.0, pi, 2.0 * pi]
         tick_labels = ["0", r"$\pi$", r"$2\pi$"]
         if axis_name == "x":

--- a/tests/distributions/test_abstract_hypertoroidal_distribution.py
+++ b/tests/distributions/test_abstract_hypertoroidal_distribution.py
@@ -1,3 +1,4 @@
+import inspect
 import unittest
 
 import matplotlib
@@ -46,6 +47,13 @@ class TestAbstractHypertoroidalDistribution(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "undefined"):
             dist.mean_direction()
+
+    def test_setup_axis_circular_does_not_capture_axes_at_import(self):
+        signature = inspect.signature(
+            AbstractHypertoroidalDistribution.setup_axis_circular
+        )
+
+        self.assertIsNone(signature.parameters["ax"].default)
 
     def test_plot_2d(self):
         mu = array([0.0, 1.0])


### PR DESCRIPTION
## Summary
- Make `setup_axis_circular` resolve `plt.gca()` lazily instead of as a default argument
- Add regression coverage that the helper no longer captures a Matplotlib axes object at import time

## Root cause
`AbstractHypertoroidalDistribution.setup_axis_circular` used `ax=plt.gca()` in the function signature. Python evaluates default arguments at import time, so importing `pyrecest.distributions` could create a Matplotlib figure and fail in environments without a usable GUI backend.

## Tests
- `PYTHONPATH=src python -c "from pyrecest.distributions import WrappedNormalDistribution; print(WrappedNormalDistribution.__name__)"`
- `PYTHONPATH=src python -m pytest tests/distributions/test_abstract_hypertoroidal_distribution.py -q -p no:cacheprovider --basetemp .pytest-tmp`
- `python -m ruff check src/pyrecest/distributions/hypertorus/abstract_hypertoroidal_distribution.py tests/distributions/test_abstract_hypertoroidal_distribution.py`
- `PYTHONPATH=src python -m pylint --persistent=no --disable=import-error src/pyrecest/distributions/hypertorus/abstract_hypertoroidal_distribution.py tests/distributions/test_abstract_hypertoroidal_distribution.py`
- `git diff --check`