### PR TITLE
Validate candidate pruning probability matrices

### DIFF
--- a/src/pyrecest/utils/candidate_pruning.py
+++ b/src/pyrecest/utils/candidate_pruning.py
@@ -245,6 +245,9 @@ def _as_probability_matrix(
     probabilities = np.asarray(probability_matrix, dtype=float)
     if probabilities.shape != shape:
         raise ValueError("probability_matrix must match cost_matrix shape")
+    finite = np.isfinite(probabilities)
+    if np.any(finite & ((probabilities < 0.0) | (probabilities > 1.0))):
+        raise ValueError("finite probability_matrix entries must lie in [0, 1]")
     return probabilities
 
 

--- a/tests/test_candidate_pruning.py
+++ b/tests/test_candidate_pruning.py
@@ -71,6 +71,32 @@ class TestCandidatePruning(unittest.TestCase):
         ):
             prune_pairwise_cost_matrix(costs, config=config)
 
+    def test_probability_matrix_rejects_finite_values_outside_unit_interval(self):
+        config = CandidatePruningConfig(probability_threshold=0.5)
+
+        for probabilities in (np.array([[1.2, 0.5]]), np.array([[0.5, -0.1]])):
+            with self.subTest(probabilities=probabilities):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "finite probability_matrix entries must lie in \\[0, 1\\]",
+                ):
+                    candidate_mask_from_costs(
+                        np.array([[1.0, 2.0]]),
+                        probability_matrix=probabilities,
+                        config=config,
+                    )
+
+    def test_probability_matrix_ignores_nonfinite_values(self):
+        config = CandidatePruningConfig(probability_threshold=0.5)
+
+        mask = candidate_mask_from_costs(
+            np.array([[1.0, 2.0]]),
+            probability_matrix=np.array([[np.nan, 0.75]]),
+            config=config,
+        )
+
+        npt.assert_array_equal(mask, np.array([[False, True]]))
+
     def test_percentile_rule_and_large_cost_replacement(self):
         costs = np.array([[1.0, 2.0, 100.0], [3.0, 4.0, 5.0]])
 


### PR DESCRIPTION
## Summary
- Reject finite candidate-pruning probability entries outside `[0, 1]` instead of letting invalid probabilities select candidates.
- Keep non-finite probabilities as non-selecting entries, matching the existing threshold mask behavior.
- Add regression coverage for out-of-range and non-finite probability entries.

## Testing
- Added focused regression tests in `tests/test_candidate_pruning.py`.

## Bug
Before this change, `probability_matrix=[[1.2, 0.5]]` with `probability_threshold=0.5` would treat `1.2` as a valid high probability and retain that candidate. Probability-threshold pruning should only accept finite probabilities in `[0, 1]`.