### PR TITLE
Validate hyperhemispherical Watson inputs explicitly

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/hyperhemispherical_watson_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/hyperhemispherical_watson_distribution.py
@@ -12,7 +12,11 @@ from .watson_distribution import WatsonDistribution
 
 class HyperhemisphericalWatsonDistribution(AbstractHyperhemisphericalDistribution):
     def __init__(self, mu, kappa):
-        assert mu[-1] >= 0
+        mu = array(mu)
+        if mu.ndim != 1:
+            raise ValueError("mu must be a 1-D vector")
+        if bool(mu[-1] < 0):
+            raise ValueError("mu must lie on the upper hyperhemisphere")
         self.dist_full_sphere = WatsonDistribution(mu, kappa)
         AbstractHyperhemisphericalDistribution.__init__(
             self, dim=self.dist_full_sphere.dim
@@ -22,7 +26,11 @@ class HyperhemisphericalWatsonDistribution(AbstractHyperhemisphericalDistributio
         return 2.0 * self.dist_full_sphere.pdf(xs)
 
     def set_mode(self, mu) -> "HyperhemisphericalWatsonDistribution":
-        assert mu.shape == self.mu.shape
+        mu = array(mu)
+        if mu.shape != self.mu.shape:
+            raise ValueError("mu must have the same shape as the current mode")
+        if bool(mu[-1] < 0):
+            raise ValueError("mu must lie on the upper hyperhemisphere")
         dist = copy.deepcopy(self)
         dist.mu = copy.deepcopy(mu)
         return dist
@@ -54,8 +62,9 @@ class HyperhemisphericalWatsonDistribution(AbstractHyperhemisphericalDistributio
 
     def shift(self, shift_by) -> "HyperhemisphericalWatsonDistribution":
         canonical_mu = concatenate((zeros(self.input_dim - 1), array([1.0])))
-        assert allclose(self.mu, canonical_mu), (
-            "There is no true shifting for the hyperhemisphere. This is a "
-            "function for compatibility and only works when mu is [0,0,...,1]."
-        )
+        if not bool(allclose(self.mu, canonical_mu)):
+            raise ValueError(
+                "There is no true shifting for the hyperhemisphere. This is a "
+                "function for compatibility and only works when mu is [0,0,...,1]."
+            )
         return self.set_mode(shift_by)

--- a/tests/distributions/test_hyperhemispherical_watson_distribution.py
+++ b/tests/distributions/test_hyperhemispherical_watson_distribution.py
@@ -1,0 +1,43 @@
+import unittest
+
+import numpy.testing as npt
+
+from pyrecest.backend import array
+from pyrecest.distributions.hypersphere_subset.hyperhemispherical_watson_distribution import (
+    HyperhemisphericalWatsonDistribution,
+)
+
+
+class HyperhemisphericalWatsonDistributionTest(unittest.TestCase):
+    def test_constructor_rejects_lower_hemisphere_mode(self):
+        with self.assertRaisesRegex(ValueError, "upper hyperhemisphere"):
+            HyperhemisphericalWatsonDistribution(array([0.0, 0.0, -1.0]), 2.0)
+
+    def test_set_mode_returns_new_distribution(self):
+        dist = HyperhemisphericalWatsonDistribution(array([0.0, 0.0, 1.0]), 2.0)
+        new_mode = array([1.0, 0.0, 0.0])
+
+        shifted = dist.set_mode(new_mode)
+
+        self.assertIsNot(shifted, dist)
+        npt.assert_allclose(dist.mu, array([0.0, 0.0, 1.0]))
+        npt.assert_allclose(shifted.mu, new_mode)
+
+    def test_set_mode_rejects_invalid_mode(self):
+        dist = HyperhemisphericalWatsonDistribution(array([0.0, 0.0, 1.0]), 2.0)
+
+        invalid_modes = (array([1.0, 0.0]), array([0.0, 0.0, -1.0]))
+        for new_mode in invalid_modes:
+            with self.subTest(new_mode=new_mode):
+                with self.assertRaises(ValueError):
+                    dist.set_mode(new_mode)
+
+    def test_shift_rejects_noncanonical_base_direction(self):
+        dist = HyperhemisphericalWatsonDistribution(array([1.0, 0.0, 0.0]), 2.0)
+
+        with self.assertRaisesRegex(ValueError, "compatibility"):
+            dist.shift(array([0.0, 0.0, 1.0]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Replace assert-backed hyperhemispherical Watson constructor, mode, and shift validation with explicit ValueErrors.
- Keep set_mode constrained to the upper hyperhemisphere, matching constructor behavior.
- Add focused regressions for invalid lower-hemisphere modes, wrong mode shapes, and noncanonical shifts.

## Validation
- `.venv\Scripts\python -m pytest -q tests\distributions\test_hyperhemispherical_watson_distribution.py`
- `.venv\Scripts\python -O -m pytest -q tests\distributions\test_hyperhemispherical_watson_distribution.py`
- `.venv\Scripts\python -m ruff check src\pyrecest\distributions\hypersphere_subset\hyperhemispherical_watson_distribution.py tests\distributions\test_hyperhemispherical_watson_distribution.py`