### PR TITLE
Validate assignment cost matrix sentinels

### DIFF
--- a/src/pyrecest/utils/assignment.py
+++ b/src/pyrecest/utils/assignment.py
@@ -16,6 +16,8 @@ from pyrecest.backend import concatenate as _concatenate
 from pyrecest.backend import full as _full
 from pyrecest.backend import int64 as _int64
 from pyrecest.backend import isfinite as _isfinite
+from pyrecest.backend import isinf as _isinf
+from pyrecest.backend import isnan as _isnan
 from pyrecest.backend import sum as _sum
 from pyrecest.backend import where as _where
 from pyrecest.backend import zeros as _zeros
@@ -65,6 +67,29 @@ def _validate_assignment_count(k: int) -> int:
 def _has_boolean_dtype(value) -> bool:
     dtype = getattr(value, "dtype", None)
     return dtype is not None and str(dtype).lower() in {"bool", "bool_", "torch.bool"}
+
+
+def _coerce_cost_matrix(cost_matrix):
+    try:
+        raw_cost_matrix = _asarray(cost_matrix)
+    except (TypeError, ValueError, OverflowError, RuntimeError) as exc:
+        raise ValueError("cost_matrix must be numeric") from exc
+    if _has_boolean_dtype(raw_cost_matrix):
+        raise ValueError("cost_matrix must be numeric, not boolean")
+
+    try:
+        coerced_cost_matrix = _asarray(raw_cost_matrix, dtype=float)
+    except (TypeError, ValueError, OverflowError, RuntimeError) as exc:
+        raise ValueError("cost_matrix must be numeric") from exc
+    if coerced_cost_matrix.ndim != 2:
+        raise ValueError("cost_matrix must be a two-dimensional array")
+    if _any(_isnan(coerced_cost_matrix)) or _any(
+        _isinf(coerced_cost_matrix) & (coerced_cost_matrix < 0.0)
+    ):
+        raise ValueError(
+            "cost_matrix may only contain finite values or positive infinity"
+        )
+    return coerced_cost_matrix
 
 
 def _coerce_non_assignment_costs(costs, size: int, name: str):
@@ -214,9 +239,7 @@ def murty_k_best_assignments(  # pylint: disable=too-many-locals
             "murty_k_best_assignments is not supported on the JAX backend."
         )
 
-    cost_matrix = _asarray(cost_matrix, dtype=float)
-    if cost_matrix.ndim != 2:
-        raise ValueError("cost_matrix must be a two-dimensional array")
+    cost_matrix = _coerce_cost_matrix(cost_matrix)
 
     n_rows, n_cols = cost_matrix.shape
     row_non_assignment_costs = _coerce_non_assignment_costs(
@@ -314,9 +337,7 @@ def min_cost_max_cardinality_assignment(cost_matrix):
             "min_cost_max_cardinality_assignment is not supported on the JAX backend."
         )
 
-    cost_matrix = _asarray(cost_matrix, dtype=float)
-    if cost_matrix.ndim != 2:
-        raise ValueError("cost_matrix must be a two-dimensional array")
+    cost_matrix = _coerce_cost_matrix(cost_matrix)
 
     n_rows, n_cols = cost_matrix.shape
     assignment = _full((n_rows,), -1, dtype=_int64)

--- a/tests/utils/test_assignment_cost_matrix_validation.py
+++ b/tests/utils/test_assignment_cost_matrix_validation.py
@@ -1,0 +1,67 @@
+import unittest
+
+import numpy as np
+import pyrecest.backend
+from pyrecest.utils import (
+    min_cost_max_cardinality_assignment,
+    murty_k_best_assignments,
+)
+
+
+class AssignmentCostMatrixValidationTest(unittest.TestCase):
+    @staticmethod
+    def _solvers():
+        return (
+            ("murty", lambda matrix: murty_k_best_assignments(matrix, k=1)),
+            ("max_cardinality", min_cost_max_cardinality_assignment),
+        )
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on the JAX backend",
+    )
+    def test_nan_cost_matrix_entries_are_rejected(self):
+        for solver_name, solver in self._solvers():
+            with self.subTest(solver=solver_name):
+                with self.assertRaisesRegex(ValueError, "positive infinity"):
+                    solver(np.array([[np.nan, 1.0]]))
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on the JAX backend",
+    )
+    def test_negative_infinite_cost_matrix_entries_are_rejected(self):
+        for solver_name, solver in self._solvers():
+            with self.subTest(solver=solver_name):
+                with self.assertRaisesRegex(ValueError, "positive infinity"):
+                    solver(np.array([[-np.inf, 1.0]]))
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on the JAX backend",
+    )
+    def test_boolean_cost_matrix_is_rejected(self):
+        for solver_name, solver in self._solvers():
+            with self.subTest(solver=solver_name):
+                with self.assertRaisesRegex(ValueError, "not boolean"):
+                    solver(np.array([[True, False]]))
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on the JAX backend",
+    )
+    def test_positive_infinity_remains_infeasible_edge_sentinel(self):
+        solutions = murty_k_best_assignments(
+            np.array([[np.inf, 1.0]]),
+            k=1,
+            row_non_assignment_costs=5.0,
+            col_non_assignment_costs=0.0,
+        )
+
+        self.assertEqual(len(solutions), 1)
+        np.testing.assert_array_equal(solutions[0]["assignment"], np.array([1]))
+        self.assertAlmostEqual(solutions[0]["cost"], 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reject boolean assignment cost matrices instead of silently converting them to numeric 0/1 costs
- reject `NaN` and `-inf` cost-matrix entries while preserving `+inf` as the infeasible-edge sentinel
- add regression tests for Murty k-best and min-cost max-cardinality assignment entry points

## Bug
The assignment utilities intentionally accept `+inf` in cost matrices as an infeasible-edge sentinel. Before this change, all non-finite values were treated the same way downstream, so accidental `NaN` or `-inf` entries were silently converted into infeasible edges instead of surfacing invalid input. Boolean matrices were also coerced to 0/1 costs.

## Validation
- Inspected the branch diff with GitHub compare.
- Local clone/test execution was blocked in the sandbox by DNS resolution for github.com, so CI should be treated as the executable validation source for this PR.