### PR TITLE
Validate spherical EOT harmonic order

### DIFF
--- a/src/pyrecest/filters/spherical_harmonics_eot_tracker.py
+++ b/src/pyrecest/filters/spherical_harmonics_eot_tracker.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from operator import index as operator_index
+
 import numpy as np
 import pyrecest.backend
 
@@ -31,6 +33,18 @@ from pyrecest.distributions.hypersphere_subset.spherical_harmonics_distribution_
 from pyrecest.sampling.sigma_points import MerweScaledSigmaPoints
 
 from .abstract_extended_object_tracker import AbstractExtendedObjectTracker
+
+
+def _validate_nonnegative_integer(value, name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be a non-negative integer")
+    try:
+        value = operator_index(value)
+    except TypeError as exc:
+        raise ValueError(f"{name} must be a non-negative integer") from exc
+    if value < 0:
+        raise ValueError(f"{name} must be non-negative")
+    return value
 
 
 class SphericalHarmonicsEOTTracker(
@@ -75,9 +89,7 @@ class SphericalHarmonicsEOTTracker(
                 "numpy backend"
             )
 
-        self.order = int(order)
-        if self.order < 0:
-            raise ValueError("order must be non-negative")
+        self.order = _validate_nonnegative_integer(order, "order")
         self.n_coefficients = (self.order + 1) ** 2
         self.state_dim = 3 + self.n_coefficients
 

--- a/tests/filters/test_spherical_harmonics_eot_tracker.py
+++ b/tests/filters/test_spherical_harmonics_eot_tracker.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-member,no-name-in-module
@@ -13,6 +14,19 @@ from pyrecest.filters import SphericalHarmonicsEOTTracker
     reason="Spherical-harmonics EOT tracker currently uses pyshtools/numpy",
 )
 class TestSphericalHarmonicsEOTTracker(unittest.TestCase):
+    def test_order_requires_nonnegative_integer(self):
+        invalid_orders = (True, np.bool_(True), 1.5, np.array(1.5), np.array([1]), -1)
+        for invalid in invalid_orders:
+            with self.subTest(order=invalid):
+                with self.assertRaisesRegex(ValueError, "order"):
+                    SphericalHarmonicsEOTTracker(invalid)
+
+        for valid in (np.int64(1), np.array(1)):
+            with self.subTest(order=valid):
+                tracker = SphericalHarmonicsEOTTracker(valid)
+                self.assertEqual(tracker.order, 1)
+                self.assertEqual(tracker.n_coefficients, 4)
+
     def test_coefficient_vector_matrix_roundtrip(self):
         coefficients = array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0])
 


### PR DESCRIPTION
## Summary
- validate spherical-harmonics EOT tracker order with the integer protocol before deriving coefficient dimensions
- reject booleans, fractional values, non-scalar arrays, and negative orders instead of silently truncating them
- add regression coverage for invalid orders and accepted NumPy integer scalar orders

## Tests
- `PYTHONPATH=src python -m pytest tests/filters/test_spherical_harmonics_eot_tracker.py`
- `PYTHONPATH=src python -O -m pytest tests/filters/test_spherical_harmonics_eot_tracker.py`
- `python -m ruff check src/pyrecest/filters/spherical_harmonics_eot_tracker.py tests/filters/test_spherical_harmonics_eot_tracker.py`
- `git diff --check`
