### PR TITLE
Validate association model boolean controls

### DIFF
--- a/src/pyrecest/utils/association_models.py
+++ b/src/pyrecest/utils/association_models.py
@@ -121,6 +121,12 @@ def _normalize_positive_integer(value: Any, message: str) -> int:
     return parsed
 
 
+def _normalize_bool_flag(value: Any, message: str) -> bool:
+    if isinstance(value, (bool, _numpy.bool_)):
+        return bool(value)
+    raise ValueError(message)
+
+
 class LogisticPairwiseAssociationModel:  # pylint: disable=too-many-instance-attributes
     """Learn pairwise match probabilities from arbitrary association features.
 
@@ -183,6 +189,14 @@ class LogisticPairwiseAssociationModel:  # pylint: disable=too-many-instance-att
         )
         tolerance = _normalize_positive_scalar(tolerance, "tolerance must be positive")
         probability_clip = _normalize_probability_clip(probability_clip)
+        fit_intercept = _normalize_bool_flag(
+            fit_intercept,
+            "fit_intercept must be a boolean",
+        )
+        standardize = _normalize_bool_flag(
+            standardize,
+            "standardize must be a boolean",
+        )
         if (
             class_weight != "balanced"
             and class_weight is not None
@@ -196,7 +210,7 @@ class LogisticPairwiseAssociationModel:  # pylint: disable=too-many-instance-att
         self.l2_regularization = l2_regularization
         self.max_iterations = max_iterations
         self.tolerance = tolerance
-        self.standardize = bool(standardize)
+        self.standardize = standardize
         self.class_weight = class_weight
         self.probability_clip = probability_clip
 

--- a/tests/test_association_model_validation.py
+++ b/tests/test_association_model_validation.py
@@ -44,6 +44,20 @@ class TestLogisticAssociationScalarValidation(unittest.TestCase):
 
         self.assertEqual(model.max_iterations, 3)
 
+    def test_constructor_rejects_nonboolean_controls(self):
+        for field_name in ("fit_intercept", "standardize"):
+            with self.subTest(field_name=field_name):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    f"{field_name} must be a boolean",
+                ):
+                    LogisticPairwiseAssociationModel(**{field_name: "False"})
+
+                model = LogisticPairwiseAssociationModel(
+                    **{field_name: np.bool_(False)}
+                )
+                self.assertIs(getattr(model, field_name), False)
+
     def test_class_weight_rejects_boolean_and_non_scalar_weights(self):
         features = array([[0.0], [1.0]])
         labels = array([0, 1])


### PR DESCRIPTION
## Summary

- Validate `fit_intercept` and `standardize` as boolean controls in `LogisticPairwiseAssociationModel`.
- Preserve NumPy boolean scalar support.
- Add regression coverage for serialized string false values.

## Why

These controls change the learned design matrix by adding/removing an intercept and applying/removing feature standardization. Raw truthiness meant values like `"False"` enabled those behaviors instead of disabling them, changing learned probabilities silently.

## Validation

- `poetry run pytest tests/test_association_model_validation.py tests/test_association_models.py`
- `poetry run python -O -m pytest tests/test_association_model_validation.py tests/test_association_models.py`
- `poetry run ruff check src/pyrecest/utils/association_models.py tests/test_association_model_validation.py`
- `git diff --check`