### PR TITLE
Validate spherical harmonics multiplication

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/spherical_harmonics_distribution_complex.py
+++ b/src/pyrecest/distributions/hypersphere_subset/spherical_harmonics_distribution_complex.py
@@ -431,12 +431,12 @@ class SphericalHarmonicsDistributionComplex(AbstractSphericalHarmonicsDistributi
         For ``'sqrt'``: ``sqrt(p) * sqrt(q) = sqrt(p*q)`` which is the correct
         sqrt-transformed product density.
         """
-        assert isinstance(
-            other, SphericalHarmonicsDistributionComplex
-        ), "other must be a SphericalHarmonicsDistributionComplex"
-        assert (
-            self.transformation == other.transformation
-        ), "multiply: both distributions must use the same transformation"
+        if not isinstance(other, SphericalHarmonicsDistributionComplex):
+            raise TypeError("other must be a SphericalHarmonicsDistributionComplex")
+        if self.transformation != other.transformation:
+            raise ValueError(
+                "multiply: both distributions must use the same transformation"
+            )
 
         degree = self.coeff_mat.shape[0] - 1
 

--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,

--- a/tests/distributions/test_spherical_harmonics_complex_validation.py
+++ b/tests/distributions/test_spherical_harmonics_complex_validation.py
@@ -1,0 +1,33 @@
+import unittest
+
+import pyrecest.backend
+
+from pyrecest.backend import array, pi, sqrt
+from pyrecest.distributions.hypersphere_subset.spherical_harmonics_distribution_complex import (
+    SphericalHarmonicsDistributionComplex,
+)
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+    reason="Spherical harmonics distributions are not supported on JAX.",
+)
+class SphericalHarmonicsComplexValidationTest(unittest.TestCase):
+    def test_multiply_rejects_invalid_type(self):
+        dist = SphericalHarmonicsDistributionComplex(array([[1.0 / sqrt(4.0 * pi)]]))
+
+        with self.assertRaisesRegex(TypeError, "SphericalHarmonicsDistributionComplex"):
+            dist.multiply(object())
+
+    def test_multiply_rejects_mixed_transformations(self):
+        identity_dist = SphericalHarmonicsDistributionComplex(
+            array([[1.0 / sqrt(4.0 * pi)]]), "identity"
+        )
+        sqrt_dist = SphericalHarmonicsDistributionComplex(array([[1.0]]), "sqrt")
+
+        with self.assertRaisesRegex(ValueError, "same transformation"):
+            identity_dist.multiply(sqrt_dist)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Replace assertion-only `SphericalHarmonicsDistributionComplex.multiply()` input validation with runtime exceptions.
- Reject invalid operand types and mixed transformations before any grid fitting can produce an invalid product under `python -O`.
- Add optimized-mode regression coverage for both validation paths.

## Tests
- `poetry run pytest tests/distributions/test_spherical_harmonics_complex_validation.py`
- `poetry run python -O -m pytest tests/distributions/test_spherical_harmonics_complex_validation.py`
- `poetry run ruff check src/pyrecest/distributions/hypersphere_subset/spherical_harmonics_distribution_complex.py tests/distributions/test_spherical_harmonics_complex_validation.py`
- `git diff --check`