### PR TITLE
Validate MEM-RBPF particle counts

### DIFF
--- a/src/pyrecest/filters/mem_rbpf_tracker.py
+++ b/src/pyrecest/filters/mem_rbpf_tracker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from numbers import Integral
+from operator import index as operator_index
 
 from pyrecest import backend
 from pyrecest.backend import abs as backend_abs
@@ -50,6 +51,18 @@ from .abstract_extended_object_tracker import AbstractExtendedObjectTracker
 # pylint: disable=too-many-positional-arguments,too-many-locals
 
 
+def _validate_positive_integer(value, name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be a positive integer")
+    try:
+        value = operator_index(value)
+    except TypeError as exc:
+        raise ValueError(f"{name} must be a positive integer") from exc
+    if value <= 0:
+        raise ValueError(f"{name} must be positive")
+    return value
+
+
 class MEMRBPFTracker(AbstractExtendedObjectTracker):
     """Rao-Blackwellized MEM tracker for a single 2-D elliptical target.
 
@@ -91,9 +104,7 @@ class MEMRBPFTracker(AbstractExtendedObjectTracker):
             log_prior_extents=log_prior_extents,
             log_posterior_extents=log_posterior_extents,
         )
-        if n_particles <= 0:
-            raise ValueError("n_particles must be positive")
-        self.n_particles = int(n_particles)
+        self.n_particles = _validate_positive_integer(n_particles, "n_particles")
         self._seed_backend_random(rng)
         self.resampling_mode = str(resampling_mode).lower()
         self.resampling_threshold = resampling_threshold

--- a/tests/test_mem_rbpf_tracker.py
+++ b/tests/test_mem_rbpf_tracker.py
@@ -10,20 +10,33 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def _make_tracker():
+def _make_tracker(**kwargs):
     random.seed(0)
-    return MEMRBPFTracker(
-        kinematic_state=array([0.0, 0.0, 1.0, -0.5]),
-        covariance=eye(4),
-        shape_state=array([0.2, 2.0, 1.0]),
-        shape_covariance=diag(array([0.05, 0.1, 0.1])),
-        meas_noise_cov=0.05 * eye(2),
-        sys_noise=0.01 * eye(4),
-        shape_sys_noise=diag(array([0.01, 0.01, 0.01])),
-        n_particles=32,
-        resampling_threshold=16,
-        axis_floor=1e-3,
-    )
+    parameters = {
+        "kinematic_state": array([0.0, 0.0, 1.0, -0.5]),
+        "covariance": eye(4),
+        "shape_state": array([0.2, 2.0, 1.0]),
+        "shape_covariance": diag(array([0.05, 0.1, 0.1])),
+        "meas_noise_cov": 0.05 * eye(2),
+        "sys_noise": 0.01 * eye(4),
+        "shape_sys_noise": diag(array([0.01, 0.01, 0.01])),
+        "n_particles": 32,
+        "resampling_threshold": 16,
+        "axis_floor": 1e-3,
+    }
+    parameters.update(kwargs)
+    return MEMRBPFTracker(**parameters)
+
+
+def test_mem_rbpf_validates_particle_count():
+    for invalid in (True, np.bool_(True), 1.5, np.array(1.5), np.array([3]), 0, -1):
+        with pytest.raises(ValueError, match="n_particles"):
+            _make_tracker(n_particles=invalid)
+
+    for valid in (np.int64(3), np.array(3)):
+        tracker = _make_tracker(n_particles=valid)
+        assert tracker.n_particles == 3
+        assert tracker.weights.shape == (3,)
 
 
 def test_mem_rbpf_predict_update_smoke():


### PR DESCRIPTION
## Summary
- validate MEM-RBPF particle counts with the integer protocol before allocating particle arrays
- reject booleans, fractional values, non-scalar arrays, and non-positive counts instead of silently truncating them
- add regression coverage for invalid counts and accepted NumPy integer scalar counts

## Tests
- `PYTHONPATH=src python -m pytest tests/test_mem_rbpf_tracker.py`
- `PYTHONPATH=src python -O -m pytest tests/test_mem_rbpf_tracker.py`
- `python -m ruff check src/pyrecest/filters/mem_rbpf_tracker.py tests/test_mem_rbpf_tracker.py`
- `git diff --check`
