### PR TITLE
Fix similarity max_gap for inferred session sizes

### DIFF
--- a/src/pyrecest/utils/multisession_assignment_score.py
+++ b/src/pyrecest/utils/multisession_assignment_score.py
@@ -123,17 +123,12 @@ def solve_multisession_assignment_from_similarity(  # pylint: disable=R0913,R091
     if score_to_cost is None:
         score_to_cost = _default_score_to_cost
 
-    session_positions = {
-        session_idx: position
-        for position, session_idx in enumerate(sorted(session_sizes_map))
-    }
-
     transformed_pairwise_costs: dict[tuple[int, int], Any] = {}
     for (
         source_session,
         target_session,
     ), score_matrix in normalized_pairwise_scores.items():
-        gap = session_positions[target_session] - session_positions[source_session] - 1
+        gap = int(target_session) - int(source_session) - 1
         if max_gap is not None and gap > max_gap:
             continue
 

--- a/tests/test_multisession_assignment_similarity_gap.py
+++ b/tests/test_multisession_assignment_similarity_gap.py
@@ -1,0 +1,35 @@
+"""Regression tests for score-native multi-session assignment gap handling."""
+
+import unittest
+
+from pyrecest.backend import __backend_name__, array  # pylint: disable=no-name-in-module
+from pyrecest.utils import solve_multisession_assignment_from_similarity
+
+
+class TestMultiSessionAssignmentSimilarityGap(unittest.TestCase):
+    @staticmethod
+    def _canonical_tracks(tracks):
+        return sorted(tuple(sorted(track.items())) for track in tracks)
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_max_gap_uses_numeric_session_indices_when_sizes_are_inferred(self):
+        result = solve_multisession_assignment_from_similarity(
+            {(0, 2): array([[0.95]], dtype=float)},
+            max_gap=0,
+            start_cost=1.0,
+            end_cost=1.0,
+        )
+
+        self.assertEqual(
+            self._canonical_tracks(result.tracks),
+            [((0, 0),), ((2, 0),)],
+        )
+        self.assertEqual(result.matched_edges, [])
+        self.assertAlmostEqual(result.total_cost, 4.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Fix `solve_multisession_assignment_from_similarity` so `max_gap` uses numeric session indices.
- Add a regression test for inferred session sizes where a `(0, 2)` similarity edge must not pass `max_gap=0`.

## Testing
- Added focused regression test.