### PR TITLE
Accept empty scans in GGIW tracker update

### DIFF
--- a/src/pyrecest/filters/ggiw_tracker.py
+++ b/src/pyrecest/filters/ggiw_tracker.py
@@ -152,6 +152,8 @@ class GGIWTracker(
     def _normalize_measurements(self, measurements):
         measurements = array(measurements)
         if measurements.ndim == 1:
+            if measurements.shape[0] == 0:
+                return zeros((self.measurement_dim, 0))
             if measurements.shape[0] != self.measurement_dim:
                 raise ValueError(
                     "A single measurement vector must match the measurement dimension"

--- a/tests/filters/test_ggiw_tracker.py
+++ b/tests/filters/test_ggiw_tracker.py
@@ -91,6 +91,27 @@ class TestGGIWTracker(unittest.TestCase):
         self.assertLess(self.tracker.covariance[0, 0], prior_covariance[0, 0])
         self.assertTrue(isfinite(self.tracker.latest_log_likelihood))
 
+    def test_update_accepts_empty_scan(self):
+        prior_kinematic_state = self.tracker.kinematic_state.copy()
+        prior_covariance = self.tracker.covariance.copy()
+        prior_extent = self.tracker.get_point_estimate_extent().copy()
+        prior_degrees_of_freedom = self.tracker.extent_degrees_of_freedom
+        prior_shape = self.tracker.gamma_shape
+        prior_rate = self.tracker.gamma_rate
+
+        self.tracker.update([])
+
+        npt.assert_allclose(self.tracker.kinematic_state, prior_kinematic_state)
+        npt.assert_allclose(self.tracker.covariance, prior_covariance)
+        npt.assert_allclose(self.tracker.get_point_estimate_extent(), prior_extent)
+        self.assertAlmostEqual(
+            self.tracker.extent_degrees_of_freedom,
+            prior_degrees_of_freedom,
+        )
+        self.assertAlmostEqual(self.tracker.gamma_shape, prior_shape)
+        self.assertAlmostEqual(self.tracker.gamma_rate, prior_rate + 1.0)
+        self.assertTrue(isfinite(self.tracker.latest_log_likelihood))
+
     def test_update_accepts_transposed_measurement_layout(self):
         measurements_by_row = array(
             [


### PR DESCRIPTION
## Summary
- Treat an empty one-dimensional measurement input as a zero-detection scan in `GGIWTracker`.
- Add a regression test for `update([])` so the existing no-detection update branch is reachable through the natural empty-scan input.

## Bug
`GGIWTracker.update` has explicit logic for `n_measurements == 0`, but `_normalize_measurements` rejected `[]`/empty 1-D inputs before that branch could run.

## Testing
- Not run locally; repository access is through the GitHub connector in this environment.