### PR TITLE
Validate robust Kalman scalar controls

### DIFF
--- a/src/pyrecest/filters/_linear_gaussian.py
+++ b/src/pyrecest/filters/_linear_gaussian.py
@@ -33,7 +33,7 @@ def _as_matrix(x, name):
     return x
 
 
-def _as_finite_scalar_float(x, name):
+def _as_finite_scalar_float(x, name, requirement="finite"):
     try:
         scalar = np.asarray(x)
     except Exception as exc:  # pragma: no cover - backend-specific conversion errors
@@ -52,19 +52,19 @@ def _as_finite_scalar_float(x, name):
         raise ValueError(f"{name} must be a finite scalar number") from exc
 
     if not math.isfinite(value):
-        raise ValueError(f"{name} must be finite")
+        raise ValueError(f"{name} must be {requirement}")
     return value
 
 
 def _as_positive_float(x, name):
-    x = _as_finite_scalar_float(x, name)
+    x = _as_finite_scalar_float(x, name, "finite and positive")
     if x <= 0.0:
         raise ValueError(f"{name} must be finite and positive")
     return x
 
 
 def _as_nonnegative_float(x, name):
-    x = _as_finite_scalar_float(x, name)
+    x = _as_finite_scalar_float(x, name, "finite and nonnegative")
     if x < 0.0:
         raise ValueError(f"{name} must be finite and nonnegative")
     return x
