### PR TITLE
Validate spherical harmonics convolution input

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/spherical_harmonics_distribution_complex.py
+++ b/src/pyrecest/distributions/hypersphere_subset/spherical_harmonics_distribution_complex.py
@@ -350,9 +350,8 @@ class SphericalHarmonicsDistributionComplex(AbstractSphericalHarmonicsDistributi
         transformation a grid-based approach with a 2× finer intermediate grid
         is used so that squaring the sqrt functions introduces no aliasing.
         """
-        assert isinstance(
-            other, SphericalHarmonicsDistributionComplex
-        ), "other must be a SphericalHarmonicsDistributionComplex"
+        if not isinstance(other, SphericalHarmonicsDistributionComplex):
+            raise TypeError("other must be a SphericalHarmonicsDistributionComplex")
 
         degree = self.coeff_mat.shape[0] - 1
 

--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,

--- a/tests/distributions/test_spherical_harmonics_convolution_validation.py
+++ b/tests/distributions/test_spherical_harmonics_convolution_validation.py
@@ -1,0 +1,24 @@
+import unittest
+
+import pyrecest.backend
+
+from pyrecest.backend import array, pi, sqrt
+from pyrecest.distributions.hypersphere_subset.spherical_harmonics_distribution_complex import (
+    SphericalHarmonicsDistributionComplex,
+)
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+    reason="Spherical harmonics distributions are not supported on JAX.",
+)
+class SphericalHarmonicsConvolutionValidationTest(unittest.TestCase):
+    def test_convolve_rejects_invalid_type(self):
+        dist = SphericalHarmonicsDistributionComplex(array([[1.0 / sqrt(4.0 * pi)]]))
+
+        with self.assertRaisesRegex(TypeError, "SphericalHarmonicsDistributionComplex"):
+            dist.convolve(object())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Replace assertion-only `SphericalHarmonicsDistributionComplex.convolve()` operand validation with a runtime `TypeError`.
- Add optimized-mode regression coverage so invalid operands are rejected before entering convolution logic.

## Tests
- `poetry run pytest tests/distributions/test_spherical_harmonics_convolution_validation.py`
- `poetry run python -O -m pytest tests/distributions/test_spherical_harmonics_convolution_validation.py`
- `poetry run ruff check src/pyrecest/distributions/hypersphere_subset/spherical_harmonics_distribution_complex.py tests/distributions/test_spherical_harmonics_convolution_validation.py`
- `git diff --check`