### PR TITLE
Validate point-set metric boolean flags

### DIFF
--- a/src/pyrecest/evaluation/point_set_metrics.py
+++ b/src/pyrecest/evaluation/point_set_metrics.py
@@ -87,6 +87,7 @@ def nearest_neighbor_distances(
     reference_array = as_point_set(reference, name="reference")
     _validate_matching_dimension(query_array, reference_array)
     query_chunk_size = _validate_chunk_size(query_chunk_size)
+    return_indices = _validate_boolean_flag(return_indices, "return_indices")
 
     tree_result = _nearest_neighbor_distances_ckdtree(
         query_array,
@@ -119,6 +120,9 @@ def chamfer_distance(
     diagnostics. ``squared=True`` applies the same convention to squared
     nearest-neighbor distances.
     """
+
+    squared = _validate_boolean_flag(squared, "squared")
+    symmetric = _validate_boolean_flag(symmetric, "symmetric")
 
     a_to_b = nearest_neighbor_distances(
         points_a, points_b, query_chunk_size=query_chunk_size
@@ -345,6 +349,12 @@ def _validate_matching_dimension(query: np.ndarray, reference: np.ndarray) -> No
         raise ValueError(
             f"query and reference must have the same point dimension, got {query.shape[1]} and {reference.shape[1]}."
         )
+
+
+def _validate_boolean_flag(value: Any, name: str) -> bool:
+    if isinstance(value, (bool, np.bool_)):
+        return bool(value)
+    raise TypeError(f"{name} must be a boolean.")
 
 
 def _validate_chunk_size(query_chunk_size: int) -> int:

--- a/tests/evaluation/test_point_set_metrics.py
+++ b/tests/evaluation/test_point_set_metrics.py
@@ -145,3 +145,34 @@ def test_nonfinite_thresholds_raise_clear_errors():
 
     with pytest.raises(ValueError, match="finite and non-negative"):
         precision_recall_curve(points, points, (0.25, np.nan))
+
+
+@pytest.mark.parametrize("invalid_flag", ["False", "True", 0, 1, np.array(False)])
+def test_nearest_neighbor_distances_rejects_non_boolean_return_indices(invalid_flag):
+    points = np.array([[0.0], [1.0]])
+
+    with pytest.raises(TypeError, match="return_indices must be a boolean"):
+        nearest_neighbor_distances(points, points, return_indices=invalid_flag)
+
+
+@pytest.mark.parametrize("flag_name", ["squared", "symmetric"])
+@pytest.mark.parametrize("invalid_flag", ["False", "True", 0, 1, np.array(True)])
+def test_chamfer_distance_rejects_non_boolean_flags(flag_name, invalid_flag):
+    points = np.array([[0.0], [1.0]])
+
+    with pytest.raises(TypeError, match=f"{flag_name} must be a boolean"):
+        chamfer_distance(points, points, **{flag_name: invalid_flag})
+
+
+def test_numpy_boolean_flags_remain_supported():
+    points = np.array([[0.0], [1.0]])
+
+    distances, indices = nearest_neighbor_distances(
+        points, points, return_indices=np.bool_(True)
+    )
+
+    np.testing.assert_allclose(distances, [0.0, 0.0])
+    np.testing.assert_array_equal(indices, [0, 1])
+    assert chamfer_distance(
+        points, points, squared=np.bool_(False), symmetric=np.bool_(True)
+    ) == pytest.approx(0.0)


### PR DESCRIPTION
Summary:
- Validate boolean switches before use in point-set metrics.
- Reject non-boolean truthy or falsy values for return_indices, squared, and symmetric.
- Add regression coverage and keep np.bool_ scalar flags supported.

Validation:
- python -m py_compile on the modified source and focused test content.
- Targeted local harness passed: 16 tests.