### PR TITLE
Validate backend helper inputs

### DIFF
--- a/src/pyrecest/backend_tools.py
+++ b/src/pyrecest/backend_tools.py
@@ -18,6 +18,20 @@ def is_backend(expected: str) -> bool:
     return get_backend_name() == expected
 
 
+def _normalize_expected_backend_names(expected: str | tuple[str, ...]) -> tuple[str, ...]:
+    message = "expected must name at least one backend."
+    if isinstance(expected, str):
+        names = (expected,)
+    else:
+        try:
+            names = tuple(expected)
+        except TypeError as exc:
+            raise ValueError(message) from exc
+    if not names or any(not isinstance(name, str) or not name for name in names):
+        raise ValueError(message)
+    return names
+
+
 def assert_backend(expected: str | tuple[str, ...]) -> None:
     """Raise ``RuntimeError`` unless the active backend matches ``expected``.
 
@@ -27,7 +41,7 @@ def assert_backend(expected: str | tuple[str, ...]) -> None:
         Allowed backend name or names.
     """
     active = get_backend_name()
-    expected_names = (expected,) if isinstance(expected, str) else tuple(expected)
+    expected_names = _normalize_expected_backend_names(expected)
     if active not in expected_names:
         allowed = ", ".join(expected_names)
         raise RuntimeError(

--- a/tests/test_backend_tools.py
+++ b/tests/test_backend_tools.py
@@ -19,6 +19,12 @@ def test_assert_backend_rejects_unexpected_backend():
         pyrecest.assert_backend(unexpected)
 
 
+@pytest.mark.parametrize("expected", [(), ("",), ("numpy", 1), 1])
+def test_assert_backend_rejects_invalid_expected_names(expected):
+    with pytest.raises(ValueError, match="expected"):
+        pyrecest.assert_backend(expected)
+
+
 def test_warn_if_backend_env_changed(monkeypatch):
     active = pyrecest.get_backend_name()
     changed = "jax" if active != "jax" else "numpy"


### PR DESCRIPTION
## Summary
- validate expected backend names before comparing the active backend
- reject empty names and non-string entries with a clean ValueError
- add focused pytest coverage

## Testing
- Not run locally; changes were applied through the GitHub connector.