### PR TITLE
Validate mixture distribution lists explicitly

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/hyperspherical_mixture.py
+++ b/src/pyrecest/distributions/hypersphere_subset/hyperspherical_mixture.py
@@ -15,9 +15,12 @@ class HypersphericalMixture(AbstractMixture, AbstractHypersphericalDistribution)
             dists (List[AbstractHypersphericalDistribution]): The list of hyperspherical distributions.
             w (List[float]): The list of weights for each distribution.
         """
-        AbstractHypersphericalDistribution.__init__(self, dim=dists[0].dim)
-        assert all(
+        if len(dists) == 0:
+            raise ValueError("Mixture must contain at least one distribution")
+        if not all(
             isinstance(dist, AbstractHypersphericalDistribution) for dist in dists
-        ), "dists must be a list of hyperspherical distributions"
+        ):
+            raise ValueError("dists must be a list of hyperspherical distributions")
+        AbstractHypersphericalDistribution.__init__(self, dim=dists[0].dim)
 
         AbstractMixture.__init__(self, dists, w)

--- a/src/pyrecest/distributions/nonperiodic/linear_mixture.py
+++ b/src/pyrecest/distributions/nonperiodic/linear_mixture.py
@@ -10,9 +10,10 @@ class LinearMixture(AbstractMixture, AbstractLinearDistribution):
     def __init__(self, dists: Sequence[AbstractLinearDistribution], w):
         from .gaussian_mixture import GaussianMixture
 
-        assert all(
-            isinstance(dist, AbstractLinearDistribution) for dist in dists
-        ), "dists must be a list of linear distributions"
+        if len(dists) == 0:
+            raise ValueError("Mixture must contain at least one distribution")
+        if not all(isinstance(dist, AbstractLinearDistribution) for dist in dists):
+            raise ValueError("dists must be a list of linear distributions")
         if not isinstance(self, GaussianMixture) and all(
             isinstance(dist, GaussianDistribution) for dist in dists
         ):

--- a/tests/distributions/test_hyperspherical_mixture.py
+++ b/tests/distributions/test_hyperspherical_mixture.py
@@ -14,6 +14,17 @@ from pyrecest.distributions import (
 
 
 class HypersphericalMixtureTest(unittest.TestCase):
+    def test_constructor_rejects_invalid_distribution_list(self):
+        invalid_cases = (
+            ([], array([]), "at least one"),
+            ([object()], array([1.0]), "hyperspherical distributions"),
+        )
+
+        for dists, weights, message in invalid_cases:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(ValueError, message):
+                    HypersphericalMixture(dists, weights)
+
     def test_pdf_3d(self):
         wad = WatsonDistribution(array([0.0, 0.0, 1.0]), -10.0)
         vmf = VonMisesFisherDistribution(array([0.0, 0.0, 1.0]), 1.0)

--- a/tests/distributions/test_linear_mixture.py
+++ b/tests/distributions/test_linear_mixture.py
@@ -32,6 +32,17 @@ class LinearMixtureTest(unittest.TestCase):
                 str(w[-1].message),
             )
 
+    def test_constructor_rejects_invalid_distribution_list(self):
+        invalid_cases = (
+            ([], array([]), "at least one"),
+            ([object()], array([1.0]), "linear distributions"),
+        )
+
+        for dists, weights, message in invalid_cases:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(ValueError, message):
+                    LinearMixture(dists, weights)
+
     def test_prunes_zero_weight_components(self):
         gm1 = GaussianDistribution(array([1.0]), array([[1.0]]))
         gm2 = GaussianDistribution(array([50.0]), array([[1.0]]))


### PR DESCRIPTION
## Summary
- Replace assert-backed distribution-type checks in linear and hyperspherical mixture constructors with explicit ValueErrors.
- Reject empty distribution lists before indexing the first component.
- Add regressions for empty and wrong-type distribution lists under normal and optimized Python.

## Validation
- `.venv\Scripts\python -m pytest -q tests\distributions\test_linear_mixture.py tests\distributions\test_hyperspherical_mixture.py`
- `.venv\Scripts\python -O -m pytest -q tests\distributions\test_linear_mixture.py tests\distributions\test_hyperspherical_mixture.py`
- `.venv\Scripts\python -m ruff check src\pyrecest\distributions\nonperiodic\linear_mixture.py src\pyrecest\distributions\hypersphere_subset\hyperspherical_mixture.py tests\distributions\test_linear_mixture.py tests\distributions\test_hyperspherical_mixture.py`