### PR TITLE
Validate complex hypersphere inputs explicitly

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/complex_angular_central_gaussian_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/complex_angular_central_gaussian_distribution.py
@@ -12,6 +12,7 @@ from pyrecest.backend import (
     exp,
     eye,
     gammaln,
+    isfinite,
     linalg,
     log,
     pi,
@@ -74,11 +75,14 @@ class ComplexAngularCentralGaussianDistribution:
             Hermitian positive definite parameter matrix.
         """
         C = array(C)
-        assert C.ndim == 2 and C.shape[0] == C.shape[1], "C must be a square matrix"
-        assert _to_python_bool(allclose(C, conj(transpose(C)))), "C must be Hermitian"
-        assert _to_python_bool(
-            backend_all(linalg.eigvalsh(C) > 0.0)
-        ), "C must be positive definite"
+        if C.ndim != 2 or C.shape[0] != C.shape[1]:
+            raise ValueError("C must be a square matrix")
+        if not _to_python_bool(backend_all(isfinite(C))):
+            raise ValueError("C must contain only finite values")
+        if not _to_python_bool(allclose(C, conj(transpose(C)))):
+            raise ValueError("C must be Hermitian")
+        if not _to_python_bool(backend_all(linalg.eigvalsh(C) > 0.0)):
+            raise ValueError("C must be positive definite")
         self.C = C
         self.dim = C.shape[0]
 
@@ -95,6 +99,9 @@ class ComplexAngularCentralGaussianDistribution:
         p : array-like of shape (n,) or scalar
             PDF values at each row of za.
         """
+        za = array(za)
+        if za.ndim == 0 or za.shape[-1] != self.dim:
+            raise ValueError(f"za must have trailing dimension {self.dim}, got {za.shape}.")
         single = za.ndim == 1
         if single:
             za = za.reshape(1, -1)

--- a/src/pyrecest/distributions/hypersphere_subset/complex_watson_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/complex_watson_distribution.py
@@ -346,7 +346,6 @@ class ComplexWatsonDistribution:
         Returns:
             log(C_D(kappa)); same shape as kappa (scalar if scalar input)
         """  # pylint: disable=too-many-locals
-        _validate_numpy_or_pytorch_backend("log_norm()")
         if isinstance(D, bool) or not isinstance(D, Integral):
             raise ValueError("D must be a positive integer")
         D = int(D)
@@ -356,6 +355,7 @@ class ComplexWatsonDistribution:
         kappa_arr = atleast_1d(asarray(kappa, dtype=float)).ravel()
         if not _to_python_bool(all(isfinite(kappa_arr))):
             raise ValueError("kappa must contain only finite values")
+        _validate_numpy_or_pytorch_backend("log_norm()")
         log_c = zeros_like(kappa_arr)
 
         # ----------------------------------------------------------

--- a/src/pyrecest/distributions/hypersphere_subset/complex_watson_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/complex_watson_distribution.py
@@ -1,4 +1,6 @@
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
+from numbers import Integral
+
 import mpmath
 import numpy as np
 import pyrecest.backend
@@ -17,6 +19,7 @@ from pyrecest.backend import (
     eye,
     flip,
     gammaln,
+    isfinite,
     linalg,
     log,
     maximum,
@@ -56,6 +59,46 @@ def _validate_positive_sample_count(n) -> int:
     return count_int
 
 
+def _to_python_bool(value) -> bool:
+    if isinstance(value, bool):
+        return value
+    if hasattr(value, "item"):
+        return bool(value.item())
+    return bool(value)
+
+
+def _validate_numpy_or_pytorch_backend(method_name: str):
+    if pyrecest.backend.__backend_name__ == "jax":  # pylint: disable=no-member
+        raise NotImplementedError(
+            f"{method_name} uses in-place array assignment which is incompatible "
+            "with JAX. Use numpy or pytorch backend instead."
+        )
+
+
+def _validate_unit_vector(mu, tolerance: float):
+    mu = asarray(mu, dtype=complex128)
+    if mu.ndim != 1:
+        raise ValueError("mu must be a 1-D vector")
+    if not _to_python_bool(all(isfinite(mu))):
+        raise ValueError("mu must contain only finite values")
+    if not _to_python_bool(abs(linalg.norm(mu) - 1.0) < tolerance):
+        raise ValueError("mu must be a unit vector")
+    return mu
+
+
+def _validate_finite_scalar(value, name: str) -> float:
+    value_array = np.asarray(value)
+    if value_array.ndim != 0:
+        raise ValueError(f"{name} must be a finite scalar")
+    try:
+        scalar = float(value_array.item())
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a finite scalar") from exc
+    if not np.isfinite(scalar):
+        raise ValueError(f"{name} must be finite")
+    return scalar
+
+
 class ComplexWatsonDistribution:
     """Complex Watson distribution on the complex unit sphere C^D.
 
@@ -74,12 +117,10 @@ class ComplexWatsonDistribution:
             mu: 1-D complex array of shape (D,), must be a unit vector
             kappa: scalar concentration parameter
         """
-        mu = asarray(mu, dtype=complex128)
-        assert mu.ndim == 1, "mu must be a 1-D vector"
-        assert abs(linalg.norm(mu) - 1.0) < self.EPSILON, "mu must be a unit vector"
+        mu = _validate_unit_vector(mu, self.EPSILON)
 
         self.mu = mu
-        self.kappa = float(kappa)
+        self.kappa = _validate_finite_scalar(kappa, "kappa")
         self.dim = mu.shape[0]  # D: length of the complex feature vector
         self._log_norm_const = None
 
@@ -106,6 +147,8 @@ class ComplexWatsonDistribution:
             Real-valued array of shape (N,) or a scalar
         """
         za = asarray(za, dtype=complex128)
+        if za.ndim == 0 or za.shape[-1] != self.dim:
+            raise ValueError(f"za must have trailing dimension {self.dim}, got {za.shape}.")
         inner = za @ conj(self.mu)  # complex inner product, shape (N,) or scalar
         return real(exp(self.log_norm_const + self.kappa * abs(inner) ** 2))
 
@@ -121,9 +164,7 @@ class ComplexWatsonDistribution:
         Returns:
             complex array of shape (n, D)
         """  # pylint: disable=too-many-locals
-        assert (
-            pyrecest.backend.__backend_name__ != "jax"  # pylint: disable=no-member
-        ), "sample() uses in-place array assignment which is incompatible with JAX. Use numpy or pytorch backend instead."
+        _validate_numpy_or_pytorch_backend("sample()")
         n = _validate_positive_sample_count(n)
 
         D = self.dim
@@ -203,15 +244,27 @@ class ComplexWatsonDistribution:
             tuple (mu_hat, kappa_hat)
         """
         Z = asarray(Z, dtype=complex128)
+        if Z.ndim != 2:
+            raise ValueError("Z must be a two-dimensional array")
+        if not _to_python_bool(all(isfinite(Z))):
+            raise ValueError("Z must contain only finite values")
         N, D = Z.shape
 
         # Build the Hermitian scatter matrix S (D x D)
         if weights is None:
             S = conj(Z).T @ Z
         else:
-            weights = asarray(weights).ravel()
-            assert weights.shape[0] == N, "dimensions of Z and weights mismatch"
-            assert weights.ndim == 1, "weights must be a 1-D vector"
+            weights = asarray(weights, dtype=float)
+            if weights.ndim != 1:
+                raise ValueError("weights must be a 1-D vector")
+            if weights.shape[0] != N:
+                raise ValueError("dimensions of Z and weights mismatch")
+            if not _to_python_bool(all(isfinite(weights))):
+                raise ValueError("weights must contain only finite values")
+            if not _to_python_bool(all(weights >= 0.0)):
+                raise ValueError("weights must be nonnegative")
+            if not _to_python_bool(sum(weights) > 0.0):
+                raise ValueError("weights must have positive total mass")
             # Weighted scatter: Σ_i w_i·z_i·z_i^H, normalised so uniform
             # weights (w_i=1) reproduce the unweighted result Z^H Z.
             S = (Z * weights[:, None]).conj().T @ Z * (N / sum(weights))
@@ -226,10 +279,11 @@ class ComplexWatsonDistribution:
         eigvals = real(eigvals[idx])
         eigvecs = eigvecs[:, idx]
 
-        assert all(eigvals > 0), (
-            "All eigenvalues of the scatter matrix must be positive; "
-            "this may indicate that fewer samples than features were provided."
-        )
+        if not _to_python_bool(all(eigvals > 0)):
+            raise ValueError(
+                "All eigenvalues of the scatter matrix must be positive; "
+                "this may indicate that fewer samples than features were provided."
+            )
 
         mu_hat = eigvecs[:, 0]
 
@@ -292,11 +346,16 @@ class ComplexWatsonDistribution:
         Returns:
             log(C_D(kappa)); same shape as kappa (scalar if scalar input)
         """  # pylint: disable=too-many-locals
-        assert (
-            pyrecest.backend.__backend_name__ != "jax"  # pylint: disable=no-member
-        ), "log_norm() uses in-place array assignment which is incompatible with JAX. Use numpy or pytorch backend instead."
+        _validate_numpy_or_pytorch_backend("log_norm()")
+        if isinstance(D, bool) or not isinstance(D, Integral):
+            raise ValueError("D must be a positive integer")
+        D = int(D)
+        if D <= 0:
+            raise ValueError("D must be a positive integer")
         scalar_input = ndim(asarray(kappa)) == 0
         kappa_arr = atleast_1d(asarray(kappa, dtype=float)).ravel()
+        if not _to_python_bool(all(isfinite(kappa_arr))):
+            raise ValueError("kappa must contain only finite values")
         log_c = zeros_like(kappa_arr)
 
         # ----------------------------------------------------------

--- a/tests/distributions/test_complex_angular_central_gaussian_distribution.py
+++ b/tests/distributions/test_complex_angular_central_gaussian_distribution.py
@@ -44,8 +44,18 @@ class TestComplexAngularCentralGaussianDistribution(unittest.TestCase):
     def test_constructor_non_hermitian_raises(self):
         """Test that constructor rejects a non-Hermitian matrix."""
         C_bad = array([[1.0 + 0j, 2.0 + 1.0j], [0.0 + 0j, 1.0 + 0j]])
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(ValueError, "Hermitian"):
             ComplexAngularCentralGaussianDistribution(C_bad)
+
+    def test_constructor_rejects_invalid_shape_or_nonfinite_matrix(self):
+        invalid_matrices = [
+            ([[1.0 + 0j, 0.0 + 0j]], "square"),
+            (array([[float("nan") + 0j, 0.0 + 0j], [0.0 + 0j, 1.0 + 0j]]), "finite"),
+        ]
+
+        for C_bad, message in invalid_matrices:
+            with self.subTest(message=message), self.assertRaisesRegex(ValueError, message):
+                ComplexAngularCentralGaussianDistribution(C_bad)
 
     def test_constructor_rejects_non_positive_definite_matrix(self):
         """Hermitian parameter matrices must be positive definite."""
@@ -54,7 +64,9 @@ class TestComplexAngularCentralGaussianDistribution(unittest.TestCase):
             array([[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, -1.0 + 0j]]),
         ]
         for C_bad in invalid_matrices:
-            with self.subTest(C=C_bad), self.assertRaises(AssertionError):
+            with self.subTest(C=C_bad), self.assertRaisesRegex(
+                ValueError, "positive definite"
+            ):
                 ComplexAngularCentralGaussianDistribution(C_bad)
 
     @unittest.skipIf(
@@ -122,6 +134,20 @@ class TestComplexAngularCentralGaussianDistribution(unittest.TestCase):
                 float(real(p_single[0])),
                 rtol=1e-10,
             )
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on JAX backend",
+    )  # pylint: disable=no-member
+    def test_pdf_accepts_list_and_rejects_wrong_dimension(self):
+        z = [[1.0 + 0j, 0.0 + 0j]]
+
+        npt.assert_allclose(self.dist_identity_2d.pdf(z), self.dist_identity_2d.pdf(array(z)))
+
+        for invalid_z in (1.0 + 0j, [1.0 + 0j], [[1.0 + 0j, 0.0 + 0j, 0.0 + 0j]]):
+            with self.subTest(invalid_z=invalid_z):
+                with self.assertRaisesRegex(ValueError, "trailing dimension"):
+                    self.dist_identity_2d.pdf(invalid_z)
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",

--- a/tests/distributions/test_complex_watson_distribution.py
+++ b/tests/distributions/test_complex_watson_distribution.py
@@ -40,12 +40,25 @@ class TestComplexWatsonDistribution(unittest.TestCase):
         self.assertEqual(cw.dim, 2)
 
     def test_constructor_rejects_unnormalized_mu(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(ValueError, "unit vector"):
             ComplexWatsonDistribution(array([1.0, 1.0], dtype=complex128), 1.0)
 
     def test_constructor_rejects_2d_mu(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(ValueError, "1-D"):
             ComplexWatsonDistribution(array([[1.0, 0.0]], dtype=complex128), 1.0)
+
+    def test_constructor_rejects_nonfinite_mu_or_kappa(self):
+        invalid_cases = [
+            (array([float("nan"), 0.0], dtype=complex128), 1.0, "finite"),
+            (self.mu2, float("nan"), "finite"),
+            (self.mu2, float("inf"), "finite"),
+            (self.mu2, [1.0, 2.0], "scalar"),
+        ]
+
+        for mu, kappa, message in invalid_cases:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(ValueError, message):
+                    ComplexWatsonDistribution(mu, kappa)
 
     # ------------------------------------------------------------------
     # mean
@@ -146,6 +159,14 @@ class TestComplexWatsonDistribution(unittest.TestCase):
         cw = ComplexWatsonDistribution(self.mu2, self.kappa2)
         p = cw.pdf(self.mu2)
         self.assertIsInstance(float(p), float)
+
+    def test_pdf_rejects_wrong_dimension(self):
+        cw = ComplexWatsonDistribution(self.mu2, self.kappa2)
+
+        for za in (1.0 + 0j, [1.0 + 0j], [[1.0 + 0j, 0.0 + 0j, 0.0 + 0j]]):
+            with self.subTest(za=za):
+                with self.assertRaisesRegex(ValueError, "trailing dimension"):
+                    cw.pdf(za)
 
     # ------------------------------------------------------------------
     # sample
@@ -253,6 +274,44 @@ class TestComplexWatsonDistribution(unittest.TestCase):
         w = ones(200)
         cw_fit = ComplexWatsonDistribution.fit(Z, weights=w)
         self.assertIsInstance(cw_fit, ComplexWatsonDistribution)
+
+    def test_estimate_parameters_rejects_invalid_inputs(self):
+        valid_Z = array(
+            [[1.0 + 0j, 0.0 + 0j], [0.0 + 0j, 1.0 + 0j]], dtype=complex128
+        )
+        invalid_cases = [
+            ([1.0 + 0j, 0.0 + 0j], None, "two-dimensional"),
+            (array([[float("nan") + 0j, 0.0 + 0j]], dtype=complex128), None, "finite"),
+            (valid_Z, array([[1.0, 1.0]]), "1-D"),
+            (valid_Z, ones(3), "dimensions"),
+            (valid_Z, array([1.0, float("nan")]), "finite"),
+            (valid_Z, array([1.0, -1.0]), "nonnegative"),
+            (valid_Z, array([0.0, 0.0]), "positive total mass"),
+        ]
+
+        for Z, weights, message in invalid_cases:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(ValueError, message):
+                    ComplexWatsonDistribution.estimate_parameters(Z, weights=weights)
+
+    def test_estimate_parameters_rejects_rank_deficient_scatter(self):
+        Z = array([[1.0 + 0j, 0.0 + 0j], [1.0 + 0j, 0.0 + 0j]], dtype=complex128)
+
+        with self.assertRaisesRegex(ValueError, "positive"):
+            ComplexWatsonDistribution.estimate_parameters(Z)
+
+    def test_log_norm_rejects_invalid_inputs(self):
+        invalid_cases = [
+            (0, 1.0, "positive integer"),
+            (1.5, 1.0, "positive integer"),
+            (2, float("nan"), "finite"),
+            (2, [1.0, float("inf")], "finite"),
+        ]
+
+        for D, kappa, message in invalid_cases:
+            with self.subTest(D=D, kappa=kappa):
+                with self.assertRaisesRegex(ValueError, message):
+                    ComplexWatsonDistribution.log_norm(D, kappa)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace assertion-only validation in complex angular central Gaussian and complex Watson distributions with explicit exceptions
- validate Hermitian positive-definite matrices, unit complex mean vectors, finite scalar concentrations, PDF input dimensions, weighted fitting inputs, rank-deficient scatter matrices, and log-normalizer inputs
- add regression coverage for normal and optimized Python execution paths

## Why
These complex hypersphere distributions require strict matrix, unit-vector, and weighted-fit invariants. Several checks used `assert`, so optimized Python could skip them and allow invalid distributions, malformed PDF calls, or incorrect fitted parameters instead of failing clearly.

## Validation
- `.\.venv\Scripts\python -m pytest -q tests\distributions\test_complex_angular_central_gaussian_distribution.py tests\distributions\test_complex_watson_distribution.py`
- `.\.venv\Scripts\python -O -m pytest -q tests\distributions\test_complex_angular_central_gaussian_distribution.py tests\distributions\test_complex_watson_distribution.py`
- `.\.venv\Scripts\python -m ruff check src\pyrecest\distributions\hypersphere_subset\complex_angular_central_gaussian_distribution.py src\pyrecest\distributions\hypersphere_subset\complex_watson_distribution.py tests\distributions\test_complex_angular_central_gaussian_distribution.py tests\distributions\test_complex_watson_distribution.py`