### PR TITLE
Add sparse transition row cache

### DIFF
--- a/docs/reference/sparse_transition_cache.md
+++ b/docs/reference/sparse_transition_cache.md
@@ -1,0 +1,45 @@
+# Sparse transition-row cache
+
+`pyrecest.filters.SparseTransitionRowCache` is a small utility for finite-support
+grid filters whose transition rows are expensive to build but frequently reused.
+
+It is intentionally domain-neutral. A row is represented as:
+
+```python
+(destination_indices, weights)
+```
+
+and callers define the cache key.
+
+```python
+from pyrecest.filters import SparseTransitionRowCache
+
+cache = SparseTransitionRowCache()
+
+dst, weights = cache.get_or_build(
+    key=("mode", 1, "source", 42),
+    builder=lambda: expensive_transition_row(),
+)
+
+print(cache.diagnostics())
+```
+
+The cache does not normalize or validate rows. That responsibility belongs to
+the filter or model-evidence routine consuming the rows. This keeps the cache
+useful for Euclidean grids, manifold grids, pair-state HMMs, and custom finite
+support transitions.
+
+The helper `cached_sparse_transition_rows` applies the same idea to a batch of
+source states:
+
+```python
+rows, cache = cached_sparse_transition_rows(
+    source_states,
+    row_builder=lambda state: build_row(state),
+    cache_key_builder=lambda state: tuple(state),
+)
+```
+
+The sparse second-order grid evidence primitive accepts an external cache via
+`transition_row_cache`, which lets callers keep row-reuse diagnostics or share
+a cache across repeated evidence calls with the same transition semantics.

