### PR TITLE
Fix fragment completion candidate observation validation

### DIFF
--- a/src/pyrecest/utils/track_completion.py
+++ b/src/pyrecest/utils/track_completion.py
@@ -398,16 +398,26 @@ def _coerce_candidate(
 
 
 def _normalize_candidate_observation(value: Any) -> int:
-    if isinstance(value, (bool, np.bool_)):
+    value_array = np.asarray(value)
+    if value_array.shape != () or value_array.dtype == np.bool_:
         raise ValueError("candidate observations must be non-negative integers")
-    if isinstance(value, (float, np.floating)) and not float(value).is_integer():
+
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
         raise ValueError("candidate observations must be non-negative integers")
-    try:
-        observation = int(value)
-    except (TypeError, ValueError) as exc:
-        raise ValueError(
-            "candidate observations must be non-negative integers"
-        ) from exc
+    if isinstance(scalar, (int, np.integer)):
+        observation = int(scalar)
+    elif isinstance(scalar, (float, np.floating)):
+        if not np.isfinite(scalar) or not float(scalar).is_integer():
+            raise ValueError("candidate observations must be non-negative integers")
+        observation = int(scalar)
+    else:
+        try:
+            observation = int(scalar)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(
+                "candidate observations must be non-negative integers"
+            ) from exc
     if observation < 0:
         raise ValueError("candidate observations must be non-negative integers")
     return observation

--- a/tests/test_track_completion_candidate_validation.py
+++ b/tests/test_track_completion_candidate_validation.py
@@ -1,0 +1,61 @@
+"""Regression tests for fragment-completion candidate validation."""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+
+from pyrecest.utils.track_completion import (
+    CompletionCandidate,
+    enumerate_fragment_completion_paths,
+    path_observations,
+)
+
+
+class TestTrackCompletionCandidateValidation(unittest.TestCase):
+    def test_numpy_scalar_array_candidates_do_not_truncate(self) -> None:
+        tracks = [[0, None]]
+        invalid_candidates = (
+            np.array(1.5),
+            np.array([1.5]),
+            np.array(True),
+            CompletionCandidate(np.array(1.5)),
+        )
+
+        for invalid_candidate in invalid_candidates:
+            with self.subTest(invalid_candidate=repr(invalid_candidate)):
+
+                def provider(session: int, observation: int, target_session: int):
+                    del session, observation, target_session
+                    return [invalid_candidate]
+
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "candidate observations must be non-negative integers",
+                ):
+                    enumerate_fragment_completion_paths(
+                        tracks,
+                        direction="suffix",
+                        candidate_provider=provider,
+                    )
+
+    def test_numpy_integer_scalar_array_candidates_are_accepted(self) -> None:
+        tracks = [[0, None]]
+
+        def provider(session: int, observation: int, target_session: int):
+            del session, observation, target_session
+            return [np.array(1.0)]
+
+        paths = enumerate_fragment_completion_paths(
+            tracks,
+            direction="suffix",
+            candidate_provider=provider,
+        )
+
+        self.assertEqual(len(paths), 1)
+        self.assertEqual(path_observations(paths[0]), (0, 1))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Reject NumPy scalar/array candidate observations that are boolean, non-scalar, non-finite, or non-integral instead of letting `int(...)` truncate them.
- Preserve valid integer-like scalar candidates such as `np.array(1.0)`.
- Add regression tests for NumPy candidate-observation validation.

## Testing
- Added focused regression tests in `tests/test_track_completion_candidate_validation.py`.
