### PR TITLE
Reject string model validation tolerances

### DIFF
--- a/src/pyrecest/models/validation.py
+++ b/src/pyrecest/models/validation.py
@@ -48,7 +48,10 @@ def _validate_nonnegative_finite_scalar(value: Any, name: str) -> float:
     if value_array.shape != () or value_array.dtype == np.bool_:
         raise ValueError(f"{name} must be a finite nonnegative scalar.")
     scalar = value_array.item()
-    if isinstance(scalar, (bool, np.bool_)):
+    if isinstance(
+        scalar,
+        (bool, np.bool_, str, bytes, bytearray, np.str_, np.bytes_),
+    ):
         raise ValueError(f"{name} must be a finite nonnegative scalar.")
     try:
         parsed = float(scalar)

--- a/tests/models/test_validation_scalar_parameters.py
+++ b/tests/models/test_validation_scalar_parameters.py
@@ -1,0 +1,52 @@
+"""Regression tests for model-validation scalar parameters."""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+from pyrecest.models.validation import validate_covariance_matrix
+
+
+class TestModelValidationScalarParameters(unittest.TestCase):
+    def test_symmetry_tolerances_reject_string_like_scalars(self) -> None:
+        covariance = [[1.0, 0.0], [0.0, 1.0]]
+        invalid_values = (
+            "0.0",
+            b"0.0",
+            np.array("0.0"),
+            np.array(b"0.0", dtype="S3"),
+            np.array("0.0", dtype=object),
+        )
+
+        for tolerance_name in ("symmetric_rtol", "symmetric_atol"):
+            for invalid_value in invalid_values:
+                with self.subTest(
+                    tolerance_name=tolerance_name,
+                    invalid_value=repr(invalid_value),
+                ):
+                    with self.assertRaisesRegex(
+                        ValueError,
+                        f"{tolerance_name} must be a finite nonnegative scalar",
+                    ):
+                        validate_covariance_matrix(
+                            covariance,
+                            check_symmetric=True,
+                            **{tolerance_name: invalid_value},
+                        )
+
+    def test_symmetry_tolerances_accept_numeric_scalar_arrays(self) -> None:
+        covariance = [[1.0, 0.0], [0.0, 1.0]]
+
+        validated = validate_covariance_matrix(
+            covariance,
+            check_symmetric=True,
+            symmetric_rtol=np.array(0.0),
+            symmetric_atol=np.array(0.0),
+        )
+
+        self.assertEqual(tuple(validated.shape), (2, 2))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reject string- and bytes-like scalar values in model-validation finite nonnegative scalar parameters
- prevent `validate_covariance_matrix` from silently coercing values such as `"0.0"` into numeric symmetry tolerances
- add regression coverage for `symmetric_rtol` and `symmetric_atol`, while preserving numeric scalar-array tolerance support

## Tests
- Locally syntax-checked the reconstructed modified module and new test file with Python AST parsing.
- Full pytest not run locally; repository access here is through the GitHub connector.