### PR TITLE
Validate stacked Cartesian product inputs explicitly

### DIFF
--- a/src/pyrecest/distributions/cart_prod/abstract_lin_periodic_cart_prod_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/abstract_lin_periodic_cart_prod_distribution.py
@@ -13,7 +13,8 @@ class AbstractLinPeriodicCartProdDistribution(AbstractLinBoundedCartProdDistribu
         AbstractLinBoundedCartProdDistribution.__init__(self, bound_dim, lin_dim)
 
     def get_manifold_size(self):
-        assert (
-            self.lin_dim > 0
-        ), "This class is not intended to be used for purely periodic domains."
+        if self.lin_dim <= 0:
+            raise ValueError(
+                "This class is not intended to be used for purely periodic domains."
+            )
         return float("inf")

--- a/src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py
@@ -64,7 +64,8 @@ class CartProdStackedDistribution(AbstractCartProdDistribution):
         return prod(stack(ps), axis=0)
 
     def shift(self, shift_by):
-        assert len(shift_by) == self.dim, "Incorrect number of offsets"
+        if len(shift_by) != self.dim:
+            raise ValueError("Incorrect number of offsets.")
         shifted_dists = []
         curr_dim = 0
         for dist in self.dists:

--- a/src/pyrecest/distributions/cart_prod/se3_lin_vel_cart_prod_stacked_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/se3_lin_vel_cart_prod_stacked_distribution.py
@@ -9,17 +9,22 @@ from .cart_prod_stacked_distribution import CartProdStackedDistribution
 
 class SE3LinVelCartProdStackedDistribution(CartProdStackedDistribution):
     def __init__(self, dists):
-        assert len(dists) == 2, "There must be exactly 2 distributions in dists"
-        assert (
-            dists[0].input_dim == 4
-        ), "The first distribution must have input dimension 4"
-        assert isinstance(
-            dists[0], AbstractHyperhemisphericalDistribution
-        ), "The first distribution must be an instance of AbstractHyperhemisphericalDistribution"
-        assert dists[1].dim == 6, "The second distribution must have 6 dimensions"
-        assert isinstance(
-            dists[1], AbstractLinearDistribution
-        ), "The second distribution must be an instance of AbstractLinearDistribution"
+        if len(dists) != 2:
+            raise ValueError("There must be exactly 2 distributions in dists.")
+        if not isinstance(dists[0], AbstractHyperhemisphericalDistribution):
+            raise TypeError(
+                "The first distribution must be an instance of "
+                "AbstractHyperhemisphericalDistribution."
+            )
+        if dists[0].input_dim != 4:
+            raise ValueError("The first distribution must have input dimension 4.")
+        if not isinstance(dists[1], AbstractLinearDistribution):
+            raise TypeError(
+                "The second distribution must be an instance of "
+                "AbstractLinearDistribution."
+            )
+        if dists[1].dim != 6:
+            raise ValueError("The second distribution must have 6 dimensions.")
 
         super().__init__(dists)
         self.boundD = dists[0].input_dim

--- a/tests/distributions/test_cart_prod_stacked_distribution.py
+++ b/tests/distributions/test_cart_prod_stacked_distribution.py
@@ -3,9 +3,30 @@ import unittest
 import numpy as np
 from pyrecest.backend import allclose, array, eye
 from pyrecest.distributions import GaussianDistribution, VonMisesFisherDistribution
+from pyrecest.distributions.cart_prod.abstract_lin_periodic_cart_prod_distribution import (
+    AbstractLinPeriodicCartProdDistribution,
+)
 from pyrecest.distributions.cart_prod.cart_prod_stacked_distribution import (
     CartProdStackedDistribution,
 )
+
+
+class PurePeriodicLinPeriodicDistribution(AbstractLinPeriodicCartProdDistribution):
+    def __init__(self):
+        super().__init__(bound_dim=1, lin_dim=0)
+
+    @property
+    def input_dim(self):
+        return self.dim
+
+    def pdf(self, _xs):
+        raise NotImplementedError
+
+    def marginalize_linear(self):
+        raise NotImplementedError
+
+    def marginalize_periodic(self):
+        raise NotImplementedError
 
 
 class ConcreteCartProdStackedDistribution(CartProdStackedDistribution):
@@ -18,6 +39,12 @@ class ConcreteCartProdStackedDistribution(CartProdStackedDistribution):
 
 
 class TestCartProdStackedDistribution(unittest.TestCase):
+    def test_lin_periodic_base_rejects_purely_periodic_manifold_size(self):
+        dist = PurePeriodicLinPeriodicDistribution()
+
+        with self.assertRaisesRegex(ValueError, "purely periodic"):
+            dist.get_manifold_size()
+
     def test_base_class_is_instantiable_and_reports_geometry(self):
         dist = CartProdStackedDistribution(
             [
@@ -135,6 +162,17 @@ class TestCartProdStackedDistribution(unittest.TestCase):
         self.assertIsInstance(shifted, ConcreteCartProdStackedDistribution)
         self.assertTrue(allclose(shifted.dists[0].mu, array([11.0, 22.0])))
         self.assertTrue(allclose(shifted.dists[1].mu, array([33.0, 44.0, 55.0])))
+
+    def test_shift_rejects_wrong_offset_count(self):
+        dist = ConcreteCartProdStackedDistribution(
+            [
+                GaussianDistribution(array([1.0, 2.0]), eye(2)),
+                GaussianDistribution(array([3.0, 4.0, 5.0]), eye(3)),
+            ]
+        )
+
+        with self.assertRaisesRegex(ValueError, "offsets"):
+            dist.shift(array([1.0, 2.0]))
 
     def test_set_mode_preserves_concrete_distribution_type(self):
         dist = ConcreteCartProdStackedDistribution(

--- a/tests/distributions/test_se3_lin_vel_cart_prod_stacked_distribution.py
+++ b/tests/distributions/test_se3_lin_vel_cart_prod_stacked_distribution.py
@@ -33,6 +33,39 @@ class TestSE3LinVelCartProdStackedDistribution(unittest.TestCase):
             ]
         )
 
+    def test_constructor_rejects_invalid_components(self):
+        valid_orientation = HyperhemisphericalUniformDistribution(3)
+        valid_velocity = GaussianDistribution(
+            array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+            diag(array([3.0, 2.0, 1.0, 4.0, 3.0, 4.0])),
+        )
+
+        with self.assertRaisesRegex(ValueError, "exactly 2"):
+            SE3LinVelCartProdStackedDistribution([valid_orientation])
+
+        with self.assertRaisesRegex(
+            TypeError, "AbstractHyperhemisphericalDistribution"
+        ):
+            SE3LinVelCartProdStackedDistribution([valid_velocity, valid_velocity])
+
+        with self.assertRaisesRegex(ValueError, "input dimension 4"):
+            SE3LinVelCartProdStackedDistribution(
+                [HyperhemisphericalUniformDistribution(2), valid_velocity]
+            )
+
+        with self.assertRaisesRegex(TypeError, "AbstractLinearDistribution"):
+            SE3LinVelCartProdStackedDistribution(
+                [valid_orientation, HyperhemisphericalUniformDistribution(6)]
+            )
+
+        with self.assertRaisesRegex(ValueError, "6 dimensions"):
+            SE3LinVelCartProdStackedDistribution(
+                [
+                    valid_orientation,
+                    GaussianDistribution(array([1.0, 2.0, 3.0]), diag(ones(3))),
+                ]
+            )
+
     def test_sampling(self):
         cpd = SE3LinVelCartProdStackedDistribution(
             [


### PR DESCRIPTION
## Summary

- Replace assert-only stacked Cartesian product shift validation with an explicit `ValueError`.
- Validate SE3 linear-velocity stacked component count, types, and dimensions explicitly.
- Reject purely periodic use of the linear-periodic cartesian product base with a stable error.
- Add optimized-mode regressions for these constructor and shape contracts.

## Validation

- `.venv\Scripts\python -m pytest -q tests\distributions\test_cart_prod_stacked_distribution.py tests\distributions\test_se3_lin_vel_cart_prod_stacked_distribution.py`
- `.venv\Scripts\python -O -m pytest -q tests\distributions\test_cart_prod_stacked_distribution.py tests\distributions\test_se3_lin_vel_cart_prod_stacked_distribution.py`
- `.venv\Scripts\python -m ruff check src\pyrecest\distributions\cart_prod\abstract_lin_periodic_cart_prod_distribution.py src\pyrecest\distributions\cart_prod\cart_prod_stacked_distribution.py src\pyrecest\distributions\cart_prod\se3_lin_vel_cart_prod_stacked_distribution.py tests\distributions\test_cart_prod_stacked_distribution.py tests\distributions\test_se3_lin_vel_cart_prod_stacked_distribution.py`