### PR TITLE
Validate CLI expected-result tolerance

### DIFF
--- a/src/pyrecest/cli.py
+++ b/src/pyrecest/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import platform
 import sys
 from importlib.metadata import PackageNotFoundError, version
@@ -11,11 +12,28 @@ from pathlib import Path
 from typing import Any
 
 
+_INVALID_TOLERANCE_MESSAGE = "tolerance must be a non-negative finite number"
+
+
 def _package_version(name: str) -> str | None:
     try:
         return version(name)
     except PackageNotFoundError:
         return None
+
+
+def _validate_tolerance(value: Any) -> float:
+    """Return a validated comparison tolerance for expected-result checks."""
+
+    if isinstance(value, (bool, str, bytes, bytearray)):
+        raise ValueError(_INVALID_TOLERANCE_MESSAGE)
+    try:
+        tolerance = float(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(_INVALID_TOLERANCE_MESSAGE) from exc
+    if not math.isfinite(tolerance) or tolerance < 0.0:
+        raise ValueError(_INVALID_TOLERANCE_MESSAGE)
+    return tolerance
 
 
 def _cmd_info(_args: argparse.Namespace) -> int:
@@ -67,6 +85,7 @@ def _check_expected_mapping(
     *,
     tolerance: float,
 ) -> list[str]:
+    tolerance = _validate_tolerance(tolerance)
     errors: list[str] = []
     for key, expected_value in expected.items():
         if key not in actual:
@@ -94,11 +113,16 @@ def _cmd_run_scenario(args: argparse.Namespace) -> int:
 
     if args.expected is not None:
         expected = json.loads(Path(args.expected).read_text(encoding="utf-8"))
-        tolerance = (
+        raw_tolerance = (
             args.tolerance
             if args.tolerance is not None
-            else float(expected.get("tolerance", 1e-8))
+            else expected.get("tolerance", 1e-8)
         )
+        try:
+            tolerance = _validate_tolerance(raw_tolerance)
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            return 2
         failures: list[str] = []
         expected_estimate = expected.get("final_estimate")
         if expected_estimate is not None:

--- a/tests/test_cli_tolerance_validation.py
+++ b/tests/test_cli_tolerance_validation.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+from pyrecest.cli import _check_expected_mapping, _validate_tolerance
+
+
+def test_validate_tolerance_accepts_finite_nonnegative_numbers() -> None:
+    assert _validate_tolerance(0.0) == 0.0
+    assert _validate_tolerance(1e-8) == 1e-8
+
+
+def test_validate_tolerance_rejects_invalid_values() -> None:
+    for tolerance in (math.nan, math.inf, -1.0, True, "0.1"):
+        with pytest.raises(ValueError, match="tolerance"):
+            _validate_tolerance(tolerance)
+
+
+def test_expected_mapping_rejects_nan_tolerance() -> None:
+    with pytest.raises(ValueError, match="tolerance"):
+        _check_expected_mapping(
+            "metrics",
+            {"rmse": 1.0},
+            {"rmse": 2.0},
+            tolerance=math.nan,
+        )


### PR DESCRIPTION
## Summary
- add a shared CLI tolerance validator for expected-result comparisons
- reject non-finite, negative, boolean, and text tolerance values
- validate mapping-comparison tolerances so `NaN` cannot make mismatches pass silently
- add focused regression coverage for invalid CLI tolerance handling

## Bug
`pyrecest run-scenario --expected ... --tolerance nan` could make numeric mismatches pass because comparisons such as `delta > float("nan")` are always false. Expected-result JSON with `"tolerance": NaN`-like or malformed nonnumeric tolerance values could therefore hide regressions instead of failing the scenario check.

## Validation
- `python -m py_compile src/pyrecest/cli.py tests/test_cli_tolerance_validation.py` in a reconstructed local harness
- `PYTHONPATH=/mnt/data/pyrecest_syntax/src pytest -q /mnt/data/pyrecest_syntax/tests/test_cli_tolerance_validation.py` → `3 passed`

Full repository pytest was not run locally because this sandbox cannot resolve github.com for cloning; CI should run the complete suite on the PR.