### PR TITLE
Validate observation-cost scalar parameters

### DIFF
--- a/src/pyrecest/utils/multisession_assignment_observation_costs.py
+++ b/src/pyrecest/utils/multisession_assignment_observation_costs.py
@@ -8,6 +8,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
+import numpy as np
 from pyrecest.backend import (
     __backend_name__,
 )
@@ -74,11 +75,11 @@ def solve_multisession_assignment_with_observation_costs(  # pylint: disable=R09
     """Solve multi-session assignment with per-observation start/end costs."""
     _ensure_supported_backend("solve_multisession_assignment_with_observation_costs")
 
-    _validate_scalar_cost("start_cost", start_cost)
-    _validate_scalar_cost("end_cost", end_cost)
-    _validate_scalar_cost("gap_penalty", gap_penalty)
+    start_cost = _normalize_scalar_cost("start_cost", start_cost)
+    end_cost = _normalize_scalar_cost("end_cost", end_cost)
+    gap_penalty = _normalize_scalar_cost("gap_penalty", gap_penalty)
     if cost_threshold is not None:
-        _validate_scalar_cost("cost_threshold", cost_threshold)
+        cost_threshold = _normalize_scalar_cost("cost_threshold", cost_threshold)
 
     normalized_pairwise = _normalize_pairwise_costs(pairwise_costs)
     normalized_sizes = _normalize_session_sizes(session_sizes)
@@ -165,9 +166,22 @@ def solve_multisession_assignment_with_observation_costs(  # pylint: disable=R09
     )
 
 
-def _validate_scalar_cost(name: str, value: float) -> None:
-    if not math.isfinite(value):
-        raise ValueError(f"{name} must be finite.")
+def _normalize_scalar_cost(name: str, value: float) -> float:
+    value_array = np.asarray(value)
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError(f"{name} must be a finite scalar.")
+
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(f"{name} must be a finite scalar.")
+
+    try:
+        parsed = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be a finite scalar.") from exc
+    if not math.isfinite(parsed):
+        raise ValueError(f"{name} must be a finite scalar.")
+    return parsed
 
 
 def _array_length(values: Any) -> int:

--- a/tests/test_multisession_assignment_observation_costs.py
+++ b/tests/test_multisession_assignment_observation_costs.py
@@ -170,6 +170,22 @@ class TestMultiSessionAssignmentObservationCosts(unittest.TestCase):
                         **cost_kwargs,
                     )
 
+    def test_rejects_boolean_scalar_cost_parameters(self):
+        invalid_cost_kwargs = (
+            {"start_cost": True},
+            {"end_cost": True},
+            {"gap_penalty": True},
+            {"cost_threshold": True},
+        )
+
+        for cost_kwargs in invalid_cost_kwargs:
+            with self.subTest(cost_kwargs=cost_kwargs):
+                with self.assertRaisesRegex(ValueError, "must be a finite scalar"):
+                    solve_multisession_assignment_with_observation_costs(
+                        [array([[1.0]], dtype=float)],
+                        **cost_kwargs,
+                    )
+
     def test_rejects_mismatched_lengths(self):
         with self.assertRaises(ValueError):
             solve_multisession_assignment_with_observation_costs(


### PR DESCRIPTION
## Summary
- reject boolean and non-scalar observation-cost wrapper parameters before they are interpreted as numeric costs
- normalize accepted scalar cost parameters to Python floats before passing them into the base multi-session assignment solver
- add regression coverage for boolean `start_cost`, `end_cost`, `gap_penalty`, and `cost_threshold`

## Rationale
`math.isfinite(True)` evaluates to true, so boolean scalar cost parameters were previously accepted and silently treated as `1.0`. This makes accidental boolean configuration values affect assignment costs instead of failing fast.

## Testing
- Not run locally; the execution environment cannot resolve `github.com` for cloning/installing the repository.