### PR TITLE
Fix observation-cost gap handling for inferred sessions

### DIFF
--- a/src/pyrecest/utils/multisession_assignment_observation_costs.py
+++ b/src/pyrecest/utils/multisession_assignment_observation_costs.py
@@ -50,7 +50,6 @@ def _ensure_supported_backend(feature_name: str) -> None:
 
 @dataclass(frozen=True)
 class _ObservationCostTransform:
-    session_positions: Mapping[int, int]
     start_costs: Mapping[int, Any]
     end_costs: Mapping[int, Any]
     uniform_start_cost: float
@@ -111,12 +110,7 @@ def solve_multisession_assignment_with_observation_costs(  # pylint: disable=R09
         for costs in normalized_end_costs.values()
     )
 
-    session_positions = {
-        session_idx: position
-        for position, session_idx in enumerate(sorted(session_sizes_map))
-    }
     transform = _ObservationCostTransform(
-        session_positions=session_positions,
         start_costs=normalized_start_costs,
         end_costs=normalized_end_costs,
         uniform_start_cost=max_start_cost,
@@ -145,7 +139,7 @@ def solve_multisession_assignment_with_observation_costs(  # pylint: disable=R09
     for source, target, _ in base_result.matched_edges:
         source_session, source_detection = source
         target_session, target_detection = target
-        gap = _session_gap(source_session, target_session, session_positions)
+        gap = _session_gap(source_session, target_session)
         original_cost = normalized_pairwise[(source_session, target_session)][
             source_detection, target_detection
         ]
@@ -173,12 +167,8 @@ def _array_length(values: Any) -> int:
     return int(values.shape[0])
 
 
-def _session_gap(
-    source_session: int,
-    target_session: int,
-    session_positions: Mapping[int, int],
-) -> int:
-    gap = session_positions[target_session] - session_positions[source_session] - 1
+def _session_gap(source_session: int, target_session: int) -> int:
+    gap = int(target_session) - int(source_session) - 1
     if gap < 0:
         raise ValueError("Session indices must define a forward-in-time edge ordering.")
     return gap
@@ -255,7 +245,7 @@ def _transform_pairwise_costs(
 ) -> dict[tuple[int, int], Any]:
     transformed: dict[tuple[int, int], Any] = {}
     for (source_session, target_session), matrix in pairwise_costs.items():
-        gap = _session_gap(source_session, target_session, transform.session_positions)
+        gap = _session_gap(source_session, target_session)
         source_end = transform.end_costs[source_session][:, None]
         target_start = transform.start_costs[target_session][None, :]
         transformed_matrix = (

--- a/tests/test_multisession_assignment_observation_costs.py
+++ b/tests/test_multisession_assignment_observation_costs.py
@@ -118,6 +118,37 @@ class TestMultiSessionAssignmentObservationCosts(unittest.TestCase):
         )
         self.assertEqual(result.matched_edges, [])
 
+    def test_gap_penalty_uses_numeric_session_indices_when_sizes_are_inferred(self):
+        result = solve_multisession_assignment_with_observation_costs(
+            {(0, 2): array([[0.3]], dtype=float)},
+            start_cost=4.0,
+            end_cost=4.0,
+            gap_penalty=0.5,
+        )
+
+        self.assertEqual(
+            self._canonical_tracks(result.tracks),
+            [((0, 0), (2, 0))],
+        )
+        self.assertEqual(result.matched_edges, [((0, 0), (2, 0), 0.8)])
+        self.assertAlmostEqual(result.total_cost, 8.8)
+
+    def test_cost_threshold_uses_numeric_session_indices_when_sizes_are_inferred(self):
+        result = solve_multisession_assignment_with_observation_costs(
+            {(0, 2): array([[0.3]], dtype=float)},
+            start_cost=4.0,
+            end_cost=4.0,
+            gap_penalty=0.5,
+            cost_threshold=0.75,
+        )
+
+        self.assertEqual(
+            self._canonical_tracks(result.tracks),
+            [((0, 0),), ((2, 0),)],
+        )
+        self.assertEqual(result.matched_edges, [])
+        self.assertAlmostEqual(result.total_cost, 16.0)
+
     def test_rejects_unknown_sessions(self):
         with self.assertRaises(ValueError):
             solve_multisession_assignment_with_observation_costs(


### PR DESCRIPTION
## Summary
- Fix observation-cost assignment gap handling to use numeric session indices instead of compressed observed-session positions.
- Make cost-threshold filtering and returned adjusted edge costs consistent with the core assignment solver when `session_sizes` is omitted.
- Add regression tests for inferred `(0, 2)` session edges.

## Testing
- Added focused regression tests.