### PR TITLE
Validate finite Gaussian parameters

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
@@ -10,6 +10,7 @@ from pyrecest.backend import (
     allclose,
     exp,
     eye,
+    isfinite,
     linalg,
     matvec,
     ndim,
@@ -87,6 +88,10 @@ class GaussianDistribution(AbstractLinearDistribution):
         self.mu = mu
 
         if check_validity:
+            if not _to_python_bool(backend_all(isfinite(mu))):
+                raise ValueError("mu must contain only finite values.")
+            if not _to_python_bool(backend_all(isfinite(C))):
+                raise ValueError("C must contain only finite values.")
             if not _to_python_bool(allclose(C, transpose(C))):
                 raise ValueError("C must be symmetric.")
             if not _to_python_bool(backend_all(linalg.eigvalsh(C) > 0.0)):

--- a/tests/distributions/test_gaussian_distribution_validation.py
+++ b/tests/distributions/test_gaussian_distribution_validation.py
@@ -1,0 +1,26 @@
+import unittest
+
+from pyrecest.backend import array, eye
+from pyrecest.distributions import GaussianDistribution
+
+
+class TestGaussianDistributionValidation(unittest.TestCase):
+    def test_constructor_rejects_nonfinite_mean_by_default(self):
+        covariance = eye(1)
+
+        for bad_mean in (float("nan"), float("inf"), -float("inf")):
+            with self.subTest(bad_mean=bad_mean):
+                with self.assertRaisesRegex(ValueError, "mu.*finite"):
+                    GaussianDistribution(array([bad_mean]), covariance)
+
+    def test_constructor_rejects_nonfinite_covariance_by_default(self):
+        mean = array([0.0])
+
+        for bad_covariance in (float("nan"), float("inf"), -float("inf")):
+            with self.subTest(bad_covariance=bad_covariance):
+                with self.assertRaisesRegex(ValueError, "C.*finite"):
+                    GaussianDistribution(mean, array([[bad_covariance]]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reject non-finite Gaussian means when default constructor validation is enabled
- reject non-finite Gaussian covariance entries before symmetry / positive-definiteness checks
- add regression tests for NaN, +Inf, and -Inf in both parameters

## Rationale
`GaussianDistribution` previously validated covariance shape, symmetry, and positive definiteness but did not explicitly reject non-finite parameters. This allowed non-finite means and some non-finite covariances, such as `[[inf]]`, to construct a distribution and contaminate downstream density/filter computations.

## Testing
- Not run locally; changes were made through the GitHub connector.