### PR TITLE
Validate particle resampling sample count

### DIFF
--- a/src/pyrecest/scenarios.py
+++ b/src/pyrecest/scenarios.py
@@ -127,6 +127,18 @@ def _normalized_particle_weights(raw_weights: Any, particle_count: int, backend)
     )
 
 
+def _positive_integer_config_value(value: Any, name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be a positive integer")
+    try:
+        scalar = float(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be a positive integer") from exc
+    if not math.isfinite(scalar) or scalar <= 0.0 or not scalar.is_integer():
+        raise ValueError(f"{name} must be a positive integer")
+    return int(scalar)
+
+
 @scenario_runner("linear_gaussian")
 def run_linear_gaussian_scenario(path: str | Path) -> ScenarioResult:
     """Run a constant-size linear Gaussian Kalman filtering scenario.
@@ -228,7 +240,10 @@ def run_particle_resampling_scenario(path: str | Path) -> ScenarioResult:
         int(particles.shape[0]),
         be,
     )
-    num_samples = int(data.get("num_samples", int(particles.shape[0])))
+    num_samples = _positive_integer_config_value(
+        data.get("num_samples", int(particles.shape[0])),
+        "num_samples",
+    )
 
     indices = be.random.choice(
         be.arange(int(particles.shape[0])),

--- a/tests/test_scenario_registry_and_reproducibility.py
+++ b/tests/test_scenario_registry_and_reproducibility.py
@@ -4,7 +4,7 @@ import pytest
 from pyrecest.scenarios import available_scenario_types, run_scenario
 
 
-def _write_particle_scenario(path: Path, weights: str) -> None:
+def _write_particle_scenario(path: Path, weights: str, num_samples: str = "4") -> None:
     path.write_text(
         f"""
 [scenario]
@@ -15,7 +15,7 @@ seed = 7
 [data]
 particles = [[0.0, 0.0], [1.0, 0.0]]
 weights = {weights}
-num_samples = 4
+num_samples = {num_samples}
 """.strip(),
         encoding="utf-8",
     )
@@ -48,6 +48,17 @@ num_samples = 8
         == second.diagnostics["metadata"]["indices"]
     )
     assert first.metrics["effective_sample_size"] > 0.0
+
+
+@pytest.mark.parametrize("num_samples", ["0", "-1", "1.5", "true"])
+def test_particle_resampling_scenario_rejects_invalid_num_samples(
+    tmp_path: Path, num_samples: str
+):
+    scenario = tmp_path / "invalid_num_samples.toml"
+    _write_particle_scenario(scenario, "[0.5, 0.5]", num_samples=num_samples)
+
+    with pytest.raises(ValueError, match="num_samples must be a positive integer"):
+        run_scenario(scenario)
 
 
 def test_particle_resampling_scenario_rejects_zero_weight_mass(tmp_path: Path):


### PR DESCRIPTION
## Summary
- Validate `particle_resampling` scenario `num_samples` as a positive integer before sampling.
- Reject zero, negative, fractional, and boolean sample counts instead of producing empty/NaN estimates or relying on backend-level errors.
- Add regression coverage for invalid `num_samples` TOML values.

## Bug
Before this change, `num_samples = 0` reached `sampled_mean = ... / float(num_samples)`, yielding a degenerate non-finite scenario estimate instead of a clear configuration error. Fractional values were also silently truncated via `int(...)`.

## Testing
- Added focused regression coverage in `tests/test_scenario_registry_and_reproducibility.py`.
- Not run locally; this environment cannot clone GitHub or install the repository dependencies, so CI should run the tests on the PR.