### PR TITLE
[codex] Add event likelihood and Pareto utilities

### DIFF
--- a/docs/reference/evaluation.md
+++ b/docs/reference/evaluation.md
@@ -30,4 +30,16 @@ These utilities are useful for model comparison, parameter selection, and
 paper-quality diagnostics whenever multiple filters, smoothers, or trackers emit
 comparable log marginal likelihoods.
 
+## Pareto and equal-quality selection
+
+`pyrecest.evaluation.pareto` contains small dataframe-oriented utilities for
+rate--distortion and equal-quality comparisons.  Callers provide objective
+columns and objective directions, so the helpers are intentionally domain-neutral
+and can be used for particle-count, runtime, storage-size, or accuracy/quality
+trade-offs.
+
+Useful entry points include `pareto_front_indices`, `is_pareto_front`,
+`record_dominates`, `constraint_mask`, `select_under_constraints`, and
+`equal_quality_selection`.
+
 ::: pyrecest.evaluation

--- a/src/pyrecest/evaluation/__init__.py
+++ b/src/pyrecest/evaluation/__init__.py
@@ -25,6 +25,14 @@ from .model_comparison import (
     paired_model_margin_threshold_sweep,
     select_paired_model_margin_threshold,
 )
+from .pareto import (
+    constraint_mask,
+    equal_quality_selection,
+    is_pareto_front,
+    pareto_front_indices,
+    record_dominates,
+    select_under_constraints,
+)
 from .perform_predict_update_cycles import perform_predict_update_cycles
 from .plot_results import plot_results
 from .simulation_database import simulation_database
@@ -60,4 +68,10 @@ __all__ = [
     "paired_model_margin_summary",
     "paired_model_margin_threshold_sweep",
     "select_paired_model_margin_threshold",
+    "constraint_mask",
+    "equal_quality_selection",
+    "is_pareto_front",
+    "pareto_front_indices",
+    "record_dominates",
+    "select_under_constraints",
 ]

