### PR TITLE
Validate JPDAF backend support

### DIFF
--- a/src/pyrecest/filters/joint_probabilistic_data_association_filter.py
+++ b/src/pyrecest/filters/joint_probabilistic_data_association_filter.py
@@ -74,6 +74,11 @@ class JointProbabilisticDataAssociationFilter(AbstractNearestNeighborTracker):
             self.filter_state = initial_prior
 
     @staticmethod
+    def _ensure_numpy_backend():
+        if pyrecest.backend.__backend_name__ != "numpy":
+            raise NotImplementedError("JPDAF is only supported for the numpy backend.")
+
+    @staticmethod
     def _get_measurement_covariance(cov_mats_meas, measurement_index):
         if cov_mats_meas.ndim == 2:
             return cov_mats_meas
@@ -154,9 +159,7 @@ class JointProbabilisticDataAssociationFilter(AbstractNearestNeighborTracker):
                 missed detection. The second entry is the most likely joint event,
                 encoded as measurement indices and ``-1`` for missed detections.
         """
-        assert (
-            pyrecest.backend.__backend_name__ == "numpy"
-        ), "Only supported for numpy backend"
+        self._ensure_numpy_backend()
 
         n_targets = self.get_number_of_targets()
         if n_targets == 0:
@@ -346,9 +349,7 @@ class JointProbabilisticDataAssociationFilter(AbstractNearestNeighborTracker):
         covMatsMeas,
         pairwise_cost_matrix=None,
     ):
-        assert (
-            pyrecest.backend.__backend_name__ == "numpy"
-        ), "Only supported for numpy backend"
+        self._ensure_numpy_backend()
         if pairwise_cost_matrix is not None:
             raise NotImplementedError("JPDAF does not support pairwise_cost_matrix.")
 

--- a/tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py
+++ b/tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py
@@ -1,9 +1,12 @@
 """Regression tests for PyTorch Sylvester solver shortcuts."""
 
+import pytest
+
 from tests.support.backend_runner import run_backend_code
 
 
 def test_pytorch_semidefinite_sylvester_shortcut_respects_nonzero_denominators():
+    pytest.importorskip("torch")
     code = """
 import torch
 from pyrecest.backend import linalg

--- a/tests/filters/test_joint_probabilistic_data_association_filter.py
+++ b/tests/filters/test_joint_probabilistic_data_association_filter.py
@@ -1,5 +1,6 @@
 import unittest
 import warnings
+from unittest.mock import patch
 
 import numpy.testing as npt
 
@@ -72,6 +73,34 @@ class JointProbabilisticDataAssociationFilterTest(unittest.TestCase):
             self.meas_cov,
         )
         npt.assert_array_equal(shuffled_map_association, array([1, 0]))
+
+    def test_find_association_probabilities_rejects_unsupported_backend(self):
+        tracker = JPDAF(self.kfs_init, association_param=self.association_param)
+        perfect_meas_ordered = (
+            self.meas_mat @ array([kf.get_point_estimate() for kf in self.kfs_init]).T
+        )
+
+        with patch.object(pyrecest.backend, "__backend_name__", "jax"):
+            with self.assertRaisesRegex(NotImplementedError, "numpy backend"):
+                tracker.find_association_probabilities(
+                    perfect_meas_ordered,
+                    self.meas_mat,
+                    self.meas_cov,
+                )
+
+    def test_update_linear_rejects_unsupported_backend(self):
+        tracker = JPDAF(self.kfs_init, association_param=self.association_param)
+        perfect_meas_ordered = (
+            self.meas_mat @ array([kf.get_point_estimate() for kf in self.kfs_init]).T
+        )
+
+        with patch.object(pyrecest.backend, "__backend_name__", "jax"):
+            with self.assertRaisesRegex(NotImplementedError, "numpy backend"):
+                tracker.update_linear(
+                    perfect_meas_ordered,
+                    self.meas_mat,
+                    self.meas_cov,
+                )
 
     def test_gated_measurements_do_not_emit_no_measurement_warning(self):
         tracker = JPDAF(self.kfs_init, association_param=self.association_param)


### PR DESCRIPTION
## Summary
- replace optimized-away JPDAF backend asserts with explicit NotImplementedError checks
- cover association-probability and update entry points under patched unsupported backends
- skip the PyTorch backend-support regression when torch is not installed

## Tests
- poetry run pytest tests/filters/test_joint_probabilistic_data_association_filter.py tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py
- poetry run python -O -m pytest tests/filters/test_joint_probabilistic_data_association_filter.py
- poetry run ruff check src/pyrecest/filters/joint_probabilistic_data_association_filter.py tests/filters/test_joint_probabilistic_data_association_filter.py tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py