### PR TITLE
Accept None evidence mode metadata

### DIFF
--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -46,7 +46,7 @@ class EvidenceComputationMode:
     mode: EvidenceComputationKind = "full_smoothing"
     return_smoothed: bool = True
     terminal_posterior: bool = True
-    metadata: dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] | None = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if self.mode not in {"full_smoothing", "evidence_only"}:
@@ -61,7 +61,11 @@ class EvidenceComputationMode:
             raise ValueError("full_smoothing mode must return smoothed posteriors")
         object.__setattr__(self, "return_smoothed", return_smoothed)
         object.__setattr__(self, "terminal_posterior", terminal_posterior)
-        object.__setattr__(self, "metadata", dict(self.metadata))
+        object.__setattr__(
+            self,
+            "metadata",
+            {} if self.metadata is None else dict(self.metadata),
+        )
 
     @classmethod
     def full_smoothing(

--- a/tests/test_evidence_only_mode.py
+++ b/tests/test_evidence_only_mode.py
@@ -25,6 +25,13 @@ def test_evidence_computation_mode_accepts_numpy_bool_flags():
     assert fast.mode == "evidence_only"
 
 
+def test_evidence_computation_mode_accepts_none_metadata_constructor():
+    mode = EvidenceComputationMode(metadata=None)
+
+    assert mode.metadata == {}
+    assert mode.to_diagnostics()["evidence_computation_mode"] == "full_smoothing"
+
+
 def test_evidence_computation_mode_rejects_invalid_boolean_strings():
     with pytest.raises(ValueError, match="return_smoothed"):
         resolve_evidence_computation_mode(return_smoothed="definitely")


### PR DESCRIPTION
## Summary
- Normalize explicit `metadata=None` in `EvidenceComputationMode` to an empty metadata dictionary.
- Keep existing defensive copying for mapping metadata.
- Add a focused regression test for the direct dataclass constructor.

## Testing
- Added `tests/test_evidence_only_mode.py` coverage.