### PR TITLE
Validate association accepted flags

### DIFF
--- a/src/pyrecest/filters/association_hypotheses.py
+++ b/src/pyrecest/filters/association_hypotheses.py
@@ -68,6 +68,12 @@ def validate_association_backend(*, strict: bool = False) -> dict[str, str]:
     return support
 
 
+def _coerce_bool_flag(value: Any, name: str) -> bool:
+    if isinstance(value, (bool, np.bool_)):
+        return bool(value)
+    raise ValueError(f"{name} must be a boolean")
+
+
 @dataclass(frozen=True)
 class AssociationHypothesis:
     """Pairwise association score between one track and one measurement.
@@ -91,6 +97,13 @@ class AssociationHypothesis:
     reason: str | None = None
     metadata: dict[str, Any] | None = None
 
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "accepted",
+            _coerce_bool_flag(self.accepted, "accepted"),
+        )
+
     @property
     def is_missed_detection(self) -> bool:
         """Return whether the hypothesis represents an unmatched track."""
@@ -98,7 +111,11 @@ class AssociationHypothesis:
 
     def with_acceptance(self, accepted: bool, reason: str | None = None):
         """Return a copy with updated gate acceptance metadata."""
-        return replace(self, accepted=bool(accepted), reason=reason)
+        return replace(
+            self,
+            accepted=_coerce_bool_flag(accepted, "accepted"),
+            reason=reason,
+        )
 
 
 def _nonnegative_index(value: Any, name: str) -> int:
@@ -413,8 +430,9 @@ def gate_hypotheses(
         if not hypothesis.accepted:
             result.append(hypothesis)
             continue
-        accepted = bool(
-            gate(hypothesis) if callable(gate) else gate.accepts(hypothesis)
+        accepted = _coerce_bool_flag(
+            gate(hypothesis) if callable(gate) else gate.accepts(hypothesis),
+            "gate result",
         )
         reason = None if accepted else reject_reason or type(gate).__name__
         result.append(hypothesis.with_acceptance(accepted, reason))

--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,

--- a/tests/filters/test_association_hypotheses.py
+++ b/tests/filters/test_association_hypotheses.py
@@ -135,6 +135,24 @@ class AssociationHypothesesTest(unittest.TestCase):
         hypothesis = AssociationHypothesis(0, 0, probability=0.0)
         self.assertTrue(ProbabilityThresholdGate(0.0).accepts(hypothesis))
 
+    def test_hypothesis_accepted_flag_must_be_boolean(self):
+        rejected = AssociationHypothesis(0, 0, cost=1.0, accepted=np.bool_(False))
+
+        self.assertFalse(rejected.accepted)
+        self.assertEqual(filter_hypotheses([rejected]), [])
+
+        with self.assertRaisesRegex(ValueError, "accepted"):
+            AssociationHypothesis(0, 0, cost=1.0, accepted="False")
+
+        with self.assertRaisesRegex(ValueError, "accepted"):
+            AssociationHypothesis(0, 0, cost=1.0).with_acceptance("False")
+
+    def test_callable_gate_result_must_be_boolean(self):
+        hypotheses = [AssociationHypothesis(0, 0, cost=1.0)]
+
+        with self.assertRaisesRegex(ValueError, "gate result"):
+            filter_hypotheses(hypotheses, lambda _hypothesis: "False")
+
     def test_measurement_axis_auto_uses_measurement_dimension(self):
         state_covariance = array(
             [


### PR DESCRIPTION
## Summary

- Validate `AssociationHypothesis.accepted` as an actual boolean value.
- Validate `with_acceptance` and callable gate results instead of relying on truthiness.
- Add regression coverage for serialized `"False"` values that would otherwise remain accepted.

## Why

Association filtering uses `hypothesis.accepted` to decide which hypotheses remain active. Raw truthiness meant values like `"False"` could be treated as accepted, keeping rejected associations in the candidate set.

## Validation

- `poetry run pytest tests/filters/test_association_hypotheses.py tests/filters/test_association_gate_monotonicity.py tests/filters/test_association_hypothesis_index_validation.py`
- `poetry run python -O -m pytest tests/filters/test_association_hypotheses.py tests/filters/test_association_gate_monotonicity.py tests/filters/test_association_hypothesis_index_validation.py`
- `poetry run ruff check src/pyrecest/filters/association_hypotheses.py tests/filters/test_association_hypotheses.py`
- `git diff --check`