### PR TITLE
Validate optional dependency names

### DIFF
--- a/src/pyrecest/optional_dependencies.py
+++ b/src/pyrecest/optional_dependencies.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 
 import importlib
 from types import ModuleType
+from typing import Any
 
 from pyrecest.exceptions import OptionalDependencyError
+
+
+def _validate_nonempty_string(value: Any, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must be a non-empty string")
+    return value.strip()
 
 
 def _is_missing_requested_package(exc: ModuleNotFoundError, package: str) -> bool:
@@ -29,6 +36,9 @@ def require_optional_dependency(
     feature:
         Optional user-facing feature name for the error message.
     """
+    package = _validate_nonempty_string(package, "package")
+    extra = _validate_nonempty_string(extra, "extra")
+
     try:
         return importlib.import_module(package)
     except ModuleNotFoundError as exc:

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -17,6 +17,22 @@ def test_require_optional_dependency_reports_extra_for_missing_module():
     assert "pyrecest[plot]" in str(exc_info.value)
 
 
+@pytest.mark.parametrize(
+    ("package", "extra"),
+    [
+        (None, "plot"),
+        ("", "plot"),
+        ("   ", "plot"),
+        ("math", None),
+        ("math", ""),
+        ("math", b"plot"),
+    ],
+)
+def test_require_optional_dependency_rejects_invalid_names(package, extra):
+    with pytest.raises(ValueError, match="must be a non-empty string"):
+        require_optional_dependency(package, extra)
+
+
 def test_require_optional_dependency_reports_missing_parent_for_submodule():
     import_error = ModuleNotFoundError(
         "No module named 'missing_parent'",


### PR DESCRIPTION
## Summary
- validate `package` and `extra` inputs before importing optional modules
- raise a clear `ValueError` for empty or non-string package/extra names
- add regression coverage for invalid package/extra values

## Tests
- not run locally in this environment