### PR TITLE
Validate circular grid point counts

### DIFF
--- a/src/pyrecest/distributions/circle/circular_grid_distribution.py
+++ b/src/pyrecest/distributions/circle/circular_grid_distribution.py
@@ -1,3 +1,5 @@
+from numbers import Integral
+
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 from pyrecest.backend import (
     arange,
@@ -19,6 +21,15 @@ from pyrecest.backend import (
 from ..abstract_grid_distribution import AbstractGridDistribution
 from .abstract_circular_distribution import AbstractCircularDistribution
 from .circular_fourier_distribution import CircularFourierDistribution
+
+
+def _validate_no_of_gridpoints(no_of_gridpoints) -> int:
+    if isinstance(no_of_gridpoints, bool) or not isinstance(no_of_gridpoints, Integral):
+        raise ValueError("no_of_gridpoints must be a positive integer.")
+    no_of_gridpoints = int(no_of_gridpoints)
+    if no_of_gridpoints <= 0:
+        raise ValueError("no_of_gridpoints must be a positive integer.")
+    return no_of_gridpoints
 
 
 class CircularGridDistribution(AbstractCircularDistribution, AbstractGridDistribution):
@@ -112,6 +123,7 @@ class CircularGridDistribution(AbstractCircularDistribution, AbstractGridDistrib
 
     @staticmethod
     def from_function(fun, no_of_gridpoints, enforce_pdf_nonnegative=True):
+        no_of_gridpoints = _validate_no_of_gridpoints(no_of_gridpoints)
         grid_points = linspace(0.0, 2.0 * pi, no_of_gridpoints, endpoint=False)
         grid_values = array(fun(grid_points))
         return CircularGridDistribution(grid_values, enforce_pdf_nonnegative)

--- a/tests/distributions/test_circular_grid_distribution.py
+++ b/tests/distributions/test_circular_grid_distribution.py
@@ -60,6 +60,28 @@ class CircularGridDistributionTest(unittest.TestCase):
         indices = array([0, 3, 7])
         npt.assert_allclose(dist.get_grid_point(indices), dist.get_grid()[indices])
 
+    def test_from_function_rejects_invalid_gridpoint_count(self):
+        invalid_counts = (True, False, 0, -1, 1.5)
+
+        for no_of_gridpoints in invalid_counts:
+            with self.subTest(no_of_gridpoints=no_of_gridpoints):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
+                    CircularGridDistribution.from_function(
+                        lambda xs: xs + 1.0,
+                        no_of_gridpoints,
+                    )
+
+    def test_from_distribution_rejects_invalid_gridpoint_count(self):
+        dist = VonMisesDistribution(0.4, 1.3)
+
+        for no_of_gridpoints in (True, 0, 1.5):
+            with self.subTest(no_of_gridpoints=no_of_gridpoints):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
+                    CircularGridDistribution.from_distribution(
+                        dist,
+                        no_of_gridpoints,
+                    )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- reject boolean, non-integer, zero, and negative circular grid point counts
- route from_distribution through the same validation via from_function
- add regression coverage for invalid public grid-count inputs

## Tests
- poetry run pytest tests/distributions/test_circular_grid_distribution.py
- poetry run python -O -m pytest tests/distributions/test_circular_grid_distribution.py
- poetry run ruff check src/pyrecest/distributions/circle/circular_grid_distribution.py tests/distributions/test_circular_grid_distribution.py
- git diff --check
