### PR TITLE
Import backend all for registration point validation

### DIFF
--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,


### PR DESCRIPTION
## Summary
- Import the backend `all` reduction used by shared point-set registration validation.
- Fix the non-finite point validation path so it raises the intended `ValueError` instead of `NameError`.

## Bug
`as_point_array()` now checks `backend_all(isfinite(point_array))`, but `_point_set_registration_common.py` did not import `backend_all`. Any call that reached point validation, including the existing non-finite point regression test, crashed with `NameError` instead of a controlled validation error.

## Testing
- Not run locally; repository access here is through the GitHub connector, so CI should validate the PR.