### PR TITLE
Reject text scalar selection parameters

### DIFF
--- a/src/pyrecest/evaluation/selection.py
+++ b/src/pyrecest/evaluation/selection.py
@@ -9,6 +9,7 @@ and point-set or extended-object evaluation pipelines.
 
 from __future__ import annotations
 
+from numbers import Real
 from typing import Literal, cast
 
 import numpy as np
@@ -22,7 +23,7 @@ def _normalize_nonnegative_integer(value, name: str) -> int:
         raise ValueError(f"{name} must be a non-negative integer.")
 
     scalar = value_array.item()
-    if isinstance(scalar, (bool, np.bool_)):
+    if isinstance(scalar, (bool, np.bool_)) or not isinstance(scalar, Real):
         raise ValueError(f"{name} must be a non-negative integer.")
     if isinstance(scalar, (int, np.integer)):
         integer = int(scalar)
@@ -56,7 +57,7 @@ def _normalize_finite_scalar(value, message: str) -> float:
         raise ValueError(message)
 
     scalar = value_array.item()
-    if isinstance(scalar, (bool, np.bool_)):
+    if isinstance(scalar, (bool, np.bool_)) or not isinstance(scalar, Real):
         raise ValueError(message)
     try:
         result = float(scalar)

--- a/tests/evaluation/test_selection.py
+++ b/tests/evaluation/test_selection.py
@@ -28,7 +28,7 @@ def test_top_count_mask_uses_tie_break_scores() -> None:
 
 
 def test_top_count_mask_rejects_invalid_retained_count_scalars() -> None:
-    invalid_counts = (True, False, 1.5, np.nan, np.inf, np.array([1]))
+    invalid_counts = (True, False, "1", 1.5, np.nan, np.inf, np.array([1]))
 
     for retained_count in invalid_counts:
         with pytest.raises(ValueError, match="retained_count"):
@@ -60,7 +60,7 @@ def test_top_fraction_mask_uses_ceil_retained_count() -> None:
 
 
 def test_retained_count_from_fraction_rejects_invalid_count_scalars() -> None:
-    invalid_counts = (True, False, 1.5, np.nan, np.inf, np.array([1]))
+    invalid_counts = (True, False, "1", 1.5, np.nan, np.inf, np.array([1]))
 
     for item_count in invalid_counts:
         with pytest.raises(ValueError, match="item_count"):
@@ -69,6 +69,11 @@ def test_retained_count_from_fraction_rejects_invalid_count_scalars() -> None:
     for min_count in invalid_counts:
         with pytest.raises(ValueError, match="min_count"):
             retained_count_from_fraction(10, 0.5, min_count=min_count)
+
+
+def test_retained_count_from_fraction_rejects_text_fraction() -> None:
+    with pytest.raises(ValueError, match="retention_fraction"):
+        retained_count_from_fraction(10, "0.5")
 
 
 def test_quantile_tail_mask_selects_lower_tail() -> None:
@@ -91,7 +96,7 @@ def test_quantile_tail_mask_selects_upper_tail() -> None:
 
 
 def test_quantile_tail_mask_validates_empty_inputs_before_empty_return() -> None:
-    for bad_quantile in (0.0, 1.0, np.nan, True, np.array([0.5])):
+    for bad_quantile in (0.0, 1.0, "0.5", np.nan, True, np.array([0.5])):
         with pytest.raises(ValueError, match="quantile"):
             quantile_tail_mask([], bad_quantile)
 
@@ -153,12 +158,13 @@ def test_tail_rescue_topk_mask_swaps_in_missing_tail_items() -> None:
 
 def test_tail_rescue_quota_count_validates_fraction() -> None:
     assert tail_rescue_quota_count(10, rescue_fraction=0.2) == 2
-    with pytest.raises(ValueError, match="rescue_fraction"):
-        tail_rescue_quota_count(10, rescue_fraction=0.0)
+    for rescue_fraction in (0.0, "0.2"):
+        with pytest.raises(ValueError, match="rescue_fraction"):
+            tail_rescue_quota_count(10, rescue_fraction=rescue_fraction)
 
 
 def test_tail_rescue_quota_count_rejects_invalid_retained_count_scalars() -> None:
-    invalid_counts = (True, False, 1.5, np.nan, np.inf, np.array([1]))
+    invalid_counts = (True, False, "1", 1.5, np.nan, np.inf, np.array([1]))
 
     for retained_count in invalid_counts:
         with pytest.raises(ValueError, match="retained_count"):


### PR DESCRIPTION
## Summary
- reject text-valued scalar counts and fractions in evaluation selection validators
- keep real Python/NumPy scalar values accepted while blocking string coercion via `float(...)`
- add regression coverage for text count, retention fraction, quantile, and rescue-fraction inputs

## Bug
Selection helpers converted scalar values with `float(...)`, so strings such as `"1"` or `"0.5"` were silently accepted for numeric control parameters. That can hide malformed configuration inputs and is inconsistent with the package's validation hardening elsewhere.

## Testing
- Performed an isolated syntax check of the modified module and test file content.
- Exercised the changed validator paths in a minimal local harness for text counts/fractions.
- Full project CI should run on this PR because this environment cannot clone/install the full repository from GitHub.