### PR TITLE
Handle mixed result parameter types

### DIFF
--- a/src/pyrecest/evaluation/group_results_by_filter.py
+++ b/src/pyrecest/evaluation/group_results_by_filter.py
@@ -1,8 +1,17 @@
+def _parameter_sort_key(parameter):
+    if parameter is None:
+        return (0, "")
+    try:
+        return (1, float(parameter))
+    except (TypeError, ValueError, OverflowError):
+        return (2, str(parameter))
+
+
 def group_results_by_filter(data):
     # Sort the data by 'parameter', treating None as negative infinity for sorting purposes
     sorted_data = sorted(
         data,
-        key=lambda x: (float("-inf") if x["parameter"] is None else x["parameter"]),
+        key=lambda x: _parameter_sort_key(x["parameter"]),
     )
 
     output_dict = {}

--- a/tests/test_group_results_by_filter.py
+++ b/tests/test_group_results_by_filter.py
@@ -1,0 +1,21 @@
+import unittest
+
+from pyrecest.evaluation.group_results_by_filter import group_results_by_filter
+
+
+class TestGroupResultsByFilter(unittest.TestCase):
+    def test_mixed_parameters_do_not_crash_sorting(self):
+        rows = [
+            {"name": "pf", "parameter": "b", "score": 3.0},
+            {"name": "pf", "parameter": 1, "score": 1.0},
+            {"name": "pf", "parameter": None, "score": 0.0},
+        ]
+
+        grouped = group_results_by_filter(rows)
+
+        self.assertEqual(grouped["pf"]["parameter"], [None, 1, "b"])
+        self.assertEqual(grouped["pf"]["score"], [0.0, 1.0, 3.0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a deterministic sort key for `group_results_by_filter()` parameters.
- Preserve the existing `None`-first behavior and numeric ordering while allowing non-numeric parameter values to sort after numeric parameters.
- Add a regression test covering mixed `None`, numeric, and string parameters.

## Bug
`group_results_by_filter()` previously sorted raw `parameter` values. Mixed result tables containing `None`, numeric parameters, and string/categorical parameters could raise `TypeError` during sorting before grouping.

## Testing
- Not run locally; repository access here is through the GitHub connector, so CI should validate the branch.