### PR TITLE
Validate finite robust Gaussian scale controls

### DIFF
--- a/src/pyrecest/filters/_linear_gaussian.py
+++ b/src/pyrecest/filters/_linear_gaussian.py
@@ -1,6 +1,8 @@
 # pylint: disable=no-name-in-module,no-member,redefined-outer-name
 """Backend-native linear-Gaussian predict/update primitives."""
 
+import math
+
 from pyrecest.backend import (
     asarray,
     atleast_1d,
@@ -30,9 +32,12 @@ def _as_matrix(x, name):
 
 
 def _as_positive_float(x, name):
-    x = float(x)
-    if x <= 0.0:
-        raise ValueError(f"{name} must be positive")
+    try:
+        x = float(x)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be finite and positive") from exc
+    if not math.isfinite(x) or x <= 0.0:
+        raise ValueError(f"{name} must be finite and positive")
     return x
 
 
@@ -70,9 +75,7 @@ def huber_covariance_scale(  # pylint: disable=redefined-outer-name
     huber_threshold : float, optional
         Huber threshold ``k`` in Mahalanobis-norm units. Must be positive.
     """
-    huber_threshold = float(huber_threshold)
-    if huber_threshold <= 0.0:
-        raise ValueError("huber_threshold must be positive")
+    huber_threshold = _as_positive_float(huber_threshold, "huber_threshold")
 
     nis = asarray(normalized_innovation_squared, dtype=float64)
     return maximum(1.0, sqrt(nis) / huber_threshold)
@@ -114,12 +117,12 @@ def student_t_covariance_scale(  # pylint: disable=redefined-outer-name
         raise ValueError("measurement_dim must be positive")
 
     dof = float(dof)
-    if dof <= 2.0:
-        raise ValueError("dof must be greater than 2")
+    if not math.isfinite(dof) or dof <= 2.0:
+        raise ValueError("dof must be finite and greater than 2")
 
     min_scale = float(min_scale)
-    if min_scale < 0.0:
-        raise ValueError("min_scale must be nonnegative")
+    if not math.isfinite(min_scale) or min_scale < 0.0:
+        raise ValueError("min_scale must be finite and nonnegative")
 
     nis = asarray(normalized_innovation_squared, dtype=float64)
     scale = (dof + nis) / (dof + measurement_dim)
@@ -271,9 +274,7 @@ def linear_gaussian_update(
     if meas_noise.shape != (meas_dim, meas_dim):
         raise ValueError("meas_noise must have shape (meas_dim, meas_dim)")
 
-    scale = float(scale)
-    if scale <= 0.0:
-        raise ValueError("scale must be positive")
+    scale = _as_positive_float(scale, "scale")
 
     innovation = measurement - measurement_matrix @ mean
     nominal_innovation_cov = (

--- a/tests/filters/test_linear_gaussian_robust.py
+++ b/tests/filters/test_linear_gaussian_robust.py
@@ -3,7 +3,11 @@
 
 import pytest
 from pyrecest.backend import allclose, array
-from pyrecest.filters._linear_gaussian import huber_covariance_scale
+from pyrecest.filters._linear_gaussian import (
+    huber_covariance_scale,
+    linear_gaussian_update,
+    student_t_covariance_scale,
+)
 
 
 def test_huber_covariance_scale_leaves_inliers_unchanged():
@@ -23,3 +27,41 @@ def test_huber_covariance_scale_vectorizes_over_nis():
 def test_huber_covariance_scale_rejects_nonpositive_threshold():
     with pytest.raises(ValueError, match="positive"):
         huber_covariance_scale(1.0, huber_threshold=0.0)
+
+
+@pytest.mark.parametrize("invalid_threshold", [float("nan"), float("inf"), -float("inf")])
+def test_huber_covariance_scale_rejects_nonfinite_threshold(invalid_threshold):
+    with pytest.raises(ValueError, match="finite and positive"):
+        huber_covariance_scale(1.0, huber_threshold=invalid_threshold)
+
+
+@pytest.mark.parametrize("invalid_dof", [float("nan"), float("inf"), -float("inf")])
+def test_student_t_covariance_scale_rejects_nonfinite_dof(invalid_dof):
+    with pytest.raises(ValueError, match="finite and greater than 2"):
+        student_t_covariance_scale(1.0, measurement_dim=1, dof=invalid_dof)
+
+
+@pytest.mark.parametrize(
+    "invalid_min_scale",
+    [float("nan"), float("inf"), -float("inf")],
+)
+def test_student_t_covariance_scale_rejects_nonfinite_min_scale(invalid_min_scale):
+    with pytest.raises(ValueError, match="finite and nonnegative"):
+        student_t_covariance_scale(
+            1.0,
+            measurement_dim=1,
+            min_scale=invalid_min_scale,
+        )
+
+
+@pytest.mark.parametrize("invalid_scale", [float("nan"), float("inf"), -float("inf")])
+def test_linear_gaussian_update_rejects_nonfinite_scale(invalid_scale):
+    with pytest.raises(ValueError, match="scale must be finite and positive"):
+        linear_gaussian_update(
+            array([0.0]),
+            array([[1.0]]),
+            array([0.0]),
+            array([[1.0]]),
+            array([[1.0]]),
+            scale=invalid_scale,
+        )


### PR DESCRIPTION
## Summary
- Reject non-finite robust linear-Gaussian scalar controls before they enter covariance scaling.
- Route Huber thresholds and linear-update scale through finite-positive validation.
- Validate Student-t `dof` and `min_scale` for finite values.
- Add regression tests for `NaN`, `+Inf`, and `-Inf` controls.

## Bug
`NaN` and infinite scalar controls passed comparisons such as `x <= 0.0` and `x < 0.0`, allowing them to propagate into robust covariance scaling or linear-Gaussian updates instead of failing fast with a controlled `ValueError`.

## Testing
- Added focused regression tests in `tests/filters/test_linear_gaussian_robust.py`.
- Not run locally; repository access here is through the GitHub connector, so CI should run the tests on the PR.