### PR TITLE
Validate spherical harmonics filter inputs

### DIFF
--- a/src/pyrecest/filters/spherical_harmonics_filter.py
+++ b/src/pyrecest/filters/spherical_harmonics_filter.py
@@ -61,9 +61,10 @@ class SphericalHarmonicsFilter(AbstractFilter, HypersphericalFilterMixin):
 
     @filter_state.setter
     def filter_state(self, new_state):
-        assert isinstance(
-            new_state, SphericalHarmonicsDistributionComplex
-        ), "filter_state must be a SphericalHarmonicsDistributionComplex"
+        if not isinstance(new_state, SphericalHarmonicsDistributionComplex):
+            raise TypeError(
+                "filter_state must be a SphericalHarmonicsDistributionComplex."
+            )
         self._filter_state = copy.deepcopy(new_state)
 
     @property
@@ -77,9 +78,8 @@ class SphericalHarmonicsFilter(AbstractFilter, HypersphericalFilterMixin):
 
     def set_state(self, state):
         """Set the filter state with optional warnings about mismatches."""
-        assert isinstance(
-            state, SphericalHarmonicsDistributionComplex
-        ), "state must be a SphericalHarmonicsDistributionComplex"
+        if not isinstance(state, SphericalHarmonicsDistributionComplex):
+            raise TypeError("state must be a SphericalHarmonicsDistributionComplex.")
         if self._filter_state.transformation != state.transformation:
             warnings.warn(
                 "setState:transDiffer: New density is transformed differently.",
@@ -114,19 +114,21 @@ class SphericalHarmonicsFilter(AbstractFilter, HypersphericalFilterMixin):
             Must be a zonal distribution (rotationally symmetric around the
             z-axis) in the same transformation as the filter state.
         """
-        assert isinstance(
-            sys_noise, SphericalHarmonicsDistributionComplex
-        ), "sys_noise must be a SphericalHarmonicsDistributionComplex"
+        if not isinstance(sys_noise, SphericalHarmonicsDistributionComplex):
+            raise TypeError(
+                "sys_noise must be a SphericalHarmonicsDistributionComplex."
+            )
         if (
             self._filter_state.transformation == "sqrt"
             and sys_noise.transformation == "identity"
         ):
             state_degree = self._filter_state.coeff_mat.shape[0] - 1
             noise_degree = sys_noise.coeff_mat.shape[0] - 1
-            assert 2 * state_degree == noise_degree, (
-                "If the sqrt variant is used and sys_noise is given in "
-                "identity form, sys_noise should have degree 2 * state_degree."
-            )
+            if 2 * state_degree != noise_degree:
+                raise ValueError(
+                    "If the sqrt variant is used and sys_noise is given in "
+                    "identity form, sys_noise should have degree 2 * state_degree."
+                )
         self._filter_state = self._filter_state.convolve(sys_noise)
 
     # ------------------------------------------------------------------
@@ -147,9 +149,10 @@ class SphericalHarmonicsFilter(AbstractFilter, HypersphericalFilterMixin):
         z : array-like, shape (3,)
             Measurement direction on the unit sphere.
         """
-        assert isinstance(
-            meas_noise, SphericalHarmonicsDistributionComplex
-        ), "meas_noise must be a SphericalHarmonicsDistributionComplex"
+        if not isinstance(meas_noise, SphericalHarmonicsDistributionComplex):
+            raise TypeError(
+                "meas_noise must be a SphericalHarmonicsDistributionComplex."
+            )
         z = array(z, dtype=float).ravel()
         z_norm = linalg.norm(z)
         not_near_north_pole = (
@@ -192,9 +195,8 @@ class SphericalHarmonicsFilter(AbstractFilter, HypersphericalFilterMixin):
         measurements : list of array-like
             Corresponding measurements.
         """
-        assert len(likelihoods) == len(
-            measurements
-        ), "likelihoods and measurements must have the same length"
+        if len(likelihoods) != len(measurements):
+            raise ValueError("likelihoods and measurements must have the same length.")
         self._update_nonlinear_impl(likelihoods, measurements)
 
     # ------------------------------------------------------------------

--- a/tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py
+++ b/tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py
@@ -1,9 +1,12 @@
 """Regression tests for PyTorch Sylvester solver shortcuts."""
 
+import pytest
+
 from tests.support.backend_runner import run_backend_code
 
 
 def test_pytorch_semidefinite_sylvester_shortcut_respects_nonzero_denominators():
+    pytest.importorskip("torch")
     code = """
 import torch
 from pyrecest.backend import linalg

--- a/tests/filters/test_spherical_harmonics_filter.py
+++ b/tests/filters/test_spherical_harmonics_filter.py
@@ -20,6 +20,54 @@ _skip_non_numpy = unittest.skipIf(
 
 
 class SphericalHarmonicsFilterTest(unittest.TestCase):
+    @staticmethod
+    def _make_shd(degree, transformation="identity"):
+        coeff_mat = np.zeros((degree + 1, 2 * degree + 1), dtype=complex)
+        coeff_mat[0, 0] = 1.0
+        return SphericalHarmonicsDistributionComplex(coeff_mat, transformation)
+
+    @_skip_non_numpy
+    def test_filter_state_rejects_invalid_type(self):
+        sh_filter = SphericalHarmonicsFilter(1)
+
+        with self.assertRaisesRegex(TypeError, "SphericalHarmonicsDistributionComplex"):
+            sh_filter.filter_state = object()
+
+    @_skip_non_numpy
+    def test_set_state_rejects_invalid_type(self):
+        sh_filter = SphericalHarmonicsFilter(1)
+
+        with self.assertRaisesRegex(TypeError, "SphericalHarmonicsDistributionComplex"):
+            sh_filter.set_state(object())
+
+    @_skip_non_numpy
+    def test_predict_identity_rejects_invalid_noise_type(self):
+        sh_filter = SphericalHarmonicsFilter(1)
+
+        with self.assertRaisesRegex(TypeError, "SphericalHarmonicsDistributionComplex"):
+            sh_filter.predict_identity(object())
+
+    @_skip_non_numpy
+    def test_predict_identity_rejects_sqrt_identity_degree_mismatch(self):
+        sh_filter = SphericalHarmonicsFilter(2, "sqrt")
+        sys_noise = self._make_shd(3, "identity")
+
+        with self.assertRaisesRegex(ValueError, "2 \\* state_degree"):
+            sh_filter.predict_identity(sys_noise)
+
+    @_skip_non_numpy
+    def test_update_identity_rejects_invalid_noise_type(self):
+        sh_filter = SphericalHarmonicsFilter(1)
+
+        with self.assertRaisesRegex(TypeError, "SphericalHarmonicsDistributionComplex"):
+            sh_filter.update_identity(object(), array([0.0, 0.0, 1.0]))
+
+    @_skip_non_numpy
+    def test_update_nonlinear_multiple_rejects_count_mismatch(self):
+        sh_filter = SphericalHarmonicsFilter(1)
+
+        with self.assertRaisesRegex(ValueError, "same length"):
+            sh_filter.update_nonlinear_multiple([lambda z, x: x[0]], [])
 
     @_skip_non_numpy
     def test_update_identity(self):


### PR DESCRIPTION
## Summary
- replace optimizer-stripped spherical harmonics filter assertions with explicit exceptions
- add regression coverage for invalid state/noise inputs, sqrt-vs-identity degree mismatches, and nonlinear update count mismatches
- skip the PyTorch Sylvester backend contract test when `torch` is absent so NumPy-only jobs do not fail on an optional dependency

## Validation
- `poetry run pytest tests/filters/test_spherical_harmonics_filter.py tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py`
- `poetry run python -O -m pytest tests/filters/test_spherical_harmonics_filter.py`
- `poetry run ruff check src/pyrecest/filters/spherical_harmonics_filter.py tests/filters/test_spherical_harmonics_filter.py tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py`
- `rg -n "assert " src/pyrecest/filters/spherical_harmonics_filter.py` returned no matches