### PR TITLE
Validate sphere coordinate inputs explicitly

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/abstract_sphere_subset_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/abstract_sphere_subset_distribution.py
@@ -47,7 +47,8 @@ class AbstractSphereSubsetDistribution(AbstractHypersphereSubsetDistribution):
           ``AbstractHypersphereSubsetDistribution.hypersph_to_cart`` and thus
           matches the integration convention used for S2.
         """
-        assert ndim(angles1) == 1 and ndim(angles2) == 1, "Inputs must be 1-dimensional"
+        if ndim(angles1) != 1 or ndim(angles2) != 1:
+            raise ValueError("Inputs must be 1-dimensional")
         if mode == "inclination":
             # This follows the legacy (azimuth, colatitude) S2 convention.
             x, y, z = AbstractSphereSubsetDistribution._sph_to_cart_inclination(
@@ -83,9 +84,8 @@ class AbstractSphereSubsetDistribution(AbstractHypersphereSubsetDistribution):
         Returns:
             tuple: Spherical coordinates.
         """
-        assert (
-            ndim(x) == 1 and ndim(y) == 1 and ndim(z) == 1
-        ), "Inputs must be 1-dimensional"
+        if ndim(x) != 1 or ndim(y) != 1 or ndim(z) != 1:
+            raise ValueError("Inputs must be 1-dimensional")
         if mode == "inclination":
             phi, theta = AbstractSphereSubsetDistribution._cart_to_sph_inclination(
                 x, y, z
@@ -111,9 +111,8 @@ class AbstractSphereSubsetDistribution(AbstractHypersphereSubsetDistribution):
     def _sph_to_cart_inclination(theta_inc, phi_az_right) -> tuple:
         # Conversion for the (r, θ_inc, φ_az,right) convention. Used by many textbooks.
         # Downside is that it does not generalize well to higher dimensions.
-        assert (
-            ndim(theta_inc) == 1 and ndim(phi_az_right) == 1
-        ), "Inputs must be 1-dimensional"
+        if ndim(theta_inc) != 1 or ndim(phi_az_right) != 1:
+            raise ValueError("Inputs must be 1-dimensional")
         x = sin(phi_az_right) * cos(theta_inc)
         y = sin(phi_az_right) * sin(theta_inc)
         z = cos(phi_az_right)
@@ -132,9 +131,8 @@ class AbstractSphereSubsetDistribution(AbstractHypersphereSubsetDistribution):
         Returns:
             tuple: Cartesian coordinates.
         """
-        assert (
-            ndim(azimuth) == 1 and ndim(elevation) == 1
-        ), "Inputs must be 1-dimensional"
+        if ndim(azimuth) != 1 or ndim(elevation) != 1:
+            raise ValueError("Inputs must be 1-dimensional")
         # elevation is π/2 - colatitude, so we calculate colatitude from elevation
         if map_to_inclination:
             inclination = pi / 2 - elevation
@@ -149,7 +147,8 @@ class AbstractSphereSubsetDistribution(AbstractHypersphereSubsetDistribution):
 
     @staticmethod
     def _cart_to_sph_inclination(x, y, z) -> tuple:
-        assert ndim(x) == 1 and ndim(y) == 1 and ndim(z) == 1
+        if ndim(x) != 1 or ndim(y) != 1 or ndim(z) != 1:
+            raise ValueError("Inputs must be 1-dimensional")
         azimuth = arctan2(y, x)
         azimuth = where(azimuth < 0, azimuth + 2 * pi, azimuth)
         colatitude = arccos(clip(z, -1.0, 1.0))
@@ -157,7 +156,8 @@ class AbstractSphereSubsetDistribution(AbstractHypersphereSubsetDistribution):
 
     @staticmethod
     def _cart_to_sph_elevation(x, y, z) -> tuple:
-        assert ndim(x) == 1 and ndim(y) == 1 and ndim(z) == 1
+        if ndim(x) != 1 or ndim(y) != 1 or ndim(z) != 1:
+            raise ValueError("Inputs must be 1-dimensional")
         azimuth = arctan2(y, x)
         azimuth = where(azimuth < 0, azimuth + 2 * pi, azimuth)
         elevation = pi / 2 - arccos(clip(z, -1.0, 1.0))

--- a/tests/distributions/test_abstract_sphere_subset_distribution.py
+++ b/tests/distributions/test_abstract_sphere_subset_distribution.py
@@ -112,8 +112,15 @@ class TestAbstractSphereSubsetDistribution(unittest.TestCase):
         y = array([0.0, 1.0])
         z = array([[0.0, 0.0]])
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(ValueError, "1-dimensional"):
             AbstractSphereSubsetDistribution.cart_to_sph(x, y, z)
+
+    def test_sph_to_cart_rejects_matrix_angles(self):
+        azimuth = array([0.0, 0.5])
+        colatitude = array([[0.1, 0.2]])
+
+        with self.assertRaisesRegex(ValueError, "1-dimensional"):
+            AbstractSphereSubsetDistribution.sph_to_cart(azimuth, colatitude)
 
     def test_inclination_helpers_reject_matrix_inputs(self):
         azimuth = array([0.0, 0.5])
@@ -122,12 +129,26 @@ class TestAbstractSphereSubsetDistribution(unittest.TestCase):
         y = array([0.0, 1.0])
         z = array([[0.0, 0.0]])
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(ValueError, "1-dimensional"):
             AbstractSphereSubsetDistribution._sph_to_cart_inclination(
                 azimuth, colatitude
             )
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(ValueError, "1-dimensional"):
             AbstractSphereSubsetDistribution._cart_to_sph_inclination(x, y, z)
+
+    def test_elevation_helpers_reject_matrix_inputs(self):
+        azimuth = array([0.0, 0.5])
+        elevation = array([[0.1, 0.2]])
+        x = array([1.0, 0.0])
+        y = array([0.0, 1.0])
+        z = array([[0.0, 0.0]])
+
+        with self.assertRaisesRegex(ValueError, "1-dimensional"):
+            AbstractSphereSubsetDistribution._sph_to_cart_elevation(
+                azimuth, elevation
+            )
+        with self.assertRaisesRegex(ValueError, "1-dimensional"):
+            AbstractSphereSubsetDistribution._cart_to_sph_elevation(x, y, z)
 
     def test_elevation_map_to_inclination_matches_direct_formula(self):
         azimuth = array([0.25, 1.25, 2.25])


### PR DESCRIPTION
## Summary
- Replace assert-backed 1D shape checks in sphere coordinate conversion helpers with explicit ValueErrors.
- Add optimized-mode-safe regression coverage for public and helper conversion validation.

## Validation
- `.venv\Scripts\python -m pytest -q tests\distributions\test_abstract_sphere_subset_distribution.py`
- `.venv\Scripts\python -O -m pytest -q tests\distributions\test_abstract_sphere_subset_distribution.py`
- `.venv\Scripts\python -m ruff check src\pyrecest\distributions\hypersphere_subset\abstract_sphere_subset_distribution.py tests\distributions\test_abstract_sphere_subset_distribution.py`