### PR TITLE
Validate sparse second-order initial weights

### DIFF
--- a/src/pyrecest/filters/sparse_second_order_grid.py
+++ b/src/pyrecest/filters/sparse_second_order_grid.py
@@ -122,10 +122,18 @@ def sparse_second_order_grid_evidence(
     prev = np.asarray(prev, dtype=int)
     curr = np.asarray(curr, dtype=int)
     alpha = np.asarray(alpha, dtype=float)
-    if prev.shape != curr.shape or prev.shape != alpha.shape:
+    if (
+        prev.ndim != 1
+        or curr.ndim != 1
+        or alpha.ndim != 1
+        or prev.shape != curr.shape
+        or prev.shape != alpha.shape
+    ):
         raise ValueError(
             "initial pair arrays must have matching one-dimensional shapes"
         )
+    if np.any(~np.isfinite(alpha)) or np.any(alpha < 0.0):
+        raise ValueError("initial pair weights must be finite and nonnegative")
     if (
         np.any(prev < 0)
         or np.any(prev >= n_states)

--- a/tests/test_sparse_second_order_grid.py
+++ b/tests/test_sparse_second_order_grid.py
@@ -118,6 +118,59 @@ def test_sparse_second_order_grid_validates_transition_rows():
         raise AssertionError("bad transition row should fail")
 
 
+def test_sparse_second_order_grid_validates_initial_pair_weights_and_shape():
+    log_likelihood = np.zeros((3, 2), dtype=float)
+
+    def row(prev, curr, transition_index):
+        del prev, curr, transition_index
+        return np.array([0]), np.array([1.0])
+
+    def negative_weight_init(scaled):
+        del scaled
+        return np.array([0, 1]), np.array([0, 1]), np.array([2.0, -1.0]), [1, 1]
+
+    _assert_raises_value_error_containing(
+        "initial pair weights",
+        lambda: sparse_second_order_grid_evidence(
+            log_likelihood, negative_weight_init, row
+        ),
+    )
+
+    def nonfinite_weight_init(scaled):
+        del scaled
+        return np.array([0, 1]), np.array([0, 1]), np.array([1.0, np.nan]), [1, 1]
+
+    _assert_raises_value_error_containing(
+        "initial pair weights",
+        lambda: sparse_second_order_grid_evidence(
+            log_likelihood, nonfinite_weight_init, row
+        ),
+    )
+
+    def nonvector_init(scaled):
+        del scaled
+        return (
+            np.array([[0], [1]]),
+            np.array([[0], [1]]),
+            np.array([[0.5], [0.5]]),
+            [1, 1],
+        )
+
+    _assert_raises_value_error_containing(
+        "one-dimensional",
+        lambda: sparse_second_order_grid_evidence(log_likelihood, nonvector_init, row),
+    )
+
+
+def _assert_raises_value_error_containing(expected_message, callback):
+    try:
+        callback()
+    except ValueError as exc:
+        assert expected_message in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError(f"expected ValueError containing {expected_message!r}")
+
+
 def _dense_second_order_log_evidence(log_likelihood, initial_transition, transition):
     likelihood = np.exp(log_likelihood)
     n_time, n_states = likelihood.shape


### PR DESCRIPTION
## Summary
- enforce one-dimensional initial sparse-pair arrays before running the sparse second-order recursion
- reject non-finite or negative initial pair weights instead of normalizing them into invalid probabilities
- add a focused regression test for negative, NaN, and non-vector initial pair initializers

## Notes
I could not run the local test suite from this environment because the container cannot resolve github.com to clone/install the repository, so this relies on the GitHub PR checks.