### PR TITLE
Validate track completion limits

### DIFF
--- a/src/pyrecest/utils/track_completion.py
+++ b/src/pyrecest/utils/track_completion.py
@@ -139,12 +139,15 @@ def enumerate_fragment_completion_paths(
         high-branching production trackers should pre-prune in the provider.
     """
 
-    if max_path_length < 1:
-        raise ValueError("max_path_length must be positive")
+    max_path_length = _normalize_positive_integer(
+        max_path_length, "max_path_length"
+    )
     if direction not in {"prefix", "suffix", "both"}:
         raise ValueError("direction must be 'prefix', 'suffix', or 'both'")
-    if max_paths_per_fragment is not None and int(max_paths_per_fragment) < 1:
-        raise ValueError("max_paths_per_fragment must be positive or None")
+    if max_paths_per_fragment is not None:
+        max_paths_per_fragment = _normalize_positive_integer(
+            max_paths_per_fragment, "max_paths_per_fragment"
+        )
 
     matrix = normalize_track_matrix(track_matrix)
     occupied = occupied_observations_by_session(matrix)
@@ -178,7 +181,7 @@ def enumerate_fragment_completion_paths(
                 steps=(),
                 seen={(int(endpoint_session), endpoint_observation)},
                 occupied=occupied,
-                max_path_length=int(max_path_length),
+                max_path_length=max_path_length,
                 candidate_provider=candidate_provider,
                 candidate_session_provider=candidate_session_provider,
                 allow_duplicate_source=bool(allow_duplicate_source),
@@ -194,7 +197,7 @@ def enumerate_fragment_completion_paths(
                         path.path_length,
                         path_observations(path),
                     ),
-                )[: int(max_paths_per_fragment)]
+                )[:max_paths_per_fragment]
             paths.extend(fragment_paths)
     return paths
 
@@ -336,6 +339,24 @@ def _candidate_sessions(
             continue
         sessions.append(int(value))
     return tuple(dict.fromkeys(sessions))
+
+
+def _normalize_positive_integer(value: Any, name: str) -> int:
+    value_array = np.asarray(value)
+    if value_array.shape != () or np.issubdtype(value_array.dtype, np.bool_):
+        raise ValueError(f"{name} must be a positive integer")
+    if np.issubdtype(value_array.dtype, np.integer):
+        parsed = int(value_array.item())
+    elif np.issubdtype(value_array.dtype, np.floating):
+        scalar = float(value_array.item())
+        if not np.isfinite(scalar) or not scalar.is_integer():
+            raise ValueError(f"{name} must be a positive integer")
+        parsed = int(scalar)
+    else:
+        raise ValueError(f"{name} must be a positive integer")
+    if parsed < 1:
+        raise ValueError(f"{name} must be a positive integer")
+    return parsed
 
 
 def _coerce_candidate_session(value: Any) -> int | None:

--- a/tests/test_track_completion_limits_validation.py
+++ b/tests/test_track_completion_limits_validation.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pytest
+
+from pyrecest.utils.track_completion import enumerate_fragment_completion_paths
+
+
+def candidates(*_args):
+    return [1]
+
+
+def test_max_path_length_rejects_fractional_values():
+    with pytest.raises(ValueError, match="max_path_length"):
+        enumerate_fragment_completion_paths(
+            [[0, None, None]],
+            direction="suffix",
+            candidate_provider=candidates,
+            max_path_length=1.5,
+        )
+
+
+def test_max_paths_per_fragment_rejects_fractional_values():
+    with pytest.raises(ValueError, match="max_paths_per_fragment"):
+        enumerate_fragment_completion_paths(
+            [[0, None, None]],
+            direction="suffix",
+            candidate_provider=candidates,
+            max_paths_per_fragment=np.array(1.5),
+        )
+
+
+def test_integer_like_limits_are_accepted():
+    paths = enumerate_fragment_completion_paths(
+        [[0, None, None]],
+        direction="suffix",
+        candidate_provider=candidates,
+        max_path_length=np.array(1.0),
+        max_paths_per_fragment=np.float64(1.0),
+    )
+    assert len(paths) == 1


### PR DESCRIPTION
Summary:
- validate `max_path_length` and `max_paths_per_fragment` as scalar positive integers instead of truncating fractional floats via `int(...)`
- keep integer-like scalar arrays accepted
- add regression tests for fractional and integer-like control arguments

Testing: not run locally; repository access is through the GitHub connector.