### PR TITLE
[codex] Fix backend contracts and model aliases

### DIFF
--- a/src/pyrecest/_backend/capabilities.py
+++ b/src/pyrecest/_backend/capabilities.py
@@ -8,7 +8,7 @@ module gives tests and documentation a single source of truth.
 
 from __future__ import annotations
 
-from typing import Final
+from typing import Any, Final, cast
 
 BACKEND_NAMES: Final = ("numpy", "pytorch", "jax")
 
@@ -156,8 +156,8 @@ def get_unsupported_functions(
     backend_name: str, module_name: str = ""
 ) -> tuple[str, ...]:
     """Return unsupported facade functions for a backend module."""
-    backend = BACKEND_CAPABILITIES.get(backend_name, {})
-    unsupported = backend.get("unsupported", {})
+    backend = cast(dict[str, Any], BACKEND_CAPABILITIES.get(backend_name, {}))
+    unsupported = cast(dict[str, tuple[str, ...]], backend.get("unsupported", {}))
     return tuple(unsupported.get(module_name, ()))
 
 
@@ -165,8 +165,8 @@ def get_partial_capabilities(
     backend_name: str, module_name: str = ""
 ) -> dict[str, str]:
     """Return partial-support notes for a backend module."""
-    backend = BACKEND_CAPABILITIES.get(backend_name, {})
-    partial = backend.get("partial", {})
+    backend = cast(dict[str, Any], BACKEND_CAPABILITIES.get(backend_name, {}))
+    partial = cast(dict[str, dict[str, str]], backend.get("partial", {}))
     return dict(partial.get(module_name, {}))
 
 
@@ -174,8 +174,8 @@ def get_bridged_capabilities(
     backend_name: str, module_name: str = ""
 ) -> dict[str, str]:
     """Return operations that work by crossing into another numerical stack."""
-    backend = BACKEND_CAPABILITIES.get(backend_name, {})
-    bridged = backend.get("bridged", {})
+    backend = cast(dict[str, Any], BACKEND_CAPABILITIES.get(backend_name, {}))
+    bridged = cast(dict[str, dict[str, str]], backend.get("bridged", {}))
     return dict(bridged.get(module_name, {}))
 
 

