### PR TITLE
Preserve nested optional dependency import errors

### DIFF
--- a/src/pyrecest/optional_dependencies.py
+++ b/src/pyrecest/optional_dependencies.py
@@ -8,6 +8,13 @@ from types import ModuleType
 from pyrecest.exceptions import OptionalDependencyError
 
 
+def _is_missing_requested_package(exc: ModuleNotFoundError, package: str) -> bool:
+    missing_name = exc.name
+    if missing_name is None:
+        return False
+    return missing_name == package or package.startswith(f"{missing_name}.")
+
+
 def require_optional_dependency(
     package: str, extra: str, *, feature: str | None = None
 ) -> ModuleType:
@@ -25,8 +32,10 @@ def require_optional_dependency(
     try:
         return importlib.import_module(package)
     except (
-        ImportError
-    ) as exc:  # pragma: no cover - exercised through tests with a missing sentinel package
+        ModuleNotFoundError
+    ) as exc:  # pragma: no cover - branch behavior is covered through tests
+        if not _is_missing_requested_package(exc, package):
+            raise
         subject = f" for {feature}" if feature else ""
         raise OptionalDependencyError(
             f"Optional dependency {package!r} is required{subject}. "

--- a/src/pyrecest/optional_dependencies.py
+++ b/src/pyrecest/optional_dependencies.py
@@ -31,9 +31,7 @@ def require_optional_dependency(
     """
     try:
         return importlib.import_module(package)
-    except (
-        ModuleNotFoundError
-    ) as exc:  # pragma: no cover - branch behavior is covered through tests
+    except ModuleNotFoundError as exc:
         if not _is_missing_requested_package(exc, package):
             raise
         subject = f" for {feature}" if feature else ""

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 from pyrecest.exceptions import OptionalDependencyError
 from pyrecest.optional_dependencies import require_optional_dependency
@@ -13,3 +15,37 @@ def test_require_optional_dependency_reports_extra_for_missing_module():
             "definitely_missing_pyrecest_dependency", "plot", feature="plotting"
         )
     assert "pyrecest[plot]" in str(exc_info.value)
+
+
+def test_require_optional_dependency_reports_missing_parent_for_submodule():
+    import_error = ModuleNotFoundError(
+        "No module named 'missing_parent'",
+        name="missing_parent",
+    )
+
+    with mock.patch("importlib.import_module", side_effect=import_error):
+        with pytest.raises(OptionalDependencyError):
+            require_optional_dependency("missing_parent.child", "plot")
+
+
+def test_require_optional_dependency_preserves_nested_missing_imports():
+    import_error = ModuleNotFoundError(
+        "No module named 'missing_nested_dependency'",
+        name="missing_nested_dependency",
+    )
+
+    with mock.patch("importlib.import_module", side_effect=import_error):
+        with pytest.raises(ModuleNotFoundError) as exc_info:
+            require_optional_dependency("available_optional_package", "plot")
+
+    assert exc_info.value is import_error
+
+
+def test_require_optional_dependency_preserves_generic_import_errors():
+    import_error = ImportError("optional package failed while importing")
+
+    with mock.patch("importlib.import_module", side_effect=import_error):
+        with pytest.raises(ImportError) as exc_info:
+            require_optional_dependency("available_optional_package", "plot")
+
+    assert exc_info.value is import_error


### PR DESCRIPTION
## Summary
- only convert `ModuleNotFoundError` for the requested optional package into `OptionalDependencyError`
- preserve nested missing imports and generic import-time failures from installed optional packages
- extend optional dependency tests for missing parent packages, nested missing dependencies, and generic import errors

## Rationale
`require_optional_dependency` previously caught every `ImportError` raised by `importlib.import_module`. That obscured real import-time failures inside an installed optional package by reporting the package itself as missing.

## Testing
- Not run locally; the container cannot resolve `github.com` for cloning/installing this repository.