### PR TITLE
Fix JAX divide and Pareto numeric coercion

### DIFF
--- a/src/pyrecest/_backend/jax/__init__.py
+++ b/src/pyrecest/_backend/jax/__init__.py
@@ -575,8 +575,12 @@ def divide(a, b, ignore_div_zero=False):
     if ignore_div_zero is False:
         return _jnp.divide(a_arr, b_arr)
 
-    quotient = _jnp.divide(a_arr, b_arr)
-    return _jnp.where(b_arr != 0, quotient, _jnp.zeros_like(quotient))
+    nonzero_denominator = b_arr != 0
+    safe_denominator = _jnp.where(
+        nonzero_denominator, b_arr, _jnp.ones_like(b_arr)
+    )
+    quotient = _jnp.divide(a_arr, safe_denominator)
+    return _jnp.where(nonzero_denominator, quotient, _jnp.zeros_like(quotient))
 
 
 def dot(a, b):

--- a/src/pyrecest/evaluation/pareto.py
+++ b/src/pyrecest/evaluation/pareto.py
@@ -333,7 +333,14 @@ def _lookup_numeric(record: Mapping[str, Any] | pd.Series, key: str) -> float:
     value = record.get(key, np.nan)
     if _is_missing(value):
         return float("nan")
-    return float(value)
+    return _coerce_numeric(value)
+
+
+def _coerce_numeric(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return float("nan")
 
 
 def _is_missing(value: Any) -> bool:

--- a/tests/evaluation/test_pareto.py
+++ b/tests/evaluation/test_pareto.py
@@ -106,6 +106,25 @@ def test_record_dominates_can_skip_missing_optional_metrics() -> None:
     )
 
 
+def test_record_dominates_treats_non_numeric_metrics_as_missing_when_allowed() -> None:
+    left = {"size": 4.0, "quality": 0.95, "optional": "not available"}
+    right = {"size": 5.0, "quality": 0.95, "optional": 2.0}
+
+    assert record_dominates(
+        left,
+        right,
+        ["size", "quality", "optional"],
+        directions={"size": "min", "quality": "max", "optional": "max"},
+    )
+    assert not record_dominates(
+        left,
+        right,
+        ["size", "quality", "optional"],
+        directions={"size": "min", "quality": "max", "optional": "max"},
+        allow_missing=False,
+    )
+
+
 def test_constraint_mask_supports_tuple_and_mapping_specs() -> None:
     table = pd.DataFrame(
         [

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -127,6 +127,30 @@ assert np.all(np.isfinite(gradient))
     assert result.returncode == 0, result.stderr
 
 
+def test_jax_divide_ignore_div_zero_has_finite_gradients():
+    pytest.importorskip("jax")
+
+    code = """
+import jax
+import jax.numpy as jnp
+import pyrecest.backend as backend
+
+
+def objective(denominator):
+    return jnp.sum(
+        backend.divide(jnp.array([1.0, 2.0]), denominator, ignore_div_zero=True)
+    )
+
+
+gradient = jax.grad(objective)(jnp.array([0.0, 2.0]))
+assert jnp.all(jnp.isfinite(gradient))
+assert float(gradient[0]) == 0.0
+assert float(gradient[1]) == -0.5
+"""
+    result = run_backend_code("jax", code)
+    assert result.returncode == 0, result.stderr
+
+
 def _to_python(value):
     value = backend.to_numpy(value)
     if hasattr(value, "tolist"):


### PR DESCRIPTION
## Summary
- avoid differentiating through zero denominators for JAX divide with `ignore_div_zero=True`
- treat non-numeric Pareto metric values as missing when allowed
- add regression coverage for both edge cases

## Validation
- Did not run local tests per request.
- Ran lightweight local checks only: `git diff --check`, conflict-marker scan, and Python syntax compilation for touched files.