### PR TITLE
Validate Metropolis-Hastings sample count scalars

### DIFF
--- a/src/pyrecest/distributions/abstract_manifold_specific_distribution.py
+++ b/src/pyrecest/distributions/abstract_manifold_specific_distribution.py
@@ -2,7 +2,7 @@ import inspect
 import math
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-from numbers import Integral
+from numbers import Integral, Number
 from typing import Union
 
 import pyrecest.backend
@@ -22,11 +22,20 @@ def _to_scalar(value):
 
 
 def _validate_integer_sample_parameter(value, name: str, minimum: int) -> int:
+    shape = getattr(value, "shape", None)
+    if shape is not None:
+        try:
+            shape_tuple = tuple(shape)
+        except TypeError:
+            shape_tuple = (shape,)
+        if shape_tuple != ():
+            raise ValueError(f"{name} must be a scalar integer")
+
     try:
         scalar = value.item()
     except AttributeError:
         scalar = value
-    except ValueError as exc:
+    except (TypeError, ValueError, RuntimeError) as exc:
         raise ValueError(f"{name} must be a scalar integer") from exc
 
     if isinstance(scalar, bool):
@@ -35,6 +44,8 @@ def _validate_integer_sample_parameter(value, name: str, minimum: int) -> int:
     if isinstance(scalar, Integral):
         integer = int(scalar)
     else:
+        if not isinstance(scalar, Number):
+            raise ValueError(f"{name} must be an integer")
         try:
             scalar_float = float(scalar)
             integer = int(scalar)

--- a/tests/distributions/test_abstract_manifold_specific_distribution.py
+++ b/tests/distributions/test_abstract_manifold_specific_distribution.py
@@ -122,11 +122,16 @@ class AbstractManifoldSpecificDistributionTest(unittest.TestCase):
             {"n": 1.5},
             {"n": True},
             {"n": [1]},
+            {"n": np.array([1])},
+            {"n": array([1])},
+            {"n": "1"},
             {"burn_in": -1},
             {"burn_in": False},
+            {"burn_in": np.array([0])},
             {"skipping": 0},
             {"skipping": 1.5},
             {"skipping": True},
+            {"skipping": "1"},
         )
 
         for overrides in invalid_parameters:


### PR DESCRIPTION
## Summary
- reject shaped array/tensor values for Metropolis-Hastings count parameters before calling `.item()`
- reject non-numeric inputs such as numeric strings instead of coercing them through `float`/`int`
- extend regression coverage for one-element arrays, backend arrays, and numeric strings

## Rationale
`sample_metropolis_hastings` documents `n`, `burn_in`, and `skipping` as scalar count parameters. The previous validator rejected plain lists such as `[1]`, but one-element arrays/tensors could pass through `.item()` and numeric strings could be accepted through `float(...)`/`int(...)`, silently treating invalid inputs as valid counts.

## Testing
- Not run locally; changes were made through the GitHub connector and inspected via the branch diff.