### PR TITLE
Validate unique tracklet IDs

### DIFF
--- a/src/pyrecest/tracking/tracklet_graph.py
+++ b/src/pyrecest/tracking/tracklet_graph.py
@@ -187,6 +187,7 @@ def build_tracklet_adjacency(
     """Build adjacency lists for a time-ordered tracklet DAG."""
 
     ordered = sort_tracklets(tracklets)
+    _require_unique_tracklet_ids(ordered)
     max_gap_value = None if max_gap is None else float(max_gap)
     adjacency: dict[Hashable, list[tuple[Hashable, float]]] = {
         item.id: [] for item in ordered
@@ -399,6 +400,24 @@ def sort_tracklets(tracklets: Iterable[Tracklet]) -> list[Tracklet]:
     return sorted(
         tracklets, key=lambda item: (item.start_time, item.end_time, str(item.id))
     )
+
+
+def _require_unique_tracklet_ids(tracklets: Sequence[Tracklet]) -> None:
+    seen: set[Hashable] = set()
+    duplicates: set[str] = set()
+    for item in tracklets:
+        try:
+            if item.id in seen:
+                duplicates.add(str(item.id))
+            else:
+                seen.add(item.id)
+        except TypeError as exc:
+            raise ValueError("tracklet ids must be hashable") from exc
+    if duplicates:
+        duplicate_text = ", ".join(sorted(duplicates))
+        raise ValueError(
+            f"tracklet ids must be unique; duplicate id(s): {duplicate_text}"
+        )
 
 
 def _node_cost(tracklet: Tracklet, node_cost_fn: CostFn | None) -> float:

--- a/tests/tracking/test_tracklet_graph.py
+++ b/tests/tracking/test_tracklet_graph.py
@@ -50,6 +50,24 @@ def test_k_best_tracklet_paths_prefers_feasible_low_cost_chain() -> None:
     assert paths[0].length == 2
 
 
+def test_duplicate_tracklet_ids_are_rejected() -> None:
+    tracklets = [
+        _tracklet("dup", 0.0, 1.0, 0.0, 1.0),
+        _tracklet("dup", 2.0, 3.0, 2.0, 3.0),
+    ]
+
+    try:
+        k_best_tracklet_paths(
+            tracklets,
+            edge_cost_fn=constant_velocity_edge_cost(max_gap=5.0),
+            config=TrackletGraphConfig(top_k=2),
+        )
+    except ValueError as exc:
+        assert "tracklet ids must be unique" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected ValueError")
+
+
 def test_switch_penalty_and_node_cost_are_reflected() -> None:
     tracklets = [
         _tracklet("a", 0.0, 1.0, 0.0, 1.0, cost=-5.0, label="one"),


### PR DESCRIPTION
## Summary
- Reject duplicate tracklet IDs when building a tracklet adjacency graph.
- Prevent k-best path extraction from silently overwriting nodes in dictionaries keyed by tracklet ID.
- Add a regression test for duplicate IDs.

## Rationale
`build_tracklet_adjacency()` and `k_best_tracklet_paths()` key internal graph structures by `Tracklet.id`. Duplicate IDs therefore collapse distinct tracklets into a single dictionary entry, which can produce silently wrong path candidates. Failing fast is safer and makes malformed inputs explicit.

## Testing
- Not run locally in this environment; the change is covered by `tests/tracking/test_tracklet_graph.py::test_duplicate_tracklet_ids_are_rejected` and CI should run on the PR.