### PR TITLE
Validate additive-noise vectorized flags

### DIFF
--- a/src/pyrecest/models/additive_noise.py
+++ b/src/pyrecest/models/additive_noise.py
@@ -4,6 +4,8 @@ import inspect
 from collections.abc import Callable
 from typing import Any
 
+import numpy as np
+
 # pylint: disable=no-name-in-module,no-member,too-many-instance-attributes,too-many-positional-arguments
 from pyrecest.backend import asarray, is_array
 
@@ -72,6 +74,13 @@ def _reject_unexpected_kwargs(kwargs: dict[str, Any]) -> None:
     if kwargs:
         unexpected = ", ".join(sorted(kwargs))
         raise TypeError(f"Unexpected keyword argument(s): {unexpected}")
+
+
+def _validate_bool_flag(value: Any, name: str) -> bool:
+    value_array = np.asarray(value)
+    if value_array.shape != () or not np.issubdtype(value_array.dtype, np.bool_):
+        raise TypeError(f"{name} must be a boolean")
+    return bool(value_array.item())
 
 
 def _dt_call_mode(function: Callable[..., Any]) -> str | None:
@@ -228,7 +237,7 @@ class AdditiveNoiseTransitionModel:
 
     @vectorized.setter
     def vectorized(self, value):
-        self._function_is_vectorized = bool(value)
+        self._function_is_vectorized = _validate_bool_flag(value, "vectorized")
 
     @property
     def function_is_vectorized(self):
@@ -237,7 +246,9 @@ class AdditiveNoiseTransitionModel:
 
     @function_is_vectorized.setter
     def function_is_vectorized(self, value):
-        self._function_is_vectorized = bool(value)
+        self._function_is_vectorized = _validate_bool_flag(
+            value, "function_is_vectorized"
+        )
 
     def evaluate(self, state, dt=None, **kwargs):
         """Evaluate the noise-free transition, including default function args."""
@@ -341,7 +352,7 @@ class AdditiveNoiseMeasurementModel:
         self._noise_mean = _as_optional_array(noise_mean)
         self._noise_covariance = _as_optional_array(noise_covariance)
         self._jacobian = jacobian
-        self.vectorized = vectorized
+        self.vectorized = _validate_bool_flag(vectorized, "vectorized")
         self.function_args = dict(function_args or {})
 
     def evaluate(self, state, **kwargs):

--- a/tests/models/test_additive_noise_models.py
+++ b/tests/models/test_additive_noise_models.py
@@ -1,5 +1,7 @@
 import unittest
 
+import numpy as np
+
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import allclose, array, diag, eye
 from pyrecest.models import (
@@ -65,7 +67,7 @@ class AdditiveNoiseTransitionModelTest(unittest.TestCase):
         self.assertTrue(model.has_jacobian())
 
     def test_transition_vectorized_aliases_stay_in_sync(self):
-        model = AdditiveNoiseTransitionModel(lambda x: x, vectorized=True)
+        model = AdditiveNoiseTransitionModel(lambda x: x, vectorized=np.bool_(True))
 
         self.assertTrue(model.vectorized)
         self.assertTrue(model.function_is_vectorized)
@@ -73,6 +75,16 @@ class AdditiveNoiseTransitionModelTest(unittest.TestCase):
         self.assertFalse(model.vectorized)
         model.vectorized = True
         self.assertTrue(model.function_is_vectorized)
+
+        invalid_flags = ("False", 1, np.array([True]))
+        for flag in invalid_flags:
+            with self.subTest(flag=flag):
+                with self.assertRaisesRegex(TypeError, "vectorized"):
+                    AdditiveNoiseTransitionModel(lambda x: x, vectorized=flag)
+                with self.assertRaisesRegex(TypeError, "vectorized"):
+                    model.vectorized = flag
+                with self.assertRaisesRegex(TypeError, "function_is_vectorized"):
+                    model.function_is_vectorized = flag
 
     def test_transition_density_uses_additive_residual(self):
         noise = DummyNoise(
@@ -231,6 +243,15 @@ class AdditiveNoiseMeasurementModelTest(unittest.TestCase):
             self, model.measurement_function(array([3.0])), array([6.0])
         )
         assert_backend_allclose(self, model.jacobian(array([3.0])), array([[1.0]]))
+
+    def test_measurement_vectorized_flag_requires_boolean(self):
+        model = AdditiveNoiseMeasurementModel(lambda x: x, vectorized=np.bool_(True))
+        self.assertTrue(model.vectorized)
+
+        for flag in ("False", 1, np.array([True])):
+            with self.subTest(flag=flag):
+                with self.assertRaisesRegex(TypeError, "vectorized"):
+                    AdditiveNoiseMeasurementModel(lambda x: x, vectorized=flag)
 
     def test_missing_measurement_capabilities_raise(self):
         model = AdditiveNoiseMeasurementModel(lambda x: x)


### PR DESCRIPTION
## Summary
- validate additive-noise vectorized flags as real boolean scalars instead of coercing arbitrary truthy values
- keep transition `vectorized` and `function_is_vectorized` aliases synchronized through the same validation
- add regression coverage for transition setters and measurement constructor input

## Tests
- `PYTHONPATH=src python -m pytest tests/models/test_additive_noise_models.py`
- `PYTHONPATH=src python -O -m pytest tests/models/test_additive_noise_models.py`
- `python -m ruff check src/pyrecest/models/additive_noise.py tests/models/test_additive_noise_models.py`
- `git diff --check`
