### PR TITLE
Validate quantile tail scalar inputs

### DIFF
--- a/src/pyrecest/evaluation/selection.py
+++ b/src/pyrecest/evaluation/selection.py
@@ -198,9 +198,14 @@ def quantile_tail_threshold(
         reliability_scores,
         nonnegative=sanitize_nonnegative,
     )
-    q = float(quantile)
-    if not np.isfinite(q) or not 0.0 < q < 1.0:
-        raise ValueError("quantile must be finite and in (0, 1).")
+    q = _normalize_bounded_fraction(
+        quantile,
+        lower=0.0,
+        upper=1.0,
+        include_lower=False,
+        include_upper=False,
+        message="quantile must be finite and in (0, 1).",
+    )
     if tail not in {"lower", "upper"}:
         raise ValueError("tail must be 'lower' or 'upper'.")
     if scores.size == 0:

--- a/tests/evaluation/test_selection.py
+++ b/tests/evaluation/test_selection.py
@@ -74,7 +74,7 @@ def test_quantile_tail_mask_selects_upper_tail() -> None:
 
 
 def test_quantile_tail_mask_validates_empty_inputs_before_empty_return() -> None:
-    for bad_quantile in (0.0, 1.0, np.nan):
+    for bad_quantile in (0.0, 1.0, np.nan, True, np.array([0.5])):
         with pytest.raises(ValueError, match="quantile"):
             quantile_tail_mask([], bad_quantile)
 


### PR DESCRIPTION
## Summary
- Route `quantile_tail_threshold` through the existing bounded scalar validator instead of raw `float(...)` conversion.
- Reject non-scalar array and boolean quantile inputs with the module's controlled `ValueError` path.
- Extend the empty-input regression test so invalid quantiles are validated before any early empty return.

## Testing
- Added focused regression coverage in `tests/evaluation/test_selection.py`.

Note: I did not run the tests locally because repository access here is through the GitHub connector.