### PR TITLE
Validate grid distribution compatibility explicitly

### DIFF
--- a/src/pyrecest/distributions/abstract_grid_distribution.py
+++ b/src/pyrecest/distributions/abstract_grid_distribution.py
@@ -6,7 +6,7 @@ from math import prod
 from beartype import beartype
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
-from pyrecest.backend import abs, any, mean
+from pyrecest.backend import abs, allclose, any, mean
 
 from .abstract_distribution_type import AbstractDistributionType
 
@@ -22,18 +22,22 @@ class AbstractGridDistribution(AbstractDistributionType):
         dim=None,
         enforce_pdf_nonnegative: bool = True,
     ):
-        assert (
-            not grid_type == "custom" or grid is not None
-        )  # if grid_type is custom, grid needs to be given
-        assert (
+        if grid_type == "custom" and grid is None:
+            raise ValueError("Custom grids require grid coordinates.")
+        if grid is not None and grid.shape != ():
             # Use builtin prod because .shape is a tuple of ints
-            grid is None
-            or grid.shape == ()
-            or grid.shape[0] == prod(grid_values.shape)
-        )
-        assert (
-            grid is None or grid.shape == () or grid.ndim == 1 or grid.shape[1] == dim
-        )
+            expected_grid_points = prod(grid_values.shape)
+            if grid.shape[0] != expected_grid_points:
+                raise ValueError(
+                    "The number of grid coordinates must match the number of "
+                    f"grid values. Expected {expected_grid_points}, got "
+                    f"{grid.shape[0]}."
+                )
+            if grid.ndim != 1 and grid.shape[1] != dim:
+                raise ValueError(
+                    f"Grid coordinates must have dimension {dim}, got "
+                    f"{grid.shape[1]}."
+                )
         if grid is None or grid.ndim > 1 and grid.shape[0] < grid.shape[1]:
             warnings.warn(
                 "Warning: Dimension is higher than number of grid points. Verify that this is really intended."
@@ -67,9 +71,10 @@ class AbstractGridDistribution(AbstractDistributionType):
         pass
 
     def integrate(self, integration_boundaries=None):
-        assert (
-            integration_boundaries is None
-        ), "Custom integration boundaries are currently not supported"
+        if integration_boundaries is not None:
+            raise NotImplementedError(
+                "Custom integration boundaries are currently not supported."
+            )
         return self.get_manifold_size() * mean(self.grid_values)
 
     def normalize_in_place(self, tol=1e-4, warn_unnorm=True):
@@ -105,7 +110,20 @@ class AbstractGridDistribution(AbstractDistributionType):
         return self.grid[indices, :]
 
     def multiply(self, other):
-        assert self.enforce_pdf_nonnegative == other.enforce_pdf_nonnegative
+        if not isinstance(other, AbstractGridDistribution):
+            raise TypeError("other must be an AbstractGridDistribution.")
+        if self.enforce_pdf_nonnegative != other.enforce_pdf_nonnegative:
+            raise ValueError(
+                "Both grid distributions must agree on enforce_pdf_nonnegative."
+            )
+        if self.grid_values.shape != other.grid_values.shape:
+            raise ValueError("Grid value shapes must match before multiplication.")
+        if self.grid_type != other.grid_type:
+            raise ValueError("Grid types must match before multiplication.")
+        if (self.grid is None) != (other.grid is None):
+            raise ValueError("Both grid distributions must either store grids or omit them.")
+        if self.grid is not None and not allclose(self.grid, other.grid):
+            raise ValueError("Grid coordinates must match before multiplication.")
         gd = copy.deepcopy(self)
         gd.grid_values = gd.grid_values * other.grid_values
         gd = gd.normalize(warn_unnorm=False)

--- a/tests/distributions/test_abstract_grid_distribution.py
+++ b/tests/distributions/test_abstract_grid_distribution.py
@@ -4,13 +4,26 @@ from pyrecest.backend import array
 from pyrecest.distributions.abstract_grid_distribution import AbstractGridDistribution
 
 
+_DEFAULT_GRID = object()
+
+
 class DummyGridDistribution(AbstractGridDistribution):
-    def __init__(self, grid_values):
+    def __init__(
+        self,
+        grid_values,
+        grid_type="custom",
+        grid=_DEFAULT_GRID,
+        dim=1,
+        enforce_pdf_nonnegative=True,
+    ):
+        if grid is _DEFAULT_GRID:
+            grid = array([[0.0], [1.0]])
         super().__init__(
             grid_values,
-            grid_type="custom",
-            grid=array([[0.0], [1.0]]),
-            dim=1,
+            grid_type=grid_type,
+            grid=grid,
+            dim=dim,
+            enforce_pdf_nonnegative=enforce_pdf_nonnegative,
         )
 
     def get_closest_point(self, xs):
@@ -21,6 +34,64 @@ class DummyGridDistribution(AbstractGridDistribution):
 
 
 class AbstractGridDistributionTest(unittest.TestCase):
+    def test_constructor_rejects_custom_grid_without_coordinates(self):
+        with self.assertRaisesRegex(ValueError, "Custom grids"):
+            DummyGridDistribution(array([1.0, 1.0]), grid=None)
+
+    def test_constructor_rejects_grid_value_count_mismatch(self):
+        with self.assertRaisesRegex(ValueError, "number of grid coordinates"):
+            DummyGridDistribution(array([1.0, 1.0]), grid=array([[0.0]]))
+
+    def test_constructor_rejects_grid_dimension_mismatch(self):
+        with self.assertRaisesRegex(ValueError, "dimension 1"):
+            DummyGridDistribution(
+                array([1.0, 1.0]), grid=array([[0.0, 0.0], [1.0, 1.0]])
+            )
+
+    def test_integrate_rejects_custom_boundaries(self):
+        dist = DummyGridDistribution(array([1.0, 1.0]))
+
+        with self.assertRaisesRegex(NotImplementedError, "boundaries"):
+            dist.integrate((0.0, 1.0))
+
+    def test_multiply_rejects_incompatible_grids(self):
+        dist = DummyGridDistribution(array([1.0, 1.0]))
+
+        with self.assertRaisesRegex(TypeError, "AbstractGridDistribution"):
+            dist.multiply(object())
+
+        with self.assertRaisesRegex(ValueError, "enforce_pdf_nonnegative"):
+            dist.multiply(
+                DummyGridDistribution(
+                    array([1.0, 1.0]), enforce_pdf_nonnegative=False
+                )
+            )
+
+        with self.assertRaisesRegex(ValueError, "Grid value shapes"):
+            dist.multiply(DummyGridDistribution(array([[1.0, 1.0]])))
+
+        with self.assertRaisesRegex(ValueError, "Grid types"):
+            dist.multiply(
+                DummyGridDistribution(
+                    array([1.0, 1.0]), grid_type="cartesian_prod"
+                )
+            )
+
+        with self.assertRaisesRegex(ValueError, "Grid coordinates"):
+            dist.multiply(
+                DummyGridDistribution(
+                    array([1.0, 1.0]), grid=array([[0.0], [2.0]])
+                )
+            )
+
+    def test_multiply_combines_compatible_values(self):
+        dist = DummyGridDistribution(array([1.0, 1.0]))
+        other = DummyGridDistribution(array([2.0, 2.0]))
+
+        result = dist.multiply(other)
+
+        self.assertEqual(result.grid_values.shape, (2,))
+
     def test_normalize_rejects_near_zero_integral_even_with_negative_values(self):
         dist = DummyGridDistribution(array([1.0, -1.0]))
 


### PR DESCRIPTION
## Summary

- Replace assert-only grid constructor checks with explicit errors for missing custom grids, coordinate count mismatches, and coordinate dimension mismatches.
- Reject unsupported integration boundaries explicitly.
- Validate grid distribution multiply operands, nonnegative-pdf policy, value shapes, grid types, and coordinates before combining densities.
- Add focused regressions that run consistently with optimized Python.

## Validation

- `.venv\Scripts\python -m pytest -q tests\distributions\test_abstract_grid_distribution.py`
- `.venv\Scripts\python -O -m pytest -q tests\distributions\test_abstract_grid_distribution.py`
- `.venv\Scripts\python -m ruff check src\pyrecest\distributions\abstract_grid_distribution.py tests\distributions\test_abstract_grid_distribution.py`