### PR TITLE
Validate fixed-lag smoother lag values

### DIFF
--- a/src/pyrecest/smoothers/record_smoother.py
+++ b/src/pyrecest/smoothers/record_smoother.py
@@ -30,7 +30,7 @@ class RecordSmootherConfig:
         applies the same backward recursion only over future records within
         ``lag`` seconds.  ``"none"`` returns copied records.
     lag:
-        Nonnegative fixed-lag horizon in seconds. Required for ``"fixed-lag"``.
+        Finite nonnegative fixed-lag horizon in seconds. Required for ``"fixed-lag"``.
     time_key, state_key, covariance_key:
         Keys used to extract timestamp, filtered state, and filtered covariance.
     output_state_key, output_covariance_key:
@@ -158,8 +158,9 @@ def _smooth_records_with_config(
 ) -> list[dict[str, Any]]:
     if config.method not in ("none", "rts", "fixed-lag"):
         raise ValueError(f"unknown smoothing method {config.method!r}")
-    if config.method == "fixed-lag" and (config.lag is None or config.lag < 0.0):
-        raise ValueError("fixed-lag smoothing requires a nonnegative lag")
+    fixed_lag = None
+    if config.method == "fixed-lag":
+        fixed_lag = _validate_fixed_lag(config.lag)
     if not records:
         return []
 
@@ -187,13 +188,14 @@ def _smooth_records_with_config(
             end_index=len(copied) - 1,
         )
     else:
+        assert fixed_lag is not None
         smoothed_states, smoothed_covariances = _fixed_lag_smooth_arrays(
             times,
             filtered_states,
             filtered_covariances,
             transition_model=transition_model,
             process_noise_model=process_noise_model,
-            lag=float(config.lag),
+            lag=fixed_lag,
         )
 
     out: list[dict[str, Any]] = []
@@ -206,6 +208,23 @@ def _smooth_records_with_config(
         item.update(metadata)
         out.append(item)
     return out
+
+
+def _validate_fixed_lag(lag: float | None) -> float:
+    if lag is None:
+        raise ValueError("fixed-lag smoothing requires a finite nonnegative lag")
+    lag_array = np.asarray(lag)
+    if lag_array.shape != () or lag_array.dtype == np.bool_:
+        raise ValueError("fixed-lag smoothing requires a finite nonnegative lag")
+    try:
+        lag_value = float(lag_array.item())
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(
+            "fixed-lag smoothing requires a finite nonnegative lag"
+        ) from exc
+    if not np.isfinite(lag_value) or lag_value < 0.0:
+        raise ValueError("fixed-lag smoothing requires a finite nonnegative lag")
+    return lag_value
 
 
 def _record_arrays(

--- a/tests/smoothers/test_record_smoother.py
+++ b/tests/smoothers/test_record_smoother.py
@@ -98,14 +98,15 @@ def test_none_returns_copied_records_with_metadata() -> None:
     assert records[0]["state"][0] == 0.0
 
 
-def test_fixed_lag_requires_nonnegative_lag() -> None:
-    with pytest.raises(ValueError, match="nonnegative lag"):
+@pytest.mark.parametrize("bad_lag", [None, -1.0, np.nan, np.inf, -np.inf, np.array([1.0]), "later"])
+def test_fixed_lag_requires_finite_nonnegative_lag(bad_lag) -> None:
+    with pytest.raises(ValueError, match="finite nonnegative lag"):
         smooth_records(
             _records(),
             method="fixed-lag",
             transition_model=_transition,
             process_noise_model=_process_noise,
-            lag=None,
+            lag=bad_lag,
         )
 
 


### PR DESCRIPTION
## Summary

- Validate fixed-lag smoother `lag` before smoothing starts.
- Reject NaN, infinities, non-scalar, missing, and non-numeric lag values with a clear `ValueError`.
- Add regression coverage for invalid lag values that previously bypassed the nonnegative check.

## Why

`NaN` lag values pass `lag < 0.0` checks and then reach `np.searchsorted`, silently changing the effective smoothing horizon. Fixed-lag smoothing should fail fast for non-finite lag values.

## Validation

- `python -m py_compile /mnt/data/record_smoother.py`
- `python -m py_compile /mnt/data/test_record_smoother.py`
- `python -m pytest -q tests/test_record_smoother.py` in a temporary local package mirror: 11 passed
