### PR TITLE
Reject text reliability scalar inputs

### DIFF
--- a/src/pyrecest/tracking/measurement_reliability.py
+++ b/src/pyrecest/tracking/measurement_reliability.py
@@ -276,11 +276,20 @@ def _scale_upper_bound(value: float, name: str) -> float:
     return value
 
 
-def _finite_scalar(value: float, name: str) -> float:
+def _finite_scalar(value: Any, name: str) -> float:
     array = np.asarray(value)
     if array.shape != () or array.dtype == np.bool_:
         raise ValueError(f"{name} must be a finite scalar")
-    parsed = float(array.item())
+    scalar = array.item()
+    if isinstance(
+        scalar,
+        (bool, np.bool_, str, bytes, bytearray, np.str_, np.bytes_),
+    ):
+        raise ValueError(f"{name} must be a finite scalar")
+    try:
+        parsed = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be a finite scalar") from exc
     if not np.isfinite(parsed):
         raise ValueError(f"{name} must be finite")
     return parsed

--- a/tests/tracking/test_measurement_reliability.py
+++ b/tests/tracking/test_measurement_reliability.py
@@ -26,6 +26,33 @@ def test_max_scale_caps_at_or_above_nominal_scale() -> None:
         MeasurementReliabilityConfig(max_scale=0.5)
 
 
+def test_scalar_reliability_inputs_reject_text_and_object_booleans() -> None:
+    invalid_values = (
+        "0.5",
+        b"0.5",
+        np.array("0.5"),
+        np.array("0.5", dtype=object),
+        np.array(True, dtype=object),
+    )
+
+    for value in invalid_values:
+        with pytest.raises(ValueError, match="finite scalar"):
+            reliability_to_covariance_scale(value)
+
+
+def test_reliability_config_rejects_text_and_object_boolean_scalars() -> None:
+    invalid_configs = (
+        {"threshold": "0.5"},
+        {"floor": np.array("0.1")},
+        {"exponent": "2.0"},
+        {"max_scale": np.array(True, dtype=object)},
+    )
+
+    for kwargs in invalid_configs:
+        with pytest.raises(ValueError):
+            MeasurementReliabilityConfig(**kwargs)
+
+
 def test_scale_covariance_by_reliability_returns_scaled_copy() -> None:
     cov = np.diag([4.0, 9.0])
     scaled, scale = scale_covariance_by_reliability(cov, 0.25)


### PR DESCRIPTION
## Summary
- Reject text-like scalar values and object-dtype boolean scalars in measurement-reliability numeric validators.
- Add focused regressions for direct reliability inputs and `MeasurementReliabilityConfig` controls.

## Bug
`_finite_scalar` converted scalar values with `float(...)` after only rejecting native boolean dtype arrays. That meant values such as `"0.5"`, `b"0.5"`, and `np.array(True, dtype=object)` were accepted as numeric reliability/floor/exponent/max-scale values. This can silently turn malformed configuration into valid probabilities or scales.

## Validation
- Syntax-checked the modified source and test content locally with `ast.parse`.
- Full pytest was not run locally because the repository cannot be cloned from this environment; CI should run on the PR.