### PR TITLE
Fix JAX random.normal broadcast sample shape

### DIFF
--- a/src/pyrecest/_backend/jax/random.py
+++ b/src/pyrecest/_backend/jax/random.py
@@ -204,8 +204,9 @@ def _normal(state, loc=0.0, scale=1.0, size=None, *args, **kwargs):
     scale = _jnp.asarray(scale)
     if bool(_jnp.any(scale < 0)):
         raise ValueError("scale must be non-negative")
+    sample_shape = _bounded_sampler_shape(size, loc, scale)
     state, key = jax.random.split(state)
-    samples = jax.random.normal(key, _shape_from_size(size), *args, **kwargs)
+    samples = jax.random.normal(key, sample_shape, *args, **kwargs)
     return state, loc + scale * samples
 
 

--- a/tests/backend/test_jax_random_backend.py
+++ b/tests/backend/test_jax_random_backend.py
@@ -109,6 +109,15 @@ def test_normal_integer_tuple_location_with_array_scale_is_not_legacy_shape():
     assert sample.shape == (2,)
 
 
+def test_normal_accepts_numpy_broadcasted_parameters_without_explicit_size():
+    random.seed(0)
+
+    sample = random.normal(jnp.array([0.0, 0.0]), jnp.ones(2))
+
+    assert sample.shape == (2,)
+    assert sample[0] != sample[1]
+
+
 def test_normal_rejects_negative_scale():
     with pytest.raises(ValueError, match="non-negative"):
         random.normal(scale=-1.0)


### PR DESCRIPTION
## Summary
- sample JAX `random.normal` draws using the broadcasted `loc`/`scale` shape when `size` is omitted
- preserve explicit `size` behavior for NumPy-compatible calls
- add regression coverage for array-valued `loc`/`scale` without an explicit `size`

## Rationale
The JAX backend previously drew a scalar standard-normal value whenever `size=None`, then broadcast that single draw across array-valued `loc`/`scale` parameters. This produced perfectly correlated output elements where NumPy-style semantics should draw independent samples with the broadcasted parameter shape.

## Validation
- local JAX smoke check comparing the old scalar-draw behavior with the patched broadcast-shape behavior
- focused regression test added in `tests/backend/test_jax_random_backend.py`
- full suite left to GitHub Actions because direct repository cloning is unavailable from this session