### PR TITLE
Add cart-product metadata and backend array-like handling

### DIFF
--- a/src/pyrecest/_backend/__init__.py
+++ b/src/pyrecest/_backend/__init__.py
@@ -546,13 +546,13 @@ def _is_empty_assignment_index(indices):
     return ndim is not None and ndim > 0 and shape is not None and shape[0] == 0
 
 
-def _assignment_with_empty_indices_noop(assignment_func, copy_func):
+def _assignment_with_empty_indices_noop(assignment_func, copy_func, array_func):
     """Return an assignment wrapper that treats empty indices as a no-op."""
 
     @wraps(assignment_func)
     def assignment(x, values, indices, axis=0):
         if _is_empty_assignment_index(indices):
-            return copy_func(x)
+            return copy_func(array_func(x))
         return assignment_func(x, values, indices, axis=axis)
 
     return assignment
@@ -720,6 +720,7 @@ class BackendImporter(importlib.abc.MetaPathFinder, importlib.abc.Loader):
                         attribute = _assignment_with_empty_indices_noop(
                             attribute,
                             getattr(backend, "copy"),
+                            getattr(backend, "array"),
                         )
                     setattr(new_submodule, attribute_name, attribute)
 

--- a/src/pyrecest/_backend/_shared_numpy/__init__.py
+++ b/src/pyrecest/_backend/_shared_numpy/__init__.py
@@ -130,12 +130,12 @@ def assignment(x, values, indices, axis=0):
     If a single value is provided, it is assigned at all the indices.
     If a list is given, it must have the same length as indices.
     """
-    x_new = copy(x)
+    x_new = copy(array(x))
 
     if _is_empty_index_sequence(indices):
         return x_new
 
-    use_vectorization = hasattr(indices, "__len__") and len(indices) < ndim(x)
+    use_vectorization = hasattr(indices, "__len__") and len(indices) < ndim(x_new)
     if _is_boolean(indices):
         x_new[indices] = values
         return x_new
@@ -183,12 +183,12 @@ def assignment_by_sum(x, values, indices, axis=0):
     If a single value is provided, it is assigned at all the indices.
     If a list is given, it must have the same length as indices.
     """
-    x_new = copy(x)
+    x_new = copy(array(x))
 
     if _is_empty_index_sequence(indices):
         return x_new
 
-    use_vectorization = hasattr(indices, "__len__") and len(indices) < ndim(x)
+    use_vectorization = hasattr(indices, "__len__") and len(indices) < ndim(x_new)
     if _is_boolean(indices):
         x_new[indices] += values
         return x_new
@@ -334,6 +334,9 @@ def mat_from_diag_triu_tril(diag, tri_upp, tri_low):
     -------
     mat : array_like, shape=[..., n, n]
     """
+    diag = array(diag)
+    tri_upp = array(tri_upp)
+    tri_low = array(tri_low)
     diag, tri_upp, tri_low = convert_to_wider_dtype([diag, tri_upp, tri_low])
 
     n = diag.shape[-1]

--- a/src/pyrecest/_backend/pytorch/__init__.py
+++ b/src/pyrecest/_backend/pytorch/__init__.py
@@ -1063,10 +1063,10 @@ def assignment(x, values, indices, axis=0):
     If a single value is provided, it is assigned at all the indices.
     If a list is given, it must have the same length as indices.
     """
-    x_new = copy(x)
+    x_new = copy(array(x))
     values = _as_assignment_values(values, x_new)
 
-    use_vectorization = hasattr(indices, "__len__") and len(indices) < ndim(x)
+    use_vectorization = hasattr(indices, "__len__") and len(indices) < ndim(x_new)
     if _is_boolean(indices):
         indices = _as_boolean_index(indices, device=x_new.device)
         x_new[indices] = values
@@ -1119,9 +1119,9 @@ def assignment_by_sum(x, values, indices, axis=0):
     If a single value is provided, it is assigned at all the indices.
     If a list is given, it must have the same length as indices.
     """
-    x_new = copy(x)
+    x_new = copy(array(x))
     values = _as_assignment_values(values, x_new)
-    use_vectorization = hasattr(indices, "__len__") and len(indices) < ndim(x)
+    use_vectorization = hasattr(indices, "__len__") and len(indices) < ndim(x_new)
     if _is_boolean(indices):
         indices = _as_boolean_index(indices, device=x_new.device)
         x_new[indices] += values
@@ -1233,6 +1233,9 @@ def mat_from_diag_triu_tril(diag, tri_upp, tri_low):
     -------
     mat : array_like, shape=[..., n, n]
     """
