### PR TITLE
Validate HypersphericalUKF Gaussian noise means

### DIFF
--- a/src/pyrecest/filters/hyperspherical_ukf.py
+++ b/src/pyrecest/filters/hyperspherical_ukf.py
@@ -118,6 +118,15 @@ class HypersphericalUKF(AbstractFilter, HypersphericalFilterMixin):
             raise ValueError("Mean is zero; normalization failed.")
         return x / n
 
+    @staticmethod
+    def _validate_zero_mean_noise(noise: GaussianDistribution, parameter_name: str):
+        noise_mean = reshape(asarray(noise.mu, dtype=float64), (-1,))
+        if not all(noise_mean == 0.0):
+            raise ValueError(
+                f"{parameter_name} must have zero mean; HypersphericalUKF "
+                "uses only the covariance of Gaussian additive noise."
+            )
+
     # ------------------------------------------------------------------
     # Prediction
     # ------------------------------------------------------------------
@@ -132,12 +141,14 @@ class HypersphericalUKF(AbstractFilter, HypersphericalFilterMixin):
         f:
             Function from S^(d-1) to S^(d-1).
         gauss_sys:
-            Distribution of additive system noise (mean is ignored).
+            Distribution of additive system noise. It must have zero mean; only
+            the covariance is applied.
         """
         _assert_supported_backend("pytorch", "jax")
 
         if not isinstance(gauss_sys, GaussianDistribution):
             gauss_sys = GaussianDistribution.from_distribution(gauss_sys)
+        self._validate_zero_mean_noise(gauss_sys, "gauss_sys")
 
         Q = asarray(gauss_sys.C, dtype=float64)
         dim_x = self._filter_state.dim
@@ -239,7 +250,8 @@ class HypersphericalUKF(AbstractFilter, HypersphericalFilterMixin):
         Parameters
         ----------
         gauss_sys:
-            Distribution of additive system noise (mean is ignored).
+            Distribution of additive system noise. It must have zero mean; only
+            the covariance is applied.
         """
         self.predict_nonlinear(lambda x: x, gauss_sys)
 
@@ -257,7 +269,8 @@ class HypersphericalUKF(AbstractFilter, HypersphericalFilterMixin):
         f:
             Measurement function from S^(d-1) to R^m.
         gauss_meas:
-            Distribution of additive measurement noise (mean is ignored).
+            Distribution of additive measurement noise. It must have zero mean;
+            only the covariance is applied.
         z:
             Measurement vector of shape (m,) or scalar.
         """
@@ -265,6 +278,7 @@ class HypersphericalUKF(AbstractFilter, HypersphericalFilterMixin):
 
         if not isinstance(gauss_meas, GaussianDistribution):
             gauss_meas = GaussianDistribution.from_distribution(gauss_meas)
+        self._validate_zero_mean_noise(gauss_meas, "gauss_meas")
 
         z_arr = reshape(asarray(z, dtype=float64), (-1,))
         dim_z = z_arr.shape[0]
@@ -294,7 +308,8 @@ class HypersphericalUKF(AbstractFilter, HypersphericalFilterMixin):
         Parameters
         ----------
         gauss_meas:
-            Distribution of additive measurement noise (mean is ignored).
+            Distribution of additive measurement noise. It must have zero mean;
+            only the covariance is applied.
         z:
             Measurement vector on S^(d-1).
         """

--- a/tests/filters/test_hyperspherical_ukf_zero_mean_noise.py
+++ b/tests/filters/test_hyperspherical_ukf_zero_mean_noise.py
@@ -1,0 +1,56 @@
+import unittest
+
+import numpy as np
+
+# pylint: disable=no-name-in-module,no-member
+import pyrecest.backend
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array, eye
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.filters.hyperspherical_ukf import HypersphericalUKF
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+    reason="HypersphericalUKF prediction/update are supported only on the NumPy backend.",
+)
+class HypersphericalUKFZeroMeanNoiseTest(unittest.TestCase):
+    def setUp(self):
+        self.ukf = HypersphericalUKF(dim=3)
+        self.ukf.filter_state = GaussianDistribution(
+            array([1.0, 0.0, 0.0]), eye(3), check_validity=False
+        )
+
+    def test_predict_rejects_nonzero_system_noise_mean(self):
+        nonzero_system_noise = GaussianDistribution(
+            array([0.1, 0.0, 0.0]), 0.01 * eye(3), check_validity=False
+        )
+
+        with self.assertRaisesRegex(ValueError, "gauss_sys.*zero mean"):
+            self.ukf.predict_identity(nonzero_system_noise)
+
+    def test_update_rejects_nonzero_measurement_noise_mean(self):
+        nonzero_measurement_noise = GaussianDistribution(
+            array([0.0, 0.1, 0.0]), 0.01 * eye(3), check_validity=False
+        )
+
+        with self.assertRaisesRegex(ValueError, "gauss_meas.*zero mean"):
+            self.ukf.update_identity(
+                nonzero_measurement_noise, array([1.0, 0.0, 0.0])
+            )
+
+    def test_zero_mean_gaussian_noise_still_runs(self):
+        zero_mean_noise = GaussianDistribution(
+            array([0.0, 0.0, 0.0]), 0.01 * eye(3), check_validity=False
+        )
+
+        self.ukf.predict_identity(zero_mean_noise)
+        self.ukf.update_identity(zero_mean_noise, array([0.0, 1.0, 0.0]))
+
+        estimate = np.asarray(self.ukf.get_point_estimate(), dtype=float)
+        self.assertTrue(np.isfinite(estimate).all())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reject nonzero-mean Gaussian system noise in `HypersphericalUKF.predict_nonlinear` before only the covariance is used
- reject nonzero-mean Gaussian measurement noise in `HypersphericalUKF.update_nonlinear` before only the covariance is used
- clarify Gaussian noise docstrings and add focused regression tests for prediction/update zero-mean contracts

## Root cause
`HypersphericalUKF` accepted `GaussianDistribution` noise objects but used only `C` in the Gaussian-noise prediction/update paths. A nonzero `mu` was silently ignored, which can make caller intent and filter behavior diverge without warning.

## Validation
- local syntax check: `python -m py_compile /tmp/hyperspherical_ukf.py /tmp/test_hyperspherical_ukf_zero_mean_noise.py`
- GitHub compare: 2 commits ahead of `main`, 2 files changed (+75/-4)