### PR TITLE
Validate history recorder boolean flags

### DIFF
--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,

--- a/src/pyrecest/utils/history_recorder.py
+++ b/src/pyrecest/utils/history_recorder.py
@@ -22,7 +22,10 @@ class _HistoryEntry:
 def _validate_bool_flag(value: Any, name: str) -> bool:
     if isinstance(value, bool):
         return value
-    value_array = asarray(value)
+    try:
+        value_array = asarray(value)
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise TypeError(f"{name} must be a boolean") from exc
     if getattr(value_array, "shape", None) == ():
         scalar = value_array.item()
         if isinstance(scalar, bool):

--- a/src/pyrecest/utils/history_recorder.py
+++ b/src/pyrecest/utils/history_recorder.py
@@ -19,6 +19,17 @@ class _HistoryEntry:
     pad_with_nan: bool
 
 
+def _validate_bool_flag(value: Any, name: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    value_array = asarray(value)
+    if getattr(value_array, "shape", None) == ():
+        scalar = value_array.item()
+        if isinstance(scalar, bool):
+            return bool(scalar)
+    raise TypeError(f"{name} must be a boolean")
+
+
 class HistoryRecorder:
     """Record and retrieve named histories.
 
@@ -35,6 +46,7 @@ class HistoryRecorder:
 
     def register(self, name: str, initial_value=None, pad_with_nan: bool = False):
         """Register a named history and return its storage object."""
+        pad_with_nan = _validate_bool_flag(pad_with_nan, "pad_with_nan")
         if name in self._entries:
             raise ValueError(f"History '{name}' is already registered.")
 
@@ -56,8 +68,12 @@ class HistoryRecorder:
         copy_value: bool = True,
     ):
         """Append a value to the named history and return the updated history."""
+        copy_value = _validate_bool_flag(copy_value, "copy_value")
+        if pad_with_nan is not None:
+            pad_with_nan = _validate_bool_flag(pad_with_nan, "pad_with_nan")
+
         if name not in self._entries:
-            self.register(name, pad_with_nan=bool(pad_with_nan))
+            self.register(name, pad_with_nan=False if pad_with_nan is None else pad_with_nan)
 
         entry = self._entries[name]
         if pad_with_nan is not None and entry.pad_with_nan != pad_with_nan:

--- a/tests/test_history_recorder.py
+++ b/tests/test_history_recorder.py
@@ -90,6 +90,31 @@ class HistoryRecorderTest(unittest.TestCase):
 
         self.assertEqual(recorder["state"][0], {"x": [1, 2]})
 
+    def test_register_and_record_reject_nonboolean_pad_with_nan_flags(self):
+        recorder = HistoryRecorder()
+
+        with self.assertRaisesRegex(TypeError, "pad_with_nan"):
+            recorder.register("bad_register", pad_with_nan="False")
+
+        with self.assertRaisesRegex(TypeError, "pad_with_nan"):
+            recorder.record("bad_record", [1.0], pad_with_nan="False")
+
+    def test_record_rejects_nonboolean_copy_value_flag(self):
+        recorder = HistoryRecorder()
+        recorder.register("events")
+
+        with self.assertRaisesRegex(TypeError, "copy_value"):
+            recorder.record("events", {"value": 1}, copy_value="False")
+
+    def test_backend_boolean_scalar_flags_remain_accepted(self):
+        recorder = HistoryRecorder()
+        flag = array(True)
+
+        recorder.register("states", pad_with_nan=flag)
+        history = recorder.record("states", [1.0], pad_with_nan=flag)
+
+        self.assertEqual(tuple(history.shape), (1, 1))
+
     def test_filter_helpers_record_state_and_point_estimate(self):
         filter_obj = _DummyFilter(_DummyBelief([1.0, 2.0]))
         filter_obj.record_filter_state()


### PR DESCRIPTION
## Summary
- Add strict boolean validation for `HistoryRecorder.register(..., pad_with_nan=...)`.
- Validate `HistoryRecorder.record(..., pad_with_nan=..., copy_value=...)` instead of relying on Python truthiness.
- Add regression coverage for string flags such as `"False"` and backend boolean scalar flags.

## Bug
`HistoryRecorder` previously coerced `pad_with_nan` with `bool(...)` when implicitly registering a history from `record()`, and accepted arbitrary truthy values in `register()`. As a result, `pad_with_nan="False"` was silently treated as `True`, changing a list-backed history into a padded numeric history. `copy_value="False"` was similarly treated as truthy rather than rejected.

## Tests
- Added focused regressions in `tests/test_history_recorder.py`.
- Not run locally; changes were applied through the GitHub connector.