### PR TITLE
Validate hyperspherical mode backend

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/abstract_hyperspherical_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/abstract_hyperspherical_distribution.py
@@ -216,9 +216,10 @@ class AbstractHypersphericalDistribution(AbstractHypersphereSubsetDistribution):
         return super().entropy_numerical()
 
     def mode_numerical(self):
-        assert (
-            pyrecest.backend.__backend_name__ != "jax"
-        ), "Not supported on this backend"
+        if pyrecest.backend.__backend_name__ == "jax":
+            raise NotImplementedError(
+                "mode_numerical is not supported on the JAX backend."
+            )
 
         def fun(s):
             return -self.pdf(

--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,

--- a/tests/distributions/test_abstract_hyperspherical_distribution.py
+++ b/tests/distributions/test_abstract_hyperspherical_distribution.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 import matplotlib
 import pyrecest.backend
@@ -97,6 +98,14 @@ class AbstractHypersphericalDistributionTest(unittest.TestCase):
         uniform_circle = HypersphericalUniformDistribution(1)
         with self.assertRaisesRegex(ValueError, "Mean direction is undefined"):
             uniform_circle.mean_direction_numerical()
+
+    def test_mode_numerical_rejects_jax_backend(self):
+        mu = array([1.0, 0.0, 0.0])
+        vmf = VonMisesFisherDistribution(mu, 1.0)
+
+        with patch.object(pyrecest.backend, "__backend_name__", "jax"):
+            with self.assertRaisesRegex(NotImplementedError, "JAX backend"):
+                vmf.mode_numerical()
 
     def test_plotting_error_free_1d(self):
         """Tests the plotting function for circular distributions."""


### PR DESCRIPTION
## Summary
- Replace the assertion-only JAX backend guard in `AbstractHypersphericalDistribution.mode_numerical()` with a runtime `NotImplementedError`.
- Add a regression test proving the guard remains active under optimized Python.

## Tests
- `poetry run pytest tests/distributions/test_abstract_hyperspherical_distribution.py::AbstractHypersphericalDistributionTest::test_mode_numerical_rejects_jax_backend`
- `poetry run python -O -m pytest tests/distributions/test_abstract_hyperspherical_distribution.py::AbstractHypersphericalDistributionTest::test_mode_numerical_rejects_jax_backend`
- `poetry run ruff check src/pyrecest/distributions/hypersphere_subset/abstract_hyperspherical_distribution.py tests/distributions/test_abstract_hyperspherical_distribution.py`
- `git diff --check`