### PR TITLE
Reject boolean non-assignment costs

### DIFF
--- a/src/pyrecest/utils/assignment.py
+++ b/src/pyrecest/utils/assignment.py
@@ -37,11 +37,23 @@ def _validate_assignment_count(k: int) -> int:
     return int(k)
 
 
+def _has_boolean_dtype(value) -> bool:
+    dtype = getattr(value, "dtype", None)
+    return dtype is not None and str(dtype).lower() in {"bool", "bool_", "torch.bool"}
+
+
 def _coerce_non_assignment_costs(costs, size: int, name: str):
     if costs is None:
         return _zeros(size, dtype=float)
 
-    costs_array = _asarray(costs, dtype=float)
+    raw_costs_array = _asarray(costs)
+    if _has_boolean_dtype(raw_costs_array):
+        raise ValueError(f"{name} must be numeric and finite")
+
+    try:
+        costs_array = _asarray(raw_costs_array, dtype=float)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be numeric and finite") from exc
     if costs_array.ndim == 0:
         cost = float(costs_array)
         if not _is_scalar_finite(cost):

--- a/tests/utils/test_assignment.py
+++ b/tests/utils/test_assignment.py
@@ -203,6 +203,31 @@ class MurtyAssignmentTest(unittest.TestCase):
                         col_non_assignment_costs=np.array([invalid_cost]),
                     )
 
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on the JAX backend",
+    )
+    def test_boolean_non_assignment_costs_are_rejected(self):
+        cost_matrix = np.array([[1.0]])
+
+        for invalid_cost in (True, np.array(True), np.array([True])):
+            with self.subTest(kind="row", invalid_cost=invalid_cost):
+                with self.assertRaisesRegex(
+                    ValueError, "row_non_assignment_costs must be numeric and finite"
+                ):
+                    murty_k_best_assignments(
+                        cost_matrix,
+                        row_non_assignment_costs=invalid_cost,
+                    )
+            with self.subTest(kind="column", invalid_cost=invalid_cost):
+                with self.assertRaisesRegex(
+                    ValueError, "col_non_assignment_costs must be numeric and finite"
+                ):
+                    murty_k_best_assignments(
+                        cost_matrix,
+                        col_non_assignment_costs=invalid_cost,
+                    )
+
     def test_non_positive_k_returns_empty_list(self):
         self.assertEqual(murty_k_best_assignments(np.eye(2), k=0), [])
 


### PR DESCRIPTION
## Summary
- Reject boolean scalar and vector non-assignment costs before numeric coercion in `murty_k_best_assignments`.
- Wrap non-numeric cost coercion in a controlled `ValueError`.
- Add regression coverage for boolean row/column non-assignment costs.

## Bug
`row_non_assignment_costs` and `col_non_assignment_costs` were coerced with `asarray(..., dtype=float)`, so `True` and boolean arrays silently became `1.0`. That can change assignment costs without warning and is inconsistent with the existing `k` boolean rejection.

## Testing
- Added focused regression coverage in `tests/utils/test_assignment.py`.

Note: I did not run tests locally because repository access here is through the GitHub connector.