### PR TITLE
Validate cart product particle filter sizes

### DIFF
--- a/src/pyrecest/filters/hyperhemisphere_cart_prod_particle_filter.py
+++ b/src/pyrecest/filters/hyperhemisphere_cart_prod_particle_filter.py
@@ -1,4 +1,5 @@
 import copy
+from numbers import Integral
 
 from beartype import beartype
 
@@ -21,6 +22,15 @@ from pyrecest.distributions.hypersphere_subset.von_mises_fisher_distribution imp
 from .abstract_particle_filter import AbstractParticleFilter
 
 
+def _validate_positive_integer(value, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError(f"{name} must be a positive integer.")
+    value = int(value)
+    if value <= 0:
+        raise ValueError(f"{name} must be a positive integer.")
+    return value
+
+
 class HyperhemisphereCartProdParticleFilter(AbstractParticleFilter):
     def __init__(
         self, n_particles: int, dim_hemisphere: int, n_hemispheres: int
@@ -32,6 +42,9 @@ class HyperhemisphereCartProdParticleFilter(AbstractParticleFilter):
         n_particles (int > 0): Number of particles to use
         dim (int > 0): Dimension
         """
+        n_particles = _validate_positive_integer(n_particles, "n_particles")
+        dim_hemisphere = _validate_positive_integer(dim_hemisphere, "dim_hemisphere")
+        n_hemispheres = _validate_positive_integer(n_hemispheres, "n_hemispheres")
         initial_filter_state = HyperhemisphereCartProdDiracDistribution(
             empty((n_particles, (dim_hemisphere + 1) * n_hemispheres)),
             ones(n_particles) / n_particles,

--- a/tests/filters/test_hyperhemisphere_cart_prod_particle_filter.py
+++ b/tests/filters/test_hyperhemisphere_cart_prod_particle_filter.py
@@ -28,6 +28,24 @@ class HyperHemisphereCartProdParticleFilterTest(unittest.TestCase):
             (n_particles, (dim_hemisphere + 1) * n_hemispheres),
         )
 
+    def test_constructor_rejects_invalid_particle_count(self):
+        for n_particles in (True, 0, -1, 1.5):
+            with self.subTest(n_particles=n_particles):
+                with self.assertRaisesRegex(ValueError, "n_particles"):
+                    HyperhemisphereCartProdParticleFilter(n_particles, 3, 2)
+
+    def test_constructor_rejects_invalid_hemisphere_dimension(self):
+        for dim_hemisphere in (True, 0, -1, 1.5):
+            with self.subTest(dim_hemisphere=dim_hemisphere):
+                with self.assertRaisesRegex(ValueError, "dim_hemisphere"):
+                    HyperhemisphereCartProdParticleFilter(5, dim_hemisphere, 2)
+
+    def test_constructor_rejects_invalid_hemisphere_count(self):
+        for n_hemispheres in (True, 0, -1, 1.5):
+            with self.subTest(n_hemispheres=n_hemispheres):
+                with self.assertRaisesRegex(ValueError, "n_hemispheres"):
+                    HyperhemisphereCartProdParticleFilter(5, 3, n_hemispheres)
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__  # pylint: disable=no-name-in-module,no-member
         in (


### PR DESCRIPTION
## Summary
- validate cart-product hyperhemisphere particle-filter size parameters before constructing the initial state
- reject boolean, fractional, zero, and negative n_particles, dim_hemisphere, and n_hemispheres inputs
- add optimized-mode-safe constructor regression coverage

## Tests
- poetry run pytest tests/filters/test_hyperhemisphere_cart_prod_particle_filter.py
- poetry run python -O -m pytest tests/filters/test_hyperhemisphere_cart_prod_particle_filter.py
- poetry run ruff check src/pyrecest/filters/hyperhemisphere_cart_prod_particle_filter.py tests/filters/test_hyperhemisphere_cart_prod_particle_filter.py
- git diff --check
