### PR TITLE
Validate Euclidean sampler invariants

### DIFF
--- a/src/pyrecest/sampling/euclidean_sampler.py
+++ b/src/pyrecest/sampling/euclidean_sampler.py
@@ -483,9 +483,8 @@ class FibonacciGridSampler(AbstractEuclideanSampler):
 
         # Identify points fully inside [-1/2, 1/2]^d
         ind = np.all((xy <= 0.5) & (xy >= -0.5), axis=0)
-        assert (
-            ind.sum() % 2 == n_points % 2
-        ), "Parity of in-box points does not match n_points"
+        if ind.sum() % 2 != n_points % 2:
+            raise RuntimeError("Parity of in-box points does not match n_points.")
 
         # Keep only points whose non-first coordinates are in [-1/2, 1/2]
         ind0 = np.all((xy[1:, :] <= 0.5) & (xy[1:, :] >= -0.5), axis=0)  # noqa: E203
@@ -495,9 +494,11 @@ class FibonacciGridSampler(AbstractEuclideanSampler):
         # Fine-tune the number of samples by adjusting the x_1 boundary
         n_current = int(ind.sum())
         diff = n_points - n_current
-        assert (
-            diff % 2 == 0
-        ), f"Sample count parity mismatch after slicing: expected difference to be even but got {diff}"
+        if diff % 2 != 0:
+            raise RuntimeError(
+                "Sample count parity mismatch after slicing: expected difference "
+                f"to be even but got {diff}."
+            )
         n_add = diff // 2
 
         sort_idx = np.argsort(xy[0, :], kind="stable")  # noqa: E203
@@ -526,10 +527,13 @@ class FibonacciGridSampler(AbstractEuclideanSampler):
         border_vec = np.ones(d) * 0.5
         border_vec[0] = border_x
         border_vec_rot = V.T @ border_vec
-        assert np.all(
-            np.abs(border_vec_rot) <= np.max(vec)
-        ), "Increase 'extra' variable"
-        assert int(ind.sum()) == n_points
+        if not np.all(np.abs(border_vec_rot) <= np.max(vec)):
+            raise RuntimeError("Increase 'extra' variable.")
+        if int(ind.sum()) != n_points:
+            raise RuntimeError(
+                f"Fibonacci grid selected {int(ind.sum())} samples, "
+                f"expected {n_points}."
+            )
 
         # Extract the selected points and center them
         xy = xy[:, ind]

--- a/tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py
+++ b/tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py
@@ -1,9 +1,12 @@
 """Regression tests for PyTorch Sylvester solver shortcuts."""
 
+import pytest
+
 from tests.support.backend_runner import run_backend_code
 
 
 def test_pytorch_semidefinite_sylvester_shortcut_respects_nonzero_denominators():
+    pytest.importorskip("torch")
     code = """
 import torch
 from pyrecest.backend import linalg

--- a/tests/test_euclidean_sampler.py
+++ b/tests/test_euclidean_sampler.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 import numpy as np
 import numpy.testing as npt
@@ -8,6 +9,7 @@ from pyrecest.sampling import (
 )
 from pyrecest.sampling import HaltonGridSampler as PublicHaltonGridSampler
 from pyrecest.sampling import SobolGridSampler as PublicSobolGridSampler
+import pyrecest.sampling.euclidean_sampler as euclidean_sampler
 from pyrecest.sampling.euclidean_sampler import (
     FibonacciGridSampler,
     FibonacciRejectionSampler,
@@ -213,6 +215,28 @@ class TestFibonacciGridSampler(unittest.TestCase):
             self.assertEqual(V.shape, (d, d))
             self.assertEqual(R.shape, (d,))
             npt.assert_allclose(V.T @ V, np.eye(d), atol=1e-12)
+
+    def test_fibonacci_grid_invariant_rejects_in_box_parity_mismatch(self):
+        bad_basis = np.array([[1.0, 10.0], [0.0, 1.0]])
+
+        with patch.object(
+            euclidean_sampler,
+            "_fibonacci_eigen",
+            return_value=(bad_basis, np.ones(2)),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "Parity"):
+                self.sampler.get_uniform_samples(6, 2)
+
+    def test_fibonacci_grid_invariant_rejects_insufficient_grid_extent(self):
+        bad_basis = 10.0 * np.eye(2)
+
+        with patch.object(
+            euclidean_sampler,
+            "_fibonacci_eigen",
+            return_value=(bad_basis, np.ones(2)),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "extra"):
+                self.sampler.get_uniform_samples(3, 2)
 
 
 class TestFibonacciRejectionSampler(unittest.TestCase):


### PR DESCRIPTION
## Summary
- replace optimizer-stripped Fibonacci grid sampler invariant assertions with explicit `RuntimeError` failures
- add regression coverage for in-box parity and grid-extent invariant failures under optimized Python
- skip the PyTorch Sylvester backend contract test when `torch` is absent so NumPy-only jobs do not fail on an optional dependency while the CI guard is landing

## Validation
- `poetry run pytest tests/test_euclidean_sampler.py tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py`
- `poetry run python -O -m pytest tests/test_euclidean_sampler.py`
- `poetry run ruff check src/pyrecest/sampling/euclidean_sampler.py tests/test_euclidean_sampler.py tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py`
- `rg -n "assert " src/pyrecest/sampling/euclidean_sampler.py` returned no matches