### PR TITLE
Validate vectorized prediction flag

### DIFF
--- a/src/pyrecest/evaluation/configure_for_filter.py
+++ b/src/pyrecest/evaluation/configure_for_filter.py
@@ -1,6 +1,8 @@
 from collections.abc import Callable
 from typing import Any
 
+import numpy as np
+
 from pyrecest.filters import (
     EuclideanParticleFilter,
     HypertoroidalParticleFilter,
@@ -33,13 +35,23 @@ def get_registered_filter_factory(filter_name: str) -> FilterFactory | None:
     return _FILTER_FACTORIES.get(filter_name)
 
 
+def _as_bool_scalar(value: Any, name: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    value_array = np.asarray(value)
+    if value_array.shape == () and value_array.dtype == np.bool_:
+        return bool(value_array.item())
+    raise ValueError(f"{name} must be a boolean scalar")
+
+
 def _gen_next_state_with_noise_is_vectorized(scenario_config) -> bool:
-    return bool(
-        scenario_config.get(
-            "gen_next_state_with_noise_is_vectorized",
-            scenario_config.get("genNextStateWithNoiseIsVectorized", False),
-        )
-    )
+    snake_case_key = "gen_next_state_with_noise_is_vectorized"
+    camel_case_key = "genNextStateWithNoiseIsVectorized"
+    if snake_case_key in scenario_config:
+        return _as_bool_scalar(scenario_config[snake_case_key], snake_case_key)
+    if camel_case_key in scenario_config:
+        return _as_bool_scalar(scenario_config[camel_case_key], camel_case_key)
+    return False
 
 
 # pylint: disable=too-many-branches

--- a/tests/evaluation/test_configure_for_filter_flags.py
+++ b/tests/evaluation/test_configure_for_filter_flags.py
@@ -1,0 +1,39 @@
+import unittest
+
+import numpy as np
+from pyrecest.evaluation.configure_for_filter import (
+    _gen_next_state_with_noise_is_vectorized,
+)
+
+
+class ConfigureForFilterFlagValidationTest(unittest.TestCase):
+    def test_vectorized_flag_defaults_to_false(self):
+        self.assertFalse(_gen_next_state_with_noise_is_vectorized({}))
+
+    def test_vectorized_flag_accepts_boolean_scalars(self):
+        self.assertTrue(
+            _gen_next_state_with_noise_is_vectorized(
+                {"gen_next_state_with_noise_is_vectorized": True}
+            )
+        )
+        self.assertFalse(
+            _gen_next_state_with_noise_is_vectorized(
+                {"genNextStateWithNoiseIsVectorized": np.bool_(False)}
+            )
+        )
+
+    def test_vectorized_flag_rejects_truthy_strings_and_numeric_values(self):
+        invalid_configs = (
+            {"gen_next_state_with_noise_is_vectorized": "False"},
+            {"gen_next_state_with_noise_is_vectorized": 1},
+            {"genNextStateWithNoiseIsVectorized": np.array([False])},
+        )
+
+        for config in invalid_configs:
+            with self.subTest(config=config):
+                with self.assertRaisesRegex(ValueError, "must be a boolean scalar"):
+                    _gen_next_state_with_noise_is_vectorized(config)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Replace generic `bool(...)` coercion for `gen_next_state_with_noise_is_vectorized` / `genNextStateWithNoiseIsVectorized` with explicit boolean-scalar validation.
- Prevent truthy strings such as `"False"`, numeric values, or non-scalar arrays from silently selecting the vectorized prediction path.
- Add focused regression tests for the default, accepted boolean scalars, and invalid flag values.

## Testing
- Added `tests/evaluation/test_configure_for_filter_flags.py`.

Note: I did not run the tests locally because repository access here is through the GitHub connector; CI should validate the branch.