### PR TITLE
Validate quantile tail mask inputs before empty return

### DIFF
--- a/src/pyrecest/evaluation/selection.py
+++ b/src/pyrecest/evaluation/selection.py
@@ -181,14 +181,14 @@ def quantile_tail_mask(
         reliability_scores,
         nonnegative=sanitize_nonnegative,
     )
-    if scores.size == 0:
-        return np.zeros((0,), dtype=bool)
     threshold = quantile_tail_threshold(
         scores,
         quantile,
         tail=tail,
         sanitize_nonnegative=sanitize_nonnegative,
     )
+    if scores.size == 0:
+        return np.zeros((0,), dtype=bool)
     if tail == "lower":
         return scores <= threshold
     return scores >= threshold

--- a/tests/evaluation/test_selection.py
+++ b/tests/evaluation/test_selection.py
@@ -73,6 +73,15 @@ def test_quantile_tail_mask_selects_upper_tail() -> None:
     ]
 
 
+def test_quantile_tail_mask_validates_empty_inputs_before_empty_return() -> None:
+    for bad_quantile in (0.0, 1.0, np.nan):
+        with pytest.raises(ValueError, match="quantile"):
+            quantile_tail_mask([], bad_quantile)
+
+    with pytest.raises(ValueError, match="tail"):
+        quantile_tail_mask([], 0.5, tail="middle")
+
+
 def test_protected_tail_topk_mask_preserves_proportional_tail_capacity() -> None:
     primary = np.asarray([10.0, 9.0, 8.0, 7.0, 6.0, 5.0])
     tail_score = np.asarray([0.0, 0.0, 30.0, 20.0, 10.0, 1.0])


### PR DESCRIPTION
## Summary
- validate `quantile` and `tail` in `quantile_tail_mask` before returning an empty mask
- add regression coverage for empty reliability arrays with invalid quantile/tail arguments

## Bug
`quantile_tail_mask` returned an empty mask before checking `quantile` or `tail`, so invalid calls such as `quantile_tail_mask([], 1.0)` could silently succeed. This was inconsistent with `quantile_tail_threshold` and non-empty inputs.

## Tests
- Added focused regression coverage in `tests/evaluation/test_selection.py`
- Not run locally; repository dependencies are not available in this connector-only GitHub environment.