### PR TITLE
Validate track metric session times

### DIFF
--- a/src/pyrecest/utils/track_metrics.py
+++ b/src/pyrecest/utils/track_metrics.py
@@ -323,14 +323,29 @@ def _session_times(
 ) -> np.ndarray:
     if session_times is None:
         return np.arange(n_sessions, dtype=float)
-    times = np.asarray(session_times, dtype=float)
-    if times.shape != (n_sessions,):
+    raw_times = np.asarray(session_times, dtype=object)
+    if raw_times.shape != (n_sessions,):
         raise ValueError(
             "session_times must have length equal to the number of sessions"
         )
+    if _contains_bool_or_text(raw_times):
+        raise ValueError("session_times must contain only finite numeric values")
+    try:
+        times = raw_times.astype(float)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(
+            "session_times must contain only finite numeric values"
+        ) from exc
     if not np.all(np.isfinite(times)):
         raise ValueError("session_times must contain only finite values")
+    if np.any(np.diff(times) < 0):
+        raise ValueError("session_times must be nondecreasing")
     return times
+
+
+def _contains_bool_or_text(values: np.ndarray) -> bool:
+    invalid_types = (bool, np.bool_, str, bytes, bytearray, np.str_, np.bytes_)
+    return any(isinstance(value, invalid_types) for value in values.flat)
 
 
 def _as_positive_int(value: Any, name: str) -> int:

--- a/tests/test_track_metrics.py
+++ b/tests/test_track_metrics.py
@@ -90,6 +90,54 @@ class TestTrackMetrics(unittest.TestCase):
                         session_times=session_times,
                     )
 
+    def test_track_latency_rejects_nonmonotonic_session_times(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "session_times must be nondecreasing",
+        ):
+            track_latencies(
+                self.predicted,
+                self.reference,
+                session_times=[0.0, 2.0, 1.0],
+            )
+        with self.assertRaisesRegex(
+            ValueError,
+            "session_times must be nondecreasing",
+        ):
+            score_track_latency(
+                self.predicted,
+                self.reference,
+                session_times=[0.0, 2.0, 1.0],
+            )
+
+    def test_track_latency_rejects_bool_and_text_session_times(self):
+        invalid_session_times = (
+            [0.0, True, 2.0],
+            [0.0, "1.0", 2.0],
+            [0.0, b"1.0", 2.0],
+        )
+
+        for session_times in invalid_session_times:
+            with self.subTest(session_times=session_times):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "session_times must contain only finite numeric values",
+                ):
+                    track_latencies(
+                        self.predicted,
+                        self.reference,
+                        session_times=session_times,
+                    )
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "session_times must contain only finite numeric values",
+                ):
+                    score_track_latency(
+                        self.predicted,
+                        self.reference,
+                        session_times=session_times,
+                    )
+
     def test_min_length_limits_false_track_observation_rate_denominator(self):
         predicted = [
             [99, None, None],


### PR DESCRIPTION
## Summary
- reject boolean and text-valued `session_times` before latency computation
- require custom `session_times` to be nondecreasing so first-detection latency cannot become negative because of an inverted timeline
- add regression coverage for invalid `session_times` inputs in track metric latency helpers

## Bug
`track_latencies` accepted arbitrary finite `session_times` after coercing them with `np.asarray(..., dtype=float)`. This allowed inputs such as `[0.0, 2.0, 1.0]` to compute negative latency for detections in later sessions, and also silently accepted `True` or numeric strings as timestamps.

## Validation
- Syntax-checked the reconstructed modified `track_metrics.py` and `test_track_metrics.py` with `py_compile`.
- Exercised the changed validation path in a small local harness for nonmonotonic, boolean, text, and valid numeric `session_times`.
- Full project pytest was not run locally because the sandbox cannot clone the repository directly; CI should run the full suite on this PR.