### PR TITLE
Fix backend autodiff and PyTorch contracts

### DIFF
--- a/src/pyrecest/_backend/jax/autodiff.py
+++ b/src/pyrecest/_backend/jax/autodiff.py
@@ -4,10 +4,10 @@ Based on autodiff.py by emilemathieu on
 https://github.com/oxcsml/geomstats/blob/master/geomstats/_backend/jax/autodiff.py
 """
 
+import jax
 import jax.numpy as anp
-from autograd.extend import defvjp, primitive  # TODO: replace
 from jax import grad, jacfwd
-from jax import value_and_grad as _value_and_grad
+from jax import value_and_grad as _jax_value_and_grad
 
 
 def detach(x):
@@ -51,6 +51,14 @@ def custom_gradient(*grad_funcs):
     """
 
     def decorator(func):
+        try:
+            from autograd.extend import defvjp, primitive  # TODO: replace
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(
+                "custom_gradient in the JAX backend requires the optional "
+                "'autograd' dependency."
+            ) from exc
+
         wrapped_function = primitive(func)
 
         def wrapped_grad_func(i, ans, *args, **kwargs):
@@ -97,27 +105,28 @@ def jacobian(func):
     return jacfwd(func)
 
 
-def value_and_grad(func, to_numpy=False):
-    """Wrap autograd value_and_grad function."""
+def value_and_grad(func, argnums=0, point_ndims=1, to_numpy=False):
+    """Wrap JAX ``value_and_grad`` with the shared autodiff backend contract.
 
-    def aux_value_and_grad(*args):
-        n_args = len(args)
-        value = func(*args)
+    The autograd and PyTorch backends expose ``argnums`` and accept keyword
+    arguments when evaluating the wrapped function.  JAX already supports those
+    semantics natively; this wrapper forwards them and preserves the historical
+    ``to_numpy`` argument for callers that used the JAX-only signature.
+    """
+    if isinstance(argnums, bool):
+        to_numpy = bool(argnums)
+        argnums = 0
+    del point_ndims  # JAX value_and_grad is scalar-output only.
 
-        all_grads = []
-        for i in range(n_args):
+    def aux_value_and_grad(*args, **kwargs):
+        def func_with_kwargs(*inner_args):
+            return func(*inner_args, **kwargs)
 
-            def func_of_ith(*args):
-                reorg_args = args[1 : i + 1] + (args[0],) + args[i + 1 :]
-                return func(*reorg_args)
-
-            new_args = (args[i],) + args[:i] + args[i + 1 :]
-            _, grad_i = _value_and_grad(func_of_ith)(*new_args)
-            all_grads.append(grad_i)
-
-        if n_args == 1:
-            return value, all_grads[0]
-        return value, tuple(all_grads)
+        value, grads = _jax_value_and_grad(func_with_kwargs, argnums=argnums)(*args)
+        if to_numpy:
+            value = jax.device_get(value)
+            grads = jax.tree_util.tree_map(jax.device_get, grads)
+        return value, grads
 
     return aux_value_and_grad
 

--- a/src/pyrecest/_backend/pytorch/__init__.py
+++ b/src/pyrecest/_backend/pytorch/__init__.py
@@ -1,6 +1,7 @@
 """Pytorch based computation backend."""
 
 import builtins as _builtins
+from operator import index as _operator_index
 
 import numpy as _np
 import torch as _torch
@@ -524,27 +525,50 @@ def allclose(a, b, atol=atol, rtol=rtol):
 
 
 def apply_along_axis(func, axis, tensor):
-    # Create a list to hold the output results
+    """Apply ``func`` to 1-D slices along ``axis`` with NumPy semantics."""
+    if not _torch.is_tensor(tensor):
+        tensor = array(tensor)
+
+    (axis,) = _normalize_reduction_axes(axis, tensor.ndim)
+    iteration_shape = tuple(tensor.shape[:axis]) + tuple(tensor.shape[axis + 1 :])
+
+    # Move the target axis to the end so each row of ``flat_slices`` is one
+    # NumPy-style 1-D slice.  The remaining dimensions keep their original
+    # order and are restored below.
+    moved = _torch.movedim(tensor, axis, -1)
+    num_slices = int(_np.prod(iteration_shape, dtype=int)) if iteration_shape else 1
+    if num_slices == 0:
+        raise ValueError("Cannot apply_along_axis when any iteration dimensions are 0")
+    flat_slices = moved.reshape((num_slices, moved.shape[-1]))
+
     output_list = []
-
-    # Loop through the tensor along the specified axis
-    for index in range(tensor.shape[axis]):
-        # Create a slice object that selects `index` along the specified axis
-        slice_obj = [slice(None)] * tensor.ndim
-        slice_obj[axis] = index
-
-        # Extract the slice and apply the function
-        tensor_slice = tensor[slice_obj]
-        result_slice = func(tensor_slice)
-
-        # Convert the result to a tensor and append to the list
-        result_tensor = array(result_slice)
+    for tensor_slice in flat_slices:
+        result_tensor = array(func(tensor_slice))
+        if _torch.is_tensor(result_tensor) and result_tensor.device != tensor.device:
+            result_tensor = result_tensor.to(device=tensor.device)
         output_list.append(result_tensor)
 
