### PR TITLE
Normalize overflowing seed scalar errors

### DIFF
--- a/src/pyrecest/reproducibility.py
+++ b/src/pyrecest/reproducibility.py
@@ -29,7 +29,7 @@ def _normalize_seed(seed: int | None) -> int | None:
 
     try:
         scalar = seed.item() if hasattr(seed, "item") else seed
-    except (TypeError, ValueError, RuntimeError) as exc:
+    except (TypeError, ValueError, RuntimeError, OverflowError) as exc:
         raise ValueError(message) from exc
 
     if isinstance(scalar, bool):

--- a/tests/test_reproducibility_seed.py
+++ b/tests/test_reproducibility_seed.py
@@ -5,6 +5,13 @@ import numpy as np
 from pyrecest.reproducibility import seed_all
 
 
+class _OverflowingScalar:
+    shape = ()
+
+    def item(self):
+        raise OverflowError("simulated overflow")
+
+
 class ReproducibilitySeedValidationTest(unittest.TestCase):
     def test_seed_all_rejects_invalid_seed_values(self):
         invalid_seeds = (
@@ -17,6 +24,7 @@ class ReproducibilitySeedValidationTest(unittest.TestCase):
             [1],
             np.array([1]),
             object(),
+            _OverflowingScalar(),
         )
 
         for seed in invalid_seeds:


### PR DESCRIPTION
## Summary
- Catch `OverflowError` from scalar `.item()` extraction in `_normalize_seed`.
- Preserve the public validation contract by raising `ValueError("seed must be a non-negative integer or None")` for malformed scalar seed inputs.
- Add a regression test using a scalar-like object whose `item()` raises `OverflowError`.

## Notes
- Without this, `seed_all(...)` could leak a raw `OverflowError` for malformed scalar-like seed objects, unlike the other invalid seed cases handled by the validator.