### PR TITLE
Validate MEM-RBPF sample axis flag

### DIFF
--- a/src/pyrecest/smoothers/mem_rbpf_ffbsi_smoother.py
+++ b/src/pyrecest/smoothers/mem_rbpf_ffbsi_smoother.py
@@ -143,6 +143,12 @@ class RBFFBSiResult:
         return self.kinematic_covariance
 
 
+def _coerce_bool_flag(value, name: str) -> bool:
+    if isinstance(value, (bool, np.bool_)):
+        return bool(value)
+    raise ValueError(f"{name} must be a bool")
+
+
 class MEMRBPFFFBSiSmoother(AbstractSmoother):
     """Fixed-interval Rao-Blackwellized FFBSi smoother for MEM-RBPF records.
 
@@ -166,7 +172,7 @@ class MEMRBPFFFBSiSmoother(AbstractSmoother):
         if axis_floor <= 0.0:
             raise ValueError("axis_floor must be positive")
         self.n_trajectories = None if n_trajectories is None else int(n_trajectories)
-        self.sample_axis = bool(sample_axis)
+        self.sample_axis = _coerce_bool_flag(sample_axis, "sample_axis")
         self.angle_wrap_terms = int(angle_wrap_terms)
         self.axis_floor = float(axis_floor)
 
@@ -432,7 +438,11 @@ class MEMRBPFFFBSiSmoother(AbstractSmoother):
             n_samples = final_particles
         if n_samples <= 0:
             raise ValueError("n_trajectories must be positive")
-        do_sample_axis = self.sample_axis if sample_axis is None else bool(sample_axis)
+        do_sample_axis = (
+            self.sample_axis
+            if sample_axis is None
+            else _coerce_bool_flag(sample_axis, "sample_axis")
+        )
         terms = (
             self.angle_wrap_terms if angle_wrap_terms is None else int(angle_wrap_terms)
         )

--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,

--- a/tests/smoothers/test_mem_rbpf_ffbsi_smoother.py
+++ b/tests/smoothers/test_mem_rbpf_ffbsi_smoother.py
@@ -56,6 +56,25 @@ def test_aliases():
     assert RBFFBSiSmoother is MEMRBPFFFBSiSmoother
 
 
+def test_sample_axis_requires_boolean_flags():
+    smoother = MEMRBPFFFBSiSmoother(n_trajectories=1, sample_axis=np.bool_(False))
+
+    assert smoother.sample_axis is False
+
+    with pytest.raises(ValueError, match="sample_axis"):
+        MEMRBPFFFBSiSmoother(sample_axis="False")
+
+    record = _record(
+        [0.0],
+        [[1.0]],
+        [0.0],
+        [[2.0, 1.0]],
+        np.repeat(np.eye(2)[np.newaxis, :, :] * 0.1, 1, axis=0),
+    )
+    with pytest.raises(ValueError, match="sample_axis"):
+        smoother.smooth([record], rng=0, sample_axis="False")
+
+
 def test_two_record_deterministic_backward_kernel_matches_rts_moments():
     axis_cov = np.repeat(np.eye(2)[np.newaxis, :, :] * 0.5, 1, axis=0)
     records = [


### PR DESCRIPTION
## Summary

- Validate `sample_axis` in `MEMRBPFFFBSiSmoother` instead of using raw truthiness.
- Apply the same validation to the per-call `smooth(..., sample_axis=...)` override.
- Add regression coverage for serialized string flags and NumPy boolean scalars.

## Why

`sample_axis` controls whether semi-axis states are drawn from their conditional covariance or kept at the conditional mean. Raw truthiness meant values such as `"False"` enabled sampling instead of disabling it, changing smoother outputs silently.

## Validation

- `poetry run pytest tests/smoothers/test_mem_rbpf_ffbsi_smoother.py`
- `poetry run python -O -m pytest tests/smoothers/test_mem_rbpf_ffbsi_smoother.py`
- `poetry run ruff check src/pyrecest/smoothers/mem_rbpf_ffbsi_smoother.py tests/smoothers/test_mem_rbpf_ffbsi_smoother.py`
- `git diff --check`