### PR TITLE
Fix PyTorch multinomial size handling

### DIFF
--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -189,11 +189,44 @@ def rand(size=None, dtype=None):
     return _torch.rand(_shape_from_size(size), dtype=dtype)
 
 
-def multinomial(n, pvals):
+def _multinomial_sample_count(sample_shape):
+    return _prod(sample_shape) if sample_shape else 1
+
+
+def multinomial(n, pvals, size=None):
+    if not _looks_like_integer_dimension(n):
+        raise TypeError("n must be a non-negative integer")
+    n = int(n)
+    if n < 0:
+        raise ValueError("n must be non-negative")
+
+    sample_shape = _shape_from_size(size)
     device = pvals.device if _torch.is_tensor(pvals) else None
     pvals = _torch.as_tensor(pvals, dtype=_torch.float32, device=device)
-    pvals = pvals / pvals.sum()
-    return _torch.multinomial(pvals, n, replacement=True).bincount(minlength=len(pvals))
+    if pvals.ndim != 1:
+        raise ValueError("pvals must be 1-dimensional")
+    if pvals.numel() == 0:
+        raise ValueError("pvals must contain at least one probability")
+
+    p_sum = pvals.sum()
+    if (
+        bool(_torch.any(pvals < 0))
+        or not bool(_torch.isfinite(p_sum))
+        or bool(p_sum <= 0)
+    ):
+        raise ValueError("probabilities do not sum to a positive value")
+    pvals = pvals / p_sum
+
+    output_shape = (*sample_shape, pvals.shape[0])
+    sample_count = _multinomial_sample_count(sample_shape)
+    if n == 0 or sample_count == 0:
+        return _torch.zeros(output_shape, dtype=_torch.long, device=pvals.device)
+
+    samples = _torch.multinomial(pvals.expand(sample_count, -1), n, replacement=True)
+    counts = _torch.nn.functional.one_hot(samples, num_classes=pvals.shape[0]).sum(
+        dim=-2
+    )
+    return counts.reshape(output_shape)
 
 
 @_allow_complex_dtype

--- a/tests/test_backend_random.py
+++ b/tests/test_backend_random.py
@@ -93,11 +93,7 @@ class TestBackendRandom(unittest.TestCase):
         self.assertEqual(sample.shape, (2,))
         self.assertEqual(int(pyrecest.backend.sum(sample)), 12)
 
-    @unittest.skipIf(
-        pyrecest.backend.__backend_name__ != "jax",
-        "JAX-specific multinomial size support",
-    )
-    def test_jax_multinomial_accepts_size_argument(self):
+    def test_multinomial_accepts_size_argument(self):
         samples = random.multinomial(5, [0.25, 0.75], size=(2, 3))
 
         self.assertEqual(tuple(pyrecest.backend.shape(samples)), (2, 3, 2))
@@ -105,6 +101,11 @@ class TestBackendRandom(unittest.TestCase):
             pyrecest.backend.to_numpy(pyrecest.backend.sum(samples, axis=-1)),
             [[5, 5, 5], [5, 5, 5]],
         )
+
+    def test_multinomial_accepts_zero_sized_size_argument(self):
+        samples = random.multinomial(5, [0.25, 0.75], size=(0, 3))
+
+        self.assertEqual(tuple(pyrecest.backend.shape(samples)), (0, 3, 2))
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ != "jax", "JAX-specific size validation"
@@ -128,10 +129,10 @@ class TestBackendRandom(unittest.TestCase):
                         random_call(invalid_size)
 
     @unittest.skipIf(
-        pyrecest.backend.__backend_name__ != "jax",
-        "JAX-specific multinomial validation",
+        pyrecest.backend.__backend_name__ not in ("jax", "pytorch"),
+        "JAX/PyTorch-specific multinomial validation",
     )
-    def test_jax_multinomial_rejects_invalid_trial_count(self):
+    def test_multinomial_rejects_invalid_trial_count(self):
         for invalid_n in (True, 1.5, -1):
             with self.subTest(n=invalid_n):
                 with self.assertRaises((TypeError, ValueError)):


### PR DESCRIPTION
## Summary
- add NumPy-style `size=` support to the PyTorch random backend's `multinomial`
- validate PyTorch multinomial trial counts and probability vectors before sampling
- make the multinomial size regression test backend-general and keep stricter trial-count validation for JAX/PyTorch

## Validation
- Exercised the new PyTorch multinomial sampling logic locally in isolation with torch 2.10.0+cpu for `size=None`, `size=()`, scalar `size`, tuple `size`, zero-sized samples, zero-trial samples, and invalid size/trial/probability inputs.
- Full repository checkout/tests were not run from the sandbox; CI should cover the integrated test matrix on the PR.