### PR TITLE
Skip disabled callable dim attributes during inference

### DIFF
--- a/src/pyrecest/models/validation.py
+++ b/src/pyrecest/models/validation.py
@@ -276,9 +276,12 @@ def infer_state_dim_from_distribution(
     """
     for attr_name in ("dim", "input_dim"):
         if hasattr(distribution, attr_name):
-            attr_value = _maybe_call(
-                getattr(distribution, attr_name), allow_methods=allow_methods
-            )
+            try:
+                attr_value = _maybe_call(
+                    getattr(distribution, attr_name), allow_methods=allow_methods
+                )
+            except (TypeError, ValueError):
+                continue
             inferred_dim = _positive_int_or_none(attr_value)
             if inferred_dim is not None:
                 return inferred_dim

--- a/tests/models/test_validation.py
+++ b/tests/models/test_validation.py
@@ -114,6 +114,20 @@ class TestModelValidation(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Could not infer"):
             infer_state_dim_from_distribution(DistributionWithBooleanDim())
 
+    def test_infer_state_dim_skips_disabled_callable_dim_attribute(self):
+        class DistributionWithCallableDimAndMean:
+            mu = array([0.0, 1.0])
+
+            def dim(self):
+                raise AssertionError("dim() must not be called when methods are disabled")
+
+        self.assertEqual(
+            infer_state_dim_from_distribution(
+                DistributionWithCallableDimAndMean(), allow_methods=False
+            ),
+            2,
+        )
+
     def test_infer_state_dim_from_mean_attribute(self):
         class DistributionWithMean:
             mu = array([0.0, 1.0, 2.0])


### PR DESCRIPTION
## Summary
- Skip callable `dim`/`input_dim` attributes when `infer_state_dim_from_distribution(..., allow_methods=False)` disables method calls.
- Let inference continue to safe non-callable fallbacks such as `mu` instead of aborting early.
- Add a regression test covering a callable `dim` plus a non-callable mean attribute.

## Testing
- Added focused regression test in `tests/models/test_validation.py`.