### PR TITLE
Validate track completion candidate sessions

### DIFF
--- a/src/pyrecest/utils/track_completion.py
+++ b/src/pyrecest/utils/track_completion.py
@@ -322,12 +322,12 @@ def _candidate_sessions(
         adjacent = anchor_session + 1 if direction == "suffix" else anchor_session - 1
         raw = (adjacent,)
     else:
-        raw = tuple(
-            int(value)
-            for value in provider(anchor_session, anchor_observation, direction)
-        )
+        raw = tuple(provider(anchor_session, anchor_observation, direction))
     sessions = []
-    for value in raw:
+    for raw_value in raw:
+        value = _coerce_candidate_session(raw_value)
+        if value is None:
+            continue
         if value < 0 or value >= matrix.shape[1] or value == anchor_session:
             continue
         if direction == "suffix" and value <= anchor_session:
@@ -336,6 +336,18 @@ def _candidate_sessions(
             continue
         sessions.append(int(value))
     return tuple(dict.fromkeys(sessions))
+
+
+def _coerce_candidate_session(value: Any) -> int | None:
+    if isinstance(value, (bool, np.bool_)):
+        return None
+    if isinstance(value, (int, np.integer)):
+        return int(value)
+    if isinstance(value, (float, np.floating)):
+        if np.isfinite(value) and float(value).is_integer():
+            return int(value)
+        return None
+    return None
 
 
 def _completion_step(

--- a/tests/test_track_completion.py
+++ b/tests/test_track_completion.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import unittest
 
+import numpy as np
+
 from pyrecest.utils.track_completion import (
     CompletionCandidate,
     enumerate_fragment_completion_paths,
@@ -105,6 +107,29 @@ class TestTrackCompletion(unittest.TestCase):
         self.assertEqual(path_observations(paths[0]), (7, 9))
         self.assertEqual(calls[0], (0, 7, "suffix"))
         self.assertEqual(calls[1], (2, 9, "suffix"))
+
+    def test_custom_candidate_sessions_do_not_truncate_invalid_scalars(self) -> None:
+        tracks = [[7, None, None]]
+
+        def candidate_sessions(session: int, observation: int, direction: str):
+            del session, observation, direction
+            return [True, np.bool_(True), 1.5, np.float64(1.0)]
+
+        def provider(session: int, observation: int, target_session: int):
+            if (session, observation, target_session) == (0, 7, 1):
+                return [8]
+            return []
+
+        paths = enumerate_fragment_completion_paths(
+            tracks,
+            direction="suffix",
+            candidate_provider=provider,
+            candidate_session_provider=candidate_sessions,
+        )
+
+        self.assertEqual(len(paths), 1)
+        self.assertEqual(path_sessions(paths[0]), (0, 1))
+        self.assertEqual(path_observations(paths[0]), (7, 8))
 
 
 if __name__ == "__main__":

--- a/tests/test_track_completion.py
+++ b/tests/test_track_completion.py
@@ -113,7 +113,7 @@ class TestTrackCompletion(unittest.TestCase):
 
         def candidate_sessions(session: int, observation: int, direction: str):
             del session, observation, direction
-            return [True, np.bool_(True), 1.5, np.float64(1.0)]
+            return [True, np.bool_(True), 1.5, np.float64(1.5)]
 
         def provider(session: int, observation: int, target_session: int):
             if (session, observation, target_session) == (0, 7, 1):
@@ -127,9 +127,7 @@ class TestTrackCompletion(unittest.TestCase):
             candidate_session_provider=candidate_sessions,
         )
 
-        self.assertEqual(len(paths), 1)
-        self.assertEqual(path_sessions(paths[0]), (0, 1))
-        self.assertEqual(path_observations(paths[0]), (7, 8))
+        self.assertEqual(paths, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Stop silently truncating custom track-completion candidate session values with `int(...)`.
- Ignore booleans and non-integral numeric session candidates before direction/range filtering.
- Add a regression test where `True`, `np.bool_(True)`, `1.5`, and `np.float64(1.5)` must not produce a suffix completion through session 1.

## Testing
- Not run locally; repository access is through the GitHub connector in this environment.