### PR TITLE
Accept array-like inputs in GlobalNearestNeighbor

### DIFF
--- a/src/pyrecest/filters/global_nearest_neighbor.py
+++ b/src/pyrecest/filters/global_nearest_neighbor.py
@@ -114,6 +114,10 @@ class GlobalNearestNeighbor(AbstractNearestNeighborTracker):
             ``(n_targets, n_meas)``. These costs are added to the geometric cost
             matrix before running the Hungarian algorithm.
         """
+        measurements = asarray(measurements, dtype=float)
+        measurement_matrix = asarray(measurement_matrix, dtype=float)
+        cov_mats_meas = asarray(cov_mats_meas, dtype=float)
+
         n_targets = len(self.filter_bank)
         n_meas = measurements.shape[1]
 
@@ -264,6 +268,11 @@ class GlobalNearestNeighbor(AbstractNearestNeighborTracker):
         if len(self.filter_bank) == 0:
             warnings.warn("Currently, there are zero targets")
             return
+
+        measurements = asarray(measurements, dtype=float)
+        measurement_matrix = asarray(measurement_matrix, dtype=float)
+        covMatsMeas = asarray(covMatsMeas, dtype=float)
+
         self._validate_measurement_update_inputs(
             measurements,
             measurement_matrix,

--- a/tests/filters/test_global_nearest_neighbor_array_like_inputs.py
+++ b/tests/filters/test_global_nearest_neighbor_array_like_inputs.py
@@ -1,0 +1,66 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+# pylint: disable=no-member
+import pyrecest.backend
+from pyrecest.backend import array, diag, zeros
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.filters import KalmanFilter
+from pyrecest.filters.global_nearest_neighbor import GlobalNearestNeighbor
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+    reason="GlobalNearestNeighbor array-like input regression uses numpy fixtures.",
+)
+class GlobalNearestNeighborArrayLikeInputTest(unittest.TestCase):
+    def _tracker(self):
+        tracker = GlobalNearestNeighbor()
+        tracker.filter_state = [
+            KalmanFilter(
+                GaussianDistribution(zeros(4), diag(array([1.0, 2.0, 3.0, 4.0])))
+            ),
+            KalmanFilter(
+                GaussianDistribution(
+                    array([1.0, 2.0, 3.0, 4.0]), diag(array([2.0, 2.0, 2.0, 2.0]))
+                )
+            ),
+        ]
+        return tracker
+
+    def test_find_association_accepts_array_like_inputs(self):
+        tracker = self._tracker()
+
+        association = tracker.find_association(
+            measurements=[[0.0, 1.0], [0.0, 3.0]],
+            measurement_matrix=[
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+            ],
+            cov_mats_meas=[[1.0, 0.0], [0.0, 1.0]],
+            warn_on_no_meas_for_track=False,
+        )
+
+        npt.assert_array_equal(association, np.array([0, 1]))
+
+    def test_update_linear_accepts_array_like_inputs(self):
+        tracker = self._tracker()
+
+        tracker.update_linear(
+            measurements=[[0.0, 1.0], [0.0, 3.0]],
+            measurement_matrix=[
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+            ],
+            covMatsMeas=[[1.0, 0.0], [0.0, 1.0]],
+        )
+
+        point_estimate = tracker.get_point_estimate()
+        self.assertEqual(point_estimate.shape, (4, 2))
+        self.assertTrue(np.all(np.isfinite(point_estimate)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- coerce `GlobalNearestNeighbor.find_association` measurements, measurement matrices, and measurement covariances before reading `.shape`/`.ndim`
- do the same in `update_linear` before validation
- add regression tests covering plain Python-list inputs for both direct association and update

## Testing
- Not run locally: the execution container cannot resolve github.com, so I could not clone/run pytest here. The PR relies on GitHub CI.