### PR TITLE
Add delayed output smoother interface

### DIFF
--- a/src/pyrecest/smoothers/__init__.py
+++ b/src/pyrecest/smoothers/__init__.py
@@ -1,4 +1,5 @@
 from .abstract_smoother import AbstractSmoother
+from .delayed_output import DelayedStateOutput, DelayedStateOutputMixin
 from .fixed_lag_mem_qkf_smoother import (
     FBFBMEMQKFSmoother,
     FixedIntervalMEMQKFSmoother,
@@ -57,6 +58,8 @@ from .unscented_rauch_tung_striebel_smoother import (
 
 __all__ = [
     "AbstractSmoother",
+    "DelayedStateOutput",
+    "DelayedStateOutputMixin",
     "FBFBMEMQKFSmoother",
     "FixedIntervalMEMQKFSmoother",
     "FixedIntervalMemQkfSmoother",

--- a/src/pyrecest/smoothers/delayed_output.py
+++ b/src/pyrecest/smoothers/delayed_output.py
@@ -1,0 +1,108 @@
+"""Common delayed-output interface for online fixed-lag smoothers.
+
+Some online smoothers produce an estimate only after a finite look-ahead window
+has become available.  They therefore need a small queue of ``(step, state)``
+records and a finalization path that flushes the end-of-trajectory tail.  This
+module keeps that API in one place without prescribing any particular smoothing
+algorithm or state representation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, TypeAlias
+
+
+DelayedStateOutput: TypeAlias = tuple[int, Any]
+
+
+class DelayedStateOutputMixin:
+    """Mixin implementing the delayed-output queue used by fixed-lag smoothers.
+
+    Subclasses should call :meth:`_initialize_delayed_state_outputs` during
+    initialization.  The mixin also initializes lazily, which keeps it usable in
+    lightweight test doubles and with classes restored through ``__new__``.
+
+    The public convention is intentionally simple: ready outputs are returned as
+    ``(step_index, state)`` tuples.  The state object can be a backend array,
+    NumPy array, dataclass, tracker state, or any other payload selected by the
+    concrete smoother.
+    """
+
+    outputs_delayed_states = True
+
+    def _initialize_delayed_state_outputs(
+        self,
+        *,
+        last_emitted_step: int = -1,
+    ) -> None:
+        """Reset the delayed-output queue and emitted-step cursor."""
+
+        self._ready_queue: list[DelayedStateOutput] = []
+        self._last_emitted_step = int(last_emitted_step)
+
+    def _ensure_delayed_state_outputs_initialized(self) -> None:
+        if not hasattr(self, "_ready_queue"):
+            self._ready_queue = []
+        if not hasattr(self, "_last_emitted_step"):
+            self._last_emitted_step = -1
+
+    @property
+    def last_emitted_step(self) -> int:
+        """Index of the latest queued or finalized delayed output."""
+
+        self._ensure_delayed_state_outputs_initialized()
+        return int(self._last_emitted_step)
+
+    def _queue_delayed_state(self, step: int, state: Any) -> bool:
+        """Queue ``state`` for ``step`` if it has not already been emitted.
+
+        Returns ``True`` when a new item was queued and ``False`` when ``step``
+        is negative or not newer than the current delayed-output cursor.
+        """
+
+        self._ensure_delayed_state_outputs_initialized()
+        step = int(step)
+        if step < 0 or step <= int(self._last_emitted_step):
+            return False
+        self._ready_queue.append((step, state))
+        self._last_emitted_step = step
+        return True
+
+    def pop_ready_states(self) -> list[DelayedStateOutput]:
+        """Return and clear newly available delayed outputs."""
+
+        self._ensure_delayed_state_outputs_initialized()
+        ready = list(self._ready_queue)
+        self._ready_queue = []
+        return ready
+
+    def _finalize_delayed_state_outputs(
+        self,
+        current_step: int,
+        state_for_step: Callable[[int], Any | None],
+    ) -> list[DelayedStateOutput]:
+        """Flush queued outputs and append the un-emitted trajectory tail.
+
+        ``state_for_step`` is called for every step after the current delayed
+        cursor up to and including ``current_step``.  Returning ``None`` skips a
+        step, which lets subclasses handle windows that cannot be smoothed.
+        """
+
+        self._ensure_delayed_state_outputs_initialized()
+        current_step = int(current_step)
+        if current_step < 0:
+            return self.pop_ready_states()
+
+        ready = self.pop_ready_states()
+        start_step = int(self._last_emitted_step) + 1
+        for step in range(start_step, current_step + 1):
+            state = state_for_step(step)
+            if state is None:
+                continue
+            ready.append((step, state))
+            self._last_emitted_step = step
+
+        if int(self._last_emitted_step) < current_step:
+            self._last_emitted_step = current_step
+        return ready

--- a/tests/smoothers/test_delayed_output.py
+++ b/tests/smoothers/test_delayed_output.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pyrecest.smoothers import DelayedStateOutputMixin
+
+
+class _DummyDelayedOutputSmoother(DelayedStateOutputMixin):
+    def __init__(self):
+        self._initialize_delayed_state_outputs()
+
+
+def test_delayed_output_queue_returns_items_once() -> None:
+    smoother = _DummyDelayedOutputSmoother()
+
+    assert smoother._queue_delayed_state(0, "zero")
+    assert smoother._queue_delayed_state(1, "one")
+    assert not smoother._queue_delayed_state(1, "duplicate")
+
+    assert smoother.pop_ready_states() == [(0, "zero"), (1, "one")]
+    assert smoother.pop_ready_states() == []
+    assert smoother.last_emitted_step == 1
+
+
+def test_finalize_flushes_queued_states_and_unemitted_tail() -> None:
+    smoother = _DummyDelayedOutputSmoother()
+    smoother._queue_delayed_state(2, "queued")
+
+    finalized = smoother._finalize_delayed_state_outputs(
+        4,
+        lambda step: f"tail-{step}",
+    )
+
+    assert finalized == [(2, "queued"), (3, "tail-3"), (4, "tail-4")]
+    assert smoother.pop_ready_states() == []
+    assert smoother.last_emitted_step == 4
+
+
+def test_finalize_allows_missing_tail_states() -> None:
+    smoother = _DummyDelayedOutputSmoother()
+
+    finalized = smoother._finalize_delayed_state_outputs(
+        2,
+        lambda step: None if step == 1 else f"state-{step}",
+    )
+
+    assert finalized == [(0, "state-0"), (2, "state-2")]
+    assert smoother.last_emitted_step == 2
+
+
+def test_delayed_output_mixin_initializes_lazily() -> None:
+    smoother = DelayedStateOutputMixin()
+
+    assert smoother.pop_ready_states() == []
+    assert smoother._queue_delayed_state(0, "state")
+    assert smoother.pop_ready_states() == [(0, "state")]
+    assert smoother.last_emitted_step == 0


### PR DESCRIPTION
## Summary
- add a shared delayed-output mixin for online fixed-lag smoothers
- export the delayed-output interface from pyrecest.smoothers
- add queue/finalization regression coverage

## Checks
- Not run per request.
- python -m py_compile src\pyrecest\smoothers\delayed_output.py src\pyrecest\smoothers\__init__.py tests\smoothers\test_delayed_output.py
- git diff --check