### PR TITLE
Reject non-boolean measurement reliability accepted flags

### DIFF
--- a/src/pyrecest/tracking/measurement_reliability.py
+++ b/src/pyrecest/tracking/measurement_reliability.py
@@ -76,7 +76,7 @@ class MeasurementReliabilityResult:
             _positive_scalar(self.covariance_scale, "covariance_scale"),
         )
         object.__setattr__(self, "covariance", covariance)
-        object.__setattr__(self, "accepted", bool(self.accepted))
+        object.__setattr__(self, "accepted", _bool_scalar(self.accepted, "accepted"))
         object.__setattr__(self, "action", str(self.action))
         object.__setattr__(self, "mode", str(self.mode))
 
@@ -277,6 +277,13 @@ def _finite_scalar(value: float, name: str) -> float:
     if not np.isfinite(parsed):
         raise ValueError(f"{name} must be finite")
     return parsed
+
+
+def _bool_scalar(value: Any, name: str) -> bool:
+    array = np.asarray(value)
+    if array.shape != () or array.dtype != np.bool_:
+        raise ValueError(f"{name} must be a boolean")
+    return bool(array.item())
 
 
 def _covariance_matrix(value: Any, *, dim: int | None = None) -> np.ndarray:

--- a/tests/tracking/test_measurement_reliability_result_validation.py
+++ b/tests/tracking/test_measurement_reliability_result_validation.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from pyrecest.tracking import MeasurementReliabilityResult
+
+
+def test_reliability_result_rejects_non_boolean_accepted_flags() -> None:
+    invalid_values = ("no", 1, np.array([True]))
+
+    for accepted in invalid_values:
+        with pytest.raises(ValueError, match="accepted must be a boolean"):
+            MeasurementReliabilityResult(
+                reliability=0.5,
+                covariance_scale=1.0,
+                covariance=np.eye(1),
+                accepted=accepted,
+                action="reliability_policy",
+                mode="hard",
+            )


### PR DESCRIPTION
## Summary
- Validate `MeasurementReliabilityResult.accepted` as a real boolean scalar instead of coercing through generic `bool(...)`.
- Prevent truthy strings or numeric values from silently turning rejected/invalid result flags into `True`.
- Add focused regression coverage for string, numeric, and non-scalar accepted inputs.

## Testing
- Added `tests/tracking/test_measurement_reliability_result_validation.py`.
- Not run locally; repository access here is through the GitHub connector, so CI should validate the branch.