### PR TITLE
Validate max_time_delta scalar inputs

### DIFF
--- a/src/pyrecest/calibration/bias.py
+++ b/src/pyrecest/calibration/bias.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import numpy as np
 
-from .time_offset import nearest_time_indices
+from .time_offset import _validate_max_time_delta, nearest_time_indices
 
 _FEATURE_ROW_COUNT_ERROR = (
     "features rows must match requested row count; "
@@ -169,9 +169,7 @@ def make_bias_training_examples(
 ) -> BiasTrainingExamples:
     """Match measurements to nearest reference values and compute residual bias."""
 
-    max_time_delta = float(max_time_delta_s)
-    if max_time_delta < 0.0 or np.isnan(max_time_delta):
-        raise ValueError("max_time_delta_s must be nonnegative")
+    max_time_delta = _validate_max_time_delta(max_time_delta_s)
     measurement_times = np.asarray(measurement_times_s, dtype=float).reshape(-1)
     measurements = _as_2d(measurement_values, "measurement_values")
     reference_times = np.asarray(reference_times_s, dtype=float).reshape(-1)
@@ -217,11 +215,9 @@ def make_bias_training_examples(
     references = references[order]
     nearest = nearest_time_indices(reference_times, measurement_times)
     delta_s = np.abs(reference_times[nearest] - measurement_times)
-    valid = (
-        np.isfinite(measurement_times)
-        & np.isfinite(measurements).all(axis=1)
-        & (delta_s <= max_time_delta)
-    )
+    valid = np.isfinite(measurement_times) & np.isfinite(measurements).all(axis=1)
+    if max_time_delta is not None:
+        valid &= delta_s <= max_time_delta
     valid &= np.isfinite(features).all(axis=1)
     measured = measurements[valid]
     reference = references[nearest[valid]]

--- a/src/pyrecest/calibration/time_offset.py
+++ b/src/pyrecest/calibration/time_offset.py
@@ -107,12 +107,23 @@ def apply_time_offset(times_s: np.ndarray, offset_s: float | None) -> np.ndarray
     return np.asarray(times_s, dtype=float) + offset
 
 
-def _validate_max_time_delta(max_time_delta_s: float | None) -> None:
+def _validate_max_time_delta(max_time_delta_s: float | None) -> float | None:
     if max_time_delta_s is None:
-        return
-    max_time_delta = float(max_time_delta_s)
+        return None
+    value_array = np.asarray(max_time_delta_s)
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError("max_time_delta_s must be nonnegative")
+
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError("max_time_delta_s must be nonnegative")
+    try:
+        max_time_delta = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("max_time_delta_s must be nonnegative") from exc
     if max_time_delta < 0.0 or np.isnan(max_time_delta):
         raise ValueError("max_time_delta_s must be nonnegative")
+    return max_time_delta
 
 
 def _finite_reference_rows(
@@ -163,7 +174,7 @@ def interpolate_reference_values(
 ) -> tuple[np.ndarray, np.ndarray]:
     """Interpolate reference values at query times and return a validity mask."""
 
-    _validate_max_time_delta(max_time_delta_s)
+    max_time_delta = _validate_max_time_delta(max_time_delta_s)
     reference_times = np.asarray(reference_times_s, dtype=float).reshape(-1)
     reference_values = np.asarray(reference_values, dtype=float)
     query_times = np.asarray(query_times_s, dtype=float).reshape(-1)
@@ -195,11 +206,9 @@ def interpolate_reference_values(
         & (query_times >= reference_times[0])
         & (query_times <= reference_times[-1])
     )
-    if max_time_delta_s is not None:
+    if max_time_delta is not None:
         nearest = nearest_time_indices(reference_times, query_times)
-        valid &= np.abs(reference_times[nearest] - query_times) <= float(
-            max_time_delta_s
-        )
+        valid &= np.abs(reference_times[nearest] - query_times) <= max_time_delta
     valid &= np.isfinite(interpolated).all(axis=1)
     return interpolated, valid
 

--- a/tests/calibration/test_max_time_delta_validation.py
+++ b/tests/calibration/test_max_time_delta_validation.py
@@ -1,0 +1,41 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.calibration.bias import make_bias_training_examples
+from pyrecest.calibration.time_offset import interpolate_reference_values
+
+
+class MaxTimeDeltaValidationTest(unittest.TestCase):
+    def test_interpolation_rejects_bool_and_non_scalar_max_time_delta(self):
+        for max_time_delta_s in (True, np.array([1.0])):
+            with self.subTest(max_time_delta_s=max_time_delta_s):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "max_time_delta_s must be nonnegative",
+                ):
+                    interpolate_reference_values(
+                        np.array([0.0, 1.0]),
+                        np.array([[0.0], [1.0]]),
+                        np.array([0.5]),
+                        max_time_delta_s=max_time_delta_s,
+                    )
+
+    def test_bias_training_examples_rejects_bool_and_non_scalar_max_time_delta(self):
+        for max_time_delta_s in (True, np.array([1.0])):
+            with self.subTest(max_time_delta_s=max_time_delta_s):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "max_time_delta_s must be nonnegative",
+                ):
+                    make_bias_training_examples(
+                        np.array([0.0]),
+                        np.array([[1.0]]),
+                        np.array([0.0]),
+                        np.array([[0.0]]),
+                        max_time_delta_s=max_time_delta_s,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Normalize `max_time_delta_s` through a scalar validator instead of raw `float(...)` coercion.
- Reject booleans and non-scalar arrays for timestamp interpolation and bias-training example generation.
- Preserve the existing behavior that `np.inf` is accepted as an unbounded maximum time delta.

## Bug
`max_time_delta_s=True` was silently treated as `1.0`, while non-scalar arrays could leak low-level conversion errors. This is a control parameter and should be validated consistently.

## Testing
- Added focused regression tests in `tests/calibration/test_max_time_delta_validation.py`.

Note: I did not run the tests locally because repository access here is through the GitHub connector.