### PR TITLE
Fix batched matrix RHS handling in linalg.solve

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/linalg.py
+++ b/src/pyrecest/_backend/_shared_numpy/linalg.py
@@ -121,20 +121,20 @@ def solve(a, b):
     ----------
     a : array-like, shape=[..., M, M]
         Coefficient matrix.
-    b : array-like, shape=[..., M]
-        Ordinate or "dependent variable" values".
+    b : array-like, shape=[..., M] or [..., M, K]
+        Ordinate or "dependent variable" values.
 
     Returns
     -------
-    x : array-like, shape=[..., M]
+    x : array-like, shape=[..., M] or [..., M, K]
         Solution to the system a x = b.
     """
-    batch_shape = a.shape[:-2]
-    if batch_shape:
+    vector_rhs = b.ndim == a.ndim - 1
+    if vector_rhs:
         b = _np.expand_dims(b, axis=-1)
 
     res = _np.linalg.solve(a, b)
-    if batch_shape:
+    if vector_rhs:
         return res[..., 0]
 
     return res

--- a/tests/backend_support/test_numpy_linalg_solve_contract.py
+++ b/tests/backend_support/test_numpy_linalg_solve_contract.py
@@ -1,0 +1,58 @@
+"""Regression tests for shared NumPy-backend linear solve semantics."""
+
+from __future__ import annotations
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_numpy_linalg_solve_preserves_batched_matrix_rhs_shape_and_values():
+    result = run_backend_code(
+        "numpy",
+        """
+import pyrecest.backend as backend
+
+A = backend.array([
+    [[2.0, 0.0], [0.0, 4.0]],
+    [[1.0, 0.0], [0.0, 5.0]],
+])
+B = backend.array([
+    [[2.0, 4.0], [8.0, 12.0]],
+    [[3.0, 6.0], [10.0, 15.0]],
+])
+
+X = backend.linalg.solve(A, B)
+
+assert X.shape == (2, 2, 2)
+assert backend.to_numpy(X).tolist() == [
+    [[1.0, 2.0], [2.0, 3.0]],
+    [[3.0, 6.0], [2.0, 3.0]],
+]
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.backend_portable
+def test_numpy_linalg_solve_still_squeezes_batched_vector_rhs():
+    result = run_backend_code(
+        "numpy",
+        """
+import pyrecest.backend as backend
+
+A = backend.array([
+    [[2.0, 0.0], [0.0, 4.0]],
+    [[1.0, 0.0], [0.0, 5.0]],
+])
+b = backend.array([[2.0, 8.0], [3.0, 10.0]])
+
+x = backend.linalg.solve(A, b)
+
+assert x.shape == (2, 2)
+assert backend.to_numpy(x).tolist() == [[1.0, 2.0], [3.0, 2.0]]
+""",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Fix shared NumPy backend `linalg.solve` so batched matrix right-hand sides keep their matrix RHS shape instead of being treated as vector RHS.
- Preserve the existing batched-vector RHS squeeze behavior.
- Add backend-portable NumPy regression tests for both batched matrix and batched vector RHS cases.

## Validation
- Locally reproduced the wrong batched matrix RHS result with the old logic and verified the corrected NumPy logic on the minimal example.
- Added regression tests under `tests/backend_support/test_numpy_linalg_solve_contract.py`.

Full local repository test execution was not available because the execution environment could not clone GitHub directly, so CI is the authoritative validation for this PR.