### PR TITLE
Reject nonfinite point-set thresholds

### DIFF
--- a/src/pyrecest/evaluation/point_set_metrics.py
+++ b/src/pyrecest/evaluation/point_set_metrics.py
@@ -351,6 +351,6 @@ def _validate_chunk_size(query_chunk_size: int) -> None:
 
 def _validate_threshold(threshold: float) -> float:
     threshold_float = float(threshold)
-    if threshold_float < 0.0:
-        raise ValueError("Distance thresholds must be non-negative.")
+    if not np.isfinite(threshold_float) or threshold_float < 0.0:
+        raise ValueError("Distance thresholds must be finite and non-negative.")
     return threshold_float

--- a/tests/evaluation/test_point_set_metrics.py
+++ b/tests/evaluation/test_point_set_metrics.py
@@ -114,3 +114,15 @@ def test_invalid_point_sets_raise_clear_errors():
 
     with pytest.raises(ValueError, match="non-negative"):
         precision_recall_fscore(np.array([[0.0]]), np.array([[0.0]]), -1.0)
+
+
+def test_nonfinite_thresholds_raise_clear_errors():
+    points = np.array([[0.0]])
+
+    for threshold in (np.nan, np.inf, -np.inf):
+        with pytest.raises(ValueError, match="finite and non-negative"):
+            precision_recall_fscore(points, points, threshold)
+        with pytest.raises(ValueError, match="finite and non-negative"):
+            precision_recall_curve(points, points, (threshold,))
+        with pytest.raises(ValueError, match="finite and non-negative"):
+            point_set_geometry_summary(points, points, thresholds=(threshold,))


### PR DESCRIPTION
## Summary
- Reject `NaN` and infinite distance thresholds in point-set precision/recall utilities.
- Add regression coverage for `precision_recall_fscore`, `precision_recall_curve`, and `point_set_geometry_summary`.

## Testing
- Added focused regression test in `tests/evaluation/test_point_set_metrics.py`.