### PR TITLE
Validate registration convergence tolerance

### DIFF
--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -162,6 +162,25 @@ def _validate_max_cost(max_cost) -> float:
     return max_cost_value
 
 
+def _validate_tolerance(tolerance) -> float:
+    tolerance_array = asarray(tolerance)
+    if tolerance_array.shape != ():
+        raise ValueError("tolerance must be a finite non-negative scalar.")
+
+    tolerance_scalar = tolerance_array.item()
+    if isinstance(tolerance_scalar, bool):
+        raise ValueError("tolerance must be a finite non-negative scalar.")
+
+    try:
+        tolerance_value = float(tolerance_scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("tolerance must be a finite non-negative scalar.") from exc
+
+    if not math.isfinite(tolerance_value) or tolerance_value < 0.0:
+        raise ValueError("tolerance must be a finite non-negative scalar.")
+    return tolerance_value
+
+
 def solve_gated_assignment(cost_matrix, *, max_cost: float = float("inf")):
     """Solve one-to-one assignment with optional gating."""
     costs = asarray(cost_matrix)
@@ -255,6 +274,7 @@ def run_registration_loop(  # pylint: disable=too-many-locals
     assignment = zeros((reference.shape[0],), dtype=int64) - 1
     converged = False
     iteration = 0
+    tolerance = _validate_tolerance(config.tolerance)
     association_cost = (
         default_cost if config.cost_function is None else config.cost_function
     )
@@ -300,7 +320,7 @@ def run_registration_loop(  # pylint: disable=too-many-locals
         transform = updated_transform
         assignment = new_assignment
 
-        if same_assignment and change <= config.tolerance:
+        if same_assignment and change <= tolerance:
             converged = True
             break
 

--- a/tests/test_point_set_registration.py
+++ b/tests/test_point_set_registration.py
@@ -127,6 +127,23 @@ class TestJointRegistrationAssignment(unittest.TestCase):
         pyrecest.backend.__backend_name__ == "jax",
         reason="Not supported on this backend",
     )
+    def test_joint_registration_assignment_rejects_invalid_tolerance(self):
+        points = array([[0.0, 0.0], [1.0, 0.0]])
+
+        for invalid_tolerance in (float("nan"), float("inf"), -1.0):
+            with self.subTest(invalid_tolerance=invalid_tolerance):
+                with self.assertRaisesRegex(ValueError, "tolerance"):
+                    joint_registration_assignment(
+                        points,
+                        points,
+                        model="translation",
+                        tolerance=invalid_tolerance,
+                    )
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
     def test_joint_registration_assignment_recovers_permuted_affine_matches(self):
         reference = array(
             [


### PR DESCRIPTION
## Summary
- reject non-finite, negative, and boolean registration convergence tolerances in the shared registration loop
- add regression coverage through `joint_registration_assignment`

## Rationale
`tolerance` controls registration-loop convergence. Before this change, values such as `NaN` or negative tolerances were accepted, which can silently prevent convergence even for exact repeated assignments and make the result depend on the iteration cap instead of a valid stopping criterion.

## Testing
- Not run locally; repository network access is unavailable in this environment.