### PR TITLE
Validate fixed-lag Viterbi lag window

### DIFF
--- a/src/pyrecest/filters/tracklet_viterbi.py
+++ b/src/pyrecest/filters/tracklet_viterbi.py
@@ -299,8 +299,7 @@ def solve_fixed_lag_tracklet_viterbi(
     would score it.
     """
 
-    if lag_s <= 0.0:
-        raise ValueError("lag_s must be positive")
+    lag_s = _as_positive_float(lag_s, "lag_s")
     config = TrackletViterbiConfig() if config is None else config
     if not frames:
         return TrackletViterbiResult([], 0.0)

--- a/tests/filters/test_tracklet_viterbi.py
+++ b/tests/filters/test_tracklet_viterbi.py
@@ -71,6 +71,14 @@ def test_missed_detection_branch_is_selected_when_candidates_are_expensive():
     assert result.missed_detection_count == 1
 
 
+def test_fixed_lag_solver_rejects_invalid_lag():
+    frames = [[TrackletAssociationCandidate("a0")]]
+
+    for lag_s in (0.0, -1.0, np.nan, np.inf, True, np.array([1.0])):
+        with pytest.raises(ValueError, match="lag_s"):
+            solve_fixed_lag_tracklet_viterbi(frames, lag_s=lag_s)
+
+
 def test_fixed_lag_solver_uses_prefix_memory():
     frames = [
         [TrackletAssociationCandidate("a0", unary_cost=0.0, track_id="A", time_s=0.0)],


### PR DESCRIPTION
## Summary
- validate `lag_s` in `solve_fixed_lag_tracklet_viterbi` with the existing positive finite scalar helper
- reject nonsensical lag windows such as `nan`, `inf`, booleans, arrays, and nonpositive values
- add a focused regression test for invalid fixed-lag windows

## Rationale
Previously `nan` passed the `lag_s <= 0.0` check and made the look-ahead comparison silently fail, degrading fixed-lag inference to a one-frame window. `True` was also accepted as `1.0`.

## Tests
- `tests/filters/test_tracklet_viterbi.py::test_fixed_lag_solver_rejects_invalid_lag`