### PR TITLE
Reject text scalar assignment counts

### DIFF
--- a/src/pyrecest/utils/assignment.py
+++ b/src/pyrecest/utils/assignment.py
@@ -34,7 +34,7 @@ class _MurtySubproblem:
 
 
 def _validate_assignment_count(k: int) -> int:
-    if isinstance(k, bool):
+    if isinstance(k, (bool, str, bytes)):
         raise ValueError("k must be an integer")
     if isinstance(k, Integral):
         return int(k)
@@ -52,7 +52,7 @@ def _validate_assignment_count(k: int) -> int:
         scalar = k_array.item()
     except AttributeError:
         scalar = k_array
-    if isinstance(scalar, bool):
+    if isinstance(scalar, (bool, str, bytes)):
         raise ValueError("k must be an integer")
 
     try:

--- a/tests/utils/test_assignment_count_validation.py
+++ b/tests/utils/test_assignment_count_validation.py
@@ -1,0 +1,20 @@
+import unittest
+
+import numpy as np
+from pyrecest.utils import murty_k_best_assignments
+
+
+class AssignmentCountValidationTest(unittest.TestCase):
+    def test_text_scalar_k_is_rejected(self):
+        for invalid_k in (
+            "1",
+            np.str_("1"),
+            np.array("1"),
+        ):
+            with self.subTest(invalid_k=invalid_k):
+                with self.assertRaisesRegex(ValueError, "k must be an integer"):
+                    murty_k_best_assignments(np.eye(2), k=invalid_k)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reject string/bytes scalar values for `murty_k_best_assignments(..., k=...)`
- add regression coverage for direct Python, NumPy scalar, and NumPy array text values

## Bug
`k=np.array("1")` and similar scalar text values were accepted because the assignment-count validator converted scalar values with `float(...)`. This could hide malformed configuration or test inputs as valid assignment counts instead of rejecting them.

## Validation
- Added `tests/utils/test_assignment_count_validation.py`
- Not run locally; direct cloning is unavailable in this environment, so CI should exercise the full suite on the PR.