### PR TITLE
Reject nonnumeric time-offset scalar inputs

### DIFF
--- a/src/pyrecest/calibration/time_offset.py
+++ b/src/pyrecest/calibration/time_offset.py
@@ -74,8 +74,11 @@ def _as_finite_float(value: Any, name: str) -> float:
     arr = np.asarray(value)
     if arr.ndim != 0 or arr.dtype == np.bool_:
         raise ValueError(f"{name} must be a finite scalar")
+    scalar = arr.item()
+    if isinstance(scalar, (bool, np.bool_, str, bytes, bytearray)):
+        raise ValueError(f"{name} must be a finite scalar")
     try:
-        result = float(arr.item())
+        result = float(scalar)
     except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError(f"{name} must be a finite scalar") from exc
     if not np.isfinite(result):
@@ -90,7 +93,7 @@ def _as_nonnegative_time_delta(value: Any, name: str) -> float:
     if arr.ndim != 0 or arr.dtype == np.bool_:
         raise ValueError(f"{name} must be nonnegative")
     scalar = arr.item()
-    if isinstance(scalar, (bool, np.bool_)):
+    if isinstance(scalar, (bool, np.bool_, str, bytes, bytearray)):
         raise ValueError(f"{name} must be nonnegative")
     try:
         result = float(scalar)

--- a/tests/calibration/test_max_time_delta_validation.py
+++ b/tests/calibration/test_max_time_delta_validation.py
@@ -7,7 +7,7 @@ from pyrecest.calibration.time_offset import interpolate_reference_values
 
 class MaxTimeDeltaValidationTest(unittest.TestCase):
     def test_interpolation_rejects_boolean_and_non_scalar_max_time_delta(self):
-        invalid_values = (True, np.array([1.0]))
+        invalid_values = (True, np.array([1.0]), "1.0", np.array(True, dtype=object))
 
         for max_time_delta_s in invalid_values:
             with self.subTest(max_time_delta_s=max_time_delta_s):
@@ -23,7 +23,7 @@ class MaxTimeDeltaValidationTest(unittest.TestCase):
                     )
 
     def test_bias_examples_reject_boolean_and_non_scalar_max_time_delta(self):
-        invalid_values = (True, np.array([1.0]))
+        invalid_values = (True, np.array([1.0]), "1.0", np.array(True, dtype=object))
 
         for max_time_delta_s in invalid_values:
             with self.subTest(max_time_delta_s=max_time_delta_s):

--- a/tests/calibration/test_time_offset_apply_validation.py
+++ b/tests/calibration/test_time_offset_apply_validation.py
@@ -8,7 +8,15 @@ class ApplyTimeOffsetValidationTest(unittest.TestCase):
     def test_apply_time_offset_rejects_invalid_offsets(self):
         times = np.array([0.0, 1.0])
 
-        for offset_s in (np.nan, np.inf, -np.inf, True, np.array([0.5])):
+        for offset_s in (
+            np.nan,
+            np.inf,
+            -np.inf,
+            True,
+            np.array([0.5]),
+            "0.25",
+            np.array(True, dtype=object),
+        ):
             with self.subTest(offset_s=offset_s):
                 with self.assertRaisesRegex(ValueError, "offset_s"):
                     apply_time_offset(times, offset_s)

--- a/tests/calibration/test_time_offset_grid_inputs.py
+++ b/tests/calibration/test_time_offset_grid_inputs.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 from pyrecest.calibration.time_offset import make_offset_grid
 
 
@@ -11,6 +12,8 @@ class TimeOffsetGridInputValidationTest(unittest.TestCase):
             (0.0, 1.0, float("inf")),
             ([0.0], 1.0, 0.1),
             (0.0, True, 0.1),
+            ("0.0", 1.0, 0.1),
+            (0.0, np.array(True, dtype=object), 0.1),
         )
         for min_s, max_s, step_s in invalid_cases:
             with self.subTest(min_s=min_s, max_s=max_s, step_s=step_s):


### PR DESCRIPTION
## Summary
- reject string, bytes-like, and object-wrapped boolean scalar values in time-offset finite-float validation
- apply the same nonnumeric scalar rejection to `max_time_delta_s` validation while still allowing numeric finite/infinite time-delta scalars as before
- add regression coverage for offset-grid, applied-offset, and max-time-delta validation paths

## Tests
- Ran focused local validation checks for `make_offset_grid`, `apply_time_offset`, and `interpolate_reference_values` against numeric strings and object-wrapped booleans
- Ran `python -m py_compile` on the updated `time_offset.py`

Full project pytest was not run locally because the sandbox cannot clone the repository directly; changes were made through the GitHub connector.