### PR TITLE
Validate hypertoroidal marginal dimensions

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py
@@ -95,6 +95,15 @@ class HypertoroidalDiracDistribution(
             raise ValueError("n_particles must be a positive integer.")
         return int(n_particles)
 
+    @staticmethod
+    def _validate_dimension_index(dimension, dim: int) -> int:
+        if isinstance(dimension, bool) or not isinstance(dimension, Integral):
+            raise ValueError("dimension must be an integer.")
+        dimension = int(dimension)
+        if dimension < 0 or dimension >= dim:
+            raise ValueError(f"dimension must be in [0, {dim - 1}].")
+        return dimension
+
     def plot(self, resolution=128, **kwargs):
         _ = resolution
         if self.dim > 3:
@@ -154,26 +163,32 @@ class HypertoroidalDiracDistribution(
     def marginalize_to_1D(self, dimension: Union[int, int32, int64]):
         from ..circle.circular_dirac_distribution import CircularDiracDistribution
 
+        dimension = self._validate_dimension_index(dimension, self.dim)
         return CircularDiracDistribution(self.d[:, dimension], self.w)
 
     def marginalize_out(self, dimensions: int | list[int]):
         from ..circle.circular_dirac_distribution import CircularDiracDistribution
 
-        if isinstance(dimensions, int):
+        if isinstance(dimensions, bool):
+            raise ValueError("dimensions must contain integer indices.")
+        if isinstance(dimensions, Integral):
             dimensions = [dimensions]
         else:
-            dimensions = list(dimensions)
+            try:
+                dimensions = list(dimensions)
+            except TypeError as exc:
+                raise ValueError(
+                    "dimensions must be an integer or an iterable of integers."
+                ) from exc
 
-        dimensions = [int(dim) for dim in dimensions]
+        dimensions = [
+            self._validate_dimension_index(dimension, self.dim)
+            for dimension in dimensions
+        ]
         dimensions_to_remove = set(dimensions)
 
         if len(dimensions) != len(dimensions_to_remove):
             raise ValueError("dimensions must not contain duplicates.")
-
-        if any(dim < 0 or dim >= self.dim for dim in dimensions_to_remove):
-            raise ValueError(
-                f"All marginalized-out dimensions must be in [0, {self.dim - 1}]."
-            )
 
         if len(dimensions_to_remove) == 0:
             return copy.deepcopy(self)

--- a/tests/distributions/test_hypertoroidal_dirac_marginal_dimension_validation.py
+++ b/tests/distributions/test_hypertoroidal_dirac_marginal_dimension_validation.py
@@ -1,0 +1,30 @@
+import unittest
+
+from pyrecest.backend import array
+from pyrecest.distributions import HypertoroidalDiracDistribution
+
+
+class TestHypertoroidalDiracMarginalDimensionValidation(unittest.TestCase):
+    def setUp(self):
+        self.dist = HypertoroidalDiracDistribution(
+            array([[0.5, 2.0, 0.5], [3.0, 2.0, 0.2]]),
+            array([0.25, 0.75]),
+        )
+
+    def test_marginalize_to_1d_rejects_invalid_dimension_indices(self):
+        for dimension in (-1, self.dist.dim, True, 1.5):
+            with self.subTest(dimension=dimension):
+                with self.assertRaisesRegex(ValueError, "dimension"):
+                    self.dist.marginalize_to_1D(dimension)
+
+    def test_marginalize_out_rejects_invalid_dimension_indices(self):
+        invalid_dimensions = (-1, self.dist.dim, True, [0, 1.5], [0, True])
+
+        for dimensions in invalid_dimensions:
+            with self.subTest(dimensions=dimensions):
+                with self.assertRaisesRegex(ValueError, "dimension"):
+                    self.dist.marginalize_out(dimensions)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Reject negative, out-of-range, boolean, and non-integral dimension indices in `HypertoroidalDiracDistribution.marginalize_to_1D()`.
- Apply the same index validation to `marginalize_out()` instead of truncating values with `int(...)`.
- Add focused regression coverage for invalid marginalization dimensions.

## Bug
Before this change, `marginalize_to_1D(-1)` silently selected the last coordinate via NumPy-style negative indexing. `marginalize_out()` also coerced dimensions with `int(...)`, so inputs such as `1.5` and `True` were silently converted into valid-looking indices.

## Testing
- Not run locally; changes were made through the GitHub connector and CI should run on the PR.