### PR TITLE
Validate protocol shape axes

### DIFF
--- a/src/pyrecest/protocols/testing.py
+++ b/src/pyrecest/protocols/testing.py
@@ -22,11 +22,15 @@ def _type_name(obj: object) -> str:
 
 def _normalise_shape(shape: Iterable[int], value_name: str) -> tuple[int, ...]:
     try:
-        return tuple(int(axis) for axis in shape)
+        axes = tuple(shape)
     except TypeError as exc:
         raise ProtocolAssertionError(
             f"{value_name} must be an iterable shape."
         ) from exc
+    return tuple(
+        _nonnegative_integer(axis, f"{value_name}[{axis_index}]")
+        for axis_index, axis in enumerate(axes)
+    )
 
 
 def _shape_of(value: object, value_name: str) -> tuple[int, ...]:

--- a/tests/protocols/test_protocol_testing_helpers.py
+++ b/tests/protocols/test_protocol_testing_helpers.py
@@ -152,9 +152,15 @@ def test_shape_helpers_report_mismatches():
 def test_shape_helpers_reject_non_integer_axes():
     value = ArrayLikeObject((2, 3))
 
-    with pytest.raises(ProtocolAssertionError, match=r"expected_shape\[0\] must be an integer"):
+    with pytest.raises(
+        ProtocolAssertionError,
+        match=r"expected_shape\[0\] must be an integer",
+    ):
         assert_shape(value, (2.5, 3))
-    with pytest.raises(ProtocolAssertionError, match=r"value\[0\] must be an integer"):
+    with pytest.raises(
+        ProtocolAssertionError,
+        match=r"value\[0\] must be an integer",
+    ):
         assert_shape(ArrayLikeObject((2.5, 3)), (2, 3))
 
 
@@ -210,6 +216,5 @@ def test_model_helpers_return_method_results():
     )
     assert assert_supports_transition_density(transition_model, next_state, state) == (
         next_state,
-        state_previous,
+        state,
     )
-".replace("state_previous

--- a/tests/protocols/test_protocol_testing_helpers.py
+++ b/tests/protocols/test_protocol_testing_helpers.py
@@ -149,6 +149,15 @@ def test_shape_helpers_report_mismatches():
         assert_shape(object(), ())
 
 
+def test_shape_helpers_reject_non_integer_axes():
+    value = ArrayLikeObject((2, 3))
+
+    with pytest.raises(ProtocolAssertionError, match=r"expected_shape\[0\] must be an integer"):
+        assert_shape(value, (2.5, 3))
+    with pytest.raises(ProtocolAssertionError, match=r"value\[0\] must be an integer"):
+        assert_shape(ArrayLikeObject((2.5, 3)), (2, 3))
+
+
 def test_common_dimension_helpers_return_dimensions():
     obj = ObjectWithDimensions()
 
@@ -201,5 +210,6 @@ def test_model_helpers_return_method_results():
     )
     assert assert_supports_transition_density(transition_model, next_state, state) == (
         next_state,
-        state,
+        state_previous,
     )
+".replace("state_previous


### PR DESCRIPTION
## Summary
- reject non-integral and negative shape axes in protocol test helpers instead of truncating via int()
- add regression coverage for both expected and actual shapes with float axes

## Tests
- Not run locally; changes were made through the GitHub connector and CI should run on the PR.