### PR TITLE
Validate Gaussian conversion source contract

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/conversion.py
+++ b/src/pyrecest/distributions/nonperiodic/conversion.py
@@ -1,0 +1,23 @@
+"""Compatibility import path for nonperiodic distribution conversions."""
+
+from pyrecest.distributions.conversion import (
+    ConversionError,
+    ConversionResult,
+    can_convert,
+    convert_distribution,
+    register_conversion,
+    register_conversion_alias,
+    registered_conversion_aliases,
+    registered_conversions,
+)
+
+__all__ = [
+    "ConversionError",
+    "ConversionResult",
+    "can_convert",
+    "convert_distribution",
+    "register_conversion",
+    "register_conversion_alias",
+    "registered_conversion_aliases",
+    "registered_conversions",
+]

--- a/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
@@ -307,16 +307,24 @@ class GaussianDistribution(AbstractLinearDistribution):
         distributions must expose mean and covariance information compatible
         with :class:`GaussianDistribution`.
         """
+        from .conversion import ConversionError
         from .gaussian_mixture import GaussianMixture
 
         if isinstance(distribution, GaussianMixture):
             gaussian = distribution.to_gaussian(check_validity=check_validity)
         else:
-            mean = distribution.mean
+            try:
+                mean = distribution.mean
+                covariance = distribution.covariance
+            except AttributeError as exc:
+                raise ConversionError(
+                    "GaussianDistribution.from_distribution requires the source "
+                    "distribution to expose mean() and covariance()."
+                ) from exc
+
             if callable(mean):
                 mean = mean()
 
-            covariance = distribution.covariance
             if callable(covariance):
                 covariance = covariance()
 

--- a/tests/distributions/test_gaussian_conversion_contract.py
+++ b/tests/distributions/test_gaussian_conversion_contract.py
@@ -1,0 +1,29 @@
+import unittest
+
+from pyrecest.backend import array
+from pyrecest.distributions.circle.wrapped_normal_distribution import (
+    WrappedNormalDistribution,
+)
+from pyrecest.distributions.conversion import ConversionError, convert_distribution
+from pyrecest.distributions.nonperiodic.gaussian_distribution import GaussianDistribution
+
+
+class GaussianConversionContractTest(unittest.TestCase):
+    def test_non_linear_distribution_without_covariance_raises_conversion_error(self):
+        distribution = WrappedNormalDistribution(array(0.0), 0.5)
+
+        with self.assertRaisesRegex(
+            ConversionError,
+            "requires the source distribution to expose mean\(\) and covariance\(\)",
+        ):
+            convert_distribution(distribution, GaussianDistribution)
+
+    def test_gaussian_alias_reports_conversion_error_not_attribute_error(self):
+        distribution = WrappedNormalDistribution(array(0.0), 0.5)
+
+        with self.assertRaises(ConversionError):
+            convert_distribution(distribution, "gaussian")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Raise `ConversionError` instead of leaking `AttributeError` when Gaussian moment matching is requested for a source without `mean()`/`covariance()` support.
- Add regression coverage for explicit `GaussianDistribution` conversion and the generic `"gaussian"` alias on a wrapped-normal source.

## Rationale
`GaussianDistribution.from_distribution` documents that non-mixture sources must expose mean and covariance information. Before this patch, unsupported manifold distributions could reach the Gaussian target path and fail with an implementation-level `AttributeError` for `covariance`, which is inconsistent with the conversion API's error contract.

## Testing
- Not run locally; change is covered by focused unit regression tests in `tests/distributions/test_gaussian_conversion_contract.py`.