### PR TITLE
Validate custom and mixture inputs explicitly

### DIFF
--- a/src/pyrecest/distributions/abstract_custom_distribution.py
+++ b/src/pyrecest/distributions/abstract_custom_distribution.py
@@ -63,9 +63,8 @@ class AbstractCustomDistribution(AbstractDistributionType):
         :param verify: Whether to verify if the density is properly normalized, default is None.
         :returns: A copy of the original distribution, with the PDF normalized.
         """
-        assert (
-            pyrecest.backend.__backend_name__ == "numpy"
-        ), "Only supported for numpy backend"
+        if pyrecest.backend.__backend_name__ != "numpy":
+            raise NotImplementedError("Only supported for numpy backend.")
         cd = copy.deepcopy(self)
 
         integral = self.integrate()

--- a/src/pyrecest/distributions/abstract_mixture.py
+++ b/src/pyrecest/distributions/abstract_mixture.py
@@ -161,7 +161,8 @@ class AbstractMixture(AbstractDistributionType):
             # and avoids rejecting natural inputs such as xs.shape == (n,).
             p = zeros(xs.shape)
         else:
-            assert xs.shape[-1] == self.input_dim, "Dimension mismatch"
+            if xs.ndim == 0 or xs.shape[-1] != self.input_dim:
+                raise ValueError("Dimension mismatch")
             p = zeros(1) if xs.ndim == 1 else zeros(xs.shape[0])
 
         for i, dist in enumerate(self.dists):

--- a/src/pyrecest/distributions/circle/circular_mixture.py
+++ b/src/pyrecest/distributions/circle/circular_mixture.py
@@ -82,7 +82,7 @@ class CircularMixture(AbstractCircularDistribution, HypertoroidalMixture):
             xs_eval = reshape(xs, (-1,))
             scalar_input = False
         else:
-            raise AssertionError("Dimension mismatch")
+            raise ValueError("Dimension mismatch")
 
         p = zeros(shape(atleast_1d(xs_eval)))
 

--- a/tests/distributions/test_circular_mixture.py
+++ b/tests/distributions/test_circular_mixture.py
@@ -46,7 +46,7 @@ class TestCircularMixture(unittest.TestCase):
         npt.assert_allclose(actual, expected)
 
     def test_pdf_rejects_row_vector(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(ValueError, "Dimension mismatch"):
             self.mixture.pdf(array([[0.0, 0.5, 1.0]]))
 
     def test_sample_returns_vector_of_angles(self):

--- a/tests/distributions/test_custom_hyperrectangular_distribution.py
+++ b/tests/distributions/test_custom_hyperrectangular_distribution.py
@@ -133,6 +133,18 @@ class TestCustomHyperrectangularDistribution(unittest.TestCase):
 
         self.assertAlmostEqual(float(normalized.integrate()), 1.0, places=10)
 
+    def test_normalize_rejects_non_numpy_backend(self):
+        dist = CustomHyperrectangularDistribution(
+            lambda xs: 2.0 * ones(xs.shape[0]), self.bounds
+        )
+        original_backend_name = backend.__backend_name__  # pylint: disable=no-member
+        backend.__backend_name__ = "jax"  # pylint: disable=no-member
+        try:
+            with self.assertRaisesRegex(NotImplementedError, "numpy backend"):
+                dist.normalize()
+        finally:
+            backend.__backend_name__ = original_backend_name  # pylint: disable=no-member
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/distributions/test_linear_mixture.py
+++ b/tests/distributions/test_linear_mixture.py
@@ -83,6 +83,14 @@ class LinearMixtureTest(unittest.TestCase):
         npt.assert_allclose(lm.pdf(xs), expected, atol=1e-20)
         npt.assert_allclose(lm.pdf(reshape(xs, (-1, 1))), expected, atol=1e-20)
 
+    def test_pdf_rejects_wrong_point_dimension(self):
+        gm1 = GaussianDistribution(array([0.0, 0.0]), diag(array([1.0, 1.0])))
+        gm2 = GaussianDistribution(array([1.0, 1.0]), diag(array([1.0, 1.0])))
+        gmix = GaussianMixture([gm1, gm2], array([0.25, 0.75]))
+
+        with self.assertRaisesRegex(ValueError, "Dimension mismatch"):
+            gmix.pdf(array([1.0, 2.0, 3.0, 4.0]))
+
     def test_gaussian_mixture_pdf_accepts_vectorized_one_dimensional_inputs(self):
         gm1 = GaussianDistribution(array([1.0]), array([[2.0]]))
         gm2 = GaussianDistribution(-array([3.0]), array([[3.0]]))


### PR DESCRIPTION
## Summary

- Replace the NumPy-backend assert in custom distribution normalization with a stable `NotImplementedError`.
- Replace assert-only mixture pdf dimension validation with explicit `ValueError` handling.
- Align `CircularMixture.pdf` with the same explicit dimension error.
- Add regressions for wrong pdf input dimensions and non-NumPy custom normalization.

## Validation

- `.venv\Scripts\python -m pytest -q tests\distributions\test_circular_mixture.py tests\distributions\test_linear_mixture.py tests\distributions\test_custom_hyperrectangular_distribution.py`
- `.venv\Scripts\python -O -m pytest -q tests\distributions\test_circular_mixture.py tests\distributions\test_linear_mixture.py tests\distributions\test_custom_hyperrectangular_distribution.py`
- `.venv\Scripts\python -m ruff check src\pyrecest\distributions\abstract_custom_distribution.py src\pyrecest\distributions\abstract_mixture.py src\pyrecest\distributions\circle\circular_mixture.py tests\distributions\test_circular_mixture.py tests\distributions\test_linear_mixture.py tests\distributions\test_custom_hyperrectangular_distribution.py`