### PR TITLE
Validate ellipse geometry matrix inputs

### DIFF
--- a/src/pyrecest/tracking/ellipse_geometry.py
+++ b/src/pyrecest/tracking/ellipse_geometry.py
@@ -14,6 +14,7 @@ from math import isfinite as _isfinite_scalar
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import abs as backend_abs
+from pyrecest.backend import all as backend_all
 from pyrecest.backend import (
     arctan2,
     array,
@@ -21,6 +22,7 @@ from pyrecest.backend import (
     cos,
     diag,
     eye,
+    isfinite,
     linalg,
     maximum,
     pi,
@@ -50,7 +52,7 @@ def project_symmetric_covariance(covariance, minimum_eigenvalue=0.0):
     minimum_eigenvalue = _coerce_nonnegative_finite_scalar(
         minimum_eigenvalue, "minimum_eigenvalue"
     )
-    covariance = symmetrize(covariance)
+    covariance = symmetrize(_coerce_finite_square_matrix(covariance, "covariance"))
     eigenvalues, eigenvectors = linalg.eigh(covariance)
     eigenvalues = maximum(eigenvalues, minimum_eigenvalue)
     return symmetrize((eigenvectors * eigenvalues) @ eigenvectors.T)
@@ -91,6 +93,24 @@ def _coerce_nonnegative_finite_scalar(value, name: str) -> float:
     if not _isfinite_scalar(scalar_float) or scalar_float < 0.0:
         raise ValueError(message)
     return scalar_float
+
+
+def _coerce_finite_square_matrix(value, name: str):
+    matrix = asarray(value)
+    if matrix.ndim != 2 or matrix.shape[0] != matrix.shape[1]:
+        raise ValueError(f"{name} must be a finite square matrix")
+    if not bool(backend_all(isfinite(matrix))):
+        raise ValueError(f"{name} must contain only finite values")
+    return matrix
+
+
+def _coerce_finite_matrix_shape(value, name: str, shape: tuple[int, int]):
+    matrix = asarray(value)
+    if matrix.shape != shape:
+        raise ValueError(f"{name} must have shape {shape}")
+    if not bool(backend_all(isfinite(matrix))):
+        raise ValueError(f"{name} must contain only finite values")
+    return matrix
 
 
 def rotation_matrix_2d(angle):
@@ -152,7 +172,7 @@ def shape_from_extent_matrix(
     minimum_axis_length = _coerce_nonnegative_finite_scalar(
         minimum_axis_length, "minimum_axis_length"
     )
-    extent = symmetrize(extent)
+    extent = symmetrize(_coerce_finite_matrix_shape(extent, "extent", (2, 2)))
     eigenvalues, eigenvectors = linalg.eigh(extent)
     if float(eigenvalues[1]) >= float(eigenvalues[0]):
         major_index = 1
@@ -265,9 +285,11 @@ def canonicalize_ellipse_shape(
     if shape_covariance is None:
         return canonical_shape, None
 
-    shape_covariance = asarray(shape_covariance)
-    if shape_covariance.shape != (3, 3):
-        raise ValueError("shape_covariance must have shape (3, 3)")
+    shape_covariance = _coerce_finite_matrix_shape(
+        shape_covariance,
+        "shape_covariance",
+        (3, 3),
+    )
     canonical_covariance = transform @ symmetrize(shape_covariance) @ transform.T
     canonical_covariance = project_symmetric_covariance(
         canonical_covariance,
@@ -305,9 +327,11 @@ def canonicalize_ellipse_axes(
     )
     if axis_covariance is None:
         return axes, None, swapped
-    axis_covariance = asarray(axis_covariance)
-    if axis_covariance.shape != (2, 2):
-        raise ValueError("axis_covariance must have shape (2, 2)")
+    axis_covariance = _coerce_finite_matrix_shape(
+        axis_covariance,
+        "axis_covariance",
+        (2, 2),
+    )
     canonical_axis_covariance = (
         axis_transform @ symmetrize(axis_covariance) @ axis_transform.T
     )

--- a/tests/tracking/test_ellipse_geometry.py
+++ b/tests/tracking/test_ellipse_geometry.py
@@ -56,6 +56,18 @@ def test_covariance_projection_rejects_invalid_eigenvalue_floor() -> None:
             )
 
 
+def test_covariance_projection_rejects_invalid_covariance_matrix() -> None:
+    invalid_covariances = (
+        np.ones((2, 3)),
+        np.array([[1.0, np.nan], [0.0, 1.0]]),
+        np.array([[1.0, np.inf], [0.0, 1.0]]),
+    )
+
+    for covariance in invalid_covariances:
+        with pytest.raises(ValueError, match="covariance"):
+            project_symmetric_covariance(covariance)
+
+
 def test_axis_floor_rejects_invalid_values() -> None:
     extent = np.eye(2)
     shape = np.array([0.0, 1.0, 2.0])
@@ -85,6 +97,35 @@ def test_axis_floor_rejects_invalid_values() -> None:
                 shape[1:],
                 minimum_axis_length=minimum_axis_length,
             )
+
+
+def test_shape_from_extent_matrix_rejects_invalid_extent_matrix() -> None:
+    invalid_extents = (
+        np.eye(3),
+        np.array([[1.0, np.nan], [0.0, 1.0]]),
+        np.array([[1.0, np.inf], [0.0, 1.0]]),
+    )
+
+    for extent in invalid_extents:
+        with pytest.raises(ValueError, match="extent"):
+            shape_from_extent_matrix(extent)
+
+
+def test_canonicalize_ellipse_shape_rejects_nonfinite_covariance() -> None:
+    shape = np.array([0.2, 1.0, 2.0])
+    covariance = np.eye(3)
+    covariance[0, 1] = np.nan
+
+    with pytest.raises(ValueError, match="shape_covariance"):
+        canonicalize_ellipse_shape(shape, covariance)
+
+
+def test_canonicalize_ellipse_axes_rejects_nonfinite_covariance() -> None:
+    covariance = np.eye(2)
+    covariance[0, 1] = np.inf
+
+    with pytest.raises(ValueError, match="axis_covariance"):
+        canonicalize_ellipse_axes(np.array([1.0, 2.0]), covariance)
 
 
 def test_canonicalize_ellipse_shape_transforms_full_shape_covariance() -> None:


### PR DESCRIPTION
## Summary
- reject non-square and non-finite covariance inputs before PSD projection
- require `shape_from_extent_matrix` to receive a finite 2x2 extent matrix
- reject non-finite shape/axis covariance blocks during ellipse canonicalization
- add regression tests for invalid covariance and extent matrices

## Rationale
`shape_from_extent_matrix` documents a 2x2 extent matrix, but a larger square matrix could previously reach the eigendecomposition path and produce a nonsensical 2-D ellipse shape from a higher-dimensional input. Non-finite covariance entries could also reach eigensolvers instead of failing with a clear `ValueError`.

## Testing
- Not run locally; repository network access is unavailable in this environment.