### PR TITLE
Validate finite registration weights

### DIFF
--- a/src/pyrecest/utils/point_set_registration.py
+++ b/src/pyrecest/utils/point_set_registration.py
@@ -25,6 +25,7 @@ from pyrecest.backend import (
     concatenate,
     eye,
     full,
+    isfinite,
     linalg,
     ones,
     quantile,
@@ -143,6 +144,8 @@ def _normalize_weights(weights, n_points):
     weights_array = asarray(weights).reshape(-1)
     if weights_array.shape[0] != n_points:
         raise ValueError("weights must have length n_points.")
+    if any(~isfinite(weights_array)):
+        raise ValueError("weights must be finite.")
     if any(weights_array < 0.0):
         raise ValueError("weights must be non-negative.")
     weight_sum = float(weights_array.sum())

--- a/tests/test_point_set_registration_weight_validation.py
+++ b/tests/test_point_set_registration_weight_validation.py
@@ -1,0 +1,29 @@
+import unittest
+
+import pyrecest.backend
+from pyrecest.backend import array
+from pyrecest.utils.point_set_registration import estimate_transform
+
+
+class TestEstimateTransformWeightValidation(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_estimate_transform_rejects_nonfinite_weights(self):
+        source = array([[0.0, 0.0], [1.0, 0.0]])
+        target = source + array([1.0, -1.0])
+
+        for bad_weight in (float("nan"), float("inf"), -float("inf")):
+            with self.subTest(bad_weight=bad_weight):
+                with self.assertRaisesRegex(ValueError, "finite"):
+                    estimate_transform(
+                        source,
+                        target,
+                        model="translation",
+                        weights=array([1.0, bad_weight]),
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reject NaN and infinite per-point weights in `estimate_transform`
- add a regression test covering NaN, +Inf, and -Inf weights

## Rationale
Before this change, `_normalize_weights` only rejected negative weights and non-positive sums. Non-finite weights could therefore pass validation and propagate NaNs/Infs into the estimated affine transform instead of failing fast with a clear `ValueError`.

## Testing
- Not run locally; repository network access is unavailable in this environment.