### PR TITLE
Honor shuffle=False in random choice backends

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/random.py
+++ b/src/pyrecest/_backend/_shared_numpy/random.py
@@ -63,6 +63,16 @@ def _normalize_choice_axis(axis, ndim):
     return axis % ndim
 
 
+def _maybe_preserve_choice_order(indices, *, replace, p, shuffle, size):
+    if replace or p is not None or bool(shuffle) or size is None:
+        return indices
+
+    index_array = _np.asarray(indices)
+    if index_array.ndim == 0:
+        return indices
+    return _np.sort(index_array.reshape(-1)).reshape(index_array.shape)
+
+
 def choice(a, size=None, replace=True, p=None, axis=0, shuffle=True):
     """Draw samples using NumPy's seeded global random state.
 
@@ -72,18 +82,36 @@ def choice(a, size=None, replace=True, p=None, axis=0, shuffle=True):
     ``numpy.random``, so this wrapper samples indices through the seeded legacy RNG
     and then gathers along ``axis`` for multidimensional inputs.
     """
-    del shuffle  # ``numpy.random.choice`` has no equivalent shuffle argument.
 
     a_array = _np.asarray(a)
     if a_array.ndim == 0:
-        return _np.random.choice(a, size=size, replace=replace, p=p)
+        return _maybe_preserve_choice_order(
+            _np.random.choice(a, size=size, replace=replace, p=p),
+            replace=replace,
+            p=p,
+            shuffle=shuffle,
+            size=size,
+        )
 
     axis = _normalize_choice_axis(axis, a_array.ndim)
     if a_array.ndim == 1 and axis == 0:
-        return _np.random.choice(a_array, size=size, replace=replace, p=p)
+        return _maybe_preserve_choice_order(
+            _np.random.choice(a_array, size=size, replace=replace, p=p),
+            replace=replace,
+            p=p,
+            shuffle=shuffle,
+            size=size,
+        )
 
     if p is not None:
         p = _np.asarray(p)
 
     indices = _np.random.choice(a_array.shape[axis], size=size, replace=replace, p=p)
+    indices = _maybe_preserve_choice_order(
+        indices,
+        replace=replace,
+        p=p,
+        shuffle=shuffle,
+        size=size,
+    )
     return _np.take(a_array, indices, axis=axis)

--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -190,7 +190,7 @@ def _integer_population_size(a):
     return None
 
 
-def _choice_indices(population_size, size, num_samples, replace, p, device):
+def _choice_indices(population_size, size, num_samples, replace, p, device, *, shuffle=True):
     if population_size <= 0:
         if num_samples == 0:
             return _torch.empty(size or (0,), dtype=_torch.long, device=device)
@@ -230,6 +230,8 @@ def _choice_indices(population_size, size, num_samples, replace, p, device):
         )
 
     indices = _torch.randperm(population_size, device=device)[:num_samples]
+    if not bool(shuffle):
+        indices = _torch.sort(indices).values
     if size is None:
         return indices[0]
     return indices.reshape(size)
@@ -255,13 +257,13 @@ def _take_choice(a, indices, axis):
 
 
 def choice(a, size=None, replace=True, p=None, axis=0, shuffle=True):
-    del shuffle
-
     size, num_samples = _choice_size(size)
     population_size = _integer_population_size(a)
     if population_size is not None:
         device = p.device if _torch.is_tensor(p) else None
-        return _choice_indices(population_size, size, num_samples, replace, p, device)
+        return _choice_indices(
+            population_size, size, num_samples, replace, p, device, shuffle=shuffle
+        )
 
     if not _torch.is_tensor(a):
         a = _torch.as_tensor(a)
@@ -271,7 +273,9 @@ def choice(a, size=None, replace=True, p=None, axis=0, shuffle=True):
         )
 
     axis = _normalize_axis(axis, a.ndim)
-    indices = _choice_indices(a.shape[axis], size, num_samples, replace, p, a.device)
+    indices = _choice_indices(
+        a.shape[axis], size, num_samples, replace, p, a.device, shuffle=shuffle
+    )
     return _take_choice(a, indices, axis)
 
 

--- a/tests/backend/test_numpy_random_backend.py
+++ b/tests/backend/test_numpy_random_backend.py
@@ -22,3 +22,23 @@ def test_rand_keeps_numpy_positional_dimensions():
 def test_rand_rejects_ambiguous_positional_and_size_arguments():
     with pytest.raises(TypeError, match="positional dimensions or size"):
         random.rand(2, size=(3,))
+
+
+def test_choice_without_replacement_shuffle_false_preserves_order():
+    values = np.array([10, 20, 30, 40, 50])
+    matrix = np.array([[10, 20, 30], [40, 50, 60]])
+
+    random.seed(0)
+    samples = random.choice(
+        values, size=values.shape[0], replace=False, shuffle=False
+    )
+    column_samples = random.choice(
+        matrix,
+        size=matrix.shape[1],
+        replace=False,
+        axis=1,
+        shuffle=False,
+    )
+
+    np.testing.assert_array_equal(samples, values)
+    np.testing.assert_array_equal(column_samples, matrix)

--- a/tests/backend/test_pytorch_random_backend.py
+++ b/tests/backend/test_pytorch_random_backend.py
@@ -117,3 +117,23 @@ def test_zero_sized_choice_still_works_for_empty_population():
     sample = random.choice(0, size=(0,))
 
     assert sample.shape == (0,)
+
+
+def test_choice_without_replacement_shuffle_false_preserves_order():
+    values = torch.tensor([10, 20, 30, 40, 50])
+    matrix = torch.tensor([[10, 20, 30], [40, 50, 60]])
+
+    random.seed(0)
+    samples = random.choice(
+        values, size=values.shape[0], replace=False, shuffle=False
+    )
+    column_samples = random.choice(
+        matrix,
+        size=matrix.shape[1],
+        replace=False,
+        axis=1,
+        shuffle=False,
+    )
+
+    assert torch.equal(samples, values)
+    assert torch.equal(column_samples, matrix)


### PR DESCRIPTION
## Summary
- make the shared NumPy/autograd random.choice wrapper honor shuffle=False for unweighted sampling without replacement
- make the PyTorch random.choice wrapper honor the same flag
- add regression tests for full-population sampling and multidimensional axis sampling

## Tests
- Not run locally; changes were made via the GitHub connector and will be validated by CI.