### PR TITLE
Validate circular inputs explicitly

### DIFF
--- a/src/pyrecest/distributions/circle/abstract_circular_distribution.py
+++ b/src/pyrecest/distributions/circle/abstract_circular_distribution.py
@@ -24,7 +24,8 @@ class AbstractCircularDistribution(AbstractHypertoroidalDistribution):
             : The computed CDF as a numpy array.
         """
         xs = atleast_1d(array(xs))
-        assert xs.ndim == 1, "xs must be a 1D array"
+        if xs.ndim != 1:
+            raise ValueError("xs must be a 1D array.")
 
         return array([self._cdf_numerical_single(x, starting_point) for x in xs])
 
@@ -52,10 +53,12 @@ class AbstractCircularDistribution(AbstractHypertoroidalDistribution):
         Returns:
             : The Kullback-Leibler divergence D_KL(self || other).
         """
-        assert isinstance(other, AbstractCircularDistribution)
-        assert (
-            self.dim == other.dim
-        ), "Cannot compare distributions with different number of dimensions."
+        if not isinstance(other, AbstractCircularDistribution):
+            raise TypeError("other must be an AbstractCircularDistribution.")
+        if self.dim != other.dim:
+            raise ValueError(
+                "Cannot compare distributions with different number of dimensions."
+            )
 
         def kld_fun(*args):
             x = array(args)

--- a/src/pyrecest/distributions/circle/circular_dirac_distribution.py
+++ b/src/pyrecest/distributions/circle/circular_dirac_distribution.py
@@ -19,7 +19,8 @@ class CircularDiracDistribution(
             d, w, dim=1
         )  # Necessary so it is clear that the dimension is 1.
         self.d = reshape(self.d, (-1,))
-        assert self.d.shape == self.w.shape, "The shapes of d and w should match."
+        if self.d.shape != self.w.shape:
+            raise ValueError("The shapes of d and w should match.")
 
     def plot_interpolated(self, _):
         """

--- a/tests/distributions/test_abstract_circular_distribution.py
+++ b/tests/distributions/test_abstract_circular_distribution.py
@@ -55,6 +55,12 @@ class AbstractCircularDistributionTest(unittest.TestCase):
         )
         self.assertTrue(allclose(dist.cdf_numerical(xs), dist.cdf_numerical(array(xs))))
 
+    def test_cdf_numerical_rejects_multidimensional_input(self):
+        dist = WrappedNormalDistribution(array(0.3), array(0.8))
+
+        with self.assertRaisesRegex(ValueError, "1D array"):
+            dist.cdf_numerical(array([[0.5], [1.0]]))
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",
         reason="Not supported on jax backend",
@@ -123,6 +129,12 @@ class AbstractCircularDistributionTest(unittest.TestCase):
                 rtol=1e-8,
             )
         )
+
+    def test_kld_numerical_rejects_non_circular_distribution(self):
+        dist = WrappedNormalDistribution(array(0.3), array(0.8))
+
+        with self.assertRaisesRegex(TypeError, "AbstractCircularDistribution"):
+            dist.kld_numerical(object())
 
     def test_shift_moves_density_forward(self):
         """A positive shift should move mass from x to x + shift_by."""

--- a/tests/distributions/test_circular_dirac_distribution.py
+++ b/tests/distributions/test_circular_dirac_distribution.py
@@ -25,6 +25,10 @@ class TestCircularDiracDistribution(unittest.TestCase):
         self.assertEqual(wd.w.shape, (3,))
         npt.assert_allclose(wd.d, d[:, 0])
 
+    def test_rejects_multidimensional_locations_for_circular_dirac(self):
+        with self.assertRaisesRegex(ValueError, "shapes of d and w"):
+            CircularDiracDistribution(array([[0.0, pi / 2.0], [pi, 3.0 * pi / 2.0]]))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Replace assert-only circular CDF input validation with explicit `ValueError` handling.
- Validate KLD comparison operands before numerical integration.
- Reject invalid multidimensional `CircularDiracDistribution` locations after flattening instead of relying on `assert`.
- Add optimized-mode regressions for the circular validation paths.

## Validation

- `.venv\Scripts\python -m pytest -q tests\distributions\test_abstract_circular_distribution.py tests\distributions\test_circular_dirac_distribution.py`
- `.venv\Scripts\python -O -m pytest -q tests\distributions\test_abstract_circular_distribution.py tests\distributions\test_circular_dirac_distribution.py`
- `.venv\Scripts\python -m ruff check src\pyrecest\distributions\circle\abstract_circular_distribution.py src\pyrecest\distributions\circle\circular_dirac_distribution.py tests\distributions\test_abstract_circular_distribution.py tests\distributions\test_circular_dirac_distribution.py`