### PR TITLE
Fix fixed-lag Viterbi prefix context

### DIFF
--- a/src/pyrecest/filters/tracklet_viterbi.py
+++ b/src/pyrecest/filters/tracklet_viterbi.py
@@ -292,11 +292,11 @@ def solve_fixed_lag_tracklet_viterbi(
 ) -> TrackletViterbiResult:
     """Commit Viterbi decisions using at most ``lag_s`` future context.
 
-    Each frame is solved on a local look-ahead window. The previous non-missed
-    committed candidate is prepended as a zero-cost prefix candidate. The
-    committed missed-detection streak is carried into that synthetic prefix so
-    the local window scores another miss the same way the full Viterbi table
-    would score it.
+    Each frame is solved on a local look-ahead window. Either the previous
+    non-missed committed candidate or a zero-cost synthetic prefix for a pending
+    gap is prepended. The committed missed-detection streak is carried into that
+    prefix so the local window scores another miss the same way the full Viterbi
+    table would score it.
     """
 
     if lag_s <= 0.0:
@@ -318,11 +318,17 @@ def solve_fixed_lag_tracklet_viterbi(
             window_end += 1
         window_frames = [list(frame) for frame in frames[frame_index : window_end + 1]]
         prefix_candidate: TrackletAssociationCandidate | None = None
-        prefix_added = previous_committed is not None
+        prefix_added = previous_committed is not None or committed_miss_streak > 0
         local_transition_cost = transition_cost
         if prefix_added:
-            assert previous_committed is not None
-            prefix_candidate = replace(previous_committed, unary_cost=0.0)
+            if previous_committed is None:
+                prefix_candidate = TrackletAssociationCandidate(
+                    ("__pyrecest_prefix_context__", frame_index),
+                    unary_cost=0.0,
+                    time_s=start_time,
+                )
+            else:
+                prefix_candidate = replace(previous_committed, unary_cost=0.0)
             window_frames.insert(0, [prefix_candidate])
             local_transition_cost = _transition_with_prefix_miss_streak(
                 transition_cost,

--- a/tests/filters/test_tracklet_viterbi_prefix_context.py
+++ b/tests/filters/test_tracklet_viterbi_prefix_context.py
@@ -1,0 +1,29 @@
+from pyrecest.filters.tracklet_viterbi import (
+    TrackletAssociationCandidate,
+    TrackletViterbiConfig,
+    solve_fixed_lag_tracklet_viterbi,
+    solve_tracklet_viterbi,
+)
+
+
+def test_fixed_lag_prefix_context_affects_selection_after_initial_gap():
+    frames = [
+        [],
+        [TrackletAssociationCandidate("candidate", unary_cost=4.0)],
+    ]
+    config = TrackletViterbiConfig(
+        missed_detection_cost=2.0,
+        consecutive_miss_cost=5.0,
+    )
+
+    full = solve_tracklet_viterbi(frames, config=config)
+    fixed_lag = solve_fixed_lag_tracklet_viterbi(
+        frames,
+        lag_s=0.1,
+        config=config,
+    )
+
+    assert full.path == [None, frames[1][0]]
+    assert full.total_cost == 6.0
+    assert fixed_lag.path == full.path
+    assert fixed_lag.total_cost == full.total_cost


### PR DESCRIPTION
## Summary
- Carry committed prefix context even before the first selected candidate exists.
- Add a regression where fixed-lag Viterbi must make the same second-frame decision as full Viterbi after an initial gap.

## Testing
- Added focused regression test.