### PR TITLE
Fix selection fallback ranking

### DIFF
--- a/src/pyrecest/evaluation/selection.py
+++ b/src/pyrecest/evaluation/selection.py
@@ -210,8 +210,9 @@ def protected_tail_topk_mask(
     The candidate set is split at ``tail_quantile`` of ``reliability_scores``.
     The tail receives the same retention fraction as the full set, ranked by
     ``tail_scores``. The complement receives the remaining retained budget,
-    ranked by ``primary_scores``. If either side is empty the function falls
-    back to ordinary top-fraction selection by ``primary_scores``.
+    ranked by ``primary_scores``. If the tail is empty the function falls back
+    to ordinary top-fraction selection by ``primary_scores``; if the complement
+    is empty, all candidates are ranked by ``tail_scores``.
     """
     primary = sanitized_score_vector(primary_scores, nonnegative=sanitize_nonnegative)
     tail_rank = sanitized_score_vector(tail_scores, nonnegative=sanitize_nonnegative)
@@ -240,9 +241,15 @@ def protected_tail_topk_mask(
     )
     tail_indices = np.flatnonzero(tail_mask)
     complement_indices = np.flatnonzero(~tail_mask)
-    if tail_indices.size == 0 or complement_indices.size == 0:
+    if tail_indices.size == 0:
         return top_count_mask(
             primary,
+            retained_total,
+            sanitize_nonnegative=sanitize_nonnegative,
+        )
+    if complement_indices.size == 0:
+        return top_count_mask(
+            tail_rank,
             retained_total,
             sanitize_nonnegative=sanitize_nonnegative,
         )

--- a/tests/evaluation/test_selection.py
+++ b/tests/evaluation/test_selection.py
@@ -89,6 +89,22 @@ def test_protected_tail_topk_mask_preserves_proportional_tail_capacity() -> None
     assert mask.tolist() == [True, False, True, True, False, False]
 
 
+def test_protected_tail_topk_mask_uses_tail_scores_when_all_items_are_tail() -> None:
+    primary = np.asarray([100.0, 90.0, 80.0])
+    tail_score = np.asarray([0.0, 10.0, 20.0])
+    reliability = np.asarray([0.0, 0.0, 0.0])
+
+    mask = protected_tail_topk_mask(
+        primary,
+        tail_score,
+        reliability,
+        2.0 / 3.0,
+        tail_quantile=0.5,
+    )
+
+    assert mask.tolist() == [False, True, True]
+
+
 def test_tail_rescue_topk_mask_swaps_in_missing_tail_items() -> None:
     primary = np.asarray([10.0, 9.0, 8.0, 7.0, 1.0, 0.5])
     tail_score = np.asarray([0.0, 0.0, 0.0, 0.0, 100.0, 90.0])


### PR DESCRIPTION
## Summary
- Fix `protected_tail_topk_mask` so a collapsed split uses the intended score vector.
- Add a focused regression test.

## Testing
- Added regression test.