### PR TITLE
Validate replay IMM mode indices

### DIFF
--- a/src/pyrecest/filters/goal_conditioned_replay_particle_imm_filter.py
+++ b/src/pyrecest/filters/goal_conditioned_replay_particle_imm_filter.py
@@ -44,7 +44,7 @@ def _as_mode_index(value, n_modes: int) -> int:
         scalar = value.item()
     except AttributeError:
         scalar = value
-    except ValueError as exc:
+    except (RuntimeError, ValueError) as exc:
         raise ValueError("mode indices must be scalar integers") from exc
 
     if isinstance(scalar, bool) or isinstance(scalar, str):
@@ -70,7 +70,7 @@ def _contains_boolean(value) -> bool:
         return True
     try:
         scalar = value.item()
-    except (AttributeError, ValueError):
+    except (AttributeError, RuntimeError, ValueError):
         scalar = None
     if isinstance(scalar, bool):
         return True
@@ -182,7 +182,10 @@ class GoalConditionedReplayParticleIMMFilter(  # pylint: disable=too-many-instan
 
         if _contains_boolean(mode_indices):
             raise ValueError("mode_indices must be integers, not booleans")
-        mode_indices = atleast_1d(array(mode_indices))
+        try:
+            mode_indices = atleast_1d(array(mode_indices))
+        except (RuntimeError, TypeError, ValueError) as exc:
+            raise ValueError("mode_indices must be integers") from exc
         if mode_indices.shape != (self.n_particles,):
             raise ValueError(
                 "mode_indices must contain one mode index per particle; "

--- a/src/pyrecest/filters/goal_conditioned_replay_particle_imm_filter.py
+++ b/src/pyrecest/filters/goal_conditioned_replay_particle_imm_filter.py
@@ -15,6 +15,9 @@ replay dynamics:
 
 from __future__ import annotations
 
+import math
+from numbers import Integral
+
 # pylint: disable=no-name-in-module,no-member,duplicate-code
 from pyrecest import copy
 from pyrecest.backend import (
@@ -34,6 +37,50 @@ from pyrecest.backend import (
 )
 
 from .goal_conditioned_replay_particle_filter import GoalConditionedReplayParticleFilter
+
+
+def _as_mode_index(value, n_modes: int) -> int:
+    try:
+        scalar = value.item()
+    except AttributeError:
+        scalar = value
+    except ValueError as exc:
+        raise ValueError("mode indices must be scalar integers") from exc
+
+    if isinstance(scalar, bool) or isinstance(scalar, str):
+        raise ValueError("mode indices must be integers")
+    if isinstance(scalar, Integral):
+        mode_index = int(scalar)
+    else:
+        try:
+            scalar_float = float(scalar)
+            mode_index = int(scalar)
+        except (OverflowError, TypeError, ValueError) as exc:
+            raise ValueError("mode indices must be integers") from exc
+        if not math.isfinite(scalar_float) or not scalar_float.is_integer():
+            raise ValueError("mode indices must be finite integers")
+
+    if mode_index < 0 or mode_index >= n_modes:
+        raise ValueError(f"mode_indices must lie in [0, {n_modes - 1}]")
+    return mode_index
+
+
+def _contains_boolean(value) -> bool:
+    if isinstance(value, bool):
+        return True
+    try:
+        scalar = value.item()
+    except (AttributeError, ValueError):
+        scalar = None
+    if isinstance(scalar, bool):
+        return True
+    if isinstance(value, str):
+        return False
+    try:
+        iterator = iter(value)
+    except TypeError:
+        return False
+    return any(_contains_boolean(item) for item in iterator)
 
 
 class GoalConditionedReplayParticleIMMFilter(  # pylint: disable=too-many-instance-attributes
@@ -133,17 +180,17 @@ class GoalConditionedReplayParticleIMMFilter(  # pylint: disable=too-many-instan
     def set_mode_indices(self, mode_indices):
         """Set one discrete mode index per particle."""
 
+        if _contains_boolean(mode_indices):
+            raise ValueError("mode_indices must be integers, not booleans")
         mode_indices = atleast_1d(array(mode_indices))
         if mode_indices.shape != (self.n_particles,):
             raise ValueError(
                 "mode_indices must contain one mode index per particle; "
                 f"got {mode_indices.shape}"
             )
-        for mode_index in mode_indices:
-            mode_int = int(mode_index)
-            if mode_int < 0 or mode_int >= self.n_modes:
-                raise ValueError(f"mode_indices must lie in [0, {self.n_modes - 1}]")
-        self._mode_indices = mode_indices
+        self._mode_indices = array(
+            [_as_mode_index(mode_index, self.n_modes) for mode_index in mode_indices]
+        )
         return self
 
     def sample_modes_from_prior(self, mode_prior=None):

--- a/tests/filters/test_goal_conditioned_replay_particle_imm_filter.py
+++ b/tests/filters/test_goal_conditioned_replay_particle_imm_filter.py
@@ -28,6 +28,29 @@ from .test_goal_conditioned_replay_common import (
     pyrecest.backend.__backend_name__ == "jax", reason="Backend not supported"
 )
 class TestGoalConditionedReplayParticleIMMFilter(unittest.TestCase):
+    def test_set_mode_indices_validates_scalar_integer_values(self):
+        filt = GoalConditionedReplayParticleIMMFilter(
+            n_particles=4,
+            spatial_dim=2,
+        )
+
+        filt.set_mode_indices(array([0.0, 1.0, 2.0, 3.0]))
+
+        self.assertEqual(filt.mode_indices.shape, (4,))
+
+        invalid_mode_indices = (
+            [0.5, 1, 2, 3],
+            [True, 1, 2, 3],
+            ["0", 1, 2, 3],
+            [-1, 1, 2, 3],
+            [len(filt.mode_names), 1, 2, 3],
+        )
+        for mode_indices in invalid_mode_indices:
+            with self.subTest(mode_indices=mode_indices), self.assertRaises(
+                ValueError
+            ):
+                filt.set_mode_indices(mode_indices)
+
     def test_goal_directed_mode_moves_velocity_toward_goal(self):
         random.seed(0)
         goal_mode = GoalConditionedReplayParticleIMMFilter.mode_names.index(


### PR DESCRIPTION
## Summary
- validate replay IMM mode indices before storing them
- preserve integer-valued float mode arrays while rejecting booleans, strings, fractions, and out-of-range indices
- add regression coverage for `set_mode_indices`

## Tests
- `PYTHONPATH=src python -m pytest tests/filters/test_goal_conditioned_replay_particle_imm_filter.py`
- `PYTHONPATH=src python -O -m pytest tests/filters/test_goal_conditioned_replay_particle_imm_filter.py`
- `python -m ruff check src/pyrecest/filters/goal_conditioned_replay_particle_imm_filter.py tests/filters/test_goal_conditioned_replay_particle_imm_filter.py`
- `git diff --check`
