### PR TITLE
Require probability matrix for probability pruning

### DIFF
--- a/src/pyrecest/utils/candidate_pruning.py
+++ b/src/pyrecest/utils/candidate_pruning.py
@@ -127,7 +127,11 @@ def candidate_mask_from_costs(
     if cfg.column_top_k is not None:
         keep |= _column_top_k_mask(costs, cfg.column_top_k)
         any_rule = True
-    if cfg.probability_threshold is not None and probability_matrix is not None:
+    if cfg.probability_threshold is not None:
+        if probability_matrix is None:
+            raise ValueError(
+                "probability_matrix is required when probability_threshold is set"
+            )
         probabilities = _as_probability_matrix(probability_matrix, costs.shape)
         keep |= np.isfinite(probabilities) & (
             probabilities >= cfg.probability_threshold

--- a/tests/test_candidate_pruning.py
+++ b/tests/test_candidate_pruning.py
@@ -55,6 +55,22 @@ class TestCandidatePruning(unittest.TestCase):
 
         npt.assert_array_equal(mask, np.array([[True, True], [False, True]]))
 
+    def test_probability_threshold_requires_probability_matrix(self):
+        costs = np.array([[1.0, 2.0]])
+        config = CandidatePruningConfig(probability_threshold=0.9)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "probability_matrix is required when probability_threshold is set",
+        ):
+            candidate_mask_from_costs(costs, config=config)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "probability_matrix is required when probability_threshold is set",
+        ):
+            prune_pairwise_cost_matrix(costs, config=config)
+
     def test_percentile_rule_and_large_cost_replacement(self):
         costs = np.array([[1.0, 2.0, 100.0], [3.0, 4.0, 5.0]])
 


### PR DESCRIPTION
## Summary
- Make candidate pruning fail fast when `probability_threshold` is configured without a `probability_matrix`.
- Add a regression test covering both `candidate_mask_from_costs` and `prune_pairwise_cost_matrix`.

## Why
Previously, a probability-only pruning config without a probability matrix silently fell through to the "no active rule" fallback and kept all finite costs, which disables the requested pruning criterion instead of surfacing the missing input.

## Testing
- Added focused regression test.