### PR TITLE
Validate finite JAX uniform bounds

### DIFF
--- a/src/pyrecest/_backend/jax/random.py
+++ b/src/pyrecest/_backend/jax/random.py
@@ -142,12 +142,18 @@ def rand(*dims, size=None, **kwargs):
     return set_state_return(has_state, state, res)
 
 
+def _validate_uniform_bounds(low, high):
+    if bool(_jnp.any(~_jnp.isfinite(low))) or bool(_jnp.any(~_jnp.isfinite(high))):
+        raise ValueError("uniform bounds must be finite")
+    if bool(_jnp.any(low > high)):
+        raise ValueError("Upper bound must be greater than or equal to lower bound")
+
+
 def uniform(low=0.0, high=1.0, size=None, *args, **kwargs):
     low = _jnp.asarray(low)
     high = _jnp.asarray(high)
     shape = _bounded_sampler_shape(size, low, high)
-    if bool(_jnp.any(low > high)):
-        raise ValueError("Upper bound must be greater than or equal to lower bound")
+    _validate_uniform_bounds(low, high)
     state, has_state, kwargs = _get_state(**kwargs)
     state, res = _rand(state, shape, *args, minval=low, maxval=high, **kwargs)
     return set_state_return(has_state, state, res)

--- a/tests/backend/test_jax_uniform_bound_validation.py
+++ b/tests/backend/test_jax_uniform_bound_validation.py
@@ -1,0 +1,19 @@
+import numpy as np
+import pytest
+
+pytest.importorskip("jax")
+import jax.numpy as jnp  # noqa: E402
+from pyrecest._backend.jax import random  # noqa: E402
+
+
+def test_uniform_rejects_unusable_bounds():
+    too_large = np.finfo(float).max * 2.0
+
+    with pytest.raises(ValueError, match="finite"):
+        random.uniform(0.0, too_large)
+
+    with pytest.raises(ValueError, match="finite"):
+        random.uniform(-too_large, 1.0)
+
+    with pytest.raises(ValueError, match="finite"):
+        random.uniform(jnp.array([0.0, too_large]), jnp.array([1.0, 2.0]))


### PR DESCRIPTION
## Summary
- reject non-finite `random.uniform` bounds in the JAX backend before sampling
- keep the existing bound-order validation in a shared helper
- add a focused JAX regression test for scalar and broadcasted invalid bounds

## Validation
- inspected the branch diff with the GitHub compare API: 2 commits, 2 changed files
- locally syntax-checked reconstructed modified files with `python -m py_compile`
- full pytest not run in this environment