### PR TITLE
Fix URTS smoother backend guard

### DIFF
--- a/src/pyrecest/smoothers/unscented_rauch_tung_striebel_smoother.py
+++ b/src/pyrecest/smoothers/unscented_rauch_tung_striebel_smoother.py
@@ -50,10 +50,11 @@ class UnscentedRauchTungStriebelSmoother(AbstractSmoother):
         backend_name: str = getattr(
             pyrecest.backend, "__backend_name__", ""
         )  # pylint: disable=no-member
-        assert backend_name not in (
-            "pytorch",
-            "jax",
-        ), "Not supported on this backend"
+        if backend_name in ("pytorch", "jax"):
+            raise NotImplementedError(
+                "UnscentedRauchTungStriebelSmoother is not supported on the "
+                f"{backend_name} backend."
+            )
 
     @staticmethod
     def _normalize_callable_sequence(

--- a/tests/smoothers/test_unscented_rauch_tung_striebel_smoother.py
+++ b/tests/smoothers/test_unscented_rauch_tung_striebel_smoother.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 import numpy.testing as npt
 
@@ -12,6 +13,17 @@ from pyrecest.smoothers import UnscentedRauchTungStriebelSmoother
 
 
 class UnscentedRauchTungStriebelSmootherTest(unittest.TestCase):
+    def test_unsupported_backend_guard_is_not_optimized_away(self):
+        smoother = UnscentedRauchTungStriebelSmoother()
+
+        for backend_name in ("pytorch", "jax"):
+            with self.subTest(backend=backend_name):
+                with patch.object(pyrecest.backend, "__backend_name__", backend_name):
+                    with self.assertRaisesRegex(
+                        NotImplementedError, f"{backend_name} backend"
+                    ):
+                        smoother.smooth([], [], [])
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
         reason="Not supported on this backend",


### PR DESCRIPTION
## Summary
- replace the unscented RTS smoother's unsupported-backend `assert` with an explicit `NotImplementedError`
- add regression coverage that patches both PyTorch and JAX backend names and verifies the guard still raises

## Validation
- `python -m py_compile` on the touched source and test files locally in the execution environment
- diff check via GitHub compare: 2 files, +17/-4