### PR TITLE
Validate Pareto directions before empty result

### DIFF
--- a/src/pyrecest/evaluation/pareto.py
+++ b/src/pyrecest/evaluation/pareto.py
@@ -52,9 +52,9 @@ def pareto_front_indices(
 
     objective_names = _validate_objectives(objectives)
     _require_table_columns(table, objective_names, "Pareto objective")
+    direction_map = _directions_by_objective(objective_names, directions)
     if table.empty:
         return []
-    direction_map = _directions_by_objective(objective_names, directions)
     candidates = (
         table.loc[_feasible_index(table, feasible_mask)]
         if feasible_mask is not None

--- a/tests/evaluation/test_pareto_empty_validation.py
+++ b/tests/evaluation/test_pareto_empty_validation.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+from pyrecest.evaluation import pareto_front_indices
+
+
+def test_pareto_front_indices_validates_directions_on_empty_table() -> None:
+    table = pd.DataFrame(columns=["error"])
+
+    with pytest.raises(ValueError, match="Invalid objective directions"):
+        pareto_front_indices(
+            table,
+            ["error"],
+            directions={"error": "sideways"},  # type: ignore[dict-item]
+        )


### PR DESCRIPTION
## Summary
- Validate `pareto_front_indices` objective directions before taking the empty-table fast path.
- Add a regression test showing invalid directions are rejected even when the input table has no rows.

## Bug
Before this change, `pareto_front_indices()` returned `[]` for an empty table before validating `directions`, so invalid directions such as `"sideways"` were silently accepted. This was inconsistent with `is_pareto_front()` and with non-empty Pareto calls.

## Testing
- Added focused regression test in `tests/evaluation/test_pareto_empty_validation.py`.
- Not run locally; this environment cannot clone GitHub or install the repository dependencies, so CI should run the regression test on the PR.