### PR TITLE
Fix NumPy choice order for unsorted populations

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/random.py
+++ b/src/pyrecest/_backend/_shared_numpy/random.py
@@ -103,13 +103,15 @@ def choice(a, size=None, replace=True, p=None, axis=0, shuffle=True):
 
     axis = _normalize_choice_axis(axis, a_array.ndim)
     if a_array.ndim == 1 and axis == 0:
-        return _maybe_preserve_choice_order(
-            _np.random.choice(a_array, size=size, replace=replace, p=p),
+        indices = _np.random.choice(a_array.shape[0], size=size, replace=replace, p=p)
+        indices = _maybe_preserve_choice_order(
+            indices,
             replace=replace,
             p=p,
             shuffle=shuffle,
             size=size,
         )
+        return _np.take(a_array, indices, axis=0)
 
     if p is not None:
         p = _np.asarray(p)

--- a/tests/backend/test_numpy_random_backend.py
+++ b/tests/backend/test_numpy_random_backend.py
@@ -42,6 +42,19 @@ def test_choice_without_replacement_shuffle_false_preserves_order():
     np.testing.assert_array_equal(column_samples, matrix)
 
 
+def test_choice_without_replacement_shuffle_false_preserves_population_order_for_unsorted_values():
+    values = np.array([30, 10, 20, 40])
+
+    random.seed(1)
+    expected_indices = np.sort(np.random.choice(values.shape[0], size=3, replace=False))
+    expected = values[expected_indices]
+
+    random.seed(1)
+    samples = random.choice(values, size=3, replace=False, shuffle=False)
+
+    np.testing.assert_array_equal(samples, expected)
+
+
 @pytest.mark.parametrize("control", ["replace", "shuffle"])
 def test_choice_rejects_non_boolean_controls(control):
     kwargs = {control: "False"}


### PR DESCRIPTION
## Summary
- sample indices for one-dimensional NumPy choice array populations before gathering values
- preserve population order instead of sorting sampled values when replace is false and shuffle is false
- add a regression test for non-monotonic one-dimensional populations

## Bug
The NumPy random backend intended to preserve population order for choice without replacement when shuffle is false. The one-dimensional array path sampled values directly and then sorted those values. For a non-monotonic population, that returned value-sorted output instead of population-order output.

## Validation
- Ran a minimal local NumPy harness that reproduced the old failure and verified the patched path.
- Confirmed the existing matrix/order case still passes in the same harness.

Full repository pytest was not run locally; CI should run the full suite on this PR.