### PR TITLE
Validate finite hyperspherical noise weights

### DIFF
--- a/src/pyrecest/filters/hyperspherical_ukf.py
+++ b/src/pyrecest/filters/hyperspherical_ukf.py
@@ -22,6 +22,7 @@ from pyrecest.backend import (  # pylint: disable=redefined-builtin
     expand_dims,
     eye,
     float64,
+    isfinite,
     linalg,
     reshape,
     zeros,
@@ -199,6 +200,8 @@ class HypersphericalUKF(AbstractFilter, HypersphericalFilterMixin):
                 "noise_samples and noise_weights must contain the same number "
                 "of samples."
             )
+        if not all(isfinite(noise_weights)):
+            raise ValueError("noise_weights must be finite.")
         if not all(noise_weights > 0):
             raise ValueError("noise_weights must be strictly positive.")
         noise_weights = noise_weights / noise_weights.sum()

--- a/tests/filters/test_hyperspherical_ukf.py
+++ b/tests/filters/test_hyperspherical_ukf.py
@@ -264,6 +264,14 @@ class HypersphericalUKFTest(unittest.TestCase):
             self.filter_3d.predict_nonlinear_arbitrary_noise(
                 lambda x, v: x, np.ones((3, 2)), np.ones(3)
             )
+        with self.assertRaisesRegex(ValueError, "finite"):
+            self.filter_3d.predict_nonlinear_arbitrary_noise(
+                lambda x, v: x, np.ones((3, 2)), np.array([1.0, np.inf])
+            )
+        with self.assertRaisesRegex(ValueError, "finite"):
+            self.filter_3d.predict_nonlinear_arbitrary_noise(
+                lambda x, v: x, np.ones((3, 2)), np.array([1.0, np.nan])
+            )
         with self.assertRaisesRegex(ValueError, "strictly positive"):
             self.filter_3d.predict_nonlinear_arbitrary_noise(
                 lambda x, v: x, np.ones((3, 2)), np.array([1.0, 0.0])


### PR DESCRIPTION
## Summary
- reject non-finite `noise_weights` in `HypersphericalUKF.predict_nonlinear_arbitrary_noise`
- keep the existing strictly-positive validation for finite zero/negative weights
- extend the arbitrary-noise regression test to cover `Inf` and `NaN` weights

## Rationale
The method normalized arbitrary-noise weights after checking only strict positivity. Positive infinity passes that check, and normalization can then produce `NaN` weights and corrupt the predicted mean/covariance. The method now fails fast with a clear `ValueError`.

## Testing
- Not run locally; repository dependencies are not installed in this environment.