### PR TITLE
Validate circular Fourier filter inputs explicitly

### DIFF
--- a/src/pyrecest/filters/circular_fourier_filter.py
+++ b/src/pyrecest/filters/circular_fourier_filter.py
@@ -46,7 +46,11 @@ class CircularFourierFilter(AbstractCircularFilter):
 
     @filter_state.setter
     def filter_state(self, new_state):
-        assert isinstance(new_state, AbstractCircularDistribution)
+        if not isinstance(new_state, AbstractCircularDistribution):
+            raise ValueError(
+                "new_state must be an AbstractCircularDistribution, "
+                f"got {type(new_state).__name__}."
+            )
 
         if not isinstance(new_state, CircularFourierDistribution):
             state_to_set = self._convert_to_circular_fourier(
@@ -89,12 +93,16 @@ class CircularFourierFilter(AbstractCircularFilter):
 
         if is_array(d_sys):
             no_coefficients = self.no_of_coefficients
-            assert (
-                self.filter_state.transformation == "sqrt"
-            ), "Only sqrt transformation currently supported"
-            assert (
-                d_sys.size == no_coefficients
-            ), "Assume that as many grid points are used as there are coefficients."
+            if self.filter_state.transformation != "sqrt":
+                raise NotImplementedError(
+                    "Array-based predict_identity is only supported for the "
+                    "'sqrt' transformation."
+                )
+            if d_sys.size != no_coefficients:
+                raise ValueError(
+                    "d_sys must provide exactly one grid value per Fourier "
+                    f"coefficient: expected {no_coefficients}, got {d_sys.size}."
+                )
             density_values = (
                 fft.irfft(self.filter_state.get_c(), n=no_coefficients) ** 2
             )
@@ -125,7 +133,8 @@ class CircularFourierFilter(AbstractCircularFilter):
         noise_distribution,
         truncate_joint_sqrt=True,
     ):
-        assert callable(f)
+        if not callable(f):
+            raise TypeError("f must be callable.")
         hypertoroidal_filter = self._as_hypertoroidal_filter()
         hypertoroidal_filter.predict_nonlinear(
             f, noise_distribution, truncate_joint_sqrt

--- a/src/pyrecest/filters/circular_fourier_filter.py
+++ b/src/pyrecest/filters/circular_fourier_filter.py
@@ -12,6 +12,7 @@ from pyrecest.backend import (
     pi,
     reshape,
     signal,
+    size,
     sqrt,
     zeros,
 )
@@ -98,10 +99,11 @@ class CircularFourierFilter(AbstractCircularFilter):
                     "Array-based predict_identity is only supported for the "
                     "'sqrt' transformation."
                 )
-            if d_sys.size != no_coefficients:
+            grid_size = int(size(d_sys))
+            if grid_size != no_coefficients:
                 raise ValueError(
                     "d_sys must provide exactly one grid value per Fourier "
-                    f"coefficient: expected {no_coefficients}, got {d_sys.size}."
+                    f"coefficient: expected {no_coefficients}, got {grid_size}."
                 )
             density_values = (
                 fft.irfft(self.filter_state.get_c(), n=no_coefficients) ** 2

--- a/tests/filters/test_circular_fourier_filter.py
+++ b/tests/filters/test_circular_fourier_filter.py
@@ -1,3 +1,6 @@
+import os
+import subprocess
+import sys
 import unittest
 import warnings
 from math import pi
@@ -7,12 +10,66 @@ import numpy.testing as npt
 # pylint: disable=no-name-in-module,no-member
 import pyrecest.backend
 import scipy.integrate
-from pyrecest.backend import abs, linspace, sign, sin
+from pyrecest.backend import abs, array, linspace, sign, sin
 from pyrecest.distributions import CircularFourierDistribution, VonMisesDistribution
 from pyrecest.filters.circular_fourier_filter import CircularFourierFilter
 
 
 class CircularFourierFilterTest(unittest.TestCase):
+
+    def test_filter_state_rejects_non_circular_distribution_without_asserts(self):
+        fourier_filter = CircularFourierFilter(5)
+
+        with self.assertRaisesRegex(ValueError, "AbstractCircularDistribution"):
+            fourier_filter.filter_state = object()
+
+    def test_array_predict_identity_validates_transformation_without_asserts(self):
+        fourier_filter = CircularFourierFilter(5, "identity")
+
+        with self.assertRaisesRegex(NotImplementedError, "sqrt"):
+            fourier_filter.predict_identity(array([1.0, 1.0, 1.0, 1.0, 1.0]))
+
+    def test_array_predict_identity_validates_grid_size_without_asserts(self):
+        fourier_filter = CircularFourierFilter(5, "sqrt")
+
+        with self.assertRaisesRegex(ValueError, "expected 5, got 4"):
+            fourier_filter.predict_identity(array([1.0, 1.0, 1.0, 1.0]))
+
+    def test_predict_nonlinear_rejects_noncallable_without_asserts(self):
+        fourier_filter = CircularFourierFilter(5)
+
+        with self.assertRaisesRegex(TypeError, "f must be callable"):
+            fourier_filter.predict_nonlinear(None, VonMisesDistribution(0.0, 1.0))
+
+    def test_validation_survives_optimized_python(self):
+        env = os.environ.copy()
+        src_path = os.path.abspath("src")
+        env["PYTHONPATH"] = (
+            src_path
+            if not env.get("PYTHONPATH")
+            else os.pathsep.join([src_path, env["PYTHONPATH"]])
+        )
+
+        code = """
+from pyrecest.backend import array
+from pyrecest.distributions import VonMisesDistribution
+from pyrecest.filters.circular_fourier_filter import CircularFourierFilter
+
+operations = (
+    (lambda: setattr(CircularFourierFilter(5), "filter_state", object()), ValueError),
+    (lambda: CircularFourierFilter(5, "identity").predict_identity(array([1.0] * 5)), NotImplementedError),
+    (lambda: CircularFourierFilter(5).predict_identity(array([1.0] * 4)), ValueError),
+    (lambda: CircularFourierFilter(5).predict_nonlinear(None, VonMisesDistribution(0.0, 1.0)), TypeError),
+)
+for operation, expected in operations:
+    try:
+        operation()
+    except expected:
+        pass
+    else:
+        raise AssertionError(f"{expected.__name__} was not raised under optimized Python")
+"""
+        subprocess.run([sys.executable, "-O", "-c", code], check=True, env=env)
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("jax", "pytorch"),


### PR DESCRIPTION
## Summary
- replace `assert`-backed `CircularFourierFilter` input checks with explicit runtime exceptions
- reject non-circular filter states, unsupported array-based prediction transformations, wrong grid sizes, and non-callable nonlinear transition functions before later numerical code runs
- add regressions, including a `python -O` subprocess check, to ensure the validation survives optimized Python

## Validation
- Syntax-checked the modified source and test files locally with `python -m py_compile`.
- Could not run the full PyRecEst test suite locally because this execution environment cannot resolve github.com to clone/install the repository dependencies.