### PR TITLE
Validate serialized innovation measurement dimensions

### DIFF
--- a/src/pyrecest/tracking/innovation_diagnostics.py
+++ b/src/pyrecest/tracking/innovation_diagnostics.py
@@ -209,9 +209,10 @@ def diagnostic_from_record(
     if measurement_dim_value is None:
         residual = record.get("residual")
         if residual is not None:
-            measurement_dim_value = int(np.asarray(residual).reshape(-1).size)
+            measurement_dim_value = np.asarray(residual).reshape(-1).size
         else:
             measurement_dim_value = 0
+    measurement_dim = _nonnegative_integer(measurement_dim_value, measurement_dim_key)
     accepted = record.get(accepted_key)
     excluded = {
         source_key,
@@ -224,7 +225,7 @@ def diagnostic_from_record(
         gate_threshold_key,
     }
     return InnovationDiagnostic(
-        measurement_dim=int(measurement_dim_value),
+        measurement_dim=measurement_dim,
         nis=_optional_float(record.get(nis_key)),
         residual_norm=_optional_float(record.get(residual_norm_key)),
         gate_threshold=_optional_float(record.get(gate_threshold_key)),
@@ -339,6 +340,31 @@ def _optional_float(value: Any) -> float | None:
     except (TypeError, ValueError):
         return None
     return parsed if np.isfinite(parsed) else None
+
+
+def _nonnegative_integer(value: Any, name: str) -> int:
+    try:
+        value_array = np.asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a non-negative integer") from exc
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError(f"{name} must be a non-negative integer")
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(f"{name} must be a non-negative integer")
+    if isinstance(scalar, (int, np.integer)):
+        parsed = int(scalar)
+    else:
+        try:
+            scalar_float = float(scalar)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(f"{name} must be a non-negative integer") from exc
+        if not np.isfinite(scalar_float) or not scalar_float.is_integer():
+            raise ValueError(f"{name} must be a non-negative integer")
+        parsed = int(scalar_float)
+    if parsed < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+    return parsed
 
 
 def _optional_bool(value: Any) -> bool | None:

--- a/tests/tracking/test_innovation_diagnostics_measurement_dim.py
+++ b/tests/tracking/test_innovation_diagnostics_measurement_dim.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pytest
+from pyrecest.tracking import diagnostic_from_record
+
+
+def test_diagnostic_from_record_accepts_integral_measurement_dim_strings() -> None:
+    assert diagnostic_from_record({"measurement_dim": "2"}).measurement_dim == 2
+    assert diagnostic_from_record({"measurement_dim": "2.0"}).measurement_dim == 2
+
+
+def test_diagnostic_from_record_infers_measurement_dim_from_residual() -> None:
+    diagnostic = diagnostic_from_record({"residual": [1.0, -2.0, 3.0]})
+
+    assert diagnostic.measurement_dim == 3
+
+
+@pytest.mark.parametrize(
+    "measurement_dim",
+    [True, -1, 2.5, "2.5", float("nan")],
+)
+def test_diagnostic_from_record_rejects_invalid_measurement_dim(
+    measurement_dim,
+) -> None:
+    with pytest.raises(ValueError, match="measurement_dim"):
+        diagnostic_from_record({"measurement_dim": measurement_dim})


### PR DESCRIPTION
## Summary
- Parse serialized `measurement_dim` through a non-negative integer validator instead of raw `int(...)`.
- Preserve residual-based dimension inference when `measurement_dim` is absent.
- Add regression tests for integral strings, residual inference, and invalid boolean/fractional/negative/non-finite dimensions.

## Bug
`diagnostic_from_record()` previously used `int(measurement_dim_value)`, which silently truncated fractional dimensions such as `2.5` to `2` and accepted booleans as dimensions.

## Testing
- Added `tests/tracking/test_innovation_diagnostics_measurement_dim.py`
- Not run locally; repository access here is through the GitHub connector and the container cannot resolve github.com.