### PR TITLE
Validate tracker iteration counts

### DIFF
--- a/src/pyrecest/filters/iterated_batch_mem_qkf_tracker.py
+++ b/src/pyrecest/filters/iterated_batch_mem_qkf_tracker.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from numbers import Integral
 from typing import Any
 
 # pylint: disable=no-name-in-module,no-member,too-many-arguments,too-many-locals,protected-access
@@ -7,6 +8,27 @@ import numpy as np
 from pyrecest.backend import array, diag, linalg, mean, zeros
 
 from .mem_qkf_tracker import MEMQKFTracker
+
+
+def _as_positive_integer(value, name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be a positive integer")
+    try:
+        value_array = array(value)
+        if value_array.shape != ():
+            raise ValueError(f"{name} must be a scalar integer")
+        scalar = value_array.item()
+    except AttributeError:
+        scalar = value
+    except TypeError as exc:
+        raise ValueError(f"{name} must be a positive integer") from exc
+
+    if isinstance(scalar, bool) or not isinstance(scalar, Integral):
+        raise ValueError(f"{name} must be a positive integer")
+    integer = int(scalar)
+    if integer <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return integer
 
 
 class IteratedBatchMEMQKFTracker(MEMQKFTracker):
@@ -63,9 +85,7 @@ class IteratedBatchMEMQKFTracker(MEMQKFTracker):
         kwargs.pop("update_mode", None)
         super().__init__(*args, update_mode="sequential", **kwargs)
 
-        self.n_iterations = int(n_iterations)
-        if self.n_iterations < 1:
-            raise ValueError("n_iterations must be at least 1")
+        self.n_iterations = _as_positive_integer(n_iterations, "n_iterations")
 
         self.damping = float(damping)
         if not 0.0 < self.damping <= 1.0:

--- a/src/pyrecest/filters/orientation_vector_eot_tracker.py
+++ b/src/pyrecest/filters/orientation_vector_eot_tracker.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from numbers import Integral
+
 # pylint: disable=no-name-in-module,no-member
 # pylint: disable=too-many-instance-attributes,too-many-arguments
 # pylint: disable=too-many-positional-arguments,too-many-locals,duplicate-code
@@ -20,6 +22,27 @@ from pyrecest.backend import (
 )
 
 from .abstract_extended_object_tracker import AbstractExtendedObjectTracker
+
+
+def _as_positive_integer(value, name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be a positive integer")
+    try:
+        value_array = array(value)
+        if value_array.shape != ():
+            raise ValueError(f"{name} must be a scalar integer")
+        scalar = value_array.item()
+    except AttributeError:
+        scalar = value
+    except TypeError as exc:
+        raise ValueError(f"{name} must be a positive integer") from exc
+
+    if isinstance(scalar, bool) or not isinstance(scalar, Integral):
+        raise ValueError(f"{name} must be a positive integer")
+    integer = int(scalar)
+    if integer <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return integer
 
 
 class OrientationVectorEOTTracker(AbstractExtendedObjectTracker):
@@ -147,9 +170,7 @@ class OrientationVectorEOTTracker(AbstractExtendedObjectTracker):
             )
 
         self.velocity_indices = self._normalize_velocity_indices(velocity_indices)
-        self.num_iterations = int(num_iterations)
-        if self.num_iterations <= 0:
-            raise ValueError("num_iterations must be positive")
+        self.num_iterations = _as_positive_integer(num_iterations, "num_iterations")
         self.forgetting_factor = float(forgetting_factor)
         if self.forgetting_factor <= 0.0:
             raise ValueError("forgetting_factor must be positive")

--- a/src/pyrecest/filters/vbrm_tracker.py
+++ b/src/pyrecest/filters/vbrm_tracker.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from numbers import Integral
+
 # pylint: disable=no-name-in-module,no-member
 # pylint: disable=too-many-instance-attributes,too-many-arguments
 # pylint: disable=too-many-positional-arguments,too-many-locals
@@ -27,6 +29,27 @@ from pyrecest.backend import (
 )
 
 from .abstract_extended_object_tracker import AbstractExtendedObjectTracker
+
+
+def _as_positive_integer(value, name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be a positive integer")
+    try:
+        value_array = array(value)
+        if value_array.shape != ():
+            raise ValueError(f"{name} must be a scalar integer")
+        scalar = value_array.item()
+    except AttributeError:
+        scalar = value
+    except TypeError as exc:
+        raise ValueError(f"{name} must be a positive integer") from exc
+
+    if isinstance(scalar, bool) or not isinstance(scalar, Integral):
+        raise ValueError(f"{name} must be a positive integer")
+    integer = int(scalar)
+    if integer <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return integer
 
 
 class VBRMTracker(AbstractExtendedObjectTracker):
@@ -109,9 +132,7 @@ class VBRMTracker(AbstractExtendedObjectTracker):
                 "measurement_noise_cov",
             )
 
-        self.num_iterations = int(num_iterations)
-        if self.num_iterations <= 0:
-            raise ValueError("num_iterations must be positive")
+        self.num_iterations = _as_positive_integer(num_iterations, "num_iterations")
         self.forgetting_factor = float(forgetting_factor)
         if self.forgetting_factor <= 0.0:
             raise ValueError("forgetting_factor must be positive")

--- a/tests/filters/test_iterated_batch_mem_qkf_tracker.py
+++ b/tests/filters/test_iterated_batch_mem_qkf_tracker.py
@@ -69,8 +69,14 @@ class TestIteratedBatchMEMQKFTracker(unittest.TestCase):
         npt.assert_allclose(tracker.shape_state, self.shape_state)
 
     def test_rejects_invalid_parameters(self):
-        with self.assertRaises(ValueError):
-            self.make_tracker(n_iterations=0)
+        tracker = self.make_tracker(n_iterations=np.int64(2))
+        self.assertEqual(tracker.n_iterations, 2)
+
+        for invalid_iterations in (0, True, 1.5, "2", [2]):
+            with self.subTest(n_iterations=invalid_iterations), self.assertRaises(
+                ValueError
+            ):
+                self.make_tracker(n_iterations=invalid_iterations)
         with self.assertRaises(ValueError):
             self.make_tracker(damping=0.0)
         with self.assertRaises(ValueError):

--- a/tests/filters/test_orientation_vector_eot_tracker.py
+++ b/tests/filters/test_orientation_vector_eot_tracker.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member,duplicate-code
@@ -58,6 +59,30 @@ class TestOrientationVectorEOTTracker(unittest.TestCase):
             atol=1e-12,
         )
         self.assertEqual(self.tracker.get_point_estimate().shape[0], 7)
