### PR TITLE
Validate toroidal specializations explicitly

### DIFF
--- a/src/pyrecest/distributions/hypertorus/toroidal_fourier_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/toroidal_fourier_distribution.py
@@ -38,7 +38,7 @@ class ToroidalFourierDistribution(
 
     def __init__(self, coeff_mat, transformation: str = "sqrt"):
         cm = array(coeff_mat) if not hasattr(coeff_mat, "shape") else coeff_mat
-        if ndim(cm) < 2 or (ndim(cm) >= 2 and any(s == 1 for s in cm.shape)):
+        if ndim(cm) != 2 or any(s == 1 for s in cm.shape):
             raise ValueError(
                 "ToroidalFourierDistribution:VectorGiven: "
                 "ToroidalFourierDistributions require a 2-D coefficient matrix "
@@ -47,10 +47,11 @@ class ToroidalFourierDistribution(
 
         HypertoroidalFourierDistribution.__init__(self, coeff_mat, transformation)
         AbstractToroidalDistribution.__init__(self)
-        assert self.dim == 2, (
-            "ToroidalFourierDistribution requires a 2-D coefficient matrix, "
-            f"but got dim={self.dim}."
-        )
+        if self.dim != 2:
+            raise ValueError(
+                "ToroidalFourierDistribution requires a 2-D coefficient matrix, "
+                f"but got dim={self.dim}."
+            )
 
     # ------------------------------------------------------------------
     # Analytical integral with optional bounds

--- a/src/pyrecest/distributions/hypertorus/toroidal_mixture.py
+++ b/src/pyrecest/distributions/hypertorus/toroidal_mixture.py
@@ -10,9 +10,10 @@ class ToroidalMixture(HypertoroidalMixture, AbstractToroidalDistribution):
         :param hds: list of toroidal distributions
         :param w: list of weights
         """
-        assert all(
-            isinstance(hd, AbstractToroidalDistribution) for hd in hds
-        ), "hds must be a list of toroidal distributions"
+        if len(hds) == 0:
+            raise ValueError("Mixture must contain at least one distribution")
+        if not all(isinstance(hd, AbstractToroidalDistribution) for hd in hds):
+            raise ValueError("hds must be a list of toroidal distributions")
 
         HypertoroidalMixture.__init__(self, hds, w)
         AbstractToroidalDistribution.__init__(self)

--- a/tests/distributions/test_toroidal_fourier_distribution.py
+++ b/tests/distributions/test_toroidal_fourier_distribution.py
@@ -64,6 +64,12 @@ class TestToroidalFourierDistributionConstructor(unittest.TestCase):
         with self.assertRaises(ValueError):
             ToroidalFourierDistribution(array(c), "identity")
 
+    def test_higher_dimensional_coefficients_raise(self):
+        c = zeros((3, 3, 3), dtype=complex)
+
+        with self.assertRaisesRegex(ValueError, "2-D coefficient matrix"):
+            ToroidalFourierDistribution(c, "identity")
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
         reason="Not supported on JAX backend",

--- a/tests/distributions/test_toroidal_mixture.py
+++ b/tests/distributions/test_toroidal_mixture.py
@@ -1,0 +1,28 @@
+import unittest
+
+from pyrecest.backend import array
+from pyrecest.distributions.hypertorus.custom_hypertoroidal_distribution import (
+    CustomHypertoroidalDistribution,
+)
+from pyrecest.distributions.hypertorus.toroidal_mixture import ToroidalMixture
+
+
+class ToroidalMixtureTest(unittest.TestCase):
+    def test_constructor_rejects_invalid_distribution_list(self):
+        invalid_cases = (
+            ([], array([]), "at least one"),
+            (
+                [CustomHypertoroidalDistribution(lambda xs: xs[:, 0], 2)],
+                array([1.0]),
+                "toroidal distributions",
+            ),
+        )
+
+        for dists, weights, message in invalid_cases:
+            with self.subTest(message=message):
+                with self.assertRaisesRegex(ValueError, message):
+                    ToroidalMixture(dists, weights)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Reject non-2D Fourier coefficient arrays before constructing a ToroidalFourierDistribution.
- Replace the toroidal mixture assert-backed component check with explicit ValueErrors and empty-list handling.
- Add focused regressions for higher-dimensional Fourier coefficients and invalid toroidal mixture inputs.

## Validation
- `.venv\Scripts\python -m pytest -q tests\distributions\test_toroidal_fourier_distribution.py tests\distributions\test_toroidal_mixture.py`
- `.venv\Scripts\python -O -m pytest -q tests\distributions\test_toroidal_fourier_distribution.py tests\distributions\test_toroidal_mixture.py`
- `.venv\Scripts\python -m ruff check src\pyrecest\distributions\hypertorus\toroidal_fourier_distribution.py src\pyrecest\distributions\hypertorus\toroidal_mixture.py tests\distributions\test_toroidal_fourier_distribution.py tests\distributions\test_toroidal_mixture.py`