### PR TITLE
Validate Fourier and custom PDF inputs explicitly

### DIFF
--- a/src/pyrecest/distributions/circle/circular_fourier_distribution.py
+++ b/src/pyrecest/distributions/circle/circular_fourier_distribution.py
@@ -64,10 +64,13 @@ class CircularFourierDistribution(AbstractCircularDistribution):
         multiplied_by_n: bool = True,
     ):
         AbstractCircularDistribution.__init__(self)
-        assert (a is None) == (b is None)
-        assert (a is None) != (c is None)
+        if (a is None) != (b is None):
+            raise ValueError("a and b must either both be provided or both be None.")
+        if (a is None) == (c is None):
+            raise ValueError("Provide either c or the pair a and b, but not both.")
         if c is not None:  # Assumed as result from rfft
-            assert c.ndim == 1
+            if c.ndim != 1:
+                raise ValueError(f"c must be one-dimensional, got shape {c.shape}.")
             self.c = c
             self.a = None
             self.b = None
@@ -79,15 +82,31 @@ class CircularFourierDistribution(AbstractCircularDistribution):
             else:
                 self.n = int(n)
             _ensure_odd_n(self.n)
+            expected_coefficients = self.n // 2 + 1
+            if c.shape[0] != expected_coefficients:
+                raise ValueError(
+                    f"c must contain {expected_coefficients} coefficients for "
+                    f"n={self.n}, got {c.shape[0]}."
+                )
         elif a is not None and b is not None:
-            assert a.ndim == 1
-            assert b.ndim == 1
+            if a.ndim != 1:
+                raise ValueError(f"a must be one-dimensional, got shape {a.shape}.")
+            if b.ndim != 1:
+                raise ValueError(f"b must be one-dimensional, got shape {b.shape}.")
             self.a = a
             self.b = b
             self.c = None
             self.n = a.shape[0] + b.shape[0]
-            assert self.n == n or n is None
+            if n is not None and self.n != int(n):
+                raise ValueError(
+                    f"n must match len(a) + len(b), got n={n} and "
+                    f"len(a) + len(b)={self.n}."
+                )
             _ensure_odd_n(self.n)
+            if a.shape[0] != b.shape[0] + 1:
+                raise ValueError(
+                    "a must contain exactly one more coefficient than b."
+                )
         else:
             raise ValueError("Need to provide either c or a and b.")
 
@@ -98,16 +117,26 @@ class CircularFourierDistribution(AbstractCircularDistribution):
         self, other: "CircularFourierDistribution"
     ) -> "CircularFourierDistribution":
         # If transformed will not yield minus of pdfs!
-        assert (
-            (self.a is not None and other.a is not None)
-            and (self.b is not None and other.b is not None)
-        ) or (
-            self.c is not None and other.c is not None
-        ), "Either both instances should have `a` and `b` defined, or both should have `c` defined."
+        if not (
+            (
+                (self.a is not None and other.a is not None)
+                and (self.b is not None and other.b is not None)
+            )
+            or (self.c is not None and other.c is not None)
+        ):
+            raise ValueError(
+                "Either both instances should have a and b defined, or both "
+                "should have c defined."
+            )
 
-        assert self.transformation == other.transformation
-        assert self.n == other.n
-        assert self.multiplied_by_n == other.multiplied_by_n
+        if self.transformation != other.transformation:
+            raise ValueError("Both distributions must use the same transformation.")
+        if self.n != other.n:
+            raise ValueError("Both distributions must have the same n.")
+        if self.multiplied_by_n != other.multiplied_by_n:
+            raise ValueError(
+                "Both distributions must agree on multiplied_by_n before subtracting."
+            )
         if self.a is not None and self.b is not None:
             aNew = self.a - other.a
             bNew = self.b - other.b
@@ -129,7 +158,8 @@ class CircularFourierDistribution(AbstractCircularDistribution):
 
     def pdf(self, xs):
         xs = array(xs)
-        assert xs.ndim <= 2, "xs should have at most 2 dimensions."
+        if xs.ndim > 2:
+            raise ValueError(f"xs should have at most 2 dimensions, got {xs.ndim}.")
         xs = xs.reshape(-1, 1)
         a, b = self.get_a_b()
 
@@ -193,9 +223,8 @@ class CircularFourierDistribution(AbstractCircularDistribution):
 
     # pylint: disable=too-many-branches
     def integrate(self, integration_boundaries=None) -> float:
-        assert (
-            integration_boundaries is None
-        ), "Currently, only supported for entire domain."
+        if integration_boundaries is not None:
+            raise NotImplementedError("Currently, only supported for entire domain.")
         if self.a is not None and self.b is not None:
             a: array = self.a
             b: array = self.b
@@ -276,9 +305,10 @@ class CircularFourierDistribution(AbstractCircularDistribution):
             b = -2.0 * imag(self.c[1:])
         else:
             raise ValueError("Need either a and b or c.")
