### PR TITLE
Reject text assignment cost inputs

### DIFF
--- a/src/pyrecest/utils/assignment.py
+++ b/src/pyrecest/utils/assignment.py
@@ -7,6 +7,7 @@ from heapq import heappop, heappush
 from math import isfinite as _is_scalar_finite
 from numbers import Integral
 
+import numpy as _np
 import pyrecest.backend
 from pyrecest.backend import abs as _abs
 from pyrecest.backend import any as _any
@@ -22,6 +23,8 @@ from pyrecest.backend import sum as _sum
 from pyrecest.backend import where as _where
 from pyrecest.backend import zeros as _zeros
 from scipy.optimize import linear_sum_assignment
+
+_TEXT_TYPES = (str, bytes, bytearray, _np.str_, _np.bytes_)
 
 
 @dataclass(frozen=True)
@@ -69,6 +72,16 @@ def _has_boolean_dtype(value) -> bool:
     return dtype is not None and str(dtype).lower() in {"bool", "bool_", "torch.bool"}
 
 
+def _contains_text_values(value) -> bool:
+    if isinstance(value, _TEXT_TYPES):
+        return True
+    try:
+        values = _np.asarray(value, dtype=object).reshape(-1)
+    except (TypeError, ValueError, RuntimeError):
+        return False
+    return any(isinstance(item, _TEXT_TYPES) for item in values)
+
+
 def _coerce_cost_matrix(cost_matrix):
     try:
         raw_cost_matrix = _asarray(cost_matrix)
@@ -76,6 +89,8 @@ def _coerce_cost_matrix(cost_matrix):
         raise ValueError("cost_matrix must be numeric") from exc
     if _has_boolean_dtype(raw_cost_matrix):
         raise ValueError("cost_matrix must be numeric, not boolean")
+    if _contains_text_values(cost_matrix) or _contains_text_values(raw_cost_matrix):
+        raise ValueError("cost_matrix must be numeric")
 
     try:
         coerced_cost_matrix = _asarray(raw_cost_matrix, dtype=float)
@@ -101,6 +116,8 @@ def _coerce_non_assignment_costs(costs, size: int, name: str):
     except (TypeError, ValueError, OverflowError, RuntimeError) as exc:
         raise ValueError(f"{name} must be numeric and finite") from exc
     if _has_boolean_dtype(raw_costs_array):
+        raise ValueError(f"{name} must be numeric and finite")
+    if _contains_text_values(costs) or _contains_text_values(raw_costs_array):
         raise ValueError(f"{name} must be numeric and finite")
 
     try:

--- a/tests/utils/test_assignment_cost_matrix_validation.py
+++ b/tests/utils/test_assignment_cost_matrix_validation.py
@@ -50,6 +50,36 @@ class AssignmentCostMatrixValidationTest(unittest.TestCase):
         pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
         reason="Not supported on the JAX backend",
     )
+    def test_text_cost_matrix_entries_are_rejected(self):
+        text_matrices = (
+            np.array([["1.0", "2.0"]]),
+            np.array([[b"1.0", b"2.0"]], dtype=object),
+        )
+        for solver_name, solver in self._solvers():
+            for matrix in text_matrices:
+                with self.subTest(solver=solver_name, dtype=str(matrix.dtype)):
+                    with self.assertRaisesRegex(ValueError, "cost_matrix must be numeric"):
+                        solver(matrix)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on the JAX backend",
+    )
+    def test_text_non_assignment_costs_are_rejected(self):
+        matrix = np.array([[1.0]])
+        invalid_costs = (
+            {"row_non_assignment_costs": np.array(["0.5"])},
+            {"col_non_assignment_costs": np.array([b"0.5"], dtype=object)},
+        )
+        for kwargs in invalid_costs:
+            with self.subTest(kwargs=tuple(kwargs)):
+                with self.assertRaisesRegex(ValueError, "must be numeric and finite"):
+                    murty_k_best_assignments(matrix, k=1, **kwargs)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on the JAX backend",
+    )
     def test_positive_infinity_remains_infeasible_edge_sentinel(self):
         solutions = murty_k_best_assignments(
             np.array([[np.inf, 1.0]]),


### PR DESCRIPTION
## Summary
- reject string/bytes values before coercing assignment cost matrices to float
- reject string/bytes row/column non-assignment costs before float coercion
- add regression coverage for text cost-matrix and non-assignment cost inputs

## Bug
Assignment cost validation converted cost inputs with `float(...)` and therefore accepted values such as `"1.0"` or `b"0.5"` as valid costs. That can hide malformed data/configuration as numeric assignment costs.

## Validation
- `python -m py_compile src/pyrecest/utils/assignment.py tests/utils/test_assignment_cost_matrix_validation.py`

Full pytest was not run locally because this environment cannot clone/access GitHub over git; CI should run on the branch.