### PR TITLE
Expose autograd in explicit backend helper

### DIFF
--- a/src/pyrecest/backends/__init__.py
+++ b/src/pyrecest/backends/__init__.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import importlib
 from types import ModuleType
 
-SUPPORTED_BACKENDS: tuple[str, ...] = ("numpy", "pytorch", "jax")
+SUPPORTED_BACKENDS: tuple[str, ...] = ("numpy", "pytorch", "jax", "autograd")
 
 
 def get_backend(name: str) -> ModuleType:

--- a/tests/test_explicit_backends.py
+++ b/tests/test_explicit_backends.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 from pyrecest.backends import SUPPORTED_BACKENDS, get_backend
 
@@ -6,6 +8,21 @@ def test_get_backend_imports_supported_backend():
     backend = get_backend("numpy")
     assert backend.array([1.0]).shape == (1,)
     assert "numpy" in SUPPORTED_BACKENDS
+
+
+def test_get_backend_accepts_autograd_backend(monkeypatch):
+    imported = []
+    fake_backend = SimpleNamespace(has_autodiff=lambda: True)
+
+    def fake_import_module(module_name):
+        imported.append(module_name)
+        return fake_backend
+
+    monkeypatch.setattr("pyrecest.backends.importlib.import_module", fake_import_module)
+
+    assert "autograd" in SUPPORTED_BACKENDS
+    assert get_backend("autograd") is fake_backend
+    assert imported == ["pyrecest._backend.autograd"]
 
 
 def test_get_backend_rejects_unknown_backend():


### PR DESCRIPTION
## Summary
- add `autograd` to `SUPPORTED_BACKENDS` in `pyrecest.backends`
- add a regression test that verifies `get_backend("autograd")` is accepted and resolves to `pyrecest._backend.autograd`

## Notes
The public backend importer already supports `PYRECEST_BACKEND=autograd`, and the repository contains an autograd backend smoke test. This patch aligns the explicit backend access helper with that existing backend support.

## Validation
- Regression coverage added in `tests/test_explicit_backends.py`
- Full CI left to GitHub Actions because the execution container cannot clone github.com directly from this session