### PR TITLE
Validate state-space subdivision inputs

### DIFF
--- a/src/pyrecest/filters/state_space_subdivision_filter.py
+++ b/src/pyrecest/filters/state_space_subdivision_filter.py
@@ -40,7 +40,10 @@ class StateSpaceSubdivisionFilter(AbstractFilter, HypercylindricalFilterMixin):
     """
 
     def __init__(self, initial_state: StateSpaceSubdivisionGaussianDistribution):
-        assert isinstance(initial_state, StateSpaceSubdivisionGaussianDistribution)
+        if not isinstance(initial_state, StateSpaceSubdivisionGaussianDistribution):
+            raise TypeError(
+                "initial_state must be a StateSpaceSubdivisionGaussianDistribution."
+            )
         HypercylindricalFilterMixin.__init__(self)
         AbstractFilter.__init__(self, initial_state)
 
@@ -54,9 +57,10 @@ class StateSpaceSubdivisionFilter(AbstractFilter, HypercylindricalFilterMixin):
 
     @filter_state.setter
     def filter_state(self, new_state: StateSpaceSubdivisionGaussianDistribution):
-        assert isinstance(
-            new_state, StateSpaceSubdivisionGaussianDistribution
-        ), "filter_state must be a StateSpaceSubdivisionGaussianDistribution."
+        if not isinstance(new_state, StateSpaceSubdivisionGaussianDistribution):
+            raise TypeError(
+                "filter_state must be a StateSpaceSubdivisionGaussianDistribution."
+            )
         if self._filter_state is not None and len(
             self._filter_state.linear_distributions
         ) != len(new_state.linear_distributions):
@@ -292,10 +296,8 @@ class StateSpaceSubdivisionFilter(AbstractFilter, HypercylindricalFilterMixin):
 
         if likelihoods_linear is not None:
             n_likelihoods = len(likelihoods_linear)
-            assert n_likelihoods in (
-                1,
-                n_areas,
-            ), "likelihoods_linear must have 1 or n_areas elements."
+            if n_likelihoods not in (1, n_areas):
+                raise ValueError("likelihoods_linear must have 1 or n_areas elements.")
 
             if n_likelihoods == 1:
                 self._update_single_linear_likelihood(likelihoods_linear[0])

--- a/tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py
+++ b/tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py
@@ -1,9 +1,12 @@
 """Regression tests for PyTorch Sylvester solver shortcuts."""
 
+import pytest
+
 from tests.support.backend_runner import run_backend_code
 
 
 def test_pytorch_semidefinite_sylvester_shortcut_respects_nonzero_denominators():
+    pytest.importorskip("torch")
     code = """
 import torch
 from pyrecest.backend import linalg

--- a/tests/filters/test_state_space_subdivision_filter.py
+++ b/tests/filters/test_state_space_subdivision_filter.py
@@ -43,12 +43,23 @@ class TestStateSpaceSubdivisionFilterInit(unittest.TestCase):
         f = StateSpaceSubdivisionFilter(state)
         self.assertIsInstance(f.filter_state, StateSpaceSubdivisionGaussianDistribution)
 
+    def test_init_rejects_invalid_state(self):
+        with self.assertRaisesRegex(TypeError, "StateSpaceSubdivisionGaussian"):
+            StateSpaceSubdivisionFilter(object())
+
     def test_set_state(self):
         state = _make_s1_x_r1_state()
         f = StateSpaceSubdivisionFilter(state)
         new_state = _make_s1_x_r1_state(mu_lin=array([3.0]))
         f.filter_state = new_state
         npt.assert_allclose(f.filter_state.linear_distributions[0].mu, array([3.0]))
+
+    def test_set_state_rejects_invalid_state(self):
+        state = _make_s1_x_r1_state()
+        f = StateSpaceSubdivisionFilter(state)
+
+        with self.assertRaisesRegex(TypeError, "StateSpaceSubdivisionGaussian"):
+            f.filter_state = object()
 
     def test_set_state_different_size_warns(self):
         state = _make_s1_x_r1_state(n=20)
@@ -194,6 +205,14 @@ class TestStateSpaceSubdivisionFilterUpdate(unittest.TestCase):
             self.assertLess(float(ld.C[0, 0]), float(C0[0, 0]))
             # Mean should be halfway between 0 and 2
             npt.assert_allclose(ld.mu, array([1.0]), atol=1e-10)
+
+    def test_update_rejects_invalid_linear_likelihood_count(self):
+        state = _make_s1_x_r1_state(n=5)
+        f = StateSpaceSubdivisionFilter(state)
+        likelihood = GaussianDistribution(array([2.0]), eye(1))
+
+        with self.assertRaisesRegex(ValueError, "1 or n_areas"):
+            f.update(likelihoods_linear=[likelihood, likelihood])
 
     def test_update_single_linear_likelihood_matches_per_cell_likelihoods(self):
         """The single-likelihood fast path should match the generic per-cell update."""


### PR DESCRIPTION
## Summary
- replace optimizer-stripped state-space subdivision filter assertions with explicit exceptions
- add regression coverage for invalid initial/replacement states and invalid linear-likelihood counts under optimized Python
- skip the PyTorch Sylvester backend contract test when `torch` is absent so NumPy-only jobs do not fail on an optional dependency while the CI guard is landing

## Validation
- `poetry run pytest tests/filters/test_state_space_subdivision_filter.py tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py`
- `poetry run python -O -m pytest tests/filters/test_state_space_subdivision_filter.py`
- `poetry run ruff check src/pyrecest/filters/state_space_subdivision_filter.py tests/filters/test_state_space_subdivision_filter.py tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py`
- `rg -n "assert " src/pyrecest/filters/state_space_subdivision_filter.py` returned no matches