### PR TITLE
Validate NumPy choice axis bounds

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/random.py
+++ b/src/pyrecest/_backend/_shared_numpy/random.py
@@ -1,3 +1,5 @@
+import operator as _operator
+
 from ._dispatch import _common
 from ._dispatch import numpy as _np
 
@@ -49,6 +51,18 @@ multivariate_normal = _modify_func_default_dtype(
 )
 
 
+def _normalize_choice_axis(axis, ndim):
+    if isinstance(axis, (bool, _np.bool_)):
+        raise TypeError("axis must be an integer")
+    try:
+        axis = _operator.index(axis)
+    except TypeError as exc:
+        raise TypeError("axis must be an integer") from exc
+    if axis < -ndim or axis >= ndim:
+        raise ValueError(f"axis {axis} is out of bounds for array of dimension {ndim}")
+    return axis % ndim
+
+
 def choice(a, size=None, replace=True, p=None, axis=0, shuffle=True):
     """Draw samples using NumPy's seeded global random state.
 
@@ -64,7 +78,7 @@ def choice(a, size=None, replace=True, p=None, axis=0, shuffle=True):
     if a_array.ndim == 0:
         return _np.random.choice(a, size=size, replace=replace, p=p)
 
-    axis = axis % a_array.ndim
+    axis = _normalize_choice_axis(axis, a_array.ndim)
     if a_array.ndim == 1 and axis == 0:
         return _np.random.choice(a_array, size=size, replace=replace, p=p)
 

--- a/tests/test_backend_random.py
+++ b/tests/test_backend_random.py
@@ -80,6 +80,18 @@ class TestBackendRandom(unittest.TestCase):
         self.assertTrue(set(sample_np[0].tolist()).issubset({0, 1, 2}))
         self.assertTrue(set(sample_np[1].tolist()).issubset({3, 4, 5}))
 
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ != "numpy",
+        "NumPy-specific choice axis validation",
+    )
+    def test_numpy_choice_rejects_invalid_multidimensional_axis(self):
+        values = pyrecest.backend.array([[0, 1], [2, 3]])
+
+        for axis in (2, -3, 1.5, True):
+            with self.subTest(axis=axis):
+                with self.assertRaises((TypeError, ValueError)):
+                    random.choice(values, size=1, axis=axis)
+
     def test_multivariate_normal_accepts_python_sequences(self):
         samples = random.multivariate_normal(
             [0.0, 0.0], [[1.0, 0.0], [0.0, 1.0]], size=(6,)


### PR DESCRIPTION
## Summary
- reject non-integer, boolean, and out-of-range axes in the shared NumPy `random.choice` wrapper
- preserve valid negative-axis normalization
- add NumPy-backend regression coverage for invalid multidimensional axes

## Testing
- Not run locally; changes are covered by the added regression test and repository CI should run on the PR.