### PR TITLE
Accept array-like inputs in backend helpers

### DIFF
--- a/src/pyrecest/_backend/jax/__init__.py
+++ b/src/pyrecest/_backend/jax/__init__.py
@@ -186,6 +186,44 @@ from . import autodiff, linalg, random
 from ._dtype import as_dtype, set_default_dtype
 
 
+def _asarray_sequence(seq):
+    return tuple(_jnp.asarray(item) for item in seq)
+
+
+def concatenate(seq, axis=0, dtype=None):
+    return _jnp.concatenate(_asarray_sequence(seq), axis=axis, dtype=dtype)
+
+
+def stack(seq, axis=0, dtype=None):
+    return _jnp.stack(_asarray_sequence(seq), axis=axis, dtype=dtype)
+
+
+def flip(m, axis=None):
+    return _jnp.flip(_jnp.asarray(m), axis=axis)
+
+
+def sort(a, axis=-1, **kwargs):
+    return _jnp.sort(_jnp.asarray(a), axis=axis, **kwargs)
+
+
+def unique(ar, *args, **kwargs):
+    return _jnp.unique(_jnp.asarray(ar), *args, **kwargs)
+
+
+def argmax(a, axis=None, out=None, keepdims=False, **kwargs):
+    result = _jnp.argmax(_jnp.asarray(a), axis=axis, keepdims=keepdims, **kwargs)
+    if out is not None:
+        return out.at[...].set(result)
+    return result
+
+
+def argmin(a, axis=None, out=None, keepdims=False, **kwargs):
+    result = _jnp.argmin(_jnp.asarray(a), axis=axis, keepdims=keepdims, **kwargs)
+    if out is not None:
+        return out.at[...].set(result)
+    return result
+
+
 def convert_to_wider_dtype(*args, **kwargs):
     raise NotImplementedError(
         "The function convert_to_wider_dtype is not supported in this JAX backend."
@@ -477,10 +515,10 @@ def is_bool(array):
 
 
 def divide(a, b, ignore_div_zero=False):
-    if ignore_div_zero is False:
-        return _jnp.divide(a, b)
-
     a_arr, b_arr = _jnp.asarray(a), _jnp.asarray(b)
+    if ignore_div_zero is False:
+        return _jnp.divide(a_arr, b_arr)
+
     quotient = _jnp.divide(a_arr, b_arr)
     return _jnp.where(b_arr != 0, quotient, _jnp.zeros_like(quotient))
 

--- a/src/pyrecest/_backend/pytorch/__init__.py
+++ b/src/pyrecest/_backend/pytorch/__init__.py
@@ -411,10 +411,46 @@ def one_hot(labels, num_classes):
     return _torch.nn.functional.one_hot(labels, num_classes).type(_torch.uint8)
 
 
-def argmax(a, **kwargs):
+def _arg_reduction(
+    a,
+    np_func,
+    torch_func,
+    func_name,
+    axis=None,
+    out=None,
+    keepdims=False,
+    *,
+    dim=None,
+    keepdim=None,
+):
+    axis = _resolve_reduction_axis(axis, dim, func_name)
+    keepdims = _resolve_keepdims(keepdims, keepdim, func_name)
+    a = array(a)
+
     if a.dtype == _torch.bool:
-        return _torch.as_tensor(_np.argmax(a.data.numpy(), **kwargs))
-    return _torch.argmax(a, **kwargs)
+        result = _torch.as_tensor(
+            np_func(to_numpy(a), axis=axis, keepdims=bool(keepdims)),
+            device=a.device,
+        )
+    elif axis is None:
+        result = torch_func(a)
+        if keepdims:
+            result = result.reshape((1,) * a.ndim)
+    else:
+        result = torch_func(a, dim=axis, keepdim=bool(keepdims))
+
+    if out is not None:
+        out.copy_(result)
+        return out
+    return result
+
+
+def argmax(a, axis=None, out=None, keepdims=False, *, dim=None, keepdim=None):
+    return _arg_reduction(a, _np.argmax, _torch.argmax, "argmax", axis, out, keepdims, dim=dim, keepdim=keepdim)
+
+
+def argmin(a, axis=None, out=None, keepdims=False, *, dim=None, keepdim=None):
+    return _arg_reduction(a, _np.argmin, _torch.argmin, "argmin", axis, out, keepdims, dim=dim, keepdim=keepdim)
 
 
 def convert_to_wider_dtype(tensor_list):
@@ -532,6 +568,7 @@ def any(x, axis=None):
 
 
 def flip(x, axis):
+    x = array(x)
     if isinstance(axis, int):
         axis = [axis]
     if axis is None:
@@ -540,7 +577,7 @@ def flip(x, axis):
 
 
 def concatenate(seq, axis=0, out=None):
-    seq = convert_to_wider_dtype(seq)
+    seq = _tensor_sequence(seq)
     return _torch.cat(seq, dim=axis, out=out)
 
 
@@ -1201,6 +1238,22 @@ def vectorize(x, pyfunc, multiple_args=False, **kwargs):
     return stack(list(map(pyfunc, x)))
 
 
+def _tensor_sequence(seq):
+    tensors = [array(item) for item in seq]
+    if not tensors:
+        return tensors
+    return convert_to_wider_dtype(tensors)
+
+
+def stack(seq, axis=0, out=None, *, dim=None):
+    if dim is not None:
+        if axis not in (0, dim):
+            raise TypeError("stack() got both 'axis' and 'dim'")
+        axis = dim
+
+    return _torch.stack(_tensor_sequence(seq), dim=axis, out=out)
+
+
 def vec_to_diag(vec):
     return _torch.diag_embed(vec, offset=0)
 
@@ -1249,6 +1302,9 @@ def mat_from_diag_triu_tril(diag, tri_upp, tri_low):
 
 
 def divide(a, b, ignore_div_zero=False):
+    a = array(a)
+    b = array(b)
+    a, b = convert_to_wider_dtype([a, b])
     if ignore_div_zero is False:
         return _torch.divide(a, b)
     quo = _torch.divide(a, b)
@@ -1265,6 +1321,7 @@ def ravel_tril_indices(n, k=0, m=None):
 
 
 def sort(a, axis=-1):
+    a = array(a)
     sorted_a, _ = _torch.sort(a, dim=axis)
     return sorted_a
 
@@ -1492,4 +1549,4 @@ def imag(a):
 
 
 def unique(ar, axis=None):
-    return _torch.unique(ar, dim=axis)
+    return _torch.unique(array(ar), dim=axis)

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -79,6 +79,18 @@ def _to_python(value):
     return value
 
 
+def test_array_like_sequence_helpers_accept_python_lists():
+    assert _to_python(backend.concatenate(([1, 2], [3, 4]), axis=0)) == [1, 2, 3, 4]
+    assert _to_python(backend.stack(([1, 2], [3, 4]), axis=0)) == [[1, 2], [3, 4]]
+    assert _to_python(backend.flip([1, 2, 3], axis=0)) == [3, 2, 1]
+    assert _to_python(backend.sort([3, 1, 2])) == [1, 2, 3]
+    assert _to_python(backend.unique([2, 1, 2, 1])) == [1, 2]
+
+
+def test_divide_accepts_array_like_inputs():
+    assert _to_python(backend.divide([2.0, 4.0], [1.0, 2.0])) == [2.0, 2.0]
+
+
 def test_nonzero_returns_numpy_style_coordinate_tuple():
     result = backend.nonzero(array([[0, 1], [2, 0]]))
 
@@ -113,6 +125,21 @@ def test_mean_accepts_numpy_axis_keyword_and_integer_inputs():
 
     assert _to_python(axis_result) == [2.0, 3.0]
     assert _to_python(keepdims_result) == [[1.5], [3.5]]
+
+
+def test_arg_reductions_accept_numpy_axis_keepdims_and_array_like_inputs():
+    values = [[1.0, 4.0, 2.0], [3.0, 0.0, 5.0]]
+
+    assert _to_python(backend.argmax(values, axis=1)) == [1, 2]
+    assert _to_python(backend.argmin(values, axis=0)) == [0, 1, 0]
+    assert _to_python(backend.argmax(values, axis=1, keepdims=True)) == [[1], [2]]
+
+
+def test_arg_reductions_support_boolean_inputs():
+    values = array([[False, True], [False, False]])
+
+    assert _to_python(backend.argmax(values, axis=1)) == [1, 0]
+    assert _to_python(backend.argmin(values, axis=1)) == [0, 0]
 
 
 def test_sum_keepdims_without_axis_matches_numpy_contract():


### PR DESCRIPTION
## Summary
- coerce array-like inputs in JAX and PyTorch backend helper wrappers
- support NumPy-style arg reduction axis/keepdims handling in PyTorch
- add backend contract coverage for array-like helper inputs

## Checks
- Not run per request.
- python -m py_compile src\pyrecest\_backend\jax\__init__.py src\pyrecest\_backend\pytorch\__init__.py tests\test_backend_contracts.py
- git diff --check