### PR TITLE
Validate distribution inputs explicitly

### DIFF
--- a/src/pyrecest/distributions/circle/piecewise_constant_distribution.py
+++ b/src/pyrecest/distributions/circle/piecewise_constant_distribution.py
@@ -1,4 +1,6 @@
 # pylint: disable=no-name-in-module,no-member,redefined-builtin
+from numbers import Integral
+
 import numpy as np
 import pyrecest.backend
 from pyrecest.backend import (
@@ -41,6 +43,21 @@ def _validate_positive_sample_count(n) -> int:
     return count_int
 
 
+def _validate_interval_index(m, n) -> tuple[int, int]:
+    if isinstance(m, bool) or isinstance(n, bool):
+        raise ValueError("m and n must be integers")
+    if not isinstance(m, Integral) or not isinstance(n, Integral):
+        raise ValueError("m and n must be integers")
+
+    m = int(m)
+    n = int(n)
+    if n <= 0:
+        raise ValueError("n must be positive")
+    if not 1 <= m <= n:
+        raise ValueError("m must satisfy 1 <= m <= n")
+    return m, n
+
+
 class PiecewiseConstantDistribution(AbstractCircularDistribution):
     """Piecewise constant (i.e. discrete) circular distribution, similar to a histogram.
 
@@ -63,8 +80,13 @@ class PiecewiseConstantDistribution(AbstractCircularDistribution):
             Weight for each interval (will be normalized to form a valid pdf).
         """
         AbstractCircularDistribution.__init__(self)
-        w = array(w, dtype=float).ravel()
-        assert w.ndim == 1 and w.shape[0] > 0
+        w = array(w, dtype=float)
+        if w.ndim == 0:
+            w = w.reshape((1,))
+        elif w.ndim != 1:
+            raise ValueError("Weights must be a one-dimensional array")
+        if w.shape[0] == 0:
+            raise ValueError("Weights must not be empty")
         if any(not bool(isfinite(weight)) for weight in w):
             raise ValueError("Weights must be finite")
         if any(bool(weight < 0.0) for weight in w):
@@ -190,7 +212,7 @@ class PiecewiseConstantDistribution(AbstractCircularDistribution):
         float
             Left border of the m-th interval.
         """
-        assert 1 <= m <= n
+        m, n = _validate_interval_index(m, n)
         return 2.0 * pi / n * (m - 1)
 
     @staticmethod
@@ -209,7 +231,7 @@ class PiecewiseConstantDistribution(AbstractCircularDistribution):
         float
             Right border of the m-th interval.
         """
-        assert 1 <= m <= n
+        m, n = _validate_interval_index(m, n)
         return 2.0 * pi / n * m
 
     @staticmethod
@@ -228,7 +250,7 @@ class PiecewiseConstantDistribution(AbstractCircularDistribution):
         float
             Center of the m-th interval.
         """
-        assert 1 <= m <= n
+        m, n = _validate_interval_index(m, n)
         return 2.0 * pi / n * (m - 0.5)
 
     @staticmethod

--- a/src/pyrecest/distributions/circle/von_mises_distribution.py
+++ b/src/pyrecest/distributions/circle/von_mises_distribution.py
@@ -42,7 +42,9 @@ class VonMisesDistribution(AbstractCircularDistribution):
         kappa,
         norm_const: float | None = None,
     ):
-        assert kappa >= 0.0
+        kappa_scalar = self._as_float_scalar(kappa, "kappa")
+        if kappa_scalar < 0.0:
+            raise ValueError("kappa must be nonnegative.")
         super().__init__()
         self.mu = mu
         self.kappa = kappa
@@ -102,7 +104,8 @@ class VonMisesDistribution(AbstractCircularDistribution):
             cdf evaluated at columns of xs
         """
         xs = array(xs)
-        assert xs.ndim <= 1
+        if xs.ndim > 1:
+            raise ValueError("xs must be a scalar or one-dimensional array")
 
         r = zeros_like(xs)
 

--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_wrapped_normal_distribution.py
@@ -5,12 +5,14 @@ from typing import Union
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     allclose,
     arange,
     array,
     exp,
     int32,
     int64,
+    isfinite,
     linalg,
     meshgrid,
     mod,
@@ -29,7 +31,8 @@ def _as_1d_mu(mu):
     mu = array(mu)
     if mu.ndim == 0:
         mu = mu.reshape((1,))
-    assert mu.ndim == 1, f"mu must be one-dimensional, but got shape {mu.shape}"
+    if mu.ndim != 1:
+        raise ValueError(f"mu must be one-dimensional, but got shape {mu.shape}")
     return mu
 
 
@@ -56,14 +59,24 @@ class HypertoroidalWrappedNormalDistribution(AbstractHypertoroidalDistribution):
 
         :param mu: Mean vector.
         :param C: Covariance matrix.
-        :raises AssertionError: If C_ is not square, not symmetric, not positive definite, or its dimension does not match with mu_.
+        :raises ValueError: If C_ is not square, not symmetric, not positive definite, or its dimension does not match with mu_.
         """
         mu = _as_1d_mu(mu)
         C = _as_2d_covariance(C)
-        assert C.ndim == 2 and C.shape[0] == C.shape[1], "C must be of shape (dim, dim)"
-        assert allclose(C, C.T, atol=1e-8), "C must be symmetric"
-        assert len(linalg.cholesky(C)) > 0, "C must be positive definite"
-        assert mu.shape == (C.shape[0],), "mu must be of shape (dim,)"
+        if C.ndim != 2 or C.shape[0] != C.shape[1]:
+            raise ValueError("C must be of shape (dim, dim)")
+        if not bool(backend_all(isfinite(C))):
+            raise ValueError("C must contain only finite values")
+        if not bool(allclose(C, C.T, atol=1e-8)):
+            raise ValueError("C must be symmetric")
+        try:
+            cholesky_factor = linalg.cholesky(C)
+        except Exception as exc:
+            raise ValueError("C must be positive definite") from exc
+        if not bool(backend_all(isfinite(cholesky_factor))):
+            raise ValueError("C must be positive definite")
+        if mu.shape != (C.shape[0],):
+            raise ValueError("mu must be of shape (dim,)")
         AbstractHypertoroidalDistribution.__init__(self, mu.shape[0])
         self.mu = mod(mu, 2.0 * pi)
         self.C = C
@@ -79,7 +92,8 @@ class HypertoroidalWrappedNormalDistribution(AbstractHypertoroidalDistribution):
         HypertoroidalWNDistribution: A new instance of the distribution with the updated mean.
         """
         mu = _as_1d_mu(mu)
-        assert mu.shape == (self.dim,), "mu must be of shape (dim,)"
+        if mu.shape != (self.dim,):
+            raise ValueError("mu must be of shape (dim,)")
         dist = copy.deepcopy(self)
         dist.mu = mod(mu, 2.0 * pi)
         return dist
@@ -137,7 +151,8 @@ class HypertoroidalWrappedNormalDistribution(AbstractHypertoroidalDistribution):
         return int(n)
 
     def convolve(self, other: "HypertoroidalWrappedNormalDistribution"):
-        assert self.dim == other.dim, "Dimensions of the two distributions must match"
+        if self.dim != other.dim:
+            raise ValueError("Dimensions of the two distributions must match")
         mu_ = (self.mu + other.mu) % (2.0 * pi)
         C_ = self.C + other.C
         dist_result = self.__class__(mu_, C_)
@@ -154,7 +169,8 @@ class HypertoroidalWrappedNormalDistribution(AbstractHypertoroidalDistribution):
         HypertoroidalWNDistribution: A new instance of the distribution with the updated mode.
         """
         m = _as_1d_mu(m)
-        assert m.shape == (self.dim,), "m must be of shape (dim,)"
+        if m.shape != (self.dim,):
+            raise ValueError("m must be of shape (dim,)")
         dist = copy.deepcopy(self)
         dist.mu = mod(m, 2.0 * pi)
         return dist
@@ -167,7 +183,9 @@ class HypertoroidalWrappedNormalDistribution(AbstractHypertoroidalDistribution):
         :param n: Integer moment order
         :return: Trigonometric moment
         """
-        assert isinstance(n, int), "n must be an integer"
+        if isinstance(n, bool) or not isinstance(n, Integral):
+            raise ValueError("n must be an integer")
+        n = int(n)
 
         m = exp(
             array(

--- a/tests/distributions/test_hypertoroidal_wrapped_normal_distribution.py
+++ b/tests/distributions/test_hypertoroidal_wrapped_normal_distribution.py
@@ -89,6 +89,21 @@ class TestHypertoroidalWNDistribution(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, "non-negative integer"):
                     dist.pdf(0.2, m=m)
 
+    def test_constructor_rejects_invalid_parameters(self):
+        invalid_cases = [
+            ([[0.0, 1.0]], [[1.0]], "one-dimensional"),
+            ([0.0], [1.0, 2.0], "shape"),
+            ([0.0], [[float("inf")]], "finite"),
+            ([0.0, 1.0], [[1.0, 0.2], [0.1, 1.0]], "symmetric"),
+            ([0.0, 1.0], [[1.0, 2.0], [2.0, 1.0]], "positive definite"),
+            ([0.0], [[1.0, 0.0], [0.0, 1.0]], "shape"),
+        ]
+
+        for mu, C, message in invalid_cases:
+            with self.subTest(mu=mu, C=C):
+                with self.assertRaisesRegex(ValueError, message):
+                    HypertoroidalWNDistribution(mu, C)
+
     def test_vector_pdf_accepts_single_point_sequence(self):
         dist = HypertoroidalWNDistribution(
             array([0.3, 0.4]), array([[0.7, 0.0], [0.0, 0.5]])
@@ -124,6 +139,27 @@ class TestHypertoroidalWNDistribution(unittest.TestCase):
             with self.subTest(n=n):
                 with self.assertRaisesRegex(ValueError, "positive integer"):
                     dist.sample(n)
+
+    def test_operations_reject_dimension_mismatches(self):
+        dist = HypertoroidalWNDistribution([1.0, 2.0], [[0.5, 0.1], [0.1, 0.6]])
+        one_dimensional = HypertoroidalWNDistribution(0.3, 0.7)
+
+        with self.assertRaisesRegex(ValueError, "shape"):
+            dist.set_mean([0.1])
+        with self.assertRaisesRegex(ValueError, "shape"):
+            dist.set_mode([0.1])
+        with self.assertRaisesRegex(ValueError, "Dimensions"):
+            dist.convolve(one_dimensional)
+
+    def test_trigonometric_moment_rejects_invalid_order(self):
+        dist = HypertoroidalWNDistribution([1.0, 2.0], [[0.5, 0.1], [0.1, 0.6]])
+
+        npt.assert_allclose(dist.trigonometric_moment(np.int64(1)), dist.trigonometric_moment(1))
+
+        for n in (True, 1.5, [1]):
+            with self.subTest(n=n):
+                with self.assertRaisesRegex(ValueError, "integer"):
+                    dist.trigonometric_moment(n)
 
     def test_shift_accepts_scalar_for_one_dimensional_distribution(self):
         dist = HypertoroidalWNDistribution(0.3, 0.7)

--- a/tests/distributions/test_piecewise_constant_distribution.py
+++ b/tests/distributions/test_piecewise_constant_distribution.py
@@ -46,6 +46,8 @@ class PiecewiseConstantDistributionTest(unittest.TestCase):
 
     def test_constructor_rejects_invalid_weights(self):
         for invalid_weights, message in [
+            (array([]), "empty"),
+            (array([[1.0, 2.0]]), "one-dimensional"),
             (array([1.0, -0.5, 1.0]), "nonnegative"),
             (array([0.0, 0.0]), "positive total mass"),
             (array([float("nan"), 1.0]), "finite"),
@@ -111,6 +113,20 @@ class PiecewiseConstantDistributionTest(unittest.TestCase):
         self.assertAlmostEqual(
             PiecewiseConstantDistribution.right_border(2, 2), 1.0 * 2.0 * pi
         )
+
+    def test_interval_borders_reject_invalid_indices(self):
+        helpers = [
+            PiecewiseConstantDistribution.left_border,
+            PiecewiseConstantDistribution.interval_center,
+            PiecewiseConstantDistribution.right_border,
+        ]
+        invalid_args = [(0, 2), (3, 2), (1, 0), (1.5, 2), (1, 2.5), (True, 2)]
+
+        for helper in helpers:
+            for m, n in invalid_args:
+                with self.subTest(helper=helper.__name__, m=m, n=n):
+                    with self.assertRaises(ValueError):
+                        helper(m, n)
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member

--- a/tests/distributions/test_von_mises_distribution.py
+++ b/tests/distributions/test_von_mises_distribution.py
@@ -18,6 +18,12 @@ class TestVonMisesDistribution(unittest.TestCase):
         self.assertEqual(dist1.kappa, dist2.kappa)
         self.assertNotEqual(dist1.mu, dist2.mu)
 
+    def test_constructor_rejects_invalid_kappa(self):
+        for kappa in (-1.0, float("nan"), float("inf"), [1.0, 2.0]):
+            with self.subTest(kappa=kappa):
+                with self.assertRaises(ValueError):
+                    VonMisesDistribution(0.0, kappa)
+
     def test_pdf(self):
         dist = VonMisesDistribution(2, 1)
         xs = linspace(1, 7, 7)
@@ -52,6 +58,16 @@ class TestVonMisesDistribution(unittest.TestCase):
 
         npt.assert_allclose(dist.cdf(0.5), dist.cdf(array(0.5)))
         npt.assert_allclose(dist.cdf(xs), dist.cdf(array(xs)))
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
+    def test_cdf_rejects_matrix_inputs(self):
+        dist = VonMisesDistribution(0.3, 1.2)
+
+        with self.assertRaisesRegex(ValueError, "one-dimensional"):
+            dist.cdf(array([[0.5, 1.0]]))
 
     def test_uniform_trigonometric_moments(self):
         dist = VonMisesDistribution(2, 0)


### PR DESCRIPTION
## Summary
- replace assertion-only validation in selected distribution APIs with explicit `ValueError`s
- reject invalid hypertoroidal wrapped-normal parameters and dimension mismatches before they can produce invalid results
- reject non-vector piecewise weights, invalid interval indices, invalid von Mises concentrations, and matrix CDF inputs

## Why
These checks guarded public inputs with `assert`, which disappears when Python runs with optimization enabled. That can let invalid distribution parameters or query shapes proceed and return incorrect results instead of failing clearly.

## Validation
- `.\.venv\Scripts\python -m pytest -q tests\distributions\test_hypertoroidal_wrapped_normal_distribution.py tests\distributions\test_piecewise_constant_distribution.py tests\distributions\test_von_mises_distribution.py`
- `.\.venv\Scripts\python -O -m pytest -q tests\distributions\test_hypertoroidal_wrapped_normal_distribution.py tests\distributions\test_piecewise_constant_distribution.py tests\distributions\test_von_mises_distribution.py`
- `.\.venv\Scripts\python -m ruff check src\pyrecest\distributions\hypertorus\hypertoroidal_wrapped_normal_distribution.py src\pyrecest\distributions\circle\piecewise_constant_distribution.py src\pyrecest\distributions\circle\von_mises_distribution.py tests\distributions\test_hypertoroidal_wrapped_normal_distribution.py tests\distributions\test_piecewise_constant_distribution.py tests\distributions\test_von_mises_distribution.py`