### PR TITLE
Remove duplicate registration helper import

### DIFF
--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import all as backend_all
 from pyrecest.backend import (
     all as backend_all,
     array_equal,


### PR DESCRIPTION
## Summary
- Remove a duplicate `backend_all` import from the shared point-set registration helper.

## Bug
Current `main` imports `backend_all` twice in `src/pyrecest/utils/_point_set_registration_common.py`, once as a standalone import and once inside the grouped backend import. This creates duplicate-definition/import noise and can trip linting on follow-up PRs.

## Testing
- Not run locally; repository access here is through the GitHub connector, so CI should validate the branch.