### PR TITLE
Accept scalar and array-like backend products

### DIFF
--- a/src/pyrecest/_backend/_common.py
+++ b/src/pyrecest/_backend/_common.py
@@ -62,6 +62,8 @@ def dot(a, b):
     if torch_pair is not None:
         a, b = torch_pair
         torch = _torch_module_for_values(a, b)
+        if a.ndim == 0 or b.ndim == 0:
+            return torch.multiply(a, b)
         if b.ndim == 1:
             return torch.einsum("...i,i->...", a, b)
         if a.ndim == 1:
@@ -70,6 +72,8 @@ def dot(a, b):
 
     a = _np.asarray(a)
     b = _np.asarray(b)
+    if a.ndim == 0 or b.ndim == 0:
+        return _np.multiply(a, b)
     if b.ndim == 1:
         return _np.einsum("...i,i->...", a, b)
     if a.ndim == 1:

--- a/src/pyrecest/_backend/_shared_numpy/__init__.py
+++ b/src/pyrecest/_backend/_shared_numpy/__init__.py
@@ -381,6 +381,9 @@ def matmul(*args, **kwargs):
 
 
 def outer(a, b):
+    a = a if is_array(a) else array(a)
+    b = b if is_array(b) else array(b)
+
     if a.ndim > 1 and b.ndim > 1:
         return _np.einsum("...i,...j->...ij", a, b)
 
@@ -392,6 +395,9 @@ def outer(a, b):
 
 
 def matvec(A, b):
+    A = A if is_array(A) else array(A)
+    b = b if is_array(b) else array(b)
+
     if b.ndim == 1:
         return _np.matmul(A, b)
     if A.ndim == 2:

--- a/src/pyrecest/_backend/_shared_numpy/__init__.py
+++ b/src/pyrecest/_backend/_shared_numpy/__init__.py
@@ -400,6 +400,11 @@ def matvec(A, b):
 
 
 def dot(a, b):
+    a = a if is_array(a) else array(a)
+    b = b if is_array(b) else array(b)
+    if a.ndim == 0 or b.ndim == 0:
+        return _np.multiply(a, b)
+
     if b.ndim == 1:
         return _np.einsum("...i,i->...", a, b)
 

--- a/src/pyrecest/_backend/jax/__init__.py
+++ b/src/pyrecest/_backend/jax/__init__.py
@@ -489,6 +489,8 @@ def dot(a, b):
     a = _jnp.asarray(a)
     b = _jnp.asarray(b)
 
+    if a.ndim == 0 or b.ndim == 0:
+        return _jnp.multiply(a, b)
     if b.ndim == 1:
         return _jnp.einsum("...i,i->...", a, b)
     if a.ndim == 1:

--- a/src/pyrecest/_backend/pytorch/__init__.py
+++ b/src/pyrecest/_backend/pytorch/__init__.py
@@ -1398,6 +1398,9 @@ def dot(a, b):
     b = array(b)
     a, b = convert_to_wider_dtype([a, b])
 
+    if a.ndim == 0 or b.ndim == 0:
+        return _torch.multiply(a, b)
+
     if a.ndim == 1 and b.ndim == 1:
         return _torch.dot(a, b)
 

--- a/src/pyrecest/_backend/pytorch/__init__.py
+++ b/src/pyrecest/_backend/pytorch/__init__.py
@@ -1366,7 +1366,13 @@ def is_array(x):
 
 
 def outer(a, b):
+    a = array(a)
+    b = array(b)
+    a, b = convert_to_wider_dtype([a, b])
+
     # TODO: improve for torch > 1.9 (dims=0 fails in 1.9)
+    if a.ndim == 0 or b.ndim == 0:
+        return _torch.multiply(a, b)
     return _torch.einsum("...i,...j->...ij", a, b)
 
 

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -449,6 +449,13 @@ def test_batched_dot_uses_last_axis_inner_product():
     assert _to_python(result) == [17.0, 53.0]
 
 
