### PR TITLE
Validate finite registration weights

### DIFF
--- a/src/pyrecest/utils/point_set_registration.py
+++ b/src/pyrecest/utils/point_set_registration.py
@@ -25,6 +25,7 @@ from pyrecest.backend import (
     concatenate,
     eye,
     full,
+    isfinite,
     linalg,
     ones,
     quantile,
@@ -143,6 +144,8 @@ def _normalize_weights(weights, n_points):
     weights_array = asarray(weights).reshape(-1)
     if weights_array.shape[0] != n_points:
         raise ValueError("weights must have length n_points.")
+    if any(~isfinite(weights_array)):
+        raise ValueError("weights must be finite.")
     if any(weights_array < 0.0):
         raise ValueError("weights must be non-negative.")
     weight_sum = float(weights_array.sum())

--- a/tests/test_point_set_registration.py
+++ b/tests/test_point_set_registration.py
@@ -36,6 +36,22 @@ class TestEstimateTransform(unittest.TestCase):
         pyrecest.backend.__backend_name__ == "jax",
         reason="Not supported on this backend",
     )
+    def test_estimate_transform_rejects_nonfinite_weights(self):
+        source = array([[0.0, 0.0], [1.0, 0.0]])
+        target = source + array([2.0, -0.5])
+
+        with self.assertRaisesRegex(ValueError, "weights must be finite"):
+            estimate_transform(
+                source,
+                target,
+                model="translation",
+                weights=array([1.0, float("nan")]),
+            )
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
     def test_estimate_rigid_transform_recovers_rotation_and_translation(self):
         source = array(
             [[0.0, 0.0], [1.0, 0.2], [0.4, 1.1], [1.3, 1.6], [2.1, -0.3]],


### PR DESCRIPTION
## Summary
- reject non-finite weights in point-set transform estimation before normalization
- add regression coverage for NaN weights to prevent silent NaN transforms

## Testing
- Not run locally; changes pushed through GitHub connector and CI should run on the PR.