### PR TITLE
Reject reserved evidence diagnostic metadata keys

### DIFF
--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -14,6 +14,14 @@ from typing import Any, Literal
 import numpy as np
 
 EvidenceComputationKind = Literal["full_smoothing", "evidence_only"]
+_RESERVED_DIAGNOSTIC_METADATA_KEYS = frozenset(
+    {
+        "computation_mode",
+        "only",
+        "return_smoothed",
+        "terminal_posterior",
+    }
+)
 
 
 def _coerce_bool_flag(value: bool, name: str) -> bool:
@@ -60,13 +68,19 @@ class EvidenceComputationMode:
             raise ValueError("evidence_only mode cannot return smoothed posteriors")
         if self.mode == "full_smoothing" and not return_smoothed:
             raise ValueError("full_smoothing mode must return smoothed posteriors")
+        metadata = {} if self.metadata is None else dict(self.metadata)
+        conflicting_metadata_keys = _RESERVED_DIAGNOSTIC_METADATA_KEYS.intersection(
+            metadata
+        )
+        if conflicting_metadata_keys:
+            reserved = ", ".join(sorted(str(key) for key in conflicting_metadata_keys))
+            raise ValueError(
+                "metadata keys would overwrite evidence diagnostics: "
+                f"{reserved}"
+            )
         object.__setattr__(self, "return_smoothed", return_smoothed)
         object.__setattr__(self, "terminal_posterior", terminal_posterior)
-        object.__setattr__(
-            self,
-            "metadata",
-            {} if self.metadata is None else dict(self.metadata),
-        )
+        object.__setattr__(self, "metadata", metadata)
 
     @classmethod
     def full_smoothing(

--- a/tests/test_evidence_metadata_diagnostics.py
+++ b/tests/test_evidence_metadata_diagnostics.py
@@ -1,0 +1,22 @@
+import pytest
+
+from pyrecest.evidence import EvidenceComputationMode
+
+
+@pytest.mark.parametrize(
+    "key", ("computation_mode", "only", "return_smoothed", "terminal_posterior")
+)
+def test_evidence_metadata_rejects_reserved_diagnostic_keys(key):
+    with pytest.raises(ValueError, match="metadata keys would overwrite"):
+        EvidenceComputationMode.evidence_only(metadata={key: "shadow"})
+
+
+def test_evidence_metadata_cannot_overwrite_stable_diagnostics():
+    diagnostics = EvidenceComputationMode.evidence_only(
+        metadata={"scenario": "demo"}
+    ).to_diagnostics()
+
+    assert diagnostics["evidence_only"] == 1
+    assert diagnostics["evidence_return_smoothed"] == 0
+    assert diagnostics["evidence_terminal_posterior"] == 1
+    assert diagnostics["evidence_scenario"] == "demo"


### PR DESCRIPTION
## Summary
- Reject `EvidenceComputationMode` metadata keys that would overwrite stable evidence diagnostic fields.
- Add focused regression coverage for reserved metadata keys and ordinary metadata preservation.

## Bug
`to_diagnostics()` builds stable fields such as `evidence_only` and then updates the same dictionary with prefixed metadata. Metadata keys like `"only"` or `"return_smoothed"` therefore overwrite the stable diagnostic values, corrupting downstream diagnostics.

## Validation
- Parsed the patched source and regression test locally with `ast.parse`.
- Ran a local targeted harness against the patched `EvidenceComputationMode` implementation to confirm reserved keys raise and ordinary metadata is preserved.

Full repository pytest was not run locally because this environment cannot clone the repository from GitHub; CI should run on the PR.