### PR TITLE
Validate spherical harmonics backend support

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/spherical_harmonics_distribution_complex.py
+++ b/src/pyrecest/distributions/hypersphere_subset/spherical_harmonics_distribution_complex.py
@@ -44,9 +44,10 @@ from .abstract_spherical_harmonics_distribution import (
 
 class SphericalHarmonicsDistributionComplex(AbstractSphericalHarmonicsDistribution):
     def __init__(self, coeff_mat, transformation="identity", assert_real=True):
-        assert (
-            pyrecest.backend.__backend_name__ != "jax"  # pylint: disable=no-member
-        ), "SphericalHarmonicsDistributionComplex is not supported on the JAX backend"
+        if pyrecest.backend.__backend_name__ == "jax":  # pylint: disable=no-member
+            raise NotImplementedError(
+                "SphericalHarmonicsDistributionComplex is not supported on the JAX backend."
+            )
         AbstractSphericalHarmonicsDistribution.__init__(self, coeff_mat, transformation)
         self.assert_real = assert_real
 
@@ -296,9 +297,8 @@ class SphericalHarmonicsDistributionComplex(AbstractSphericalHarmonicsDistributi
             ``pysh.SHGrid.from_array`` requires plain numpy arrays, so this
             method is only supported on the ``"numpy"`` backend.
         """
-        assert (
-            pyrecest.backend.__backend_name__ == "numpy"  # pylint: disable=no-member
-        ), "pysh.SHGrid.from_array requires the numpy backend"
+        if pyrecest.backend.__backend_name__ != "numpy":  # pylint: disable=no-member
+            raise NotImplementedError("pysh.SHGrid.from_array requires the numpy backend.")
         import numpy as _np  # noqa: PLC0415
         import pyshtools as pysh  # pylint: disable=import-error
 
@@ -370,6 +370,13 @@ class SphericalHarmonicsDistributionComplex(AbstractSphericalHarmonicsDistributi
             return result
 
         if self.transformation == "sqrt" and other.transformation == "sqrt":
+            if (
+                pyrecest.backend.__backend_name__ != "numpy"
+            ):  # pylint: disable=no-member
+                raise NotImplementedError(
+                    "sqrt convolution requires the numpy backend."
+                )
+
             # Use a grid twice as fine to avoid aliasing when squaring.
             degree_fine = 2 * degree
 
@@ -384,11 +391,6 @@ class SphericalHarmonicsDistributionComplex(AbstractSphericalHarmonicsDistributi
 
             import numpy as _np  # noqa: PLC0415
             import pyshtools as pysh  # pylint: disable=import-error
-
-            assert (
-                pyrecest.backend.__backend_name__
-                == "numpy"  # pylint: disable=no-member
-            ), "pysh.SHGrid.from_array requires the numpy backend"
 
             def _grid_to_coeff(grid_vals):
                 grid_vals_np = _np.asarray(grid_vals)

--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,

--- a/tests/distributions/test_spherical_harmonics_backend_validation.py
+++ b/tests/distributions/test_spherical_harmonics_backend_validation.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import patch
 
+import numpy as np
 import pyrecest.backend
 
 from pyrecest.backend import array
@@ -23,7 +24,11 @@ class SphericalHarmonicsBackendValidationTest(unittest.TestCase):
                 )
 
     def test_sqrt_convolve_rejects_non_numpy_backend(self):
-        dist = SphericalHarmonicsDistributionComplex(array([[1.0]]), "sqrt")
+        dist = SphericalHarmonicsDistributionComplex.__new__(
+            SphericalHarmonicsDistributionComplex
+        )
+        dist.coeff_mat = np.array([[1.0]])
+        dist.transformation = "sqrt"
 
         with patch.object(pyrecest.backend, "__backend_name__", "pytorch"):
             with self.assertRaisesRegex(NotImplementedError, "numpy backend"):

--- a/tests/distributions/test_spherical_harmonics_backend_validation.py
+++ b/tests/distributions/test_spherical_harmonics_backend_validation.py
@@ -1,0 +1,34 @@
+import unittest
+from unittest.mock import patch
+
+import pyrecest.backend
+
+from pyrecest.backend import array
+from pyrecest.distributions.hypersphere_subset.spherical_harmonics_distribution_complex import (
+    SphericalHarmonicsDistributionComplex,
+)
+
+
+class SphericalHarmonicsBackendValidationTest(unittest.TestCase):
+    def test_constructor_rejects_jax_backend(self):
+        with patch.object(pyrecest.backend, "__backend_name__", "jax"):
+            with self.assertRaisesRegex(NotImplementedError, "JAX backend"):
+                SphericalHarmonicsDistributionComplex(array([[1.0]]))
+
+    def test_fit_from_grid_rejects_non_numpy_backend(self):
+        with patch.object(pyrecest.backend, "__backend_name__", "pytorch"):
+            with self.assertRaisesRegex(NotImplementedError, "numpy backend"):
+                SphericalHarmonicsDistributionComplex._fit_from_grid(
+                    array([[1.0]]), degree=0, transformation="sqrt"
+                )
+
+    def test_sqrt_convolve_rejects_non_numpy_backend(self):
+        dist = SphericalHarmonicsDistributionComplex(array([[1.0]]), "sqrt")
+
+        with patch.object(pyrecest.backend, "__backend_name__", "pytorch"):
+            with self.assertRaisesRegex(NotImplementedError, "numpy backend"):
+                dist.convolve(dist)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Replace assertion-only backend guards in complex spherical harmonics construction, grid fitting, and sqrt convolution with runtime `NotImplementedError`s.
- Move the sqrt-convolution NumPy backend check before expensive pyshtools work.
- Add optimized-mode regression coverage for all guarded backend paths.

## Tests
- `poetry run pytest tests/distributions/test_spherical_harmonics_backend_validation.py`
- `poetry run python -O -m pytest tests/distributions/test_spherical_harmonics_backend_validation.py`
- `poetry run ruff check src/pyrecest/distributions/hypersphere_subset/spherical_harmonics_distribution_complex.py tests/distributions/test_spherical_harmonics_backend_validation.py`
- `git diff --check`