### PR TITLE
Validate MEM-QKF covariance flags

### DIFF
--- a/src/pyrecest/smoothers/fixed_lag_mem_qkf_smoother.py
+++ b/src/pyrecest/smoothers/fixed_lag_mem_qkf_smoother.py
@@ -25,6 +25,21 @@ from pyrecest.filters.mem_qkf_tracker import MEMQKFTracker
 from .abstract_smoother import AbstractSmoother
 
 
+def _coerce_bool_flag(value, name: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    try:
+        value_array = asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a bool") from exc
+    if value_array.shape != ():
+        raise ValueError(f"{name} must be a scalar bool")
+    scalar = value_array.item()
+    if isinstance(scalar, bool):
+        return bool(scalar)
+    raise ValueError(f"{name} must be a bool")
+
+
 @dataclass
 class MEMQKFTrackerState:
     """Detached snapshot of a :class:`MEMQKFTracker` state."""
@@ -591,9 +606,13 @@ class ForwardBackwardForwardBackwardMEMQKFSmoother(FixedLagMEMQKFSmoother):
         if n_iterations < 1:
             raise ValueError("n_iterations must be at least one.")
         self.n_iterations = n_iterations
-        self.include_kinematic_covariance = bool(include_kinematic_covariance)
-        self.include_single_measurement_axis_covariance = bool(
-            include_single_measurement_axis_covariance
+        self.include_kinematic_covariance = _coerce_bool_flag(
+            include_kinematic_covariance,
+            "include_kinematic_covariance",
+        )
+        self.include_single_measurement_axis_covariance = _coerce_bool_flag(
+            include_single_measurement_axis_covariance,
+            "include_single_measurement_axis_covariance",
         )
 
     @staticmethod

--- a/tests/smoothers/test_fixed_lag_mem_qkf_smoother.py
+++ b/tests/smoothers/test_fixed_lag_mem_qkf_smoother.py
@@ -1,5 +1,6 @@
 import numpy as np
 import numpy.testing as npt
+import pytest
 from pyrecest.backend import array, diag, eye
 from pyrecest.filters.mem_qkf_tracker import MEMQKFTracker
 from pyrecest.smoothers import (
@@ -44,6 +45,26 @@ def test_aliases():
     assert FullIntervalMEMQKFSmoother is FixedIntervalMEMQKFSmoother
     assert FBFBMEMQKFSmoother is ForwardBackwardForwardBackwardMEMQKFSmoother
     assert ForwardBackwardMEMQKFSmoother is ForwardBackwardForwardBackwardMEMQKFSmoother
+
+
+def test_fbfb_covariance_flags_must_be_boolean():
+    smoother = ForwardBackwardForwardBackwardMEMQKFSmoother(
+        include_kinematic_covariance=np.bool_(False),
+        include_single_measurement_axis_covariance=np.bool_(False),
+    )
+
+    assert smoother.include_kinematic_covariance is False
+    assert smoother.include_single_measurement_axis_covariance is False
+
+    with pytest.raises(ValueError, match="include_kinematic_covariance"):
+        ForwardBackwardForwardBackwardMEMQKFSmoother(
+            include_kinematic_covariance="False",
+        )
+
+    with pytest.raises(ValueError, match="include_single_measurement_axis_covariance"):
+        ForwardBackwardForwardBackwardMEMQKFSmoother(
+            include_single_measurement_axis_covariance="False",
+        )
 
 
 def test_lag_one_smooths_kinematics_and_mem_qkf_shape_state():


### PR DESCRIPTION
## Summary

- Validate `include_kinematic_covariance` and `include_single_measurement_axis_covariance` as scalar booleans.
- Preserve NumPy/backend boolean scalar support.
- Add regressions for serialized string flags.

## Why

These flags control which covariance terms are included while reconditioning the MEM-QKF shape update. Raw truthiness meant values like `"False"` enabled covariance terms instead of disabling them, changing smoother results silently.

## Validation

- `poetry run pytest tests/smoothers/test_fixed_lag_mem_qkf_smoother.py`
- `poetry run python -O -m pytest tests/smoothers/test_fixed_lag_mem_qkf_smoother.py`
- `poetry run ruff check src/pyrecest/smoothers/fixed_lag_mem_qkf_smoother.py tests/smoothers/test_fixed_lag_mem_qkf_smoother.py`
- `git diff --check`