### PR TITLE
Validate ROI assignment integer controls

### DIFF
--- a/src/pyrecest/utils/roi_assignment.py
+++ b/src/pyrecest/utils/roi_assignment.py
@@ -123,9 +123,40 @@ def _setdiff_indices(size: int, selected_indices):
     return array([index for index in range(size) if index not in selected], dtype=int64)
 
 
+def _as_nonnegative_integer(value, name: str) -> int:
+    value_array = asarray(value)
+    if value_array.shape != ():
+        raise ValueError(f"{name} must be a non-negative integer.")
+
+    scalar = value_array.item() if hasattr(value_array, "item") else value_array
+    if isinstance(scalar, bool):
+        raise ValueError(f"{name} must be a non-negative integer.")
+
+    if isinstance(scalar, int):
+        integer_value = int(scalar)
+    else:
+        try:
+            scalar_float = float(scalar)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(f"{name} must be a non-negative integer.") from exc
+        if not math.isfinite(scalar_float) or not scalar_float.is_integer():
+            raise ValueError(f"{name} must be a non-negative integer.")
+        integer_value = int(scalar_float)
+
+    if integer_value < 0:
+        raise ValueError(f"{name} must be a non-negative integer.")
+    return integer_value
+
+
+def _as_positive_integer(value, name: str) -> int:
+    integer_value = _as_nonnegative_integer(value, name)
+    if integer_value <= 0:
+        raise ValueError(f"{name} must be a positive integer.")
+    return integer_value
+
+
 def _histogram(values, *, bins: int, value_min: float, value_max: float):
-    if bins <= 0:
-        raise ValueError("nbins must be positive.")
+    bins = _as_positive_integer(bins, "nbins")
 
     bin_edges = linspace(value_min, value_max, bins + 1)
     scale = bins / (value_max - value_min)
@@ -544,8 +575,8 @@ def assign_by_similarity_matrix(
 
     if num_dummy is None:
         num_dummy = max(n_rows, n_cols)
-    if num_dummy < 0:
-        raise ValueError("num_dummy must be non-negative.")
+    else:
+        num_dummy = _as_nonnegative_integer(num_dummy, "num_dummy")
 
     max_similarity = float(amax(similarities[finite_mask]))
     threshold_cost = max_similarity - min_similarity
@@ -559,7 +590,7 @@ def assign_by_similarity_matrix(
     cost_matrix = full_like(similarities, dummy_cost)
     cost_matrix[valid_mask] = max_similarity - similarities[valid_mask]
 
-    padded_size = max(n_rows, n_cols) + int(num_dummy)
+    padded_size = max(n_rows, n_cols) + num_dummy
     padded_cost = full((padded_size, padded_size), dummy_cost, dtype=float64)
     padded_cost[:n_rows, :n_cols] = cost_matrix
 

--- a/tests/test_roi_assignment_integer_controls.py
+++ b/tests/test_roi_assignment_integer_controls.py
@@ -1,0 +1,40 @@
+import unittest
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest import backend
+from pyrecest.backend import array
+from pyrecest.utils.roi_assignment import (
+    assign_by_similarity_matrix,
+    minimum_similarity_threshold,
+    otsu_similarity_threshold,
+)
+
+
+class TestRoiAssignmentIntegerControls(unittest.TestCase):
+    def test_thresholds_reject_invalid_nbins(self):
+        scores = array([0.05, 0.08, 0.1, 0.81, 0.84, 0.9])
+
+        for threshold_fn in (otsu_similarity_threshold, minimum_similarity_threshold):
+            for nbins in (0, -1, 1.5, True, [2]):
+                with self.subTest(threshold_fn=threshold_fn.__name__, nbins=nbins):
+                    with self.assertRaisesRegex(ValueError, "nbins"):
+                        threshold_fn(scores, nbins=nbins)
+
+    @unittest.skipIf(
+        backend.__backend_name__ == "jax",
+        reason="Not supported on the jax backend",
+    )
+    def test_assignment_rejects_invalid_num_dummy(self):
+        similarity_matrix = array([[1.0]])
+
+        for num_dummy in (-1, 1.5, True, [1]):
+            with self.subTest(num_dummy=num_dummy):
+                with self.assertRaisesRegex(ValueError, "num_dummy"):
+                    assign_by_similarity_matrix(
+                        similarity_matrix,
+                        num_dummy=num_dummy,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Normalize ROI histogram `nbins` through scalar positive-integer validation.
- Validate `num_dummy` as a scalar non-negative integer before sizing assignment padding.
- Add focused regression coverage for boolean, fractional, and non-scalar controls.

## Bug
`assign_by_similarity_matrix()` previously used `int(num_dummy)` after only checking it against zero, so values like `1.5` were silently truncated and booleans were treated as integer controls. The threshold helpers also let malformed `nbins` values reach lower-level histogram/backend operations or accepted booleans as valid bin counts.

## Testing
- `python -m py_compile /tmp/roi_assignment.py /tmp/test_roi_assignment_integer_controls.py`
- Targeted local validation with a NumPy-backed stub for invalid `nbins` and `num_dummy` cases.

I did not run the full repository test suite locally because the repository checkout/dependency environment was not available here.