### PR TITLE
Fix DensityTransitionModel sampler count dispatch

### DIFF
--- a/src/pyrecest/models/likelihood.py
+++ b/src/pyrecest/models/likelihood.py
@@ -205,6 +205,9 @@ class DensityTransitionModel:
 
         self._transition_density = transition_density
         self._sample_next = sample_next
+        self._sample_next_count_call_mode = (
+            _sample_count_call_mode(sample_next) if sample_next is not None else None
+        )
         self.name = name
 
     @property
@@ -223,7 +226,11 @@ class DensityTransitionModel:
 
         if self._sample_next is None:
             raise NotImplementedError("No sample_next callback was provided.")
-        return self._sample_next(state, n)
+        if self._sample_next_count_call_mode == "positional":
+            return self._sample_next(state, n)
+        if self._sample_next_count_call_mode == "keyword":
+            return self._sample_next(state, n=n)
+        return self._sample_next(state)
 
 
 __all__ = [

--- a/tests/models/test_likelihood_sampleable_models.py
+++ b/tests/models/test_likelihood_sampleable_models.py
@@ -189,6 +189,34 @@ class DensityTransitionModelTest(unittest.TestCase):
             allclose(model.sample_next(array([4.0]), n=2), array([[4.0], [5.0]]))
         )
 
+    def test_optional_sampler_with_keyword_only_count(self):
+        def sample_next(state, *, n=1):
+            return state + reshape(arange(n), (n, 1))
+
+        model = DensityTransitionModel(
+            lambda state_next, state_previous: exp(
+                -0.5 * (state_next - state_previous) ** 2
+            ),
+            sample_next=sample_next,
+        )
+
+        self.assertTrue(
+            allclose(model.sample_next(array([4.0]), n=2), array([[4.0], [5.0]]))
+        )
+
+    def test_optional_unary_sampler(self):
+        def sample_next(state):
+            return state + array([1.0])
+
+        model = DensityTransitionModel(
+            lambda state_next, state_previous: exp(
+                -0.5 * (state_next - state_previous) ** 2
+            ),
+            sample_next=sample_next,
+        )
+
+        self.assertTrue(allclose(model.sample_next(array([4.0])), array([5.0])))
+
     def test_missing_sampler_raises(self):
         model = DensityTransitionModel(
             lambda state_next, state_previous: state_next + state_previous


### PR DESCRIPTION
## Summary
- Reuse the existing sample-count call-mode detection for optional `DensityTransitionModel` samplers.
- Allow optional density-transition samplers that accept `n` as keyword-only, positionally, through `**kwargs`, or not at all.
- Add regression coverage for keyword-only and unary optional samplers.

## Validation
- Ran an isolated sandbox validation of the sampler dispatch logic for positional, keyword-only, unary, and `**kwargs` callbacks: passed.
- Full repository pytest was not run because the sandbox could not clone from GitHub (`Could not resolve host: github.com`), and repository access here is through the GitHub connector rather than a local checkout.