### PR TITLE
Apply metadata in no-op record smoothing

### DIFF
--- a/src/pyrecest/smoothers/record_smoother.py
+++ b/src/pyrecest/smoothers/record_smoother.py
@@ -164,7 +164,10 @@ def _smooth_records_with_config(
         return []
 
     copied = [_copy_record(record) for record in records]
+    metadata = {} if config.metadata is None else dict(config.metadata)
     if config.method == "none":
+        for item in copied:
+            item.update(metadata)
         return copied
 
     times, filtered_states, filtered_covariances = _record_arrays(
@@ -194,7 +197,6 @@ def _smooth_records_with_config(
         )
 
     out: list[dict[str, Any]] = []
-    metadata = {} if config.metadata is None else dict(config.metadata)
     for idx, record in enumerate(copied):
         item = _copy_record(record)
         item[config.filtered_state_key] = filtered_states[idx].copy()

--- a/tests/smoothers/test_record_smoother.py
+++ b/tests/smoothers/test_record_smoother.py
@@ -80,16 +80,18 @@ def test_rts_and_fixed_lag_match_when_lag_covers_all_future_records() -> None:
     assert np.allclose(full[0]["covariance"], lagged[0]["covariance"])
 
 
-def test_none_returns_copied_records() -> None:
+def test_none_returns_copied_records_with_metadata() -> None:
     records = _records()
     out = smooth_records(
         records,
         method="none",
         transition_model=_transition,
         process_noise_model=_process_noise,
+        metadata={"smoother_method": "none"},
     )
 
     assert out[0]["source"] == records[0]["source"]
+    assert out[0]["smoother_method"] == "none"
     assert out is not records
     assert out[0] is not records[0]
     out[0]["state"][0] = 99.0


### PR DESCRIPTION
## Summary
- Fix `smooth_records(..., method="none", metadata=...)` so no-op smoothing applies configured metadata to copied records.
- Extend the no-op record smoother test to cover metadata propagation.

## Testing
- Added focused regression coverage in `tests/smoothers/test_record_smoother.py`.