### PR TITLE
Fix toroidal Dirac row-layout statistics

### DIFF
--- a/src/pyrecest/distributions/hypertorus/toroidal_dirac_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/toroidal_dirac_distribution.py
@@ -1,6 +1,6 @@
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import column_stack, cos, diag, dot, sin, sqrt, sum, tile
+from pyrecest.backend import column_stack, cos, sin, sqrt, sum
 
 from .abstract_toroidal_distribution import AbstractToroidalDistribution
 from .hypertoroidal_dirac_distribution import HypertoroidalDiracDistribution
@@ -27,11 +27,10 @@ class ToroidalDiracDistribution(
         """
         m = self.mean_direction()
 
-        x = sum(self.w * sin(self.d[0, :] - m[0]) * sin(self.d[1, :] - m[1]))
-        y = sqrt(
-            sum(self.w * sin(self.d[0, :] - m[0]) ** 2)
-            * sum(self.w * sin(self.d[1, :] - m[1]) ** 2)
-        )
+        first_sines = sin(self.d[:, 0] - m[0])
+        second_sines = sin(self.d[:, 1] - m[1])
+        x = sum(self.w * first_sines * second_sines)
+        y = sqrt(sum(self.w * first_sines**2) * sum(self.w * second_sines**2))
         rhoc = x / y
         return rhoc
 
@@ -43,13 +42,13 @@ class ToroidalDiracDistribution(
         """
         dbar = column_stack(
             [
-                cos(self.d[0, :]),
-                sin(self.d[0, :]),
-                cos(self.d[1, :]),
-                sin(self.d[1, :]),
+                cos(self.d[:, 0]),
+                sin(self.d[:, 0]),
+                cos(self.d[:, 1]),
+                sin(self.d[:, 1]),
             ]
         )
-        mu = dot(self.w, dbar)
-        n = len(self.d)
-        C = (dbar - tile(mu, (n, 1))).T @ (diag(self.w) @ (dbar - tile(mu, (n, 1))))
+        mu = sum(self.w[:, None] * dbar, axis=0)
+        centered = dbar - mu
+        C = centered.T @ (self.w[:, None] * centered)
         return C

--- a/tests/distributions/test_toroidal_dirac_distribution.py
+++ b/tests/distributions/test_toroidal_dirac_distribution.py
@@ -1,0 +1,73 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+import pyrecest.backend
+from pyrecest.backend import array
+from pyrecest.distributions import ToroidalDiracDistribution
+
+
+def _as_numpy(value):
+    return np.asarray(pyrecest.backend.to_numpy(value))
+
+
+def _make_toroidal_dirac_distribution():
+    return ToroidalDiracDistribution(
+        array(
+            [
+                [0.1, 0.2],
+                [1.0, 2.0],
+                [2.5, 0.4],
+                [4.0, 5.0],
+            ]
+        ),
+        array([0.1, 0.2, 0.3, 0.4]),
+    )
+
+
+class TestToroidalDiracDistribution(unittest.TestCase):
+    def test_circular_correlation_uses_particle_rows(self):
+        dist = _make_toroidal_dirac_distribution()
+        d = _as_numpy(dist.d)
+        w = _as_numpy(dist.w)
+        mean = _as_numpy(dist.mean_direction())
+
+        first_sines = np.sin(d[:, 0] - mean[0])
+        second_sines = np.sin(d[:, 1] - mean[1])
+        expected = np.sum(w * first_sines * second_sines) / np.sqrt(
+            np.sum(w * first_sines**2) * np.sum(w * second_sines**2)
+        )
+
+        npt.assert_allclose(
+            _as_numpy(dist.circular_correlation_jammalamadaka()),
+            expected,
+            rtol=1e-10,
+            atol=1e-10,
+        )
+
+    def test_covariance_4d_uses_particle_rows(self):
+        dist = _make_toroidal_dirac_distribution()
+        d = _as_numpy(dist.d)
+        w = _as_numpy(dist.w)
+
+        dbar = np.column_stack(
+            [
+                np.cos(d[:, 0]),
+                np.sin(d[:, 0]),
+                np.cos(d[:, 1]),
+                np.sin(d[:, 1]),
+            ]
+        )
+        mean = np.sum(w[:, None] * dbar, axis=0)
+        centered = dbar - mean
+        expected = centered.T @ (w[:, None] * centered)
+
+        actual = _as_numpy(dist.covariance_4D())
+
+        self.assertEqual(actual.shape, (4, 4))
+        npt.assert_allclose(actual, expected, rtol=1e-10, atol=1e-10)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- read toroidal Dirac particles from the package-wide row-major `(n_particles, 2)` layout in circular correlation and 4D covariance
- compute the weighted 4D covariance directly from row-wise centered trigonometric features
- add regression tests for multi-particle toroidal circular correlation and 4D covariance against NumPy references

## Testing
- Not run locally in this environment; added focused regression tests for CI.