### PR TITLE
Reject batched means in SO(3) tangent Gaussian

### DIFF
--- a/src/pyrecest/distributions/so3_tangent_gaussian_distribution.py
+++ b/src/pyrecest/distributions/so3_tangent_gaussian_distribution.py
@@ -84,7 +84,10 @@ class SO3TangentGaussianDistribution(AbstractBoundedDomainDistribution):
 
     def __init__(self, mu, C, check_validity=True):
         super().__init__(dim=3)
-        self.mu = self._normalize_quaternions(mu)[0]
+        normalized_mu = self._normalize_quaternions(mu)
+        if normalized_mu.shape[0] != 1:
+            raise ValueError("mu must be a single SO(3) quaternion.")
+        self.mu = normalized_mu[0]
 
         C = array(C, dtype=float)
         if ndim(C) != 2 or C.shape != (3, 3):

--- a/tests/distributions/test_so3_tangent_gaussian_distribution.py
+++ b/tests/distributions/test_so3_tangent_gaussian_distribution.py
@@ -23,6 +23,21 @@ class SO3TangentGaussianDistributionTest(unittest.TestCase):
         npt.assert_allclose(dist.covariance(), covariance, atol=ATOL)
         self.assertTrue(dist.is_valid())
 
+    def test_constructor_accepts_singleton_batched_mean(self):
+        covariance = diag(array([0.1, 0.2, 0.3]))
+        dist = SO3TangentGaussianDistribution(
+            array([[0.0, 0.0, 0.0, -2.0]]), covariance
+        )
+
+        npt.assert_allclose(dist.mean(), array([0.0, 0.0, 0.0, 1.0]), atol=ATOL)
+
+    def test_constructor_rejects_batched_mean(self):
+        covariance = diag(array([0.1, 0.2, 0.3]))
+        means = array([[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 1.0, 0.0]])
+
+        with self.assertRaisesRegex(ValueError, "single SO\\(3\\) quaternion"):
+            SO3TangentGaussianDistribution(means, covariance)
+
     def test_constructor_rejects_invalid_covariance(self):
         mean = array([0.0, 0.0, 0.0, 1.0])
 


### PR DESCRIPTION
## Summary
- reject batched `mu` values in `SO3TangentGaussianDistribution` instead of silently using only the first quaternion
- keep singleton batched means with shape `(1, 4)` accepted
- add regression coverage for rejected multi-quaternion means

## Rationale
`normalize_quaternions()` accepts batched quaternions, but `SO3TangentGaussianDistribution` represents a single tangent Gaussian with one mean. The previous constructor used `[0]`, so a `(N, 4)` mean silently discarded rows `1..N-1`.

## Tests
- Not run locally; repository access is through the GitHub connector in this environment.