### PR TITLE
Validate toroidal VM parameters explicitly

### DIFF
--- a/src/pyrecest/distributions/hypertorus/abstract_toroidal_bivar_vm_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/abstract_toroidal_bivar_vm_distribution.py
@@ -1,7 +1,45 @@
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
-from pyrecest.backend import all, array, cos, exp, mod, pi
+from pyrecest.backend import all, array, cos, exp, isfinite, mod, pi
 
 from .abstract_toroidal_distribution import AbstractToroidalDistribution
+
+
+def _as_python_bool(value) -> bool:
+    if isinstance(value, bool):
+        return value
+    if hasattr(value, "item"):
+        return bool(value.item())
+    return bool(value)
+
+
+def validate_toroidal_vm_parameters(mu, kappa, *, require_positive_kappa=False):
+    """Validate shared bivariate von Mises location and concentration parameters."""
+    mu = array(mu)
+    kappa = array(kappa)
+    if mu.shape != (2,):
+        raise ValueError("mu must have shape (2,)")
+    if kappa.shape != (2,):
+        raise ValueError("kappa must have shape (2,)")
+    if not _as_python_bool(all(isfinite(mu))):
+        raise ValueError("mu must contain only finite values")
+    if not _as_python_bool(all(isfinite(kappa))):
+        raise ValueError("kappa must contain only finite values")
+    if require_positive_kappa:
+        if not _as_python_bool(all(kappa > 0.0)):
+            raise ValueError("kappa entries must be positive")
+    elif not _as_python_bool(all(kappa >= 0.0)):
+        raise ValueError("kappa entries must be nonnegative")
+    return mu, kappa
+
+
+def validate_scalar_parameter(value, name):
+    """Validate a finite scalar distribution parameter."""
+    value = array(value)
+    if value.shape != ():
+        raise ValueError(f"{name} must be a scalar")
+    if not _as_python_bool(isfinite(value)):
+        raise ValueError(f"{name} must be finite")
+    return value
 
 
 class AbstractToroidalBivarVMDistribution(AbstractToroidalDistribution):
@@ -16,11 +54,7 @@ class AbstractToroidalBivarVMDistribution(AbstractToroidalDistribution):
 
     def __init__(self, mu, kappa):
         AbstractToroidalDistribution.__init__(self)
-        mu = array(mu)
-        kappa = array(kappa)
-        assert mu.shape == (2,)
-        assert kappa.shape == (2,)
-        assert all(kappa >= 0.0)
+        mu, kappa = validate_toroidal_vm_parameters(mu, kappa)
         self.mu = mod(mu, 2.0 * pi)
         self.kappa = kappa
 

