### PR TITLE
Validate sliding-window smoother size

### DIFF
--- a/src/pyrecest/smoothers/sliding_window_manifold_mean_smoother.py
+++ b/src/pyrecest/smoothers/sliding_window_manifold_mean_smoother.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from functools import partial
+from operator import index as operator_index
 
 from pyrecest.backend import any as backend_any
 from pyrecest.backend import asarray, concatenate, ndim, stack, sum
@@ -26,6 +27,18 @@ from pyrecest.distributions import (
 )
 
 from .abstract_smoother import AbstractSmoother
+
+
+def _validate_positive_integer(value, name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be a positive integer.")
+    try:
+        value = operator_index(value)
+    except TypeError as exc:
+        raise ValueError(f"{name} must be a positive integer.") from exc
+    if value < 1:
+        raise ValueError(f"{name} must be a positive integer.")
+    return value
 
 
 class SlidingWindowManifoldMeanSmoother(AbstractSmoother):
@@ -65,9 +78,7 @@ class SlidingWindowManifoldMeanSmoother(AbstractSmoother):
         window_weights=None,
         alignment: str = "center",
     ):
-        window_size = int(window_size)
-        if window_size < 1:
-            raise ValueError("window_size must be a positive integer.")
+        window_size = _validate_positive_integer(window_size, "window_size")
         if alignment not in self._ALIGNMENTS:
             raise ValueError(f"alignment must be one of {', '.join(self._ALIGNMENTS)}.")
 

--- a/tests/smoothers/test_sliding_window_manifold_mean_smoother.py
+++ b/tests/smoothers/test_sliding_window_manifold_mean_smoother.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 from pyrecest.backend import array, pi
 from pyrecest.distributions import CircularDiracDistribution, VonMisesDistribution
@@ -8,6 +9,18 @@ from pyrecest.smoothers import SlidingWindowManifoldMeanSmoother
 
 class SlidingWindowManifoldMeanSmootherTest(unittest.TestCase):
     _CIRCULAR_ATOL = 1e-6
+
+    def test_window_size_requires_positive_integer(self):
+        invalid_values = (True, np.bool_(True), 1.5, np.array(1.5), np.array([3]), 0)
+        for invalid in invalid_values:
+            with self.subTest(window_size=invalid):
+                with self.assertRaisesRegex(ValueError, "window_size"):
+                    SlidingWindowManifoldMeanSmoother(window_size=invalid)
+
+        for valid in (np.int64(3), np.array(3)):
+            with self.subTest(window_size=valid):
+                smoother = SlidingWindowManifoldMeanSmoother(window_size=valid)
+                self.assertEqual(smoother.window_size, 3)
 
     def test_centered_window_smooths_linear_sequence(self):
         smoother = SlidingWindowManifoldMeanSmoother(window_size=3)


### PR DESCRIPTION
## Summary
- validate sliding-window smoother size with the integer protocol before using it in window bounds
- reject booleans, fractional values, non-scalar arrays, and non-positive sizes instead of silently truncating them
- add regression coverage for invalid values and accepted NumPy integer scalar sizes

## Tests
- `PYTHONPATH=src python -m pytest tests/smoothers/test_sliding_window_manifold_mean_smoother.py`
- `PYTHONPATH=src python -O -m pytest tests/smoothers/test_sliding_window_manifold_mean_smoother.py`
- `python -m ruff check src/pyrecest/smoothers/sliding_window_manifold_mean_smoother.py tests/smoothers/test_sliding_window_manifold_mean_smoother.py`
- `git diff --check`
