### PR TITLE
Parse out-of-sequence accepted diagnostics

### DIFF
--- a/src/pyrecest/filters/out_of_sequence.py
+++ b/src/pyrecest/filters/out_of_sequence.py
@@ -35,6 +35,48 @@ def _coerce_time(time):
     return time
 
 
+def _coerce_diagnostic_accepted(value):
+    if value is None:
+        return False
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "t", "yes", "y"}:
+            return True
+        if normalized in {"0", "false", "f", "no", "n"}:
+            return False
+        raise ValueError("accepted diagnostic must be a boolean-like value")
+
+    try:
+        value_array = asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("accepted diagnostic must be a boolean-like value") from exc
+    if len(value_array.shape) != 0:
+        raise ValueError("accepted diagnostic must be a scalar boolean-like value")
+
+    scalar = value_array.item()
+    if isinstance(scalar, bool):
+        return scalar
+    try:
+        parsed = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("accepted diagnostic must be a boolean-like value") from exc
+    if not isfinite(parsed):
+        raise ValueError("accepted diagnostic must be finite")
+    if parsed == 0.0:
+        return False
+    if parsed == 1.0:
+        return True
+    raise ValueError("accepted diagnostic must be a boolean-like value")
+
+
+def _diagnostics_accepted(diagnostics):
+    if diagnostics is None:
+        return True
+    return _coerce_diagnostic_accepted(diagnostics.get("accepted", True))
+
+
 @dataclass(frozen=True)
 class TimestampedItem:
     """A value stored with an ordered scalar timestamp."""
@@ -317,9 +359,7 @@ class _EventReplayMixin:
 
         self._trim_to_lag()
         diagnostics = captured_result if hasattr(captured_result, "get") else None
-        accepted = (
-            True if diagnostics is None else bool(diagnostics.get("accepted", True))
-        )
+        accepted = _diagnostics_accepted(diagnostics)
         return OutOfSequenceResult(
             time=event_time,
             final_time=self._latest_time,

--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,

--- a/tests/filters/test_out_of_sequence.py
+++ b/tests/filters/test_out_of_sequence.py
@@ -16,6 +16,15 @@ from pyrecest.filters import (
 )
 
 
+class _DiagnosticsOnlyParticleFilter:
+    def __init__(self):
+        self.filter_state = {"updates": 0}
+
+    def update_nonlinear_using_likelihood(self, likelihood, measurement=None):
+        self.filter_state = {"updates": self.filter_state["updates"] + 1}
+        return likelihood(measurement, None)
+
+
 class OutOfSequenceMeasurementTest(unittest.TestCase):
     def test_fixed_lag_buffer_orders_and_trims(self):
         buffer = FixedLagBuffer(max_lag=1.0)
@@ -140,6 +149,31 @@ class OutOfSequenceMeasurementTest(unittest.TestCase):
         self.assertTrue(result.out_of_sequence)
         self.assertTrue(allclose(delayed.filter_state.d, chronological.filter_state.d))
         self.assertTrue(allclose(delayed.filter_state.w, chronological.filter_state.w))
+
+    def test_result_parses_serialized_accepted_diagnostics(self):
+        updater = OutOfSequenceParticleUpdater(
+            _DiagnosticsOnlyParticleFilter(),
+            initial_time=0.0,
+        )
+
+        result = updater.update_nonlinear_using_likelihood(
+            1.0,
+            lambda _measurement, _particles: {"accepted": "False"},
+        )
+
+        self.assertFalse(result.accepted)
+
+    def test_result_rejects_invalid_accepted_diagnostics(self):
+        updater = OutOfSequenceParticleUpdater(
+            _DiagnosticsOnlyParticleFilter(),
+            initial_time=0.0,
+        )
+
+        with self.assertRaisesRegex(ValueError, "accepted diagnostic"):
+            updater.update_nonlinear_using_likelihood(
+                1.0,
+                lambda _measurement, _particles: {"accepted": "maybe"},
+            )
 
     @staticmethod
     def _particle_filter():


### PR DESCRIPTION
## Summary

- Parse out-of-sequence replay `accepted` diagnostics as boolean-like values instead of using raw truthiness.
- Preserve missing diagnostics as accepted, but reject invalid non-boolean accepted values.
- Add regression coverage for serialized `"False"` diagnostics and invalid strings.

## Why

The replay result previously used `bool(diagnostics.get("accepted", True))`, so serialized values such as `"False"` or `"0"` were reported as accepted. That can misrepresent rejected updates in out-of-sequence processing.

## Validation

- `poetry run pytest tests/filters/test_out_of_sequence.py`
- `poetry run python -O -m pytest tests/filters/test_out_of_sequence.py`
- `poetry run ruff check src/pyrecest/filters/out_of_sequence.py tests/filters/test_out_of_sequence.py`
- `git diff --check`