### PR TITLE
Validate symmetry distance parameters

### DIFF
--- a/src/pyrecest/evaluation/get_distance_function.py
+++ b/src/pyrecest/evaluation/get_distance_function.py
@@ -46,12 +46,29 @@ def _without_symmetry_suffix(manifold_name: str) -> str:
     )
 
 
+def _validate_symmetry_count(nSymm: Any) -> int:
+    count_array = np.asarray(to_numpy(nSymm))
+    if count_array.shape != () or np.issubdtype(count_array.dtype, np.bool_):
+        raise ValueError("nSymm must be a finite positive integer")
+    try:
+        count = float(count_array.item())
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("nSymm must be a finite positive integer") from exc
+    if not np.isfinite(count) or not count.is_integer() or count <= 0:
+        raise ValueError("nSymm must be a finite positive integer")
+    return int(count)
+
+
 def _symmetry_offsets(nSymm, symmetryOffsets):
     if symmetryOffsets is not None:
-        return list(asarray(symmetryOffsets))
+        offsets = np.asarray(to_numpy(symmetryOffsets), dtype=float).reshape(-1)
+        if not np.all(np.isfinite(offsets)):
+            raise ValueError("symmetryOffsets must be finite")
+        return [float(offset) for offset in offsets]
     if nSymm is None:
         return []
-    return [2.0 * pi * index / int(nSymm) for index in range(int(nSymm))]
+    count = _validate_symmetry_count(nSymm)
+    return [2.0 * pi * index / count for index in range(count)]
 
 
 def _symmetric_distance_function(

--- a/tests/evaluation/test_distance_function_symmetry.py
+++ b/tests/evaluation/test_distance_function_symmetry.py
@@ -1,0 +1,21 @@
+import unittest
+
+from pyrecest.evaluation.get_distance_function import get_distance_function
+
+
+class SymmetricDistanceFunctionValidationTest(unittest.TestCase):
+    def test_rejects_invalid_symmetry_counts(self):
+        for n_symm in (0, -1, 2.5, float("nan"), float("inf"), True, [2]):
+            with self.subTest(n_symm=n_symm):
+                with self.assertRaisesRegex(ValueError, "nSymm.*positive integer"):
+                    get_distance_function("circle", nSymm=n_symm)
+
+    def test_rejects_nonfinite_symmetry_offsets(self):
+        for symmetry_offsets in ([0.0, float("nan")], [float("inf")], [-float("inf")]):
+            with self.subTest(symmetry_offsets=symmetry_offsets):
+                with self.assertRaisesRegex(ValueError, "symmetryOffsets.*finite"):
+                    get_distance_function("circle", symmetryOffsets=symmetry_offsets)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reject invalid `nSymm` values instead of truncating or silently treating zero-fold symmetry as no symmetry
- reject non-finite explicit `symmetryOffsets`
- add regression coverage for invalid symmetry counts and offsets

## Rationale
`get_distance_function(..., nSymm=0)` previously produced an empty offset list that fell back to `[0.0]`, so an invalid zero-fold symmetry was silently accepted. Non-integer counts were also truncated via `int(nSymm)`, e.g. `2.5` behaved like `2`. Explicit NaN/Inf offsets could propagate into the distance calculation.

## Testing
- Not run locally; repository network access is unavailable in this environment.