### PR TITLE
Validate measurement activity masks

### DIFF
--- a/src/pyrecest/filters/measurement_reliability.py
+++ b/src/pyrecest/filters/measurement_reliability.py
@@ -25,6 +25,11 @@ class MeasurementReliabilitySelection:
     active_measurement_indices: list[int]
 
 
+def _has_boolean_dtype(value) -> bool:
+    dtype = getattr(value, "dtype", None)
+    return dtype is not None and "bool" in str(dtype).lower()
+
+
 def normalize_measurement_weights(measurement_weights, n_measurements: int):
     """Return one non-negative finite reliability weight per measurement.
 
@@ -66,6 +71,8 @@ def normalize_active_measurement_mask(
         return [True] * n_measurements
 
     mask = array(active_measurement_mask)
+    if not _has_boolean_dtype(mask):
+        raise ValueError("active_measurement_mask must contain booleans")
     if mask.ndim == 0:
         return [bool(mask)] * n_measurements
     mask = reshape(mask, (-1,))

--- a/tests/filters/test_measurement_reliability.py
+++ b/tests/filters/test_measurement_reliability.py
@@ -53,6 +53,11 @@ class TestMeasurementReliability(unittest.TestCase):
             [True, True],
         )
 
+        for invalid_mask in ("False", 1):
+            with self.subTest(mask=invalid_mask):
+                with self.assertRaisesRegex(ValueError, "booleans"):
+                    normalize_active_measurement_mask(invalid_mask, 2)
+
     def test_mask_vector_is_validated(self):
         self.assertEqual(
             normalize_active_measurement_mask(array([True, False, True]), 3),
@@ -60,6 +65,8 @@ class TestMeasurementReliability(unittest.TestCase):
         )
         with self.assertRaises(ValueError):
             normalize_active_measurement_mask(array([True, False]), 3)
+        with self.assertRaisesRegex(ValueError, "booleans"):
+            normalize_active_measurement_mask(array([1, 0, 1]), 3)
 
     def test_reliability_selection_skips_masked_and_zero_weight_measurements(self):
         reliability = normalize_measurement_reliability(


### PR DESCRIPTION
## Summary
- require active measurement masks to contain boolean values instead of coercing arbitrary truthy or numeric inputs
- preserve scalar and vector boolean mask expansion behavior
- add regression coverage for string and numeric masks

## Tests
- `PYTHONPATH=src python -m pytest tests/filters/test_measurement_reliability.py`
- `PYTHONPATH=src python -O -m pytest tests/filters/test_measurement_reliability.py`
- `python -m ruff check src/pyrecest/filters/measurement_reliability.py tests/filters/test_measurement_reliability.py`
- `git diff --check`
