### PR TITLE
Validate multisession backend support

### DIFF
--- a/src/pyrecest/utils/multisession_assignment.py
+++ b/src/pyrecest/utils/multisession_assignment.py
@@ -56,6 +56,11 @@ SessionSizesInput = Mapping[int, int] | Sequence[int]
 TrackInput = Mapping[int, int] | Sequence[Observation]
 
 
+def _ensure_supported_backend(feature_name: str) -> None:
+    if __backend_name__ == "jax":
+        raise NotImplementedError(f"{feature_name} is not supported on the JAX backend.")
+
+
 def _full_1d(size: int, fill_value: int | float, dtype: Any) -> Any:
     return full((int(size),), fill_value, dtype=dtype)
 
@@ -179,7 +184,7 @@ def solve_multisession_assignment(  # pylint: disable=too-many-locals
     its own dummy "unmatched" column.
     """
 
-    assert __backend_name__ != "jax", "Not supported on JAX backend"
+    _ensure_supported_backend("solve_multisession_assignment")
 
     _validate_scalar_cost("start_cost", start_cost)
     _validate_scalar_cost("end_cost", end_cost)
@@ -315,7 +320,7 @@ def tracks_to_session_labels(
         One integer array per session, indexed by session number.
     """
 
-    assert __backend_name__ != "jax", "Not supported on JAX backend"
+    _ensure_supported_backend("tracks_to_session_labels")
 
     inferred_sizes, max_session_index = _validate_track_session_sizes(
         tracks,

--- a/src/pyrecest/utils/multisession_assignment_observation_costs.py
+++ b/src/pyrecest/utils/multisession_assignment_observation_costs.py
@@ -41,6 +41,11 @@ ObservationCostsInput = (
 )
 
 
+def _ensure_supported_backend(feature_name: str) -> None:
+    if __backend_name__ == "jax":
+        raise NotImplementedError(f"{feature_name} is not supported on the JAX backend.")
+
+
 @dataclass(frozen=True)
 class _ObservationCostTransform:
     session_positions: Mapping[int, int]
@@ -64,7 +69,7 @@ def solve_multisession_assignment_with_observation_costs(  # pylint: disable=R09
     cost_threshold: float | None = None,
 ) -> MultiSessionAssignmentResult:
     """Solve multi-session assignment with per-observation start/end costs."""
-    assert __backend_name__ != "jax", "Not supported on JAX backend"
+    _ensure_supported_backend("solve_multisession_assignment_with_observation_costs")
 
     _validate_scalar_cost("start_cost", start_cost)
     _validate_scalar_cost("end_cost", end_cost)

--- a/src/pyrecest/utils/multisession_assignment_score.py
+++ b/src/pyrecest/utils/multisession_assignment_score.py
@@ -35,6 +35,11 @@ from .multisession_assignment import (
 )
 
 
+def _ensure_supported_backend(feature_name: str) -> None:
+    if __backend_name__ == "jax":
+        raise NotImplementedError(f"{feature_name} is not supported on the JAX backend.")
+
+
 def _default_score_to_cost(scores: Any) -> Any:
     return -asarray(scores, dtype=float)
 
@@ -73,7 +78,7 @@ def tracks_to_index_matrix(
     fill_value: int = -1,
 ):
     """Convert tracks to a dense ``track x session`` ROI-index matrix."""
-    assert __backend_name__ != "jax", "Not supported on JAX backend"
+    _ensure_supported_backend("tracks_to_index_matrix")
 
     _, max_session_index = _validate_track_session_sizes(
         tracks,
@@ -100,7 +105,7 @@ def solve_multisession_assignment_from_similarity(  # pylint: disable=R0913,R091
     score_to_cost: Callable[[Any], Any] | None = None,
 ) -> MultiSessionAssignmentResult:
     """Score-native wrapper around :func:`solve_multisession_assignment`."""
-    assert __backend_name__ != "jax", "Not supported on JAX backend"
+    _ensure_supported_backend("solve_multisession_assignment_from_similarity")
 
     if min_score is not None and not math.isfinite(min_score):
         raise ValueError("min_score must be finite.")

--- a/tests/test_multisession_assignment.py
+++ b/tests/test_multisession_assignment.py
@@ -11,6 +11,9 @@ from pyrecest.backend import (  # pylint: disable=no-name-in-module
 )
 from pyrecest.utils import multisession_assignment as multisession_assignment_module
 from pyrecest.utils import (
+    multisession_assignment_score as multisession_assignment_score_module,
+)
+from pyrecest.utils import (
     solve_multisession_assignment,
     solve_multisession_assignment_from_similarity,
     tracks_to_session_labels,
@@ -21,6 +24,34 @@ class TestMultiSessionAssignment(unittest.TestCase):
     @staticmethod
     def _canonical_tracks(tracks):
         return sorted(tuple(sorted(track.items())) for track in tracks)
+
+    def test_solve_multisession_assignment_rejects_jax_backend(self):
+        with patch.object(multisession_assignment_module, "__backend_name__", "jax"):
+            with self.assertRaisesRegex(NotImplementedError, "JAX backend"):
+                solve_multisession_assignment({}, session_sizes=[1])
+
+    def test_tracks_to_session_labels_rejects_jax_backend(self):
+        with patch.object(multisession_assignment_module, "__backend_name__", "jax"):
+            with self.assertRaisesRegex(NotImplementedError, "JAX backend"):
+                tracks_to_session_labels([{0: 0}])
+
+    def test_similarity_wrapper_rejects_jax_backend(self):
+        with patch.object(
+            multisession_assignment_score_module,
+            "__backend_name__",
+            "jax",
+        ):
+            with self.assertRaisesRegex(NotImplementedError, "JAX backend"):
+                solve_multisession_assignment_from_similarity([array([[1.0]])])
+
+    def test_tracks_to_index_matrix_rejects_jax_backend(self):
+        with patch.object(
+            multisession_assignment_score_module,
+            "__backend_name__",
+            "jax",
+        ):
+            with self.assertRaisesRegex(NotImplementedError, "JAX backend"):
+                multisession_assignment_score_module.tracks_to_index_matrix([{0: 0}])
 
     @unittest.skipIf(
         __backend_name__ == "jax",

--- a/tests/test_multisession_assignment_observation_costs.py
+++ b/tests/test_multisession_assignment_observation_costs.py
@@ -2,10 +2,14 @@
 """Tests for observation-specific multi-session assignment costs."""
 
 import unittest
+from unittest.mock import patch
 
 from pyrecest.backend import (  # pylint: disable=no-name-in-module
     __backend_name__,
     array,
+)
+from pyrecest.utils import (
+    multisession_assignment_observation_costs as observation_costs_module,
 )
 from pyrecest.utils import (
     solve_multisession_assignment,
@@ -21,6 +25,13 @@ class TestMultiSessionAssignmentObservationCosts(unittest.TestCase):
     @staticmethod
     def _canonical_tracks(tracks):
         return sorted(tuple(sorted(track.items())) for track in tracks)
+
+    def test_observation_cost_wrapper_rejects_jax_backend(self):
+        with patch.object(observation_costs_module, "__backend_name__", "jax"):
+            with self.assertRaisesRegex(NotImplementedError, "JAX backend"):
+                solve_multisession_assignment_with_observation_costs(
+                    [array([[1.0]])],
+                )
 
     def test_matches_base_solver_when_costs_are_uniform(self):
         pairwise_costs = [


### PR DESCRIPTION
## Summary
- replace optimized-away JAX backend asserts in multisession assignment utilities with explicit NotImplementedError checks
- cover base, label, score, index-matrix, and observation-cost entry points under patched JAX backend names

## Tests
- poetry run pytest tests/test_multisession_assignment.py tests/test_multisession_assignment_observation_costs.py tests/test_multisession_assignment_validation.py tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py
- poetry run python -O -m pytest tests/test_multisession_assignment.py tests/test_multisession_assignment_observation_costs.py tests/test_multisession_assignment_validation.py
- poetry run ruff check src/pyrecest/utils/multisession_assignment.py src/pyrecest/utils/multisession_assignment_observation_costs.py src/pyrecest/utils/multisession_assignment_score.py tests/test_multisession_assignment.py tests/test_multisession_assignment_observation_costs.py tests/test_multisession_assignment_validation.py tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py