### PR TITLE
Validate MEM-EKF covariance regularization

### DIFF
--- a/src/pyrecest/filters/mem_ekf_tracker.py
+++ b/src/pyrecest/filters/mem_ekf_tracker.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 # pylint: disable=no-name-in-module,no-member,too-many-instance-attributes,duplicate-code
 from pyrecest.backend import (
     array,
@@ -82,8 +84,11 @@ class MEMEKFTracker(AbstractExtendedObjectTracker):
             self._validate_measurement_matrix(self.measurement_matrix)
 
         self.covariance_regularization = float(covariance_regularization)
-        if self.covariance_regularization < 0.0:
-            raise ValueError("covariance_regularization must be non-negative")
+        if (
+            not math.isfinite(self.covariance_regularization)
+            or self.covariance_regularization < 0.0
+        ):
+            raise ValueError("covariance_regularization must be finite and non-negative")
 
     @staticmethod
     def _symmetrize(matrix):

--- a/tests/filters/test_mem_ekf_tracker.py
+++ b/tests/filters/test_mem_ekf_tracker.py
@@ -43,6 +43,19 @@ class TestMEMEKFTracker(unittest.TestCase):
         )
         self.assertEqual(self.tracker.get_point_estimate().shape[0], 7)
 
+    def test_rejects_nonfinite_covariance_regularization(self):
+        for bad_value in (float("nan"), float("inf"), -float("inf")):
+            with self.subTest(covariance_regularization=bad_value):
+                with self.assertRaisesRegex(ValueError, "finite"):
+                    MEMEKFTracker(
+                        self.kinematic_state,
+                        self.covariance,
+                        self.shape_state,
+                        self.shape_covariance,
+                        measurement_matrix=self.measurement_matrix,
+                        covariance_regularization=bad_value,
+                    )
+
     def test_extent_respects_orientation(self):
         tracker = MEMEKFTracker(
             self.kinematic_state,


### PR DESCRIPTION
## Summary
- reject NaN and infinite `covariance_regularization` values in `MEMEKFTracker`
- keep the existing non-negative constraint but make the failure explicit before update-time covariance arithmetic
- add regression coverage for NaN, +Inf, and -Inf regularization inputs

## Rationale
`float("nan") < 0.0` is false, so the previous constructor check accepted NaN regularization. Infinite values were also accepted. These values can later contaminate the innovation and pseudo-measurement covariance updates.

## Testing
- Not run locally; repository network access is unavailable in this environment.