### PR TITLE
Harden PyRecEst backend sparse and vmap behavior

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/__init__.py
+++ b/src/pyrecest/_backend/_shared_numpy/__init__.py
@@ -297,7 +297,13 @@ def array_from_sparse(indices, data, target_shape):
     """
     data = array(data)
     out = zeros(target_shape, dtype=data.dtype)
-    out.put(_np.ravel_multi_index(_np.array(indices).T, target_shape), data)
+    indices = _np.array(indices)
+    if indices.size == 0:
+        if data.size != 0:
+            raise ValueError("data must be empty when indices are empty")
+        return out
+
+    out.put(_np.ravel_multi_index(indices.T, target_shape), data)
     return out
 
 

--- a/src/pyrecest/_backend/jax/__init__.py
+++ b/src/pyrecest/_backend/jax/__init__.py
@@ -521,6 +521,10 @@ def array_from_sparse(indices, data, target_shape):
 
     # Create a dense array of zeros with the appropriate data type
     out = _jnp.zeros(target_shape, dtype=data.dtype)
+    if indices.size == 0:
+        if data.size != 0:
+            raise ValueError("data must be empty when indices are empty")
+        return out
 
     # Compute linear indices from multi-dimensional indices and apply them to
     # the flattened dense array.  Indexing the original n-D array with these

--- a/src/pyrecest/_backend/numpy/__init__.py
+++ b/src/pyrecest/_backend/numpy/__init__.py
@@ -215,17 +215,21 @@ def vmap(pyfunc, randomness="error"):
                 "All arguments must have the same size in the first dimension"
             )
 
-        # Prepare the output array (assuming the output of pyfunc is a scalar or numpy array)
+        # Prepare the output array using the first result's exact array
+        # representation so dtype and shape match NumPy's stacking semantics.
         first_output = pyfunc(*(arg[0, ...] for arg in args))
-        if _np.isscalar(first_output):
+        first_output_array = _np.asarray(first_output)
+        if first_output_array.shape == ():
             output_shape = (args[0].shape[0],)
         else:
-            output_shape = (args[0].shape[0],) + first_output.shape
+            output_shape = (args[0].shape[0],) + first_output_array.shape
 
-        output = _np.empty(output_shape)
+        output = _np.empty(output_shape, dtype=first_output_array.dtype)
+        output[0, ...] = first_output
 
-        # Apply the function to each slice
-        for i in range(args[0].shape[0]):
+        # Apply the function to each remaining slice. The first slice was
+        # already evaluated above to determine output metadata.
+        for i in range(1, args[0].shape[0]):
             output[i, ...] = pyfunc(*(arg[i, ...] for arg in args))
 
         return output

--- a/src/pyrecest/_backend/pytorch/__init__.py
+++ b/src/pyrecest/_backend/pytorch/__init__.py
@@ -1292,9 +1292,16 @@ def array_from_sparse(indices, data, target_shape):
     a : array, shape=target_shape
         Array of zeros with specified values assigned to specified indices.
     """
+    data = array(data)
+    indices = _torch.LongTensor(indices)
+    if indices.numel() == 0:
+        if data.numel() != 0:
+            raise ValueError("data must be empty when indices are empty")
+        return _torch.zeros(_torch.Size(target_shape), dtype=data.dtype, device=data.device)
+
     return _torch.sparse_coo_tensor(
-        _torch.LongTensor(indices).t(),
-        array(data),
+        indices.t(),
+        data,
         _torch.Size(target_shape),
     ).to_dense()
 

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -211,6 +211,38 @@ def test_numpy_vmap_rejects_mismatched_leading_dimensions():
         vmapped(array([[1.0], [2.0]]), array([[1.0]]))
 
 
+def test_numpy_vmap_preserves_output_dtype_and_reuses_first_result():
+    if backend.__backend_name__ != "numpy":
+        pytest.skip("NumPy-specific vmap regression test")
+
+    np = pytest.importorskip("numpy")
+    values = array([[1, 2], [3, 4]], dtype=np.int64)
+    call_count = 0
+
+    def add_one(row):
+        nonlocal call_count
+        call_count += 1
+        return row + 1
+
+    result = backend.vmap(add_one)(values)
+
+    assert _to_python(result) == [[2, 3], [4, 5]]
+    assert result.dtype == values.dtype
+    assert call_count == values.shape[0]
+
+
+def test_numpy_vmap_preserves_complex_scalar_outputs():
+    if backend.__backend_name__ != "numpy":
+        pytest.skip("NumPy-specific vmap regression test")
+
+    values = array([[1.0, 2.0], [3.0, 4.0]])
+
+    result = backend.vmap(lambda row: row[0] + 1j * row[1])(values)
+
+    assert _to_python(result) == [1.0 + 2.0j, 3.0 + 4.0j]
+    assert result.dtype.kind == "c"
+
+
 def test_default_reductions_reduce_all_elements():
     values = array([[2.0, 3.0], [4.0, 5.0]])
 
@@ -448,6 +480,18 @@ def test_scatter_add_preserves_input_values_and_uses_facade_signature():
     result = backend.scatter_add(values, 1, indices, updates)
 
     assert _to_python(result) == [[3.0, 1.0, 4.0], [1.0, 5.0, 6.0]]
+
+
+def test_array_from_sparse_accepts_empty_support():
+    result = backend.array_from_sparse([], [], (2, 3))
+
+    assert result.shape == (2, 3)
+    assert _to_python(result) == [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+
+
+def test_array_from_sparse_rejects_data_without_indices():
+    with pytest.raises(ValueError, match="data must be empty"):
+        backend.array_from_sparse([], [1.0], (2, 3))
 
 
 def test_split_integer_sections_reject_uneven_division():


### PR DESCRIPTION
## Summary
- allow `array_from_sparse` to return zeros for empty support across backends
- reject sparse data values when no indices are provided
- preserve NumPy `vmap` output dtype and avoid double-calling the first slice

## Validation
- Did not run local tests per request.
- Ran non-test checks: `git diff --check` and conflict-marker scan.