### PR TITLE
Allow vector operands in backend matmul

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/__init__.py
+++ b/src/pyrecest/_backend/_shared_numpy/__init__.py
@@ -374,9 +374,6 @@ def ravel_tril_indices(n, k=0, m=None):
 
 def matmul(*args, **kwargs):
     converted_args = tuple(arg if is_array(arg) else array(arg) for arg in args)
-    for arg in converted_args:
-        if arg.ndim == 1:
-            raise ValueError("ndims must be >=2")
     return _np.matmul(*converted_args, **kwargs)
 
 

--- a/src/pyrecest/_backend/jax/__init__.py
+++ b/src/pyrecest/_backend/jax/__init__.py
@@ -499,10 +499,6 @@ def dot(a, b):
 def matmul(x, y, out=None):
     x = _jnp.asarray(x)
     y = _jnp.asarray(y)
-    for array_ in [x, y]:
-        if array_.ndim == 1:
-            raise ValueError("ndims must be >=2")
-
     result = _jnp.matmul(x, y)
     if out is None:
         return result

--- a/tests/test_backend_matmul_contract.py
+++ b/tests/test_backend_matmul_contract.py
@@ -1,3 +1,5 @@
+import pytest
+
 import pyrecest.backend as backend
 
 
@@ -12,6 +14,24 @@ def test_matmul_accepts_matrix_like_lists():
     result = backend.matmul([[1, 2], [3, 4]], [[5], [6]])
 
     assert _as_plain_python(result) == [[17], [39]]
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "expected"),
+    [
+        ([1.0, 2.0, 3.0], [4.0, 5.0, 6.0], 32.0),
+        (
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+            [7.0, 8.0, 9.0],
+            [50.0, 122.0],
+        ),
+        ([7.0, 8.0], [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], [39.0, 54.0, 69.0]),
+    ],
+)
+def test_matmul_accepts_numpy_style_vector_operands(left, right, expected):
+    result = backend.matmul(left, right)
+
+    assert _as_plain_python(result) == expected
 
 
 def test_matmul_preserves_numpy_style_out_argument_for_lists():


### PR DESCRIPTION
## Summary
- Align NumPy/JAX backend matmul behavior with NumPy-style vector operands.
- Add backend contract coverage for vector-vector, matrix-vector, and vector-matrix products.

## Validation
- Not run, per request.