### PR TITLE
Reject NaN Gaussian hypothesis log weights

### DIFF
--- a/src/pyrecest/filters/gaussian_hypothesis_mixture.py
+++ b/src/pyrecest/filters/gaussian_hypothesis_mixture.py
@@ -59,6 +59,8 @@ def normalize_log_weights(log_weights: list[float] | np.ndarray) -> np.ndarray:
     values = np.asarray(log_weights, dtype=float).reshape(-1)
     if values.size == 0:
         raise ValueError("log_weights must not be empty")
+    if np.any(np.isnan(values)):
+        raise ValueError("log_weights must not contain NaN values")
 
     positive_infinite = np.isposinf(values)
     if np.any(positive_infinite):

--- a/tests/filters/test_gaussian_hypothesis_mixture.py
+++ b/tests/filters/test_gaussian_hypothesis_mixture.py
@@ -24,6 +24,22 @@ class GaussianHypothesisMixtureTest(unittest.TestCase):
 
         self.assertTrue(np.allclose(weights, np.array([0.5, 0.0, 0.5])))
 
+    def test_nan_log_weights_are_rejected(self):
+        with self.assertRaisesRegex(ValueError, "NaN"):
+            normalize_log_weights(np.array([0.0, np.nan]))
+
+        with self.assertRaisesRegex(ValueError, "NaN"):
+            moment_match_gaussian_hypotheses(
+                [
+                    WeightedGaussianHypothesis(
+                        np.array([0.0]), np.array([[1.0]]), log_weight=0.0
+                    ),
+                    WeightedGaussianHypothesis(
+                        np.array([1.0]), np.array([[1.0]]), log_weight=np.nan
+                    ),
+                ]
+            )
+
     def test_moment_matching_respects_dominant_infinite_weight(self):
         mean, covariance, weights = moment_match_gaussian_hypotheses(
             [


### PR DESCRIPTION
## Summary
- Reject `NaN` values in `normalize_log_weights` instead of silently returning uniform weights.
- Prevent `moment_match_gaussian_hypotheses` from assigning posterior mass to hypotheses with invalid `NaN` log weights.
- Add regression coverage for direct normalization and Gaussian hypothesis moment matching.

## Bug
`normalize_log_weights` previously let `np.max([0.0, np.nan])` become `NaN`, then treated the non-finite maximum as a degenerate all-zero case and returned uniform weights. This silently gave invalid hypotheses nonzero posterior mass.

## Testing
- Not run locally; this environment cannot clone or execute the GitHub repository because outbound DNS resolution to GitHub is unavailable. The change is covered by a targeted regression test in `tests/filters/test_gaussian_hypothesis_mixture.py`.