+
+    def test_num_iterations_must_be_positive_integer(self):
+        tracker = OrientationVectorEOTTracker(
+            self.kinematic_state,
+            self.covariance,
+            self.shape_state,
+            measurement_noise_cov=self.measurement_noise_cov,
+            measurement_matrix=self.measurement_matrix,
+            num_iterations=np.int64(2),
+        )
+        self.assertEqual(tracker.num_iterations, 2)
+
+        for invalid_iterations in (0, True, 1.5, "2", [2]):
+            with self.subTest(num_iterations=invalid_iterations), self.assertRaises(
+                ValueError
+            ):
+                OrientationVectorEOTTracker(
+                    self.kinematic_state,
+                    self.covariance,
+                    self.shape_state,
+                    measurement_noise_cov=self.measurement_noise_cov,
+                    measurement_matrix=self.measurement_matrix,
+                    num_iterations=invalid_iterations,
+                )
 
     def test_extent_respects_orientation_vector(self):
         tracker = OrientationVectorEOTTracker(

--- a/tests/filters/test_vbrm_tracker.py
+++ b/tests/filters/test_vbrm_tracker.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member,duplicate-code
@@ -49,6 +50,34 @@ class TestVBRMTracker(unittest.TestCase):
             diag(array([4.0, 1.0])),
         )
         self.assertEqual(self.tracker.get_point_estimate().shape[0], 7)
+
+    def test_num_iterations_must_be_positive_integer(self):
+        tracker = VBRMTracker(
+            self.kinematic_state,
+            self.covariance,
+            self.shape_state,
+            self.orientation_variance,
+            inverse_gamma_shape=10.0,
+            measurement_noise_cov=self.measurement_noise_cov,
+            measurement_matrix=self.measurement_matrix,
+            num_iterations=np.int64(2),
+        )
+        self.assertEqual(tracker.num_iterations, 2)
+
+        for invalid_iterations in (0, True, 1.5, "2", [2]):
+            with self.subTest(num_iterations=invalid_iterations), self.assertRaises(
+                ValueError
+            ):
+                VBRMTracker(
+                    self.kinematic_state,
+                    self.covariance,
+                    self.shape_state,
+                    self.orientation_variance,
+                    inverse_gamma_shape=10.0,
+                    measurement_noise_cov=self.measurement_noise_cov,
+                    measurement_matrix=self.measurement_matrix,
+                    num_iterations=invalid_iterations,
+                )
 
     def test_get_state_and_cov_returns_public_shape_covariance(self):
         state, covariance = self.tracker.get_state_and_cov(


### PR DESCRIPTION
## Summary
- validate MEM-QKF, orientation-vector EOT, and VBRM iteration counts as positive scalar integers
- prevent booleans, fractional values, strings, and non-scalars from being truncated into update iteration counts
- add constructor regression coverage across the affected tracker tests

## Tests
- `PYTHONPATH=src python -m pytest tests/filters/test_iterated_batch_mem_qkf_tracker.py tests/filters/test_orientation_vector_eot_tracker.py tests/filters/test_vbrm_tracker.py`
- `PYTHONPATH=src python -O -m pytest tests/filters/test_iterated_batch_mem_qkf_tracker.py tests/filters/test_orientation_vector_eot_tracker.py tests/filters/test_vbrm_tracker.py`
- `python -m ruff check src/pyrecest/filters/iterated_batch_mem_qkf_tracker.py src/pyrecest/filters/orientation_vector_eot_tracker.py src/pyrecest/filters/vbrm_tracker.py tests/filters/test_iterated_batch_mem_qkf_tracker.py tests/filters/test_orientation_vector_eot_tracker.py tests/filters/test_vbrm_tracker.py`
- `git diff --check`
