### PR TITLE
Fix constant bias prediction feature row counts

### DIFF
--- a/src/pyrecest/calibration/bias.py
+++ b/src/pyrecest/calibration/bias.py
@@ -80,7 +80,18 @@ class SensorBiasCorrectionModel:
         """Predict residual bias for feature rows."""
 
         if self.feature_dim == 0:
-            rows = 1 if n_rows is None else _as_nonnegative_int(n_rows, "n_rows")
+            if features is None:
+                rows = 1 if n_rows is None else _as_nonnegative_int(n_rows, "n_rows")
+            else:
+                x = _as_2d(features, "features")
+                if x.shape[1] != 0:
+                    raise ValueError("features have incompatible feature dimension")
+                if n_rows is None:
+                    rows = x.shape[0]
+                else:
+                    rows = _as_nonnegative_int(n_rows, "n_rows")
+                    if x.shape[0] != rows:
+                        raise ValueError("features rows must match requested row count")
             return np.repeat(self.intercept.reshape(1, -1), rows, axis=0)
         if features is None:
             raise ValueError("features are required for a nonconstant bias model")

--- a/tests/calibration/test_bias_prediction_row_count.py
+++ b/tests/calibration/test_bias_prediction_row_count.py
@@ -48,6 +48,29 @@ def test_constant_bias_predict_accepts_integer_like_n_rows():
     np.testing.assert_allclose(prediction, np.array([[2.0], [2.0]]))
 
 
+def test_constant_bias_predict_uses_zero_feature_row_count():
+    model = _constant_bias_model()
+
+    prediction = model.predict(np.empty((3, 0)))
+
+    assert prediction.shape == (3, 1)
+    np.testing.assert_allclose(prediction, np.full((3, 1), 2.0))
+
+
+def test_constant_bias_predict_rejects_mismatched_zero_feature_row_count():
+    model = _constant_bias_model()
+
+    with pytest.raises(ValueError, match="features rows must match requested row count"):
+        model.predict(np.empty((3, 0)), n_rows=2)
+
+
+def test_constant_bias_predict_rejects_nonzero_feature_columns():
+    model = _constant_bias_model()
+
+    with pytest.raises(ValueError, match="features have incompatible feature dimension"):
+        model.predict(np.ones((3, 1)))
+
+
 @pytest.mark.parametrize("n_rows", [0.5, np.nan, np.inf, False])
 def test_feature_bias_predict_validates_explicit_n_rows_before_row_comparison(n_rows):
     model = _feature_bias_model()


### PR DESCRIPTION
## Summary
- honor zero-column feature row counts for constant sensor-bias models
- reject nonzero feature columns for constant models
- add regression coverage for feature-derived rows and mismatched explicit `n_rows`

## Testing
- Not run locally: the sandbox cannot clone GitHub due DNS resolution failure, so this PR relies on the targeted regression tests added here and GitHub Actions.