### PR TITLE
Validate Pareto feasible masks

### DIFF
--- a/src/pyrecest/evaluation/pareto.py
+++ b/src/pyrecest/evaluation/pareto.py
@@ -331,8 +331,15 @@ def _feasible_index(
     if isinstance(feasible_mask, pd.Series):
         mask = feasible_mask.reindex(table.index, fill_value=False)
     else:
-        mask = pd.Series(feasible_mask, index=table.index)
-    return mask.fillna(False).astype(bool)
+        mask = pd.Series(feasible_mask)
+        if len(mask) != len(table):
+            raise ValueError("feasible_mask must have one entry per table row.")
+        mask.index = table.index
+    mask = mask.fillna(False)
+    invalid_values = mask.map(lambda value: not isinstance(value, (bool, np.bool_)))
+    if bool(invalid_values.any()):
+        raise ValueError("feasible_mask must contain only boolean or missing values.")
+    return mask.astype(bool)
 
 
 def _lookup_numeric(record: Mapping[str, Any] | pd.Series, key: str) -> float:

--- a/tests/evaluation/test_pareto.py
+++ b/tests/evaluation/test_pareto.py
@@ -75,6 +75,36 @@ def test_feasible_mask_treats_missing_nullable_values_as_infeasible() -> None:
     assert mask.tolist() == [True, False, True]
 
 
+def test_feasible_mask_rejects_non_boolean_values() -> None:
+    table = pd.DataFrame(
+        [
+            {"name": "baseline", "error": 1.0, "runtime": 2.0},
+            {"name": "fast", "error": 2.0, "runtime": 1.0},
+        ]
+    )
+    invalid_masks = (
+        ["True", "False"],
+        [1, 0],
+        np.asarray([True, 0], dtype=object),
+    )
+
+    for feasible_mask in invalid_masks:
+        with pytest.raises(ValueError, match="feasible_mask"):
+            pareto_front_indices(
+                table,
+                ["error", "runtime"],
+                directions={"error": "min", "runtime": "min"},
+                feasible_mask=feasible_mask,
+            )
+        with pytest.raises(ValueError, match="feasible_mask"):
+            is_pareto_front(
+                table,
+                ["error", "runtime"],
+                directions={"error": "min", "runtime": "min"},
+                feasible_mask=feasible_mask,
+            )
+
+
 def test_is_pareto_front_respects_feasible_mask() -> None:
     table = pd.DataFrame(
         [


### PR DESCRIPTION
## Summary
- validate `feasible_mask` values in Pareto-front helpers instead of coercing arbitrary values with truthiness
- preserve nullable boolean masks by treating missing values as infeasible
- add regression coverage for string, numeric, and mixed object masks

## Bug
`_feasible_index` previously ended with `mask.fillna(False).astype(bool)`, which silently accepted values such as `"False"` and `1` as feasible. That can put rows on the Pareto front even though callers supplied an invalid mask.

## Testing
- Focused local pytest reproduction for `tests/evaluation/test_pareto.py`: 13 passed

Note: I could not clone the full repository in the local sandbox because DNS resolution for `github.com` failed, so the full project test suite is left to GitHub Actions.