### PR TITLE
[codex] Fix PyTorch divide zero masking

### DIFF
--- a/src/pyrecest/_backend/pytorch/__init__.py
+++ b/src/pyrecest/_backend/pytorch/__init__.py
@@ -1324,11 +1324,21 @@ def mat_from_diag_triu_tril(diag, tri_upp, tri_low):
 def divide(a, b, ignore_div_zero=False):
     a = array(a)
     b = array(b)
+    non_cpu_device = next(
+        (value.device for value in (a, b) if value.device.type != "cpu"),
+        None,
+    )
+    if non_cpu_device is not None:
+        a = a.to(device=non_cpu_device)
+        b = b.to(device=non_cpu_device)
     a, b = convert_to_wider_dtype([a, b])
+    quotient = _torch.divide(a, b)
+
     if ignore_div_zero is False:
-        return _torch.divide(a, b)
-    quo = _torch.divide(a, b)
-    return _torch.nan_to_num(quo, nan=0.0, posinf=0.0, neginf=0.0)
+        return quotient
+
+    zero = _torch.zeros((), dtype=quotient.dtype, device=quotient.device)
+    return _torch.where(b != 0, quotient, zero)
 
 
 def ravel_tril_indices(n, k=0, m=None):

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -414,6 +414,21 @@ def test_divide_ignore_div_zero_accepts_scalars_and_integer_inputs():
     ]
 
 
+def test_pytorch_divide_ignore_div_zero_only_masks_zero_denominators():
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific divide regression test")
+
+    masked = backend.divide([1.0, 2.0], [0.0, 4.0], ignore_div_zero=True)
+    assert _to_python(masked) == [0.0, 0.5]
+
+    overflow = backend.divide(
+        backend.asarray([1e308], dtype=backend.float64),
+        backend.asarray([1e-308], dtype=backend.float64),
+        ignore_div_zero=True,
+    )
+    assert _to_python(backend.isinf(overflow)) == [True]
+
+
 def test_vec_to_diag_preserves_leading_singleton_batch_dimension():
     result = backend.vec_to_diag(array([[1.0, 2.0]]))
 


### PR DESCRIPTION
## Summary
- Convert PyTorch `divide` inputs to tensors, keep them on a non-CPU tensor device when present, and widen dtypes before division.
- Preserve overflow/inf results when `ignore_div_zero=True`; only zero-denominator positions are masked to zero.
- Add a PyTorch-specific regression test for the zero-denominator masking behavior.

## Validation
- Not run locally per request; waiting for GitHub checks.