### PR TITLE
Support tuple axes in shared NumPy squeeze

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/__init__.py
+++ b/src/pyrecest/_backend/_shared_numpy/__init__.py
@@ -83,13 +83,30 @@ def from_numpy(x):
     return x
 
 
+def _normalize_squeeze_axes(axis):
+    if isinstance(axis, (int, _np.integer)):
+        return (int(axis),)
+    return tuple(axis)
+
+
 def squeeze(x, axis=None):
     x = _np.asarray(x)
     if axis is None:
         return _np.squeeze(x)
-    if x.shape[axis] != 1:
+
+    axes = _normalize_squeeze_axes(axis)
+    if not axes:
         return x
-    return _np.squeeze(x, axis=axis)
+
+    normalized_axes = tuple(
+        one_axis + x.ndim if one_axis < 0 else one_axis for one_axis in axes
+    )
+    if len(set(normalized_axes)) != len(normalized_axes):
+        raise ValueError("duplicate value in 'axis'")
+    if any(x.shape[one_axis] != 1 for one_axis in normalized_axes):
+        return x
+    squeeze_axis = normalized_axes[0] if len(normalized_axes) == 1 else normalized_axes
+    return _np.squeeze(x, axis=squeeze_axis)
 
 
 def flatten(x):

--- a/tests/test_shared_numpy_squeeze.py
+++ b/tests/test_shared_numpy_squeeze.py
@@ -1,0 +1,20 @@
+import pyrecest.backend as backend
+import pytest
+from pyrecest.backend import array
+
+
+def _to_python(value):
+    value = backend.to_numpy(value)
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    return value
+
+
+def test_shared_numpy_squeeze_accepts_tuple_axis():
+    if backend.__backend_name__ not in ("numpy", "autograd"):
+        pytest.skip("shared NumPy/autograd squeeze regression test")
+
+    result = backend.squeeze(array([[[1], [2]]]), axis=(0, 2))
+
+    assert result.shape == (2,)
+    assert _to_python(result) == [1, 2]


### PR DESCRIPTION
## Summary
- fix the shared NumPy/autograd backend `squeeze` wrapper for tuple-valued axes
- preserve the existing behavior of returning the input unchanged for requested non-singleton axes
- add a regression test for squeezing axes `(0, 2)` on a `(1, 2, 1)` array

## Bug
The previous implementation indexed `x.shape[axis]` directly. That works for scalar axes, but raises `TypeError` for tuple axes before reaching NumPy's tuple-axis squeeze support.

## Testing
- Added `tests/test_shared_numpy_squeeze.py`
- Not run locally here because this environment cannot clone GitHub or install the repository; CI should run the regression test.