### PR TITLE
Validate SO3 conversion covariance regularization

### DIFF
--- a/src/pyrecest/distributions/so3_conversion.py
+++ b/src/pyrecest/distributions/so3_conversion.py
@@ -1,7 +1,8 @@
 """Conversion registrations for SO(3) distribution representations."""
 
 # pylint: disable=no-name-in-module,no-member
-from numbers import Integral
+from math import isfinite
+from numbers import Integral, Real
 
 from pyrecest.backend import array, diag, matmul, reshape, sum, transpose
 
@@ -12,6 +13,11 @@ from .so3_product_tangent_gaussian_distribution import (
     SO3ProductTangentGaussianDistribution,
 )
 from .so3_tangent_gaussian_distribution import SO3TangentGaussianDistribution
+
+
+_COVARIANCE_REGULARIZATION_ERROR = (
+    "covariance_regularization must be a nonnegative finite scalar"
+)
 
 
 def _sample_so3_product_dirac(distribution, n_particles):
@@ -30,6 +36,17 @@ def _validate_particle_count(n_particles):
     return int(n_particles)
 
 
+def _validate_covariance_regularization(covariance_regularization):
+    if isinstance(covariance_regularization, bool) or not isinstance(
+        covariance_regularization, Real
+    ):
+        raise ValueError(_COVARIANCE_REGULARIZATION_ERROR)
+    covariance_regularization = float(covariance_regularization)
+    if not isfinite(covariance_regularization) or covariance_regularization < 0.0:
+        raise ValueError(_COVARIANCE_REGULARIZATION_ERROR)
+    return covariance_regularization
+
+
 def _so3_tangent_gaussian_from_dirac(
     distribution,
     n_particles=None,
@@ -41,6 +58,9 @@ def _so3_tangent_gaussian_from_dirac(
     Dirac inputs are moment-matched in the local tangent chart. Non-Dirac inputs
     can be converted by sampling first when ``n_particles`` is supplied.
     """
+    covariance_regularization = _validate_covariance_regularization(
+        covariance_regularization
+    )
     if isinstance(distribution, SO3TangentGaussianDistribution):
         return SO3TangentGaussianDistribution(
             distribution.mean(),
@@ -74,7 +94,7 @@ def _so3_tangent_gaussian_from_dirac(
     centered = residuals - residual_mean
     covariance = matmul(transpose(weights * centered), centered)
 
-    if covariance_regularization != 0.0:
+    if covariance_regularization > 0.0:
         covariance = covariance + covariance_regularization * diag(
             array([1.0, 1.0, 1.0])
         )
@@ -95,6 +115,9 @@ def _so3_product_tangent_gaussian_from_dirac(
     Dirac inputs are moment-matched in the local tangent chart. Non-Dirac inputs
     can be converted by sampling first when ``n_particles`` is supplied.
     """
+    covariance_regularization = _validate_covariance_regularization(
+        covariance_regularization
+    )
     if isinstance(distribution, SO3ProductTangentGaussianDistribution):
         return SO3ProductTangentGaussianDistribution(
             distribution.mean(),
@@ -138,7 +161,7 @@ def _so3_product_tangent_gaussian_from_dirac(
     centered = residuals - residual_mean
     covariance = matmul(transpose(weights * centered), centered)
 
-    if covariance_regularization != 0.0:
+    if covariance_regularization > 0.0:
         covariance = covariance + covariance_regularization * diag(
             array([1.0] * (3 * num_rotations))
         )

--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,

--- a/tests/distributions/test_so3_conversion_validation.py
+++ b/tests/distributions/test_so3_conversion_validation.py
@@ -1,0 +1,65 @@
+import unittest
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array
+from pyrecest.distributions.conversion import convert_distribution
+from pyrecest.distributions.so3_dirac_distribution import SO3DiracDistribution
+from pyrecest.distributions.so3_product_dirac_distribution import (
+    SO3ProductDiracDistribution,
+)
+from pyrecest.distributions.so3_product_tangent_gaussian_distribution import (
+    SO3ProductTangentGaussianDistribution,
+)
+from pyrecest.distributions.so3_tangent_gaussian_distribution import (
+    SO3TangentGaussianDistribution,
+)
+
+
+class SO3ConversionValidationTest(unittest.TestCase):
+    def test_so3_tangent_gaussian_rejects_invalid_covariance_regularization(self):
+        base = array([0.0, 0.0, 0.0, 1.0])
+        rotations = SO3TangentGaussianDistribution.exp_map(
+            array([[0.01, 0.0, 0.0], [-0.01, 0.0, 0.0]]),
+            base=base,
+        )
+        particles = SO3DiracDistribution(rotations, array([0.5, 0.5]))
+
+        for covariance_regularization in (True, -1.0e-6, float("nan"), float("inf"), "1e-3"):
+            with self.subTest(covariance_regularization=covariance_regularization):
+                with self.assertRaisesRegex(
+                    ValueError, "covariance_regularization must be a nonnegative finite scalar"
+                ):
+                    convert_distribution(
+                        particles,
+                        "so3_tangent_gaussian",
+                        covariance_regularization=covariance_regularization,
+                    )
+
+    def test_so3_product_tangent_gaussian_rejects_invalid_covariance_regularization(self):
+        mean = array([[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.0, 1.0]])
+        rotations = SO3ProductTangentGaussianDistribution.exp_map(
+            array(
+                [
+                    [0.01, 0.0, 0.0, 0.0, 0.02, 0.0],
+                    [-0.01, 0.0, 0.0, 0.0, -0.02, 0.0],
+                ]
+            ),
+            base=mean,
+            num_rotations=2,
+        )
+        particles = SO3ProductDiracDistribution(rotations, array([0.5, 0.5]))
+
+        for covariance_regularization in (True, -1.0e-6, float("nan"), float("inf"), "1e-3"):
+            with self.subTest(covariance_regularization=covariance_regularization):
+                with self.assertRaisesRegex(
+                    ValueError, "covariance_regularization must be a nonnegative finite scalar"
+                ):
+                    convert_distribution(
+                        particles,
+                        "so3_product_tangent_gaussian",
+                        covariance_regularization=covariance_regularization,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- validate `covariance_regularization` before SO(3) and SO(3)^K tangent-Gaussian moment matching
- reject booleans, nonnumeric values, negative values, NaN, and infinity instead of adding them to the covariance
- add regression tests for both SO(3) conversion paths

## Tests
- Not run locally; changes were made through the GitHub connector and the regression tests are included in this PR.