### PR TITLE
Validate state-space subdivision inputs explicitly

### DIFF
--- a/src/pyrecest/distributions/cart_prod/hypercylindrical_state_space_subdivision_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/hypercylindrical_state_space_subdivision_distribution.py
@@ -63,6 +63,11 @@ def _validate_positive_sample_count(n) -> int:
     return count_int
 
 
+def _require_numpy_backend() -> None:
+    if backend_name != "numpy":
+        raise NotImplementedError("Only supported for numpy backend.")
+
+
 class HypercylindricalStateSpaceSubdivisionDistribution(
     StateSpaceSubdivisionDistribution, AbstractHypercylindricalDistribution
 ):
@@ -106,7 +111,7 @@ class HypercylindricalStateSpaceSubdivisionDistribution(
         -------
         p : array, shape (n_samples,)
         """
-        assert backend_name == "numpy", "Only supported for numpy backend"
+        _require_numpy_backend()
         xs = atleast_2d(asarray(xs))
         n_eval = xs.shape[0]
         x_bound = xs[:, : self.bound_dim]  # (n_eval, bound_dim)
@@ -152,7 +157,7 @@ class HypercylindricalStateSpaceSubdivisionDistribution(
         -------
         m : array, shape (bound_dim + lin_dim,)
         """
-        assert backend_name == "numpy", "Only supported for numpy backend"
+        _require_numpy_backend()
         n = self.gd.n_grid_points
         pdf_at_grid_points = zeros(n)
         lin_modes = zeros((n, self.lin_dim))
@@ -183,7 +188,7 @@ class HypercylindricalStateSpaceSubdivisionDistribution(
         -------
         s : array, shape (n, bound_dim + lin_dim)
         """
-        assert backend_name == "numpy", "Only supported for numpy backend"
+        _require_numpy_backend()
         n = _validate_positive_sample_count(n)
         # Sample indices from the grid distribution weighted by grid_values
         weights = reshape(self.gd.grid_values, (-1,))
@@ -266,8 +271,10 @@ class HypercylindricalStateSpaceSubdivisionDistribution(
         -------
         HypercylindricalStateSpaceSubdivisionDistribution
         """
-        assert dim_lin == 1, "Currently, linear dimension must be 1."
-        assert dim_bound == 1, "Currently, bounded dimension must be 1."
+        if dim_lin != 1:
+            raise NotImplementedError("Currently, linear dimension must be 1.")
+        if dim_bound != 1:
+            raise NotImplementedError("Currently, bounded dimension must be 1.")
 
         # Generate equidistant grid on the circle: shape (no_of_grid_points, 1)
         grid = HypertoroidalGridDistribution.generate_cartesian_product_grid(

--- a/src/pyrecest/distributions/cart_prod/state_space_subdivision_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/state_space_subdivision_distribution.py
@@ -26,13 +26,20 @@ class StateSpaceSubdivisionDistribution:
             One distribution per grid point representing the conditional
             distribution of the linear state given that grid point.
         """
-        assert gd.n_grid_points == len(
-            linear_distributions
-        ), "Number of grid points in gd must match length of linear_distributions."
+        if gd.n_grid_points != len(linear_distributions):
+            raise ValueError(
+                "Number of grid points in gd must match length of "
+                "linear_distributions."
+            )
+        if not linear_distributions:
+            raise ValueError("linear_distributions must not be empty.")
+        first_dim = linear_distributions[0].dim
+        if any(ld.dim != first_dim for ld in linear_distributions):
+            raise ValueError("All linear_distributions must have the same dimension.")
         self.gd = copy.deepcopy(gd)
         self.linear_distributions = list(copy.deepcopy(linear_distributions))
         self.bound_dim = self.gd.dim
-        self.lin_dim = self.linear_distributions[0].dim
+        self.lin_dim = first_dim
 
     @property
     def bound_dim(self):

--- a/src/pyrecest/distributions/cart_prod/state_space_subdivision_gaussian_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/state_space_subdivision_gaussian_distribution.py
@@ -43,9 +43,10 @@ class StateSpaceSubdivisionGaussianDistribution(StateSpaceSubdivisionDistributio
         gaussians : list of GaussianDistribution
             One Gaussian per grid point of *gd*.
         """
-        assert all(
-            isinstance(g, GaussianDistribution) for g in gaussians
-        ), "All elements of gaussians must be GaussianDistribution instances."
+        if not all(isinstance(g, GaussianDistribution) for g in gaussians):
+            raise TypeError(
+                "All elements of gaussians must be GaussianDistribution instances."
+            )
         super().__init__(gd, gaussians)
 
     # ------------------------------------------------------------------
@@ -129,14 +130,19 @@ class StateSpaceSubdivisionGaussianDistribution(StateSpaceSubdivisionDistributio
         -------
         StateSpaceSubdivisionGaussianDistribution
         """
-        assert isinstance(other, StateSpaceSubdivisionGaussianDistribution)
-        assert self.gd.n_grid_points == other.gd.n_grid_points, (
-            "Can only multiply distributions defined on grids with the same "
-            "number of grid points."
-        )
+        if not isinstance(other, StateSpaceSubdivisionGaussianDistribution):
+            raise TypeError(
+                "other must be a StateSpaceSubdivisionGaussianDistribution."
+            )
+        if self.gd.n_grid_points != other.gd.n_grid_points:
+            raise ValueError(
+                "Can only multiply distributions defined on grids with the same "
+                "number of grid points."
+            )
         self_grid = asarray(self.gd.get_grid())
         other_grid = asarray(other.gd.get_grid())
-        assert allclose(self_grid, other_grid), "Can only multiply for equal grids."
+        if not allclose(self_grid, other_grid):
+            raise ValueError("Can only multiply for equal grids.")
 
         n = len(self.linear_distributions)
         new_linear_distributions = []

--- a/tests/distributions/test_hypercylindrical_state_space_subdivision_distribution.py
+++ b/tests/distributions/test_hypercylindrical_state_space_subdivision_distribution.py
@@ -3,6 +3,7 @@ from math import pi
 
 import numpy as np
 import numpy.testing as npt
+import pyrecest.distributions.cart_prod.hypercylindrical_state_space_subdivision_distribution as hsssd_module
 from pyrecest.backend import __backend_name__ as backend_name
 from pyrecest.backend import all as backend_all
 from pyrecest.backend import (
@@ -46,6 +47,17 @@ class HypercylindricalStateSpaceSubdivisionDistributionTest(unittest.TestCase):
             self.fun, self.n, 1, 1
         )
         self.assertIsInstance(hcrbd, HypercylindricalStateSpaceSubdivisionDistribution)
+
+    def test_from_function_rejects_unsupported_dimensions(self):
+        with self.assertRaisesRegex(NotImplementedError, "linear dimension"):
+            HypercylindricalStateSpaceSubdivisionDistribution.from_function(
+                self.fun, self.n, 2, 1
+            )
+
+        with self.assertRaisesRegex(NotImplementedError, "bounded dimension"):
+            HypercylindricalStateSpaceSubdivisionDistribution.from_function(
+                self.fun, self.n, 1, 2
+            )
 
     def test_marginalize_linear(self):
         from pyrecest.distributions.hypertorus.hypertoroidal_grid_distribution import (
@@ -193,6 +205,37 @@ class HypercylindricalStateSpaceSubdivisionDistributionTest(unittest.TestCase):
             with self.subTest(n=n):
                 with self.assertRaises(ValueError):
                     hcrbd.sample(n)
+
+    def test_numpy_only_methods_reject_other_backends(self):
+        from pyrecest.distributions.circle.circular_uniform_distribution import (
+            CircularUniformDistribution,
+        )
+        from pyrecest.distributions.hypertorus.hypertoroidal_grid_distribution import (
+            HypertoroidalGridDistribution,
+        )
+
+        n_grid = 3
+        gd = HypertoroidalGridDistribution.from_distribution(
+            CircularUniformDistribution(), (n_grid,)
+        )
+        lin_dists = [
+            GaussianDistribution(array([0.0]), array([[1.0]])) for _ in range(n_grid)
+        ]
+        hcrbd = HypercylindricalStateSpaceSubdivisionDistribution(gd, lin_dists)
+
+        original_backend_name = hsssd_module.backend_name
+        hsssd_module.backend_name = "jax"
+        try:
+            with self.assertRaisesRegex(NotImplementedError, "numpy backend"):
+                hcrbd.pdf(array([[0.0, 0.0]]))
+
+            with self.assertRaisesRegex(NotImplementedError, "numpy backend"):
+                hcrbd.mode()
+
+            with self.assertRaisesRegex(NotImplementedError, "numpy backend"):
+                hcrbd.sample(1)
+        finally:
+            hsssd_module.backend_name = original_backend_name
 
     @unittest.skipIf(
         backend_name != "numpy",

--- a/tests/distributions/test_state_space_subdivision_gaussian_distribution.py
+++ b/tests/distributions/test_state_space_subdivision_gaussian_distribution.py
@@ -27,6 +27,66 @@ from pyrecest.distributions.nonperiodic.gaussian_distribution import (
 
 
 class TestStateSpaceSubdivisionGaussianDistribution(unittest.TestCase):
+    @staticmethod
+    def _make_grid(n):
+        return HypertoroidalGridDistribution.from_distribution(
+            CircularUniformDistribution(), (n,)
+        )
+
+    @staticmethod
+    def _make_gaussians(n, dim=1):
+        return [GaussianDistribution(array([0.0] * dim), eye(dim)) for _ in range(n)]
+
+    def test_constructor_rejects_non_gaussian_conditionals(self):
+        gd = self._make_grid(2)
+
+        with self.assertRaisesRegex(TypeError, "GaussianDistribution"):
+            StateSpaceSubdivisionGaussianDistribution(
+                gd, [GaussianDistribution(array([0.0]), eye(1)), object()]
+            )
+
+    def test_constructor_rejects_grid_length_mismatch(self):
+        gd = self._make_grid(3)
+
+        with self.assertRaisesRegex(ValueError, "Number of grid points"):
+            StateSpaceSubdivisionGaussianDistribution(gd, self._make_gaussians(2))
+
+    def test_constructor_rejects_mismatched_linear_dimensions(self):
+        gd = self._make_grid(2)
+        gaussians = [
+            GaussianDistribution(array([0.0]), eye(1)),
+            GaussianDistribution(array([0.0, 0.0]), eye(2)),
+        ]
+
+        with self.assertRaisesRegex(ValueError, "same dimension"):
+            StateSpaceSubdivisionGaussianDistribution(gd, gaussians)
+
+    def test_multiply_rejects_incompatible_operands(self):
+        gd = self._make_grid(2)
+        rbd = StateSpaceSubdivisionGaussianDistribution(gd, self._make_gaussians(2))
+
+        with self.assertRaisesRegex(
+            TypeError, "StateSpaceSubdivisionGaussianDistribution"
+        ):
+            rbd.multiply(object())
+
+        other_count = StateSpaceSubdivisionGaussianDistribution(
+            self._make_grid(3), self._make_gaussians(3)
+        )
+        with self.assertRaisesRegex(ValueError, "same number"):
+            rbd.multiply(other_count)
+
+        gd_shifted = HypertoroidalGridDistribution(
+            array([1.0, 1.0]),
+            grid_type="custom",
+            grid=array([[0.1], [pi + 0.1]]),
+        )
+        other_grid = StateSpaceSubdivisionGaussianDistribution(
+            gd_shifted, self._make_gaussians(2)
+        )
+        with self.assertRaisesRegex(ValueError, "equal grids"):
+            rbd.multiply(other_grid)
+
     def test_multiply_s1_x_r1_identical_precise(self):
         """Multiply two S1xR1 distributions; linear uncertainty must decrease."""
         n = 100


### PR DESCRIPTION
## Summary

- Replace assert-only state-space subdivision constructor checks with explicit validation for grid length and linear dimensions.
- Validate Gaussian conditionals and multiply operands/grid compatibility explicitly.
- Convert numpy-only hypercylindrical subdivision guards and unsupported dimensions into stable exceptions.
- Add regressions for invalid inputs in both normal and optimized Python.

## Validation

- `.venv\Scripts\python -m pytest -q tests\distributions\test_state_space_subdivision_gaussian_distribution.py tests\distributions\test_hypercylindrical_state_space_subdivision_distribution.py`
- `.venv\Scripts\python -O -m pytest -q tests\distributions\test_state_space_subdivision_gaussian_distribution.py tests\distributions\test_hypercylindrical_state_space_subdivision_distribution.py`
- `.venv\Scripts\python -m ruff check src\pyrecest\distributions\cart_prod\state_space_subdivision_distribution.py src\pyrecest\distributions\cart_prod\state_space_subdivision_gaussian_distribution.py src\pyrecest\distributions\cart_prod\hypercylindrical_state_space_subdivision_distribution.py tests\distributions\test_state_space_subdivision_gaussian_distribution.py tests\distributions\test_hypercylindrical_state_space_subdivision_distribution.py`