### PR TITLE
Fix PyTorch dot and matvec backend helpers

### DIFF
--- a/src/pyrecest/_backend/_common.py
+++ b/src/pyrecest/_backend/_common.py
@@ -1,4 +1,5 @@
 import math as _math
+import os as _os
 
 import numpy as _np
 from numpy import pi
@@ -26,3 +27,71 @@ def size(x, axis=None):
     for dim in shape:
         result *= dim
     return result
+
+
+def _torch_module_for_values(*values):
+    try:
+        import torch as _torch
+    except ModuleNotFoundError:
+        return None
+
+    if _os.environ.get("PYRECEST_BACKEND") == "pytorch" or any(
+        _torch.is_tensor(value) for value in values
+    ):
+        return _torch
+    return None
+
+
+def _torch_promoted_pair(first, second):
+    torch = _torch_module_for_values(first, second)
+    if torch is None:
+        return None
+
+    device = next(
+        (value.device for value in (first, second) if torch.is_tensor(value)),
+        None,
+    )
+    first_tensor = torch.as_tensor(first, device=device)
+    second_tensor = torch.as_tensor(second, device=device)
+    dtype = torch.promote_types(first_tensor.dtype, second_tensor.dtype)
+    return first_tensor.to(dtype=dtype), second_tensor.to(dtype=dtype)
+
+
+def dot(a, b):
+    torch_pair = _torch_promoted_pair(a, b)
+    if torch_pair is not None:
+        a, b = torch_pair
+        torch = _torch_module_for_values(a, b)
+        if b.ndim == 1:
+            return torch.einsum("...i,i->...", a, b)
+        if a.ndim == 1:
+            return torch.einsum("i,...i->...", a, b)
+        return torch.einsum("...i,...i->...", a, b)
+
+    a = _np.asarray(a)
+    b = _np.asarray(b)
+    if b.ndim == 1:
+        return _np.einsum("...i,i->...", a, b)
+    if a.ndim == 1:
+        return _np.einsum("i,...i->...", a, b)
+    return _np.einsum("...i,...i->...", a, b)
+
+
+def matvec(matrix, vector):
+    torch_pair = _torch_promoted_pair(matrix, vector)
+    if torch_pair is not None:
+        matrix, vector = torch_pair
+        torch = _torch_module_for_values(matrix, vector)
+        if vector.ndim == 1:
+            return torch.matmul(matrix, vector)
+        if matrix.ndim == 2:
+            return torch.matmul(matrix, vector.T).T
+        return torch.einsum("...ij,...j->...i", matrix, vector)
+
+    matrix = _np.asarray(matrix)
+    vector = _np.asarray(vector)
+    if vector.ndim == 1:
+        return _np.matmul(matrix, vector)
+    if matrix.ndim == 2:
+        return _np.matmul(matrix, vector.T).T
+    return _np.einsum("...ij,...j->...i", matrix, vector)

--- a/src/pyrecest/_backend/pytorch/__init__.py
+++ b/src/pyrecest/_backend/pytorch/__init__.py
@@ -1219,6 +1219,8 @@ def outer(a, b):
 
 
 def matvec(A, b):
+    A = array(A)
+    b = array(b)
     A, b = convert_to_wider_dtype([A, b])
 
     if A.ndim == 2 and b.ndim == 1:
@@ -1234,6 +1236,8 @@ def matvec(A, b):
 
 
 def dot(a, b):
+    a = array(a)
+    b = array(b)
     a, b = convert_to_wider_dtype([a, b])
 
     if a.ndim == 1 and b.ndim == 1:

--- a/tests/backend_support/test_pytorch_linear_helpers_contract.py
+++ b/tests/backend_support/test_pytorch_linear_helpers_contract.py
@@ -1,0 +1,32 @@
+import pyrecest.backend as backend
+import pytest
+
+
+def _to_python(value):
+    value = backend.to_numpy(value)
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    return value
+
+
+def test_pytorch_backend_exposes_dot_and_matvec():
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific backend helper contract")
+
+    first = backend.asarray([[1.0, 2.0], [3.0, 4.0]])
+    second = backend.asarray([[5.0, 6.0], [7.0, 8.0]])
+
+    assert _to_python(backend.dot(first, second)) == [17.0, 53.0]
+    assert _to_python(backend.dot(first, [5.0, 6.0])) == [17.0, 39.0]
+
+    batched_matvec = backend.matvec(
+        backend.asarray([[[1.0, 0.0], [0.0, 1.0]], [[2.0, 0.0], [0.0, 3.0]]]),
+        first,
+    )
+    shared_vector_matvec = backend.matvec(
+        backend.asarray([[[1.0, 0.0], [0.0, 1.0]], [[2.0, 0.0], [0.0, 3.0]]]),
+        backend.asarray([1.0, 2.0]),
+    )
+
+    assert _to_python(batched_matvec) == [[1.0, 2.0], [6.0, 12.0]]
+    assert _to_python(shared_vector_matvec) == [[1.0, 2.0], [2.0, 6.0]]


### PR DESCRIPTION
## Summary
- Add shared backend fallback implementations for `dot` and `matvec` so the PyTorch facade can resolve its required attributes.
- Preserve Torch tensor outputs under `PYRECEST_BACKEND=pytorch`, including mixed tensor / array-like operands.
- Add PyTorch regression coverage for batched dot products and matrix-vector helpers.

## Validation
- Not run locally; changes were reviewed via the GitHub connector because the execution environment cannot clone from GitHub.