### PR TITLE
Accept scalar array Murty assignment counts

### DIFF
--- a/src/pyrecest/utils/assignment.py
+++ b/src/pyrecest/utils/assignment.py
@@ -36,6 +36,8 @@ def _validate_assignment_count(k: int) -> int:
         raise ValueError("k must be an integer")
     if isinstance(k, Integral):
         return int(k)
+    if not (hasattr(k, "ndim") or hasattr(k, "shape") or hasattr(k, "item")):
+        raise ValueError("k must be an integer")
 
     try:
         k_array = _asarray(k)

--- a/src/pyrecest/utils/assignment.py
+++ b/src/pyrecest/utils/assignment.py
@@ -32,9 +32,32 @@ class _MurtySubproblem:
 
 
 def _validate_assignment_count(k: int) -> int:
-    if isinstance(k, bool) or not isinstance(k, Integral):
+    if isinstance(k, bool):
         raise ValueError("k must be an integer")
-    return int(k)
+    if isinstance(k, Integral):
+        return int(k)
+
+    try:
+        k_array = _asarray(k)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("k must be an integer") from exc
+    if k_array.ndim != 0:
+        raise ValueError("k must be an integer")
+
+    try:
+        scalar = k_array.item()
+    except AttributeError:
+        scalar = k_array
+    if isinstance(scalar, bool):
+        raise ValueError("k must be an integer")
+
+    try:
+        scalar_float = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("k must be an integer") from exc
+    if not _is_scalar_finite(scalar_float) or not scalar_float.is_integer():
+        raise ValueError("k must be an integer")
+    return int(scalar_float)
 
 
 def _coerce_non_assignment_costs(costs, size: int, name: str):

--- a/tests/utils/test_assignment.py
+++ b/tests/utils/test_assignment.py
@@ -182,6 +182,22 @@ class MurtyAssignmentTest(unittest.TestCase):
         pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
         reason="Not supported on the JAX backend",
     )
+    def test_scalar_array_assignment_count_is_accepted(self):
+        solutions = murty_k_best_assignments(
+            np.array([[1.0, 100.0], [100.0, 1.0]]),
+            k=np.array(1.0),
+            row_non_assignment_costs=5.0,
+            col_non_assignment_costs=5.0,
+        )
+
+        self.assertEqual(len(solutions), 1)
+        npt.assert_array_equal(solutions[0]["assignment"], np.array([0, 1]))
+        self.assertAlmostEqual(solutions[0]["cost"], 2.0)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on the JAX backend",
+    )
     def test_nonfinite_non_assignment_costs_are_rejected(self):
         cost_matrix = np.array([[1.0]])
 
@@ -207,7 +223,16 @@ class MurtyAssignmentTest(unittest.TestCase):
         self.assertEqual(murty_k_best_assignments(np.eye(2), k=0), [])
 
     def test_non_integer_k_is_rejected(self):
-        for invalid_k in (True, False, 1.5):
+        for invalid_k in (
+            True,
+            False,
+            1.5,
+            np.nan,
+            np.inf,
+            np.array(True),
+            np.array(1.5),
+            np.array([1]),
+        ):
             with self.subTest(invalid_k=invalid_k):
                 with self.assertRaisesRegex(ValueError, "k must be an integer"):
                     murty_k_best_assignments(np.eye(2), k=invalid_k)


### PR DESCRIPTION
## Summary
- Normalize `murty_k_best_assignments(k=...)` with the same scalar-array handling used by nearby assignment cost normalization.
- Accept zero-dimensional integer-like array values such as `np.array(1.0)` as scalar counts instead of rejecting them as non-`Integral` objects.
- Keep booleans, non-finite values, non-integral values, and non-scalar arrays rejected with `ValueError`.

## Bug
`murty_k_best_assignments` validated `k` with `isinstance(k, Integral)`, so scalar array counts from NumPy/backend code paths were rejected even though scalar array non-assignment costs are already treated as broadcast scalars. This made otherwise valid calls with `k=np.array(1.0)` fail before solving.

## Testing
- Added focused regression coverage in `tests/utils/test_assignment.py`.
- Not run locally; GitHub is not resolvable from the execution container, so CI should validate the branch.
