### PR TITLE
Validate observation-cost session keys

### DIFF
--- a/src/pyrecest/utils/multisession_assignment_observation_costs.py
+++ b/src/pyrecest/utils/multisession_assignment_observation_costs.py
@@ -31,6 +31,7 @@ from .multisession_assignment import (
     SessionSizesInput,
     _infer_and_validate_session_sizes,
     _normalize_pairwise_costs,
+    _normalize_session_index,
     _normalize_session_sizes,
     solve_multisession_assignment,
 )
@@ -202,9 +203,10 @@ def _normalize_observation_costs(
     if observation_costs is None:
         raw_entries: dict[int, ObservationCostValue] = {}
     elif isinstance(observation_costs, Mapping):
-        raw_entries = {
-            int(session_idx): value for session_idx, value in observation_costs.items()
-        }
+        raw_entries = {}
+        for session_idx, value in observation_costs.items():
+            normalized_session_idx = _normalize_session_index(session_idx)
+            raw_entries[normalized_session_idx] = value
     else:
         raw_entries = dict(enumerate(observation_costs))
 

--- a/tests/test_multisession_assignment_observation_costs.py
+++ b/tests/test_multisession_assignment_observation_costs.py
@@ -154,6 +154,20 @@ class TestMultiSessionAssignmentObservationCosts(unittest.TestCase):
                 start_costs={2: array([1.0], dtype=float)},
             )
 
+    def test_rejects_invalid_mapping_session_keys(self):
+        invalid_cost_kwargs = (
+            {"start_costs": {True: array([1.0], dtype=float)}},
+            {"end_costs": {1.5: array([1.0], dtype=float)}},
+        )
+
+        for cost_kwargs in invalid_cost_kwargs:
+            with self.subTest(cost_kwargs=cost_kwargs):
+                with self.assertRaisesRegex(ValueError, "Session indices"):
+                    solve_multisession_assignment_with_observation_costs(
+                        [array([[1.0]], dtype=float)],
+                        **cost_kwargs,
+                    )
+
     def test_rejects_mismatched_lengths(self):
         with self.assertRaises(ValueError):
             solve_multisession_assignment_with_observation_costs(


### PR DESCRIPTION
## Summary
- Reuse the core multi-session session-index validator for observation-cost mapping keys.
- Reject invalid keys such as booleans and non-integral floats instead of silently coercing them with `int(...)`.
- Add a regression test covering `start_costs={True: ...}` and `end_costs={1.5: ...}`.

## Testing
- Not run locally; GitHub Actions will validate the branch.