### PR TITLE
Fix PyTorch fftconvolve empty axes handling

### DIFF
--- a/src/pyrecest/_backend/pytorch/signal.py
+++ b/src/pyrecest/_backend/pytorch/signal.py
@@ -3,12 +3,16 @@ import torch as _torch
 
 
 def _normalize_axes(axes, ndim):
+    axes_were_provided = axes is not None
     if axes is None:
         axes = tuple(range(ndim))
     elif isinstance(axes, (int, _np.integer)):
         axes = (int(axes),)
     else:
         axes = tuple(int(axis) for axis in axes)
+
+    if axes_were_provided and len(axes) == 0 and ndim > 0:
+        raise ValueError("when provided, axes cannot be empty")
 
     normalized_axes = []
     for axis in axes:

--- a/tests/backend_support/test_pytorch_fftconvolve_contract.py
+++ b/tests/backend_support/test_pytorch_fftconvolve_contract.py
@@ -66,3 +66,28 @@ def test_pytorch_fftconvolve_valid_allows_mixed_singleton_axes():
 
     assert actual.shape == expected.shape
     assert np.allclose(actual, expected)
+
+
+@pytest.mark.parametrize("axes", [(), []])
+def test_pytorch_fftconvolve_rejects_empty_axes_for_arrays(axes):
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific signal backend contract")
+
+    first = backend.asarray([1.0, 2.0])
+    second = backend.asarray([3.0, 4.0])
+
+    with pytest.raises(ValueError, match="axes cannot be empty"):
+        backend.signal.fftconvolve(first, second, axes=axes)
+
+
+def test_pytorch_fftconvolve_scalar_empty_axes_matches_scipy():
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific signal backend contract")
+
+    first = backend.asarray(2.0)
+    second = backend.asarray(3.0)
+
+    actual = _as_numpy(backend.signal.fftconvolve(first, second, axes=()))
+    expected = scipy_fftconvolve(_as_numpy(first), _as_numpy(second), axes=())
+
+    assert np.allclose(actual, expected)


### PR DESCRIPTION
## Summary
- reject explicitly empty `axes` for non-scalar PyTorch `fftconvolve` inputs, matching SciPy semantics
- keep scalar empty-axis convolution allowed, also matching SciPy
- add PyTorch backend contract regression tests for both cases

## Validation
- locally reproduced the current mismatch against SciPy: `axes=()` / `axes=[]` on 1D arrays returned pointwise multiplication instead of raising
- locally checked the patched helper behavior against SciPy for 1D arrays and scalar inputs

