### PR TITLE
Handle scalar single-target MTT groundtruth

### DIFF
--- a/src/pyrecest/evaluation/generate_measurements.py
+++ b/src/pyrecest/evaluation/generate_measurements.py
@@ -31,10 +31,13 @@ def _as_shapely_scalar(value):
 def _mtt_state_at(groundtruth, t, target_no, n_targets):
     """Return one target state from dense or per-step object ground truth."""
     state_at_t = np.asarray(groundtruth[t])
-    if n_targets == 1 and state_at_t.ndim == 1:
+    if n_targets == 1:
         if target_no != 0:
             raise IndexError("target_no out of bounds for single-target ground truth")
-        return state_at_t
+        if state_at_t.ndim == 0:
+            return state_at_t.reshape(1)
+        if state_at_t.ndim == 1:
+            return state_at_t
     if state_at_t.ndim != 2:
         raise ValueError(
             "MTT groundtruth entries must have shape (n_targets, dim); "
@@ -217,7 +220,6 @@ def generate_measurements(groundtruth, simulation_config):
                 curr_dist = copy.deepcopy(meas_noise)
                 curr_dist.mu = groundtruth[t]
                 measurements[t] = curr_dist.sample(n_meas)
-
             elif isinstance(meas_noise, GaussianDistribution):
                 noise_samples = meas_noise.sample(n_meas)
                 measurements[t] = squeeze(

--- a/tests/test_generate_measurements_mtt.py
+++ b/tests/test_generate_measurements_mtt.py
@@ -41,6 +41,28 @@ class TestGenerateMeasurementsMtt(unittest.TestCase):
         self.assertEqual(measurements[1].shape, (1, 2))
 
     @pytest.mark.skipif(
+        IS_JAX_BACKEND, reason="MTT measurement generation is unsupported with JAX."
+    )
+    def test_mtt_accepts_scalar_single_target_groundtruth_entries(self):
+        simulation_param = check_and_fix_config(
+            {
+                "mtt": True,
+                "eot": False,
+                "n_timesteps": 2,
+                "n_targets": 1,
+                "initial_prior": GaussianDistribution(array([0.0]), eye(1)),
+                "meas_matrix_for_each_target": eye(1),
+                "meas_noise": GaussianDistribution(array([0.0]), 1.0e-12 * eye(1)),
+            }
+        )
+        groundtruth = np.array([1.0, 3.0])
+
+        measurements = generate_measurements(groundtruth, simulation_param)
+
+        self.assertEqual(measurements[0].shape, (1, 1))
+        self.assertEqual(measurements[1].shape, (1, 1))
+
+    @pytest.mark.skipif(
         not IS_JAX_BACKEND, reason="JAX-only guard for MTT measurement generation."
     )
     def test_mtt_measurement_generation_raises_for_jax_backend(self):


### PR DESCRIPTION
## Summary
- Treat scalar single-target MTT groundtruth entries as one-dimensional states in `_mtt_state_at`.
- Preserve the existing single-target vector and dense `(n_targets, dim)` handling.
- Add a regression test covering scalar single-target, one-dimensional MTT groundtruth.

## Rationale
`generate_groundtruth()` can squeeze a single-target, one-dimensional state to a scalar. Passing such entries into MTT `generate_measurements()` currently raises a shape `ValueError` before the measurement matrix projection, even though the state is valid for a one-dimensional target.

## Testing
- Added focused regression coverage in `tests/test_generate_measurements_mtt.py`.
- Not run locally in this environment; GitHub Actions should exercise the normal matrix.