### PR TITLE
Validate covariance dimension argument

### DIFF
--- a/src/pyrecest/numerics.py
+++ b/src/pyrecest/numerics.py
@@ -68,6 +68,12 @@ def _validate_nonnegative_integer(name: str, value: int) -> int:
     return value
 
 
+def _validate_optional_dimension(name: str, value: int | None) -> int | None:
+    if value is None:
+        return None
+    return _validate_nonnegative_integer(name, value)
+
+
 def _is_finite_matrix(matrix: np.ndarray) -> bool:
     return bool(np.all(np.isfinite(matrix)))
 
@@ -112,6 +118,8 @@ def is_positive_semidefinite(matrix, *, atol: float = 1e-10) -> bool:
         or not is_symmetric(arr, atol=atol)
     ):
         return False
+    if arr.shape[0] == 0:
+        return True
     return bool(np.min(np.linalg.eigvalsh(arr)) >= -atol)
 
 
@@ -166,6 +174,7 @@ def assert_covariance_matrix(
 ):
     """Validate a covariance matrix and return it in the active backend representation."""
     atol = _validate_nonnegative_finite("atol", atol)
+    dim = _validate_optional_dimension("dim", dim)
     arr = _to_numpy_array(matrix)
     if arr.ndim != 2 or arr.shape[0] != arr.shape[1]:
         raise ShapeError(f"{name} must be a square matrix, got shape {arr.shape}.")

--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,

--- a/tests/test_numerics.py
+++ b/tests/test_numerics.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from pyrecest.exceptions import NumericalStabilityError, ShapeError
+from pyrecest.exceptions import DimensionMismatchError, NumericalStabilityError, ShapeError
 from pyrecest.numerics import (
     assert_covariance_matrix,
     is_positive_semidefinite,
@@ -19,6 +19,15 @@ def test_symmetrize_matrix_and_psd_projection():
     repaired = np.asarray(nearest_symmetric_psd(matrix))
     assert is_symmetric(repaired)
     assert is_positive_semidefinite(repaired)
+
+
+def test_empty_square_matrix_is_symmetric_psd_covariance():
+    matrix = np.empty((0, 0))
+
+    assert is_symmetric(matrix)
+    assert is_positive_semidefinite(matrix)
+    validated = np.asarray(assert_covariance_matrix(matrix, dim=0))
+    assert validated.shape == (0, 0)
 
 
 def test_covariance_helpers_reject_nonfinite_matrices():
@@ -78,6 +87,19 @@ def test_jittered_cholesky_accepts_numpy_integer_retry_count():
     _, jitter = jittered_cholesky(matrix, max_attempts=np.int64(3))
 
     assert jitter > 0.0
+
+
+def test_assert_covariance_matrix_validates_dimension_argument():
+    matrix = np.eye(2)
+
+    np.testing.assert_array_equal(np.asarray(assert_covariance_matrix(matrix, dim=2)), matrix)
+
+    with pytest.raises(DimensionMismatchError, match="dimension 2"):
+        assert_covariance_matrix(matrix, dim=3)
+
+    for invalid_dim in (-1, 2.0, True, np.array([2])):
+        with pytest.raises(ValueError, match="dim"):
+            assert_covariance_matrix(matrix, dim=invalid_dim)
 
 
 def test_assert_covariance_matrix_rejects_non_psd():


### PR DESCRIPTION
## Summary
- Validate `assert_covariance_matrix(..., dim=...)` as a nonnegative integer before shape comparison.
- Prevent booleans, floats, negative values, and non-scalar arrays from being silently accepted or causing NumPy ambiguous truth-value errors.
- Treat the empty 0x0 matrix as symmetric PSD for predicate/validation consistency and add regression coverage.

## Bug
`assert_covariance_matrix()` compared the optional `dim` argument directly with `arr.shape[0]`. Invalid values such as `True`, `2.0`, or `np.array([2])` were not rejected consistently; the array case could raise a low-level ambiguous truth-value error. `is_positive_semidefinite()` also attempted `np.min` on an empty eigenvalue array for a 0x0 matrix.

## Tests
- Added focused regressions in `tests/test_numerics.py`.
- Not run locally because the execution container cannot resolve `github.com`; changes were verified by GitHub file fetch/compare.