### PR TITLE
Reject non-finite Pareto constraint thresholds

### DIFF
--- a/src/pyrecest/evaluation/pareto.py
+++ b/src/pyrecest/evaluation/pareto.py
@@ -156,10 +156,10 @@ def constraint_mask(
     mask = pd.Series(True, index=table.index, dtype=bool)
     for column, spec in constraints.items():
         op, threshold = _parse_constraint_spec(spec)
-        threshold_value = _coerce_finite_threshold(threshold, column)
         if column not in table.columns:
             mask &= False
             continue
+        threshold_value = _coerce_finite_threshold(threshold, column)
         values = pd.to_numeric(table[column], errors="coerce")
         present_values = values.notna()
         if op == "<=":

--- a/src/pyrecest/evaluation/pareto.py
+++ b/src/pyrecest/evaluation/pareto.py
@@ -156,23 +156,24 @@ def constraint_mask(
     mask = pd.Series(True, index=table.index, dtype=bool)
     for column, spec in constraints.items():
         op, threshold = _parse_constraint_spec(spec)
+        threshold_value = _coerce_finite_threshold(threshold, column)
         if column not in table.columns:
             mask &= False
             continue
         values = pd.to_numeric(table[column], errors="coerce")
         present_values = values.notna()
         if op == "<=":
-            comparison = values <= float(threshold) + eps
+            comparison = values <= threshold_value + eps
         elif op == ">=":
-            comparison = values >= float(threshold) - eps
+            comparison = values >= threshold_value - eps
         elif op == "<":
-            comparison = values < float(threshold) - eps
+            comparison = values < threshold_value - eps
         elif op == ">":
-            comparison = values > float(threshold) + eps
+            comparison = values > threshold_value + eps
         elif op == "==":
-            comparison = np.isclose(values, float(threshold), atol=eps, rtol=0.0)
+            comparison = np.isclose(values, threshold_value, atol=eps, rtol=0.0)
         elif op == "!=":
-            comparison = ~np.isclose(values, float(threshold), atol=eps, rtol=0.0)
+            comparison = ~np.isclose(values, threshold_value, atol=eps, rtol=0.0)
         else:  # pragma: no cover - protected by _parse_constraint_spec.
             raise ValueError(f"Unsupported constraint operator {op!r}.")
         comparison = pd.Series(comparison, index=table.index).fillna(False).astype(bool)
@@ -339,7 +340,7 @@ def _lookup_numeric(record: Mapping[str, Any] | pd.Series, key: str) -> float:
 def _coerce_numeric(value: Any) -> float:
     try:
         return float(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return float("nan")
 
 
@@ -358,3 +359,15 @@ def _parse_constraint_spec(spec: ConstraintSpec | Mapping[str, Any]) -> Constrai
     if op not in {"<=", ">=", "<", ">", "==", "!="}:
         raise ValueError(f"Unsupported constraint operator {op!r}.")
     return op, threshold
+
+
+def _coerce_finite_threshold(value: Any, column: str) -> float:
+    try:
+        threshold = float(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(
+            f"Constraint threshold for {column!r} must be a finite scalar."
+        ) from exc
+    if not np.isfinite(threshold):
+        raise ValueError(f"Constraint threshold for {column!r} must be a finite scalar.")
+    return threshold

--- a/tests/evaluation/test_pareto_constraints_validation.py
+++ b/tests/evaluation/test_pareto_constraints_validation.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+import pytest
+from pyrecest.evaluation import constraint_mask
+
+
+def test_constraint_mask_rejects_nonfinite_thresholds() -> None:
+    table = pd.DataFrame([{"name": "candidate", "score": 1.0}])
+
+    for threshold in (math.nan, math.inf, -math.inf):
+        with pytest.raises(ValueError, match="finite scalar"):
+            constraint_mask(table, {"score": ("!=", threshold)})
+
+
+def test_constraint_mask_rejects_nonnumeric_thresholds() -> None:
+    table = pd.DataFrame([{"name": "candidate", "score": 1.0}])
+
+    with pytest.raises(ValueError, match="finite scalar"):
+        constraint_mask(table, {"score": ("<=", "not-a-number")})


### PR DESCRIPTION
## Summary
- Reject NaN, infinite, and nonnumeric scalar thresholds in Pareto/equal-quality constraint masks.
- Avoid the silent `("!=", NaN)` path where every present value could pass a constraint.
- Add focused regression coverage for non-finite and nonnumeric thresholds.

## Tests
- Not run locally; repository access here is through the GitHub connector only. Covered by the added pytest regression tests and CI.