### PR TITLE
Validate nearly coordinated turn variance

### DIFF
--- a/src/pyrecest/models/__init__.py
+++ b/src/pyrecest/models/__init__.py
@@ -55,7 +55,6 @@ from .motion_models import (
     kinematic_transition_matrix,
     nearly_constant_speed_model,
     nearly_constant_speed_transition,
-    nearly_coordinated_turn_model,
     se2_unicycle_model,
     se2_unicycle_transition,
     se3_pose_twist_model,
@@ -67,6 +66,7 @@ from .motion_models import (
     white_noise_jerk_covariance,
     white_noise_snap_covariance,
 )
+from ._validated_motion_models import nearly_coordinated_turn_model
 from .sensor_models import (
     bearing_only_measurement,
     bearing_only_model,

--- a/src/pyrecest/models/_validated_motion_models.py
+++ b/src/pyrecest/models/_validated_motion_models.py
@@ -1,0 +1,36 @@
+"""Validated wrappers for motion-model catalog helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from . import motion_models as _motion_models
+
+_nearly_coordinated_turn_model_impl = _motion_models.nearly_coordinated_turn_model
+
+
+def nearly_coordinated_turn_model(
+    dt: float = 1.0,
+    position_spectral_density: float = 1.0,
+    turn_rate_variance: float = 1e-4,
+) -> Any:
+    """Return a coordinated-turn model with validated nearly-constant-turn covariance."""
+    dt = _motion_models._as_nonnegative_float(  # pylint: disable=protected-access
+        dt,
+        "dt",
+    )
+    turn_rate_variance = _motion_models._as_nonnegative_float(  # pylint: disable=protected-access
+        turn_rate_variance,
+        "turn_rate_variance",
+    )
+    return _nearly_coordinated_turn_model_impl(
+        dt=dt,
+        position_spectral_density=position_spectral_density,
+        turn_rate_variance=turn_rate_variance,
+    )
+
+
+_motion_models.nearly_coordinated_turn_model = nearly_coordinated_turn_model
+
+
+__all__ = ["nearly_coordinated_turn_model"]

--- a/tests/models/test_nearly_coordinated_turn_model.py
+++ b/tests/models/test_nearly_coordinated_turn_model.py
@@ -1,0 +1,29 @@
+"""Regression tests for nearly coordinated-turn motion-model validation."""
+
+import unittest
+
+import numpy as np
+from pyrecest.models import nearly_coordinated_turn_model
+from pyrecest.models.motion_models import (
+    nearly_coordinated_turn_model as module_nearly_coordinated_turn_model,
+)
+
+
+class TestNearlyCoordinatedTurnModelValidation(unittest.TestCase):
+    def test_rejects_invalid_turn_rate_variance(self):
+        constructors = (
+            nearly_coordinated_turn_model,
+            module_nearly_coordinated_turn_model,
+        )
+        for constructor in constructors:
+            for turn_rate_variance in (-1.0, np.nan, np.inf, True):
+                with self.subTest(
+                    constructor=constructor.__module__,
+                    turn_rate_variance=turn_rate_variance,
+                ):
+                    with self.assertRaisesRegex(ValueError, "turn_rate_variance"):
+                        constructor(turn_rate_variance=turn_rate_variance)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a validated wrapper for `nearly_coordinated_turn_model`
- reject negative, non-finite, and boolean `turn_rate_variance` values before constructing the covariance
- register the validated wrapper on the motion-model submodule so normal package and submodule imports see the same validation
- add a regression test covering the invalid variance cases

## Testing
- Not run locally: this environment cannot clone GitHub directly, so validation is left to CI.