### PR TITLE
Fix backend array-like helper contracts

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/__init__.py
+++ b/src/pyrecest/_backend/_shared_numpy/__init__.py
@@ -87,9 +87,10 @@ def squeeze(x, axis=None):
     x = x if is_array(x) else array(x)
     if axis is None:
         return _np.squeeze(x)
-    if x.shape[axis] != 1:
+    axes = (int(axis),) if isinstance(axis, (int, _np.integer)) else tuple(axis)
+    if any(x.shape[one_axis] != 1 for one_axis in axes):
         return x
-    return _np.squeeze(x, axis=axis)
+    return _np.squeeze(x, axis=axes)
 
 
 def flatten(x):
@@ -407,7 +408,7 @@ def matvec(A, b):
     if b.ndim == 1:
         return _np.matmul(A, b)
     if A.ndim == 2:
-        return _np.matmul(A, b.T).T
+        return _np.einsum("ij,...j->...i", A, b)
     return _np.einsum("...ij,...j->...i", A, b)
 
 
@@ -456,8 +457,8 @@ def scatter_add(input, dim, index, src):
     if dim == 1:
         for j in range(len(input)):
             for i, val in zip(index[j], src[j]):
-                if not isinstance(val, _np.float64) and BACKEND_NAME == "autograd":
-                    val = float(val._value)
-                input[j, i] += float(val)
+                if BACKEND_NAME == "autograd" and hasattr(val, "_value"):
+                    val = val._value
+                input[j, i] += val
         return input
     raise NotImplementedError

--- a/src/pyrecest/_backend/_shared_numpy/__init__.py
+++ b/src/pyrecest/_backend/_shared_numpy/__init__.py
@@ -83,30 +83,13 @@ def from_numpy(x):
     return x
 
 
-def _normalize_squeeze_axes(axis):
-    if isinstance(axis, (int, _np.integer)):
-        return (int(axis),)
-    return tuple(axis)
-
-
 def squeeze(x, axis=None):
-    x = _np.asarray(x)
+    x = x if is_array(x) else array(x)
     if axis is None:
         return _np.squeeze(x)
-
-    axes = _normalize_squeeze_axes(axis)
-    if not axes:
+    if x.shape[axis] != 1:
         return x
-
-    normalized_axes = tuple(
-        one_axis + x.ndim if one_axis < 0 else one_axis for one_axis in axes
-    )
-    if len(set(normalized_axes)) != len(normalized_axes):
-        raise ValueError("duplicate value in 'axis'")
-    if any(x.shape[one_axis] != 1 for one_axis in normalized_axes):
-        return x
-    squeeze_axis = normalized_axes[0] if len(normalized_axes) == 1 else normalized_axes
-    return _np.squeeze(x, axis=squeeze_axis)
+    return _np.squeeze(x, axis=axis)
 
 
 def flatten(x):
