### PR TITLE
Reject boolean Gaussian marginal dimensions

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
@@ -277,7 +277,9 @@ class GaussianDistribution(AbstractLinearDistribution):
         invalid_dimensions = [
             dim
             for dim in dimensions
-            if not isinstance(dim, Integral) or not 0 <= int(dim) < self.dim
+            if isinstance(dim, bool)
+            or not isinstance(dim, Integral)
+            or not 0 <= int(dim) < self.dim
         ]
         if invalid_dimensions:
             raise ValueError(

--- a/tests/distributions/test_gaussian_distribution.py
+++ b/tests/distributions/test_gaussian_distribution.py
@@ -226,6 +226,12 @@ class GaussianDistributionTest(unittest.TestCase):
             g.marginalize_out(2)
 
         with self.assertRaises(ValueError):
+            g.marginalize_out(True)
+
+        with self.assertRaises(ValueError):
+            g.marginalize_out([False])
+
+        with self.assertRaises(ValueError):
             g.marginalize_out([0, 2])
 
     def test_default_linear_metropolis_hastings_proposal_shape(self):


### PR DESCRIPTION
## Summary
- reject boolean dimension selectors in Gaussian marginalization instead of treating them as indices 0 or 1
- preserve existing validation for out-of-range and non-integer dimensions
- add regression coverage for scalar and list boolean selectors

## Tests
- `PYTHONPATH=src python -m pytest tests/distributions/test_gaussian_distribution.py`
- `PYTHONPATH=src python -O -m pytest tests/distributions/test_gaussian_distribution.py`
- `python -m ruff check src/pyrecest/distributions/nonperiodic/gaussian_distribution.py tests/distributions/test_gaussian_distribution.py`
- `git diff --check`
