### PR TITLE
Validate tracking event scalar fields

### DIFF
--- a/src/pyrecest/tracking/event_records.py
+++ b/src/pyrecest/tracking/event_records.py
@@ -59,6 +59,30 @@ def _optional_bool(value: Any, *, name: str) -> bool | None:
     raise ValueError(f"{name} must be a boolean or None")
 
 
+def _finite_scalar(value: Any, *, name: str, message: str) -> float:
+    value_array = np.asarray(value)
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError(message)
+
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(message)
+    try:
+        parsed = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if not np.isfinite(parsed):
+        raise ValueError(message)
+    return parsed
+
+
+def _nonnegative_scalar(value: Any, *, name: str, message: str) -> float:
+    parsed = _finite_scalar(value, name=name, message=message)
+    if parsed < 0.0:
+        raise ValueError(message)
+    return parsed
+
+
 def _jsonable(value: Any) -> Any:
     if isinstance(value, np.ndarray):
         return value.tolist()
@@ -85,9 +109,7 @@ class TrackingEvent:
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        time = float(self.time)
-        if not np.isfinite(time):
-            raise ValueError("time must be finite")
+        time = _finite_scalar(self.time, name="time", message="time must be finite")
         measurement = _array_or_none(self.measurement, name="measurement", ndim=1)
         covariance = (
             None
@@ -146,9 +168,7 @@ class TrackingRecord:
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        time = float(self.time)
-        if not np.isfinite(time):
-            raise ValueError("time must be finite")
+        time = _finite_scalar(self.time, name="time", message="time must be finite")
         prior_mean = _vector(self.prior_mean, name="prior_mean")
         posterior_mean = _vector(self.posterior_mean, name="posterior_mean")
         if posterior_mean.shape != prior_mean.shape:
@@ -169,9 +189,15 @@ class TrackingRecord:
             if innovation_cov.shape != (innovation.size, innovation.size):
                 raise ValueError("innovation_cov must match innovation dimension")
         measurement = _array_or_none(self.measurement, name="measurement", ndim=1)
-        nis = None if self.nis is None else float(self.nis)
-        if nis is not None and (not np.isfinite(nis) or nis < 0.0):
-            raise ValueError("nis must be finite and nonnegative")
+        nis = (
+            None
+            if self.nis is None
+            else _nonnegative_scalar(
+                self.nis,
+                name="nis",
+                message="nis must be finite and nonnegative",
+            )
+        )
         object.__setattr__(self, "time", time)
         object.__setattr__(self, "source", str(self.source))
         object.__setattr__(self, "action", str(self.action))

--- a/tests/test_event_records.py
+++ b/tests/test_event_records.py
@@ -1,0 +1,59 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.tracking.event_records import TrackingEvent, TrackingRecord
+
+
+class TestTrackingEventScalarValidation(unittest.TestCase):
+    def test_time_accepts_scalar_numeric_values(self):
+        event = TrackingEvent(time=np.array(1.25), source="sensor")
+
+        self.assertEqual(event.time, 1.25)
+
+    def test_time_rejects_bool_and_non_scalar_values(self):
+        for time in (True, np.bool_(False), np.array([1.0]), np.array([[1.0]])):
+            with self.subTest(time=time):
+                with self.assertRaisesRegex(ValueError, "time must be finite"):
+                    TrackingEvent(time=time, source="sensor")
+
+
+class TestTrackingRecordScalarValidation(unittest.TestCase):
+    def _valid_record_kwargs(self):
+        return {
+            "time": 0.0,
+            "source": "sensor",
+            "action": "update",
+            "prior_mean": np.array([0.0, 0.0]),
+            "prior_cov": np.eye(2),
+            "posterior_mean": np.array([1.0, 0.0]),
+            "posterior_cov": np.eye(2),
+        }
+
+    def test_nis_accepts_nonnegative_scalar_numeric_values(self):
+        record = TrackingRecord(**self._valid_record_kwargs(), nis=np.array(2.5))
+
+        self.assertEqual(record.nis, 2.5)
+
+    def test_time_rejects_bool_and_non_scalar_values(self):
+        for time in (True, np.bool_(False), np.array([1.0]), np.array([[1.0]])):
+            kwargs = self._valid_record_kwargs()
+            kwargs["time"] = time
+            with self.subTest(time=time):
+                with self.assertRaisesRegex(ValueError, "time must be finite"):
+                    TrackingRecord(**kwargs)
+
+    def test_nis_rejects_bool_non_scalar_and_negative_values(self):
+        invalid_nis_values = (True, np.bool_(False), np.array([1.0]), -1.0, np.nan)
+
+        for nis in invalid_nis_values:
+            with self.subTest(nis=nis):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "nis must be finite and nonnegative",
+                ):
+                    TrackingRecord(**self._valid_record_kwargs(), nis=nis)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- validate `TrackingEvent.time` and `TrackingRecord.time` as finite scalar numeric values instead of relying on `float(...)` conversion
- validate `TrackingRecord.nis` as a finite nonnegative scalar and reject bool/non-scalar inputs before casting
- add regression tests for accepted numeric scalar values and rejected boolean, shaped-array, negative, and NaN inputs

## Bug fixed
`float(...)` silently accepts boolean values such as `True` as `1.0`, so event times and NIS diagnostics could be stored from invalid control/metadata values. Non-scalar arrays also produced low-level conversion behavior rather than the module's normal validation errors. These scalar fields now fail fast with deterministic `ValueError`s.

## Tests
- Not run locally; repository access/modification was through the GitHub connector.