### PR TITLE
Accept array-like backend matrix helpers

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/__init__.py
+++ b/src/pyrecest/_backend/_shared_numpy/__init__.py
@@ -84,6 +84,7 @@ def from_numpy(x):
 
 
 def squeeze(x, axis=None):
+    x = _np.asarray(x)
     if axis is None:
         return _np.squeeze(x)
     if x.shape[axis] != 1:

--- a/src/pyrecest/_backend/jax/__init__.py
+++ b/src/pyrecest/_backend/jax/__init__.py
@@ -209,6 +209,59 @@ def unique(ar, *args, **kwargs):
     return _jnp.unique(_jnp.asarray(ar), *args, **kwargs)
 
 
+def _asarray_or_none(value):
+    return None if value is None else _jnp.asarray(value)
+
+
+def cov(
+    m,
+    y=None,
+    rowvar=True,
+    bias=False,
+    ddof=None,
+    fweights=None,
+    aweights=None,
+    dtype=None,
+):
+    return _jnp.cov(
+        _jnp.asarray(m),
+        y=_asarray_or_none(y),
+        rowvar=rowvar,
+        bias=bias,
+        ddof=ddof,
+        fweights=_asarray_or_none(fweights),
+        aweights=_asarray_or_none(aweights),
+        dtype=dtype,
+    )
+
+
+def diagonal(a, offset=0, axis1=0, axis2=1):
+    return _jnp.diagonal(_jnp.asarray(a), offset=offset, axis1=axis1, axis2=axis2)
+
+
+def squeeze(a, axis=None):
+    return _jnp.squeeze(_jnp.asarray(a), axis=axis)
+
+
+def trace(a, offset=0, axis1=0, axis2=1, dtype=None, out=None):
+    return _jnp.trace(
+        _jnp.asarray(a),
+        offset=offset,
+        axis1=axis1,
+        axis2=axis2,
+        dtype=dtype,
+        out=out,
+    )
+
+
+def tril(m, k=0):
+    return _jnp.tril(_jnp.asarray(m), k=k)
+
+
+def triu(m, k=0):
+    return _jnp.triu(_jnp.asarray(m), k=k)
+
+
 def argmax(a, axis=None, out=None, keepdims=False, **kwargs):
     result = _jnp.argmax(_jnp.asarray(a), axis=axis, keepdims=keepdims, **kwargs)
     if out is not None:

--- a/src/pyrecest/_backend/pytorch/__init__.py
+++ b/src/pyrecest/_backend/pytorch/__init__.py
@@ -237,7 +237,12 @@ def std(
 
 
 def cov(input, correction=1, fweights=None, aweights=None, bias=False):
-    # for pyrecest
+    input = array(input)
+    if fweights is not None:
+        fweights = asarray(fweights, device=input.device)
+    if aweights is not None:
+        aweights = asarray(aweights, dtype=input.dtype, device=input.device)
+
     if not bias:
         return _torch.cov(
             input, correction=correction, fweights=fweights, aweights=aweights
@@ -247,9 +252,7 @@ def cov(input, correction=1, fweights=None, aweights=None, bias=False):
     if aweights is None:
         aweights = ones(input.shape[1], dtype=input.dtype, device=input.device)
     else:
-        aweights = asarray(
-            aweights, dtype=input.dtype, device=input.device
-        ).clone()
+        aweights = copy(aweights)
 
     # Ensure weights sum to 1
     aweights = aweights / sum(aweights)
@@ -800,13 +803,15 @@ def transpose(x, axes=None):
 
 def squeeze(x, axis=None):
     if not is_array(x):
-        return x
+        x = array(x)
     if axis is None:
         return _torch.squeeze(x)
     return _torch.squeeze(x, dim=axis)
 
 
 def trace(x):
+    if not is_array(x):
+        x = array(x)
     if x.ndim == 2:
         return _torch.trace(x)
 
@@ -879,10 +884,14 @@ def diag_indices(*args, **kwargs):
 
 
 def tril(mat, k=0):
+    if not is_array(mat):
+        mat = array(mat)
     return _torch.tril(mat, diagonal=k)
 
 
 def triu(mat, k=0):
+    if not is_array(mat):
+        mat = array(mat)
     return _torch.triu(mat, diagonal=k)
 
 
@@ -946,6 +955,8 @@ def hsplit(x, indices_or_sections):
 
 
 def diagonal(x, offset=0, axis1=0, axis2=1):
+    if not is_array(x):
+        x = array(x)
     return _torch.diagonal(x, offset=offset, dim1=axis1, dim2=axis2)
 
 
@@ -1320,7 +1331,10 @@ def mat_from_diag_triu_tril(diag, tri_upp, tri_low):
     n = diag.shape[-1]
     (i,) = diag_indices(n, ndim=1)
     j, k = triu_indices(n, k=1)
-    mat = _torch.zeros((diag.shape + (n,)), dtype=diag.dtype)
+    i = i.to(device=diag.device)
+    j = j.to(device=diag.device)
+    k = k.to(device=diag.device)
+    mat = _torch.zeros((diag.shape + (n,)), dtype=diag.dtype, device=diag.device)
     mat[..., i, i] = diag
     mat[..., j, k] = tri_upp
     mat[..., k, j] = tri_low

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -139,6 +139,21 @@ def test_array_like_sequence_helpers_accept_python_lists():
     assert _to_python(backend.unique([2, 1, 2, 1])) == [1, 2]
 
 
+def test_array_like_matrix_helpers_accept_python_lists():
+    assert _to_python(backend.squeeze([[[1], [2]]], axis=2)) == [[1, 2]]
+    assert _to_python(backend.trace([[1, 2], [3, 4]])) == 5
+    assert _to_python(backend.diagonal([[1, 2], [3, 4]])) == [1, 4]
+    assert _to_python(backend.tril([[1, 2], [3, 4]])) == [[1, 0], [3, 4]]
+    assert _to_python(backend.triu([[1, 2], [3, 4]])) == [[1, 2], [0, 4]]
+
+
+def test_cov_accepts_array_like_inputs():
+    result = backend.cov([[1.0, 2.0, 3.0], [2.0, 4.0, 6.0]])
+
+    assert result.shape == (2, 2)
+    assert bool(_to_python(backend.allclose(result, array([[1.0, 2.0], [2.0, 4.0]]))))
+
+
 def test_one_hot_accepts_list_labels_and_returns_uint8_indicators():
     result = backend.one_hot([0, 2], 3)
 


### PR DESCRIPTION
## Summary
- Add JAX backend wrappers for covariance and matrix helper functions that coerce array-like inputs.
- Make PyTorch covariance and matrix helper wrappers accept Python lists and preserve tensor device placement.
- Add backend contract coverage for array-like matrix helpers.

## Validation
- Ran `git diff --check` locally only, per request.
- Remote CI will be allowed to run to completion.