### PR TITLE
Accept integer-like session label fill values

### DIFF
--- a/src/pyrecest/utils/_multisession_assignment_labels.py
+++ b/src/pyrecest/utils/_multisession_assignment_labels.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import math
 from collections.abc import Sequence
 from numbers import Integral
 from typing import Any
 
+import numpy as np
 from pyrecest.backend import int64
 
 from .multisession_assignment import (  # pylint: disable=protected-access
@@ -19,12 +21,28 @@ from .multisession_assignment import (  # pylint: disable=protected-access
 
 
 def _normalize_fill_value(fill_value: Any, track_count: int) -> int:
-    if isinstance(fill_value, bool) or not isinstance(fill_value, Integral):
+    fill_value_array = np.asarray(fill_value)
+    if fill_value_array.shape != () or fill_value_array.dtype == np.bool_:
         raise ValueError("fill_value must be an integer.")
-    fill_value = int(fill_value)
-    if 0 <= fill_value < int(track_count):
+
+    fill_value_value = fill_value_array.item()
+    if isinstance(fill_value_value, (bool, np.bool_)):
+        raise ValueError("fill_value must be an integer.")
+
+    if isinstance(fill_value_value, Integral):
+        integer_fill_value = int(fill_value_value)
+    else:
+        try:
+            fill_value_float = float(fill_value_value)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError("fill_value must be an integer.") from exc
+        if not math.isfinite(fill_value_float) or not fill_value_float.is_integer():
+            raise ValueError("fill_value must be an integer.")
+        integer_fill_value = int(fill_value_float)
+
+    if 0 <= integer_fill_value < int(track_count):
         raise ValueError("fill_value must not collide with track labels.")
-    return fill_value
+    return integer_fill_value
 
 
 def tracks_to_session_labels(

--- a/tests/test_multisession_assignment_labels.py
+++ b/tests/test_multisession_assignment_labels.py
@@ -2,8 +2,13 @@
 
 import unittest
 
+import numpy as np
 import pyrecest.utils.multisession_assignment as multisession_assignment_module
-from pyrecest.backend import __backend_name__
+from pyrecest.backend import (  # pylint: disable=no-name-in-module
+    __backend_name__,
+    array,
+    array_equal,
+)
 from pyrecest.utils import MultiSessionAssignmentResult, tracks_to_session_labels
 
 
@@ -37,6 +42,23 @@ class TestMultiSessionAssignmentLabels(unittest.TestCase):
                     "Each detection can only belong to a single track",
                 ):
                     converter(tracks, session_sizes=[1], fill_value=-99)
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_integer_like_fill_values_are_accepted(self):
+        tracks = [{0: 0}, {0: 1}]
+        valid_fill_values = (-2.0, np.int64(-3), np.array(-4))
+
+        for fill_value in valid_fill_values:
+            expected_fill_value = int(np.asarray(fill_value).item())
+            for name, converter in self._converters():
+                with self.subTest(converter=name, fill_value=repr(fill_value)):
+                    labels = converter(tracks, session_sizes=[3], fill_value=fill_value)
+                    self.assertTrue(
+                        array_equal(labels[0], array([0, 1, expected_fill_value], dtype=int))
+                    )
 
     @unittest.skipIf(
         __backend_name__ == "jax",


### PR DESCRIPTION
## Summary
- normalize `tracks_to_session_labels` fill values from scalar NumPy arrays and integral floats before constructing backend integer arrays
- keep rejecting bool, non-scalar, non-integral, and label-colliding fill values
- add regression coverage through the public utility, patched module export, and `MultiSessionAssignmentResult.to_session_labels`

## Tests
- Not run locally; repository access was through the GitHub connector.
