### PR TITLE
Validate hypertoroidal grid resolutions

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_grid_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_grid_distribution.py
@@ -9,7 +9,6 @@ from beartype import beartype
 from pyrecest.backend import (
     abs,
     all,
-    any,
     argmin,
     array,
     cast,
@@ -51,6 +50,29 @@ def _normalize_hypertoroidal_resolution(value, dim: int, name: str) -> tuple[int
             f"{name} must contain one entry per dimension. "
             f"Expected {dim}, got {len(resolution)}."
         )
+    if builtins.any(v <= 0 for v in resolution):
+        raise ValueError(f"{name} entries must be positive integers.")
+    return resolution
+
+
+def _normalize_hypertoroidal_grid_shape(value, name: str) -> tuple[int, ...]:
+    """Normalize a direct grid shape without an external dimension."""
+    if isinstance(value, bool):
+        raise ValueError(f"{name} entries must be positive integers.")
+    if isinstance(value, Integral):
+        resolution = (int(value),)
+    else:
+        try:
+            resolution = tuple(
+                _validate_hypertoroidal_resolution_entry(v, name) for v in value
+            )
+        except TypeError as exc:
+            raise TypeError(
+                f"{name} must be an integer or a sequence of integers."
+            ) from exc
+
+    if len(resolution) == 0:
+        raise ValueError(f"{name} must contain at least one entry.")
     if builtins.any(v <= 0 for v in resolution):
         raise ValueError(f"{name} entries must be positive integers.")
     return resolution
@@ -168,8 +190,9 @@ class HypertoroidalGridDistribution(
         n_grid_points : int or sequence of int
             Number of grid points along each dimension.
         """
-        if any(array(n_grid_points) <= 0):
-            raise ValueError("n_grid_points must contain positive integers")
+        n_grid_points = _normalize_hypertoroidal_grid_shape(
+            n_grid_points, "n_grid_points"
+        )
 
         axes = [linspace(0.0, 2.0 * pi - 2.0 * pi / n, n) for n in n_grid_points]
         mesh = meshgrid(*axes, indexing="ij")
@@ -328,7 +351,7 @@ class HypertoroidalGridDistribution(
     @beartype
     def from_function(
         fun,
-        n_grid_points: tuple | list,
+        n_grid_points: int | tuple | list,
         grid_type: str = "cartesian_prod",
         enforce_pdf_nonnegative: bool = True,
     ):
@@ -346,6 +369,9 @@ class HypertoroidalGridDistribution(
 
         """
         if grid_type == "cartesian_prod":
+            n_grid_points = _normalize_hypertoroidal_grid_shape(
+                n_grid_points, "n_grid_points"
+            )
             grid = HypertoroidalGridDistribution.generate_cartesian_product_grid(
                 n_grid_points
             )

--- a/tests/distributions/test_hypertoroidal_grid_distribution.py
+++ b/tests/distributions/test_hypertoroidal_grid_distribution.py
@@ -144,6 +144,47 @@ class HypertoroidalGridDistributionTest(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, "positive integers"):
                     HypertoroidalGridDistribution.from_distribution(dist, n_grid_points)
 
+    def test_generate_cartesian_product_grid_accepts_scalar_resolution(self):
+        grid = HypertoroidalGridDistribution.generate_cartesian_product_grid(4)
+
+        self.assertEqual(grid.shape, (4, 1))
+        npt.assert_allclose(grid[:, 0], array([0.0, 0.5 * pi, pi, 1.5 * pi]))
+
+    def test_generate_cartesian_product_grid_rejects_invalid_resolution_counts(self):
+        invalid_resolutions = (
+            True,
+            (True, 3),
+            (1.5, 3),
+            (),
+            (0, 3),
+            (3, -1),
+        )
+
+        for n_grid_points in invalid_resolutions:
+            with self.subTest(n_grid_points=n_grid_points):
+                with self.assertRaisesRegex(ValueError, "positive integers|one entry"):
+                    HypertoroidalGridDistribution.generate_cartesian_product_grid(
+                        n_grid_points
+                    )
+
+    def test_from_function_rejects_boolean_grid_resolution_counts(self):
+        with self.assertRaisesRegex(ValueError, "positive integers"):
+            HypertoroidalGridDistribution.from_function(
+                lambda xs: xs[:, 0],
+                (True, 3),
+                "cartesian_prod",
+            )
+
+    def test_from_function_accepts_scalar_resolution(self):
+        hgd = HypertoroidalGridDistribution.from_function(
+            lambda xs: 1.0 + 0.0 * xs[:, 0],
+            4,
+            "cartesian_prod",
+        )
+
+        self.assertEqual(hgd.dim, 1)
+        self.assertEqual(hgd.grid_values.shape, (4,))
+
     def test_from_function_3D(self):
         random.seed(0)
         test_points = 2 * pi * random.uniform(size=(30, 3))


### PR DESCRIPTION
## Summary
- normalize direct hypertoroidal Cartesian grid resolution inputs before building axes
- reject boolean, empty, non-integer, and non-positive grid counts in direct grid-generation paths
- allow documented scalar grid counts for one-dimensional direct grids and from_function

## Tests
- poetry run pytest tests/distributions/test_hypertoroidal_grid_distribution.py
- poetry run python -O -m pytest tests/distributions/test_hypertoroidal_grid_distribution.py
- poetry run ruff check src/pyrecest/distributions/hypertorus/hypertoroidal_grid_distribution.py tests/distributions/test_hypertoroidal_grid_distribution.py
- git diff --check
