### PR TITLE
Validate candidate pruning scalar controls

### DIFF
--- a/src/pyrecest/utils/candidate_pruning.py
+++ b/src/pyrecest/utils/candidate_pruning.py
@@ -41,25 +41,35 @@ class CandidatePruningConfig:
             object.__setattr__(self, name, parsed)
 
         if self.probability_threshold is not None:
-            threshold = float(self.probability_threshold)
-            if not 0.0 <= threshold <= 1.0:
-                raise ValueError("probability_threshold must lie in [0, 1]")
+            threshold = _normalize_bounded_scalar(
+                self.probability_threshold,
+                lower=0.0,
+                upper=1.0,
+                message="probability_threshold must lie in [0, 1]",
+            )
             object.__setattr__(self, "probability_threshold", threshold)
 
         if self.max_cost is not None:
-            max_cost = float(self.max_cost)
-            if not np.isfinite(max_cost):
-                raise ValueError("max_cost must be finite or None")
+            max_cost = _normalize_finite_scalar(
+                self.max_cost,
+                message="max_cost must be finite or None",
+            )
             object.__setattr__(self, "max_cost", max_cost)
 
         if self.max_cost_percentile is not None:
-            percentile = float(self.max_cost_percentile)
-            if not 0.0 <= percentile <= 100.0:
-                raise ValueError("max_cost_percentile must lie in [0, 100]")
+            percentile = _normalize_bounded_scalar(
+                self.max_cost_percentile,
+                lower=0.0,
+                upper=100.0,
+                message="max_cost_percentile must lie in [0, 100]",
+            )
             object.__setattr__(self, "max_cost_percentile", percentile)
 
-        large_cost = float(self.large_cost)
-        if not np.isfinite(large_cost) or large_cost <= 0.0:
+        large_cost = _normalize_finite_scalar(
+            self.large_cost,
+            message="large_cost must be finite and positive",
+        )
+        if large_cost <= 0.0:
             raise ValueError("large_cost must be finite and positive")
         object.__setattr__(self, "large_cost", large_cost)
 
@@ -97,6 +107,36 @@ def _normalize_positive_integer(value: Any, name: str) -> int:
         parsed = int(scalar_float)
 
     if parsed <= 0:
+        raise ValueError(message)
+    return parsed
+
+
+def _normalize_finite_scalar(value: Any, *, message: str) -> float:
+    value_array = np.asarray(value)
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError(message)
+
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(message)
+    try:
+        parsed = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if not np.isfinite(parsed):
+        raise ValueError(message)
+    return parsed
+
+
+def _normalize_bounded_scalar(
+    value: Any,
+    *,
+    lower: float,
+    upper: float,
+    message: str,
+) -> float:
+    parsed = _normalize_finite_scalar(value, message=message)
+    if not lower <= parsed <= upper:
         raise ValueError(message)
     return parsed
 
