### PR TITLE
Validate tracker logging boolean controls

### DIFF
--- a/src/pyrecest/filters/abstract_extended_object_tracker.py
+++ b/src/pyrecest/filters/abstract_extended_object_tracker.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import vstack
 
-from .abstract_tracker_with_logging import AbstractTrackerWithLogging
+from .abstract_tracker_with_logging import AbstractTrackerWithLogging, _coerce_bool_flag
 
 
 # pylint: disable=too-many-instance-attributes
@@ -21,13 +21,19 @@ class AbstractExtendedObjectTracker(AbstractTrackerWithLogging):
             log_prior_estimates=log_prior_estimates,
             log_posterior_estimates=log_posterior_estimates,
         )
-        self.log_prior_extents = log_prior_extents
-        self.log_posterior_extents = log_posterior_extents
-        if log_prior_extents:
+        self.log_prior_extents = _coerce_bool_flag(
+            log_prior_extents,
+            "log_prior_extents",
+        )
+        self.log_posterior_extents = _coerce_bool_flag(
+            log_posterior_extents,
+            "log_posterior_extents",
+        )
+        if self.log_prior_extents:
             self.prior_extents_over_time = self.history.register(
                 "prior_extents", pad_with_nan=True
             )
-        if log_posterior_extents:
+        if self.log_posterior_extents:
             self.posterior_extents_over_time = self.history.register(
                 "posterior_extents", pad_with_nan=True
             )

--- a/src/pyrecest/filters/abstract_tracker_with_logging.py
+++ b/src/pyrecest/filters/abstract_tracker_with_logging.py
@@ -1,24 +1,46 @@
 from abc import ABC
 
+from pyrecest.backend import asarray
 from pyrecest.utils.history_recorder import HistoryRecorder
+
+
+def _coerce_bool_flag(value, name: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    try:
+        value_array = asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a bool") from exc
+    if value_array.shape != ():
+        raise ValueError(f"{name} must be a scalar bool")
+    scalar = value_array.item()
+    if isinstance(scalar, bool):
+        return bool(scalar)
+    raise ValueError(f"{name} must be a bool")
 
 
 class AbstractTrackerWithLogging(ABC):
     def __init__(self, log_prior_estimates=False, log_posterior_estimates=False):
-        self.log_prior_estimates = log_prior_estimates
-        self.log_posterior_estimates = log_posterior_estimates
+        self.log_prior_estimates = _coerce_bool_flag(
+            log_prior_estimates,
+            "log_prior_estimates",
+        )
+        self.log_posterior_estimates = _coerce_bool_flag(
+            log_posterior_estimates,
+            "log_posterior_estimates",
+        )
         self.history = HistoryRecorder()
         self.prior_estimates_over_time = None
         self.posterior_estimates_over_time = None
         self.prior_extents_over_time = None
         self.posterior_extents_over_time = None
 
-        if log_prior_estimates:
+        if self.log_prior_estimates:
             self.prior_estimates_over_time = self.history.register(
                 "prior_estimates", pad_with_nan=True
             )
 
-        if log_posterior_estimates:
+        if self.log_posterior_estimates:
             self.posterior_estimates_over_time = self.history.register(
                 "posterior_estimates", pad_with_nan=True
             )

--- a/tests/test_history_recorder.py
+++ b/tests/test_history_recorder.py
@@ -1,6 +1,7 @@
 import unittest
 from math import nan
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
@@ -31,8 +32,10 @@ class _DummyFilter(AbstractFilter):
 
 
 class _DummyMultitargetTracker(AbstractMultitargetTracker):
-    def __init__(self):
-        super().__init__(log_prior_estimates=True, log_posterior_estimates=True)
+    def __init__(self, **kwargs):
+        options = dict(log_prior_estimates=True, log_posterior_estimates=True)
+        options.update(kwargs)
+        super().__init__(**options)
         self.estimate = array([])
 
     def get_point_estimate(self, flatten_vector=False):
@@ -45,13 +48,15 @@ class _DummyMultitargetTracker(AbstractMultitargetTracker):
 
 
 class _DummyExtendedTracker(AbstractExtendedObjectTracker):
-    def __init__(self):
-        super().__init__(
+    def __init__(self, **kwargs):
+        options = dict(
             log_prior_estimates=True,
             log_posterior_estimates=True,
             log_prior_extents=True,
             log_posterior_extents=True,
         )
+        options.update(kwargs)
+        super().__init__(**options)
         self.estimate = array([])
         self.extent = array([[]])
 
@@ -135,6 +140,28 @@ class HistoryRecorderTest(unittest.TestCase):
         npt.assert_allclose(
             tracker.history["posterior_estimates"], expected_posterior, equal_nan=True
         )
+
+    def test_tracker_logging_flags_must_be_boolean(self):
+        tracker = _DummyMultitargetTracker(log_prior_estimates=np.bool_(False))
+
+        self.assertIs(tracker.log_prior_estimates, False)
+        self.assertIsNone(tracker.prior_estimates_over_time)
+
+        for field_name in ("log_prior_estimates", "log_posterior_estimates"):
+            with self.subTest(field_name=field_name):
+                with self.assertRaisesRegex(ValueError, field_name):
+                    _DummyMultitargetTracker(**{field_name: "False"})
+
+    def test_extended_tracker_extent_logging_flags_must_be_boolean(self):
+        tracker = _DummyExtendedTracker(log_prior_extents=np.bool_(False))
+
+        self.assertIs(tracker.log_prior_extents, False)
+        self.assertIsNone(tracker.prior_extents_over_time)
+
+        for field_name in ("log_prior_extents", "log_posterior_extents"):
+            with self.subTest(field_name=field_name):
+                with self.assertRaisesRegex(ValueError, field_name):
+                    _DummyExtendedTracker(**{field_name: "False"})
 
     def test_extended_tracker_logs_extents_via_same_recorder(self):
         tracker = _DummyExtendedTracker()


### PR DESCRIPTION
## Summary

- Validate common tracker estimate logging controls as scalar booleans.
- Validate single extended-object extent logging controls as scalar booleans.
- Add history-recorder regressions for NumPy boolean scalars and serialized string false values.

## Why

Tracker logging flags register and populate history arrays. Raw truthiness meant values like `"False"` enabled histories instead of disabling them, changing tracker side effects and diagnostics silently.

## Validation

- `poetry run pytest tests/test_history_recorder.py`
- `poetry run python -O -m pytest tests/test_history_recorder.py`
- `poetry run ruff check src/pyrecest/filters/abstract_tracker_with_logging.py src/pyrecest/filters/abstract_extended_object_tracker.py tests/test_history_recorder.py`
- `git diff --check`
