### PR TITLE
Harden HypersphericalUKF validation

### DIFF
--- a/src/pyrecest/filters/hyperspherical_ukf.py
+++ b/src/pyrecest/filters/hyperspherical_ukf.py
@@ -35,6 +35,14 @@ from .abstract_filter import AbstractFilter
 from .manifold_mixins import HypersphericalFilterMixin
 
 
+def _assert_supported_backend(*unsupported_backends):
+    if pyrecest.backend.__backend_name__ in unsupported_backends:
+        raise NotImplementedError(
+            "HypersphericalUKF is not supported on the "
+            f"{pyrecest.backend.__backend_name__} backend."
+        )
+
+
 class HypersphericalUKF(AbstractFilter, HypersphericalFilterMixin):
     """
     Unscented Kalman filter on the unit hypersphere S^(d-1).
@@ -58,9 +66,7 @@ class HypersphericalUKF(AbstractFilter, HypersphericalFilterMixin):
         beta: float = 2.0,
         kappa: float = 0.0,
     ):
-        assert pyrecest.backend.__backend_name__ not in (
-            "jax",
-        ), "HypersphericalUKF is not supported on the JAX backend"
+        _assert_supported_backend("jax")
         self._alpha = alpha
         self._beta = beta
         self._kappa = kappa
@@ -128,10 +134,7 @@ class HypersphericalUKF(AbstractFilter, HypersphericalFilterMixin):
         gauss_sys:
             Distribution of additive system noise (mean is ignored).
         """
-        assert pyrecest.backend.__backend_name__ not in (
-            "pytorch",
-            "jax",
-        ), "Not supported on this backend"
+        _assert_supported_backend("pytorch", "jax")
 
         if not isinstance(gauss_sys, GaussianDistribution):
             gauss_sys = GaussianDistribution.from_distribution(gauss_sys)
@@ -172,15 +175,21 @@ class HypersphericalUKF(AbstractFilter, HypersphericalFilterMixin):
         noise_weights:
             Array of length ``n_noise`` with positive weights.
         """
-        assert pyrecest.backend.__backend_name__ not in (
-            "pytorch",
-            "jax",
-        ), "Not supported on this backend"
+        _assert_supported_backend("pytorch", "jax")
 
         noise_samples = asarray(noise_samples, dtype=float64)
         noise_weights = reshape(asarray(noise_weights, dtype=float64), (-1,))
-        assert noise_samples.shape[1] == noise_weights.shape[0]
-        assert all(noise_weights > 0)
+        if noise_samples.ndim != 2:
+            raise ValueError(
+                "noise_samples must be a 2D array with shape (noise_dim, n_noise)."
+            )
+        if noise_samples.shape[1] != noise_weights.shape[0]:
+            raise ValueError(
+                "noise_samples and noise_weights must contain the same number "
+                "of samples."
+            )
+        if not all(noise_weights > 0):
+            raise ValueError("noise_weights must be strictly positive.")
         noise_weights = noise_weights / noise_weights.sum()
 
         mu = reshape(asarray(self._filter_state.mu, dtype=float64), (-1,))
@@ -252,10 +261,7 @@ class HypersphericalUKF(AbstractFilter, HypersphericalFilterMixin):
         z:
             Measurement vector of shape (m,) or scalar.
         """
-        assert pyrecest.backend.__backend_name__ not in (
-            "pytorch",
-            "jax",
-        ), "Not supported on this backend"
+        _assert_supported_backend("pytorch", "jax")
 
         if not isinstance(gauss_meas, GaussianDistribution):
             gauss_meas = GaussianDistribution.from_distribution(gauss_meas)

--- a/tests/filters/test_hyperspherical_ukf.py
+++ b/tests/filters/test_hyperspherical_ukf.py
@@ -56,6 +56,30 @@ class HypersphericalUKFTest(unittest.TestCase):
         npt.assert_array_equal(np.asarray(self.gauss_2d.mu), np.asarray(g.mu))
         npt.assert_array_equal(np.asarray(self.gauss_2d.C), np.asarray(g.C))
 
+    def test_initialization_rejects_jax_backend_without_asserts(self):
+        """Unsupported-backend checks must survive optimized Python."""
+        original_backend = pyrecest.backend.__backend_name__
+        try:
+            pyrecest.backend.__backend_name__ = "jax"
+            with self.assertRaisesRegex(NotImplementedError, "jax backend"):
+                HypersphericalUKF(dim=2)
+        finally:
+            pyrecest.backend.__backend_name__ = original_backend
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("jax",),
+        reason="Not supported on this backend",
+    )
+    def test_predict_rejects_unsupported_backend_without_asserts(self):
+        """Predict-time backend checks must not rely on assert statements."""
+        original_backend = pyrecest.backend.__backend_name__
+        try:
+            pyrecest.backend.__backend_name__ = "pytorch"
+            with self.assertRaisesRegex(NotImplementedError, "pytorch backend"):
+                self.filter_2d.predict_identity(self.gauss_2d)
+        finally:
+            pyrecest.backend.__backend_name__ = original_backend
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
         reason="Not supported on this backend",
@@ -216,6 +240,34 @@ class HypersphericalUKFTest(unittest.TestCase):
         npt.assert_allclose(
             float(linalg.norm(self.filter_3d.get_point_estimate())), 1.0, atol=1e-10
         )
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
+    def test_predict_nonlinear_arbitrary_noise_validates_noise_samples(self):
+        """Malformed arbitrary-noise samples should fail before prediction math."""
+        with self.assertRaisesRegex(ValueError, "2D array"):
+            self.filter_3d.predict_nonlinear_arbitrary_noise(
+                lambda x, v: x,
+                np.ones(3),
+                np.ones(3),
+            )
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
+    def test_predict_nonlinear_arbitrary_noise_validates_weights(self):
+        """Weight validation should not disappear under optimized Python."""
+        with self.assertRaisesRegex(ValueError, "same number"):
+            self.filter_3d.predict_nonlinear_arbitrary_noise(
+                lambda x, v: x, np.ones((3, 2)), np.ones(3)
+            )
+        with self.assertRaisesRegex(ValueError, "strictly positive"):
+            self.filter_3d.predict_nonlinear_arbitrary_noise(
+                lambda x, v: x, np.ones((3, 2)), np.array([1.0, 0.0])
+            )
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),


### PR DESCRIPTION
## Summary
- Reject unsupported HypersphericalUKF backends with runtime validation that works under optimized Python.
- Validate arbitrary-noise sample shapes and weights before nonlinear prediction.
- Add regression coverage for backend and noise input validation.

## Validation
- Not run locally per request.
- Remote GitHub checks will run on the PR.