### PR TITLE
Validate implicit surface sign flag

### DIFF
--- a/src/pyrecest/evaluation/implicit_surfaces.py
+++ b/src/pyrecest/evaluation/implicit_surfaces.py
@@ -44,6 +44,7 @@ def classify_inside_outside(values: Any, *, negative_inside: bool = True) -> np.
     non-finite values. Set ``negative_inside=False`` for the opposite sign
     convention.
     """
+    negative_inside = _boolean_flag("negative_inside", negative_inside)
     array = np.asarray(values, dtype=np.float64)
     labels = np.zeros(array.shape, dtype=np.int8)
     finite = np.isfinite(array)
@@ -74,6 +75,18 @@ def surface_band_probability_from_signed_distance(
     upper = (epsilon - distance) / std
     lower = (-epsilon - distance) / std
     return _clip_01(cdf(upper) - cdf(lower))
+
+
+def _boolean_flag(name: str, value: bool) -> bool:
+    message = f"{name} must be a boolean."
+    value_array = np.asarray(value)
+    if value_array.shape != ():
+        raise TypeError(message)
+
+    scalar = value_array.item()
+    if not isinstance(scalar, (bool, np.bool_)):
+        raise TypeError(message)
+    return bool(scalar)
 
 
 def _positive_float(name: str, value: float) -> float:

--- a/tests/evaluation/test_implicit_surfaces.py
+++ b/tests/evaluation/test_implicit_surfaces.py
@@ -77,6 +77,22 @@ def test_surface_band_mask_and_inside_outside_classification() -> None:
     ]
 
 
+def test_classify_inside_outside_accepts_numpy_boolean_scalar() -> None:
+    values = np.asarray([-0.2, 0.0, 0.3])
+
+    assert classify_inside_outside(values, negative_inside=np.bool_(False)).tolist() == [
+        1,
+        0,
+        -1,
+    ]
+
+
+@pytest.mark.parametrize("bad_flag", ["False", "true", 0, 1, None, [False]])
+def test_classify_inside_outside_rejects_non_boolean_sign_flag(bad_flag) -> None:
+    with pytest.raises(TypeError, match="negative_inside must be a boolean"):
+        classify_inside_outside(np.asarray([1.0]), negative_inside=bad_flag)
+
+
 def test_surface_band_probability_from_signed_distance() -> None:
     probability = surface_band_probability_from_signed_distance(
         np.asarray([0.0, 0.2], dtype=np.float64),


### PR DESCRIPTION
Summary: validates the implicit-surface sign convention flag as a real scalar boolean, keeps NumPy boolean scalars supported, and adds focused regression tests for invalid serialized flag values.

Validation: added tests in tests/evaluation/test_implicit_surfaces.py. Full suite not run locally because edits were made through the GitHub connector.