### PR TITLE
Validate sine-skewed k support explicitly

### DIFF
--- a/src/pyrecest/distributions/circle/sine_skewed_distributions.py
+++ b/src/pyrecest/distributions/circle/sine_skewed_distributions.py
@@ -54,7 +54,8 @@ class GeneralizedKSineSkewedVonMisesDistribution(AbstractCircularDistribution):
 
     def pdf(self, xs):
         # Evaluate the von Mises distribution and multiply by (1 + lambda_ * sin(xa - mu))
-        assert self.k == 1, "Currently, only k=1 is supported"
+        if self.k != 1:
+            raise NotImplementedError("Currently, only k=1 is supported")
         vm_pdf = VonMisesDistribution(self.mu, self.kappa).pdf(xs)
         skew_factor = (1 + self.lambda_ * sin(self.k * (xs - self.mu))) ** self.m
         if self.m == 1:
@@ -236,7 +237,8 @@ class GeneralizedKSineSkewedWrappedCauchyDistribution(AbstractCircularDistributi
         self.m = _validate_sine_power(self.m, "m")
 
     def pdf(self, xs):
-        assert self.k == 1, "Currently, only k=1 is supported"
+        if self.k != 1:
+            raise NotImplementedError("Currently, only k=1 is supported")
         # Use the WC pdf formula directly to ensure correct centering at mu
         wc_pdf_vals = (
             1 / (2 * pi) * sinh(self.gamma) / (cosh(self.gamma) - cos(xs - self.mu))

--- a/tests/distributions/test_sine_skewed_distributions.py
+++ b/tests/distributions/test_sine_skewed_distributions.py
@@ -48,6 +48,14 @@ class TestGeneralizedKSineSkewedVonMisesDistribution(unittest.TestCase):
         # This is more of a sanity check; a more comprehensive test would compare against a known result
         self.assertTrue(0 <= pdf_val <= 2, "PDF value out of expected range.")
 
+    def test_pdf_rejects_unsupported_k(self):
+        dist = GeneralizedKSineSkewedVonMisesDistribution(
+            mu=pi, kappa=1, lambda_=0.5, k=2, m=1
+        )
+
+        with self.assertRaisesRegex(NotImplementedError, "k=1"):
+            dist.pdf(array([0.0]))
+
     def test_shift(self):
         """Test the shift method modifies mu correctly."""
         dist = GeneralizedKSineSkewedVonMisesDistribution(
@@ -265,6 +273,14 @@ class TestGeneralizedKSineSkewedWrappedCauchyDistribution(unittest.TestCase):
             )
             xs = array([0.0, pi / 4, pi / 2, pi, 3 * pi / 2, 2 * pi - 0.01])
             assert all(dist.pdf(xs) >= 0), f"Negative PDF value for m={m}"
+
+    def test_pdf_rejects_unsupported_k(self):
+        dist = GeneralizedKSineSkewedWrappedCauchyDistribution(
+            mu=pi, gamma=0.5, lambda_=0.5, k=2, m=1
+        )
+
+        with self.assertRaisesRegex(NotImplementedError, "k=1"):
+            dist.pdf(array([0.0]))
 
     def test_shift(self):
         """Test the shift method modifies mu correctly."""


### PR DESCRIPTION
## Summary
- Replace assert-backed unsupported-`k` checks in generalized sine-skewed PDFs with explicit NotImplementedErrors.
- Add regressions for unsupported `k` in the von Mises and wrapped Cauchy variants.

## Validation
- `.venv\Scripts\python -m pytest -q tests\distributions\test_sine_skewed_distributions.py`
- `.venv\Scripts\python -O -m pytest -q tests\distributions\test_sine_skewed_distributions.py`
- `.venv\Scripts\python -m ruff check src\pyrecest\distributions\circle\sine_skewed_distributions.py tests\distributions\test_sine_skewed_distributions.py`