### PR TITLE
Validate source-specific scalar lookup values

### DIFF
--- a/src/pyrecest/filters/linear_update_planning.py
+++ b/src/pyrecest/filters/linear_update_planning.py
@@ -367,7 +367,7 @@ def source_float_value(
 
     if values_by_source and str(measurement.source) in values_by_source:
         value = values_by_source[str(measurement.source)]
-        return None if value is None else float(value)
+        return None if value is None else _as_finite_scalar(value, "source value")
     return default
 
 

--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,

--- a/tests/filters/test_linear_update_planning_values.py
+++ b/tests/filters/test_linear_update_planning_values.py
@@ -1,0 +1,13 @@
+import numpy as np
+import pytest
+from pyrecest.filters import linear_update_planning as lup
+
+
+class Measurement:
+    source = "s"
+    vector = np.array([0.0])
+
+
+def test_lookup_rejects_bool_scalar_value():
+    with pytest.raises(ValueError, match="finite scalar"):
+        lup.source_float_value(Measurement(), {"s": True}, default=0.0)


### PR DESCRIPTION
## Summary
- Route configured `source_float_value` entries through the existing finite-scalar validator instead of raw `float(...)` coercion.
- Prevent boolean source-specific values from being silently accepted as numeric scalars.
- Add focused regression coverage for the boolean case.

## Testing
- Added `tests/filters/test_linear_update_planning_values.py`.

Note: I did not run tests locally because repository access here is through the GitHub connector.