### PR TITLE
Validate point-set subsample max_points

### DIFF
--- a/src/pyrecest/evaluation/point_set_metrics.py
+++ b/src/pyrecest/evaluation/point_set_metrics.py
@@ -54,13 +54,18 @@ def deterministic_subsample(
     """
 
     point_array = as_point_set(points)
-    if max_points is None or max_points <= 0 or point_array.shape[0] <= max_points:
+    max_points_int = _normalize_optional_integer(max_points, "max_points")
+    if (
+        max_points_int is None
+        or max_points_int <= 0
+        or point_array.shape[0] <= max_points_int
+    ):
         indices = np.arange(point_array.shape[0], dtype=np.int64)
         return point_array, indices
 
     rng = np.random.default_rng(seed)
     indices = np.sort(
-        rng.choice(point_array.shape[0], size=max_points, replace=False)
+        rng.choice(point_array.shape[0], size=max_points_int, replace=False)
     ).astype(np.int64)
     return point_array[indices], indices
 
@@ -347,6 +352,30 @@ def _validate_matching_dimension(query: np.ndarray, reference: np.ndarray) -> No
 def _validate_chunk_size(query_chunk_size: int) -> None:
     if query_chunk_size < 1:
         raise ValueError("query_chunk_size must be positive.")
+
+
+def _normalize_optional_integer(value: Any, name: str) -> int | None:
+    if value is None:
+        return None
+
+    value_array = np.asarray(value)
+    message = f"{name} must be None or an integer."
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError(message)
+
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(message)
+    if isinstance(scalar, (int, np.integer)):
+        return int(scalar)
+
+    try:
+        scalar_float = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if not np.isfinite(scalar_float) or not scalar_float.is_integer():
+        raise ValueError(message)
+    return int(scalar_float)
 
 
 def _validate_threshold(threshold: float) -> float:

--- a/tests/evaluation/test_point_set_metrics.py
+++ b/tests/evaluation/test_point_set_metrics.py
@@ -102,6 +102,22 @@ def test_deterministic_subsample_returns_sorted_indices_and_is_reproducible():
     assert np.all(indices_a[:-1] <= indices_a[1:])
 
 
+def test_deterministic_subsample_validates_max_points_integrality():
+    points = np.arange(30.0).reshape(10, 3)
+
+    subset, indices = deterministic_subsample(points, max_points=4.0, seed=7)
+    assert subset.shape == (4, 3)
+    assert indices.shape == (4,)
+
+    all_points, all_indices = deterministic_subsample(points, max_points=-1)
+    np.testing.assert_array_equal(all_points, points)
+    np.testing.assert_array_equal(all_indices, np.arange(points.shape[0]))
+
+    for max_points in (True, 1.5, np.nan, np.array([3])):
+        with pytest.raises(ValueError, match="max_points"):
+            deterministic_subsample(points, max_points=max_points)
+
+
 def test_invalid_point_sets_raise_clear_errors():
     with pytest.raises(ValueError, match="shape"):
         nearest_neighbor_distances(np.array([0.0, 1.0]), np.array([[0.0], [1.0]]))


### PR DESCRIPTION
## Summary
- Normalize `deterministic_subsample(max_points=...)` before using it as a NumPy RNG sample size.
- Preserve the documented all-points behavior for `None`, zero, negative, or overlarge integer values.
- Reject boolean, array-valued, NaN, and non-integral `max_points` values with a clear `ValueError` instead of silently treating `True` as one sample or failing inside NumPy.

## Bug
`deterministic_subsample()` previously compared and forwarded `max_points` directly to `rng.choice(size=...)`. That meant values such as `True` could be interpreted as `1`, while non-integral floats or arrays failed later with backend/NumPy-specific errors.

## Testing
- Added focused regression coverage in `tests/evaluation/test_point_set_metrics.py`.
- Not run locally; this environment cannot clone GitHub or install repository dependencies, so CI should run the test on the PR.