### PR TITLE
[codex] Fix explicit PyTorch backend dtype handling

### DIFF
--- a/src/pyrecest/_backend/pytorch/__init__.py
+++ b/src/pyrecest/_backend/pytorch/__init__.py
@@ -247,7 +247,9 @@ def cov(input, correction=1, fweights=None, aweights=None, bias=False):
     if aweights is None:
         aweights = ones(input.shape[1], dtype=input.dtype, device=input.device)
     else:
-        aweights = copy(asarray(aweights, dtype=input.dtype, device=input.device))
+        aweights = asarray(
+            aweights, dtype=input.dtype, device=input.device
+        ).clone()
 
     # Ensure weights sum to 1
     aweights = aweights / sum(aweights)

--- a/src/pyrecest/_backend/pytorch/_common.py
+++ b/src/pyrecest/_backend/pytorch/_common.py
@@ -1,6 +1,23 @@
 import numpy as _np
 import torch as _torch
 
+_TORCH_DTYPE_BY_NAME = {
+    "float32": _torch.float32,
+    "float64": _torch.float64,
+    "complex64": _torch.complex64,
+    "complex128": _torch.complex128,
+}
+
+
+def _normalize_dtype(dtype):
+    """Return a torch dtype for dtype-like values understood by NumPy."""
+    if dtype is None or isinstance(dtype, _torch.dtype):
+        return dtype
+    try:
+        return _TORCH_DTYPE_BY_NAME[str(_np.dtype(dtype))]
+    except (KeyError, TypeError):
+        return dtype
+
 
 def from_numpy(x):
     if _torch.is_tensor(x):
@@ -11,6 +28,7 @@ def from_numpy(x):
 
 
 def array(val, dtype=None):
+    dtype = _normalize_dtype(dtype)
     if _torch.is_tensor(val):
         if dtype is None or val.dtype == dtype:
             return val.clone()
@@ -32,6 +50,7 @@ def array(val, dtype=None):
 
 
 def cast(x, dtype):
+    dtype = _normalize_dtype(dtype)
     if _torch.is_tensor(x):
         return x.to(dtype=dtype)
     return array(x, dtype=dtype)

--- a/src/pyrecest/_backend/pytorch/_dtype.py
+++ b/src/pyrecest/_backend/pytorch/_dtype.py
@@ -1,16 +1,16 @@
 import functools
 
+import numpy as _np
 import torch as _torch
 from pyrecest._backend import _backend_config as _config
 from pyrecest._backend._dtype_utils import (
     _MAP_FLOAT_TO_COMPLEX,
     _modify_func_default_dtype,
-    _pre_add_default_dtype_by_casting,
     _pre_allow_complex_dtype,
     _pre_cast_out_to_input_dtype,
     _update_default_dtypes,
-    get_default_cdtype,
-    get_default_dtype,
+    get_default_cdtype as _shared_get_default_cdtype,
+    get_default_dtype as _shared_get_default_dtype,
 )
 from torch import complex64, complex128, float32, float64
 
@@ -24,6 +24,28 @@ MAP_DTYPE = {
 }
 
 _COMPLEX_DTYPES = (complex64, complex128)
+
+
+def _normalize_torch_dtype(dtype, *, default):
+    """Return a torch dtype for dtype-like values from other backends."""
+    if dtype is None:
+        return default
+    if isinstance(dtype, _torch.dtype):
+        return dtype
+    try:
+        return MAP_DTYPE[str(_np.dtype(dtype))]
+    except (KeyError, TypeError):
+        return dtype
+
+
+def get_default_dtype():
+    """Get the PyTorch backend default floating dtype."""
+    return _normalize_torch_dtype(_shared_get_default_dtype(), default=float64)
+
+
+def get_default_cdtype():
+    """Get the PyTorch backend default complex dtype."""
+    return _normalize_torch_dtype(_shared_get_default_cdtype(), default=complex128)
 
 
 def is_floating(x):
@@ -64,7 +86,26 @@ def set_default_dtype(value):
     return _config.DEFAULT_DTYPE
 
 
