### PR TITLE
Normalize PyTorch default dtype inputs

### DIFF
--- a/src/pyrecest/_backend/pytorch/_dtype.py
+++ b/src/pyrecest/_backend/pytorch/_dtype.py
@@ -4,7 +4,6 @@ import numpy as _np
 import torch as _torch
 from pyrecest._backend import _backend_config as _config
 from pyrecest._backend._dtype_utils import (
-    _MAP_FLOAT_TO_COMPLEX,
     _modify_func_default_dtype,
     _pre_allow_complex_dtype,
     _pre_cast_out_to_input_dtype,
@@ -25,6 +24,11 @@ MAP_DTYPE = {
     "float64": float64,
     "complex64": complex64,
     "complex128": complex128,
+}
+
+_FLOAT_TO_COMPLEX_DTYPE = {
+    float32: complex64,
+    float64: complex128,
 }
 
 _COMPLEX_DTYPES = (complex64, complex128)
@@ -78,11 +82,19 @@ def set_default_dtype(value):
 
     Parameters
     ----------
-    value : str
-        Possible values are "float32" as "float64".
+    value : str or dtype-like
+        Floating dtype alias resolving to ``float32`` or ``float64``.
     """
-    _config.DEFAULT_DTYPE = as_dtype(value)
-    _config.DEFAULT_COMPLEX_DTYPE = as_dtype(_MAP_FLOAT_TO_COMPLEX.get(value))
+    dtype = _normalize_torch_dtype(value, default=None)
+    try:
+        complex_dtype = _FLOAT_TO_COMPLEX_DTYPE[dtype]
+    except KeyError as exc:
+        raise ValueError(
+            "PyTorch default dtype must resolve to torch.float32 or torch.float64."
+        ) from exc
+
+    _config.DEFAULT_DTYPE = dtype
+    _config.DEFAULT_COMPLEX_DTYPE = complex_dtype
     _torch.set_default_dtype(_config.DEFAULT_DTYPE)
 
     _update_default_dtypes()

--- a/tests/test_explicit_backend_pytorch_dtype.py
+++ b/tests/test_explicit_backend_pytorch_dtype.py
@@ -30,3 +30,27 @@ def test_explicit_pytorch_backend_accepts_numpy_dtype_arguments():
 
     assert result.dtype == torch.float64
     np.testing.assert_allclose(torch_backend.to_numpy(result), [1.0, 2.0])
+
+
+def test_explicit_pytorch_backend_set_default_dtype_accepts_dtype_objects():
+    torch = pytest.importorskip("torch")
+
+    from pyrecest.backends import get_backend
+
+    torch_backend = get_backend("pytorch")
+    previous_dtype = torch_backend.get_default_dtype()
+
+    try:
+        result = torch_backend.set_default_dtype(np.dtype("float32"))
+        assert result == torch.float32
+        assert torch_backend.get_default_dtype() == torch.float32
+        assert torch_backend.get_default_cdtype() == torch.complex64
+        assert torch_backend.linspace(0, 1, 2).dtype == torch.float32
+
+        result = torch_backend.set_default_dtype(torch.float64)
+        assert result == torch.float64
+        assert torch_backend.get_default_dtype() == torch.float64
+        assert torch_backend.get_default_cdtype() == torch.complex128
+        assert torch_backend.linspace(0, 1, 2).dtype == torch.float64
+    finally:
+        torch_backend.set_default_dtype(previous_dtype)


### PR DESCRIPTION
## Summary
- Fix PyTorch `set_default_dtype` so it accepts dtype-like values such as `np.dtype("float32")` and `torch.float64`, not only string keys.
- Keep the associated default complex dtype in sync via a direct torch dtype mapping.
- Add a regression test covering dtype-object inputs and restoration of the previous dtype.

## Testing
- Not run locally: the sandbox cannot resolve github.com to clone/install the repository, so validation is delegated to GitHub Actions.