### PR TITLE
Validate track completion path limits as integers

### DIFF
--- a/src/pyrecest/utils/track_completion.py
+++ b/src/pyrecest/utils/track_completion.py
@@ -139,12 +139,15 @@ def enumerate_fragment_completion_paths(
         high-branching production trackers should pre-prune in the provider.
     """
 
-    if max_path_length < 1:
-        raise ValueError("max_path_length must be positive")
+    max_path_length = _normalize_positive_integer(max_path_length, "max_path_length")
     if direction not in {"prefix", "suffix", "both"}:
         raise ValueError("direction must be 'prefix', 'suffix', or 'both'")
-    if max_paths_per_fragment is not None and int(max_paths_per_fragment) < 1:
-        raise ValueError("max_paths_per_fragment must be positive or None")
+    if max_paths_per_fragment is not None:
+        max_paths_per_fragment = _normalize_positive_integer(
+            max_paths_per_fragment,
+            "max_paths_per_fragment",
+            none_allowed=True,
+        )
 
     matrix = normalize_track_matrix(track_matrix)
     occupied = occupied_observations_by_session(matrix)
@@ -178,7 +181,7 @@ def enumerate_fragment_completion_paths(
                 steps=(),
                 seen={(int(endpoint_session), endpoint_observation)},
                 occupied=occupied,
-                max_path_length=int(max_path_length),
+                max_path_length=max_path_length,
                 candidate_provider=candidate_provider,
                 candidate_session_provider=candidate_session_provider,
                 allow_duplicate_source=bool(allow_duplicate_source),
@@ -194,7 +197,7 @@ def enumerate_fragment_completion_paths(
                         path.path_length,
                         path_observations(path),
                     ),
-                )[: int(max_paths_per_fragment)]
+                )[:max_paths_per_fragment]
             paths.extend(fragment_paths)
     return paths
 
@@ -225,6 +228,35 @@ def path_observations(path: CompletionPath[Any]) -> tuple[int, ...]:
         path.steps[0].from_observation,
         *(step.to_observation for step in path.steps),
     )
+
+
+def _normalize_positive_integer(
+    value: Any,
+    name: str,
+    *,
+    none_allowed: bool = False,
+) -> int:
+    message = f"{name} must be positive" + (" or None" if none_allowed else "")
+    value_array = np.asarray(value)
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError(message)
+
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(message)
+    if isinstance(scalar, (int, np.integer)):
+        parsed = int(scalar)
+    else:
+        try:
+            scalar_float = float(scalar)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(message) from exc
+        if not np.isfinite(scalar_float) or not scalar_float.is_integer():
+            raise ValueError(message)
+        parsed = int(scalar_float)
+    if parsed < 1:
+        raise ValueError(message)
+    return parsed
 
 
 def _extend_completion_path(

--- a/tests/test_track_completion.py
+++ b/tests/test_track_completion.py
@@ -149,6 +149,42 @@ class TestTrackCompletion(unittest.TestCase):
 
         self.assertEqual(paths, [])
 
+    def test_rejects_invalid_path_limit_scalars(self) -> None:
+        tracks = [[7, None]]
+
+        def provider(session: int, observation: int, target_session: int):
+            del session, observation, target_session
+            return []
+
+        invalid_limits = (0, -1, True, 1.5, np.nan, np.inf, np.array([1]))
+        for invalid_limit in invalid_limits:
+            with self.subTest(max_path_length=invalid_limit):
+                with self.assertRaisesRegex(ValueError, "max_path_length"):
+                    enumerate_fragment_completion_paths(
+                        tracks,
+                        max_path_length=invalid_limit,
+                        direction="suffix",
+                        candidate_provider=provider,
+                    )
+
+    def test_rejects_invalid_max_paths_per_fragment_scalars(self) -> None:
+        tracks = [[7, None]]
+
+        def provider(session: int, observation: int, target_session: int):
+            del session, observation, target_session
+            return []
+
+        invalid_limits = (0, -1, True, 1.5, np.nan, np.inf, np.array([1]))
+        for invalid_limit in invalid_limits:
+            with self.subTest(max_paths_per_fragment=invalid_limit):
+                with self.assertRaisesRegex(ValueError, "max_paths_per_fragment"):
+                    enumerate_fragment_completion_paths(
+                        tracks,
+                        direction="suffix",
+                        candidate_provider=provider,
+                        max_paths_per_fragment=invalid_limit,
+                    )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Reject non-integer, boolean, non-finite, and non-positive `max_path_length` values.
- Reject invalid `max_paths_per_fragment` values instead of silently truncating with `int(...)`.
- Add regression tests for both limit parameters.

## Notes
- Before this change, values such as `max_path_length=1.5` or `max_paths_per_fragment=True` were accepted and coerced to `1`, which could silently change enumeration behavior.