### PR TITLE
Fix 1D replay grid position inputs

### DIFF
--- a/src/pyrecest/filters/replay_grid_likelihood.py
+++ b/src/pyrecest/filters/replay_grid_likelihood.py
@@ -320,8 +320,13 @@ def _coerce_bin_centers(bin_centers) -> np.ndarray:
 
 def _coerce_positions(positions, expected_dim: int, name: str) -> np.ndarray:
     positions = np.asarray(positions, dtype=float)
-    if positions.ndim == 1:
-        positions = positions.reshape(1, -1)
+    if positions.ndim == 0:
+        positions = positions.reshape(1, 1)
+    elif positions.ndim == 1:
+        if expected_dim == 1:
+            positions = positions.reshape(-1, 1)
+        else:
+            positions = positions.reshape(1, -1)
     if positions.ndim != 2 or positions.shape[1] != expected_dim:
         raise ValueError(f"{name} must have shape (n_positions, {expected_dim})")
     return positions

--- a/tests/filters/test_replay_grid_likelihood_1d_positions.py
+++ b/tests/filters/test_replay_grid_likelihood_1d_positions.py
@@ -1,0 +1,52 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.filters import (
+    particle_position_log_posterior,
+    replay_grid_log_likelihood_values,
+)
+
+
+class TestReplayGridLikelihoodOneDimensionalPositions(unittest.TestCase):
+    def test_log_likelihood_accepts_vector_of_scalar_positions(self):
+        bin_centers = np.asarray([[0.0], [1.0], [2.0]])
+        values = np.asarray([0.0, 1.0, 2.0])
+
+        result = replay_grid_log_likelihood_values(
+            [0.2, 1.8],
+            values,
+            bin_centers,
+            interpolation="nearest",
+        )
+
+        self.assertTrue(np.allclose(result, [0.0, 2.0]))
+
+    def test_log_likelihood_accepts_scalar_position(self):
+        bin_centers = np.asarray([[0.0], [1.0], [2.0]])
+        values = np.asarray([0.0, 1.0, 2.0])
+
+        result = replay_grid_log_likelihood_values(
+            0.9,
+            values,
+            bin_centers,
+            interpolation="nearest",
+        )
+
+        self.assertTrue(np.allclose(result, [1.0]))
+
+    def test_particle_position_log_posterior_accepts_1d_position_vector(self):
+        bin_centers = np.asarray([[0.0], [1.0]])
+        weights = np.asarray([0.25, 0.75])
+
+        log_posterior = particle_position_log_posterior(
+            [0.1, 0.9],
+            weights,
+            bin_centers,
+        )
+
+        self.assertTrue(np.allclose(np.exp(log_posterior), [0.25, 0.75]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Interpret one-dimensional position vectors as multiple scalar positions when the replay grid is one-dimensional.
- Preserve the previous behavior for higher-dimensional vectors, where a 1-D array represents one position vector.
- Add regression coverage for scalar 1-D positions, vectorized 1-D positions, and 1-D posterior accumulation.

## Testing
- Ran the patched module's core 1-D coercion checks locally by importing the modified file directly.
- Full repository tests not run locally because this environment cannot clone GitHub.