### PR TITLE
Validate tracking record innovation covariance shape

### DIFF
--- a/src/pyrecest/tracking/event_records.py
+++ b/src/pyrecest/tracking/event_records.py
@@ -148,12 +148,15 @@ class TrackingRecord:
             self.posterior_cov, name="posterior_cov", dim=prior_mean.size
         )
         innovation = _array_or_none(self.innovation, name="innovation", ndim=1)
-        innovation_cov = _array_or_none(
-            self.innovation_cov, name="innovation_cov", ndim=2
+        innovation_cov = (
+            None
+            if self.innovation_cov is None
+            else _square_matrix(
+                self.innovation_cov,
+                name="innovation_cov",
+                dim=None if innovation is None else int(innovation.size),
+            )
         )
-        if innovation is not None and innovation_cov is not None:
-            if innovation_cov.shape != (innovation.size, innovation.size):
-                raise ValueError("innovation_cov must match innovation dimension")
         measurement = _array_or_none(self.measurement, name="measurement", ndim=1)
         nis = None if self.nis is None else float(self.nis)
         if nis is not None and (not np.isfinite(nis) or nis < 0.0):

--- a/tests/tracking/test_event_records.py
+++ b/tests/tracking/test_event_records.py
@@ -65,6 +65,20 @@ def test_record_from_update_preserves_prior_posterior_and_legacy_aliases() -> No
     json.dumps(as_dict)
 
 
+def test_tracking_record_rejects_rectangular_innovation_cov_without_innovation() -> None:
+    event = event_from_measurement(time=0.0, source="imu", action="coast")
+
+    with pytest.raises(ValueError, match="innovation_cov must be a square matrix"):
+        record_from_update(
+            event=event,
+            prior_mean=[0.0, 0.0],
+            prior_cov=np.eye(2),
+            posterior_mean=[0.0, 0.0],
+            posterior_cov=np.eye(2),
+            innovation_cov=np.ones((2, 3)),
+        )
+
+
 def test_records_to_dicts_matrix_and_action_counts() -> None:
     event = event_from_measurement(time=0.0, source="radar", action="update")
     record_a = record_from_update(


### PR DESCRIPTION
## Summary
- Validate `TrackingRecord.innovation_cov` with the existing square-matrix helper even when no innovation vector is supplied.
- Keep the innovation-dimension check when an innovation vector is present.
- Add a regression test for rectangular `innovation_cov` on records without an innovation vector.

## Testing
- Added focused regression test in `tests/tracking/test_event_records.py`.