### PR TITLE
Fix PyTorch fftconvolve shape edge cases

### DIFF
--- a/src/pyrecest/_backend/pytorch/signal.py
+++ b/src/pyrecest/_backend/pytorch/signal.py
@@ -39,11 +39,11 @@ def _as_tensor_pair(in1, in2):
     return x.to(dtype=dtype), y.to(dtype=dtype)
 
 
-def _centered_slice(full_shape, target_shape, axes):
-    slices = [slice(None)] * len(full_shape)
-    for axis in axes:
-        start = (full_shape[axis] - target_shape[axis]) // 2
-        slices[axis] = slice(start, start + target_shape[axis])
+def _centered_slice(full_shape, target_shape):
+    slices = []
+    for full, target in zip(full_shape, target_shape, strict=True):
+        start = (full - target) // 2
+        slices.append(slice(start, start + target))
     return tuple(slices)
 
 
@@ -67,11 +67,14 @@ def fftconvolve(in1, in2, mode="full", axes=None):
 
     axes = _normalize_axes(axes, x.ndim)
     if mode == "valid":
-        x_larger = all(x.shape[axis] >= y.shape[axis] for axis in axes)
-        y_larger = all(y.shape[axis] >= x.shape[axis] for axis in axes)
+        comparison_axes = tuple(
+            axis for axis in axes if x.shape[axis] != 1 and y.shape[axis] != 1
+        )
+        x_larger = all(x.shape[axis] >= y.shape[axis] for axis in comparison_axes)
+        y_larger = all(y.shape[axis] >= x.shape[axis] for axis in comparison_axes)
         if not (x_larger or y_larger):
             raise ValueError(
-                "For mode='valid', one input must be at least as large as the other in every selected dimension."
+                "For mode='valid', one input must be at least as large as the other in every selected non-singleton dimension."
             )
 
     fft_shape = tuple(int(x.shape[axis] + y.shape[axis] - 1) for axis in axes)
@@ -87,7 +90,7 @@ def fftconvolve(in1, in2, mode="full", axes=None):
         result = result.real
 
     if mode == "same":
-        return result[_centered_slice(tuple(result.shape), tuple(x.shape), axes)]
+        return result[_centered_slice(tuple(result.shape), tuple(x.shape))]
     if mode == "valid":
         return result[_valid_slice(tuple(x.shape), tuple(y.shape), axes)]
     return result

--- a/tests/backend_support/test_pytorch_fftconvolve_contract.py
+++ b/tests/backend_support/test_pytorch_fftconvolve_contract.py
@@ -36,3 +36,33 @@ def test_pytorch_fftconvolve_matches_scipy_selected_axes():
     )
 
     assert np.allclose(actual, expected)
+
+
+def test_pytorch_fftconvolve_same_crops_broadcast_non_convolved_axes():
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific signal backend contract")
+
+    first = backend.asarray([[2.0]])
+    second = backend.asarray([[1.0, 3.0, 5.0]])
+
+    actual = _as_numpy(backend.signal.fftconvolve(first, second, mode="same", axes=(0,)))
+    expected = scipy_fftconvolve(
+        _as_numpy(first), _as_numpy(second), mode="same", axes=(0,)
+    )
+
+    assert actual.shape == expected.shape == _as_numpy(first).shape
+    assert np.allclose(actual, expected)
+
+
+def test_pytorch_fftconvolve_valid_allows_mixed_singleton_axes():
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific signal backend contract")
+
+    first = backend.asarray([[1.0, 2.0]])
+    second = backend.asarray([[0.5], [1.5]])
+
+    actual = _as_numpy(backend.signal.fftconvolve(first, second, mode="valid"))
+    expected = scipy_fftconvolve(_as_numpy(first), _as_numpy(second), mode="valid")
+
+    assert actual.shape == expected.shape
+    assert np.allclose(actual, expected)


### PR DESCRIPTION
## Summary
- fix the PyTorch backend `fftconvolve(..., mode="same", axes=...)` crop so it matches SciPy when non-convolved dimensions are broadcast
- make the `mode="valid"` size check ignore singleton selected axes, matching SciPy's FFT convolution behavior
- add PyTorch backend contract tests for both edge cases

## Validation
- exercised the patched logic against `scipy.signal.fftconvolve` for the two new edge cases in an isolated local script
- local full repository test run was not possible here because the execution container cannot clone GitHub; the PR CI should run the normal matrix