### PR TITLE
Validate SO3 tangent smoother parameters

### DIFF
--- a/src/pyrecest/smoothers/so3_tangent_savitzky_golay_smoother.py
+++ b/src/pyrecest/smoothers/so3_tangent_savitzky_golay_smoother.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import Sequence
+from operator import index as operator_index
 
 # pylint: disable=no-member,too-many-locals
 from pyrecest.backend import array, asarray, eye, linalg, ndim, reshape, stack, zeros
@@ -33,9 +34,11 @@ class SO3TangentSavitzkyGolaySmoother(AbstractSmoother):
 
     @staticmethod
     def _validate_window_size(window_size: int) -> int:
+        if isinstance(window_size, bool):
+            raise ValueError("window_size must be a positive odd integer.")
         try:
-            window_size_int = int(window_size)
-        except (TypeError, ValueError) as exc:
+            window_size_int = operator_index(window_size)
+        except TypeError as exc:
             raise ValueError("window_size must be a positive odd integer.") from exc
         if window_size_int < 1 or window_size_int % 2 == 0:
             raise ValueError("window_size must be a positive odd integer.")
@@ -43,9 +46,11 @@ class SO3TangentSavitzkyGolaySmoother(AbstractSmoother):
 
     @staticmethod
     def _validate_polynomial_degree(polynomial_degree: int) -> int:
+        if isinstance(polynomial_degree, bool):
+            raise ValueError("polynomial_degree must be a non-negative integer.")
         try:
-            degree_int = int(polynomial_degree)
-        except (TypeError, ValueError) as exc:
+            degree_int = operator_index(polynomial_degree)
+        except TypeError as exc:
             raise ValueError(
                 "polynomial_degree must be a non-negative integer."
             ) from exc

--- a/tests/smoothers/test_so3_tangent_savitzky_golay_smoother.py
+++ b/tests/smoothers/test_so3_tangent_savitzky_golay_smoother.py
@@ -1,6 +1,7 @@
 import math
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 from pyrecest.backend import array, cos, eye, sin, stack
 from pyrecest.smoothers import SO3TangentSavitzkyGolaySmoother, SO3TSGSmoother
@@ -67,8 +68,46 @@ class SO3TangentSavitzkyGolaySmootherTest(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             SO3TangentSavitzkyGolaySmoother(window_size=4)
+        for invalid_window in (
+            True,
+            np.bool_(True),
+            5.5,
+            np.array(5.5),
+            np.array([5]),
+            0,
+        ):
+            with self.subTest(window_size=invalid_window):
+                with self.assertRaisesRegex(ValueError, "window_size"):
+                    SO3TangentSavitzkyGolaySmoother(window_size=invalid_window)
+
         with self.assertRaises(ValueError):
             SO3TangentSavitzkyGolaySmoother(polynomial_degree=-1)
+        for invalid_degree in (
+            True,
+            np.bool_(True),
+            1.5,
+            np.array(1.5),
+            np.array([1]),
+            -1,
+        ):
+            with self.subTest(polynomial_degree=invalid_degree):
+                with self.assertRaisesRegex(ValueError, "polynomial_degree"):
+                    SO3TangentSavitzkyGolaySmoother(
+                        polynomial_degree=invalid_degree
+                    )
+
+        valid = SO3TangentSavitzkyGolaySmoother(
+            window_size=np.array(5),
+            polynomial_degree=np.int64(1),
+        )
+        self.assertEqual(valid.window_size, 5)
+        self.assertEqual(valid.polynomial_degree, 1)
+
+        with self.assertRaisesRegex(ValueError, "window_size"):
+            smoother.smooth([eye(3), eye(3)], window_size=1.5)
+        with self.assertRaisesRegex(ValueError, "polynomial_degree"):
+            smoother.smooth([eye(3), eye(3)], polynomial_degree=True)
+
         with self.assertRaises(ValueError):
             smoother.smooth([eye(3), eye(3)], mask=[False, False])
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Summary
- validate SO(3) tangent smoother window sizes and polynomial degrees with the integer protocol
- reject booleans, fractional values, non-scalar arrays, and invalid bounds instead of silently truncating them
- add regression coverage for constructor validation and smooth-time overrides

## Tests
- `PYTHONPATH=src python -m pytest tests/smoothers/test_so3_tangent_savitzky_golay_smoother.py`
- `PYTHONPATH=src python -O -m pytest tests/smoothers/test_so3_tangent_savitzky_golay_smoother.py`
- `python -m ruff check src/pyrecest/smoothers/so3_tangent_savitzky_golay_smoother.py tests/smoothers/test_so3_tangent_savitzky_golay_smoother.py`
- `git diff --check`
