### PR TITLE
Validate ellipse major-axis flag

### DIFF
--- a/src/pyrecest/tracking/ellipse_geometry.py
+++ b/src/pyrecest/tracking/ellipse_geometry.py
@@ -51,6 +51,21 @@ def project_symmetric_covariance(covariance, minimum_eigenvalue=0.0):
     return symmetrize((eigenvectors * eigenvalues) @ eigenvectors.T)
 
 
+def _coerce_bool_flag(value, name: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    try:
+        value_array = asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a bool") from exc
+    if value_array.shape != ():
+        raise ValueError(f"{name} must be a scalar bool")
+    scalar = value_array.item()
+    if isinstance(scalar, bool):
+        return bool(scalar)
+    raise ValueError(f"{name} must be a bool")
+
+
 def rotation_matrix_2d(angle):
     """Return the 2-D rotation matrix for ``angle``."""
 
@@ -161,6 +176,7 @@ def ellipse_shape_canonicalization_transform(
     """
 
     shape_state = asarray(shape_state).reshape(3)
+    major_axis_first = _coerce_bool_flag(major_axis_first, "major_axis_first")
     orientation = shape_state[0]
     axes = shape_state[1:]
     transform = eye(3)
@@ -172,7 +188,7 @@ def ellipse_shape_canonicalization_transform(
         transform = sign_transform @ transform
     axes = maximum(backend_abs(axes), float(minimum_axis_length))
 
-    if bool(major_axis_first) and float(axes[1]) > float(axes[0]):
+    if major_axis_first and float(axes[1]) > float(axes[0]):
         swap_transform = array(
             [
                 [1.0, 0.0, 0.0],

--- a/tests/tracking/test_ellipse_geometry.py
+++ b/tests/tracking/test_ellipse_geometry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 import numpy.testing as npt
+import pytest
 from pyrecest.tracking import (
     canonicalize_ellipse_axes,
     canonicalize_ellipse_shape,
@@ -16,6 +17,22 @@ from pyrecest.tracking import (
 def test_ellipse_angle_delta_is_pi_periodic() -> None:
     assert np.isclose(float(ellipse_angle_delta(0.0, np.pi - 0.1)), -0.1)
     assert np.isclose(float(wrap_ellipse_angle_to_reference(0.0, np.pi - 0.1)), -0.1)
+
+
+def test_major_axis_first_requires_boolean_flag() -> None:
+    axes, _axis_covariance, swapped = canonicalize_ellipse_axes(
+        np.array([1.0, 2.0]),
+        major_axis_first=np.bool_(False),
+    )
+
+    npt.assert_allclose(axes, np.array([1.0, 2.0]))
+    assert not swapped
+
+    with pytest.raises(ValueError, match="major_axis_first"):
+        canonicalize_ellipse_axes(
+            np.array([1.0, 2.0]),
+            major_axis_first="False",
+        )
 
 
 def test_canonicalize_ellipse_shape_transforms_full_shape_covariance() -> None:


### PR DESCRIPTION
## Summary

- Validate `major_axis_first` as a scalar boolean before canonicalizing ellipse axes.
- Preserve backend/NumPy scalar boolean support.
- Add regression coverage for serialized string false values.

## Why

`major_axis_first` decides whether ellipse axes are swapped and the orientation is rotated by pi/2. Raw truthiness meant `"False"` triggered the swap, returning the wrong ellipse representation silently.

## Validation

- `poetry run pytest tests/tracking/test_ellipse_geometry.py`
- `poetry run python -O -m pytest tests/tracking/test_ellipse_geometry.py`
- `poetry run ruff check src/pyrecest/tracking/ellipse_geometry.py tests/tracking/test_ellipse_geometry.py`
- `git diff --check`