### PR TITLE
Validate hypertoroidal Dirac helpers explicitly

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py
@@ -97,7 +97,8 @@ class HypertoroidalDiracDistribution(
 
     def plot(self, resolution=128, **kwargs):
         _ = resolution
-        assert self.dim <= 3, "Plotting not supported for this dimension"
+        if self.dim > 3:
+            raise ValueError("Plotting not supported for this dimension")
         LinearDiracDistribution.plot(self, **kwargs)
         if self.dim >= 1:
             plt.xlim(0, 2 * pi)
@@ -145,7 +146,8 @@ class HypertoroidalDiracDistribution(
     def to_toroidal_wd(self):
         from .toroidal_dirac_distribution import ToroidalDiracDistribution
 
-        assert self.dim == 2, "The dimension must be 2"
+        if self.dim != 2:
+            raise ValueError("The dimension must be 2")
         twd = ToroidalDiracDistribution(self.d, self.w)
         return twd
 
@@ -208,7 +210,8 @@ class HypertoroidalDiracDistribution(
         raise NotImplementedError("Entropy calculation is not implemented")
 
     def to_wd(self):
-        assert self.dim == 1
+        if self.dim != 1:
+            raise ValueError("The dimension must be 1")
         from ..circle.circular_dirac_distribution import CircularDiracDistribution
 
         return CircularDiracDistribution(self.d, self.w)

--- a/tests/distributions/test_hypertoroidal_dirac_distribution.py
+++ b/tests/distributions/test_hypertoroidal_dirac_distribution.py
@@ -203,6 +203,18 @@ class TestHypertoroidalDiracDistribution(TestAbstractDiracDistribution):
         npt.assert_array_almost_equal(twd1.d, twd2.d, decimal=10)
         npt.assert_array_almost_equal(twd1.w, twd2.w, decimal=10)
 
+    def test_to_toroidal_wd_rejects_wrong_dimension(self):
+        hwd = TestHypertoroidalDiracDistribution.get_pseudorandom_hypertoroidal_wd(3)
+
+        with self.assertRaisesRegex(ValueError, "dimension"):
+            hwd.to_toroidal_wd()
+
+    def test_to_wd_rejects_wrong_dimension(self):
+        hwd = TestHypertoroidalDiracDistribution.get_pseudorandom_hypertoroidal_wd(2)
+
+        with self.assertRaisesRegex(ValueError, "dimension"):
+            hwd.to_wd()
+
     def test_marginalization(self):
         hwd = TestHypertoroidalDiracDistribution.get_pseudorandom_hypertoroidal_wd(2)
         wd1 = hwd.marginalize_to_1D(0)
@@ -242,6 +254,12 @@ class TestHypertoroidalDiracDistribution(TestAbstractDiracDistribution):
     )
     def test_plot(self, name, dist, dim):
         self._test_plot_helper(name, dist, dim, HypertoroidalDiracDistribution)
+
+    def test_plot_rejects_unsupported_dimension(self):
+        dist = TestHypertoroidalDiracDistribution.get_pseudorandom_hypertoroidal_wd(4)
+
+        with self.assertRaisesRegex(ValueError, "Plotting"):
+            dist.plot()
 
     # jscpd:ignore-end
 


### PR DESCRIPTION
## Summary
- Replace assert-backed dimension guards in hypertoroidal Dirac plot and conversion helpers with explicit ValueErrors.
- Add regressions for unsupported plot dimensions and wrong-dimensional conversions.

## Validation
- `.venv\Scripts\python -m pytest -q tests\distributions\test_hypertoroidal_dirac_distribution.py`
- `.venv\Scripts\python -O -m pytest -q tests\distributions\test_hypertoroidal_dirac_distribution.py`
- `.venv\Scripts\python -m ruff check src\pyrecest\distributions\hypertorus\hypertoroidal_dirac_distribution.py tests\distributions\test_hypertoroidal_dirac_distribution.py`