### PR TITLE
Validate GGIW scatter noise flag

### DIFF
--- a/src/pyrecest/filters/ggiw_tracker.py
+++ b/src/pyrecest/filters/ggiw_tracker.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import numpy as np
+
 # pylint: disable=no-name-in-module,no-member,redefined-builtin,duplicate-code
 from pyrecest.backend import (
     array,
@@ -17,6 +19,13 @@ from pyrecest.backend import (
 )
 
 from .abstract_extended_object_tracker import AbstractExtendedObjectTracker
+
+
+def _validate_bool_flag(value, name: str) -> bool:
+    value_array = np.asarray(value)
+    if value_array.shape != () or not np.issubdtype(value_array.dtype, np.bool_):
+        raise TypeError(f"{name} must be a boolean")
+    return bool(value_array.item())
 
 
 class GGIWTracker(
@@ -76,8 +85,9 @@ class GGIWTracker(
         self.gamma_shape = float(gamma_shape)
         self.gamma_rate = float(gamma_rate)
         self.extent_innovation_weight = float(extent_innovation_weight)
-        self.subtract_measurement_noise_from_scatter = bool(
-            subtract_measurement_noise_from_scatter
+        self.subtract_measurement_noise_from_scatter = _validate_bool_flag(
+            subtract_measurement_noise_from_scatter,
+            "subtract_measurement_noise_from_scatter",
         )
         self.latest_log_likelihood = None
 

--- a/tests/filters/test_ggiw_tracker.py
+++ b/tests/filters/test_ggiw_tracker.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
@@ -40,6 +41,33 @@ class TestGGIWTracker(unittest.TestCase):
         npt.assert_allclose(self.tracker.extent_scale, 6.0 * self.extent)
         self.assertEqual(self.tracker.get_measurement_rate_estimate(), 2.0)
         self.assertEqual(self.tracker.get_point_estimate().shape[0], 9)
+
+    def test_subtract_measurement_noise_flag_requires_boolean(self):
+        tracker = GGIWTracker(
+            self.kinematic_state,
+            self.covariance,
+            self.extent,
+            extent_degrees_of_freedom=12.0,
+            gamma_shape=4.0,
+            gamma_rate=2.0,
+            subtract_measurement_noise_from_scatter=np.bool_(True),
+        )
+        self.assertTrue(tracker.subtract_measurement_noise_from_scatter)
+
+        for flag in ("False", 1, np.array([True])):
+            with self.subTest(flag=flag):
+                with self.assertRaisesRegex(
+                    TypeError, "subtract_measurement_noise_from_scatter"
+                ):
+                    GGIWTracker(
+                        self.kinematic_state,
+                        self.covariance,
+                        self.extent,
+                        extent_degrees_of_freedom=12.0,
+                        gamma_shape=4.0,
+                        gamma_rate=2.0,
+                        subtract_measurement_noise_from_scatter=flag,
+                    )
 
     def test_predict_linear_preserves_extent_mean_with_forgetting(self):
         system_matrix = array(


### PR DESCRIPTION
## Summary
- validate the GGIW scatter-noise subtraction flag as a real boolean scalar
- reject truthy strings, numeric values, and non-scalar arrays instead of changing scatter-update behavior through `bool(...)`
- add regression coverage for accepted NumPy boolean scalars and invalid flag values

## Tests
- `PYTHONPATH=src python -m pytest tests/filters/test_ggiw_tracker.py`
- `PYTHONPATH=src python -O -m pytest tests/filters/test_ggiw_tracker.py`
- `python -m ruff check src/pyrecest/filters/ggiw_tracker.py tests/filters/test_ggiw_tracker.py`
- `git diff --check`
