### PR TITLE
Reject nonnumeric registration max_cost

### DIFF
--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -150,13 +150,16 @@ def evaluate_registration_costs(transform, reference, moving, association_cost):
 
 
 def _validate_max_cost(max_cost) -> float:
-    max_cost_array = asarray(max_cost)
+    try:
+        max_cost_array = asarray(max_cost)
+    except (TypeError, ValueError, OverflowError, RuntimeError) as exc:
+        raise ValueError("max_cost must be a scalar numeric value.") from exc
     if max_cost_array.shape != ():
         raise ValueError("max_cost must be a scalar.")
 
     try:
         max_cost_scalar = max_cost_array.item()
-    except (TypeError, ValueError, AttributeError) as exc:
+    except (TypeError, ValueError, AttributeError, RuntimeError) as exc:
         raise ValueError("max_cost must be a scalar numeric value.") from exc
     if isinstance(max_cost_scalar, (bool, str, bytes, bytearray)):
         raise ValueError("max_cost must be a scalar numeric value.")

--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -153,8 +153,16 @@ def _validate_max_cost(max_cost) -> float:
     max_cost_array = asarray(max_cost)
     if max_cost_array.shape != ():
         raise ValueError("max_cost must be a scalar.")
+
     try:
-        max_cost_value = float(max_cost_array)
+        max_cost_scalar = max_cost_array.item()
+    except (TypeError, ValueError, AttributeError) as exc:
+        raise ValueError("max_cost must be a scalar numeric value.") from exc
+    if isinstance(max_cost_scalar, (bool, str, bytes, bytearray)):
+        raise ValueError("max_cost must be a scalar numeric value.")
+
+    try:
+        max_cost_value = float(max_cost_scalar)
     except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError("max_cost must be a scalar numeric value.") from exc
     if math.isnan(max_cost_value) or max_cost_value < 0.0:

--- a/tests/test_point_set_registration_max_cost_validation.py
+++ b/tests/test_point_set_registration_max_cost_validation.py
@@ -1,0 +1,35 @@
+import unittest
+
+import numpy.testing as npt
+import pyrecest.backend
+from pyrecest.backend import array
+from pyrecest.utils.point_set_registration import solve_gated_assignment
+
+
+class TestRegistrationMaxCostValidation(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_solve_gated_assignment_rejects_nonnumeric_max_cost(self):
+        cost_matrix = array([[0.5]])
+
+        for invalid_max_cost in (True, False, "1.0", b"1.0"):
+            with self.subTest(invalid_max_cost=invalid_max_cost):
+                with self.assertRaisesRegex(ValueError, "max_cost"):
+                    solve_gated_assignment(cost_matrix, max_cost=invalid_max_cost)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_solve_gated_assignment_preserves_numeric_scalar_max_cost(self):
+        cost_matrix = array([[0.5], [2.0]])
+
+        assignment = solve_gated_assignment(cost_matrix, max_cost=array(1.0))
+
+        npt.assert_array_equal(assignment, array([0, -1]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reject boolean, string, bytes, and bytearray `max_cost` values in registration gated assignment
- preserve numeric scalar-array support for `max_cost`
- add focused regression tests for invalid and valid scalar inputs

## Bug
`solve_gated_assignment(..., max_cost=True)` was silently interpreted as `max_cost=1.0` because the validator cast scalar inputs with `float(...)`. Numeric strings such as `"1.0"` were likewise accepted. `max_cost` is a numeric gate threshold, so nonnumeric scalars should fail fast instead of producing plausible but unintended gating behavior.

## Testing
- Not run locally; repository access here is through the GitHub connector. CI should exercise the added regression tests.