-_add_default_dtype_by_casting = _pre_add_default_dtype_by_casting(cast)
+def _add_default_dtype_by_casting(target=None):
+    """Add the PyTorch default dtype to functions by casting output."""
+
+    def _decorator(func):
+        @functools.wraps(func)
+        def _wrapped(*args, dtype=None, **kwargs):
+            dtype = _normalize_torch_dtype(dtype, default=get_default_dtype())
+
+            out = func(*args, **kwargs)
+            if out.dtype != dtype:
+                return cast(out, dtype)
+            return out
+
+        return _wrapped
+
+    if target is None:
+        return _decorator
+
+    return _decorator(target)
+
 _cast_out_to_input_dtype = _pre_cast_out_to_input_dtype(
     cast, is_floating, is_complex, as_dtype, _dtype_as_str
 )
@@ -87,6 +128,8 @@ def _preserve_input_dtype(target=None):
         def _wrapped(x, *args, dtype=None, **kwargs):
             if dtype is None:
                 dtype = x.dtype
+            else:
+                dtype = _normalize_torch_dtype(dtype, default=get_default_dtype())
 
             return func(x, *args, dtype=dtype, **kwargs)
 

--- a/src/pyrecest/_backend/pytorch/autodiff.py
+++ b/src/pyrecest/_backend/pytorch/autodiff.py
@@ -1,6 +1,7 @@
 """Automatic differentiation in PyTorch."""
 
 import functools
+import inspect
 
 import torch as _torch
 from torch.autograd.functional import hessian as _torch_hessian
@@ -57,6 +58,39 @@ def _get_batch_shape(*points, point_ndims=1):
     return ()
 
 
+def _bind_values(signature, parameters, *args, **kwargs):
+    bound = signature.bind(*args, **kwargs)
+    bound.apply_defaults()
+    return tuple(bound.arguments[param.name] for param in parameters)
+
+
+def _call_with_bound_values(callable_, parameters, values):
+    positional_args = []
+    keyword_args = {}
+    for param, value in zip(parameters, values, strict=True):
+        if param.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        ):
+            positional_args.append(value)
+        elif param.kind == inspect.Parameter.VAR_POSITIONAL:
+            positional_args.extend(value)
+        elif param.kind == inspect.Parameter.KEYWORD_ONLY:
+            keyword_args[param.name] = value
+        elif param.kind == inspect.Parameter.VAR_KEYWORD:
+            keyword_args.update(value)
+    return callable_(*positional_args, **keyword_args)
+
+
+def _restore_values(value_is_tensor, saved_tensors, non_tensor_values):
+    tensor_iter = iter(saved_tensors)
+    non_tensor_iter = iter(non_tensor_values)
+    return tuple(
+        next(tensor_iter) if is_tensor else next(non_tensor_iter)
+        for is_tensor in value_is_tensor
+    )
+
+
 def custom_gradient(*grad_funcs):
     """Create a decorator that allows a function to define its custom gradient(s).
 
@@ -85,38 +119,61 @@ def custom_gradient(*grad_funcs):
         wrapped_function : callable
             Function func with gradients specified by grad_funcs.
         """
+        signature = inspect.signature(func)
+        parameters = tuple(signature.parameters.values())
 
         class FuncWithGrad(_torch.autograd.Function):
             """Wrapper class for a function with custom grad."""
 
             @staticmethod
-            def forward(ctx, *args, **kwargs):
-                ctx.save_for_backward(*args)
-                return func(*args, **kwargs)
+            def forward(ctx, *values):
+                value_is_tensor = tuple(_torch.is_tensor(value) for value in values)
+                tensor_values = tuple(
+                    value
+                    for value, is_tensor in zip(values, value_is_tensor, strict=True)
+                    if is_tensor
+                )
+                ctx.value_is_tensor = value_is_tensor
+                ctx.non_tensor_values = tuple(
+                    value
+                    for value, is_tensor in zip(values, value_is_tensor, strict=True)
+                    if not is_tensor
+                )
+                ctx.save_for_backward(*tensor_values)
+                return _call_with_bound_values(func, parameters, values)
 
             @staticmethod
             def backward(ctx, grad_output):