--- a/src/pyrecest/_backend/jax/__init__.py
+++ b/src/pyrecest/_backend/jax/__init__.py
@@ -126,7 +126,6 @@ from jax.numpy import (  # For pyrecest; For Riemannian score-based SDE
     tan,
     tanh,
     tile,
-    trace,
     transpose,
     tril,
     tril_indices,
@@ -570,9 +569,13 @@ def matvec(matrix, vector):
     return _jnp.einsum("...ij,...j->...i", matrix, vector)
 
 
+def trace(a):
+    return _jnp.trace(_jnp.asarray(a), axis1=-2, axis2=-1)
+
+
 # One-hot encoding
 def one_hot(indices, depth):
-    return _jnp.eye(depth)[indices]
+    return _jnp.eye(depth, dtype=_jnp.uint8)[_jnp.asarray(indices)]
 
 
 # Scatter-add operation

--- a/src/pyrecest/filters/update_diagnostics.py
+++ b/src/pyrecest/filters/update_diagnostics.py
@@ -41,6 +41,8 @@ class MeasurementUpdateDiagnostics:
     @property
     def active_measurement_count(self) -> int:
         """Return the number of measurements that contributed to the update."""
+        if self.active_measurement_indices is None:
+            return 0
         return len(self.active_measurement_indices)
 
     @property

--- a/src/pyrecest/models/adapters.py
+++ b/src/pyrecest/models/adapters.py
@@ -74,7 +74,7 @@ def as_likelihood_model(
 
 
 def as_sampleable_transition_model(
-    model_or_sampler: SupportsTransitionSampling | Callable[[Any, int], Any],
+    model_or_sampler: SupportsTransitionSampling | Callable[..., Any],
     *,
     transition_density: Callable[[Any, Any], Any] | None = None,
     name: str | None = None,
@@ -101,7 +101,7 @@ def as_sampleable_transition_model(
 def as_density_transition_model(
     model_or_density: SupportsTransitionDensity | Callable[[Any, Any], Any],
     *,
-    sample_next: Callable[[Any, int], Any] | None = None,
+    sample_next: Callable[..., Any] | None = None,
     name: str | None = None,
 ) -> SupportsTransitionDensity:
     """Return a density-capable transition model, wrapping callbacks when needed."""

--- a/src/pyrecest/models/likelihood.py
+++ b/src/pyrecest/models/likelihood.py
@@ -114,17 +114,18 @@ class LikelihoodMeasurementModel:
             distribution = distribution_factory(state)
             return _evaluate_distribution_method(distribution, pdf_method, measurement)
 
-        if log_pdf_method is None:
-            log_likelihood = None
-        else:
+        log_likelihood_callback: Callable[[Any, Any], Any] | None = None
+        if log_pdf_method is not None:
 
-            def log_likelihood(measurement: Any, state: Any) -> Any:
+            def _log_likelihood_from_distribution(measurement: Any, state: Any) -> Any:
                 distribution = distribution_factory(state)
                 return _evaluate_distribution_method(
                     distribution, log_pdf_method, measurement
                 )
 
-        return cls(likelihood, log_likelihood=log_likelihood, name=name)
+            log_likelihood_callback = _log_likelihood_from_distribution
+
+        return cls(likelihood, log_likelihood=log_likelihood_callback, name=name)
 
     @property
     def has_log_likelihood(self) -> bool:
@@ -196,7 +197,7 @@ class DensityTransitionModel:
         self,
         transition_density: Callable[[Any, Any], Any],
         *,
-        sample_next: Callable[[Any, int], Any] | None = None,
+        sample_next: Callable[..., Any] | None = None,
         name: str | None = None,
     ):
         _ensure_callable(transition_density, "transition_density")

--- a/src/pyrecest/models/particle.py
+++ b/src/pyrecest/models/particle.py
@@ -1,9 +1,13 @@
-class SampleableTransitionModel:
-    def __init__(self, sample_next, function_is_vectorized=True):
-        self.sample_next = sample_next
-        self.function_is_vectorized = function_is_vectorized
+"""Backward-compatible particle-model aliases.
 
+The canonical implementations live in :mod:`pyrecest.models.likelihood`.
+This module keeps the historical import path ``pyrecest.models.particle`` from
+drifting away from the public model API.
+"""
 
-class LikelihoodMeasurementModel:
-    def __init__(self, likelihood):
-        self.likelihood = likelihood
+from .likelihood import LikelihoodMeasurementModel, SampleableTransitionModel
+
+__all__ = [
+    "LikelihoodMeasurementModel",
+    "SampleableTransitionModel",
+]

--- a/tests/models/test_particle_model_aliases.py
+++ b/tests/models/test_particle_model_aliases.py
@@ -1,0 +1,36 @@
+"""Regression tests for legacy particle model import aliases."""
+
+from pyrecest.backend import allclose, arange, array, reshape
+from pyrecest.models import (
+    LikelihoodMeasurementModel,
+    SampleableTransitionModel,
+)
+from pyrecest.models.particle import (
+    LikelihoodMeasurementModel as ParticleLikelihoodMeasurementModel,
+)
+from pyrecest.models.particle import (
+    SampleableTransitionModel as ParticleSampleableTransitionModel,
+)
+
+
+def test_particle_model_imports_share_canonical_implementations():
+    assert ParticleLikelihoodMeasurementModel is LikelihoodMeasurementModel
+    assert ParticleSampleableTransitionModel is SampleableTransitionModel
+
+
+def test_particle_sampleable_alias_supports_public_constructor_features():
+    def sample_next(state, *, n=1):
+        return state + reshape(arange(n), (n, 1))
+
+    model = ParticleSampleableTransitionModel(
+        sample_next,
+        transition_density=lambda state_next, state_previous: state_next - state_previous,
+        name="legacy-particle-transition",
+        function_is_vectorized=False,
+    )
+
+    assert model.name == "legacy-particle-transition"
+    assert model.function_is_vectorized is False
+    assert model.has_transition_density
+    assert allclose(model.sample_next(array([4.0]), n=2), array([[4.0], [5.0]]))
+    assert allclose(model.transition_density(array([3.0]), array([1.0])), array([2.0]))

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -87,6 +87,28 @@ def test_array_like_sequence_helpers_accept_python_lists():
     assert _to_python(backend.unique([2, 1, 2, 1])) == [1, 2]
 
 
+def test_one_hot_accepts_list_labels_and_returns_uint8_indicators():
+    result = backend.one_hot([0, 2], 3)
+
+    assert result.shape == (2, 3)
+    assert str(backend.to_numpy(result).dtype) == "uint8"
+    assert _to_python(result) == [[1, 0, 0], [0, 0, 1]]
+
+
+def test_trace_uses_trailing_matrix_axes_for_batches():
+    values = array(
+        [
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
+            [[10.0, 11.0, 12.0], [13.0, 14.0, 15.0], [16.0, 17.0, 18.0]],
+        ]
+    )
+
+    result = backend.trace(values)
+
+    assert result.shape == (2,)
+    assert _to_python(result) == [15.0, 42.0]
+
+
 def test_divide_accepts_array_like_inputs():
     assert _to_python(backend.divide([2.0, 4.0], [1.0, 2.0])) == [2.0, 2.0]
 


### PR DESCRIPTION
## Summary
- Make JAX backend `one_hot` accept list labels with `uint8` indicators and align `trace` with trailing matrix axes.
- Add typed casts for backend capability lookups and keep measurement diagnostics safe when no active indices are present.
- Preserve legacy `pyrecest.models.particle` imports by aliasing the canonical model classes and covering the constructor behavior.

## Validation
- `git diff --check`
- Local tests were not run per request.