### PR TITLE
Harden PyRecEst backend and Pareto edge cases

### DIFF
--- a/src/pyrecest/_backend/_common.py
+++ b/src/pyrecest/_backend/_common.py
@@ -11,6 +11,19 @@ def comb(n, k):
 
 def outer(a, b):
     """Return a batched outer product for array/tensor backends."""
+    torch_pair = _torch_promoted_pair(a, b)
+    if torch_pair is not None:
+        a, b = torch_pair
+        if a.ndim == 0 or b.ndim == 0:
+            return a * b
+        a_expanded = a[..., :, None]
+        b_expanded = b[..., None, :]
+        return a_expanded * b_expanded
+
+    a = _np.asarray(a)
+    b = _np.asarray(b)
+    if a.ndim == 0 or b.ndim == 0:
+        return _np.multiply(a, b)
     a_expanded = a[..., :, None]
     b_expanded = b[..., None, :]
     return a_expanded * b_expanded
@@ -69,6 +82,8 @@ def dot(a, b):
     if torch_pair is not None:
         a, b = torch_pair
         torch = _torch_module_for_values(a, b)
+        if a.ndim == 0 or b.ndim == 0:
+            return torch.multiply(a, b)
         if b.ndim == 1:
             return torch.einsum("...i,i->...", a, b)
         if a.ndim == 1:
@@ -77,6 +92,8 @@ def dot(a, b):
 
     a = _np.asarray(a)
     b = _np.asarray(b)
+    if a.ndim == 0 or b.ndim == 0:
+        return _np.multiply(a, b)
     if b.ndim == 1:
         return _np.einsum("...i,i->...", a, b)
     if a.ndim == 1:

--- a/src/pyrecest/_backend/autograd/linalg.py
+++ b/src/pyrecest/_backend/autograd/linalg.py
@@ -36,16 +36,19 @@ from .._shared_numpy.linalg import (
 )
 
 
-def _adjoint(_ans, x, fn):
-    vectorized = x.ndim == 3
-    axes = (0, 2, 1) if vectorized else (1, 0)
+def _matrix_transpose(x):
+    """Transpose trailing matrix axes while preserving any leading batch axes."""
+    return _np.swapaxes(x, -1, -2)
 
+
+def _adjoint(_ans, x, fn):
     def vjp(g):
         n = x.shape[-1]
         size_m = x.shape[:-2] + (2 * n, 2 * n)
+        transposed_x = _matrix_transpose(x)
         mat = _np.zeros(size_m)
-        mat[..., :n, :n] = x.transpose(axes)
-        mat[..., n:, n:] = x.transpose(axes)
+        mat[..., :n, :n] = transposed_x
+        mat[..., n:, n:] = transposed_x
         mat[..., :n, n:] = g
         return fn(mat)[..., :n, n:]
 

