### PR TITLE
Fix rand positional dimension handling for JAX and PyTorch

### DIFF
--- a/src/pyrecest/_backend/jax/random.py
+++ b/src/pyrecest/_backend/jax/random.py
@@ -80,6 +80,15 @@ def _shape_from_size(size):
     return tuple(_integer_dimension(dim) for dim in size)
 
 
+def _shape_from_rand_args(dims, size):
+    """Convert NumPy-style ``rand`` dimensions and ``size=`` to a shape."""
+    if dims:
+        if size is not None:
+            raise TypeError("Specify either positional dimensions or size, not both.")
+        size = dims[0] if len(dims) == 1 else dims
+    return _shape_from_size(size)
+
+
 def _broadcast_shape_from_values(*values):
     return _np.broadcast_shapes(*(tuple(value.shape) for value in values))
 
@@ -122,9 +131,9 @@ def _rand(state, size, *args, **kwargs):
     return state, jax.random.uniform(key, _shape_from_size(size), *args, **kwargs)
 
 
-def rand(size=None, *args, **kwargs):
+def rand(*dims, size=None, **kwargs):
     state, has_state, kwargs = _get_state(**kwargs)
-    state, res = _rand(state, size, *args, **kwargs)
+    state, res = _rand(state, _shape_from_rand_args(dims, size), **kwargs)
     return set_state_return(has_state, state, res)
 
 

--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -45,6 +45,15 @@ def _shape_from_size(size):
     return tuple(_integer_dimension(dim) for dim in size)
 
 
+def _shape_from_rand_args(dims, size):
+    """Convert NumPy-style ``rand`` dimensions and ``size=`` to a shape."""
+    if dims:
+        if size is not None:
+            raise TypeError("Specify either positional dimensions or size, not both.")
+        size = dims[0] if len(dims) == 1 else dims
+    return _shape_from_size(size)
+
+
 def _choice_size(size):
     if size is None:
         return None, 1
@@ -185,8 +194,8 @@ def seed(*args, **kwargs):
     return _torch.manual_seed(*args, **kwargs)
 
 
-def rand(size=None, dtype=None):
-    return _torch.rand(_shape_from_size(size), dtype=dtype)
+def rand(*dims, size=None, dtype=None):
+    return _torch.rand(_shape_from_rand_args(dims, size), dtype=dtype)
 
 
 def _multinomial_sample_count(sample_shape):

--- a/tests/backend/test_jax_random_backend.py
+++ b/tests/backend/test_jax_random_backend.py
@@ -27,6 +27,18 @@ def test_multivariate_normal_accepts_shape_keyword():
         random.multivariate_normal(mean, cov, size=(1,), shape=(2,))
 
 
+def test_rand_accepts_numpy_positional_dimensions():
+    random.seed(0)
+
+    assert random.rand(2, 3).shape == (2, 3)
+    assert random.rand(4).shape == (4,)
+
+
+def test_rand_rejects_ambiguous_positional_and_size_arguments():
+    with pytest.raises(TypeError, match="positional dimensions or size"):
+        random.rand(2, size=(3,))
+
+
 def test_uniform_accepts_numpy_broadcasted_bounds_without_explicit_size():
     random.seed(0)
 

--- a/tests/backend/test_pytorch_random_backend.py
+++ b/tests/backend/test_pytorch_random_backend.py
@@ -40,6 +40,18 @@ def test_size_arguments_reject_negative_dimensions(bad_size):
             sampler(bad_size)
 
 
+def test_rand_accepts_numpy_positional_dimensions():
+    random.seed(0)
+
+    assert random.rand(2, 3).shape == (2, 3)
+    assert random.rand(4).shape == (4,)
+
+
+def test_rand_rejects_ambiguous_positional_and_size_arguments():
+    with pytest.raises(TypeError, match="positional dimensions or size"):
+        random.rand(2, size=(3,))
+
+
 def test_scalar_and_empty_tuple_sizes_keep_scalar_shape():
     assert random.rand().shape == ()
     assert random.rand(size=()).shape == ()


### PR DESCRIPTION
## Summary
- add NumPy-style positional dimension support to the JAX and PyTorch random backends' `rand`
- reject ambiguous `rand(…, size=…)` calls consistently with the NumPy backend wrapper
- add backend-specific regression tests for JAX and PyTorch `rand(2, 3)` / `rand(4)` behavior

## Why
The NumPy backend accepts both `random.rand(size=(2, 3))` and legacy NumPy positional dimensions such as `random.rand(2, 3)`. The JAX and PyTorch backends previously treated additional positional dimensions as backend-specific arguments instead of shape dimensions, so `rand(2, 3)` did not honor the common PyRecEst/NumPy contract.

## Validation
- Inspected the generated branch diff through the GitHub compare API: 4 changed files, limited to JAX/PyTorch random backend code and their backend-specific tests.
- Full repository checkout/tests were not run from the sandbox; CI should cover the integrated backend matrix on this PR.