### PR TITLE
Validate Pareto epsilon inputs

### DIFF
--- a/src/pyrecest/evaluation/pareto.py
+++ b/src/pyrecest/evaluation/pareto.py
@@ -53,6 +53,7 @@ def pareto_front_indices(
     objective_names = _validate_objectives(objectives)
     _require_table_columns(table, objective_names, "Pareto objective")
     direction_map = _directions_by_objective(objective_names, directions)
+    eps = _validate_eps(eps)
     if table.empty:
         return []
     candidates = (
@@ -87,6 +88,7 @@ def is_pareto_front(
     objective_names = _validate_objectives(objectives)
     _require_table_columns(table, objective_names, "Pareto objective")
     direction_map = _directions_by_objective(objective_names, directions)
+    eps = _validate_eps(eps)
     if feasible_mask is None:
         candidate_mask = pd.Series(True, index=table.index, dtype=bool)
     else:
@@ -123,6 +125,7 @@ def record_dominates(
 
     objective_names = _validate_objectives(objectives)
     direction_map = _directions_by_objective(objective_names, directions)
+    eps = _validate_eps(eps)
     weak: list[bool] = []
     strict: list[bool] = []
     for objective in objective_names:
@@ -153,6 +156,7 @@ def constraint_mask(
     ``{"op": "<=", "value": value}`` keys.
     """
 
+    eps = _validate_eps(eps)
     mask = pd.Series(True, index=table.index, dtype=bool)
     for column, spec in constraints.items():
         op, threshold = _parse_constraint_spec(spec)
@@ -192,6 +196,7 @@ def select_under_constraints(
 ) -> pd.DataFrame:
     """Return feasible rows sorted by one objective plus optional tie-breakers."""
 
+    eps = _validate_eps(eps)
     if objective not in table.columns:
         raise ValueError(f"objective column {objective!r} is not present.")
     direction = _validate_direction(direction, f"objective {objective!r}")
@@ -342,6 +347,19 @@ def _coerce_numeric(value: Any) -> float:
         return float(value)
     except (TypeError, ValueError, OverflowError):
         return float("nan")
+
+
+def _validate_eps(eps: Any) -> float:
+    value_array = np.asarray(eps)
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError("eps must be a finite non-negative scalar.")
+    try:
+        value = float(value_array.item())
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("eps must be a finite non-negative scalar.") from exc
+    if not np.isfinite(value) or value < 0.0:
+        raise ValueError("eps must be a finite non-negative scalar.")
+    return value
 
 
 def _is_missing(value: Any) -> bool:

--- a/tests/evaluation/test_pareto.py
+++ b/tests/evaluation/test_pareto.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import numpy as np
 import pandas as pd
 import pytest
 from pyrecest.evaluation import (
@@ -241,3 +242,47 @@ def test_equal_quality_selection_returns_best_compression_row() -> None:
     )
 
     assert selected.iloc[0]["name"] == "safe_small"
+
+
+def test_pareto_helpers_reject_invalid_eps_values() -> None:
+    table = pd.DataFrame(
+        [
+            {"name": "a", "error": 1.0, "runtime": 2.0},
+            {"name": "b", "error": 2.0, "runtime": 1.0},
+        ]
+    )
+    invalid_eps_values = (-1e-12, float("nan"), float("inf"), True, np.array([1e-12]))
+
+    for eps in invalid_eps_values:
+        with pytest.raises(ValueError, match="eps"):
+            pareto_front_indices(
+                table,
+                ["error", "runtime"],
+                directions={"error": "min", "runtime": "min"},
+                eps=eps,
+            )
+        with pytest.raises(ValueError, match="eps"):
+            is_pareto_front(
+                table,
+                ["error", "runtime"],
+                directions={"error": "min", "runtime": "min"},
+                eps=eps,
+            )
+        with pytest.raises(ValueError, match="eps"):
+            record_dominates(
+                table.iloc[0],
+                table.iloc[1],
+                ["error", "runtime"],
+                directions={"error": "min", "runtime": "min"},
+                eps=eps,
+            )
+        with pytest.raises(ValueError, match="eps"):
+            constraint_mask(table, {"error": ("<=", 2.0)}, eps=eps)
+        with pytest.raises(ValueError, match="eps"):
+            select_under_constraints(
+                table,
+                constraints={"error": ("<=", 2.0)},
+                objective="runtime",
+                direction="min",
+                eps=eps,
+            )


### PR DESCRIPTION
## Summary
- Validate Pareto/constraint tolerance `eps` as a finite, non-negative scalar before using it in dominance and feasibility comparisons.
- Reject negative, NaN, infinite, boolean, and non-scalar epsilon values instead of silently changing front/constraint outcomes.
- Add regression coverage across `pareto_front_indices`, `is_pareto_front`, `record_dominates`, `constraint_mask`, and `select_under_constraints`.

## Testing
- Not run locally; repository access is through the GitHub connector and CI should validate the branch.