### PR TITLE
Validate hypertoroidal mixture conversions explicitly

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_mixture.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_mixture.py
@@ -63,7 +63,8 @@ class HypertoroidalMixture(AbstractMixture, AbstractHypertoroidalDistribution):
 
         :returns: CircularMixture with same parameters
         """
-        assert self.dim == 1
+        if self.dim != 1:
+            raise ValueError("Conversion to CircularMixture requires dim == 1")
         from ..circle.circular_mixture import CircularMixture
 
         return CircularMixture(self.dists, self.w)
@@ -74,7 +75,8 @@ class HypertoroidalMixture(AbstractMixture, AbstractHypertoroidalDistribution):
 
         :returns: ToroidalMixture with same parameters
         """
-        assert self.dim == 2
+        if self.dim != 2:
+            raise ValueError("Conversion to ToroidalMixture requires dim == 2")
         from .toroidal_mixture import ToroidalMixture
 
         return ToroidalMixture(self.dists, self.w)

--- a/tests/distributions/test_hypertoroidal_mixture.py
+++ b/tests/distributions/test_hypertoroidal_mixture.py
@@ -1,0 +1,28 @@
+import unittest
+
+from pyrecest.distributions.hypertorus.custom_hypertoroidal_distribution import (
+    CustomHypertoroidalDistribution,
+)
+from pyrecest.distributions.hypertorus.hypertoroidal_mixture import (
+    HypertoroidalMixture,
+)
+
+
+class HypertoroidalMixtureTest(unittest.TestCase):
+    def test_to_circular_mixture_rejects_multidimensional_mixture(self):
+        dist = CustomHypertoroidalDistribution(lambda xs: xs[:, 0], 2)
+        mixture = HypertoroidalMixture([dist])
+
+        with self.assertRaisesRegex(ValueError, "dim == 1"):
+            mixture.to_circular_mixture()
+
+    def test_to_toroidal_mixture_rejects_wrong_dimension(self):
+        dist = CustomHypertoroidalDistribution(lambda xs: xs, 1)
+        mixture = HypertoroidalMixture([dist])
+
+        with self.assertRaisesRegex(ValueError, "dim == 2"):
+            mixture.to_toroidal_mixture()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Replace assert-backed dimension checks in hypertoroidal mixture conversion helpers with explicit ValueErrors.
- Add focused regressions for wrong-dimension circular and toroidal mixture conversions.

## Validation
- `.venv\Scripts\python -m pytest -q tests\distributions\test_hypertoroidal_mixture.py`
- `.venv\Scripts\python -O -m pytest -q tests\distributions\test_hypertoroidal_mixture.py`
- `.venv\Scripts\python -m ruff check src\pyrecest\distributions\hypertorus\hypertoroidal_mixture.py tests\distributions\test_hypertoroidal_mixture.py`