### PR TITLE
Validate selection boolean controls

### DIFF
--- a/src/pyrecest/evaluation/selection.py
+++ b/src/pyrecest/evaluation/selection.py
@@ -9,7 +9,7 @@ and point-set or extended-object evaluation pipelines.
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Literal, cast
 
 import numpy as np
 
@@ -40,6 +40,16 @@ def _normalize_nonnegative_integer(value, name: str) -> int:
     return integer
 
 
+def _normalize_bool_flag(value, name: str) -> bool:
+    value_array = np.asarray(value)
+    if value_array.shape != ():
+        raise ValueError(f"{name} must be a boolean.")
+    scalar = value_array.item()
+    if not isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(f"{name} must be a boolean.")
+    return bool(scalar)
+
+
 def _normalize_finite_scalar(value, message: str) -> float:
     value_array = np.asarray(value)
     if value_array.shape != () or value_array.dtype == np.bool_:
@@ -55,6 +65,12 @@ def _normalize_finite_scalar(value, message: str) -> float:
     if not np.isfinite(result):
         raise ValueError(message)
     return result
+
+
+def _normalize_tail_side(tail) -> TailSide:
+    if not isinstance(tail, str) or tail not in {"lower", "upper"}:
+        raise ValueError("tail must be 'lower' or 'upper'.")
+    return cast(TailSide, tail)
 
 
 def _normalize_bounded_fraction(
@@ -81,6 +97,7 @@ def sanitized_score_vector(values, *, nonnegative: bool = True) -> np.ndarray:
     clipped to zero, matching the common interpretation of scores as confidence,
     reliability, probability, or non-negative utility.
     """
+    nonnegative = _normalize_bool_flag(nonnegative, "nonnegative")
     clean = np.asarray(values, dtype=np.float64).reshape(-1).copy()
     clean[~np.isfinite(clean)] = 0.0
     if nonnegative:
@@ -128,6 +145,8 @@ def top_count_mask(
     Ties are resolved by the optional ``tie_break_scores`` and then by increasing
     original index, making the selection reproducible across NumPy versions.
     """
+    largest = _normalize_bool_flag(largest, "largest")
+    sanitize_nonnegative = _normalize_bool_flag(sanitize_nonnegative, "sanitize_nonnegative")
     primary = sanitized_score_vector(scores, nonnegative=sanitize_nonnegative)
     count = int(primary.shape[0])
     retained = _normalize_nonnegative_integer(retained_count, "retained_count")
@@ -171,6 +190,8 @@ def top_fraction_mask(
     sanitize_nonnegative: bool = True,
 ) -> np.ndarray:
     """Return a top-k mask whose size is derived from a retention fraction."""
+    largest = _normalize_bool_flag(largest, "largest")
+    sanitize_nonnegative = _normalize_bool_flag(sanitize_nonnegative, "sanitize_nonnegative")
     primary = sanitized_score_vector(scores, nonnegative=sanitize_nonnegative)
     retained = retained_count_from_fraction(
         int(primary.shape[0]),
@@ -194,6 +215,8 @@ def quantile_tail_threshold(
     sanitize_nonnegative: bool = True,
 ) -> float:
     """Return the threshold separating a reliability-score quantile tail."""
+    tail = _normalize_tail_side(tail)
+    sanitize_nonnegative = _normalize_bool_flag(sanitize_nonnegative, "sanitize_nonnegative")
     scores = sanitized_score_vector(
         reliability_scores,
         nonnegative=sanitize_nonnegative,
@@ -206,8 +229,6 @@ def quantile_tail_threshold(
         include_upper=False,
         message="quantile must be finite and in (0, 1).",
     )
-    if tail not in {"lower", "upper"}:
-        raise ValueError("tail must be 'lower' or 'upper'.")
     if scores.size == 0:
         return float("nan")
     return float(np.quantile(scores, q if tail == "lower" else 1.0 - q))
@@ -221,6 +242,8 @@ def quantile_tail_mask(
     sanitize_nonnegative: bool = True,
 ) -> np.ndarray:
     """Return a boolean mask for the lower or upper reliability-score tail."""
+    tail = _normalize_tail_side(tail)
+    sanitize_nonnegative = _normalize_bool_flag(sanitize_nonnegative, "sanitize_nonnegative")
     scores = sanitized_score_vector(
         reliability_scores,
         nonnegative=sanitize_nonnegative,
@@ -258,6 +281,8 @@ def protected_tail_topk_mask(
     to ordinary top-fraction selection by ``primary_scores``; if the complement
     is empty, all candidates are ranked by ``tail_scores``.
     """
+    tail = _normalize_tail_side(tail)
+    sanitize_nonnegative = _normalize_bool_flag(sanitize_nonnegative, "sanitize_nonnegative")
     primary = sanitized_score_vector(primary_scores, nonnegative=sanitize_nonnegative)
     tail_rank = sanitized_score_vector(tail_scores, nonnegative=sanitize_nonnegative)
     reliability = sanitized_score_vector(
@@ -374,6 +399,8 @@ def tail_rescue_topk_mask(
     sanitize_nonnegative: bool = True,
 ) -> np.ndarray:
     """Top-k selection with a bounded quota rescued from a reliability tail."""
+    tail = _normalize_tail_side(tail)
+    sanitize_nonnegative = _normalize_bool_flag(sanitize_nonnegative, "sanitize_nonnegative")
     primary = sanitized_score_vector(primary_scores, nonnegative=sanitize_nonnegative)
     tail_rank = sanitized_score_vector(tail_scores, nonnegative=sanitize_nonnegative)
     reliability = sanitized_score_vector(

--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,

--- a/tests/evaluation/test_selection.py
+++ b/tests/evaluation/test_selection.py
@@ -7,6 +7,7 @@ from pyrecest.evaluation.selection import (
     quantile_tail_mask,
     quantile_tail_threshold,
     retained_count_from_fraction,
+    sanitized_score_vector,
     tail_rescue_quota_count,
     tail_rescue_topk_mask,
     top_count_mask,
@@ -35,6 +36,22 @@ def test_top_count_mask_rejects_invalid_retained_count_scalars() -> None:
 
     with pytest.raises(ValueError, match="retained_count"):
         top_count_mask([1.0, 2.0], 3)
+
+
+def test_top_count_mask_rejects_non_boolean_largest_flag() -> None:
+    for largest in ("False", 1, np.array([True])):
+        with pytest.raises(ValueError, match="largest"):
+            top_count_mask([1.0, 2.0], 1, largest=largest)
+
+
+def test_selection_helpers_reject_non_boolean_sanitize_flags() -> None:
+    for nonnegative in ("False", 1, np.array([True])):
+        with pytest.raises(ValueError, match="nonnegative"):
+            sanitized_score_vector([-1.0, 2.0], nonnegative=nonnegative)
+
+    for sanitize_nonnegative in ("False", 1, np.array([True])):
+        with pytest.raises(ValueError, match="sanitize_nonnegative"):
+            top_count_mask([-1.0, 2.0], 1, sanitize_nonnegative=sanitize_nonnegative)
 
 
 def test_top_fraction_mask_uses_ceil_retained_count() -> None:
@@ -78,8 +95,9 @@ def test_quantile_tail_mask_validates_empty_inputs_before_empty_return() -> None
         with pytest.raises(ValueError, match="quantile"):
             quantile_tail_mask([], bad_quantile)
 
-    with pytest.raises(ValueError, match="tail"):
-        quantile_tail_mask([], 0.5, tail="middle")
+    for bad_tail in ("middle", np.array("lower")):
+        with pytest.raises(ValueError, match="tail"):
+            quantile_tail_mask([], 0.5, tail=bad_tail)
 
 
 def test_protected_tail_topk_mask_preserves_proportional_tail_capacity() -> None:


### PR DESCRIPTION
## Summary
- Add strict boolean validation for the evaluation selection helpers' `nonnegative`, `largest`, and `sanitize_nonnegative` controls.
- Validate `tail` as a plain `"lower"`/`"upper"` selector before set-membership checks.
- Add regression coverage for truthy non-boolean flags and array-like tail selectors.

## Bug
Selection helpers previously relied on Python truthiness for boolean controls. Values such as `largest="False"` or `sanitize_nonnegative="False"` were accepted and treated as `True`, silently changing ranking/clipping semantics instead of rejecting malformed control arguments. Array-like `tail` values could also leak low-level errors instead of the documented `ValueError` path.

## Testing
- Locally compiled and exercised the patched selection helper logic with focused smoke checks in this environment.
- Full repository test suite not run locally because this environment cannot resolve `github.com` for cloning/dependency setup.