### PR TITLE
Validate replay IMM backend support

### DIFF
--- a/src/pyrecest/filters/goal_conditioned_replay_imm_filter.py
+++ b/src/pyrecest/filters/goal_conditioned_replay_imm_filter.py
@@ -142,9 +142,10 @@ class GoalConditionedReplayIMMFilter(  # pylint: disable=too-many-instance-attri
         weight_floor: float = 1e-300,
         finite_difference_epsilon: float = 1e-5,
     ):
-        assert (
-            pyrecest.backend.__backend_name__ != "jax"
-        ), "GoalConditionedReplayIMMFilter is not supported on the JAX backend"
+        if pyrecest.backend.__backend_name__ == "jax":
+            raise NotImplementedError(
+                "GoalConditionedReplayIMMFilter is not supported on the JAX backend"
+            )
         raw_mean, raw_cov = self._extract_mean_and_cov(initial_state)
         raw_state_dim = raw_mean.shape[0]
 

--- a/tests/filters/test_goal_conditioned_replay_imm_filter.py
+++ b/tests/filters/test_goal_conditioned_replay_imm_filter.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 # pylint: disable=no-name-in-module,no-member
 import pyrecest.backend
@@ -12,6 +13,14 @@ from .test_goal_conditioned_replay_common import (
 
 
 class TestGoalConditionedReplayIMMFilter(unittest.TestCase):
+    def test_constructor_rejects_jax_backend(self):
+        with patch.object(pyrecest.backend, "__backend_name__", "jax"):
+            with self.assertRaisesRegex(NotImplementedError, "JAX backend"):
+                GoalConditionedReplayIMMFilter(
+                    initial_state=(array([0.0, 0.0]), 0.01 * eye(2)),
+                    candidate_goals=array([[1.0, 0.0]]),
+                )
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",
         reason="Not supported on this backend",


### PR DESCRIPTION
## Summary
- replace the optimized-away JAX backend assert in GoalConditionedReplayIMMFilter with NotImplementedError
- add optimized-mode regression coverage for constructor backend validation

## Tests
- poetry run pytest tests/filters/test_goal_conditioned_replay_imm_filter.py tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py
- poetry run python -O -m pytest tests/filters/test_goal_conditioned_replay_imm_filter.py
- poetry run ruff check src/pyrecest/filters/goal_conditioned_replay_imm_filter.py tests/filters/test_goal_conditioned_replay_imm_filter.py tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py