### PR TITLE
Handle string return_smoothed flags explicitly

### DIFF
--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -14,6 +14,20 @@ from typing import Any, Literal
 EvidenceComputationKind = Literal["full_smoothing", "evidence_only"]
 
 
+def _coerce_bool_flag(value: bool | str, name: str) -> bool:
+    """Return a bool flag without treating arbitrary truthy objects as true."""
+
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "t", "yes", "y", "on"}:
+            return True
+        if normalized in {"0", "false", "f", "no", "n", "off"}:
+            return False
+    raise ValueError(f"{name} must be a boolean or boolean-like string")
+
+
 @dataclass(frozen=True, slots=True)
 class EvidenceComputationMode:
     """Declare whether an evidence computation should also smooth posteriors.
@@ -41,10 +55,16 @@ class EvidenceComputationMode:
     def __post_init__(self) -> None:
         if self.mode not in {"full_smoothing", "evidence_only"}:
             raise ValueError(f"unknown evidence computation mode {self.mode!r}")
-        if self.mode == "evidence_only" and self.return_smoothed:
+        return_smoothed = _coerce_bool_flag(self.return_smoothed, "return_smoothed")
+        terminal_posterior = _coerce_bool_flag(
+            self.terminal_posterior, "terminal_posterior"
+        )
+        if self.mode == "evidence_only" and return_smoothed:
             raise ValueError("evidence_only mode cannot return smoothed posteriors")
-        if self.mode == "full_smoothing" and not self.return_smoothed:
+        if self.mode == "full_smoothing" and not return_smoothed:
             raise ValueError("full_smoothing mode must return smoothed posteriors")
+        object.__setattr__(self, "return_smoothed", return_smoothed)
+        object.__setattr__(self, "terminal_posterior", terminal_posterior)
         object.__setattr__(self, "metadata", dict(self.metadata))
 
     @classmethod
@@ -74,10 +94,16 @@ class EvidenceComputationMode:
         )
 
     @classmethod
-    def from_return_smoothed(cls, return_smoothed: bool) -> "EvidenceComputationMode":
+    def from_return_smoothed(
+        cls, return_smoothed: bool | str
+    ) -> "EvidenceComputationMode":
         """Build a mode from the common Boolean smoothing flag."""
 
-        return cls.full_smoothing() if bool(return_smoothed) else cls.evidence_only()
+        return (
+            cls.full_smoothing()
+            if _coerce_bool_flag(return_smoothed, "return_smoothed")
+            else cls.evidence_only()
+        )
 
     @property
     def evidence_only_requested(self) -> bool:
@@ -101,13 +127,13 @@ class EvidenceComputationMode:
 
 
 def _require_return_smoothed_agreement(
-    mode: EvidenceComputationMode, return_smoothed: bool | None
+    mode: EvidenceComputationMode, return_smoothed: bool | str | None
 ) -> EvidenceComputationMode:
     """Reject contradictory explicit mode and compatibility flag requests."""
 
     if return_smoothed is None:
         return mode
-    if bool(return_smoothed) != mode.return_smoothed:
+    if _coerce_bool_flag(return_smoothed, "return_smoothed") != mode.return_smoothed:
         raise ValueError("mode and return_smoothed request inconsistent smoothing")
     return mode
 
@@ -115,7 +141,7 @@ def _require_return_smoothed_agreement(
 def resolve_evidence_computation_mode(
     mode: EvidenceComputationMode | str | None = None,
     *,
-    return_smoothed: bool | None = None,
+    return_smoothed: bool | str | None = None,
 ) -> EvidenceComputationMode:
     """Resolve a string/Boolean compatibility mode into a typed object."""
 
@@ -123,7 +149,7 @@ def resolve_evidence_computation_mode(
         return _require_return_smoothed_agreement(mode, return_smoothed)
     if mode is None:
         return EvidenceComputationMode.from_return_smoothed(
-            True if return_smoothed is None else bool(return_smoothed)
+            True if return_smoothed is None else return_smoothed
         )
 
     key = str(mode).strip().lower().replace("-", "_")

--- a/tests/test_evidence_only_mode.py
+++ b/tests/test_evidence_only_mode.py
@@ -7,6 +7,7 @@ from pyrecest.filters import sparse_second_order_grid_evidence
 def test_evidence_computation_mode_resolves_boolean_and_string_aliases():
     full = resolve_evidence_computation_mode(return_smoothed=True)
     fast = resolve_evidence_computation_mode("evidence-only")
+    string_fast = resolve_evidence_computation_mode(return_smoothed="false")
 
     assert full.mode == "full_smoothing"
     assert full.return_smoothed
@@ -14,7 +15,17 @@ def test_evidence_computation_mode_resolves_boolean_and_string_aliases():
     assert fast.mode == "evidence_only"
     assert not fast.return_smoothed
     assert fast.evidence_only_requested
+    assert string_fast.mode == "evidence_only"
+    assert not string_fast.return_smoothed
+    assert string_fast.evidence_only_requested
     assert fast.to_diagnostics()["evidence_computation_mode"] == "evidence_only"
+
+
+def test_evidence_computation_mode_rejects_invalid_boolean_strings():
+    with pytest.raises(ValueError, match="return_smoothed"):
+        resolve_evidence_computation_mode(return_smoothed="definitely")
+    with pytest.raises(ValueError, match="return_smoothed"):
+        resolve_evidence_computation_mode("full_smoothing", return_smoothed="false")
 
 
 def test_evidence_computation_mode_rejects_inconsistent_flags():


### PR DESCRIPTION
## Summary
- Fix evidence-mode resolution so boolean-like string compatibility flags are parsed explicitly.
- Prevent `return_smoothed="false"` from being treated as truthy and incorrectly selecting full smoothing.
- Add regression coverage for string false and invalid boolean-like strings.

## Testing
- Added focused tests in `tests/test_evidence_only_mode.py`.