### PR TITLE
Fix circular Fourier grid generation

### DIFF
--- a/src/pyrecest/distributions/circle/circular_fourier_distribution.py
+++ b/src/pyrecest/distributions/circle/circular_fourier_distribution.py
@@ -390,9 +390,7 @@ class CircularFourierDistribution(AbstractCircularDistribution):
                 fd.c = fd.c * fd.n
                 fd.multiplied_by_n = True
         else:
-            xs = arange(
-                0.0, 2.0 * pi, 2.0 * pi / n
-            )  # Like linspace without endpoint but with compatbiility for pytorch
+            xs = linspace(0.0, 2.0 * pi, n, endpoint=False)
             fvals = distribution.pdf(xs)
             if transformation == "identity":
                 pass

--- a/tests/distributions/test_circular_fourier_linspace_grid_regression.py
+++ b/tests/distributions/test_circular_fourier_linspace_grid_regression.py
@@ -1,0 +1,23 @@
+import unittest
+
+import numpy.testing as npt
+
+import pyrecest.backend
+from pyrecest.backend import ceil, linspace, pi
+from pyrecest.distributions import CircularFourierDistribution, VonMisesDistribution
+
+
+class TestCircularFourierLinspaceGridRegression(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_from_distribution_uses_exactly_requested_odd_grid_size(self):
+        dist = VonMisesDistribution(2.5, 1.5)
+        fd = CircularFourierDistribution.from_distribution(
+            dist, n=999, transformation="identity"
+        )
+        self.assertEqual(fd.n, 999)
+        self.assertEqual(fd.c.shape[0], ceil(999 / 2.0))
+        xs = linspace(0.0, 2.0 * pi, 32, endpoint=False)
+        npt.assert_allclose(fd.pdf(xs), dist.pdf(xs), rtol=2e-3, atol=5e-5)


### PR DESCRIPTION
## Summary
- Replace floating-step `arange` grid generation in `CircularFourierDistribution.from_distribution()` with endpoint-free `linspace`.
- Add a regression test for an odd grid size (`n=999`) that previously could yield 1000 samples and fail the odd-length Fourier coefficient guard.

## Notes
The old `arange(0, 2π, 2π/n)` construction is numerically unstable for some valid odd `n` because the endpoint can be included by roundoff. `linspace(..., endpoint=False)` gives exactly the requested number of samples.