### PR TITLE
Reject boolean scalar choice populations in PyTorch backend

### DIFF
--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -186,11 +186,14 @@ def _normal_array_parameters(loc, scale):
 
 
 def _integer_population_size(a):
+    if isinstance(a, bool):
+        return None
     if isinstance(a, _Integral):
         return int(a)
     if (
         _torch.is_tensor(a)
         and a.ndim == 0
+        and a.dtype != _torch.bool
         and not _torch.is_floating_point(a)
         and not _torch.is_complex(a)
     ):

--- a/tests/backend/test_pytorch_random_backend.py
+++ b/tests/backend/test_pytorch_random_backend.py
@@ -113,6 +113,15 @@ def test_scalar_and_empty_tuple_sizes_keep_scalar_shape():
     assert random.multivariate_normal([0.0], [[1.0]], size=()).shape == (1,)
 
 
+@pytest.mark.parametrize(
+    "population",
+    [True, False, torch.tensor(True), torch.tensor(False)],
+)
+def test_choice_rejects_boolean_scalar_population(population):
+    with pytest.raises(ValueError, match="positive integer or an array"):
+        random.choice(population)
+
+
 def test_zero_sized_choice_still_works_for_empty_population():
     sample = random.choice(0, size=(0,))
 


### PR DESCRIPTION
## Summary
- reject Python `bool` and scalar `torch.bool` values as integer populations for the PyTorch random `choice` backend
- add a regression test covering Python and tensor boolean scalar populations

## Rationale
Boolean scalar populations were previously treated as integer population sizes (`True` -> 1), allowing `random.choice(True)` and `random.choice(torch.tensor(True))` to silently sample from a one-element population. This is inconsistent with the backend's explicit rejection of booleans as integer dimensions and with the scalar-array error path for non-population values.

## Validation
- Targeted local PyTorch random-backend pytest harness passed: `26 passed`