### PR TITLE
Fix PyTorch randint array-valued bounds

### DIFF
--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -65,11 +65,91 @@ def _randint_size(size):
     return _shape_from_size(size)
 
 
+def _is_array_parameter(value):
+    return (
+        _torch.is_tensor(value)
+        or isinstance(value, (list, tuple))
+        or (not isinstance(value, (str, bytes)) and hasattr(value, "__array__"))
+    )
+
+
+def _randint_device(*values, device=None):
+    if device is not None:
+        return device
+    for value in values:
+        if _torch.is_tensor(value):
+            return value.device
+    return None
+
+
+def _randint_array_size(size, low, high):
+    try:
+        parameter_shape = tuple(_torch.broadcast_shapes(low.shape, high.shape))
+    except RuntimeError as exc:
+        raise ValueError("low and high could not be broadcast together") from exc
+
+    if size is None:
+        return parameter_shape
+
+    sample_shape = _shape_from_size(size)
+    try:
+        broadcast_shape = tuple(_torch.broadcast_shapes(sample_shape, parameter_shape))
+    except RuntimeError as exc:
+        raise ValueError("size, low, and high could not be broadcast together") from exc
+    if broadcast_shape != sample_shape:
+        raise ValueError("size, low, and high could not be broadcast together")
+    return sample_shape
+
+
+def _randint_array(low, high, size, *args, **kwargs):
+    if args:
+        raise TypeError(
+            "array-valued randint bounds do not support additional positional arguments"
+        )
+
+    dtype = kwargs.pop("dtype", None)
+    if dtype is None:
+        dtype = _torch.int64
+    device = kwargs.pop("device", None)
+    generator = kwargs.pop("generator", None)
+    out = kwargs.pop("out", None)
+    if kwargs:
+        unexpected = ", ".join(sorted(kwargs))
+        raise TypeError(f"Unexpected keyword argument(s): {unexpected}")
+
+    device = _randint_device(low, high, device=device)
+    low = _torch.as_tensor(low, device=device)
+    high = _torch.as_tensor(high, device=device)
+    sample_shape = _randint_array_size(size, low, high)
+
+    try:
+        low = _torch.broadcast_to(low, sample_shape)
+        high = _torch.broadcast_to(high, sample_shape)
+    except RuntimeError as exc:
+        raise ValueError("size, low, and high could not be broadcast together") from exc
+
+    if bool(_torch.any(high <= low)):
+        raise ValueError("high must be greater than low")
+
+    span = high - low
+    unit_samples = _torch.rand(sample_shape, device=device, generator=generator)
+    result = _torch.floor(unit_samples * span).to(dtype=dtype) + low.to(dtype=dtype)
+
+    if out is not None:
+        out.copy_(result)
+        return out
+    return result
+
+
 def randint(low, high=None, size=None, *args, **kwargs):
     if high is None:
         if low is None:
             raise TypeError("randint() missing required argument 'high'")
+        if _is_array_parameter(low):
+            return _randint_array(0, low, size, *args, **kwargs)
         return _torch.randint(low, _randint_size(size), *args, **kwargs)
+    if _is_array_parameter(low) or _is_array_parameter(high):
+        return _randint_array(low, high, size, *args, **kwargs)
     return _torch.randint(low, high, _randint_size(size), *args, **kwargs)
 
 
@@ -84,14 +164,6 @@ def _normal_device(*values):
         if _torch.is_tensor(value):
             return value.device
     return None
-
-
-def _is_array_parameter(value):
-    return (
-        _torch.is_tensor(value)
-        or isinstance(value, (list, tuple))
-        or (not isinstance(value, (str, bytes)) and hasattr(value, "__array__"))
-    )
 
 
 def _normal_array_parameters(loc, scale):

--- a/tests/backend/test_pytorch_random_backend.py
+++ b/tests/backend/test_pytorch_random_backend.py
@@ -1,6 +1,6 @@
 import pytest
 
-pytest.importorskip("torch")
+torch = pytest.importorskip("torch")
 
 from pyrecest._backend.pytorch import random  # noqa: E402
 
@@ -50,6 +50,58 @@ def test_rand_accepts_numpy_positional_dimensions():
 def test_rand_rejects_ambiguous_positional_and_size_arguments():
     with pytest.raises(TypeError, match="positional dimensions or size"):
         random.rand(2, size=(3,))
+
+
+def test_randint_accepts_numpy_broadcasted_bounds_without_explicit_size():
+    random.seed(0)
+    low = torch.tensor([0, 10])
+    high = torch.tensor([3, 13])
+
+    samples = random.randint(low, high)
+
+    assert samples.shape == (2,)
+    assert torch.all(samples >= low)
+    assert torch.all(samples < high)
+
+
+def test_randint_accepts_numpy_broadcasted_bounds_with_explicit_size():
+    random.seed(0)
+    low = torch.tensor([0, 10])
+    high = torch.tensor([3, 13])
+
+    samples = random.randint(low, high, size=(4, 2))
+
+    assert samples.shape == (4, 2)
+    assert torch.all(samples >= low)
+    assert torch.all(samples < high)
+
+
+def test_randint_accepts_array_high_only():
+    random.seed(0)
+    high = torch.tensor([3, 13])
+
+    samples = random.randint(high)
+
+    assert samples.shape == (2,)
+    assert torch.all(samples >= 0)
+    assert torch.all(samples < high)
+
+
+def test_randint_rejects_incompatible_array_bounds_and_size():
+    with pytest.raises(ValueError, match="broadcast"):
+        random.randint(torch.tensor([0, 10]), torch.tensor([3, 13]), size=(3,))
+
+
+@pytest.mark.parametrize(
+    ("low", "high"),
+    [
+        (torch.tensor([0, 10]), torch.tensor([3])),
+        (torch.tensor([0, 10]), torch.tensor([0, 13])),
+    ],
+)
+def test_randint_rejects_invalid_array_bounds(low, high):
+    with pytest.raises(ValueError):
+        random.randint(low, high)
 
 
 def test_scalar_and_empty_tuple_sizes_keep_scalar_shape():


### PR DESCRIPTION
## Summary
- add NumPy-compatible handling for array-valued/broadcasted `low` and `high` bounds in the PyTorch random backend's `randint`
- preserve scalar-bound behavior by continuing to delegate to `torch.randint`
- add regression tests for broadcasted bounds, array-only `high`, incompatible sizes, and invalid bounds

## Validation
- Not run locally against the full repository because the execution environment cannot clone GitHub. The patch is covered by focused regression tests added in this PR.