### PR TITLE
Handle overflowing optional diagnostics scalars

### DIFF
--- a/src/pyrecest/evaluation/diagnostic_summaries.py
+++ b/src/pyrecest/evaluation/diagnostic_summaries.py
@@ -295,7 +295,7 @@ def _optional_float(value: Any) -> float | None:
         return None
     try:
         out = float(value)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return None
     return out if math.isfinite(out) else None
 
@@ -303,6 +303,8 @@ def _optional_float(value: Any) -> float | None:
 def _is_nan(value: Any) -> bool:
     try:
         return bool(math.isnan(float(value)))
+    except OverflowError:
+        return True
     except (TypeError, ValueError):
         return False
 

--- a/tests/evaluation/test_diagnostic_summaries.py
+++ b/tests/evaluation/test_diagnostic_summaries.py
@@ -11,6 +11,11 @@ from pyrecest.evaluation.diagnostic_summaries import (
 )
 
 
+class _OverflowFloat:
+    def __float__(self):
+        raise OverflowError("simulated overflow")
+
+
 class DiagnosticSummariesTest(unittest.TestCase):
     def setUp(self):
         self.records = [
@@ -112,6 +117,29 @@ class DiagnosticSummariesTest(unittest.TestCase):
 
         self.assertEqual(summary["top_n"], 2)
         self.assertEqual(summary["window_s"], 5.0)
+
+    def test_summary_treats_overflowing_optional_scalars_as_missing(self):
+        records = [
+            {
+                "time_s": _OverflowFloat(),
+                "track_id": _OverflowFloat(),
+                "source": "rf",
+                "residual_norm": _OverflowFloat(),
+                "covariance_scale": _OverflowFloat(),
+                "error": _OverflowFloat(),
+            }
+        ]
+
+        self.assertEqual(top_residuals(records), [])
+        self.assertEqual(track_switch_summary(records)["updates_with_track_id"], 0)
+        self.assertEqual(covariance_inflation_summary(records)["count"], 0)
+        self.assertEqual(worst_time_windows(records), [])
+
+        summary = build_diagnostic_summary(records, top_n=2, window_s=5.0)
+        self.assertEqual(summary["top_residuals"], [])
+        self.assertEqual(summary["track_switches"]["updates_with_track_id"], 0)
+        self.assertEqual(summary["covariance_inflation"]["count"], 0)
+        self.assertEqual(summary["worst_time_windows"], [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Treat `OverflowError` during optional diagnostic scalar parsing like other malformed/non-finite optional values.
- Treat overflowing track-id numeric conversions as non-finite in `_is_nan` so track-switch summaries do not crash.
- Add a regression test covering overflowing optional fields across the diagnostic summary helpers.

## Notes
- This fixes a robustness bug where malformed numeric record fields could raise out of summary generation instead of being ignored as missing optional diagnostics.