### PR TITLE
Reject non-finite Daum-Huang jitter

### DIFF
--- a/src/pyrecest/filters/daum_huang_particle_filter.py
+++ b/src/pyrecest/filters/daum_huang_particle_filter.py
@@ -357,8 +357,8 @@ def _validate_positive_int(value, name: str) -> int:
 
 def _validate_nonnegative_float(value, name: str) -> float:
     value = float(value)
-    if value < 0.0:
-        raise ValueError(f"{name} must be nonnegative.")
+    if not np.isfinite(value) or value < 0.0:
+        raise ValueError(f"{name} must be finite and nonnegative.")
     return value
 
 

--- a/tests/filters/test_daum_huang_particle_filter_validation.py
+++ b/tests/filters/test_daum_huang_particle_filter_validation.py
@@ -1,0 +1,17 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.filters import EDHParticleFlowFilter
+
+
+class DaumHuangParticleFlowValidationTest(unittest.TestCase):
+    def test_constructor_rejects_nonfinite_jitter(self):
+        for invalid_jitter in (np.nan, np.inf, -np.inf):
+            with self.subTest(jitter=invalid_jitter):
+                with self.assertRaisesRegex(ValueError, "jitter"):
+                    EDHParticleFlowFilter(n_particles=2, dim=1, jitter=invalid_jitter)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Reject `NaN` and infinite `jitter` values in the Daum-Huang particle-flow validator.
- Add a regression test for constructor validation so invalid jitter fails before covariance regularization.

## Testing
- Added focused regression test `tests/filters/test_daum_huang_particle_filter_validation.py`.