### PR TITLE
Ensure candidate pruning penalties stay large

### DIFF
--- a/src/pyrecest/utils/candidate_pruning.py
+++ b/src/pyrecest/utils/candidate_pruning.py
@@ -168,6 +168,7 @@ def prune_pairwise_cost_matrix(
     penalty = cfg.large_cost if large_cost is None else float(large_cost)
     if not np.isfinite(penalty) or penalty <= 0.0:
         raise ValueError("large_cost must be finite and positive")
+    penalty = _effective_large_cost(costs, penalty)
 
     mask = candidate_mask_from_costs(
         costs,
@@ -213,6 +214,21 @@ def _finite_percentile(costs: np.ndarray, percentile: float) -> float | None:
     if finite.size == 0:
         return None
     return float(np.percentile(finite, float(percentile)))
+
+
+def _effective_large_cost(costs: np.ndarray, penalty: float) -> float:
+    finite = costs[np.isfinite(costs)]
+    if finite.size == 0:
+        return penalty
+
+    max_finite = float(np.max(finite))
+    if penalty > max_finite:
+        return penalty
+
+    adjusted_penalty = float(np.nextafter(max_finite, np.inf))
+    if not np.isfinite(adjusted_penalty):
+        raise ValueError("large_cost is too small to exceed finite costs")
+    return adjusted_penalty
 
 
 def _as_cost_matrix(cost_matrix: Any) -> np.ndarray:

--- a/tests/test_candidate_pruning.py
+++ b/tests/test_candidate_pruning.py
@@ -84,6 +84,18 @@ class TestCandidatePruning(unittest.TestCase):
             np.array([[1.0, 2.0, 999.0], [3.0, 999.0, 999.0]]),
         )
 
+    def test_pruned_entries_remain_more_expensive_than_large_finite_costs(self):
+        costs = np.array([[2.0e6, 3.0e6]])
+
+        pruned = prune_pairwise_cost_matrix(
+            costs,
+            config=CandidatePruningConfig(row_top_k=1),
+        )
+
+        self.assertEqual(pruned[0, 0], costs[0, 0])
+        self.assertTrue(np.isfinite(pruned[0, 1]))
+        self.assertGreater(pruned[0, 1], costs[0, 1])
+
     def test_always_keep_finite_overrides_selective_rules(self):
         costs = np.array([[1.0, 10.0], [3.0, np.inf]])
 


### PR DESCRIPTION
## Summary
- Ensure `prune_pairwise_cost_matrix` does not make pruned entries cheaper than finite input costs when `large_cost` is too small for the matrix scale.
- Keep the configured/default penalty when it is already larger than all finite costs; otherwise bump it to the next representable float above the largest finite cost.
- Add a regression test for multi-million cost matrices with the default `large_cost=1e6`.

## Why
`CandidatePruningConfig.large_cost` defaults to `1e6`. For cost matrices whose valid finite entries exceed that scale, replacing pruned entries by `1e6` can make pruned entries preferable to kept candidates, defeating the pruning contract.

## Tests
- Added `test_pruned_entries_remain_more_expensive_than_large_finite_costs` in `tests/test_candidate_pruning.py`.