### PR TITLE
[codex] Fix backend axes and SCGP empty updates

### DIFF
--- a/src/pyrecest/_backend/__init__.py
+++ b/src/pyrecest/_backend/__init__.py
@@ -7,6 +7,7 @@ import importlib
 import importlib.abc
 import importlib.machinery
 import logging
+import numbers as _numbers
 import os
 import sys
 import types
@@ -366,7 +367,7 @@ def _mean_with_numpy_signature(
 
 def _normalize_reduction_axes(axis, ndim):
     """Return normalized reduction axes for NumPy-style ``axis`` arguments."""
-    if isinstance(axis, int):
+    if isinstance(axis, _numbers.Integral):
         axes = (axis,)
     else:
         axes = tuple(axis)

--- a/src/pyrecest/_backend/_shared_numpy/__init__.py
+++ b/src/pyrecest/_backend/_shared_numpy/__init__.py
@@ -401,7 +401,7 @@ def matvec(A, b):
     if b.ndim == 1:
         return _np.matmul(A, b)
     if A.ndim == 2:
-        return _np.matmul(A, b.T).T
+        return _np.einsum("ij,...j->...i", A, b)
     return _np.einsum("...ij,...j->...i", A, b)
 
 

--- a/src/pyrecest/_backend/jax/__init__.py
+++ b/src/pyrecest/_backend/jax/__init__.py
@@ -566,7 +566,7 @@ def matvec(matrix, vector):
     if vector.ndim == 1:
         return _jnp.matmul(matrix, vector)
     if matrix.ndim == 2:
-        return _jnp.matmul(matrix, vector.T).T
+        return _jnp.einsum("ij,...j->...i", matrix, vector)
     return _jnp.einsum("...ij,...j->...i", matrix, vector)
 
 

--- a/src/pyrecest/_backend/pytorch/__init__.py
+++ b/src/pyrecest/_backend/pytorch/__init__.py
@@ -1475,7 +1475,7 @@ def matvec(A, b):
         return _torch.matmul(A, b)
 
     if A.ndim == 2:  # b.ndim > 1
-        return _torch.matmul(A, b.T).T
+        return _torch.einsum("ij,...j->...i", A, b)
 
     return _torch.einsum("...ij,...j->...i", A, b)
 

--- a/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
@@ -287,10 +287,11 @@ class GaussianDistribution(AbstractLinearDistribution):
 
         dimensions = [int(dim) for dim in dimensions]
         remaining_dims = [i for i in range(self.dim) if i not in dimensions]
-        new_mu = self.mu[remaining_dims]
-        new_C = self.C[remaining_dims][
-            :, remaining_dims
-        ]  # Instead of np.ix_ for interface compatibiliy
+        remaining_indices = pyrecest.backend.asarray(remaining_dims)
+        new_mu = self.mu[remaining_indices]
+        new_C = self.C[remaining_indices][
+            :, remaining_indices
+        ]  # Instead of np.ix_ for interface compatibility
         return GaussianDistribution(new_mu, new_C, check_validity=False)
 
     def sample(self, n):

--- a/src/pyrecest/filters/measurement_reliability.py
+++ b/src/pyrecest/filters/measurement_reliability.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-from pyrecest.backend import all, array, isfinite, ones, reshape, stack
+from pyrecest.backend import all, array, isfinite, ones, reshape, stack, zeros
 
 
 @dataclass(frozen=True)
@@ -117,6 +117,9 @@ def normalize_measurement_noise_covariances(
         raise ValueError("n_measurements must be non-negative")
     if measurement_dim <= 0:
         raise ValueError("measurement_dim must be positive")
+
+    if n_measurements == 0:
+        return zeros((0, measurement_dim, measurement_dim))
 
     noise = array(measurement_noise)
     if noise.ndim == 3:

--- a/tests/distributions/test_gaussian_distribution_regression.py
+++ b/tests/distributions/test_gaussian_distribution_regression.py
@@ -1,8 +1,13 @@
+import importlib.util
 import math
+import os
+import subprocess
+import sys
 import unittest
 
 import numpy as np
 import numpy.testing as npt
+import pytest
 from pyrecest.backend import array, to_numpy
 from pyrecest.distributions import GaussianDistribution
 
@@ -45,6 +50,50 @@ class GaussianDistributionRegressionTest(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             distribution.marginalize_out([2])
+
+
+def test_marginalize_out_uses_backend_index_arrays():
+    distribution = GaussianDistribution(
+        array([1.0, 2.0, 3.0]),
+        array([[4.0, 0.1, 0.2], [0.1, 5.0, 0.3], [0.2, 0.3, 6.0]]),
+    )
+
+    marginalized = distribution.marginalize_out([1])
+
+    npt.assert_allclose(to_numpy(marginalized.mu), np.array([1.0, 3.0]))
+    npt.assert_allclose(to_numpy(marginalized.C), np.array([[4.0, 0.2], [0.2, 6.0]]))
+
+
+@pytest.mark.backend_portable
+def test_jax_marginalize_out_accepts_list_dimensions():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("jax is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "jax"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import numpy as np
+from pyrecest.backend import array, to_numpy
+from pyrecest.distributions import GaussianDistribution
+
+distribution = GaussianDistribution(
+    array([1.0, 2.0, 3.0]),
+    array([[4.0, 0.1, 0.2], [0.1, 5.0, 0.3], [0.2, 0.3, 6.0]]),
+)
+marginalized = distribution.marginalize_out([1])
+np.testing.assert_allclose(to_numpy(marginalized.mu), np.array([1.0, 3.0]))
+np.testing.assert_allclose(
+    to_numpy(marginalized.C), np.array([[4.0, 0.2], [0.2, 6.0]])
+)
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)
 
 
 if __name__ == "__main__":

--- a/tests/filters/test_measurement_reliability.py
+++ b/tests/filters/test_measurement_reliability.py
@@ -83,6 +83,16 @@ class TestMeasurementReliability(unittest.TestCase):
         self.assertEqual(float(covariances[0, 0, 0]), 0.5)
         self.assertEqual(float(covariances[2, 1, 1]), 0.5)
 
+    def test_empty_measurement_covariances_have_batch_shape(self):
+        covariances = normalize_measurement_noise_covariances(
+            0.5,
+            0,
+            2,
+            as_covariance_matrix=_as_covariance_matrix,
+        )
+
+        self.assertEqual(covariances.shape, (0, 2, 2))
+
     def test_per_measurement_covariances_are_validated(self):
         covariances = normalize_measurement_noise_covariances(
             array([0.1 * eye(2), 0.2 * eye(2)]),

--- a/tests/filters/test_scgp_tracker.py
+++ b/tests/filters/test_scgp_tracker.py
@@ -92,6 +92,22 @@ class TestSCGPTracker(unittest.TestCase):
         self.assertTrue(tracker.last_update_diagnostics.updated)
         npt.assert_array_less(-1e-10, linalg.eigvalsh(tracker.covariance))
 
+    def test_empty_measurement_batch_is_noop(self):
+        tracker = self._make_tracker()
+        state_before = array(tracker.state)
+        covariance_before = array(tracker.covariance)
+
+        tracker.update(zeros((0, 2)))
+
+        npt.assert_allclose(tracker.state, state_before, atol=0.0)
+        npt.assert_allclose(tracker.covariance, covariance_before, atol=0.0)
+        self.assertIsNone(tracker.last_quadratic_form)
+        self.assertEqual(tracker.last_active_measurement_indices, [])
+        self.assertEqual(
+            tracker.last_update_diagnostics.skipped_reason,
+            "no_active_measurements",
+        )
+
     def test_decorrelated_update_keeps_cross_covariance_zero(self):
         tracker = self._make_tracker(DecorrelatedSCGPTracker)
 

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -175,6 +175,15 @@ def test_prod_accepts_tuple_axis():
     assert _to_python(result) == [252.0, 1440.0]
 
 
+def test_reductions_accept_numpy_integer_axis():
+    np = pytest.importorskip("numpy")
+    values = array([[1.0, 2.0], [3.0, 4.0]])
+
+    result = backend.max(values, axis=np.int64(0))
+
+    assert _to_python(result) == [3.0, 4.0]
+
+
 def test_default_cumprod_flattens_all_elements():
     values = array([[2.0, 3.0], [4.0, 5.0]])
 
@@ -488,6 +497,24 @@ def test_matvec_accepts_array_like_inputs():
     )
 
     assert _to_python(result) == [17.0, 39.0]
+
+
+def test_matvec_accepts_high_rank_vector_batches_for_shared_matrix():
+    matrix = array([[1.0, 2.0], [3.0, 4.0]])
+    vectors = array(
+        [
+            [[5.0, 6.0], [7.0, 8.0], [9.0, 10.0]],
+            [[11.0, 12.0], [13.0, 14.0], [15.0, 16.0]],
+        ]
+    )
+
+    result = backend.matvec(matrix, vectors)
+
+    assert result.shape == (2, 3, 2)
+    assert _to_python(result) == [
+        [[17.0, 39.0], [23.0, 53.0], [29.0, 67.0]],
+        [[35.0, 81.0], [41.0, 95.0], [47.0, 109.0]],
+    ]
 
 
 def test_batched_dot_uses_last_axis_inner_product():


### PR DESCRIPTION
## Summary
- accept NumPy integer axes in backend reductions
- fix shared-matrix matvec for high-rank vector batches across NumPy, JAX, and PyTorch
- use backend index arrays for Gaussian marginalization under JAX
- return empty covariance batches for empty SCGP measurement updates

## Validation
- `git diff --check`
- Local tests not run, per request.