### PR TITLE
Validate spherical harmonics real outputs

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/spherical_harmonics_distribution_complex.py
+++ b/src/pyrecest/distributions/hypersphere_subset/spherical_harmonics_distribution_complex.py
@@ -71,9 +71,10 @@ class SphericalHarmonicsDistributionComplex(AbstractSphericalHarmonicsDistributi
                 vals += self.coeff_mat[n_curr, n_curr + m_curr] * y_lm
 
         if self.assert_real:
-            assert all(
-                abs(imag(vals)) < 5e-8
-            ), "Coefficients apparently do not represent a real function."
+            if not bool(all(abs(imag(vals)) < 5e-8)):
+                raise ValueError(
+                    "Coefficients apparently do not represent a real function."
+                )
             return real(vals)
 
         return vals

--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,

--- a/tests/distributions/test_spherical_harmonics_distribution_complex.py
+++ b/tests/distributions/test_spherical_harmonics_distribution_complex.py
@@ -68,6 +68,18 @@ class SphericalHarmonicsDistributionComplexTest(unittest.TestCase):
     def test_mormalization_error(self):
         self.assertRaises(ValueError, SphericalHarmonicsDistributionComplex, array(0.0))
 
+    def test_value_sph_rejects_complex_values_when_real_requested(self):
+        coeff_mat = array(
+            [
+                [1.0 / sqrt(4.0 * pi), float("NaN"), float("NaN")],
+                [1j, 0.0, 0.0],
+            ]
+        )
+        shd = SphericalHarmonicsDistributionComplex(coeff_mat)
+
+        with self.assertRaisesRegex(ValueError, "real function"):
+            shd.value_sph(array([0.0]), array([pi / 2.0]))
+
     def test_normalization(self):
         with self.assertWarns(Warning):
             shd = SphericalHarmonicsDistributionComplex(self.unnormalized_coeffs)


### PR DESCRIPTION
## Summary
- Replace the assertion-only real-valued spherical harmonics check with a runtime `ValueError`.
- Add a regression test using coefficients that would otherwise have their imaginary density component silently discarded under `python -O`.

## Tests
- `poetry run pytest tests/distributions/test_spherical_harmonics_distribution_complex.py::SphericalHarmonicsDistributionComplexTest::test_value_sph_rejects_complex_values_when_real_requested`
- `poetry run python -O -m pytest tests/distributions/test_spherical_harmonics_distribution_complex.py::SphericalHarmonicsDistributionComplexTest::test_value_sph_rejects_complex_values_when_real_requested`
- `poetry run ruff check src/pyrecest/distributions/hypersphere_subset/spherical_harmonics_distribution_complex.py tests/distributions/test_spherical_harmonics_distribution_complex.py`
- `git diff --check`