### PR TITLE
Fix PyTorch backend device and autograd edge cases

### DIFF
--- a/src/pyrecest/_backend/autograd/__init__.py
+++ b/src/pyrecest/_backend/autograd/__init__.py
@@ -208,16 +208,13 @@ def vmap(pyfunc, randomness="error"):
                 "All arguments must have the same size in the first dimension"
             )
 
-        first_output = pyfunc(*(arg[0, ...] for arg in args))
-        if _np.isscalar(first_output):
-            output_shape = (args[0].shape[0],)
-        else:
-            output_shape = (args[0].shape[0],) + first_output.shape
-
-        output = empty(output_shape)
-        for i in range(args[0].shape[0]):
-            output[i, ...] = pyfunc(*(arg[i, ...] for arg in args))
-        return output
+        # Use autograd.numpy.stack instead of preallocating and assigning into
+        # an output array.  The old implementation coerced integer/complex
+        # results to the backend default float dtype and in-place assignment is
+        # not a reliable autograd operation when pyfunc returns ArrayBox values.
+        return _np.stack(
+            [pyfunc(*(arg[i, ...] for arg in args)) for i in range(args[0].shape[0])]
+        )
 
     return vmapped_fun
 

--- a/src/pyrecest/_backend/pytorch/__init__.py
+++ b/src/pyrecest/_backend/pytorch/__init__.py
@@ -1072,6 +1072,10 @@ def _is_iterable(x):
     return False
 
 
+def _is_empty_index_sequence(indices):
+    return _is_iterable(indices) and len(indices) == 0
+
+
 def _as_assignment_values(values, x):
     if _torch.is_tensor(values):
         return values.to(device=x.device, dtype=x.dtype)
@@ -1168,8 +1172,10 @@ def assignment(x, values, indices, axis=0):
     If a list is given, it must have the same length as indices.
     """
     x_new = copy(array(x))
-    values = _as_assignment_values(values, x_new)
+    if _is_empty_index_sequence(indices):
+        return x_new
 
+    values = _as_assignment_values(values, x_new)
     use_vectorization = hasattr(indices, "__len__") and len(indices) < ndim(x_new)
     if _is_boolean(indices):
         indices = _as_boolean_index(indices, device=x_new.device)
@@ -1224,6 +1230,9 @@ def assignment_by_sum(x, values, indices, axis=0):
     If a list is given, it must have the same length as indices.
     """
     x_new = copy(array(x))
+    if _is_empty_index_sequence(indices):
+        return x_new
+
     values = _as_assignment_values(values, x_new)
     use_vectorization = hasattr(indices, "__len__") and len(indices) < ndim(x_new)
     if _is_boolean(indices):