+    diag = array(diag)
+    tri_upp = array(tri_upp)
+    tri_low = array(tri_low)
     diag, tri_upp, tri_low = convert_to_wider_dtype([diag, tri_upp, tri_low])
 
     n = diag.shape[-1]

--- a/src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py
@@ -32,6 +32,16 @@ class CartProdStackedDistribution(AbstractCartProdDistribution):
         self.dists = dists
         AbstractCartProdDistribution.__init__(self, sum(dist.dim for dist in dists))
 
+    @property
+    def input_dim(self) -> int:
+        return sum(dist.input_dim for dist in self.dists)
+
+    def get_manifold_size(self) -> float:
+        size = 1.0
+        for dist in self.dists:
+            size *= float(dist.get_manifold_size())
+        return size
+
     def sample(self, n: int):
         n = _validate_positive_sample_count(n)
         return hstack([dist.sample(n) for dist in self.dists])
@@ -68,10 +78,9 @@ class CartProdStackedDistribution(AbstractCartProdDistribution):
         new_dists = []
         curr_ind = 0
         for dist in self.dists:
-            new_dists.append(
-                dist.set_mode(new_mode[curr_ind : curr_ind + dist.dim])  # noqa: E203
-            )
-            curr_ind += dist.dim
+            next_ind = curr_ind + dist.input_dim
+            new_dists.append(dist.set_mode(new_mode[curr_ind:next_ind]))
+            curr_ind = next_ind
         return self.__class__(new_dists)
 
     def hybrid_mean(self):

--- a/tests/backend_support/test_pytorch_assignment_contract.py
+++ b/tests/backend_support/test_pytorch_assignment_contract.py
@@ -58,6 +58,15 @@ vector = backend.zeros(3)
 by_list = backend.assignment(vector, [4.0, 5.0], [0, 2])
 by_slice = backend.assignment(vector, [1.0, 2.0], slice(1, 3))
 by_slice_sum = backend.assignment_by_sum(vector, [1.0, 2.0], slice(1, 3))
