### PR TITLE
Validate block particle indices

### DIFF
--- a/src/pyrecest/filters/block_particle_filter.py
+++ b/src/pyrecest/filters/block_particle_filter.py
@@ -1,6 +1,7 @@
 """Generic block particle-filter mechanics for product-state particle filters."""
 
 from collections.abc import Callable, Sequence
+from numbers import Integral
 from typing import Any, Protocol
 
 # pylint: disable=no-name-in-module,no-member,too-many-positional-arguments
@@ -30,6 +31,27 @@ class _WeightedParticleState(Protocol):
 PartitionSpec = str | Sequence[Sequence[int]] | None
 
 
+def _as_integer(value, name: str, minimum: int | None = None) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be an integer")
+    try:
+        value_array = array(value)
+        if value_array.shape != ():
+            raise ValueError(f"{name} must be a scalar integer")
+        scalar = value_array.item()
+    except AttributeError:
+        scalar = value
+    except TypeError as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+
+    if isinstance(scalar, bool) or not isinstance(scalar, Integral):
+        raise ValueError(f"{name} must be an integer")
+    integer = int(scalar)
+    if minimum is not None and integer < minimum:
+        raise ValueError(f"{name} must be at least {minimum}.")
+    return integer
+
+
 def validate_partition(
     partition: Sequence[Sequence[int]], n_components: int
 ) -> tuple[tuple[int, ...], ...]:
