### PR TITLE
Validate Metropolis-Hastings sample counts

### DIFF
--- a/src/pyrecest/distributions/abstract_manifold_specific_distribution.py
+++ b/src/pyrecest/distributions/abstract_manifold_specific_distribution.py
@@ -1,6 +1,8 @@
 import inspect
+import math
 from abc import ABC, abstractmethod
 from collections.abc import Callable
+from numbers import Integral
 from typing import Union
 
 import pyrecest.backend
@@ -17,6 +19,33 @@ def _to_scalar(value):
         return float(value)
     except (TypeError, ValueError, RuntimeError):
         return float(value.reshape(-1)[0])
+
+
+def _validate_integer_sample_parameter(value, name: str, minimum: int) -> int:
+    try:
+        scalar = value.item()
+    except AttributeError:
+        scalar = value
+    except ValueError as exc:
+        raise ValueError(f"{name} must be a scalar integer") from exc
+
+    if isinstance(scalar, bool):
+        raise ValueError(f"{name} must be an integer, not a boolean")
+
+    if isinstance(scalar, Integral):
+        integer = int(scalar)
+    else:
+        try:
+            scalar_float = float(scalar)
+            integer = int(scalar)
+        except (OverflowError, TypeError, ValueError) as exc:
+            raise ValueError(f"{name} must be an integer") from exc
+        if not math.isfinite(scalar_float) or not scalar_float.is_integer():
+            raise ValueError(f"{name} must be a finite integer")
+
+    if integer < minimum:
+        raise ValueError(f"{name} must be at least {minimum}")
+    return integer
 
 
 class AbstractManifoldSpecificDistribution(ABC):
@@ -129,6 +158,10 @@ class AbstractManifoldSpecificDistribution(ABC):
         ``log q(candidate | current)``. If it is omitted, the proposal is
         assumed symmetric, recovering the ordinary Metropolis ratio.
         """
+        n = _validate_integer_sample_parameter(n, "n", 1)
+        burn_in = _validate_integer_sample_parameter(burn_in, "burn_in", 0)
+        skipping = _validate_integer_sample_parameter(skipping, "skipping", 1)
+
         if pyrecest.backend.__backend_name__ == "jax":
             # Get a key from your global JAX random state *outside* of lax.scan
             import jax as _jax  # pylint: disable=import-error
@@ -149,9 +182,9 @@ class AbstractManifoldSpecificDistribution(ABC):
                 log_pdf=self.ln_pdf,
                 proposal=proposal,  # must be (key, x) -> x_prop for JAX
                 start_point=start_point,
-                n=int(n),
-                burn_in=int(burn_in),
-                skipping=int(skipping),
+                n=n,
+                burn_in=burn_in,
+                skipping=skipping,
                 proposal_log_pdf=proposal_log_pdf,
             )
             # You could optionally stash `key_out` somewhere if you want chain continuation.

--- a/tests/distributions/test_abstract_manifold_specific_distribution.py
+++ b/tests/distributions/test_abstract_manifold_specific_distribution.py
@@ -2,6 +2,7 @@ import unittest
 from math import log as math_log
 from unittest.mock import patch
 
+import numpy as np
 import numpy.testing as npt
 import pyrecest.backend
 
@@ -109,6 +110,36 @@ class AbstractManifoldSpecificDistributionTest(unittest.TestCase):
             distribution.sample_metropolis_hastings(
                 n=1, burn_in=0, skipping=1, proposal=proposal, start_point=array([0.0])
             )
+
+    def test_sample_metropolis_hastings_validates_count_parameters(self):
+        distribution = DeterministicOneDimensionalDistribution()
+
+        def proposal(x):
+            return x
+
+        invalid_parameters = (
+            {"n": 0},
+            {"n": 1.5},
+            {"n": True},
+            {"n": [1]},
+            {"burn_in": -1},
+            {"burn_in": False},
+            {"skipping": 0},
+            {"skipping": 1.5},
+            {"skipping": True},
+        )
+
+        for overrides in invalid_parameters:
+            kwargs = {
+                "n": np.array(1.0),
+                "burn_in": np.array(0.0),
+                "skipping": np.array(1.0),
+                "proposal": proposal,
+                "start_point": array([0.0]),
+            }
+            kwargs.update(overrides)
+            with self.subTest(overrides=overrides), self.assertRaises(ValueError):
+                distribution.sample_metropolis_hastings(**kwargs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- validate Metropolis-Hastings `n`, `burn_in`, and `skipping` before sampling
- reject booleans, non-scalars, fractional values, and out-of-range values consistently across backend paths
- add regression coverage for invalid count parameters while preserving scalar integer-like inputs

## Tests
- `PYTHONPATH=src python -m pytest tests/distributions/test_abstract_manifold_specific_distribution.py`
- `PYTHONPATH=src python -O -m pytest tests/distributions/test_abstract_manifold_specific_distribution.py`
- `python -m ruff check src/pyrecest/distributions/abstract_manifold_specific_distribution.py tests/distributions/test_abstract_manifold_specific_distribution.py`
- `git diff --check`
