### PR TITLE
Reject invalid track-completion candidate observations

### DIFF
--- a/src/pyrecest/utils/track_completion.py
+++ b/src/pyrecest/utils/track_completion.py
@@ -377,5 +377,25 @@ def _coerce_candidate(
     value: int | CompletionCandidate[PayloadT],
 ) -> CompletionCandidate[PayloadT]:
     if isinstance(value, CompletionCandidate):
-        return value
-    return CompletionCandidate(observation=int(value))
+        return CompletionCandidate(
+            observation=_normalize_candidate_observation(value.observation),
+            score=value.score,
+            payload=value.payload,
+        )
+    return CompletionCandidate(observation=_normalize_candidate_observation(value))
+
+
+def _normalize_candidate_observation(value: Any) -> int:
+    if isinstance(value, (bool, np.bool_)):
+        raise ValueError("candidate observations must be non-negative integers")
+    if isinstance(value, (float, np.floating)) and not float(value).is_integer():
+        raise ValueError("candidate observations must be non-negative integers")
+    try:
+        observation = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "candidate observations must be non-negative integers"
+        ) from exc
+    if observation < 0:
+        raise ValueError("candidate observations must be non-negative integers")
+    return observation

--- a/tests/test_track_completion.py
+++ b/tests/test_track_completion.py
@@ -61,6 +61,27 @@ class TestTrackCompletion(unittest.TestCase):
         )
         self.assertEqual(len(allowed), 1)
 
+    def test_rejects_negative_candidate_observations(self) -> None:
+        tracks = [[0, None]]
+        invalid_candidates = (-1, CompletionCandidate(-1))
+
+        for invalid_candidate in invalid_candidates:
+            with self.subTest(invalid_candidate=invalid_candidate):
+
+                def provider(session: int, observation: int, target_session: int):
+                    del session, observation, target_session
+                    return [invalid_candidate]
+
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "candidate observations must be non-negative integers",
+                ):
+                    enumerate_fragment_completion_paths(
+                        tracks,
+                        direction="suffix",
+                        candidate_provider=provider,
+                    )
+
     def test_enumerates_prefix_paths(self) -> None:
         tracks = [[None, 5, 6]]
 

--- a/tests/test_track_completion.py
+++ b/tests/test_track_completion.py
@@ -67,7 +67,6 @@ class TestTrackCompletion(unittest.TestCase):
 
         for invalid_candidate in invalid_candidates:
             with self.subTest(invalid_candidate=invalid_candidate):
-
                 def provider(session: int, observation: int, target_session: int):
                     del session, observation, target_session
                     return [invalid_candidate]


### PR DESCRIPTION
## Summary
- reject negative/non-integral track-completion candidate observation ids instead of emitting invalid completion paths
- preserve scores/payloads while normalizing valid `CompletionCandidate` observations to integers
- add a regression test for raw and structured negative candidates

## Testing
- Not run locally; repository is only accessible here through the GitHub connector.