+def test_dot_accepts_scalar_operands():
+    assert _to_python(backend.dot(2.0, 3.0)) == 6.0
+    assert _to_python(backend.dot(2.0, array([1.0, 2.0]))) == [2.0, 4.0]
+    assert _to_python(backend.dot(array([1.0, 2.0]), 3.0)) == [3.0, 6.0]
+    assert _to_python(backend.dot(array(2.0), array(3.0))) == 6.0
+
+
 def test_batched_dot_accepts_high_rank_right_operand():
     first = array([1.0, 2.0])
     second = array(

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -439,6 +439,15 @@ def test_batched_matvec_pairs_leading_dimensions():
     assert _to_python(result) == [[1.0, 2.0], [6.0, 12.0]]
 
 
+def test_matvec_accepts_array_like_inputs():
+    result = backend.matvec(
+        [[1.0, 2.0], [3.0, 4.0]],
+        [5.0, 6.0],
+    )
+
+    assert _to_python(result) == [17.0, 39.0]
+
+
 def test_batched_dot_uses_last_axis_inner_product():
     first = array([[1.0, 2.0], [3.0, 4.0]])
     second = array([[5.0, 6.0], [7.0, 8.0]])
@@ -454,6 +463,10 @@ def test_dot_accepts_scalar_operands():
     assert _to_python(backend.dot(2.0, array([1.0, 2.0]))) == [2.0, 4.0]
     assert _to_python(backend.dot(array([1.0, 2.0]), 3.0)) == [3.0, 6.0]
     assert _to_python(backend.dot(array(2.0), array(3.0))) == 6.0
+
+
+def test_dot_accepts_array_like_inputs():
+    assert _to_python(backend.dot([1.0, 2.0], [3.0, 4.0])) == 11.0
 
 
 def test_batched_dot_accepts_high_rank_right_operand():
@@ -482,6 +495,17 @@ def test_batched_outer_pairs_leading_dimensions():
         [[5.0, 6.0], [10.0, 12.0]],
         [[21.0, 24.0], [28.0, 32.0]],
     ]
+
+
+def test_outer_accepts_array_like_inputs():
+    result = backend.outer([1.0, 2.0], [3.0, 4.0])
+
+    assert _to_python(result) == [[3.0, 4.0], [6.0, 8.0]]
+
+
+def test_outer_accepts_scalar_operands():
+    assert _to_python(backend.outer(2.0, array([1.0, 2.0]))) == [2.0, 4.0]
+    assert _to_python(backend.outer(array([1.0, 2.0]), 3.0)) == [3.0, 6.0]
 
 
 def test_outer_accepts_high_rank_right_operand():


### PR DESCRIPTION
# Pull request

## Summary

- handle scalar operands in shared backend dot helpers by multiplying instead of using vector einsum paths
- coerce array-like inputs for backend outer and matvec helpers
- add backend contract coverage for scalar dot/outer and array-like dot/outer/matvec inputs
- fix PyTorch `dot` scalar handling (`0-D` operands) to use multiplication before einsum/dot paths, resolving the CI failures in `test_dot_accepts_scalar_operands`

## Checklist

- [x] Tests were added or updated.
- [ ] Backend limitations were documented or added to `src/pyrecest/_backend/capabilities.py`.
- [ ] Shape, dtype, and measurement-set conventions were checked against `docs/conventions.md`.
- [ ] New user-facing failures use clear messages or shared exceptions from `pyrecest.exceptions`.
- [ ] Public examples and docs were updated when relevant.
- [ ] Performance-sensitive changes were checked against `benchmarks/basic_regressions.py` or a focused benchmark.
- [ ] `python scripts/check_release_consistency.py --local-only` passes when release metadata changed.
- [ ] The package smoke path still works: `python -m build`, `twine check dist/*`, install wheel, run a basic example.