### PR TITLE
Validate finite session times in track latency metrics

### DIFF
--- a/src/pyrecest/utils/track_metrics.py
+++ b/src/pyrecest/utils/track_metrics.py
@@ -328,6 +328,8 @@ def _session_times(
         raise ValueError(
             "session_times must have length equal to the number of sessions"
         )
+    if not np.all(np.isfinite(times)):
+        raise ValueError("session_times must contain only finite values")
     return times
 
 

--- a/tests/test_track_metrics.py
+++ b/tests/test_track_metrics.py
@@ -62,6 +62,34 @@ class TestTrackMetrics(unittest.TestCase):
         self.assertEqual(scores["false_tracks"], 1)
         npt.assert_allclose(scores["observation_weighted_track_purity"], 6.0 / 7.0)
 
+    def test_track_latency_rejects_nonfinite_session_times(self):
+        invalid_session_times = (
+            [0.0, np.nan, 2.0],
+            [0.0, np.inf, 2.0],
+            [0.0, -np.inf, 2.0],
+        )
+
+        for session_times in invalid_session_times:
+            with self.subTest(session_times=session_times):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "session_times must contain only finite values",
+                ):
+                    track_latencies(
+                        self.predicted,
+                        self.reference,
+                        session_times=session_times,
+                    )
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "session_times must contain only finite values",
+                ):
+                    score_track_latency(
+                        self.predicted,
+                        self.reference,
+                        session_times=session_times,
+                    )
+
     def test_min_length_limits_false_track_observation_rate_denominator(self):
         predicted = [
             [99, None, None],


### PR DESCRIPTION
## Summary
- Reject NaN and infinite `session_times` in `track_latencies` before latency aggregation.
- Add regression coverage for NaN, +inf, and -inf session timestamp inputs through both `track_latencies` and `score_track_latency`.

## Bug fixed
Previously, non-finite `session_times` could propagate NaN/inf latency values into `score_track_latency`. Because the summary treats non-finite latency values as missed detections, invalid timestamps could silently change detection and missed-track counts instead of failing fast.

## Tests
- Added focused unit coverage in `tests/test_track_metrics.py`.
- Not run locally in this environment; relying on GitHub CI.