### PR TITLE
Reject text integer scalars in point-set metrics

### DIFF
--- a/src/pyrecest/evaluation/point_set_metrics.py
+++ b/src/pyrecest/evaluation/point_set_metrics.py
@@ -352,7 +352,7 @@ def _validate_chunk_size(query_chunk_size: int) -> int:
     if array.shape != () or array.dtype == np.bool_:
         raise ValueError("query_chunk_size must be a positive integer.")
     scalar = array.item()
-    if isinstance(scalar, (bool, np.bool_)):
+    if isinstance(scalar, (bool, np.bool_, str, bytes)):
         raise ValueError("query_chunk_size must be a positive integer.")
     try:
         chunk_size_float = float(scalar)
@@ -377,7 +377,7 @@ def _normalize_optional_integer(value: Any, name: str) -> int | None:
         raise ValueError(message)
 
     scalar = value_array.item()
-    if isinstance(scalar, (bool, np.bool_)):
+    if isinstance(scalar, (bool, np.bool_, str, bytes)):
         raise ValueError(message)
     if isinstance(scalar, (int, np.integer)):
         return int(scalar)

--- a/tests/evaluation/test_point_set_metrics_text_integer_validation.py
+++ b/tests/evaluation/test_point_set_metrics_text_integer_validation.py
@@ -1,0 +1,17 @@
+import numpy as np
+import pytest
+
+from pyrecest.evaluation.point_set_metrics import (
+    deterministic_subsample,
+    nearest_neighbor_distances,
+)
+
+
+def test_point_set_integer_validators_reject_text_scalars():
+    points = np.array([[0.0], [1.0]])
+
+    with pytest.raises(ValueError, match="positive integer"):
+        nearest_neighbor_distances(points, points, query_chunk_size="1")
+
+    with pytest.raises(ValueError, match="max_points"):
+        deterministic_subsample(points, max_points="1")


### PR DESCRIPTION
## Summary
- reject text scalars before converting point-set integer parameters through `float(...)`
- cover `query_chunk_size="1"` and `max_points="1"` as regression cases

## Rationale
The point-set metric validators documented these parameters as integer-like scalars but still accepted numeric strings because they were converted via `float(...)`. This could silently accept text input for chunk sizing and deterministic subsampling limits.

## Tests
- Added `tests/evaluation/test_point_set_metrics_text_integer_validation.py`
- Not run locally; repository access in this environment was via the GitHub connector only.