### PR TITLE
Add evidence modes and tracking records

### DIFF
--- a/docs/reference/sparse_second_order_grid.md
+++ b/docs/reference/sparse_second_order_grid.md
@@ -14,3 +14,15 @@ The implementation is intentionally domain-neutral: replay, map matching,
 maneuvering target tracking, and other second-order grid models can supply their
 own transition-row builder while sharing the same forward/backward evidence
 calculation.
+
+## Evidence-only mode
+
+Set `evidence_mode="evidence_only"` or `return_smoothed=False` when a model
+comparison or parameter sweep only needs `log p(y_1:T | model)`.  The forward
+recursion and terminal posterior are still computed, but the backward smoother
+and smoothed time-marginals are skipped.
+
+The log evidence must match full-smoothing mode to numerical precision.  The
+diagnostics include `evidence_computation_mode`, `evidence_only`,
+`smoothed_posterior_returned`, and `terminal_posterior_returned` so downstream
+artifact tables can make the output mode explicit.

--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -23,6 +23,10 @@ from pyrecest.exceptions import (  # noqa: F401
     ShapeError,
     ValidationError,
 )
+from pyrecest.evidence import (  # noqa: F401
+    EvidenceComputationMode,
+    resolve_evidence_computation_mode,
+)
 from pyrecest.stability import (  # noqa: F401
     get_public_api_status,
     iter_public_api_status,
@@ -38,6 +42,7 @@ __all__ = [
     "BackendNotSupportedError",
     "BackendSupportError",
     "DimensionMismatchError",
+    "EvidenceComputationMode",
     "NumericalStabilityError",
     "OptionalDependencyError",
     "PyRecEstError",
@@ -55,4 +60,5 @@ __all__ = [
     "iter_public_api_status",
     "stability",
     "warn_if_backend_env_changed",
+    "resolve_evidence_computation_mode",
 ]

--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -1,0 +1,121 @@
+"""Generic evidence-computation mode helpers.
+
+Many filters and smoothers can compute the model evidence with a forward pass
+without also constructing a fixed-interval smoothed posterior.  This module
+provides a small domain-neutral way to make that choice explicit and to expose
+consistent diagnostics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+EvidenceComputationKind = Literal["full_smoothing", "evidence_only"]
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceComputationMode:
+    """Declare whether an evidence computation should also smooth posteriors.
+
+    Parameters
+    ----------
+    mode:
+        ``"full_smoothing"`` requests the standard forward/backward output;
+        ``"evidence_only"`` requests forward evidence and terminal posterior
+        only.
+    return_smoothed:
+        Whether fixed-interval smoothed posterior marginals should be returned.
+    terminal_posterior:
+        Whether a terminal posterior is expected.  Most evidence-only filters
+        can return this cheaply from the final filtering distribution.
+    metadata:
+        Optional caller-provided metadata copied into diagnostics.
+    """
+
+    mode: EvidenceComputationKind = "full_smoothing"
+    return_smoothed: bool = True
+    terminal_posterior: bool = True
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.mode not in {"full_smoothing", "evidence_only"}:
+            raise ValueError(f"unknown evidence computation mode {self.mode!r}")
+        if self.mode == "evidence_only" and self.return_smoothed:
+            raise ValueError("evidence_only mode cannot return smoothed posteriors")
+        if self.mode == "full_smoothing" and not self.return_smoothed:
+            raise ValueError("full_smoothing mode must return smoothed posteriors")
+        object.__setattr__(self, "metadata", dict(self.metadata))
+
+    @classmethod
+    def full_smoothing(cls, *, metadata: dict[str, Any] | None = None) -> "EvidenceComputationMode":
+        """Return a mode that computes full fixed-interval smoothing."""
+
+        return cls(
+            mode="full_smoothing",
+            return_smoothed=True,
+            terminal_posterior=True,
+            metadata={} if metadata is None else metadata,
+        )
+
+    @classmethod
+    def evidence_only(cls, *, metadata: dict[str, Any] | None = None) -> "EvidenceComputationMode":
+        """Return a mode that skips smoothing and keeps evidence semantics."""
+
+        return cls(
+            mode="evidence_only",
+            return_smoothed=False,
+            terminal_posterior=True,
+            metadata={} if metadata is None else metadata,
+        )
+
+    @classmethod
+    def from_return_smoothed(cls, return_smoothed: bool) -> "EvidenceComputationMode":
+        """Build a mode from the common Boolean smoothing flag."""
+
+        return cls.full_smoothing() if bool(return_smoothed) else cls.evidence_only()
+
+    @property
+    def evidence_only_requested(self) -> bool:
+        """Whether this mode is the evidence-only fast path."""
+
+        return self.mode == "evidence_only"
+
+    def to_diagnostics(self, prefix: str = "evidence") -> dict[str, Any]:
+        """Return stable scalar diagnostics for reports and artifacts."""
+
+        diagnostics = {
+            f"{prefix}_computation_mode": self.mode,
+            f"{prefix}_only": int(self.evidence_only_requested),
+            f"{prefix}_return_smoothed": int(self.return_smoothed),
+            f"{prefix}_terminal_posterior": int(self.terminal_posterior),
+        }
+        diagnostics.update({f"{prefix}_{key}": value for key, value in self.metadata.items()})
+        return diagnostics
+
+
+def resolve_evidence_computation_mode(
+    mode: EvidenceComputationMode | str | None = None,
+    *,
+    return_smoothed: bool | None = None,
+) -> EvidenceComputationMode:
+    """Resolve a string/Boolean compatibility mode into a typed object."""
+
+    if isinstance(mode, EvidenceComputationMode):
+        return mode
+    if mode is None:
+        return EvidenceComputationMode.from_return_smoothed(True if return_smoothed is None else bool(return_smoothed))
+
+    key = str(mode).strip().lower().replace("-", "_")
+    if key in {"full", "full_smoothing", "smoothed", "smoothing"}:
+        return EvidenceComputationMode.full_smoothing()
+    if key in {"evidence", "evidence_only", "forward_only", "filter_only", "no_smoothing"}:
+        return EvidenceComputationMode.evidence_only()
+    raise ValueError(f"unknown evidence computation mode {mode!r}")
+
+
+__all__ = [
+    "EvidenceComputationKind",
+    "EvidenceComputationMode",
+    "resolve_evidence_computation_mode",
+]

--- a/src/pyrecest/filters/sparse_second_order_grid.py
+++ b/src/pyrecest/filters/sparse_second_order_grid.py
@@ -15,6 +15,7 @@ from typing import Any
 
 import numpy as np
 
+from pyrecest.evidence import EvidenceComputationMode, resolve_evidence_computation_mode
 from .discrete_state import probabilities_to_log_probabilities, scaled_emissions
 from .sparse_transition_cache import SparseTransitionRowCache
 
@@ -70,7 +71,8 @@ def sparse_second_order_grid_evidence(
     *,
     transition_cache_key_builder: SparsePairTransitionCacheKeyBuilder | None = None,
     transition_row_cache: SparseTransitionRowCache | None = None,
-    return_smoothed: bool = True,
+    return_smoothed: bool | None = True,
+    evidence_mode: EvidenceComputationMode | str | None = None,
     return_pair_lattice: bool = False,
 ) -> SparseSecondOrderGridResult:
     """Compute exact evidence for a sparse second-order grid HMM.
@@ -96,7 +98,11 @@ def sparse_second_order_grid_evidence(
         Optional reusable cache instance. When omitted, a fresh cache is used
         for this call.
     return_smoothed:
-        If true, compute fixed-interval smoothed single-state marginals.
+        Compatibility flag.  If true, compute fixed-interval smoothed
+        single-state marginals.  Ignored when ``evidence_mode`` is supplied.
+    evidence_mode:
+        Optional explicit computation mode; use ``"evidence_only"`` to skip
+        backward smoothing while keeping the same log evidence.
     return_pair_lattice:
         If true, retain the normalized pair filtering lattice in the result.
     """
@@ -107,6 +113,10 @@ def sparse_second_order_grid_evidence(
         raise ValueError(
             "sparse second-order evidence requires at least two time steps"
         )
+    mode = resolve_evidence_computation_mode(
+        evidence_mode, return_smoothed=return_smoothed
+    )
+    return_smoothed = mode.return_smoothed
 
     prev, curr, alpha, initial_edge_counts = initial_pair_initializer(scaled)
     prev = np.asarray(prev, dtype=int)
@@ -226,6 +236,9 @@ def sparse_second_order_grid_evidence(
         "transition_row_cache_misses": int(cache_misses),
         "backward_transition_rows": backward_label,
     }
+    diagnostics.update(mode.to_diagnostics())
+    diagnostics["smoothed_posterior_returned"] = int(smoothed_log is not None)
+    diagnostics["terminal_posterior_returned"] = 1
 
     return SparseSecondOrderGridResult(
         log_marginal_likelihood=float(logp),

--- a/src/pyrecest/tracking/__init__.py
+++ b/src/pyrecest/tracking/__init__.py
@@ -1,0 +1,21 @@
+"""Generic tracking event and replay-record helpers."""
+
+from .event_records import (
+    TrackingEvent,
+    TrackingRecord,
+    action_counts,
+    event_from_measurement,
+    record_from_update,
+    records_to_dicts,
+    records_to_matrix,
+)
+
+__all__ = [
+    "TrackingEvent",
+    "TrackingRecord",
+    "action_counts",
+    "event_from_measurement",
+    "record_from_update",
+    "records_to_dicts",
+    "records_to_matrix",
+]

--- a/src/pyrecest/tracking/event_records.py
+++ b/src/pyrecest/tracking/event_records.py
@@ -1,0 +1,292 @@
+"""Asynchronous tracking events and replay-record containers.
+
+The classes in this module are deliberately filter-independent.  They provide a
+small, serializable schema for multi-sensor replay pipelines that need to keep
+accepted updates, rejected measurements, and predict-only/coast events in one
+chronological record table.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+import numpy as np
+
+TrackingAction = Literal["predict", "update", "reject", "coast"] | str
+
+
+def _array_or_none(value: Any, *, name: str, ndim: int | None = None) -> np.ndarray | None:
+    if value is None:
+        return None
+    array = np.asarray(value, dtype=float)
+    if ndim is not None and array.ndim != ndim:
+        raise ValueError(f"{name} must have ndim={ndim}")
+    if not np.isfinite(array).all():
+        raise ValueError(f"{name} must contain only finite values")
+    return array.copy()
+
+
+def _vector(value: Any, *, name: str) -> np.ndarray:
+    array = np.asarray(value, dtype=float).reshape(-1)
+    if array.size == 0:
+        raise ValueError(f"{name} must contain at least one element")
+    if not np.isfinite(array).all():
+        raise ValueError(f"{name} must contain only finite values")
+    return array.copy()
+
+
+def _square_matrix(value: Any, *, name: str, dim: int | None = None) -> np.ndarray:
+    matrix = np.asarray(value, dtype=float)
+    if matrix.ndim != 2 or matrix.shape[0] != matrix.shape[1]:
+        raise ValueError(f"{name} must be a square matrix")
+    if dim is not None and matrix.shape != (dim, dim):
+        raise ValueError(f"{name} must have shape ({dim}, {dim})")
+    if not np.isfinite(matrix).all():
+        raise ValueError(f"{name} must contain only finite values")
+    return matrix.copy()
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    return value
+
+
+@dataclass(frozen=True)
+class TrackingEvent:
+    """One asynchronous sensor event or predict-only replay event."""
+
+    time: float
+    source: str
+    action: TrackingAction = "update"
+    measurement: np.ndarray | None = None
+    measurement_model: Any | None = None
+    covariance: np.ndarray | None = None
+    accepted: bool | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        time = float(self.time)
+        if not np.isfinite(time):
+            raise ValueError("time must be finite")
+        measurement = _array_or_none(self.measurement, name="measurement", ndim=1)
+        covariance = _array_or_none(self.covariance, name="covariance", ndim=2)
+        if measurement is not None and covariance is not None:
+            if covariance.shape != (measurement.size, measurement.size):
+                raise ValueError("covariance must match measurement dimension")
+        object.__setattr__(self, "time", time)
+        object.__setattr__(self, "source", str(self.source))
+        object.__setattr__(self, "action", str(self.action))
+        object.__setattr__(self, "measurement", measurement)
+        object.__setattr__(self, "covariance", covariance)
+        object.__setattr__(self, "accepted", None if self.accepted is None else bool(self.accepted))
+        object.__setattr__(self, "metadata", dict(self.metadata))
+
+    @property
+    def measurement_dim(self) -> int | None:
+        return None if self.measurement is None else int(self.measurement.size)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON/CSV-friendly shallow dictionary."""
+
+        return {
+            "time": self.time,
+            "source": self.source,
+            "action": self.action,
+            "measurement": _jsonable(self.measurement),
+            "covariance": _jsonable(self.covariance),
+            "accepted": self.accepted,
+            "measurement_dim": self.measurement_dim,
+            "metadata": _jsonable(dict(self.metadata)),
+        }
+
+
+@dataclass(frozen=True)
+class TrackingRecord:
+    """Prior/posterior record for one processed tracking event."""
+
+    time: float
+    source: str
+    action: str
+    prior_mean: np.ndarray
+    prior_cov: np.ndarray
+    posterior_mean: np.ndarray
+    posterior_cov: np.ndarray
+    innovation: np.ndarray | None = None
+    innovation_cov: np.ndarray | None = None
+    nis: float | None = None
+    accepted: bool | None = None
+    measurement: np.ndarray | None = None
+    event_metadata: Mapping[str, Any] = field(default_factory=dict)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        time = float(self.time)
+        if not np.isfinite(time):
+            raise ValueError("time must be finite")
+        prior_mean = _vector(self.prior_mean, name="prior_mean")
+        posterior_mean = _vector(self.posterior_mean, name="posterior_mean")
+        if posterior_mean.shape != prior_mean.shape:
+            raise ValueError("posterior_mean must match prior_mean shape")
+        prior_cov = _square_matrix(self.prior_cov, name="prior_cov", dim=prior_mean.size)
+        posterior_cov = _square_matrix(self.posterior_cov, name="posterior_cov", dim=prior_mean.size)
+        innovation = _array_or_none(self.innovation, name="innovation", ndim=1)
+        innovation_cov = _array_or_none(self.innovation_cov, name="innovation_cov", ndim=2)
+        if innovation is not None and innovation_cov is not None:
+            if innovation_cov.shape != (innovation.size, innovation.size):
+                raise ValueError("innovation_cov must match innovation dimension")
+        measurement = _array_or_none(self.measurement, name="measurement", ndim=1)
+        nis = None if self.nis is None else float(self.nis)
+        if nis is not None and (not np.isfinite(nis) or nis < 0.0):
+            raise ValueError("nis must be finite and nonnegative")
+        object.__setattr__(self, "time", time)
+        object.__setattr__(self, "source", str(self.source))
+        object.__setattr__(self, "action", str(self.action))
+        object.__setattr__(self, "prior_mean", prior_mean)
+        object.__setattr__(self, "prior_cov", prior_cov)
+        object.__setattr__(self, "posterior_mean", posterior_mean)
+        object.__setattr__(self, "posterior_cov", posterior_cov)
+        object.__setattr__(self, "innovation", innovation)
+        object.__setattr__(self, "innovation_cov", innovation_cov)
+        object.__setattr__(self, "nis", nis)
+        object.__setattr__(self, "accepted", None if self.accepted is None else bool(self.accepted))
+        object.__setattr__(self, "measurement", measurement)
+        object.__setattr__(self, "event_metadata", dict(self.event_metadata))
+        object.__setattr__(self, "metadata", dict(self.metadata))
+
+    @property
+    def state_dim(self) -> int:
+        return int(self.posterior_mean.size)
+
+    def to_dict(self, *, include_legacy_aliases: bool = False) -> dict[str, Any]:
+        """Return a JSON/CSV-friendly dictionary.
+
+        ``include_legacy_aliases`` adds ``time_s``, ``state``, and ``covariance``
+        keys used by existing record-table code in many trackers.
+        """
+
+        result = {
+            "time": self.time,
+            "source": self.source,
+            "action": self.action,
+            "accepted": self.accepted,
+            "prior_mean": self.prior_mean.copy(),
+            "prior_cov": self.prior_cov.copy(),
+            "posterior_mean": self.posterior_mean.copy(),
+            "posterior_cov": self.posterior_cov.copy(),
+            "innovation": None if self.innovation is None else self.innovation.copy(),
+            "innovation_cov": None if self.innovation_cov is None else self.innovation_cov.copy(),
+            "nis": self.nis,
+            "measurement": None if self.measurement is None else self.measurement.copy(),
+            "event_metadata": dict(self.event_metadata),
+            "metadata": dict(self.metadata),
+        }
+        if include_legacy_aliases:
+            result.update(
+                {
+                    "time_s": self.time,
+                    "state": self.posterior_mean.copy(),
+                    "covariance": self.posterior_cov.copy(),
+                }
+            )
+        return result
+
+
+def event_from_measurement(
+    *,
+    time: float,
+    source: str,
+    measurement: Any | None = None,
+    measurement_model: Any | None = None,
+    covariance: Any | None = None,
+    accepted: bool | None = None,
+    action: TrackingAction = "update",
+    metadata: Mapping[str, Any] | None = None,
+) -> TrackingEvent:
+    """Construct a :class:`TrackingEvent` from generic measurement fields."""
+
+    return TrackingEvent(
+        time=time,
+        source=source,
+        action=action,
+        measurement=measurement,
+        measurement_model=measurement_model,
+        covariance=covariance,
+        accepted=accepted,
+        metadata={} if metadata is None else dict(metadata),
+    )
+
+
+def record_from_update(
+    *,
+    event: TrackingEvent,
+    prior_mean: Any,
+    prior_cov: Any,
+    posterior_mean: Any,
+    posterior_cov: Any,
+    innovation: Any | None = None,
+    innovation_cov: Any | None = None,
+    nis: float | None = None,
+    accepted: bool | None = None,
+    action: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> TrackingRecord:
+    """Construct a tracking record from one event and prior/posterior states."""
+
+    resolved_accepted = event.accepted if accepted is None else accepted
+    return TrackingRecord(
+        time=event.time,
+        source=event.source,
+        action=event.action if action is None else action,
+        prior_mean=prior_mean,
+        prior_cov=prior_cov,
+        posterior_mean=posterior_mean,
+        posterior_cov=posterior_cov,
+        innovation=innovation,
+        innovation_cov=innovation_cov,
+        nis=nis,
+        accepted=resolved_accepted,
+        measurement=event.measurement,
+        event_metadata=event.metadata,
+        metadata={} if metadata is None else dict(metadata),
+    )
+
+
+def records_to_dicts(
+    records: Iterable[TrackingRecord], *, include_legacy_aliases: bool = False
+) -> list[dict[str, Any]]:
+    """Convert tracking records to dictionaries."""
+
+    return [record.to_dict(include_legacy_aliases=include_legacy_aliases) for record in records]
+
+
+def records_to_matrix(
+    records: Iterable[TrackingRecord], *, field: str = "posterior_mean") -> np.ndarray:
+    """Stack a vector-valued field from records into a matrix."""
+
+    arrays = [np.asarray(getattr(record, field), dtype=float).reshape(-1) for record in records]
+    if not arrays:
+        return np.empty((0, 0), dtype=float)
+    return np.stack(arrays)
+
+
+def action_counts(records: Iterable[TrackingRecord | Mapping[str, Any]]) -> dict[str, int]:
+    """Count tracking records by action label."""
+
+    counter: Counter[str] = Counter()
+    for record in records:
+        if isinstance(record, TrackingRecord):
+            action = record.action
+        else:
+            action = str(record.get("action", record.get("update_action", "unknown")))
+        counter[str(action)] += 1
+    return dict(counter)

--- a/src/pyrecest/utils/__init__.py
+++ b/src/pyrecest/utils/__init__.py
@@ -65,6 +65,15 @@ from .pairwise_covariance_features import (
     pairwise_covariance_shape_components,
     pairwise_mahalanobis_distances,
 )
+from .track_edit_whatif import (
+    TrackEdit,
+    TrackEditApplication,
+    TrackEditDelta,
+    apply_track_edit,
+    rank_track_edits_by_delta,
+    score_track_edit_delta,
+    score_track_edits,
+)
 from .track_evaluation import (
     complete_track_set,
     normalize_track_matrix,
@@ -138,6 +147,13 @@ __all__ = [
     "score_track_purity",
     "track_latencies",
     "track_purity",
+    "TrackEdit",
+    "TrackEditApplication",
+    "TrackEditDelta",
+    "apply_track_edit",
+    "rank_track_edits_by_delta",
+    "score_track_edit_delta",
+    "score_track_edits",
     "CalibratedPairwiseAssociationModel",
     "LogisticPairwiseAssociationModel",
     "NamedPairwiseFeatureSchema",

--- a/src/pyrecest/utils/track_edit_whatif.py
+++ b/src/pyrecest/utils/track_edit_whatif.py
@@ -1,0 +1,518 @@
+"""Track-matrix edit what-if scoring utilities."""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+import numpy as np
+
+from .track_evaluation import normalize_track_matrix
+
+TrackEditKind = Literal["add_link", "remove_link", "swap_link", "split_track", "merge_tracks"]
+TrackLink = tuple[int, int, int, int]
+_COUNT_KEYS = (
+    "pairwise_true_positives",
+    "pairwise_false_positives",
+    "pairwise_false_negatives",
+    "complete_track_true_positives",
+    "complete_track_false_positives",
+    "complete_track_false_negatives",
+)
+
+
+@dataclass(frozen=True)
+class TrackEdit:
+    """A local structural edit to a multi-session track matrix.
+
+    The common link-edit fields describe an adjacent or non-adjacent link
+    ``session_a:source_observation -> session_b:target_observation``. Extra
+    edit-specific details, such as the wrong edge removed by a swap, live in
+    ``metadata`` so domain packages can annotate edits without extending the
+    generic API.
+    """
+
+    kind: TrackEditKind
+    session_a: int | None = None
+    session_b: int | None = None
+    source_observation: int | None = None
+    target_observation: int | None = None
+    track_index: int | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class TrackEditApplication:
+    """Result of applying one structural edit to a track matrix."""
+
+    edit: TrackEdit
+    track_matrix: np.ndarray
+    applied: bool
+    action: str
+    reason: str
+    creates_duplicate_source: bool = False
+    creates_duplicate_target: bool = False
+
+
+@dataclass(frozen=True)
+class TrackEditDelta:
+    """Metric delta induced by a structural track edit."""
+
+    edit: TrackEdit
+    pairwise_tp_delta: int
+    pairwise_fp_delta: int
+    pairwise_fn_delta: int
+    complete_tp_delta: int
+    complete_fp_delta: int
+    complete_fn_delta: int
+    new_pairwise_f1: float
+    new_complete_track_f1: float
+    creates_duplicate_source: bool
+    creates_duplicate_target: bool
+    breaks_complete_track: bool
+    applied: bool = False
+    action: str = ""
+    reason: str = ""
+
+
+def apply_track_edit(track_matrix: Any, edit: TrackEdit) -> TrackEditApplication:
+    """Apply ``edit`` to ``track_matrix`` and return the edited matrix.
+
+    Missing observations are represented as ``None`` in the returned matrix.
+    Callers that use integer ``-1`` sentinels can convert the result after the
+    edit, while scoring functions in this module can consume it directly.
+    """
+
+    matrix = normalize_track_matrix(track_matrix)
+    if edit.kind == "add_link":
+        return _apply_add_link(matrix, edit)
+    if edit.kind == "remove_link":
+        return _apply_remove_link(matrix, edit)
+    if edit.kind == "swap_link":
+        return _apply_swap_link(matrix, edit)
+    if edit.kind == "split_track":
+        return _apply_split_track(matrix, edit)
+    if edit.kind == "merge_tracks":
+        return _apply_merge_tracks(matrix, edit)
+    raise ValueError(f"Unsupported track edit kind: {edit.kind!r}")
+
+
+def score_track_edit_delta(
+    predicted_track_matrix: Any,
+    reference_track_matrix: Any,
+    edit: TrackEdit,
+    *,
+    session_pairs: Iterable[tuple[int, int]] | None = None,
+    complete_session_indices: Sequence[int] | None = None,
+    count_duplicates: bool = False,
+) -> TrackEditDelta:
+    """Score the metric delta produced by one edit.
+
+    By default, pairwise and complete tracks are scored as identity sets, matching
+    PyRecEst's generic track-evaluation helpers.  Set ``count_duplicates=True``
+    for benchmark protocols where duplicate predicted rows or links should count
+    as false positives.
+    """
+
+    predicted = normalize_track_matrix(predicted_track_matrix)
+    reference = normalize_track_matrix(reference_track_matrix)
+    _validate_compatible_shapes(predicted, reference)
+    application = apply_track_edit(predicted, edit)
+    baseline = _score_track_matrices(
+        predicted,
+        reference,
+        session_pairs=session_pairs,
+        complete_session_indices=complete_session_indices,
+        count_duplicates=count_duplicates,
+    )
+    candidate = _score_track_matrices(
+        application.track_matrix,
+        reference,
+        session_pairs=session_pairs,
+        complete_session_indices=complete_session_indices,
+        count_duplicates=count_duplicates,
+    )
+    deltas = {key: int(candidate[key]) - int(baseline[key]) for key in _COUNT_KEYS}
+    return TrackEditDelta(
+        edit=edit,
+        pairwise_tp_delta=deltas["pairwise_true_positives"],
+        pairwise_fp_delta=deltas["pairwise_false_positives"],
+        pairwise_fn_delta=deltas["pairwise_false_negatives"],
+        complete_tp_delta=deltas["complete_track_true_positives"],
+        complete_fp_delta=deltas["complete_track_false_positives"],
+        complete_fn_delta=deltas["complete_track_false_negatives"],
+        new_pairwise_f1=float(candidate["pairwise_f1"]),
+        new_complete_track_f1=float(candidate["complete_track_f1"]),
+        creates_duplicate_source=bool(application.creates_duplicate_source),
+        creates_duplicate_target=bool(application.creates_duplicate_target),
+        breaks_complete_track=bool(
+            int(candidate["complete_track_true_positives"])
+            < int(baseline["complete_track_true_positives"])
+        ),
+        applied=bool(application.applied),
+        action=str(application.action),
+        reason=str(application.reason),
+    )
+
+
+def score_track_edits(
+    predicted_track_matrix: Any,
+    reference_track_matrix: Any,
+    edits: Iterable[TrackEdit],
+    *,
+    session_pairs: Iterable[tuple[int, int]] | None = None,
+    complete_session_indices: Sequence[int] | None = None,
+    count_duplicates: bool = False,
+) -> tuple[TrackEditDelta, ...]:
+    """Score a collection of independent one-edit what-ifs."""
+
+    edit_rows = tuple(edits)
+    return tuple(
+        score_track_edit_delta(
+            predicted_track_matrix,
+            reference_track_matrix,
+            edit,
+            session_pairs=session_pairs,
+            complete_session_indices=complete_session_indices,
+            count_duplicates=count_duplicates,
+        )
+        for edit in edit_rows
+    )
+
+
+def rank_track_edits_by_delta(
+    predicted_track_matrix: Any,
+    reference_track_matrix: Any,
+    edits: Iterable[TrackEdit],
+    *,
+    session_pairs: Iterable[tuple[int, int]] | None = None,
+    complete_session_indices: Sequence[int] | None = None,
+    count_duplicates: bool = False,
+) -> tuple[TrackEditDelta, ...]:
+    """Return independent edits sorted by complete-track then pairwise F1 gain."""
+
+    deltas = score_track_edits(
+        predicted_track_matrix,
+        reference_track_matrix,
+        edits,
+        session_pairs=session_pairs,
+        complete_session_indices=complete_session_indices,
+        count_duplicates=count_duplicates,
+    )
+    return tuple(sorted(deltas, key=_rank_key))
+
+
+def _apply_add_link(matrix: np.ndarray, edit: TrackEdit) -> TrackEditApplication:
+    session_a, session_b, source, target = _require_link_fields(edit)
+    output = matrix.copy()
+    source_rows = tuple(int(row) for row in np.flatnonzero(output[:, session_a] == source))
+    target_rows = tuple(int(row) for row in np.flatnonzero(output[:, session_b] == target))
+    duplicate_source = any(
+        output[row_index, session_b] is not None and output[row_index, session_b] != target
+        for row_index in source_rows
+    )
+    duplicate_target = any(
+        output[row_index, session_a] is not None and output[row_index, session_a] != source
+        for row_index in target_rows
+    )
+    if duplicate_source or duplicate_target:
+        return TrackEditApplication(
+            edit,
+            output,
+            False,
+            "reject",
+            "duplicate_source_or_target",
+            creates_duplicate_source=bool(duplicate_source),
+            creates_duplicate_target=bool(duplicate_target),
+        )
+    if len(source_rows) == 1 and len(target_rows) == 0:
+        output[int(source_rows[0]), session_b] = int(target)
+        return TrackEditApplication(edit, output, True, "insert_target", "accepted")
+    if len(source_rows) == 0 and len(target_rows) == 1:
+        output[int(target_rows[0]), session_a] = int(source)
+        return TrackEditApplication(edit, output, True, "insert_source", "accepted")
+    if len(source_rows) == 1 and len(target_rows) == 1:
+        source_row = int(source_rows[0])
+        target_row = int(target_rows[0])
+        if source_row == target_row:
+            return TrackEditApplication(edit, output, True, "already_same_component", "accepted")
+        merged = _merge_rows_if_compatible(output[source_row], output[target_row])
+        if merged is not None:
+            keep = [index for index in range(output.shape[0]) if index != target_row]
+            output[source_row] = merged
+            return TrackEditApplication(edit, output[np.asarray(keep, dtype=int)], True, "merge_components", "accepted")
+    if len(source_rows) == 0 and len(target_rows) == 0:
+        new_row = np.empty((1, output.shape[1]), dtype=object)
+        new_row[:] = None
+        new_row[0, session_a] = int(source)
+        new_row[0, session_b] = int(target)
+        return TrackEditApplication(edit, np.vstack([output, new_row]), True, "add_partial_component", "accepted")
+    return TrackEditApplication(edit, output, False, "reject", "ambiguous_multiple_components")
+
+
+def _apply_remove_link(matrix: np.ndarray, edit: TrackEdit) -> TrackEditApplication:
+    session_a, session_b, source, target = _require_link_fields(edit)
+    occurrence_index = int(edit.metadata.get("occurrence_index", 0))
+    output = matrix.copy()
+    matching_rows = tuple(
+        int(row)
+        for row in np.flatnonzero(
+            (output[:, session_a] == source) & (output[:, session_b] == target)
+        )
+    )
+    if occurrence_index >= len(matching_rows):
+        return TrackEditApplication(edit, output, False, "reject", "edge_not_found")
+    row_index = matching_rows[occurrence_index]
+    left = output[row_index].copy()
+    right = output[row_index].copy()
+    left[session_b:] = None
+    right[:session_b] = None
+    pieces = [row for index, row in enumerate(output) if index != row_index]
+    if any(value is not None for value in left):
+        pieces.append(left)
+    if any(value is not None for value in right):
+        pieces.append(right)
+    candidate = np.vstack(pieces).astype(object, copy=False) if pieces else output[:0]
+    return TrackEditApplication(edit, candidate, True, "split_component_at_edge", "accepted")
+
+
+def _apply_swap_link(matrix: np.ndarray, edit: TrackEdit) -> TrackEditApplication:
+    session_a, session_b, source, target = _require_link_fields(edit)
+    wrong_session_a = int(edit.metadata.get("remove_session_a", session_a))
+    wrong_session_b = int(edit.metadata.get("remove_session_b", session_b))
+    wrong_source = _metadata_int(edit, "remove_source_observation")
+    wrong_target = _metadata_int(edit, "remove_target_observation")
+    output = matrix.copy()
+    if (session_a, session_b) != (wrong_session_a, wrong_session_b):
+        return TrackEditApplication(edit, output, False, "reject", "session_pair_mismatch")
+    matching_rows = tuple(
+        int(row)
+        for row in np.flatnonzero(
+            (output[:, session_a] == wrong_source) & (output[:, session_b] == wrong_target)
+        )
+    )
+    if not matching_rows:
+        return TrackEditApplication(edit, output, False, "reject", "wrong_edge_not_found")
+    row_index = int(matching_rows[0])
+    row_indices = np.arange(output.shape[0])
+    duplicate_source = bool(
+        source != wrong_source
+        and np.any((output[:, session_a] == source) & (row_indices != row_index))
+    )
+    duplicate_target = bool(
+        target != wrong_target
+        and np.any((output[:, session_b] == target) & (row_indices != row_index))
+    )
+    output[row_index, session_a] = int(source)
+    output[row_index, session_b] = int(target)
+    return TrackEditApplication(
+        edit,
+        output,
+        True,
+        "swap_adjacent_edge",
+        "accepted",
+        creates_duplicate_source=duplicate_source,
+        creates_duplicate_target=duplicate_target,
+    )
+
+
+def _apply_split_track(matrix: np.ndarray, edit: TrackEdit) -> TrackEditApplication:
+    if edit.track_index is None:
+        raise ValueError("split_track edits require track_index")
+    if edit.session_b is None:
+        raise ValueError("split_track edits require session_b as split point")
+    row_index = int(edit.track_index)
+    split_session = int(edit.session_b)
+    output = matrix.copy()
+    if row_index < 0 or row_index >= output.shape[0]:
+        return TrackEditApplication(edit, output, False, "reject", "track_index_out_of_bounds")
+    if split_session <= 0 or split_session >= output.shape[1]:
+        return TrackEditApplication(edit, output, False, "reject", "split_session_out_of_bounds")
+    left = output[row_index].copy()
+    right = output[row_index].copy()
+    left[split_session:] = None
+    right[:split_session] = None
+    pieces = [row for index, row in enumerate(output) if index != row_index]
+    if any(value is not None for value in left):
+        pieces.append(left)
+    if any(value is not None for value in right):
+        pieces.append(right)
+    return TrackEditApplication(edit, np.vstack(pieces).astype(object, copy=False), True, "split_track", "accepted")
+
+
+def _apply_merge_tracks(matrix: np.ndarray, edit: TrackEdit) -> TrackEditApplication:
+    if edit.track_index is None:
+        raise ValueError("merge_tracks edits require track_index")
+    other = edit.metadata.get("other_track_index")
+    if other is None:
+        raise ValueError("merge_tracks edits require metadata['other_track_index']")
+    left_index = int(edit.track_index)
+    right_index = int(other)
+    output = matrix.copy()
+    if left_index < 0 or right_index < 0 or left_index >= output.shape[0] or right_index >= output.shape[0]:
+        return TrackEditApplication(edit, output, False, "reject", "track_index_out_of_bounds")
+    if left_index == right_index:
+        return TrackEditApplication(edit, output, True, "already_same_component", "accepted")
+    merged = _merge_rows_if_compatible(output[left_index], output[right_index])
+    if merged is None:
+        return TrackEditApplication(edit, output, False, "reject", "row_conflict")
+    keep = [index for index in range(output.shape[0]) if index != right_index]
+    output[left_index] = merged
+    return TrackEditApplication(edit, output[np.asarray(keep, dtype=int)], True, "merge_tracks", "accepted")
+
+
+def _require_link_fields(edit: TrackEdit) -> TrackLink:
+    fields = (edit.session_a, edit.session_b, edit.source_observation, edit.target_observation)
+    if any(value is None for value in fields):
+        raise ValueError(f"{edit.kind} edits require session_a, session_b, source_observation, and target_observation")
+    session_a, session_b, source, target = (int(value) for value in fields if value is not None)
+    if session_a < 0 or session_b < 0 or session_a >= session_b:
+        raise ValueError("edit sessions must satisfy 0 <= session_a < session_b")
+    return session_a, session_b, source, target
+
+
+def _metadata_int(edit: TrackEdit, name: str) -> int:
+    if name not in edit.metadata:
+        raise ValueError(f"swap_link edits require metadata[{name!r}]")
+    return int(edit.metadata[name])
+
+
+def _merge_rows_if_compatible(left: np.ndarray, right: np.ndarray) -> np.ndarray | None:
+    values: list[int | None] = []
+    for left_value, right_value in zip(left, right, strict=True):
+        if left_value is not None and right_value is not None and left_value != right_value:
+            return None
+        values.append(left_value if left_value is not None else right_value)
+    return np.asarray(values, dtype=object)
+
+
+def _score_track_matrices(
+    predicted: np.ndarray,
+    reference: np.ndarray,
+    *,
+    session_pairs: Iterable[tuple[int, int]] | None,
+    complete_session_indices: Sequence[int] | None,
+    count_duplicates: bool,
+) -> dict[str, float | int]:
+    if count_duplicates:
+        pairwise = _score_multiset_identities(
+            _track_link_counter(predicted, session_pairs=session_pairs),
+            _track_link_counter(reference, session_pairs=session_pairs),
+            prefix="pairwise",
+        )
+        complete = _score_multiset_identities(
+            _complete_track_counter(predicted, session_indices=complete_session_indices),
+            _complete_track_counter(reference, session_indices=complete_session_indices),
+            prefix="complete_track",
+        )
+    else:
+        pairwise = _score_set_identities(
+            set(_track_link_counter(predicted, session_pairs=session_pairs)),
+            set(_track_link_counter(reference, session_pairs=session_pairs)),
+            prefix="pairwise",
+        )
+        complete = _score_set_identities(
+            set(_complete_track_counter(predicted, session_indices=complete_session_indices)),
+            set(_complete_track_counter(reference, session_indices=complete_session_indices)),
+            prefix="complete_track",
+        )
+    return {**pairwise, **complete}
+
+
+def _score_set_identities(predicted: set[Any], reference: set[Any], *, prefix: str) -> dict[str, float | int]:
+    true_positives = len(predicted & reference)
+    false_positives = len(predicted - reference)
+    false_negatives = len(reference - predicted)
+    return _count_row(prefix, true_positives, false_positives, false_negatives)
+
+
+def _score_multiset_identities(predicted: Counter[Any], reference: Counter[Any], *, prefix: str) -> dict[str, float | int]:
+    true_positives = int(sum((predicted & reference).values()))
+    false_positives = int(sum(predicted.values())) - true_positives
+    false_negatives = int(sum(reference.values())) - true_positives
+    return _count_row(prefix, true_positives, false_positives, false_negatives)
+
+
+def _count_row(prefix: str, true_positives: int, false_positives: int, false_negatives: int) -> dict[str, float | int]:
+    return {
+        f"{prefix}_true_positives": int(true_positives),
+        f"{prefix}_false_positives": int(false_positives),
+        f"{prefix}_false_negatives": int(false_negatives),
+        f"{prefix}_f1": _f1(true_positives, false_positives, false_negatives),
+    }
+
+
+def _track_link_counter(
+    track_matrix: np.ndarray,
+    *,
+    session_pairs: Iterable[tuple[int, int]] | None,
+) -> Counter[TrackLink]:
+    counter: Counter[TrackLink] = Counter()
+    for session_a, session_b in _session_pairs(track_matrix, session_pairs):
+        for row in track_matrix:
+            observation_a = row[session_a]
+            observation_b = row[session_b]
+            if observation_a is not None and observation_b is not None:
+                counter[(int(session_a), int(session_b), int(observation_a), int(observation_b))] += 1
+    return counter
+
+
+def _complete_track_counter(
+    track_matrix: np.ndarray,
+    *,
+    session_indices: Sequence[int] | None,
+) -> Counter[tuple[int, ...]]:
+    selected = tuple(range(track_matrix.shape[1])) if session_indices is None else tuple(int(index) for index in session_indices)
+    counter: Counter[tuple[int, ...]] = Counter()
+    for row in track_matrix:
+        observations: list[int] = []
+        for session_index in selected:
+            value = row[int(session_index)]
+            if value is None:
+                break
+            observations.append(int(value))
+        else:
+            counter[tuple(observations)] += 1
+    return counter
+
+
+def _session_pairs(
+    matrix: np.ndarray,
+    session_pairs: Iterable[tuple[int, int]] | None,
+) -> tuple[tuple[int, int], ...]:
+    if session_pairs is None:
+        return tuple((index, index + 1) for index in range(max(0, matrix.shape[1] - 1)))
+    pairs = tuple((int(session_a), int(session_b)) for session_a, session_b in session_pairs)
+    for session_a, session_b in pairs:
+        if session_a < 0 or session_b <= session_a:
+            raise ValueError("session pairs must satisfy 0 <= session_a < session_b")
+        if session_b >= matrix.shape[1]:
+            raise IndexError(f"session pair {(session_a, session_b)} out of bounds for {matrix.shape[1]} sessions")
+    return pairs
+
+
+def _validate_compatible_shapes(predicted: np.ndarray, reference: np.ndarray) -> None:
+    if predicted.ndim != 2 or reference.ndim != 2:
+        raise ValueError("track matrices must have shape (n_tracks, n_sessions)")
+    if predicted.shape[1] != reference.shape[1]:
+        raise ValueError("predicted and reference track matrices must have the same number of sessions")
+
+
+def _f1(tp: int, fp: int, fn: int) -> float:
+    denominator = 2 * int(tp) + int(fp) + int(fn)
+    if denominator == 0:
+        return 1.0
+    return float(2 * int(tp) / denominator)
+
+
+def _rank_key(delta: TrackEditDelta) -> tuple[float, float, bool, bool, bool, str]:
+    return (
+        -float(delta.new_complete_track_f1),
+        -float(delta.new_pairwise_f1),
+        not delta.applied,
+        bool(delta.creates_duplicate_source),
+        bool(delta.creates_duplicate_target),
+        str(delta.edit.kind),
+    )

--- a/tests/test_evidence_only_mode.py
+++ b/tests/test_evidence_only_mode.py
@@ -1,0 +1,76 @@
+import numpy as np
+import pytest
+
+from pyrecest.evidence import EvidenceComputationMode, resolve_evidence_computation_mode
+from pyrecest.filters import sparse_second_order_grid_evidence
+
+
+def test_evidence_computation_mode_resolves_boolean_and_string_aliases():
+    full = resolve_evidence_computation_mode(return_smoothed=True)
+    fast = resolve_evidence_computation_mode("evidence-only")
+
+    assert full.mode == "full_smoothing"
+    assert full.return_smoothed
+    assert not full.evidence_only_requested
+    assert fast.mode == "evidence_only"
+    assert not fast.return_smoothed
+    assert fast.evidence_only_requested
+    assert fast.to_diagnostics()["evidence_computation_mode"] == "evidence_only"
+
+
+def test_evidence_computation_mode_rejects_inconsistent_flags():
+    with pytest.raises(ValueError, match="evidence_only"):
+        EvidenceComputationMode(mode="evidence_only", return_smoothed=True)
+    with pytest.raises(ValueError, match="full_smoothing"):
+        EvidenceComputationMode(mode="full_smoothing", return_smoothed=False)
+    with pytest.raises(ValueError, match="unknown"):
+        resolve_evidence_computation_mode("posterior-only")
+
+
+def test_sparse_second_order_grid_accepts_evidence_only_mode_object():
+    log_likelihood = np.log(
+        np.array(
+            [
+                [0.7, 0.3],
+                [0.4, 0.6],
+                [0.5, 0.5],
+            ],
+            dtype=float,
+        )
+    )
+
+    def initial_pair_initializer(scaled):
+        prev = np.array([0, 0, 1, 1])
+        curr = np.array([0, 1, 0, 1])
+        prior = np.array([0.5, 0.5])
+        values = prior[prev] * 0.5 * scaled[0, prev] * scaled[1, curr]
+        return prev, curr, values, [2, 2]
+
+    def transition_row_builder(prev: int, curr: int, transition_index: int):
+        del prev, transition_index
+        if curr == 0:
+            return np.array([0, 1]), np.array([0.8, 0.2])
+        return np.array([0, 1]), np.array([0.3, 0.7])
+
+    full = sparse_second_order_grid_evidence(
+        log_likelihood,
+        initial_pair_initializer,
+        transition_row_builder,
+        evidence_mode=EvidenceComputationMode.full_smoothing(),
+    )
+    fast = sparse_second_order_grid_evidence(
+        log_likelihood,
+        initial_pair_initializer,
+        transition_row_builder,
+        evidence_mode=EvidenceComputationMode.evidence_only(),
+    )
+
+    assert fast.smoothed_log_probabilities is None
+    assert full.smoothed_log_probabilities is not None
+    assert full.log_marginal_likelihood == pytest.approx(fast.log_marginal_likelihood, abs=1e-12)
+    np.testing.assert_allclose(np.exp(fast.terminal_log_probabilities).sum(), 1.0)
+    assert fast.diagnostics["evidence_computation_mode"] == "evidence_only"
+    assert fast.diagnostics["evidence_only"] == 1
+    assert fast.diagnostics["backward_transition_rows"] == "skipped_evidence_only"
+    assert fast.diagnostics["smoothed_posterior_returned"] == 0
+    assert fast.diagnostics["terminal_posterior_returned"] == 1

--- a/tests/test_track_edit_whatif.py
+++ b/tests/test_track_edit_whatif.py
@@ -1,0 +1,130 @@
+"""Tests for generic track-edit what-if scoring."""
+
+from pyrecest.utils.track_edit_whatif import (
+    TrackEdit,
+    apply_track_edit,
+    rank_track_edits_by_delta,
+    score_track_edit_delta,
+)
+
+
+def test_add_link_scores_clean_completion_delta() -> None:
+    predicted = [[1, 2, None]]
+    reference = [[1, 2, 3]]
+    edit = TrackEdit(
+        kind="add_link",
+        session_a=1,
+        session_b=2,
+        source_observation=2,
+        target_observation=3,
+    )
+
+    delta = score_track_edit_delta(predicted, reference, edit)
+
+    assert delta.applied
+    assert delta.action == "insert_target"
+    assert delta.pairwise_tp_delta == 1
+    assert delta.pairwise_fn_delta == -1
+    assert delta.complete_tp_delta == 1
+    assert delta.new_complete_track_f1 == 1.0
+
+
+def test_remove_link_splits_track_and_removes_false_positive() -> None:
+    predicted = [[1, 2, 99, 4]]
+    reference = [[1, 2, 3, 4]]
+    edit = TrackEdit(
+        kind="remove_link",
+        session_a=1,
+        session_b=2,
+        source_observation=2,
+        target_observation=99,
+    )
+
+    application = apply_track_edit(predicted, edit)
+    delta = score_track_edit_delta(predicted, reference, edit)
+
+    assert application.applied
+    assert application.action == "split_component_at_edge"
+    assert application.track_matrix.tolist() == [[1, 2, None, None], [None, None, 99, 4]]
+    assert delta.pairwise_fp_delta == -1
+    assert delta.complete_fp_delta == -1
+
+
+def test_swap_link_replaces_wrong_adjacent_edge() -> None:
+    predicted = [[1, 2, 99]]
+    reference = [[1, 2, 3]]
+    edit = TrackEdit(
+        kind="swap_link",
+        session_a=1,
+        session_b=2,
+        source_observation=2,
+        target_observation=3,
+        metadata={
+            "remove_session_a": 1,
+            "remove_session_b": 2,
+            "remove_source_observation": 2,
+            "remove_target_observation": 99,
+        },
+    )
+
+    delta = score_track_edit_delta(predicted, reference, edit)
+
+    assert delta.applied
+    assert delta.action == "swap_adjacent_edge"
+    assert delta.pairwise_tp_delta == 1
+    assert delta.pairwise_fp_delta == -1
+    assert delta.pairwise_fn_delta == -1
+    assert delta.complete_tp_delta == 1
+    assert delta.complete_fp_delta == -1
+
+
+def test_add_link_rejects_duplicate_source() -> None:
+    predicted = [[1, 2, 99]]
+    reference = [[1, 2, 3]]
+    edit = TrackEdit(
+        kind="add_link",
+        session_a=1,
+        session_b=2,
+        source_observation=2,
+        target_observation=3,
+    )
+
+    delta = score_track_edit_delta(predicted, reference, edit)
+
+    assert not delta.applied
+    assert delta.creates_duplicate_source
+    assert delta.reason == "duplicate_source_or_target"
+    assert delta.pairwise_tp_delta == 0
+
+
+def test_duplicate_sensitive_scoring_counts_duplicate_false_positive() -> None:
+    predicted = [[1, 2], [1, 2]]
+    reference = [[1, 2]]
+    edit = TrackEdit(
+        kind="remove_link",
+        session_a=0,
+        session_b=1,
+        source_observation=1,
+        target_observation=2,
+        metadata={"occurrence_index": 1},
+    )
+
+    set_delta = score_track_edit_delta(predicted, reference, edit)
+    multiset_delta = score_track_edit_delta(predicted, reference, edit, count_duplicates=True)
+
+    assert set_delta.pairwise_fp_delta == 0
+    assert multiset_delta.pairwise_fp_delta == -1
+
+
+def test_rank_track_edits_prefers_complete_track_improvement() -> None:
+    predicted = [[1, 2, None], [8, 9, 10]]
+    reference = [[1, 2, 3], [8, 9, 10]]
+    edits = [
+        TrackEdit(kind="remove_link", session_a=0, session_b=1, source_observation=8, target_observation=9),
+        TrackEdit(kind="add_link", session_a=1, session_b=2, source_observation=2, target_observation=3),
+    ]
+
+    ranked = rank_track_edits_by_delta(predicted, reference, edits)
+
+    assert ranked[0].edit.kind == "add_link"
+    assert ranked[0].complete_tp_delta == 1

--- a/tests/tracking/test_event_records.py
+++ b/tests/tracking/test_event_records.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pyrecest.tracking import (
+    TrackingEvent,
+    action_counts,
+    event_from_measurement,
+    record_from_update,
+    records_to_dicts,
+    records_to_matrix,
+)
+
+
+def test_tracking_event_validates_measurement_covariance_shape() -> None:
+    event = TrackingEvent(
+        time=1.5,
+        source="radar",
+        action="update",
+        measurement=np.array([1.0, 2.0]),
+        covariance=np.eye(2),
+        accepted=True,
+    )
+
+    assert event.measurement_dim == 2
+    assert event.to_dict()["source"] == "radar"
+
+    with pytest.raises(ValueError, match="covariance must match"):
+        TrackingEvent(time=0.0, source="rf", measurement=np.ones(2), covariance=np.eye(3))
+
+
+def test_record_from_update_preserves_prior_posterior_and_legacy_aliases() -> None:
+    event = event_from_measurement(
+        time=2.0,
+        source="rf",
+        measurement=[10.0, -1.0],
+        covariance=np.diag([4.0, 4.0]),
+        accepted=False,
+        action="reject",
+        metadata={"sensor": "keysight"},
+    )
+    prior_mean = np.array([0.0, 0.0, 0.0, 1.0])
+    posterior_mean = np.array([1.0, 0.0, 0.0, 1.0])
+    record = record_from_update(
+        event=event,
+        prior_mean=prior_mean,
+        prior_cov=np.eye(4),
+        posterior_mean=posterior_mean,
+        posterior_cov=2.0 * np.eye(4),
+        innovation=[10.0, -1.0],
+        innovation_cov=np.eye(2),
+        nis=3.0,
+    )
+
+    as_dict = record.to_dict(include_legacy_aliases=True)
+    assert record.state_dim == 4
+    assert as_dict["time_s"] == 2.0
+    assert np.allclose(as_dict["state"], posterior_mean)
+    assert np.allclose(as_dict["prior_mean"], prior_mean)
+    assert as_dict["event_metadata"] == {"sensor": "keysight"}
+
+
+def test_records_to_dicts_matrix_and_action_counts() -> None:
+    event = event_from_measurement(time=0.0, source="radar", action="update")
+    record_a = record_from_update(
+        event=event,
+        prior_mean=[0.0, 0.0],
+        prior_cov=np.eye(2),
+        posterior_mean=[1.0, 0.0],
+        posterior_cov=np.eye(2),
+        action="updated",
+    )
+    record_b = record_from_update(
+        event=event_from_measurement(time=1.0, source="rf", action="coast"),
+        prior_mean=[1.0, 0.0],
+        prior_cov=np.eye(2),
+        posterior_mean=[2.0, 0.0],
+        posterior_cov=np.eye(2),
+    )
+
+    assert records_to_matrix([record_a, record_b]).shape == (2, 2)
+    assert len(records_to_dicts([record_a, record_b])) == 2
+    assert action_counts([record_a, record_b]) == {"updated": 1, "coast": 1}


### PR DESCRIPTION
Summary:
- add generic evidence computation mode helpers
- add tracking event and record helpers
- add track-edit what-if scoring utilities and sparse second-order evidence-only diagnostics

Verification:
- python -m py_compile src\pyrecest\evidence.py src\pyrecest\filters\sparse_second_order_grid.py src\pyrecest\tracking\event_records.py src\pyrecest\utils\track_edit_whatif.py tests\test_evidence_only_mode.py tests\tracking\test_event_records.py tests\test_track_edit_whatif.py
- git diff --check

Tests were not run per request.