### PR TITLE
Validate weak measurement dimension order coverage

### DIFF
--- a/src/pyrecest/models/weak_measurement.py
+++ b/src/pyrecest/models/weak_measurement.py
@@ -51,15 +51,19 @@ def block_diag_measurement_covariance(
             raise TypeError("weak_std must be a mapping when trusted_std is a mapping")
         trusted_map = dict(trusted_std or {})
         weak_map = dict(weak_std or {})
+        provided_order = [
+            *trusted_map.keys(),
+            *(key for key in weak_map if key not in trusted_map),
+        ]
         if dimension_order is None:
-            order = [
-                *trusted_map.keys(),
-                *(key for key in weak_map if key not in trusted_map),
-            ]
+            order = provided_order
         else:
             order = list(dimension_order)
             if len(set(order)) != len(order):
                 raise ValueError("dimension_order must not contain duplicate entries")
+            omitted = [key for key in provided_order if key not in order]
+            if omitted:
+                raise KeyError(f"dimension_order omits std entries: {omitted}")
         missing = [
             key for key in order if key not in trusted_map and key not in weak_map
         ]

--- a/tests/test_weak_measurement_dimension_order.py
+++ b/tests/test_weak_measurement_dimension_order.py
@@ -1,0 +1,28 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+from pyrecest.models.weak_measurement import block_diag_measurement_covariance
+
+
+class TestWeakMeasurementDimensionOrder(unittest.TestCase):
+    def test_explicit_dimension_order_must_cover_all_mapping_keys(self):
+        with self.assertRaisesRegex(KeyError, "omits std entries"):
+            block_diag_measurement_covariance(
+                trusted_std={"x": 1.0, "y": 2.0},
+                weak_std={"range": 10.0},
+                dimension_order=["x", "range"],
+            )
+
+    def test_explicit_dimension_order_preserves_complete_mapping_order(self):
+        covariance = block_diag_measurement_covariance(
+            trusted_std={"x": 1.0, "y": 2.0},
+            weak_std={"range": 10.0},
+            dimension_order=["range", "x", "y"],
+        )
+
+        npt.assert_allclose(covariance, np.diag([100.0, 1.0, 4.0]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- require explicit weak-measurement `dimension_order` values to cover every mapped standard-deviation key
- prevent silent covariance-dimension drops when a mapping key is omitted from the requested order
- add regression coverage for both omitted-key rejection and successful reordered covariance construction

## Tests
- Not run locally in this environment; repository checkout/network access is unavailable. Added focused unit coverage in `tests/test_weak_measurement_dimension_order.py`.