### PR TITLE
Validate JAX choice replace flag

### DIFF
--- a/src/pyrecest/_backend/jax/random.py
+++ b/src/pyrecest/_backend/jax/random.py
@@ -272,6 +272,12 @@ def _normalize_choice_axis(axis, ndim):
     return axis % ndim
 
 
+def _choice_bool(value, name):
+    if isinstance(value, (bool, _np.bool_)):
+        return bool(value)
+    raise TypeError(f"{name} must be a boolean")
+
+
 def _choice_population_size(a, kwargs):
     population_size = _integer_population_size(a)
     if population_size is not None:
@@ -303,6 +309,7 @@ def _choice(state, a, size=None, replace=True, p=None, *args, **kwargs):
     state, key = jax.random.split(state)
     a = _jnp.asarray(a)
     shape = _shape_from_size(size)
+    replace = _choice_bool(replace, "replace")
     population_size = _choice_population_size(a, kwargs)
     if population_size == 0:
         if _shape_has_no_samples(shape):

--- a/tests/backend/test_jax_random_backend.py
+++ b/tests/backend/test_jax_random_backend.py
@@ -94,6 +94,20 @@ def test_size_arguments_reject_bool_and_non_integral_dimensions(bad_size):
             sampler(bad_size)
 
 
+@pytest.mark.parametrize("bad_replace", ["False", "True", 1, 0, None, np.array(True)])
+def test_choice_rejects_non_boolean_replace_flag(bad_replace):
+    with pytest.raises(TypeError, match="replace must be a boolean"):
+        random.choice(jnp.array([0, 1, 2]), size=2, replace=bad_replace)
+
+
+def test_choice_accepts_numpy_boolean_replace_flag():
+    random.seed(0)
+
+    sample = random.choice(jnp.array([0, 1, 2]), size=2, replace=np.bool_(False))
+
+    assert sample.shape == (2,)
+
+
 @pytest.mark.parametrize("bad_size", [-1, (2, -1)])
 def test_size_arguments_reject_negative_dimensions(bad_size):
     for sampler in _size_aware_samplers():


### PR DESCRIPTION
## Summary
- validate the JAX `random.choice(..., replace=...)` flag before forwarding to `jax.random.choice`
- reject non-boolean truthy/falsy values such as `"False"`, `1`, `0`, `None`, and bool arrays
- add regression coverage while keeping `np.bool_` scalar flags accepted

## Bug
The JAX backend passed `replace` through to `jax.random.choice` unchanged. JAX accepts truthy/falsy non-boolean values, so `replace="False"` is silently treated as replacement-enabled sampling instead of being rejected. The NumPy backend already enforces a boolean contract for this flag.

## Validation
- `python -m py_compile /tmp/random_patched.py /tmp/test_jax_random_backend_patched.py`
- local targeted harness: invalid `replace` values raise `TypeError`; `np.bool_(False)` still works

Full repository pytest was not run locally because direct cloning from GitHub is unavailable in this environment.