### PR TITLE
Harden PyRecEst evaluation and backend edge cases

### DIFF
--- a/src/pyrecest/_backend/jax/__init__.py
+++ b/src/pyrecest/_backend/jax/__init__.py
@@ -403,7 +403,7 @@ def _normalize_assignment_index(indices, ndim_x, axis=0):
     if isinstance(indices, _jnp.ndarray) and indices.ndim > 0:
         return indices, False, indices.shape[0]
     if isinstance(indices, tuple):
-        if all(_is_scalar_index(index) for index in indices):
+        if _builtins.all(_is_scalar_index(index) for index in indices):
             return indices, False, 1
         if indices and _is_iterable_index(indices[0]):
             return indices, False, len(indices[0])

--- a/src/pyrecest/evaluation/model_comparison.py
+++ b/src/pyrecest/evaluation/model_comparison.py
@@ -226,7 +226,10 @@ def paired_model_margin_decisions(
         positive_value = float(by_model.loc[positive_model, evidence_col])
         reference_value = float(by_model.loc[reference_model, evidence_col])
         delta = positive_value - reference_value
-        if delta >= threshold:
+        if delta == 0.0:
+            decision = "ambiguous"
+            positive_claimed = False
+        elif delta >= threshold:
             decision = positive_model
             positive_claimed = True
         elif delta <= -threshold:

--- a/src/pyrecest/evaluation/pareto.py
+++ b/src/pyrecest/evaluation/pareto.py
@@ -310,7 +310,7 @@ def _feasible_index(
         mask = feasible_mask.reindex(table.index, fill_value=False)
     else:
         mask = pd.Series(feasible_mask, index=table.index)
-    return mask.astype(bool)
+    return mask.fillna(False).astype(bool)
 
 
 def _lookup_numeric(record: Mapping[str, Any] | pd.Series, key: str) -> float:

--- a/tests/backend_support/test_jax_assignment_contract.py
+++ b/tests/backend_support/test_jax_assignment_contract.py
@@ -31,6 +31,28 @@ assert backend.to_numpy(summed).tolist() == [[1.0, 6.0, 1.0], [1.0, 1.0, 8.0], [
 
 
 @pytest.mark.backend_portable
+def test_jax_assignment_accepts_scalar_tuple_index():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("JAX is not installed")
+
+    result = run_backend_code(
+        "jax",
+        """
+import pyrecest.backend as backend
+
+x = backend.zeros((2, 3))
+assigned = backend.assignment(x, 9.0, (0, 1))
+summed = backend.assignment_by_sum(backend.ones((2, 3)), 4.0, (1, 2))
+
+assert backend.to_numpy(assigned).tolist() == [[0.0, 9.0, 0.0], [0.0, 0.0, 0.0]]
+assert backend.to_numpy(summed).tolist() == [[1.0, 1.0, 1.0], [1.0, 1.0, 5.0]]
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.backend_portable
 def test_jax_assignment_accepts_list_and_boolean_indices():
     if importlib.util.find_spec("jax") is None:
         pytest.skip("JAX is not installed")

--- a/tests/evaluation/test_pareto.py
+++ b/tests/evaluation/test_pareto.py
@@ -46,6 +46,27 @@ def test_pareto_front_handles_duplicate_index_labels() -> None:
     assert mask.index.tolist() == ["same", "same"]
 
 
+def test_feasible_mask_treats_missing_nullable_values_as_infeasible() -> None:
+    table = pd.DataFrame(
+        [
+            {"name": "balanced", "error": 1.0, "runtime": 2.0},
+            {"name": "best_but_unknown", "error": 0.5, "runtime": 0.5},
+            {"name": "fast", "error": 2.0, "runtime": 1.0},
+        ]
+    )
+    feasible_mask = pd.Series([True, pd.NA, True], dtype="boolean")
+
+    indices = pareto_front_indices(
+        table, ["error", "runtime"], directions={"error": "min", "runtime": "min"}, feasible_mask=feasible_mask
+    )
+    mask = is_pareto_front(
+        table, ["error", "runtime"], directions={"error": "min", "runtime": "min"}, feasible_mask=feasible_mask
+    )
+
+    assert indices == [0, 2]
+    assert mask.tolist() == [True, False, True]
+
+
 def test_is_pareto_front_respects_feasible_mask() -> None:
     table = pd.DataFrame(
         [

--- a/tests/test_backend_reduction_keepdims_contract.py
+++ b/tests/test_backend_reduction_keepdims_contract.py
@@ -22,6 +22,7 @@ def test_reductions_accept_keepdims_keyword():
         [[True], [True]]
     ]
     assert _to_python(backend.max(values, axis=(0, 2), keepdims=True)) == [[[4], [2]]]
+    assert _to_python(backend.amin(values, axis=(0, 2), keepdims=True)) == [[[0], [0]]]
     assert _to_python(backend.min(values, axis=(0, 2), keepdims=True)) == [[[0], [0]]]
     assert _to_python(backend.prod(values + 1, axis=(0, 2), keepdims=True)) == [
         [[40], [3]]
@@ -42,6 +43,7 @@ values = backend.array([[[0, 1], [2, 0]], [[3, 4], [0, 0]]])
 assert backend.to_numpy(backend.any(values, axis=(0, 2), keepdims=True)).tolist() == [[[True], [True]]]
 assert backend.to_numpy(backend.all(values > -1, axis=(0, 2), keepdims=True)).tolist() == [[[True], [True]]]
 assert backend.to_numpy(backend.max(values, axis=(0, 2), keepdims=True)).tolist() == [[[4], [2]]]
+assert backend.to_numpy(backend.amin(values, axis=(0, 2), keepdims=True)).tolist() == [[[0], [0]]]
 assert backend.to_numpy(backend.min(values, axis=(0, 2), keepdims=True)).tolist() == [[[0], [0]]]
 assert backend.to_numpy(backend.prod(values + 1, axis=(0, 2), keepdims=True)).tolist() == [[[40], [3]]]
 print("ok")

--- a/tests/test_model_comparison.py
+++ b/tests/test_model_comparison.py
@@ -65,6 +65,27 @@ def test_paired_model_margin_decisions_summary_and_threshold_selection():
     assert selected.iloc[0]["selected_margin_threshold"] == 0.0
 
 
+def test_paired_model_margin_decisions_treats_exact_ties_as_ambiguous():
+    scores = pd.DataFrame(
+        [
+            _score("s1", 0, "positive", 4.0),
+            _score("s1", 0, "reference", 4.0),
+        ]
+    )
+
+    decisions = paired_model_margin_decisions(
+        scores,
+        positive_model="positive",
+        reference_model="reference",
+        margin_threshold=0.0,
+        group_cols=("session", "event_index"),
+    )
+
+    assert decisions["margin_decision"].tolist() == ["ambiguous"]
+    assert decisions["positive_model_claimed"].tolist() == [False]
+    assert decisions["positive_minus_reference_log_evidence"].tolist() == [0.0]
+
+
 def test_grouped_leave_one_out_and_cluster_bootstrap_are_generic():
     decisions = pd.DataFrame(
         [


### PR DESCRIPTION
## Summary
- treat exact paired-model evidence ties as ambiguous at zero margin
- handle nullable feasible masks by treating missing values as infeasible
- fix JAX scalar tuple assignment indexing
- add PyTorch `amin` keepdims contract coverage

## Validation
- Did not run local tests per request.
- Ran non-test checks: `git diff --check` and conflict-marker scan.