### PR TITLE
Reject object boolean distance scalars

### DIFF
--- a/src/pyrecest/evaluation/get_distance_function.py
+++ b/src/pyrecest/evaluation/get_distance_function.py
@@ -57,8 +57,11 @@ def _validate_symmetry_count(nSymm: Any) -> int:
     count_array = np.asarray(to_numpy(nSymm))
     if count_array.shape != () or np.issubdtype(count_array.dtype, np.bool_):
         raise ValueError("nSymm must be a finite positive integer")
+    scalar = count_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError("nSymm must be a finite positive integer")
     try:
-        count = float(count_array.item())
+        count = float(scalar)
     except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError("nSymm must be a finite positive integer") from exc
     if not np.isfinite(count) or not count.is_integer() or count <= 0:
@@ -114,8 +117,11 @@ def _validate_mtt_cutoff_distance(value: Any) -> float:
     value_array = np.asarray(to_numpy(value))
     if value_array.shape != () or np.issubdtype(value_array.dtype, np.bool_):
         raise ValueError("cutoff_distance must be a finite nonnegative scalar")
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError("cutoff_distance must be a finite nonnegative scalar")
     try:
-        cutoff_distance = float(value_array.item())
+        cutoff_distance = float(scalar)
     except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError("cutoff_distance must be a finite nonnegative scalar") from exc
     if not np.isfinite(cutoff_distance) or cutoff_distance < 0.0:

--- a/tests/evaluation/test_distance_function_symmetry.py
+++ b/tests/evaluation/test_distance_function_symmetry.py
@@ -1,11 +1,22 @@
 import unittest
 
+import numpy as np
 from pyrecest.evaluation.get_distance_function import get_distance_function
 
 
 class SymmetricDistanceFunctionValidationTest(unittest.TestCase):
     def test_rejects_invalid_symmetry_counts(self):
-        for n_symm in (0, -1, 2.5, float("nan"), float("inf"), True, [2]):
+        for n_symm in (
+            0,
+            -1,
+            2.5,
+            float("nan"),
+            float("inf"),
+            True,
+            np.array(True, dtype=object),
+            np.array(False, dtype=object),
+            [2],
+        ):
             with self.subTest(n_symm=n_symm):
                 with self.assertRaisesRegex(ValueError, "nSymm.*positive integer"):
                     get_distance_function("circle", nSymm=n_symm)

--- a/tests/evaluation/test_get_distance_function_mtt.py
+++ b/tests/evaluation/test_get_distance_function_mtt.py
@@ -6,7 +6,15 @@ from pyrecest.evaluation.get_distance_function import get_distance_function
 
 class EuclideanMttDistanceTest(unittest.TestCase):
     def test_rejects_invalid_cutoff_distances(self):
-        for cutoff_distance in (-1.0, float("nan"), float("inf"), True, [1.0]):
+        for cutoff_distance in (
+            -1.0,
+            float("nan"),
+            float("inf"),
+            True,
+            np.array(True, dtype=object),
+            np.array(False, dtype=object),
+            [1.0],
+        ):
             with self.subTest(cutoff_distance=cutoff_distance):
                 with self.assertRaisesRegex(ValueError, "cutoff_distance.*finite"):
                     get_distance_function(


### PR DESCRIPTION
## Summary
- Reject object-dtype boolean scalars in distance scalar validators.
- Cover both symmetric `nSymm` and Euclidean-MTT `cutoff_distance` validation regressions.

## Bug
The validators rejected native boolean scalar dtypes, but object-dtype NumPy scalar arrays such as `np.array(True, dtype=object)` were unwrapped with `.item()` and then accepted by `float(...)`. This allowed boolean values to be interpreted as numeric distance parameters.

## Validation
- Added focused unittest regressions for `nSymm` and `cutoff_distance`.
- Not run locally; this environment used the GitHub connector rather than a local checkout.