@@ -1293,7 +1302,7 @@ def array_from_sparse(indices, data, target_shape):
         Array of zeros with specified values assigned to specified indices.
     """
     data = array(data)
-    indices = _torch.LongTensor(indices)
+    indices = _torch.as_tensor(indices, dtype=_torch.long, device=data.device)
     if indices.numel() == 0:
         if data.numel() != 0:
             raise ValueError("data must be empty when indices are empty")
@@ -1303,6 +1312,7 @@ def array_from_sparse(indices, data, target_shape):
         indices.t(),
         data,
         _torch.Size(target_shape),
+        device=data.device,
     ).to_dense()
 
 
@@ -1677,7 +1687,7 @@ def imag(a):
         a = _torch.tensor(a)
     if is_complex(a):
         return _torch.imag(a)
-    return _torch.zeros(a.shape, dtype=a.dtype)
+    return _torch.zeros(a.shape, dtype=a.dtype, device=a.device)
 
 
 def unique(ar, axis=None):

--- a/tests/backend_support/test_pytorch_assignment_contract.py
+++ b/tests/backend_support/test_pytorch_assignment_contract.py
@@ -67,6 +67,7 @@ by_array_like_sum = backend.assignment_by_sum(
     [0.0, 0.0, 0.0], [2.0, 3.0], [0, 2]
 )
 empty_array_like = backend.assignment([1.0, 2.0, 3.0], 99.0, [])
+empty_sum_array_like = backend.assignment_by_sum([1.0, 2.0, 3.0], 99.0, [])
 
 matrix = backend.zeros((3, 3))
 by_mask = backend.assignment(
@@ -87,6 +88,7 @@ assert backend.to_numpy(by_slice_sum).tolist() == [0.0, 1.0, 2.0]
 assert backend.to_numpy(by_array_like).tolist() == [[0.0, 4.0], [5.0, 0.0]]
 assert backend.to_numpy(by_array_like_sum).tolist() == [2.0, 0.0, 3.0]
 assert backend.to_numpy(empty_array_like).tolist() == [1.0, 2.0, 3.0]
+assert backend.to_numpy(empty_sum_array_like).tolist() == [1.0, 2.0, 3.0]
 assert backend.to_numpy(by_mask).tolist() == [
     [1.0, 0.0, 0.0],
     [0.0, 2.0, 0.0],

--- a/tests/backend_support/test_pytorch_device_contract.py
+++ b/tests/backend_support/test_pytorch_device_contract.py
@@ -1,0 +1,43 @@
+"""Regression tests for PyTorch backend device preservation."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_pytorch_imag_and_sparse_helpers_preserve_tensor_device():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import torch
+import pyrecest.backend as backend
+
+device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+
+real_tensor = torch.tensor([1.0, 2.0], dtype=torch.float64, device=device)
+imag_part = backend.imag(real_tensor)
+assert imag_part.device == real_tensor.device
+assert imag_part.dtype == real_tensor.dtype
+assert backend.to_numpy(imag_part).tolist() == [0.0, 0.0]
+
+sparse_values = torch.tensor([5.0, 7.0], dtype=torch.float64, device=device)
+sparse_array = backend.array_from_sparse(
+    [(0, 1), (1, 0)],
+    sparse_values,
+    (2, 2),
+)
+
+assert sparse_array.device == sparse_values.device
+assert sparse_array.dtype == sparse_values.dtype
+assert backend.to_numpy(sparse_array).tolist() == [[0.0, 5.0], [7.0, 0.0]]
+""",
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/tests/backend_support/test_pytorch_linear_helpers_contract.py
+++ b/tests/backend_support/test_pytorch_linear_helpers_contract.py
@@ -18,6 +18,13 @@ def test_pytorch_backend_exposes_dot_and_matvec():
 
     assert _to_python(backend.dot(first, second)) == [17.0, 53.0]
     assert _to_python(backend.dot(first, [5.0, 6.0])) == [17.0, 39.0]
+    assert _to_python(backend.outer([1.0, 2.0], [3.0, 4.0])) == [
+        [3.0, 4.0],
+        [6.0, 8.0],
+    ]
+    assert float(_to_python(backend.dot(backend.asarray(2.0), 3.0))) == pytest.approx(
+        6.0
+    )
 
     batched_matvec = backend.matvec(
         backend.asarray([[[1.0, 0.0], [0.0, 1.0]], [[2.0, 0.0], [0.0, 3.0]]]),

--- a/tests/test_autograd_backend_import.py
+++ b/tests/test_autograd_backend_import.py
@@ -30,10 +30,29 @@ assert backend.fft.rfft(backend.array([1.0, 0.0])).shape == (2,)
 assert backend.dot([1.0, 2.0], [3.0, 4.0]) == 11.0
 assert backend.to_numpy(backend.outer([1.0, 2.0], [3.0, 4.0])).tolist() == [[3.0, 4.0], [6.0, 8.0]]
 assert backend.to_numpy(backend.outer(2.0, backend.array([1.0, 2.0]))).tolist() == [2.0, 4.0]
+_calls = []
+def _add_one(row):
+    _calls.append(None)
+    return row + 1
+_vmap_int = backend.vmap(_add_one)(
+    backend.array([[1, 2], [3, 4]], dtype=backend.int64)
+)
+assert backend.to_numpy(_vmap_int).tolist() == [[2, 3], [4, 5]]
+assert backend.to_numpy(_vmap_int).dtype.kind in ("i", "u")
+assert len(_calls) == 2
+_vmap_complex = backend.vmap(lambda row: row[0] + 1j * row[1])(
+    backend.array([[1.0, 2.0], [3.0, 4.0]])
+)
+assert backend.to_numpy(_vmap_complex).tolist() == [1.0 + 2.0j, 3.0 + 4.0j]
+assert backend.to_numpy(_vmap_complex).dtype.kind == "c"
 from autograd import grad
 
 def _outer_sum(x):
     return backend.sum(backend.outer(x, backend.array([2.0, 3.0])))
 assert backend.to_numpy(grad(_outer_sum)(backend.array([1.0, 2.0]))).tolist() == [5.0, 5.0]
+
+def _vmap_square_sum(x):
+    return backend.sum(backend.vmap(lambda row: row * row)(x))
+assert backend.to_numpy(grad(_vmap_square_sum)(backend.array([1.0, 2.0]))).tolist() == [2.0, 4.0]
 """
     subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- guard empty PyTorch assignment index sequences
- preserve device placement for sparse construction and real-valued imag helpers
- harden autograd backend import handling and add regression coverage

## Validation
- Did not run local tests per request
- Ran `git diff --check`, conflict-marker scan, and `python -m py_compile` on touched Python files