### PR TITLE
Validate custom hypertoroidal conversions explicitly

### DIFF
--- a/src/pyrecest/distributions/hypertorus/custom_hypertoroidal_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/custom_hypertoroidal_distribution.py
@@ -44,7 +44,10 @@ class CustomHypertoroidalDistribution(
         # Returns:
         #   ccd (CustomCircularDistribution)
         #       CustomCircularDistribution with same parameters
-        assert self.dim == 1
+        if self.dim != 1:
+            raise ValueError(
+                "Conversion to CustomCircularDistribution requires dim == 1"
+            )
         ccd = CustomCircularDistribution(
             self.f, scale_by=self.scale_by, shift_by=self.shift_by[0]
         )
@@ -58,7 +61,10 @@ class CustomHypertoroidalDistribution(
         #       CustomToroidalDistribution with same parameters
         from .custom_toroidal_distribution import CustomToroidalDistribution
 
-        assert self.dim == 2
+        if self.dim != 2:
+            raise ValueError(
+                "Conversion to CustomToroidalDistribution requires dim == 2"
+            )
         ctd = CustomToroidalDistribution(
             self.f, scale_by=self.scale_by, shift_by=self.shift_by
         )

--- a/tests/distributions/test_custom_hypertoroidal_distribution.py
+++ b/tests/distributions/test_custom_hypertoroidal_distribution.py
@@ -68,6 +68,12 @@ class CustomHypertoroidalDistributionTest(unittest.TestCase):
 
         npt.assert_allclose(circular.pdf(xs), dist.pdf(xs))
 
+    def test_to_custom_circular_rejects_multidimensional_distribution(self):
+        dist = CustomHypertoroidalDistribution(lambda xs: xs[:, 0], 2)
+
+        with self.assertRaisesRegex(ValueError, "dim == 1"):
+            dist.to_custom_circular()
+
     def test_to_custom_toroidal_preserves_scale_and_shift(self):
         dist = CustomHypertoroidalDistribution(
             lambda xs: xs[:, 0] + 2.0 * xs[:, 1],
@@ -81,6 +87,12 @@ class CustomHypertoroidalDistributionTest(unittest.TestCase):
 
         self.assertIsInstance(toroidal, CustomToroidalDistribution)
         npt.assert_allclose(toroidal.pdf(xs), dist.pdf(xs))
+
+    def test_to_custom_toroidal_rejects_wrong_dimension(self):
+        dist = CustomHypertoroidalDistribution(cos, 1)
+
+        with self.assertRaisesRegex(ValueError, "dim == 2"):
+            dist.to_custom_toroidal()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Replace assert-backed dimension checks in custom hypertoroidal conversion helpers with explicit ValueErrors.
- Add regressions for trying to convert 2D distributions to circular and 1D distributions to toroidal.

## Validation
- `.venv\Scripts\python -m pytest -q tests\distributions\test_custom_hypertoroidal_distribution.py`
- `.venv\Scripts\python -O -m pytest -q tests\distributions\test_custom_hypertoroidal_distribution.py`
- `.venv\Scripts\python -m ruff check src\pyrecest\distributions\hypertorus\custom_hypertoroidal_distribution.py tests\distributions\test_custom_hypertoroidal_distribution.py`