### PR TITLE
Validate Mardia-Sutton pdf inputs explicitly

### DIFF
--- a/src/pyrecest/distributions/cart_prod/mardia_sutton_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/mardia_sutton_distribution.py
@@ -124,7 +124,8 @@ class MardiaSuttonDistribution(AbstractHypercylindricalDistribution):
             p (...,): value of the pdf at each location
         """
         xs = atleast_2d(xs)
-        assert xs.shape[-1] == 2
+        if xs.shape[-1] != 2:
+            raise ValueError("xs must contain circular and linear coordinates.")
 
         circular = xs[..., 0]
         linear = xs[..., 1]

--- a/tests/distributions/test_mardia_sutton_distribution.py
+++ b/tests/distributions/test_mardia_sutton_distribution.py
@@ -58,6 +58,10 @@ class TestMardiaSuttonDistribution(unittest.TestCase):
         self.assertEqual(p.shape, (1,))
         self.assertTrue(float(p[0]) > 0)
 
+    def test_pdf_rejects_wrong_point_dimension(self):
+        with self.assertRaisesRegex(ValueError, "circular and linear"):
+            self.dist.pdf(array([[1.0, 2.0, 3.0]]))
+
     def test_pdf_normalization(self):
         import math
 


### PR DESCRIPTION
## Summary

- Replace assert-only Mardia-Sutton pdf point-shape validation with an explicit `ValueError`.
- Add a regression for wrong coordinate counts so optimized Python rejects invalid pdf inputs too.

## Validation

- `.venv\Scripts\python -m pytest -q tests\distributions\test_mardia_sutton_distribution.py`
- `.venv\Scripts\python -O -m pytest -q tests\distributions\test_mardia_sutton_distribution.py`
- `.venv\Scripts\python -m ruff check src\pyrecest\distributions\cart_prod\mardia_sutton_distribution.py tests\distributions\test_mardia_sutton_distribution.py`