### PR TITLE
Validate similarity min_score inputs

### DIFF
--- a/src/pyrecest/utils/multisession_assignment_score.py
+++ b/src/pyrecest/utils/multisession_assignment_score.py
@@ -46,6 +46,24 @@ def _default_score_to_cost(scores: Any) -> Any:
     return -asarray(scores, dtype=float)
 
 
+def _normalize_min_score(min_score: Any) -> float:
+    min_score_array = np.asarray(min_score)
+    if min_score_array.shape != () or min_score_array.dtype == np.bool_:
+        raise ValueError("min_score must be a finite scalar.")
+
+    min_score_value = min_score_array.item()
+    if isinstance(min_score_value, (bool, np.bool_)):
+        raise ValueError("min_score must be a finite scalar.")
+
+    try:
+        min_score_float = float(min_score_value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("min_score must be a finite scalar.") from exc
+    if not math.isfinite(min_score_float):
+        raise ValueError("min_score must be a finite scalar.")
+    return min_score_float
+
+
 def _normalize_max_gap(max_gap: Any) -> int:
     max_gap_array = np.asarray(max_gap)
     if max_gap_array.shape != () or max_gap_array.dtype == np.bool_:
@@ -109,8 +127,8 @@ def solve_multisession_assignment_from_similarity(  # pylint: disable=R0913,R091
     """Score-native wrapper around :func:`solve_multisession_assignment`."""
     _ensure_supported_backend("solve_multisession_assignment_from_similarity")
 
-    if min_score is not None and not math.isfinite(min_score):
-        raise ValueError("min_score must be finite.")
+    if min_score is not None:
+        min_score = _normalize_min_score(min_score)
     if max_gap is not None:
         max_gap = _normalize_max_gap(max_gap)
 
@@ -136,7 +154,7 @@ def solve_multisession_assignment_from_similarity(  # pylint: disable=R0913,R091
         score_finite_mask = isfinite(score_matrix_array)
         admissible_mask = backend_copy(score_finite_mask)
         if min_score is not None:
-            admissible_mask &= score_matrix_array >= float(min_score)
+            admissible_mask &= score_matrix_array >= min_score
 
         safe_scores = where(score_finite_mask, score_matrix_array, 0.0)
         cost_matrix = asarray(score_to_cost(safe_scores), dtype=float)

--- a/tests/test_multisession_assignment_similarity_min_score.py
+++ b/tests/test_multisession_assignment_similarity_min_score.py
@@ -12,7 +12,7 @@ class TestMultiSessionAssignmentSimilarityMinScore(unittest.TestCase):
         __backend_name__ == "jax",
         reason="Not supported on this backend",
     )
-    def test_accepts_scalar_integer_like_min_score(self):
+    def test_accepts_scalar_float_min_score(self):
         result = solve_multisession_assignment_from_similarity(
             [array([[0.25]], dtype=float)],
             min_score=np.array(0.2),
@@ -32,7 +32,10 @@ class TestMultiSessionAssignmentSimilarityMinScore(unittest.TestCase):
 
         for min_score in invalid_min_scores:
             with self.subTest(min_score=min_score):
-                with self.assertRaisesRegex(ValueError, "min_score must be a finite scalar"):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "min_score must be a finite scalar",
+                ):
                     solve_multisession_assignment_from_similarity(
                         pairwise_scores,
                         min_score=min_score,

--- a/tests/test_multisession_assignment_similarity_min_score.py
+++ b/tests/test_multisession_assignment_similarity_min_score.py
@@ -1,0 +1,43 @@
+"""Regression tests for score-native multi-session min_score validation."""
+
+import unittest
+
+import numpy as np
+from pyrecest.backend import __backend_name__, array
+from pyrecest.utils import solve_multisession_assignment_from_similarity
+
+
+class TestMultiSessionAssignmentSimilarityMinScore(unittest.TestCase):
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_accepts_scalar_integer_like_min_score(self):
+        result = solve_multisession_assignment_from_similarity(
+            [array([[0.25]], dtype=float)],
+            min_score=np.array(0.2),
+            start_cost=1.0,
+            end_cost=1.0,
+        )
+
+        self.assertEqual(result.tracks, [{0: 0, 1: 0}])
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_rejects_invalid_min_score_scalars(self):
+        pairwise_scores = [array([[0.25]], dtype=float)]
+        invalid_min_scores = (True, np.nan, np.inf, -np.inf, np.array([0.2]))
+
+        for min_score in invalid_min_scores:
+            with self.subTest(min_score=min_score):
+                with self.assertRaisesRegex(ValueError, "min_score must be a finite scalar"):
+                    solve_multisession_assignment_from_similarity(
+                        pairwise_scores,
+                        min_score=min_score,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Normalize `min_score` in `solve_multisession_assignment_from_similarity` through a scalar finite-value validator.
- Reject booleans, non-finite values, and non-scalar arrays with a controlled `ValueError` instead of accepting or leaking low-level conversion errors.
- Add focused regression tests for accepted scalar arrays and invalid `min_score` inputs.

## Testing
- Added `tests/test_multisession_assignment_similarity_min_score.py`.
