### PR TITLE
Handle non-parametric plot result summaries

### DIFF
--- a/src/pyrecest/evaluation/plot_results.py
+++ b/src/pyrecest/evaluation/plot_results.py
@@ -185,8 +185,8 @@ def get_plot_style_for_filter(filter_name):
 
     Returns:
         color (str or list): Color for the plot.
-        style_marker (str): Marker style for the plot.
-        style_line (str): Line style for the plot.
+        style_marker (str): Marker style.
+        style_line (str): Line style.
     """
 
     switcher = {
@@ -263,6 +263,8 @@ def get_min_max_param(results_summarized):
     valid_parameters = [
         res["parameter"] for res in results_summarized if res["parameter"] is not None
     ]
+    if not valid_parameters:
+        return 0.0, 1.0
     # Finding min and max values
     min_parameter = min(valid_parameters)
     max_parameter = max(valid_parameters)

--- a/tests/test_plot_results_helper_bounds.py
+++ b/tests/test_plot_results_helper_bounds.py
@@ -1,0 +1,26 @@
+import unittest
+
+from pyrecest.evaluation.plot_results import get_min_max_param
+
+
+class PlotResultsHelperBoundsTest(unittest.TestCase):
+    def test_fallback_without_numeric_parameters(self):
+        summaries = [
+            {"name": "kf", "parameter": None},
+            {"name": "wn", "parameter": None},
+        ]
+
+        self.assertEqual(get_min_max_param(summaries), (0.0, 1.0))
+
+    def test_numeric_parameter_bounds(self):
+        summaries = [
+            {"name": "kf", "parameter": None},
+            {"name": "pf", "parameter": 100},
+            {"name": "pf", "parameter": 10},
+        ]
+
+        self.assertEqual(get_min_max_param(summaries), (10, 100))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Make `get_min_max_param` return a harmless default range when all summarized filter parameters are `None`.
- This prevents `plot_results()` from crashing before it reaches the existing non-parametric plotting path.
- Add focused regression coverage for all-`None` and mixed numeric parameter summaries.

## Testing
- Added `tests/test_plot_results_helper_bounds.py`.

Note: I did not run the tests locally because repository access here is through the GitHub connector.