### PR TITLE
Validate candidate pruning boolean flag

### DIFF
--- a/src/pyrecest/utils/candidate_pruning.py
+++ b/src/pyrecest/utils/candidate_pruning.py
@@ -40,6 +40,12 @@ class CandidatePruningConfig:
             parsed = _normalize_positive_integer(value, name)
             object.__setattr__(self, name, parsed)
 
+        object.__setattr__(
+            self,
+            "always_keep_finite",
+            _normalize_bool(self.always_keep_finite, "always_keep_finite"),
+        )
+
         if self.probability_threshold is not None:
             threshold = _normalize_bounded_scalar(
                 self.probability_threshold,
@@ -84,6 +90,13 @@ def candidate_pruning_config_from_mapping(
     if isinstance(value, CandidatePruningConfig):
         return value
     return CandidatePruningConfig(**dict(value))
+
+
+def _normalize_bool(value: Any, name: str) -> bool:
+    value_array = np.asarray(value)
+    if value_array.shape == () and value_array.dtype == np.bool_:
+        return bool(value_array.item())
+    raise ValueError(f"{name} must be a boolean")
 
 
 def _normalize_positive_integer(value: Any, name: str) -> int:

--- a/tests/test_candidate_pruning.py
+++ b/tests/test_candidate_pruning.py
@@ -136,6 +136,20 @@ class TestCandidatePruning(unittest.TestCase):
 
         npt.assert_array_equal(mask, np.array([[True, True], [True, False]]))
 
+    def test_always_keep_finite_rejects_truthy_non_bools(self):
+        invalid_values = ("yes", 1, np.array([True]))
+
+        for value in invalid_values:
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "always_keep_finite must be a boolean",
+                ):
+                    CandidatePruningConfig(always_keep_finite=value)
+
+        cfg = CandidatePruningConfig(always_keep_finite=np.array(True))
+        self.assertIs(cfg.always_keep_finite, True)
+
     def test_mapping_config_normalization_and_validation(self):
         cfg = candidate_pruning_config_from_mapping({"row_top_k": np.array(2.0)})
         self.assertIsInstance(cfg, CandidatePruningConfig)


### PR DESCRIPTION
## Summary
- validate `CandidatePruningConfig.always_keep_finite` as an actual boolean instead of relying on truthiness
- reject strings, integers, and non-scalar arrays that could otherwise silently enable all finite candidates
- add regression coverage for invalid truthy values while preserving scalar NumPy booleans

## Rationale
`always_keep_finite` controls whether selective pruning is bypassed for every finite cost. Before this change, values such as `"yes"` or `1` were treated as true by the downstream `if cfg.always_keep_finite:` branch, which could unexpectedly disable pruning.

## Testing
- Not run locally; repository access is through the GitHub connector only in this environment.