### PR TITLE
Validate hyperhemispherical particle filter sizes

### DIFF
--- a/src/pyrecest/filters/hyperhemispherical_particle_filter.py
+++ b/src/pyrecest/filters/hyperhemispherical_particle_filter.py
@@ -1,3 +1,5 @@
+from numbers import Integral
+
 from pyrecest.backend import empty
 from pyrecest.distributions.hypersphere_subset.abstract_hyperhemispherical_distribution import (
     AbstractHyperhemisphericalDistribution,
@@ -8,6 +10,15 @@ from pyrecest.distributions.hypersphere_subset.hyperhemispherical_dirac_distribu
 
 from .abstract_particle_filter import AbstractParticleFilter
 from .manifold_mixins import HyperhemisphericalFilterMixin
+
+
+def _validate_positive_integer(value, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError(f"{name} must be a positive integer.")
+    value = int(value)
+    if value <= 0:
+        raise ValueError(f"{name} must be a positive integer.")
+    return value
 
 
 class HyperhemisphericalParticleFilter(
@@ -21,6 +32,8 @@ class HyperhemisphericalParticleFilter(
         n_particles (int > 0): Number of particles to use
         dim (int > 0): Dimension
         """
+        n_particles = _validate_positive_integer(n_particles, "n_particles")
+        dim = _validate_positive_integer(dim, "dim")
         initial_filter_state = HyperhemisphericalDiracDistribution(
             empty((n_particles, dim + 1))
         )

--- a/tests/filters/test_hyperhemispherical_particle_filter.py
+++ b/tests/filters/test_hyperhemispherical_particle_filter.py
@@ -33,6 +33,18 @@ class HyperhemisphericalParticleFilterTest(unittest.TestCase):
         self.assertEqual(hpf.filter_state.w.shape, (self.n_particles,))
         self.assertEqual(hpf.filter_state.d.shape, (self.n_particles, 4))
 
+    def test_constructor_rejects_invalid_particle_count(self):
+        for n_particles in (True, 0, -1, 1.5):
+            with self.subTest(n_particles=n_particles):
+                with self.assertRaisesRegex(ValueError, "n_particles"):
+                    HyperhemisphericalParticleFilter(n_particles, 3)
+
+    def test_constructor_rejects_invalid_dimension(self):
+        for dim in (True, 0, -1, 1.5):
+            with self.subTest(dim=dim):
+                with self.assertRaisesRegex(ValueError, "dim"):
+                    HyperhemisphericalParticleFilter(5, dim)
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",
         reason="Not supported on this backend",


### PR DESCRIPTION
## Summary
- validate hyperhemispherical particle filter n_particles and dim constructor inputs
- reject boolean, fractional, zero, and negative values before allocating the initial Dirac state
- add optimized-mode-safe constructor regression coverage

## Tests
- poetry run pytest tests/filters/test_hyperhemispherical_particle_filter.py
- poetry run python -O -m pytest tests/filters/test_hyperhemispherical_particle_filter.py
- poetry run ruff check src/pyrecest/filters/hyperhemispherical_particle_filter.py tests/filters/test_hyperhemispherical_particle_filter.py
- git diff --check
