### PR TITLE
Validate hyperspherical particle filter sizes

### DIFF
--- a/src/pyrecest/filters/hyperspherical_particle_filter.py
+++ b/src/pyrecest/filters/hyperspherical_particle_filter.py
@@ -1,4 +1,5 @@
 import copy
+from numbers import Integral
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 from pyrecest.backend import eye, tile
@@ -11,8 +12,19 @@ from .abstract_particle_filter import AbstractParticleFilter
 from .manifold_mixins import HypersphericalFilterMixin
 
 
+def _validate_positive_integer(value, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise ValueError(f"{name} must be a positive integer.")
+    value = int(value)
+    if value <= 0:
+        raise ValueError(f"{name} must be a positive integer.")
+    return value
+
+
 class HypersphericalParticleFilter(AbstractParticleFilter, HypersphericalFilterMixin):
     def __init__(self, n_particles, dim):
+        n_particles = _validate_positive_integer(n_particles, "n_particles")
+        dim = _validate_positive_integer(dim, "dim")
         HypersphericalFilterMixin.__init__(self)
         # Initialize with valid points on the sphere
         AbstractParticleFilter.__init__(

--- a/tests/filters/test_hyperspherical_particle_filter.py
+++ b/tests/filters/test_hyperspherical_particle_filter.py
@@ -15,6 +15,18 @@ from pyrecest.filters.hyperspherical_particle_filter import HypersphericalPartic
 
 
 class HypersphericalParticleFilterTest(unittest.TestCase):
+    def test_constructor_rejects_invalid_particle_count(self):
+        for n_particles in (True, 0, -1, 1.5):
+            with self.subTest(n_particles=n_particles):
+                with self.assertRaisesRegex(ValueError, "n_particles"):
+                    HypersphericalParticleFilter(n_particles, 3)
+
+    def test_constructor_rejects_invalid_dimension(self):
+        for dim in (True, 0, -1, 1.5):
+            with self.subTest(dim=dim):
+                with self.assertRaisesRegex(ValueError, "dim"):
+                    HypersphericalParticleFilter(5, dim)
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
         reason="Not supported on this backend",


### PR DESCRIPTION
## Summary
- validate hyperspherical particle-filter n_particles and dim constructor inputs
- reject boolean, fractional, zero, and negative values before creating the initial Dirac support
- add optimized-mode-safe regression coverage

## Tests
- poetry run pytest tests/filters/test_hyperspherical_particle_filter.py
- poetry run python -O -m pytest tests/filters/test_hyperspherical_particle_filter.py
- poetry run ruff check src/pyrecest/filters/hyperspherical_particle_filter.py tests/filters/test_hyperspherical_particle_filter.py
- git diff --check
