### PR TITLE
Validate finite Gaussian hypothesis inputs

### DIFF
--- a/src/pyrecest/filters/gaussian_hypothesis_mixture.py
+++ b/src/pyrecest/filters/gaussian_hypothesis_mixture.py
@@ -20,11 +20,18 @@ class WeightedGaussianHypothesis:
     def __post_init__(self) -> None:
         mean = np.asarray(self.mean, dtype=float).reshape(-1)
         covariance = np.asarray(self.covariance, dtype=float)
+        if not np.all(np.isfinite(mean)):
+            raise ValueError("mean must contain only finite values")
         if covariance.shape != (mean.size, mean.size):
             raise ValueError("covariance must match mean dimension")
+        if not np.all(np.isfinite(covariance)):
+            raise ValueError("covariance must contain only finite values")
+        log_weight = float(self.log_weight)
+        if np.isnan(log_weight):
+            raise ValueError("log_weight must not be NaN")
         object.__setattr__(self, "mean", mean)
         object.__setattr__(self, "covariance", _symmetrized(covariance))
-        object.__setattr__(self, "log_weight", float(self.log_weight))
+        object.__setattr__(self, "log_weight", log_weight)
         if self.metadata is not None:
             object.__setattr__(self, "metadata", dict(self.metadata))
 

--- a/tests/filters/test_gaussian_hypothesis_mixture.py
+++ b/tests/filters/test_gaussian_hypothesis_mixture.py
@@ -40,6 +40,19 @@ class GaussianHypothesisMixtureTest(unittest.TestCase):
                 ]
             )
 
+    def test_hypotheses_reject_nonfinite_mean_and_covariance(self):
+        with self.assertRaisesRegex(ValueError, "mean"):
+            WeightedGaussianHypothesis(np.array([np.nan]), np.array([[1.0]]))
+
+        with self.assertRaisesRegex(ValueError, "mean"):
+            WeightedGaussianHypothesis(np.array([np.inf]), np.array([[1.0]]))
+
+        with self.assertRaisesRegex(ValueError, "covariance"):
+            WeightedGaussianHypothesis(np.array([0.0]), np.array([[np.nan]]))
+
+        with self.assertRaisesRegex(ValueError, "covariance"):
+            WeightedGaussianHypothesis(np.array([0.0]), np.array([[np.inf]]))
+
     def test_moment_matching_respects_dominant_infinite_weight(self):
         mean, covariance, weights = moment_match_gaussian_hypotheses(
             [


### PR DESCRIPTION
## Summary
- Reject nonfinite Gaussian hypothesis means and covariances at construction time.
- Reject NaN log weights before moment matching.
- Add regression coverage so invalid hypotheses no longer silently propagate `nan`/`inf` through moment matching.

## Testing
- Added focused regression test in `tests/filters/test_gaussian_hypothesis_mixture.py`.
- Not run locally: this environment cannot clone GitHub directly, so validation is left to CI.