### PR TITLE
Validate hypothesis replay score controls

### DIFF
--- a/src/pyrecest/tracking/hypothesis_replay.py
+++ b/src/pyrecest/tracking/hypothesis_replay.py
@@ -40,6 +40,34 @@ class InnovationConsistencyScoreConfig:
     residual_clip: float = 500.0
     residual_normalizer: float = 100.0
 
+    def __post_init__(self) -> None:
+        for name in (
+            "graph_cost_weight",
+            "nis_weight",
+            "residual_weight",
+            "switch_weight",
+            "missed_detection_weight",
+            "rejected_weight",
+            "coast_weight",
+            "unsupported_measurement_weight",
+            "hard_quarantine_weight",
+            "tail_duration_weight",
+            "coverage_reward",
+        ):
+            object.__setattr__(self, name, _finite_float(getattr(self, name), name))
+
+        for name in ("nis_clip", "residual_clip"):
+            object.__setattr__(
+                self,
+                name,
+                _nonnegative_float(getattr(self, name), name),
+            )
+        object.__setattr__(
+            self,
+            "residual_normalizer",
+            _positive_float(self.residual_normalizer, "residual_normalizer"),
+        )
+
 
 @dataclass(frozen=True)
 class HypothesisReplay:
@@ -328,7 +356,16 @@ def _record_value(record: Any, keys: tuple[str, ...]) -> Any | None:
 
 
 def _finite_float(value: Any, name: str) -> float:
-    parsed = float(value)
+    value_array = np.asarray(value)
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError(f"{name} must be finite")
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(f"{name} must be finite")
+    try:
+        parsed = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be finite") from exc
     if not np.isfinite(parsed):
         raise ValueError(f"{name} must be finite")
     return parsed
@@ -341,8 +378,30 @@ def _nonnegative_float(value: Any, name: str) -> float:
     return parsed
 
 
+def _positive_float(value: Any, name: str) -> float:
+    parsed = _finite_float(value, name)
+    if parsed <= 0.0:
+        raise ValueError(f"{name} must be positive")
+    return parsed
+
+
 def _nonnegative_int(value: Any, name: str) -> int:
-    parsed = int(value)
+    value_array = np.asarray(value)
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError(f"{name} must be a nonnegative integer")
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(f"{name} must be a nonnegative integer")
+    if isinstance(scalar, (int, np.integer)):
+        parsed = int(scalar)
+    else:
+        try:
+            scalar_float = float(scalar)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(f"{name} must be a nonnegative integer") from exc
+        if not np.isfinite(scalar_float) or not scalar_float.is_integer():
+            raise ValueError(f"{name} must be a nonnegative integer")
+        parsed = int(scalar_float)
     if parsed < 0:
         raise ValueError(f"{name} must be nonnegative")
     return parsed

--- a/tests/tracking/test_hypothesis_replay.py
+++ b/tests/tracking/test_hypothesis_replay.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 from pyrecest.tracking import (
     HypothesisReplay,
     InnovationConsistencyScoreConfig,
@@ -64,6 +65,28 @@ def test_hypothesis_replay_accepts_tracking_record_objects() -> None:
     assert score.finite_nis_count == 1
     assert score.finite_residual_count == 1
     assert score.robust_sum_residual == 5.0 / 100.0
+
+
+def test_score_config_rejects_invalid_scalar_controls() -> None:
+    invalid_cases = (
+        ("residual_weight", np.inf, "residual_weight must be finite"),
+        ("coverage_reward", True, "coverage_reward must be finite"),
+        ("nis_clip", -1.0, "nis_clip must be nonnegative"),
+        ("residual_clip", np.array([1.0]), "residual_clip must be finite"),
+        ("residual_normalizer", 0.0, "residual_normalizer must be positive"),
+    )
+
+    for field_name, value, message in invalid_cases:
+        with pytest.raises(ValueError, match=message):
+            InnovationConsistencyScoreConfig(**{field_name: value})
+
+
+def test_hypothesis_replay_rejects_fractional_count_fields() -> None:
+    with pytest.raises(
+        ValueError,
+        match="track_switches must be a nonnegative integer",
+    ):
+        HypothesisReplay(hypothesis_id="bad-count", records=[], track_switches=1.5)
 
 
 def test_rank_replayed_hypotheses_calls_replay_function() -> None:


### PR DESCRIPTION
## Summary
- Validate `InnovationConsistencyScoreConfig` scalar weights, clips, and `residual_normalizer` at construction time.
- Reject invalid replay count fields such as fractional `track_switches` instead of truncating through `int(...)`.
- Prevent a zero `residual_normalizer` from being accepted and later causing division-by-zero during replay scoring.

## Testing
- Added focused regression coverage in `tests/tracking/test_hypothesis_replay.py`.

Note: I did not run the tests locally because repository access here is through the GitHub connector.