### PR TITLE
Validate apply_time_offset inputs

### DIFF
--- a/src/pyrecest/calibration/time_offset.py
+++ b/src/pyrecest/calibration/time_offset.py
@@ -103,7 +103,7 @@ def make_offset_grid(min_s: float, max_s: float, step_s: float) -> np.ndarray:
 def apply_time_offset(times_s: np.ndarray, offset_s: float | None) -> np.ndarray:
     """Return a copy of ``times_s`` shifted by ``offset_s`` seconds."""
 
-    offset = 0.0 if offset_s is None else float(offset_s)
+    offset = 0.0 if offset_s is None else _as_finite_float(offset_s, "offset_s")
     return np.asarray(times_s, dtype=float) + offset
 
 

--- a/tests/calibration/test_time_offset_apply_validation.py
+++ b/tests/calibration/test_time_offset_apply_validation.py
@@ -1,0 +1,23 @@
+import unittest
+
+import numpy as np
+from pyrecest.calibration.time_offset import apply_time_offset
+
+
+class ApplyTimeOffsetValidationTest(unittest.TestCase):
+    def test_apply_time_offset_rejects_invalid_offsets(self):
+        times = np.array([0.0, 1.0])
+
+        for offset_s in (np.nan, np.inf, -np.inf, True, np.array([0.5])):
+            with self.subTest(offset_s=offset_s):
+                with self.assertRaisesRegex(ValueError, "offset_s"):
+                    apply_time_offset(times, offset_s)
+
+    def test_apply_time_offset_accepts_scalar_numpy_offset(self):
+        shifted = apply_time_offset(np.array([0.0, 1.0]), np.array(0.25))
+
+        np.testing.assert_allclose(shifted, np.array([0.25, 1.25]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Validate `apply_time_offset(offset_s=...)` with the existing finite-scalar helper instead of raw `float(...)` coercion.
- Reject `NaN`, infinities, booleans, and non-scalar arrays before producing invalid shifted timestamps.
- Add focused regression coverage for invalid offsets and scalar NumPy offsets.

## Bug
Previously, `apply_time_offset()` accepted invalid offset controls such as `np.nan`, `np.inf`, `True`, or `np.array([0.5])` through raw `float(...)` conversion. That could propagate non-finite timestamps or silently treat booleans as numerical offsets.

## Testing
- Added `tests/calibration/test_time_offset_apply_validation.py`.
- Not run locally; repository access here is through the GitHub connector, so CI should validate the branch.