### PR TITLE
Validate Gaussian mixture PHD inputs

### DIFF
--- a/src/pyrecest/filters/gaussian_mixture_phd_filter.py
+++ b/src/pyrecest/filters/gaussian_mixture_phd_filter.py
@@ -91,9 +91,11 @@ class GaussianMixturePHDFilter(
         log_prior_estimates: bool = True,
         log_posterior_estimates: bool = True,
     ):
-        assert (
-            pyrecest.backend.__backend_name__ == "numpy"
-        ), "Currently only supported for the numpy backend."
+        if pyrecest.backend.__backend_name__ != "numpy":
+            raise NotImplementedError(
+                "GaussianMixturePHDFilter is currently only supported for the "
+                "numpy backend."
+            )
 
         AbstractMultitargetTracker.__init__(
             self,
@@ -270,7 +272,8 @@ class GaussianMixturePHDFilter(
         survival_probability=None,
     ):
         if isinstance(sys_noise, GaussianDistribution):
-            assert all(sys_noise.mu == 0)
+            if not bool(all(sys_noise.mu == 0)):
+                raise ValueError("Gaussian system noise must have zero mean.")
             sys_noise_cov = sys_noise.C
         else:
             sys_noise_cov = sys_noise

--- a/tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py
+++ b/tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py
@@ -1,9 +1,12 @@
 """Regression tests for PyTorch Sylvester solver shortcuts."""
 
+import pytest
+
 from tests.support.backend_runner import run_backend_code
 
 
 def test_pytorch_semidefinite_sylvester_shortcut_respects_nonzero_denominators():
+    pytest.importorskip("torch")
     code = """
 import torch
 from pyrecest.backend import linalg

--- a/tests/filters/test_gaussian_mixture_phd_filter.py
+++ b/tests/filters/test_gaussian_mixture_phd_filter.py
@@ -1,5 +1,6 @@
 import copy
 import unittest
+from unittest.mock import patch
 
 import numpy.testing as npt
 
@@ -18,6 +19,14 @@ from pyrecest.filters.gaussian_mixture_phd_filter import (
     reason="Currently only supported for the numpy backend",
 )
 class TestGaussianMixturePHDFilter(unittest.TestCase):
+    def test_constructor_rejects_unsupported_backend(self):
+        with patch.object(pyrecest.backend, "__backend_name__", "jax"):
+            with self.assertRaisesRegex(NotImplementedError, "numpy backend"):
+                GaussianMixturePHDFilter(
+                    log_prior_estimates=False,
+                    log_posterior_estimates=False,
+                )
+
     def test_filter_state_roundtrip(self):
         component = GaussianDistribution(array([0.0, 0.0]), eye(2))
         tracker = GaussianMixturePHDFilter(
@@ -57,6 +66,22 @@ class TestGaussianMixturePHDFilter(unittest.TestCase):
         npt.assert_allclose(state.dists[0].C, 1.1 * eye(2))
         npt.assert_allclose(state.dists[1].mu, array([5.0, 5.0]))
         npt.assert_allclose(state.dists[1].C, 2.0 * eye(2))
+
+    def test_predict_linear_rejects_nonzero_mean_gaussian_system_noise(self):
+        tracker = GaussianMixturePHDFilter(
+            initial_components=[
+                GaussianDistribution(array([0.0, 0.0]), eye(2)),
+            ],
+            initial_weights=array([0.8]),
+            log_prior_estimates=False,
+            log_posterior_estimates=False,
+        )
+
+        with self.assertRaisesRegex(ValueError, "zero mean"):
+            tracker.predict_linear(
+                eye(2),
+                GaussianDistribution(array([1.0, 0.0]), 0.1 * eye(2)),
+            )
 
     def test_update_linear_extracts_reasonable_point_estimate(self):
         tracker = GaussianMixturePHDFilter(


### PR DESCRIPTION
## Summary
- replace optimized-away Gaussian mixture PHD backend and zero-mean noise asserts with explicit exceptions
- add regression coverage for unsupported backends and nonzero-mean Gaussian system noise
- skip the PyTorch backend-support regression when torch is not installed

## Tests
- poetry run pytest tests/filters/test_gaussian_mixture_phd_filter.py tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py
- poetry run python -O -m pytest tests/filters/test_gaussian_mixture_phd_filter.py
- poetry run ruff check src/pyrecest/filters/gaussian_mixture_phd_filter.py tests/filters/test_gaussian_mixture_phd_filter.py tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py