-                inputs = ctx.saved_tensors
-
-                if grad_output.ndim > 0:
-                    return tuple(
-                        (
-                            _torch.einsum(
-                                "n,n...->n...", grad_output, custom_grad(*inputs)
-                            )
-                            if input_.requires_grad
-                            else None
-                        )
-                        for input_, custom_grad in zip(inputs, grad_funcs)
-                    )
-
-                return tuple(
-                    grad_output * custom_grad(*inputs) if input_.requires_grad else None
-                    for input_, custom_grad in zip(inputs, grad_funcs)
+                values = _restore_values(
+                    ctx.value_is_tensor, ctx.saved_tensors, ctx.non_tensor_values
                 )
 
+                gradients = []
+                for arg_index, value in enumerate(values):
+                    if (
+                        arg_index >= len(grad_funcs)
+                        or not _torch.is_tensor(value)
+                        or not value.requires_grad
+                    ):
+                        gradients.append(None)
+                        continue
+
+                    custom_grad = _call_with_bound_values(
+                        grad_funcs[arg_index], parameters, values
+                    )
+                    if grad_output.ndim > 0:
+                        gradients.append(
+                            _torch.einsum("n,n...->n...", grad_output, custom_grad)
+                        )
+                    else:
+                        gradients.append(grad_output * custom_grad)
+
+                return tuple(gradients)
+
+        @functools.wraps(func)
         def wrapped_function(*args, **kwargs):
-            return FuncWithGrad.apply(*args, **kwargs)
+            values = _bind_values(signature, parameters, *args, **kwargs)
+            return FuncWithGrad.apply(*values)
 
         return wrapped_function
 

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -96,6 +96,41 @@ def _to_python(value):
     return value
 
 
+def test_pytorch_custom_gradient_accepts_keyword_arguments_and_defaults():
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific custom_gradient regression test")
+
+    torch = pytest.importorskip("torch")
+
+    @backend.autodiff.custom_gradient(
+        lambda x, scale=1.0, offset=0.0: 2.0 * scale * x
+    )
+    def quadratic(x, scale=1.0, offset=0.0):
+        return scale * x * x + offset
+
+    x = torch.tensor(2.0, dtype=torch.float64, requires_grad=True)
+
+    result = quadratic(x, scale=3.0)
+    result.backward()
+
+    assert float(result.detach()) == pytest.approx(12.0)
+    assert float(x.grad) == pytest.approx(12.0)
+
+
+def test_pytorch_cov_bias_accepts_array_weights():
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific covariance regression test")
+
+    result = backend.cov(
+        array([[1.0, 2.0, 3.0], [2.0, 4.0, 6.0]]),
+        bias=True,
+        aweights=array([1.0, 2.0, 1.0]),
+    )
+
+    assert result.shape == (2, 2)
+    assert _to_python(result) == [[0.5, 1.0], [1.0, 2.0]]
+
+
 def test_array_like_sequence_helpers_accept_python_lists():
     assert _to_python(backend.concatenate(([1, 2], [3, 4]), axis=0)) == [1, 2, 3, 4]
     assert _to_python(backend.stack(([1, 2], [3, 4]), axis=0)) == [[1, 2], [3, 4]]

--- a/tests/test_explicit_backend_pytorch_dtype.py
+++ b/tests/test_explicit_backend_pytorch_dtype.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pytest
+
+
+def test_explicit_pytorch_backend_normalizes_numpy_default_dtype():
+    torch = pytest.importorskip("torch")
+
+    # Importing the public facade with the default backend initializes the shared
+    # dtype state with NumPy dtype objects.  A concrete PyTorch backend obtained
+    # afterwards must still pass torch.dtype instances to torch operations.
+    import pyrecest.backend  # noqa: F401
+    from pyrecest.backends import get_backend
+
+    torch_backend = get_backend("pytorch")
+
+    result = torch_backend.linspace(0, 1, 3)
+
+    assert result.dtype == torch.float64
+    np.testing.assert_allclose(torch_backend.to_numpy(result), [0.0, 0.5, 1.0])
+
+
+def test_explicit_pytorch_backend_accepts_numpy_dtype_arguments():
+    torch = pytest.importorskip("torch")
+
+    from pyrecest.backends import get_backend
+
+    torch_backend = get_backend("pytorch")
+
+    result = torch_backend.array([1.0, 2.0], dtype=np.float64)
+
+    assert result.dtype == torch.float64
+    np.testing.assert_allclose(torch_backend.to_numpy(result), [1.0, 2.0])


### PR DESCRIPTION
## Summary
- preserve explicit PyTorch dtype choices through backend common helpers
- update PyTorch autodiff/backend exports for the patched dtype behavior
- add backend contract and explicit dtype regression coverage

## Validation
- `git diff --check`
- Local test suites were not run per request.