### PR TITLE
Validate sampleable transition vectorized flag

### DIFF
--- a/src/pyrecest/models/likelihood.py
+++ b/src/pyrecest/models/likelihood.py
@@ -29,6 +29,8 @@ from pyrecest.protocols.models import (
     SupportsTransitionSampling,
 )
 
+from .validation import _validate_bool_flag
+
 
 def _ensure_callable(value: Any, name: str) -> None:
     if not callable(value):
@@ -164,7 +166,9 @@ class SampleableTransitionModel:
         self._sample_next = sample_next
         self._sample_next_count_call_mode = _sample_count_call_mode(sample_next)
         self._transition_density = transition_density
-        self.function_is_vectorized = function_is_vectorized
+        self.function_is_vectorized = _validate_bool_flag(
+            function_is_vectorized, "function_is_vectorized"
+        )
         self.name = name
 
     @property

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,8 +1,14 @@
 import unittest
 
+import numpy as np
+
 from pyrecest.backend import allclose, array, diag
 from pyrecest.distributions import GaussianDistribution
-from pyrecest.models import AdditiveNoiseMeasurementModel, AdditiveNoiseTransitionModel
+from pyrecest.models import (
+    AdditiveNoiseMeasurementModel,
+    AdditiveNoiseTransitionModel,
+    SampleableTransitionModel,
+)
 
 
 class ModelObjectTest(unittest.TestCase):
@@ -56,6 +62,28 @@ class ModelObjectTest(unittest.TestCase):
         self.assertTrue(
             allclose(model.evaluate(array([1.0, 2.0])), array([1.25, 1.75]))
         )
+
+    def test_sampleable_transition_model_validates_vectorized_flag(self):
+        self.assertTrue(
+            SampleableTransitionModel(
+                lambda value: value,
+                function_is_vectorized=np.bool_(True),
+            ).function_is_vectorized
+        )
+        self.assertFalse(
+            SampleableTransitionModel(
+                lambda value: value,
+                function_is_vectorized=False,
+            ).function_is_vectorized
+        )
+
+        for invalid_flag in ("False", 1):
+            with self.subTest(invalid_flag=invalid_flag):
+                with self.assertRaises(TypeError):
+                    SampleableTransitionModel(
+                        lambda value: value,
+                        function_is_vectorized=invalid_flag,
+                    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- validate `SampleableTransitionModel.function_is_vectorized` as a real boolean instead of storing arbitrary truthy values
- prevent strings like `"False"` or integers like `1` from routing particle-filter adapters through the wrong vectorized path
- add regression coverage while preserving Python/NumPy boolean inputs

## Tests
- Added focused coverage in `tests/test_models.py`

I could not run the suite locally from this environment because direct network cloning is unavailable; GitHub Actions should run on the PR.