### PR TITLE
Reject text random seeds

### DIFF
--- a/src/pyrecest/reproducibility.py
+++ b/src/pyrecest/reproducibility.py
@@ -32,7 +32,7 @@ def _normalize_seed(seed: int | None) -> int | None:
     except (TypeError, ValueError, RuntimeError, OverflowError) as exc:
         raise ValueError(message) from exc
 
-    if isinstance(scalar, bool):
+    if isinstance(scalar, bool | str | bytes):
         raise ValueError(message)
     if isinstance(scalar, Integral):
         normalized_seed = int(scalar)

--- a/tests/test_reproducibility.py
+++ b/tests/test_reproducibility.py
@@ -1,0 +1,27 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.reproducibility import _normalize_seed
+
+
+class ReproducibilityValidationTest(unittest.TestCase):
+    def test_normalize_seed_rejects_text_values(self):
+        for value in ("1", np.array("1")):
+            with self.subTest(value=repr(value)):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "seed must be a non-negative integer or None",
+                ):
+                    _normalize_seed(value)
+
+    def test_normalize_seed_preserves_numeric_scalar_support(self):
+        self.assertIsNone(_normalize_seed(None))
+        self.assertEqual(_normalize_seed(1), 1)
+        self.assertEqual(_normalize_seed(2.0), 2)
+        self.assertEqual(_normalize_seed(np.array(3)), 3)
+        self.assertEqual(_normalize_seed(np.array(4.0)), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reproducibility_seed.py
+++ b/tests/test_reproducibility_seed.py
@@ -20,6 +20,7 @@ class ReproducibilitySeedValidationTest(unittest.TestCase):
             1.5,
             float("nan"),
             float("inf"),
+            "8",
             [1],
             np.array([1]),
             object(),
@@ -37,7 +38,6 @@ class ReproducibilitySeedValidationTest(unittest.TestCase):
     def test_seed_all_accepts_integer_like_scalar_seed(self):
         self.assertIsNone(seed_all(None))
         self.assertEqual(seed_all(np.array(7.0)), 7)
-        self.assertEqual(seed_all("8"), 8)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- reject string and bytes-like scalar seeds before numeric fallback conversion
- preserve existing integer-like numeric scalar support, including scalar NumPy arrays
- add focused regression coverage for text seed inputs

## Validation
- Locally syntax-checked the reconstructed modified module with `python -m py_compile`
- Exercised `_normalize_seed` manually against rejected text inputs and accepted numeric scalar inputs
- Full project test suite not run locally because the execution environment cannot clone the repository and lacks the full development dependency set