-    # Stack the output tensors along the same axis
-    output_tensor = stack(output_list, dim=axis)
+    stacked = stack(output_list, dim=0)
+    result_shape = tuple(stacked.shape[1:])
+    output = stacked.reshape(iteration_shape + result_shape)
 
-    return output_tensor
+    if result_shape:
+        prefix_ndim = axis
+        suffix_ndim = tensor.ndim - axis - 1
+        result_ndim = len(result_shape)
+        permutation = (
+            tuple(range(prefix_ndim))
+            + tuple(
+                range(
+                    prefix_ndim + suffix_ndim,
+                    prefix_ndim + suffix_ndim + result_ndim,
+                )
+            )
+            + tuple(range(prefix_ndim, prefix_ndim + suffix_ndim))
+        )
+        output = output.permute(permutation)
+
+    return output
 
 
 def shape(val):
@@ -643,42 +667,55 @@ def trace(x):
 
 
 def linspace(start, stop, num=50, endpoint=True, dtype=None):
-    start_is_array = _torch.is_tensor(start)
-    stop_is_array = _torch.is_tensor(stop)
+    num = _operator_index(num)
+    if num < 0:
+        raise ValueError("num must be non-negative")
 
-    if not (start_is_array or stop_is_array) and endpoint:
-        return _torch.linspace(start=start, end=stop, steps=num, dtype=dtype)
+    device = next(
+        (value.device for value in (start, stop) if _torch.is_tensor(value)),
+        None,
+    )
 
-    if not start_is_array:
-        start = _torch.tensor(start)
-    if not stop_is_array:
-        stop = _torch.tensor(stop)
+    if not _torch.is_tensor(start):
+        start = _torch.as_tensor(start, dtype=dtype, device=device)
+    elif dtype is not None or (device is not None and start.device != device):
+        start = start.to(
+            dtype=dtype if dtype is not None else start.dtype, device=device
+        )
+
+    if not _torch.is_tensor(stop):
+        stop = _torch.as_tensor(stop, dtype=dtype, device=device)
+    elif dtype is not None or (device is not None and stop.device != device):
+        stop = stop.to(
+            dtype=dtype if dtype is not None else stop.dtype, device=device
+        )
+
+    result_dtype = dtype if dtype is not None else _torch.result_type(start, stop)
+    if dtype is None and not (result_dtype.is_floating_point or result_dtype.is_complex):
+        result_dtype = get_default_dtype()
+
+    start = start.to(dtype=result_dtype)
+    stop = stop.to(dtype=result_dtype)
     start, stop = _torch.broadcast_tensors(start, stop)
-    result_shape = (num, *start.shape)
-    start = _torch.flatten(start)
-    stop = _torch.flatten(stop)
 
-    if endpoint:
-        result = _torch.vstack(
-            [
-                _torch.linspace(start=start[i], end=stop[i], steps=num, dtype=dtype)
-                for i in range(start.shape[0])
-            ]
-        ).T
-    else:
-        result = _torch.vstack(
-            [
-                _torch.arange(
-                    start=start[i],
-                    end=stop[i],
-                    step=(stop[i] - start[i]) / num,
-                    dtype=dtype,
-                )
-                for i in range(start.shape[0])
-            ]
-        ).T
+    fraction_dtype = result_dtype
+    if result_dtype == complex64:
+        fraction_dtype = float32
+    elif result_dtype == complex128:
+        fraction_dtype = float64
+    elif not result_dtype.is_floating_point:
+        fraction_dtype = get_default_dtype()
 
-    return _torch.reshape(result, result_shape)
+    fractions = _torch.arange(num, dtype=fraction_dtype, device=start.device)
+    denominator = num - 1 if endpoint and num > 1 else num
+    if denominator > 0:
+        fractions = fractions / denominator
+    fractions = fractions.reshape((num,) + (1,) * start.ndim)
+
+    result = start + (stop - start) * fractions
+    if result.dtype != result_dtype:
+        result = result.to(dtype=result_dtype)
+    return result
 
 
 def equal(a, b, **kwargs):

