### PR TITLE
Reject ambiguous fill values in session label conversion

### DIFF
--- a/src/pyrecest/utils/_multisession_assignment_labels.py
+++ b/src/pyrecest/utils/_multisession_assignment_labels.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from numbers import Integral
 from typing import Any
 
 from pyrecest.backend import int64
@@ -17,6 +18,15 @@ from .multisession_assignment import (  # pylint: disable=protected-access
 )
 
 
+def _normalize_fill_value(fill_value: Any, track_count: int) -> int:
+    if isinstance(fill_value, bool) or not isinstance(fill_value, Integral):
+        raise ValueError("fill_value must be an integer.")
+    fill_value = int(fill_value)
+    if 0 <= fill_value < int(track_count):
+        raise ValueError("fill_value must not collide with track labels.")
+    return fill_value
+
+
 def tracks_to_session_labels(
     tracks: Sequence[TrackInput],
     session_sizes: SessionSizesInput | None = None,
@@ -25,6 +35,7 @@ def tracks_to_session_labels(
 ) -> tuple[Any, ...]:
     """Convert explicit tracks to dense per-session label arrays."""
     _ensure_supported_backend("tracks_to_session_labels")
+    fill_value = _normalize_fill_value(fill_value, len(tracks))
 
     inferred_sizes, max_session_index = _validate_track_session_sizes(
         tracks,

--- a/tests/test_multisession_assignment_labels.py
+++ b/tests/test_multisession_assignment_labels.py
@@ -9,13 +9,9 @@ import pyrecest.utils.multisession_assignment as multisession_assignment_module
 
 
 class TestMultiSessionAssignmentLabels(unittest.TestCase):
-    @unittest.skipIf(
-        __backend_name__ == "jax",
-        reason="Not supported on this backend",
-    )
-    def test_duplicate_detection_rejected_when_fill_value_matches_track_label(self):
-        tracks = [{0: 0}, {0: 0}]
-        converters = (
+    @staticmethod
+    def _converters():
+        return (
             ("public", tracks_to_session_labels),
             ("module", multisession_assignment_module.tracks_to_session_labels),
             (
@@ -28,13 +24,35 @@ class TestMultiSessionAssignmentLabels(unittest.TestCase):
             ),
         )
 
-        for name, converter in converters:
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_duplicate_detection_rejected_when_fill_value_matches_track_label(self):
+        tracks = [{0: 0}, {0: 0}]
+
+        for name, converter in self._converters():
             with self.subTest(converter=name):
                 with self.assertRaisesRegex(
                     ValueError,
                     "Each detection can only belong to a single track",
                 ):
-                    converter(tracks, session_sizes=[1], fill_value=0)
+                    converter(tracks, session_sizes=[1], fill_value=-99)
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_fill_value_cannot_collide_with_track_labels(self):
+        tracks = [{0: 0}, {0: 1}]
+
+        for name, converter in self._converters():
+            with self.subTest(converter=name):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "fill_value must not collide with track labels",
+                ):
+                    converter(tracks, session_sizes=[3], fill_value=0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- reject `fill_value`s that collide with generated track labels in dense session-label conversion
- keep the duplicate-detection regression covered with a non-colliding fill sentinel
- add a regression test for ambiguous `fill_value=0` outputs with unassigned detections

## Testing
- Not run locally; repository access is through the GitHub connector in this environment.
