### PR TITLE
Reject string scalar pruning config values

### DIFF
--- a/src/pyrecest/utils/candidate_pruning.py
+++ b/src/pyrecest/utils/candidate_pruning.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+from numbers import Real
 from typing import Any
 
 import numpy as np
@@ -106,15 +107,12 @@ def _normalize_positive_integer(value: Any, name: str) -> int:
         raise ValueError(message)
 
     scalar = value_array.item()
-    if isinstance(scalar, (bool, np.bool_)):
+    if isinstance(scalar, (bool, np.bool_)) or not isinstance(scalar, Real):
         raise ValueError(message)
     if isinstance(scalar, (int, np.integer)):
         parsed = int(scalar)
     else:
-        try:
-            scalar_float = float(scalar)
-        except (TypeError, ValueError, OverflowError) as exc:
-            raise ValueError(message) from exc
+        scalar_float = float(scalar)
         if not np.isfinite(scalar_float) or not scalar_float.is_integer():
             raise ValueError(message)
         parsed = int(scalar_float)
@@ -130,12 +128,9 @@ def _normalize_finite_scalar(value: Any, *, message: str) -> float:
         raise ValueError(message)
 
     scalar = value_array.item()
-    if isinstance(scalar, (bool, np.bool_)):
+    if isinstance(scalar, (bool, np.bool_)) or not isinstance(scalar, Real):
         raise ValueError(message)
-    try:
-        parsed = float(scalar)
-    except (TypeError, ValueError, OverflowError) as exc:
-        raise ValueError(message) from exc
+    parsed = float(scalar)
     if not np.isfinite(parsed):
         raise ValueError(message)
     return parsed

--- a/src/pyrecest/utils/candidate_pruning.py
+++ b/src/pyrecest/utils/candidate_pruning.py
@@ -112,7 +112,10 @@ def _normalize_positive_integer(value: Any, name: str) -> int:
     if isinstance(scalar, (int, np.integer)):
         parsed = int(scalar)
     else:
-        scalar_float = float(scalar)
+        try:
+            scalar_float = float(scalar)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(message) from exc
         if not np.isfinite(scalar_float) or not scalar_float.is_integer():
             raise ValueError(message)
         parsed = int(scalar_float)
@@ -130,7 +133,10 @@ def _normalize_finite_scalar(value: Any, *, message: str) -> float:
     scalar = value_array.item()
     if isinstance(scalar, (bool, np.bool_)) or not isinstance(scalar, Real):
         raise ValueError(message)
-    parsed = float(scalar)
+    try:
+        parsed = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
     if not np.isfinite(parsed):
         raise ValueError(message)
     return parsed

--- a/tests/test_candidate_pruning.py
+++ b/tests/test_candidate_pruning.py
@@ -168,8 +168,8 @@ class TestCandidatePruning(unittest.TestCase):
                 config=CandidatePruningConfig(probability_threshold=0.4),
             )
 
-    def test_scalar_cost_controls_reject_bools_and_non_scalars(self):
-        invalid_values = (True, np.array([1.0]))
+    def test_scalar_cost_controls_reject_invalid_scalar_types(self):
+        invalid_values = (True, np.array([1.0]), "0.5", np.array("0.5", dtype=object))
         cases = (
             (
                 "probability_threshold",
@@ -189,18 +189,28 @@ class TestCandidatePruning(unittest.TestCase):
                     with self.assertRaisesRegex(ValueError, re.escape(message)):
                         CandidatePruningConfig(**{field_name: value})
 
-        with self.assertRaisesRegex(
-            ValueError,
-            "large_cost must be finite and positive",
-        ):
-            prune_pairwise_cost_matrix(
-                np.array([[1.0]]),
-                config=CandidatePruningConfig(row_top_k=1),
-                large_cost=True,
-            )
+        for invalid_large_cost in (True, "2.0"):
+            with self.subTest(invalid_large_cost=invalid_large_cost):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "large_cost must be finite and positive",
+                ):
+                    prune_pairwise_cost_matrix(
+                        np.array([[1.0]]),
+                        config=CandidatePruningConfig(row_top_k=1),
+                        large_cost=invalid_large_cost,
+                    )
 
     def test_top_k_rejects_non_integer_values(self):
-        invalid_top_k_values = (True, 1.5, np.nan, np.inf, np.array([1]))
+        invalid_top_k_values = (
+            True,
+            1.5,
+            np.nan,
+            np.inf,
+            np.array([1]),
+            "2",
+            np.array("2", dtype=object),
+        )
 
         for field_name in ("row_top_k", "column_top_k"):
             for value in invalid_top_k_values:


### PR DESCRIPTION
## Summary
- reject string/object scalar values in candidate-pruning integer and finite-scalar validators
- preserve accepted numeric scalar behavior for Python and NumPy numeric scalars
- add regression coverage for numeric strings in top-k fields, scalar cost controls, and the `large_cost` override

## Rationale
`CandidatePruningConfig` previously accepted values such as `row_top_k="2"` and `probability_threshold="0.5"` because the validators called `float(...)` on any scalar object. That silently normalized malformed configuration values instead of rejecting them, unlike the stricter scalar-validation behavior used elsewhere in the repository.

## Testing
- Not run locally: the execution environment cannot clone GitHub from the sandbox, so I verified the patch by inspecting the updated files through the GitHub connector.