### PR TITLE
Accept array-like inputs in backend ndim

### DIFF
--- a/src/pyrecest/_backend/_common.py
+++ b/src/pyrecest/_backend/_common.py
@@ -49,6 +49,15 @@ def size(x, axis=None):
     return result
 
 
+def ndim(x):
+    """Return the number of dimensions for arrays and array-like inputs."""
+    ndim_value = getattr(x, "ndim", None)
+    if ndim_value is not None:
+        return ndim_value
+
+    return _np.ndim(x)
+
+
 def _torch_module_for_values(*values):
     try:
         import torch as _torch

--- a/src/pyrecest/_backend/_shared_numpy/__init__.py
+++ b/src/pyrecest/_backend/_shared_numpy/__init__.py
@@ -209,7 +209,7 @@ def assignment_by_sum(x, values, indices, axis=0):
 
 
 def ndim(x):
-    return x.ndim
+    return _np.ndim(x)
 
 
 def get_slice(x, indices):

--- a/tests/test_backend_contracts.py
+++ b/tests/test_backend_contracts.py
@@ -270,6 +270,12 @@ def test_array_like_matrix_helpers_accept_python_lists():
     assert _to_python(backend.triu([[1, 2], [3, 4]])) == [[1, 2], [0, 4]]
 
 
+def test_ndim_accepts_array_like_inputs():
+    assert backend.ndim(3.0) == 0
+    assert backend.ndim([1.0, 2.0]) == 1
+    assert backend.ndim([[1.0], [2.0]]) == 2
+
+
 def test_cov_accepts_array_like_inputs():
     result = backend.cov([[1.0, 2.0, 3.0], [2.0, 4.0, 6.0]])
 


### PR DESCRIPTION
## Summary
- Add a shared backend `ndim` helper for array-like inputs.
- Make the NumPy shared backend use `numpy.ndim` so scalars and Python lists are accepted.
- Add backend contract coverage for scalar, vector, and matrix-like inputs.

## Validation
- Did not run the local test suite, per request.
- Ran `git diff --check`.
- Ran conflict-marker scan across `src` and `tests`.
- Ran `python -m py_compile` for touched Python files.