### PR TITLE
Handle overflowing particle diagnostics values

### DIFF
--- a/src/pyrecest/diagnostics.py
+++ b/src/pyrecest/diagnostics.py
@@ -72,7 +72,7 @@ def _coerce_numeric_values(values: Any) -> list[float]:
     except TypeError:
         try:
             return [float(values)]
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
             return []
     for value in iterator:
         out.extend(_coerce_numeric_values(value))

--- a/tests/test_particle_filter_result.py
+++ b/tests/test_particle_filter_result.py
@@ -4,6 +4,11 @@ from pyrecest.backend import array
 from pyrecest.diagnostics import ParticleFilterResult
 
 
+class _OverflowFloat:
+    def __float__(self):
+        raise OverflowError("simulated overflow")
+
+
 class ParticleFilterResultTest(unittest.TestCase):
     def test_mapping_compatibility_and_aliases(self):
         result = ParticleFilterResult(
@@ -52,6 +57,20 @@ class ParticleFilterResultTest(unittest.TestCase):
 
         self.assertEqual(result.resampling_count, 0)
         self.assertEqual(result.resampling_fraction, 0.0)
+        self.assertAlmostEqual(summary["mean_effective_sample_size"], 3.0)
+        self.assertAlmostEqual(summary["final_effective_sample_size"], 4.0)
+        self.assertAlmostEqual(summary["mean_particle_spread"], 0.5)
+
+    def test_summary_statistics_ignore_overflowing_numeric_values(self):
+        result = ParticleFilterResult(
+            estimates=[],
+            effective_sample_size=[_OverflowFloat(), [2.0, 4.0]],
+            resampled=[],
+            particle_spread=[_OverflowFloat(), 0.5],
+        )
+
+        summary = result.summary_statistics()
+
         self.assertAlmostEqual(summary["mean_effective_sample_size"], 3.0)
         self.assertAlmostEqual(summary["final_effective_sample_size"], 4.0)
         self.assertAlmostEqual(summary["mean_particle_spread"], 0.5)


### PR DESCRIPTION
## Summary
- Catch `OverflowError` when coercing optional particle summary values.
- Add a regression test for overflowing numeric-like inputs.

## Tests
- Added focused unit test in `tests/test_particle_filter_result.py`.