### PR TITLE
Validate deviation input sizes

### DIFF
--- a/src/pyrecest/evaluation/determine_all_deviations.py
+++ b/src/pyrecest/evaluation/determine_all_deviations.py
@@ -20,20 +20,25 @@ def determine_all_deviations(
     if mean_calculation_symm != "":
         raise NotImplementedError("Not implemented yet")
 
-    if groundtruths.ndim != 2 or groundtruths[0, 0].ndim not in (
+    if groundtruths.ndim != 2 or groundtruths.size == 0 or groundtruths[0, 0].ndim not in (
         1,
         2,
     ):
         raise ValueError(
-            "Assuming groundtruths to be a 2-D array of shape "
+            "Assuming groundtruths to be a non-empty 2-D array of shape "
             "(n_runs, n_timesteps) composed arrays of shape (n_dim,) or "
             "(n_targets,n_dim)."
         )
 
-    all_deviations_last_mat = empty((len(results), groundtruths.shape[0]))
+    n_runs = groundtruths.shape[0]
+    all_deviations_last_mat = empty((len(results), n_runs))
 
     for config_no, result_curr_config in enumerate(results):
-        for run in range(len(groundtruths)):
+        if len(result_curr_config) != n_runs:
+            raise ValueError(
+                "Each result configuration must contain one entry per groundtruth run."
+            )
+        for run in range(n_runs):
             if is_array(result_curr_config[run]):
                 # If estimates are already given as an array, use it
                 final_estimate = result_curr_config[run]

--- a/src/pyrecest/evaluation/determine_all_deviations.py
+++ b/src/pyrecest/evaluation/determine_all_deviations.py
@@ -6,6 +6,16 @@ from beartype.typing import Callable
 from pyrecest.backend import any, empty, is_array, isinf, sum
 
 
+def _shape_size(container):
+    shape = getattr(container, "shape", None)
+    if shape is None:
+        return len(container)
+    n_entries = 1
+    for dimension in shape:
+        n_entries *= int(dimension)
+    return n_entries
+
+
 @beartype
 def determine_all_deviations(
     results,
@@ -20,9 +30,10 @@ def determine_all_deviations(
     if mean_calculation_symm != "":
         raise NotImplementedError("Not implemented yet")
 
-    if groundtruths.ndim != 2 or groundtruths.size == 0 or groundtruths[0, 0].ndim not in (
-        1,
-        2,
+    if (
+        getattr(groundtruths, "ndim", None) != 2
+        or _shape_size(groundtruths) == 0
+        or groundtruths[0, 0].ndim not in (1, 2)
     ):
         raise ValueError(
             "Assuming groundtruths to be a non-empty 2-D array of shape "

--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,

--- a/tests/evaluation/test_determine_all_deviations_validation.py
+++ b/tests/evaluation/test_determine_all_deviations_validation.py
@@ -1,0 +1,38 @@
+import numpy as np
+import pytest
+
+import pyrecest.backend
+from pyrecest.evaluation.determine_all_deviations import determine_all_deviations
+
+
+pytestmark = pytest.mark.skipif(
+    pyrecest.backend.__backend_name__ == "jax",
+    reason="determine_all_deviations is not supported on the JAX backend",
+)
+
+
+def test_determine_all_deviations_rejects_empty_groundtruths():
+    groundtruths = np.empty((0, 0), dtype=object)
+
+    with pytest.raises(ValueError, match="non-empty"):
+        determine_all_deviations(
+            [],
+            None,
+            lambda estimate, truth: 0.0,
+            groundtruths,
+        )
+
+
+def test_determine_all_deviations_rejects_mismatched_result_run_count():
+    groundtruths = np.empty((2, 1), dtype=object)
+    groundtruths[0, 0] = np.asarray([0.0])
+    groundtruths[1, 0] = np.asarray([1.0])
+    results = [[np.asarray([0.0])]]
+
+    with pytest.raises(ValueError, match="one entry per groundtruth run"):
+        determine_all_deviations(
+            results,
+            None,
+            lambda estimate, truth: float(np.linalg.norm(estimate - truth)),
+            groundtruths,
+        )


### PR DESCRIPTION
## Summary
- Reject empty groundtruth arrays before validation indexing.
- Reject result configurations whose run count does not match the groundtruth run count.
- Add regression tests for both cases.

## Testing
Not run locally; changes were made through the GitHub connector.