### PR TITLE
Add model comparison diagnostics and hypothesis replay ranking

### DIFF
--- a/docs/reference/evaluation.md
+++ b/docs/reference/evaluation.md
@@ -1,3 +1,33 @@
 # Evaluation
 
+## Model-comparison evidence margins
+
+`pyrecest.evaluation.model_comparison` contains lightweight, dataframe-oriented
+helpers for comparing model-evidence tables. The helpers are intentionally
+domain-neutral: callers provide the model labels, grouping columns, thresholds,
+and cluster/group identifiers.
+
+Useful entry points include:
+
+- `paired_model_margin_decisions`, which compares a positive model against a
+  reference model and separates positive claims, reference claims, and ambiguous
+  events using a symmetric log-evidence threshold;
+- `paired_model_margin_summary`, which summarizes raw wins, confident claims,
+  ambiguous events, and mean/median log-evidence margins;
+- `paired_model_margin_threshold_sweep`, which evaluates the paired decision
+  rule over multiple candidate thresholds;
+- `select_paired_model_margin_threshold`, which selects the smallest threshold
+  satisfying synthetic false-positive and recall constraints;
+- `leave_one_group_out_summary`, a generic leave-one-group-out wrapper for
+  grouped robustness checks;
+- `cluster_bootstrap_margin_summary`, which returns cluster-resampled
+  uncertainty intervals for raw-win fractions, claim fractions, and evidence
+  margins; and
+- `grouped_claim_gate_summary`, which summarizes whether every group satisfies
+  majority/no-forbidden-claim/positive-margin gates.
+
+These utilities are useful for model comparison, parameter selection, and
+paper-quality diagnostics whenever multiple filters, smoothers, or trackers emit
+comparable log marginal likelihoods.
+
 ::: pyrecest.evaluation

--- a/src/pyrecest/evaluation/__init__.py
+++ b/src/pyrecest/evaluation/__init__.py
@@ -15,6 +15,20 @@ from .perform_predict_update_cycles import perform_predict_update_cycles
 from .plot_results import plot_results
 from .simulation_database import simulation_database
 from .summarize_filter_results import summarize_filter_results
