### PR TITLE
Validate cart-product Dirac inputs

### DIFF
--- a/src/pyrecest/distributions/cart_prod/lin_bounded_cart_prod_dirac_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/lin_bounded_cart_prod_dirac_distribution.py
@@ -47,6 +47,9 @@ class LinBoundedCartProdDiracDistribution(
         Needs to be overwritten to allow the specification of bound_dim for Cartesian
         products of bounded and Euclidean manifolds
         """
-        assert cls.is_valid_for_conversion(distribution)
+        if not cls.is_valid_for_conversion(distribution):
+            raise TypeError(
+                "distribution is not valid for conversion to this Dirac type"
+            )
         samples = distribution.sample(n_particles)
         return cls(distribution.bound_dim, samples)

--- a/src/pyrecest/distributions/cart_prod/lin_hypersphere_cart_prod_dirac_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/lin_hypersphere_cart_prod_dirac_distribution.py
@@ -12,9 +12,11 @@ class LinHypersphereCartProdDiracDistribution(
 ):
     def __init__(self, bound_dim, d, w=None):
         d = asarray(d)
-        assert (
-            amax(abs(linalg.norm(d[:, : (bound_dim + 1)], None, -1) - 1), 0) < 1e-5
-        ), "The hypersphere ssubset part of d must be normalized"
+        if not bool(
+            amax(abs(linalg.norm(d[:, : (bound_dim + 1)], None, -1) - 1), 0)
+            < 1e-5
+        ):
+            raise ValueError("The hypersphere subset part of d must be normalized")
         AbstractSE3Distribution.__init__(self)
         LinBoundedCartProdDiracDistribution.__init__(self, d, w)
 

--- a/tests/distributions/test_hypercylindrical_dirac_distribution.py
+++ b/tests/distributions/test_hypercylindrical_dirac_distribution.py
@@ -19,6 +19,7 @@ from pyrecest.backend import (
     sum,
     zeros_like,
 )
+from pyrecest.distributions import GaussianDistribution
 from pyrecest.distributions.cart_prod.hypercylindrical_dirac_distribution import (
     HypercylindricalDiracDistribution,
 )
@@ -134,6 +135,12 @@ class TestHypercylindricalDiracDistribution(TestAbstractDiracDistribution):
         hwn = PartiallyWrappedNormalDistribution(array([1.0, 2.0, 3.0, 4.0]), C, 2)
         hddist = HypercylindricalDiracDistribution.from_distribution(hwn, 200000)
         npt.assert_allclose(hddist.hybrid_mean(), hwn.hybrid_mean(), atol=0.2)
+
+    def test_from_distribution_rejects_wrong_source_type(self):
+        source = GaussianDistribution(array([0.0, 0.0]), eye(2))
+
+        with self.assertRaisesRegex(TypeError, "valid for conversion"):
+            HypercylindricalDiracDistribution.from_distribution(source, 3)
 
     # jscpd:ignore-start
     @parameterized.expand(

--- a/tests/distributions/test_se3_dirac_distribution.py
+++ b/tests/distributions/test_se3_dirac_distribution.py
@@ -45,6 +45,12 @@ class SE3DiracDistributionTest(unittest.TestCase):
         npt.assert_allclose(dist.w, array(weights))
         self.assertEqual(dist.d.shape, (2, 7))
 
+    def test_constructor_rejects_non_unit_hypersphere_particles(self):
+        particles = array([[2.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0]])
+
+        with self.assertRaisesRegex(ValueError, "normalized"):
+            SE3DiracDistribution(particles)
+
     def test_from_distribution(self):
         cpsd = SE3CartProdStackedDistribution(
             [


### PR DESCRIPTION
## Summary
- replace optimized-away cart-product Dirac conversion and hypersphere normalization asserts with explicit exceptions
- add regression coverage for invalid conversion sources and non-unit SE3 particles under optimized Python

## Tests
- poetry run pytest tests/distributions/test_hypercylindrical_dirac_distribution.py tests/distributions/test_se3_dirac_distribution.py tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py
- poetry run python -O -m pytest tests/distributions/test_hypercylindrical_dirac_distribution.py tests/distributions/test_se3_dirac_distribution.py
- poetry run ruff check src/pyrecest/distributions/cart_prod/lin_bounded_cart_prod_dirac_distribution.py src/pyrecest/distributions/cart_prod/lin_hypersphere_cart_prod_dirac_distribution.py tests/distributions/test_hypercylindrical_dirac_distribution.py tests/distributions/test_se3_dirac_distribution.py tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py