### PR TITLE
Validate hypercylindrical Dirac plotting explicitly

### DIFF
--- a/src/pyrecest/distributions/cart_prod/hypercylindrical_dirac_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/hypercylindrical_dirac_distribution.py
@@ -49,7 +49,8 @@ class HypercylindricalDiracDistribution(
         return self.w @ S
 
     def plot(self, *args, **kwargs):
-        assert self.dim <= 3, "Plotting not supported for this dimension"
+        if self.dim > 3:
+            raise ValueError("Plotting not supported for this dimension")
         LinearDiracDistribution.plot(self, *args, **kwargs)
         if self.bound_dim >= 1:
             plt.xlim(0, 2 * pi)

--- a/tests/distributions/test_hypercylindrical_dirac_distribution.py
+++ b/tests/distributions/test_hypercylindrical_dirac_distribution.py
@@ -167,4 +167,12 @@ class TestHypercylindricalDiracDistribution(TestAbstractDiracDistribution):
             name, dist, dim, HypercylindricalDiracDistribution, bound_dim=1
         )
 
+    def test_plot_rejects_unsupported_dimension(self):
+        dist = HypercylindricalDiracDistribution(
+            1, array([[0.1, 1.0, 2.0, 3.0]])
+        )
+
+        with self.assertRaisesRegex(ValueError, "Plotting"):
+            dist.plot()
+
     # jscpd:ignore-end


### PR DESCRIPTION
## Summary
- Replace the assert-backed hypercylindrical Dirac plot dimension guard with an explicit ValueError.
- Add a regression for unsupported 4D plotting so validation survives optimized Python.

## Validation
- `.venv\Scripts\python -m pytest -q tests\distributions\test_hypercylindrical_dirac_distribution.py`
- `.venv\Scripts\python -O -m pytest -q tests\distributions\test_hypercylindrical_dirac_distribution.py`
- `.venv\Scripts\python -m ruff check src\pyrecest\distributions\cart_prod\hypercylindrical_dirac_distribution.py tests\distributions\test_hypercylindrical_dirac_distribution.py`