### PR TITLE
Parse evidence support boolean metadata

### DIFF
--- a/src/pyrecest/diagnostics.py
+++ b/src/pyrecest/diagnostics.py
@@ -23,6 +23,26 @@ EvidenceSupportType = Literal[
 _EVIDENCE_SUPPORT_TYPES = set(EvidenceSupportType.__args__)
 
 
+def _coerce_metadata_bool(value: Any, name: str) -> bool:
+    """Return a boolean metadata value without string truthiness surprises."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int) and value in (0, 1):
+        return bool(value)
+    if hasattr(value, "item"):
+        try:
+            return _coerce_metadata_bool(value.item(), name)
+        except (AttributeError, TypeError, ValueError):
+            pass
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes"}:
+            return True
+        if normalized in {"false", "0", "no", ""}:
+            return False
+    raise ValueError(f"{name} must be a boolean value")
+
+
 def _coerce_weight_values(weights: Any) -> list[float]:
     """Return backend-independent Python floats from an array-like weight vector."""
     try:
@@ -213,6 +233,12 @@ class EvidenceSupport:
                 f"unsupported evidence support type {self.support_type!r}; "
                 f"expected one of {sorted(_EVIDENCE_SUPPORT_TYPES)}"
             )
+        object.__setattr__(
+            self, "comparable", _coerce_metadata_bool(self.comparable, "comparable")
+        )
+        object.__setattr__(
+            self, "lower_bound", _coerce_metadata_bool(self.lower_bound, "lower_bound")
+        )
         if not isinstance(self.diagnostics, dict):
             object.__setattr__(self, "diagnostics", dict(self.diagnostics))
         if self.support_type == "truncated_lower_bound" and not self.lower_bound:
@@ -261,8 +287,8 @@ class EvidenceSupport:
         )
         return cls(
             support_type=mapping.get("support_type", "unknown"),
-            comparable=bool(mapping.get("comparable", False)),
-            lower_bound=bool(mapping.get("lower_bound", False)),
+            comparable=mapping.get("comparable", False),
+            lower_bound=mapping.get("lower_bound", False),
             diagnostics=diagnostics,
         )
 

--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,

--- a/tests/test_evidence_support.py
+++ b/tests/test_evidence_support.py
@@ -43,6 +43,30 @@ def test_evidence_support_from_mapping_preserves_unknown_fields_as_diagnostics()
     assert support.diagnostics["support_size"] == 17
 
 
+def test_evidence_support_from_mapping_parses_serialized_boolean_strings() -> None:
+    support = EvidenceSupport.from_mapping(
+        {
+            "support_type": "exact_sparse",
+            "comparable": "False",
+            "lower_bound": "False",
+        }
+    )
+
+    assert not support.comparable
+    assert not support.lower_bound
+    assert not support.headline_comparable
+
+
+def test_evidence_support_rejects_invalid_serialized_boolean_strings() -> None:
+    with pytest.raises(ValueError, match="comparable"):
+        EvidenceSupport.from_mapping(
+            {
+                "support_type": "exact_sparse",
+                "comparable": "sometimes",
+            }
+        )
+
+
 def test_coerce_evidence_support_rejects_unknown_support_type() -> None:
     with pytest.raises(ValueError, match="unsupported evidence support type"):
         coerce_evidence_support("candidate_magic")


### PR DESCRIPTION
## Summary
- Parse serialized `EvidenceSupport` boolean metadata explicitly instead of using Python truthiness.
- Prevent strings like `"False"` from marking evidence as comparable or lower-bound incorrectly.
- Reject invalid boolean strings so corrupted metadata does not silently affect evidence rankings.

## Tests
- `poetry run pytest tests/test_evidence_support.py`
- `poetry run python -O -m pytest tests/test_evidence_support.py`
- `poetry run ruff check src/pyrecest/diagnostics.py tests/test_evidence_support.py`
- `git diff --check`