### PR TITLE
Reject conflicting evidence mode flags

### DIFF
--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -100,6 +100,18 @@ class EvidenceComputationMode:
         return diagnostics
 
 
+def _require_return_smoothed_agreement(
+    mode: EvidenceComputationMode, return_smoothed: bool | None
+) -> EvidenceComputationMode:
+    """Reject contradictory explicit mode and compatibility flag requests."""
+
+    if return_smoothed is None:
+        return mode
+    if bool(return_smoothed) != mode.return_smoothed:
+        raise ValueError("mode and return_smoothed request inconsistent smoothing")
+    return mode
+
+
 def resolve_evidence_computation_mode(
     mode: EvidenceComputationMode | str | None = None,
     *,
@@ -108,7 +120,7 @@ def resolve_evidence_computation_mode(
     """Resolve a string/Boolean compatibility mode into a typed object."""
 
     if isinstance(mode, EvidenceComputationMode):
-        return mode
+        return _require_return_smoothed_agreement(mode, return_smoothed)
     if mode is None:
         return EvidenceComputationMode.from_return_smoothed(
             True if return_smoothed is None else bool(return_smoothed)
@@ -116,7 +128,9 @@ def resolve_evidence_computation_mode(
 
     key = str(mode).strip().lower().replace("-", "_")
     if key in {"full", "full_smoothing", "smoothed", "smoothing"}:
-        return EvidenceComputationMode.full_smoothing()
+        return _require_return_smoothed_agreement(
+            EvidenceComputationMode.full_smoothing(), return_smoothed
+        )
     if key in {
         "evidence",
         "evidence_only",
@@ -124,7 +138,9 @@ def resolve_evidence_computation_mode(
         "filter_only",
         "no_smoothing",
     }:
-        return EvidenceComputationMode.evidence_only()
+        return _require_return_smoothed_agreement(
+            EvidenceComputationMode.evidence_only(), return_smoothed
+        )
     raise ValueError(f"unknown evidence computation mode {mode!r}")
 
 

--- a/src/pyrecest/filters/sparse_second_order_grid.py
+++ b/src/pyrecest/filters/sparse_second_order_grid.py
@@ -71,7 +71,7 @@ def sparse_second_order_grid_evidence(
     *,
     transition_cache_key_builder: SparsePairTransitionCacheKeyBuilder | None = None,
     transition_row_cache: SparseTransitionRowCache | None = None,
-    return_smoothed: bool | None = True,
+    return_smoothed: bool | None = None,
     evidence_mode: EvidenceComputationMode | str | None = None,
     return_pair_lattice: bool = False,
 ) -> SparseSecondOrderGridResult:

--- a/tests/test_evidence_only_mode.py
+++ b/tests/test_evidence_only_mode.py
@@ -26,6 +26,15 @@ def test_evidence_computation_mode_rejects_inconsistent_flags():
         resolve_evidence_computation_mode("posterior-only")
 
 
+def test_resolver_rejects_conflicting_explicit_mode_and_boolean_flag():
+    with pytest.raises(ValueError, match="mode and return_smoothed"):
+        resolve_evidence_computation_mode("evidence_only", return_smoothed=True)
+    with pytest.raises(ValueError, match="mode and return_smoothed"):
+        resolve_evidence_computation_mode(
+            EvidenceComputationMode.full_smoothing(), return_smoothed=False
+        )
+
+
 def test_sparse_second_order_grid_accepts_evidence_only_mode_object():
     log_likelihood = np.log(
         np.array(


### PR DESCRIPTION
## Summary
- Reject contradictory `mode` and `return_smoothed` requests in `resolve_evidence_computation_mode`.
- Keep the boolean-only compatibility path unchanged.
- Add regression tests for string and typed explicit-mode conflicts.
- Let `sparse_second_order_grid_evidence` treat an omitted compatibility flag as `None`, so an explicit `EvidenceComputationMode.evidence_only()` no longer conflicts with the wrapper's previous default smoothing value.

## Validation
- Investigated the failing PR CI logs: all resolver regression tests passed, but `test_sparse_second_order_grid_accepts_evidence_only_mode_object` failed because the wrapper passed `return_smoothed=True` alongside `EvidenceComputationMode.evidence_only()`.
- Not run locally: this environment cannot clone from GitHub because outbound DNS resolution to github.com failed, so I used the GitHub connector for the code changes.
- Updated the existing PR branch with a focused wrapper fix; the new commit is ready for CI validation.