### PR TITLE
Validate hypertoroidal particle filter sizes

### DIFF
--- a/src/pyrecest/filters/circular_particle_filter.py
+++ b/src/pyrecest/filters/circular_particle_filter.py
@@ -5,7 +5,10 @@ from pyrecest.backend import float64, int32, int64, linspace, pi, sum
 from pyrecest.distributions import CircularDiracDistribution
 
 from .abstract_particle_filter import AbstractParticleFilter
-from .hypertoroidal_particle_filter import HypertoroidalParticleFilter
+from .hypertoroidal_particle_filter import (
+    HypertoroidalParticleFilter,
+    _validate_positive_integer,
+)
 from .manifold_mixins import CircularFilterMixin
 
 
@@ -25,6 +28,7 @@ class CircularParticleFilter(HypertoroidalParticleFilter, CircularFilterMixin):
 
         :param n_particles: number of particles
         """
+        n_particles = _validate_positive_integer(n_particles, "n_particles")
         filter_state = CircularDiracDistribution(
             linspace(0.0, 2.0 * pi, n_particles, endpoint=False)
         )

--- a/src/pyrecest/filters/hypertoroidal_particle_filter.py
+++ b/src/pyrecest/filters/hypertoroidal_particle_filter.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from numbers import Integral
 from typing import Union
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
@@ -21,12 +22,23 @@ from .abstract_particle_filter import AbstractParticleFilter
 from .manifold_mixins import HypertoroidalFilterMixin
 
 
+def _validate_positive_integer(value, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError(f"{name} must be a positive integer.")
+    value = int(value)
+    if value <= 0:
+        raise ValueError(f"{name} must be a positive integer.")
+    return value
+
+
 class HypertoroidalParticleFilter(AbstractParticleFilter, HypertoroidalFilterMixin):
     def __init__(
         self,
         n_particles: Union[int, int32, int64],
         dim: Union[int, int32, int64],
     ):
+        n_particles = _validate_positive_integer(n_particles, "n_particles")
+        dim = _validate_positive_integer(dim, "dim")
         if dim == 1:
             points = linspace(0.0, 2.0 * pi, num=n_particles, endpoint=False)
         else:

--- a/tests/filters/test_circular_particle_filter.py
+++ b/tests/filters/test_circular_particle_filter.py
@@ -29,6 +29,12 @@ class CircularParticleFilterTest(unittest.TestCase):
     def test_estimate(self):
         npt.assert_array_almost_equal(self.dist.trigonometric_moment(1), 0.0)
 
+    def test_constructor_rejects_invalid_particle_count(self):
+        for n_particles in (True, 0, -1, 1.5):
+            with self.subTest(n_particles=n_particles):
+                with self.assertRaisesRegex(ValueError, "n_particles"):
+                    CircularParticleFilter(n_particles)
+
     def test_setting_state(self):
         # sanity check
         self.filter.filter_state = self.dist

--- a/tests/filters/test_hypertoroidal_particle_filter.py
+++ b/tests/filters/test_hypertoroidal_particle_filter.py
@@ -29,6 +29,18 @@ class HypertoroidalParticleFilterTest(unittest.TestCase):
         self.forced_mean = array([1.0, 2.0, 3.0])
         random.seed(self.seed)
 
+    def test_constructor_rejects_invalid_particle_count(self):
+        for n_particles in (True, 0, -1, 1.5):
+            with self.subTest(n_particles=n_particles):
+                with self.assertRaisesRegex(ValueError, "n_particles"):
+                    HypertoroidalParticleFilter(n_particles, 3)
+
+    def test_constructor_rejects_invalid_dimension(self):
+        for dim in (True, 0, -1, 1.5):
+            with self.subTest(dim=dim):
+                with self.assertRaisesRegex(ValueError, "dim"):
+                    HypertoroidalParticleFilter(5, dim)
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax", reason="Backend not supported'"
     )


### PR DESCRIPTION
## Summary
- validate n_particles and dim in hypertoroidal particle filters before generating support points
- validate n_particles in the circular particle-filter specialization
- add optimized-mode-safe constructor regression coverage for invalid counts and dimensions

## Tests
- poetry run pytest tests/filters/test_circular_particle_filter.py tests/filters/test_hypertoroidal_particle_filter.py
- poetry run python -O -m pytest tests/filters/test_circular_particle_filter.py tests/filters/test_hypertoroidal_particle_filter.py
- poetry run ruff check src/pyrecest/filters/circular_particle_filter.py src/pyrecest/filters/hypertoroidal_particle_filter.py tests/filters/test_circular_particle_filter.py tests/filters/test_hypertoroidal_particle_filter.py
- git diff --check
