### PR TITLE
Validate diagnostic summary scalar controls

### DIFF
--- a/src/pyrecest/evaluation/diagnostic_summaries.py
+++ b/src/pyrecest/evaluation/diagnostic_summaries.py
@@ -13,11 +13,20 @@ Record = Mapping[str, Any]
 
 
 def _as_scalar_float(value: Any, name: str) -> float:
-    value_array = np.asarray(value)
-    if value_array.shape != () or value_array.dtype == np.bool_:
+    try:
+        value_array = np.asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a scalar number") from exc
+    if value_array.shape != ():
         raise ValueError(f"{name} must be a scalar number")
     try:
-        scalar = float(value_array.item())
+        scalar_value = value_array.item()
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be a scalar number") from exc
+    if isinstance(scalar_value, (bool, np.bool_, str, bytes, np.str_, np.bytes_)):
+        raise ValueError(f"{name} must be a scalar number")
+    try:
+        scalar = float(scalar_value)
     except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError(f"{name} must be a scalar number") from exc
     if not math.isfinite(scalar):

--- a/tests/evaluation/test_diagnostic_summaries.py
+++ b/tests/evaluation/test_diagnostic_summaries.py
@@ -87,7 +87,17 @@ class DiagnosticSummariesTest(unittest.TestCase):
         self.assertEqual(summary["covariance_inflation"]["count"], 2)
 
     def test_summary_rejects_invalid_top_n(self):
-        for top_n in (0, 1.5, math.nan, math.inf, True, np.array([1])):
+        for top_n in (
+            0,
+            1.5,
+            math.nan,
+            math.inf,
+            True,
+            "2",
+            b"2",
+            np.array("2"),
+            np.array([1]),
+        ):
             with self.subTest(top_n=top_n):
                 with self.assertRaisesRegex(ValueError, "top_n"):
                     build_diagnostic_summary(self.records, top_n=top_n)
@@ -101,7 +111,17 @@ class DiagnosticSummariesTest(unittest.TestCase):
                     worst_time_windows(self.records, top_n=top_n)
 
     def test_summary_rejects_invalid_window_s(self):
-        for window_s in (0.0, -1.0, math.nan, math.inf, True, np.array([1.0])):
+        for window_s in (
+            0.0,
+            -1.0,
+            math.nan,
+            math.inf,
+            True,
+            "5.0",
+            b"5.0",
+            np.array("5.0"),
+            np.array([1.0]),
+        ):
             with self.subTest(window_s=window_s):
                 with self.assertRaisesRegex(ValueError, "window_s"):
                     build_diagnostic_summary(self.records, window_s=window_s)


### PR DESCRIPTION
## Summary
- Reject string and bytes scalar controls for diagnostic summary parameters.
- Keep numeric scalar controls, including scalar NumPy arrays, supported.
- Add regression coverage for string-like `top_n` and `window_s` values.

## Bug
`_as_scalar_float()` accepted string-like controls because `float("2")` and `float(b"2")` succeed. That meant public diagnostic helpers could silently accept textual `top_n` / `window_s` values instead of enforcing their documented scalar-number contract.

## Testing
- Not run locally; patch was applied through GitHub only.