### PR TITLE
Fix Pareto missing checks for non-scalar metrics

### DIFF
--- a/src/pyrecest/evaluation/pareto.py
+++ b/src/pyrecest/evaluation/pareto.py
@@ -345,7 +345,10 @@ def _coerce_numeric(value: Any) -> float:
 
 
 def _is_missing(value: Any) -> bool:
-    return bool(pd.isna(value))
+    missing = pd.isna(value)
+    if isinstance(missing, (bool, np.bool_)):
+        return bool(missing)
+    return False
 
 
 def _parse_constraint_spec(spec: ConstraintSpec | Mapping[str, Any]) -> ConstraintSpec:

--- a/tests/evaluation/test_pareto.py
+++ b/tests/evaluation/test_pareto.py
@@ -131,6 +131,25 @@ def test_record_dominates_treats_non_numeric_metrics_as_missing_when_allowed() -
     )
 
 
+def test_record_dominates_treats_nonscalar_metrics_as_missing_when_allowed() -> None:
+    left = {"size": 4.0, "quality": 0.95, "optional": [1.0, 2.0]}
+    right = {"size": 5.0, "quality": 0.95, "optional": 2.0}
+
+    assert record_dominates(
+        left,
+        right,
+        ["size", "quality", "optional"],
+        directions={"size": "min", "quality": "max", "optional": "max"},
+    )
+    assert not record_dominates(
+        left,
+        right,
+        ["size", "quality", "optional"],
+        directions={"size": "min", "quality": "max", "optional": "max"},
+        allow_missing=False,
+    )
+
+
 def test_constraint_mask_supports_tuple_and_mapping_specs() -> None:
     table = pd.DataFrame(
         [


### PR DESCRIPTION
## Summary
- Make Pareto missing-value detection robust to non-scalar cells such as lists or arrays.
- Preserve the existing behavior that non-numeric optional metrics are coerced to missing rather than crashing dominance checks.
- Add regression coverage for sequence-valued optional metrics in `record_dominates`.

## Bug
`record_dominates` calls `_is_missing` before numeric coercion. For sequence-valued objective cells, `pd.isna(value)` returns an array-like mask, and `bool(...)` raises instead of allowing the value to be treated as a non-numeric/missing optional metric.

## Testing
- Added focused regression test in `tests/evaluation/test_pareto.py`.
- Not run locally; changes were pushed through the GitHub connector and CI should run on the PR.