@@ -312,14 +295,13 @@ def array_from_sparse(indices, data, target_shape):
     a : array, shape=target_shape
         Array of zeros with specified values assigned to specified indices.
     """
+    indices = _np.asarray(indices)
     data = array(data)
     out = zeros(target_shape, dtype=data.dtype)
-    indices = _np.array(indices)
     if indices.size == 0:
         if data.size != 0:
             raise ValueError("data must be empty when indices are empty")
         return out
-
     out.put(_np.ravel_multi_index(indices.T, target_shape), data)
     return out
 
@@ -425,7 +407,7 @@ def matvec(A, b):
     if b.ndim == 1:
         return _np.matmul(A, b)
     if A.ndim == 2:
-        return _np.einsum("ij,...j->...i", A, b)
+        return _np.matmul(A, b.T).T
     return _np.einsum("...ij,...j->...i", A, b)
 
 
@@ -474,10 +456,8 @@ def scatter_add(input, dim, index, src):
     if dim == 1:
         for j in range(len(input)):
             for i, val in zip(index[j], src[j]):
-                # Preserve the source dtype.  In particular, complex values are
-                # valid scatter-add inputs and must not be coerced through float().
-                if BACKEND_NAME == "autograd" and hasattr(val, "_value"):
-                    val = val._value
-                input[j, i] += val
+                if not isinstance(val, _np.float64) and BACKEND_NAME == "autograd":
+                    val = float(val._value)
+                input[j, i] += float(val)
         return input
     raise NotImplementedError

--- a/src/pyrecest/_backend/jax/__init__.py
+++ b/src/pyrecest/_backend/jax/__init__.py
@@ -126,6 +126,7 @@ from jax.numpy import (  # For pyrecest; For Riemannian score-based SDE
     tan,
     tanh,
     tile,
+    trace,
     transpose,
     tril,
     tril_indices,
@@ -209,49 +210,29 @@ def unique(ar, *args, **kwargs):
     return _jnp.unique(_jnp.asarray(ar), *args, **kwargs)
 
 
-def _asarray_or_none(value):
-    return None if value is None else _jnp.asarray(value)
+def array_equal(a, b, **kwargs):
+    return _jnp.array_equal(_jnp.asarray(a), _jnp.asarray(b), **kwargs)
 
 
-def cov(
-    m,
-    y=None,
-    rowvar=True,
-    bias=False,
-    ddof=None,
-    fweights=None,
-    aweights=None,
-    dtype=None,
-):
-    return _jnp.cov(
-        _jnp.asarray(m),
-        y=_asarray_or_none(y),
-        rowvar=rowvar,
-        bias=bias,
-        ddof=ddof,
-        fweights=_asarray_or_none(fweights),
-        aweights=_asarray_or_none(aweights),
-        dtype=dtype,
-    )
+def ndim(a):
+    return _jnp.ndim(_jnp.asarray(a))
+
+
+def squeeze(a, axis=None):
+    a = _jnp.asarray(a)
+    if axis is None:
+        return _jnp.squeeze(a)
+    if a.shape[axis] != 1:
+        return a
+    return _jnp.squeeze(a, axis=axis)
 
 
 def diagonal(a, offset=0, axis1=0, axis2=1):
     return _jnp.diagonal(_jnp.asarray(a), offset=offset, axis1=axis1, axis2=axis2)
 
 
-def squeeze(a, axis=None):
-    return _jnp.squeeze(_jnp.asarray(a), axis=axis)
-
-
-def trace(a, offset=0, axis1=0, axis2=1, dtype=None, out=None):
-    return _jnp.trace(
-        _jnp.asarray(a),
-        offset=offset,
-        axis1=axis1,
-        axis2=axis2,
-        dtype=dtype,
-        out=out,
-    )
+def trace(a):
+    return _jnp.trace(_jnp.asarray(a), axis1=-2, axis2=-1)
 
 
 def tril(m, k=0):
@@ -575,10 +556,8 @@ def divide(a, b, ignore_div_zero=False):
     if ignore_div_zero is False:
         return _jnp.divide(a_arr, b_arr)
 
-    nonzero_denominator = b_arr != 0
-    safe_denominator = _jnp.where(nonzero_denominator, b_arr, _jnp.ones_like(b_arr))
-    quotient = _jnp.divide(a_arr, safe_denominator)
-    return _jnp.where(nonzero_denominator, quotient, _jnp.zeros_like(quotient))
+    quotient = _jnp.divide(a_arr, b_arr)
+    return _jnp.where(b_arr != 0, quotient, _jnp.zeros_like(quotient))
 
 
 def dot(a, b):
@@ -587,7 +566,11 @@ def dot(a, b):
 
     if a.ndim == 0 or b.ndim == 0:
         return _jnp.multiply(a, b)
-    return _jnp.dot(a, b)
+    if b.ndim == 1:
+        return _jnp.einsum("...i,i->...", a, b)
+    if a.ndim == 1:
+        return _jnp.einsum("i,...i->...", a, b)
+    return _jnp.einsum("...i,...i->...", a, b)
 
 
 def matmul(x, y, out=None):
@@ -620,12 +603,8 @@ def matvec(matrix, vector):
     if vector.ndim == 1:
         return _jnp.matmul(matrix, vector)
     if matrix.ndim == 2:
-        return _jnp.einsum("ij,...j->...i", matrix, vector)
+        return _jnp.matmul(matrix, vector.T).T
     return _jnp.einsum("...ij,...j->...i", matrix, vector)
-
-
-def trace(a):
-    return _jnp.trace(_jnp.asarray(a), axis1=-2, axis2=-1)
 
 
 # One-hot encoding


### PR DESCRIPTION
Summary:
- Normalize array-like inputs in shared NumPy/autograd and JAX backend helpers.
- Make empty sparse support handling consistent across backends.
- Preserve JAX one-hot list label support with uint8 indicators.

Validation:
- compileall for backend modules
- ruff F821/F822/F823 checks on changed files
- targeted NumPy, PyTorch, and JAX regression checks for dimension, squeeze, sparse, and one-hot behavior