+from .model_comparison import (
+    add_evidence_margin_columns,
+    classify_evidence_margin,
+    cluster_bootstrap_margin_summary,
+    evidence_margin_table,
+    grouped_claim_gate_summary,
+    grouped_paired_model_margin_summary,
+    infer_paired_model_group_cols,
+    leave_one_group_out_summary,
+    paired_model_margin_decisions,
+    paired_model_margin_summary,
+    paired_model_margin_threshold_sweep,
+    select_paired_model_margin_threshold,
+)
 
 __all__ = [
     "generate_groundtruth",
@@ -34,4 +48,16 @@ __all__ = [
     "evaluate_for_file",
     "evaluate_for_simulation_config",
     "evaluate_for_variables",
+    "add_evidence_margin_columns",
+    "classify_evidence_margin",
+    "cluster_bootstrap_margin_summary",
+    "evidence_margin_table",
+    "grouped_claim_gate_summary",
+    "grouped_paired_model_margin_summary",
+    "infer_paired_model_group_cols",
+    "leave_one_group_out_summary",
+    "paired_model_margin_decisions",
+    "paired_model_margin_summary",
+    "paired_model_margin_threshold_sweep",
+    "select_paired_model_margin_threshold",
 ]

--- a/src/pyrecest/evaluation/model_comparison.py
+++ b/src/pyrecest/evaluation/model_comparison.py
@@ -1,0 +1,653 @@
+"""Generic model-comparison helpers for log-evidence tables.
+
+The functions in this module operate on ordinary ``pandas.DataFrame`` objects.
+They deliberately avoid application-specific vocabulary such as replay events,
+rats, maps, or paper rows.  Downstream projects provide their own model labels,
+grouping columns, cluster identifiers, and threshold values.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+
+import numpy as np
+import pandas as pd
+
+EVIDENCE_MARGIN_CATEGORIES: tuple[tuple[str, float], ...] = (
+    ("tie", 1.0),
+    ("weak", 3.0),
+    ("strong", 10.0),
+    ("decisive", np.inf),
+)
+
+DEFAULT_MARGIN_SENSITIVITY_THRESHOLDS = (0.0, 1.0, 3.0, 5.5, 10.0, 20.0)
+DEFAULT_BOOTSTRAP_REPLICATES = 2000
+DEFAULT_BOOTSTRAP_RANDOM_SEED = 1
+
+__all__ = [
+    "DEFAULT_BOOTSTRAP_RANDOM_SEED",
+    "DEFAULT_BOOTSTRAP_REPLICATES",
+    "DEFAULT_MARGIN_SENSITIVITY_THRESHOLDS",
+    "EVIDENCE_MARGIN_CATEGORIES",
+    "add_evidence_margin_columns",
+    "classify_evidence_margin",
+    "cluster_bootstrap_margin_summary",
+    "evidence_margin_table",
+    "grouped_claim_gate_summary",
+    "grouped_paired_model_margin_summary",
+    "infer_paired_model_group_cols",
+    "leave_one_group_out_summary",
+    "paired_model_margin_decisions",
+    "paired_model_margin_summary",
+    "paired_model_margin_threshold_sweep",
+    "select_paired_model_margin_threshold",
+]
+
+
+def _successful_rows(scores: pd.DataFrame) -> pd.DataFrame:
+    if scores.empty:
+        return scores.copy()
+    if "status" in scores.columns:
+        return scores[scores["status"].astype(str).eq("success")].copy()
+    return scores.copy()
+
+
+def _comparable_rows(scores: pd.DataFrame) -> pd.DataFrame:
+    ok = _successful_rows(scores)
+    if ok.empty:
+        return ok
+    if "evidence_comparable" in ok.columns:
+        ok = ok[ok["evidence_comparable"].fillna(False).astype(bool)].copy()
+    return ok
+
+
+def classify_evidence_margin(delta_log_evidence: float) -> str:
+    """Classify a non-negative log-evidence margin into qualitative buckets."""
+
+    value = float(delta_log_evidence)
+    if not np.isfinite(value):
+        return "missing"
+    for label, upper in EVIDENCE_MARGIN_CATEGORIES:
+        if value <= upper:
+            return label
+    return "decisive"
+
+
+def evidence_margin_table(
+    scores: pd.DataFrame,
+    *,
+    group_cols: Sequence[str] = ("session", "event_index"),
+    evidence_col: str = "log_evidence",
+    model_col: str = "model",
+) -> pd.DataFrame:
+    """Return one best-vs-runner-up evidence-margin row per group."""
+
+    group_cols = tuple(group_cols)
+    columns = [
+        *group_cols,
+        "best_model_by_evidence",
+        "second_best_model_by_evidence",
+        "best_log_evidence",
+        "second_best_log_evidence",
+        "evidence_margin_to_second_best",
+        "evidence_margin_category",
+        "models_compared",
+    ]
+    ok = _comparable_rows(scores)
+    if ok.empty:
+        return pd.DataFrame(columns=columns)
+    missing = [column for column in (*group_cols, evidence_col, model_col) if column not in ok.columns]
+    if missing:
+        raise KeyError(f"scores is missing required columns: {missing}")
+
+    rows: list[dict[str, object]] = []
+    for key, group in ok.groupby(list(group_cols), sort=False):
+        key_tuple = key if isinstance(key, tuple) else (key,)
+        ranked = group.dropna(subset=[evidence_col]).sort_values(evidence_col, ascending=False)
+        if ranked.empty:
+            continue
+        best = ranked.iloc[0]
+        second = ranked.iloc[1] if len(ranked) > 1 else None
+        best_value = float(best[evidence_col])
+        second_value = float(second[evidence_col]) if second is not None else np.nan
+        margin = best_value - second_value if second is not None else np.inf
+        row = {column: value for column, value in zip(group_cols, key_tuple, strict=True)}
+        row.update(
+            {
+                "best_model_by_evidence": str(best[model_col]),
+                "second_best_model_by_evidence": "" if second is None else str(second[model_col]),
+                "best_log_evidence": best_value,
+                "second_best_log_evidence": second_value,
+                "evidence_margin_to_second_best": float(margin),
+                "evidence_margin_category": classify_evidence_margin(margin),
+                "models_compared": int(len(ranked)),
+            }
+        )
+        rows.append(row)
+    return pd.DataFrame(rows, columns=columns)
+
+
+def add_evidence_margin_columns(
+    scores: pd.DataFrame,
+    *,
+    group_cols: Sequence[str] = ("session", "event_index"),
+) -> pd.DataFrame:
+    """Merge event-level evidence-margin diagnostics back into score rows."""
+
+    if scores.empty:
+        return scores.copy()
+    margins = evidence_margin_table(scores, group_cols=group_cols)
+    if margins.empty:
+        out = scores.copy()
+        out["evidence_margin_to_second_best"] = np.nan
+        out["evidence_margin_category"] = "missing"
+        return out
+    return scores.merge(margins, on=list(group_cols), how="left")
+
+
+def paired_model_margin_decisions(
+    scores: pd.DataFrame,
+    *,
+    positive_model: str,
+    reference_model: str,
+    margin_threshold: float = 0.0,
+    group_cols: Sequence[str] = ("session", "event_index"),
+    evidence_col: str = "log_evidence",
+    model_col: str = "model",
+    true_model_col: str | None = None,
+    positive_true_label: str | None = None,
+) -> pd.DataFrame:
+    """Classify paired model wins using a symmetric log-evidence margin."""
+
+    threshold = float(margin_threshold)
+    if threshold < 0.0:
+        raise ValueError("margin_threshold must be non-negative")
+    group_cols = tuple(group_cols)
+    columns = [
+        *group_cols,
+        "positive_model",
+        "reference_model",
+        "positive_log_evidence",
+        "reference_log_evidence",
+        "positive_minus_reference_log_evidence",
+        "margin_threshold",
+        "margin_decision",
+        "positive_model_claimed",
+    ]
+    if true_model_col:
+        columns.extend([true_model_col, "positive_true_label", "true_is_positive", "margin_binary_correct"])
+
+    ok = _comparable_rows(scores)
+    if ok.empty:
+        return pd.DataFrame(columns=columns)
+    missing = [column for column in (*group_cols, evidence_col, model_col) if column not in ok.columns]
+    if true_model_col and true_model_col not in ok.columns:
+        missing.append(true_model_col)
+    if missing:
+        raise KeyError(f"scores is missing required columns: {missing}")
+
+    positive_label = positive_true_label or _model_family_label(positive_model)
+    rows: list[dict[str, object]] = []
+    for key, group in ok.groupby(list(group_cols), sort=False):
+        key_tuple = key if isinstance(key, tuple) else (key,)
+        paired = group[group[model_col].astype(str).isin([positive_model, reference_model])]
+        pivot = paired.dropna(subset=[evidence_col]).drop_duplicates(model_col, keep="last")
+        by_model = pivot.set_index(model_col)
+        if positive_model not in by_model.index or reference_model not in by_model.index:
+            continue
+        positive_value = float(by_model.loc[positive_model, evidence_col])
+        reference_value = float(by_model.loc[reference_model, evidence_col])
+        delta = positive_value - reference_value
+        if delta >= threshold:
+            decision = positive_model
+            positive_claimed = True
+        elif delta <= -threshold:
+            decision = reference_model
+            positive_claimed = False
+        else:
+            decision = "ambiguous"
+            positive_claimed = False
+        row = {column: value for column, value in zip(group_cols, key_tuple, strict=True)}
+        row.update(
+            {
+                "positive_model": positive_model,
+                "reference_model": reference_model,
+                "positive_log_evidence": positive_value,
+                "reference_log_evidence": reference_value,
+                "positive_minus_reference_log_evidence": float(delta),
+                "margin_threshold": threshold,
+                "margin_decision": decision,
+                "positive_model_claimed": bool(positive_claimed),
+            }
+        )
+        if true_model_col:
+            true_label = _unique_text_value(group[true_model_col])
+            true_is_positive = _model_family_label(true_label) == _model_family_label(positive_label)
+            row.update(
+                {
+                    true_model_col: true_label,
+                    "positive_true_label": positive_label,
+                    "true_is_positive": bool(true_is_positive),
+                    "margin_binary_correct": bool(positive_claimed) == bool(true_is_positive),
+                }
+            )
+        rows.append(row)
+    return pd.DataFrame(rows, columns=columns)
+
+
+def infer_paired_model_group_cols(scores: pd.DataFrame) -> tuple[str, ...]:
+    """Infer columns that define one paired model-decision unit."""
+
+    columns: list[str] = []
+    for candidate in ("matrix_id", "random_seed", "session"):
+        if candidate in scores.columns:
+            columns.append(candidate)
+    if "simulation_event_index" in scores.columns:
+        columns.append("simulation_event_index")
+    elif "event_index" in scores.columns:
+        columns.append("event_index")
+    if not columns:
+        raise KeyError("could not infer paired event grouping columns")
+    return tuple(columns)
+
+
+def paired_model_margin_summary(
+    decisions: pd.DataFrame,
+    *,
+    group_cols: Sequence[str] = (),
+    true_model_col: str | None = None,
+) -> pd.DataFrame:
+    """Summarize a paired margin-decision table, optionally by groups."""
+
+    group_cols = tuple(group_cols)
+    base_columns = [
+        *group_cols,
+        "events",
+        "positive_model",
+        "reference_model",
+        "margin_threshold",
+        "positive_raw_wins",
+        "reference_raw_wins",
+        "raw_ties",
+        "positive_raw_win_fraction",
+        "positive_model_claims",
+        "reference_model_claims",
+        "ambiguous_events",
+        "positive_claim_fraction",
+        "reference_claim_fraction",
+        "ambiguous_fraction",
+        "mean_positive_minus_reference_log_evidence",
+        "median_positive_minus_reference_log_evidence",
+    ]
+    true_columns = [
+        "thresholded_binary_accuracy",
+        "positive_true_events",
+        "reference_true_events",
+        "positive_true_claimed_events",
+        "reference_true_rejected_events",
+        "positive_claim_recall",
+        "reference_specificity",
+        "false_positive_claims",
+        "false_negative_claims",
+    ]
+    columns = base_columns + (true_columns if true_model_col else [])
+    if decisions.empty:
+        return pd.DataFrame(columns=columns)
+
+    rows: list[dict[str, object]] = []
+    groups = [((), decisions)] if not group_cols else decisions.groupby(list(group_cols), sort=True)
+    for key, group in groups:
+        key_tuple = key if isinstance(key, tuple) else (key,)
+        delta = pd.to_numeric(group["positive_minus_reference_log_evidence"], errors="coerce")
+        events = int(len(group))
+        positive_claims = int(group["positive_model_claimed"].fillna(False).astype(bool).sum())
+        reference_claims = int((group["margin_decision"] == group["reference_model"]).sum())
+        ambiguous = int((group["margin_decision"] == "ambiguous").sum())
+        row = {column: value for column, value in zip(group_cols, key_tuple, strict=True)}
+        row.update(
+            {
+                "events": events,
+                "positive_model": str(group["positive_model"].dropna().iloc[0]),
+                "reference_model": str(group["reference_model"].dropna().iloc[0]),
+                "margin_threshold": float(group["margin_threshold"].dropna().iloc[0]),
+                "positive_raw_wins": int((delta > 0.0).sum()),
+                "reference_raw_wins": int((delta < 0.0).sum()),
+                "raw_ties": int((delta == 0.0).sum()),
+                "positive_raw_win_fraction": float((delta > 0.0).mean()),
+                "positive_model_claims": positive_claims,
+                "reference_model_claims": reference_claims,
+                "ambiguous_events": ambiguous,
+                "positive_claim_fraction": float(positive_claims / max(events, 1)),
+                "reference_claim_fraction": float(reference_claims / max(events, 1)),
+                "ambiguous_fraction": float(ambiguous / max(events, 1)),
+                "mean_positive_minus_reference_log_evidence": float(delta.mean()),
+                "median_positive_minus_reference_log_evidence": float(delta.median()),
+            }
+        )
+        if true_model_col and true_model_col in group:
+            correct = group["margin_binary_correct"].fillna(False).astype(bool)
+            true_positive = group["true_is_positive"].fillna(False).astype(bool)
+            claims = group["positive_model_claimed"].fillna(False).astype(bool)
+            row.update(
+                {
+                    "thresholded_binary_accuracy": float(correct.mean()),
+                    "positive_true_events": int(true_positive.sum()),
+                    "reference_true_events": int((~true_positive).sum()),
+                    "positive_true_claimed_events": int((claims & true_positive).sum()),
+                    "reference_true_rejected_events": int((~claims & ~true_positive).sum()),
+                    "positive_claim_recall": _safe_ratio(int((claims & true_positive).sum()), int(true_positive.sum())),
+                    "reference_specificity": _safe_ratio(int((~claims & ~true_positive).sum()), int((~true_positive).sum())),
+                    "false_positive_claims": int((claims & ~true_positive).sum()),
+                    "false_negative_claims": int((~claims & true_positive).sum()),
+                }
+            )
+        rows.append(row)
+    return pd.DataFrame(rows, columns=columns)
+
+
+def grouped_paired_model_margin_summary(
+    decisions: pd.DataFrame,
+    *,
+    group_cols: Sequence[str],
+) -> pd.DataFrame:
+    """Alias for grouped paired-margin summaries used by downstream reports."""
+
+    return paired_model_margin_summary(decisions, group_cols=tuple(group_cols))
+
+
+def paired_model_margin_threshold_sweep(
+    scores: pd.DataFrame,
+    *,
+    positive_model: str,
+    reference_model: str,
+    thresholds: Sequence[float],
+    group_cols: Sequence[str] | None = None,
+    summary_group_cols: Sequence[str] = (),
+    evidence_col: str = "log_evidence",
+    model_col: str = "model",
+    true_model_col: str | None = None,
+    positive_true_label: str | None = None,
+) -> pd.DataFrame:
+    """Summarize paired margin decisions over candidate thresholds."""
+
+    paired_group_cols = tuple(group_cols) if group_cols is not None else infer_paired_model_group_cols(scores)
+    rows: list[pd.DataFrame] = []
+    for threshold in thresholds:
+        decisions = paired_model_margin_decisions(
+            scores,
+            positive_model=positive_model,
+            reference_model=reference_model,
+            margin_threshold=float(threshold),
+            group_cols=paired_group_cols,
+            evidence_col=evidence_col,
+            model_col=model_col,
+            true_model_col=true_model_col,
+            positive_true_label=positive_true_label,
+        )
+        summary = paired_model_margin_summary(
+            decisions,
+            group_cols=tuple(summary_group_cols),
+            true_model_col=true_model_col,
+        )
+        summary["group_cols"] = ",".join(paired_group_cols)
+        rows.append(summary)
+    if not rows:
+        return pd.DataFrame()
+    sort_cols = ["margin_threshold", *tuple(summary_group_cols)]
+    return pd.concat(rows, ignore_index=True).sort_values(sort_cols, kind="stable").reset_index(drop=True)
+
+
+def select_paired_model_margin_threshold(
+    threshold_sweep: pd.DataFrame,
+    *,
+    max_false_positive_claims: int = 0,
+    min_positive_claim_recall: float = 0.0,
+) -> pd.DataFrame:
+    """Select the smallest threshold satisfying synthetic specificity gates."""
+
+    if threshold_sweep.empty:
+        return pd.DataFrame([{"selection_status": "empty_threshold_sweep", "selected_margin_threshold": np.nan}])
+    if "false_positive_claims" not in threshold_sweep or "positive_claim_recall" not in threshold_sweep:
+        raise KeyError("threshold_sweep must include true-model false-positive and recall columns")
+    sweep = threshold_sweep.copy()
+    sweep["passes_threshold_gate"] = (
+        pd.to_numeric(sweep["false_positive_claims"], errors="coerce").fillna(np.inf) <= int(max_false_positive_claims)
+    ) & (
+        pd.to_numeric(sweep["positive_claim_recall"], errors="coerce").fillna(-np.inf) >= float(min_positive_claim_recall)
+    )
+    if sweep["passes_threshold_gate"].any():
+        selected = sweep[sweep["passes_threshold_gate"]].sort_values("margin_threshold", kind="stable").head(1).copy()
+        selected["selection_status"] = "passed_specificity_gate"
+    else:
+        selected = (
+            sweep.sort_values(
+                ["false_positive_claims", "positive_claim_recall", "margin_threshold"],
+                ascending=[True, False, True],
+                kind="stable",
+            )
+            .head(1)
+            .copy()
+        )
+        selected["selection_status"] = "fallback_no_gate_pass"
+    selected["selected_margin_threshold"] = selected["margin_threshold"].astype(float)
+    selected["max_false_positive_claims"] = int(max_false_positive_claims)
+    selected["min_positive_claim_recall"] = float(min_positive_claim_recall)
+    return selected.reset_index(drop=True)
+
+
+def leave_one_group_out_summary(
+    frame: pd.DataFrame,
+    *,
+    group_col: str,
+    summary_fn: Callable[[pd.DataFrame], pd.DataFrame],
+    held_out_col: str = "held_out_group",
+) -> pd.DataFrame:
+    """Apply a summary after holding out each value of ``group_col``."""
+
+    if frame.empty:
+        return pd.DataFrame()
+    if group_col not in frame:
+        raise KeyError(f"frame is missing required group column {group_col!r}")
+    rows: list[pd.DataFrame] = []
+    for group_value in sorted(frame[group_col].dropna().astype(str).unique()):
+        retained = frame[frame[group_col].astype(str) != group_value]
+        summary = summary_fn(retained)
+        if summary.empty:
+            continue
+        summary = summary.copy()
+        summary.insert(0, held_out_col, group_value)
+        rows.append(summary)
+    if not rows:
+        return pd.DataFrame()
+    return pd.concat(rows, ignore_index=True).sort_values(held_out_col).reset_index(drop=True)
+
+
+def cluster_bootstrap_margin_summary(
+    frame: pd.DataFrame,
+    *,
+    cluster_col: str,
+    delta_col: str,
+    positive_claim_col: str,
+    n_bootstrap: int = DEFAULT_BOOTSTRAP_REPLICATES,
+    random_seed: int = DEFAULT_BOOTSTRAP_RANDOM_SEED,
+) -> pd.DataFrame:
+    """Return cluster-bootstrap intervals for paired evidence-margin summaries."""
+
+    columns = [
+        "bootstrap_unit",
+        "bootstrap_replicates",
+        "random_seed",
+        "observed_events",
+        "observed_clusters",
+        "observed_positive_raw_win_fraction",
+        "positive_raw_win_fraction_ci95_low",
+        "positive_raw_win_fraction_ci95_high",
+        "observed_positive_claim_fraction",
+        "positive_claim_fraction_ci95_low",
+        "positive_claim_fraction_ci95_high",
+        "observed_mean_delta",
+        "mean_delta_ci95_low",
+        "mean_delta_ci95_high",
+        "probability_mean_delta_gt_0",
+        "observed_median_delta",
+        "median_delta_ci95_low",
+        "median_delta_ci95_high",
+        "probability_median_delta_gt_0",
+    ]
+    if frame.empty:
+        return pd.DataFrame(columns=columns)
+    missing = [column for column in (cluster_col, delta_col, positive_claim_col) if column not in frame]
+    if missing:
+        raise KeyError(f"frame is missing required columns: {missing}")
+    if n_bootstrap <= 0:
+        raise ValueError("n_bootstrap must be positive")
+
+    clusters = sorted(frame[cluster_col].dropna().astype(str).unique())
+    if not clusters:
+        return pd.DataFrame(columns=columns)
+    by_cluster = {cluster: frame[frame[cluster_col].astype(str).eq(cluster)] for cluster in clusters}
+    observed = _bootstrap_margin_metrics(frame, delta_col=delta_col, positive_claim_col=positive_claim_col)
+    rng = np.random.default_rng(int(random_seed))
+    replicate_rows = []
+    for _ in range(int(n_bootstrap)):
+        sampled = rng.choice(clusters, size=len(clusters), replace=True)
+        sample = pd.concat([by_cluster[cluster] for cluster in sampled], ignore_index=True)
+        replicate_rows.append(_bootstrap_margin_metrics(sample, delta_col=delta_col, positive_claim_col=positive_claim_col))
+    replicates = pd.DataFrame(replicate_rows)
+
+    def ci(metric: str, q: float) -> float:
+        return float(np.nanquantile(replicates[metric].to_numpy(dtype=float), q))
+
+    return pd.DataFrame(
+        [
+            {
+                "bootstrap_unit": str(cluster_col),
+                "bootstrap_replicates": int(n_bootstrap),
+                "random_seed": int(random_seed),
+                "observed_events": int(len(frame)),
+                "observed_clusters": int(len(clusters)),
+                "observed_positive_raw_win_fraction": observed["positive_raw_win_fraction"],
+                "positive_raw_win_fraction_ci95_low": ci("positive_raw_win_fraction", 0.025),
+                "positive_raw_win_fraction_ci95_high": ci("positive_raw_win_fraction", 0.975),
+                "observed_positive_claim_fraction": observed["positive_claim_fraction"],
+                "positive_claim_fraction_ci95_low": ci("positive_claim_fraction", 0.025),
+                "positive_claim_fraction_ci95_high": ci("positive_claim_fraction", 0.975),
+                "observed_mean_delta": observed["mean_delta"],
+                "mean_delta_ci95_low": ci("mean_delta", 0.025),
+                "mean_delta_ci95_high": ci("mean_delta", 0.975),
+                "probability_mean_delta_gt_0": float((replicates["mean_delta"] > 0.0).mean()),
+                "observed_median_delta": observed["median_delta"],
+                "median_delta_ci95_low": ci("median_delta", 0.025),
+                "median_delta_ci95_high": ci("median_delta", 0.975),
+                "probability_median_delta_gt_0": float((replicates["median_delta"] > 0.0).mean()),
+            }
+        ],
+        columns=columns,
+    )
+
+
+def grouped_claim_gate_summary(
+    summary: pd.DataFrame,
+    *,
+    group_col: str,
+    claim_fraction_col: str,
+    forbidden_claims_col: str | None = None,
+    mean_delta_col: str | None = None,
+    median_delta_col: str | None = None,
+    min_claim_fraction: float = 0.5,
+) -> pd.DataFrame:
+    """Return generic pass/fail gates for grouped claim robustness."""
+
+    columns = ["gate", "passed", "observed", "criterion", "details"]
+    rows: list[dict[str, object]] = []
+
+    def add(gate: str, passed: bool, observed: object, criterion: str, details: str = "") -> None:
+        rows.append(
+            {
+                "gate": gate,
+                "passed": bool(passed),
+                "observed": observed,
+                "criterion": criterion,
+                "details": details,
+            }
+        )
+
+    if summary.empty:
+        add("groups_present", False, 0, f"{group_col} groups > 0")
+        result = pd.DataFrame(rows, columns=columns)
+    else:
+        missing = [column for column in (group_col, claim_fraction_col) if column not in summary]
+        for optional in (forbidden_claims_col, mean_delta_col, median_delta_col):
+            if optional and optional not in summary:
+                missing.append(optional)
+        if missing:
+            raise KeyError(f"summary is missing required columns: {missing}")
+        add("groups_present", True, int(summary[group_col].nunique()), f"{group_col} groups > 0")
+        min_claim = float(pd.to_numeric(summary[claim_fraction_col], errors="coerce").min())
+        add(
+            "all_groups_claim_majority",
+            min_claim > float(min_claim_fraction),
+            f"{min_claim:.6g}",
+            f"min {claim_fraction_col} > {float(min_claim_fraction):g}",
+        )
+        if forbidden_claims_col:
+            max_forbidden = int(pd.to_numeric(summary[forbidden_claims_col], errors="coerce").fillna(np.inf).max())
+            add("all_groups_no_forbidden_claims", max_forbidden == 0, max_forbidden, f"max {forbidden_claims_col} == 0")
+        if mean_delta_col:
+            min_mean = float(pd.to_numeric(summary[mean_delta_col], errors="coerce").min())
+            add("all_groups_mean_delta_positive", min_mean > 0.0, f"{min_mean:.6g}", f"min {mean_delta_col} > 0")
+        if median_delta_col:
+            min_median = float(pd.to_numeric(summary[median_delta_col], errors="coerce").min())
+            add("all_groups_median_delta_positive", min_median > 0.0, f"{min_median:.6g}", f"min {median_delta_col} > 0")
+        result = pd.DataFrame(rows, columns=columns)
+
+    overall = pd.DataFrame(
+        [
+            {
+                "gate": "overall",
+                "passed": bool(result["passed"].all()) if not result.empty else False,
+                "observed": f"{int(result['passed'].sum())}/{len(result)} gates passed" if not result.empty else "0/0",
+                "criterion": "all grouped claim gates pass",
+                "details": "",
+            }
+        ],
+        columns=columns,
+    )
+    return pd.concat([result, overall], ignore_index=True)
+
+
+def _bootstrap_margin_metrics(
+    frame: pd.DataFrame,
+    *,
+    delta_col: str,
+    positive_claim_col: str,
+) -> dict[str, float]:
+    delta = pd.to_numeric(frame[delta_col], errors="coerce")
+    return {
+        "positive_raw_win_fraction": float((delta > 0.0).mean()),
+        "positive_claim_fraction": float(frame[positive_claim_col].fillna(False).astype(bool).mean()),
+        "mean_delta": float(delta.mean()),
+        "median_delta": float(delta.median()),
+    }
+
+
+def _unique_text_value(values: pd.Series) -> str:
+    unique = [str(value) for value in values.dropna().unique()]
+    if not unique:
+        return ""
+    return unique[0]
+
+
+def _model_family_label(value: str) -> str:
+    text = str(value).lower()
+    if "momentum" in text:
+        return "momentum"
+    if "diffusion" in text:
+        return "diffusion"
+    return text
+
+
+def _safe_ratio(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        return float("nan")
+    return float(numerator / denominator)

--- a/src/pyrecest/tracking/__init__.py
+++ b/src/pyrecest/tracking/__init__.py
@@ -19,3 +19,23 @@ __all__ = [
     "records_to_dicts",
     "records_to_matrix",
 ]
+
+from .hypothesis_replay import (
+    HypothesisReplay,
+    HypothesisReplayScore,
+    InnovationConsistencyScoreConfig,
+    rank_hypothesis_replays,
+    rank_replayed_hypotheses,
+    score_hypothesis_replay,
+    scores_to_dicts,
+)
+
+__all__ += [
+    "HypothesisReplay",
+    "HypothesisReplayScore",
+    "InnovationConsistencyScoreConfig",
+    "rank_hypothesis_replays",
+    "rank_replayed_hypotheses",
+    "score_hypothesis_replay",
+    "scores_to_dicts",
+]

--- a/src/pyrecest/tracking/__init__.py
+++ b/src/pyrecest/tracking/__init__.py
@@ -39,3 +39,33 @@ __all__ += [
     "score_hypothesis_replay",
     "scores_to_dicts",
 ]
+
+from .tracklet_graph import (
+    Tracklet,
+    TrackletEdge,
+    TrackletGraphConfig,
+    TrackletPath,
+    build_tracklet_adjacency,
+    constant_velocity_edge_cost,
+    diverse_k_best_tracklet_paths,
+    k_best_tracklet_paths,
+    materialize_tracklet_path,
+    path_jaccard,
+    sort_tracklets,
+    tracklet_paths_to_dicts,
+)
+
+__all__ += [
+    "Tracklet",
+    "TrackletEdge",
+    "TrackletGraphConfig",
+    "TrackletPath",
+    "build_tracklet_adjacency",
+    "constant_velocity_edge_cost",
+    "diverse_k_best_tracklet_paths",
+    "k_best_tracklet_paths",
+    "materialize_tracklet_path",
+    "path_jaccard",
+    "sort_tracklets",
+    "tracklet_paths_to_dicts",
+]

--- a/src/pyrecest/tracking/__init__.py
+++ b/src/pyrecest/tracking/__init__.py
@@ -69,3 +69,21 @@ __all__ += [
     "sort_tracklets",
     "tracklet_paths_to_dicts",
 ]
+
+from .measurement_reliability import (
+    MeasurementReliabilityConfig,
+    MeasurementReliabilityResult,
+    ReliabilityWeightedMeasurement,
+    apply_measurement_reliability,
+    reliability_to_covariance_scale,
+    scale_covariance_by_reliability,
+)
+
+__all__ += [
+    "MeasurementReliabilityConfig",
+    "MeasurementReliabilityResult",
+    "ReliabilityWeightedMeasurement",
+    "apply_measurement_reliability",
+    "reliability_to_covariance_scale",
+    "scale_covariance_by_reliability",
+]

--- a/src/pyrecest/tracking/hypothesis_replay.py
+++ b/src/pyrecest/tracking/hypothesis_replay.py
@@ -1,0 +1,327 @@
+"""Innovation-consistency ranking for replayed association hypotheses.
+
+The functions in this module are filter-independent.  They score candidate
+association hypotheses after a caller has replayed each hypothesis through a
+tracker and produced ordinary record dictionaries or :class:`TrackingRecord`
+instances.  This lets multi-sensor trackers rank top-k association/path
+hypotheses by innovation consistency without using ground truth.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Hashable
+
+import numpy as np
+
+try:  # Optional only so this module can be used without event_records imports at runtime.
+    from .event_records import TrackingRecord
+except Exception:  # pragma: no cover - defensive for partial downstream copies
+    TrackingRecord = object  # type: ignore[misc,assignment]
+
+
+@dataclass(frozen=True)
+class InnovationConsistencyScoreConfig:
+    """Weights and clipping thresholds for replay-hypothesis ranking."""
+
+    graph_cost_weight: float = 1.0
+    nis_weight: float = 1.0
+    residual_weight: float = 0.01
+    switch_weight: float = 2.0
+    missed_detection_weight: float = 1.0
+    rejected_weight: float = 0.25
+    coast_weight: float = 0.25
+    unsupported_measurement_weight: float = 5.0
+    hard_quarantine_weight: float = 1000.0
+    tail_duration_weight: float = 0.05
+    coverage_reward: float = 0.001
+    nis_clip: float = 50.0
+    residual_clip: float = 500.0
+    residual_normalizer: float = 100.0
+
+
+@dataclass(frozen=True)
+class HypothesisReplay:
+    """One candidate hypothesis and its already-computed replay records."""
+
+    hypothesis_id: Hashable
+    records: Sequence[Any]
+    graph_cost: float = 0.0
+    track_switches: int = 0
+    missed_detection_count: int = 0
+    rejected_count: int = 0
+    coast_count: int = 0
+    unsupported_measurement_count: int = 0
+    hard_quarantine_count: int = 0
+    tail_duration_s: float = 0.0
+    coverage_count: int = 0
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "records", tuple(self.records))
+        object.__setattr__(self, "graph_cost", _finite_float(self.graph_cost, "graph_cost"))
+        object.__setattr__(self, "track_switches", _nonnegative_int(self.track_switches, "track_switches"))
+        object.__setattr__(
+            self,
+            "missed_detection_count",
+            _nonnegative_int(self.missed_detection_count, "missed_detection_count"),
+        )
+        object.__setattr__(self, "rejected_count", _nonnegative_int(self.rejected_count, "rejected_count"))
+        object.__setattr__(self, "coast_count", _nonnegative_int(self.coast_count, "coast_count"))
+        object.__setattr__(
+            self,
+            "unsupported_measurement_count",
+            _nonnegative_int(self.unsupported_measurement_count, "unsupported_measurement_count"),
+        )
+        object.__setattr__(
+            self,
+            "hard_quarantine_count",
+            _nonnegative_int(self.hard_quarantine_count, "hard_quarantine_count"),
+        )
+        object.__setattr__(self, "tail_duration_s", _nonnegative_float(self.tail_duration_s, "tail_duration_s"))
+        object.__setattr__(self, "coverage_count", _nonnegative_int(self.coverage_count, "coverage_count"))
+        object.__setattr__(self, "metadata", dict(self.metadata))
+
+
+@dataclass(frozen=True)
+class HypothesisReplayScore:
+    """Score and diagnostics for one replayed hypothesis."""
+
+    hypothesis_id: Hashable
+    total_score: float
+    graph_cost: float
+    robust_sum_nis: float
+    robust_sum_residual: float
+    finite_nis_count: int
+    finite_residual_count: int
+    track_switches: int
+    missed_detection_count: int
+    rejected_count: int
+    coast_count: int
+    unsupported_measurement_count: int
+    hard_quarantine_count: int
+    tail_duration_s: float
+    coverage_count: int
+    rank: int | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def with_rank(self, rank: int) -> "HypothesisReplayScore":
+        """Return a copy with ``rank`` set."""
+
+        return HypothesisReplayScore(
+            hypothesis_id=self.hypothesis_id,
+            total_score=self.total_score,
+            graph_cost=self.graph_cost,
+            robust_sum_nis=self.robust_sum_nis,
+            robust_sum_residual=self.robust_sum_residual,
+            finite_nis_count=self.finite_nis_count,
+            finite_residual_count=self.finite_residual_count,
+            track_switches=self.track_switches,
+            missed_detection_count=self.missed_detection_count,
+            rejected_count=self.rejected_count,
+            coast_count=self.coast_count,
+            unsupported_measurement_count=self.unsupported_measurement_count,
+            hard_quarantine_count=self.hard_quarantine_count,
+            tail_duration_s=self.tail_duration_s,
+            coverage_count=self.coverage_count,
+            rank=int(rank),
+            metadata=dict(self.metadata),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON/CSV-friendly dictionary."""
+
+        return {
+            "rank": self.rank,
+            "hypothesis_id": self.hypothesis_id,
+            "total_score": self.total_score,
+            "graph_cost": self.graph_cost,
+            "robust_sum_nis": self.robust_sum_nis,
+            "robust_sum_residual": self.robust_sum_residual,
+            "finite_nis_count": self.finite_nis_count,
+            "finite_residual_count": self.finite_residual_count,
+            "track_switches": self.track_switches,
+            "missed_detection_count": self.missed_detection_count,
+            "rejected_count": self.rejected_count,
+            "coast_count": self.coast_count,
+            "unsupported_measurement_count": self.unsupported_measurement_count,
+            "hard_quarantine_count": self.hard_quarantine_count,
+            "tail_duration_s": self.tail_duration_s,
+            "coverage_count": self.coverage_count,
+            **{f"metadata_{key}": _jsonable(value) for key, value in dict(self.metadata).items()},
+        }
+
+
+def score_hypothesis_replay(
+    replay: HypothesisReplay,
+    config: InnovationConsistencyScoreConfig | None = None,
+) -> HypothesisReplayScore:
+    """Score one replayed hypothesis without using truth information."""
+
+    cfg = InnovationConsistencyScoreConfig() if config is None else config
+    nis_values = _finite_record_values(replay.records, ("nis",))
+    residual_values = _finite_record_values(
+        replay.records,
+        ("residual_norm_m", "residual_norm", "innovation_norm", "innovation_norm_m"),
+        fallback_norm_keys=("innovation", "residual"),
+    )
+    robust_sum_nis = float(np.sum(np.minimum(nis_values, float(cfg.nis_clip)))) if nis_values.size else 0.0
+    robust_sum_residual = (
+        float(np.sum(np.minimum(residual_values, float(cfg.residual_clip)))) / float(cfg.residual_normalizer)
+        if residual_values.size
+        else 0.0
+    )
+    missed = int(replay.missed_detection_count + _count_record_actions(replay.records, {"missed_detection"}))
+    rejected = int(replay.rejected_count + _count_record_actions(replay.records, {"rejected", "residual_rejected", "safety_rejected"}))
+    coast = int(replay.coast_count + _count_record_actions(replay.records, {"coast", "predict"}))
+    total = (
+        cfg.graph_cost_weight * replay.graph_cost
+        + cfg.nis_weight * robust_sum_nis
+        + cfg.residual_weight * robust_sum_residual
+        + cfg.switch_weight * replay.track_switches
+        + cfg.missed_detection_weight * missed
+        + cfg.rejected_weight * rejected
+        + cfg.coast_weight * coast
+        + cfg.unsupported_measurement_weight * replay.unsupported_measurement_count
+        + cfg.hard_quarantine_weight * replay.hard_quarantine_count
+        + cfg.tail_duration_weight * replay.tail_duration_s
+        - cfg.coverage_reward * replay.coverage_count
+    )
+    return HypothesisReplayScore(
+        hypothesis_id=replay.hypothesis_id,
+        total_score=float(total),
+        graph_cost=float(replay.graph_cost),
+        robust_sum_nis=float(robust_sum_nis),
+        robust_sum_residual=float(robust_sum_residual),
+        finite_nis_count=int(nis_values.size),
+        finite_residual_count=int(residual_values.size),
+        track_switches=int(replay.track_switches),
+        missed_detection_count=missed,
+        rejected_count=rejected,
+        coast_count=coast,
+        unsupported_measurement_count=int(replay.unsupported_measurement_count),
+        hard_quarantine_count=int(replay.hard_quarantine_count),
+        tail_duration_s=float(replay.tail_duration_s),
+        coverage_count=int(replay.coverage_count),
+        metadata=dict(replay.metadata),
+    )
+
+
+def rank_hypothesis_replays(
+    replays: Iterable[HypothesisReplay],
+    config: InnovationConsistencyScoreConfig | None = None,
+) -> list[HypothesisReplayScore]:
+    """Return replay scores sorted from best to worst."""
+
+    scores = [score_hypothesis_replay(replay, config=config) for replay in replays]
+    scores.sort(key=lambda item: (item.total_score, str(item.hypothesis_id)))
+    return [score.with_rank(rank) for rank, score in enumerate(scores, start=1)]
+
+
+def rank_replayed_hypotheses(
+    hypotheses: Iterable[Any],
+    replay_fn: Callable[[Any], HypothesisReplay],
+    config: InnovationConsistencyScoreConfig | None = None,
+) -> list[HypothesisReplayScore]:
+    """Replay hypotheses with ``replay_fn`` and rank the resulting replays."""
+
+    return rank_hypothesis_replays((replay_fn(hypothesis) for hypothesis in hypotheses), config=config)
+
+
+def scores_to_dicts(scores: Iterable[HypothesisReplayScore]) -> list[dict[str, Any]]:
+    """Return ranked score dictionaries."""
+
+    return [score.to_dict() for score in scores]
+
+
+def _finite_record_values(
+    records: Sequence[Any],
+    keys: tuple[str, ...],
+    *,
+    fallback_norm_keys: tuple[str, ...] = (),
+) -> np.ndarray:
+    values: list[float] = []
+    for record in records:
+        value = _record_value(record, keys)
+        if value is None and fallback_norm_keys:
+            vector = _record_value(record, fallback_norm_keys)
+            if vector is not None:
+                try:
+                    value = float(np.linalg.norm(np.asarray(vector, dtype=float).reshape(-1)))
+                except (TypeError, ValueError):
+                    value = None
+        if value is None:
+            continue
+        try:
+            parsed = float(np.asarray(value, dtype=float))
+        except (TypeError, ValueError, OverflowError):
+            continue
+        if np.isfinite(parsed):
+            values.append(parsed)
+    return np.asarray(values, dtype=float)
+
+
+def _count_record_actions(records: Sequence[Any], actions: set[str]) -> int:
+    count = 0
+    for record in records:
+        action = _record_value(record, ("action", "update_action"))
+        if action is not None and str(action) in actions:
+            count += 1
+    return count
+
+
+def _record_value(record: Any, keys: tuple[str, ...]) -> Any | None:
+    if isinstance(record, Mapping):
+        for key in keys:
+            if key in record:
+                return record[key]
+        return None
+    for key in keys:
+        if hasattr(record, key):
+            return getattr(record, key)
+    return None
+
+
+def _finite_float(value: Any, name: str) -> float:
+    parsed = float(value)
+    if not np.isfinite(parsed):
+        raise ValueError(f"{name} must be finite")
+    return parsed
+
+
+def _nonnegative_float(value: Any, name: str) -> float:
+    parsed = _finite_float(value, name)
+    if parsed < 0.0:
+        raise ValueError(f"{name} must be nonnegative")
+    return parsed
+
+
+def _nonnegative_int(value: Any, name: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise ValueError(f"{name} must be nonnegative")
+    return parsed
+
+
+def _jsonable(value: Any) -> Any:
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    return value
+
+
+__all__ = [
+    "HypothesisReplay",
+    "HypothesisReplayScore",
+    "InnovationConsistencyScoreConfig",
+    "rank_hypothesis_replays",
+    "rank_replayed_hypotheses",
+    "score_hypothesis_replay",
+    "scores_to_dicts",
+]

--- a/src/pyrecest/tracking/measurement_reliability.py
+++ b/src/pyrecest/tracking/measurement_reliability.py
@@ -1,0 +1,282 @@
+"""Measurement reliability helpers for covariance scaling and hard rejection.
+
+The utilities in this module are intentionally filter-independent.  A caller can
+score a measurement with any truth-free reliability model, then use these helpers
+to turn that score into a covariance inflation scale or a hard accept/reject
+decision.  This is useful for asynchronous multi-sensor trackers where some
+measurements are intermittent or have reliability metadata that should not be
+encoded directly in the nominal Gaussian covariance.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+import numpy as np
+
+ReliabilityMode = Literal["off", "inflate", "hard"] | str
+
+
+@dataclass(frozen=True)
+class MeasurementReliabilityConfig:
+    """Configuration for converting reliability scores into update decisions."""
+
+    mode: ReliabilityMode = "inflate"
+    threshold: float | None = None
+    floor: float = 0.05
+    exponent: float = 1.0
+    max_scale: float | None = None
+
+    def __post_init__(self) -> None:
+        mode = str(self.mode)
+        if mode not in {"off", "inflate", "hard"}:
+            raise ValueError("mode must be one of 'off', 'inflate', or 'hard'")
+        threshold = None if self.threshold is None else _probability(self.threshold, "threshold")
+        floor = _probability(self.floor, "floor")
+        if floor <= 0.0:
+            raise ValueError("floor must be positive")
+        exponent = _positive_scalar(self.exponent, "exponent")
+        max_scale = None if self.max_scale is None else _positive_scalar(self.max_scale, "max_scale")
+        object.__setattr__(self, "mode", mode)
+        object.__setattr__(self, "threshold", threshold)
+        object.__setattr__(self, "floor", floor)
+        object.__setattr__(self, "exponent", exponent)
+        object.__setattr__(self, "max_scale", max_scale)
+
+
+@dataclass(frozen=True)
+class MeasurementReliabilityResult:
+    """Reliability-weighted measurement decision and covariance."""
+
+    reliability: float
+    covariance_scale: float
+    covariance: np.ndarray
+    accepted: bool
+    action: str
+    mode: str
+
+    def __post_init__(self) -> None:
+        covariance = _covariance_matrix(self.covariance)
+        object.__setattr__(self, "reliability", _probability(self.reliability, "reliability"))
+        object.__setattr__(self, "covariance_scale", _positive_scalar(self.covariance_scale, "covariance_scale"))
+        object.__setattr__(self, "covariance", covariance)
+        object.__setattr__(self, "accepted", bool(self.accepted))
+        object.__setattr__(self, "action", str(self.action))
+        object.__setattr__(self, "mode", str(self.mode))
+
+
+@dataclass(frozen=True)
+class ReliabilityWeightedMeasurement:
+    """Container for a measurement with a truth-free reliability score."""
+
+    measurement: np.ndarray
+    covariance: np.ndarray
+    reliability: float
+    source: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        measurement = np.asarray(self.measurement, dtype=float).reshape(-1)
+        if measurement.size == 0:
+            raise ValueError("measurement must contain at least one value")
+        if not np.isfinite(measurement).all():
+            raise ValueError("measurement must contain only finite values")
+        covariance = _covariance_matrix(self.covariance, dim=measurement.size)
+        object.__setattr__(self, "measurement", measurement.copy())
+        object.__setattr__(self, "covariance", covariance)
+        object.__setattr__(self, "reliability", _probability(self.reliability, "reliability"))
+        object.__setattr__(self, "source", None if self.source is None else str(self.source))
+        object.__setattr__(self, "metadata", dict(self.metadata))
+
+    def apply_reliability(
+        self,
+        config: MeasurementReliabilityConfig | None = None,
+        **kwargs: Any,
+    ) -> MeasurementReliabilityResult:
+        """Return the covariance/action decision for this measurement."""
+
+        return apply_measurement_reliability(
+            self.covariance,
+            reliability=self.reliability,
+            config=config,
+            **kwargs,
+        )
+
+
+def reliability_to_covariance_scale(
+    reliability: float,
+    *,
+    floor: float = 0.05,
+    exponent: float = 1.0,
+    max_scale: float | None = None,
+) -> float:
+    """Convert a probability-like reliability score into covariance scale.
+
+    ``reliability=1`` leaves the covariance unchanged.  Lower reliability values
+    inflate the covariance as ``1 / max(reliability, floor)**exponent``.  The
+    floor prevents singularly large scales when a reliability model emits zero.
+    """
+
+    reliability = _probability(reliability, "reliability")
+    floor = _probability(floor, "floor")
+    if floor <= 0.0:
+        raise ValueError("floor must be positive")
+    exponent = _positive_scalar(exponent, "exponent")
+    scale = 1.0 / max(reliability, floor) ** exponent
+    if max_scale is not None:
+        scale = min(scale, _positive_scalar(max_scale, "max_scale"))
+    return float(max(1.0, scale))
+
+
+def scale_covariance_by_reliability(
+    covariance: np.ndarray,
+    reliability: float,
+    *,
+    floor: float = 0.05,
+    exponent: float = 1.0,
+    max_scale: float | None = None,
+) -> tuple[np.ndarray, float]:
+    """Return ``covariance * scale`` and the applied reliability scale."""
+
+    covariance = _covariance_matrix(covariance)
+    scale = reliability_to_covariance_scale(
+        reliability,
+        floor=floor,
+        exponent=exponent,
+        max_scale=max_scale,
+    )
+    return covariance * scale, scale
+
+
+def apply_measurement_reliability(
+    covariance: np.ndarray,
+    *,
+    reliability: float,
+    config: MeasurementReliabilityConfig | None = None,
+    mode: ReliabilityMode | None = None,
+    threshold: float | None = None,
+    floor: float | None = None,
+    exponent: float | None = None,
+    max_scale: float | None = None,
+) -> MeasurementReliabilityResult:
+    """Apply reliability policy to one measurement covariance.
+
+    Modes
+    -----
+    ``off``
+        Always accept and return the nominal covariance.
+    ``hard``
+        Reject when ``reliability < threshold``. Accepted measurements keep the
+        nominal covariance.
+    ``inflate``
+        Accept by default and inflate covariance by inverse reliability.  If a
+        threshold is supplied, values below it are rejected before inflation.
+    """
+
+    base = MeasurementReliabilityConfig() if config is None else config
+    effective = MeasurementReliabilityConfig(
+        mode=base.mode if mode is None else mode,
+        threshold=base.threshold if threshold is None else threshold,
+        floor=base.floor if floor is None else floor,
+        exponent=base.exponent if exponent is None else exponent,
+        max_scale=base.max_scale if max_scale is None else max_scale,
+    )
+    covariance = _covariance_matrix(covariance)
+    reliability = _probability(reliability, "reliability")
+
+    if effective.mode == "off":
+        return MeasurementReliabilityResult(
+            reliability=reliability,
+            covariance_scale=1.0,
+            covariance=covariance,
+            accepted=True,
+            action="reliability_off",
+            mode=effective.mode,
+        )
+
+    threshold_value = effective.threshold
+    if effective.mode == "hard":
+        if threshold_value is None:
+            threshold_value = effective.floor
+        accepted = reliability >= threshold_value
+        return MeasurementReliabilityResult(
+            reliability=reliability,
+            covariance_scale=1.0,
+            covariance=covariance,
+            accepted=accepted,
+            action="reliability_accepted" if accepted else "reliability_rejected",
+            mode=effective.mode,
+        )
+
+    if threshold_value is not None and reliability < threshold_value:
+        return MeasurementReliabilityResult(
+            reliability=reliability,
+            covariance_scale=1.0,
+            covariance=covariance,
+            accepted=False,
+            action="reliability_rejected",
+            mode=effective.mode,
+        )
+
+    scaled, scale = scale_covariance_by_reliability(
+        covariance,
+        reliability,
+        floor=effective.floor,
+        exponent=effective.exponent,
+        max_scale=effective.max_scale,
+    )
+    return MeasurementReliabilityResult(
+        reliability=reliability,
+        covariance_scale=scale,
+        covariance=scaled,
+        accepted=True,
+        action="reliability_inflated" if scale > 1.0 else "reliability_accepted",
+        mode=effective.mode,
+    )
+
+
+def _probability(value: float, name: str) -> float:
+    value = _finite_scalar(value, name)
+    if not 0.0 <= value <= 1.0:
+        raise ValueError(f"{name} must be in [0, 1]")
+    return value
+
+
+def _positive_scalar(value: float, name: str) -> float:
+    value = _finite_scalar(value, name)
+    if value <= 0.0:
+        raise ValueError(f"{name} must be positive")
+    return value
+
+
+def _finite_scalar(value: float, name: str) -> float:
+    array = np.asarray(value)
+    if array.shape != () or array.dtype == np.bool_:
+        raise ValueError(f"{name} must be a finite scalar")
+    parsed = float(array.item())
+    if not np.isfinite(parsed):
+        raise ValueError(f"{name} must be finite")
+    return parsed
+
+
+def _covariance_matrix(value: Any, *, dim: int | None = None) -> np.ndarray:
+    covariance = np.asarray(value, dtype=float)
+    if covariance.ndim != 2 or covariance.shape[0] != covariance.shape[1]:
+        raise ValueError("covariance must be a square matrix")
+    if dim is not None and covariance.shape != (dim, dim):
+        raise ValueError(f"covariance must have shape ({dim}, {dim})")
+    if not np.isfinite(covariance).all():
+        raise ValueError("covariance must contain only finite values")
+    return covariance.copy()
+
+
+__all__ = [
+    "MeasurementReliabilityConfig",
+    "MeasurementReliabilityResult",
+    "ReliabilityWeightedMeasurement",
+    "apply_measurement_reliability",
+    "reliability_to_covariance_scale",
+    "scale_covariance_by_reliability",
+]

--- a/src/pyrecest/tracking/tracklet_graph.py
+++ b/src/pyrecest/tracking/tracklet_graph.py
@@ -1,0 +1,435 @@
+"""Generic tracklet DAG and k-best association path utilities.
+
+This module is intentionally application-independent.  A caller supplies
+tracklet nodes with start/end times, endpoint states, and optional metadata;
+PyRecEst builds a directed acyclic graph over plausible transitions and returns
+low-cost tracklet paths.  Domain-specific features such as radar class
+probabilities, RF contradiction scores, or sensor-specific range gates should be
+converted into node/edge costs by the calling project.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Hashable
+
+import numpy as np
+
+CostFn = Callable[["Tracklet"], float]
+EdgeCostFn = Callable[["Tracklet", "Tracklet"], float | None]
+
+
+@dataclass(frozen=True)
+class Tracklet:
+    """A time-bounded association primitive used as a graph node."""
+
+    id: Hashable
+    start_time: float
+    end_time: float
+    start_state: Any
+    end_state: Any
+    cost: float = 0.0
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        start_time = _finite_float(self.start_time, "start_time")
+        end_time = _finite_float(self.end_time, "end_time")
+        if end_time < start_time:
+            raise ValueError("tracklet end_time must be >= start_time")
+        start_state = _state_vector(self.start_state, "start_state")
+        end_state = _state_vector(self.end_state, "end_state")
+        if start_state.shape != end_state.shape:
+            raise ValueError("start_state and end_state must have the same shape")
+        object.__setattr__(self, "start_time", start_time)
+        object.__setattr__(self, "end_time", end_time)
+        object.__setattr__(self, "start_state", start_state)
+        object.__setattr__(self, "end_state", end_state)
+        object.__setattr__(self, "cost", _finite_float(self.cost, "cost"))
+        object.__setattr__(self, "metadata", dict(self.metadata))
+
+    @property
+    def duration(self) -> float:
+        """Return ``end_time - start_time``."""
+
+        return float(self.end_time - self.start_time)
+
+
+@dataclass(frozen=True)
+class TrackletEdge:
+    """Directed transition edge between two tracklets."""
+
+    source_id: Hashable
+    target_id: Hashable
+    cost: float
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "cost", _finite_float(self.cost, "cost"))
+        object.__setattr__(self, "metadata", dict(self.metadata))
+
+
+@dataclass(frozen=True)
+class TrackletPath:
+    """A candidate sequence of tracklets through a DAG."""
+
+    tracklet_ids: tuple[Hashable, ...]
+    cost: float
+    node_cost: float = 0.0
+    edge_cost: float = 0.0
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.tracklet_ids:
+            raise ValueError("tracklet path must contain at least one tracklet id")
+        cost = _finite_float(self.cost, "cost")
+        node_cost = _finite_float(self.node_cost, "node_cost")
+        edge_cost = _finite_float(self.edge_cost, "edge_cost")
+        object.__setattr__(self, "tracklet_ids", tuple(self.tracklet_ids))
+        object.__setattr__(self, "cost", cost)
+        object.__setattr__(self, "node_cost", node_cost)
+        object.__setattr__(self, "edge_cost", edge_cost)
+        object.__setattr__(self, "metadata", dict(self.metadata))
+
+    @property
+    def length(self) -> int:
+        """Return the number of tracklets in the path."""
+
+        return int(len(self.tracklet_ids))
+
+
+@dataclass(frozen=True)
+class TrackletGraphConfig:
+    """Configuration for k-best path extraction from a tracklet DAG."""
+
+    top_k: int = 10
+    beam_width: int | None = None
+    allow_overlap: bool = False
+    max_gap: float | None = None
+    diversity_weight: float = 0.0
+    candidate_multiplier: int = 5
+
+    def __post_init__(self) -> None:
+        top_k = int(self.top_k)
+        if top_k <= 0:
+            raise ValueError("top_k must be positive")
+        beam_width = None if self.beam_width is None else int(self.beam_width)
+        if beam_width is not None and beam_width <= 0:
+            raise ValueError("beam_width must be positive when supplied")
+        max_gap = None if self.max_gap is None else float(self.max_gap)
+        if max_gap is not None and max_gap < 0.0:
+            raise ValueError("max_gap must be nonnegative when supplied")
+        diversity_weight = float(self.diversity_weight)
+        if diversity_weight < 0.0:
+            raise ValueError("diversity_weight must be nonnegative")
+        candidate_multiplier = int(self.candidate_multiplier)
+        if candidate_multiplier <= 0:
+            raise ValueError("candidate_multiplier must be positive")
+        object.__setattr__(self, "top_k", top_k)
+        object.__setattr__(self, "beam_width", beam_width)
+        object.__setattr__(self, "max_gap", max_gap)
+        object.__setattr__(self, "diversity_weight", diversity_weight)
+        object.__setattr__(self, "candidate_multiplier", candidate_multiplier)
+
+
+def constant_velocity_edge_cost(
+    *,
+    max_gap: float | None = None,
+    max_speed: float | None = None,
+    state_slice: slice | Sequence[int] = slice(None),
+    gap_weight: float = 0.0,
+    speed_weight: float = 1.0,
+    switch_metadata_key: str | None = None,
+    switch_penalty: float = 0.0,
+) -> EdgeCostFn:
+    """Build a generic constant-velocity feasibility/cost function."""
+
+    max_gap_value = None if max_gap is None else float(max_gap)
+    max_speed_value = None if max_speed is None else float(max_speed)
+    if max_gap_value is not None and max_gap_value < 0.0:
+        raise ValueError("max_gap must be nonnegative when supplied")
+    if max_speed_value is not None and max_speed_value <= 0.0:
+        raise ValueError("max_speed must be positive when supplied")
+
+    def edge_cost(left: Tracklet, right: Tracklet) -> float:
+        gap = float(right.start_time - left.end_time)
+        if gap < -1.0e-9:
+            return float("inf")
+        if max_gap_value is not None and gap > max_gap_value:
+            return float("inf")
+        dt = max(gap, 1.0e-9)
+        left_state = left.end_state[state_slice]
+        right_state = right.start_state[state_slice]
+        distance = float(np.linalg.norm(np.asarray(right_state) - np.asarray(left_state)))
+        speed = distance / dt
+        if max_speed_value is not None and speed > max_speed_value:
+            return float("inf")
+        switch = 0.0
+        if switch_metadata_key is not None:
+            if left.metadata.get(switch_metadata_key) != right.metadata.get(switch_metadata_key):
+                switch = float(switch_penalty)
+        return float(float(gap_weight) * gap + float(speed_weight) * speed + switch)
+
+    return edge_cost
+
+
+def build_tracklet_adjacency(
+    tracklets: Sequence[Tracklet],
+    edge_cost_fn: EdgeCostFn,
+    *,
+    allow_overlap: bool = False,
+    max_gap: float | None = None,
+) -> dict[Hashable, list[tuple[Hashable, float]]]:
+    """Build adjacency lists for a time-ordered tracklet DAG."""
+
+    ordered = sort_tracklets(tracklets)
+    max_gap_value = None if max_gap is None else float(max_gap)
+    adjacency: dict[Hashable, list[tuple[Hashable, float]]] = {item.id: [] for item in ordered}
+    for left_index, left in enumerate(ordered):
+        for right in ordered[left_index + 1 :]:
+            gap = float(right.start_time - left.end_time)
+            if not allow_overlap and gap < -1.0e-9:
+                continue
+            if max_gap_value is not None and gap > max_gap_value:
+                break
+            cost = edge_cost_fn(left, right)
+            if cost is None or not np.isfinite(float(cost)):
+                continue
+            adjacency[left.id].append((right.id, float(cost)))
+    return adjacency
+
+
+def k_best_tracklet_paths(
+    tracklets: Sequence[Tracklet],
+    *,
+    edge_cost_fn: EdgeCostFn,
+    config: TrackletGraphConfig | None = None,
+    node_cost_fn: CostFn | None = None,
+    start_cost_fn: CostFn | None = None,
+    end_cost_fn: CostFn | None = None,
+) -> list[TrackletPath]:
+    """Return the k lowest-cost paths through a tracklet DAG."""
+
+    cfg = TrackletGraphConfig() if config is None else config
+    ordered = sort_tracklets(tracklets)
+    if not ordered:
+        return []
+    adjacency = build_tracklet_adjacency(
+        ordered,
+        edge_cost_fn,
+        allow_overlap=cfg.allow_overlap,
+        max_gap=cfg.max_gap,
+    )
+    by_id = {item.id: item for item in ordered}
+    index_by_id = {item.id: index for index, item in enumerate(ordered)}
+    beam_width = cfg.beam_width or max(cfg.top_k, 1)
+    paths_by_end: dict[Hashable, list[TrackletPath]] = {}
+
+    for tracklet in ordered:
+        node_cost = _node_cost(tracklet, node_cost_fn)
+        start_cost = 0.0 if start_cost_fn is None else _finite_cost(start_cost_fn(tracklet))
+        candidates = [
+            TrackletPath(
+                tracklet_ids=(tracklet.id,),
+                cost=start_cost + node_cost,
+                node_cost=node_cost,
+                edge_cost=0.0,
+            )
+        ]
+        for left in ordered[: index_by_id[tracklet.id]]:
+            for right_id, edge_cost in adjacency[left.id]:
+                if right_id != tracklet.id:
+                    continue
+                for previous in paths_by_end.get(left.id, []):
+                    candidates.append(
+                        TrackletPath(
+                            tracklet_ids=(*previous.tracklet_ids, tracklet.id),
+                            cost=previous.cost + edge_cost + node_cost,
+                            node_cost=previous.node_cost + node_cost,
+                            edge_cost=previous.edge_cost + edge_cost,
+                        )
+                    )
+        paths_by_end[tracklet.id] = sorted(candidates, key=_path_sort_key)[:beam_width]
+
+    all_paths: dict[tuple[Hashable, ...], TrackletPath] = {}
+    for path_list in paths_by_end.values():
+        for path in path_list:
+            last = by_id[path.tracklet_ids[-1]]
+            end_cost = 0.0 if end_cost_fn is None else _finite_cost(end_cost_fn(last))
+            final_path = TrackletPath(
+                tracklet_ids=path.tracklet_ids,
+                cost=path.cost + end_cost,
+                node_cost=path.node_cost,
+                edge_cost=path.edge_cost,
+            )
+            if final_path.tracklet_ids not in all_paths or final_path.cost < all_paths[final_path.tracklet_ids].cost:
+                all_paths[final_path.tracklet_ids] = final_path
+
+    return sorted(all_paths.values(), key=_path_sort_key)[: cfg.top_k]
+
+
+def diverse_k_best_tracklet_paths(
+    tracklets: Sequence[Tracklet],
+    *,
+    edge_cost_fn: EdgeCostFn,
+    config: TrackletGraphConfig | None = None,
+    node_cost_fn: CostFn | None = None,
+    start_cost_fn: CostFn | None = None,
+    end_cost_fn: CostFn | None = None,
+) -> list[TrackletPath]:
+    """Return k paths with an optional greedy Jaccard overlap penalty."""
+
+    cfg = TrackletGraphConfig() if config is None else config
+    if cfg.diversity_weight <= 0.0:
+        return k_best_tracklet_paths(
+            tracklets,
+            edge_cost_fn=edge_cost_fn,
+            config=cfg,
+            node_cost_fn=node_cost_fn,
+            start_cost_fn=start_cost_fn,
+            end_cost_fn=end_cost_fn,
+        )
+    candidate_cfg = TrackletGraphConfig(
+        top_k=max(cfg.top_k * cfg.candidate_multiplier, cfg.top_k),
+        beam_width=cfg.beam_width,
+        allow_overlap=cfg.allow_overlap,
+        max_gap=cfg.max_gap,
+        diversity_weight=0.0,
+        candidate_multiplier=cfg.candidate_multiplier,
+    )
+    candidates = k_best_tracklet_paths(
+        tracklets,
+        edge_cost_fn=edge_cost_fn,
+        config=candidate_cfg,
+        node_cost_fn=node_cost_fn,
+        start_cost_fn=start_cost_fn,
+        end_cost_fn=end_cost_fn,
+    )
+    selected: list[TrackletPath] = []
+    remaining = list(candidates)
+    while remaining and len(selected) < cfg.top_k:
+        def adjusted(path: TrackletPath) -> tuple[float, float, tuple[str, ...]]:
+            overlap = max((path_jaccard(path, kept) for kept in selected), default=0.0)
+            return (
+                path.cost + cfg.diversity_weight * overlap,
+                path.cost,
+                tuple(str(item) for item in path.tracklet_ids),
+            )
+
+        best = min(remaining, key=adjusted)
+        overlap = max((path_jaccard(best, kept) for kept in selected), default=0.0)
+        selected.append(
+            TrackletPath(
+                tracklet_ids=best.tracklet_ids,
+                cost=best.cost,
+                node_cost=best.node_cost,
+                edge_cost=best.edge_cost,
+                metadata={**dict(best.metadata), "jaccard_to_previous": overlap},
+            )
+        )
+        remaining = [path for path in remaining if path.tracklet_ids != best.tracklet_ids]
+    return selected
+
+
+def path_jaccard(left: TrackletPath, right: TrackletPath) -> float:
+    """Return Jaccard overlap between two tracklet paths."""
+
+    left_set = set(left.tracklet_ids)
+    right_set = set(right.tracklet_ids)
+    union = left_set | right_set
+    if not union:
+        return 0.0
+    return float(len(left_set & right_set) / len(union))
+
+
+def materialize_tracklet_path(path: TrackletPath, tracklets: Mapping[Hashable, Tracklet]) -> list[Tracklet]:
+    """Return path tracklets in path order."""
+
+    return [tracklets[tracklet_id] for tracklet_id in path.tracklet_ids]
+
+
+def tracklet_paths_to_dicts(
+    paths: Iterable[TrackletPath],
+    *,
+    tracklets: Mapping[Hashable, Tracklet] | None = None,
+) -> list[dict[str, Any]]:
+    """Serialize tracklet paths for CSV/JSON diagnostics."""
+
+    rows: list[dict[str, Any]] = []
+    for rank, path in enumerate(paths):
+        row: dict[str, Any] = {
+            "rank": int(rank),
+            "tracklet_ids": ";".join(str(item) for item in path.tracklet_ids),
+            "path_length": int(path.length),
+            "cost": float(path.cost),
+            "node_cost": float(path.node_cost),
+            "edge_cost": float(path.edge_cost),
+        }
+        row.update({f"metadata_{key}": value for key, value in dict(path.metadata).items()})
+        if tracklets is not None:
+            members = materialize_tracklet_path(path, tracklets)
+            start = min(member.start_time for member in members)
+            end = max(member.end_time for member in members)
+            row.update({"start_time": start, "end_time": end, "duration": end - start})
+        rows.append(row)
+    return rows
+
+
+def sort_tracklets(tracklets: Iterable[Tracklet]) -> list[Tracklet]:
+    """Return tracklets sorted by start time, end time, and id string."""
+
+    return sorted(tracklets, key=lambda item: (item.start_time, item.end_time, str(item.id)))
+
+
+def _node_cost(tracklet: Tracklet, node_cost_fn: CostFn | None) -> float:
+    if node_cost_fn is None:
+        return float(tracklet.cost)
+    return _finite_cost(node_cost_fn(tracklet))
+
+
+def _finite_cost(value: float) -> float:
+    value = float(value)
+    if not np.isfinite(value):
+        raise ValueError("cost functions must return finite costs")
+    return value
+
+
+def _path_sort_key(path: TrackletPath) -> tuple[float, int, tuple[str, ...]]:
+    return (float(path.cost), int(path.length), tuple(str(item) for item in path.tracklet_ids))
+
+
+def _state_vector(value: Any, name: str) -> np.ndarray:
+    vector = np.asarray(value, dtype=float).reshape(-1)
+    if vector.size == 0:
+        raise ValueError(f"{name} must contain at least one value")
+    if not np.isfinite(vector).all():
+        raise ValueError(f"{name} must contain only finite values")
+    return vector.copy()
+
+
+def _finite_float(value: Any, name: str) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be finite") from exc
+    if not np.isfinite(parsed):
+        raise ValueError(f"{name} must be finite")
+    return parsed
+
+
+__all__ = [
+    "CostFn",
+    "EdgeCostFn",
+    "Tracklet",
+    "TrackletEdge",
+    "TrackletGraphConfig",
+    "TrackletPath",
+    "build_tracklet_adjacency",
+    "constant_velocity_edge_cost",
+    "diverse_k_best_tracklet_paths",
+    "k_best_tracklet_paths",
+    "materialize_tracklet_path",
+    "path_jaccard",
+    "sort_tracklets",
+    "tracklet_paths_to_dicts",
+]

--- a/tests/test_model_comparison.py
+++ b/tests/test_model_comparison.py
@@ -1,0 +1,162 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from pyrecest.evaluation.model_comparison import (
+    add_evidence_margin_columns,
+    cluster_bootstrap_margin_summary,
+    evidence_margin_table,
+    grouped_claim_gate_summary,
+    infer_paired_model_group_cols,
+    leave_one_group_out_summary,
+    paired_model_margin_decisions,
+    paired_model_margin_summary,
+    paired_model_margin_threshold_sweep,
+    select_paired_model_margin_threshold,
+)
+
+
+def test_paired_model_margin_decisions_summary_and_threshold_selection():
+    scores = pd.DataFrame(
+        [
+            _score("s1", 0, "positive", 10.0, true_model="positive"),
+            _score("s1", 0, "reference", 4.0, true_model="positive"),
+            _score("s1", 1, "positive", 3.0, true_model="reference"),
+            _score("s1", 1, "reference", 5.0, true_model="reference"),
+            _score("s2", 2, "positive", 4.0, true_model="positive"),
+            _score("s2", 2, "reference", 2.5, true_model="positive"),
+        ]
+    )
+
+    decisions = paired_model_margin_decisions(
+        scores,
+        positive_model="positive",
+        reference_model="reference",
+        margin_threshold=2.0,
+        true_model_col="true_model",
+        positive_true_label="positive",
+    )
+    assert decisions["margin_decision"].tolist() == ["positive", "reference", "ambiguous"]
+    assert decisions["positive_model_claimed"].tolist() == [True, False, False]
+
+    summary = paired_model_margin_summary(decisions, true_model_col="true_model")
+    row = summary.iloc[0]
+    assert row["events"] == 3
+    assert row["positive_model_claims"] == 1
+    assert row["reference_model_claims"] == 1
+    assert row["ambiguous_events"] == 1
+    assert row["false_positive_claims"] == 0
+    assert row["positive_claim_recall"] == pytest.approx(0.5)
+
+    sweep = paired_model_margin_threshold_sweep(
+        scores,
+        positive_model="positive",
+        reference_model="reference",
+        thresholds=(0.0, 2.0, 5.0),
+        group_cols=("session", "event_index"),
+        true_model_col="true_model",
+        positive_true_label="positive",
+    )
+    selected = select_paired_model_margin_threshold(sweep, max_false_positive_claims=0)
+    assert selected.iloc[0]["selection_status"] == "passed_specificity_gate"
+    assert selected.iloc[0]["selected_margin_threshold"] == 0.0
+
+
+def test_grouped_leave_one_out_and_cluster_bootstrap_are_generic():
+    decisions = pd.DataFrame(
+        [
+            _decision("Rat1", 10.0, True),
+            _decision("Rat1", 4.0, False),
+            _decision("Rat2", 8.0, True),
+            _decision("Rat2", 7.0, True),
+            _decision("Rat3", 9.0, True),
+            _decision("Rat3", -1.0, False),
+        ]
+    )
+
+    grouped = paired_model_margin_summary(decisions, group_cols=("rat",))
+    gates = grouped_claim_gate_summary(
+        grouped,
+        group_col="rat",
+        claim_fraction_col="positive_claim_fraction",
+        forbidden_claims_col="reference_model_claims",
+        mean_delta_col="mean_positive_minus_reference_log_evidence",
+        median_delta_col="median_positive_minus_reference_log_evidence",
+        min_claim_fraction=0.0,
+    )
+    assert bool(gates.set_index("gate").loc["all_groups_mean_delta_positive", "passed"])
+
+    leave_one = leave_one_group_out_summary(
+        decisions,
+        group_col="rat",
+        held_out_col="held_out_rat",
+        summary_fn=lambda frame: paired_model_margin_summary(frame),
+    )
+    assert set(leave_one["held_out_rat"]) == {"Rat1", "Rat2", "Rat3"}
+    assert (leave_one["events"] == 4).all()
+
+    bootstrap = cluster_bootstrap_margin_summary(
+        decisions,
+        cluster_col="rat",
+        delta_col="positive_minus_reference_log_evidence",
+        positive_claim_col="positive_model_claimed",
+        n_bootstrap=100,
+        random_seed=7,
+    )
+    assert bootstrap.iloc[0]["bootstrap_unit"] == "rat"
+    assert bootstrap.iloc[0]["observed_clusters"] == 3
+    assert bootstrap.iloc[0]["probability_mean_delta_gt_0"] > 0.9
+
+
+def test_best_vs_second_best_margin_table_and_group_inference():
+    scores = pd.DataFrame(
+        [
+            _score("s1", 0, "a", 0.0),
+            _score("s1", 0, "b", 3.0),
+            _score("s1", 0, "c", 1.0),
+            _score("s1", 1, "a", 2.0, comparable=False),
+            _score("s1", 1, "b", 1.0),
+            _score("s1", 1, "c", 5.0),
+        ]
+    )
+    margins = evidence_margin_table(scores)
+    assert margins["best_model_by_evidence"].tolist() == ["b", "c"]
+    assert margins["evidence_margin_to_second_best"].tolist() == [2.0, 4.0]
+
+    augmented = add_evidence_margin_columns(scores)
+    assert "evidence_margin_category" in augmented
+    assert infer_paired_model_group_cols(scores) == ("session", "event_index")
+
+
+def _score(
+    session: str,
+    event_index: int,
+    model: str,
+    log_evidence: float,
+    *,
+    true_model: str | None = None,
+    comparable: bool = True,
+) -> dict[str, object]:
+    row: dict[str, object] = {
+        "status": "success",
+        "session": session,
+        "event_index": event_index,
+        "model": model,
+        "log_evidence": log_evidence,
+        "evidence_comparable": comparable,
+    }
+    if true_model is not None:
+        row["true_model"] = true_model
+    return row
+
+
+def _decision(rat: str, delta: float, positive_claimed: bool) -> dict[str, object]:
+    return {
+        "rat": rat,
+        "positive_model": "positive",
+        "reference_model": "reference",
+        "margin_threshold": 2.0,
+        "positive_minus_reference_log_evidence": delta,
+        "positive_model_claimed": positive_claimed,
+        "margin_decision": "positive" if positive_claimed else "ambiguous",
+    }

--- a/tests/tracking/test_hypothesis_replay.py
+++ b/tests/tracking/test_hypothesis_replay.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import numpy as np
+
+from pyrecest.tracking import (
+    HypothesisReplay,
+    InnovationConsistencyScoreConfig,
+    TrackingRecord,
+    rank_hypothesis_replays,
+    rank_replayed_hypotheses,
+    scores_to_dicts,
+)
+
+
+def test_rank_hypothesis_replays_prefers_innovation_consistency_over_graph_cost() -> None:
+    bad_graph_winner = HypothesisReplay(
+        hypothesis_id="graph-rank-1",
+        records=[{"nis": 200.0, "residual_norm_m": 1000.0, "action": "updated"}],
+        graph_cost=0.0,
+        coverage_count=100,
+    )
+    good_replay = HypothesisReplay(
+        hypothesis_id="graph-rank-2",
+        records=[{"nis": 1.0, "residual_norm_m": 10.0, "action": "updated"}],
+        graph_cost=10.0,
+        coverage_count=100,
+    )
+
+    scores = rank_hypothesis_replays(
+        [bad_graph_winner, good_replay],
+        config=InnovationConsistencyScoreConfig(
+            graph_cost_weight=0.1,
+            nis_weight=1.0,
+            residual_weight=0.1,
+            nis_clip=50.0,
+            residual_clip=500.0,
+        ),
+    )
+
+    assert [score.hypothesis_id for score in scores] == ["graph-rank-2", "graph-rank-1"]
+    assert scores[0].rank == 1
+    assert scores_to_dicts(scores)[0]["hypothesis_id"] == "graph-rank-2"
+
+
+def test_hypothesis_replay_accepts_tracking_record_objects() -> None:
+    record = TrackingRecord(
+        time=1.0,
+        source="radar",
+        action="update",
+        prior_mean=np.zeros(2),
+        prior_cov=np.eye(2),
+        posterior_mean=np.ones(2),
+        posterior_cov=np.eye(2),
+        innovation=np.array([3.0, 4.0]),
+        innovation_cov=np.eye(2),
+        nis=25.0,
+        accepted=True,
+    )
+    replay = HypothesisReplay(hypothesis_id=1, records=[record], graph_cost=0.0)
+
+    score = rank_hypothesis_replays([replay])[0]
+
+    assert score.finite_nis_count == 1
+    assert score.finite_residual_count == 1
+    assert score.robust_sum_residual == 5.0 / 100.0
+
+
+def test_rank_replayed_hypotheses_calls_replay_function() -> None:
+    def replay_fn(value: int) -> HypothesisReplay:
+        return HypothesisReplay(
+            hypothesis_id=value,
+            records=[{"nis": float(value), "action": "updated"}],
+            graph_cost=0.0,
+        )
+
+    scores = rank_replayed_hypotheses([3, 1, 2], replay_fn)
+
+    assert [score.hypothesis_id for score in scores] == [1, 2, 3]

--- a/tests/tracking/test_measurement_reliability.py
+++ b/tests/tracking/test_measurement_reliability.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pyrecest.tracking import (
+    MeasurementReliabilityConfig,
+    ReliabilityWeightedMeasurement,
+    apply_measurement_reliability,
+    reliability_to_covariance_scale,
+    scale_covariance_by_reliability,
+)
+
+
+def test_reliability_to_covariance_scale_uses_inverse_probability() -> None:
+    assert reliability_to_covariance_scale(1.0) == 1.0
+    assert reliability_to_covariance_scale(0.5) == 2.0
+    assert reliability_to_covariance_scale(0.01, floor=0.1) == 10.0
+
+
+def test_scale_covariance_by_reliability_returns_scaled_copy() -> None:
+    cov = np.diag([4.0, 9.0])
+    scaled, scale = scale_covariance_by_reliability(cov, 0.25)
+
+    assert scale == 4.0
+    assert np.allclose(scaled, np.diag([16.0, 36.0]))
+    assert np.allclose(cov, np.diag([4.0, 9.0]))
+
+
+def test_hard_mode_rejects_low_reliability_measurement() -> None:
+    result = apply_measurement_reliability(
+        np.eye(2),
+        reliability=0.4,
+        mode="hard",
+        threshold=0.5,
+    )
+
+    assert not result.accepted
+    assert result.action == "reliability_rejected"
+    assert result.covariance_scale == 1.0
+    assert np.allclose(result.covariance, np.eye(2))
+
+
+def test_inflate_mode_can_also_apply_threshold() -> None:
+    rejected = apply_measurement_reliability(
+        np.eye(2),
+        reliability=0.2,
+        mode="inflate",
+        threshold=0.25,
+    )
+    accepted = apply_measurement_reliability(
+        np.eye(2),
+        reliability=0.5,
+        mode="inflate",
+        threshold=0.25,
+    )
+
+    assert not rejected.accepted
+    assert rejected.action == "reliability_rejected"
+    assert accepted.accepted
+    assert accepted.action == "reliability_inflated"
+    assert accepted.covariance_scale == 2.0
+
+
+def test_reliability_weighted_measurement_validates_covariance_dimension() -> None:
+    measurement = ReliabilityWeightedMeasurement(
+        measurement=np.array([1.0, 2.0]),
+        covariance=np.eye(2),
+        reliability=0.5,
+        source="rf",
+        metadata={"row": 3},
+    )
+    result = measurement.apply_reliability(MeasurementReliabilityConfig(mode="inflate"))
+
+    assert measurement.source == "rf"
+    assert measurement.metadata == {"row": 3}
+    assert result.covariance_scale == 2.0
+    assert np.allclose(result.covariance, 2.0 * np.eye(2))
+
+    with pytest.raises(ValueError, match="covariance must have shape"):
+        ReliabilityWeightedMeasurement(
+            measurement=np.array([1.0, 2.0]),
+            covariance=np.eye(3),
+            reliability=0.5,
+        )
+
+
+def test_invalid_reliability_raises() -> None:
+    with pytest.raises(ValueError, match="reliability"):
+        reliability_to_covariance_scale(1.5)

--- a/tests/tracking/test_tracklet_graph.py
+++ b/tests/tracking/test_tracklet_graph.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import numpy as np
+
+from pyrecest.tracking.tracklet_graph import (
+    Tracklet,
+    TrackletGraphConfig,
+    constant_velocity_edge_cost,
+    diverse_k_best_tracklet_paths,
+    k_best_tracklet_paths,
+    path_jaccard,
+    tracklet_paths_to_dicts,
+)
+
+
+def _tracklet(identifier: str, start: float, end: float, x0: float, x1: float, *, cost: float = 0.0, label: str = "a") -> Tracklet:
+    return Tracklet(
+        id=identifier,
+        start_time=start,
+        end_time=end,
+        start_state=np.array([x0, 0.0]),
+        end_state=np.array([x1, 0.0]),
+        cost=cost,
+        metadata={"label": label},
+    )
+
+
+def test_k_best_tracklet_paths_prefers_feasible_low_cost_chain() -> None:
+    tracklets = [
+        _tracklet("a", 0.0, 1.0, 0.0, 1.0, cost=-5.0),
+        _tracklet("b", 2.0, 3.0, 2.0, 3.0, cost=-5.0),
+        _tracklet("c", 2.0, 3.0, 80.0, 81.0),
+    ]
+    edge_cost = constant_velocity_edge_cost(max_gap=5.0, max_speed=10.0)
+
+    paths = k_best_tracklet_paths(tracklets, edge_cost_fn=edge_cost, config=TrackletGraphConfig(top_k=3))
+
+    assert paths[0].tracklet_ids == ("a", "b")
+    assert ("a", "c") not in [path.tracklet_ids for path in paths]
+    assert paths[0].length == 2
+
+
+def test_switch_penalty_and_node_cost_are_reflected() -> None:
+    tracklets = [
+        _tracklet("a", 0.0, 1.0, 0.0, 1.0, cost=-5.0, label="one"),
+        _tracklet("b", 2.0, 3.0, 2.0, 3.0, cost=-5.0, label="two"),
+    ]
+    edge_cost = constant_velocity_edge_cost(
+        max_gap=5.0,
+        max_speed=10.0,
+        switch_metadata_key="label",
+        switch_penalty=7.0,
+    )
+
+    paths = k_best_tracklet_paths(tracklets, edge_cost_fn=edge_cost, config=TrackletGraphConfig(top_k=3))
+    path = next(item for item in paths if item.tracklet_ids == ("a", "b"))
+
+    assert path.edge_cost >= 7.0
+
+
+def test_diverse_path_selection_penalizes_overlap() -> None:
+    tracklets = [
+        _tracklet("a", 0.0, 1.0, 0.0, 1.0),
+        _tracklet("b", 2.0, 3.0, 2.0, 3.0),
+        _tracklet("c", 4.0, 5.0, 4.0, 5.0),
+        _tracklet("x", 0.0, 1.0, 100.0, 101.0, cost=0.1),
+        _tracklet("y", 2.0, 3.0, 102.0, 103.0, cost=0.1),
+    ]
+    edge_cost = constant_velocity_edge_cost(max_gap=5.0, max_speed=10.0)
+
+    paths = diverse_k_best_tracklet_paths(
+        tracklets,
+        edge_cost_fn=edge_cost,
+        config=TrackletGraphConfig(top_k=2, diversity_weight=100.0),
+    )
+
+    assert len(paths) == 2
+    assert path_jaccard(paths[0], paths[1]) < 1.0
+    assert "jaccard_to_previous" in paths[1].metadata
+
+
+def test_tracklet_paths_to_dicts_includes_materialized_times() -> None:
+    tracklets = {
+        "a": _tracklet("a", 0.0, 1.0, 0.0, 1.0, cost=-5.0),
+        "b": _tracklet("b", 2.0, 3.0, 2.0, 3.0, cost=-5.0),
+    }
+    edge_cost = constant_velocity_edge_cost(max_gap=5.0, max_speed=10.0)
+    path = k_best_tracklet_paths(list(tracklets.values()), edge_cost_fn=edge_cost, config=TrackletGraphConfig(top_k=1))[0]
+
+    rows = tracklet_paths_to_dicts([path], tracklets=tracklets)
+
+    assert rows[0]["rank"] == 0
+    assert rows[0]["tracklet_ids"] == "a;b"
+    assert rows[0]["start_time"] == 0.0
+    assert rows[0]["end_time"] == 3.0
+
+
+def test_tracklet_validation_rejects_bad_state() -> None:
+    try:
+        Tracklet("bad", 1.0, 0.0, np.zeros(2), np.zeros(2))
+    except ValueError as exc:
+        assert "end_time" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected ValueError")


### PR DESCRIPTION
## Summary
- add dataframe-oriented model-comparison evidence margin helpers
- add hypothesis replay ranking utilities for tracking workflows
- document and export the new APIs

## Validation
- `python -m py_compile ...` on touched Python files
- `git diff --check`

Per request, no test suite was run.