### PR TITLE
Normalize overflowing assignment costs

### DIFF
--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,

--- a/src/pyrecest/utils/assignment.py
+++ b/src/pyrecest/utils/assignment.py
@@ -71,13 +71,16 @@ def _coerce_non_assignment_costs(costs, size: int, name: str):
     if costs is None:
         return _zeros(size, dtype=float)
 
-    raw_costs_array = _asarray(costs)
+    try:
+        raw_costs_array = _asarray(costs)
+    except (TypeError, ValueError, OverflowError, RuntimeError) as exc:
+        raise ValueError(f"{name} must be numeric and finite") from exc
     if _has_boolean_dtype(raw_costs_array):
         raise ValueError(f"{name} must be numeric and finite")
 
     try:
         costs_array = _asarray(raw_costs_array, dtype=float)
-    except (TypeError, ValueError, OverflowError) as exc:
+    except (TypeError, ValueError, OverflowError, RuntimeError) as exc:
         raise ValueError(f"{name} must be numeric and finite") from exc
     if costs_array.ndim == 0:
         try:

--- a/src/pyrecest/utils/assignment.py
+++ b/src/pyrecest/utils/assignment.py
@@ -77,10 +77,13 @@ def _coerce_non_assignment_costs(costs, size: int, name: str):
 
     try:
         costs_array = _asarray(raw_costs_array, dtype=float)
-    except (TypeError, ValueError) as exc:
+    except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError(f"{name} must be numeric and finite") from exc
     if costs_array.ndim == 0:
-        cost = float(costs_array)
+        try:
+            cost = float(costs_array)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(f"{name} must be numeric and finite") from exc
         if not _is_scalar_finite(cost):
             raise ValueError(f"{name} must be finite")
         return _full((size,), cost, dtype=float)

--- a/tests/utils/test_assignment.py
+++ b/tests/utils/test_assignment.py
@@ -9,6 +9,11 @@ from pyrecest.utils import (
 )
 
 
+class _OverflowFloat:
+    def __float__(self):
+        raise OverflowError("simulated overflow")
+
+
 class MurtyAssignmentTest(unittest.TestCase):
     @staticmethod
     def _brute_force_solutions(
@@ -217,6 +222,32 @@ class MurtyAssignmentTest(unittest.TestCase):
                     murty_k_best_assignments(
                         cost_matrix,
                         col_non_assignment_costs=np.array([invalid_cost]),
+                    )
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on the JAX backend",
+    )
+    def test_overflowing_non_assignment_costs_are_rejected(self):
+        cost_matrix = np.array([[1.0]])
+        invalid_costs = (_OverflowFloat(), np.array(_OverflowFloat(), dtype=object))
+
+        for invalid_cost in invalid_costs:
+            with self.subTest(kind="row", invalid_cost=invalid_cost):
+                with self.assertRaisesRegex(
+                    ValueError, "row_non_assignment_costs must be numeric and finite"
+                ):
+                    murty_k_best_assignments(
+                        cost_matrix,
+                        row_non_assignment_costs=invalid_cost,
+                    )
+            with self.subTest(kind="column", invalid_cost=invalid_cost):
+                with self.assertRaisesRegex(
+                    ValueError, "col_non_assignment_costs must be numeric and finite"
+                ):
+                    murty_k_best_assignments(
+                        cost_matrix,
+                        col_non_assignment_costs=invalid_cost,
                     )
 
     @unittest.skipIf(


### PR DESCRIPTION
## Summary
- Catch `OverflowError` while coercing Murty non-assignment cost controls.
- Re-raise malformed scalar non-assignment costs as the existing `ValueError` validation contract instead of leaking backend/Python conversion errors.
- Add regression coverage for overflowing row and column non-assignment costs.

## Tests
- Added focused unit coverage in `tests/utils/test_assignment.py`.

Note: I could not run the tests locally because repository access here is through the GitHub connector.