### PR TITLE
Use sanitized Student-t dof in update planning

### DIFF
--- a/src/pyrecest/filters/linear_update_planning.py
+++ b/src/pyrecest/filters/linear_update_planning.py
@@ -127,7 +127,7 @@ def student_t_covariance_scale(
                 _student_t_covariance_scale(
                     nis,
                     measurement_dim,
-                    dof=degrees_of_freedom,
+                    dof=dof,
                 ),
                 dtype=float,
             )

--- a/tests/filters/test_linear_update_planning.py
+++ b/tests/filters/test_linear_update_planning.py
@@ -120,6 +120,22 @@ def test_robust_scale_rejects_nonfinite_parameters():
             robust_update_covariance_scale(**kwargs)
 
 
+def test_student_t_covariance_scale_uses_sanitized_degrees_of_freedom():
+    expected = student_t_covariance_scale(
+        10.0,
+        measurement_dim=2,
+        degrees_of_freedom=4.0,
+    )
+
+    actual = student_t_covariance_scale(
+        10.0,
+        measurement_dim=2,
+        degrees_of_freedom="4.0",
+    )
+
+    assert np.isclose(actual, expected)
+
+
 def test_student_t_covariance_scale_rejects_nonfinite_dof():
     with pytest.raises(ValueError, match="degrees_of_freedom"):
         student_t_covariance_scale(1.0, measurement_dim=2, degrees_of_freedom=np.nan)


### PR DESCRIPTION
## Summary
- pass the validated `dof` value into the backend Student-t covariance-scale helper
- add regression coverage for wrapper-accepted degrees-of-freedom coercion

## Bug
`student_t_covariance_scale` validated `degrees_of_freedom` into the local `dof` variable, but then called the backend helper with the original unsanitized argument. Inputs accepted by the wrapper validation could still fail or behave inconsistently downstream.

## Testing
- Not run locally; repository access is through the GitHub connector in this environment.