### PR TITLE
Fix JAX random.normal scale handling

### DIFF
--- a/src/pyrecest/_backend/jax/random.py
+++ b/src/pyrecest/_backend/jax/random.py
@@ -98,6 +98,11 @@ def _looks_like_shape(value):
     )
 
 
+def _is_default_normal_scale(value):
+    scale = _np.asarray(value)
+    return scale.ndim == 0 and bool(scale == 1.0)
+
+
 def _looks_like_shape_sequence(value):
     return isinstance(value, (list, tuple)) and all(
         _looks_like_integer_dimension(dim) for dim in value
@@ -195,6 +200,10 @@ def randint(low=None, high=None, size=None, *args, **kwargs):
 
 
 def _normal(state, loc=0.0, scale=1.0, size=None, *args, **kwargs):
+    loc = _jnp.asarray(loc)
+    scale = _jnp.asarray(scale)
+    if bool(_jnp.any(scale < 0)):
+        raise ValueError("scale must be non-negative")
     state, key = jax.random.split(state)
     samples = jax.random.normal(key, _shape_from_size(size), *args, **kwargs)
     return state, loc + scale * samples
@@ -206,7 +215,7 @@ def normal(loc=0.0, scale=1.0, size=None, *args, **kwargs):
     The legacy JAX-backend call form ``normal(size)`` is still accepted when the
     first positional argument looks like a shape and ``size`` is omitted.
     """
-    if size is None and _looks_like_shape(loc) and scale == 1.0:
+    if size is None and _looks_like_shape(loc) and _is_default_normal_scale(scale):
         size = loc
         loc = 0.0
 

--- a/tests/backend/test_jax_random_backend.py
+++ b/tests/backend/test_jax_random_backend.py
@@ -99,3 +99,19 @@ def test_normal_bool_location_is_not_interpreted_as_legacy_shape():
     random.seed(0)
 
     assert random.normal(True).shape == ()
+
+
+def test_normal_integer_tuple_location_with_array_scale_is_not_legacy_shape():
+    random.seed(0)
+
+    sample = random.normal((1, 2), scale=jnp.ones(2))
+
+    assert sample.shape == (2,)
+
+
+def test_normal_rejects_negative_scale():
+    with pytest.raises(ValueError, match="non-negative"):
+        random.normal(scale=-1.0)
+
+    with pytest.raises(ValueError, match="non-negative"):
+        random.normal(scale=jnp.array([1.0, -0.1]))


### PR DESCRIPTION
## Summary
- reject negative scalar and vector `scale` values in the JAX `random.normal` backend path
- avoid interpreting integer tuple locations as legacy shape arguments when an explicit array scale is provided
- add focused JAX regression coverage for both cases

## Rationale
The JAX backend previously implemented `normal` as `loc + scale * samples` without validating that `scale` is non-negative. This silently accepted invalid standard deviations where NumPy/PyTorch-compatible semantics should reject them. The legacy `normal(size)` shortcut also used a direct `scale == 1.0` guard, which is unsafe for array-valued scales and can misclassify integer tuple locations.

## Validation
- `python -m py_compile` on the modified standalone module and test file copies
- local JAX smoke check of the patched helper logic for negative scalar scale, negative vector scale, legacy shape arguments, and integer tuple location with array scale
- not run: full repository test suite, because direct GitHub clone/network access from this execution container failed with DNS resolution errors