--- a/src/pyrecest/distributions/hypertorus/toroidal_vm_matrix_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/toroidal_vm_matrix_distribution.py
@@ -4,10 +4,12 @@ from math import factorial
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 from pyrecest.backend import (
     abs,
+    all,
     arctan2,
     array,
     cos,
     exp,
+    isfinite,
     linalg,
     max,
     mod,
@@ -21,6 +23,10 @@ from scipy.special import iv
 from ..circle.custom_circular_distribution import CustomCircularDistribution
 from ._input_validation import as_shift_vector
 from .abstract_toroidal_distribution import AbstractToroidalDistribution
+from .abstract_toroidal_bivar_vm_distribution import (
+    _as_python_bool,
+    validate_toroidal_vm_parameters,
+)
 
 _2pi = 2.0 * pi
 
@@ -43,14 +49,14 @@ class ToroidalVMMatrixDistribution(AbstractToroidalDistribution):
 
     def __init__(self, mu, kappa, A):
         AbstractToroidalDistribution.__init__(self)
-        mu = array(mu)
-        kappa = array(kappa)
+        mu, kappa = validate_toroidal_vm_parameters(
+            mu, kappa, require_positive_kappa=True
+        )
         A = array(A)
-        assert mu.shape == (2,)
-        assert kappa.shape == (2,)
-        assert A.shape == (2, 2)
-        assert kappa[0] > 0
-        assert kappa[1] > 0
+        if A.shape != (2, 2):
+            raise ValueError("A must have shape (2, 2)")
+        if not _as_python_bool(all(isfinite(A))):
+            raise ValueError("A must contain only finite values")
 
         self.mu = mod(mu, _2pi)
         self.kappa = kappa
@@ -270,7 +276,8 @@ class ToroidalVMMatrixDistribution(AbstractToroidalDistribution):
 
     def multiply(self, other):
         """Multiply two ToroidalVMMatrixDistributions (exact product)."""
-        assert isinstance(other, ToroidalVMMatrixDistribution)
+        if not isinstance(other, ToroidalVMMatrixDistribution):
+            raise ValueError("other must be a ToroidalVMMatrixDistribution")
 
         C1 = self.kappa[0] * cos(self.mu[0]) + other.kappa[0] * cos(other.mu[0])
         S1 = self.kappa[0] * sin(self.mu[0]) + other.kappa[0] * sin(other.mu[0])
@@ -308,7 +315,8 @@ class ToroidalVMMatrixDistribution(AbstractToroidalDistribution):
         Integrates out the *other* dimension analytically using the Bessel
         function identity for the von-Mises-type integral.
         """
-        assert dimension in (0, 1)
+        if dimension not in (0, 1):
+            raise ValueError("dimension must be 0 or 1")
         other = 1 - dimension
 
         mu_d = self.mu[dimension]

--- a/src/pyrecest/distributions/hypertorus/toroidal_vm_rivest_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/toroidal_vm_rivest_distribution.py
@@ -1,9 +1,13 @@
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
-from pyrecest.backend import all, array, asarray, cos, exp, mod, pi, sin, sqrt
+from pyrecest.backend import array, cos, exp, mod, pi, sin, sqrt
 from scipy.special import iv
 
 from ._input_validation import as_shift_vector
 from .abstract_toroidal_distribution import AbstractToroidalDistribution
+from .abstract_toroidal_bivar_vm_distribution import (
+    validate_scalar_parameter,
+    validate_toroidal_vm_parameters,
+)
 
 
 class ToroidalVMRivestDistribution(AbstractToroidalDistribution):
@@ -18,15 +22,9 @@ class ToroidalVMRivestDistribution(AbstractToroidalDistribution):
 
     def __init__(self, mu, kappa, alpha, beta):
         AbstractToroidalDistribution.__init__(self)
-        mu = array(mu)
-        kappa = array(kappa)
-        assert mu.shape == (2,)
-        assert kappa.shape == (2,)
-        alpha = asarray(alpha)
-        beta = asarray(beta)
-        assert alpha.shape == ()
-        assert beta.shape == ()
-        assert all(kappa >= 0.0)
+        mu, kappa = validate_toroidal_vm_parameters(mu, kappa)
+        alpha = validate_scalar_parameter(alpha, "alpha")
+        beta = validate_scalar_parameter(beta, "beta")
 
         self.mu = mod(mu, 2.0 * pi)
         self.kappa = kappa

--- a/src/pyrecest/distributions/hypertorus/toroidal_von_mises_cosine_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/toroidal_von_mises_cosine_distribution.py
@@ -2,11 +2,14 @@
 import math
 
 import numpy as np
-from pyrecest.backend import asarray, cos, mod, pi
+from pyrecest.backend import cos, mod, pi
 from scipy.special import iv
 
 from ._input_validation import as_shift_vector
-from .abstract_toroidal_bivar_vm_distribution import AbstractToroidalBivarVMDistribution
+from .abstract_toroidal_bivar_vm_distribution import (
+    AbstractToroidalBivarVMDistribution,
+    validate_scalar_parameter,
+)
 
 _SERIES_RTOL = 1e-14
 _SERIES_MIN_TERMS = 10
@@ -61,8 +64,7 @@ class ToroidalVonMisesCosineDistribution(AbstractToroidalBivarVMDistribution):
 
     def __init__(self, mu, kappa, kappa3):
         AbstractToroidalBivarVMDistribution.__init__(self, mu, kappa)
-        kappa3 = asarray(kappa3)
-        assert kappa3.shape == ()
+        kappa3 = validate_scalar_parameter(kappa3, "kappa3")
         self.kappa3 = kappa3
         self.C = 1.0 / self.norm_const
 

--- a/src/pyrecest/distributions/hypertorus/toroidal_von_mises_sine_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/toroidal_von_mises_sine_distribution.py
@@ -2,10 +2,13 @@
 # pylint: disable=no-name-in-module,no-member
 import math
 
-from pyrecest.backend import asarray, sin
+from pyrecest.backend import sin
 from scipy.special import gammaln, iv
 
-from .abstract_toroidal_bivar_vm_distribution import AbstractToroidalBivarVMDistribution
+from .abstract_toroidal_bivar_vm_distribution import (
+    AbstractToroidalBivarVMDistribution,
+    validate_scalar_parameter,
+)
 
 _SERIES_RTOL = 1e-12
 _SERIES_MIN_TERMS = 10
@@ -50,8 +53,7 @@ class ToroidalVonMisesSineDistribution(AbstractToroidalBivarVMDistribution):
 
     def __init__(self, mu, kappa, lambda_):
         AbstractToroidalBivarVMDistribution.__init__(self, mu, kappa)
-        lambda_ = asarray(lambda_)
-        assert lambda_.shape == ()
+        lambda_ = validate_scalar_parameter(lambda_, "lambda_")
         self.lambda_ = lambda_
         self.C = 1.0 / self.norm_const
 

--- a/tests/distributions/test_toroidal_vm_matrix_distribution.py
+++ b/tests/distributions/test_toroidal_vm_matrix_distribution.py
@@ -33,6 +33,22 @@ class TestToroidalVMMatrixDistribution(unittest.TestCase):
         npt.assert_allclose(tvm.kappa, self.kappa, atol=1e-10)
         npt.assert_allclose(tvm.A, self.A, atol=1e-10)
 
+    def test_constructor_rejects_invalid_parameters(self):
+        invalid_cases = [
+            ([1.0], self.kappa, self.A, "mu"),
+            (self.mu, [0.5], self.A, "kappa"),
+            (self.mu, [0.0, 0.7], self.A, "positive"),
+            (self.mu, [-0.5, 0.7], self.A, "positive"),
+            (self.mu, [float("nan"), 0.7], self.A, "finite"),
+            (self.mu, self.kappa, [[0.3, 0.1]], "shape"),
+            (self.mu, self.kappa, [[float("nan"), 0.1], [-0.2, 0.4]], "finite"),
+        ]
+
+        for mu, kappa, A, message in invalid_cases:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(ValueError, message):
+                    ToroidalVMMatrixDistribution(mu, kappa, A)
+
     def test_pdf_positive(self):
         xs = array([[0.5, 1.0], [1.0, 2.0], [3.0, 4.0]])
         vals = self.tvm.pdf(xs)
@@ -87,6 +103,10 @@ class TestToroidalVMMatrixDistribution(unittest.TestCase):
         self.assertIsInstance(product, ToroidalVMMatrixDistribution)
         self.assertAlmostEqual(product.integrate(), 1.0, delta=2e-3)
 
+    def test_multiply_rejects_wrong_type(self):
+        with self.assertRaisesRegex(ValueError, "ToroidalVMMatrixDistribution"):
+            self.tvm.multiply(object())
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
         reason="Not supported on this backend",
@@ -102,6 +122,12 @@ class TestToroidalVMMatrixDistribution(unittest.TestCase):
     def test_marginalize_to_1d_dim1(self):
         marginal = self.tvm.marginalize_to_1d(1)
         self.assertAlmostEqual(marginal.integrate(), 1.0, delta=1e-4)
+
+    def test_marginalize_to_1d_rejects_invalid_dimension(self):
+        for dimension in (-1, 2):
+            with self.subTest(dimension=dimension):
+                with self.assertRaisesRegex(ValueError, "dimension"):
+                    self.tvm.marginalize_to_1d(dimension)
 
     def test_shift(self):
         shift = array([0.5, -0.3])

--- a/tests/distributions/test_toroidal_vm_rivest_distribution.py
+++ b/tests/distributions/test_toroidal_vm_rivest_distribution.py
@@ -51,6 +51,23 @@ class ToroidalVMRivestDistributionTest(unittest.TestCase):
         npt.assert_allclose(dist.pdf(x), self.dist.pdf(x), rtol=5e-7)
         npt.assert_allclose(dist.C, self.dist.C, rtol=5e-7)
 
+    def test_constructor_rejects_invalid_parameters(self):
+        invalid_cases = [
+            ([1.0], self.kappa, self.alpha, self.beta, "mu"),
+            (self.mu, [0.7], self.alpha, self.beta, "kappa"),
+            (self.mu, [-0.7, 1.4], self.alpha, self.beta, "nonnegative"),
+            (self.mu, [float("nan"), 1.4], self.alpha, self.beta, "finite"),
+            (self.mu, self.kappa, [0.5, 0.6], self.beta, "alpha"),
+            (self.mu, self.kappa, float("nan"), self.beta, "alpha"),
+            (self.mu, self.kappa, self.alpha, [0.3, 0.4], "beta"),
+            (self.mu, self.kappa, self.alpha, float("nan"), "beta"),
+        ]
+
+        for mu, kappa, alpha, beta, message in invalid_cases:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(ValueError, message):
+                    ToroidalVMRivestDistribution(mu, kappa, alpha, beta)
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
         reason="Not supported on this backend",

--- a/tests/distributions/test_toroidal_von_mises_cosine_distribution.py
+++ b/tests/distributions/test_toroidal_von_mises_cosine_distribution.py
@@ -96,6 +96,21 @@ class ToroidalVMCosineDistributionTest(ToroidalBivarVMTestMixin, unittest.TestCa
             tvm.trigonometric_moment(1), self.tvm.trigonometric_moment(1), rtol=5e-7
         )
 
+    def test_constructor_rejects_invalid_parameters(self):
+        invalid_cases = [
+            ([1.0], self.kappa, self.kappa3, "mu"),
+            (self.mu, [0.7], self.kappa3, "kappa"),
+            (self.mu, [-0.7, 1.4], self.kappa3, "nonnegative"),
+            (self.mu, [float("nan"), 1.4], self.kappa3, "finite"),
+            (self.mu, self.kappa, [0.5, 0.6], "kappa3"),
+            (self.mu, self.kappa, float("nan"), "kappa3"),
+        ]
+
+        for mu, kappa, kappa3, message in invalid_cases:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(ValueError, message):
+                    ToroidalVonMisesCosineDistribution(mu, kappa, kappa3)
+
     def _unnormalized_pdf(self, xs):
         return exp(
             self.kappa[0] * cos(xs[..., 0] - self.mu[0])

--- a/tests/distributions/test_toroidal_von_mises_sine_distribution.py
+++ b/tests/distributions/test_toroidal_von_mises_sine_distribution.py
@@ -109,6 +109,21 @@ class ToroidalVMSineDistributionTest(ToroidalBivarVMTestMixin, unittest.TestCase
         npt.assert_allclose(tvm.pdf(x), self.tvm.pdf(x), rtol=5e-7)
         npt.assert_allclose(tvm.norm_const, self.tvm.norm_const, rtol=5e-7)
 
+    def test_constructor_rejects_invalid_parameters(self):
+        invalid_cases = [
+            ([1.0], self.kappa, self.lambda_, "mu"),
+            (self.mu, [0.7], self.lambda_, "kappa"),
+            (self.mu, [-0.7, 1.4], self.lambda_, "nonnegative"),
+            (self.mu, [float("nan"), 1.4], self.lambda_, "finite"),
+            (self.mu, self.kappa, [0.5, 0.6], "lambda_"),
+            (self.mu, self.kappa, float("nan"), "lambda_"),
+        ]
+
+        for mu, kappa, lambda_, message in invalid_cases:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(ValueError, message):
+                    ToroidalVonMisesSineDistribution(mu, kappa, lambda_)
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ != "numpy",
         reason="Regression test uses NumPy/scipy scalar semantics",


### PR DESCRIPTION
## Summary
- replace assertion-only toroidal bivariate von Mises parameter checks with explicit `ValueError`s
- validate shared `mu`/`kappa` shapes, finiteness, and nonnegative or positive concentration constraints
- validate matrix coupling parameters, Rivest scalar correlations, sine/cosine coupling scalars, multiply operand type, and marginal dimension

## Why
The toroidal von Mises families rely on strict shape and concentration invariants. Several checks used `assert`, so optimized Python could skip them and allow malformed distributions or invalid operations to produce incorrect densities or marginalization results.

## Validation
- `.\.venv\Scripts\python -m pytest -q tests\distributions\test_toroidal_vm_matrix_distribution.py tests\distributions\test_toroidal_vm_rivest_distribution.py tests\distributions\test_toroidal_von_mises_sine_distribution.py tests\distributions\test_toroidal_von_mises_cosine_distribution.py`
- `.\.venv\Scripts\python -O -m pytest -q tests\distributions\test_toroidal_vm_matrix_distribution.py tests\distributions\test_toroidal_vm_rivest_distribution.py tests\distributions\test_toroidal_von_mises_sine_distribution.py tests\distributions\test_toroidal_von_mises_cosine_distribution.py`
- `.\.venv\Scripts\python -m ruff check src\pyrecest\distributions\hypertorus\abstract_toroidal_bivar_vm_distribution.py src\pyrecest\distributions\hypertorus\toroidal_vm_matrix_distribution.py src\pyrecest\distributions\hypertorus\toroidal_vm_rivest_distribution.py src\pyrecest\distributions\hypertorus\toroidal_von_mises_sine_distribution.py src\pyrecest\distributions\hypertorus\toroidal_von_mises_cosine_distribution.py tests\distributions\test_toroidal_vm_matrix_distribution.py tests\distributions\test_toroidal_vm_rivest_distribution.py tests\distributions\test_toroidal_von_mises_sine_distribution.py tests\distributions\test_toroidal_von_mises_cosine_distribution.py`