### PR TITLE
Validate kernel SME filter inputs

### DIFF
--- a/src/pyrecest/filters/kernel_sme_filter.py
+++ b/src/pyrecest/filters/kernel_sme_filter.py
@@ -91,9 +91,10 @@ class KernelSMEFilter(AbstractMultitargetTracker):
         sys_noise,
         inputs=None,
     ):
-        assert (
-            inputs is None
-        ), "Inputs are currently not supported for the Kernel SME filter"
+        if inputs is not None:
+            raise NotImplementedError(
+                "Inputs are currently not supported for the Kernel SME filter."
+            )
         if isinstance(sys_noise, GaussianDistribution):
             sys_noise_cov = sys_noise.C
         else:
@@ -152,9 +153,11 @@ class KernelSMEFilter(AbstractMultitargetTracker):
             chi2,
         )
 
-        assert (
-            not gating_threshold or enable_gating
-        ), "Changed gating threshold without enabling gating, this does not make sense."
+        if gating_threshold is not None and not enable_gating:
+            raise ValueError(
+                "Changed gating threshold without enabling gating, "
+                "this does not make sense."
+            )
         if gating_threshold is None:
             gating_threshold = chi2.ppf(0.99, len(measurements))
         n_meas = measurements.shape[1]
@@ -234,9 +237,8 @@ class KernelSMEFilter(AbstractMultitargetTracker):
 
     @staticmethod
     def gen_test_points(measurements, kernel_width):
-        assert (
-            pyrecest.backend.__backend_name__ != "pytorch"
-        ), "Not supported on this backend"
+        if pyrecest.backend.__backend_name__ == "pytorch":
+            raise NotImplementedError("Not supported on this backend.")
         meas_dim = measurements.shape[0]
         n_meas = measurements.shape[1]
 
@@ -252,9 +254,8 @@ class KernelSMEFilter(AbstractMultitargetTracker):
 
     @staticmethod
     def calc_pseudo_meas(testPoints, measurements, kernel_width):
-        assert (
-            pyrecest.backend.__backend_name__ != "jax"
-        ), "Not supported on this backend"
+        if pyrecest.backend.__backend_name__ == "jax":
+            raise NotImplementedError("Not supported on this backend.")
         n_meas = measurements.shape[1]
         meas_dim = measurements.shape[0]
         n_test_points = testPoints.shape[1]
@@ -301,9 +302,8 @@ class KernelSMEFilter(AbstractMultitargetTracker):
             lambda_vec = float(lambdaMultimeas) * ones(n_targets)
         else:
             lambda_vec = array(lambdaMultimeas).reshape(-1)
-            assert (
-                lambda_vec.shape[0] == n_targets
-            ), "lambdaMultimeas must be scalar or length n_targets"
+            if lambda_vec.shape[0] != n_targets:
+                raise ValueError("lambdaMultimeas must be scalar or length n_targets.")
 
         lam_c = float(falseAlarmRate)
 

--- a/tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py
+++ b/tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py
@@ -1,9 +1,12 @@
 """Regression tests for PyTorch Sylvester solver shortcuts."""
 
+import pytest
+
 from tests.support.backend_runner import run_backend_code
 
 
 def test_pytorch_semidefinite_sylvester_shortcut_respects_nonzero_denominators():
+    pytest.importorskip("torch")
     code = """
 import torch
 from pyrecest.backend import linalg

--- a/tests/filters/test_kernel_sme_filter.py
+++ b/tests/filters/test_kernel_sme_filter.py
@@ -1,6 +1,7 @@
 import copy
 import math
 import unittest
+from unittest.mock import patch
 
 import numpy.testing as npt
 
@@ -142,6 +143,16 @@ class TestKernelSMEFilter(unittest.TestCase):
             )
             + eye(12),
         )
+
+    def test_predict_linear_rejects_inputs(self):
+        tracker = KernelSMEFilter(self.initial_priors)
+
+        with self.assertRaisesRegex(NotImplementedError, "Inputs"):
+            tracker.predict_linear(
+                self.system_matrix,
+                self.sys_noise_cov,
+                inputs=array([1.0, 0.0]),
+            )
 
     def testPredictLinearAllSameMatsNoInputs3DCV(self):
         tracker = KernelSMEFilter()
@@ -398,6 +409,43 @@ class TestKernelSMEFilter(unittest.TestCase):
         npt.assert_allclose(tracker.x, prior_x)
         npt.assert_allclose(tracker.C, prior_c)
         self.assertEqual(tracker.posterior_estimates_over_time.shape, (12, 1))
+
+    def test_update_rejects_gating_threshold_without_gating(self):
+        tracker = KernelSMEFilter(self.initial_priors)
+
+        with self.assertRaisesRegex(ValueError, "gating"):
+            tracker.update_linear(
+                self.measurements,
+                eye(2),
+                self.measurement_noise_cov,
+                enable_gating=False,
+                gating_threshold=1.0,
+            )
+
+    def test_gen_test_points_rejects_pytorch_backend(self):
+        with patch.object(pyrecest.backend, "__backend_name__", "pytorch"):
+            with self.assertRaisesRegex(NotImplementedError, "backend"):
+                KernelSMEFilter.gen_test_points(array([[0.0]]), 1.0)
+
+    def test_calc_pseudo_meas_rejects_jax_backend(self):
+        with patch.object(pyrecest.backend, "__backend_name__", "jax"):
+            with self.assertRaisesRegex(NotImplementedError, "backend"):
+                KernelSMEFilter.calc_pseudo_meas(
+                    array([[0.0]]), array([[0.0]]), 1.0
+                )
+
+    def test_calc_moments_rejects_bad_lambda_multimeas_length(self):
+        with self.assertRaisesRegex(ValueError, "lambdaMultimeas"):
+            KernelSMEFilter.calc_moments(
+                array([0.0, 0.0, 1.0, 1.0]),
+                eye(4),
+                eye(2),
+                eye(2),
+                array([[0.0], [0.0]]),
+                1.0,
+                2,
+                lambdaMultimeas=array([1.0, 2.0, 3.0]),
+            )
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),


### PR DESCRIPTION
## Summary
- replace optimizer-stripped Kernel SME filter assertions with explicit exceptions
- add regression coverage for unsupported inputs, gating-threshold misuse, backend-incompatible helpers, and invalid `lambdaMultimeas` lengths under optimized Python
- skip the PyTorch Sylvester backend contract test when `torch` is absent so NumPy-only jobs do not fail on an optional dependency while the CI guard is landing

## Validation
- `poetry run pytest tests/filters/test_kernel_sme_filter.py tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py`
- `poetry run python -O -m pytest tests/filters/test_kernel_sme_filter.py`
- `poetry run ruff check src/pyrecest/filters/kernel_sme_filter.py tests/filters/test_kernel_sme_filter.py tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py`
- `rg -n "assert " src/pyrecest/filters/kernel_sme_filter.py` returned no matches