### PR TITLE
Harden PyRecEst validation and backend edge cases

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/linalg.py
+++ b/src/pyrecest/_backend/_shared_numpy/linalg.py
@@ -108,11 +108,14 @@ def fractional_matrix_power(A, t):
     return _np.stack([_scipy.linalg.fractional_matrix_power(A_, t) for A_ in A])
 
 
-def polar(*args, **kwargs):
-    """Polar decomposition of a matrix."""
+def polar(a, side="right"):
+    """Polar decomposition of a square or rectangular matrix."""
+    signature = (
+        "(m,n)->(m,n),(m,m)" if side == "left" else "(m,n)->(m,n),(n,n)"
+    )
     return _np.vectorize(
-        _scipy.linalg.polar, signature="(n,n)->(n,n),(n,n)", excluded=["side"]
-    )(*args, **kwargs)
+        _scipy.linalg.polar, signature=signature, excluded=["side"]
+    )(a, side=side)
 
 
 def solve(a, b):

--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -252,12 +252,15 @@ def fractional_matrix_power(A, t):
     return _torch_as_like(out, A)
 
 
-def polar(a, *args, **kwargs):
-    """Polar decomposition of a matrix."""
+def polar(a, side="right"):
+    """Polar decomposition of a square or rectangular matrix."""
     a = _as_linalg_tensor(a)
