### PR TITLE
Validate point-set metric scalar parameters

### DIFF
--- a/src/pyrecest/evaluation/point_set_metrics.py
+++ b/src/pyrecest/evaluation/point_set_metrics.py
@@ -273,11 +273,9 @@ def distance_quantiles(
 ) -> dict[float, float]:
     """Return quantiles of directed nearest-neighbor distances."""
 
-    quantile_values = tuple(float(quantile) for quantile in quantiles)
+    quantile_values = tuple(_validate_quantile(quantile) for quantile in quantiles)
     if not quantile_values:
         raise ValueError("At least one quantile is required.")
-    if any(quantile < 0.0 or quantile > 1.0 for quantile in quantile_values):
-        raise ValueError("Quantiles must be in [0, 1].")
     distances = nearest_neighbor_distances(
         query, reference, query_chunk_size=query_chunk_size
     )
@@ -393,8 +391,37 @@ def _normalize_optional_integer(value: Any, name: str) -> int | None:
     return int(scalar_float)
 
 
+def _validate_numeric_scalar(value: Any, message: str) -> float:
+    try:
+        array = np.asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(message) from exc
+    if array.shape != () or array.dtype == np.bool_:
+        raise ValueError(message)
+
+    scalar = array.item()
+    if isinstance(scalar, (bool, np.bool_, str, bytes)):
+        raise ValueError(message)
+    try:
+        value_float = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if not np.isfinite(value_float):
+        raise ValueError(message)
+    return value_float
+
+
 def _validate_threshold(threshold: float) -> float:
-    threshold_float = float(threshold)
-    if not np.isfinite(threshold_float) or threshold_float < 0.0:
-        raise ValueError("Distance thresholds must be finite and non-negative.")
+    message = "Distance thresholds must be finite and non-negative numeric scalars."
+    threshold_float = _validate_numeric_scalar(threshold, message)
+    if threshold_float < 0.0:
+        raise ValueError(message)
     return threshold_float
+
+
+def _validate_quantile(quantile: float) -> float:
+    message = "Quantiles must be finite numeric scalars in [0, 1]."
+    quantile_float = _validate_numeric_scalar(quantile, message)
+    if quantile_float < 0.0 or quantile_float > 1.0:
+        raise ValueError("Quantiles must be in [0, 1].")
+    return quantile_float

--- a/tests/evaluation/test_point_set_metrics_scalar_validation.py
+++ b/tests/evaluation/test_point_set_metrics_scalar_validation.py
@@ -37,7 +37,7 @@ def test_distance_quantiles_reject_non_numeric_scalar_probabilities(quantile):
 
 @pytest.mark.parametrize("quantile", [-0.1, 1.1])
 def test_distance_quantiles_reject_out_of_range_probabilities(quantile):
-    with pytest.raises(ValueError, match="\[0, 1\]"):
+    with pytest.raises(ValueError, match=r"\[0, 1\]"):
         distance_quantiles(_POINTS, _POINTS, quantiles=(quantile,))
 
 

--- a/tests/evaluation/test_point_set_metrics_scalar_validation.py
+++ b/tests/evaluation/test_point_set_metrics_scalar_validation.py
@@ -1,0 +1,49 @@
+import numpy as np
+import pytest
+
+from pyrecest.evaluation.point_set_metrics import (
+    distance_quantiles,
+    point_set_geometry_summary,
+    precision_recall_curve,
+    precision_recall_fscore,
+)
+
+_POINTS = np.array([[0.0]])
+
+
+@pytest.mark.parametrize(
+    "threshold",
+    [True, False, "0.25", np.array([0.25]), np.array([[0.25]])],
+)
+def test_point_set_metric_thresholds_reject_non_numeric_scalars(threshold):
+    with pytest.raises(ValueError, match="Distance thresholds"):
+        precision_recall_fscore(_POINTS, _POINTS, threshold)
+
+    with pytest.raises(ValueError, match="Distance thresholds"):
+        precision_recall_curve(_POINTS, _POINTS, (threshold,))
+
+    with pytest.raises(ValueError, match="Distance thresholds"):
+        point_set_geometry_summary(_POINTS, _POINTS, thresholds=(threshold,))
+
+
+@pytest.mark.parametrize(
+    "quantile",
+    [True, False, "0.5", np.array([0.5]), np.array([[0.5]]), np.nan, np.inf],
+)
+def test_distance_quantiles_reject_non_numeric_scalar_probabilities(quantile):
+    with pytest.raises(ValueError, match="Quantiles"):
+        distance_quantiles(_POINTS, _POINTS, quantiles=(quantile,))
+
+
+@pytest.mark.parametrize("quantile", [-0.1, 1.1])
+def test_distance_quantiles_reject_out_of_range_probabilities(quantile):
+    with pytest.raises(ValueError, match="\[0, 1\]"):
+        distance_quantiles(_POINTS, _POINTS, quantiles=(quantile,))
+
+
+def test_point_set_metric_numeric_scalar_arrays_remain_supported():
+    metrics = precision_recall_fscore(_POINTS, _POINTS, np.array(0.25))
+    assert metrics["threshold"] == pytest.approx(0.25)
+
+    quantiles = distance_quantiles(_POINTS, _POINTS, quantiles=(np.array(0.5),))
+    assert quantiles == {0.5: pytest.approx(0.0)}


### PR DESCRIPTION
## Summary
- reject boolean, string, and non-scalar distance thresholds before computing point-set precision/recall metrics
- validate distance quantile probabilities through the same finite numeric-scalar path and preserve the [0, 1] bounds check
- add regression tests for invalid threshold/quantile inputs and supported numeric scalar arrays

## Rationale
Point-set metric thresholds and quantile probabilities are numeric scalar parameters. Before this change, values such as `threshold=True` or `quantiles=("0.5",)` were silently coerced to `1.0` / `0.5`, which can mask caller bugs and produce plausible but unintended evaluation results.

## Validation
- Performed local isolated syntax/import checks of the updated module and exercised the new scalar-validation cases in a minimal Python harness.
- Full project CI should run on the PR.