### PR TITLE
Accept scalar array evidence bool flags

### DIFF
--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -19,8 +19,9 @@ EvidenceComputationKind = Literal["full_smoothing", "evidence_only"]
 def _coerce_bool_flag(value: bool, name: str) -> bool:
     """Return a bool flag without treating arbitrary truthy objects as true."""
 
-    if isinstance(value, (bool, np.bool_)):
-        return bool(value)
+    value_array = np.asarray(value)
+    if value_array.shape == () and np.issubdtype(value_array.dtype, np.bool_):
+        return bool(value_array.item())
     raise ValueError(f"{name} must be a bool")
 
 
@@ -124,9 +125,7 @@ def _coerce_return_smoothed(return_smoothed: bool | None) -> bool | None:
 
     if return_smoothed is None:
         return None
-    if isinstance(return_smoothed, (bool, np.bool_)):
-        return bool(return_smoothed)
-    raise ValueError("return_smoothed must be a bool or None")
+    return _coerce_bool_flag(return_smoothed, "return_smoothed")
 
 
 def _require_return_smoothed_agreement(


### PR DESCRIPTION
## Summary
- accept zero-dimensional NumPy boolean arrays for evidence-mode boolean flags
- keep rejecting numeric/string truthy values and non-scalar arrays

## Rationale
`np.bool_(False)` was accepted as a boolean flag, but the equivalent scalar `np.array(False)` was rejected. This made config values coming from NumPy-backed scalar containers fail even though they are explicit booleans.

## Testing
- Not run locally. The source change is limited to the evidence-mode bool coercion helper; attempts to add a focused regression test through the connector were blocked by the connector safety layer.