### PR TITLE
Expose EOT state and covariance

### DIFF
--- a/src/pyrecest/filters/mem_qkf_tracker.py
+++ b/src/pyrecest/filters/mem_qkf_tracker.py
@@ -6,6 +6,7 @@ from typing import Any
 from pyrecest.backend import abs as backend_abs
 from pyrecest.backend import (
     array,
+    concatenate,
     cos,
     diag,
     eye,
@@ -301,6 +302,40 @@ class MEMQKFTracker(MEMEKFTracker):
             self.store_posterior_estimates()
         if self.log_posterior_extents:
             self.store_posterior_extents()
+
+    def get_state(self, full_axis_lengths=True):
+        """Return the public MEM-QKF state vector.
+
+        The internal shape state stores semi-axis lengths.  With
+        ``full_axis_lengths=True`` this method returns the common EOT public
+        convention ``[kinematics..., orientation, length, width]``.
+        """
+
+        shape_state = self.shape_state
+        if full_axis_lengths:
+            shape_state = array(
+                [shape_state[0], 2.0 * shape_state[1], 2.0 * shape_state[2]]
+            )
+        return concatenate([self.kinematic_state, shape_state])
+
+    def get_state_and_cov(self, full_axis_lengths=True):
+        """Return the public MEM-QKF state and matching covariance.
+
+        The returned covariance uses the same axis-length convention as the
+        returned state.  Therefore, when full axis lengths are requested, the
+        two semi-axis covariance entries are scaled by a factor of four and
+        their cross-covariance by the corresponding linear transform.
+        """
+
+        shape_transform = eye(3)
+        if full_axis_lengths:
+            shape_transform = diag(array([1.0, 2.0, 2.0]))
+        shape_covariance = shape_transform @ self.shape_covariance @ shape_transform.T
+        covariance = linalg.block_diag(
+            self._project_symmetric_covariance(self.covariance),
+            self._project_symmetric_covariance(shape_covariance),
+        )
+        return self.get_state(full_axis_lengths=full_axis_lengths), self._project_symmetric_covariance(covariance)
 
     # pylint: disable=too-many-arguments,too-many-positional-arguments
     def _update_single_measurement_qkf(

--- a/src/pyrecest/filters/mem_rbpf_tracker.py
+++ b/src/pyrecest/filters/mem_rbpf_tracker.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from numbers import Integral
 
 from pyrecest import backend
+from pyrecest.backend import abs as backend_abs
 from pyrecest.backend import any as backend_any
 from pyrecest.backend import (
     arange,
@@ -640,6 +641,97 @@ class MEMRBPFTracker(AbstractExtendedObjectTracker):
         if full_axis_lengths:
             return concatenate([state[:-2], 2.0 * state[-2:]])
         return state
+
+    def get_state_and_cov(self, full_axis_lengths=True):
+        """Return the public RBPF state and its mixture covariance.
+
+        The state follows :meth:`get_state`.  The covariance combines the
+        shared kinematic covariance, per-particle conditional semi-axis
+        covariance, and weighted particle spread.  Orientation differences are
+        treated as axial because ``theta`` and ``theta + pi`` encode the same
+        ellipse.
+        """
+
+        state = self.get_state(full_axis_lengths=full_axis_lengths)
+        particle_states = self._particle_public_states(
+            full_axis_lengths=full_axis_lengths
+        )
+        n_particles = int(particle_states.shape[0])
+        weights = self._normalized_particle_weights(n_particles=n_particles)
+        axis_covariances = self._particle_public_axis_covariances(
+            n_particles,
+            full_axis_lengths=full_axis_lengths,
+        )
+
+        covariance = zeros((state.shape[0], state.shape[0]))
+        kinematic_covariance = self._regularize_public_covariance(self.covariance)
+        angle_index = self.state_dim
+        axis_start = self.state_dim + 1
+        for particle_index in range(n_particles):
+            delta = copy(particle_states[particle_index] - state)
+            delta[angle_index] = self._ellipse_angle_delta(
+                state[angle_index],
+                particle_states[particle_index, angle_index],
+            )
+
+            conditional_covariance = zeros((state.shape[0], state.shape[0]))
+            conditional_covariance[: self.state_dim, : self.state_dim] = (
+                kinematic_covariance
+            )
+            conditional_covariance[axis_start:, axis_start:] = axis_covariances[
+                particle_index
+            ]
+            covariance = covariance + weights[particle_index] * (
+                conditional_covariance + delta.reshape((-1, 1)) @ delta.reshape((1, -1))
+            )
+        return state, self._regularize_public_covariance(covariance)
+
+    def _particle_public_states(self, full_axis_lengths=True):
+        theta = self.theta.reshape((-1,))
+        n_particles = int(theta.shape[0])
+        kinematic_rows = ones((n_particles, self.state_dim)) * self.kinematic_state
+        axis = backend_abs(self.axis.reshape((n_particles, 2)))
+        if full_axis_lengths:
+            axis = 2.0 * axis
+        return concatenate([kinematic_rows, theta.reshape((n_particles, 1)), axis], axis=1)
+
+    def _particle_public_axis_covariances(self, n_particles, full_axis_lengths=True):
+        covariances = self.axis_covariances
+        if covariances.shape != (n_particles, 2, 2):
+            return zeros((n_particles, 2, 2))
+        scale = 4.0 if full_axis_lengths else 1.0
+        public_covariances = scale * covariances
+        return stack(
+            [
+                self._regularize_public_covariance(public_covariances[index])
+                for index in range(n_particles)
+            ]
+        )
+
+    def _normalized_particle_weights(self, n_particles=None):
+        weights = self.weights.reshape((-1,))
+        if n_particles is not None:
+            weights = weights[: int(n_particles)]
+        if int(weights.shape[0]) == 0:
+            raise ValueError("MEMRBPFTracker has no particles")
+        weights = where(isfinite(weights) & (weights > 0.0), weights, 0.0)
+        total = float(backend_sum(weights))
+        if total <= 0.0:
+            return full(weights.shape, 1.0 / int(weights.shape[0]))
+        return weights / total
+
+    @classmethod
+    def _regularize_public_covariance(cls, covariance):
+        covariance = cls._symmetrize(covariance)
+        if int(covariance.shape[0]) == 0:
+            return covariance
+        eigenvalues, eigenvectors = linalg.eigh(covariance)
+        eigenvalues = maximum(eigenvalues, 0.0)
+        return cls._symmetrize((eigenvectors * eigenvalues) @ eigenvectors.T)
+
+    @staticmethod
+    def _ellipse_angle_delta(reference, theta):
+        return 0.5 * arctan2(sin(2.0 * (theta - reference)), cos(2.0 * (theta - reference)))
 
     def get_state_array(self, with_weight=False, full_axis_lengths=False):
         kinematic_rows = ones((self.n_particles, self.state_dim)) * self.kinematic_state

--- a/src/pyrecest/filters/vbrm_tracker.py
+++ b/src/pyrecest/filters/vbrm_tracker.py
@@ -12,14 +12,17 @@ from pyrecest.backend import (
     diagonal,
     exp,
     eye,
+    isfinite,
     linalg,
     linspace,
+    maximum,
     mean,
     pi,
     sin,
     sqrt,
     stack,
     trace,
+    where,
     zeros,
 )
 
@@ -122,6 +125,13 @@ class VBRMTracker(AbstractExtendedObjectTracker):
     @staticmethod
     def _symmetrize(matrix):
         return 0.5 * (matrix + matrix.T)
+
+    @classmethod
+    def _project_symmetric_covariance(cls, covariance, minimum_eigenvalue=0.0):
+        covariance = cls._symmetrize(covariance)
+        eigenvalues, eigenvectors = linalg.eigh(covariance)
+        eigenvalues = maximum(eigenvalues, float(minimum_eigenvalue))
+        return cls._symmetrize((eigenvectors * eigenvalues) @ eigenvectors.T)
 
     @staticmethod
     def _validate_positive_definite(matrix, name):
@@ -292,6 +302,47 @@ class VBRMTracker(AbstractExtendedObjectTracker):
     def get_point_estimate(self):
         return concatenate([self.kinematic_state, self.get_point_estimate_shape()])
 
+    def get_state(self, full_axes=True):
+        """Return kinematics and shape in a public EOT state convention."""
+
+        return concatenate(
+            [self.kinematic_state, self.get_point_estimate_shape(full_axes=full_axes)]
+        )
+
+    def get_state_and_cov(
+        self,
+        full_axes=True,
+        minimum_axis_length=1e-9,
+        minimum_extent_eigenvalue=1e-9,
+        minimum_covariance_eigenvalue=0.0,
+    ):
+        """Return public VBRM state and covariance.
+
+        VBRM stores axis uncertainty through inverse-gamma parameters over the
+        principal extent variances.  This method converts those moments to the
+        reported axis-length convention with a first-order delta method.
+        """
+
+        state = self.get_state(full_axes=full_axes)
+        orientation_covariance = array(
+            [[maximum(self.orientation_variance, minimum_covariance_eigenvalue)]]
+        )
+        axis_covariance = self._public_axis_covariance_from_inverse_gamma(
+            state[-2:],
+            full_axes=full_axes,
+            minimum_axis_length=minimum_axis_length,
+            minimum_extent_eigenvalue=minimum_extent_eigenvalue,
+            minimum_covariance_eigenvalue=minimum_covariance_eigenvalue,
+        )
+        covariance = linalg.block_diag(
+            self._project_symmetric_covariance(
+                self.covariance,
+                minimum_covariance_eigenvalue,
+            ),
+            linalg.block_diag(orientation_covariance, axis_covariance),
+        )
+        return state, self._project_symmetric_covariance(covariance, minimum_covariance_eigenvalue)
+
     def get_point_estimate_kinematics(self):
         return self.kinematic_state
 
@@ -311,6 +362,48 @@ class VBRMTracker(AbstractExtendedObjectTracker):
     def get_inverse_gamma_parameters(self):
         """Return copies of the internal inverse-gamma shape and scale vectors."""
         return copy(self.alpha), copy(self.beta)
+
+    def _public_axis_covariance_from_inverse_gamma(
+        self,
+        axes,
+        full_axes=True,
+        minimum_axis_length=1e-9,
+        minimum_extent_eigenvalue=1e-9,
+        minimum_covariance_eigenvalue=0.0,
+    ):
+        """Approximate reported-axis covariance from inverse-gamma moments."""
+
+        floor = max(float(minimum_covariance_eigenvalue), 1e-12)
+        axes = array(axes).reshape(2)
+        axis_floor = 2.0 * float(minimum_axis_length) if full_axes else float(minimum_axis_length)
+        axes = maximum(axes, axis_floor)
+        semi_axes = 0.5 * axes if full_axes else axes
+        semi_axes = maximum(semi_axes, float(minimum_axis_length))
+        mean_extent_variance = maximum(
+            semi_axes**2,
+            float(minimum_extent_eigenvalue),
+        )
+
+        try:
+            alpha = array(self.alpha).reshape(-1)[:2]
+            beta = array(self.beta).reshape(-1)[:2]
+        except (AttributeError, ValueError, TypeError):
+            return floor * eye(2)
+        if alpha.shape != (2,) or beta.shape != (2,):
+            return floor * eye(2)
+
+        alpha_minus_one = maximum(alpha - 1.0, 1e-12)
+        alpha_minus_two = maximum(alpha - 2.0, 1e-12)
+        beta = maximum(beta, 0.0)
+        extent_variance = beta * beta / (
+            alpha_minus_one * alpha_minus_one * alpha_minus_two
+        )
+        axis_variance = extent_variance / mean_extent_variance
+        if not full_axes:
+            axis_variance = 0.25 * axis_variance
+        axis_variance = where(isfinite(axis_variance), axis_variance, floor)
+        axis_variance = maximum(axis_variance, floor)
+        return diag(axis_variance)
 
     def predict_linear(
         self,

--- a/tests/filters/test_mem_qkf_tracker.py
+++ b/tests/filters/test_mem_qkf_tracker.py
@@ -53,6 +53,20 @@ class TestMEMQKFTracker(unittest.TestCase):
         )
         self.assertEqual(self.tracker.get_point_estimate().shape[0], 7)
 
+    def test_get_state_and_cov_returns_public_full_axis_covariance(self):
+        state, covariance = self.tracker.get_state_and_cov()
+
+        npt.assert_allclose(state, array([0.0, 0.0, 1.0, -1.0, 0.0, 4.0, 2.0]))
+        self.assertEqual(covariance.shape, (7, 7))
+        npt.assert_allclose(covariance[:4, :4], self.covariance)
+        npt.assert_allclose(covariance[4:, 4:], diag(array([0.01, 0.4, 0.8])))
+
+        semi_axis_state, semi_axis_covariance = self.tracker.get_state_and_cov(
+            full_axis_lengths=False
+        )
+        npt.assert_allclose(semi_axis_state, self.tracker.get_point_estimate())
+        npt.assert_allclose(semi_axis_covariance[4:, 4:], self.shape_covariance)
+
     def test_rejects_unknown_update_mode(self):
         with self.assertRaises(ValueError):
             MEMQKFTracker(

--- a/tests/filters/test_mem_rbpf_tracker_public_covariance.py
+++ b/tests/filters/test_mem_rbpf_tracker_public_covariance.py
@@ -1,0 +1,56 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+import pyrecest.backend
+from pyrecest.backend import array, diag, eye, pi
+from pyrecest.filters.mem_rbpf_tracker import MEMRBPFTracker
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ != "numpy",
+    reason="MEM-RBPF public covariance tests use numpy.testing assertions",
+)
+class TestMEMRBPFTrackerPublicCovariance(unittest.TestCase):
+    def _make_tracker(self):
+        tracker = MEMRBPFTracker.__new__(MEMRBPFTracker)
+        tracker.n_particles = 2
+        tracker.state_dim = 4
+        tracker.kinematic_state = array([1.0, 2.0, 3.0, 4.0])
+        tracker.covariance = diag(array([0.1, 0.2, 0.3, 0.4]))
+        tracker.theta = array([0.0, pi])
+        tracker.axis = array([[2.0, 1.0], [2.0, 1.0]])
+        tracker.axis_covariances = array(
+            [
+                [[0.10, 0.01], [0.01, 0.20]],
+                [[0.10, 0.01], [0.01, 0.20]],
+            ]
+        )
+        tracker.weights = array([0.5, 0.5])
+        tracker.measurement_matrix = eye(2, 4)
+        return tracker
+
+    def test_get_state_and_cov_returns_public_particle_covariance(self):
+        tracker = self._make_tracker()
+
+        state, covariance = tracker.get_state_and_cov()
+
+        npt.assert_allclose(state, array([1.0, 2.0, 3.0, 4.0, 0.0, 4.0, 2.0]))
+        self.assertEqual(covariance.shape, (7, 7))
+        npt.assert_allclose(covariance[:4, :4], tracker.covariance)
+        self.assertAlmostEqual(float(covariance[4, 4]), 0.0)
+        self.assertAlmostEqual(float(covariance[5, 5]), 0.4)
+        self.assertAlmostEqual(float(covariance[6, 6]), 0.8)
+        self.assertAlmostEqual(float(covariance[5, 6]), 0.04)
+        self.assertTrue(np.all(np.linalg.eigvalsh(covariance) >= -1e-12))
+
+    def test_particle_weight_normalization_falls_back_to_uniform(self):
+        tracker = self._make_tracker()
+        tracker.weights = array([np.nan, 0.0])
+
+        npt.assert_allclose(tracker._normalized_particle_weights(), array([0.5, 0.5]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/filters/test_vbrm_tracker.py
+++ b/tests/filters/test_vbrm_tracker.py
@@ -50,6 +50,38 @@ class TestVBRMTracker(unittest.TestCase):
         )
         self.assertEqual(self.tracker.get_point_estimate().shape[0], 7)
 
+    def test_get_state_and_cov_returns_public_shape_covariance(self):
+        state, covariance = self.tracker.get_state_and_cov(
+            minimum_covariance_eigenvalue=1e-9
+        )
+
+        npt.assert_allclose(state, array([0.0, 0.0, 1.0, -1.0, 0.0, 4.0, 2.0]))
+        self.assertEqual(covariance.shape, (7, 7))
+        npt.assert_allclose(covariance[:4, :4], self.covariance)
+        self.assertAlmostEqual(float(covariance[4, 4]), self.orientation_variance)
+        self.assertGreater(float(covariance[5, 5]), 0.0)
+        self.assertGreater(float(covariance[6, 6]), 0.0)
+        self.assertTrue(all(linalg.eigvalsh(covariance) > 0.0))
+
+    def test_axis_covariance_falls_back_for_invalid_inverse_gamma_shapes(self):
+        tracker = VBRMTracker(
+            self.kinematic_state,
+            self.covariance,
+            self.shape_state,
+            self.orientation_variance,
+            inverse_gamma_shape=10.0,
+            measurement_noise_cov=self.measurement_noise_cov,
+            measurement_matrix=self.measurement_matrix,
+        )
+        tracker.alpha = array([5.0])
+
+        axis_covariance = tracker._public_axis_covariance_from_inverse_gamma(
+            array([4.0, 2.0]),
+            minimum_covariance_eigenvalue=1e-8,
+        )
+
+        npt.assert_allclose(axis_covariance, 1e-8 * eye(2))
+
     def test_extent_respects_orientation(self):
         tracker = VBRMTracker(
             self.kinematic_state,


### PR DESCRIPTION
## Summary
- expose state and covariance helpers for MEM-QKF, MEM-RBPF, and VBRM EOT trackers
- add public covariance coverage for the EOT tracker implementations
- reuse shared ellipse geometry utilities from the preceding branch

## Validation
- Not run per request
- Syntax checked with `python -m py_compile src/pyrecest/filters/mem_qkf_tracker.py src/pyrecest/filters/mem_rbpf_tracker.py src/pyrecest/filters/vbrm_tracker.py tests/filters/test_mem_qkf_tracker.py tests/filters/test_mem_rbpf_tracker_public_covariance.py tests/filters/test_vbrm_tracker.py`
- Checked diff with `git diff --check`