### PR TITLE
Fix PyTorch backend NumPy integer dtype normalization

### DIFF
--- a/src/pyrecest/_backend/pytorch/_common.py
+++ b/src/pyrecest/_backend/pytorch/_common.py
@@ -2,6 +2,13 @@ import numpy as _np
 import torch as _torch
 
 _TORCH_DTYPE_BY_NAME = {
+    "bool": _torch.bool,
+    "uint8": _torch.uint8,
+    "int8": _torch.int8,
+    "int16": _torch.int16,
+    "int32": _torch.int32,
+    "int64": _torch.int64,
+    "float16": _torch.float16,
     "float32": _torch.float32,
     "float64": _torch.float64,
     "complex64": _torch.complex64,

--- a/tests/test_backend_contract.py
+++ b/tests/test_backend_contract.py
@@ -16,6 +16,19 @@ class BackendContractTest(unittest.TestCase):
                 )
                 self.assertEqual(duplicates, [])
 
+    @unittest.skipUnless(
+        backend.__backend_name__ == "pytorch",
+        reason="PyTorch-specific NumPy dtype normalization regression test",
+    )
+    def test_pytorch_array_accepts_numpy_integer_and_bool_dtypes(self):
+        int_values = array([1, 2, 3], dtype=np.int64)
+        bool_values = array([1, 0, 1], dtype=np.bool_)
+
+        self.assertEqual(to_numpy(int_values).dtype, np.dtype("int64"))
+        self.assertEqual(to_numpy(bool_values).dtype, np.dtype("bool"))
+        npt.assert_array_equal(to_numpy(int_values), np.array([1, 2, 3]))
+        npt.assert_array_equal(to_numpy(bool_values), np.array([True, False, True]))
+
     def test_convert_to_wider_dtype_preserves_matching_boolean_dtype(self):
         if backend.__backend_name__ not in {"autograd", "numpy"}:
             self.skipTest("shared NumPy dtype promotion regression test")


### PR DESCRIPTION
## Summary
- normalize common NumPy integer, unsigned byte, bool, and float16 dtypes to matching `torch.dtype` values in the PyTorch backend
- add a PyTorch-specific regression test covering `np.int64` and `np.bool_` dtype arguments to `backend.array`

## Bug
The PyTorch backend advertises NumPy-style dtype normalization in `_normalize_dtype`, but only mapped floating and complex dtype names. Calls such as `backend.array([1, 2, 3], dtype=np.int64)` therefore passed a NumPy dtype object through to `torch.tensor`, which raises `TypeError` instead of constructing an integer tensor.

## Testing
- Not run locally; this environment cannot install or clone the repository from GitHub, so CI should exercise the backend matrix.