-        assert (
-            self.n is None or (a.shape[0] + b.shape[0]) == self.n
-        )  # Other case not implemented yet!
+        if self.n is not None and (a.shape[0] + b.shape[0]) != self.n:
+            raise ValueError(
+                "The number of real Fourier coefficients does not match n."
+            )
         return a, b
 
     def get_c(self):
@@ -309,7 +339,8 @@ class CircularFourierDistribution(AbstractCircularDistribution):
         return fd
 
     def get_full_c(self):
-        assert self.c is not None
+        if self.c is None:
+            raise ValueError("Full complex coefficients are only available when c is set.")
         neg_c = conj(self.c[-1:0:-1])  # Create array for negative-frequency components
         full_c = concatenate([neg_c, self.c])  # Concatenate arrays to get full spectrum
         return full_c

--- a/src/pyrecest/distributions/nonperiodic/custom_linear_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/custom_linear_distribution.py
@@ -60,13 +60,21 @@ class CustomLinearDistribution(
 
     def pdf(self, xs):
         xs = array(xs)
-        assert self.dim == 1 and xs.ndim <= 1 or xs.shape[-1] == self.dim
+        if not (
+            (self.dim == 1 and xs.ndim <= 1)
+            or (xs.ndim > 0 and xs.shape[-1] == self.dim)
+        ):
+            raise ValueError(
+                f"xs must be scalar, one-dimensional for dim=1, or have last "
+                f"dimension {self.dim}; got shape {xs.shape}."
+            )
         p = self.scale_by * self.f(
             # To ensure 2-d for broadcasting
             reshape(xs, (-1, self.dim))
             - reshape(self.shift_by, (1, -1))
         )
-        assert ndim(p) <= 1
+        if ndim(p) > 1:
+            raise ValueError("The custom pdf function must return at most 1-D values.")
         return p
 
     @staticmethod

--- a/tests/distributions/test_circular_fourier_distribution.py
+++ b/tests/distributions/test_circular_fourier_distribution.py
@@ -100,6 +100,75 @@ class TestCircularFourierDistribution(unittest.TestCase):
         npt.assert_allclose(fd.pdf(0.5), fd.pdf(array([0.5])))
         npt.assert_allclose(fd.pdf([0.5, 1.0]), fd.pdf(array([0.5, 1.0])))
 
+    def test_constructor_rejects_invalid_coefficient_sets(self):
+        with self.assertRaisesRegex(ValueError, "a and b"):
+            CircularFourierDistribution(
+                a=array([1.0]),
+                transformation="identity",
+            )
+
+        with self.assertRaisesRegex(ValueError, "either c or"):
+            CircularFourierDistribution(
+                a=array([1.0]),
+                b=array([]),
+                c=array([1.0]),
+                transformation="identity",
+            )
+
+        with self.assertRaisesRegex(ValueError, "c must be one-dimensional"):
+            CircularFourierDistribution(
+                c=array([[1.0]]),
+                n=1,
+                transformation="identity",
+            )
+
+        with self.assertRaisesRegex(ValueError, "a must be one-dimensional"):
+            CircularFourierDistribution(
+                a=array([[1.0]]),
+                b=array([]),
+                transformation="identity",
+            )
+
+        with self.assertRaisesRegex(ValueError, "b must be one-dimensional"):
+            CircularFourierDistribution(
+                a=array([1.0]),
+                b=array([[0.0]]),
+                transformation="identity",
+            )
+
+        with self.assertRaisesRegex(ValueError, "one more coefficient"):
+            CircularFourierDistribution(
+                a=array([1.0, 2.0, 3.0]),
+                b=array([]),
+                transformation="identity",
+            )
+
+        with self.assertRaisesRegex(ValueError, "len\\(a\\) \\+ len\\(b\\)"):
+            CircularFourierDistribution(
+                a=array([1.0, 2.0]),
+                b=array([0.0]),
+                n=5,
+                transformation="identity",
+            )
+
+        with self.assertRaisesRegex(ValueError, "coefficients for n=5"):
+            CircularFourierDistribution(
+                c=array([1.0, 0.0]),
+                n=5,
+                transformation="identity",
+            )
+
+    def test_pdf_rejects_more_than_two_dimensions(self):
+        fd = CircularFourierDistribution(
+            c=array([1.0]),
+            n=1,
+            transformation="identity",
+            multiplied_by_n=False,
+        )
+
+        with self.assertRaisesRegex(ValueError, "at most 2 dimensions"):
+            fd.pdf(array([[[0.0]]]))
+
     def test_even_number_of_grid_values_is_rejected(self):
         dist = VonMisesDistribution(2.5, 1.5)
 
@@ -153,6 +222,88 @@ class TestCircularFourierDistribution(unittest.TestCase):
         npt.assert_allclose(a_round_trip, a)
         npt.assert_allclose(b_round_trip, b)
         npt.assert_allclose(fd_complex.pdf(xs), fd_real.pdf(xs))
+
+    def test_subtraction_rejects_incompatible_distributions(self):
+        fd_real = CircularFourierDistribution(
+            a=array([1.0, 0.0]),
+            b=array([0.0]),
+            n=3,
+            transformation="identity",
+            multiplied_by_n=False,
+        )
+        fd_complex = CircularFourierDistribution(
+            c=fd_real.get_c(),
+            n=3,
+            transformation="identity",
+            multiplied_by_n=False,
+        )
+        fd_sqrt = CircularFourierDistribution(
+            a=array([1.0, 0.0]),
+            b=array([0.0]),
+            n=3,
+            transformation="sqrt",
+            multiplied_by_n=False,
+        )
+        fd_n5 = CircularFourierDistribution(
+            a=array([1.0, 0.0, 0.0]),
+            b=array([0.0, 0.0]),
+            n=5,
+            transformation="identity",
+            multiplied_by_n=False,
+        )
+        fd_scaled = CircularFourierDistribution(
+            a=array([1.0, 0.0]),
+            b=array([0.0]),
+            n=3,
+            transformation="identity",
+            multiplied_by_n=True,
+        )
+
+        with self.assertRaisesRegex(ValueError, "Either both"):
+            fd_real - fd_complex
+
+        with self.assertRaisesRegex(ValueError, "same transformation"):
+            fd_real - fd_sqrt
+
+        with self.assertRaisesRegex(ValueError, "same n"):
+            fd_real - fd_n5
+
+        with self.assertRaisesRegex(ValueError, "multiplied_by_n"):
+            fd_real - fd_scaled
+
+    def test_integrate_rejects_partial_boundaries(self):
+        fd = CircularFourierDistribution(
+            c=array([1.0]),
+            n=1,
+            transformation="identity",
+            multiplied_by_n=False,
+        )
+
+        with self.assertRaisesRegex(NotImplementedError, "entire domain"):
+            fd.integrate((0.0, 1.0))
+
+    def test_getters_reject_inconsistent_storage(self):
+        fd_real = CircularFourierDistribution(
+            a=array([1.0, 0.0]),
+            b=array([0.0]),
+            n=3,
+            transformation="identity",
+            multiplied_by_n=False,
+        )
+
+        with self.assertRaisesRegex(ValueError, "only available when c is set"):
+            fd_real.get_full_c()
+
+        fd_complex = CircularFourierDistribution(
+            c=array([1.0, 0.0, 0.0]),
+            n=5,
+            transformation="identity",
+            multiplied_by_n=False,
+        )
+        fd_complex.n = 7
+
+        with self.assertRaisesRegex(ValueError, "does not match n"):
+            fd_complex.get_a_b()
 
     @parameterized.expand(
         [

--- a/tests/distributions/test_custom_linear_distribution.py
+++ b/tests/distributions/test_custom_linear_distribution.py
@@ -57,6 +57,18 @@ class CustomLinearDistributionTest(unittest.TestCase):
 
         npt.assert_allclose(list_pdf, array_pdf)
 
+    def test_pdf_rejects_wrong_input_shape(self):
+        cld = CustomLinearDistribution(lambda xs: xs[:, 0], 2)
+
+        with self.assertRaisesRegex(ValueError, "last dimension 2"):
+            cld.pdf(array([1.0, 2.0, 3.0, 4.0]))
+
+    def test_pdf_rejects_multidimensional_custom_output(self):
+        cld = CustomLinearDistribution(lambda xs: array([[1.0]]), 1)
+
+        with self.assertRaisesRegex(ValueError, "at most 1-D"):
+            cld.pdf(array([0.0]))
+
     def test_constructor_rejects_wrong_shift_shape(self):
         with self.assertRaisesRegex(ValueError, "shift_by"):
             CustomLinearDistribution(lambda xs: xs[:, 0], 2, shift_by=[0.2])


### PR DESCRIPTION
## Summary

- Replace assert-only validation in `CustomLinearDistribution.pdf` with explicit shape and return-rank errors.
- Validate `CircularFourierDistribution` coefficient combinations, coefficient lengths, subtraction compatibility, input rank, partial integration bounds, and full-complex getter state explicitly.
- Add regressions for invalid inputs so normal and optimized Python both reject them.

## Validation

- `.venv\Scripts\python -m pytest -q tests\distributions\test_custom_linear_distribution.py tests\distributions\test_circular_fourier_distribution.py`
- `.venv\Scripts\python -O -m pytest -q tests\distributions\test_custom_linear_distribution.py tests\distributions\test_circular_fourier_distribution.py`
- `.venv\Scripts\python -m ruff check src\pyrecest\distributions\nonperiodic\custom_linear_distribution.py src\pyrecest\distributions\circle\circular_fourier_distribution.py tests\distributions\test_custom_linear_distribution.py tests\distributions\test_circular_fourier_distribution.py`