### PR TITLE
[codex] Fix PyTorch backend padding and logm batches

### DIFF
--- a/src/pyrecest/_backend/pytorch/__init__.py
+++ b/src/pyrecest/_backend/pytorch/__init__.py
@@ -1440,9 +1440,43 @@ def _torch_pad_width(pad_width, ndim_):
     return [int(value) for pair in reversed(pad_pairs.tolist()) for value in pair]
 
 
+def _trim_leading_zero_pad_pairs_for_nonconstant_mode(torch_pad_width, ndim_):
+    """Drop zero-padded leading axes unsupported by PyTorch nonconstant padding."""
+
+    # ``torch.nn.functional.pad`` supports nonconstant modes only for a suffix
+    # of dimensions.  PyRecEst accepts NumPy-style per-axis pad widths, so a
+    # common image-shaped request such as ``((0, 0), (0, 0), (1, 1), (1, 1))``
+    # becomes ``[1, 1, 1, 1, 0, 0, 0, 0]`` for PyTorch.  The trailing zero pairs
+    # address leading axes and must be stripped before calling PyTorch.
+    min_supported_pairs = {
+        2: 1,
+        3: 1,
+        4: 2,
+        5: 3,
+    }.get(ndim_)
+    if min_supported_pairs is None:
+        return torch_pad_width
+
+    pad_pairs = [
+        torch_pad_width[index : index + 2]
+        for index in range(0, len(torch_pad_width), 2)
+    ]
+    while len(pad_pairs) > min_supported_pairs and pad_pairs[-1] == [0, 0]:
+        pad_pairs.pop()
+
+    return [value for pair in pad_pairs for value in pair]
+
+
 def pad(a, pad_width, mode="constant", constant_values=0.0):
     a = array(a)
     torch_pad_width = _torch_pad_width(pad_width, a.ndim)
+    if mode != "constant":
+        torch_pad_width = _trim_leading_zero_pad_pairs_for_nonconstant_mode(
+            torch_pad_width,
+            a.ndim,
+        )
+        return _torch.nn.functional.pad(a, torch_pad_width, mode=mode)
+
     return _torch.nn.functional.pad(
         a, torch_pad_width, mode=mode, value=constant_values
     )

--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -110,9 +110,7 @@ class _Logm(_torch.autograd.Function):
         """Run gradients backward."""
         (tensor,) = ctx.saved_tensors
 
-        vectorized = tensor.ndim == 3
-        axes = (0, 2, 1) if vectorized else (1, 0)
-        tensor_H = tensor.permute(axes).conj().to(grad.dtype)
+        tensor_H = tensor.transpose(-2, -1).conj().to(grad.dtype)
         n = tensor.size(-1)
         bshape = tensor.shape[:-2] + (2 * n, 2 * n)
         backward_tensor = _torch.zeros(*bshape, dtype=grad.dtype, device=grad.device)

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -72,6 +72,23 @@ def test_pytorch_to_numpy_resolves_conjugate_views():
     assert converted.tolist() == [1.0 - 2.0j, 3.0 + 4.0j]
 
 
+def test_pytorch_logm_backward_handles_high_rank_batches():
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific logm gradient regression test")
+
+    torch = pytest.importorskip("torch")
+
+    values = torch.eye(2, dtype=torch.float64).repeat(2, 3, 1, 1)
+    values.requires_grad_(True)
+
+    result = linalg.logm(values)
+    result.sum().backward()
+
+    assert values.grad is not None
+    assert values.grad.shape == values.shape
+    assert bool(torch.isfinite(values.grad).all())
+
+
 def _to_python(value):
     value = backend.to_numpy(value)
     if hasattr(value, "tolist"):
@@ -318,6 +335,24 @@ def test_pad_uses_per_axis_pad_pairs_in_numpy_order():
 def test_pad_rejects_negative_widths():
     with pytest.raises(ValueError):
         backend.pad(array([1, 2, 3]), (-1, 0))
+
+
+def test_pytorch_pad_reflects_spatial_dimensions_with_unpadded_leading_axes():
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific nonconstant pad regression test")
+
+    values = backend.reshape(backend.arange(9.0), (1, 1, 3, 3))
+
+    result = backend.pad(values, ((0, 0), (0, 0), (1, 1), (1, 1)), mode="reflect")
+
+    assert result.shape == (1, 1, 5, 5)
+    assert _to_python(result[0, 0]) == [
+        [4.0, 3.0, 4.0, 5.0, 4.0],
+        [1.0, 0.0, 1.0, 2.0, 1.0],
+        [4.0, 3.0, 4.0, 5.0, 4.0],
+        [7.0, 6.0, 7.0, 8.0, 7.0],
+        [4.0, 3.0, 4.0, 5.0, 4.0],
+    ]
 
 
 def test_cross_uses_trailing_vector_axis_for_batched_vectors():


### PR DESCRIPTION
## Summary

- trim unsupported leading zero pad pairs for PyTorch nonconstant padding modes
- use trailing matrix-axis transpose in PyTorch `logm` backward for high-rank batches
- add backend contract regressions for reflect padding and high-rank batched `logm` gradients

## Validation

- `git diff --check`
- `git diff --cached --check`
- local tests were not run, per request