### PR TITLE
Fix observation-cost skipped-session gaps

### DIFF
--- a/src/pyrecest/utils/multisession_assignment_observation_costs.py
+++ b/src/pyrecest/utils/multisession_assignment_observation_costs.py
@@ -178,7 +178,15 @@ def _session_gap(
     target_session: int,
     session_positions: Mapping[int, int],
 ) -> int:
-    gap = session_positions[target_session] - session_positions[source_session] - 1
+    try:
+        source_position = session_positions[source_session]
+        target_position = session_positions[target_session]
+    except KeyError as exc:
+        raise ValueError("Pairwise costs reference an unknown session.") from exc
+    if target_position <= source_position:
+        raise ValueError("Session indices must define a forward-in-time edge ordering.")
+
+    gap = int(target_session) - int(source_session) - 1
     if gap < 0:
         raise ValueError("Session indices must define a forward-in-time edge ordering.")
     return gap

--- a/tests/test_multisession_assignment_observation_costs.py
+++ b/tests/test_multisession_assignment_observation_costs.py
@@ -118,6 +118,35 @@ class TestMultiSessionAssignmentObservationCosts(unittest.TestCase):
         )
         self.assertEqual(result.matched_edges, [])
 
+    def test_gap_penalty_uses_numeric_session_gap_when_sessions_are_omitted(self):
+        result = solve_multisession_assignment_with_observation_costs(
+            {(0, 2): array([[0.3]], dtype=float)},
+            start_cost=4.0,
+            end_cost=4.0,
+            gap_penalty=0.5,
+        )
+
+        self.assertEqual(
+            result.matched_edges,
+            [((0, 0), (2, 0), 0.8)],
+        )
+        self.assertAlmostEqual(result.total_cost, 8.8)
+
+    def test_cost_threshold_uses_numeric_gap_when_sessions_are_omitted(self):
+        result = solve_multisession_assignment_with_observation_costs(
+            {(0, 2): array([[0.3]], dtype=float)},
+            start_cost=4.0,
+            end_cost=4.0,
+            gap_penalty=0.5,
+            cost_threshold=0.75,
+        )
+
+        self.assertEqual(
+            self._canonical_tracks(result.tracks),
+            [((0, 0),), ((2, 0),)],
+        )
+        self.assertEqual(result.matched_edges, [])
+
     def test_rejects_unknown_sessions(self):
         with self.assertRaises(ValueError):
             solve_multisession_assignment_with_observation_costs(


### PR DESCRIPTION
## Summary
- Use numeric session-index gaps in the observation-cost multi-session wrapper instead of compressed observed-session positions.
- This keeps reported matched-edge costs and original-domain cost-thresholding consistent with the core solver.
- Add regressions for omitted intermediate sessions.

## Testing
- Not run locally; changes are covered by the added focused unit tests and GitHub Actions should run on the PR.