### PR TITLE
Fix backend array contract edge cases

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/__init__.py
+++ b/src/pyrecest/_backend/_shared_numpy/__init__.py
@@ -457,8 +457,10 @@ def scatter_add(input, dim, index, src):
     if dim == 1:
         for j in range(len(input)):
             for i, val in zip(index[j], src[j]):
-                if not isinstance(val, _np.float64) and BACKEND_NAME == "autograd":
-                    val = float(val._value)
-                input[j, i] += float(val)
+                # Preserve the source dtype.  In particular, complex values are
+                # valid scatter-add inputs and must not be coerced through float().
+                if BACKEND_NAME == "autograd" and hasattr(val, "_value"):
+                    val = val._value
+                input[j, i] += val
         return input
     raise NotImplementedError

--- a/src/pyrecest/_backend/pytorch/__init__.py
+++ b/src/pyrecest/_backend/pytorch/__init__.py
@@ -28,7 +28,6 @@ from torch import (  # The ones below are for pyrecest; For Riemannian score-bas
     empty,
     empty_like,
 )
-from torch import equal as array_equal  # For PyRecEst
 from torch import (  # The ones below are for pyrecest; For Riemannian score-based SDE
     erf,
     eye,
@@ -387,6 +386,11 @@ def to_numpy(x):
     if not _torch.is_tensor(x):
         return _np.asarray(x)
     return x.detach().resolve_conj().resolve_neg().cpu().numpy()
+
+
+def array_equal(a, b):
+    """Return whether two array-like inputs have the same shape and elements."""
+    return _torch.equal(array(a), array(b))
 
 
 def one_hot(labels, num_classes):

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -158,6 +158,25 @@ def _to_python(value):
     return value
 
 
+def test_shared_numpy_scatter_add_dim_one_preserves_complex_source_values():
+    if backend.__backend_name__ not in ("numpy", "autograd"):
+        pytest.skip("shared NumPy scatter_add regression test")
+
+    values = backend.zeros((2, 3), dtype=backend.complex128)
+    indices = backend.asarray([[0, 2], [1, 2]], dtype=backend.int64)
+    src = array(
+        [[1.0 + 2.0j, 3.0 - 4.0j], [5.0 + 0.5j, -1.0j]],
+        dtype=backend.complex128,
+    )
+
+    result = backend.scatter_add(values, 1, indices, src)
+
+    assert _to_python(result) == [
+        [1.0 + 2.0j, 0.0 + 0.0j, 3.0 - 4.0j],
+        [0.0 + 0.0j, 5.0 + 0.5j, 0.0 - 1.0j],
+    ]
+
+
 def test_pytorch_fractional_matrix_power_promotes_integer_inputs():
     if backend.__backend_name__ != "pytorch":
         pytest.skip("PyTorch-specific fractional_matrix_power regression test")
@@ -235,6 +254,12 @@ def test_array_like_sequence_helpers_accept_python_lists():
     assert _to_python(backend.flip([1, 2, 3], axis=0)) == [3, 2, 1]
     assert _to_python(backend.sort([3, 1, 2])) == [1, 2, 3]
     assert _to_python(backend.unique([2, 1, 2, 1])) == [1, 2]
+
+
+def test_array_equal_accepts_array_like_inputs():
+    assert bool(backend.array_equal([1, 2, 3], [1, 2, 3]))
+    assert not bool(backend.array_equal([1, 2, 3], [1, 2, 4]))
+    assert not bool(backend.array_equal([1, 2, 3], [1, 2]))
 
 
 def test_array_like_matrix_helpers_accept_python_lists():


### PR DESCRIPTION
## Summary
- preserve complex values in shared NumPy scatter-add
- make PyTorch `array_equal` accept array-like inputs by coercing through the backend array helper
- add backend contract coverage for both cases

## Validation
- Did not run local tests per request.
- Ran lightweight local checks only: `git diff --check`, conflict-marker scan, and Python syntax compilation for touched files.