### PR TITLE
Reject ambiguous index-matrix fill values

### DIFF
--- a/src/pyrecest/utils/multisession_assignment_score.py
+++ b/src/pyrecest/utils/multisession_assignment_score.py
@@ -91,6 +91,31 @@ def _normalize_max_gap(max_gap: Any) -> int:
     return int(max_gap_float)
 
 
+def _normalize_index_matrix_fill_value(fill_value: Any) -> int:
+    fill_value_array = np.asarray(fill_value)
+    if fill_value_array.shape != () or fill_value_array.dtype == np.bool_:
+        raise ValueError("fill_value must be a negative integer.")
+
+    fill_value_value = fill_value_array.item()
+    if isinstance(fill_value_value, (bool, np.bool_)):
+        raise ValueError("fill_value must be a negative integer.")
+
+    if isinstance(fill_value_value, (int, np.integer)):
+        integer_fill_value = int(fill_value_value)
+    else:
+        try:
+            fill_value_float = float(fill_value_value)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError("fill_value must be a negative integer.") from exc
+        if not math.isfinite(fill_value_float) or not fill_value_float.is_integer():
+            raise ValueError("fill_value must be a negative integer.")
+        integer_fill_value = int(fill_value_float)
+
+    if integer_fill_value >= 0:
+        raise ValueError("fill_value must be a negative integer.")
+    return integer_fill_value
+
+
 def tracks_to_index_matrix(
     tracks: list[TrackInput],
     session_sizes: SessionSizesInput | None = None,
@@ -99,6 +124,7 @@ def tracks_to_index_matrix(
 ):
     """Convert tracks to a dense ``track x session`` ROI-index matrix."""
     _ensure_supported_backend("tracks_to_index_matrix")
+    fill_value = _normalize_index_matrix_fill_value(fill_value)
 
     _, max_session_index = _validate_track_session_sizes(
         tracks,

--- a/tests/test_multisession_assignment_index_matrix.py
+++ b/tests/test_multisession_assignment_index_matrix.py
@@ -1,0 +1,49 @@
+"""Regression tests for score-native multi-session index matrices."""
+
+import unittest
+
+import numpy as np
+from pyrecest.backend import (  # pylint: disable=no-name-in-module
+    __backend_name__,
+    array,
+    array_equal,
+)
+from pyrecest.utils.multisession_assignment_score import tracks_to_index_matrix
+
+
+class TestMultiSessionAssignmentIndexMatrix(unittest.TestCase):
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_fill_value_must_not_collide_with_detection_indices(self):
+        invalid_fill_values = (0, np.array(0), True, 1.5, np.array([-1]))
+
+        for fill_value in invalid_fill_values:
+            with self.subTest(fill_value=fill_value):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "fill_value must be a negative integer",
+                ):
+                    tracks_to_index_matrix(
+                        [{0: 0}],
+                        session_sizes=[1, 0],
+                        fill_value=fill_value,
+                    )
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_negative_fill_value_preserves_missing_sessions(self):
+        matrix = tracks_to_index_matrix(
+            [{0: 0, 2: 1}],
+            session_sizes=[1, 0, 2],
+            fill_value=-1,
+        )
+
+        self.assertTrue(array_equal(matrix, array([[0, -1, 1]], dtype=int)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reject nonnegative `fill_value` values in `tracks_to_index_matrix`, because detection indices are nonnegative and would be indistinguishable from missing-session sentinels
- add regression coverage for ambiguous, non-integer, bool, and non-scalar fill values
- preserve the valid negative-sentinel behavior for missing sessions

## Tests
- Not run locally; repository access was through the GitHub connector.
