### PR TITLE
Validate Gaussian hypothesis dimensions before stacking

### DIFF
--- a/src/pyrecest/filters/gaussian_hypothesis_mixture.py
+++ b/src/pyrecest/filters/gaussian_hypothesis_mixture.py
@@ -44,18 +44,19 @@ def moment_match_gaussian_hypotheses(
     """Return moment-matched mean/covariance and normalized weights."""
     if not hypotheses:
         raise ValueError("hypotheses must not be empty")
+
+    dim = hypotheses[0].mean.size
+    if any(hypothesis.mean.size != dim for hypothesis in hypotheses):
+        raise ValueError("all hypothesis means must have the same dimension")
+
     weights = normalize_log_weights(
         [hypothesis.log_weight for hypothesis in hypotheses]
     )
     means = np.stack([hypothesis.mean for hypothesis in hypotheses], axis=0)
-    if not all(mean.size == means.shape[1] for mean in means):
-        raise ValueError("all hypothesis means must have the same dimension")
 
     mean = weights @ means
     covariance = np.zeros((mean.size, mean.size), dtype=float)
     for weight, hypothesis in zip(weights, hypotheses):
-        if hypothesis.mean.size != mean.size:
-            raise ValueError("all hypothesis means must have the same dimension")
         diff = hypothesis.mean - mean
         covariance += float(weight) * (hypothesis.covariance + np.outer(diff, diff))
     return mean, _symmetrized(covariance), weights

--- a/tests/filters/test_gaussian_hypothesis_mixture.py
+++ b/tests/filters/test_gaussian_hypothesis_mixture.py
@@ -53,6 +53,18 @@ class GaussianHypothesisMixtureTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "covariance"):
             WeightedGaussianHypothesis(np.array([0.0]), np.array([[np.inf]]))
 
+    def test_moment_matching_rejects_mixed_state_dimensions(self):
+        with self.assertRaisesRegex(ValueError, "same dimension"):
+            moment_match_gaussian_hypotheses(
+                [
+                    WeightedGaussianHypothesis(np.array([0.0]), np.array([[1.0]])),
+                    WeightedGaussianHypothesis(
+                        np.array([1.0, 2.0]),
+                        np.eye(2),
+                    ),
+                ]
+            )
+
     def test_moment_matching_respects_dominant_infinite_weight(self):
         mean, covariance, weights = moment_match_gaussian_hypotheses(
             [


### PR DESCRIPTION
## Summary
- Validate all Gaussian hypotheses have the same state dimension before stacking their means.
- Remove the unreachable post-stack dimension check.
- Add a regression test for mixed-dimensional hypotheses.

## Testing
- Added focused regression test in `tests/filters/test_gaussian_hypothesis_mixture.py`.