### PR TITLE
Validate online time-offset estimator inputs

### DIFF
--- a/src/pyrecest/filters/online_time_offset_estimator.py
+++ b/src/pyrecest/filters/online_time_offset_estimator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 import numpy as np
 
@@ -17,6 +18,14 @@ class OnlineTimeOffsetEstimator:
     min_speed: float = 1.0
 
     def __post_init__(self) -> None:
+        self.offset = _as_finite_scalar(self.offset, "offset")
+        self.variance = _as_finite_scalar(self.variance, "variance")
+        self.process_variance = _as_finite_scalar(
+            self.process_variance,
+            "process_variance",
+        )
+        self.min_speed = _as_finite_scalar(self.min_speed, "min_speed")
+
         if self.variance <= 0.0:
             raise ValueError("variance must be positive")
         if self.process_variance < 0.0:
@@ -41,6 +50,15 @@ class OnlineTimeOffsetEstimator:
         velocity = np.asarray(velocity, dtype=float).reshape(-1)
         if residual.size != velocity.size:
             raise ValueError("residual and velocity must have the same dimension")
+        if not np.isfinite(residual).all() or not np.isfinite(velocity).all():
+            raise ValueError("residual and velocity must be finite")
+        measurement_variance = _as_finite_scalar(
+            measurement_variance,
+            "measurement_variance",
+        )
+        if measurement_variance < 0.0:
+            raise ValueError("measurement_variance must be nonnegative")
+
         speed2 = float(velocity @ velocity)
         if speed2 < float(self.min_speed) ** 2:
             return float("nan")
@@ -57,3 +75,19 @@ class OnlineTimeOffsetEstimator:
     def std(self) -> float:
         """Return the posterior offset standard deviation."""
         return float(np.sqrt(max(self.variance, 0.0)))
+
+
+def _as_finite_scalar(value: Any, name: str) -> float:
+    value_array = np.asarray(value)
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError(f"{name} must be a finite scalar")
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(f"{name} must be a finite scalar")
+    try:
+        parsed = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be a finite scalar") from exc
+    if not np.isfinite(parsed):
+        raise ValueError(f"{name} must be a finite scalar")
+    return parsed

--- a/tests/filters/test_online_time_offset_estimator.py
+++ b/tests/filters/test_online_time_offset_estimator.py
@@ -40,6 +40,42 @@ class OnlineTimeOffsetEstimatorTest(unittest.TestCase):
 
         self.assertAlmostEqual(estimator.variance, 1.25)
 
+    def test_constructor_rejects_nonfinite_scalar_controls(self):
+        invalid_values = (np.nan, np.inf, -np.inf, True, np.array([1.0]))
+        for field_name in ("offset", "variance", "process_variance", "min_speed"):
+            for value in invalid_values:
+                with self.subTest(field_name=field_name, value=value):
+                    with self.assertRaisesRegex(
+                        ValueError,
+                        f"{field_name} must be a finite scalar",
+                    ):
+                        OnlineTimeOffsetEstimator(**{field_name: value})
+
+    def test_update_rejects_invalid_measurement_inputs_without_state_change(self):
+        invalid_updates = (
+            {"measurement_variance": np.nan},
+            {"measurement_variance": np.inf},
+            {"measurement_variance": True},
+            {"measurement_variance": np.array([1.0])},
+            {"measurement_variance": -1.0},
+            {"residual": np.array([np.nan])},
+            {"velocity": np.array([np.inf])},
+        )
+
+        for override in invalid_updates:
+            estimator = OnlineTimeOffsetEstimator(offset=1.0, variance=2.0)
+            kwargs = {
+                "residual": np.array([1.0]),
+                "velocity": np.array([2.0]),
+                "measurement_variance": 1.0,
+            }
+            kwargs.update(override)
+            with self.subTest(override=override):
+                with self.assertRaises(ValueError):
+                    estimator.update_from_position_residual(**kwargs)
+                self.assertEqual(estimator.offset, 1.0)
+                self.assertEqual(estimator.variance, 2.0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Normalize and validate online time-offset estimator constructor scalars before they can enter estimator state.
- Reject non-finite, boolean, and non-scalar `offset`, `variance`, `process_variance`, and `min_speed` inputs.
- Reject invalid update inputs (`measurement_variance`, non-finite residuals/velocities) before mutating estimator state.

## Bug
Previously, inputs such as `variance=np.nan` or `measurement_variance=np.nan` could pass existing comparisons and propagate `NaN` into the online estimator state.

## Testing
- Added focused regression coverage in `tests/filters/test_online_time_offset_estimator.py`.

Note: I did not run tests locally because repository access here is through the GitHub connector.