### PR TITLE
Reject text ridge alpha in bias calibration

### DIFF
--- a/src/pyrecest/calibration/bias.py
+++ b/src/pyrecest/calibration/bias.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+from numbers import Real
 from typing import Any
 
 import numpy as np
@@ -359,7 +360,7 @@ def _as_nonnegative_finite_float(value: Any, name: str) -> float:
     if arr.ndim != 0 or arr.dtype == np.bool_:
         raise ValueError(f"{name} must be a nonnegative finite scalar")
     scalar = arr.item()
-    if isinstance(scalar, (bool, np.bool_)):
+    if isinstance(scalar, (bool, np.bool_)) or not isinstance(scalar, Real):
         raise ValueError(f"{name} must be a nonnegative finite scalar")
     try:
         result = float(scalar)

--- a/tests/calibration/test_bias.py
+++ b/tests/calibration/test_bias.py
@@ -53,6 +53,7 @@ def test_apply_accepts_matching_feature_rows():
         ("feature_dim", 1.5, "feature_dim"),
         ("training_count", 2.5, "training_count"),
         ("ridge_alpha", np.nan, "ridge_alpha"),
+        ("ridge_alpha", "0.0", "ridge_alpha"),
     ],
 )
 def test_model_rejects_invalid_scalar_metadata(field_name, invalid_value, match):


### PR DESCRIPTION
## Summary
- reject text-valued `ridge_alpha` in bias calibration scalar validation
- keep numeric scalar arrays accepted while requiring the parsed value to be a real numeric scalar
- add a regression case for `ridge_alpha="0.0"`

## Rationale
`SensorBiasCorrectionModel` and `fit_sensor_bias_correction_from_examples(...)` use `_as_nonnegative_finite_float(...)` for the ridge regularization strength. Before this change, a numeric string such as `"0.0"` was silently accepted through `float(...)`, which can hide malformed configuration or deserialization inputs.

## Validation
- Performed an isolated syntax check of the modified module content.
- Exercised the changed helper path locally in a minimal harness: `ridge_alpha="0.0"` now raises `ValueError`, while `ridge_alpha=np.array(0.0)` remains accepted.
- Full project CI should run on this PR.