### PR TITLE
Harden particle filter validation

### DIFF
--- a/src/pyrecest/filters/abstract_particle_filter.py
+++ b/src/pyrecest/filters/abstract_particle_filter.py
@@ -11,6 +11,7 @@ from pyrecest.backend import (
     ndim,
     ones_like,
     random,
+    reshape,
     sum,
     vmap,
     vstack,
@@ -170,10 +171,13 @@ class AbstractParticleFilter(AbstractFilter):
         function_is_vectorized: bool = True,
         shift_instead_of_add: bool = True,
     ):
-        assert (
-            noise_distribution is None
-            or self.filter_state.dim == noise_distribution.dim
-        )
+        if (
+            noise_distribution is not None
+            and self.filter_state.dim != noise_distribution.dim
+        ):
+            raise ValueError(
+                f"Noise distribution dimension {noise_distribution.dim} does not match filter-state dimension {self.filter_state.dim}."
+            )
 
         if function_is_vectorized:
             d_f_applied = f(self.filter_state.d)
@@ -206,9 +210,8 @@ class AbstractParticleFilter(AbstractFilter):
 
     def predict_nonlinear_nonadditive(self, f, samples, weights):
         weights = array(weights, dtype=float)
-        assert (
-            samples.shape[0] == weights.shape[0]
-        ), "samples and weights must match in size"
+        if samples.shape[0] != weights.shape[0]:
+            raise ValueError("samples and weights must match in size")
 
         if not bool(all(isfinite(weights))):
             raise ValueError("Noise weights must be finite.")
@@ -236,11 +239,18 @@ class AbstractParticleFilter(AbstractFilter):
         if self._filter_state is None:
             self._filter_state = copy.deepcopy(new_state)
         elif isinstance(new_state, type(self.filter_state)):
-            assert self.filter_state.d.shape == new_state.d.shape
+            if self.filter_state.d.shape != new_state.d.shape:
+                raise ValueError(
+                    "The shape of new state does not match with the existing state."
+                )
             self._filter_state = copy.deepcopy(new_state)
         else:
             samples = new_state.sample(self.filter_state.w.shape[0])
-            assert samples.shape == self.filter_state.d.shape
+            if samples.shape != self.filter_state.d.shape:
+                raise ValueError(
+                    "Samples from new state have shape "
+                    f"{samples.shape}, expected {self.filter_state.d.shape}."
+                )
             self._filter_state.d = samples
             self._filter_state.w = (
                 ones_like(self.filter_state.w) / self.filter_state.w.shape[0]
@@ -269,13 +279,16 @@ class AbstractParticleFilter(AbstractFilter):
         *,
         return_diagnostics=False,
     ):
-        assert (
-            measurement is None
-            or measurement.shape == (meas_noise.dim,)
-            or meas_noise.dim == 1
-            and measurement.shape == ()
-        )
-        assert ndim(measurement) == 1 or ndim(measurement) == 0 and meas_noise.dim == 1
+        if measurement is None:
+            raise ValueError("measurement must not be None.")
+
+        measurement = array(measurement)
+        if meas_noise.dim == 1 and ndim(measurement) == 0:
+            measurement = reshape(measurement, (1,))
+        if ndim(measurement) != 1 or measurement.shape[0] != meas_noise.dim:
+            raise ValueError(
+                f"measurement must have shape ({meas_noise.dim},), got {measurement.shape}."
+            )
         if not shift_instead_of_add:
             raise NotImplementedError()
 

--- a/tests/filters/test_euclidean_particle_filter.py
+++ b/tests/filters/test_euclidean_particle_filter.py
@@ -53,6 +53,30 @@ class EuclideanParticleFilterTest(unittest.TestCase):
         npt.assert_allclose(pf.filter_state.d, particles)
         npt.assert_allclose(noise.d, noise_particles)
 
+    def test_predict_nonlinear_rejects_dimension_mismatched_noise(self):
+        mismatched_noise = GaussianDistribution(
+            array([0.0, 0.0]), array([[1.0, 0.0], [0.0, 1.0]])
+        )
+
+        with self.assertRaisesRegex(ValueError, "dimension"):
+            self.pf.predict_nonlinear(lambda xs: xs, mismatched_noise)
+
+    def test_update_identity_accepts_scalar_measurement_for_one_dimensional_noise(self):
+        pf = EuclideanParticleFilter(n_particles=3, dim=1)
+        particles = array([[0.0], [1.0], [2.0]])
+        pf.filter_state = LinearDiracDistribution(particles)
+        pf.set_resampling_criterion(lambda _state: False)
+        meas_noise = GaussianDistribution(array([0.0]), array([[1.0]]))
+
+        pf.update_identity(meas_noise, 1.0)
+
+        npt.assert_allclose(pf.filter_state.d, particles)
+        self.assertEqual(pf.filter_state.w.shape, (3,))
+
+    def test_update_identity_rejects_wrong_measurement_shape(self):
+        with self.assertRaisesRegex(ValueError, "measurement"):
+            self.pf.update_identity(self.sys_noise_default, array([1.0, 2.0]))
+
     def test_predict_update_cycle_3d(self):
         for _ in range(50):
             self.pf.predict_identity(GaussianDistribution(zeros(3), self.C_prior))
@@ -77,6 +101,16 @@ class EuclideanParticleFilterTest(unittest.TestCase):
         est = self.pf.get_point_estimate()
         self.assertEqual(self.pf.get_point_estimate().shape, (3,))
         npt.assert_allclose(est, self.prior.mu + mean(samples, axis=0), atol=0.1)
+
+    def test_predict_nonlinear_nonadditive_rejects_sample_weight_size_mismatch(self):
+        samples = array([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
+        weights = array([1.0])
+
+        def f(x, w):
+            return x + w
+
+        with self.assertRaisesRegex(ValueError, "samples and weights"):
+            self.pf.predict_nonlinear_nonadditive(f, samples, weights)
 
     def test_predict_nonlinear_nonadditive_rejects_invalid_weights(self):
         samples = array([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])


### PR DESCRIPTION
## Summary
- replace particle-filter shape assertions with explicit validation errors
- accept scalar identity measurements for one-dimensional measurement noise
- add regression coverage for particle-filter validation paths

## Validation
- Not run locally per request.
- Remote GitHub checks will run on the PR.