### PR TITLE
Validate grid distribution inputs

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/hyperhemispherical_grid_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/hyperhemispherical_grid_distribution.py
@@ -35,12 +35,10 @@ class HyperhemisphericalGridDistribution(
 
     def __init__(self, grid, grid_values, enforce_pdf_nonnegative=True):
         # Do not test norm precisely, only quick test if any coordinate exceeds 1.
-        assert all(
-            abs(grid) <= 1 + 1e-12
-        ), "Grid points must not lie outside the unit cube."
-        assert all(
-            grid[:, -1] >= -1e-12
-        ), "Always using upper hemisphere (along last dimension)."
+        if not bool(all(abs(grid) <= 1 + 1e-12)):
+            raise ValueError("Grid points must not lie outside the unit cube.")
+        if not bool(all(grid[:, -1] >= -1e-12)):
+            raise ValueError("Always using upper hemisphere along the last dimension.")
 
         super().__init__(grid, grid_values, enforce_pdf_nonnegative)
 
@@ -71,11 +69,12 @@ class HyperhemisphericalGridDistribution(
         The grid is mirrored, and the values are halved to keep the resulting
         hyperspherical distribution normalized.
         """
-        assert method == "antipodal", (
-            "Currently only 'antipodal' method is supported for "
-            "converting hyperhemispherical grid distributions to "
-            "full-sphere grid distributions."
-        )
+        if method != "antipodal":
+            raise ValueError(
+                "Currently only 'antipodal' method is supported for "
+                "converting hyperhemispherical grid distributions to "
+                "full-sphere grid distributions."
+            )
         from .hyperspherical_grid_distribution import HypersphericalGridDistribution
 
         grid_full = vstack((self.grid, -self.grid))
@@ -246,10 +245,11 @@ class HyperhemisphericalGridDistribution(
         depends on (dim, no_of_grid_points, grid_type). For 'healpix',
         only dim == 3 is supported and `healpy` must be installed.
         """
-        assert grid_type in (
-            "leopardi_symm",
-            "healpix",
-        ), "For hyperhemispheres, use one of the symmetric grid types 'leopardi_symm' or 'healpix'."
+        if grid_type not in ("leopardi_symm", "healpix"):
+            raise ValueError(
+                "For hyperhemispheres, use one of the symmetric grid types "
+                "'leopardi_symm' or 'healpix'."
+            )
         grid, _ = get_grid_hyperhemisphere(grid_type, no_of_grid_points, dim=dim)
 
         grid_values = fun(grid)

--- a/src/pyrecest/distributions/hypersphere_subset/spherical_grid_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/spherical_grid_distribution.py
@@ -70,7 +70,8 @@ class SphericalGridDistribution(
         use_harmonics = False -> piecewise constant interpolation via self.pdf(..., False).
         use_harmonics = True -> spherical harmonics interpolation (currently unsupported).
         """
-        assert not use_harmonics, "Using spherical harmonics currently unsupported"
+        if use_harmonics:
+            raise NotImplementedError("Using spherical harmonics is currently unsupported")
         chd = CustomHypersphericalDistribution(
             lambda x: self.pdf(x, use_harmonics=False),
             self.dim,
@@ -107,7 +108,8 @@ class SphericalGridDistribution(
         else:
             raise ValueError("xs must be 1D or 2D array.")
 
-        assert not use_harmonics, "Using spherical harmonics currently unsupported"
+        if use_harmonics:
+            raise NotImplementedError("Using spherical harmonics is currently unsupported")
 
         dots = self.grid @ xs.T
         max_index = argmax(dots, axis=0)
@@ -127,7 +129,8 @@ class SphericalGridDistribution(
         """
         Construct a SphericalGridDistribution from an AbstractHypersphericalDistribution.
         """
-        assert distribution.dim == 2
+        if distribution.dim != 2:
+            raise ValueError("SphericalGridDistribution requires a two-dimensional source")
         return SphericalGridDistribution.from_function(
             distribution.pdf,
             no_of_grid_points,
@@ -151,9 +154,10 @@ class SphericalGridDistribution(
             - 'leopardi' : Leopardi equal point set on S²
             - 'sh_grid'      : spherical harmonics grid (lat/lon mesh).
         """
-        assert (
-            dim == 2
-        ), "Use HypersphericalGridDistribution for dimensions other than 2."
+        if dim != 2:
+            raise ValueError(
+                "Use HypersphericalGridDistribution for dimensions other than 2."
+            )
         if grid_type == "leopardi":
             # Reuse HypersphericalGridDistribution's generator in 3D
             ls = LeopardiSampler()

--- a/tests/distributions/test_hyperhemispherical_grid_distribution.py
+++ b/tests/distributions/test_hyperhemispherical_grid_distribution.py
@@ -25,6 +25,37 @@ class HyperhemisphericalGridDistributionTest(unittest.TestCase):
     def _normalized_grid_values(grid_distribution, raw_values):
         return raw_values / (grid_distribution.get_manifold_size() * mean(raw_values))
 
+    def test_constructor_rejects_grid_points_outside_unit_cube(self):
+        with self.assertRaisesRegex(ValueError, "unit cube"):
+            HyperhemisphericalGridDistribution(
+                array([[1.5, 0.0, 1.0]]),
+                array([1.0]),
+            )
+
+    def test_constructor_rejects_lower_hemisphere_grid_points(self):
+        with self.assertRaisesRegex(ValueError, "upper hemisphere"):
+            HyperhemisphericalGridDistribution(
+                array([[0.0, 0.0, -1.0]]),
+                array([1.0]),
+            )
+
+    def test_to_full_sphere_rejects_unsupported_method(self):
+        dist = HyperhemisphericalGridDistribution(
+            array([[0.0, 0.0, 1.0]]),
+            array([1.0]),
+        )
+
+        with self.assertRaisesRegex(ValueError, "antipodal"):
+            dist.to_full_sphere(method="copy")
+
+    def test_from_function_rejects_unknown_grid_type(self):
+        with self.assertRaisesRegex(ValueError, "symmetric grid types"):
+            HyperhemisphericalGridDistribution.from_function(
+                lambda xs: array([1.0] * xs.shape[0]),
+                42,
+                grid_type="leopardi",
+            )
+
     # ------------------------------------------------------------------ #
     # Warning tests (testWarningAsymm)
     # ------------------------------------------------------------------ #

--- a/tests/distributions/test_hypersphere_grid_intrinsic_dimension.py
+++ b/tests/distributions/test_hypersphere_grid_intrinsic_dimension.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy.testing as npt
 import pyrecest
-from pyrecest.backend import pi
+from pyrecest.backend import array, ones, pi
 from pyrecest.distributions.hypersphere_subset.hyperhemispherical_grid_distribution import (
     HyperhemisphericalGridDistribution,
 )
@@ -49,6 +49,41 @@ class HypersphereGridIntrinsicDimensionTest(unittest.TestCase):
         npt.assert_allclose(sgd.get_manifold_size(), 4 * pi, rtol=0, atol=1e-12)
         npt.assert_allclose(sgd.integrate(), 1.0, rtol=0, atol=1e-12)
         npt.assert_allclose(sgd.pdf(sgd.get_grid()[:3]), sgd.grid_values[:3])
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on this backend",
+    )
+    def test_spherical_grid_rejects_unsupported_harmonic_interpolation(self):
+        dist = SphericalGridDistribution.from_function(
+            lambda xs: ones(xs.shape[0]),
+            42,
+        )
+
+        with self.assertRaisesRegex(NotImplementedError, "harmonics"):
+            dist.pdf(array([0.0, 0.0, 1.0]), use_harmonics=True)
+
+        with self.assertRaisesRegex(NotImplementedError, "harmonics"):
+            dist.plot_interpolated(use_harmonics=True)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on this backend",
+    )
+    def test_spherical_grid_rejects_wrong_intrinsic_dimension(self):
+        with self.assertRaisesRegex(ValueError, "two-dimensional"):
+            SphericalGridDistribution.from_distribution(
+                HypersphericalUniformDistribution(3),
+                42,
+                "leopardi",
+            )
+
+        with self.assertRaisesRegex(ValueError, "dimensions other than 2"):
+            SphericalGridDistribution.from_function(
+                lambda xs: ones(xs.shape[0]),
+                42,
+                dim=3,
+            )
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member


### PR DESCRIPTION
## Summary
- replace optimized-away spherical and hyperhemispherical grid distribution asserts with explicit exceptions
- cover unsupported harmonic interpolation, wrong intrinsic dimensions, invalid hemisphere grids, unsupported full-sphere methods, and unknown grid types

## Tests
- poetry run pytest tests/distributions/test_hypersphere_grid_intrinsic_dimension.py tests/distributions/test_hyperhemispherical_grid_distribution.py tests/distributions/test_spherical_grid_distribution_driscoll_healy.py tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py
- poetry run python -O -m pytest tests/distributions/test_hypersphere_grid_intrinsic_dimension.py tests/distributions/test_hyperhemispherical_grid_distribution.py tests/distributions/test_spherical_grid_distribution_driscoll_healy.py
- poetry run ruff check src/pyrecest/distributions/hypersphere_subset/spherical_grid_distribution.py src/pyrecest/distributions/hypersphere_subset/hyperhemispherical_grid_distribution.py tests/distributions/test_hypersphere_grid_intrinsic_dimension.py tests/distributions/test_hyperhemispherical_grid_distribution.py tests/distributions/test_spherical_grid_distribution_driscoll_healy.py tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py