### PR TITLE
Validate Watson default feature dimension

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/bayesian_complex_watson_mixture_model.py
+++ b/src/pyrecest/distributions/hypersphere_subset/bayesian_complex_watson_mixture_model.py
@@ -128,9 +128,10 @@ class BayesianComplexWatsonMixtureModel:
         Returns:
             tuple: (BayesianComplexWatsonMixtureModel, posterior dict)
         """
-        assert (
-            Z.shape[0] < 100
-        ), "fit_default assumes D < 100 (feature dimension, not sample count)"
+        if Z.shape[0] >= 100:
+            raise ValueError(
+                "fit_default assumes D < 100 (feature dimension, not sample count)."
+            )
         D = Z.shape[0]
         parameters = BayesianComplexWatsonMixtureModel.parameters_default(D, K)
         return BayesianComplexWatsonMixtureModel.fit(Z, parameters)

--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,

--- a/tests/distributions/test_bayesian_complex_watson_default_validation.py
+++ b/tests/distributions/test_bayesian_complex_watson_default_validation.py
@@ -1,0 +1,24 @@
+import unittest
+
+import pyrecest.backend
+
+from pyrecest.backend import zeros
+from pyrecest.distributions.hypersphere_subset.bayesian_complex_watson_mixture_model import (
+    BayesianComplexWatsonMixtureModel,
+)
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+    reason="Bayesian complex Watson fitting is not supported on JAX.",
+)
+class BayesianComplexWatsonDefaultValidationTest(unittest.TestCase):
+    def test_fit_default_rejects_feature_dimension_limit(self):
+        Z = zeros((100, 1), dtype=complex)
+
+        with self.assertRaisesRegex(ValueError, "D < 100"):
+            BayesianComplexWatsonMixtureModel.fit_default(Z, K=1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Replace the assertion-only `fit_default()` feature-dimension limit with a runtime `ValueError`.
- Add optimized-mode regression coverage so the D < 100 guard is not removed by `python -O`.

## Tests
- `poetry run pytest tests/distributions/test_bayesian_complex_watson_default_validation.py`
- `poetry run python -O -m pytest tests/distributions/test_bayesian_complex_watson_default_validation.py`
- `poetry run ruff check src/pyrecest/distributions/hypersphere_subset/bayesian_complex_watson_mixture_model.py tests/distributions/test_bayesian_complex_watson_default_validation.py`
- `git diff --check`