### PR TITLE
Validate evaluation registry inputs

### DIFF
--- a/src/pyrecest/evaluation/get_distance_function.py
+++ b/src/pyrecest/evaluation/get_distance_function.py
@@ -13,13 +13,20 @@ DistanceFactory = Callable[[str, dict[str, Any] | None], Callable[[Any, Any], fl
 _DISTANCE_FUNCTION_FACTORIES: dict[str, DistanceFactory] = {}
 
 
+def _normalize_registry_name(manifold_name: str) -> str:
+    if not isinstance(manifold_name, str) or not manifold_name.strip():
+        raise ValueError("manifold_name must be a non-empty string")
+    return manifold_name.lower()
+
+
 def register_distance_function(
     manifold_name: str, factory: DistanceFactory
 ) -> DistanceFactory:
     """Register a custom distance-function factory for a manifold name."""
-    if not manifold_name:
-        raise ValueError("manifold_name must be a non-empty string")
-    _DISTANCE_FUNCTION_FACTORIES[manifold_name.lower()] = factory
+    normalized_name = _normalize_registry_name(manifold_name)
+    if not callable(factory):
+        raise TypeError("factory must be callable")
+    _DISTANCE_FUNCTION_FACTORIES[normalized_name] = factory
     return factory
 
 

--- a/src/pyrecest/evaluation/get_extract_mean.py
+++ b/src/pyrecest/evaluation/get_extract_mean.py
@@ -7,13 +7,20 @@ MeanExtractorFactory = Callable[[str, bool], Callable[[Any], Any]]
 _EXTRACT_MEAN_FACTORIES: dict[str, MeanExtractorFactory] = {}
 
 
+def _normalize_registry_name(manifold_name: str) -> str:
+    if not isinstance(manifold_name, str) or not manifold_name.strip():
+        raise ValueError("manifold_name must be a non-empty string")
+    return manifold_name.lower()
+
+
 def register_extract_mean(
     manifold_name: str, factory: MeanExtractorFactory
 ) -> MeanExtractorFactory:
     """Register a custom mean-extraction factory for a manifold name."""
-    if not manifold_name:
-        raise ValueError("manifold_name must be a non-empty string")
-    _EXTRACT_MEAN_FACTORIES[manifold_name.lower()] = factory
+    normalized_name = _normalize_registry_name(manifold_name)
+    if not callable(factory):
+        raise TypeError("factory must be callable")
+    _EXTRACT_MEAN_FACTORIES[normalized_name] = factory
     return factory
 
 

--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,

--- a/tests/evaluation/test_evaluation_registries.py
+++ b/tests/evaluation/test_evaluation_registries.py
@@ -21,6 +21,20 @@ def test_custom_distance_function_registry():
     )
 
 
+def test_custom_registries_validate_names_and_factories():
+    registries = (register_distance_function, register_extract_mean)
+
+    for register in registries:
+        with pytest.raises(ValueError, match="non-empty string"):
+            register("", lambda *_args: None)
+        with pytest.raises(ValueError, match="non-empty string"):
+            register("   ", lambda *_args: None)
+        with pytest.raises(ValueError, match="non-empty string"):
+            register(123, lambda *_args: None)
+        with pytest.raises(TypeError, match="factory must be callable"):
+            register("invalid-factory", None)
+
+
 def test_euclidean_mtt_distance_uses_assignment_with_cutoff():
     distance = get_distance_function("euclideanMTT", {"cutoff_distance": 10.0})
 


### PR DESCRIPTION
## Summary
- validate custom distance/mean registry names as real non-empty strings
- reject non-callable registry factories at registration time
- add regression coverage for invalid registry names and factories

## Rationale
The registry APIs promised non-empty string manifold names but only checked truthiness. As a result, values such as `123` raised an incidental `AttributeError` from `.lower()`, whitespace-only names were accepted, and non-callable factories could be registered and fail later during lookup.

## Testing
- Not run locally; repository network access is unavailable in this environment.