### PR TITLE
Make tracking record dictionaries JSON serializable

### DIFF
--- a/src/pyrecest/tracking/event_records.py
+++ b/src/pyrecest/tracking/event_records.py
@@ -88,7 +88,9 @@ class TrackingEvent:
         object.__setattr__(self, "action", str(self.action))
         object.__setattr__(self, "measurement", measurement)
         object.__setattr__(self, "covariance", covariance)
-        object.__setattr__(self, "accepted", None if self.accepted is None else bool(self.accepted))
+        object.__setattr__(
+            self, "accepted", None if self.accepted is None else bool(self.accepted)
+        )
         object.__setattr__(self, "metadata", dict(self.metadata))
 
     @property
@@ -138,9 +140,13 @@ class TrackingRecord:
         if posterior_mean.shape != prior_mean.shape:
             raise ValueError("posterior_mean must match prior_mean shape")
         prior_cov = _square_matrix(self.prior_cov, name="prior_cov", dim=prior_mean.size)
-        posterior_cov = _square_matrix(self.posterior_cov, name="posterior_cov", dim=prior_mean.size)
+        posterior_cov = _square_matrix(
+            self.posterior_cov, name="posterior_cov", dim=prior_mean.size
+        )
         innovation = _array_or_none(self.innovation, name="innovation", ndim=1)
-        innovation_cov = _array_or_none(self.innovation_cov, name="innovation_cov", ndim=2)
+        innovation_cov = _array_or_none(
+            self.innovation_cov, name="innovation_cov", ndim=2
+        )
         if innovation is not None and innovation_cov is not None:
             if innovation_cov.shape != (innovation.size, innovation.size):
                 raise ValueError("innovation_cov must match innovation dimension")
@@ -158,7 +164,9 @@ class TrackingRecord:
         object.__setattr__(self, "innovation", innovation)
         object.__setattr__(self, "innovation_cov", innovation_cov)
         object.__setattr__(self, "nis", nis)
-        object.__setattr__(self, "accepted", None if self.accepted is None else bool(self.accepted))
+        object.__setattr__(
+            self, "accepted", None if self.accepted is None else bool(self.accepted)
+        )
         object.__setattr__(self, "measurement", measurement)
         object.__setattr__(self, "event_metadata", dict(self.event_metadata))
         object.__setattr__(self, "metadata", dict(self.metadata))
@@ -179,23 +187,23 @@ class TrackingRecord:
             "source": self.source,
             "action": self.action,
             "accepted": self.accepted,
-            "prior_mean": self.prior_mean.copy(),
-            "prior_cov": self.prior_cov.copy(),
-            "posterior_mean": self.posterior_mean.copy(),
-            "posterior_cov": self.posterior_cov.copy(),
-            "innovation": None if self.innovation is None else self.innovation.copy(),
-            "innovation_cov": None if self.innovation_cov is None else self.innovation_cov.copy(),
+            "prior_mean": _jsonable(self.prior_mean),
+            "prior_cov": _jsonable(self.prior_cov),
+            "posterior_mean": _jsonable(self.posterior_mean),
+            "posterior_cov": _jsonable(self.posterior_cov),
+            "innovation": _jsonable(self.innovation),
+            "innovation_cov": _jsonable(self.innovation_cov),
             "nis": self.nis,
-            "measurement": None if self.measurement is None else self.measurement.copy(),
-            "event_metadata": dict(self.event_metadata),
-            "metadata": dict(self.metadata),
+            "measurement": _jsonable(self.measurement),
+            "event_metadata": _jsonable(dict(self.event_metadata)),
+            "metadata": _jsonable(dict(self.metadata)),
         }
         if include_legacy_aliases:
             result.update(
                 {
                     "time_s": self.time,
-                    "state": self.posterior_mean.copy(),
-                    "covariance": self.posterior_cov.copy(),
+                    "state": _jsonable(self.posterior_mean),
+                    "covariance": _jsonable(self.posterior_cov),
                 }
             )
         return result
@@ -270,10 +278,13 @@ def records_to_dicts(
 
 
 def records_to_matrix(
-    records: Iterable[TrackingRecord], *, field: str = "posterior_mean") -> np.ndarray:
+    records: Iterable[TrackingRecord], *, field: str = "posterior_mean"
+) -> np.ndarray:
     """Stack a vector-valued field from records into a matrix."""
 
-    arrays = [np.asarray(getattr(record, field), dtype=float).reshape(-1) for record in records]
+    arrays = [
+        np.asarray(getattr(record, field), dtype=float).reshape(-1) for record in records
+    ]
     if not arrays:
         return np.empty((0, 0), dtype=float)
     return np.stack(arrays)

--- a/tests/tracking/test_event_records.py
+++ b/tests/tracking/test_event_records.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import numpy as np
 import pytest
 
@@ -59,6 +61,7 @@ def test_record_from_update_preserves_prior_posterior_and_legacy_aliases() -> No
     assert np.allclose(as_dict["state"], posterior_mean)
     assert np.allclose(as_dict["prior_mean"], prior_mean)
     assert as_dict["event_metadata"] == {"sensor": "keysight"}
+    json.dumps(as_dict)
 
 
 def test_records_to_dicts_matrix_and_action_counts() -> None:
@@ -80,5 +83,7 @@ def test_records_to_dicts_matrix_and_action_counts() -> None:
     )
 
     assert records_to_matrix([record_a, record_b]).shape == (2, 2)
-    assert len(records_to_dicts([record_a, record_b])) == 2
+    as_dicts = records_to_dicts([record_a, record_b])
+    assert len(as_dicts) == 2
+    json.dumps(as_dicts)
     assert action_counts([record_a, record_b]) == {"updated": 1, "coast": 1}


### PR DESCRIPTION
Summary:
- make `TrackingRecord.to_dict()` recursively convert NumPy arrays and NumPy scalars into JSON-friendly Python values
- apply the same conversion to legacy aliases and nested metadata
- add regression checks that record dictionaries and bulk record dictionaries can be passed to `json.dumps`

Verification:
- Not run locally; changes were inspected via repository diff/compare.