### PR TITLE
Validate calibration max_time_delta scalars

### DIFF
--- a/src/pyrecest/calibration/bias.py
+++ b/src/pyrecest/calibration/bias.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import numpy as np
 
-from .time_offset import nearest_time_indices
+from .time_offset import _as_nonnegative_time_delta, nearest_time_indices
 
 _FEATURE_ROW_COUNT_ERROR = (
     "features rows must match requested row count; "
@@ -169,9 +169,7 @@ def make_bias_training_examples(
 ) -> BiasTrainingExamples:
     """Match measurements to nearest reference values and compute residual bias."""
 
-    max_time_delta = float(max_time_delta_s)
-    if max_time_delta < 0.0 or np.isnan(max_time_delta):
-        raise ValueError("max_time_delta_s must be nonnegative")
+    max_time_delta = _as_nonnegative_time_delta(max_time_delta_s, "max_time_delta_s")
     measurement_times = np.asarray(measurement_times_s, dtype=float).reshape(-1)
     measurements = _as_2d(measurement_values, "measurement_values")
     reference_times = np.asarray(reference_times_s, dtype=float).reshape(-1)

--- a/src/pyrecest/calibration/time_offset.py
+++ b/src/pyrecest/calibration/time_offset.py
@@ -83,6 +83,24 @@ def _as_finite_float(value: Any, name: str) -> float:
     return result
 
 
+def _as_nonnegative_time_delta(value: Any, name: str) -> float:
+    """Return ``value`` as a nonnegative scalar time delta, allowing infinity."""
+
+    arr = np.asarray(value)
+    if arr.ndim != 0 or arr.dtype == np.bool_:
+        raise ValueError(f"{name} must be nonnegative")
+    scalar = arr.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(f"{name} must be nonnegative")
+    try:
+        result = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be nonnegative") from exc
+    if result < 0.0 or np.isnan(result):
+        raise ValueError(f"{name} must be nonnegative")
+    return result
+
+
 def make_offset_grid(min_s: float, max_s: float, step_s: float) -> np.ndarray:
     """Return an inclusive offset grid rounded to nanosecond precision."""
 
@@ -110,9 +128,7 @@ def apply_time_offset(times_s: np.ndarray, offset_s: float | None) -> np.ndarray
 def _validate_max_time_delta(max_time_delta_s: float | None) -> None:
     if max_time_delta_s is None:
         return
-    max_time_delta = float(max_time_delta_s)
-    if max_time_delta < 0.0 or np.isnan(max_time_delta):
-        raise ValueError("max_time_delta_s must be nonnegative")
+    _as_nonnegative_time_delta(max_time_delta_s, "max_time_delta_s")
 
 
 def _finite_reference_rows(

--- a/tests/calibration/test_max_time_delta_validation.py
+++ b/tests/calibration/test_max_time_delta_validation.py
@@ -1,0 +1,44 @@
+import unittest
+
+import numpy as np
+from pyrecest.calibration.bias import make_bias_training_examples
+from pyrecest.calibration.time_offset import interpolate_reference_values
+
+
+class MaxTimeDeltaValidationTest(unittest.TestCase):
+    def test_interpolation_rejects_boolean_and_non_scalar_max_time_delta(self):
+        invalid_values = (True, np.array([1.0]))
+
+        for max_time_delta_s in invalid_values:
+            with self.subTest(max_time_delta_s=max_time_delta_s):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "max_time_delta_s must be nonnegative",
+                ):
+                    interpolate_reference_values(
+                        np.array([0.0, 1.0]),
+                        np.array([[0.0], [1.0]]),
+                        np.array([0.5]),
+                        max_time_delta_s=max_time_delta_s,
+                    )
+
+    def test_bias_examples_reject_boolean_and_non_scalar_max_time_delta(self):
+        invalid_values = (True, np.array([1.0]))
+
+        for max_time_delta_s in invalid_values:
+            with self.subTest(max_time_delta_s=max_time_delta_s):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "max_time_delta_s must be nonnegative",
+                ):
+                    make_bias_training_examples(
+                        np.array([0.0]),
+                        np.array([[1.0]]),
+                        np.array([0.0]),
+                        np.array([[0.0]]),
+                        max_time_delta_s=max_time_delta_s,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add scalar validation for calibration `max_time_delta_s` values while preserving `np.inf` as an unbounded delta.
- Reject boolean values such as `True`, which were previously coerced to `1.0` by raw `float(...)` calls.
- Share the same validation path between timestamp interpolation and bias-training example generation.

## Testing
- Added focused regression tests in `tests/calibration/test_max_time_delta_validation.py`.

Note: I did not run tests locally because the execution container cannot resolve github.com, so repository access here is through the GitHub connector.