### PR TITLE
Validate JAX choice populations

### DIFF
--- a/src/pyrecest/_backend/jax/random.py
+++ b/src/pyrecest/_backend/jax/random.py
@@ -265,6 +265,8 @@ def _normalize_choice_axis(axis, ndim):
 def _choice_population_size(a, kwargs):
     population_size = _integer_population_size(a)
     if population_size is not None:
+        if population_size <= 0:
+            raise ValueError("a must be a positive integer or a non-empty array")
         return population_size
 
     if a.ndim == 0:
@@ -275,6 +277,8 @@ def _choice_population_size(a, kwargs):
     axis = _normalize_choice_axis(kwargs.get("axis", 0), a.ndim)
     if "axis" in kwargs:
         kwargs["axis"] = axis
+    if a.shape[axis] == 0:
+        raise ValueError("a must be a positive integer or a non-empty array")
     return a.shape[axis]
 
 

--- a/src/pyrecest/_backend/jax/random.py
+++ b/src/pyrecest/_backend/jax/random.py
@@ -81,6 +81,10 @@ def _shape_from_size(size):
     return tuple(_integer_dimension(dim) for dim in size)
 
 
+def _shape_has_no_samples(shape):
+    return any(dim == 0 for dim in shape)
+
+
 def _shape_from_rand_args(dims, size):
     """Convert NumPy-style ``rand`` dimensions and ``size=`` to a shape."""
     if dims:
@@ -265,8 +269,6 @@ def _normalize_choice_axis(axis, ndim):
 def _choice_population_size(a, kwargs):
     population_size = _integer_population_size(a)
     if population_size is not None:
-        if population_size <= 0:
-            raise ValueError("a must be a positive integer or a non-empty array")
         return population_size
 
     if a.ndim == 0:
@@ -277,8 +279,6 @@ def _choice_population_size(a, kwargs):
     axis = _normalize_choice_axis(kwargs.get("axis", 0), a.ndim)
     if "axis" in kwargs:
         kwargs["axis"] = axis
-    if a.shape[axis] == 0:
-        raise ValueError("a must be a positive integer or a non-empty array")
     return a.shape[axis]
 
 
@@ -296,14 +296,21 @@ def _validate_choice_probabilities(p, population_size):
 def _choice(state, a, size=None, replace=True, p=None, *args, **kwargs):
     state, key = jax.random.split(state)
     a = _jnp.asarray(a)
+    shape = _shape_from_size(size)
     population_size = _choice_population_size(a, kwargs)
+    if population_size == 0:
+        if _shape_has_no_samples(shape):
+            return state, _jnp.empty(shape, dtype=a.dtype)
+        raise ValueError("a must be a positive integer or a non-empty array")
+    if population_size < 0:
+        raise ValueError("a must be a positive integer or a non-empty array")
     if p is not None:
         p = _validate_choice_probabilities(p, population_size)
     res = jax.random.choice(
         key,
         a,
         *args,
-        shape=_shape_from_size(size),
+        shape=shape,
         replace=replace,
         p=p,
         **kwargs,

--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,

--- a/tests/backend_support/test_jax_random_integer_contract.py
+++ b/tests/backend_support/test_jax_random_integer_contract.py
@@ -28,6 +28,15 @@ assert bool(backend.all(compat_positional_shape >= 2))
 assert bool(backend.all(compat_positional_shape < 7))
 assert bool(backend.all(compat_keyword_shape >= 2))
 assert bool(backend.all(compat_keyword_shape < 7))
+
+for invalid_population in (0, -1, []):
+    try:
+        random.choice(invalid_population, size=(1,))
+    except ValueError as exc:
+        assert "positive integer or a non-empty array" in str(exc)
+    else:
+        raise AssertionError("invalid choice population was accepted")
+
 print("ok")
 """
 


### PR DESCRIPTION
## Summary
- Reject non-positive integer populations in the JAX `random.choice` backend before calling JAX.
- Reject empty array populations along the selected choice axis.
- Extend the JAX backend regression test to cover invalid choice populations.

## Bug
The JAX backend advertises a NumPy-like `choice` contract, but `random.choice(0, ...)`, `random.choice(-1, ...)`, and empty population arrays were passed through to low-level JAX instead of being rejected consistently at the PyRecEst boundary.

## Testing
- Not run locally; changes were applied through GitHub only.