### PR TITLE
Require square tracking event covariance

### DIFF
--- a/src/pyrecest/tracking/event_records.py
+++ b/src/pyrecest/tracking/event_records.py
@@ -81,7 +81,11 @@ class TrackingEvent:
         if not np.isfinite(time):
             raise ValueError("time must be finite")
         measurement = _array_or_none(self.measurement, name="measurement", ndim=1)
-        covariance = _array_or_none(self.covariance, name="covariance", ndim=2)
+        covariance = (
+            None
+            if self.covariance is None
+            else _square_matrix(self.covariance, name="covariance")
+        )
         if measurement is not None and covariance is not None:
             if covariance.shape != (measurement.size, measurement.size):
                 raise ValueError("covariance must match measurement dimension")

--- a/tests/tracking/test_event_records.py
+++ b/tests/tracking/test_event_records.py
@@ -33,6 +33,15 @@ def test_tracking_event_validates_measurement_covariance_shape() -> None:
         )
 
 
+def test_tracking_event_requires_square_covariance_without_measurement() -> None:
+    with pytest.raises(ValueError, match="covariance must be a square matrix"):
+        TrackingEvent(
+            time=0.0,
+            source="rf",
+            covariance=np.ones((2, 3)),
+        )
+
+
 def test_record_from_update_preserves_prior_posterior_and_legacy_aliases() -> None:
     event = event_from_measurement(
         time=2.0,


### PR DESCRIPTION
## Summary
- Validate `TrackingEvent.covariance` with the existing square-matrix helper even when no measurement vector is supplied.
- Add a regression test for non-square event covariance without a measurement.

## Testing
- Added focused regression test in `tests/tracking/test_event_records.py`.