### PR TITLE
Reject boolean TPS regularization

### DIFF
--- a/src/pyrecest/utils/nonrigid_point_set_registration.py
+++ b/src/pyrecest/utils/nonrigid_point_set_registration.py
@@ -149,7 +149,10 @@ def _validate_regularization(regularization: float) -> float:
     regularization_array = asarray(regularization)
     if regularization_array.shape != ():
         raise ValueError("regularization must be a finite non-negative scalar.")
-    regularization_value = float(regularization_array)
+    regularization_scalar = regularization_array.item()
+    if isinstance(regularization_scalar, bool):
+        raise ValueError("regularization must be a finite non-negative scalar.")
+    regularization_value = float(regularization_scalar)
     if not math.isfinite(regularization_value) or regularization_value < 0.0:
         raise ValueError("regularization must be a finite non-negative scalar.")
     return regularization_value

--- a/tests/test_nonrigid_point_set_registration.py
+++ b/tests/test_nonrigid_point_set_registration.py
@@ -75,6 +75,8 @@ class TestThinPlateSplineEstimation(unittest.TestCase):
             float("nan"),
             float("inf"),
             -float("inf"),
+            True,
+            False,
             array([1e-3]),
         ):
             with self.subTest(bad_regularization=bad_regularization):


### PR DESCRIPTION
## Summary
- reject boolean `regularization` values before fitting thin-plate splines
- extend the invalid-regularization regression test to cover both `True` and `False`

## Rationale
`regularization` is a numeric ridge penalty. Because `bool` is a subclass of `int`, the previous validator silently accepted `True` as `1.0` and `False` as `0.0`, which can hide accidental flag/configuration values and change TPS fitting behavior.

## Testing
- Not run locally; repository access was through the GitHub connector.