### PR TITLE
Validate reproducibility seed inputs

### DIFF
--- a/src/pyrecest/reproducibility.py
+++ b/src/pyrecest/reproducibility.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import copy
+import math
 from collections.abc import Iterator
 from contextlib import contextmanager
+from numbers import Integral
 from typing import Any
 
 
@@ -14,6 +16,40 @@ def _random_backend() -> Any:
     return random
 
 
+def _normalize_seed(seed: int | None) -> int | None:
+    """Return a validated backend seed or ``None``."""
+
+    if seed is None:
+        return None
+
+    message = "seed must be a non-negative integer or None"
+
+    if hasattr(seed, "shape") and tuple(seed.shape) != ():
+        raise ValueError(message)
+
+    try:
+        scalar = seed.item() if hasattr(seed, "item") else seed
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise ValueError(message) from exc
+
+    if isinstance(scalar, bool):
+        raise ValueError(message)
+    if isinstance(scalar, Integral):
+        normalized_seed = int(scalar)
+    else:
+        try:
+            scalar_float = float(scalar)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(message) from exc
+        if not math.isfinite(scalar_float) or not scalar_float.is_integer():
+            raise ValueError(message)
+        normalized_seed = int(scalar_float)
+
+    if normalized_seed < 0:
+        raise ValueError(message)
+    return normalized_seed
+
+
 def seed_all(seed: int | None) -> int | None:
     """Seed the active backend random module and return the normalized seed.
 
@@ -21,9 +57,9 @@ def seed_all(seed: int | None) -> int | None:
     scenario runners and tests one explicit entry point instead of relying on
     ad-hoc calls to ``pyrecest.backend.random.seed``.
     """
-    if seed is None:
+    normalized_seed = _normalize_seed(seed)
+    if normalized_seed is None:
         return None
-    normalized_seed = int(seed)
     _random_backend().seed(normalized_seed)
     return normalized_seed
 

--- a/tests/test_reproducibility_seed.py
+++ b/tests/test_reproducibility_seed.py
@@ -1,0 +1,37 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.reproducibility import seed_all
+
+
+class ReproducibilitySeedValidationTest(unittest.TestCase):
+    def test_seed_all_rejects_invalid_seed_values(self):
+        invalid_seeds = (
+            True,
+            False,
+            -1,
+            1.5,
+            float("nan"),
+            float("inf"),
+            [1],
+            np.array([1]),
+            object(),
+        )
+
+        for seed in invalid_seeds:
+            with self.subTest(seed=repr(seed)):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "seed must be a non-negative integer or None",
+                ):
+                    seed_all(seed)
+
+    def test_seed_all_accepts_integer_like_scalar_seed(self):
+        self.assertIsNone(seed_all(None))
+        self.assertEqual(seed_all(np.array(7.0)), 7)
+        self.assertEqual(seed_all("8"), 8)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add explicit validation for `seed_all()` seed values before calling backend RNG seeding.
- Reject booleans, negative values, fractional values, non-finite values, non-scalar arrays, and non-numeric objects instead of silently converting them with `int(...)`.
- Add focused regression tests for invalid and integer-like scalar seeds.

## Bug
`seed_all()` previously normalized seeds with raw `int(seed)`. That silently converted values such as `True -> 1` and `1.5 -> 1`, making reproducibility configuration mistakes difficult to detect and backend-dependent.

## Testing
- Added `tests/test_reproducibility_seed.py`.
- Not run locally; this environment cannot clone GitHub or install the repository dependencies, so CI should run the tests on the PR.