### PR TITLE
Validate Watson mixture posterior parameters

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/bayesian_complex_watson_mixture_model.py
+++ b/src/pyrecest/distributions/hypersphere_subset/bayesian_complex_watson_mixture_model.py
@@ -76,13 +76,16 @@ class BayesianComplexWatsonMixtureModel:
         alpha = asarray(alpha, dtype=float).ravel()
 
         K = alpha.shape[0]
-        assert B.shape[2] == K, "B.shape[2] must equal len(alpha)"
-        assert concentrations.shape[0] == K, "len(concentrations) must equal len(alpha)"
+        if B.ndim != 3 or B.shape[0] != B.shape[1]:
+            raise ValueError("B must have shape (D, D, K).")
+        if B.shape[2] != K:
+            raise ValueError("B.shape[2] must equal len(alpha).")
+        if concentrations.shape[0] != K:
+            raise ValueError("len(concentrations) must equal len(alpha).")
 
         for k in range(K):
-            assert allclose(
-                B[:, :, k], B[:, :, k].conj().T, atol=1e-6
-            ), f"B[:,:,{k}] must be Hermitian"
+            if not bool(allclose(B[:, :, k], B[:, :, k].conj().T, atol=1e-6)):
+                raise ValueError(f"B[:,:,{k}] must be Hermitian.")
 
         self.B = B
         self.concentrations = concentrations

--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,

--- a/tests/distributions/test_bayesian_complex_watson_mixture_model.py
+++ b/tests/distributions/test_bayesian_complex_watson_mixture_model.py
@@ -121,8 +121,26 @@ class TestBayesianComplexWatsonMixtureModelConstructor(unittest.TestCase):
     def test_non_hermitian_B_raises(self):
         D, K = 2, 1
         B = ones((D, D, K), dtype=complex) * (1 + 1j)
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(ValueError, "Hermitian"):
             BayesianComplexWatsonMixtureModel(B, array([1.0]), array([1.0]))
+
+    def test_constructor_rejects_invalid_B_shape(self):
+        B = zeros((2, 2), dtype=complex)
+
+        with self.assertRaisesRegex(ValueError, "shape"):
+            BayesianComplexWatsonMixtureModel(B, array([1.0]), array([1.0]))
+
+    def test_constructor_rejects_component_count_mismatch(self):
+        B = zeros((2, 2, 2), dtype=complex)
+
+        with self.assertRaisesRegex(ValueError, "B.shape"):
+            BayesianComplexWatsonMixtureModel(B, array([1.0]), array([1.0]))
+
+    def test_constructor_rejects_concentration_count_mismatch(self):
+        B = zeros((2, 2, 1), dtype=complex)
+
+        with self.assertRaisesRegex(ValueError, "concentrations"):
+            BayesianComplexWatsonMixtureModel(B, array([1.0, 2.0]), array([1.0]))
 
 
 class TestParametersDefault(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Replace assertion-only Bayesian complex Watson mixture constructor checks with runtime `ValueError`s.
- Reject malformed Bingham parameter tensor shapes, component count mismatches, concentration count mismatches, and non-Hermitian component matrices under optimized Python.
- Extend constructor validation tests for normal and optimized execution.

## Tests
- `poetry run pytest tests/distributions/test_bayesian_complex_watson_mixture_model.py::TestBayesianComplexWatsonMixtureModelConstructor`
- `poetry run python -O -m pytest tests/distributions/test_bayesian_complex_watson_mixture_model.py::TestBayesianComplexWatsonMixtureModelConstructor`
- `poetry run ruff check src/pyrecest/distributions/hypersphere_subset/bayesian_complex_watson_mixture_model.py tests/distributions/test_bayesian_complex_watson_mixture_model.py`
- `git diff --check`