### PR TITLE
Add ellipse geometry utilities

### DIFF
--- a/src/pyrecest/filters/mem_qkf_tracker.py
+++ b/src/pyrecest/filters/mem_qkf_tracker.py
@@ -6,6 +6,7 @@ from typing import Any
 from pyrecest.backend import abs as backend_abs
 from pyrecest.backend import (
     array,
+    concatenate,
     cos,
     diag,
     eye,
@@ -301,6 +302,40 @@ class MEMQKFTracker(MEMEKFTracker):
             self.store_posterior_estimates()
         if self.log_posterior_extents:
             self.store_posterior_extents()
+
+    def get_state(self, full_axis_lengths=True):
+        """Return the public MEM-QKF state vector.
+
+        The internal shape state stores semi-axis lengths.  With
+        ``full_axis_lengths=True`` this method returns the common EOT public
+        convention ``[kinematics..., orientation, length, width]``.
+        """
+
+        shape_state = self.shape_state
+        if full_axis_lengths:
+            shape_state = array(
+                [shape_state[0], 2.0 * shape_state[1], 2.0 * shape_state[2]]
+            )
+        return concatenate([self.kinematic_state, shape_state])
+
+    def get_state_and_cov(self, full_axis_lengths=True):
+        """Return the public MEM-QKF state and matching covariance.
+
+        The returned covariance uses the same axis-length convention as the
+        returned state.  Therefore, when full axis lengths are requested, the
+        two semi-axis covariance entries are scaled by a factor of four and
+        their cross-covariance by the corresponding linear transform.
+        """
+
+        shape_transform = eye(3)
+        if full_axis_lengths:
+            shape_transform = diag(array([1.0, 2.0, 2.0]))
+        shape_covariance = shape_transform @ self.shape_covariance @ shape_transform.T
+        covariance = linalg.block_diag(
+            self._project_symmetric_covariance(self.covariance),
+            self._project_symmetric_covariance(shape_covariance),
+        )
+        return self.get_state(full_axis_lengths=full_axis_lengths), self._project_symmetric_covariance(covariance)
 
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     def _update_single_measurement_qkf(

--- a/src/pyrecest/filters/mem_rbpf_tracker.py
+++ b/src/pyrecest/filters/mem_rbpf_tracker.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from numbers import Integral
 
 from pyrecest import backend
+from pyrecest.backend import abs as backend_abs
 from pyrecest.backend import any as backend_any
 from pyrecest.backend import (
     arange,
@@ -640,6 +641,97 @@ class MEMRBPFTracker(AbstractExtendedObjectTracker):
         if full_axis_lengths:
             return concatenate([state[:-2], 2.0 * state[-2:]])
         return state
+
+    def get_state_and_cov(self, full_axis_lengths=True):
+        """Return the public RBPF state and its mixture covariance.
+
+        The state follows :meth:`get_state`.  The covariance combines the
+        shared kinematic covariance, per-particle conditional semi-axis
+        covariance, and weighted particle spread.  Orientation differences are
+        treated as axial because ``theta`` and ``theta + pi`` encode the same
+        ellipse.
+        """
+
+        state = self.get_state(full_axis_lengths=full_axis_lengths)
+        particle_states = self._particle_public_states(
+            full_axis_lengths=full_axis_lengths
+        )
+        n_particles = int(particle_states.shape[0])
+        weights = self._normalized_particle_weights(n_particles=n_particles)
+        axis_covariances = self._particle_public_axis_covariances(
+            n_particles,
+            full_axis_lengths=full_axis_lengths,
+        )
+
+        covariance = zeros((state.shape[0], state.shape[0]))
+        kinematic_covariance = self._regularize_public_covariance(self.covariance)
+        angle_index = self.state_dim
+        axis_start = self.state_dim + 1
+        for particle_index in range(n_particles):
+            delta = copy(particle_states[particle_index] - state)
+            delta[angle_index] = self._ellipse_angle_delta(
+                state[angle_index],
+                particle_states[particle_index, angle_index],
+            )
+
+            conditional_covariance = zeros((state.shape[0], state.shape[0]))
+            conditional_covariance[: self.state_dim, : self.state_dim] = (
+                kinematic_covariance
+            )
+            conditional_covariance[axis_start:, axis_start:] = axis_covariances[
+                particle_index
+            ]
+            covariance = covariance + weights[particle_index] * (
+                conditional_covariance + delta.reshape((-1, 1)) @ delta.reshape((1, -1))
+            )
+        return state, self._regularize_public_covariance(covariance)
+
+    def _particle_public_states(self, full_axis_lengths=True):
+        theta = self.theta.reshape((-1,))
+        n_particles = int(theta.shape[0])
+        kinematic_rows = ones((n_particles, self.state_dim)) * self.kinematic_state
+        axis = backend_abs(self.axis.reshape((n_particles, 2)))
+        if full_axis_lengths:
+            axis = 2.0 * axis
+        return concatenate([kinematic_rows, theta.reshape((n_particles, 1)), axis], axis=1)
+
+    def _particle_public_axis_covariances(self, n_particles, full_axis_lengths=True):
+        covariances = self.axis_covariances
+        if covariances.shape != (n_particles, 2, 2):
+            return zeros((n_particles, 2, 2))
+        scale = 4.0 if full_axis_lengths else 1.0
+        public_covariances = scale * covariances
+        return stack(
+            [
+                self._regularize_public_covariance(public_covariances[index])
+                for index in range(n_particles)
+            ]
+        )
+
+    def _normalized_particle_weights(self, n_particles=None):
+        weights = self.weights.reshape((-1,))
+        if n_particles is not None:
+            weights = weights[: int(n_particles)]
+        if int(weights.shape[0]) == 0:
+            raise ValueError("MEMRBPFTracker has no particles")
+        weights = where(isfinite(weights) & (weights > 0.0), weights, 0.0)
+        total = float(backend_sum(weights))
+        if total <= 0.0:
+            return full(weights.shape, 1.0 / int(weights.shape[0]))
+        return weights / total
+
+    @classmethod
+    def _regularize_public_covariance(cls, covariance):
+        covariance = cls._symmetrize(covariance)
+        if int(covariance.shape[0]) == 0:
+            return covariance
+        eigenvalues, eigenvectors = linalg.eigh(covariance)
+        eigenvalues = maximum(eigenvalues, 0.0)
+        return cls._symmetrize((eigenvectors * eigenvalues) @ eigenvectors.T)
+
+    @staticmethod
+    def _ellipse_angle_delta(reference, theta):
+        return 0.5 * arctan2(sin(2.0 * (theta - reference)), cos(2.0 * (theta - reference)))
 
     def get_state_array(self, with_weight=False, full_axis_lengths=False):
         kinematic_rows = ones((self.n_particles, self.state_dim)) * self.kinematic_state

--- a/src/pyrecest/filters/vbrm_tracker.py
+++ b/src/pyrecest/filters/vbrm_tracker.py
@@ -12,14 +12,17 @@ from pyrecest.backend import (
     diagonal,
     exp,
     eye,
+    isfinite,
     linalg,
     linspace,
+    maximum,
     mean,
     pi,
     sin,
     sqrt,
     stack,
     trace,
+    where,
     zeros,
 )
 
@@ -122,6 +125,13 @@ class VBRMTracker(AbstractExtendedObjectTracker):
     @staticmethod
     def _symmetrize(matrix):
         return 0.5 * (matrix + matrix.T)
+
+    @classmethod
+    def _project_symmetric_covariance(cls, covariance, minimum_eigenvalue=0.0):
+        covariance = cls._symmetrize(covariance)
+        eigenvalues, eigenvectors = linalg.eigh(covariance)
+        eigenvalues = maximum(eigenvalues, float(minimum_eigenvalue))
+        return cls._symmetrize((eigenvectors * eigenvalues) @ eigenvectors.T)
 
     @staticmethod
     def _validate_positive_definite(matrix, name):
@@ -292,6 +302,47 @@ class VBRMTracker(AbstractExtendedObjectTracker):
     def get_point_estimate(self):
         return concatenate([self.kinematic_state, self.get_point_estimate_shape()])
 
+    def get_state(self, full_axes=True):
+        """Return kinematics and shape in a public EOT state convention."""
+
+        return concatenate(
+            [self.kinematic_state, self.get_point_estimate_shape(full_axes=full_axes)]
+        )
+
+    def get_state_and_cov(
+        self,
+        full_axes=True,
+        minimum_axis_length=1e-9,
+        minimum_extent_eigenvalue=1e-9,
+        minimum_covariance_eigenvalue=0.0,
+    ):
+        """Return public VBRM state and covariance.
+
+        VBRM stores axis uncertainty through inverse-gamma parameters over the
+        principal extent variances.  This method converts those moments to the
+        reported axis-length convention with a first-order delta method.
+        """
+
+        state = self.get_state(full_axes=full_axes)
+        orientation_covariance = array(
+            [[maximum(self.orientation_variance, minimum_covariance_eigenvalue)]]
+        )
+        axis_covariance = self._public_axis_covariance_from_inverse_gamma(
+            state[-2:],
+            full_axes=full_axes,
+            minimum_axis_length=minimum_axis_length,
+            minimum_extent_eigenvalue=minimum_extent_eigenvalue,
+            minimum_covariance_eigenvalue=minimum_covariance_eigenvalue,
+        )
+        covariance = linalg.block_diag(
+            self._project_symmetric_covariance(
+                self.covariance,
+                minimum_covariance_eigenvalue,
+            ),
+            linalg.block_diag(orientation_covariance, axis_covariance),
+        )
+        return state, self._project_symmetric_covariance(covariance, minimum_covariance_eigenvalue)
+
     def get_point_estimate_kinematics(self):
         return self.kinematic_state
 
@@ -311,6 +362,48 @@ class VBRMTracker(AbstractExtendedObjectTracker):
     def get_inverse_gamma_parameters(self):
         """Return copies of the internal inverse-gamma shape and scale vectors."""
         return copy(self.alpha), copy(self.beta)
+
+    def _public_axis_covariance_from_inverse_gamma(
+        self,
+        axes,
+        full_axes=True,
+        minimum_axis_length=1e-9,
+        minimum_extent_eigenvalue=1e-9,
+        minimum_covariance_eigenvalue=0.0,
+    ):
+        """Approximate reported-axis covariance from inverse-gamma moments."""
+
+        floor = max(float(minimum_covariance_eigenvalue), 1e-12)
+        axes = array(axes).reshape(2)
+        axis_floor = 2.0 * float(minimum_axis_length) if full_axes else float(minimum_axis_length)
+        axes = maximum(axes, axis_floor)
+        semi_axes = 0.5 * axes if full_axes else axes
+        semi_axes = maximum(semi_axes, float(minimum_axis_length))
+        mean_extent_variance = maximum(
+            semi_axes**2,
+            float(minimum_extent_eigenvalue),
+        )
+
+        try:
+            alpha = array(self.alpha).reshape(-1)[:2]
+            beta = array(self.beta).reshape(-1)[:2]
+        except (AttributeError, ValueError, TypeError):
+            return floor * eye(2)
+        if alpha.shape != (2,) or beta.shape != (2,):
+            return floor * eye(2)
+
+        alpha_minus_one = maximum(alpha - 1.0, 1e-12)
+        alpha_minus_two = maximum(alpha - 2.0, 1e-12)
+        beta = maximum(beta, 0.0)
+        extent_variance = beta * beta / (
+            alpha_minus_one * alpha_minus_one * alpha_minus_two
+        )
+        axis_variance = extent_variance / mean_extent_variance
+        if not full_axes:
+            axis_variance = 0.25 * axis_variance
+        axis_variance = where(isfinite(axis_variance), axis_variance, floor)
+        axis_variance = maximum(axis_variance, floor)
+        return diag(axis_variance)
 
     def predict_linear(
         self,

--- a/src/pyrecest/tracking/__init__.py
+++ b/src/pyrecest/tracking/__init__.py
@@ -137,3 +137,31 @@ __all__ += [
     "hypothesis_to_dict",
     "select_residual_hypothesis",
 ]
+
+from .ellipse_geometry import (
+    canonicalize_ellipse_axes,
+    canonicalize_ellipse_shape,
+    ellipse_angle_delta,
+    ellipse_extent_matrix,
+    ellipse_shape_canonicalization_transform,
+    extent_matrix_from_shape,
+    project_symmetric_covariance,
+    rotation_matrix_2d,
+    shape_from_extent_matrix,
+    symmetrize,
+    wrap_ellipse_angle_to_reference,
+)
+
+__all__ += [
+    "canonicalize_ellipse_axes",
+    "canonicalize_ellipse_shape",
+    "ellipse_angle_delta",
+    "ellipse_extent_matrix",
+    "ellipse_shape_canonicalization_transform",
+    "extent_matrix_from_shape",
+    "project_symmetric_covariance",
+    "rotation_matrix_2d",
+    "shape_from_extent_matrix",
+    "symmetrize",
+    "wrap_ellipse_angle_to_reference",
+]

--- a/src/pyrecest/tracking/ellipse_geometry.py
+++ b/src/pyrecest/tracking/ellipse_geometry.py
@@ -1,0 +1,261 @@
+"""Geometry helpers for 2-D elliptical extended-object states.
+
+The canonical MEM-style ellipse shape vector is
+``[orientation, semi_axis_1, semi_axis_2]``.  Several EOT filters also expose a
+public full-axis convention by doubling the two semi-axis entries.  This module
+keeps the common angle wrapping, axis-sign, axis-swap, and covariance-transform
+logic in one place so individual trackers do not need to reimplement the same
+representation bookkeeping.
+"""
+
+from __future__ import annotations
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import abs as backend_abs
+from pyrecest.backend import (
+    arctan2,
+    array,
+    asarray,
+    cos,
+    diag,
+    eye,
+    linalg,
+    maximum,
+    pi,
+    sin,
+    sqrt,
+)
+
+
+def symmetrize(matrix):
+    """Return the symmetric part of ``matrix``."""
+
+    matrix = asarray(matrix)
+    return 0.5 * (matrix + matrix.T)
+
+
+def project_symmetric_covariance(covariance, minimum_eigenvalue=0.0):
+    """Project a symmetric covariance matrix to the PSD cone.
+
+    Parameters
+    ----------
+    covariance : array-like
+        Square covariance matrix to regularize.
+    minimum_eigenvalue : float, default=0.0
+        Eigenvalue floor used after symmetrization.
+    """
+
+    covariance = symmetrize(covariance)
+    eigenvalues, eigenvectors = linalg.eigh(covariance)
+    eigenvalues = maximum(eigenvalues, float(minimum_eigenvalue))
+    return symmetrize((eigenvectors * eigenvalues) @ eigenvectors.T)
+
+
+def rotation_matrix_2d(angle):
+    """Return the 2-D rotation matrix for ``angle``."""
+
+    return array(
+        [
+            [cos(angle), -sin(angle)],
+            [sin(angle), cos(angle)],
+        ]
+    )
+
+
+def ellipse_angle_delta(reference, theta):
+    """Return the axial orientation residual ``theta - reference``.
+
+    Ellipse orientations are pi-periodic: ``theta`` and ``theta + pi`` describe
+    the same physical extent.  The returned residual lies in the principal axial
+    interval ``[-pi/2, pi/2]`` up to floating-point boundary effects.
+    """
+
+    return 0.5 * arctan2(sin(2.0 * (theta - reference)), cos(2.0 * (theta - reference)))
+
+
+def wrap_ellipse_angle_to_reference(reference, theta):
+    """Return the representation of ``theta`` closest to ``reference`` modulo pi."""
+
+    return reference + ellipse_angle_delta(reference, theta)
+
+
+def ellipse_extent_matrix(orientation, semi_axes):
+    """Return the SPD extent matrix encoded by ``orientation`` and semi-axes."""
+
+    semi_axes = maximum(asarray(semi_axes).reshape(2), 0.0)
+    rotation = rotation_matrix_2d(orientation)
+    return symmetrize(rotation @ diag(semi_axes**2) @ rotation.T)
+
+
+def extent_matrix_from_shape(shape_state):
+    """Return the SPD extent matrix for ``[orientation, semi_axis_1, semi_axis_2]``."""
+
+    shape_state = asarray(shape_state).reshape(3)
+    return ellipse_extent_matrix(shape_state[0], shape_state[1:])
+
+
+def shape_from_extent_matrix(
+    extent,
+    *,
+    reference_orientation=None,
+    minimum_axis_length=0.0,
+):
+    """Convert a 2x2 SPD extent matrix to MEM-style ellipse shape coordinates.
+
+    The returned axes are ordered with the larger semi-axis first.  When
+    ``reference_orientation`` is supplied, the orientation is unwrapped to the
+    nearest pi-equivalent representation of that reference.
+    """
+
+    extent = symmetrize(extent)
+    eigenvalues, eigenvectors = linalg.eigh(extent)
+    if float(eigenvalues[1]) >= float(eigenvalues[0]):
+        major_index = 1
+        minor_index = 0
+    else:
+        major_index = 0
+        minor_index = 1
+
+    axis_floor_sq = float(minimum_axis_length) ** 2
+    major_axis = sqrt(maximum(eigenvalues[major_index], axis_floor_sq))
+    minor_axis = sqrt(maximum(eigenvalues[minor_index], axis_floor_sq))
+    major_vector = eigenvectors[:, major_index]
+    orientation = arctan2(major_vector[1], major_vector[0])
+    if reference_orientation is not None:
+        orientation = wrap_ellipse_angle_to_reference(reference_orientation, orientation)
+    return array([orientation, major_axis, minor_axis])
+
+
+def ellipse_shape_canonicalization_transform(
+    shape_state,
+    *,
+    minimum_axis_length=1e-9,
+    major_axis_first=False,
+    reference_orientation=None,
+):
+    """Canonicalize a MEM-style ellipse shape and return its covariance transform.
+
+    Parameters
+    ----------
+    shape_state : array-like, shape (3,)
+        Shape vector ``[orientation, semi_axis_1, semi_axis_2]``.
+    minimum_axis_length : float, default=1e-9
+        Lower bound applied to both semi-axis lengths.
+    major_axis_first : bool, default=False
+        If true, swap the two axes when the second axis is longer than the
+        first, and add ``pi/2`` to the orientation.
+    reference_orientation : float, optional
+        If supplied, unwrap the final orientation to the nearest pi-equivalent
+        representation of the reference.
+
+    Returns
+    -------
+    canonical_shape_state : array-like, shape (3,)
+        Canonicalized shape vector.
+    transform : array-like, shape (3, 3)
+        Linear transform to apply to a covariance block in the same local shape
+        coordinates: ``P_canonical = transform @ P @ transform.T``.  Orientation
+        unwrapping does not change the covariance transform.
+    """
+
+    shape_state = asarray(shape_state).reshape(3)
+    orientation = shape_state[0]
+    axes = shape_state[1:]
+    transform = eye(3)
+
+    sign_1 = -1.0 if float(axes[0]) < 0.0 else 1.0
+    sign_2 = -1.0 if float(axes[1]) < 0.0 else 1.0
+    if sign_1 < 0.0 or sign_2 < 0.0:
+        sign_transform = diag(array([1.0, sign_1, sign_2]))
+        transform = sign_transform @ transform
+    axes = maximum(backend_abs(axes), float(minimum_axis_length))
+
+    if bool(major_axis_first) and float(axes[1]) > float(axes[0]):
+        swap_transform = array(
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0],
+                [0.0, 1.0, 0.0],
+            ]
+        )
+        transform = swap_transform @ transform
+        axes = array([axes[1], axes[0]])
+        orientation = orientation + 0.5 * pi
+
+    if reference_orientation is not None:
+        orientation = wrap_ellipse_angle_to_reference(reference_orientation, orientation)
+    return array([orientation, axes[0], axes[1]]), transform
+
+
+def canonicalize_ellipse_shape(
+    shape_state,
+    shape_covariance=None,
+    *,
+    minimum_axis_length=1e-9,
+    minimum_covariance_eigenvalue=0.0,
+    major_axis_first=False,
+    reference_orientation=None,
+):
+    """Canonicalize a MEM-style ellipse shape and optional shape covariance.
+
+    This applies the same sign and swap transforms to the covariance that are
+    applied to the shape state.  Cross-covariance terms inside the 3x3 shape
+    covariance are preserved and transformed consistently.
+    """
+
+    canonical_shape, transform = ellipse_shape_canonicalization_transform(
+        shape_state,
+        minimum_axis_length=minimum_axis_length,
+        major_axis_first=major_axis_first,
+        reference_orientation=reference_orientation,
+    )
+    if shape_covariance is None:
+        return canonical_shape, None
+
+    shape_covariance = asarray(shape_covariance)
+    if shape_covariance.shape != (3, 3):
+        raise ValueError("shape_covariance must have shape (3, 3)")
+    canonical_covariance = transform @ symmetrize(shape_covariance) @ transform.T
+    canonical_covariance = project_symmetric_covariance(
+        canonical_covariance,
+        minimum_eigenvalue=minimum_covariance_eigenvalue,
+    )
+    return canonical_shape, canonical_covariance
+
+
+def canonicalize_ellipse_axes(
+    semi_axes,
+    axis_covariance=None,
+    *,
+    minimum_axis_length=1e-9,
+    minimum_covariance_eigenvalue=0.0,
+    major_axis_first=False,
+):
+    """Canonicalize only the two semi-axis coordinates and optional covariance.
+
+    Returns ``(canonical_axes, canonical_axis_covariance, swapped)``.  The
+    orientation shift associated with a swap is intentionally not returned here;
+    callers that track orientation should use :func:`canonicalize_ellipse_shape`
+    or :func:`ellipse_shape_canonicalization_transform` instead.
+    """
+
+    semi_axes = asarray(semi_axes).reshape(2)
+    shape, transform = ellipse_shape_canonicalization_transform(
+        array([0.0, semi_axes[0], semi_axes[1]]),
+        minimum_axis_length=minimum_axis_length,
+        major_axis_first=major_axis_first,
+    )
+    axes = shape[1:]
+    axis_transform = transform[1:, 1:]
+    swapped = bool(float(axis_transform[0, 1]) != 0.0 or float(axis_transform[1, 0]) != 0.0)
+    if axis_covariance is None:
+        return axes, None, swapped
+    axis_covariance = asarray(axis_covariance)
+    if axis_covariance.shape != (2, 2):
+        raise ValueError("axis_covariance must have shape (2, 2)")
+    canonical_axis_covariance = axis_transform @ symmetrize(axis_covariance) @ axis_transform.T
+    canonical_axis_covariance = project_symmetric_covariance(
+        canonical_axis_covariance,
+        minimum_eigenvalue=minimum_covariance_eigenvalue,
+    )
+    return axes, canonical_axis_covariance, swapped

--- a/tests/filters/test_mem_qkf_tracker.py
+++ b/tests/filters/test_mem_qkf_tracker.py
@@ -53,6 +53,20 @@ class TestMEMQKFTracker(unittest.TestCase):
         )
         self.assertEqual(self.tracker.get_point_estimate().shape[0], 7)
 
+    def test_get_state_and_cov_returns_public_full_axis_covariance(self):
+        state, covariance = self.tracker.get_state_and_cov()
+
+        npt.assert_allclose(state, array([0.0, 0.0, 1.0, -1.0, 0.0, 4.0, 2.0]))
+        self.assertEqual(covariance.shape, (7, 7))
+        npt.assert_allclose(covariance[:4, :4], self.covariance)
+        npt.assert_allclose(covariance[4:, 4:], diag(array([0.01, 0.4, 0.8])))
+
+        semi_axis_state, semi_axis_covariance = self.tracker.get_state_and_cov(
+            full_axis_lengths=False
+        )
+        npt.assert_allclose(semi_axis_state, self.tracker.get_point_estimate())
+        npt.assert_allclose(semi_axis_covariance[4:, 4:], self.shape_covariance)
+
     def test_rejects_unknown_update_mode(self):
         with self.assertRaises(ValueError):
             MEMQKFTracker(

--- a/tests/filters/test_mem_rbpf_tracker_public_covariance.py
+++ b/tests/filters/test_mem_rbpf_tracker_public_covariance.py
@@ -1,0 +1,56 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+import pyrecest.backend
+from pyrecest.backend import array, diag, eye, pi
+from pyrecest.filters.mem_rbpf_tracker import MEMRBPFTracker
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ != "numpy",
+    reason="MEM-RBPF public covariance tests use numpy.testing assertions",
+)
+class TestMEMRBPFTrackerPublicCovariance(unittest.TestCase):
+    def _make_tracker(self):
+        tracker = MEMRBPFTracker.__new__(MEMRBPFTracker)
+        tracker.n_particles = 2
+        tracker.state_dim = 4
+        tracker.kinematic_state = array([1.0, 2.0, 3.0, 4.0])
+        tracker.covariance = diag(array([0.1, 0.2, 0.3, 0.4]))
+        tracker.theta = array([0.0, pi])
+        tracker.axis = array([[2.0, 1.0], [2.0, 1.0]])
+        tracker.axis_covariances = array(
+            [
+                [[0.10, 0.01], [0.01, 0.20]],
+                [[0.10, 0.01], [0.01, 0.20]],
+            ]
+        )
+        tracker.weights = array([0.5, 0.5])
+        tracker.measurement_matrix = eye(2, 4)
+        return tracker
+
+    def test_get_state_and_cov_returns_public_particle_covariance(self):
+        tracker = self._make_tracker()
+
+        state, covariance = tracker.get_state_and_cov()
+
+        npt.assert_allclose(state, array([1.0, 2.0, 3.0, 4.0, 0.0, 4.0, 2.0]))
+        self.assertEqual(covariance.shape, (7, 7))
+        npt.assert_allclose(covariance[:4, :4], tracker.covariance)
+        self.assertAlmostEqual(float(covariance[4, 4]), 0.0)
+        self.assertAlmostEqual(float(covariance[5, 5]), 0.4)
+        self.assertAlmostEqual(float(covariance[6, 6]), 0.8)
+        self.assertAlmostEqual(float(covariance[5, 6]), 0.04)
+        self.assertTrue(np.all(np.linalg.eigvalsh(covariance) >= -1e-12))
+
+    def test_particle_weight_normalization_falls_back_to_uniform(self):
+        tracker = self._make_tracker()
+        tracker.weights = array([np.nan, 0.0])
+
+        npt.assert_allclose(tracker._normalized_particle_weights(), array([0.5, 0.5]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/filters/test_vbrm_tracker.py
+++ b/tests/filters/test_vbrm_tracker.py
@@ -50,6 +50,38 @@ class TestVBRMTracker(unittest.TestCase):
         )
         self.assertEqual(self.tracker.get_point_estimate().shape[0], 7)
 
+    def test_get_state_and_cov_returns_public_shape_covariance(self):
+        state, covariance = self.tracker.get_state_and_cov(
+            minimum_covariance_eigenvalue=1e-9
+        )
+
+        npt.assert_allclose(state, array([0.0, 0.0, 1.0, -1.0, 0.0, 4.0, 2.0]))
+        self.assertEqual(covariance.shape, (7, 7))
+        npt.assert_allclose(covariance[:4, :4], self.covariance)
+        self.assertAlmostEqual(float(covariance[4, 4]), self.orientation_variance)
+        self.assertGreater(float(covariance[5, 5]), 0.0)
+        self.assertGreater(float(covariance[6, 6]), 0.0)
+        self.assertTrue(all(linalg.eigvalsh(covariance) > 0.0))
+
+    def test_axis_covariance_falls_back_for_invalid_inverse_gamma_shapes(self):
+        tracker = VBRMTracker(
+            self.kinematic_state,
+            self.covariance,
+            self.shape_state,
+            self.orientation_variance,
+            inverse_gamma_shape=10.0,
+            measurement_noise_cov=self.measurement_noise_cov,
+            measurement_matrix=self.measurement_matrix,
+        )
+        tracker.alpha = array([5.0])
+
+        axis_covariance = tracker._public_axis_covariance_from_inverse_gamma(
+            array([4.0, 2.0]),
+            minimum_covariance_eigenvalue=1e-8,
+        )
+
+        npt.assert_allclose(axis_covariance, 1e-8 * eye(2))
+
     def test_extent_respects_orientation(self):
         tracker = VBRMTracker(
             self.kinematic_state,

--- a/tests/tracking/test_ellipse_geometry.py
+++ b/tests/tracking/test_ellipse_geometry.py
@@ -93,7 +93,7 @@ def test_extent_matrix_is_invariant_to_axis_swap_representation() -> None:
     axes = np.array([3.0, 1.0])
 
     extent = ellipse_extent_matrix(theta, axes)
-    swapped_extent = ellipse_extent_matrix(theta + np.pi / 2.0, axes[::-1])
+    swapped_extent = ellipse_extent_matrix(theta + np.pi / 2.0, axes[::-1].copy())
 
     npt.assert_allclose(extent, swapped_extent, atol=1e-12)
 
@@ -102,4 +102,3 @@ def test_shape_from_extent_matrix_orders_axes_and_respects_reference() -> None:
     extent = ellipse_extent_matrix(np.pi - 0.2, np.array([4.0, 1.5]))
 
     shape = shape_from_extent_matrix(extent, reference_orientation=-0.2)
-

--- a/tests/tracking/test_ellipse_geometry.py
+++ b/tests/tracking/test_ellipse_geometry.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import numpy as np
+import numpy.testing as npt
+
+from pyrecest.tracking import (
+    canonicalize_ellipse_axes,
+    canonicalize_ellipse_shape,
+    ellipse_angle_delta,
+    ellipse_extent_matrix,
+    ellipse_shape_canonicalization_transform,
+    shape_from_extent_matrix,
+    wrap_ellipse_angle_to_reference,
+)
+
+
+def test_ellipse_angle_delta_is_pi_periodic() -> None:
+    assert np.isclose(float(ellipse_angle_delta(0.0, np.pi - 0.1)), -0.1)
+    assert np.isclose(float(wrap_ellipse_angle_to_reference(0.0, np.pi - 0.1)), -0.1)
+
+
+def test_canonicalize_ellipse_shape_transforms_full_shape_covariance() -> None:
+    shape = np.array([0.2, -1.0, 2.0])
+    covariance = np.array(
+        [
+            [4.0, 0.5, -0.25],
+            [0.5, 9.0, 1.5],
+            [-0.25, 1.5, 16.0],
+        ],
+        dtype=float,
+    )
+
+    canonical_shape, canonical_covariance = canonicalize_ellipse_shape(
+        shape,
+        covariance,
+        major_axis_first=True,
+        reference_orientation=shape[0],
+    )
+
+    sign_transform = np.diag([1.0, -1.0, 1.0])
+    swap_transform = np.eye(3)
+    swap_transform[[1, 2], :] = swap_transform[[2, 1], :]
+    expected_covariance = swap_transform @ sign_transform @ covariance
+    expected_covariance = expected_covariance @ sign_transform.T @ swap_transform.T
+
+    npt.assert_allclose(canonical_shape[1:], np.array([2.0, 1.0]))
+    assert np.isclose(
+        float(ellipse_angle_delta(shape[0] + np.pi / 2.0, canonical_shape[0])),
+        0.0,
+    )
+    npt.assert_allclose(canonical_covariance, expected_covariance)
+
+
+def test_canonicalization_transform_can_be_embedded_in_larger_covariance() -> None:
+    mean = np.array([5.0, 0.2, -1.0, 2.0])
+    covariance = np.eye(4)
+    covariance[0, 2] = covariance[2, 0] = 0.3
+    covariance[2, 3] = covariance[3, 2] = -0.4
+
+    canonical_shape, shape_transform = ellipse_shape_canonicalization_transform(
+        mean[1:],
+        major_axis_first=True,
+    )
+    transform = np.eye(4)
+    transform[1:, 1:] = np.asarray(shape_transform, dtype=float)
+    canonical_covariance = transform @ covariance @ transform.T
+
+    sign_transform = np.eye(4)
+    sign_transform[2, 2] = -1.0
+    swap_transform = np.eye(4)
+    swap_transform[[2, 3], :] = swap_transform[[3, 2], :]
+    expected_covariance = swap_transform @ sign_transform @ covariance
+    expected_covariance = expected_covariance @ sign_transform.T @ swap_transform.T
+
+    npt.assert_allclose(canonical_shape[1:], np.array([2.0, 1.0]))
+    npt.assert_allclose(canonical_covariance, expected_covariance)
+
+
+def test_canonicalize_ellipse_axes_matches_shape_axis_block() -> None:
+    axes, axis_covariance, swapped = canonicalize_ellipse_axes(
+        np.array([-1.0, 2.0]),
+        np.array([[9.0, 1.5], [1.5, 16.0]]),
+        major_axis_first=True,
+    )
+
+    npt.assert_allclose(axes, np.array([2.0, 1.0]))
+    npt.assert_allclose(axis_covariance, np.array([[16.0, -1.5], [-1.5, 9.0]]))
+    assert swapped
+
+
+def test_extent_matrix_is_invariant_to_axis_swap_representation() -> None:
+    theta = 0.3
+    axes = np.array([3.0, 1.0])
+
+    extent = ellipse_extent_matrix(theta, axes)
+    swapped_extent = ellipse_extent_matrix(theta + np.pi / 2.0, axes[::-1])
+
+    npt.assert_allclose(extent, swapped_extent, atol=1e-12)
+
+
+def test_shape_from_extent_matrix_orders_axes_and_respects_reference() -> None:
+    extent = ellipse_extent_matrix(np.pi - 0.2, np.array([4.0, 1.5]))
+
+    shape = shape_from_extent_matrix(extent, reference_orientation=-0.2)
+


### PR DESCRIPTION
# Pull request

## Summary

- Added shared ellipse geometry conversion and canonicalization helpers.
- Exported the new tracking utilities.
- Added coverage for geometry conversion, canonicalization, and covariance projection.
- Fixed CI test failures on PyTorch backends by updating the axis-swap test to pass a copied reversed array (`axes[::-1].copy()`), avoiding negative-stride array issues.

## Checklist

- [x] Tests were added or updated.
- [ ] Backend limitations were documented or added to `src/pyrecest/_backend/capabilities.py`.
- [ ] Shape, dtype, and measurement-set conventions were checked against `docs/conventions.md`.
- [ ] New user-facing failures use clear messages or shared exceptions from `pyrecest.exceptions`.
- [ ] Public examples and docs were updated when relevant.
- [ ] Performance-sensitive changes were checked against `benchmarks/basic_regressions.py` or a focused benchmark.
- [ ] `python scripts/check_release_consistency.py --local-only` passes when release metadata changed.
- [ ] The package smoke path still works: `python -m build`, `twine check dist/*`, install wheel, run a basic example.