### PR TITLE
Preserve masked measurement observed dims from iterables

### DIFF
--- a/src/pyrecest/models/weak_measurement.py
+++ b/src/pyrecest/models/weak_measurement.py
@@ -119,14 +119,17 @@ class MaskedLinearMeasurementModel(LinearGaussianMeasurementModel):
     ) -> None:
         if (measurement_noise_cov is None) == (stds is None):
             raise ValueError("provide exactly one of measurement_noise_cov or stds")
-        matrix = selection_matrix(state_dim, observed_dims)
+        observed_dims_tuple = tuple(observed_dims)
+        matrix = selection_matrix(state_dim, observed_dims_tuple)
         covariance = (
             diagonal_measurement_covariance(stds)
             if stds is not None
             else np.asarray(measurement_noise_cov, dtype=float)
         )
         super().__init__(matrix, covariance)
-        self.observed_dims = tuple(int(dim) for dim in observed_dims)
+        self.observed_dims = tuple(
+            _nonnegative_int(dim, "observed_dims") for dim in observed_dims_tuple
+        )
 
 
 class WeakDimensionMeasurementModel(LinearGaussianMeasurementModel):

--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,

--- a/tests/models/test_weak_measurement.py
+++ b/tests/models/test_weak_measurement.py
@@ -71,6 +71,17 @@ def test_masked_linear_measurement_model_updates_only_observed_dimensions() -> N
     assert estimate[2] > 15.0
 
 
+def test_masked_linear_measurement_model_preserves_generator_observed_dims() -> None:
+    model = MaskedLinearMeasurementModel(
+        state_dim=3,
+        observed_dims=(dim for dim in [0, 2]),
+        stds=[1.0, 2.0],
+    )
+
+    assert model.observed_dims == (0, 2)
+    assert np.allclose(model.matrix, selection_matrix(3, [0, 2]))
+
+
 def test_weak_dimension_measurement_model_keeps_weak_dimension_nearly_untrusted() -> (
     None
 ):


### PR DESCRIPTION
## Summary
- Materialize `observed_dims` once in `MaskedLinearMeasurementModel` before building the selection matrix.
- Store the validated observed-dimension tuple from the materialized values.
- Add regression coverage for one-shot generator inputs.

## Bug
`MaskedLinearMeasurementModel` previously passed `observed_dims` directly into `selection_matrix()` and then iterated over it again to populate `self.observed_dims`. For one-shot iterables such as generators, the first pass consumed all values, so the model matrix was correct but `model.observed_dims` was silently recorded as `()`.

## Testing
- Added `tests/models/test_weak_measurement.py::test_masked_linear_measurement_model_preserves_generator_observed_dims`.
- Not run locally; repository access here is through the GitHub connector, so CI should validate the branch.