### PR TITLE
Reject text scalar numerics

### DIFF
--- a/src/pyrecest/numerics.py
+++ b/src/pyrecest/numerics.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from numbers import Real
+
 import numpy as np
 from pyrecest.exceptions import (
     DimensionMismatchError,
@@ -37,8 +39,11 @@ def _validate_nonnegative_finite(name: str, value: float) -> float:
         raise ValueError(f"{name} must be a scalar number.") from exc
     if value_array.shape != () or np.issubdtype(value_array.dtype, np.bool_):
         raise ValueError(f"{name} must be a scalar number.")
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)) or not isinstance(scalar, Real):
+        raise ValueError(f"{name} must be a scalar number.")
     try:
-        value = float(value_array.item())
+        value = float(scalar)
     except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError(f"{name} must be a scalar number.") from exc
     if not np.isfinite(value) or value < 0.0:

--- a/tests/test_numerics_text_scalars.py
+++ b/tests/test_numerics_text_scalars.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pytest
+
+from pyrecest.numerics import (
+    assert_covariance_matrix,
+    is_positive_semidefinite,
+    is_symmetric,
+    jittered_cholesky,
+    nearest_symmetric_psd,
+)
+
+
+def test_numerical_scalar_controls_reject_text_values():
+    matrix = np.eye(2)
+
+    with pytest.raises(ValueError, match="atol"):
+        is_symmetric(matrix, atol="1e-9")
+    with pytest.raises(ValueError, match="atol"):
+        is_positive_semidefinite(matrix, atol="1e-9")
+    with pytest.raises(ValueError, match="atol"):
+        assert_covariance_matrix(matrix, atol="1e-9")
+    with pytest.raises(ValueError, match="min_eigenvalue"):
+        nearest_symmetric_psd(matrix, min_eigenvalue="0.0")
+    with pytest.raises(ValueError, match="initial_jitter"):
+        jittered_cholesky(matrix, initial_jitter="1e-12")


### PR DESCRIPTION
## Summary
- reject string/bytes scalar inputs in the shared numerical finite-scalar validator
- add regression coverage for text tolerances, PSD projection floors, and Cholesky jitter controls

## Rationale
`_validate_nonnegative_finite` previously accepted scalar strings such as `"1e-9"` because `float(value_array.item())` converted them. These controls are numerical API parameters and should reject text inputs rather than silently coercing them.

## Testing
- Added `tests/test_numerics_text_scalars.py`
- Not run locally; changes were made through the GitHub connector and should be covered by CI.