### PR TITLE
Validate multiple EOT boolean controls

### DIFF
--- a/src/pyrecest/filters/abstract_multiple_extended_object_tracker.py
+++ b/src/pyrecest/filters/abstract_multiple_extended_object_tracker.py
@@ -12,6 +12,21 @@ from pyrecest.backend import asarray, concatenate, empty, stack
 from .abstract_multitarget_tracker import AbstractMultitargetTracker
 
 
+def _coerce_bool_flag(value: Any, name: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    try:
+        value_array = asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a bool") from exc
+    if value_array.shape != ():
+        raise ValueError(f"{name} must be a scalar bool")
+    scalar = value_array.item()
+    if isinstance(scalar, bool):
+        return bool(scalar)
+    raise ValueError(f"{name} must be a bool")
+
+
 @dataclass
 class ExtendedObjectEstimate:  # pylint: disable=too-many-instance-attributes
     """Extracted estimate of one extended object.
@@ -100,14 +115,32 @@ class AbstractMultipleExtendedObjectTracker(AbstractMultitargetTracker):
 
         self.extraction_threshold = extraction_threshold
         self.max_extracted_objects = max_extracted_objects
-        self.extract_confirmed_only = bool(extract_confirmed_only)
+        self.extract_confirmed_only = _coerce_bool_flag(
+            extract_confirmed_only,
+            "extract_confirmed_only",
+        )
 
-        self.log_prior_extents = bool(log_prior_extents)
-        self.log_posterior_extents = bool(log_posterior_extents)
-        self.log_prior_measurement_rates = bool(log_prior_measurement_rates)
-        self.log_posterior_measurement_rates = bool(log_posterior_measurement_rates)
-        self.log_cardinality = bool(log_cardinality)
-        self.log_associations = bool(log_associations)
+        self.log_prior_extents = _coerce_bool_flag(
+            log_prior_extents,
+            "log_prior_extents",
+        )
+        self.log_posterior_extents = _coerce_bool_flag(
+            log_posterior_extents,
+            "log_posterior_extents",
+        )
+        self.log_prior_measurement_rates = _coerce_bool_flag(
+            log_prior_measurement_rates,
+            "log_prior_measurement_rates",
+        )
+        self.log_posterior_measurement_rates = _coerce_bool_flag(
+            log_posterior_measurement_rates,
+            "log_posterior_measurement_rates",
+        )
+        self.log_cardinality = _coerce_bool_flag(log_cardinality, "log_cardinality")
+        self.log_associations = _coerce_bool_flag(
+            log_associations,
+            "log_associations",
+        )
 
         self.prior_measurement_rates_over_time = None
         self.posterior_measurement_rates_over_time = None

--- a/tests/filters/test_abstract_multiple_extended_object_tracker.py
+++ b/tests/filters/test_abstract_multiple_extended_object_tracker.py
@@ -1,6 +1,7 @@
 # pylint: disable=duplicate-code,too-many-arguments,too-many-positional-arguments
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 from pyrecest.backend import array, diag, zeros
 from pyrecest.filters import (
@@ -12,8 +13,8 @@ from pyrecest.filters import (
 
 
 class _DummyMultipleExtendedObjectTracker(AbstractMultipleExtendedObjectTracker):
-    def __init__(self):
-        super().__init__(
+    def __init__(self, **kwargs):
+        options = dict(
             log_prior_extents=True,
             log_posterior_extents=True,
             log_prior_measurement_rates=True,
@@ -21,6 +22,8 @@ class _DummyMultipleExtendedObjectTracker(AbstractMultipleExtendedObjectTracker)
             log_cardinality=True,
             log_associations=True,
         )
+        options.update(kwargs)
+        super().__init__(**options)
         self.predict_calls = []
         self.update_calls = []
         self.objects = [
@@ -126,6 +129,29 @@ class _DummyMultipleExtendedObjectTracker(AbstractMultipleExtendedObjectTracker)
 
 
 class AbstractMultipleExtendedObjectTrackerTest(unittest.TestCase):
+    def test_constructor_boolean_controls_must_be_boolean(self):
+        tracker = _DummyMultipleExtendedObjectTracker(
+            extract_confirmed_only=np.bool_(False),
+            log_cardinality=np.bool_(False),
+        )
+
+        self.assertIs(tracker.extract_confirmed_only, False)
+        self.assertIs(tracker.log_cardinality, False)
+
+        flag_names = (
+            "extract_confirmed_only",
+            "log_prior_extents",
+            "log_posterior_extents",
+            "log_prior_measurement_rates",
+            "log_posterior_measurement_rates",
+            "log_cardinality",
+            "log_associations",
+        )
+        for flag_name in flag_names:
+            with self.subTest(flag_name=flag_name):
+                with self.assertRaisesRegex(ValueError, flag_name):
+                    _DummyMultipleExtendedObjectTracker(**{flag_name: "False"})
+
     def test_vectorized_and_structured_estimates_are_available(self):
         tracker = _DummyMultipleExtendedObjectTracker()
 


### PR DESCRIPTION
## Summary

- Validate `extract_confirmed_only` and multiple extended-object logging controls as scalar booleans.
- Preserve backend/NumPy boolean scalar support.
- Add dummy tracker regressions for serialized string false values.

## Why

`extract_confirmed_only` changes which object estimates are returned, and the logging flags decide which histories are registered and populated. Raw truthiness meant values like `"False"` enabled those behaviors instead of disabling them.

## Validation

- `poetry run pytest tests/filters/test_abstract_multiple_extended_object_tracker.py`
- `poetry run python -O -m pytest tests/filters/test_abstract_multiple_extended_object_tracker.py`
- `poetry run ruff check src/pyrecest/filters/abstract_multiple_extended_object_tracker.py tests/filters/test_abstract_multiple_extended_object_tracker.py`
- `git diff --check`