### PR TITLE
Validate SO3 chordal smoother window size

### DIFF
--- a/src/pyrecest/smoothers/so3_chordal_mean_smoother.py
+++ b/src/pyrecest/smoothers/so3_chordal_mean_smoother.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from operator import index as operator_index
 from typing import Sequence
 
 # pylint: disable=no-member
@@ -42,10 +43,12 @@ class SO3ChordalMeanSmoother(AbstractSmoother):
     @staticmethod
     def _validate_window_size(window_size: int) -> int:
         try:
-            window_size_int = int(window_size)
-        except (TypeError, ValueError) as exc:
+            window_size_int = operator_index(window_size)
+        except TypeError as exc:
             raise ValueError("window_size must be a positive integer.") from exc
 
+        if isinstance(window_size, bool):
+            raise ValueError("window_size must be a positive integer.")
         if window_size_int < 1:
             raise ValueError("window_size must be a positive integer.")
         return window_size_int

--- a/tests/smoothers/test_so3_chordal_mean_smoother.py
+++ b/tests/smoothers/test_so3_chordal_mean_smoother.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 from pyrecest.backend import array, cos, eye, linalg, sin, stack
 from pyrecest.smoothers import SO3ChordalMeanSmoother, SO3CMSmoother
@@ -18,6 +19,24 @@ def z_rotation(angle):
 
 
 class SO3ChordalMeanSmootherTest(unittest.TestCase):
+    def test_window_size_requires_positive_integer(self):
+        invalid_values = (True, np.bool_(True), 1.5, np.array(1.5), np.array([3]), 0)
+        for invalid in invalid_values:
+            with self.subTest(window_size=invalid):
+                with self.assertRaisesRegex(ValueError, "window_size"):
+                    SO3ChordalMeanSmoother(window_size=invalid)
+
+        for valid in (np.int64(3), np.array(3)):
+            with self.subTest(window_size=valid):
+                smoother = SO3ChordalMeanSmoother(window_size=valid)
+                self.assertEqual(smoother.window_size, 3)
+
+    def test_smooth_rejects_fractional_window_override(self):
+        smoother = SO3ChordalMeanSmoother(window_size=3)
+
+        with self.assertRaisesRegex(ValueError, "window_size"):
+            smoother.smooth([eye(3), eye(3)], window_size=1.5)
+
     def test_chordal_mean_between_two_z_rotations(self):
         identity = eye(3)
         quarter_turn = z_rotation(0.5 * 3.141592653589793)


### PR DESCRIPTION
## Summary
- validate SO(3) chordal smoother window sizes with the integer protocol
- reject booleans, fractional values, non-scalar arrays, and non-positive sizes instead of silently truncating them
- add regression coverage for constructor and smooth-time window overrides

## Tests
- `PYTHONPATH=src python -m pytest tests/smoothers/test_so3_chordal_mean_smoother.py`
- `PYTHONPATH=src python -O -m pytest tests/smoothers/test_so3_chordal_mean_smoother.py`
- `python -m ruff check src/pyrecest/smoothers/so3_chordal_mean_smoother.py tests/smoothers/test_so3_chordal_mean_smoother.py`
- `git diff --check`