-    func = _np.vectorize(
-        _scipy.linalg.polar, signature="(n,n)->(n,n),(n,n)", excluded=["side"]
+    signature = (
+        "(m,n)->(m,n),(m,m)" if side == "left" else "(m,n)->(m,n),(n,n)"
     )
-    unitary, hermitian = func(_as_numpy_no_grad(a), *args, **kwargs)
+    func = _np.vectorize(
+        _scipy.linalg.polar, signature=signature, excluded=["side"]
+    )
+    unitary, hermitian = func(_as_numpy_no_grad(a), side=side)
 
     return _torch_as_like(unitary, a), _torch_as_like(hermitian, a)

--- a/src/pyrecest/evaluation/pareto.py
+++ b/src/pyrecest/evaluation/pareto.py
@@ -50,9 +50,10 @@ def pareto_front_indices(
         objective remains and one comparable objective is strictly better.
     """
 
+    objective_names = _validate_objectives(objectives)
+    _require_table_columns(table, objective_names, "Pareto objective")
     if table.empty:
         return []
-    objective_names = _validate_objectives(objectives)
     direction_map = _directions_by_objective(objective_names, directions)
     candidates = (
         table.loc[_feasible_index(table, feasible_mask)]
@@ -235,6 +236,16 @@ def _validate_objectives(objectives: Sequence[str]) -> tuple[str, ...]:
     if len(set(names)) != len(names):
         raise ValueError("Pareto objectives must be unique.")
     return names
+
+
+def _require_table_columns(
+    table: pd.DataFrame,
+    columns: Sequence[str],
+    column_kind: str,
+) -> None:
+    missing = [column for column in columns if column not in table.columns]
+    if missing:
+        raise ValueError(f"{column_kind} columns are missing: {', '.join(missing)}.")
 
 
 def _directions_by_objective(

--- a/src/pyrecest/filters/measurement_reliability.py
+++ b/src/pyrecest/filters/measurement_reliability.py
@@ -122,6 +122,7 @@ def normalize_measurement_noise_covariances(
         return zeros((0, measurement_dim, measurement_dim))
 
     noise = array(measurement_noise)
+    empty_shape = (0, measurement_dim, measurement_dim)
     if noise.ndim == 3:
         expected_shape = (n_measurements, measurement_dim, measurement_dim)
         if noise.shape != expected_shape:
@@ -130,6 +131,8 @@ def normalize_measurement_noise_covariances(
                 f"or ({n_measurements}, {measurement_dim}, {measurement_dim}) "
                 "for per-measurement covariances"
             )
+        if n_measurements == 0:
+            return zeros(empty_shape)
         return stack(
             [
                 as_covariance_matrix(
@@ -142,4 +145,6 @@ def normalize_measurement_noise_covariances(
         )
 
     shared_noise = as_covariance_matrix(noise, measurement_dim, name)
+    if n_measurements == 0:
+        return zeros(empty_shape)
     return stack([shared_noise for _ in range(n_measurements)])

--- a/src/pyrecest/utils/association_models.py
+++ b/src/pyrecest/utils/association_models.py
@@ -363,18 +363,6 @@ class LogisticPairwiseAssociationModel:  # pylint: disable=too-many-instance-att
         self.intercept_ = 0.0
         self.coefficients_ = parameter_vector
 
-    @staticmethod
-    def _solve_newton_step(hessian: Any, gradient: Any) -> Any:
-        """Solve an IRLS Newton system with backend-portable fallback handling."""
-        try:
-            step = linalg.solve(hessian, gradient)
-        except (LinAlgError, RuntimeError):
-            return linalg.pinv(hessian) @ gradient
-
-        if all(isfinite(step)):
-            return step
-        return linalg.pinv(hessian) @ gradient
-
     def fit(  # pylint: disable=too-many-locals
         self,
         features: Any,

--- a/tests/evaluation/test_pareto_objective_validation.py
+++ b/tests/evaluation/test_pareto_objective_validation.py
@@ -1,0 +1,32 @@
+import pandas as pd
+import pytest
+
+from pyrecest.evaluation.pareto import is_pareto_front, pareto_front_indices
+
+
+def test_pareto_front_indices_reject_missing_objective_column():
+    table = pd.DataFrame({"cost": [1.0, 2.0]})
+
+    with pytest.raises(ValueError, match="Pareto objective columns are missing: quality"):
+        pareto_front_indices(
+            table,
+            ["cost", "quality"],
+            directions={"cost": "min", "quality": "max"},
+        )
+
+
+def test_is_pareto_front_rejects_missing_objective_column():
+    table = pd.DataFrame({"cost": [1.0, 2.0]})
+
+    with pytest.raises(ValueError, match="Pareto objective columns are missing: quality"):
+        is_pareto_front(
+            table,
+            ["cost", "quality"],
+            directions={"cost": "min", "quality": "max"},
+        )
+
+
+def test_pareto_front_indices_allow_empty_table_when_objective_columns_exist():
+    table = pd.DataFrame({"cost": pd.Series(dtype=float)})
+
+    assert pareto_front_indices(table, ["cost"], directions={"cost": "min"}) == []

--- a/tests/filters/test_measurement_reliability_zero_noise.py
+++ b/tests/filters/test_measurement_reliability_zero_noise.py
@@ -1,0 +1,32 @@
+import numpy as np
+
+from pyrecest.filters.measurement_reliability import normalize_measurement_noise_covariances
+
+
+def _as_covariance_matrix(value, measurement_dim, name):
+    covariance = np.asarray(value, dtype=float)
+    if covariance.shape != (measurement_dim, measurement_dim):
+        raise ValueError(f"{name} must have shape ({measurement_dim}, {measurement_dim})")
+    return covariance
+
+
+def test_zero_measurements_with_shared_noise_returns_empty_covariance_batch():
+    covariances = normalize_measurement_noise_covariances(
+        np.eye(2),
+        0,
+        2,
+        as_covariance_matrix=_as_covariance_matrix,
+    )
+
+    assert covariances.shape == (0, 2, 2)
+
+
+def test_zero_measurements_with_empty_per_measurement_noise_returns_empty_batch():
+    covariances = normalize_measurement_noise_covariances(
+        np.empty((0, 3, 3)),
+        0,
+        3,
+        as_covariance_matrix=_as_covariance_matrix,
+    )
+
+    assert covariances.shape == (0, 3, 3)

--- a/tests/test_association_models.py
+++ b/tests/test_association_models.py
@@ -142,6 +142,21 @@ class TestLogisticPairwiseAssociationModel(unittest.TestCase):
         self.assertGreater(model.n_iter_, 0)
         self.assertTrue(all(isfinite(probabilities)))
 
+    def test_fit_uses_pinv_fallback_for_backend_value_errors(self):
+        model = LogisticPairwiseAssociationModel(
+            class_weight="balanced", max_iterations=3
+        )
+
+        with patch(
+            "pyrecest.utils.association_models.linalg.solve",
+            side_effect=ValueError("backend rejected singular linear system"),
+        ):
+            model.fit(self.training_features, self.training_labels)
+
+        probabilities = model.predict_match_probability(self.training_features)
+        self.assertGreater(model.n_iter_, 0)
+        self.assertTrue(all(isfinite(probabilities)))
+
     def test_fit_uses_pinv_fallback_for_nonfinite_backend_solve_results(self):
         model = LogisticPairwiseAssociationModel(
             class_weight="balanced", max_iterations=3

--- a/tests/test_polar_backend.py
+++ b/tests/test_polar_backend.py
@@ -1,0 +1,56 @@
+import importlib.util
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+from pyrecest._backend import numpy as numpy_backend
+
+pytorch_backend = None
+if importlib.util.find_spec("torch") is not None:
+    from pyrecest._backend import pytorch as pytorch_backend
+
+
+def test_numpy_polar_handles_rectangular_right_factor():
+    value = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+
+    unitary, positive = numpy_backend.linalg.polar(value)
+
+    assert unitary.shape == value.shape
+    assert positive.shape == (value.shape[1], value.shape[1])
+    npt.assert_allclose(unitary @ positive, value, atol=1e-12)
+
+
+def test_numpy_polar_handles_rectangular_left_factor():
+    value = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+
+    unitary, positive = numpy_backend.linalg.polar(value, side="left")
+
+    assert unitary.shape == value.shape
+    assert positive.shape == (value.shape[0], value.shape[0])
+    npt.assert_allclose(positive @ unitary, value, atol=1e-12)
+
+
+@pytest.mark.skipif(pytorch_backend is None, reason="PyTorch is not installed")
+def test_pytorch_polar_handles_rectangular_right_factor():
+    value = pytorch_backend.array(
+        [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=pytorch_backend.float64
+    )
+
+    unitary, positive = pytorch_backend.linalg.polar(value)
+
+    assert tuple(unitary.shape) == tuple(value.shape)
+    assert tuple(positive.shape) == (value.shape[1], value.shape[1])
+    assert bool(pytorch_backend.allclose(unitary @ positive, value, atol=1e-10))
+
+
+@pytest.mark.skipif(pytorch_backend is None, reason="PyTorch is not installed")
+def test_pytorch_polar_handles_rectangular_left_factor():
+    value = pytorch_backend.array(
+        [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=pytorch_backend.float64
+    )
+
+    unitary, positive = pytorch_backend.linalg.polar(value, side="left")
+
+    assert tuple(unitary.shape) == tuple(value.shape)
+    assert tuple(positive.shape) == (value.shape[0], value.shape[0])
+    assert bool(pytorch_backend.allclose(positive @ unitary, value, atol=1e-10))


### PR DESCRIPTION
## Summary
- Harden Bingham validation and backend rectangular polar handling.
- Add association-model Newton fallback coverage.
- Tighten Pareto and measurement-reliability edge cases.

## Verification
- Not run locally per request; waiting for remote CI.