### PR TITLE
Harden nearest-neighbor tracker validation

### DIFF
--- a/src/pyrecest/filters/abstract_nearest_neighbor_tracker.py
+++ b/src/pyrecest/filters/abstract_nearest_neighbor_tracker.py
@@ -6,6 +6,7 @@ from abc import abstractmethod
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import any as backend_any
 from pyrecest.backend import ndim, stack
 from pyrecest.distributions import GaussianDistribution
 
@@ -31,6 +32,35 @@ class AbstractNearestNeighborTracker(AbstractMultitargetTracker):
             self.filter_state = initial_prior
         else:
             self._filter_state = None
+
+    @staticmethod
+    def _ensure_numpy_backend():
+        if pyrecest.backend.__backend_name__ != "numpy":
+            raise NotImplementedError(
+                "Nearest-neighbor trackers are only supported for the numpy backend."
+            )
+
+    @staticmethod
+    def _validate_unique_filter_handles(new_state):
+        if any(
+            id(new_state[i]) == id(new_state[j])
+            for i in range(len(new_state))
+            for j in range(i + 1, len(new_state))
+        ):
+            raise ValueError(
+                "No two filters of the filter bank should have the same handle. "
+                "Updating the state of one target would update it for all!"
+            )
+
+    def _validate_measurement_matrix_shape(self, measurement_matrix, measurements):
+        if (
+            measurement_matrix.shape[0] != measurements.shape[0]
+            or measurement_matrix.shape[1]
+            != self.filter_bank[0].get_point_estimate().shape[0]
+        ):
+            raise ValueError(
+                "Dimensions of measurement matrix must match state and measurement dimensions."
+            )
 
     @abstractmethod
     def find_association(self, measurements, measurement_matrix, cov_mats_meas):
@@ -64,11 +94,7 @@ class AbstractNearestNeighborTracker(AbstractMultitargetTracker):
         if isinstance(new_state, list) and all(
             isinstance(item, EuclideanFilterMixin) for item in new_state
         ):
-            assert all(
-                id(new_state[i]) != id(new_state[j])
-                for i in range(len(new_state))
-                for j in range(i + 1, len(new_state))
-            ), "No two filters of the filter bank should have the same handle. Updating the state of one target would update it for all!"
+            self._validate_unique_filter_handles(new_state)
             self.filter_bank = copy.deepcopy(new_state)
         else:
             self.filter_bank = [
@@ -83,12 +109,15 @@ class AbstractNearestNeighborTracker(AbstractMultitargetTracker):
             warnings.warn("Currently, there are zero targets.")
             return
 
-        assert all(
-            dim == self.filter_bank[0].dim for dim in system_matrices.shape[:2]
-        ), "system_matrices may be a single (dimSingleState, dimSingleState) matrix or a (dimSingleState, dimSingleState, noTargets) tensor."
+        if any(dim != self.filter_bank[0].dim for dim in system_matrices.shape[:2]):
+            raise ValueError(
+                "system_matrices may be a single (dimSingleState, dimSingleState) matrix or a "
+                "(dimSingleState, dimSingleState, noTargets) tensor."
+            )
 
         if isinstance(sys_noises, GaussianDistribution):
-            assert all(sys_noises.mu == 0)
+            if backend_any(sys_noises.mu != 0):
+                raise ValueError("Gaussian system noise distributions must have zero mean.")
             sys_noises = sys_noises.C
 
         curr_sys_matrix = system_matrices
@@ -117,17 +146,11 @@ class AbstractNearestNeighborTracker(AbstractMultitargetTracker):
         covMatsMeas,
         pairwise_cost_matrix=None,
     ):
-        assert (
-            pyrecest.backend.__backend_name__ == "numpy"
-        ), "Only supported for numpy backend"
+        self._ensure_numpy_backend()
         if len(self.filter_bank) == 0:
             warnings.warn("Currently, there are zero targets")
             return
