### PR TITLE
Validate identity Gaussian model dimensions

### DIFF
--- a/src/pyrecest/models/linear_gaussian.py
+++ b/src/pyrecest/models/linear_gaussian.py
@@ -1,5 +1,8 @@
 """Reusable linear Gaussian transition and measurement models."""
 
+import math
+from numbers import Integral
+
 from pyrecest.backend import (
     asarray,
     eye,
@@ -31,6 +34,34 @@ def _as_vector(value, name):
 
 def _shape(value):
     return tuple(value.shape)
+
+
+def _as_positive_integer(value, name):
+    message = f"{name} must be a positive integer"
+    if isinstance(value, bool):
+        raise ValueError(message)
+    arr = asarray(value)
+    if ndim(arr) != 0:
+        raise ValueError(message)
+    try:
+        scalar = arr.item()
+    except AttributeError:
+        scalar = arr
+    if isinstance(scalar, bool):
+        raise ValueError(message)
+    if isinstance(scalar, Integral):
+        parsed = int(scalar)
+    else:
+        try:
+            scalar_float = float(scalar)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(message) from exc
+        if not math.isfinite(scalar_float) or not scalar_float.is_integer():
+            raise ValueError(message)
+        parsed = int(scalar_float)
+    if parsed <= 0:
+        raise ValueError(message)
+    return parsed
 
 
 def _as_square(value, name):
@@ -120,6 +151,7 @@ class LinearGaussianTransitionModel:
 
 class IdentityGaussianTransitionModel(LinearGaussianTransitionModel):
     def __init__(self, dim, noise_cov, offset=None):
+        dim = _as_positive_integer(dim, "dim")
         super().__init__(eye(dim), noise_cov, offset=offset)
 
 
@@ -177,4 +209,5 @@ class LinearGaussianMeasurementModel:
 
 class IdentityGaussianMeasurementModel(LinearGaussianMeasurementModel):
     def __init__(self, dim, noise_cov):
+        dim = _as_positive_integer(dim, "dim")
         super().__init__(eye(dim), noise_cov)

--- a/tests/models/test_linear_gaussian_models.py
+++ b/tests/models/test_linear_gaussian_models.py
@@ -69,6 +69,17 @@ class LinearGaussianModelsTest(unittest.TestCase):
             to_numpy(measurement_model.measurement_matrix), to_numpy(eye(2)), atol=1e-12
         )
 
+    def test_identity_models_reject_invalid_dimensions(self):
+        invalid_dims = (True, False, 0, -1, 1.5, float("inf"))
+
+        for dim in invalid_dims:
+            with self.subTest(model="transition", dim=dim):
+                with self.assertRaisesRegex(ValueError, "dim must be a positive integer"):
+                    IdentityGaussianTransitionModel(dim, array([[1.0]]))
+            with self.subTest(model="measurement", dim=dim):
+                with self.assertRaisesRegex(ValueError, "dim must be a positive integer"):
+                    IdentityGaussianMeasurementModel(dim, array([[1.0]]))
+
     def test_rejects_incompatible_shapes(self):
         with self.assertRaises(ValueError):
             LinearGaussianTransitionModel(array([[1.0, 0.0]]), diag(array([0.1, 0.2])))


### PR DESCRIPTION
## Summary
- reject bool, non-positive, non-finite, and non-integral identity-model dimensions before constructing backend identity matrices
- apply the validation consistently to identity transition and measurement models
- add regression coverage for invalid identity-model dimensions

## Tests
- Not run locally; repository access was through the GitHub connector.
