### PR TITLE
[codex] Add standard update diagnostics

### DIFF
--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -129,6 +129,14 @@ Zero-weight measurements and masked measurements are skipped. `R` may be a
 shared `(2, 2)` covariance matrix or a per-measurement array with shape
 `(num_measurements, 2, 2)`.
 
+After a tracker update, inspect `tracker.last_update_diagnostics` for a
+standardized `MeasurementUpdateDiagnostics` snapshot.  For SCGP trackers this
+records active measurement indices, normalized measurement weights, the stacked
+residual, the innovation covariance, the residual quadratic form, and an optional
+`skipped_reason` such as `"no_active_measurements"`.  Legacy convenience fields
+such as `last_quadratic_form`, `last_active_measurement_indices`, and
+`last_measurement_weights` remain available for backward compatibility.
+
 ## Distribution Inputs
 
 Many distribution `pdf` methods accept either one point or a batch of points.

--- a/src/pyrecest/filters/__init__.py
+++ b/src/pyrecest/filters/__init__.py
@@ -127,6 +127,7 @@ _FILTER_EXPORTS: Final[dict[str, str]] = {
     "ManifoldExponentialMovingAverage": ".manifold_exponential_moving_average",
     "MeasurementRecord": ".out_of_sequence",
     "MeasurementTimeBuffer": ".out_of_sequence",
+    "MeasurementUpdateDiagnostics": ".update_diagnostics",
     "MultiBernoulliTracker": ".multi_bernoulli_tracker",
     "MultiHypothesisTracker": ".multi_hypothesis_tracker",
     "MultipleExtendedObjectStepResult": ".abstract_multiple_extended_object_tracker",

--- a/src/pyrecest/filters/gprhm_tracker.py
+++ b/src/pyrecest/filters/gprhm_tracker.py
@@ -29,6 +29,7 @@ from pyrecest.backend import (
 )
 
 from .abstract_extended_object_tracker import AbstractExtendedObjectTracker
+from .update_diagnostics import MeasurementUpdateDiagnostics
 
 
 def pol2cart(phi, r=1.0):
@@ -311,6 +312,9 @@ class FullSCGPTracker(AbstractExtendedObjectTracker):
         self.last_quadratic_form = None
         self.last_active_measurement_indices = None
         self.last_measurement_weights = None
+        self.last_update_diagnostics = MeasurementUpdateDiagnostics(
+            skipped_reason="not_updated",
+        )
 
     @staticmethod
     def _symmetrize(matrix):
@@ -767,6 +771,11 @@ class FullSCGPTracker(AbstractExtendedObjectTracker):
         )
         if not active_indices:
             self.last_quadratic_form = None
+            self.last_update_diagnostics = MeasurementUpdateDiagnostics.skipped(
+                "no_active_measurements",
+                measurement_count=measurements.shape[0],
+                measurement_weights=self.last_measurement_weights,
+            )
             return
 
         residual = concatenate([measurements[index] for index in active_indices])
@@ -783,7 +792,15 @@ class FullSCGPTracker(AbstractExtendedObjectTracker):
         )
         self._sync_state_views()
         solved_residual = linalg.solve(covariance_measurement, residual)
-        self.last_quadratic_form = residual @ solved_residual
+        self.last_quadratic_form = float(residual @ solved_residual)
+        self.last_update_diagnostics = MeasurementUpdateDiagnostics(
+            active_measurement_indices=tuple(active_indices),
+            measurement_count=measurements.shape[0],
+            measurement_weights=self.last_measurement_weights,
+            residual=residual,
+            innovation_covariance=covariance_measurement,
+            quadratic_form=self.last_quadratic_form,
+        )
 
         if self.log_posterior_estimates:
             self.store_posterior_estimates()