@@ -153,7 +153,7 @@ def student_t_covariance_scale(  # pylint: disable=redefined-outer-name
     """
     measurement_dim = _as_positive_integer(measurement_dim, "measurement_dim")
 
-    dof = _as_finite_scalar_float(dof, "dof")
+    dof = _as_finite_scalar_float(dof, "dof", "finite and greater than 2")
     if dof <= 2.0:
         raise ValueError("dof must be finite and greater than 2")
 

--- a/src/pyrecest/filters/_linear_gaussian.py
+++ b/src/pyrecest/filters/_linear_gaussian.py
@@ -3,6 +3,8 @@
 
 import math
 
+import numpy as np
+
 from pyrecest.backend import (
     asarray,
     atleast_1d,
@@ -31,13 +33,50 @@ def _as_matrix(x, name):
     return x
 
 
-def _as_positive_float(x, name):
+def _as_finite_scalar_float(x, name):
     try:
-        x = float(x)
+        scalar = np.asarray(x)
+    except Exception as exc:  # pragma: no cover - backend-specific conversion errors
+        raise ValueError(f"{name} must be a finite scalar number") from exc
+
+    if scalar.ndim != 0:
+        raise ValueError(f"{name} must be a scalar number")
+
+    value = scalar.item()
+    if isinstance(value, (bool, np.bool_, str, bytes, np.bytes_)):
+        raise ValueError(f"{name} must be a numeric scalar")
+
+    try:
+        value = float(value)
     except (TypeError, ValueError, OverflowError) as exc:
-        raise ValueError(f"{name} must be finite and positive") from exc
-    if not math.isfinite(x) or x <= 0.0:
+        raise ValueError(f"{name} must be a finite scalar number") from exc
+
+    if not math.isfinite(value):
+        raise ValueError(f"{name} must be finite")
+    return value
+
+
+def _as_positive_float(x, name):
+    x = _as_finite_scalar_float(x, name)
+    if x <= 0.0:
         raise ValueError(f"{name} must be finite and positive")
+    return x
+
+
+def _as_nonnegative_float(x, name):
+    x = _as_finite_scalar_float(x, name)
+    if x < 0.0:
+        raise ValueError(f"{name} must be finite and nonnegative")
+    return x
+
+
+def _as_positive_integer(x, name):
+    x = _as_finite_scalar_float(x, name)
+    if not x.is_integer():
+        raise ValueError(f"{name} must be a finite positive integer")
+    x = int(x)
+    if x <= 0:
+        raise ValueError(f"{name} must be positive")
     return x
 
 
@@ -112,17 +151,13 @@ def student_t_covariance_scale(  # pylint: disable=redefined-outer-name
     min_scale : float, optional
         Lower bound on the returned covariance scale. Must be nonnegative.
     """
-    measurement_dim = int(measurement_dim)
-    if measurement_dim <= 0:
-        raise ValueError("measurement_dim must be positive")
+    measurement_dim = _as_positive_integer(measurement_dim, "measurement_dim")
 
-    dof = float(dof)
-    if not math.isfinite(dof) or dof <= 2.0:
+    dof = _as_finite_scalar_float(dof, "dof")
+    if dof <= 2.0:
         raise ValueError("dof must be finite and greater than 2")
 
-    min_scale = float(min_scale)
-    if not math.isfinite(min_scale) or min_scale < 0.0:
-        raise ValueError("min_scale must be finite and nonnegative")
+    min_scale = _as_nonnegative_float(min_scale, "min_scale")
 
     nis = asarray(normalized_innovation_squared, dtype=float64)
     scale = (dof + nis) / (dof + measurement_dim)

--- a/tests/filters/test_robust_linear_gaussian_update.py
+++ b/tests/filters/test_robust_linear_gaussian_update.py
@@ -47,6 +47,87 @@ class RobustLinearGaussianUpdateTest(unittest.TestCase):
         self.assertEqual(float(inlier), 1.0)
         self.assertGreater(float(outlier), 1.0)
 
+    def test_scalar_scale_controls_reject_bool_strings_and_arrays(self):
+        invalid_values = (True, "2.0", np.array([1.0]))
+        control_calls = (
+            (
+                "scale",
+                lambda value: linear_gaussian_update(
+                    self.mean,
+                    self.covariance,
+                    array([1.0, -1.0]),
+                    self.measurement_matrix,
+                    self.meas_noise,
+                    scale=value,
+                ),
+            ),
+            (
+                "gate_threshold",
+                lambda value: linear_gaussian_update_robust(
+                    self.mean,
+                    self.covariance,
+                    array([100.0, 100.0]),
+                    self.measurement_matrix,
+                    self.meas_noise,
+                    robust_update="none",
+                    gate_threshold=value,
+                ),
+            ),
+            (
+                "huber_threshold",
+                lambda value: huber_covariance_scale(4.0, huber_threshold=value),
+            ),
+            (
+                "inflation_alpha",
+                lambda value: linear_gaussian_update_robust(
+                    self.mean,
+                    self.covariance,
+                    array([100.0, 100.0]),
+                    self.measurement_matrix,
+                    self.meas_noise,
+                    robust_update="nis-inflate",
+                    gate_threshold=1.0,
+                    inflation_alpha=value,
+                ),
+            ),
+        )
+
+        for control_name, call_control in control_calls:
+            for value in invalid_values:
+                with self.subTest(control=control_name, value=value):
+                    with self.assertRaisesRegex(ValueError, control_name):
+                        call_control(value)
+
+    def test_student_t_scale_rejects_invalid_scalar_controls(self):
+        invalid_cases = (
+            (
+                "measurement_dim",
+                (True, 1.5, "2", np.array([2.0])),
+                lambda value: student_t_covariance_scale(2.0, value, dof=4.0),
+            ),
+            (
+                "dof",
+                (True, "4.0", np.array([4.0])),
+                lambda value: student_t_covariance_scale(2.0, 2, dof=value),
+            ),
+            (
+                "min_scale",
+                (True, "1.0", np.array([1.0])),
+                lambda value: student_t_covariance_scale(
+                    2.0,
+                    2,
+                    dof=4.0,
+                    min_scale=value,
+                ),
+            ),
+        )
+
+        for control_name, invalid_values, call_control in invalid_cases:
+            for value in invalid_values:
+                with self.subTest(control=control_name, value=value):
+                    with self.assertRaisesRegex(ValueError, control_name):
+                        call_control(value)
+
     def test_student_t_update_downweights_outlier(self):
         measurement = array([100.0, 100.0])
         plain_mean, _ = linear_gaussian_update(


### PR DESCRIPTION
## Summary
- reject boolean, string, non-finite, and non-scalar robust Kalman tuning controls instead of silently coercing them with `float(...)` or `int(...)`
- validate Student-t `measurement_dim`, `dof`, and `min_scale` with scalar-aware checks
- add regression coverage for invalid `scale`, `gate_threshold`, `huber_threshold`, `inflation_alpha`, `measurement_dim`, `dof`, and `min_scale` inputs

## Bug fixed
Robust linear-Gaussian update controls could previously accept invalid configuration values such as `scale=True`, `gate_threshold="2.0"`, `inflation_alpha=np.array([1.0])`, or `measurement_dim=1.5`. These were coerced to plausible numeric values and changed filtering behavior instead of failing with a clear `ValueError`.

## Validation
- Syntax-checked the modified source and test files locally with `python -m py_compile`.
- Full pytest was not run locally because the sandbox cannot clone/install the repository from GitHub; CI should run the integrated suite.