### PR TITLE
Validate Fourier RHM count parameters

### DIFF
--- a/src/pyrecest/filters/fourier_rhm_tracker.py
+++ b/src/pyrecest/filters/fourier_rhm_tracker.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from numbers import Integral
+
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member,redefined-builtin,duplicate-code
@@ -73,9 +75,7 @@ class FourierRHMTracker(
                 "FourierRHMTracker is not supported on the JAX backend"
             )
 
-        self.n_harmonics = int(n_harmonics)
-        if self.n_harmonics < 0:
-            raise ValueError("n_harmonics must be non-negative")
+        self.n_harmonics = self._as_integer(n_harmonics, "n_harmonics", 0)
         self.n_fourier_coefficients = 2 * self.n_harmonics + 1
         self.state_dim = self.n_fourier_coefficients + 2
 
@@ -137,6 +137,27 @@ class FourierRHMTracker(
         if matrix.shape[0] != matrix.shape[1]:
             raise ValueError(f"{name} must be square")
         linalg.cholesky(matrix)
+
+    @staticmethod
+    def _as_integer(value, name, minimum):
+        if isinstance(value, bool):
+            raise ValueError(f"{name} must be an integer")
+        try:
+            value_array = array(value)
+            if value_array.shape != ():
+                raise ValueError(f"{name} must be a scalar integer")
+            scalar = value_array.item()
+        except AttributeError:
+            scalar = value
+        except TypeError as exc:
+            raise ValueError(f"{name} must be an integer") from exc
+
+        if isinstance(scalar, bool) or not isinstance(scalar, Integral):
+            raise ValueError(f"{name} must be an integer")
+        integer = int(scalar)
+        if integer < minimum:
+            raise ValueError(f"{name} must be at least {minimum}")
+        return integer
 
     @staticmethod
     def _as_vector(value, dim, name):
@@ -208,10 +229,12 @@ class FourierRHMTracker(
         return self.fourier_coefficients
 
     def get_extents_on_grid(self, n=100):
+        n = self._as_integer(n, "n", 1)
         angles = linspace(0.0, 2.0 * pi, n, endpoint=False)
         return self.evaluate_radius(angles)
 
     def get_contour_points(self, n=100):
+        n = self._as_integer(n, "n", 1)
         angles = linspace(0.0, 2.0 * pi, n, endpoint=False)
         radii = self.evaluate_radius(angles)
         contour_points = self.kinematic_state[:, None] + _pol2cart(angles, radii)

--- a/tests/filters/test_fourier_rhm_tracker.py
+++ b/tests/filters/test_fourier_rhm_tracker.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
@@ -20,6 +21,19 @@ class TestFourierRHMTracker(unittest.TestCase):
 
         npt.assert_allclose(basis, array([0.5, 1.0, 0.0, 1.0, 0.0]))
 
+    def test_constructor_accepts_scalar_integer_harmonic_count(self):
+        tracker = FourierRHMTracker(np.array(2))
+
+        self.assertEqual(tracker.n_harmonics, 2)
+        self.assertEqual(tracker.n_fourier_coefficients, 5)
+
+    def test_constructor_rejects_invalid_harmonic_counts(self):
+        for invalid_count in (True, -1, 1.5, "2", [2]):
+            with self.subTest(n_harmonics=invalid_count), self.assertRaises(
+                ValueError
+            ):
+                FourierRHMTracker(invalid_count)
+
     def test_radius_and_contour_points_follow_fourier_coefficients(self):
         tracker = FourierRHMTracker(
             2,
@@ -35,6 +49,19 @@ class TestFourierRHMTracker(unittest.TestCase):
         self.assertEqual(contour_points.shape, (4, 2))
         npt.assert_allclose(contour_points[0], array([4.5, -1.0]))
         npt.assert_allclose(contour_points[1], array([1.0, 0.5]))
+
+    def test_grid_and_contour_counts_must_be_positive_integers(self):
+        tracker = FourierRHMTracker(1)
+
+        for invalid_count in (0, True, 4.5, "4", [4]):
+            with self.subTest(method="grid", n=invalid_count), self.assertRaises(
+                ValueError
+            ):
+                tracker.get_extents_on_grid(invalid_count)
+            with self.subTest(method="contour", n=invalid_count), self.assertRaises(
+                ValueError
+            ):
+                tracker.get_contour_points(invalid_count)
 
     def test_update_increases_radius_toward_far_measurement(self):
         tracker = FourierRHMTracker(


### PR DESCRIPTION
## Summary
- validate Fourier RHM harmonic counts before deriving the coefficient vector size
- validate grid and contour point counts before creating angular samples
- add regression coverage for booleans, fractional values, strings, and non-scalar counts

## Tests
- `PYTHONPATH=src python -m pytest tests/filters/test_fourier_rhm_tracker.py`
- `PYTHONPATH=src python -O -m pytest tests/filters/test_fourier_rhm_tracker.py`
- `python -m ruff check src/pyrecest/filters/fourier_rhm_tracker.py tests/filters/test_fourier_rhm_tracker.py`
- `git diff --check`
