### PR TITLE
Fix Autograd quadratic assignment default options

### DIFF
--- a/src/pyrecest/_backend/autograd/linalg.py
+++ b/src/pyrecest/_backend/autograd/linalg.py
@@ -65,5 +65,5 @@ _logm_vjp = _functools.partial(_adjoint, fn=logm)
 _defvjp(logm, _logm_vjp)
 
 
-def quadratic_assignment(a, b, options):
+def quadratic_assignment(a, b, options=None):
     return list(_quadratic_assignment(a, b, options=options).col_ind)

--- a/tests/test_quadratic_assignment_defaults.py
+++ b/tests/test_quadratic_assignment_defaults.py
@@ -7,6 +7,10 @@ pytorch_backend = None
 if importlib.util.find_spec("torch") is not None:
     from pyrecest._backend import pytorch as pytorch_backend
 
+autograd_backend = None
+if importlib.util.find_spec("autograd") is not None:
+    from pyrecest._backend import autograd as autograd_backend
+
 
 def _problem_matrices():
     adjacency = np.array(
@@ -48,6 +52,19 @@ def test_pytorch_quadratic_assignment_accepts_default_options():
     assignment = pytorch_backend.linalg.quadratic_assignment(
         pytorch_backend.array(adjacency),
         pytorch_backend.array(permuted),
+    )
+
+    assert sorted(assignment) == [0, 1, 2]
+
+
+def test_autograd_quadratic_assignment_accepts_default_options():
+    if autograd_backend is None:
+        return
+    adjacency, permuted = _problem_matrices()
+
+    assignment = autograd_backend.linalg.quadratic_assignment(
+        autograd_backend.array(adjacency),
+        autograd_backend.array(permuted),
     )
 
     assert sorted(assignment) == [0, 1, 2]


### PR DESCRIPTION
Summary:
- make the Autograd backend's `quadratic_assignment` accept `options=None`, matching the NumPy/PyTorch backend contract
- add a conditional Autograd regression test alongside the existing NumPy/PyTorch default-options tests

Checks:
- local syntax compile of the two modified files
- Autograd runtime test not run locally because the container does not have the optional Autograd dependency installed