### PR TITLE
Validate track completion duplicate flags

### DIFF
--- a/src/pyrecest/utils/track_completion.py
+++ b/src/pyrecest/utils/track_completion.py
@@ -140,6 +140,12 @@ def enumerate_fragment_completion_paths(
     """
 
     max_path_length = _as_positive_int(max_path_length, "max_path_length")
+    allow_duplicate_source = _as_bool_flag(
+        allow_duplicate_source, "allow_duplicate_source"
+    )
+    allow_duplicate_target = _as_bool_flag(
+        allow_duplicate_target, "allow_duplicate_target"
+    )
     if direction not in {"prefix", "suffix", "both"}:
         raise ValueError("direction must be 'prefix', 'suffix', or 'both'")
     if max_paths_per_fragment is not None:
@@ -182,8 +188,8 @@ def enumerate_fragment_completion_paths(
                 max_path_length=max_path_length,
                 candidate_provider=candidate_provider,
                 candidate_session_provider=candidate_session_provider,
-                allow_duplicate_source=bool(allow_duplicate_source),
-                allow_duplicate_target=bool(allow_duplicate_target),
+                allow_duplicate_source=allow_duplicate_source,
+                allow_duplicate_target=allow_duplicate_target,
                 score_path=score_path,
                 out=fragment_paths,
             )
@@ -447,3 +453,15 @@ def _as_positive_int(value: Any, name: str) -> int:
     if parsed <= 0:
         raise ValueError(message)
     return parsed
+
+
+def _as_bool_flag(value: Any, name: str) -> bool:
+    value_array = np.asarray(value)
+    message = f"{name} must be a boolean"
+    if value_array.shape != ():
+        raise ValueError(message)
+
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        return bool(scalar)
+    raise ValueError(message)

--- a/tests/test_track_completion.py
+++ b/tests/test_track_completion.py
@@ -62,6 +62,34 @@ class TestTrackCompletion(unittest.TestCase):
         )
         self.assertEqual(len(allowed), 1)
 
+        allowed_from_numpy_bool = enumerate_fragment_completion_paths(
+            tracks,
+            direction="suffix",
+            candidate_provider=provider,
+            allow_duplicate_target=np.bool_(True),
+        )
+        self.assertEqual(len(allowed_from_numpy_bool), 1)
+
+    def test_duplicate_controls_must_be_boolean(self) -> None:
+        tracks = [[0, None]]
+
+        def provider(session: int, observation: int, target_session: int):
+            del session, observation, target_session
+            return [1]
+
+        for field_name in ("allow_duplicate_source", "allow_duplicate_target"):
+            with self.subTest(field_name=field_name):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    f"{field_name} must be a boolean",
+                ):
+                    enumerate_fragment_completion_paths(
+                        tracks,
+                        direction="suffix",
+                        candidate_provider=provider,
+                        **{field_name: "False"},
+                    )
+
     def test_rejects_negative_candidate_observations(self) -> None:
         tracks = [[0, None]]
         invalid_candidates = (-1, CompletionCandidate(-1))


### PR DESCRIPTION
## Summary

- Validate `allow_duplicate_source` and `allow_duplicate_target` as boolean controls.
- Preserve NumPy boolean scalar support.
- Add regressions for serialized string false values.

## Why

These flags decide whether fragment-completion paths may reuse already occupied source or target observations. Raw truthiness meant values like `"False"` allowed duplicate paths instead of rejecting them, changing completion candidates silently.

## Validation

- `poetry run pytest tests/test_track_completion.py tests/test_track_completion_limits_validation.py tests/test_track_completion_candidate_validation.py`
- `poetry run python -O -m pytest tests/test_track_completion.py tests/test_track_completion_limits_validation.py tests/test_track_completion_candidate_validation.py`
- `poetry run ruff check src/pyrecest/utils/track_completion.py tests/test_track_completion.py`
- `git diff --check`