### PR TITLE
Accept scalar array model validation bool flags

### DIFF
--- a/src/pyrecest/models/validation.py
+++ b/src/pyrecest/models/validation.py
@@ -38,6 +38,9 @@ def _format_shape(shape: tuple[int, ...]) -> str:
 def _validate_bool_flag(value: Any, name: str) -> bool:
     if isinstance(value, (bool, np.bool_)):
         return bool(value)
+    value_array = np.asarray(value)
+    if value_array.shape == () and value_array.dtype == np.bool_:
+        return bool(value_array.item())
     raise TypeError(f"{name} must be a boolean.")
 
 

--- a/tests/models/test_validation_bool_flags.py
+++ b/tests/models/test_validation_bool_flags.py
@@ -20,7 +20,7 @@ def test_validate_state_vector_rejects_nonboolean_allow_scalar() -> None:
             validate_state_vector(1.0, allow_scalar=flag)
 
 
-@pytest.mark.parametrize("flag", [True, np.bool_(True)])
+@pytest.mark.parametrize("flag", [True, np.bool_(True), np.array(True)])
 def test_validate_state_vector_accepts_boolean_allow_scalar(flag: bool) -> None:
     vector = validate_state_vector(1.0, allow_scalar=flag)
 
@@ -38,8 +38,22 @@ def test_validate_covariance_matrix_rejects_nonboolean_flags() -> None:
             validate_covariance_matrix([[1.0]], check_symmetric=flag)
 
 
+def test_validate_covariance_matrix_accepts_scalar_array_bool_flags() -> None:
+    covariance = validate_covariance_matrix(
+        1.0, allow_scalar=np.array(True), check_symmetric=np.array(True)
+    )
+
+    assert tuple(int(dim) for dim in backend.shape(covariance)) == (1, 1)
+
+
 def test_infer_state_dim_rejects_nonboolean_allow_methods() -> None:
     distribution = SimpleNamespace(mean=lambda: np.array([1.0, 2.0]))
 
     with pytest.raises(TypeError, match="allow_methods"):
         infer_state_dim_from_distribution(distribution, allow_methods="False")
+
+
+def test_infer_state_dim_accepts_scalar_array_allow_methods() -> None:
+    distribution = SimpleNamespace(mean=lambda: np.array([1.0, 2.0]))
+
+    assert infer_state_dim_from_distribution(distribution, allow_methods=np.array(True)) == 2


### PR DESCRIPTION
## Summary
- accept zero-dimensional NumPy boolean arrays in the shared model-validation boolean flag helper
- keep rejecting serialized strings, numeric values, and non-scalar arrays
- add regression coverage for `allow_scalar`, `check_symmetric`, and `allow_methods`

## Bug fixed
Model validation flags accepted Python `bool` and `np.bool_`, but rejected equivalent scalar NumPy boolean arrays such as `np.array(True)`. This made explicit boolean config values coming from NumPy scalar containers fail in public validation paths.

## Validation
- `python -m py_compile /mnt/data/validation.py`
- `python -m py_compile /mnt/data/test_validation_bool_flags.py`

Full pytest was not run locally because repository access here is through the GitHub connector.