### PR TITLE
Reject invalid weak-measurement index scalars

### DIFF
--- a/src/pyrecest/models/weak_measurement.py
+++ b/src/pyrecest/models/weak_measurement.py
@@ -209,10 +209,17 @@ def _positive_int(value: int, name: str) -> int:
 
 def _nonnegative_int(value: int, name: str) -> int:
     try:
-        parsed = int(value)
+        array_value = np.asarray(value)
     except (TypeError, ValueError) as exc:
         raise ValueError(f"{name} must be an integer") from exc
-    if parsed != value or parsed < 0:
+    if array_value.ndim != 0 or np.issubdtype(array_value.dtype, np.bool_):
+        raise ValueError(f"{name} must be a nonnegative integer")
+    scalar = array_value.item()
+    try:
+        parsed = int(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+    if parsed != scalar or parsed < 0:
         raise ValueError(f"{name} must be a nonnegative integer")
     return parsed
 

--- a/tests/models/test_weak_measurement.py
+++ b/tests/models/test_weak_measurement.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 from pyrecest.filters import KalmanFilter
 from pyrecest.models import (
     MaskedLinearMeasurementModel,
@@ -34,6 +35,18 @@ def test_selection_matrix_selects_state_components() -> None:
     assert np.allclose(
         matrix @ np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]), [1.0, 3.0, 6.0]
     )
+
+
+def test_selection_matrix_rejects_bool_and_vector_indices() -> None:
+    invalid_cases = (
+        (True, [0], "state_dim"),
+        (3, [False], "observed_dims"),
+        (3, [np.array([1])], "observed_dims"),
+    )
+
+    for state_dim, observed_dims, message in invalid_cases:
+        with pytest.raises(ValueError, match=message):
+            selection_matrix(state_dim, observed_dims)
 
 
 def test_masked_linear_measurement_model_updates_only_observed_dimensions() -> None:


### PR DESCRIPTION
## Summary
- reject boolean and vector-valued weak-measurement dimensions/indices before `int(...)` coercion
- keep valid scalar integer-like values working while avoiding NumPy size-1 array scalar conversion
- add a regression test for `selection_matrix` invalid state and observed dimensions

## Testing
- Not run locally; GitHub connector editing only in this environment.