### PR TITLE
Validate Pareto constraint thresholds as scalars

### DIFF
--- a/src/pyrecest/evaluation/pareto.py
+++ b/src/pyrecest/evaluation/pareto.py
@@ -383,14 +383,17 @@ def _parse_constraint_spec(spec: ConstraintSpec | Mapping[str, Any]) -> Constrai
 
 
 def _coerce_finite_threshold(value: Any, column: str) -> float:
+    message = f"Constraint threshold for {column!r} must be a finite scalar."
+    value_array = np.asarray(value)
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError(message)
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(message)
     try:
-        threshold = float(value)
+        threshold = float(scalar)
     except (TypeError, ValueError, OverflowError) as exc:
-        raise ValueError(
-            f"Constraint threshold for {column!r} must be a finite scalar."
-        ) from exc
+        raise ValueError(message) from exc
     if not np.isfinite(threshold):
-        raise ValueError(
-            f"Constraint threshold for {column!r} must be a finite scalar."
-        )
+        raise ValueError(message)
     return threshold

--- a/tests/evaluation/test_pareto_threshold_validation.py
+++ b/tests/evaluation/test_pareto_threshold_validation.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from pyrecest.evaluation import constraint_mask
+
+
+def test_constraint_threshold_rejects_bool_and_non_scalar_values() -> None:
+    table = pd.DataFrame([{"score": 1.0}])
+    invalid_thresholds = (True, np.array([1.0]))
+
+    for threshold in invalid_thresholds:
+        with pytest.raises(
+            ValueError,
+            match="Constraint threshold for 'score' must be a finite scalar",
+        ):
+            constraint_mask(table, {"score": ("<=", threshold)})
+
+
+def test_constraint_threshold_accepts_scalar_numpy_float() -> None:
+    table = pd.DataFrame([{"name": "keep", "score": 1.0}, {"name": "drop", "score": 2.0}])
+
+    mask = constraint_mask(table, {"score": ("<=", np.array(1.0))})
+
+    assert table.loc[mask, "name"].tolist() == ["keep"]


### PR DESCRIPTION
## Summary
- Validate Pareto constraint thresholds with scalar-aware NumPy checks before converting to float.
- Reject booleans and non-scalar arrays instead of treating `True` as `1.0` or accepting size-one arrays as thresholds.
- Preserve scalar NumPy float thresholds.

## Testing
- Added `tests/evaluation/test_pareto_threshold_validation.py`.

Note: I did not run the tests locally because repository access here is through the GitHub connector.