### PR TITLE
Add JAX backend regression coverage

### DIFF
--- a/tests/backend/test_jax_random_backend.py
+++ b/tests/backend/test_jax_random_backend.py
@@ -80,6 +80,7 @@ def _size_aware_samplers():
         lambda size: random.randint(0, 3, size=size),
         lambda size: random.choice(values, size=size),
         lambda size: random.multivariate_normal(mean, cov, size=size),
+        lambda size: random.multinomial(3, [0.25, 0.75], size=size),
     )
 
 
@@ -136,3 +137,24 @@ def test_normal_rejects_negative_scale():
 
     with pytest.raises(ValueError, match="non-negative"):
         random.normal(scale=jnp.array([1.0, -0.1]))
+
+
+def test_multinomial_accepts_numpy_size_argument():
+    random.seed(0)
+
+    samples = random.multinomial(12, jnp.array([0.25, 0.75]), size=(2, 3))
+
+    assert samples.shape == (2, 3, 2)
+    assert jnp.all(jnp.sum(samples, axis=-1) == 12)
+
+
+def test_multinomial_explicit_state_with_size_does_not_mutate_global_state():
+    state = random.create_random_state(123)
+    original_global_state = random.get_state()
+
+    state_after, samples = random.multinomial(5, [0.25, 0.75], size=4, state=state)
+
+    assert samples.shape == (4, 2)
+    assert jnp.all(jnp.sum(samples, axis=-1) == 5)
+    assert jnp.array_equal(random.get_state(), original_global_state)
+    assert not jnp.array_equal(state, state_after)

--- a/tests/test_backend_jax_dtype_contract.py
+++ b/tests/test_backend_jax_dtype_contract.py
@@ -1,0 +1,32 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_jax_set_default_dtype_sets_and_returns_dtype():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("jax is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "jax"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import pyrecest.backend as backend
+result = backend.set_default_dtype('float32')
+assert not callable(result)
+assert str(result).endswith('float32')
+result = backend.set_default_dtype('float64')
+assert not callable(result)
+assert str(result).endswith('float64')
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)

--- a/tests/test_backend_jax_dtype_contract.py
+++ b/tests/test_backend_jax_dtype_contract.py
@@ -24,9 +24,9 @@ def test_jax_set_default_dtype_sets_and_returns_dtype():
 import pyrecest.backend as backend
 result = backend.set_default_dtype('float32')
 assert not callable(result)
-assert str(result).endswith('float32')
+assert result == backend.float32
 result = backend.set_default_dtype('float64')
 assert not callable(result)
-assert str(result).endswith('float64')
+assert result == backend.float64
 """
     subprocess.run([sys.executable, "-c", code], check=True, env=env)

--- a/tests/test_backend_jax_dtype_contract.py
+++ b/tests/test_backend_jax_dtype_contract.py
@@ -23,10 +23,14 @@ def test_jax_set_default_dtype_sets_and_returns_dtype():
     code = """
 import pyrecest.backend as backend
 result = backend.set_default_dtype('float32')
-assert not callable(result)
-assert result == backend.float32
+assert result == backend.as_dtype('float32')
 result = backend.set_default_dtype('float64')
-assert not callable(result)
-assert result == backend.float64
+assert result == backend.as_dtype('float64')
 """
-    subprocess.run([sys.executable, "-c", code], check=True, env=env)
+    subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        check=True,
+        env=env,
+        text=True,
+    )


### PR DESCRIPTION
## Summary

- add regression coverage for sized JAX multinomial draws
- add subprocess coverage for the JAX `set_default_dtype` contract returning dtype values
- keep the follow-up limited to regression tests for fixes that are already present on `main`

## Validation

- `python -m ruff check . --output-format concise`
- `python -m pytest --rootdir . -q tests/backend/test_jax_random_backend.py tests/test_backend_jax_dtype_contract.py` (skipped locally because JAX is not installed in this venv)