### PR TITLE
Validate replay particle dimensions

### DIFF
--- a/src/pyrecest/filters/goal_conditioned_replay_particle_filter.py
+++ b/src/pyrecest/filters/goal_conditioned_replay_particle_filter.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import copy
 from collections.abc import Callable
+from numbers import Integral
 from typing import Any
 
 import pyrecest.backend
@@ -63,6 +64,27 @@ from pyrecest.distributions.nonperiodic.abstract_linear_distribution import (
 )
 
 from .euclidean_particle_filter import EuclideanParticleFilter
+
+
+def _as_positive_integer(value, name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be a positive integer")
+    try:
+        value_array = array(value)
+        if value_array.shape != ():
+            raise ValueError(f"{name} must be a scalar integer")
+        scalar = value_array.item()
+    except AttributeError:
+        scalar = value
+    except TypeError as exc:
+        raise ValueError(f"{name} must be a positive integer") from exc
+
+    if isinstance(scalar, bool) or not isinstance(scalar, Integral):
+        raise ValueError(f"{name} must be a positive integer")
+    integer = int(scalar)
+    if integer <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return integer
 
 
 # pylint: disable=too-many-instance-attributes,too-many-public-methods
@@ -154,26 +176,18 @@ class GoalConditionedReplayParticleFilter(EuclideanParticleFilter):
 
         if position_dim is None:
             position_dim = spatial_dim
-        elif spatial_dim is not None and int(spatial_dim) != int(position_dim):
-            raise ValueError(
-                "position_dim and spatial_dim must match when both are provided"
-            )
 
         if position_dim is None:
             raise ValueError("Either position_dim or spatial_dim must be provided")
 
-        try:
-            position_dim = int(position_dim)
-            n_particles = int(n_particles)
-        except (TypeError, ValueError) as exc:
-            raise ValueError(
-                "position_dim/spatial_dim and n_particles must be positive integers"
-            ) from exc
-
-        if position_dim <= 0:
-            raise ValueError("position_dim/spatial_dim must be a positive integer")
-        if n_particles <= 0:
-            raise ValueError("n_particles must be a positive integer")
+        position_dim = _as_positive_integer(position_dim, "position_dim/spatial_dim")
+        if spatial_dim is not None:
+            spatial_dim = _as_positive_integer(spatial_dim, "spatial_dim")
+            if spatial_dim != position_dim:
+                raise ValueError(
+                    "position_dim and spatial_dim must match when both are provided"
+                )
+        n_particles = _as_positive_integer(n_particles, "n_particles")
         if dt <= 0.0:
             raise ValueError("dt must be positive")
 

--- a/tests/filters/test_goal_conditioned_replay_particle_filter.py
+++ b/tests/filters/test_goal_conditioned_replay_particle_filter.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
@@ -16,6 +17,30 @@ from .test_goal_conditioned_replay_common import (
     pyrecest.backend.__backend_name__ == "jax", reason="Backend not supported"
 )
 class TestGoalConditionedReplayParticleFilter(unittest.TestCase):
+    def test_constructor_accepts_integral_scalar_counts(self):
+        filt = GoalConditionedReplayParticleFilter(
+            n_particles=np.int64(4),
+            position_dim=np.int64(2),
+        )
+
+        self.assertEqual(filt.n_particles, 4)
+        self.assertEqual(filt.state_dim, 6)
+
+    def test_constructor_rejects_invalid_particle_and_dimension_counts(self):
+        invalid_arguments = (
+            {"n_particles": True, "position_dim": 2},
+            {"n_particles": 4.5, "position_dim": 2},
+            {"n_particles": 4, "position_dim": True},
+            {"n_particles": 4, "position_dim": 2.5},
+            {"n_particles": 4, "position_dim": [2]},
+            {"n_particles": 4, "position_dim": 2, "spatial_dim": 2.5},
+            {"n_particles": 4, "position_dim": 2.5, "spatial_dim": 2.5},
+        )
+
+        for kwargs in invalid_arguments:
+            with self.subTest(kwargs=kwargs), self.assertRaises(ValueError):
+                GoalConditionedReplayParticleFilter(**kwargs)
+
     def test_predict_replay_moves_velocity_toward_goal(self):
         random.seed(0)
 


### PR DESCRIPTION
## Summary
- validate replay particle `n_particles`, `position_dim`, and `spatial_dim` as scalar positive integers
- prevent booleans and fractional dimensions from being truncated into state sizes
- add constructor regression coverage for invalid particle and dimension counts

## Tests
- `PYTHONPATH=src python -m pytest tests/filters/test_goal_conditioned_replay_particle_filter.py`
- `PYTHONPATH=src python -O -m pytest tests/filters/test_goal_conditioned_replay_particle_filter.py`
- `python -m ruff check src/pyrecest/filters/goal_conditioned_replay_particle_filter.py tests/filters/test_goal_conditioned_replay_particle_filter.py`
- `git diff --check`
