### PR TITLE
Export partitioned SO3 product filter alias

### DIFF
--- a/src/pyrecest/filters/__init__.py
+++ b/src/pyrecest/filters/__init__.py
@@ -146,6 +146,7 @@ _FILTER_EXPORTS: Final[dict[str, str]] = {
     "OutOfSequenceParticleUpdater": ".out_of_sequence",
     "OutOfSequenceResult": ".out_of_sequence",
     "PartitionedSO3ProductBlockParticleFilter": ".so3_product_block_particle_filter",
+    "PartitionedSO3ProductParticleFilter": ".partitioned_so3_product_particle_filter",
     "PiecewiseConstantFilter": ".piecewise_constant_filter",
     "ProbabilityThresholdGate": ".association_hypotheses",
     "RandomMatrixTracker": ".random_matrix_tracker",

--- a/tests/filters/test_filter_lazy_exports.py
+++ b/tests/filters/test_filter_lazy_exports.py
@@ -1,0 +1,7 @@
+def test_partitioned_so3_product_particle_filter_is_public_lazy_export():
+    from pyrecest.filters import PartitionedSO3ProductParticleFilter
+    from pyrecest.filters.partitioned_so3_product_particle_filter import (
+        PartitionedSO3ProductParticleFilter as DirectPartitionedSO3ProductParticleFilter,
+    )
+
+    assert PartitionedSO3ProductParticleFilter is DirectPartitionedSO3ProductParticleFilter


### PR DESCRIPTION
Superseded by a clean test-only PR after `main` advanced and already contained the export-registry fix. The useful remaining regression coverage is in the replacement PR.