### PR TITLE
Reject boolean selection fractions

### DIFF
--- a/src/pyrecest/evaluation/selection.py
+++ b/src/pyrecest/evaluation/selection.py
@@ -40,6 +40,40 @@ def _normalize_nonnegative_integer(value, name: str) -> int:
     return integer
 
 
+def _normalize_finite_scalar(value, message: str) -> float:
+    value_array = np.asarray(value)
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError(message)
+
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(message)
+    try:
+        result = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if not np.isfinite(result):
+        raise ValueError(message)
+    return result
+
+
+def _normalize_bounded_fraction(
+    value,
+    *,
+    lower: float,
+    upper: float,
+    include_lower: bool,
+    include_upper: bool,
+    message: str,
+) -> float:
+    fraction = _normalize_finite_scalar(value, message)
+    lower_ok = fraction >= lower if include_lower else fraction > lower
+    upper_ok = fraction <= upper if include_upper else fraction < upper
+    if not lower_ok or not upper_ok:
+        raise ValueError(message)
+    return fraction
+
+
 def sanitized_score_vector(values, *, nonnegative: bool = True) -> np.ndarray:
     """Return a finite one-dimensional ``float64`` score vector.
 
@@ -67,9 +101,14 @@ def retained_count_from_fraction(
     behavior.
     """
     count = _normalize_nonnegative_integer(item_count, "item_count")
-    fraction = float(retention_fraction)
-    if not np.isfinite(fraction) or not 0.0 <= fraction <= 1.0:
-        raise ValueError("retention_fraction must be finite and in [0, 1].")
+    fraction = _normalize_bounded_fraction(
+        retention_fraction,
+        lower=0.0,
+        upper=1.0,
+        include_lower=True,
+        include_upper=True,
+        message="retention_fraction must be finite and in [0, 1].",
+    )
     minimum = _normalize_nonnegative_integer(min_count, "min_count")
     if count == 0 or fraction == 0.0:
         return 0
@@ -297,9 +336,14 @@ def protected_tail_topk_mask(
 def tail_rescue_quota_count(retained_count: int, *, rescue_fraction: float) -> int:
     """Return a bounded tail-rescue quota inside a retained budget."""
     retained = _normalize_nonnegative_integer(retained_count, "retained_count")
-    rescue = float(rescue_fraction)
-    if not np.isfinite(rescue) or not 0.0 < rescue <= 1.0:
-        raise ValueError("rescue_fraction must be finite and in (0, 1].")
+    rescue = _normalize_bounded_fraction(
+        rescue_fraction,
+        lower=0.0,
+        upper=1.0,
+        include_lower=False,
+        include_upper=True,
+        message="rescue_fraction must be finite and in (0, 1].",
+    )
     if retained == 0:
         return 0
     return int(min(retained, max(1, np.ceil(rescue * retained))))

--- a/tests/evaluation/test_selection_fraction_validation.py
+++ b/tests/evaluation/test_selection_fraction_validation.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pyrecest.evaluation.selection import (
+    retained_count_from_fraction,
+    tail_rescue_quota_count,
+)
+
+
+def test_retained_count_from_fraction_rejects_bool_and_vector_fractions() -> None:
+    for retention_fraction in (True, False, np.array([0.5])):
+        with pytest.raises(ValueError, match="retention_fraction"):
+            retained_count_from_fraction(10, retention_fraction)
+
+    assert retained_count_from_fraction(10, np.array(0.5)) == 5
+
+
+def test_tail_rescue_quota_count_rejects_bool_and_vector_fractions() -> None:
+    for rescue_fraction in (True, False, np.array([0.5])):
+        with pytest.raises(ValueError, match="rescue_fraction"):
+            tail_rescue_quota_count(10, rescue_fraction=rescue_fraction)
+
+    assert tail_rescue_quota_count(10, rescue_fraction=np.array(0.2)) == 2


### PR DESCRIPTION
## Summary
- Normalize selection fraction controls with scalar finite-value validation instead of raw `float(...)` coercion.
- Reject boolean and non-scalar array inputs for `retention_fraction` and `rescue_fraction`.
- Preserve scalar NumPy arrays such as `np.array(0.5)` as valid scalar-like inputs.

## Testing
- Added focused regression tests in `tests/evaluation/test_selection_fraction_validation.py`.

Note: I did not run tests locally because repository access here is through the GitHub connector.