### PR TITLE
Validate covariance symmetry tolerances

### DIFF
--- a/src/pyrecest/models/validation.py
+++ b/src/pyrecest/models/validation.py
@@ -41,6 +41,22 @@ def _validate_bool_flag(value: Any, name: str) -> bool:
     raise TypeError(f"{name} must be a boolean.")
 
 
+def _validate_nonnegative_finite_scalar(value: Any, name: str) -> float:
+    value_array = np.asarray(value)
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError(f"{name} must be a finite nonnegative scalar.")
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(f"{name} must be a finite nonnegative scalar.")
+    try:
+        parsed = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be a finite nonnegative scalar.") from exc
+    if not np.isfinite(parsed) or parsed < 0.0:
+        raise ValueError(f"{name} must be a finite nonnegative scalar.")
+    return parsed
+
+
 def _validate_expected_dim(
     actual_dim: int, expected_dim: int | None, name: str, dim_name: str
 ) -> None:
@@ -188,6 +204,14 @@ def validate_covariance_matrix(
     """
     allow_scalar = _validate_bool_flag(allow_scalar, "allow_scalar")
     check_symmetric = _validate_bool_flag(check_symmetric, "check_symmetric")
+    symmetric_rtol = _validate_nonnegative_finite_scalar(
+        symmetric_rtol,
+        "symmetric_rtol",
+    )
+    symmetric_atol = _validate_nonnegative_finite_scalar(
+        symmetric_atol,
+        "symmetric_atol",
+    )
     covariance = _as_backend_array(covariance, name)
 
     if backend.ndim(covariance) == 0 and allow_scalar:

--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array_equal,
     asarray,
     cast,

--- a/tests/test_covariance_tolerance.py
+++ b/tests/test_covariance_tolerance.py
@@ -8,7 +8,7 @@ from pyrecest.models.validation import validate_covariance_matrix
 class CovarianceToleranceTest(unittest.TestCase):
     def test_symmetry_tolerances_reject_invalid_scalars(self):
         covariance = np.eye(2)
-        invalid_values = (-1.0, np.nan, np.inf, np.array([1.0]))
+        invalid_values = (bool(1), np.bool_(1), -1.0, np.nan, np.inf, np.array([1.0]))
 
         for value in invalid_values:
             with self.subTest(parameter="symmetric_atol", value=value):
@@ -31,6 +31,19 @@ class CovarianceToleranceTest(unittest.TestCase):
                         check_symmetric=True,
                         symmetric_rtol=value,
                     )
+
+    def test_boolean_tolerance_is_rejected_before_symmetry_check(self):
+        nonsymmetric_covariance = np.array([[1.0, 0.5], [0.0, 1.0]])
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "symmetric_atol must be a finite nonnegative scalar",
+        ):
+            validate_covariance_matrix(
+                nonsymmetric_covariance,
+                check_symmetric=True,
+                symmetric_atol=bool(1),
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_covariance_tolerance.py
+++ b/tests/test_covariance_tolerance.py
@@ -1,0 +1,37 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.models.validation import validate_covariance_matrix
+
+
+class CovarianceToleranceTest(unittest.TestCase):
+    def test_symmetry_tolerances_reject_invalid_scalars(self):
+        covariance = np.eye(2)
+        invalid_values = (-1.0, np.nan, np.inf, np.array([1.0]))
+
+        for value in invalid_values:
+            with self.subTest(parameter="symmetric_atol", value=value):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "symmetric_atol must be a finite nonnegative scalar",
+                ):
+                    validate_covariance_matrix(
+                        covariance,
+                        check_symmetric=True,
+                        symmetric_atol=value,
+                    )
+            with self.subTest(parameter="symmetric_rtol", value=value):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "symmetric_rtol must be a finite nonnegative scalar",
+                ):
+                    validate_covariance_matrix(
+                        covariance,
+                        check_symmetric=True,
+                        symmetric_rtol=value,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Validate `symmetric_rtol` and `symmetric_atol` in `validate_covariance_matrix` as finite nonnegative scalar controls.
- Reject booleans, nonfinite values, negative values, and non-scalar arrays before calling backend `allclose`.
- Add regression tests showing invalid symmetry tolerances are rejected before they can loosen or corrupt symmetry validation.

## Testing
- Added focused regression coverage in `tests/test_covariance_tolerance.py`.

Note: I did not run tests locally because repository access here is through the GitHub connector.