### PR TITLE
Reject non-finite registration points

### DIFF
--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,
@@ -92,6 +93,8 @@ def as_point_array(
         raise ValueError("points must have shape (n_points, dim).")
     if point_array.shape[0] == 0:
         raise ValueError("At least one point is required.")
+    if not bool(backend_all(isfinite(point_array))):
+        raise ValueError("points must contain only finite values.")
     if expected_dim is None:
         if point_array.shape[1] == 0:
             raise ValueError("Point dimension must be positive.")

--- a/tests/test_point_set_registration.py
+++ b/tests/test_point_set_registration.py
@@ -52,6 +52,21 @@ class TestEstimateTransform(unittest.TestCase):
         npt.assert_allclose(estimated.matrix, true_rotation, atol=1e-10)
         npt.assert_allclose(estimated.offset, true_offset, atol=1e-10)
 
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_estimate_transform_rejects_nonfinite_points(self):
+        target = array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+
+        for invalid_value in (float("nan"), float("inf"), -float("inf")):
+            with self.subTest(invalid_value=invalid_value):
+                source = array(
+                    [[0.0, 0.0], [1.0, invalid_value], [0.0, 1.0]],
+                )
+                with self.assertRaisesRegex(ValueError, "finite"):
+                    estimate_transform(source, target, model="affine")
+
     def test_estimate_transform_rejects_jax_backend_without_asserts(self):
         source = array([[0.0, 0.0]])
 


### PR DESCRIPTION
## Summary
- Validate point-set registration inputs with an explicit finite-value check in the shared `as_point_array()` helper.
- Reject NaN and infinite coordinates before they reach transform estimation, registration assignment, SciPy distance computations, or backend linear algebra.
- Add regression coverage for NaN, +Inf, and -Inf source points in `estimate_transform()`.

## Bug
Point-set registration accepted non-finite point coordinates as long as the array shape was valid. Those values could propagate into affine/rigid estimation or registration assignment and fail later with backend/SciPy-specific errors or produce invalid transforms.

## Testing
- Added `tests/test_point_set_registration.py::TestEstimateTransform::test_estimate_transform_rejects_nonfinite_points`.
- Not run locally; repository access here is through the GitHub connector, so CI should validate the branch.