### PR TITLE
Fix shared NumPy Sylvester complex shortcut

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/linalg.py
+++ b/src/pyrecest/_backend/_shared_numpy/linalg.py
@@ -14,12 +14,16 @@ def _transpose(array):
     return _np.transpose(array, axes=axes)
 
 
+def _adjoint(array):
+    return _np.conj(_transpose(array))
+
+
 def _is_symmetric(x, tol=atol):
     return (_np.abs(x - _transpose(x)) < tol).all()
 
 
 def _is_hermitian(x, tol=atol):
-    return (_np.abs(x - _np.conj(_transpose(x))) < tol).all()
+    return (_np.abs(x - _adjoint(x)) < tol).all()
 
 
 _diag_vec = _np.vectorize(_np.diag, signature="(n)->(n,n)")
@@ -48,12 +52,13 @@ def logm(x):
 
 def solve_sylvester(a, b, q, tol=atol):
     if a.shape == b.shape:
-        if _np.all(_np.isclose(a, b)) and _np.all(_np.abs(a - _transpose(a)) < tol):
+        if _np.all(_np.isclose(a, b)) and _is_hermitian(a, tol=tol):
             eigvals, eigvecs = _np.linalg.eigh(a)
             if _np.all(eigvals >= tol):
-                tilde_q = _transpose(eigvecs) @ q @ eigvecs
+                adjoint_eigvecs = _adjoint(eigvecs)
+                tilde_q = adjoint_eigvecs @ q @ eigvecs
                 tilde_x = tilde_q / (eigvals[..., :, None] + eigvals[..., None, :])
-                return eigvecs @ tilde_x @ _transpose(eigvecs)
+                return eigvecs @ tilde_x @ adjoint_eigvecs
 
     return _np.vectorize(
         _scipy.linalg.solve_sylvester, signature="(m,m),(n,n),(m,n)->(m,n)"

--- a/tests/test_sylvester_complex_shortcut.py
+++ b/tests/test_sylvester_complex_shortcut.py
@@ -44,4 +44,5 @@ def test_pytorch_solve_sylvester_handles_complex_hermitian_general_path():
     x = pytorch_backend.linalg.solve_sylvester(a, a, q)
 
     residual = a @ x + x @ a - q
-    assert float(pytorch_backend.to_numpy(pytorch_backend.linalg.norm(residual))) < 1e-12
+    residual_norm = pytorch_backend.linalg.norm(residual)
+    assert float(pytorch_backend.to_numpy(residual_norm)) < 1e-12

--- a/tests/test_sylvester_complex_shortcut.py
+++ b/tests/test_sylvester_complex_shortcut.py
@@ -1,0 +1,47 @@
+import importlib.util
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+from pyrecest._backend import numpy as numpy_backend
+
+pytorch_backend = None
+if importlib.util.find_spec("torch") is not None:
+    from pyrecest._backend import pytorch as pytorch_backend
+
+
+def test_numpy_solve_sylvester_falls_back_for_complex_symmetric_nonhermitian():
+    a = np.array([[2.0 + 0.0j, 1.0j], [1.0j, 2.0 + 0.0j]], dtype=np.complex128)
+    q = np.eye(2, dtype=np.complex128)
+
+    x = numpy_backend.linalg.solve_sylvester(a, a, q)
+
+    residual = a @ x + x @ a - q
+    npt.assert_allclose(residual, np.zeros_like(q), atol=1e-12)
+
+
+def test_numpy_solve_sylvester_handles_complex_hermitian_shortcut():
+    a = np.array([[2.0 + 0.0j, 1.0j], [-1.0j, 2.0 + 0.0j]], dtype=np.complex128)
+    q = np.eye(2, dtype=np.complex128)
+
+    x = numpy_backend.linalg.solve_sylvester(a, a, q)
+
+    residual = a @ x + x @ a - q
+    npt.assert_allclose(residual, np.zeros_like(q), atol=1e-12)
+
+
+@pytest.mark.skipif(pytorch_backend is None, reason="PyTorch is not installed")
+def test_pytorch_solve_sylvester_handles_complex_hermitian_general_path():
+    a = pytorch_backend.array(
+        [[2.0 + 0.0j, 1.0j], [-1.0j, 2.0 + 0.0j]],
+        dtype=pytorch_backend.complex128,
+    )
+    q = pytorch_backend.array(
+        [[1.0 + 0.0j, 0.0 + 0.0j], [0.0 + 0.0j, 1.0 + 0.0j]],
+        dtype=pytorch_backend.complex128,
+    )
+
+    x = pytorch_backend.linalg.solve_sylvester(a, a, q)
+
+    residual = a @ x + x @ a - q
+    assert float(pytorch_backend.to_numpy(pytorch_backend.linalg.norm(residual))) < 1e-12


### PR DESCRIPTION
## Summary
- Restrict the shared NumPy Sylvester eigensolver shortcut to Hermitian inputs instead of plain transpose-symmetric inputs.
- Use the conjugate transpose when projecting complex Hermitian factors into and out of the eigenbasis.
- Add regression coverage for complex symmetric non-Hermitian matrices and complex Hermitian matrices.

## Rationale
The previous shortcut treated complex symmetric matrices as if `eigh`/orthogonal projection semantics applied. For a complex symmetric but non-Hermitian matrix, this can silently return a solution with a large Sylvester residual. The general SciPy solver handles that case correctly, while the shortcut remains valid for real symmetric and complex Hermitian factors.

## Testing
- Not run locally because the execution container cannot clone GitHub (`Could not resolve host: github.com`).
- Added focused regression tests in `tests/test_sylvester_complex_shortcut.py`.