@@ -39,13 +61,19 @@ def validate_partition(
     overlapping blocks, missing components, and out-of-range component indices
     raise ``ValueError``.
     """
-    if int(n_components) <= 0:
-        raise ValueError("n_components must be positive.")
+    n_components = _as_integer(n_components, "n_components", 1)
 
     normalized = []
     seen = set()
     for block_idx, raw_block in enumerate(partition):
-        block = tuple(int(component_idx) for component_idx in raw_block)
+        block = tuple(
+            _as_integer(
+                component_idx,
+                f"partition block {block_idx} component index",
+                0,
+            )
+            for component_idx in raw_block
+        )
         if not block:
             raise ValueError(f"partition block {block_idx} is empty.")
         for component_idx in block:
@@ -76,12 +104,8 @@ def contiguous_partition(
     n_components: int, block_size: int = 4
 ) -> tuple[tuple[int, ...], ...]:
     """Return contiguous blocks over ``range(n_components)``."""
-    n_components = int(n_components)
-    block_size = int(block_size)
-    if n_components <= 0:
-        raise ValueError("n_components must be positive.")
-    if block_size <= 0:
-        raise ValueError("block_size must be positive.")
+    n_components = _as_integer(n_components, "n_components", 1)
+    block_size = _as_integer(block_size, "block_size", 1)
     return tuple(
         tuple(range(start, min(start + block_size, n_components)))
         for start in range(0, n_components, block_size)
@@ -95,9 +119,7 @@ def resolve_partition(
     contiguous_block_size: int = 4,
 ) -> tuple[tuple[int, ...], ...]:
     """Resolve a named or explicit product-state partition."""
-    n_components = int(n_components)
-    if n_components <= 0:
-        raise ValueError("n_components must be positive.")
+    n_components = _as_integer(n_components, "n_components", 1)
     if partition is None:
         return (tuple(range(n_components)),)
 
@@ -155,10 +177,9 @@ class BlockParticleFilter:
                     "(n_particles, n_components, ...)."
                 )
             n_components = int(particles.shape[1])
-        if int(n_components) <= 0:
-            raise ValueError("n_components must be positive.")
+        n_components = _as_integer(n_components, "n_components", 1)
 
-        self._n_block_components = int(n_components)
+        self._n_block_components = n_components
         self.partition = self._validate_partition(partition, self._n_block_components)
         self._component_to_block = self._build_component_to_block(
             self.partition, self._n_block_components
@@ -300,7 +321,7 @@ class BlockParticleFilter:
 
     def component_weights(self, component_idx: int):
         """Return the weight vector used for one product-state component."""
-        component_idx = int(component_idx)
+        component_idx = _as_integer(component_idx, "component_idx", 0)
         if component_idx < 0 or component_idx >= self._n_block_components:
             raise ValueError("component_idx is out of range.")
         return self._block_weights[self._component_to_block[component_idx]]
@@ -346,7 +367,7 @@ class BlockParticleFilter:
 
     def resample_block_systematic(self, block_index: int):
         """Systematically resample one partition block and reset its weights."""
-        block_index = int(block_index)
+        block_index = _as_integer(block_index, "block_index", 0)
         if block_index < 0 or block_index >= self.n_blocks:
             raise ValueError("block_index is out of range.")
         indices = self._systematic_indices(

--- a/tests/filters/test_block_particle_filter.py
+++ b/tests/filters/test_block_particle_filter.py
@@ -62,6 +62,18 @@ class BlockParticleFilterTest(unittest.TestCase):
         npt.assert_allclose(filt.component_weights(0), array([0.8, 0.2]))
         npt.assert_allclose(filt.component_weights(1), array([0.2, 0.8]))
 
+    def test_component_indices_must_be_integral(self):
+        filt = DummyBlockParticleFilter(
+            array([[0.0, 10.0], [1.0, 11.0]]),
+            partition="singleton",
+        )
+
+        for invalid_index in (True, 0.5, "0", [0]):
+            with self.subTest(component_idx=invalid_index), self.assertRaises(
+                ValueError
+            ):
+                filt.component_weights(invalid_index)
+
     def test_resampling_assembles_hybrid_product_particles(self):
         filt = DummyBlockParticleFilter(
             array([[0.0, 10.0], [1.0, 11.0]]),
@@ -74,6 +86,23 @@ class BlockParticleFilterTest(unittest.TestCase):
         npt.assert_allclose(filt.particles, array([[0.0, 11.0], [0.0, 11.0]]))
         npt.assert_allclose(filt.block_weights, ones((2, 2)) / 2)
         npt.assert_allclose(filt.weights, ones(2) / 2)
+
+    def test_resample_block_indices_must_be_integral(self):
+        filt = DummyBlockParticleFilter(
+            array([[0.0, 10.0], [1.0, 11.0]]),
+            partition="singleton",
+            block_weights=array([[1.0, 0.0], [0.0, 1.0]]),
+        )
+
+        for invalid_index in (True, 0.5, "0", [0]):
+            with self.subTest(block_index=invalid_index), self.assertRaises(
+                ValueError
+            ):
+                filt.resample_block_systematic(invalid_index)
+            with self.subTest(block_indices=invalid_index), self.assertRaises(
+                ValueError
+            ):
+                filt.resample_blocks_systematic([invalid_index])
 
     def test_rejects_nonfinite_weights(self):
         for invalid_weight in (float("nan"), float("inf"), -float("inf")):

--- a/tests/filters/test_block_partition_helpers.py
+++ b/tests/filters/test_block_partition_helpers.py
@@ -22,6 +22,39 @@ class BlockPartitionHelpersTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             validate_partition([(0,)], 3)
 
+    def test_partition_counts_must_be_integral(self):
+        invalid_counts = (True, 3.5, "3", [3])
+
+        for invalid_count in invalid_counts:
+            with self.subTest(function="contiguous", count=invalid_count):
+                with self.assertRaises(ValueError):
+                    contiguous_partition(invalid_count, block_size=2)
+            with self.subTest(function="resolve", count=invalid_count):
+                with self.assertRaises(ValueError):
+                    resolve_partition(invalid_count, "singleton")
+            with self.subTest(function="validate", count=invalid_count):
+                with self.assertRaises(ValueError):
+                    validate_partition([(0,)], invalid_count)
+
+    def test_contiguous_block_size_must_be_integral(self):
+        for invalid_size in (True, 0, 2.5, "2", [2]):
+            with self.subTest(block_size=invalid_size), self.assertRaises(ValueError):
+                contiguous_partition(3, block_size=invalid_size)
+
+    def test_partition_component_indices_must_be_integral(self):
+        invalid_partitions = (
+            [(0.5, 1), (2,)],
+            [(True, 1), (2,)],
+            [("0", 1), (2,)],
+            [([0], 1), (2,)],
+        )
+
+        for invalid_partition in invalid_partitions:
+            with self.subTest(partition=invalid_partition), self.assertRaises(
+                ValueError
+            ):
+                validate_partition(invalid_partition, 3)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- validate block particle component counts, block sizes, partition indices, and resampling indices as scalar integers
- prevent booleans, fractional values, strings, and non-scalars from being truncated into valid component or block indices
- add regression coverage for partition helpers and block filter index entry points

## Tests
- `PYTHONPATH=src python -m pytest tests/filters/test_block_partition_helpers.py tests/filters/test_block_particle_filter.py`
- `PYTHONPATH=src python -O -m pytest tests/filters/test_block_partition_helpers.py tests/filters/test_block_particle_filter.py`
- `python -m ruff check src/pyrecest/filters/block_particle_filter.py tests/filters/test_block_partition_helpers.py tests/filters/test_block_particle_filter.py`
- `git diff --check`
