### PR TITLE
Validate EKF spline tracker controls

### DIFF
--- a/src/pyrecest/filters/ekf_spline_tracker.py
+++ b/src/pyrecest/filters/ekf_spline_tracker.py
@@ -1,4 +1,6 @@
 # pylint: disable=duplicate-code,no-member,no-name-in-module,too-many-lines
+from numbers import Integral
+
 from pyrecest.backend import (
     abs,
     all,
@@ -104,17 +106,27 @@ class EKFSplineTracker(AbstractExtendedObjectTracker):
         self.acceleration_variance = float(acceleration_variance)
         self.turn_rate_variance = float(turn_rate_variance)
         self.scale_process_noise = float(scale_process_noise)
-        self.scale_correction = bool(scale_correction)
-        self.orientation_correction = bool(orientation_correction)
+        self.scale_correction = self._as_bool_flag(
+            scale_correction,
+            "scale_correction",
+        )
+        self.orientation_correction = self._as_bool_flag(
+            orientation_correction,
+            "orientation_correction",
+        )
         self.finite_difference_step = float(finite_difference_step)
-        self.closest_point_grid_size = int(closest_point_grid_size)
-        self.closest_point_iterations = int(closest_point_iterations)
+        self.closest_point_grid_size = self._as_integer(
+            closest_point_grid_size,
+            "closest_point_grid_size",
+            2,
+        )
+        self.closest_point_iterations = self._as_integer(
+            closest_point_iterations,
+            "closest_point_iterations",
+            0,
+        )
         if self.finite_difference_step <= 0.0:
             raise ValueError("finite_difference_step must be positive")
-        if self.closest_point_grid_size <= 1:
-            raise ValueError("closest_point_grid_size must be greater than one")
-        if self.closest_point_iterations < 0:
-            raise ValueError("closest_point_iterations must be non-negative")
         self.last_quadratic_form = None
         self._sync_state_views()
 
@@ -137,6 +149,41 @@ class EKFSplineTracker(AbstractExtendedObjectTracker):
     @staticmethod
     def _symmetrize(matrix):
         return 0.5 * (matrix + matrix.T)
+
+    @staticmethod
+    def _as_bool_flag(value, name):
+        if isinstance(value, bool):
+            return value
+        try:
+            value_array = array(value)
+            if value_array.shape == ():
+                scalar = value_array.item()
+                if isinstance(scalar, bool):
+                    return bool(scalar)
+        except (AttributeError, TypeError, ValueError):
+            pass
+        raise ValueError(f"{name} must be a boolean")
+
+    @staticmethod
+    def _as_integer(value, name, minimum):
+        if isinstance(value, bool):
+            raise ValueError(f"{name} must be an integer")
+        try:
+            value_array = array(value)
+            if value_array.shape != ():
+                raise ValueError(f"{name} must be a scalar integer")
+            scalar = value_array.item()
+        except AttributeError:
+            scalar = value
+        except TypeError as exc:
+            raise ValueError(f"{name} must be an integer") from exc
+
+        if isinstance(scalar, bool) or not isinstance(scalar, Integral):
+            raise ValueError(f"{name} must be an integer")
+        integer = int(scalar)
+        if integer < minimum:
+            raise ValueError(f"{name} must be at least {minimum}")
+        return integer
 
     @classmethod
     def _as_covariance_matrix(
@@ -508,8 +555,7 @@ class EKFSplineTracker(AbstractExtendedObjectTracker):
         return scaled_control_points
 
     def get_contour_points(self, n=100, scaling_factor=1.0):
-        if n <= 0:
-            raise ValueError("n must be positive")
+        n = self._as_integer(n, "n", 1)
         segment_coordinates = linspace(
             0.0,
             float(self.num_control_points),

--- a/tests/filters/test_ekf_spline_tracker.py
+++ b/tests/filters/test_ekf_spline_tracker.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
@@ -80,6 +81,45 @@ class TestEKFSplineTracker(unittest.TestCase):
         tracker.update(array([3.0, 0.0]))
 
         npt.assert_allclose(tracker.scale_state, array([1.0, 1.0]), atol=1e-10)
+
+    def test_scalar_array_correction_flags_are_honored(self):
+        tracker = EKFSplineTracker(
+            scale_correction=np.array(False),
+            orientation_correction=np.array(False),
+        )
+
+        self.assertFalse(tracker.scale_correction)
+        self.assertFalse(tracker.orientation_correction)
+
+    def test_constructor_rejects_invalid_correction_flags(self):
+        invalid_flags = ("false", 0, 1, [False])
+
+        for invalid_flag in invalid_flags:
+            with self.subTest(flag=invalid_flag), self.assertRaises(ValueError):
+                EKFSplineTracker(scale_correction=invalid_flag)
+            with self.subTest(flag=invalid_flag), self.assertRaises(ValueError):
+                EKFSplineTracker(orientation_correction=invalid_flag)
+
+    def test_constructor_rejects_invalid_iteration_counts(self):
+        invalid_grid_sizes = (True, 1, 2.5, "3", [3])
+        invalid_iterations = (False, -1, 1.5, "2", [2])
+
+        for invalid_grid_size in invalid_grid_sizes:
+            with self.subTest(grid_size=invalid_grid_size), self.assertRaises(
+                ValueError
+            ):
+                EKFSplineTracker(closest_point_grid_size=invalid_grid_size)
+
+        for invalid_iteration in invalid_iterations:
+            with self.subTest(iterations=invalid_iteration), self.assertRaises(
+                ValueError
+            ):
+                EKFSplineTracker(closest_point_iterations=invalid_iteration)
+
+    def test_contour_point_count_must_be_positive_integer(self):
+        for invalid_n in (0, True, 4.5, "8", [8]):
+            with self.subTest(n=invalid_n), self.assertRaises(ValueError):
+                self.tracker.get_contour_points(invalid_n)
 
     def test_update_accepts_multiple_measurement_layouts(self):
         measurements = array([[3.0, 0.2], [0.0, 1.5], [-2.5, -0.1]])


### PR DESCRIPTION
## Summary
- validate EKF spline correction flags as real booleans instead of coercing truthy values
- validate closest-point grid, Newton iteration, and contour point counts as scalar integers
- add regression coverage for invalid flags/counts and scalar boolean arrays

## Tests
- `PYTHONPATH=src python -m pytest tests/filters/test_ekf_spline_tracker.py`
- `PYTHONPATH=src python -O -m pytest tests/filters/test_ekf_spline_tracker.py`
- `python -m ruff check src/pyrecest/filters/ekf_spline_tracker.py tests/filters/test_ekf_spline_tracker.py`
- `git diff --check`