@@ -165,8 +205,11 @@ def prune_pairwise_cost_matrix(
     if cfg is None:
         return costs
 
-    penalty = cfg.large_cost if large_cost is None else float(large_cost)
-    if not np.isfinite(penalty) or penalty <= 0.0:
+    penalty = cfg.large_cost if large_cost is None else _normalize_finite_scalar(
+        large_cost,
+        message="large_cost must be finite and positive",
+    )
+    if penalty <= 0.0:
         raise ValueError("large_cost must be finite and positive")
     penalty = _effective_large_cost(costs, penalty)
 
@@ -238,19 +281,18 @@ def _as_cost_matrix(cost_matrix: Any) -> np.ndarray:
     return np.nan_to_num(costs, nan=np.inf, posinf=np.inf, neginf=np.inf)
 
 
-def _as_probability_matrix(
-    probability_matrix: Any,
-    shape: tuple[int, int],
-) -> np.ndarray:
+def _as_probability_matrix(probability_matrix: Any, shape: tuple[int, int]) -> np.ndarray:
     probabilities = np.asarray(probability_matrix, dtype=float)
     if probabilities.shape != shape:
         raise ValueError("probability_matrix must match cost_matrix shape")
+    if np.any(np.isfinite(probabilities) & ((probabilities < 0.0) | (probabilities > 1.0))):
+        raise ValueError("probability_matrix entries must lie in [0, 1]")
     return probabilities
 
 
-__all__ = (
+__all__ = [
     "CandidatePruningConfig",
     "candidate_mask_from_costs",
     "candidate_pruning_config_from_mapping",
     "prune_pairwise_cost_matrix",
-)
+]

--- a/src/pyrecest/utils/candidate_pruning.py
+++ b/src/pyrecest/utils/candidate_pruning.py
@@ -205,10 +205,13 @@ def prune_pairwise_cost_matrix(
     if cfg is None:
         return costs
 
-    penalty = cfg.large_cost if large_cost is None else _normalize_finite_scalar(
-        large_cost,
-        message="large_cost must be finite and positive",
-    )
+    if large_cost is None:
+        penalty = cfg.large_cost
+    else:
+        penalty = _normalize_finite_scalar(
+            large_cost,
+            message="large_cost must be finite and positive",
+        )
     if penalty <= 0.0:
         raise ValueError("large_cost must be finite and positive")
     penalty = _effective_large_cost(costs, penalty)
@@ -281,18 +284,19 @@ def _as_cost_matrix(cost_matrix: Any) -> np.ndarray:
     return np.nan_to_num(costs, nan=np.inf, posinf=np.inf, neginf=np.inf)
 
 
-def _as_probability_matrix(probability_matrix: Any, shape: tuple[int, int]) -> np.ndarray:
+def _as_probability_matrix(
+    probability_matrix: Any,
+    shape: tuple[int, int],
+) -> np.ndarray:
     probabilities = np.asarray(probability_matrix, dtype=float)
     if probabilities.shape != shape:
         raise ValueError("probability_matrix must match cost_matrix shape")
-    if np.any(np.isfinite(probabilities) & ((probabilities < 0.0) | (probabilities > 1.0))):
-        raise ValueError("probability_matrix entries must lie in [0, 1]")
     return probabilities
 
 
-__all__ = [
+__all__ = (
     "CandidatePruningConfig",
     "candidate_mask_from_costs",
     "candidate_pruning_config_from_mapping",
     "prune_pairwise_cost_matrix",
-]
+)

--- a/tests/test_candidate_pruning.py
+++ b/tests/test_candidate_pruning.py
@@ -1,3 +1,4 @@
+import re
 import unittest
 
 import numpy as np
@@ -145,7 +146,7 @@ class TestCandidatePruning(unittest.TestCase):
         for field_name, message in cases:
             for value in invalid_values:
                 with self.subTest(field_name=field_name, value=value):
-                    with self.assertRaisesRegex(ValueError, message):
+                    with self.assertRaisesRegex(ValueError, re.escape(message)):
                         CandidatePruningConfig(**{field_name: value})
 
         with self.assertRaisesRegex(

--- a/tests/test_candidate_pruning.py
+++ b/tests/test_candidate_pruning.py
@@ -127,6 +127,37 @@ class TestCandidatePruning(unittest.TestCase):
                 config=CandidatePruningConfig(probability_threshold=0.4),
             )
 
+    def test_scalar_cost_controls_reject_bools_and_non_scalars(self):
+        invalid_values = (True, np.array([1.0]))
+        cases = (
+            (
+                "probability_threshold",
+                "probability_threshold must lie in [0, 1]",
+            ),
+            ("max_cost", "max_cost must be finite or None"),
+            (
+                "max_cost_percentile",
+                "max_cost_percentile must lie in [0, 100]",
+            ),
+            ("large_cost", "large_cost must be finite and positive"),
+        )
+
+        for field_name, message in cases:
+            for value in invalid_values:
+                with self.subTest(field_name=field_name, value=value):
+                    with self.assertRaisesRegex(ValueError, message):
+                        CandidatePruningConfig(**{field_name: value})
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "large_cost must be finite and positive",
+        ):
+            prune_pairwise_cost_matrix(
+                np.array([[1.0]]),
+                config=CandidatePruningConfig(row_top_k=1),
+                large_cost=True,
+            )
+
     def test_top_k_rejects_non_integer_values(self):
         invalid_top_k_values = (True, 1.5, np.nan, np.inf, np.array([1]))
 


### PR DESCRIPTION
## Summary
- Validate candidate-pruning scalar controls through finite-scalar helpers instead of raw `float(...)` coercion.
- Reject booleans and non-scalar arrays for `probability_threshold`, `max_cost`, `max_cost_percentile`, `large_cost`, and the `large_cost` override.
- Preserve existing probability-matrix semantics; this PR only fixes scalar control validation.

## Testing
- Added focused regression coverage in `tests/test_candidate_pruning.py`.

Note: I did not run the tests locally because repository access here is through the GitHub connector.