### PR TITLE
Validate Bayesian Watson fit_default observations

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/bayesian_complex_watson_mixture_model.py
+++ b/src/pyrecest/distributions/hypersphere_subset/bayesian_complex_watson_mixture_model.py
@@ -133,9 +133,13 @@ class BayesianComplexWatsonMixtureModel:
         Returns:
             tuple: (BayesianComplexWatsonMixtureModel, posterior dict)
         """
-        assert (
-            Z.shape[0] < 100
-        ), "fit_default assumes D < 100 (feature dimension, not sample count)"
+        Z = asarray(Z, dtype=complex)
+        if Z.ndim != 2:
+            raise ValueError("Z must have shape (D, N).")
+        if Z.shape[0] >= 100:
+            raise ValueError(
+                "fit_default assumes D < 100 (feature dimension, not sample count)"
+            )
         D = Z.shape[0]
         parameters = BayesianComplexWatsonMixtureModel.parameters_default(D, K)
         return BayesianComplexWatsonMixtureModel.fit(Z, parameters)

--- a/tests/distributions/test_bayesian_complex_watson_mixture_validation.py
+++ b/tests/distributions/test_bayesian_complex_watson_mixture_validation.py
@@ -2,7 +2,7 @@ import unittest
 
 import pyrecest.backend
 
-from pyrecest.backend import array, ones
+from pyrecest.backend import array, ones, zeros
 from pyrecest.distributions.hypersphere_subset.bayesian_complex_watson_mixture_model import (
     BayesianComplexWatsonMixtureModel,
 )
@@ -43,6 +43,18 @@ class BayesianComplexWatsonMixtureValidationTest(unittest.TestCase):
             BayesianComplexWatsonMixtureModel.estimate_posterior(
                 _observations(), params
             )
+
+    def test_fit_default_rejects_large_feature_dimension(self):
+        observations = zeros((100, 1), dtype=complex)
+
+        with self.assertRaisesRegex(ValueError, "D < 100"):
+            BayesianComplexWatsonMixtureModel.fit_default(observations, 1)
+
+    def test_fit_default_rejects_non_matrix_observations(self):
+        observations = zeros((3,), dtype=complex)
+
+        with self.assertRaisesRegex(ValueError, "shape"):
+            BayesianComplexWatsonMixtureModel.fit_default(observations, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace the `fit_default` dimension assertion with explicit validation that survives `python -O`
- coerce observations to a backend array and reject non-matrix inputs with a clear `ValueError`
- add regression coverage for large feature dimensions and non-matrix observations

## Tests
- Added focused unit tests in `tests/distributions/test_bayesian_complex_watson_mixture_validation.py`