### PR TITLE
Validate association prediction threshold

### DIFF
--- a/src/pyrecest/utils/association_models.py
+++ b/src/pyrecest/utils/association_models.py
@@ -97,6 +97,14 @@ def _normalize_probability_clip(value: Any) -> float:
     return parsed
 
 
+def _normalize_probability_threshold(value: Any) -> float:
+    message = "threshold must lie in (0, 1)"
+    parsed = _normalize_finite_scalar(value, message)
+    if not 0.0 < parsed < 1.0:
+        raise ValueError(message)
+    return parsed
+
+
 def _normalize_positive_integer(value: Any, message: str) -> int:
     value_array = _numpy.asarray(value)
     if value_array.shape != () or value_array.dtype == _numpy.bool_:
@@ -516,8 +524,7 @@ class LogisticPairwiseAssociationModel:  # pylint: disable=too-many-instance-att
 
     def predict(self, features: Any, threshold: float = 0.5) -> Any:
         """Predict binary match decisions using the supplied threshold."""
-        if not 0.0 < threshold < 1.0:
-            raise ValueError("threshold must lie in (0, 1)")
+        threshold = _normalize_probability_threshold(threshold)
         return self.predict_match_probability(features) >= threshold
 
     def pairwise_cost_matrix(

--- a/tests/test_association_models.py
+++ b/tests/test_association_models.py
@@ -87,6 +87,24 @@ class TestLogisticPairwiseAssociationModel(unittest.TestCase):
         self.assertLess(costs[0, 0], costs[0, 1])
         self.assertLess(costs[1, 1], costs[1, 0])
 
+    def test_predict_rejects_invalid_thresholds(self):
+        model = LogisticPairwiseAssociationModel(class_weight="balanced")
+        model.fit(self.training_features, self.training_labels)
+
+        invalid_thresholds = (
+            0.0,
+            1.0,
+            float("nan"),
+            float("inf"),
+            -float("inf"),
+            array([0.5]),
+            "not-a-number",
+        )
+        for threshold in invalid_thresholds:
+            with self.subTest(threshold=threshold):
+                with self.assertRaisesRegex(ValueError, "threshold"):
+                    model.predict(self.training_features[:2], threshold=threshold)
+
     def test_flattened_pairwise_training_tensor_is_supported(self):
         model = LogisticPairwiseAssociationModel(class_weight="balanced")
 


### PR DESCRIPTION
## Summary
- add scalar validation for logistic association prediction thresholds
- reject non-scalar, non-finite, and out-of-range thresholds before comparison
- add regression coverage for invalid threshold inputs

## Rationale
The previous chained comparison accepted one-element arrays as thresholds and could surface `TypeError` for invalid inputs instead of the model's normal `ValueError` validation path.

## Testing
- Not run locally; this environment cannot resolve `github.com` for cloning/installing the repository.