--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -24,7 +24,6 @@ from .._backend_config import np_atol as atol
 from ..numpy import linalg as _gsnplinalg
 from ._common import array, cast
 from ._dtype import (
-    _cast_out_to_input_dtype,
     get_default_dtype,
     is_complex,
     is_floating,
@@ -34,7 +33,7 @@ from ._dtype import (
 def _as_numpy_no_grad(value):
     """Return a CPU NumPy view/copy for SciPy bridge functions."""
     if isinstance(value, _torch.Tensor):
-        return value.detach().cpu().numpy()
+        return value.detach().resolve_conj().resolve_neg().cpu().numpy()
     return _np.asarray(value)
 
 
@@ -240,14 +239,19 @@ def is_single_matrix_pd(mat):
         return False
 
 
-@_cast_out_to_input_dtype
 def fractional_matrix_power(A, t):
     """Compute the fractional power of a matrix."""
+    A = _as_linalg_tensor(A)
     A_np = _as_numpy_no_grad(A)
     if A_np.ndim == 2:
         out = _scipy.linalg.fractional_matrix_power(A_np, t)
     else:
         out = _np.stack([_scipy.linalg.fractional_matrix_power(A_, t) for A_ in A_np])
+
+    if out.dtype.kind == "c":
+        target_complex_dtype = _COMPLEX_DTYPE_FOR_TENSOR_DTYPE.get(A.dtype)
+        if target_complex_dtype is not None:
+            out = out.astype(target_complex_dtype, copy=False)
 
     return _torch_as_like(out, A)
 

--- a/src/pyrecest/evaluation/pareto.py
+++ b/src/pyrecest/evaluation/pareto.py
@@ -10,7 +10,7 @@ selection problems.
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 import numpy as np
 import pandas as pd
@@ -160,20 +160,23 @@ def constraint_mask(
             mask &= False
             continue
         values = pd.to_numeric(table[column], errors="coerce")
+        present_values = values.notna()
         if op == "<=":
-            mask &= values <= float(threshold) + eps
+            comparison = values <= float(threshold) + eps
         elif op == ">=":
-            mask &= values >= float(threshold) - eps
+            comparison = values >= float(threshold) - eps
         elif op == "<":
-            mask &= values < float(threshold) - eps
+            comparison = values < float(threshold) - eps
         elif op == ">":
-            mask &= values > float(threshold) + eps
+            comparison = values > float(threshold) + eps
         elif op == "==":
-            mask &= np.isclose(values, float(threshold), atol=eps, rtol=0.0)
+            comparison = np.isclose(values, float(threshold), atol=eps, rtol=0.0)
         elif op == "!=":
-            mask &= ~np.isclose(values, float(threshold), atol=eps, rtol=0.0)
+            comparison = ~np.isclose(values, float(threshold), atol=eps, rtol=0.0)
         else:  # pragma: no cover - protected by _parse_constraint_spec.
             raise ValueError(f"Unsupported constraint operator {op!r}.")
+        comparison = pd.Series(comparison, index=table.index).fillna(False).astype(bool)
+        mask &= present_values & comparison
     return mask.fillna(False)
 
 
@@ -190,6 +193,11 @@ def select_under_constraints(
 
     if objective not in table.columns:
         raise ValueError(f"objective column {objective!r} is not present.")
+    direction = _validate_direction(direction, f"objective {objective!r}")
+    tie_breakers = tuple(
+        (column, _validate_direction(tie_direction, f"tie-breaker {column!r}"))
+        for column, tie_direction in tie_breakers
+    )
     sorted_columns = [objective, *(column for column, _ in tie_breakers)]
     missing = [column for column in sorted_columns if column not in table.columns]
     if missing:
@@ -300,6 +308,14 @@ def _directions_by_objective(
     if invalid:
         raise ValueError(f"Invalid objective directions for: {', '.join(invalid)}.")
     return result
+
+
+def _validate_direction(direction: Any, context: str) -> ObjectiveDirection:
+    if direction not in ("min", "max"):
+        raise ValueError(
+            f"Invalid {context} direction {direction!r}; expected 'min' or 'max'."
+        )
+    return cast(ObjectiveDirection, direction)
 
 
 def _feasible_index(

--- a/tests/evaluation/test_pareto.py
+++ b/tests/evaluation/test_pareto.py
@@ -8,6 +8,7 @@ from pyrecest.evaluation import (
     is_pareto_front,
     pareto_front_indices,
     record_dominates,
+    select_under_constraints,
 )
 
 
@@ -119,6 +120,42 @@ def test_constraint_mask_supports_tuple_and_mapping_specs() -> None:
     )
 
     assert table.loc[mask, "name"].tolist() == ["a"]
+
+
+def test_constraint_mask_treats_missing_not_equal_values_as_infeasible() -> None:
+    table = pd.DataFrame(
+        [
+            {"name": "different", "score": 0.2},
+            {"name": "same", "score": 0.0},
+            {"name": "missing", "score": None},
+            {"name": "non_numeric", "score": "unknown"},
+        ]
+    )
+
+    mask = constraint_mask(table, {"score": ("!=", 0.0)})
+
+    assert table.loc[mask, "name"].tolist() == ["different"]
+
+
+def test_select_under_constraints_rejects_invalid_directions() -> None:
+    table = pd.DataFrame([{"name": "a", "score": 1.0, "tie": 0.0}])
+
+    with pytest.raises(ValueError, match="objective"):
+        select_under_constraints(
+            table,
+            constraints={},
+            objective="score",
+            direction="sideways",  # type: ignore[arg-type]
+        )
+
+    with pytest.raises(ValueError, match="tie-breaker"):
+        select_under_constraints(
+            table,
+            constraints={},
+            objective="score",
+            direction="min",
+            tie_breakers=(("tie", "sideways"),),  # type: ignore[arg-type]
+        )
 
 
 def test_equal_quality_selection_returns_best_compression_row() -> None:

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -2,6 +2,7 @@ import pyrecest.backend as backend
 import pytest
 from pyrecest._backend.capabilities import get_unsupported_functions
 from pyrecest.backend import array, linalg
+from tests.support.backend_runner import run_backend_code
 
 _MATRIX = array([[1.0, 0.0], [0.0, 1.0]])
 
@@ -72,6 +73,20 @@ def test_pytorch_to_numpy_resolves_conjugate_views():
     assert converted.tolist() == [1.0 - 2.0j, 3.0 + 4.0j]
 
 
+def test_pytorch_linalg_numpy_bridge_resolves_conjugate_views():
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific linalg SciPy bridge conversion")
+
+    torch = pytest.importorskip("torch")
+
+    value = torch.eye(2, dtype=torch.complex128).conj()
+    assert value.is_conj()
+
+    result = linalg.sqrtm(value)
+
+    assert torch.allclose(result, torch.eye(2, dtype=torch.complex128))
+
+
 def test_pytorch_logm_backward_handles_high_rank_batches():
     if backend.__backend_name__ != "pytorch":
         pytest.skip("PyTorch-specific logm gradient regression test")
@@ -89,11 +104,58 @@ def test_pytorch_logm_backward_handles_high_rank_batches():
     assert bool(torch.isfinite(values.grad).all())
 
 
+def test_autograd_logm_vjp_handles_high_rank_batches():
+    pytest.importorskip("autograd")
+
+    code = """
+import autograd.numpy as np
+from autograd import grad
+from pyrecest.backend import linalg
+
+values = np.tile(np.eye(2), (2, 3, 1, 1))
+
+
+def objective(x):
+    return np.sum(linalg.logm(x))
+
+
+gradient = grad(objective)(values)
+assert gradient.shape == values.shape
+assert np.all(np.isfinite(gradient))
+"""
+    result = run_backend_code("autograd", code)
+    assert result.returncode == 0, result.stderr
+
+
 def _to_python(value):
     value = backend.to_numpy(value)
     if hasattr(value, "tolist"):
         return value.tolist()
     return value
+
+
+def test_pytorch_fractional_matrix_power_promotes_integer_inputs():
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific fractional_matrix_power regression test")
+
+    values = backend.asarray([[2, 0], [0, 3]], dtype=backend.int64)
+
+    result = linalg.fractional_matrix_power(values, 0.5)
+    expected = array([[2.0**0.5, 0.0], [0.0, 3.0**0.5]])
+
+    assert backend.is_floating(result)
+    assert bool(_to_python(backend.allclose(result, expected)))
+
+
+def test_pytorch_fractional_matrix_power_accepts_python_lists():
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific fractional_matrix_power regression test")
+
+    result = linalg.fractional_matrix_power([[2, 0], [0, 3]], 0.5)
+    expected = array([[2.0**0.5, 0.0], [0.0, 3.0**0.5]])
+
+    assert backend.is_floating(result)
+    assert bool(_to_python(backend.allclose(result, expected)))
 
 
 def test_pytorch_custom_gradient_accepts_keyword_arguments_and_defaults():


### PR DESCRIPTION
## Summary
- handle scalar and Torch inputs in shared backend outer/dot helpers
- make Autograd and PyTorch SciPy bridge paths robust for high-rank batches, conjugate views, and integer inputs
- harden Pareto constraint handling for missing values and invalid directions

## Validation
- git diff --check
- conflict marker scan

Local tests were not run per request.