--- a/src/pyrecest/filters/update_diagnostics.py
+++ b/src/pyrecest/filters/update_diagnostics.py
@@ -1,0 +1,65 @@
+"""Reusable diagnostics for measurement-update based filters and trackers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class MeasurementUpdateDiagnostics:
+    """Diagnostics captured from one measurement update.
+
+    The class intentionally stores backend arrays as opaque objects so it can be
+    reused by NumPy, PyTorch, and JAX-backed filters.  It standardizes the fields
+    that are useful for gating, logging, and explaining why a measurement batch
+    was skipped or accepted without imposing a specific distribution class.
+    """
+
+    active_measurement_indices: Sequence[int] | None = ()
+    measurement_count: int | None = None
+    measurement_weights: Any = None
+    residual: Any = None
+    innovation_covariance: Any = None
+    quadratic_form: float | None = None
+    skipped_reason: str | None = None
+    metadata: Mapping[str, Any] | None = None
+
+    def __post_init__(self):
+        indices = () if self.active_measurement_indices is None else tuple(
+            int(index) for index in self.active_measurement_indices
+        )
+        object.__setattr__(self, "active_measurement_indices", indices)
+        if self.measurement_count is not None and self.measurement_count < 0:
+            raise ValueError("measurement_count must be non-negative when provided")
+        metadata = {} if self.metadata is None else dict(self.metadata)
+        object.__setattr__(self, "metadata", metadata)
+
+    @property
+    def active_measurement_count(self) -> int:
+        """Return the number of measurements that contributed to the update."""
+        return len(self.active_measurement_indices)
+
+    @property
+    def updated(self) -> bool:
+        """Return whether the update used at least one active measurement."""
+        return self.skipped_reason is None and self.active_measurement_count > 0
+
+    @classmethod
+    def skipped(
+        cls,
+        reason: str,
+        *,
+        measurement_count: int | None = None,
+        measurement_weights: Any = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> "MeasurementUpdateDiagnostics":
+        """Construct diagnostics for an update that intentionally did nothing."""
+        return cls(
+            active_measurement_indices=(),
+            measurement_count=measurement_count,
+            measurement_weights=measurement_weights,
+            skipped_reason=reason,
+            metadata=metadata,
+        )

--- a/tests/filters/test_scgp_tracker.py
+++ b/tests/filters/test_scgp_tracker.py
@@ -12,6 +12,7 @@ from pyrecest.filters import (
     GPRHMTracker,
     SCGPTracker,
     ScGpTracker,
+    MeasurementUpdateDiagnostics,
 )
 
 
@@ -82,6 +83,11 @@ class TestSCGPTracker(unittest.TestCase):
         cross_covariance = tracker.covariance[:5, 5:]
         self.assertFalse(all(abs(cross_covariance) <= 1e-12))
         self.assertIsNotNone(tracker.last_quadratic_form)
+        self.assertIsInstance(
+            tracker.last_update_diagnostics,
+            MeasurementUpdateDiagnostics,
+        )
+        self.assertTrue(tracker.last_update_diagnostics.updated)
         npt.assert_array_less(-1e-10, linalg.eigvalsh(tracker.covariance))
 
     def test_decorrelated_update_keeps_cross_covariance_zero(self):
@@ -111,6 +117,8 @@ class TestSCGPTracker(unittest.TestCase):
             atol=1e-12,
         )
         self.assertEqual(masked_tracker.last_active_measurement_indices, [0])
+        self.assertEqual(masked_tracker.last_update_diagnostics.active_measurement_indices, (0,))
+        self.assertEqual(masked_tracker.last_update_diagnostics.active_measurement_count, 1)
         npt.assert_allclose(masked_tracker.last_measurement_weights, array([1.0, 1.0]))
 
     def test_zero_measurement_weight_skips_measurement(self):
@@ -124,6 +132,10 @@ class TestSCGPTracker(unittest.TestCase):
         npt.assert_allclose(tracker.covariance, covariance_before, atol=1e-12)
         self.assertEqual(tracker.last_active_measurement_indices, [])
         self.assertIsNone(tracker.last_quadratic_form)
+        self.assertFalse(tracker.last_update_diagnostics.updated)
+        self.assertEqual(
+            tracker.last_update_diagnostics.skipped_reason, "no_active_measurements"
+        )
 
     def test_measurement_weight_changes_update_strength(self):
         high_weight_tracker = self._make_tracker()


### PR DESCRIPTION
## Summary

- Adds a shared update diagnostics helper for filter update metadata.
- Exports the helper from `pyrecest.filters` and applies it to the GPRHM tracker update path.
- Documents the convention and adds regression coverage for the expected diagnostic keys.

## Validation

- Not run locally per request.
- Remote GitHub checks will be used for validation.