### PR TITLE
Fix sampler count dispatch with keyword-only n

### DIFF
--- a/src/pyrecest/models/likelihood.py
+++ b/src/pyrecest/models/likelihood.py
@@ -43,6 +43,12 @@ def _sample_count_call_mode(callback: Callable[..., Any]) -> str | None:
     except (TypeError, ValueError):
         return "positional"
 
+    for parameter in parameters:
+        if parameter.name == "n":
+            if parameter.kind is Parameter.KEYWORD_ONLY:
+                return "keyword"
+            return "positional"
+
     if any(parameter.kind is Parameter.VAR_POSITIONAL for parameter in parameters):
         return "positional"
 
@@ -54,12 +60,6 @@ def _sample_count_call_mode(callback: Callable[..., Any]) -> str | None:
     ]
     if len(positional_parameters) >= 2:
         return "positional"
-
-    for parameter in parameters:
-        if parameter.name == "n":
-            if parameter.kind is Parameter.KEYWORD_ONLY:
-                return "keyword"
-            return "positional"
 
     if any(parameter.kind is Parameter.VAR_KEYWORD for parameter in parameters):
         return "keyword"

--- a/tests/models/test_likelihood_sampleable_models.py
+++ b/tests/models/test_likelihood_sampleable_models.py
@@ -108,6 +108,23 @@ class SampleableTransitionModelTest(unittest.TestCase):
             )
         )
 
+    def test_sample_next_callback_with_varargs_and_keyword_only_count(self):
+        calls = []
+
+        def sample_next(state, *args, n=1):
+            calls.append(args)
+            return state + reshape(arange(n), (n, 1))
+
+        model = SampleableTransitionModel(sample_next)
+
+        self.assertTrue(
+            allclose(
+                model.sample_next(array([10.0]), n=3),
+                array([[10.0], [11.0], [12.0]]),
+            )
+        )
+        self.assertEqual(calls, [()])
+
     def test_unary_sample_next_callback(self):
         def shift_state(state):
             return state + array([1.0])
@@ -203,6 +220,25 @@ class DensityTransitionModelTest(unittest.TestCase):
         self.assertTrue(
             allclose(model.sample_next(array([4.0]), n=2), array([[4.0], [5.0]]))
         )
+
+    def test_optional_sampler_with_varargs_and_keyword_only_count(self):
+        calls = []
+
+        def sample_next(state, *args, n=1):
+            calls.append(args)
+            return state + reshape(arange(n), (n, 1))
+
+        model = DensityTransitionModel(
+            lambda state_next, state_previous: exp(
+                -0.5 * (state_next - state_previous) ** 2
+            ),
+            sample_next=sample_next,
+        )
+
+        self.assertTrue(
+            allclose(model.sample_next(array([4.0]), n=2), array([[4.0], [5.0]]))
+        )
+        self.assertEqual(calls, [()])
 
     def test_optional_unary_sampler(self):
         def sample_next(state):


### PR DESCRIPTION
## Summary
- Fix `_sample_count_call_mode` so an explicit keyword-only `n` parameter takes precedence over a fallback `*args` parameter.
- Add regression coverage for `SampleableTransitionModel` and `DensityTransitionModel` callbacks with signatures like `sample_next(state, *args, n=1)`.

## Bug fixed
Before this change, a sampler callback containing both `*args` and keyword-only `n` was classified as accepting the count positionally. A call such as `model.sample_next(state, n=3)` could therefore be routed as `sample_next(state, 3)`, leaving the callback's keyword-only `n` at its default and silently misrouting the requested sample count into `args`.

## Validation
- Not run locally: the execution container cannot clone from GitHub because outbound DNS resolution for `github.com` is unavailable.
- Added focused regression tests that exercise the failing dispatch pattern for both reusable transition model wrappers.