### PR TITLE
Reject boolean observation cost entries

### DIFF
--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,

--- a/src/pyrecest/utils/multisession_assignment_observation_costs.py
+++ b/src/pyrecest/utils/multisession_assignment_observation_costs.py
@@ -258,7 +258,12 @@ def _normalize_observation_cost_entry(
     session_idx: int,
     name: str,
 ) -> Any:
-    values = asarray(value, dtype=float64)
+    raw_values = np.asarray(value)
+    if raw_values.dtype == np.bool_:
+        raise ValueError(
+            f"{name} entry for session {session_idx} must be numeric, not boolean."
+        )
+    values = asarray(raw_values, dtype=float64)
     if values.ndim == 0:
         return full((session_size,), float(values), dtype=float64)
     if values.ndim != 1:

--- a/tests/test_multisession_assignment_observation_costs_boolean_entries.py
+++ b/tests/test_multisession_assignment_observation_costs_boolean_entries.py
@@ -1,0 +1,33 @@
+"""Regression tests for boolean per-observation cost validation."""
+
+import unittest
+
+from pyrecest.backend import (  # pylint: disable=no-name-in-module
+    __backend_name__,
+    array,
+)
+from pyrecest.utils import solve_multisession_assignment_with_observation_costs
+
+
+@unittest.skipIf(
+    __backend_name__ == "jax",
+    reason="Not supported on this backend",
+)
+class TestObservationCostBooleanEntries(unittest.TestCase):
+    def test_rejects_boolean_observation_cost_entries(self):
+        invalid_cost_kwargs = (
+            {"start_costs": {0: True}},
+            {"end_costs": {1: array([True])}},
+        )
+
+        for cost_kwargs in invalid_cost_kwargs:
+            with self.subTest(cost_kwargs=cost_kwargs):
+                with self.assertRaisesRegex(ValueError, "not boolean"):
+                    solve_multisession_assignment_with_observation_costs(
+                        [array([[1.0]], dtype=float)],
+                        **cost_kwargs,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reject boolean scalar and vector entries passed through `start_costs`/`end_costs`
- add regression coverage for boolean per-observation costs

## Rationale
The observation-cost wrapper already rejects boolean scalar parameters such as `start_cost=True`, but per-observation entries were still cast through `dtype=float64`. This meant values like `start_costs={0: True}` or `end_costs={1: array([True])}` were silently interpreted as numeric costs. The new validation keeps per-observation cost entries consistent with the scalar cost path.

## Testing
- Not run locally; changes were made through the GitHub connector.