### PR TITLE
Reject text scalar score-assignment parameters

### DIFF
--- a/src/pyrecest/utils/multisession_assignment_score.py
+++ b/src/pyrecest/utils/multisession_assignment_score.py
@@ -46,13 +46,19 @@ def _default_score_to_cost(scores: Any) -> Any:
     return -asarray(scores, dtype=float)
 
 
+def _is_text_scalar(value: Any) -> bool:
+    return isinstance(value, (str, bytes, np.str_, np.bytes_))
+
+
 def _normalize_min_score(min_score: Any) -> float:
     min_score_array = np.asarray(min_score)
     if min_score_array.shape != () or min_score_array.dtype == np.bool_:
         raise ValueError("min_score must be a finite scalar.")
 
     min_score_value = min_score_array.item()
-    if isinstance(min_score_value, (bool, np.bool_)):
+    if isinstance(min_score_value, (bool, np.bool_)) or _is_text_scalar(
+        min_score_value
+    ):
         raise ValueError("min_score must be a finite scalar.")
 
     try:
@@ -70,7 +76,7 @@ def _normalize_max_gap(max_gap: Any) -> int:
         raise ValueError("max_gap must be a non-negative integer.")
 
     max_gap_value = max_gap_array.item()
-    if isinstance(max_gap_value, (bool, np.bool_)):
+    if isinstance(max_gap_value, (bool, np.bool_)) or _is_text_scalar(max_gap_value):
         raise ValueError("max_gap must be a non-negative integer.")
 
     if isinstance(max_gap_value, (int, np.integer)):
@@ -97,7 +103,9 @@ def _normalize_index_matrix_fill_value(fill_value: Any) -> int:
         raise ValueError("fill_value must be a negative integer.")
 
     fill_value_value = fill_value_array.item()
-    if isinstance(fill_value_value, (bool, np.bool_)):
+    if isinstance(fill_value_value, (bool, np.bool_)) or _is_text_scalar(
+        fill_value_value
+    ):
         raise ValueError("fill_value must be a negative integer.")
 
     if isinstance(fill_value_value, (int, np.integer)):

--- a/tests/test_multisession_assignment_score_validation.py
+++ b/tests/test_multisession_assignment_score_validation.py
@@ -1,0 +1,71 @@
+import unittest
+
+import numpy as np
+from pyrecest.backend import __backend_name__, array
+from pyrecest.utils import multisession_assignment_score as score_module
+from pyrecest.utils import solve_multisession_assignment_from_similarity
+
+
+class TestMultiSessionAssignmentScoreValidation(unittest.TestCase):
+    @staticmethod
+    def _text_scalars(text: str):
+        return (text, text.encode(), np.str_(text), np.array(text))
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_similarity_wrapper_rejects_text_scalar_min_score(self):
+        pairwise_scores = {(0, 1): array([[0.9]], dtype=float)}
+
+        for min_score in self._text_scalars("0.5"):
+            with self.subTest(min_score=min_score):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "min_score must be a finite scalar",
+                ):
+                    solve_multisession_assignment_from_similarity(
+                        pairwise_scores,
+                        session_sizes=[1, 1],
+                        min_score=min_score,
+                    )
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_similarity_wrapper_rejects_text_scalar_max_gap(self):
+        pairwise_scores = {(0, 2): array([[0.9]], dtype=float)}
+
+        for max_gap in self._text_scalars("1"):
+            with self.subTest(max_gap=max_gap):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "max_gap must be a non-negative integer",
+                ):
+                    solve_multisession_assignment_from_similarity(
+                        pairwise_scores,
+                        session_sizes=[1, 0, 1],
+                        max_gap=max_gap,
+                    )
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_tracks_to_index_matrix_rejects_text_scalar_fill_value(self):
+        for fill_value in self._text_scalars("-1"):
+            with self.subTest(fill_value=fill_value):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "fill_value must be a negative integer",
+                ):
+                    score_module.tracks_to_index_matrix(
+                        [{0: 0}],
+                        session_sizes=[1],
+                        fill_value=fill_value,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reject text scalar inputs for score-native multi-session assignment parameters (`min_score`, `max_gap`, and index-matrix `fill_value`)
- add regression coverage for Python strings, bytes, NumPy text scalars, and zero-dimensional text arrays

## Bug
The score-native multi-session assignment validators converted scalar-like values with `float(...)` or integer-like parsing. Text values such as `"1"`, `b"1"`, or `np.array("1")` were therefore accepted silently as numeric parameters, which can hide configuration mistakes.

## Tests
- Not run locally; repository access was via the GitHub connector only.