### PR TITLE
Reject non-finite point-set registration inputs

### DIFF
--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,
@@ -92,6 +93,8 @@ def as_point_array(
         raise ValueError("points must have shape (n_points, dim).")
     if point_array.shape[0] == 0:
         raise ValueError("At least one point is required.")
+    if not bool(backend_all(isfinite(point_array))):
+        raise ValueError("points must contain only finite values.")
     if expected_dim is None:
         if point_array.shape[1] == 0:
             raise ValueError("Point dimension must be positive.")

--- a/tests/test_point_set_registration.py
+++ b/tests/test_point_set_registration.py
@@ -52,6 +52,21 @@ class TestEstimateTransform(unittest.TestCase):
         npt.assert_allclose(estimated.matrix, true_rotation, atol=1e-10)
         npt.assert_allclose(estimated.offset, true_offset, atol=1e-10)
 
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_estimate_transform_rejects_nonfinite_points(self):
+        target = array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+
+        for invalid_value in (float("nan"), float("inf"), -float("inf")):
+            with self.subTest(invalid_value=invalid_value):
+                source = array(
+                    [[0.0, 0.0], [1.0, invalid_value], [0.0, 1.0]],
+                )
+                with self.assertRaisesRegex(ValueError, "finite"):
+                    estimate_transform(source, target, model="affine")
+
     def test_estimate_transform_rejects_jax_backend_without_asserts(self):
         source = array([[0.0, 0.0]])
 


### PR DESCRIPTION
## Summary
- Validate registration point arrays to ensure all coordinates are finite before transform fitting or registration assignment.
- Add a regression test covering `NaN`, `+Inf`, and `-Inf` source coordinates in `estimate_transform()`.

## Bug
`as_point_array()` previously accepted point arrays containing `NaN` or infinite coordinates. Those values could propagate into centroid computation, SVD/least-squares transform fitting, or SciPy distance computations, producing invalid transforms or backend-dependent downstream errors instead of a controlled `ValueError`.

## Testing
- Added focused regression coverage in `tests/test_point_set_registration.py`.
- Not run locally; repository access here is through the GitHub connector, so CI should validate the branch.