### PR TITLE
Reject subunit reliability max_scale

### DIFF
--- a/src/pyrecest/tracking/measurement_reliability.py
+++ b/src/pyrecest/tracking/measurement_reliability.py
@@ -45,7 +45,7 @@ class MeasurementReliabilityConfig:
         max_scale = (
             None
             if self.max_scale is None
-            else _positive_scalar(self.max_scale, "max_scale")
+            else _scale_upper_bound(self.max_scale, "max_scale")
         )
         object.__setattr__(self, "mode", mode)
         object.__setattr__(self, "threshold", threshold)
@@ -144,7 +144,7 @@ def reliability_to_covariance_scale(
     exponent = _positive_scalar(exponent, "exponent")
     scale = 1.0 / max(reliability, floor) ** exponent
     if max_scale is not None:
-        scale = min(scale, _positive_scalar(max_scale, "max_scale"))
+        scale = min(scale, _scale_upper_bound(max_scale, "max_scale"))
     return float(max(1.0, scale))
 
 
@@ -266,6 +266,13 @@ def _positive_scalar(value: float, name: str) -> float:
     value = _finite_scalar(value, name)
     if value <= 0.0:
         raise ValueError(f"{name} must be positive")
+    return value
+
+
+def _scale_upper_bound(value: float, name: str) -> float:
+    value = _positive_scalar(value, name)
+    if value < 1.0:
+        raise ValueError(f"{name} must be at least 1")
     return value
 
 

--- a/tests/tracking/test_measurement_reliability.py
+++ b/tests/tracking/test_measurement_reliability.py
@@ -17,6 +17,15 @@ def test_reliability_to_covariance_scale_uses_inverse_probability() -> None:
     assert reliability_to_covariance_scale(0.01, floor=0.1) == 10.0
 
 
+def test_max_scale_caps_at_or_above_nominal_scale() -> None:
+    assert reliability_to_covariance_scale(0.25, max_scale=2.0) == 2.0
+
+    with pytest.raises(ValueError, match="max_scale must be at least 1"):
+        reliability_to_covariance_scale(0.25, max_scale=0.5)
+    with pytest.raises(ValueError, match="max_scale must be at least 1"):
+        MeasurementReliabilityConfig(max_scale=0.5)
+
+
 def test_scale_covariance_by_reliability_returns_scaled_copy() -> None:
     cov = np.diag([4.0, 9.0])
     scaled, scale = scale_covariance_by_reliability(cov, 0.25)


### PR DESCRIPTION
## Summary
- Require measurement-reliability `max_scale` to be at least 1.0 when used as an inflation upper bound.
- Apply the same validation in `MeasurementReliabilityConfig` and direct `reliability_to_covariance_scale(...)` calls.
- Add regression coverage for capping at 2.0 and rejecting `max_scale=0.5`.

## Bug
`max_scale < 1` was accepted although reliability scaling is later clamped to at least one. This made subunit caps behave like a silent no-inflation switch rather than a meaningful inflation upper bound.

## Testing
- Added focused tests in `tests/tracking/test_measurement_reliability.py`.

Note: I did not run the tests locally because repository access here is through the GitHub connector.