### PR TITLE
Fix Euclidean mean extraction for raw array states

### DIFF
--- a/src/pyrecest/evaluation/get_extract_mean.py
+++ b/src/pyrecest/evaluation/get_extract_mean.py
@@ -35,13 +35,20 @@ def _is_hypersphere_symmetric_name(normalized_name: str) -> bool:
     )
 
 
+def _is_array_state(filter_state) -> bool:
+    return hasattr(filter_state, "ndim") and hasattr(filter_state, "shape")
+
+
 def _point_estimate_or_mean(filter_state):
     if hasattr(filter_state, "get_point_estimate"):
         return filter_state.get_point_estimate()
-    if hasattr(filter_state, "mean"):
-        return filter_state.mean()
     if hasattr(filter_state, "mu"):
         return filter_state.mu
+    if _is_array_state(filter_state):
+        return filter_state
+    if hasattr(filter_state, "mean"):
+        mean = filter_state.mean
+        return mean() if callable(mean) else mean
     return filter_state
 
 

--- a/tests/evaluation/test_evaluation_registries.py
+++ b/tests/evaluation/test_evaluation_registries.py
@@ -92,6 +92,14 @@ def test_custom_extract_mean_registry():
     assert get_extract_mean("unit-test-mean")({"mean": 3}) == 3
 
 
+def test_euclidean_extract_mean_preserves_raw_array_state():
+    state = array([1.0, 2.0])
+
+    extracted = get_extract_mean("euclidean")(state)
+
+    assert to_numpy(extracted).tolist() == pytest.approx([1.0, 2.0])
+
+
 def test_symmetric_hypersphere_extract_mean_requires_custom_extractor():
     with pytest.raises(NotImplementedError, match="custom extractor"):
         get_extract_mean("hypersphereSymmetric")


### PR DESCRIPTION
## Summary
- Preserve raw backend array states in Euclidean mean extraction instead of calling their `.mean()` method.
- Keep distribution/filter mean extraction behavior via `get_point_estimate`, `mu`, or callable/object `mean` attributes.
- Add a regression test showing that a Euclidean raw state vector remains a vector.

## Testing
- Added focused regression test in `tests/evaluation/test_evaluation_registries.py`.