### PR TITLE
Reject unsupported measurement noise distributions

### DIFF
--- a/src/pyrecest/evaluation/generate_measurements.py
+++ b/src/pyrecest/evaluation/generate_measurements.py
@@ -257,6 +257,11 @@ def generate_measurements(groundtruth, simulation_config):
                         1,
                     ),
                 ) + noise_samples
+            else:
+                raise TypeError(
+                    "meas_noise must be a supported PyRecEst distribution; "
+                    f"got {type(meas_noise).__name__}."
+                )
 
     return measurements
 

--- a/tests/test_generate_measurements_unsupported_noise.py
+++ b/tests/test_generate_measurements_unsupported_noise.py
@@ -1,0 +1,21 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.evaluation.generate_measurements import generate_measurements
+
+
+class TestGenerateMeasurementsUnsupportedNoise(unittest.TestCase):
+    def test_rejects_unsupported_measurement_noise_distribution(self):
+        simulation_config = {
+            "n_timesteps": 2,
+            "n_meas_at_individual_time_step": np.ones(2, dtype=int),
+            "meas_noise": object(),
+        }
+
+        with self.assertRaisesRegex(TypeError, "meas_noise"):
+            generate_measurements(np.zeros((2, 1)), simulation_config)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- raise a clear `TypeError` when `generate_measurements` receives an unsupported `meas_noise` object in the standard non-EOT/non-MTT path
- add a regression test that covers the previous silent-uninitialized-output behavior

## Rationale
Before this change, the Gaussian/hypertoroidal/directional distribution branches were exhaustive in practice but lacked a final `else`. Unsupported noise objects therefore left each `measurements[t]` slot unset and returned an object array with undefined entries instead of failing at the offending configuration.

## Tests
- Not run locally; repository access is through the GitHub connector in this environment.