### PR TITLE
Reject negative remove-link occurrence indices

### DIFF
--- a/src/pyrecest/utils/track_edit_whatif.py
+++ b/src/pyrecest/utils/track_edit_whatif.py
@@ -286,7 +286,7 @@ def _apply_remove_link(matrix: np.ndarray, edit: TrackEdit) -> TrackEditApplicat
             (output[:, session_a] == source) & (output[:, session_b] == target)
         )
     )
-    if occurrence_index >= len(matching_rows):
+    if occurrence_index < 0 or occurrence_index >= len(matching_rows):
         return TrackEditApplication(edit, output, False, "reject", "edge_not_found")
     row_index = matching_rows[occurrence_index]
     left = output[row_index].copy()

--- a/tests/test_track_edit_whatif.py
+++ b/tests/test_track_edit_whatif.py
@@ -121,6 +121,25 @@ def test_duplicate_sensitive_scoring_counts_duplicate_false_positive() -> None:
     assert multiset_delta.pairwise_fp_delta == -1
 
 
+def test_remove_link_rejects_negative_occurrence_index() -> None:
+    predicted = [[1, 2], [1, 2]]
+    edit = TrackEdit(
+        kind="remove_link",
+        session_a=0,
+        session_b=1,
+        source_observation=1,
+        target_observation=2,
+        metadata={"occurrence_index": -1},
+    )
+
+    application = apply_track_edit(predicted, edit)
+
+    assert not application.applied
+    assert application.action == "reject"
+    assert application.reason == "edge_not_found"
+    assert application.track_matrix.tolist() == predicted
+
+
 def test_rank_track_edits_prefers_complete_track_improvement() -> None:
     predicted = [[1, 2, None], [8, 9, 10]]
     reference = [[1, 2, 3], [8, 9, 10]]


### PR DESCRIPTION
Fixes a track-edit what-if edge case where `remove_link` accepted a negative `occurrence_index`. Python negative indexing then removed the last matching duplicate instead of rejecting the edit.

Changes:
- Reject negative `occurrence_index` values as `edge_not_found`.
- Add regression coverage for duplicate `remove_link` rows with `occurrence_index=-1`.