### PR TITLE
Fix backend size and comb edge cases

### DIFF
--- a/src/pyrecest/_backend/_common.py
+++ b/src/pyrecest/_backend/_common.py
@@ -1,10 +1,11 @@
 import math as _math
 
+import numpy as _np
 from numpy import pi
 
 
 def comb(n, k):
-    return _math.factorial(n) // _math.factorial(k) // _math.factorial(n - k)
+    return _math.comb(n, k)
 
 
 def size(x, axis=None):
@@ -16,9 +17,7 @@ def size(x, axis=None):
 
     shape = getattr(x, "shape", None)
     if shape is None:
-        if axis is not None:
-            raise ValueError("axis is only supported for array-like inputs")
-        return 1
+        shape = _np.shape(x)
 
     if axis is not None:
         return shape[axis]

--- a/tests/test_backend_size.py
+++ b/tests/test_backend_size.py
@@ -1,6 +1,6 @@
 import unittest
 
-from pyrecest.backend import array, size
+from pyrecest.backend import array, comb, size
 
 
 class TestBackendSize(unittest.TestCase):
@@ -9,6 +9,22 @@ class TestBackendSize(unittest.TestCase):
 
     def test_size_returns_axis_length(self):
         self.assertEqual(size(array([[1, 2, 3], [4, 5, 6]]), axis=1), 3)
+
+    def test_size_handles_python_array_like_inputs(self):
+        values = [[1, 2, 3], [4, 5, 6]]
+
+        self.assertEqual(size(values), 6)
+        self.assertEqual(size(values, axis=0), 2)
+        self.assertEqual(size(values, axis=1), 3)
+
+    def test_size_handles_python_scalars(self):
+        self.assertEqual(size(3.0), 1)
+
+
+class TestBackendComb(unittest.TestCase):
+    def test_comb_returns_standard_binomial_values(self):
+        self.assertEqual(comb(5, 2), 10)
+        self.assertEqual(comb(3, 4), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Fix backend `size(...)` to infer shapes for Python array-like inputs instead of treating them as scalars.
- Use `math.comb` for standard binomial coefficient semantics, including out-of-range selections such as `comb(3, 4) == 0`.
- Add regression tests for Python list sizes, scalar sizes, and `comb(3, 4)`.

## Validation
- Not run locally; changes were reviewed through the GitHub connector.