### PR TITLE
Validate custom hypersphere inputs explicitly

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/custom_hyperhemispherical_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/custom_hyperhemispherical_distribution.py
@@ -37,7 +37,8 @@ class CustomHyperhemisphericalDistribution(
         if xs.ndim == 0 or xs.shape[-1] != self.dim + 1:
             raise ValueError("Invalid shape of input data points.")
         p = asarray(self.scale_by * self.f(xs))
-        assert p.ndim <= 1, "Output format of pdf is not as expected"
+        if p.ndim > 1:
+            raise ValueError("Output format of pdf is not as expected")
         return p
 
     def integrate(self, integration_boundaries=None):

--- a/src/pyrecest/distributions/hypersphere_subset/custom_hyperspherical_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/custom_hyperspherical_distribution.py
@@ -11,7 +11,8 @@ class CustomHypersphericalDistribution(
 
     @staticmethod
     def from_distribution(distribution):
-        assert isinstance(distribution, AbstractHypersphericalDistribution)
+        if not isinstance(distribution, AbstractHypersphericalDistribution):
+            raise ValueError("Input variable distribution is of the wrong class.")
 
         chd = CustomHypersphericalDistribution(distribution.pdf, distribution.dim)
         return chd

--- a/tests/distributions/test_custom_hyperhemispherical_distribution.py
+++ b/tests/distributions/test_custom_hyperhemispherical_distribution.py
@@ -27,6 +27,12 @@ class CustomHyperhemisphericalDistributionTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             dist.pdf([1.0, 0.0])
 
+    def test_pdf_rejects_matrix_callback_output(self):
+        dist = CustomHyperhemisphericalDistribution(lambda xs: ones((2, 2)), 2)
+
+        with self.assertRaisesRegex(ValueError, "Output format"):
+            dist.pdf([1.0, 0.0, 0.0])
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
         reason="Numerical integration is only supported for the NumPy backend",

--- a/tests/distributions/test_custom_hyperspherical_distribution.py
+++ b/tests/distributions/test_custom_hyperspherical_distribution.py
@@ -71,6 +71,10 @@ class CustomHypersphericalDistributionTest(unittest.TestCase):
             "Type mismatch when creating from distribution.",
         )
 
+    def test_from_distribution_rejects_wrong_type(self):
+        with self.assertRaisesRegex(ValueError, "wrong class"):
+            CustomHypersphericalDistribution.from_distribution(object())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Replace assert-backed custom hyperhemispherical callback-output validation with an explicit ValueError.
- Replace the custom hyperspherical from-distribution type assertion with an explicit ValueError.
- Add regressions for malformed callback output and wrong adapter input type.

## Validation
- `.venv\Scripts\python -m pytest -q tests\distributions\test_custom_hyperhemispherical_distribution.py tests\distributions\test_custom_hyperspherical_distribution.py`
- `.venv\Scripts\python -O -m pytest -q tests\distributions\test_custom_hyperhemispherical_distribution.py tests\distributions\test_custom_hyperspherical_distribution.py`
- `.venv\Scripts\python -m ruff check src\pyrecest\distributions\hypersphere_subset\custom_hyperhemispherical_distribution.py src\pyrecest\distributions\hypersphere_subset\custom_hyperspherical_distribution.py tests\distributions\test_custom_hyperhemispherical_distribution.py tests\distributions\test_custom_hyperspherical_distribution.py`