### PR TITLE
Validate point-set query chunk sizes

### DIFF
--- a/src/pyrecest/evaluation/point_set_metrics.py
+++ b/src/pyrecest/evaluation/point_set_metrics.py
@@ -81,7 +81,7 @@ def nearest_neighbor_distances(
     query_array = as_point_set(query, name="query")
     reference_array = as_point_set(reference, name="reference")
     _validate_matching_dimension(query_array, reference_array)
-    _validate_chunk_size(query_chunk_size)
+    query_chunk_size = _validate_chunk_size(query_chunk_size)
 
     tree_result = _nearest_neighbor_distances_ckdtree(
         query_array,
@@ -344,9 +344,24 @@ def _validate_matching_dimension(query: np.ndarray, reference: np.ndarray) -> No
         )
 
 
-def _validate_chunk_size(query_chunk_size: int) -> None:
-    if query_chunk_size < 1:
-        raise ValueError("query_chunk_size must be positive.")
+def _validate_chunk_size(query_chunk_size: int) -> int:
+    array = np.asarray(query_chunk_size)
+    if array.shape != () or array.dtype == np.bool_:
+        raise ValueError("query_chunk_size must be a positive integer.")
+    scalar = array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError("query_chunk_size must be a positive integer.")
+    try:
+        chunk_size_float = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("query_chunk_size must be a positive integer.") from exc
+    if (
+        not np.isfinite(chunk_size_float)
+        or not chunk_size_float.is_integer()
+        or chunk_size_float < 1.0
+    ):
+        raise ValueError("query_chunk_size must be a positive integer.")
+    return int(chunk_size_float)
 
 
 def _validate_threshold(threshold: float) -> float:

--- a/tests/evaluation/test_point_set_metrics_chunk_size.py
+++ b/tests/evaluation/test_point_set_metrics_chunk_size.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+
+from pyrecest.evaluation.point_set_metrics import nearest_neighbor_distances
+
+
+def test_nearest_neighbor_distances_rejects_noninteger_chunk_sizes():
+    points = np.array([[0.0], [1.0]])
+
+    for chunk_size in (0, -1, 1.5, np.nan, np.inf, True, np.array([1])):
+        with pytest.raises(ValueError, match="positive integer"):
+            nearest_neighbor_distances(
+                points,
+                points,
+                query_chunk_size=chunk_size,
+            )
+
+
+def test_nearest_neighbor_distances_accepts_integer_like_chunk_size():
+    points = np.array([[0.0], [1.0]])
+
+    distances = nearest_neighbor_distances(
+        points,
+        points,
+        query_chunk_size=np.array(1.0),
+    )
+
+    np.testing.assert_allclose(distances, [0.0, 0.0])


### PR DESCRIPTION
## Summary
- Normalize `query_chunk_size` before nearest-neighbor chunk iteration.
- Reject non-scalar, boolean, non-finite, non-integer, and non-positive chunk sizes with a clear `ValueError`.
- Add regression coverage for invalid chunk sizes and integer-like scalar acceptance.

## Bug
Before this change, `query_chunk_size` was only checked with `< 1`. Values such as `1.5`, `True`, or array inputs could pass validation and then either crash inside `range(...)` or silently behave as an unintended chunk size.

## Testing
- Added focused regression tests in `tests/evaluation/test_point_set_metrics_chunk_size.py`.
