### PR TITLE
Validate surface band distance std

### DIFF
--- a/src/pyrecest/evaluation/implicit_surfaces.py
+++ b/src/pyrecest/evaluation/implicit_surfaces.py
@@ -69,7 +69,7 @@ def surface_band_probability_from_signed_distance(
     min_std = _positive_float("min_std", min_std)
     cdf = ndtr if normal_cdf is None else normal_cdf
     distance = _as_numeric_field(distance)
-    distance_std = _as_numeric_field(distance_std)
+    distance_std = _nonnegative_finite_numeric_field(distance_std, "distance_std")
     std = _maximum(distance_std, min_std)
     upper = (epsilon - distance) / std
     lower = (-epsilon - distance) / std
@@ -87,6 +87,24 @@ def _as_numeric_field(values: Any) -> Any:
     if hasattr(values, "clamp"):
         return values
     return np.asarray(values, dtype=np.float64)
+
+
+def _nonnegative_finite_numeric_field(values: Any, name: str) -> Any:
+    if hasattr(values, "clamp"):
+        if hasattr(values, "isfinite"):
+            finite = values.isfinite()
+            if bool((~finite).any()):
+                raise ValueError(f"{name} must contain only finite values.")
+        if bool((values < 0.0).any()):
+            raise ValueError(f"{name} must be non-negative.")
+        return values
+
+    array = np.asarray(values, dtype=np.float64)
+    if np.any(~np.isfinite(array)):
+        raise ValueError(f"{name} must contain only finite values.")
+    if np.any(array < 0.0):
+        raise ValueError(f"{name} must be non-negative.")
+    return array
 
 
 def _maximum(values: Any, minimum: float) -> Any:

--- a/tests/evaluation/test_implicit_surfaces.py
+++ b/tests/evaluation/test_implicit_surfaces.py
@@ -88,6 +88,20 @@ def test_surface_band_probability_from_signed_distance() -> None:
     assert 0.0 <= probability[1] < probability[0]
 
 
+def test_surface_band_probability_accepts_zero_std_floor() -> None:
+    probability = surface_band_probability_from_signed_distance(
+        np.asarray([0.0, 2.0], dtype=np.float64),
+        np.asarray([0.0, 0.5], dtype=np.float64),
+        1.0,
+        min_std=0.1,
+    )
+
+    assert probability.shape == (2,)
+    assert np.all(np.isfinite(probability))
+    assert np.all((0.0 <= probability) & (probability <= 1.0))
+    assert probability[0] > probability[1]
+
+
 def test_surface_band_probability_rejects_invalid_scales() -> None:
     with pytest.raises(ValueError, match="threshold"):
         surface_band_mask(np.asarray([0.0]), 0.0)
@@ -104,3 +118,19 @@ def test_surface_band_probability_rejects_invalid_scales() -> None:
             0.1,
             min_std=0.0,
         )
+    with pytest.raises(ValueError, match="distance_std must be non-negative"):
+        surface_band_probability_from_signed_distance(
+            np.asarray([0.0]),
+            np.asarray([-1.0]),
+            0.1,
+        )
+    for invalid_std in (np.nan, np.inf, -np.inf):
+        with pytest.raises(
+            ValueError,
+            match="distance_std must contain only finite values",
+        ):
+            surface_band_probability_from_signed_distance(
+                np.asarray([0.0]),
+                np.asarray([invalid_std]),
+                0.1,
+            )


### PR DESCRIPTION
Summary:
- validate distance standard deviations before computing surface band probabilities
- preserve the existing floor for valid zero and small standard deviations
- add regression tests

Testing: not run locally; repository access is through the GitHub connector.