### PR TITLE
Handle nonfinite replay grid positions

### DIFF
--- a/src/pyrecest/filters/replay_grid_likelihood.py
+++ b/src/pyrecest/filters/replay_grid_likelihood.py
@@ -315,6 +315,8 @@ def _coerce_bin_centers(bin_centers) -> np.ndarray:
         raise ValueError(
             "bin_centers must contain at least one point and one dimension"
         )
+    if not np.all(np.isfinite(bin_centers)):
+        raise ValueError("bin_centers must be finite")
     return bin_centers
 
 
@@ -406,14 +408,20 @@ def _nearest_grid_values(
     *,
     log_zero: float,
 ) -> np.ndarray:
-    indices = _nearest_bin_indices(positions, bin_tree)
-    output = values[indices]
-    if not np.all(np.isfinite(output)):
+    finite_positions = np.isfinite(positions).all(axis=1)
+    output = np.full(positions.shape[0], float(log_zero), dtype=float)
+    if not np.any(finite_positions):
+        return output
+
+    indices = _nearest_bin_indices(positions[finite_positions], bin_tree)
+    nearest_values = values[indices]
+    if not np.all(np.isfinite(nearest_values)):
         finite_values = values[np.isfinite(values)]
         replacement = (
             float(np.min(finite_values)) if finite_values.size else float(log_zero)
         )
-        output = np.where(np.isfinite(output), output, replacement)
+        nearest_values = np.where(np.isfinite(nearest_values), nearest_values, replacement)
+    output[finite_positions] = nearest_values
     return output
 
 

--- a/tests/filters/test_replay_grid_likelihood.py
+++ b/tests/filters/test_replay_grid_likelihood.py
@@ -71,6 +71,28 @@ class TestReplayGridLikelihood(unittest.TestCase):
 
         self.assertEqual(lookup.method, "nearest")
 
+    def test_nearest_grid_likelihood_maps_nonfinite_positions_to_log_zero(self):
+        bin_centers = np.asarray([[0.0, 0.0], [1.0, 0.0]])
+        values = np.asarray([0.0, 2.0])
+
+        result = replay_grid_log_likelihood_values(
+            np.asarray([[np.nan, 0.0], [np.inf, 0.0], [1.1, 0.0]]),
+            values,
+            bin_centers,
+            interpolation="nearest",
+            log_zero=-123.0,
+        )
+
+        np.testing.assert_allclose(result, [-123.0, -123.0, 2.0])
+
+    def test_replay_grid_likelihood_rejects_nonfinite_bin_centers(self):
+        with self.assertRaisesRegex(ValueError, "bin_centers must be finite"):
+            replay_grid_log_likelihood_values(
+                np.asarray([[0.0, 0.0]]),
+                np.asarray([0.0]),
+                np.asarray([[0.0, np.nan]]),
+            )
+
     def test_position_proposal_probability_is_ess_adaptive(self):
         self.assertAlmostEqual(effective_sample_size_fraction(np.ones(4)), 1.0)
         probability, ess_fraction = adaptive_position_proposal_probability(


### PR DESCRIPTION
## Summary
- Map non-finite replay-grid query positions to the configured `log_zero` value before nearest-neighbour lookup, avoiding `cKDTree.query` failures.
- Reject non-finite replay grid bin centers before constructing lookup/KD-tree structures.
- Add regression coverage for non-finite query positions and bin centers.

## Tests
- `python -m py_compile` on the modified source and test file in a local scratch copy.
- Exercised the fixed helper behavior in an isolated local import of the modified module.