### PR TITLE
Validate scenario numeric configuration values

### DIFF
--- a/src/pyrecest/scenarios.py
+++ b/src/pyrecest/scenarios.py
@@ -10,6 +10,8 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
+_TEXT_TYPES = (str, bytes, bytearray)
+
 
 @dataclass(slots=True)
 class ScenarioResult:
@@ -66,13 +68,37 @@ def load_scenario_config(path: str | Path) -> dict[str, Any]:
         return tomllib.load(handle)
 
 
+def _numeric_config_scalar(value: Any, message: str) -> float:
+    if isinstance(value, bool) or isinstance(value, _TEXT_TYPES):
+        raise ValueError(message)
+    try:
+        return float(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+
+
+def _integer_config_value(value: Any, name: str, *, positive: bool) -> int:
+    descriptor = "positive" if positive else "non-negative"
+    message = f"{name} must be a {descriptor} integer"
+    scalar = _numeric_config_scalar(value, message)
+    if not math.isfinite(scalar) or not scalar.is_integer():
+        raise ValueError(message)
+    integer = int(scalar)
+    if positive:
+        if integer <= 0:
+            raise ValueError(message)
+    elif integer < 0:
+        raise ValueError(message)
+    return integer
+
+
 def _scenario_seed(config: dict[str, Any]) -> int | None:
     for section_name in ("random", "scenario"):
         section = config.get(section_name, {})
         if isinstance(section, dict) and "seed" in section:
-            return int(section["seed"])
+            return _integer_config_value(section["seed"], "seed", positive=False)
     if "seed" in config:
-        return int(config["seed"])
+        return _integer_config_value(config["seed"], "seed", positive=False)
     return None
 
 
@@ -86,7 +112,12 @@ def _apply_scenario_seed(config: dict[str, Any]) -> int | None:
     return seed
 
 
-def _to_float_list(value: Any) -> list[float]:
+def _to_float_list(
+    value: Any,
+    *,
+    name: str = "value",
+    reject_text_or_bool: bool = False,
+) -> list[float]:
     try:
         from pyrecest.backend import to_numpy
 
@@ -96,9 +127,22 @@ def _to_float_list(value: Any) -> list[float]:
 
     if hasattr(value, "tolist"):
         value = value.tolist()
+
+    message = f"{name} must contain numeric values"
+
+    def convert(item: Any) -> float:
+        if reject_text_or_bool and (isinstance(item, bool) or isinstance(item, _TEXT_TYPES)):
+            raise ValueError(message)
+        try:
+            return float(item)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(message) from exc
+
+    if reject_text_or_bool and isinstance(value, _TEXT_TYPES):
+        raise ValueError(message)
     if isinstance(value, int | float):
-        return [float(value)]
-    return [float(item) for item in value]
+        return [convert(value)]
+    return [convert(item) for item in value]
 
 
 def _normalized_particle_weights(raw_weights: Any, particle_count: int, backend):
@@ -108,7 +152,11 @@ def _normalized_particle_weights(raw_weights: Any, particle_count: int, backend)
     if raw_weights is None:
         weight_values = [1.0 for _ in range(particle_count)]
     else:
-        weight_values = _to_float_list(raw_weights)
+        weight_values = _to_float_list(
+            raw_weights,
+            name="weights",
+            reject_text_or_bool=True,
+        )
 
     if len(weight_values) != particle_count:
         raise ValueError("weights must contain one entry per particle")
@@ -128,15 +176,7 @@ def _normalized_particle_weights(raw_weights: Any, particle_count: int, backend)
 
 
 def _positive_integer_config_value(value: Any, name: str) -> int:
-    if isinstance(value, bool):
-        raise ValueError(f"{name} must be a positive integer")
-    try:
-        scalar = float(value)
-    except (TypeError, ValueError, OverflowError) as exc:
-        raise ValueError(f"{name} must be a positive integer") from exc
-    if not math.isfinite(scalar) or scalar <= 0.0 or not scalar.is_integer():
-        raise ValueError(f"{name} must be a positive integer")
-    return int(scalar)
+    return _integer_config_value(value, name, positive=True)
 
 
 @scenario_runner("linear_gaussian")

--- a/tests/test_scenario_registry_and_reproducibility.py
+++ b/tests/test_scenario_registry_and_reproducibility.py
@@ -4,13 +4,18 @@ import pytest
 from pyrecest.scenarios import available_scenario_types, run_scenario
 
 
-def _write_particle_scenario(path: Path, weights: str, num_samples: str = "4") -> None:
+def _write_particle_scenario(
+    path: Path,
+    weights: str,
+    num_samples: str = "4",
+    seed: str = "7",
+) -> None:
     path.write_text(
         f"""
 [scenario]
 type = "particle_resampling"
 name = "particle-resampling"
-seed = 7
+seed = {seed}
 
 [data]
 particles = [[0.0, 0.0], [1.0, 0.0]]
@@ -50,7 +55,7 @@ num_samples = 8
     assert first.metrics["effective_sample_size"] > 0.0
 
 
-@pytest.mark.parametrize("num_samples", ["0", "-1", "1.5", "true"])
+@pytest.mark.parametrize("num_samples", ["0", "-1", "1.5", "true", '"4"'])
 def test_particle_resampling_scenario_rejects_invalid_num_samples(
     tmp_path: Path, num_samples: str
 ):
@@ -58,6 +63,30 @@ def test_particle_resampling_scenario_rejects_invalid_num_samples(
     _write_particle_scenario(scenario, "[0.5, 0.5]", num_samples=num_samples)
 
     with pytest.raises(ValueError, match="num_samples must be a positive integer"):
+        run_scenario(scenario)
+
+
+@pytest.mark.parametrize("seed", ["-1", "1.5", "true", '"7"'])
+def test_particle_resampling_scenario_rejects_invalid_seed(
+    tmp_path: Path,
+    seed: str,
+):
+    scenario = tmp_path / "invalid_seed.toml"
+    _write_particle_scenario(scenario, "[0.5, 0.5]", seed=seed)
+
+    with pytest.raises(ValueError, match="seed must be a non-negative integer"):
+        run_scenario(scenario)
+
+
+@pytest.mark.parametrize("weights", ["[true, false]", '["0.5", "0.5"]'])
+def test_particle_resampling_scenario_rejects_nonnumeric_weights(
+    tmp_path: Path,
+    weights: str,
+):
+    scenario = tmp_path / "nonnumeric_weights.toml"
+    _write_particle_scenario(scenario, weights)
+
+    with pytest.raises(ValueError, match="weights must contain numeric values"):
         run_scenario(scenario)
 
 


### PR DESCRIPTION
## Summary
- reject boolean and text scenario seeds instead of coercing them with `int(...)`
- centralize positive/non-negative integer validation for scenario numeric config values
- reject boolean and string particle weights instead of silently converting them to numeric weights
- add regression coverage for invalid seeds, quoted `num_samples`, and nonnumeric weights

## Bug
The scenario runner parsed TOML configuration scalars with broad `int(...)`/`float(...)` coercions. That allowed values such as `seed = true`, `seed = 1.5`, `num_samples = "4"`, and `weights = ["0.5", "0.5"]` to be accepted as valid numeric configuration. These inputs are likely configuration mistakes and should fail early.

## Validation
- `python -m py_compile` on the modified scenario module and test file
- `pytest -q tests/test_scenario_registry_and_reproducibility.py` against a minimal local package stub for the touched scenario path

Full project pytest was not run because this sandbox cannot clone the repository directly; file updates were made through the GitHub connector.