### PR TITLE
Validate SO3 batch shapes explicitly

### DIFF
--- a/src/pyrecest/distributions/_so3_helpers.py
+++ b/src/pyrecest/distributions/_so3_helpers.py
@@ -26,10 +26,14 @@ def as_batch(values, width, name):
     """Return values with a fixed trailing width as a two-dimensional batch."""
     values = array(values, dtype=float)
     if ndim(values) == 1:
-        assert values.shape[0] == width, f"{name} must have length {width}."
+        if values.shape[0] != width:
+            raise ValueError(f"{name} must have length {width}.")
         values = reshape(values, (1, width))
+    elif ndim(values) == 0:
+        raise ValueError(f"{name} must have length {width}.")
     else:
-        assert values.shape[-1] == width, f"{name} must have length {width}."
+        if values.shape[-1] != width:
+            raise ValueError(f"{name} must have length {width}.")
         values = reshape(values, (-1, width))
     return values
 
@@ -96,7 +100,8 @@ def so3_exp_map_volume_log_jacobian(tangent_vectors):
     ``log(dV / dv)`` and preserves all leading dimensions of ``tangent_vectors``.
     """
     tangent_vectors = array(tangent_vectors, dtype=float)
-    assert tangent_vectors.shape[-1] == 3, "SO(3) tangent vectors must have length 3."
+    if ndim(tangent_vectors) == 0 or tangent_vectors.shape[-1] != 3:
+        raise ValueError("SO(3) tangent vectors must have length 3.")
 
     angles = linalg.norm(tangent_vectors, axis=-1)
     safe_angles = where(angles > 1e-8, angles, 1.0)
@@ -109,14 +114,14 @@ def exp_map_identity(tangent_vectors):
     """Map SO(3) tangent vectors at identity to scalar-last quaternions."""
     tangent_vectors = array(tangent_vectors, dtype=float)
     if ndim(tangent_vectors) == 1:
-        assert (
-            tangent_vectors.shape[0] == 3
-        ), "SO(3) tangent vectors must have length 3."
+        if tangent_vectors.shape[0] != 3:
+            raise ValueError("SO(3) tangent vectors must have length 3.")
         tangent_vectors = reshape(tangent_vectors, (1, 3))
+    elif ndim(tangent_vectors) == 0:
+        raise ValueError("SO(3) tangent vectors must have length 3.")
     else:
-        assert (
-            tangent_vectors.shape[-1] == 3
-        ), "SO(3) tangent vectors must have length 3."
+        if tangent_vectors.shape[-1] != 3:
+            raise ValueError("SO(3) tangent vectors must have length 3.")
 
     angles = linalg.norm(tangent_vectors, axis=-1)
     angles_col = reshape(angles, tuple(angles.shape) + (1,))

--- a/src/pyrecest/distributions/so3_product_tangent_gaussian_distribution.py
+++ b/src/pyrecest/distributions/so3_product_tangent_gaussian_distribution.py
@@ -116,13 +116,17 @@ class SO3ProductTangentGaussianDistribution(AbstractBoundedDomainDistribution):
         rotations = array(rotations, dtype=float)
 
         if ndim(rotations) == 1:
-            assert (
-                rotations.shape[0] % 4 == 0
-            ), "Flattened SO(3)^K rotations need 4 entries per component."
+            if rotations.shape[0] == 0 or rotations.shape[0] % 4 != 0:
+                raise ValueError(
+                    "Flattened SO(3)^K rotations need 4 entries per component."
+                )
             inferred_num_rotations = rotations.shape[0] // 4
             rotations = reshape(rotations, (inferred_num_rotations, 4))
         elif ndim(rotations) == 2:
-            assert rotations.shape[-1] == 4, "SO(3) quaternions must have length 4."
+            if rotations.shape[-1] != 4:
+                raise ValueError("SO(3) quaternions must have length 4.")
+            if rotations.shape[0] == 0:
+                raise ValueError("SO(3)^K rotations must contain at least one component.")
             inferred_num_rotations = rotations.shape[0]
         else:
             raise ValueError("A product point must have shape (K, 4) or (4 * K,).")
@@ -140,27 +144,36 @@ class SO3ProductTangentGaussianDistribution(AbstractBoundedDomainDistribution):
         rotations = array(rotations, dtype=float)
 
         if ndim(rotations) == 1:
-            assert (
-                rotations.shape[0] % 4 == 0
-            ), "Flattened SO(3)^K rotations need 4 entries per component."
+            if rotations.shape[0] == 0 or rotations.shape[0] % 4 != 0:
+                raise ValueError(
+                    "Flattened SO(3)^K rotations need 4 entries per component."
+                )
             inferred_num_rotations = rotations.shape[0] // 4
             rotations = reshape(rotations, (1, inferred_num_rotations, 4))
         elif ndim(rotations) == 2:
             if rotations.shape[-1] == 4 and (
                 num_rotations is None or rotations.shape[0] == num_rotations
             ):
+                if rotations.shape[0] == 0:
+                    raise ValueError(
+                        "SO(3)^K rotations must contain at least one component."
+                    )
                 inferred_num_rotations = rotations.shape[0]
                 rotations = reshape(rotations, (1, inferred_num_rotations, 4))
             else:
-                assert (
-                    rotations.shape[-1] % 4 == 0
-                ), "Flattened SO(3)^K rotations need 4 entries per component."
+                if rotations.shape[-1] == 0 or rotations.shape[-1] % 4 != 0:
+                    raise ValueError(
+                        "Flattened SO(3)^K rotations need 4 entries per component."
+                    )
                 inferred_num_rotations = rotations.shape[-1] // 4
                 rotations = reshape(
                     rotations, (rotations.shape[0], inferred_num_rotations, 4)
                 )
         elif ndim(rotations) == 3:
-            assert rotations.shape[-1] == 4, "SO(3) quaternions must have length 4."
+            if rotations.shape[-1] != 4:
+                raise ValueError("SO(3) quaternions must have length 4.")
+            if rotations.shape[1] == 0:
+                raise ValueError("SO(3)^K rotations must contain at least one component.")
             inferred_num_rotations = rotations.shape[1]
         else:
             raise ValueError(
@@ -181,32 +194,41 @@ class SO3ProductTangentGaussianDistribution(AbstractBoundedDomainDistribution):
         tangent_vectors = array(tangent_vectors, dtype=float)
 
         if ndim(tangent_vectors) == 1:
-            assert (
-                tangent_vectors.shape[0] % 3 == 0
-            ), "Flattened SO(3)^K tangent vectors need 3 entries per component."
+            if tangent_vectors.shape[0] == 0 or tangent_vectors.shape[0] % 3 != 0:
+                raise ValueError(
+                    "Flattened SO(3)^K tangent vectors need 3 entries per component."
+                )
             inferred_num_rotations = tangent_vectors.shape[0] // 3
             tangent_vectors = reshape(tangent_vectors, (1, inferred_num_rotations, 3))
         elif ndim(tangent_vectors) == 2:
             if tangent_vectors.shape[-1] == 3 and (
                 num_rotations is None or tangent_vectors.shape[0] == num_rotations
             ):
+                if tangent_vectors.shape[0] == 0:
+                    raise ValueError(
+                        "SO(3)^K tangent vectors must contain at least one component."
+                    )
                 inferred_num_rotations = tangent_vectors.shape[0]
                 tangent_vectors = reshape(
                     tangent_vectors, (1, inferred_num_rotations, 3)
                 )
             else:
-                assert (
-                    tangent_vectors.shape[-1] % 3 == 0
-                ), "Flattened SO(3)^K tangent vectors need 3 entries per component."
+                if tangent_vectors.shape[-1] == 0 or tangent_vectors.shape[-1] % 3 != 0:
+                    raise ValueError(
+                        "Flattened SO(3)^K tangent vectors need 3 entries per component."
+                    )
                 inferred_num_rotations = tangent_vectors.shape[-1] // 3
                 tangent_vectors = reshape(
                     tangent_vectors,
                     (tangent_vectors.shape[0], inferred_num_rotations, 3),
                 )
         elif ndim(tangent_vectors) == 3:
-            assert (
-                tangent_vectors.shape[-1] == 3
-            ), "SO(3) tangent vectors must have length 3."
+            if tangent_vectors.shape[-1] != 3:
+                raise ValueError("SO(3) tangent vectors must have length 3.")
+            if tangent_vectors.shape[1] == 0:
+                raise ValueError(
+                    "SO(3)^K tangent vectors must contain at least one component."
+                )
             inferred_num_rotations = tangent_vectors.shape[1]
         else:
             raise ValueError(

--- a/tests/distributions/test_so3_helpers.py
+++ b/tests/distributions/test_so3_helpers.py
@@ -48,6 +48,39 @@ class SO3HelpersTest(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, message):
                     private_normalize_quaternions(quaternions)
 
+    def test_helpers_reject_invalid_batch_widths(self):
+        invalid_calls = [
+            (
+                lambda: so3_helpers.as_batch(array(1.0), 3, "SO(3) tangent vectors"),
+                "length 3",
+            ),
+            (
+                lambda: so3_helpers.as_batch(
+                    array([[1.0, 2.0]]), 3, "SO(3) tangent vectors"
+                ),
+                "length 3",
+            ),
+            (
+                lambda: so3_helpers.so3_exp_map_volume_log_jacobian(
+                    array([1.0, 2.0])
+                ),
+                "length 3",
+            ),
+            (lambda: so3_helpers.exp_map_identity(array(1.0)), "length 3"),
+            (lambda: so3_helpers.exp_map(array([1.0, 2.0])), "length 3"),
+            (
+                lambda: so3_helpers.rotate_vectors(
+                    array([0.0, 0.0, 0.0, 1.0]), array([1.0, 2.0])
+                ),
+                "length 3",
+            ),
+        ]
+
+        for invalid_call, message in invalid_calls:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(ValueError, message):
+                    invalid_call()
+
     def test_exp_log_roundtrip_with_base_rotation(self):
         base = z_quaternion(pi / 3.0)
         tangent_vectors = array([[0.1, -0.2, 0.05], [0.0, 0.0, 0.0]])

--- a/tests/distributions/test_so3_product_tangent_gaussian_distribution.py
+++ b/tests/distributions/test_so3_product_tangent_gaussian_distribution.py
@@ -69,6 +69,44 @@ class SO3ProductTangentGaussianDistributionTest(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, message):
                     SO3ProductTangentGaussianDistribution(mean, covariance)
 
+    def test_constructor_rejects_invalid_mean_shapes(self):
+        invalid_means = [
+            (array([]), "4 entries"),
+            (array([0.0, 0.0, 0.0]), "4 entries"),
+            (array([[0.0, 0.0, 0.0]]), "length 4"),
+        ]
+
+        for mean, message in invalid_means:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(ValueError, message):
+                    SO3ProductTangentGaussianDistribution(mean, eye(3))
+
+    def test_maps_reject_invalid_product_rotation_shapes(self):
+        invalid_rotations = [
+            (array([]), "4 entries"),
+            (array([0.0, 0.0, 0.0]), "4 entries"),
+            (array([[0.0, 0.0, 0.0, 1.0, 0.0]]), "4 entries"),
+            (array([[[0.0, 0.0, 0.0]]]), "length 4"),
+        ]
+
+        for rotations, message in invalid_rotations:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(ValueError, message):
+                    SO3ProductTangentGaussianDistribution.log_map(rotations)
+
+    def test_exp_map_rejects_invalid_product_tangent_shapes(self):
+        invalid_tangent_vectors = [
+            (array([]), "3 entries"),
+            (array([0.1, 0.2]), "3 entries"),
+            (array([[0.1, 0.2, 0.3, 0.4]]), "3 entries"),
+            (array([[[0.1, 0.2]]]), "length 3"),
+        ]
+
+        for tangent_vectors, message in invalid_tangent_vectors:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(ValueError, message):
+                    SO3ProductTangentGaussianDistribution.exp_map(tangent_vectors)
+
     def test_exp_log_roundtrip_with_base_product_rotation(self):
         base = array(
             [


### PR DESCRIPTION
## Summary
- replace assertion-only SO(3) helper width checks with explicit `ValueError`s
- reject malformed flattened SO(3)^K rotations and tangent vectors before reshaping
- add regression coverage for invalid helper, rotation batch, and tangent batch shapes

## Why
Several SO(3) shape checks used `assert`, so optimized Python could skip validation and allow malformed vectors to be reshaped or mapped as different rotation products. That can produce incorrect geometric results instead of a clear input error.

## Validation
- `.\.venv\Scripts\python -m pytest -q tests\distributions\test_so3_helpers.py tests\distributions\test_so3_product_tangent_gaussian_distribution.py tests\distributions\test_so3_tangent_gaussian_distribution.py`
- `.\.venv\Scripts\python -O -m pytest -q tests\distributions\test_so3_helpers.py tests\distributions\test_so3_product_tangent_gaussian_distribution.py tests\distributions\test_so3_tangent_gaussian_distribution.py`
- `.\.venv\Scripts\python -m ruff check src\pyrecest\distributions\_so3_helpers.py src\pyrecest\distributions\so3_product_tangent_gaussian_distribution.py tests\distributions\test_so3_helpers.py tests\distributions\test_so3_product_tangent_gaussian_distribution.py`