### PR TITLE
Fix PyTorch backend contract edge cases

### DIFF
--- a/src/pyrecest/_backend/pytorch/__init__.py
+++ b/src/pyrecest/_backend/pytorch/__init__.py
@@ -54,7 +54,6 @@ from torch import (  # The ones below are for pyrecest; For Riemannian score-bas
     mean,
     meshgrid,
     moveaxis,
-    nonzero,
     ones,
     ones_like,
     polygamma,
@@ -318,13 +317,16 @@ def isscalar(x):
     return _np.isscalar(x)
 
 
+def nonzero(x):
+    """Return index arrays for non-zero elements using the NumPy contract."""
+    if not _torch.is_tensor(x):
+        x = _torch.as_tensor(x)
+    return _torch.nonzero(x, as_tuple=True)
+
+
 def matmul(x, y, out=None):
     x = array(x)
     y = array(y)
-    for array_ in [x, y]:
-        if array_.ndim == 1:
-            raise ValueError("ndims must be >=2")
-
     x, y = convert_to_wider_dtype([x, y])
     return _torch.matmul(x, y, out=out)
 
@@ -333,7 +335,7 @@ def to_numpy(x):
     """Convert a tensor to a NumPy array without preserving autograd state."""
     if not _torch.is_tensor(x):
         return _np.asarray(x)
-    return x.detach().cpu().numpy()
+    return x.detach().resolve_conj().resolve_neg().cpu().numpy()
 
 
 def one_hot(labels, num_classes):
@@ -742,13 +744,15 @@ def triu(mat, k=0):
 def tril_indices(n, k=0, m=None):
     if m is None:
         m = n
-    return _torch.tril_indices(row=n, col=m, offset=k)
+    indices = _torch.tril_indices(row=n, col=m, offset=k)
+    return indices[0], indices[1]
 
 
 def triu_indices(n, k=0, m=None):
     if m is None:
         m = n
-    return _torch.triu_indices(row=n, col=m, offset=k)
+    indices = _torch.triu_indices(row=n, col=m, offset=k)
+    return indices[0], indices[1]
 
 
 def tile(x, y):

--- a/tests/backend_support/test_pytorch_matmul_contract.py
+++ b/tests/backend_support/test_pytorch_matmul_contract.py
@@ -1,0 +1,55 @@
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+@pytest.mark.parametrize(
+    ("left", "right", "expected_shape", "expected"),
+    [
+        (
+            [1.0, 2.0, 3.0],
+            [4.0, 5.0, 6.0],
+            (),
+            32.0,
+        ),
+        (
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+            [7.0, 8.0, 9.0],
+            (2,),
+            [50.0, 122.0],
+        ),
+        (
+            [7.0, 8.0],
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+            (3,),
+            [39.0, 54.0, 69.0],
+        ),
+    ],
+)
+def test_pytorch_matmul_matches_numpy_for_vector_operands(
+    left, right, expected_shape, expected
+):
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        f"""
+import pyrecest.backend as backend
+
+left = backend.array({left!r})
+right = backend.array({right!r})
+expected = backend.array({expected!r})
+actual = backend.matmul(left, right)
+
+assert tuple(actual.shape) == {expected_shape!r}
+assert backend.allclose(actual, expected)
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -62,11 +62,30 @@ def test_pytorch_to_numpy_detaches_tensors_requiring_grad():
     assert converted.tolist() == [1.0, 2.0]
 
 
+def test_pytorch_to_numpy_resolves_conjugate_views():
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific conjugate-view conversion")
+
+    values = backend.conj(array([1.0 + 2.0j, 3.0 - 4.0j]))
+    converted = backend.to_numpy(values)
+
+    assert converted.tolist() == [1.0 - 2.0j, 3.0 + 4.0j]
+
+
 def _to_python(value):
     value = backend.to_numpy(value)
     if hasattr(value, "tolist"):
         return value.tolist()
     return value
+
+
+def test_nonzero_returns_numpy_style_coordinate_tuple():
+    result = backend.nonzero(array([[0, 1], [2, 0]]))
+
+    assert isinstance(result, tuple)
+    assert len(result) == 2
+    assert _to_python(result[0]) == [0, 1]
+    assert _to_python(result[1]) == [1, 0]
 
 
 def test_numpy_vmap_rejects_mismatched_leading_dimensions():
@@ -281,6 +300,23 @@ def test_as_dtype_string_lookup_is_available():
 
 def test_ravel_tril_indices_returns_flat_indices():
     assert _to_python(backend.ravel_tril_indices(3)) == [0, 3, 4, 6, 7, 8]
+
+
+def test_triangular_index_helpers_return_coordinate_tuples():
+    tril = backend.tril_indices(3)
+    triu = backend.triu_indices(3)
+
+    assert isinstance(tril, tuple)
+    assert isinstance(triu, tuple)
+    assert len(tril) == 2
+    assert len(triu) == 2
+
+    tril_rows, tril_cols = tril
+    triu_rows, triu_cols = triu
+    assert _to_python(tril_rows) == [0, 1, 1, 2, 2, 2]
+    assert _to_python(tril_cols) == [0, 0, 1, 0, 1, 2]
+    assert _to_python(triu_rows) == [0, 0, 0, 1, 1, 2]
+    assert _to_python(triu_cols) == [0, 1, 2, 1, 2, 2]
 
 
 def test_triangular_matrix_helpers_return_compact_vectors():


### PR DESCRIPTION
## Summary
- tighten PyTorch backend contract handling for backend array helpers
- add focused backend contract coverage, including matmul behavior

## Validation
- `python -m py_compile src\pyrecest\_backend\pytorch\__init__.py tests\test_backend_contracts.py tests\backend_support\test_pytorch_matmul_contract.py`
- `git diff --check`

Did not run tests per request.