### PR TITLE
Validate CircularUKF periodic measurement flag

### DIFF
--- a/src/pyrecest/filters/circular_ukf.py
+++ b/src/pyrecest/filters/circular_ukf.py
@@ -48,6 +48,22 @@ def _to_python_bool(value):
     return bool(value)
 
 
+def _validate_bool_flag(value, name):
+    """Validate public boolean flags without truthiness coercion."""
+    if isinstance(value, bool):
+        return value
+    try:
+        value_array = asarray(value)
+    except Exception as exc:  # pragma: no cover - backend-specific failures
+        raise TypeError(f"{name} must be a boolean.") from exc
+    if getattr(value_array, "shape", ()) != () or not hasattr(value_array, "item"):
+        raise TypeError(f"{name} must be a boolean.")
+    scalar = value_array.item()
+    if not isinstance(scalar, bool):
+        raise TypeError(f"{name} must be a boolean.")
+    return scalar
+
+
 def _as_circular_gaussian(distribution, role):
     """Return a validated 1-D Gaussian for circular UKF state/noise."""
     if not isinstance(distribution, GaussianDistribution):
@@ -327,6 +343,9 @@ class CircularUKF(AbstractFilter, CircularFilterMixin):
                     "measurement noise must be convertible to GaussianDistribution."
                 ) from exc
         _validate_backend_supported("CircularUKF.update_nonlinear")
+        measurement_periodic = _validate_bool_flag(
+            measurement_periodic, "measurement_periodic"
+        )
 
         z = _measurement_vector(z)
         dim_z = len(z)

--- a/tests/filters/test_circular_ukf_bool.py
+++ b/tests/filters/test_circular_ukf_bool.py
@@ -1,0 +1,29 @@
+"""Regression tests for CircularUKF boolean flag validation."""
+
+import pytest
+import pyrecest.backend
+from pyrecest.backend import array
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.filters.circular_ukf import CircularUKF
+
+
+def _identity(angle):
+    return angle
+
+
+def test_update_nonlinear_rejects_non_boolean_measurement_periodic():
+    if pyrecest.backend.__backend_name__ in ("pytorch", "jax"):
+        pytest.skip("Not supported on this backend")
+
+    filt = CircularUKF()
+    prior = GaussianDistribution(array([0.5]), array([[0.7]]))
+    meas_noise = GaussianDistribution(array([0.0]), array([[0.7]]))
+
+    filt.filter_state = prior
+    with pytest.raises(TypeError, match="measurement_periodic"):
+        filt.update_nonlinear(
+            _identity,
+            meas_noise,
+            prior.mu,
+            measurement_periodic="False",
+        )


### PR DESCRIPTION
## Summary
- add strict boolean validation for `CircularUKF.update_nonlinear(..., measurement_periodic=...)`
- reject truthy non-boolean values such as `"False"` instead of treating them as periodic measurements
- add a focused regression test for the invalid string flag case

## Bug
`measurement_periodic` was previously used directly in `if measurement_periodic:` branches. This meant values such as `"False"`, `1`, or other truthy objects selected the periodic-measurement code path silently, despite the API being a boolean switch.

## Validation
- syntax-compiled the modified `circular_ukf.py` locally
- syntax-compiled the new regression test locally

Full pytest was not run locally because the repository and dependency environment are only available through the GitHub connector in this session.