### PR TITLE
Reject boolean scalar NumPy choice populations

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/random.py
+++ b/src/pyrecest/_backend/_shared_numpy/random.py
@@ -69,6 +69,14 @@ def _choice_bool(value, name):
     raise TypeError(f"{name} must be a boolean")
 
 
+def _validate_choice_population(a_array):
+    if a_array.ndim != 0:
+        return
+    scalar = a_array.item()
+    if isinstance(scalar, (bool, _np.bool_)):
+        raise ValueError("a must be a positive integer or a non-empty array")
+
+
 def _maybe_preserve_choice_order(indices, *, replace, p, shuffle, size):
     if replace or p is not None or shuffle or size is None:
         return indices
@@ -92,6 +100,7 @@ def choice(a, size=None, replace=True, p=None, axis=0, shuffle=True):
     replace = _choice_bool(replace, "replace")
     shuffle = _choice_bool(shuffle, "shuffle")
     a_array = _np.asarray(a)
+    _validate_choice_population(a_array)
     if a_array.ndim == 0:
         return _maybe_preserve_choice_order(
             _np.random.choice(a, size=size, replace=replace, p=p),

--- a/tests/backend_support/test_numpy_random_choice_bool_population.py
+++ b/tests/backend_support/test_numpy_random_choice_bool_population.py
@@ -1,0 +1,34 @@
+"""Regression tests for NumPy backend ``random.choice`` populations."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import pyrecest._backend.numpy.random as numpy_random
+
+
+@pytest.mark.parametrize(
+    "population",
+    (
+        True,
+        False,
+        np.bool_(True),
+        np.bool_(False),
+        np.array(True),
+        np.array(False),
+        np.array(True, dtype=object),
+        np.array(False, dtype=object),
+    ),
+)
+@pytest.mark.parametrize("size", (None, (0,), (1,)))
+def test_choice_rejects_boolean_scalar_population(population, size):
+    with pytest.raises(ValueError, match="positive integer or a non-empty array"):
+        numpy_random.choice(population, size=size)
+
+
+def test_choice_keeps_boolean_array_populations_valid():
+    selected = numpy_random.choice(np.array([True, False]), size=(4,), replace=True)
+
+    assert selected.shape == (4,)
+    assert selected.dtype == np.bool_


### PR DESCRIPTION
## Summary
- reject boolean scalar populations in the NumPy random backend's `choice` wrapper
- preserve boolean array populations as valid sampled arrays
- add focused regression coverage for Python, NumPy scalar, and zero-dimensional boolean populations

## Bug
`pyrecest._backend.numpy.random.choice(True)` and equivalent zero-dimensional boolean inputs were forwarded directly to `numpy.random.choice`. NumPy treats boolean scalars as integer population sizes (`True -> 1`, `False -> 0`), so malformed population inputs could be silently accepted as population-size requests. The wrapper now rejects boolean scalar populations before delegating to NumPy while still allowing non-scalar boolean arrays to be sampled.

## Validation
- Parsed the modified source and new regression test locally with `ast.parse`.
- Full pytest was not run locally because the execution sandbox cannot resolve `github.com` for a repository clone; GitHub Actions should run on the PR.