### PR TITLE
[codex] Accept array-like inputs in PyTorch helpers

### DIFF
--- a/src/pyrecest/_backend/pytorch/__init__.py
+++ b/src/pyrecest/_backend/pytorch/__init__.py
@@ -785,11 +785,13 @@ def einsum(equation, *inputs):
 
 
 def transpose(x, axes=None):
-    if axes:
+    if not is_array(x):
+        x = array(x)
+    if axes is not None:
         return x.permute(axes)
     if x.dim() == 1:
         return x
-    if x.dim() > 2 and axes is None:
+    if x.dim() > 2:
         return x.permute(tuple(range(x.ndim)[::-1]))
     return x.t()
 
@@ -931,6 +933,8 @@ def meshgrid(*arrays, indexing="xy"):
 
 
 def ndim(x):
+    if not is_array(x):
+        x = array(x)
     return x.dim()
 
 

--- a/tests/test_pytorch_backend.py
+++ b/tests/test_pytorch_backend.py
@@ -178,6 +178,17 @@ class TestPytorchBackendCopy(unittest.TestCase):
 
 
 @unittest.skipIf(pytorch_backend is None, "PyTorch is not installed")
+class TestPytorchBackendArrayLikeInputs(unittest.TestCase):
+    def test_ndim_accepts_python_sequence(self):
+        self.assertEqual(pytorch_backend.ndim([[1, 2], [3, 4]]), 2)
+
+    def test_transpose_accepts_python_sequence(self):
+        result = pytorch_backend.transpose([[1, 2, 3], [4, 5, 6]])
+
+        self.assertEqual(result.tolist(), [[1, 4], [2, 5], [3, 6]])
+
+
+@unittest.skipIf(pytorch_backend is None, "PyTorch is not installed")
 class TestPytorchBackendRandom(unittest.TestCase):
     def test_randint_matches_numpy_scalar_contract(self):
         sample = pytorch_backend.random.randint(0, 5)


### PR DESCRIPTION
Summary:
- Coerce array-like inputs before PyTorch transpose and ndim helpers inspect tensor methods.
- Add backend tests covering Python-sequence inputs.

Validation:
- git diff --check
- Local tests not run, per request.