### PR TITLE
Validate Gauss-von-Mises pdf inputs explicitly

### DIFF
--- a/src/pyrecest/distributions/cart_prod/gauss_von_mises_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/gauss_von_mises_distribution.py
@@ -168,7 +168,8 @@ class GaussVonMisesDistribution(AbstractHypercylindricalDistribution):
         if single_point:
             xa = xa.reshape(-1, 1)
 
-        assert xa.shape[0] == self.lin_dim + 1
+        if xa.shape[0] != self.lin_dim + 1:
+            raise ValueError("xs must have lin_dim + 1 rows/elements")
 
         theta = self.get_theta(xa[1:, :])
         mvn_vals = GaussianDistribution(self.mu, self.P, check_validity=False).pdf(

--- a/tests/distributions/test_gauss_von_mises_distribution.py
+++ b/tests/distributions/test_gauss_von_mises_distribution.py
@@ -67,6 +67,10 @@ class GaussVonMisesDistributionTest(unittest.TestCase):
             )
         )
 
+    def test_pdf_rejects_wrong_point_dimension(self):
+        with self.assertRaisesRegex(ValueError, "lin_dim"):
+            self.g.pdf(array([0.0, 1.0, 2.0]))
+
     def test_integral(self):
         self.assertAlmostEqual(self.g.integrate(), 1, delta=1e-5)
 


### PR DESCRIPTION
## Summary
- Replace assert-backed Gauss-von-Mises pdf shape validation with an explicit ValueError.
- Add a regression test for wrong point dimensionality so validation still works under optimized Python.

## Validation
- `.venv\Scripts\python -m pytest -q tests\distributions\test_gauss_von_mises_distribution.py`
- `.venv\Scripts\python -O -m pytest -q tests\distributions\test_gauss_von_mises_distribution.py`
- `.venv\Scripts\python -m ruff check src\pyrecest\distributions\cart_prod\gauss_von_mises_distribution.py tests\distributions\test_gauss_von_mises_distribution.py`