### PR TITLE
Validate robust linear-Gaussian update inputs

### DIFF
--- a/src/pyrecest/filters/_linear_gaussian.py
+++ b/src/pyrecest/filters/_linear_gaussian.py
@@ -341,11 +341,14 @@ def linear_gaussian_update_robust(
     measurement_matrix = _as_matrix(measurement_matrix, "measurement_matrix")
     meas_noise = _as_matrix(meas_noise, "meas_noise")
 
-    meas_dim = measurement_matrix.shape[0]
-    innovation = measurement - measurement_matrix @ mean
-    nominal_innovation_cov = (
-        measurement_matrix @ covariance @ transpose(measurement_matrix) + meas_noise
+    innovation, nominal_innovation_cov = linear_gaussian_innovation(
+        mean,
+        covariance,
+        measurement,
+        measurement_matrix,
+        meas_noise,
     )
+    meas_dim = measurement_matrix.shape[0]
     nis = normalized_innovation_squared(innovation, nominal_innovation_cov)
     accepted, action, scale = _robust_update_decision(
         nis,

--- a/tests/filters/test_robust_linear_gaussian_update.py
+++ b/tests/filters/test_robust_linear_gaussian_update.py
@@ -192,7 +192,7 @@ class RobustLinearGaussianUpdateTest(unittest.TestCase):
 
         self.assertIn("nis", diagnostics)
         self.assertTrue(diagnostics["accepted"])
-        self.assertGreater(float(diagnostics["scale"],), 1.0)
+        self.assertGreater(float(diagnostics["scale"]), 1.0)
 
 
 if __name__ == "__main__":

--- a/tests/filters/test_robust_linear_gaussian_update.py
+++ b/tests/filters/test_robust_linear_gaussian_update.py
@@ -139,6 +139,30 @@ class RobustLinearGaussianUpdateTest(unittest.TestCase):
         npt.assert_allclose(to_numpy(robust_mean), to_numpy(self.mean))
         npt.assert_allclose(to_numpy(robust_covariance), to_numpy(self.covariance))
 
+    def test_robust_update_rejects_wrong_measurement_shape(self):
+        with self.assertRaisesRegex(ValueError, "measurement has incompatible shape"):
+            linear_gaussian_update_robust(
+                self.mean,
+                self.covariance,
+                array([1.0]),
+                self.measurement_matrix,
+                self.meas_noise,
+                robust_update="none",
+                gate_threshold=1.0,
+            )
+
+    def test_robust_update_rejects_wrong_measurement_noise_shape(self):
+        with self.assertRaisesRegex(ValueError, "meas_noise must have shape"):
+            linear_gaussian_update_robust(
+                self.mean,
+                self.covariance,
+                array([1.0, -1.0]),
+                self.measurement_matrix,
+                eye(1),
+                robust_update="none",
+                gate_threshold=1.0,
+            )
+
     def test_kalman_filter_update_linear_robust_returns_diagnostics(self):
         kf = KalmanFilter(GaussianDistribution(self.mean, self.covariance))
         diagnostics = kf.update_linear_robust(
@@ -168,7 +192,7 @@ class RobustLinearGaussianUpdateTest(unittest.TestCase):
 
         self.assertIn("nis", diagnostics)
         self.assertTrue(diagnostics["accepted"])
-        self.assertGreater(float(diagnostics["scale"]), 1.0)
+        self.assertGreater(float(diagnostics["scale"],), 1.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Reuse the linear-Gaussian innovation helper inside `linear_gaussian_update_robust` so robust updates get the same state, measurement, matrix, and noise-shape validation as the standard update path before NIS/gating decisions.
- Add regression tests for invalid measurement and measurement-noise shapes on the gated rejection path.

## Validation

- `python -m py_compile /tmp/_linear_gaussian.py /tmp/test_robust_linear_gaussian_update.py`

I could not run the full repository test suite locally in this environment, so CI should be treated as the authoritative validation.