### PR TITLE
Add residual hypothesis MHT selector

### DIFF
--- a/src/pyrecest/tracking/__init__.py
+++ b/src/pyrecest/tracking/__init__.py
@@ -117,3 +117,23 @@ __all__ += [
     "summaries_to_dicts",
     "summarize_innovation_diagnostics",
 ]
+
+from .residual_hypothesis_mht import (
+    ResidualEditCandidate,
+    ResidualHypothesis,
+    ResidualMHTConfig,
+    enumerate_residual_hypotheses,
+    hypotheses_to_dicts,
+    hypothesis_to_dict,
+    select_residual_hypothesis,
+)
+
+__all__ += [
+    "ResidualEditCandidate",
+    "ResidualHypothesis",
+    "ResidualMHTConfig",
+    "enumerate_residual_hypotheses",
+    "hypotheses_to_dicts",
+    "hypothesis_to_dict",
+    "select_residual_hypothesis",
+]

--- a/src/pyrecest/tracking/residual_hypothesis_mht.py
+++ b/src/pyrecest/tracking/residual_hypothesis_mht.py
@@ -1,0 +1,135 @@
+"""Bounded residual multi-hypothesis selection for discrete edit candidates."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from itertools import combinations
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ResidualEditCandidate:
+    """One discrete residual edit candidate."""
+
+    candidate_id: str
+    score: float
+    conflict_keys: frozenset[str] = field(default_factory=frozenset)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ResidualHypothesis:
+    """A bounded set of residual edit candidates."""
+
+    candidate_ids: tuple[str, ...]
+    score: float
+    candidate_scores: tuple[float, ...]
+
+    @property
+    def n_edits(self) -> int:
+        """Return the number of edits in this hypothesis."""
+
+        return len(self.candidate_ids)
+
+
+@dataclass(frozen=True)
+class ResidualMHTConfig:
+    """Configuration for bounded residual-MHT enumeration."""
+
+    max_edits: int = 2
+    max_hypotheses: int = 16
+    edit_penalty: float = 0.25
+    score_threshold: float = 1.0
+    include_empty: bool = True
+
+
+def enumerate_residual_hypotheses(
+    candidates: Iterable[ResidualEditCandidate],
+    *,
+    config: ResidualMHTConfig | None = None,
+) -> tuple[ResidualHypothesis, ...]:
+    """Enumerate compatible bounded residual hypotheses."""
+
+    cfg = config or ResidualMHTConfig()
+    ordered = sorted(
+        tuple(candidates),
+        key=lambda candidate: (-float(candidate.score), str(candidate.candidate_id)),
+    )
+    max_edits = max(0, int(cfg.max_edits))
+    max_hypotheses = max(1, int(cfg.max_hypotheses))
+    hypotheses: list[ResidualHypothesis] = []
+    if cfg.include_empty:
+        hypotheses.append(ResidualHypothesis((), 0.0, ()))
+
+    for size in range(1, min(max_edits, len(ordered)) + 1):
+        for group in combinations(ordered, size):
+            if not _compatible(group):
+                continue
+            candidate_scores = tuple(float(candidate.score) for candidate in group)
+            score = sum(candidate_scores) - float(cfg.edit_penalty) * float(size)
+            hypotheses.append(
+                ResidualHypothesis(
+                    candidate_ids=tuple(str(candidate.candidate_id) for candidate in group),
+                    score=float(score),
+                    candidate_scores=candidate_scores,
+                )
+            )
+
+    hypotheses.sort(
+        key=lambda hypothesis: (
+            -float(hypothesis.score),
+            int(hypothesis.n_edits),
+            tuple(hypothesis.candidate_ids),
+        )
+    )
+    return tuple(hypotheses[:max_hypotheses])
+
+
+def select_residual_hypothesis(
+    candidates: Iterable[ResidualEditCandidate],
+    *,
+    config: ResidualMHTConfig | None = None,
+) -> ResidualHypothesis:
+    """Return the best residual hypothesis above threshold, else no-edit."""
+
+    cfg = config or ResidualMHTConfig()
+    hypotheses = enumerate_residual_hypotheses(candidates, config=cfg)
+    empty = ResidualHypothesis((), 0.0, ())
+    if not hypotheses:
+        return empty
+    best = hypotheses[0]
+    if best.n_edits <= 0:
+        return best
+    if float(best.score) < float(cfg.score_threshold):
+        return empty
+    return best
+
+
+def hypothesis_to_dict(hypothesis: ResidualHypothesis) -> dict[str, Any]:
+    """Return a JSON/CSV-friendly hypothesis record."""
+
+    return {
+        "candidate_ids": ";".join(hypothesis.candidate_ids),
+        "n_edits": int(hypothesis.n_edits),
+        "score": float(hypothesis.score),
+        "candidate_scores": ";".join(f"{score:.12g}" for score in hypothesis.candidate_scores),
+    }
+
+
+def hypotheses_to_dicts(
+    hypotheses: Sequence[ResidualHypothesis],
+) -> tuple[dict[str, Any], ...]:
+    """Serialize hypotheses for diagnostics."""
+
+    return tuple(hypothesis_to_dict(hypothesis) for hypothesis in hypotheses)
+
+
+def _compatible(candidates: Sequence[ResidualEditCandidate]) -> bool:
+    seen: set[str] = set()
+    for candidate in candidates:
+        overlap = seen.intersection(set(candidate.conflict_keys))
+        if overlap:
+            return False
+        seen.update(candidate.conflict_keys)
+    return True

--- a/tests/tracking/test_residual_hypothesis_mht.py
+++ b/tests/tracking/test_residual_hypothesis_mht.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pyrecest.tracking import (
+    ResidualEditCandidate,
+    ResidualMHTConfig,
+    enumerate_residual_hypotheses,
+    select_residual_hypothesis,
+)
+
+
+def test_selects_best_compatible_residual_hypothesis():
+    candidates = [
+        ResidualEditCandidate("a", 2.0, frozenset({"target:1"})),
+        ResidualEditCandidate("b", 1.8, frozenset({"target:2"})),
+        ResidualEditCandidate("c", 3.0, frozenset({"target:1"})),
+    ]
+
+    selected = select_residual_hypothesis(
+        candidates,
+        config=ResidualMHTConfig(max_edits=2, edit_penalty=0.1, score_threshold=0.0),
+    )
+
+    assert selected.candidate_ids == ("c", "b")
+    assert selected.n_edits == 2
+
+
+def test_returns_no_edit_below_threshold():
+    selected = select_residual_hypothesis(
+        [ResidualEditCandidate("weak", 0.5)],
+        config=ResidualMHTConfig(max_edits=1, edit_penalty=0.0, score_threshold=1.0),
+    )
+
+    assert selected.candidate_ids == ()
+    assert selected.score == 0.0
+
+
+def test_enumerates_no_edit_when_requested():
+    hypotheses = enumerate_residual_hypotheses(
+        [ResidualEditCandidate("a", 1.0)],
+        config=ResidualMHTConfig(max_edits=1, include_empty=True),
+    )
+
+    assert any(hypothesis.candidate_ids == () for hypothesis in hypotheses)
+
+
+def test_conflicting_candidates_are_not_combined():
+    hypotheses = enumerate_residual_hypotheses(
+        [
+            ResidualEditCandidate("a", 1.0, frozenset({"x"})),
+            ResidualEditCandidate("b", 1.0, frozenset({"x"})),
+        ],
+        config=ResidualMHTConfig(max_edits=2, include_empty=False),
+    )
+
+    assert all(len(hypothesis.candidate_ids) == 1 for hypothesis in hypotheses)


### PR DESCRIPTION
## Summary
- Add a bounded residual multi-hypothesis selector for discrete edit candidates.
- Export the new tracking helpers from `pyrecest.tracking`.
- Add focused coverage for compatible selection, threshold fallback, no-edit enumeration, and conflict handling.

## Validation
- `PYTHONPATH=src python -m pytest tests/tracking/test_residual_hypothesis_mht.py`