### PR TITLE
Validate hypersphere directions explicitly

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/von_mises_fisher_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/von_mises_fisher_distribution.py
@@ -18,6 +18,7 @@ from pyrecest.backend import (
     exp,
     int32,
     int64,
+    isfinite,
     isnan,
     linalg,
     ndim,
@@ -31,6 +32,38 @@ from pyrecest.backend import (
 from scipy.special import iv, ive
 
 from .abstract_hyperspherical_distribution import AbstractHypersphericalDistribution
+
+
+def _as_python_bool(value) -> bool:
+    if isinstance(value, bool):
+        return value
+    if hasattr(value, "item"):
+        return bool(value.item())
+    return bool(value)
+
+
+def _as_finite_scalar(value, name: str) -> float:
+    try:
+        scalar = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a finite scalar.") from exc
+
+    if not math.isfinite(scalar):
+        raise ValueError(f"{name} must be finite.")
+    return scalar
+
+
+def _as_unit_direction(mu, *, name: str = "mu", tolerance: float = 1e-6):
+    mu = array(mu)
+    if ndim(mu) != 1:
+        raise ValueError(f"{name} must be a vector")
+    if mu.shape[0] < 2:
+        raise ValueError(f"{name} must be at least two-dimensional")
+    if not _as_python_bool(all(isfinite(mu))):
+        raise ValueError(f"{name} must contain only finite values")
+    if not _as_python_bool(abs(linalg.norm(mu) - 1.0) < tolerance):
+        raise ValueError(f"{name} must be normalized")
+    return mu
 
 
 class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
@@ -63,20 +96,16 @@ class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
             mass around ``mu``. ``kappa == 0`` is the uniform distribution on the
             hypersphere.
         """
-        mu = array(mu)
-        epsilon = 1e-6
-        assert mu.ndim == 1, "mu must be a vector"
-        assert (
-            mu.shape[0] >= 2
-        ), "mu must be at least two-dimensional for the circular case"
-        assert kappa >= 0, "kappa must be a nonnegative scalar"
-        assert abs(linalg.norm(mu) - 1.0) < epsilon, "mu must be a normalized"
+        mu = _as_unit_direction(mu)
+        kappa_scalar = _as_finite_scalar(kappa, "kappa")
+        if kappa_scalar < 0.0:
+            raise ValueError("kappa must be a nonnegative scalar")
         AbstractHypersphericalDistribution.__init__(self, dim=mu.shape[0] - 1)
 
         self.mu = mu
         self.kappa = kappa
 
-        if kappa <= self._KAPPA_EPS:
+        if kappa_scalar <= self._KAPPA_EPS:
             self.C = 1.0 / self.compute_unit_hypersphere_surface(self.dim)
         elif self.dim == 2:
             self.C = kappa / (4 * pi * sinh(kappa))
@@ -124,9 +153,8 @@ class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
         Sampling currently requires the NumPy backend and SciPy's
         ``vonmises_fisher`` implementation.
         """
-        assert (
-            pyrecest.backend.__backend_name__ == "numpy"
-        ), "Only supported on NumPy backend"
+        if pyrecest.backend.__backend_name__ != "numpy":
+            raise NotImplementedError("sample is only supported on the NumPy backend.")
 
         if self.kappa <= self._KAPPA_EPS:
             from .hyperspherical_uniform_distribution import (
@@ -186,7 +214,8 @@ class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
     @staticmethod
     def from_distribution(d):
         """Fit a von Mises-Fisher distribution to mean-resultant information."""
-        assert d.input_dim >= 2, "mu must be at least 2-D for the circular case"
+        if d.input_dim < 2:
+            raise ValueError("mu must be at least 2-D for the circular case")
 
         m = d.mean_resultant_vector()
         return VonMisesFisherDistribution.from_mean_resultant_vector(m)
@@ -209,8 +238,12 @@ class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
             distribution and therefore receives an arbitrary stored direction.
         """
         m = array(m)
-        assert ndim(m) == 1, "mu must be a vector"
-        assert len(m) >= 2, "mu must be at least 2 for the circular case"
+        if ndim(m) != 1:
+            raise ValueError("mu must be a vector")
+        if len(m) < 2:
+            raise ValueError("mu must be at least 2 for the circular case")
+        if not _as_python_bool(all(isfinite(m))):
+            raise ValueError("mu must contain only finite values")
 
         mean_res_length = linalg.norm(m)
         if mean_res_length <= VonMisesFisherDistribution._KAPPA_EPS:
@@ -230,23 +263,26 @@ class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
 
     def set_mean(self, new_mean):
         """Replace the mean direction and return the distribution."""
-        new_mean = array(new_mean)
-        assert new_mean.shape == self.mu.shape
+        new_mean = _as_unit_direction(new_mean, name="new_mean")
+        if new_mean.shape != self.mu.shape:
+            raise ValueError("new_mean must have the same shape as mu")
         dist = copy.deepcopy(self)
         dist.mu = copy.deepcopy(new_mean)
         return dist
 
     def set_mode(self, new_mode):
         """Replace the modal direction and return the distribution."""
-        new_mode = array(new_mode)
-        assert new_mode.shape == self.mu.shape
+        new_mode = _as_unit_direction(new_mode, name="new_mode")
+        if new_mode.shape != self.mu.shape:
+            raise ValueError("new_mode must have the same shape as mu")
         dist = copy.deepcopy(self)
         dist.mu = copy.deepcopy(new_mode)
         return dist
 
     def multiply(self, other: "VonMisesFisherDistribution"):
         """Multiply two vMF densities and return the normalized product."""
-        assert self.mu.shape == other.mu.shape
+        if self.mu.shape != other.mu.shape:
+            raise ValueError("Dimensions must match")
 
         mu_ = self.kappa * self.mu + other.kappa * other.mu
         kappa_ = linalg.norm(mu_)
@@ -263,13 +299,15 @@ class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
         ``other`` must be zonal around the final coordinate axis unless either
         operand is uniform. Convolution with a uniform density is uniform.
         """
-        assert all(self.mu.shape == other.mu.shape)
+        if self.mu.shape != other.mu.shape:
+            raise ValueError("Dimensions must match")
         if self.kappa <= self._KAPPA_EPS or other.kappa <= self._KAPPA_EPS:
             return VonMisesFisherDistribution(
                 self._default_mean_direction(self.input_dim), 0.0
             )
 
-        assert other.mu[-1] == 1, "Other is not zonal"
+        if not _as_python_bool(abs(other.mu[-1] - 1.0) < 1e-8):
+            raise ValueError("Other is not zonal")
         d = self.dim + 1
 
         mu_ = self.mu

--- a/src/pyrecest/distributions/hypersphere_subset/watson_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/watson_distribution.py
@@ -1,4 +1,5 @@
 import copy
+import math
 
 import mpmath
 import pyrecest.backend
@@ -6,6 +7,7 @@ import pyrecest.backend
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 from pyrecest.backend import (
     abs,
+    all,
     allclose,
     array,
     concatenate,
@@ -14,8 +16,10 @@ from pyrecest.backend import (
     full,
     gammaln,
     hstack,
+    isfinite,
     linalg,
     log,
+    ndim,
     ones,
     tile,
     zeros,
@@ -23,6 +27,38 @@ from pyrecest.backend import (
 
 from .abstract_hyperspherical_distribution import AbstractHypersphericalDistribution
 from .bingham_distribution import BinghamDistribution
+
+
+def _as_python_bool(value) -> bool:
+    if isinstance(value, bool):
+        return value
+    if hasattr(value, "item"):
+        return bool(value.item())
+    return bool(value)
+
+
+def _as_finite_scalar(value, name: str) -> float:
+    try:
+        scalar = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a finite scalar.") from exc
+
+    if not math.isfinite(scalar):
+        raise ValueError(f"{name} must be finite.")
+    return scalar
+
+
+def _as_unit_direction(mu, *, name: str = "mu", tolerance: float = 1e-6):
+    mu = array(mu)
+    if ndim(mu) != 1:
+        raise ValueError(f"{name} must be a 1-D vector")
+    if mu.shape[0] < 2:
+        raise ValueError(f"{name} must be at least two-dimensional")
+    if not _as_python_bool(all(isfinite(mu))):
+        raise ValueError(f"{name} must contain only finite values")
+    if not _as_python_bool(abs(linalg.norm(mu) - 1.0) < tolerance):
+        raise ValueError(f"{name} is unnormalized")
+    return mu
 
 
 class WatsonDistribution(AbstractHypersphericalDistribution):
@@ -36,9 +72,8 @@ class WatsonDistribution(AbstractHypersphericalDistribution):
             mu (): The mean direction of the distribution.
             kappa (float): The concentration parameter of the distribution.
         """
-        mu = array(mu)
-        assert mu.ndim == 1, "mu must be a 1-D vector"
-        assert abs(linalg.norm(mu) - 1.0) < self.EPSILON, "mu is unnormalized"
+        mu = _as_unit_direction(mu, tolerance=self.EPSILON)
+        _as_finite_scalar(kappa, "kappa")
         AbstractHypersphericalDistribution.__init__(self, dim=mu.shape[0] - 1)
 
         self.mu = mu
@@ -123,16 +158,18 @@ class WatsonDistribution(AbstractHypersphericalDistribution):
         return self.mode_numerical()
 
     def set_mode(self, new_mode):
-        new_mode = array(new_mode)
-        assert new_mode.shape == self.mu.shape
+        new_mode = _as_unit_direction(new_mode, name="new_mode", tolerance=self.EPSILON)
+        if new_mode.shape != self.mu.shape:
+            raise ValueError("new_mode must have the same shape as mu")
         dist = copy.deepcopy(self)
         dist.mu = copy.deepcopy(new_mode)
         return dist
 
     def shift(self, shift_by):
         canonical_mu = concatenate((zeros(self.input_dim - 1), array([1.0])))
-        assert allclose(self.mu, canonical_mu), (
-            "There is no true shifting for the hypersphere. This is a function "
-            "for compatibility and only works when mu is [0,0,...,1]."
-        )
+        if not _as_python_bool(allclose(self.mu, canonical_mu)):
+            raise ValueError(
+                "There is no true shifting for the hypersphere. This is a function "
+                "for compatibility and only works when mu is [0,0,...,1]."
+            )
         return self.set_mode(shift_by)

--- a/tests/distributions/test_von_mises_fisher_distribution.py
+++ b/tests/distributions/test_von_mises_fisher_distribution.py
@@ -78,6 +78,23 @@ class TestVonMisesFisherDistribution(
 
         npt.assert_allclose(vmf.mu, self.mu)
 
+    def test_constructor_rejects_invalid_parameters(self):
+        invalid_cases = [
+            ([[1.0, 0.0, 0.0]], 1.0),
+            ([1.0], 1.0),
+            ([1.0, 1.0, 0.0], 1.0),
+            ([float("nan"), 0.0, 1.0], 1.0),
+            ([1.0, 0.0, 0.0], -1.0),
+            ([1.0, 0.0, 0.0], float("nan")),
+            ([1.0, 0.0, 0.0], float("inf")),
+            ([1.0, 0.0, 0.0], [1.0, 2.0]),
+        ]
+
+        for mu, kappa in invalid_cases:
+            with self.subTest(mu=mu, kappa=kappa):
+                with self.assertRaises(ValueError):
+                    VonMisesFisherDistribution(mu, kappa)
+
     def test_zero_kappa_is_uniform_density(self):
         vmf = VonMisesFisherDistribution(array([1.0, 0.0, 0.0]), 0.0)
         points = array(
@@ -113,6 +130,12 @@ class TestVonMisesFisherDistribution(
         npt.assert_allclose(self.vmf.mu, self.mu)
         npt.assert_allclose(shifted.mu, array(new_mu))
 
+    def test_set_mean_rejects_invalid_direction(self):
+        for new_mean in ([0.0, 1.0], [0.0, 0.0, 2.0]):
+            with self.subTest(new_mean=new_mean):
+                with self.assertRaises(ValueError):
+                    self.vmf.set_mean(new_mean)
+
     def test_set_mode_returns_new_distribution(self):
         new_mu = array([0.0, 0.0, 1.0])
 
@@ -131,6 +154,12 @@ class TestVonMisesFisherDistribution(
         npt.assert_allclose(self.vmf.mu, self.mu)
         npt.assert_allclose(shifted.mu, array(new_mu))
 
+    def test_set_mode_rejects_invalid_direction(self):
+        for new_mode in ([0.0, 1.0], [0.0, 0.0, 2.0]):
+            with self.subTest(new_mode=new_mode):
+                with self.assertRaises(ValueError):
+                    self.vmf.set_mode(new_mode)
+
     def test_from_zero_mean_resultant_vector_returns_uniform(self):
         vmf = VonMisesFisherDistribution.from_mean_resultant_vector(
             array([0.0, 0.0, 0.0])
@@ -146,6 +175,14 @@ class TestVonMisesFisherDistribution(
 
         npt.assert_allclose(vmf.mu, array([1.0, 0.0, 0.0]))
         self.assertGreater(_as_float(vmf.kappa), 0.0)
+
+    def test_from_mean_resultant_vector_rejects_invalid_vectors(self):
+        for mean_resultant in ([[0.2, 0.0, 0.0]], [0.2], [float("nan"), 0.0]):
+            with self.subTest(mean_resultant=mean_resultant):
+                with self.assertRaises(ValueError):
+                    VonMisesFisherDistribution.from_mean_resultant_vector(
+                        mean_resultant
+                    )
 
     def test_opposite_equal_vmf_product_is_uniform(self):
         mu = array([1.0, 0.0, 0.0])
@@ -165,6 +202,18 @@ class TestVonMisesFisherDistribution(
             1.0 / (4.0 * pi),
             places=12,
         )
+
+    def test_multiply_and_convolve_reject_invalid_partner(self):
+        other_dim = VonMisesFisherDistribution(array([1.0, 0.0, 0.0, 0.0]), 1.0)
+        non_zonal = VonMisesFisherDistribution(array([1.0, 0.0, 0.0]), 1.0)
+
+        with self.assertRaises(ValueError):
+            self.vmf.multiply(other_dim)
+        with self.assertRaises(ValueError):
+            self.vmf.convolve(other_dim)
+        with self.assertRaisesRegex(ValueError, "zonal"):
+            self.vmf.convolve(non_zonal)
+
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",
@@ -363,6 +412,17 @@ class TestVonMisesFisherDistribution(
 
         npt.assert_allclose(vmf1.mu, vmf2.mu, rtol=1e-10)
         npt.assert_allclose(vmf1.kappa, vmf2.kappa, rtol=5e-7)
+
+    def test_from_distribution_rejects_one_dimensional_source(self):
+        class OneDimensionalSource:
+            input_dim = 1
+
+            @staticmethod
+            def mean_resultant_vector():
+                return array([1.0])
+
+        with self.assertRaises(ValueError):
+            VonMisesFisherDistribution.from_distribution(OneDimensionalSource())
 
     def test_from_distribution_dirac(self):
         dirac_dist = HypersphericalDiracDistribution(

--- a/tests/distributions/test_watson_distribution.py
+++ b/tests/distributions/test_watson_distribution.py
@@ -45,6 +45,22 @@ class TestWatsonDistribution(unittest.TestCase):
 
         npt.assert_allclose(w.mu, mu)
 
+    def test_constructor_rejects_invalid_parameters(self):
+        invalid_cases = [
+            ([[1.0, 0.0, 0.0]], 2.0),
+            ([1.0], 2.0),
+            ([1.0, 1.0, 0.0], 2.0),
+            ([float("nan"), 0.0, 1.0], 2.0),
+            ([1.0, 0.0, 0.0], float("nan")),
+            ([1.0, 0.0, 0.0], float("inf")),
+            ([1.0, 0.0, 0.0], [1.0, 2.0]),
+        ]
+
+        for mu, kappa in invalid_cases:
+            with self.subTest(mu=mu, kappa=kappa):
+                with self.assertRaises(ValueError):
+                    WatsonDistribution(mu, kappa)
+
     def test_pdf(self):
         mu = array([1.0, 2.0, 3.0])
         mu = mu / linalg.norm(mu)
@@ -177,6 +193,14 @@ class TestWatsonDistribution(unittest.TestCase):
         npt.assert_allclose(dist.mu, mu)
         npt.assert_allclose(shifted.mu, new_mode)
 
+    def test_set_mode_rejects_invalid_direction(self):
+        dist = WatsonDistribution(array([0.0, 0.0, 1.0]), 2.0)
+
+        for new_mode in ([1.0, 0.0], [2.0, 0.0, 0.0]):
+            with self.subTest(new_mode=new_mode):
+                with self.assertRaises(ValueError):
+                    dist.set_mode(new_mode)
+
     def test_shift_accepts_flat_canonical_mu_and_returns_new_distribution(self):
         mu = array([0.0, 0.0, 1.0])
         new_mode = array([1.0, 0.0, 0.0])
@@ -187,6 +211,12 @@ class TestWatsonDistribution(unittest.TestCase):
         self.assertIsNot(shifted, dist)
         npt.assert_allclose(dist.mu, mu)
         npt.assert_allclose(shifted.mu, new_mode)
+
+    def test_shift_rejects_noncanonical_base_direction(self):
+        dist = WatsonDistribution(array([1.0, 0.0, 0.0]), 2.0)
+
+        with self.assertRaisesRegex(ValueError, "compatibility"):
+            dist.shift([0.0, 0.0, 1.0])
 
     def test_shift_accepts_list_mode(self):
         mu = array([0.0, 0.0, 1.0])


### PR DESCRIPTION
## Summary
- replace assertion-only vMF and Watson direction validation with explicit `ValueError`s
- reject invalid concentration values, mean-resultant vectors, dimension mismatches, and non-zonal vMF convolutions before they can create invalid distributions
- add regression coverage for constructors, mutators, fitting helpers, multiplication/convolution, and Watson shift compatibility

## Why
These distributions require unit directions and compatible hypersphere dimensions. Several checks used `assert`, so optimized Python could skip them and leave invalid distribution state or incorrect convolution/product results instead of raising clear input errors.

## Validation
- `.\.venv\Scripts\python -m pytest -q tests\distributions\test_von_mises_fisher_distribution.py tests\distributions\test_watson_distribution.py`
- `.\.venv\Scripts\python -O -m pytest -q tests\distributions\test_von_mises_fisher_distribution.py tests\distributions\test_watson_distribution.py`
- `.\.venv\Scripts\python -m ruff check src\pyrecest\distributions\hypersphere_subset\von_mises_fisher_distribution.py src\pyrecest\distributions\hypersphere_subset\watson_distribution.py tests\distributions\test_von_mises_fisher_distribution.py tests\distributions\test_watson_distribution.py`