### PR TITLE
Validate joint TPS regularization before matching

### DIFF
--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,

--- a/src/pyrecest/utils/nonrigid_point_set_registration.py
+++ b/src/pyrecest/utils/nonrigid_point_set_registration.py
@@ -263,6 +263,8 @@ def joint_tps_registration_assignment(  # pylint: disable=too-many-arguments,too
             "joint_tps_registration_assignment is not supported on the JAX backend."
         )
 
+    regularization = _validate_regularization(regularization)
+
     reference = _as_point_array(
         reference_points,
         expected_dim=2,

--- a/tests/test_nonrigid_tps_regularization_validation.py
+++ b/tests/test_nonrigid_tps_regularization_validation.py
@@ -1,0 +1,38 @@
+import unittest
+
+import pyrecest.backend
+from pyrecest.backend import array
+from pyrecest.utils.nonrigid_point_set_registration import (
+    ThinPlateSplineTransform,
+    joint_tps_registration_assignment,
+)
+
+
+class TestJointThinPlateSplineRegularizationValidation(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_joint_tps_registration_rejects_invalid_regularization_before_matching(self):
+        reference = array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+        moving = reference + array([100.0, 100.0])
+
+        for bad_regularization in (
+            float("nan"),
+            float("inf"),
+            -float("inf"),
+            array([1e-3]),
+        ):
+            with self.subTest(bad_regularization=bad_regularization):
+                with self.assertRaisesRegex(ValueError, "regularization"):
+                    joint_tps_registration_assignment(
+                        reference,
+                        moving,
+                        initial_transform=ThinPlateSplineTransform.identity(),
+                        max_cost=0.0,
+                        regularization=bad_regularization,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- validate `joint_tps_registration_assignment(..., regularization=...)` before entering the registration loop
- add a regression test for the no-refit path where invalid regularization was previously not checked

## Rationale
`estimate_thin_plate_spline` already validates TPS regularization, but `joint_tps_registration_assignment` only reached that validation after enough matches were found and a refit was attempted. If association stopped before refitting, non-finite or non-scalar regularization values could be silently accepted.

## Testing
- Not run locally; this environment cannot resolve `github.com` for cloning or dependency setup.