### PR TITLE
Validate covariance feature scalar controls

### DIFF
--- a/src/pyrecest/utils/pairwise_covariance_features.py
+++ b/src/pyrecest/utils/pairwise_covariance_features.py
@@ -79,8 +79,11 @@ def pairwise_mahalanobis_distances(
         Matrix with shape ``(n_a, n_b)``.
     """
 
-    if not math.isfinite(float(regularization)) or regularization < 0.0:
-        raise ValueError("regularization must be finite and non-negative")
+    regularization = _validate_control_scalar(
+        regularization,
+        "regularization",
+        allow_zero=True,
+    )
 
     means_a, covariances_a = _validate_mean_covariance_stack(
         "means_a", means_a, "covariances_a", covariances_a
@@ -103,9 +106,7 @@ def pairwise_mahalanobis_distances(
         moved_covariances_a[:, None, :, :] + moved_covariances_b[None, :, :, :]
     )
     if regularization > 0.0:
-        covariance_sums = (
-            covariance_sums + float(regularization) * eye(dim)[None, None, :, :]
-        )
+        covariance_sums = covariance_sums + regularization * eye(dim)[None, None, :, :]
 
     mean_differences = transpose(means_a)[:, None, :] - transpose(means_b)[None, :, :]
     flat_differences = reshape(mean_differences, (n_a * n_b, dim))
@@ -144,8 +145,7 @@ def pairwise_covariance_shape_components(
         Three matrices with shape ``(n_a, n_b)``.
     """
 
-    if not math.isfinite(float(epsilon)) or epsilon <= 0.0:
-        raise ValueError("epsilon must be finite and strictly positive")
+    epsilon = _validate_control_scalar(epsilon, "epsilon", allow_zero=False)
 
     covariances_a = _validate_covariance_stack("covariances_a", covariances_a)
     covariances_b = _validate_covariance_stack("covariances_b", covariances_b)
@@ -180,6 +180,32 @@ def pairwise_covariance_shape_components(
     determinants_b = _positive_floor(linalg.det(moved_covariances_b), epsilon)
     logdet_cost = abs(log(determinants_a[:, None] / determinants_b[None, :]))
     return shape_cost, logdet_cost, shape_similarity
+
+
+def _validate_control_scalar(value: Any, name: str, *, allow_zero: bool) -> float:
+    value_array = asarray(value)
+    if value_array.shape != ():
+        raise ValueError(f"{name} must be a scalar")
+
+    try:
+        scalar_value = value_array.item() if hasattr(value_array, "item") else value_array
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a scalar") from exc
+
+    if isinstance(scalar_value, bool):
+        raise ValueError(f"{name} must be numeric, not boolean")
+
+    try:
+        value_float = float(scalar_value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be numeric") from exc
+
+    if not math.isfinite(value_float):
+        raise ValueError(f"{name} must be finite")
+    if value_float < 0.0 or (not allow_zero and value_float == 0.0):
+        qualifier = "non-negative" if allow_zero else "strictly positive"
+        raise ValueError(f"{name} must be {qualifier}")
+    return value_float
 
 
 def _validate_mean_covariance_stack(
@@ -226,7 +252,7 @@ def _batch_trace(matrices: Any) -> Any:
 
 def _positive_floor(values: Any, epsilon: float) -> Any:
     values = asarray(values, dtype=float64)
-    return where(values > float(epsilon), values, float(epsilon))
+    return where(values > epsilon, values, epsilon)
 
 
 __all__ = [

--- a/tests/test_pairwise_covariance_features.py
+++ b/tests/test_pairwise_covariance_features.py
@@ -63,6 +63,21 @@ class TestPairwiseCovarianceFeatures(unittest.TestCase):
 
         self.assertEqual(distances.shape, (0, 3))
 
+    def test_pairwise_mahalanobis_distances_rejects_ambiguous_regularization(self):
+        means = array([[0.0], [0.0]])
+        covariance = zeros((2, 2, 1))
+
+        for bad_regularization in (True, array([1.0])):
+            with self.subTest(bad_regularization=bad_regularization):
+                with self.assertRaisesRegex(ValueError, "regularization"):
+                    pairwise_mahalanobis_distances(
+                        means,
+                        covariance,
+                        means,
+                        covariance,
+                        regularization=bad_regularization,
+                    )
+
     def test_pairwise_covariance_shape_components_separate_shape_and_scale(self):
         covariances_a = array(
             [
@@ -115,6 +130,18 @@ class TestPairwiseCovarianceFeatures(unittest.TestCase):
         self.assertEqual(shape_cost.shape, (0, 4))
         self.assertEqual(logdet_cost.shape, (0, 4))
         self.assertEqual(shape_similarity.shape, (0, 4))
+
+    def test_pairwise_covariance_shape_components_rejects_ambiguous_epsilon(self):
+        covariances = zeros((2, 2, 1))
+
+        for bad_epsilon in (True, array([1e-6])):
+            with self.subTest(bad_epsilon=bad_epsilon):
+                with self.assertRaisesRegex(ValueError, "epsilon"):
+                    pairwise_covariance_shape_components(
+                        covariances,
+                        covariances,
+                        epsilon=bad_epsilon,
+                    )
 
     def test_invalid_inputs_raise(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Summary
- Normalize `regularization` and `epsilon` through an explicit scalar-control validator.
- Reject booleans and non-scalar arrays instead of silently accepting them as numeric controls.
- Add regression tests for ambiguous `regularization` and `epsilon` values.

## Bug
`pairwise_mahalanobis_distances(..., regularization=True)` was accepted as a diagonal loading of `1.0`, and `pairwise_covariance_shape_components(..., epsilon=True)` was accepted as a determinant/trace floor of `1.0`. Length-one arrays could also be accepted via `float(...)` coercion depending on backend behavior. These are ambiguous control inputs and should fail with clear `ValueError`s.

## Testing
- Not run locally; changes were made through the GitHub API in this environment.