### PR TITLE
Validate hypercylindrical inputs explicitly

### DIFF
--- a/src/pyrecest/distributions/cart_prod/abstract_hypercylindrical_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/abstract_hypercylindrical_distribution.py
@@ -116,8 +116,11 @@ class AbstractHypercylindricalDistribution(AbstractLinPeriodicCartProdDistributi
         """
         if approximate_mean is None:
             approximate_mean = full((self.lin_dim,), float("NaN"))
+        else:
+            approximate_mean = asarray(approximate_mean)
 
-        assert approximate_mean.shape[0] == self.lin_dim
+        if approximate_mean.ndim != 1 or approximate_mean.shape[0] != self.lin_dim:
+            raise ValueError("approximate_mean must have shape (lin_dim,).")
 
         return self.linear_covariance_numerical(approximate_mean)
 
@@ -188,21 +191,24 @@ class AbstractHypercylindricalDistribution(AbstractLinPeriodicCartProdDistributi
             The distribution after conditioning.
         """
         input_lin = asarray(input_lin)
-        assert (
+        if not (
             input_lin.ndim == 0
             and self.lin_dim == 1
             or ndim(input_lin) == 1
             and input_lin.shape[0] == self.lin_dim
-        ), "Input should be of size (lin_dim,)."
+        ):
+            raise ValueError("Input should be of size (lin_dim,).")
 
         def f_cond_unnorm(xs, input_lin=input_lin):
             if xs.ndim == 0:
-                assert self.bound_dim == 1
+                if self.bound_dim != 1:
+                    raise ValueError("Scalar input is only valid for bound_dim == 1.")
                 n_inputs = 1
             elif xs.ndim == 1 and self.bound_dim == 1:
                 n_inputs = xs.shape[0]
             elif xs.ndim == 1:
-                assert self.bound_dim == xs.shape[0]
+                if self.bound_dim != xs.shape[0]:
+                    raise ValueError("Input should be of size (bound_dim,).")
                 n_inputs = 1
             else:
                 n_inputs = xs.shape[0]
@@ -232,23 +238,29 @@ class AbstractHypercylindricalDistribution(AbstractLinPeriodicCartProdDistributi
                 CustomLinearDistribution instance
         """
         input_periodic = asarray(input_periodic)
-        assert (
+        if not (
             input_periodic.ndim == 0
             and self.bound_dim == 1
             or ndim(input_periodic) == 1
             and input_periodic.shape[0] == self.bound_dim
-        ), "Input should be a scalar for bound_dim == 1 or of size (bound_dim,)."
+        ):
+            raise ValueError(
+                "Input should be a scalar for bound_dim == 1 or of size "
+                "(bound_dim,)."
+            )
 
         input_periodic = mod(input_periodic, 2.0 * pi)
 
         def f_cond_unnorm(xs, input_periodic=input_periodic):
             if xs.ndim == 0:
-                assert self.lin_dim == 1
+                if self.lin_dim != 1:
+                    raise ValueError("Scalar input is only valid for lin_dim == 1.")
                 n_inputs = 1
             elif xs.ndim == 1 and self.lin_dim == 1:
                 n_inputs = xs.shape[0]
             elif xs.ndim == 1:
-                assert self.lin_dim == xs.shape[0]
+                if self.lin_dim != xs.shape[0]:
+                    raise ValueError("Input should be of size (lin_dim,).")
                 n_inputs = 1
             else:
                 n_inputs = xs.shape[0]
@@ -311,10 +323,8 @@ class AbstractHypercylindricalDistribution(AbstractLinPeriodicCartProdDistributi
         m : ndarray
           The mode of the distribution.
         """
-        assert pyrecest.backend.__backend_name__ in (
-            "numpy",
-            "pytorch",
-        ), "Not supported for this backend."
+        if pyrecest.backend.__backend_name__ not in ("numpy", "pytorch"):
+            raise NotImplementedError("Not supported for this backend.")
         if starting_point is None:
             starting_point = concatenate(
                 [pi * ones(self.bound_dim), zeros(self.lin_dim)]
@@ -385,9 +395,10 @@ class AbstractHypercylindricalDistribution(AbstractLinPeriodicCartProdDistributi
 
     # pylint: disable=too-many-locals
     def plot_cylinder(self, limits_linear=None):
-        assert (
-            self.bound_dim == 1 and self.lin_dim == 1
-        ), "plot_cylinder is only implemented for bound_dim == 1 and lin_dim == 1."
+        if not (self.bound_dim == 1 and self.lin_dim == 1):
+            raise NotImplementedError(
+                "plot_cylinder is only implemented for bound_dim == 1 and lin_dim == 1."
+            )
 
         if limits_linear is None:
             scale_lin = 3

--- a/tests/distributions/test_abstract_hypercylindrical_distribution.py
+++ b/tests/distributions/test_abstract_hypercylindrical_distribution.py
@@ -17,9 +17,27 @@ from pyrecest.backend import (
     pi,
     zeros,
 )
+from pyrecest.distributions.cart_prod.abstract_hypercylindrical_distribution import (
+    AbstractHypercylindricalDistribution,
+)
 from pyrecest.distributions.cart_prod.partially_wrapped_normal_distribution import (
     PartiallyWrappedNormalDistribution,
 )
+
+
+class DummyHypercylindricalDistribution(AbstractHypercylindricalDistribution):
+    def __init__(self, bound_dim=1, lin_dim=1):
+        super().__init__(bound_dim, lin_dim)
+
+    def pdf(self, xs):
+        xs = array(xs)
+        return ones(1 if xs.ndim == 1 else xs.shape[0])
+
+    def marginalize_linear(self):
+        raise NotImplementedError
+
+    def marginalize_periodic(self):
+        raise NotImplementedError
 
 
 class AbstractHypercylindricalDistributionTest(unittest.TestCase):
@@ -58,6 +76,52 @@ class AbstractHypercylindricalDistributionTest(unittest.TestCase):
             array([1.0, 2.0]), array([[2.0, 0.3], [0.3, 1.0]]), 1
         )
         npt.assert_allclose(hwn.linear_mean_numerical(), hwn.mu[-1])
+
+    def test_linear_covariance_rejects_wrong_mean_dimension(self):
+        dist = DummyHypercylindricalDistribution()
+
+        with self.assertRaisesRegex(ValueError, "lin_dim"):
+            dist.linear_covariance(array([0.0, 1.0]))
+
+    def test_condition_on_linear_rejects_wrong_input_dimension(self):
+        hwn = PartiallyWrappedNormalDistribution(
+            array([1.0, 2.0]), array([[2.0, 0.3], [0.3, 1.0]]), 1
+        )
+
+        with self.assertRaisesRegex(ValueError, "lin_dim"):
+            hwn.condition_on_linear(array([1.0, 2.0]), normalize=False)
+
+    def test_condition_on_periodic_rejects_wrong_input_dimension(self):
+        hwn = PartiallyWrappedNormalDistribution(
+            array([1.0, 2.0, 3.0]),
+            array([[2.0, 0.3, 0.1], [0.3, 1.5, 0.2], [0.1, 0.2, 1.0]]),
+            2,
+        )
+
+        with self.assertRaisesRegex(ValueError, "bound_dim"):
+            hwn.condition_on_periodic(array([1.0]), normalize=False)
+
+    def test_mode_numerical_rejects_unsupported_backend(self):
+        hwn = PartiallyWrappedNormalDistribution(
+            array([1.0, 2.0]), array([[2.0, 0.3], [0.3, 1.0]]), 1
+        )
+        original_backend_name = pyrecest.backend.__backend_name__
+        pyrecest.backend.__backend_name__ = "jax"
+        try:
+            with self.assertRaisesRegex(NotImplementedError, "backend"):
+                hwn.mode_numerical()
+        finally:
+            pyrecest.backend.__backend_name__ = original_backend_name
+
+    def test_plot_cylinder_rejects_unsupported_dimensions(self):
+        hwn = PartiallyWrappedNormalDistribution(
+            array([1.0, 2.0, 3.0]),
+            array([[2.0, 0.3, 0.1], [0.3, 1.5, 0.2], [0.1, 0.2, 1.0]]),
+            2,
+        )
+
+        with self.assertRaisesRegex(NotImplementedError, "bound_dim == 1"):
+            hwn.plot_cylinder()
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),


### PR DESCRIPTION
## Summary

- Replace assert-only hypercylindrical validation for covariance mean shape and conditioning inputs with explicit `ValueError`s.
- Convert unsupported backend and cylinder-plot guards into stable `NotImplementedError`s.
- Add focused regressions that cover the shared validation paths under optimized Python.

## Validation

- `.venv\Scripts\python -m pytest -q tests\distributions\test_abstract_hypercylindrical_distribution.py`
- `.venv\Scripts\python -O -m pytest -q tests\distributions\test_abstract_hypercylindrical_distribution.py`
- `.venv\Scripts\python -m ruff check src\pyrecest\distributions\cart_prod\abstract_hypercylindrical_distribution.py tests\distributions\test_abstract_hypercylindrical_distribution.py`