### PR TITLE
Validate model validator boolean flags

### DIFF
--- a/src/pyrecest/models/validation.py
+++ b/src/pyrecest/models/validation.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 from numbers import Integral
 from typing import Any
 
+import numpy as np
+
 from pyrecest import backend
 
 # pylint: disable=too-many-arguments
@@ -31,6 +33,12 @@ def _shape_tuple(value: Any) -> tuple[int, ...]:
 
 def _format_shape(shape: tuple[int, ...]) -> str:
     return str(shape)
+
+
+def _validate_bool_flag(value: Any, name: str) -> bool:
+    if isinstance(value, (bool, np.bool_)):
+        return bool(value)
+    raise TypeError(f"{name} must be a boolean.")
 
 
 def _validate_expected_dim(
@@ -82,6 +90,7 @@ def validate_vector(
     backend array
         The validated vector as a backend array.
     """
+    allow_scalar = _validate_bool_flag(allow_scalar, "allow_scalar")
     vector = _as_backend_array(vector, name)
     vector_ndim = backend.ndim(vector)
 
@@ -177,6 +186,8 @@ def validate_covariance_matrix(
     dependent.  Concrete distributions may still perform stronger validity
     checks when needed.
     """
+    allow_scalar = _validate_bool_flag(allow_scalar, "allow_scalar")
+    check_symmetric = _validate_bool_flag(check_symmetric, "check_symmetric")
     covariance = _as_backend_array(covariance, name)
 
     if backend.ndim(covariance) == 0 and allow_scalar:
@@ -274,6 +285,7 @@ def infer_state_dim_from_distribution(
     ``mean()``/``covariance()`` are allowed by default but can be disabled with
     ``allow_methods=False`` to avoid expensive numerical fallbacks.
     """
+    allow_methods = _validate_bool_flag(allow_methods, "allow_methods")
     for attr_name in ("dim", "input_dim"):
         if hasattr(distribution, attr_name):
             try:

--- a/tests/models/test_validation_bool_flags.py
+++ b/tests/models/test_validation_bool_flags.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from pyrecest import backend
+from pyrecest.models.validation import (
+    infer_state_dim_from_distribution,
+    validate_covariance_matrix,
+    validate_state_vector,
+)
+
+
+def test_validate_state_vector_rejects_nonboolean_allow_scalar() -> None:
+    invalid_flags = ("False", 1, np.array([True]))
+
+    for flag in invalid_flags:
+        with pytest.raises(TypeError, match="allow_scalar"):
+            validate_state_vector(1.0, allow_scalar=flag)
+
+
+@pytest.mark.parametrize("flag", [True, np.bool_(True)])
+def test_validate_state_vector_accepts_boolean_allow_scalar(flag: bool) -> None:
+    vector = validate_state_vector(1.0, allow_scalar=flag)
+
+    assert int(backend.ndim(vector)) == 1
+    assert tuple(int(dim) for dim in backend.shape(vector)) == (1,)
+
+
+def test_validate_covariance_matrix_rejects_nonboolean_flags() -> None:
+    invalid_flags = ("False", 1, np.array([True]))
+
+    for flag in invalid_flags:
+        with pytest.raises(TypeError, match="allow_scalar"):
+            validate_covariance_matrix(1.0, allow_scalar=flag)
+        with pytest.raises(TypeError, match="check_symmetric"):
+            validate_covariance_matrix([[1.0]], check_symmetric=flag)
+
+
+def test_infer_state_dim_rejects_nonboolean_allow_methods() -> None:
+    distribution = SimpleNamespace(mean=lambda: np.array([1.0, 2.0]))
+
+    with pytest.raises(TypeError, match="allow_methods"):
+        infer_state_dim_from_distribution(distribution, allow_methods="False")


### PR DESCRIPTION
## Summary
- Add explicit boolean-flag validation for model validation helpers.
- Prevent truthy non-booleans such as `allow_scalar="False"` or `allow_methods="False"` from enabling scalar reshaping or method-based dimension inference.
- Preserve Python and NumPy boolean scalar support.

## Testing
- Added focused regression coverage in `tests/models/test_validation_bool_flags.py`.

Note: I did not run the tests locally because repository access here is through the GitHub connector.