### PR TITLE
Validate registration loop control integers

### DIFF
--- a/src/pyrecest/utils/nonrigid_point_set_registration.py
+++ b/src/pyrecest/utils/nonrigid_point_set_registration.py
@@ -155,6 +155,31 @@ def _validate_regularization(regularization: float) -> float:
     return regularization_value
 
 
+def _validate_positive_integer(value, name: str, *, minimum: int = 1) -> int:
+    value_array = asarray(value)
+    if value_array.shape != ():
+        raise ValueError(f"{name} must be a scalar integer.")
+
+    value_scalar = value_array.item()
+    if isinstance(value_scalar, bool):
+        raise ValueError(f"{name} must be a scalar integer.")
+
+    try:
+        value_float = float(value_scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be a scalar integer.") from exc
+
+    if not math.isfinite(value_float) or not value_float.is_integer():
+        raise ValueError(f"{name} must be a scalar integer.")
+
+    value_int = int(value_float)
+    if value_int < minimum:
+        if minimum == 1:
+            raise ValueError(f"{name} must be positive.")
+        raise ValueError(f"{name} must be at least {minimum}.")
+    return value_int
+
+
 def estimate_thin_plate_spline(
     source_points,
     target_points,
@@ -263,6 +288,9 @@ def joint_tps_registration_assignment(  # pylint: disable=too-many-arguments,too
             "joint_tps_registration_assignment is not supported on the JAX backend."
         )
 
+    max_iterations = _validate_positive_integer(max_iterations, "max_iterations")
+    min_matches = _validate_positive_integer(min_matches, "min_matches", minimum=3)
+
     reference = _as_point_array(
         reference_points,
         expected_dim=2,
@@ -273,11 +301,6 @@ def joint_tps_registration_assignment(  # pylint: disable=too-many-arguments,too
         expected_dim=2,
         expected_dim_error="Only 2D point sets are currently supported.",
     )
-
-    if max_iterations <= 0:
-        raise ValueError("max_iterations must be positive.")
-    if min_matches < 3:
-        raise ValueError("min_matches must be at least 3 for TPS fitting.")
 
     if initial_transform is None:
         translation = quantile(moving, 0.5, axis=0) - quantile(reference, 0.5, axis=0)

--- a/src/pyrecest/utils/point_set_registration.py
+++ b/src/pyrecest/utils/point_set_registration.py
@@ -164,6 +164,31 @@ def _minimum_required_matches(model: TransformModel, dim: int) -> int:
     raise ValueError(f"Unsupported transform model: {model}")
 
 
+def _validate_positive_integer(value, name: str, *, minimum: int = 1) -> int:
+    value_array = asarray(value)
+    if value_array.shape != ():
+        raise ValueError(f"{name} must be a scalar integer.")
+
+    value_scalar = value_array.item()
+    if isinstance(value_scalar, bool):
+        raise ValueError(f"{name} must be a scalar integer.")
+
+    try:
+        value_float = float(value_scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be a scalar integer.") from exc
+
+    if not bool(isfinite(value_float)) or not value_float.is_integer():
+        raise ValueError(f"{name} must be a scalar integer.")
+
+    value_int = int(value_float)
+    if value_int < minimum:
+        if minimum == 1:
+            raise ValueError(f"{name} must be positive.")
+        raise ValueError(f"{name} must be at least {minimum}.")
+    return value_int
+
+
 def estimate_transform(  # pylint: disable=too-many-locals
     source_points,
     target_points,
@@ -288,20 +313,19 @@ def joint_registration_assignment(  # pylint: disable=too-many-arguments,too-man
             "joint_registration_assignment is not supported on the JAX backend."
         )
 
+    max_iterations = _validate_positive_integer(max_iterations, "max_iterations")
+
     reference = _as_point_array(reference_points)
     moving = _as_point_array(moving_points)
     if reference.shape[1] != moving.shape[1]:
         raise ValueError(
             "reference_points and moving_points must have the same dimension."
         )
-    if max_iterations <= 0:
-        raise ValueError("max_iterations must be positive.")
 
     dim = reference.shape[1]
     if min_matches is None:
         min_matches = _minimum_required_matches(model, dim)
-    if min_matches <= 0:
-        raise ValueError("min_matches must be positive.")
+    min_matches = _validate_positive_integer(min_matches, "min_matches")
 
     if initial_transform is None:
         reference_location = quantile(reference, 0.5, axis=0)

--- a/src/pyrecest/utils/point_set_registration.py
+++ b/src/pyrecest/utils/point_set_registration.py
@@ -13,6 +13,7 @@ rotation, or affine deformation must be estimated before data association.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Any, Callable, Literal
 
@@ -178,7 +179,7 @@ def _validate_positive_integer(value, name: str, *, minimum: int = 1) -> int:
     except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError(f"{name} must be a scalar integer.") from exc
 
-    if not bool(isfinite(value_float)) or not value_float.is_integer():
+    if not math.isfinite(value_float) or not value_float.is_integer():
         raise ValueError(f"{name} must be a scalar integer.")
 
     value_int = int(value_float)

--- a/tests/test_registration_loop_control_validation.py
+++ b/tests/test_registration_loop_control_validation.py
@@ -1,0 +1,82 @@
+import unittest
+
+import pyrecest.backend
+from pyrecest.backend import array
+from pyrecest.utils.nonrigid_point_set_registration import joint_tps_registration_assignment
+from pyrecest.utils.point_set_registration import joint_registration_assignment
+
+
+class TestRegistrationLoopControlValidation(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_joint_registration_assignment_rejects_invalid_max_iterations(self):
+        reference = array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+        moving = reference + array([1.0, -1.0])
+
+        for bad_value in (True, 1.5, float("nan"), array([2])):
+            with self.subTest(bad_value=bad_value):
+                with self.assertRaisesRegex(ValueError, "max_iterations"):
+                    joint_registration_assignment(
+                        reference,
+                        moving,
+                        model="translation",
+                        max_iterations=bad_value,
+                    )
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_joint_registration_assignment_rejects_invalid_min_matches(self):
+        reference = array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+        moving = reference + array([1.0, -1.0])
+
+        for bad_value in (True, 1.5, float("inf"), array([1])):
+            with self.subTest(bad_value=bad_value):
+                with self.assertRaisesRegex(ValueError, "min_matches"):
+                    joint_registration_assignment(
+                        reference,
+                        moving,
+                        model="translation",
+                        min_matches=bad_value,
+                    )
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_joint_tps_registration_assignment_rejects_invalid_max_iterations(self):
+        reference = array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+        moving = reference + array([0.5, -0.25])
+
+        for bad_value in (False, 2.5, float("nan"), array([2])):
+            with self.subTest(bad_value=bad_value):
+                with self.assertRaisesRegex(ValueError, "max_iterations"):
+                    joint_tps_registration_assignment(
+                        reference,
+                        moving,
+                        max_iterations=bad_value,
+                    )
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_joint_tps_registration_assignment_rejects_invalid_min_matches(self):
+        reference = array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+        moving = reference + array([0.5, -0.25])
+
+        for bad_value in (True, 2, 2.5, float("inf"), array([3])):
+            with self.subTest(bad_value=bad_value):
+                with self.assertRaisesRegex(ValueError, "min_matches"):
+                    joint_tps_registration_assignment(
+                        reference,
+                        moving,
+                        min_matches=bad_value,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Validate `max_iterations` before it is used in `range(...)` for affine and TPS registration loops.
- Validate user-provided `min_matches` as a scalar integer, including TPS's minimum of 3.
- Add regression coverage for boolean, fractional, non-finite, and non-scalar loop-control values.

## Rationale
The registration entry points previously checked loop controls with comparisons such as `max_iterations <= 0`. That allowed booleans to be interpreted as integers and let fractional/non-scalar values reach lower-level loop code, producing either silent truncation-like semantics or low-level exceptions instead of a clear validation error.

## Testing
- Not run locally; repository execution is unavailable in this environment.