--- a/src/pyrecest/evaluation/pareto.py
+++ b/src/pyrecest/evaluation/pareto.py
@@ -1,0 +1,268 @@
+"""Generic Pareto-front and equal-quality selection utilities.
+
+The helpers in this module intentionally stay domain-neutral.  Callers provide a
+table, objective columns, objective directions, and optional quality constraints.
+This makes the same machinery usable for filter/tracker benchmarks, compression
+or pruning sweeps, particle-count trade-offs, and other rate--distortion style
+selection problems.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal
+
+import numpy as np
+import pandas as pd
+
+ObjectiveDirection = Literal["min", "max"]
+ConstraintOperator = Literal["<=", ">=", "<", ">", "==", "!="]
+ConstraintSpec = tuple[ConstraintOperator, float | int | bool]
+
+
+def pareto_front_indices(
+    table: pd.DataFrame,
+    objectives: Sequence[str],
+    *,
+    directions: Mapping[str, ObjectiveDirection] | Sequence[ObjectiveDirection],
+    feasible_mask: Sequence[bool] | pd.Series | np.ndarray | None = None,
+    eps: float = 1e-12,
+    allow_missing: bool = True,
+) -> list[Any]:
+    """Return indices of non-dominated rows.
+
+    Parameters
+    ----------
+    table:
+        DataFrame whose rows are candidates.
+    objectives:
+        Objective column names to compare.
+    directions:
+        Either a mapping from objective name to ``"min"``/``"max"`` or a
+        sequence aligned with ``objectives``.
+    feasible_mask:
+        Optional row mask.  If supplied, only feasible rows can be on the front.
+    eps:
+        Numerical tolerance for weak/strict comparisons.
+    allow_missing:
+        If true, objective values that are missing in either row are skipped for
+        that pair.  A row can dominate another only when at least one comparable
+        objective remains and one comparable objective is strictly better.
+    """
+
+    if table.empty:
+        return []
+    objective_names = _validate_objectives(objectives)
+    direction_map = _directions_by_objective(objective_names, directions)
+    candidates = table.loc[_feasible_index(table, feasible_mask)] if feasible_mask is not None else table
+    indices: list[Any] = []
+    for index, row in candidates.iterrows():
+        dominated = False
+        for other_index, other in candidates.iterrows():
+            if index == other_index:
+                continue
+            if record_dominates(other, row, objective_names, directions=direction_map, eps=eps, allow_missing=allow_missing):
+                dominated = True
+                break
+        if not dominated:
+            indices.append(index)
+    return indices
+
+
+def is_pareto_front(
+    table: pd.DataFrame,
+    objectives: Sequence[str],
+    *,
+    directions: Mapping[str, ObjectiveDirection] | Sequence[ObjectiveDirection],
+    feasible_mask: Sequence[bool] | pd.Series | np.ndarray | None = None,
+    eps: float = 1e-12,
+    allow_missing: bool = True,
+) -> pd.Series:
+    """Return a boolean Series marking non-dominated rows."""
+
+    mask = pd.Series(False, index=table.index, dtype=bool)
+    mask.loc[pareto_front_indices(table, objectives, directions=directions, feasible_mask=feasible_mask, eps=eps, allow_missing=allow_missing)] = True
+    return mask
+
+
+def record_dominates(
+    left: Mapping[str, Any] | pd.Series,
+    right: Mapping[str, Any] | pd.Series,
+    objectives: Sequence[str],
+    *,
+    directions: Mapping[str, ObjectiveDirection] | Sequence[ObjectiveDirection],
+    eps: float = 1e-12,
+    allow_missing: bool = True,
+) -> bool:
+    """Return whether ``left`` Pareto-dominates ``right``.
+
+    ``left`` dominates ``right`` if it is at least as good on all comparable
+    objectives and strictly better on at least one comparable objective.
+    """
+
+    objective_names = _validate_objectives(objectives)
+    direction_map = _directions_by_objective(objective_names, directions)
+    weak: list[bool] = []
+    strict: list[bool] = []
+    for objective in objective_names:
+        left_value = _lookup_numeric(left, objective)
+        right_value = _lookup_numeric(right, objective)
+        if _is_missing(left_value) or _is_missing(right_value):
+            if allow_missing:
+                continue
+            return False
+        if direction_map[objective] == "min":
+            weak.append(left_value <= right_value + eps)
+            strict.append(left_value < right_value - eps)
+        else:
+            weak.append(left_value >= right_value - eps)
+            strict.append(left_value > right_value + eps)
+    return bool(weak) and all(weak) and any(strict)
+
+
+def constraint_mask(
+    table: pd.DataFrame,
+    constraints: Mapping[str, ConstraintSpec | Mapping[str, Any]],
+    *,
+    eps: float = 1e-12,
+) -> pd.Series:
+    """Return rows satisfying all scalar constraints.
+
+    Constraint values may be either ``("<=", value)`` tuples or mappings with
+    ``{"op": "<=", "value": value}`` keys.
+    """
+
+    mask = pd.Series(True, index=table.index, dtype=bool)
+    for column, spec in constraints.items():
+        op, threshold = _parse_constraint_spec(spec)
+        if column not in table.columns:
+            mask &= False
+            continue
+        values = pd.to_numeric(table[column], errors="coerce")
+        if op == "<=":
+            mask &= values <= float(threshold) + eps
+        elif op == ">=":
+            mask &= values >= float(threshold) - eps
+        elif op == "<":
+            mask &= values < float(threshold) - eps
+        elif op == ">":
+            mask &= values > float(threshold) + eps
+        elif op == "==":
+            mask &= np.isclose(values, float(threshold), atol=eps, rtol=0.0)
+        elif op == "!=":
+            mask &= ~np.isclose(values, float(threshold), atol=eps, rtol=0.0)
+        else:  # pragma: no cover - protected by _parse_constraint_spec.
+            raise ValueError(f"Unsupported constraint operator {op!r}.")
+    return mask.fillna(False)
+
+
+def select_under_constraints(
+    table: pd.DataFrame,
+    *,
+    constraints: Mapping[str, ConstraintSpec | Mapping[str, Any]],
+    objective: str,
+    direction: ObjectiveDirection,
+    tie_breakers: Sequence[tuple[str, ObjectiveDirection]] = (),
+    eps: float = 1e-12,
+) -> pd.DataFrame:
+    """Return feasible rows sorted by one objective plus optional tie-breakers."""
+
+    if objective not in table.columns:
+        raise ValueError(f"objective column {objective!r} is not present.")
+    sorted_columns = [objective, *(column for column, _ in tie_breakers)]
+    missing = [column for column in sorted_columns if column not in table.columns]
+    if missing:
+        raise ValueError(f"selection columns are missing: {', '.join(missing)}.")
+    feasible = table.loc[constraint_mask(table, constraints, eps=eps)].copy()
+    if feasible.empty:
+        return feasible
+    ascending = [direction == "min", *(tie_direction == "min" for _, tie_direction in tie_breakers)]
+    return feasible.sort_values(sorted_columns, ascending=ascending, na_position="last")
+
+
+def equal_quality_selection(
+    table: pd.DataFrame,
+    *,
+    quality_constraints: Mapping[str, ConstraintSpec | Mapping[str, Any]],
+    compression_objective: str,
+    compression_direction: ObjectiveDirection = "min",
+    tie_breakers: Sequence[tuple[str, ObjectiveDirection]] = (),
+    eps: float = 1e-12,
+) -> pd.DataFrame:
+    """Select candidates under fixed quality constraints.
+
+    This is a named wrapper around :func:`select_under_constraints` for common
+    equal-quality compression/compaction comparisons.
+    """
+
+    return select_under_constraints(
+        table,
+        constraints=quality_constraints,
+        objective=compression_objective,
+        direction=compression_direction,
+        tie_breakers=tie_breakers,
+        eps=eps,
+    )
+
+
+def _validate_objectives(objectives: Sequence[str]) -> tuple[str, ...]:
+    names = tuple(str(objective) for objective in objectives)
+    if not names:
+        raise ValueError("At least one Pareto objective is required.")
+    if len(set(names)) != len(names):
+        raise ValueError("Pareto objectives must be unique.")
+    return names
+
+
+def _directions_by_objective(
+    objectives: Sequence[str],
+    directions: Mapping[str, ObjectiveDirection] | Sequence[ObjectiveDirection],
+) -> dict[str, ObjectiveDirection]:
+    if isinstance(directions, Mapping):
+        missing = [objective for objective in objectives if objective not in directions]
+        if missing:
+            raise ValueError(f"Missing objective directions for: {', '.join(missing)}.")
+        result = {objective: directions[objective] for objective in objectives}
+    else:
+        if len(directions) != len(objectives):
+            raise ValueError("directions must match the number of objectives.")
+        result = dict(zip(objectives, directions, strict=True))
+    invalid = [objective for objective, direction in result.items() if direction not in {"min", "max"}]
+    if invalid:
+        raise ValueError(f"Invalid objective directions for: {', '.join(invalid)}.")
+    return result
+
+
+def _feasible_index(
+    table: pd.DataFrame,
+    feasible_mask: Sequence[bool] | pd.Series | np.ndarray,
+) -> pd.Series:
+    if isinstance(feasible_mask, pd.Series):
+        mask = feasible_mask.reindex(table.index, fill_value=False)
+    else:
+        mask = pd.Series(feasible_mask, index=table.index)
+    return mask.astype(bool)
+
+
+def _lookup_numeric(record: Mapping[str, Any] | pd.Series, key: str) -> float:
+    value = record.get(key, np.nan)
+    if _is_missing(value):
+        return float("nan")
+    return float(value)
+
+
+def _is_missing(value: Any) -> bool:
+    return bool(pd.isna(value))
+
+
+def _parse_constraint_spec(spec: ConstraintSpec | Mapping[str, Any]) -> ConstraintSpec:
+    if isinstance(spec, Mapping):
+        op = spec.get("op")
+        threshold = spec.get("value")
+    else:
+        if len(spec) != 2:
+            raise ValueError("Constraint tuple specs must have length 2.")
+        op, threshold = spec
+    if op not in {"<=", ">=", "<", ">", "==", "!="}:
+        raise ValueError(f"Unsupported constraint operator {op!r}.")
+    return op, threshold

--- a/src/pyrecest/experimental/dvs/__init__.py
+++ b/src/pyrecest/experimental/dvs/__init__.py
@@ -23,6 +23,8 @@ from .event_likelihood import (
     contour_event_intensity,
     event_batch_log_likelihood,
     event_batch_log_likelihood_terms,
+    scgp_event_batch_log_likelihood,
+    scgp_event_batch_log_likelihood_terms,
     expected_event_count,
     normal_flow_activities,
 )
@@ -76,6 +78,8 @@ __all__ = [
     "edge_probabilities_from_activity",
     "event_batch_log_likelihood",
     "event_batch_log_likelihood_terms",
+    "scgp_event_batch_log_likelihood",
+    "scgp_event_batch_log_likelihood_terms",
     "expected_event_count",
     "normal_flow_activities",
     "normal_flow_activity",

--- a/src/pyrecest/experimental/dvs/event_likelihood.py
+++ b/src/pyrecest/experimental/dvs/event_likelihood.py
@@ -271,6 +271,77 @@ def event_batch_log_likelihood(
     ).log_likelihood
 
 
+def scgp_event_batch_log_likelihood_terms(
+    tracker,
+    event_xy: np.ndarray,
+    velocity: np.ndarray,
+    config: EventLikelihoodConfig | PointProcessUpdateConfig | None = None,
+    *,
+    contour_samples: int | None = None,
+    batch_duration: float | None = None,
+    image_area: float | None = None,
+) -> EventLikelihoodTerms:
+    """Score an event batch against a tracker-provided contour sample.
+
+    The tracker only has to provide ``sample_contour(n=...)`` returning an
+    object with ``points``, ``normals``, and ``weights`` attributes. This keeps
+    the point-process likelihood reusable for SCGP trackers without requiring a
+    tracker-specific likelihood implementation. ``config`` may be either an
+    ``EventLikelihoodConfig`` or a ``PointProcessUpdateConfig``; in the latter
+    case the embedded likelihood config and contour-sample count are used.
+    """
+    likelihood_config, sample_count = _resolve_scgp_likelihood_arguments(
+        config,
+        contour_samples,
+    )
+    contour = tracker.sample_contour(n=sample_count)
+    return event_batch_log_likelihood_terms(
+        event_xy,
+        contour,
+        velocity,
+        likelihood_config,
+        batch_duration=batch_duration,
+        image_area=image_area,
+    )
+
+
+def scgp_event_batch_log_likelihood(
+    tracker,
+    event_xy: np.ndarray,
+    velocity: np.ndarray,
+    config: EventLikelihoodConfig | PointProcessUpdateConfig | None = None,
+    *,
+    contour_samples: int | None = None,
+    batch_duration: float | None = None,
+    image_area: float | None = None,
+) -> float:
+    """Return the point-process event log likelihood for an SCGP tracker."""
+    return scgp_event_batch_log_likelihood_terms(
+        tracker,
+        event_xy,
+        velocity,
+        config,
+        contour_samples=contour_samples,
+        batch_duration=batch_duration,
+        image_area=image_area,
+    ).log_likelihood
+
+
+def _resolve_scgp_likelihood_arguments(
+    config: EventLikelihoodConfig | PointProcessUpdateConfig | None,
+    contour_samples: int | None,
+) -> tuple[EventLikelihoodConfig, int]:
+    if isinstance(config, PointProcessUpdateConfig):
+        likelihood_config = config.likelihood
+        sample_count = config.contour_samples if contour_samples is None else contour_samples
+    else:
+        likelihood_config = config or EventLikelihoodConfig()
+        sample_count = 96 if contour_samples is None else contour_samples
+    if int(sample_count) <= 2:
+        raise ValueError("contour_samples must be greater than 2")
+    return likelihood_config, int(sample_count)
+
+
 def _gaussian_contour_kernel(
     event_xy: np.ndarray,
     contour_points: np.ndarray,

--- a/tests/evaluation/test_pareto.py
+++ b/tests/evaluation/test_pareto.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from pyrecest.evaluation import (
+    constraint_mask,
+    equal_quality_selection,
+    is_pareto_front,
+    pareto_front_indices,
+    record_dominates,
+)
+
+
+def test_pareto_front_indices_handles_min_and_max_objectives() -> None:
+    table = pd.DataFrame(
+        [
+            {"name": "large_good", "size": 10.0, "quality": 0.95},
+            {"name": "small_good", "size": 5.0, "quality": 0.95},
+            {"name": "small_bad", "size": 5.0, "quality": 0.90},
+            {"name": "tiny_ok", "size": 3.0, "quality": 0.91},
+        ]
+    )
+
+    indices = pareto_front_indices(table, ["size", "quality"], directions={"size": "min", "quality": "max"})
+
+    assert set(table.loc[indices, "name"]) == {"small_good", "tiny_ok"}
+
+
+def test_is_pareto_front_respects_feasible_mask() -> None:
+    table = pd.DataFrame(
+        [
+            {"name": "baseline", "size": 10.0, "quality": 1.0, "allowed": True},
+            {"name": "fast", "size": 4.0, "quality": 0.9, "allowed": True},
+            {"name": "forbidden", "size": 3.0, "quality": 0.99, "allowed": False},
+        ]
+    )
+
+    mask = is_pareto_front(table, ["size", "quality"], directions=["min", "max"], feasible_mask=table["allowed"])
+
+    assert set(table.loc[mask, "name"]) == {"baseline", "fast"}
+
+
+def test_record_dominates_can_skip_missing_optional_metrics() -> None:
+    left = {"size": 4.0, "quality": 0.95, "optional": float("nan")}
+    right = {"size": 5.0, "quality": 0.95, "optional": 2.0}
+
+    assert record_dominates(left, right, ["size", "quality", "optional"], directions={"size": "min", "quality": "max", "optional": "max"})
+    assert not record_dominates(left, right, ["size", "quality", "optional"], directions={"size": "min", "quality": "max", "optional": "max"}, allow_missing=False)
+
+
+def test_constraint_mask_supports_tuple_and_mapping_specs() -> None:
+    table = pd.DataFrame(
+        [
+            {"name": "a", "drop": -0.02, "lpips": 0.002},
+            {"name": "b", "drop": -0.08, "lpips": 0.002},
+            {"name": "c", "drop": -0.01, "lpips": 0.006},
+        ]
+    )
+
+    mask = constraint_mask(table, {"drop": (">=", -0.06), "lpips": {"op": "<=", "value": 0.0035}})
+
+    assert table.loc[mask, "name"].tolist() == ["a"]
+
+
+def test_equal_quality_selection_returns_best_compression_row() -> None:
+    table = pd.DataFrame(
+        [
+            {"name": "safe_large", "retention": 0.8, "psnr_delta": -0.01, "lpips_delta": 0.001, "f_score": 0.24},
+            {"name": "safe_small", "retention": 0.5, "psnr_delta": -0.05, "lpips_delta": 0.003, "f_score": 0.20},
+            {"name": "unsafe_tiny", "retention": 0.4, "psnr_delta": -0.09, "lpips_delta": 0.003, "f_score": 0.26},
+        ]
+    )
+
+    selected = equal_quality_selection(
+        table,
+        quality_constraints={"psnr_delta": (">=", -0.06), "lpips_delta": ("<=", 0.0035)},
+        compression_objective="retention",
+        compression_direction="min",
+        tie_breakers=(("f_score", "max"),),
+    )
+
+    assert selected.iloc[0]["name"] == "safe_small"

--- a/tests/experimental/test_dvs_event_likelihood.py
+++ b/tests/experimental/test_dvs_event_likelihood.py
@@ -7,8 +7,19 @@ from pyrecest.experimental.dvs.event_likelihood import (
     contour_event_intensity,
     event_batch_log_likelihood,
     expected_event_count,
+    scgp_event_batch_log_likelihood_terms,
     normal_flow_activities,
 )
+
+
+class _DummySCGPTracker:
+    def __init__(self, contour: ContourSample):
+        self.contour = contour
+        self.last_sample_count = None
+
+    def sample_contour(self, n=100):
+        self.last_sample_count = int(n)
+        return self.contour
 
 
 def _rectangle_contour(width: float, height: float) -> ContourSample:
@@ -167,3 +178,36 @@ def test_likelihood_prefers_correct_width_for_two_sided_support():
     )
 
     assert correct > collapsed
+
+
+def test_scgp_event_batch_log_likelihood_terms_uses_tracker_contour_sampler():
+    contour = _rectangle_contour(width=4.0, height=2.0)
+    tracker = _DummySCGPTracker(contour)
+    events = np.array(
+        [
+            [-2.0, -0.2],
+            [2.0, 0.2],
+        ],
+        dtype=float,
+    )
+    update_config = PointProcessUpdateConfig(
+        likelihood=EventLikelihoodConfig(
+            spatial_sigma_px=0.5,
+            foreground_rate=10.0,
+            background_rate=1e-3,
+            include_expected_count=False,
+        ),
+        contour_samples=17,
+    )
+
+    terms = scgp_event_batch_log_likelihood_terms(
+        tracker,
+        events,
+        np.array([1.0, 0.0]),
+        update_config,
+    )
+
+    assert tracker.last_sample_count == 17
+    assert terms.log_likelihood == pytest.approx(
+        event_batch_log_likelihood(events, contour, np.array([1.0, 0.0]), update_config.likelihood)
+    )


### PR DESCRIPTION
## Summary
- Add reusable DVS event contour likelihood utility functions under `pyrecest.experimental.dvs`.
- Add Pareto frontier and equal-quality selection helpers under `pyrecest.evaluation`.
- Cover the new utilities with focused tests and reference docs.

## Validation
- Local tests were not run per request.
- Ran `git diff --check` / `git show --check` locally for patch hygiene only.
- Remote checks will be used for validation.