### PR TITLE
Validate replay proposal probability controls

### DIFF
--- a/src/pyrecest/filters/replay_grid_likelihood.py
+++ b/src/pyrecest/filters/replay_grid_likelihood.py
@@ -423,7 +423,16 @@ def _nearest_bin_indices(positions: np.ndarray, bin_tree: cKDTree) -> np.ndarray
 
 
 def _validate_probability(probability: float, name: str) -> float:
-    value = float(probability)
+    probability_array = np.asarray(probability)
+    if probability_array.shape != ():
+        raise ValueError(f"{name} must be a scalar probability in [0, 1]")
+    probability_scalar = probability_array.item()
+    if isinstance(probability_scalar, (bool, np.bool_)):
+        raise ValueError(f"{name} must be a scalar probability in [0, 1]")
+    try:
+        value = float(probability_scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be a scalar probability in [0, 1]") from exc
     if not np.isfinite(value) or not 0.0 <= value <= 1.0:
         raise ValueError(f"{name} must lie in [0, 1]")
     return value

--- a/tests/filters/test_replay_grid_probability_validation.py
+++ b/tests/filters/test_replay_grid_probability_validation.py
@@ -1,0 +1,34 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.filters import adaptive_position_proposal_probability
+
+
+class TestReplayGridProposalProbabilityValidation(unittest.TestCase):
+    def test_adaptive_position_proposal_probability_rejects_malformed_probabilities(
+        self,
+    ):
+        weights = np.ones(4)
+        cases = (
+            ("base_probability", True, None),
+            ("base_probability", np.asarray([0.5]), None),
+            ("ess_threshold", 0.5, False),
+            ("ess_threshold", 0.5, np.asarray([0.5])),
+        )
+
+        for expected_name, base_probability, ess_threshold in cases:
+            with self.subTest(
+                base_probability=base_probability,
+                ess_threshold=ess_threshold,
+            ):
+                with self.assertRaisesRegex(ValueError, expected_name):
+                    adaptive_position_proposal_probability(
+                        weights,
+                        base_probability,
+                        ess_threshold,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Reject boolean proposal probabilities and ESS thresholds instead of coercing them through `float(...)`.
- Reject non-scalar probability controls, including length-one arrays, before they reach the replay-grid proposal logic.
- Add regression coverage for malformed `base_probability` and `ess_threshold` inputs.

## Rationale
`adaptive_position_proposal_probability` previously normalized probability controls with raw `float(...)`. That allowed `True`/`False` to silently become `1.0`/`0.0` and could accept array-like scalar lookalikes, which is inconsistent with the surrounding validation style and can hide caller mistakes.

## Testing
- Not run locally; repository network access is unavailable in this environment.