### PR TITLE
Fix PyTorch negative-stride NumPy view conversion

### DIFF
--- a/src/pyrecest/_backend/pytorch/_common.py
+++ b/src/pyrecest/_backend/pytorch/_common.py
@@ -5,6 +5,8 @@ import torch as _torch
 def from_numpy(x):
     if _torch.is_tensor(x):
         return x
+    if isinstance(x, _np.ndarray) and any(stride < 0 for stride in x.strides):
+        x = x.copy()
     return _torch.from_numpy(x)
 
 

--- a/tests/backend_support/test_pytorch_numpy_view_conversion.py
+++ b/tests/backend_support/test_pytorch_numpy_view_conversion.py
@@ -1,0 +1,33 @@
+"""Regression tests for PyTorch backend NumPy view conversion."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_pytorch_backend_accepts_negative_stride_numpy_views():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import numpy as np
+import pyrecest.backend as backend
+from pyrecest._backend.pytorch._common import from_numpy
+
+vector_view = np.arange(5.0)[::-1]
+vector_tensor = from_numpy(vector_view)
+assert backend.to_numpy(vector_tensor).tolist() == [4.0, 3.0, 2.0, 1.0, 0.0]
+
+matrix_view = np.arange(6.0).reshape(2, 3)[:, ::-1]
+matrix_tensor = backend.array(matrix_view)
+assert backend.to_numpy(matrix_tensor).tolist() == [[2.0, 1.0, 0.0], [5.0, 4.0, 3.0]]
+""",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- copy negative-stride NumPy views before passing them to `torch.from_numpy`
- add a PyTorch backend-portable regression test for flipped vector and matrix views

## Rationale
`torch.from_numpy` raises on NumPy arrays with negative strides, e.g. `np.arange(5)[::-1]`. The backend array conversion path should accept ordinary NumPy views where NumPy itself treats them as valid array-likes.

## Tests
- Added `tests/backend_support/test_pytorch_numpy_view_conversion.py`
- Locally reproduced the underlying Torch failure mode with `torch.from_numpy(np.arange(5.0)[::-1])` and verified copying fixes it.