### PR TITLE
Harden PyRecEst backend and shape validation

### DIFF
--- a/src/pyrecest/_backend/pytorch/__init__.py
+++ b/src/pyrecest/_backend/pytorch/__init__.py
@@ -243,31 +243,11 @@ def cov(input, correction=1, fweights=None, aweights=None, bias=False):
     if aweights is not None:
         aweights = asarray(aweights, dtype=input.dtype, device=input.device)
 
-    if not bias:
-        return _torch.cov(
-            input, correction=correction, fweights=fweights, aweights=aweights
-        )
-    assert fweights is None
-
-    if aweights is None:
-        aweights = ones(input.shape[1], dtype=input.dtype, device=input.device)
-    else:
-        aweights = copy(aweights)
-
-    # Ensure weights sum to 1
-    aweights = aweights / sum(aweights)
-
-    # Calculate weighted means
-    means = sum(input * aweights, axis=1, keepdims=True)
-
-    deviation_centered = input - means
-
-    # Calculate weighted biased covariance
-    cov_matrix = _torch.einsum(
-        "ij,kj,j->ik", deviation_centered, deviation_centered, aweights
+    if bias:
+        correction = 0
+    return _torch.cov(
+        input, correction=correction, fweights=fweights, aweights=aweights
     )
-
-    return cov_matrix
 
 
 def _quantile_q(q, x):

--- a/src/pyrecest/distributions/hypersphere_subset/abstract_hypersphere_subset_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/abstract_hypersphere_subset_distribution.py
@@ -378,7 +378,8 @@ class AbstractHypersphereSubsetDistribution(AbstractBoundedDomainDistribution):
         ``AbstractHypersphereSubsetDistribution``: the first angle is the
         azimuth and all remaining angles are colatitudes.
         """
-        single_input = getattr(hypersph_coords, "ndim", 0) == 1
+        hypersph_coords = array(hypersph_coords)
+        single_input = hypersph_coords.ndim == 1
         hypersph_coords = atleast_2d(hypersph_coords)
         if mode == "colatitude":
             cart_coords = (
@@ -391,7 +392,8 @@ class AbstractHypersphereSubsetDistribution(AbstractBoundedDomainDistribution):
                 AbstractSphereSubsetDistribution,
             )
 
-            assert hypersph_coords.shape[1] == 2, "Mode only S2 dimensions"
+            if hypersph_coords.shape[1] != 2:
+                raise ValueError("Mode only supports S2 coordinates")
             x, y, z = AbstractSphereSubsetDistribution.sph_to_cart(
                 hypersph_coords[:, 0], hypersph_coords[:, 1], mode=mode
             )
@@ -404,7 +406,8 @@ class AbstractHypersphereSubsetDistribution(AbstractBoundedDomainDistribution):
     @staticmethod
     def cart_to_hypersph(cart_coords, mode: str = "colatitude"):
         """Inverse of ``hypersph_to_cart`` for the selected convention."""
-        single_input = getattr(cart_coords, "ndim", 0) == 1
+        cart_coords = array(cart_coords)
+        single_input = cart_coords.ndim == 1
         cart_coords = atleast_2d(cart_coords)
         if mode == "colatitude":
             hypersph_coords = (
@@ -417,7 +420,8 @@ class AbstractHypersphereSubsetDistribution(AbstractBoundedDomainDistribution):
                 AbstractSphereSubsetDistribution,
             )
 
-            assert cart_coords.shape[1] == 3, "Mode only supports S2"
+            if cart_coords.shape[1] != 3:
+                raise ValueError("Mode only supports S2 coordinates")
             theta, phi = AbstractSphereSubsetDistribution.cart_to_sph(
                 cart_coords[:, 0], cart_coords[:, 1], cart_coords[:, 2], mode=mode
             )

--- a/src/pyrecest/utils/point_set_registration.py
+++ b/src/pyrecest/utils/point_set_registration.py
@@ -183,9 +183,10 @@ def estimate_transform(  # pylint: disable=too-many-locals
         Only relevant for the rigid model. If ``False`` the returned rotation is
         constrained to have determinant ``+1``.
     """
-    assert (
-        pyrecest.backend.__backend_name__ != "jax"
-    ), "Not supported for the JAX backend."
+    if pyrecest.backend.__backend_name__ == "jax":  # pylint: disable=no-member
+        raise NotImplementedError(
+            "estimate_transform is not supported on the JAX backend."
+        )
 
     source, target = _validate_pair(source_points, target_points)
     n_points, dim = source.shape
@@ -279,9 +280,10 @@ def joint_registration_assignment(  # pylint: disable=too-many-arguments,too-man
     allow_reflection:
         Passed through to :func:`estimate_transform` for the rigid model.
     """
-    assert (
-        pyrecest.backend.__backend_name__ != "jax"
-    ), "Not supported for the JAX backend."
+    if pyrecest.backend.__backend_name__ == "jax":  # pylint: disable=no-member
+        raise NotImplementedError(
+            "joint_registration_assignment is not supported on the JAX backend."
+        )
 
     reference = _as_point_array(reference_points)
     moving = _as_point_array(moving_points)

--- a/tests/distributions/test_abstract_hypersphere_subset_distribution.py
+++ b/tests/distributions/test_abstract_hypersphere_subset_distribution.py
@@ -242,6 +242,45 @@ class TestAbstractHypersphereSubsetDistribution(unittest.TestCase):
 
         npt.assert_allclose(cartesian_round_trip, cartesian, atol=1e-7)
 
+    def test_single_list_inputs_keep_single_output_shape(self):
+        angles = [pi / 2.0, pi / 2.0]
+
+        cartesian_from_list = AbstractHypersphereSubsetDistribution.hypersph_to_cart(
+            angles, mode="colatitude"
+        )
+        cartesian_from_array = AbstractHypersphereSubsetDistribution.hypersph_to_cart(
+            array(angles), mode="colatitude"
+        )
+
+        self.assertEqual(cartesian_from_array.shape, cartesian_from_list.shape)
+        npt.assert_allclose(cartesian_from_list, cartesian_from_array, atol=1e-7)
+
+        coords = [0.0, 1.0, 0.0]
+        angles_from_list = AbstractHypersphereSubsetDistribution.cart_to_hypersph(
+            coords, mode="colatitude"
+        )
+        angles_from_array = AbstractHypersphereSubsetDistribution.cart_to_hypersph(
+            array(coords), mode="colatitude"
+        )
+
+        self.assertEqual(angles_from_array.shape, angles_from_list.shape)
+        npt.assert_allclose(angles_from_list, angles_from_array, atol=1e-7)
+
+    def test_s2_only_modes_reject_wrong_input_dimension(self):
+        hyperspherical_s3 = array([[0.0, pi / 2.0, pi / 4.0]])
+        cartesian_s3 = array([[0.0, 1.0, 0.0, 0.0]])
+
+        for mode in ("elevation", "inclination"):
+            with self.subTest(mode=mode):
+                with self.assertRaisesRegex(ValueError, "S2"):
+                    AbstractHypersphereSubsetDistribution.hypersph_to_cart(
+                        hyperspherical_s3, mode=mode
+                    )
+                with self.assertRaisesRegex(ValueError, "S2"):
+                    AbstractHypersphereSubsetDistribution.cart_to_hypersph(
+                        cartesian_s3, mode=mode
+                    )
+
     def test_sphere_colatitude_matches_hyperspherical_convention(self):
         azimuth = array([0.0, pi / 2.0])
         colatitude = array([pi / 2.0, pi / 2.0])

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -129,6 +129,20 @@ def test_pytorch_cov_bias_accepts_array_weights():
     assert _to_python(result) == [[0.5, 1.0], [1.0, 2.0]]
 
 
+def test_pytorch_cov_bias_honors_frequency_weights():
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific covariance regression test")
+
+    result = backend.cov(
+        array([[1.0, 2.0, 3.0], [2.0, 4.0, 6.0]]),
+        bias=True,
+        fweights=backend.asarray([1, 2, 1], dtype=backend.int64),
+    )
+
+    assert result.shape == (2, 2)
+    assert _to_python(result) == [[0.5, 1.0], [1.0, 2.0]]
+
+
 def test_array_like_sequence_helpers_accept_python_lists():
     assert _to_python(backend.concatenate(([1, 2], [3, 4]), axis=0)) == [1, 2, 3, 4]
     assert _to_python(backend.stack(([1, 2], [3, 4]), axis=0)) == [[1, 2], [3, 4]]

--- a/tests/test_point_set_registration.py
+++ b/tests/test_point_set_registration.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import mock
 
 import numpy.testing as npt
 import pyrecest.backend
@@ -51,6 +52,13 @@ class TestEstimateTransform(unittest.TestCase):
         npt.assert_allclose(estimated.matrix, true_rotation, atol=1e-10)
         npt.assert_allclose(estimated.offset, true_offset, atol=1e-10)
 
+    def test_estimate_transform_rejects_jax_backend_without_asserts(self):
+        source = array([[0.0, 0.0]])
+
+        with mock.patch.object(pyrecest.backend, "__backend_name__", "jax"):
+            with self.assertRaisesRegex(NotImplementedError, "JAX backend"):
+                estimate_transform(source, source, model="translation")
+
 
 class TestGatedAssignment(unittest.TestCase):
     @unittest.skipIf(
@@ -64,6 +72,13 @@ class TestGatedAssignment(unittest.TestCase):
 
 
 class TestJointRegistrationAssignment(unittest.TestCase):
+    def test_joint_registration_assignment_rejects_jax_backend_without_asserts(self):
+        points = array([[0.0, 0.0]])
+
+        with mock.patch.object(pyrecest.backend, "__backend_name__", "jax"):
+            with self.assertRaisesRegex(NotImplementedError, "JAX backend"):
+                joint_registration_assignment(points, points, model="translation")
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",
         reason="Not supported on this backend",


### PR DESCRIPTION
## Summary
- delegate biased PyTorch covariance to torch.cov so frequency weights are honored
- replace optimized-away JAX backend assertions in point-set registration with runtime errors
- normalize hypersphere coordinate inputs before single-input and S2 shape checks

## Validation
- Not run locally per request.
- Remote GitHub checks will run on the PR.