### PR TITLE
Validate spherical harmonics distribution input

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/spherical_harmonics_distribution_complex.py
+++ b/src/pyrecest/distributions/hypersphere_subset/spherical_harmonics_distribution_complex.py
@@ -135,9 +135,8 @@ class SphericalHarmonicsDistributionComplex(AbstractSphericalHarmonicsDistributi
 
     @staticmethod
     def from_distribution_via_integral(dist, degree, transformation="identity"):
-        assert (
-            isinstance(dist, AbstractHypersphericalDistribution) and dist.dim == 2
-        ), "dist must be a distribution on the sphere."
+        if not isinstance(dist, AbstractHypersphericalDistribution) or dist.dim != 2:
+            raise ValueError("dist must be a distribution on the sphere.")
         shd = SphericalHarmonicsDistributionComplex.from_function_via_integral_cart(
             dist.pdf, degree, transformation
         )

--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,

--- a/tests/distributions/test_spherical_harmonics_distribution_input_validation.py
+++ b/tests/distributions/test_spherical_harmonics_distribution_input_validation.py
@@ -1,0 +1,28 @@
+import unittest
+
+import pyrecest.backend
+
+from pyrecest.distributions.hypersphere_subset.hyperspherical_uniform_distribution import (
+    HypersphericalUniformDistribution,
+)
+from pyrecest.distributions.hypersphere_subset.spherical_harmonics_distribution_complex import (
+    SphericalHarmonicsDistributionComplex,
+)
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+    reason="Spherical harmonics distributions are not supported on JAX.",
+)
+class SphericalHarmonicsDistributionInputValidationTest(unittest.TestCase):
+    def test_from_distribution_via_integral_rejects_non_s2_distribution(self):
+        circle_dist = HypersphericalUniformDistribution(1)
+
+        with self.assertRaisesRegex(ValueError, "sphere"):
+            SphericalHarmonicsDistributionComplex.from_distribution_via_integral(
+                circle_dist, degree=0
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Replace assertion-only S2 distribution validation in `from_distribution_via_integral()` with a runtime `ValueError`.
- Add optimized-mode regression coverage for rejecting non-S2 hyperspherical distributions before integration.

## Tests
- `poetry run pytest tests/distributions/test_spherical_harmonics_distribution_input_validation.py`
- `poetry run python -O -m pytest tests/distributions/test_spherical_harmonics_distribution_input_validation.py`
- `poetry run ruff check src/pyrecest/distributions/hypersphere_subset/spherical_harmonics_distribution_complex.py tests/distributions/test_spherical_harmonics_distribution_input_validation.py`
- `git diff --check`