### PR TITLE
Validate implicit surface scale controls

### DIFF
--- a/src/pyrecest/evaluation/implicit_surfaces.py
+++ b/src/pyrecest/evaluation/implicit_surfaces.py
@@ -77,9 +77,20 @@ def surface_band_probability_from_signed_distance(
 
 
 def _positive_float(name: str, value: float) -> float:
-    parsed = float(value)
+    message = f"{name} must be finite and positive."
+    value_array = np.asarray(value)
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError(message)
+
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(message)
+    try:
+        parsed = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
     if not np.isfinite(parsed) or parsed <= 0.0:
-        raise ValueError(f"{name} must be finite and positive.")
+        raise ValueError(message)
     return parsed
 
 

--- a/tests/evaluation/test_implicit_surface_scale_validation.py
+++ b/tests/evaluation/test_implicit_surface_scale_validation.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pytest
+from pyrecest.evaluation import (
+    surface_band_mask,
+    surface_band_probability_from_signed_distance,
+)
+
+
+def test_surface_band_scale_controls_reject_bools_and_non_scalars() -> None:
+    invalid_values = (True, np.array([0.1]))
+
+    for invalid_value in invalid_values:
+        with pytest.raises(ValueError, match="threshold"):
+            surface_band_mask(np.asarray([0.0]), invalid_value)
+        with pytest.raises(ValueError, match="epsilon"):
+            surface_band_probability_from_signed_distance(
+                np.asarray([0.0]),
+                np.asarray([1.0]),
+                invalid_value,
+            )
+        with pytest.raises(ValueError, match="min_std"):
+            surface_band_probability_from_signed_distance(
+                np.asarray([0.0]),
+                np.asarray([1.0]),
+                0.1,
+                min_std=invalid_value,
+            )
+
+
+def test_surface_band_scale_controls_accept_scalar_arrays() -> None:
+    mask = surface_band_mask(np.asarray([0.0, 0.2]), np.array(0.1))
+    probability = surface_band_probability_from_signed_distance(
+        np.asarray([0.0]),
+        np.asarray([1.0]),
+        np.array(0.1),
+        min_std=np.array(0.01),
+    )
+
+    assert mask.tolist() == [True, False]
+    assert probability.shape == (1,)
+    assert 0.0 <= probability[0] <= 1.0


### PR DESCRIPTION
## Summary
- Validate implicit-surface positive scalar controls before coercing them to float.
- Reject booleans and non-scalar arrays for `surface_band_mask(threshold=...)` and `surface_band_probability_from_signed_distance(epsilon=..., min_std=...)`.
- Preserve scalar NumPy array inputs such as `np.array(0.1)`.

## Testing
- Added focused regression coverage in `tests/evaluation/test_implicit_surface_scale_validation.py`.

Note: I did not run tests locally because repository access here is through the GitHub connector.