### PR TITLE
Accept array-like surface band probability inputs

### DIFF
--- a/src/pyrecest/evaluation/implicit_surfaces.py
+++ b/src/pyrecest/evaluation/implicit_surfaces.py
@@ -68,6 +68,8 @@ def surface_band_probability_from_signed_distance(
     epsilon = _positive_float("epsilon", epsilon)
     min_std = _positive_float("min_std", min_std)
     cdf = ndtr if normal_cdf is None else normal_cdf
+    distance = _as_numeric_field(distance)
+    distance_std = _as_numeric_field(distance_std)
     std = _maximum(distance_std, min_std)
     upper = (epsilon - distance) / std
     lower = (-epsilon - distance) / std
@@ -79,6 +81,12 @@ def _positive_float(name: str, value: float) -> float:
     if not np.isfinite(parsed) or parsed <= 0.0:
         raise ValueError(f"{name} must be finite and positive.")
     return parsed
+
+
+def _as_numeric_field(values: Any) -> Any:
+    if hasattr(values, "clamp"):
+        return values
+    return np.asarray(values, dtype=np.float64)
 
 
 def _maximum(values: Any, minimum: float) -> Any:

--- a/tests/evaluation/test_implicit_surface_array_like_inputs.py
+++ b/tests/evaluation/test_implicit_surface_array_like_inputs.py
@@ -1,0 +1,18 @@
+"""Regression tests for implicit-surface helpers with plain array-like inputs."""
+
+import numpy as np
+
+from pyrecest.evaluation import surface_band_probability_from_signed_distance
+
+
+def test_surface_band_probability_accepts_plain_array_like_inputs() -> None:
+    probability = surface_band_probability_from_signed_distance(
+        [0.0, 0.2],
+        [0.05, 0.05],
+        0.1,
+    )
+
+    assert probability.shape == (2,)
+    assert np.all(np.isfinite(probability))
+    assert probability[0] > 0.9
+    assert 0.0 <= probability[1] < probability[0]


### PR DESCRIPTION
## Summary
- Coerce plain array-like signed-distance inputs before arithmetic in `surface_band_probability_from_signed_distance`.
- Add regression coverage for Python-list distance and standard-deviation inputs.

## Testing
- Added focused regression test.