### PR TITLE
Fix duplicate session-label detection with custom fill values

### DIFF
--- a/src/pyrecest/utils/__init__.py
+++ b/src/pyrecest/utils/__init__.py
@@ -1,5 +1,6 @@
 """Utility helpers for :mod:`pyrecest`."""
 
+from . import multisession_assignment as _multisession_assignment_module
 from .assignment import min_cost_max_cardinality_assignment, murty_k_best_assignments
 from .association_features import (
     CalibratedPairwiseAssociationModel,
@@ -45,8 +46,8 @@ from .metrics import (
 from .multisession_assignment import (
     MultiSessionAssignmentResult,
     solve_multisession_assignment,
-    tracks_to_session_labels,
 )
+from ._multisession_assignment_labels import tracks_to_session_labels
 from .multisession_assignment_observation_costs import (
     solve_multisession_assignment_with_observation_costs,
 )
@@ -115,6 +116,8 @@ from .track_metrics import (
     track_latencies,
     track_purity,
 )
+
+_multisession_assignment_module.tracks_to_session_labels = tracks_to_session_labels
 
 __all__ = [
     "MultiSessionAssignmentResult",

--- a/src/pyrecest/utils/_multisession_assignment_labels.py
+++ b/src/pyrecest/utils/_multisession_assignment_labels.py
@@ -1,0 +1,49 @@
+"""Dense label conversion helpers for multi-session assignments."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from pyrecest.backend import int64
+
+from .multisession_assignment import (  # pylint: disable=protected-access
+    SessionSizesInput,
+    TrackInput,
+    _ensure_supported_backend,
+    _full_1d,
+    _iter_track_items,
+    _validate_track_session_sizes,
+)
+
+
+def tracks_to_session_labels(
+    tracks: Sequence[TrackInput],
+    session_sizes: SessionSizesInput | None = None,
+    *,
+    fill_value: int = -1,
+) -> tuple[Any, ...]:
+    """Convert explicit tracks to dense per-session label arrays."""
+    _ensure_supported_backend("tracks_to_session_labels")
+
+    inferred_sizes, max_session_index = _validate_track_session_sizes(
+        tracks,
+        session_sizes,
+        require_unique_sessions=True,
+    )
+
+    labels = [
+        _full_1d(inferred_sizes.get(session_index, 0), fill_value, int64)
+        for session_index in range(max_session_index + 1)
+    ]
+
+    assigned_observations: set[tuple[int, int]] = set()
+    for track_index, track in enumerate(tracks):
+        for session_index, detection_index in _iter_track_items(track):
+            observation = (session_index, detection_index)
+            if observation in assigned_observations:
+                raise ValueError("Each detection can only belong to a single track.")
+            assigned_observations.add(observation)
+            labels[session_index][detection_index] = track_index
+
+    return tuple(labels)

--- a/tests/test_multisession_assignment_labels.py
+++ b/tests/test_multisession_assignment_labels.py
@@ -1,0 +1,41 @@
+"""Regression tests for multi-session label conversion."""
+
+import unittest
+
+from pyrecest.backend import __backend_name__
+from pyrecest.utils import MultiSessionAssignmentResult, tracks_to_session_labels
+
+import pyrecest.utils.multisession_assignment as multisession_assignment_module
+
+
+class TestMultiSessionAssignmentLabels(unittest.TestCase):
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_duplicate_detection_rejected_when_fill_value_matches_track_label(self):
+        tracks = [{0: 0}, {0: 0}]
+        converters = (
+            ("public", tracks_to_session_labels),
+            ("module", multisession_assignment_module.tracks_to_session_labels),
+            (
+                "result_method",
+                lambda track_list, **kwargs: MultiSessionAssignmentResult(
+                    tracks=track_list,
+                    matched_edges=[],
+                    total_cost=0.0,
+                ).to_session_labels(**kwargs),
+            ),
+        )
+
+        for name, converter in converters:
+            with self.subTest(converter=name):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "Each detection can only belong to a single track",
+                ):
+                    converter(tracks, session_sizes=[1], fill_value=0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Fix `tracks_to_session_labels` so duplicate detection checks no longer depend on comparing against `fill_value`.
- Re-export and patch the public multi-session assignment label converter to use the fill-independent implementation.
- Add a regression test covering `fill_value=0` for the package export, direct submodule import, and `MultiSessionAssignmentResult.to_session_labels`.

## Testing
- Added focused regression test.
