### PR TITLE
Validate Viterbi top-k path count

### DIFF
--- a/src/pyrecest/filters/sequence_association.py
+++ b/src/pyrecest/filters/sequence_association.py
@@ -157,9 +157,10 @@ def solve_top_k_viterbi_sequence_associations(
     Yen-style k-shortest-path enumeration.
     """
     normalized_frames = _validate_frames(frames)
-    top_k_terminal_paths = int(top_k_terminal_paths)
-    if top_k_terminal_paths < 1:
-        raise ValueError("top_k_terminal_paths must be positive")
+    top_k_terminal_paths = _validate_positive_integer(
+        top_k_terminal_paths,
+        "top_k_terminal_paths",
+    )
 
     costs: list[np.ndarray] = [
         np.array([float(node.unary_cost) for node in normalized_frames[0]])
@@ -287,3 +288,28 @@ def _validate_cost(value: object, name: str) -> float:
     if not np.isfinite(cost):
         raise ValueError(f"{name} must be finite")
     return cost
+
+
+def _validate_positive_integer(value: object, name: str) -> int:
+    message = f"{name} must be a positive integer"
+    value_array = np.asarray(value)
+    if value_array.ndim != 0 or value_array.dtype == np.bool_:
+        raise ValueError(message)
+
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(message)
+    if isinstance(scalar, (int, np.integer)):
+        result = int(scalar)
+    elif (
+        isinstance(scalar, (float, np.floating))
+        and np.isfinite(scalar)
+        and float(scalar).is_integer()
+    ):
+        result = int(scalar)
+    else:
+        raise ValueError(message)
+
+    if result < 1:
+        raise ValueError(message)
+    return result

--- a/tests/filters/test_sequence_association.py
+++ b/tests/filters/test_sequence_association.py
@@ -74,16 +74,38 @@ class SequenceAssociationTest(unittest.TestCase):
         self.assertEqual([path.candidate_indices for path in paths], [(0, 0), (1, 1)])
         self.assertLessEqual(paths[0].total_cost, paths[1].total_cost)
 
+    def test_top_k_accepts_integer_like_scalar(self):
+        frames = [
+            [_node(0, 0, "A", 0.0), _node(0, 1, "B", 0.4)],
+            [_node(1, 0, "A", 0.0), _node(1, 1, "B", 0.4)],
+        ]
+
+        paths = solve_top_k_viterbi_sequence_associations(
+            frames,
+            lambda _previous, _current, _context: 0.0,
+            top_k_terminal_paths=np.array(1.0),
+        )
+
+        self.assertEqual(len(paths), 1)
+        self.assertEqual(paths[0].payloads, ("A", "A"))
+
     def test_validation_rejects_empty_frames_and_invalid_top_k(self):
         with self.assertRaises(ValueError):
             solve_viterbi_sequence_association([], lambda _a, _b, _c: 0.0)
 
-        with self.assertRaises(ValueError):
-            solve_top_k_viterbi_sequence_associations(
-                [[_node(0, 0, "A", 0.0)]],
-                lambda _a, _b, _c: 0.0,
-                top_k_terminal_paths=0,
-            )
+        frames = [[_node(0, 0, "A", 0.0)]]
+        invalid_top_k_values = (0, -1, 1.5, np.nan, np.inf, True, "2", np.array([1]))
+        for invalid_top_k in invalid_top_k_values:
+            with self.subTest(top_k_terminal_paths=invalid_top_k):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "top_k_terminal_paths must be a positive integer",
+                ):
+                    solve_top_k_viterbi_sequence_associations(
+                        frames,
+                        lambda _a, _b, _c: 0.0,
+                        top_k_terminal_paths=invalid_top_k,
+                    )
 
         with self.assertRaises(ValueError):
             SequenceAssociationNode(0, None)


### PR DESCRIPTION
## Summary
- Replace raw `int(...)` coercion for `top_k_terminal_paths` with explicit positive-integer validation.
- Reject booleans, fractional values, non-finite values, strings, and non-scalar arrays instead of silently truncating or coercing them.
- Add regression coverage while preserving support for integer-like scalar arrays such as `np.array(1.0)`.

## Bug
Before this change, `solve_top_k_viterbi_sequence_associations(..., top_k_terminal_paths=1.5)` silently behaved like `top_k_terminal_paths=1`, and `True` was accepted as `1`. That can hide configuration mistakes in Viterbi association experiments.

## Testing
- Added focused regression coverage in `tests/filters/test_sequence_association.py`.
- Not run locally because this environment cannot clone GitHub or install repository dependencies; CI should run the tests on the PR.