### PR TITLE
Reject non-finite uniform random bounds

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/random.py
+++ b/src/pyrecest/_backend/_shared_numpy/random.py
@@ -27,11 +27,17 @@ rand = _modify_func_default_dtype(
 )
 
 
+def _validate_uniform_bounds(low, high):
+    if _np.any(~_np.isfinite(low)) or _np.any(~_np.isfinite(high)):
+        raise ValueError("uniform bounds must be finite")
+    if _np.any(low > high):
+        raise ValueError("Upper bound must be greater than or equal to lower bound")
+
+
 def _uniform(low=0.0, high=1.0, size=None):
     low_array = _np.asarray(low)
     high_array = _np.asarray(high)
-    if _np.any(low_array > high_array):
-        raise ValueError("Upper bound must be greater than or equal to lower bound")
+    _validate_uniform_bounds(low_array, high_array)
     return _np.random.uniform(low, high, size)
 
 

--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -365,6 +365,13 @@ def _uniform_size(size, low, high):
         raise ValueError("low and high could not be broadcast together") from exc
 
 
+def _validate_uniform_bounds(low, high):
+    if bool(_torch.any(~_torch.isfinite(low))) or bool(_torch.any(~_torch.isfinite(high))):
+        raise ValueError("uniform bounds must be finite")
+    if bool(_torch.any(low > high)):
+        raise ValueError("Upper bound must be greater than or equal to lower bound")
+
+
 def uniform(low=0.0, high=1.0, size=None, dtype=None):
     device = None
     if _torch.is_tensor(low):
@@ -375,8 +382,7 @@ def uniform(low=0.0, high=1.0, size=None, dtype=None):
     low = _torch.as_tensor(low, dtype=dtype, device=device)
     high = _torch.as_tensor(high, dtype=dtype, device=device)
     size = _uniform_size(size, low, high)
-    if bool(_torch.any(low > high)):
-        raise ValueError("Upper bound must be greater than or equal to lower bound")
+    _validate_uniform_bounds(low, high)
     return (high - low) * _torch.rand(size, dtype=dtype, device=device) + low
 
 

--- a/tests/backend_support/test_random_uniform_contract.py
+++ b/tests/backend_support/test_random_uniform_contract.py
@@ -41,6 +41,28 @@ print("ok")
 """
 
 
+_UNIFORM_NONFINITE_BOUNDS_REJECTION_CHECK = """
+from pyrecest.backend import random
+
+calls = [
+    ("nan low", lambda: random.uniform(float("nan"), 1.0, size=(2,))),
+    ("nan high", lambda: random.uniform(0.0, float("nan"), size=(2,))),
+    ("-inf low", lambda: random.uniform(float("-inf"), 1.0, size=(2,))),
+    ("inf high", lambda: random.uniform(0.0, float("inf"), size=(2,))),
+]
+
+for label, call in calls:
+    try:
+        call()
+    except ValueError as exc:
+        assert "finite" in str(exc)
+    else:
+        raise AssertionError(f"uniform accepted {label}")
+
+print("ok")
+"""
+
+
 @pytest.mark.backend_portable
 @pytest.mark.parametrize(
     "backend,required_module",
@@ -72,6 +94,25 @@ def test_uniform_rejects_array_valued_invalid_bounds(backend, required_module):
         pytest.skip(f"{backend} backend dependency is not installed")
 
     result = run_backend_code(backend, _UNIFORM_ARRAY_BOUNDS_REJECTION_CHECK)
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+@pytest.mark.backend_portable
+@pytest.mark.parametrize(
+    "backend,required_module",
+    [
+        ("numpy", "numpy"),
+        ("jax", "jax"),
+        ("pytorch", "torch"),
+    ],
+)
+def test_uniform_rejects_nonfinite_bounds(backend, required_module):
+    if importlib.util.find_spec(required_module) is None:
+        pytest.skip(f"{backend} backend dependency is not installed")
+
+    result = run_backend_code(backend, _UNIFORM_NONFINITE_BOUNDS_REJECTION_CHECK)
 
     assert result.returncode == 0, result.stderr
     assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- reject NaN/Inf bounds in the shared NumPy `random.uniform` implementation
- reject NaN/Inf bounds in the PyTorch `random.uniform` implementation
- add a backend-portable regression test covering NumPy, JAX, and PyTorch

## Rationale
JAX already validates non-finite uniform bounds, but the NumPy/PyTorch backends could silently produce invalid samples when given NaN or Inf limits. This makes the random backend contract consistent and prevents NaNs/Infs from entering downstream estimators through random sampling.

## Testing
- Added `tests/backend_support/test_random_uniform_contract.py::test_uniform_rejects_nonfinite_bounds`
- Not run locally in this environment because the sandbox cannot clone from GitHub / resolve `github.com`; CI should run the new backend-portable test.