### PR TITLE
Validate random choice boolean controls

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/random.py
+++ b/src/pyrecest/_backend/_shared_numpy/random.py
@@ -63,8 +63,14 @@ def _normalize_choice_axis(axis, ndim):
     return axis % ndim
 
 
+def _choice_bool(value, name):
+    if isinstance(value, (bool, _np.bool_)):
+        return bool(value)
+    raise TypeError(f"{name} must be a boolean")
+
+
 def _maybe_preserve_choice_order(indices, *, replace, p, shuffle, size):
-    if replace or p is not None or bool(shuffle) or size is None:
+    if replace or p is not None or shuffle or size is None:
         return indices
 
     index_array = _np.asarray(indices)
@@ -83,6 +89,8 @@ def choice(a, size=None, replace=True, p=None, axis=0, shuffle=True):
     and then gathers along ``axis`` for multidimensional inputs.
     """
 
+    replace = _choice_bool(replace, "replace")
+    shuffle = _choice_bool(shuffle, "shuffle")
     a_array = _np.asarray(a)
     if a_array.ndim == 0:
         return _maybe_preserve_choice_order(

--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -61,6 +61,14 @@ def _choice_size(size):
     return size, _prod(size) if size else 1
 
 
+def _choice_bool(value, name):
+    if isinstance(value, bool):
+        return value
+    if _torch.is_tensor(value) and value.ndim == 0 and value.dtype == _torch.bool:
+        return bool(value.item())
+    raise TypeError(f"{name} must be a boolean")
+
+
 def _randint_size(size):
     return _shape_from_size(size)
 
@@ -259,6 +267,8 @@ def _take_choice(a, indices, axis):
 
 
 def choice(a, size=None, replace=True, p=None, axis=0, shuffle=True):
+    replace = _choice_bool(replace, "replace")
+    shuffle = _choice_bool(shuffle, "shuffle")
     size, num_samples = _choice_size(size)
     population_size = _integer_population_size(a)
     if population_size is not None:

--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,

--- a/tests/backend/test_numpy_random_backend.py
+++ b/tests/backend/test_numpy_random_backend.py
@@ -40,3 +40,11 @@ def test_choice_without_replacement_shuffle_false_preserves_order():
 
     np.testing.assert_array_equal(samples, values)
     np.testing.assert_array_equal(column_samples, matrix)
+
+
+@pytest.mark.parametrize("control", ["replace", "shuffle"])
+def test_choice_rejects_non_boolean_controls(control):
+    kwargs = {control: "False"}
+
+    with pytest.raises(TypeError, match=f"{control} must be a boolean"):
+        random.choice(np.arange(3), size=2, **kwargs)

--- a/tests/backend/test_pytorch_random_backend.py
+++ b/tests/backend/test_pytorch_random_backend.py
@@ -135,3 +135,11 @@ def test_choice_without_replacement_shuffle_false_preserves_order():
 
     assert torch.equal(samples, values)
     assert torch.equal(column_samples, matrix)
+
+
+@pytest.mark.parametrize("control", ["replace", "shuffle"])
+def test_choice_rejects_non_boolean_controls(control):
+    kwargs = {control: "False"}
+
+    with pytest.raises(TypeError, match=f"{control} must be a boolean"):
+        random.choice(torch.arange(3), size=2, **kwargs)


### PR DESCRIPTION
## Summary

- Validate `replace` and `shuffle` in the NumPy random choice backend before sampling.
- Apply matching validation to the PyTorch random choice backend.
- Add regressions for string controls such as `"False"` that should not be treated as truthy.

## Why

`random.choice` used raw truthiness for boolean controls. Passing a serialized control value like `"False"` could silently switch sampling to replacement or keep shuffling enabled, changing results without an error.

## Validation

- `poetry run pytest tests/backend/test_numpy_random_backend.py tests/backend/test_pytorch_random_backend.py` (`test_pytorch_random_backend.py` skipped because `torch` is unavailable in this environment)
- `poetry run python -O -m pytest tests/backend/test_numpy_random_backend.py tests/backend/test_pytorch_random_backend.py` (`test_pytorch_random_backend.py` skipped because `torch` is unavailable in this environment)
- `poetry run ruff check src/pyrecest/_backend/_shared_numpy/random.py src/pyrecest/_backend/pytorch/random.py tests/backend/test_numpy_random_backend.py tests/backend/test_pytorch_random_backend.py`
- `git diff --check`