-        assert (
-            measurement_matrix.shape[0] == measurements.shape[0]
-            and measurement_matrix.shape[1]
-            == self.filter_bank[0].get_point_estimate().shape[0]
-        ), "Dimensions of measurement matrix must match state and measurement dimensions."
+        self._validate_measurement_matrix_shape(measurement_matrix, measurements)
 
         if pairwise_cost_matrix is None:
             association = self.find_association(

--- a/src/pyrecest/filters/global_nearest_neighbor.py
+++ b/src/pyrecest/filters/global_nearest_neighbor.py
@@ -1,7 +1,6 @@
 # pylint: disable=redefined-builtin,no-name-in-module,no-member,duplicate-code
 import warnings
 
-import pyrecest.backend
 from pyrecest.backend import (
     all,
     any,
@@ -261,17 +260,11 @@ class GlobalNearestNeighbor(AbstractNearestNeighborTracker):
         pairwise_cost_matrix=None,
     ):
         """Update the tracker with an optional additional association cost matrix."""
-        assert (
-            pyrecest.backend.__backend_name__ == "numpy"
-        ), "Only supported for numpy backend"
+        self._ensure_numpy_backend()
         if len(self.filter_bank) == 0:
             warnings.warn("Currently, there are zero targets")
             return
-        assert (
-            measurement_matrix.shape[0] == measurements.shape[0]
-            and measurement_matrix.shape[1]
-            == self.filter_bank[0].get_point_estimate().shape[0]
-        ), "Dimensions of measurement matrix must match state and measurement dimensions."
+        self._validate_measurement_matrix_shape(measurement_matrix, measurements)
         association = self.find_association(
             measurements,
             measurement_matrix,

--- a/tests/filters/test_nearest_neighbor_validation.py
+++ b/tests/filters/test_nearest_neighbor_validation.py
@@ -1,0 +1,55 @@
+import unittest
+from unittest.mock import patch
+
+# pylint: disable=no-name-in-module,no-member
+import pyrecest.backend
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array, eye, zeros
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.filters import KalmanFilter
+from pyrecest.filters.global_nearest_neighbor import GlobalNearestNeighbor
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+    reason="Nearest-neighbor validation tests require the numpy backend fixtures.",
+)
+class NearestNeighborValidationTest(unittest.TestCase):
+    def _tracker(self):
+        tracker = GlobalNearestNeighbor()
+        tracker.filter_state = [KalmanFilter(GaussianDistribution(zeros(4), eye(4)))]
+        return tracker
+
+    def test_duplicate_filter_handles_raise_value_error(self):
+        shared_filter = KalmanFilter(GaussianDistribution(zeros(4), eye(4)))
+        tracker = GlobalNearestNeighbor()
+
+        with self.assertRaisesRegex(ValueError, "same handle"):
+            tracker.filter_state = [shared_filter, shared_filter]
+
+    def test_predict_linear_rejects_nonzero_mean_gaussian_system_noise(self):
+        tracker = self._tracker()
+        nonzero_mean_noise = GaussianDistribution(
+            array([1.0, 0.0, 0.0, 0.0]), eye(4), check_validity=False
+        )
+
+        with self.assertRaisesRegex(ValueError, "zero mean"):
+            tracker.predict_linear(eye(4), nonzero_mean_noise)
+
+    def test_update_linear_unsupported_backend_raises_not_implemented(self):
+        tracker = self._tracker()
+
+        with patch.object(pyrecest.backend, "__backend_name__", "jax"):
+            with self.assertRaisesRegex(NotImplementedError, "numpy backend"):
+                tracker.update_linear(array([[0.0], [0.0]]), eye(4)[:2, :], eye(2))
+
+    def test_update_linear_dimension_mismatch_raises_value_error(self):
+        tracker = self._tracker()
+
+        with self.assertRaisesRegex(ValueError, "measurement matrix"):
+            tracker.update_linear(array([[0.0]]), eye(4)[:2, :], eye(2))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- replace optimizer-stripped nearest-neighbor tracker `assert` checks with explicit `ValueError` / `NotImplementedError` exceptions
- guard duplicate filter-bank handles, nonzero-mean Gaussian system noise, unsupported backends, and measurement/state dimension mismatches
- route `GlobalNearestNeighbor.update_linear` through the shared explicit validation helpers
- add regression coverage for the validation paths that used to depend on `assert`

## Validation
- local syntax check: `python -m py_compile` on the touched source files and new regression test
- GitHub compare: 3 files changed, +97/-26