### PR TITLE
Validate mode-RBPF particle counts

### DIFF
--- a/src/pyrecest/filters/mode_rbpf_manifold_ukf_tracker.py
+++ b/src/pyrecest/filters/mode_rbpf_manifold_ukf_tracker.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from numbers import Integral
+from operator import index as operator_index
 
 import numpy as np
 from pyrecest import backend
@@ -10,6 +11,18 @@ from .abstract_extended_object_tracker import AbstractExtendedObjectTracker
 
 
 # pylint: disable=too-many-instance-attributes,too-many-arguments,too-many-positional-arguments,too-many-locals,too-many-public-methods
+def _validate_positive_integer(value, name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be a positive integer")
+    try:
+        value = operator_index(value)
+    except TypeError as exc:
+        raise ValueError(f"{name} must be a positive integer") from exc
+    if value <= 0:
+        raise ValueError(f"{name} must be positive")
+    return value
+
+
 class ModeRBPFManifoldUKFTracker(AbstractExtendedObjectTracker):
     """Mode-particle RBPF with a manifold UKF per particle.
 
@@ -83,9 +96,7 @@ class ModeRBPFManifoldUKFTracker(AbstractExtendedObjectTracker):
             log_posterior_extents=log_posterior_extents,
         )
 
-        self.n_particles = int(n_particles)
-        if self.n_particles <= 0:
-            raise ValueError("n_particles must be positive")
+        self.n_particles = _validate_positive_integer(n_particles, "n_particles")
         self.rng = self._prepare_rng(rng)
         self.time_step_length = float(time_step_length)
         self.resampling_mode = str(resampling_mode).lower()

--- a/tests/filters/test_mode_rbpf_manifold_ukf_tracker.py
+++ b/tests/filters/test_mode_rbpf_manifold_ukf_tracker.py
@@ -33,23 +33,47 @@ class TestModeRBPFManifoldUKFTracker(unittest.TestCase):
         )
 
     def make_tracker(self, **kwargs):
+        parameters = {
+            "meas_noise_cov": self.meas_noise_cov,
+            "sys_noise": self.sys_noise,
+            "shape_sys_noise": self.shape_sys_noise,
+            "n_particles": 24,
+            "rng": 0,
+            "resampling_threshold": 12,
+        }
+        parameters.update(kwargs)
         return ModeRBPFManifoldUKFTracker(
             self.kinematic_state,
             self.covariance,
             self.shape_state,
             self.shape_covariance,
-            meas_noise_cov=self.meas_noise_cov,
-            sys_noise=self.sys_noise,
-            shape_sys_noise=self.shape_sys_noise,
-            n_particles=24,
-            rng=0,
-            resampling_threshold=12,
-            **kwargs,
+            **parameters,
         )
 
     def test_aliases_are_exported(self):
         self.assertIs(ModeRbpfManifoldUkfTracker, ModeRBPFManifoldUKFTracker)
         self.assertIs(ModeRBPFManifoldUKF, ModeRBPFManifoldUKFTracker)
+
+    def test_validates_particle_count(self):
+        invalid_values = (
+            True,
+            np.bool_(True),
+            1.5,
+            np.array(1.5),
+            np.array([3]),
+            0,
+            -1,
+        )
+        for invalid in invalid_values:
+            with self.subTest(n_particles=invalid):
+                with self.assertRaisesRegex(ValueError, "n_particles"):
+                    self.make_tracker(n_particles=invalid)
+
+        for valid in (np.int64(3), np.array(3)):
+            with self.subTest(n_particles=valid):
+                tracker = self.make_tracker(n_particles=valid)
+                self.assertEqual(tracker.n_particles, 3)
+                self.assertEqual(tracker.weights.shape, (3,))
 
     def test_predict_update_smoke(self):
         tracker = self.make_tracker()


### PR DESCRIPTION
## Summary
- validate mode-RBPF particle counts with the integer protocol before tracker initialization
- reject booleans, fractional values, non-scalar arrays, and non-positive counts instead of silently truncating them
- add regression coverage for invalid counts and accepted NumPy integer scalar counts

## Tests
- `PYTHONPATH=src python -m pytest tests/filters/test_mode_rbpf_manifold_ukf_tracker.py`
- `PYTHONPATH=src python -O -m pytest tests/filters/test_mode_rbpf_manifold_ukf_tracker.py`
- `python -m ruff check src/pyrecest/filters/mode_rbpf_manifold_ukf_tracker.py tests/filters/test_mode_rbpf_manifold_ukf_tracker.py`
- `git diff --check`
