### PR TITLE
Implement PyTorch fftconvolve backend helper

### DIFF
--- a/src/pyrecest/_backend/capabilities.py
+++ b/src/pyrecest/_backend/capabilities.py
@@ -20,7 +20,6 @@ BACKEND_CAPABILITIES: Final = {
     "pytorch": {
         "unsupported": {
             "": ("searchsorted",),
-            "signal": ("fftconvolve",),
         },
         "bridged": {
             "linalg": {

--- a/src/pyrecest/_backend/pytorch/signal.py
+++ b/src/pyrecest/_backend/pytorch/signal.py
@@ -1,2 +1,86 @@
-def fftconvolve(*args, **kwargs):
-    raise NotImplementedError("fftconvolve is not implemented for this backend.")
+import numpy as _np
+import torch as _torch
+
+
+def _normalize_axes(axes, ndim):
+    if axes is None:
+        axes = tuple(range(ndim))
+    elif isinstance(axes, (int, _np.integer)):
+        axes = (int(axes),)
+    else:
+        axes = tuple(int(axis) for axis in axes)
+
+    normalized_axes = []
+    for axis in axes:
+        if axis < 0:
+            axis += ndim
+        if axis < 0 or axis >= ndim:
+            raise ValueError(f"axis {axis} is out of bounds for array of dimension {ndim}")
+        normalized_axes.append(axis)
+
+    if len(set(normalized_axes)) != len(normalized_axes):
+        raise ValueError("duplicate value in 'axes'")
+    return tuple(normalized_axes)
+
+
+def _as_tensor_pair(in1, in2):
+    device = next((value.device for value in (in1, in2) if _torch.is_tensor(value)), None)
+    x = in1 if _torch.is_tensor(in1) else _torch.as_tensor(in1, device=device)
+    y = in2 if _torch.is_tensor(in2) else _torch.as_tensor(in2, device=x.device)
+    y = y.to(device=x.device)
+
+    dtype = _torch.promote_types(x.dtype, y.dtype)
+    if not (dtype.is_floating_point or dtype.is_complex):
+        dtype = _torch.get_default_dtype()
+    return x.to(dtype=dtype), y.to(dtype=dtype)
+
+
+def _centered_slice(full_shape, target_shape, axes):
+    slices = [slice(None)] * len(full_shape)
+    for axis in axes:
+        start = (full_shape[axis] - target_shape[axis]) // 2
+        slices[axis] = slice(start, start + target_shape[axis])
+    return tuple(slices)
+
+
+def _valid_slice(shape1, shape2, axes):
+    slices = [slice(None)] * len(shape1)
+    for axis in axes:
+        start = min(shape1[axis], shape2[axis]) - 1
+        length = abs(shape1[axis] - shape2[axis]) + 1
+        slices[axis] = slice(start, start + length)
+    return tuple(slices)
+
+
+def fftconvolve(in1, in2, mode="full", axes=None):
+    """Convolve two arrays using FFTs with SciPy-compatible shape semantics."""
+    if mode not in {"full", "same", "valid"}:
+        raise ValueError("mode must be 'full', 'same', or 'valid'")
+
+    x, y = _as_tensor_pair(in1, in2)
+    if x.ndim != y.ndim:
+        raise ValueError("in1 and in2 should have the same dimensionality")
+
+    axes = _normalize_axes(axes, x.ndim)
+    if mode == "valid":
+        x_larger = all(x.shape[axis] >= y.shape[axis] for axis in axes)
+        y_larger = all(y.shape[axis] >= x.shape[axis] for axis in axes)
+        if not (x_larger or y_larger):
+            raise ValueError("For mode='valid', one input must be at least as large as the other in every selected dimension.")
+
+    fft_shape = tuple(int(x.shape[axis] + y.shape[axis] - 1) for axis in axes)
+    real_result = not (x.dtype.is_complex or y.dtype.is_complex)
+
+    result = _torch.fft.ifftn(
+        _torch.fft.fftn(x, s=fft_shape, dim=axes) * _torch.fft.fftn(y, s=fft_shape, dim=axes),
+        s=fft_shape,
+        dim=axes,
+    )
+    if real_result:
+        result = result.real
+
+    if mode == "same":
+        return result[_centered_slice(tuple(result.shape), tuple(x.shape), axes)]
+    if mode == "valid":
+        return result[_valid_slice(tuple(x.shape), tuple(y.shape), axes)]
+    return result

--- a/tests/backend_support/test_pytorch_fftconvolve_contract.py
+++ b/tests/backend_support/test_pytorch_fftconvolve_contract.py
@@ -1,0 +1,34 @@
+import numpy as np
+import pyrecest.backend as backend
+import pytest
+from scipy.signal import fftconvolve as scipy_fftconvolve
+
+
+def _as_numpy(value):
+    return backend.to_numpy(value)
+
+
+def test_pytorch_fftconvolve_matches_scipy_full_same_valid():
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific signal backend contract")
+
+    first = backend.asarray([[1.0, 2.0, 0.0], [0.5, -1.0, 3.0]])
+    second = backend.asarray([[2.0, -1.0], [0.0, 0.25]])
+
+    for mode in ("full", "same", "valid"):
+        actual = _as_numpy(backend.signal.fftconvolve(first, second, mode=mode))
+        expected = scipy_fftconvolve(_as_numpy(first), _as_numpy(second), mode=mode)
+        assert np.allclose(actual, expected)
+
+
+def test_pytorch_fftconvolve_matches_scipy_selected_axes():
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific signal backend contract")
+
+    first = backend.asarray(np.arange(12.0).reshape(2, 3, 2))
+    second = backend.ones((2, 2, 2))
+
+    actual = _as_numpy(backend.signal.fftconvolve(first, second, mode="same", axes=(1, 2)))
+    expected = scipy_fftconvolve(_as_numpy(first), _as_numpy(second), mode="same", axes=(1, 2))
+
+    assert np.allclose(actual, expected)


### PR DESCRIPTION
## Summary
- Implement `pyrecest.backend.signal.fftconvolve` for the PyTorch backend using `torch.fft`.
- Preserve SciPy-compatible `mode={full,same,valid}` and selected-axis shape semantics.
- Remove PyTorch `signal.fftconvolve` from unsupported backend capability metadata.
- Add focused PyTorch regression coverage against `scipy.signal.fftconvolve`.

## Validation
- Locally validated the implementation prototype against SciPy for 1-D, 2-D, and selected-axis cases in the execution sandbox.
- Full repository test run was not possible from the sandbox because direct GitHub clone failed with DNS resolution errors; CI should validate the branch in GitHub Actions.