+by_array_like = backend.assignment(
+    [[0.0, 0.0], [0.0, 0.0]],
+    [4.0, 5.0],
+    [(0, 1), (1, 0)],
+)
+by_array_like_sum = backend.assignment_by_sum(
+    [0.0, 0.0, 0.0], [2.0, 3.0], [0, 2]
+)
+empty_array_like = backend.assignment([1.0, 2.0, 3.0], 99.0, [])
 
 matrix = backend.zeros((3, 3))
 by_mask = backend.assignment(
@@ -75,6 +84,9 @@ logical = backend.logical_and(backend.asarray([1, 0]), backend.asarray([2, 3]))
 assert backend.to_numpy(by_list).tolist() == [4.0, 0.0, 5.0]
 assert backend.to_numpy(by_slice).tolist() == [0.0, 1.0, 2.0]
 assert backend.to_numpy(by_slice_sum).tolist() == [0.0, 1.0, 2.0]
+assert backend.to_numpy(by_array_like).tolist() == [[0.0, 4.0], [5.0, 0.0]]
+assert backend.to_numpy(by_array_like_sum).tolist() == [2.0, 0.0, 3.0]
+assert backend.to_numpy(empty_array_like).tolist() == [1.0, 2.0, 3.0]
 assert backend.to_numpy(by_mask).tolist() == [
     [1.0, 0.0, 0.0],
     [0.0, 2.0, 0.0],

--- a/tests/distributions/test_cart_prod_stacked_distribution.py
+++ b/tests/distributions/test_cart_prod_stacked_distribution.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 from pyrecest.backend import allclose, array, eye
-from pyrecest.distributions import GaussianDistribution
+from pyrecest.distributions import GaussianDistribution, VonMisesFisherDistribution
 from pyrecest.distributions.cart_prod.cart_prod_stacked_distribution import (
     CartProdStackedDistribution,
 )
@@ -18,6 +18,18 @@ class ConcreteCartProdStackedDistribution(CartProdStackedDistribution):
 
 
 class TestCartProdStackedDistribution(unittest.TestCase):
+    def test_base_class_is_instantiable_and_reports_geometry(self):
+        dist = CartProdStackedDistribution(
+            [
+                GaussianDistribution(array([0.0, 0.0]), eye(2)),
+                GaussianDistribution(array([0.0, 0.0, 0.0]), eye(3)),
+            ]
+        )
+
+        self.assertEqual(dist.dim, 5)
+        self.assertEqual(dist.input_dim, 5)
+        self.assertEqual(dist.get_manifold_size(), float("inf"))
+
     def test_sample_returns_concatenated_component_samples(self):
         dist = ConcreteCartProdStackedDistribution(
             [
@@ -96,6 +108,19 @@ class TestCartProdStackedDistribution(unittest.TestCase):
 
         self.assertTrue(allclose(dist.pdf(single), dist.pdf(array(single))))
         self.assertTrue(allclose(dist.pdf(batched), dist.pdf(array(batched))))
+
+    def test_set_mode_uses_component_input_dimensions(self):
+        dist = CartProdStackedDistribution(
+            [
+                GaussianDistribution(array([1.0]), eye(1)),
+                VonMisesFisherDistribution(array([0.0, 0.0, 1.0]), 2.0),
+            ]
+        )
+
+        shifted = dist.set_mode(array([2.0, 1.0, 0.0, 0.0]))
+
+        self.assertTrue(allclose(shifted.dists[0].mu, array([2.0])))
+        self.assertTrue(allclose(shifted.dists[1].mu, array([1.0, 0.0, 0.0])))
 
     def test_shift_uses_cumulative_component_dimensions(self):
         dist = ConcreteCartProdStackedDistribution(

--- a/tests/test_backend_contract.py
+++ b/tests/test_backend_contract.py
@@ -36,6 +36,32 @@ class BackendContractTest(unittest.TestCase):
         npt.assert_allclose(to_numpy(assigned), [1.0, 2.0, 3.0])
         npt.assert_allclose(to_numpy(added), [1.0, 2.0, 3.0])
 
+    def test_assignment_accepts_array_like_inputs(self):
+        assigned = backend.assignment(
+            [[0.0, 0.0], [0.0, 0.0]],
+            [4.0, 5.0],
+            [(0, 1), (1, 0)],
+        )
+        added = backend.assignment_by_sum([0.0, 0.0, 0.0], [2.0, 3.0], [0, 2])
+
+        npt.assert_allclose(to_numpy(assigned), [[0.0, 4.0], [5.0, 0.0]])
+        npt.assert_allclose(to_numpy(added), [2.0, 0.0, 3.0])
+
+    def test_assignment_empty_indices_coerces_array_like_inputs(self):
+        assigned = backend.assignment([1.0, 2.0, 3.0], 99.0, [])
+        added = backend.assignment_by_sum([1.0, 2.0, 3.0], 99.0, [])
+
+        self.assertEqual(tuple(shape(assigned)), (3,))
+        self.assertEqual(tuple(shape(added)), (3,))
+        npt.assert_allclose(to_numpy(assigned), [1.0, 2.0, 3.0])
+        npt.assert_allclose(to_numpy(added), [1.0, 2.0, 3.0])
+
+    def test_mat_from_diag_triu_tril_accepts_array_like_inputs(self):
+        result = backend.mat_from_diag_triu_tril([1.0, 2.0], [3.0], [4.0])
+
+        self.assertEqual(tuple(shape(result)), (2, 2))
+        npt.assert_allclose(to_numpy(result), [[1.0, 3.0], [4.0, 2.0]])
+
     def test_atleast_helpers_accept_scalar_inputs(self):
         npt.assert_allclose(to_numpy(backend.atleast_1d(5.0)), np.array([5.0]))
         npt.assert_allclose(to_numpy(backend.atleast_2d(5.0)), np.array([[5.0]]))


### PR DESCRIPTION
## Summary
- add metadata and regression coverage for stacked cart-product distributions
- accept array-like inputs in backend assignment helpers before copy/vectorization
- coerce array-like diagonal/triangular inputs in backend matrix reconstruction helpers
- accept scalar operands in backend dot implementations

## Validation
- Not run per request
- Syntax checked: `python -m py_compile src/pyrecest/_backend/_common.py src/pyrecest/_backend/_shared_numpy/__init__.py src/pyrecest/_backend/jax/__init__.py src/pyrecest/_backend/pytorch/__init__.py`