### PR TITLE
Validate fixed measurement counts

### DIFF
--- a/src/pyrecest/evaluation/generate_measurements.py
+++ b/src/pyrecest/evaluation/generate_measurements.py
@@ -28,6 +28,30 @@ def _as_shapely_scalar(value):
     return float(np.asarray(value).reshape(-1)[0])
 
 
+def _as_nonnegative_measurement_count(value, name="measurement count") -> int:
+    value_array = np.asarray(value)
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError(f"{name} must be a non-negative integer.")
+
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(f"{name} must be a non-negative integer.")
+    if isinstance(scalar, (int, np.integer)):
+        count = int(scalar)
+    else:
+        try:
+            scalar_float = float(scalar)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(f"{name} must be a non-negative integer.") from exc
+        if not np.isfinite(scalar_float) or not scalar_float.is_integer():
+            raise ValueError(f"{name} must be a non-negative integer.")
+        count = int(scalar_float)
+
+    if count < 0:
+        raise ValueError(f"{name} must be a non-negative integer.")
+    return count
+
+
 def _mtt_state_at(groundtruth, t, target_no, n_targets):
     """Return one target state from dense or per-step object ground truth."""
     state_at_t = np.asarray(groundtruth[t])
@@ -123,7 +147,10 @@ def generate_measurements(groundtruth, simulation_config):
                         "Cannot use both intensity_lambda and "
                         "n_meas_at_individual_time_step."
                     )
-                n_meas_curr = simulation_config["n_meas_at_individual_time_step"][t]
+                n_meas_curr = _as_nonnegative_measurement_count(
+                    simulation_config["n_meas_at_individual_time_step"][t],
+                    name=f"n_meas_at_individual_time_step[{t}]",
+                )
             else:
                 if eot_sampling_style == "boundary":
                     n_meas_curr = generate_n_measurements_PPP(
@@ -195,7 +222,10 @@ def generate_measurements(groundtruth, simulation_config):
                 "Scenarios based on a 'measGenerator' are currently not supported."
             )
         for t in range(simulation_config["n_timesteps"]):
-            n_meas = simulation_config["n_meas_at_individual_time_step"][t]
+            n_meas = _as_nonnegative_measurement_count(
+                simulation_config["n_meas_at_individual_time_step"][t],
+                name=f"n_meas_at_individual_time_step[{t}]",
+            )
             meas_noise = simulation_config["meas_noise"]
 
             if isinstance(meas_noise, AbstractHypertoroidalDistribution):

--- a/tests/test_generate_measurements_eot_fixed_counts.py
+++ b/tests/test_generate_measurements_eot_fixed_counts.py
@@ -21,6 +21,46 @@ class TestGenerateMeasurementsEotFixedCounts(unittest.TestCase):
         self.assertEqual(measurements[0].shape, (2, 2))
         self.assertEqual(measurements[1].shape, (3, 2))
 
+    def test_eot_normalizes_integral_float_fixed_measurement_counts(self):
+        simulation_param = {
+            "eot": True,
+            "target_shape": Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]),
+            "eot_sampling_style": "within",
+            "n_timesteps": 2,
+            "n_meas_at_individual_time_step": np.array([2.0, 3.0]),
+        }
+        groundtruth = np.zeros((2, 2))
+
+        measurements = generate_measurements(groundtruth, simulation_param)
+
+        self.assertEqual(measurements[0].shape, (2, 2))
+        self.assertEqual(measurements[1].shape, (3, 2))
+
+    def test_eot_rejects_invalid_fixed_measurement_counts(self):
+        invalid_counts = (
+            np.array([1.5]),
+            np.array([-1]),
+            np.array([np.nan]),
+            np.array([True]),
+        )
+
+        for counts in invalid_counts:
+            with self.subTest(counts=counts):
+                simulation_param = {
+                    "eot": True,
+                    "target_shape": Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]),
+                    "eot_sampling_style": "within",
+                    "n_timesteps": 1,
+                    "n_meas_at_individual_time_step": counts,
+                }
+                groundtruth = np.zeros((1, 2))
+
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "n_meas_at_individual_time_step\\[0\\] must be a non-negative integer",
+                ):
+                    generate_measurements(groundtruth, simulation_param)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Normalize fixed `n_meas_at_individual_time_step` entries to non-negative integer counts before passing them to sampling/noise routines.
- Accept scalar integer-like values such as `np.float64(2.0)` while rejecting fractional, negative, NaN, and boolean counts.
- Apply the same normalization in EOT fixed-count and ordinary measurement-generation paths.

## Testing
- Added EOT fixed-count regression coverage for integral float counts and invalid counts.