### PR TITLE
Fix PyTorch uniform broadcast sample shape

### DIFF
--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -196,6 +196,18 @@ def normal(loc=0.0, scale=1.0, size=None):
     return _torch.empty(size, dtype=dtype, device=loc.device).normal_() * scale + loc
 
 
+def _uniform_size(size, low, high):
+    if size is not None:
+        if not hasattr(size, "__iter__") or isinstance(size, (str, bytes)):
+            return (size,)
+        return tuple(int(dim) for dim in size)
+
+    try:
+        return tuple(_torch.broadcast_shapes(low.shape, high.shape))
+    except RuntimeError as exc:
+        raise ValueError("low and high could not be broadcast together") from exc
+
+
 def uniform(low=0.0, high=1.0, size=None, dtype=None):
     device = None
     if _torch.is_tensor(low):
@@ -205,12 +217,9 @@ def uniform(low=0.0, high=1.0, size=None, dtype=None):
 
     low = _torch.as_tensor(low, dtype=dtype, device=device)
     high = _torch.as_tensor(high, dtype=dtype, device=device)
+    size = _uniform_size(size, low, high)
     if bool(_torch.any(low > high)):
         raise ValueError("Upper bound must be greater than or equal to lower bound")
-    if size is None:
-        size = ()
-    elif not hasattr(size, "__iter__"):
-        size = (size,)
     return (high - low) * _torch.rand(size, dtype=dtype, device=device) + low
 
 

--- a/tests/test_pytorch_backend.py
+++ b/tests/test_pytorch_backend.py
@@ -193,6 +193,24 @@ class TestPytorchBackendRandom(unittest.TestCase):
         self.assertTrue(pytorch_backend.all(samples >= 0))
         self.assertTrue(pytorch_backend.all(samples < 5))
 
+    def test_uniform_accepts_broadcasted_array_bounds_without_explicit_size(self):
+        pytorch_backend.random.seed(0)
+
+        samples = pytorch_backend.random.uniform(
+            pytorch_backend.array([0.0, 10.0]), pytorch_backend.array([1.0, 11.0])
+        )
+
+        self.assertEqual(tuple(samples.shape), (2,))
+        self.assertTrue(pytorch_backend.all(samples >= pytorch_backend.array([0.0, 10.0])))
+        self.assertTrue(pytorch_backend.all(samples <= pytorch_backend.array([1.0, 11.0])))
+        self.assertNotEqual(float(samples[0] - 0.0), float(samples[1] - 10.0))
+
+    def test_uniform_rejects_incompatible_array_bounds_without_explicit_size(self):
+        with self.assertRaises(ValueError):
+            pytorch_backend.random.uniform(
+                pytorch_backend.zeros((2,)), pytorch_backend.ones((3,))
+            )
+
     def test_choice_accepts_weighted_sampling_without_replacement(self):
         values = pytorch_backend.array([0, 1, 2, 3])
         probabilities = pytorch_backend.array([0.1, 0.2, 0.3, 0.4])


### PR DESCRIPTION
## Summary
- sample PyTorch `random.uniform` draws using the broadcasted `low`/`high` shape when `size` is omitted
- preserve explicit `size` behavior for existing callers
- add regression coverage for broadcasted array-valued bounds and incompatible bound shapes

## Rationale
The PyTorch backend previously drew a scalar random value whenever `size=None`, then broadcast that same variate across array-valued bounds. That makes different output elements perfectly correlated where NumPy-compatible semantics require independent samples over the broadcasted bound shape.

## Validation
- added focused regression tests in `tests/test_pytorch_backend.py`
- direct repository clone/test execution is unavailable from this sandbox because GitHub DNS resolution fails; full suite left to GitHub Actions