### PR TITLE
Validate boxed PF integer controls

### DIFF
--- a/src/pyrecest/filters/euclidean_boxed_particle_filter.py
+++ b/src/pyrecest/filters/euclidean_boxed_particle_filter.py
@@ -7,6 +7,7 @@ boxes are used as predicted support/proposal regions.
 
 import copy
 from collections.abc import Callable
+from numbers import Integral
 from typing import Union
 
 import numpy as _np
@@ -67,7 +68,7 @@ class EuclideanBoxedParticleFilter(EuclideanParticleFilter):
         gaussian_sigma_scale: float = 3.0,
         max_sampling_iterations: Union[int, int32, int64] = 100,
     ):
-        super().__init__(int(n_particles), int(dim))
+        super().__init__(n_particles, dim)
         self.resampling_criterion = resampling_criterion
         self.default_boxed_generation_method = self._validate_generation_method(
             boxed_generation_method
@@ -490,10 +491,13 @@ class EuclideanBoxedParticleFilter(EuclideanParticleFilter):
 
     @staticmethod
     def _validate_positive_int(value, name: str):
-        value = int(value)
-        if value <= 0:
-            raise ValueError(f"{name} must be positive")
-        return value
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, Integral)
+            or int(value) <= 0
+        ):
+            raise ValueError(f"{name} must be a positive integer")
+        return int(value)
 
     @staticmethod
     def _validate_positive_float(value, name: str):

--- a/tests/filters/test_euclidean_boxed_particle_filter.py
+++ b/tests/filters/test_euclidean_boxed_particle_filter.py
@@ -33,6 +33,45 @@ class EuclideanBoxedParticleFilterTest(unittest.TestCase):
         self.assertIsInstance(pf.filter_state, LinearDiracDistribution)
         self.assertIs(BoxedParticleFilter, EuclideanBoxedParticleFilter)
 
+    def test_rejects_bool_and_nonintegral_particle_counts(self):
+        invalid_arguments = (
+            (True, 1),
+            (1.5, 1),
+            (2, True),
+            (2, 1.5),
+        )
+
+        for n_particles, dim in invalid_arguments:
+            with self.subTest(n_particles=n_particles, dim=dim):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
+                    EuclideanBoxedParticleFilter(n_particles, dim)
+
+    def test_sampling_controls_reject_bool_and_nonintegral_values(self):
+        invalid_values = (
+            ("batch_size", True),
+            ("batch_size", 1.5),
+            ("max_sampling_iterations", True),
+            ("max_sampling_iterations", 1.5),
+            ("max_tries_per_particle", True),
+            ("max_tries_per_particle", 1.5),
+        )
+
+        for name, value in invalid_values:
+            with self.subTest(name=name, value=value):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    f"{name} must be a positive integer",
+                ):
+                    EuclideanBoxedParticleFilter._validate_positive_int(value, name)
+
+        self.assertEqual(
+            EuclideanBoxedParticleFilter._validate_positive_int(
+                np.int64(3),
+                "batch_size",
+            ),
+            3,
+        )
+
     def test_uniform_generation_places_point_particles_in_box(self):
         random.seed(1)
         pf = EuclideanBoxedParticleFilter(50, 2)


### PR DESCRIPTION
## Summary
- stop `EuclideanBoxedParticleFilter` from coercing `n_particles` and `dim` with `int(...)` before validation
- make boxed-particle sampling controls reject booleans and non-integral values instead of silently accepting/truncating them
- add regression tests for constructor validation and sampling-control validation

## Testing
- Not run locally; the execution sandbox cannot resolve github.com for a local checkout. The regression tests are included for GitHub CI.