### PR TITLE
Preserve singleton measurement axis

### DIFF
--- a/src/pyrecest/evaluation/generate_measurements.py
+++ b/src/pyrecest/evaluation/generate_measurements.py
@@ -198,16 +198,14 @@ def generate_measurements(groundtruth, simulation_config):
             if isinstance(meas_noise, AbstractHypertoroidalDistribution):
                 noise_samples = meas_noise.sample(n_meas)
                 measurements[t] = mod(
-                    squeeze(
-                        tile(
-                            groundtruth[t],
-                            (
-                                n_meas,
-                                1,
-                            ),
-                        )
-                        + noise_samples
-                    ),
+                    tile(
+                        groundtruth[t],
+                        (
+                            n_meas,
+                            1,
+                        ),
+                    )
+                    + noise_samples,
                     2.0 * pi,
                 )
 
@@ -220,16 +218,13 @@ def generate_measurements(groundtruth, simulation_config):
 
             elif isinstance(meas_noise, GaussianDistribution):
                 noise_samples = meas_noise.sample(n_meas)
-                measurements[t] = squeeze(
-                    tile(
-                        groundtruth[t],
-                        (
-                            n_meas,
-                            1,
-                        ),
-                    )
-                    + noise_samples
-                )
+                measurements[t] = tile(
+                    groundtruth[t],
+                    (
+                        n_meas,
+                        1,
+                    ),
+                ) + noise_samples
 
     return measurements
 

--- a/tests/test_generate_measurements_shape.py
+++ b/tests/test_generate_measurements_shape.py
@@ -1,0 +1,32 @@
+import unittest
+
+import numpy as np
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array, random
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.evaluation import generate_measurements
+
+
+class TestGenerateMeasurementsShape(unittest.TestCase):
+    def test_single_gaussian_measurement_keeps_measurement_axis(self):
+        random.seed(0)
+        simulation_config = {
+            "n_timesteps": 2,
+            "n_meas_at_individual_time_step": np.ones(2, dtype=int),
+            "meas_noise": GaussianDistribution(
+                array([0.0, 0.0]),
+                array([[1e-24, 0.0], [0.0, 1e-24]]),
+                check_validity=False,
+            ),
+        }
+        groundtruth = array([[1.0, 2.0], [3.0, 4.0]])
+
+        measurements = generate_measurements(groundtruth, simulation_config)
+
+        self.assertEqual(tuple(measurements[0].shape), (1, 2))
+        self.assertEqual(tuple(measurements[1].shape), (1, 2))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes a shape bug in `generate_measurements()`: Gaussian and hypertoroidal branches used `squeeze`, so timesteps with exactly one measurement returned shape `(n_dim,)` instead of the documented `(1, n_dim)`. This PR keeps the measurement axis and adds a focused Gaussian regression test.