### PR TITLE
Fix empty index assignment handling in shared NumPy backend

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/__init__.py
+++ b/src/pyrecest/_backend/_shared_numpy/__init__.py
@@ -99,6 +99,10 @@ def one_hot(labels, num_classes):
     return eye(num_classes, dtype=_np.dtype("uint8"))[labels]
 
 
+def _is_empty_index_sequence(indices):
+    return _is_iterable(indices) and len(indices) == 0
+
+
 def assignment(x, values, indices, axis=0):
     """Assign values at given indices of an array.
 
@@ -127,6 +131,9 @@ def assignment(x, values, indices, axis=0):
     If a list is given, it must have the same length as indices.
     """
     x_new = copy(x)
+
+    if _is_empty_index_sequence(indices):
+        return x_new
 
     use_vectorization = hasattr(indices, "__len__") and len(indices) < ndim(x)
     if _is_boolean(indices):
@@ -177,6 +184,9 @@ def assignment_by_sum(x, values, indices, axis=0):
     If a list is given, it must have the same length as indices.
     """
     x_new = copy(x)
+
+    if _is_empty_index_sequence(indices):
+        return x_new
 
     use_vectorization = hasattr(indices, "__len__") and len(indices) < ndim(x)
     if _is_boolean(indices):

--- a/src/pyrecest/_backend/_shared_numpy/_common.py
+++ b/src/pyrecest/_backend/_shared_numpy/_common.py
@@ -137,6 +137,8 @@ def _is_boolean(x):
     if isinstance(x, bool):
         return True
     if isinstance(x, (tuple, list)):
+        if not x:
+            return False
         return _is_boolean(x[0])
     if isinstance(x, _np.ndarray):
         return x.dtype == bool


### PR DESCRIPTION
## Summary
- Treat empty Python index sequences as no-ops in shared NumPy/autograd `assignment` and `assignment_by_sum`.
- Guard shared `_is_boolean` against empty lists/tuples so callers do not index `x[0]` on an empty index sequence.
- Reuses the existing backend contract test for empty assignment indices.

## Bug fixed
The shared NumPy/autograd assignment path called `_is_boolean(indices)` before safely handling empty sequences. For `indices=[]`, `_is_boolean` attempted to inspect `indices[0]`, raising `IndexError` instead of preserving the input unchanged.

## Validation
- Existing regression coverage: `tests/test_backend_contract.py::test_assignment_with_empty_indices_is_a_noop`.
- Diff reviewed: 12 additive lines across the shared NumPy assignment helpers.