### PR TITLE
Validate PyTorch random.choice axis bounds

### DIFF
--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -235,8 +235,17 @@ def _choice_indices(population_size, size, num_samples, replace, p, device):
     return indices.reshape(size)
 
 
+def _normalize_axis(axis, ndim):
+    if not _looks_like_integer_dimension(axis):
+        raise TypeError("axis must be an integer")
+    axis = int(axis)
+    if axis < -ndim or axis >= ndim:
+        raise ValueError(f"axis {axis} is out of bounds for array of dimension {ndim}")
+    return axis % ndim
+
+
 def _take_choice(a, indices, axis):
-    axis = axis % a.ndim
+    axis = _normalize_axis(axis, a.ndim)
     if indices.ndim == 0:
         return a.select(axis, int(indices.item()))
 
@@ -261,7 +270,7 @@ def choice(a, size=None, replace=True, p=None, axis=0, shuffle=True):
             "a must be a positive integer or an array with at least one dimension"
         )
 
-    axis = axis % a.ndim
+    axis = _normalize_axis(axis, a.ndim)
     indices = _choice_indices(a.shape[axis], size, num_samples, replace, p, a.device)
     return _take_choice(a, indices, axis)
 

--- a/tests/backend_support/test_pytorch_random_contract.py
+++ b/tests/backend_support/test_pytorch_random_contract.py
@@ -36,3 +36,23 @@ else:
     result = run_backend_code("pytorch", code)
 
     assert result.returncode == 0, result.stderr
+
+
+def test_pytorch_choice_rejects_out_of_bounds_axis():
+    pytest.importorskip("torch")
+
+    code = """
+import pyrecest.backend as backend
+
+values = [[1, 2, 3], [4, 5, 6]]
+for axis in (2, -3):
+    try:
+        backend.random.choice(values, axis=axis)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError(f"choice accepted out-of-bounds axis {axis}")
+"""
+    result = run_backend_code("pytorch", code)
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Reject non-integer and out-of-range `axis` values in the PyTorch `random.choice` backend.
- Use a shared axis normalizer instead of silently wrapping `axis` with modulo.
- Add a PyTorch backend regression test for `axis=2` and `axis=-3` on a 2-D input.

## Tests
- Not run locally in this connector-only environment; covered by the added regression test and CI.