### PR TITLE
Fix ambiguous Euclidean MTT target orientation

### DIFF
--- a/src/pyrecest/evaluation/get_distance_function.py
+++ b/src/pyrecest/evaluation/get_distance_function.py
@@ -76,8 +76,10 @@ def _as_target_matrix(value) -> np.ndarray:
     if value.ndim == 1:
         return value.reshape(1, -1)
     # Common MTT layouts are either (num_targets, dim) or (dim, num_targets).
-    # Prefer rows as targets when the orientation is ambiguous.
-    if value.shape[0] <= 4 and value.shape[1] > value.shape[0]:
+    # Prefer rows as targets when the orientation is ambiguous; only transpose
+    # dim-first layouts when the trailing axis is too large to be a common
+    # Euclidean target dimension.
+    if value.shape[0] <= 4 < value.shape[1]:
         return value.T
     return value
 

--- a/tests/evaluation/test_euclidean_mtt_distance_orientation.py
+++ b/tests/evaluation/test_euclidean_mtt_distance_orientation.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+from pyrecest.evaluation import get_distance_function
+
+
+def test_euclidean_mtt_distance_preserves_ambiguous_row_oriented_3d_targets():
+    distance = get_distance_function("euclidean_mtt", {"cutoff_distance": 100.0})
+    first = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [10.0, 0.0, 0.0],
+        ]
+    )
+    second = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [13.0, 4.0, 0.0],
+        ]
+    )
+
+    np.testing.assert_allclose(distance(first, second), 5.0)


### PR DESCRIPTION
## Summary
- Preserve row-oriented target matrices in the ambiguous Euclidean MTT case, e.g. shape `(2, 3)` as two 3D targets.
- Continue transposing clearly dim-first layouts only when the trailing axis is larger than the common Euclidean target dimension range.
- Add a regression test for a two-target 3D MTT distance.

## Bug
`_as_target_matrix()` claimed to prefer rows as targets when the orientation is ambiguous, but transposed any matrix with `rows <= 4` and `cols > rows`. A row-oriented `(2, 3)` matrix was therefore interpreted as three 2D targets instead of two 3D targets, producing an incorrect assignment distance.

## Testing
- Not run locally; changes were made through the GitHub connector and CI should exercise the new regression test.