### PR TITLE
Fix axis labels for specific manifolds

### DIFF
--- a/src/pyrecest/evaluation/get_axis_label.py
+++ b/src/pyrecest/evaluation/get_axis_label.py
@@ -5,23 +5,23 @@ def get_axis_label(manifold_name):
     elif "circle" in manifold_name or "hypertorus" in manifold_name:
         error_label = "Error in radian"
 
-    elif "hypersphere" in manifold_name:
-        error_label = "Error (orthodromic distance) in radian"
-
     elif "hypersphereSymmetric" in manifold_name:
         error_label = "Angular error in radian"
 
-    elif "se2" in manifold_name or "se2linear" in manifold_name:
-        error_label = "Error in meters"
+    elif "hypersphere" in manifold_name:
+        error_label = "Error (orthodromic distance) in radian"
 
     elif "se2bounded" in manifold_name:
         error_label = "Error in radian"
 
-    elif "se3" in manifold_name or "se3linear" in manifold_name:
+    elif "se2" in manifold_name or "se2linear" in manifold_name:
         error_label = "Error in meters"
 
     elif "se3bounded" in manifold_name:
         error_label = "Error in radian"
+
+    elif "se3" in manifold_name or "se3linear" in manifold_name:
+        error_label = "Error in meters"
 
     elif (
         "euclidean" in manifold_name or "Euclidean" in manifold_name

--- a/tests/test_axis_labels.py
+++ b/tests/test_axis_labels.py
@@ -1,0 +1,29 @@
+import pytest
+
+from pyrecest.evaluation import get_axis_label
+
+
+@pytest.mark.parametrize(
+    ("manifold_name", "expected_label"),
+    [
+        ("hypersphereSymmetric", "Angular error in radian"),
+        ("se2bounded", "Error in radian"),
+        ("se3bounded", "Error in radian"),
+    ],
+)
+def test_specific_manifolds_are_not_shadowed_by_generic_substrings(
+    manifold_name, expected_label
+):
+    assert get_axis_label(manifold_name) == expected_label
+
+
+@pytest.mark.parametrize(
+    ("manifold_name", "expected_label"),
+    [
+        ("hypersphere", "Error (orthodromic distance) in radian"),
+        ("se2", "Error in meters"),
+        ("se3", "Error in meters"),
+    ],
+)
+def test_generic_manifold_axis_labels_are_preserved(manifold_name, expected_label):
+    assert get_axis_label(manifold_name) == expected_label


### PR DESCRIPTION
## Summary
- Move specific manifold-name checks before broader substring checks in `get_axis_label`.
- Add regression coverage for `hypersphereSymmetric`, `se2bounded`, and `se3bounded` labels.

## Bug
`hypersphereSymmetric`, `se2bounded`, and `se3bounded` contain broader substrings that were checked first. As a result, they returned generic labels instead of their intended specific labels.

## Testing
- Not run locally; repository access is via the GitHub connector in this environment.
