### PR TITLE
Validate toroidal Fourier coefficient counts

### DIFF
--- a/src/pyrecest/distributions/hypertorus/toroidal_fourier_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/toroidal_fourier_distribution.py
@@ -1,4 +1,5 @@
 import warnings
+from numbers import Integral
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 from pyrecest.backend import (
@@ -18,6 +19,39 @@ from .hypertoroidal_fourier_distribution import HypertoroidalFourierDistribution
 from .hypertoroidal_wrapped_normal_distribution import (
     HypertoroidalWrappedNormalDistribution,
 )
+
+
+def _as_positive_toroidal_coefficient_count(value) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError("n_coefficients entries must be positive integers.")
+    value = int(value)
+    if value <= 0:
+        raise ValueError("n_coefficients entries must be positive integers.")
+    return value
+
+
+def _normalize_toroidal_coefficient_shape(n_coefficients) -> tuple[int, int]:
+    if isinstance(n_coefficients, bool):
+        raise ValueError("n_coefficients entries must be positive integers.")
+    if isinstance(n_coefficients, Integral):
+        count = _as_positive_toroidal_coefficient_count(n_coefficients)
+        return count, count
+
+    try:
+        counts = tuple(
+            _as_positive_toroidal_coefficient_count(value)
+            for value in n_coefficients
+        )
+    except TypeError as exc:
+        raise TypeError(
+            "n_coefficients must be an integer or a sequence of integers."
+        ) from exc
+
+    if len(counts) == 1:
+        return counts[0], counts[0]
+    if len(counts) != 2:
+        raise ValueError("n_coefficients must contain one or two entries.")
+    return counts
 
 
 class ToroidalFourierDistribution(
@@ -250,11 +284,7 @@ class ToroidalFourierDistribution(
         desired_transformation : str
             'sqrt', 'identity', or 'log'.
         """
-        if isinstance(n_coefficients, int):
-            n_coefficients = (n_coefficients, n_coefficients)
-        elif len(n_coefficients) == 1:
-            n_coefficients = (int(n_coefficients[0]), int(n_coefficients[0]))
-        n_coefficients = tuple(int(n) for n in n_coefficients)
+        n_coefficients = _normalize_toroidal_coefficient_shape(n_coefficients)
         hfd = HypertoroidalFourierDistribution.from_function(
             fun, n_coefficients, desired_transformation
         )
@@ -281,7 +311,7 @@ class ToroidalFourierDistribution(
         already_transformed : bool
         """
         if n_coefficients is not None:
-            n_coefficients = tuple(int(n) for n in n_coefficients)
+            n_coefficients = _normalize_toroidal_coefficient_shape(n_coefficients)
         return super().from_function_values(
             fvals,
             n_coefficients=n_coefficients,
@@ -307,11 +337,7 @@ class ToroidalFourierDistribution(
             Number of Fourier coefficients per dimension.
         desired_transformation : str
         """
-        if isinstance(n_coefficients, int):
-            n_coefficients = (n_coefficients, n_coefficients)
-        elif len(n_coefficients) == 1:
-            n_coefficients = (int(n_coefficients[0]), int(n_coefficients[0]))
-        n_coefficients = tuple(int(n) for n in n_coefficients)
+        n_coefficients = _normalize_toroidal_coefficient_shape(n_coefficients)
         hfd = super().from_distribution(
             distribution, n_coefficients, desired_transformation
         )

--- a/tests/distributions/test_toroidal_fourier_distribution.py
+++ b/tests/distributions/test_toroidal_fourier_distribution.py
@@ -97,6 +97,72 @@ class TestToroidalFourierDistributionConstructor(unittest.TestCase):
         )
         self.assertIsInstance(tfd, ToroidalFourierDistribution)
 
+    def test_factory_methods_normalize_scalar_and_singleton_counts(self):
+        twn = ToroidalWrappedNormalDistribution(
+            array([1.0, 2.0]), diag(array([0.3, 0.5]))
+        )
+        n = 9
+        x = linspace(0, 2 * pi, n, endpoint=False)
+        y = linspace(0, 2 * pi, n, endpoint=False)
+        X, Y = meshgrid(x, y, indexing="ij")
+        pts = column_stack((X.flatten(), Y.flatten()))
+        fvals = twn.pdf(pts).reshape((n, n))
+
+        from_dist = ToroidalFourierDistribution.from_distribution(
+            twn, n, "identity"
+        )
+        from_values = ToroidalFourierDistribution.from_function_values(
+            fvals, (n,), "identity"
+        )
+
+        def fun(x_grid, y_grid):
+            query = column_stack((x_grid.flatten(), y_grid.flatten()))
+            return twn.pdf(query).reshape(x_grid.shape)
+
+        from_fun = ToroidalFourierDistribution.from_function(fun, (n,), "identity")
+
+        self.assertEqual(from_dist.coeff_mat.shape, (n, n))
+        self.assertEqual(from_values.coeff_mat.shape, (n, n))
+        self.assertEqual(from_fun.coeff_mat.shape, (n, n))
+
+    def test_factory_methods_reject_invalid_coefficient_counts(self):
+        twn = ToroidalWrappedNormalDistribution(
+            array([1.0, 2.0]), diag(array([0.3, 0.5]))
+        )
+        fvals = zeros((5, 5))
+
+        def fun(x_grid, _y_grid):
+            return x_grid
+
+        invalid_counts = (True, (True, 5), (5, 1.5), (), (5, 0), (5, -1), (3, 3, 3))
+
+        for n_coefficients in invalid_counts:
+            with self.subTest(method="from_distribution", n_coefficients=n_coefficients):
+                with self.assertRaisesRegex(
+                    (TypeError, ValueError), "n_coefficients"
+                ):
+                    ToroidalFourierDistribution.from_distribution(
+                        twn, n_coefficients, "identity"
+                    )
+
+            with self.subTest(method="from_function", n_coefficients=n_coefficients):
+                with self.assertRaisesRegex(
+                    (TypeError, ValueError), "n_coefficients"
+                ):
+                    ToroidalFourierDistribution.from_function(
+                        fun, n_coefficients, "identity"
+                    )
+
+            with self.subTest(
+                method="from_function_values", n_coefficients=n_coefficients
+            ):
+                with self.assertRaisesRegex(
+                    (TypeError, ValueError), "n_coefficients"
+                ):
+                    ToroidalFourierDistribution.from_function_values(
+                        fvals, n_coefficients, "identity"
+                    )
+
 
 class TestToroidalFourierDistributionPDF(unittest.TestCase):
     @unittest.skipIf(


### PR DESCRIPTION
## Summary
- validate ToroidalFourierDistribution coefficient-count wrappers before coercion
- reject boolean, fractional, empty, non-positive, and wrong-length count inputs across factory methods
- keep scalar and singleton count expansion to a 2D toroidal shape covered by tests

## Tests
- poetry run pytest tests/distributions/test_toroidal_fourier_distribution.py
- poetry run python -O -m pytest tests/distributions/test_toroidal_fourier_distribution.py
- poetry run ruff check src/pyrecest/distributions/hypertorus/toroidal_fourier_distribution.py tests/distributions/test_toroidal_fourier_distribution.py
- git diff --check
