### PR TITLE
Handle flat empty MEM-EKF measurement scans

### DIFF
--- a/src/pyrecest/filters/mem_ekf_tracker.py
+++ b/src/pyrecest/filters/mem_ekf_tracker.py
@@ -167,6 +167,8 @@ class MEMEKFTracker(AbstractExtendedObjectTracker):
     def _normalize_measurements(self, measurements):
         measurements = array(measurements)
         if measurements.ndim == 1:
+            if measurements.shape[0] == 0:
+                return measurements.reshape((self.measurement_dim, 0))
             if measurements.shape[0] != self.measurement_dim:
                 raise ValueError("A single measurement must be two-dimensional")
             return measurements.reshape((self.measurement_dim, 1))

--- a/tests/filters/test_mem_ekf_tracker.py
+++ b/tests/filters/test_mem_ekf_tracker.py
@@ -121,6 +121,15 @@ class TestMEMEKFTracker(unittest.TestCase):
         npt.assert_allclose(self.tracker.kinematic_state, prior_kinematic_state)
         npt.assert_allclose(self.tracker.shape_state, prior_shape_state)
 
+    def test_update_without_flat_empty_measurements_is_noop(self):
+        prior_kinematic_state = self.tracker.kinematic_state.copy()
+        prior_shape_state = self.tracker.shape_state.copy()
+
+        self.tracker.update(array([]), meas_noise_cov=0.01 * eye(2))
+
+        npt.assert_allclose(self.tracker.kinematic_state, prior_kinematic_state)
+        npt.assert_allclose(self.tracker.shape_state, prior_shape_state)
+
     def test_get_contour_points(self):
         contour_points = self.tracker.get_contour_points(4)
 


### PR DESCRIPTION
## Summary
- Treat a flat empty measurement array as a zero-column MEM-EKF scan.
- Add a regression test that `update(array([]))` is a no-op, matching the existing `array([[], []])` empty-scan behavior.

## Testing
- `python -m py_compile /tmp/mem_ekf_tracker.py /tmp/test_mem_ekf_tracker.py`

I could not run the full repository pytest suite locally because this container cannot resolve `github.com` to clone/install the repository.