### PR TITLE
Validate MHT diverse pruning counts

### DIFF
--- a/src/pyrecest/filters/multi_hypothesis_tracker.py
+++ b/src/pyrecest/filters/multi_hypothesis_tracker.py
@@ -3,6 +3,7 @@ import warnings
 from builtins import all as builtin_all
 from copy import deepcopy
 from math import log
+from operator import index as operator_index
 
 from pyrecest.backend import all as backend_all
 from pyrecest.backend import (
@@ -29,6 +30,22 @@ from scipy.stats import chi2
 from .abstract_multitarget_tracker import AbstractMultitargetTracker
 from .kalman_filter import KalmanFilter
 from .manifold_mixins import EuclideanFilterMixin
+
+
+def _validate_integer(value, name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be an integer")
+    try:
+        return operator_index(value)
+    except TypeError as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+
+
+def _validate_positive_integer(value, name: str) -> int:
+    value = _validate_integer(value, name)
+    if value <= 0:
+        raise ValueError(f"{name} must be positive")
+    return value
 
 
 class MultiHypothesisTracker(AbstractMultitargetTracker):
@@ -660,15 +677,19 @@ class MultiHypothesisTracker(AbstractMultitargetTracker):
         return surviving_indices
 
     def _select_diverse_surviving_indices(self, candidate_indices, max_hypotheses):
-        history_length = int(self.association_param.get("diversity_history_length", 3))
+        history_length = _validate_integer(
+            self.association_param.get("diversity_history_length", 3),
+            "diversity_history_length",
+        )
         max_per_signature = self.association_param.get(
             "max_hypotheses_per_signature", 1
         )
         if max_per_signature is None:
             max_per_signature = max_hypotheses
-        max_per_signature = int(max_per_signature)
-        if max_per_signature <= 0:
-            raise ValueError("max_hypotheses_per_signature must be positive")
+        max_per_signature = _validate_positive_integer(
+            max_per_signature,
+            "max_hypotheses_per_signature",
+        )
 
         selected_indices = []
         signature_counts = {}

--- a/tests/filters/test_multi_hypothesis_tracker.py
+++ b/tests/filters/test_multi_hypothesis_tracker.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import pyrecest.backend
 from pyrecest.filters.multi_hypothesis_tracker import MultiHypothesisTracker
 
@@ -91,6 +92,55 @@ class MultiHypothesisTrackerEnumerationTest(unittest.TestCase):
         actual = tracker._enumerate_candidate_assignments([[], []], -2.0)
 
         self.assertEqual(actual, [(-2.0, (-1, -1))])
+
+    @staticmethod
+    def _make_diverse_tracker(association_param):
+        tracker = MultiHypothesisTracker.__new__(MultiHypothesisTracker)
+        tracker.association_param = association_param
+        tracker.hypothesis_diversity_key = None
+        tracker._global_hypothesis_histories = [  # pylint: disable=protected-access
+            ("first", "shared"),
+            ("second", "shared"),
+            ("third", "unique"),
+        ]
+        return tracker
+
+    def test_diverse_pruning_validates_integer_controls(self):
+        invalid_configs = (
+            {"diversity_history_length": True, "max_hypotheses_per_signature": 1},
+            {"diversity_history_length": 1.5, "max_hypotheses_per_signature": 1},
+            {
+                "diversity_history_length": np.array([1]),
+                "max_hypotheses_per_signature": 1,
+            },
+            {"diversity_history_length": 1, "max_hypotheses_per_signature": True},
+            {"diversity_history_length": 1, "max_hypotheses_per_signature": 1.5},
+            {
+                "diversity_history_length": 1,
+                "max_hypotheses_per_signature": np.array([1]),
+            },
+            {"diversity_history_length": 1, "max_hypotheses_per_signature": 0},
+        )
+        for config in invalid_configs:
+            with self.subTest(config=config):
+                tracker = self._make_diverse_tracker(config)
+                with self.assertRaisesRegex(ValueError, "must"):
+                    tracker._select_diverse_surviving_indices(  # pylint: disable=protected-access
+                        [0, 1, 2],
+                        3,
+                    )
+
+        valid_tracker = self._make_diverse_tracker(
+            {
+                "diversity_history_length": np.array(1),
+                "max_hypotheses_per_signature": np.int64(1),
+            }
+        )
+        selected = valid_tracker._select_diverse_surviving_indices(  # pylint: disable=protected-access
+            [0, 1, 2],
+            3,
+        )
+        self.assertEqual(selected, [0, 2])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- validate diverse-pruning integer controls before using them in MHT hypothesis selection
- reject booleans, fractional values, non-scalar arrays, and non-positive per-signature caps instead of silently truncating them
- add regression coverage for invalid settings and accepted NumPy integer scalar settings

## Tests
- `PYTHONPATH=src python -m pytest tests/filters/test_multi_hypothesis_tracker.py`
- `PYTHONPATH=src python -O -m pytest tests/filters/test_multi_hypothesis_tracker.py`
- `python -m ruff check src/pyrecest/filters/multi_hypothesis_tracker.py tests/filters/test_multi_hypothesis_tracker.py`
- `git diff --check`
