### PR TITLE
Reject text scalar selection parameters

### DIFF
--- a/src/pyrecest/evaluation/selection.py
+++ b/src/pyrecest/evaluation/selection.py
@@ -16,13 +16,17 @@ import numpy as np
 TailSide = Literal["lower", "upper"]
 
 
+def _is_text_scalar(value) -> bool:
+    return isinstance(value, (str, bytes, np.str_, np.bytes_))
+
+
 def _normalize_nonnegative_integer(value, name: str) -> int:
     value_array = np.asarray(value)
     if value_array.shape != () or value_array.dtype == np.bool_:
         raise ValueError(f"{name} must be a non-negative integer.")
 
     scalar = value_array.item()
-    if isinstance(scalar, (bool, np.bool_)):
+    if isinstance(scalar, (bool, np.bool_)) or _is_text_scalar(scalar):
         raise ValueError(f"{name} must be a non-negative integer.")
     if isinstance(scalar, (int, np.integer)):
         integer = int(scalar)
@@ -56,7 +60,7 @@ def _normalize_finite_scalar(value, message: str) -> float:
         raise ValueError(message)
 
     scalar = value_array.item()
-    if isinstance(scalar, (bool, np.bool_)):
+    if isinstance(scalar, (bool, np.bool_)) or _is_text_scalar(scalar):
         raise ValueError(message)
     try:
         result = float(scalar)

--- a/tests/evaluation/test_selection.py
+++ b/tests/evaluation/test_selection.py
@@ -28,7 +28,7 @@ def test_top_count_mask_uses_tie_break_scores() -> None:
 
 
 def test_top_count_mask_rejects_invalid_retained_count_scalars() -> None:
-    invalid_counts = (True, False, 1.5, np.nan, np.inf, np.array([1]))
+    invalid_counts = (True, False, 1.5, np.nan, np.inf, np.array([1]), "1", np.str_("1"), np.array("1"))
 
     for retained_count in invalid_counts:
         with pytest.raises(ValueError, match="retained_count"):
@@ -60,7 +60,7 @@ def test_top_fraction_mask_uses_ceil_retained_count() -> None:
 
 
 def test_retained_count_from_fraction_rejects_invalid_count_scalars() -> None:
-    invalid_counts = (True, False, 1.5, np.nan, np.inf, np.array([1]))
+    invalid_counts = (True, False, 1.5, np.nan, np.inf, np.array([1]), "1", np.str_("1"), np.array("1"))
 
     for item_count in invalid_counts:
         with pytest.raises(ValueError, match="item_count"):
@@ -69,6 +69,16 @@ def test_retained_count_from_fraction_rejects_invalid_count_scalars() -> None:
     for min_count in invalid_counts:
         with pytest.raises(ValueError, match="min_count"):
             retained_count_from_fraction(10, 0.5, min_count=min_count)
+
+
+def test_selection_helpers_reject_text_scalar_fractions() -> None:
+    for fraction in ("0.5", np.str_("0.5"), np.array("0.5")):
+        with pytest.raises(ValueError, match="retention_fraction"):
+            retained_count_from_fraction(10, fraction)
+        with pytest.raises(ValueError, match="quantile"):
+            quantile_tail_threshold([0.0, 1.0], fraction)
+        with pytest.raises(ValueError, match="rescue_fraction"):
+            tail_rescue_quota_count(3, rescue_fraction=fraction)
 
 
 def test_quantile_tail_mask_selects_lower_tail() -> None:
@@ -158,7 +168,7 @@ def test_tail_rescue_quota_count_validates_fraction() -> None:
 
 
 def test_tail_rescue_quota_count_rejects_invalid_retained_count_scalars() -> None:
-    invalid_counts = (True, False, 1.5, np.nan, np.inf, np.array([1]))
+    invalid_counts = (True, False, 1.5, np.nan, np.inf, np.array([1]), "1", np.str_("1"), np.array("1"))
 
     for retained_count in invalid_counts:
         with pytest.raises(ValueError, match="retained_count"):


### PR DESCRIPTION
## Summary
- reject string/bytes scalar values in selection helper integer and fraction validators
- add regression coverage for text scalar retained counts, item/min counts, retention fractions, quantiles, and rescue fractions

## Bug
Selection helpers such as `top_count_mask(..., retained_count="1")`, `retained_count_from_fraction(..., retention_fraction="0.5")`, and `quantile_tail_threshold(..., quantile="0.5")` accepted numeric-looking strings because scalar validation fell through to `float(...)`. That can silently accept malformed configuration values instead of reporting invalid parameter types.

## Validation
- `PYTHONPATH=/tmp/pyrecest_local pytest -q /tmp/pyrecest_local/tests/evaluation/test_selection.py` → `16 passed`
- Full repository test suite not run locally because the repository cannot be cloned from this environment; CI should run on the PR.