### PR TITLE
Test partitioned SO3 product filter lazy export

### DIFF
--- a/tests/filters/test_filter_lazy_exports.py
+++ b/tests/filters/test_filter_lazy_exports.py
@@ -1,0 +1,7 @@
+def test_partitioned_so3_product_particle_filter_is_public_lazy_export():
+    from pyrecest.filters import PartitionedSO3ProductParticleFilter
+    from pyrecest.filters.partitioned_so3_product_particle_filter import (
+        PartitionedSO3ProductParticleFilter as DirectPartitionedSO3ProductParticleFilter,
+    )
+
+    assert PartitionedSO3ProductParticleFilter is DirectPartitionedSO3ProductParticleFilter


### PR DESCRIPTION
## Summary
- Add regression coverage for importing `PartitionedSO3ProductParticleFilter` from the public lazy `pyrecest.filters` namespace.

## Bug guarded
`PartitionedSO3ProductParticleFilter` is a backward-compatible alias defined in `pyrecest.filters.partitioned_so3_product_particle_filter`. The public lazy export registry must keep exposing that alias; otherwise `from pyrecest.filters import PartitionedSO3ProductParticleFilter` fails while the class still exists in its implementation module.

## Validation
- This PR is intentionally test-only and based on current `main`, where the export-registry fix is already present.
- Full local test execution was not available in this connector-only environment, so CI is the authoritative validation.