### PR TITLE
Fix MEM-EKF pseudo-measurement covariance

### DIFF
--- a/src/pyrecest/filters/mem_ekf_tracker.py
+++ b/src/pyrecest/filters/mem_ekf_tracker.py
@@ -217,6 +217,31 @@ class MEMEKFTracker(AbstractExtendedObjectTracker):
         )
         return base_matrix @ scales
 
+    @staticmethod
+    def _pseudo_measurement_covariance(innovation_covariance):
+        sigma_11 = innovation_covariance[0, 0]
+        sigma_12 = innovation_covariance[0, 1]
+        sigma_22 = innovation_covariance[1, 1]
+        return array(
+            [
+                [
+                    2.0 * sigma_11**2,
+                    2.0 * sigma_11 * sigma_12,
+                    2.0 * sigma_12**2,
+                ],
+                [
+                    2.0 * sigma_11 * sigma_12,
+                    sigma_11 * sigma_22 + sigma_12**2,
+                    2.0 * sigma_22 * sigma_12,
+                ],
+                [
+                    2.0 * sigma_12**2,
+                    2.0 * sigma_22 * sigma_12,
+                    2.0 * sigma_22**2,
+                ],
+            ]
+        )
+
     @property
     def extent(self):
         return self.get_point_estimate_extent()
@@ -376,25 +401,7 @@ class MEMEKFTracker(AbstractExtendedObjectTracker):
         sigma_12 = innovation_covariance[0, 1]
         sigma_22 = innovation_covariance[1, 1]
         pseudo_mean = array([sigma_11, sigma_12, sigma_22])
-        pseudo_covariance = array(
-            [
-                [
-                    3.0 * sigma_11**2,
-                    3.0 * sigma_11 * sigma_12,
-                    sigma_11 * sigma_22 + 2.0 * sigma_12**2,
-                ],
-                [
-                    3.0 * sigma_11 * sigma_12,
-                    sigma_11 * sigma_22 + 2.0 * sigma_12**2,
-                    3.0 * sigma_22 * sigma_12,
-                ],
-                [
-                    sigma_11 * sigma_22 + 2.0 * sigma_12**2,
-                    3.0 * sigma_22 * sigma_12,
-                    3.0 * sigma_22**2,
-                ],
-            ]
-        )
+        pseudo_covariance = self._pseudo_measurement_covariance(innovation_covariance)
         if self.covariance_regularization > 0.0:
             pseudo_covariance = pseudo_covariance + (
                 self.covariance_regularization * eye(3)

--- a/tests/test_mem_ekf_tracker.py
+++ b/tests/test_mem_ekf_tracker.py
@@ -1,0 +1,39 @@
+from pyrecest.backend import allclose, array, to_numpy
+from pyrecest.filters.mem_ekf_tracker import MEMEKFTracker
+
+
+def _as_bool(value):
+    converted = to_numpy(value)
+    if hasattr(converted, "item"):
+        return bool(converted.item())
+    return bool(converted)
+
+
+def test_mem_ekf_pseudo_measurement_covariance_matches_gaussian_moments():
+    covariance = array([[2.0, 0.5], [0.5, 3.0]])
+    expected = array(
+        [
+            [8.0, 2.0, 0.5],
+            [2.0, 6.25, 3.0],
+            [0.5, 3.0, 18.0],
+        ]
+    )
+
+    result = MEMEKFTracker._pseudo_measurement_covariance(covariance)
+
+    assert _as_bool(allclose(result, expected))
+
+
+def test_mem_ekf_pseudo_measurement_covariance_is_centered_not_raw_moment():
+    covariance = array([[2.0, 0.0], [0.0, 3.0]])
+    expected = array(
+        [
+            [8.0, 0.0, 0.0],
+            [0.0, 6.0, 0.0],
+            [0.0, 0.0, 18.0],
+        ]
+    )
+
+    result = MEMEKFTracker._pseudo_measurement_covariance(covariance)
+
+    assert _as_bool(allclose(result, expected))


### PR DESCRIPTION
## Summary
- replace the MEM-EKF quadratic pseudo-measurement raw fourth-moment matrix with the centered Gaussian covariance for `[dx², dx dy, dy²]`
- keep the existing pseudo-mean subtraction and route the update through the centered covariance helper
- add regression tests for correlated and diagonal innovation covariances

## Testing
- Not run locally; the execution sandbox could not resolve github.com for a local checkout. The regression tests are included for CI.