--- a/tests/backend_support/test_pytorch_apply_along_axis_contract.py
+++ b/tests/backend_support/test_pytorch_apply_along_axis_contract.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pyrecest.backend as backend
+import pytest
+
+
+def _as_numpy(value):
+    return backend.to_numpy(value)
+
+
+@pytest.mark.parametrize("axis", [0, 1, 2, -1])
+def test_pytorch_apply_along_axis_matches_numpy_for_scalar_results(axis):
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific apply_along_axis backend contract")
+
+    values_np = np.arange(24.0).reshape(2, 3, 4)
+    values = backend.asarray(values_np)
+
+    actual = _as_numpy(backend.apply_along_axis(backend.sum, axis, values))
+    expected = np.apply_along_axis(np.sum, axis, values_np)
+
+    assert actual.shape == expected.shape
+    assert np.allclose(actual, expected)
+
+
+@pytest.mark.parametrize("axis", [0, 1, 2, -1])
+def test_pytorch_apply_along_axis_matches_numpy_for_vector_results(axis):
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific apply_along_axis backend contract")
+
+    values_np = np.arange(24.0).reshape(2, 3, 4)
+    values = backend.asarray(values_np)
+
+    actual = _as_numpy(
+        backend.apply_along_axis(lambda row: row[:2] * 2.0, axis, values)
+    )
+    expected = np.apply_along_axis(lambda row: row[:2] * 2.0, axis, values_np)
+
+    assert actual.shape == expected.shape
+    assert np.allclose(actual, expected)

--- a/tests/backend_support/test_pytorch_linspace_contract.py
+++ b/tests/backend_support/test_pytorch_linspace_contract.py
@@ -1,0 +1,57 @@
+import numpy as np
+import pyrecest.backend as backend
+import pytest
+
+
+def _as_numpy(value):
+    return backend.to_numpy(value)
+
+
+@pytest.mark.parametrize("endpoint", [True, False])
+@pytest.mark.parametrize(
+    ("start_np", "stop_np"),
+    [
+        (0.0, np.array([2.0, 3.0])),
+        (np.array([0.0, 1.0]), 1.0),
+        (np.array([0.0, 1.0]), np.array([2.0, 3.0])),
+    ],
+)
+def test_pytorch_linspace_matches_numpy_for_array_like_endpoints(
+    start_np, stop_np, endpoint
+):
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific linspace backend contract")
+
+    actual = _as_numpy(backend.linspace(start_np, stop_np, num=5, endpoint=endpoint))
+    expected = np.linspace(start_np, stop_np, num=5, endpoint=endpoint)
+
+    assert actual.shape == expected.shape
+    assert np.allclose(actual, expected)
+
+
+def test_pytorch_linspace_endpoint_false_allows_constant_lanes():
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific linspace backend contract")
+
+    start_np = np.array([0.0, 1.0])
+    stop_np = np.array([2.0, 1.0])
+
+    actual = _as_numpy(
+        backend.linspace(backend.asarray(start_np), stop_np, num=5, endpoint=False)
+    )
+    expected = np.linspace(start_np, stop_np, num=5, endpoint=False)
+
+    assert actual.shape == expected.shape
+    assert np.allclose(actual, expected)
+
+
+def test_pytorch_linspace_preserves_explicit_integer_dtype():
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific linspace backend contract")
+
+    actual = _as_numpy(backend.linspace([0, 1], [2, 3], num=3, dtype=backend.int64))
+    expected = np.linspace([0, 1], [2, 3], num=3, dtype=np.int64)
+
+    assert actual.dtype == expected.dtype
+    assert actual.shape == expected.shape
+    assert np.array_equal(actual, expected)

--- a/tests/test_jax_autodiff_backend.py
+++ b/tests/test_jax_autodiff_backend.py
@@ -22,6 +22,24 @@ def test_elementwise_grad_scalar_output_returns_regular_gradient():
     assert jnp.allclose(result, jnp.array([2.0, 4.0, -6.0]))
 
 
+def test_value_and_grad_respects_argnums_contract():
+    value_grad_fn = autodiff.value_and_grad(lambda x, y: jnp.sum(x * y), argnums=1)
+
+    value, grad = value_grad_fn(jnp.array([1.0, 2.0]), jnp.array([3.0, 4.0]))
+
+    assert jnp.allclose(value, 11.0)
+    assert jnp.allclose(grad, jnp.array([1.0, 2.0]))
+
+
+def test_value_and_grad_accepts_keyword_arguments():
+    value_grad_fn = autodiff.value_and_grad(lambda x, *, scale: jnp.sum(scale * x**2))
+
+    value, grad = value_grad_fn(jnp.array([1.0, -2.0]), scale=3.0)
+
+    assert jnp.allclose(value, 15.0)
+    assert jnp.allclose(grad, jnp.array([6.0, -12.0]))
+
+
 @pytest.mark.parametrize(
     "function_name",
     [


### PR DESCRIPTION
## Summary
- fix JAX autodiff backend behavior
- tighten PyTorch backend contract handling for linspace and apply-along-axis
- add backend contract coverage

## Validation
- `python -m py_compile src\pyrecest\_backend\pytorch\__init__.py src\pyrecest\_backend\jax\autodiff.py tests\backend_support\test_pytorch_apply_along_axis_contract.py tests\backend_support\test_pytorch_linspace_contract.py tests\test_jax_autodiff_backend.py`
- `git diff --check`

Did not run tests per request.