### PR TITLE
Validate Watson mixture fit parameters

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/bayesian_complex_watson_mixture_model.py
+++ b/src/pyrecest/distributions/hypersphere_subset/bayesian_complex_watson_mixture_model.py
@@ -13,6 +13,8 @@ Reference:
     https://github.com/libDirectional/libDirectional
 """
 
+from collections.abc import Mapping
+
 import pyrecest.backend
 from pyrecest.backend import (  # pylint: disable=no-name-in-module,no-member
     allclose,
@@ -181,21 +183,37 @@ class BayesianComplexWatsonMixtureModel:
         Returns:
             dict: Posterior with keys ``B``, ``kappa``, ``alpha``, ``gamma``.
         """
-        uniform_component = parameters.get("uniformComponent", False)
-
         if pyrecest.backend.__backend_name__ == "jax":  # pylint: disable=no-member
             raise NotImplementedError(
                 "estimate_posterior is not supported on the JAX backend."
             )
 
-        assert "initial" in parameters
-        assert "B" in parameters["initial"]
-        assert "alpha" in parameters["initial"]
-        assert "kappa" in parameters["initial"]
-        assert "prior" in parameters
-        assert "B" in parameters["prior"]
-        assert "alpha" in parameters["prior"]
-        assert "I" in parameters
+        if not isinstance(parameters, Mapping):
+            raise TypeError("parameters must be a mapping.")
+
+        missing_paths = []
+        for path in (
+            ("initial",),
+            ("initial", "B"),
+            ("initial", "alpha"),
+            ("initial", "kappa"),
+            ("prior",),
+            ("prior", "B"),
+            ("prior", "alpha"),
+            ("I",),
+        ):
+            current = parameters
+            for key in path:
+                if not isinstance(current, Mapping) or key not in current:
+                    missing_paths.append(".".join(path))
+                    break
+                current = current[key]
+        if missing_paths:
+            raise ValueError(
+                "parameters missing required entries: " + ", ".join(missing_paths)
+            )
+
+        uniform_component = parameters.get("uniformComponent", False)
 
         Z = asarray(Z, dtype=complex)
         D, N = Z.shape
@@ -203,9 +221,10 @@ class BayesianComplexWatsonMixtureModel:
 
         B_init = asarray(parameters["initial"]["B"], dtype=complex)
         for k in range(K):
-            assert allclose(
-                B_init[:, :, k], B_init[:, :, k].conj().T, atol=1e-6
-            ), "initial B must be Hermitian"
+            if not bool(
+                allclose(B_init[:, :, k], B_init[:, :, k].conj().T, atol=1e-6)
+            ):
+                raise ValueError("initial B must be Hermitian.")
 
         kappa_init = parameters["initial"]["kappa"]
         if asarray(kappa_init).ndim == 0:
@@ -230,7 +249,10 @@ class BayesianComplexWatsonMixtureModel:
             ln_saliencies = full((N, K), log(max(float(saliencies_arr), 1e-7)))
         else:
             saliencies_vec = saliencies_arr.ravel()
-            assert len(saliencies_vec) == N
+            if len(saliencies_vec) != N:
+                raise ValueError(
+                    "prior saliencies must contain one entry per observation."
+                )
             ln_saliencies = log(maximum(saliencies_vec, 1e-7))[:, None] * ones((N, K))
 
         prior_B = asarray(parameters["prior"]["B"], dtype=complex)
@@ -259,7 +281,8 @@ class BayesianComplexWatsonMixtureModel:
             gamma = exp(log_gamma)
             gamma /= gamma.sum(axis=1, keepdims=True)
 
-            assert not any(isnan(gamma)), "NaN in gamma during E-step"
+            if bool(any(isnan(gamma))):
+                raise FloatingPointError("NaN in gamma during E-step.")
             posterior["gamma"] = gamma
 
             # M-step

--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,

--- a/tests/distributions/test_bayesian_complex_watson_mixture_validation.py
+++ b/tests/distributions/test_bayesian_complex_watson_mixture_validation.py
@@ -1,0 +1,49 @@
+import unittest
+
+import pyrecest.backend
+
+from pyrecest.backend import array, ones
+from pyrecest.distributions.hypersphere_subset.bayesian_complex_watson_mixture_model import (
+    BayesianComplexWatsonMixtureModel,
+)
+
+
+def _observations():
+    return array([[1.0 + 0.0j], [0.0 + 0.0j]])
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+    reason="Bayesian complex Watson fitting is not supported on JAX.",
+)
+class BayesianComplexWatsonMixtureValidationTest(unittest.TestCase):
+    def test_estimate_posterior_requires_parameter_schema(self):
+        params = BayesianComplexWatsonMixtureModel.parameters_default(2, 1)
+        del params["prior"]["alpha"]
+
+        with self.assertRaisesRegex(ValueError, "prior.alpha"):
+            BayesianComplexWatsonMixtureModel.estimate_posterior(
+                _observations(), params
+            )
+
+    def test_estimate_posterior_rejects_non_hermitian_initial_B(self):
+        params = BayesianComplexWatsonMixtureModel.parameters_default(2, 1)
+        params["initial"]["B"] = ones((2, 2, 1), dtype=complex) * (1.0 + 1.0j)
+
+        with self.assertRaisesRegex(ValueError, "Hermitian"):
+            BayesianComplexWatsonMixtureModel.estimate_posterior(
+                _observations(), params
+            )
+
+    def test_estimate_posterior_rejects_saliencies_length_mismatch(self):
+        params = BayesianComplexWatsonMixtureModel.parameters_default(2, 1)
+        params["prior"]["saliencies"] = array([1.0, 1.0])
+
+        with self.assertRaisesRegex(ValueError, "saliencies"):
+            BayesianComplexWatsonMixtureModel.estimate_posterior(
+                _observations(), params
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Replace assertion-only Bayesian complex Watson fit parameter checks with runtime errors.
- Validate required parameter schema, Hermitian initial B matrices, saliency length, and NaN assignments under optimized Python.
- Add focused regression coverage for schema, Hermitian, and saliency validation.

## Tests
- `poetry run pytest tests/distributions/test_bayesian_complex_watson_mixture_validation.py`
- `poetry run python -O -m pytest tests/distributions/test_bayesian_complex_watson_mixture_validation.py`
- `poetry run ruff check src/pyrecest/distributions/hypersphere_subset/bayesian_complex_watson_mixture_model.py tests/distributions/test_bayesian_complex_watson_mixture_validation.py`
- `git diff --check`