### PR TITLE
Fix transition dt override precedence

### DIFF
--- a/src/pyrecest/models/additive_noise.py
+++ b/src/pyrecest/models/additive_noise.py
@@ -133,9 +133,11 @@ def _call_transition_function(
         return function(state, **call_kwargs)
 
     dt_mode = _dt_call_mode(function)
-    if dt_mode == "keyword" and "dt" not in call_kwargs:
-        return function(state, dt=dt, **call_kwargs)
+    if dt_mode == "keyword":
+        call_kwargs["dt"] = dt
+        return function(state, **call_kwargs)
     if dt_mode == "positional":
+        call_kwargs.pop("dt", None)
         return function(state, dt, **call_kwargs)
     return function(state, **call_kwargs)
 
@@ -153,9 +155,11 @@ def _call_transition_jacobian(
         return function(state, **call_kwargs)
 
     dt_mode = _dt_call_mode(function)
-    if dt_mode == "keyword" and "dt" not in call_kwargs:
-        return function(state, dt=dt, **call_kwargs)
+    if dt_mode == "keyword":
+        call_kwargs["dt"] = dt
+        return function(state, **call_kwargs)
     if dt_mode == "positional":
+        call_kwargs.pop("dt", None)
         return function(state, dt, **call_kwargs)
     return function(state, **call_kwargs)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -25,6 +25,21 @@ class ModelObjectTest(unittest.TestCase):
             allclose(model.evaluate(array([1.0, 2.0]), scale=1.0), array([1.5, 2.5]))
         )
 
+    def test_explicit_transition_dt_overrides_function_args_dt(self):
+        def fx(x, dt, scale=1.0):
+            return scale * (x + dt)
+
+        model = AdditiveNoiseTransitionModel(
+            transition_function=fx,
+            dt=0.5,
+            function_args={"dt": 10.0, "scale": 2.0},
+        )
+
+        self.assertTrue(allclose(model.evaluate(array([1.0, 2.0])), array([3.0, 5.0])))
+        self.assertTrue(
+            allclose(model.evaluate(array([1.0, 2.0]), dt=0.25), array([2.5, 4.5]))
+        )
+
     def test_measurement_model_accepts_covariance_like_noise(self):
         noise_cov = diag(array([0.3, 0.4]))
 


### PR DESCRIPTION
## Summary
- Fix additive transition function and Jacobian dispatch so an explicit model/per-call `dt` overrides a stale `dt` entry in `function_args`.
- Remove `dt` from keyword arguments when dispatching it positionally to avoid duplicate values.
- Add a regression test covering `function_args={"dt": ...}` with model-level and per-call `dt` overrides.

## Testing
- Added focused regression coverage in `tests/test_models.py`.
- Could not run tests locally in this environment because the GitHub repository is not network-accessible from the container; relying on GitHub Actions for CI.