### PR TITLE
Validate SE plotting inputs

### DIFF
--- a/src/pyrecest/distributions/abstract_se2_distribution.py
+++ b/src/pyrecest/distributions/abstract_se2_distribution.py
@@ -44,9 +44,8 @@ class AbstractSE2Distribution(AbstractHypercylindricalDistribution):
 
     # pylint: disable=too-many-locals
     def plot_state(self, scaling_factor=1, circle_color=None, angle_color=None):
-        assert (
-            pyrecest.backend.__backend_name__ != "jax"
-        ), "plot_state is not supported for the JAX backend."
+        if pyrecest.backend.__backend_name__ == "jax":
+            raise NotImplementedError("plot_state is not supported for the JAX backend.")
 
         if circle_color is None:
             circle_color = array([0, 0.4470, 0.7410])

--- a/src/pyrecest/distributions/abstract_se3_distribution.py
+++ b/src/pyrecest/distributions/abstract_se3_distribution.py
@@ -111,7 +111,10 @@ class AbstractSE3Distribution(AbstractLinBoundedCartProdDistribution):
 
     @staticmethod
     def plot_trajectory(periodicStates, linStates, animate=False, delay=0.05):
-        assert periodicStates.shape[1] == linStates.shape[1]
+        if periodicStates.shape[1] != linStates.shape[1]:
+            raise ValueError(
+                "periodicStates and linStates must contain the same number of samples"
+            )
         h = []
         for i in range(periodicStates.shape[1]):
             h.append(

--- a/tests/distributions/test_abstract_se2_distribution.py
+++ b/tests/distributions/test_abstract_se2_distribution.py
@@ -1,13 +1,32 @@
 import unittest
+from unittest.mock import patch
 
 import matplotlib.pyplot as plt
 import numpy.testing as npt
 from parameterized import parameterized
+import pyrecest.backend
 from pyrecest.backend import arange, column_stack, linspace, mod, pi, random
 from pyrecest.distributions.abstract_se2_distribution import AbstractSE2Distribution
 
 
+class _ConcreteSE2Distribution(AbstractSE2Distribution):
+    def marginalize_linear(self):
+        return None
+
+    def marginalize_periodic(self):
+        return None
+
+    def pdf(self, _):
+        return None
+
+
 class AbstractSE2DistributionTest(unittest.TestCase):
+    def test_plot_state_rejects_jax_backend(self):
+        dist = _ConcreteSE2Distribution()
+
+        with patch.object(pyrecest.backend, "__backend_name__", "jax"):
+            with self.assertRaisesRegex(NotImplementedError, "JAX backend"):
+                dist.plot_state()
 
     @parameterized.expand(
         [

--- a/tests/distributions/test_se3_dirac_distribution.py
+++ b/tests/distributions/test_se3_dirac_distribution.py
@@ -10,6 +10,7 @@ from pyrecest.distributions import (
     GaussianDistribution,
     HyperhemisphericalUniformDistribution,
 )
+from pyrecest.distributions.abstract_se3_distribution import AbstractSE3Distribution
 from pyrecest.distributions.se3_cart_prod_stacked_distribution import (
     SE3CartProdStackedDistribution,
 )
@@ -17,6 +18,13 @@ from pyrecest.distributions.se3_dirac_distribution import SE3DiracDistribution
 
 
 class SE3DiracDistributionTest(unittest.TestCase):
+    def test_plot_trajectory_rejects_mismatched_sample_counts(self):
+        periodic_states = array([[1.0, 0.0], [0.0, 1.0], [0.0, 0.0], [0.0, 0.0]])
+        lin_states = array([[0.0], [0.0], [0.0]])
+
+        with self.assertRaisesRegex(ValueError, "same number of samples"):
+            AbstractSE3Distribution.plot_trajectory(periodic_states, lin_states)
+
     def test_constructor(self):
         dSph = array(
             [


### PR DESCRIPTION
## Summary
- Replace assertion-only SE2 JAX plotting guard with a runtime `NotImplementedError`.
- Raise `ValueError` when SE3 trajectory plotting receives mismatched periodic and linear sample counts.
- Add regression tests for both validation paths.

## Tests
- `poetry run pytest tests/distributions/test_abstract_se2_distribution.py tests/distributions/test_se3_dirac_distribution.py tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py`
- `$env:MPLBACKEND='Agg'; poetry run python -O -m pytest tests/distributions/test_abstract_se2_distribution.py tests/distributions/test_se3_dirac_distribution.py`
- `poetry run ruff check src/pyrecest/distributions/abstract_se2_distribution.py src/pyrecest/distributions/abstract_se3_distribution.py tests/distributions/test_abstract_se2_distribution.py tests/distributions/test_se3_dirac_distribution.py tests/backend_support/test_pytorch_sylvester_semidefinite_shortcut.py`
- `git diff --check --cached`