--- a/src/pyrecest/filters/__init__.py
+++ b/src/pyrecest/filters/__init__.py
@@ -57,6 +57,8 @@ _FILTER_EXPORTS: Final[dict[str, str]] = {
     "mode_transition_matrix": ".discrete_state",
     "probabilities_to_log_probabilities": ".discrete_state",
     "scaled_emissions": ".discrete_state",
+    "SparseTransitionRowCache": ".sparse_transition_cache",
+    "cached_sparse_transition_rows": ".sparse_transition_cache",
     "sparse_gaussian_transition_matrix": ".discrete_state",
     "sticky_mode_transition_matrix": ".discrete_state",
     "uniform_log_probabilities": ".discrete_state",

--- a/src/pyrecest/filters/sparse_second_order_grid.py
+++ b/src/pyrecest/filters/sparse_second_order_grid.py
@@ -16,6 +16,7 @@ from typing import Any
 import numpy as np
 
 from .discrete_state import probabilities_to_log_probabilities, scaled_emissions
+from .sparse_transition_cache import SparseTransitionRowCache
 
 SparseTransitionRows = list[tuple[np.ndarray, np.ndarray]]
 SparsePairInitializer = Callable[
@@ -68,6 +69,7 @@ def sparse_second_order_grid_evidence(
     transition_row_builder: SparsePairTransitionRowBuilder,
     *,
     transition_cache_key_builder: SparsePairTransitionCacheKeyBuilder | None = None,
+    transition_row_cache: SparseTransitionRowCache | None = None,
     return_smoothed: bool = True,
     return_pair_lattice: bool = False,
 ) -> SparseSecondOrderGridResult:
@@ -90,6 +92,9 @@ def sparse_second_order_grid_evidence(
     transition_cache_key_builder:
         Optional callable used to share transition rows across repeated pair
         states.  Return ``None`` to skip caching for a row.
+    transition_row_cache:
+        Optional reusable cache instance. When omitted, a fresh cache is used
+        for this call.
     return_smoothed:
         If true, compute fixed-interval smoothed single-state marginals.
     return_pair_lattice:
@@ -131,7 +136,7 @@ def sparse_second_order_grid_evidence(
         int(value) for value in np.asarray(initial_edge_counts, dtype=int).ravel()
     ]
     transition_rows: list[SparseTransitionRows] = []
-    row_cache: dict[Hashable, tuple[np.ndarray, np.ndarray]] = {}
+    row_cache = transition_row_cache if transition_row_cache is not None else SparseTransitionRowCache()
     cache_hits = 0
     cache_misses = 0
     logp = float(np.log(first_scale) + offsets[0] + offsets[1])
@@ -216,7 +221,7 @@ def sparse_second_order_grid_evidence(
         "max_pair_count": int(pair_counts.max()),
         "mean_outgoing_count": float(np.mean(edge_counts)) if edge_counts else 0.0,
         "max_outgoing_count": int(np.max(edge_counts)) if edge_counts else 0,
-        "transition_row_cache_entries": int(len(row_cache)),
+        "transition_row_cache_entries": int(row_cache.entries),
         "transition_row_cache_hits": int(cache_hits),
         "transition_row_cache_misses": int(cache_misses),
         "backward_transition_rows": backward_label,
@@ -245,7 +250,7 @@ def _advance_sparse_pair_alpha(
     transition_index: int,
     transition_row_builder: SparsePairTransitionRowBuilder,
     cache_key_builder: SparsePairTransitionCacheKeyBuilder | None,
-    row_cache: dict[Hashable, tuple[np.ndarray, np.ndarray]],
+    row_cache: SparseTransitionRowCache[Hashable],
     store_transition_rows: bool,
 ) -> tuple[
     np.ndarray, np.ndarray, np.ndarray, list[int], SparseTransitionRows, int, int
@@ -271,8 +276,7 @@ def _advance_sparse_pair_alpha(
             if cache_key_builder is None
             else cache_key_builder(int(src_prev), int(src_curr), int(transition_index))
         )
-        cached = None if cache_key is None else row_cache.get(cache_key)
-        if cached is None:
+        def build_row() -> tuple[np.ndarray, np.ndarray]:
             dst, weights = transition_row_builder(
                 int(src_prev), int(src_curr), int(transition_index)
             )
@@ -295,12 +299,17 @@ def _advance_sparse_pair_alpha(
                 raise ValueError("transition row must contain positive mass")
             if not np.isclose(total, 1.0):
                 weights = weights / total
-            if cache_key is not None:
-                row_cache[cache_key] = (dst, weights)
+            return dst, weights
+
+        if cache_key is None:
+            dst, weights = build_row()
             cache_misses += 1
         else:
-            dst, weights = cached
-            cache_hits += 1
+            previous_hits = row_cache.hits
+            previous_misses = row_cache.misses
+            dst, weights = row_cache.get_or_build(cache_key, build_row)
+            cache_hits += int(row_cache.hits - previous_hits)
+            cache_misses += int(row_cache.misses - previous_misses)
 
         if store_transition_rows:
             transition_rows.append((dst, weights))

--- a/src/pyrecest/filters/sparse_transition_cache.py
+++ b/src/pyrecest/filters/sparse_transition_cache.py
@@ -1,0 +1,87 @@
+"""Reusable sparse transition-row cache utilities."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Hashable, Iterable
+from dataclasses import dataclass, field
+from typing import Generic, TypeVar
+
+import numpy as np
+
+SparseTransitionRow = tuple[np.ndarray, np.ndarray]
+SparseTransitionRowBuilder = Callable[[], SparseTransitionRow]
+KeyT = TypeVar("KeyT", bound=Hashable)
+StateT = TypeVar("StateT")
+
+
+@dataclass
+class SparseTransitionRowCache(Generic[KeyT]):
+    """Cache sparse transition rows keyed by caller-defined hashable values."""
+
+    rows: dict[KeyT, SparseTransitionRow] = field(default_factory=dict)
+    hits: int = 0
+    misses: int = 0
+
+    def get_or_build(self, key: KeyT, builder: SparseTransitionRowBuilder) -> SparseTransitionRow:
+        """Return the cached row for ``key`` or build/cache it on demand."""
+
+        try:
+            row = self.rows[key]
+        except KeyError:
+            row = builder()
+            self.rows[key] = row
+            self.misses += 1
+            return row
+        self.hits += 1
+        return row
+
+    @property
+    def entries(self) -> int:
+        """Number of cached transition rows."""
+
+        return len(self.rows)
+
+    def clear(self) -> None:
+        """Remove cached rows and reset hit/miss counters."""
+
+        self.rows.clear()
+        self.hits = 0
+        self.misses = 0
+
+    def diagnostics(self, prefix: str = "transition_row_cache") -> dict[str, int]:
+        """Return cache diagnostics with a configurable key prefix."""
+
+        return {
+            f"{prefix}_entries": int(self.entries),
+            f"{prefix}_hits": int(self.hits),
+            f"{prefix}_misses": int(self.misses),
+        }
+
+
+def cached_sparse_transition_rows(
+    source_states: Iterable[StateT],
+    row_builder: Callable[[StateT], SparseTransitionRow],
+    cache_key_builder: Callable[[StateT], Hashable | None],
+    *,
+    cache: SparseTransitionRowCache[Hashable] | None = None,
+) -> tuple[list[SparseTransitionRow], SparseTransitionRowCache[Hashable]]:
+    """Build transition rows with optional caller-defined row caching."""
+
+    row_cache: SparseTransitionRowCache[Hashable]
+    row_cache = cache if cache is not None else SparseTransitionRowCache()
+    rows: list[SparseTransitionRow] = []
+    for state in source_states:
+        key = cache_key_builder(state)
+        if key is None:
+            rows.append(row_builder(state))
+        else:
+            rows.append(row_cache.get_or_build(key, lambda state=state: row_builder(state)))
+    return rows, row_cache
+
+
+__all__ = [
+    "SparseTransitionRow",
+    "SparseTransitionRowBuilder",
+    "SparseTransitionRowCache",
+    "cached_sparse_transition_rows",
+]

--- a/tests/test_sparse_transition_cache.py
+++ b/tests/test_sparse_transition_cache.py
@@ -1,0 +1,74 @@
+import numpy as np
+
+from pyrecest.filters import SparseTransitionRowCache, cached_sparse_transition_rows
+
+
+def test_sparse_transition_row_cache_reuses_rows_and_reports_diagnostics():
+    cache: SparseTransitionRowCache[tuple[int, int]] = SparseTransitionRowCache()
+    build_calls = 0
+
+    def builder() -> tuple[np.ndarray, np.ndarray]:
+        nonlocal build_calls
+        build_calls += 1
+        return np.array([0, 1]), np.array([0.25, 0.75])
+
+    row1 = cache.get_or_build((1, 2), builder)
+    row2 = cache.get_or_build((1, 2), builder)
+
+    assert build_calls == 1
+    assert row1 is row2
+    assert cache.entries == 1
+    assert cache.hits == 1
+    assert cache.misses == 1
+    assert cache.diagnostics() == {
+        "transition_row_cache_entries": 1,
+        "transition_row_cache_hits": 1,
+        "transition_row_cache_misses": 1,
+    }
+
+
+def test_cached_sparse_transition_rows_bypasses_none_keys():
+    cache: SparseTransitionRowCache = SparseTransitionRowCache()
+    build_calls: list[int] = []
+
+    def builder(state: int) -> tuple[np.ndarray, np.ndarray]:
+        build_calls.append(state)
+        return np.array([state]), np.array([1.0])
+
+    rows, used_cache = cached_sparse_transition_rows(
+        [1, 1, 2, 2],
+        builder,
+        lambda state: None if state == 2 else state,
+        cache=cache,
+    )
+
+    assert used_cache is cache
+    assert [row[0].item() for row in rows] == [1, 1, 2, 2]
+    assert build_calls == [1, 2, 2]
+    assert cache.entries == 1
+    assert cache.hits == 1
+    assert cache.misses == 1
+
+
+def test_sparse_second_order_grid_accepts_external_transition_cache():
+    from pyrecest.filters import sparse_second_order_grid_evidence
+
+    cache: SparseTransitionRowCache[tuple[int, int, int]] = SparseTransitionRowCache()
+    log_likelihood = np.log(np.array([[0.6, 0.4], [0.5, 0.5], [0.4, 0.6], [0.5, 0.5]]))
+
+    def initial_pair_initializer(_scaled):
+        return np.array([0, 1]), np.array([0, 1]), np.array([0.5, 0.5]), [1, 1]
+
+    def transition_row_builder(_prev, curr, _transition_index):
+        return np.array([curr]), np.array([1.0])
+
+    result = sparse_second_order_grid_evidence(
+        log_likelihood,
+        initial_pair_initializer,
+        transition_row_builder,
+        transition_cache_key_builder=lambda prev, curr, transition_index: (prev, curr, transition_index),
+        transition_row_cache=cache,
+    )
+
+    assert result.diagnostics["transition_row_cache_entries"] == cache.entries
+    assert result.diagnostics["transition_row_cache_misses"] == cache.misses


### PR DESCRIPTION
Summary:
- add reusable sparse transition row cache utilities
- wire sparse second-order grid evidence through the cache
- document and cover cache behavior with focused regressions

Verification:
- python -m py_compile src\\pyrecest\\filters\\sparse_transition_cache.py src\\pyrecest\\filters\\sparse_second_order_grid.py tests\\test_sparse_transition_cache.py
- git diff --check

Tests were not run per request.