### PR TITLE
Reject invalid candidate pruning matrices

### DIFF
--- a/src/pyrecest/utils/candidate_pruning.py
+++ b/src/pyrecest/utils/candidate_pruning.py
@@ -15,6 +15,8 @@ from typing import Any
 
 import numpy as np
 
+_TEXT_TYPES = (str, bytes, bytearray, np.str_, np.bytes_)
+
 
 @dataclass(frozen=True)
 class CandidatePruningConfig:
@@ -155,6 +157,33 @@ def _normalize_bounded_scalar(
     return parsed
 
 
+def _contains_text_values(value: Any) -> bool:
+    if isinstance(value, _TEXT_TYPES):
+        return True
+    try:
+        values = np.asarray(value, dtype=object).reshape(-1)
+    except (TypeError, ValueError):
+        return False
+    return any(isinstance(item, _TEXT_TYPES) for item in values)
+
+
+def _as_numeric_matrix(value: Any, name: str) -> np.ndarray:
+    try:
+        raw_values = np.asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be numeric") from exc
+
+    if raw_values.dtype == np.bool_:
+        raise ValueError(f"{name} must be numeric, not boolean")
+    if _contains_text_values(value) or _contains_text_values(raw_values):
+        raise ValueError(f"{name} must be numeric")
+
+    try:
+        return np.asarray(raw_values, dtype=float)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be numeric") from exc
+
+
 def candidate_mask_from_costs(
     cost_matrix: Any,
     *,
@@ -292,7 +321,7 @@ def _effective_large_cost(costs: np.ndarray, penalty: float) -> float:
 
 
 def _as_cost_matrix(cost_matrix: Any) -> np.ndarray:
-    costs = np.asarray(cost_matrix, dtype=float)
+    costs = _as_numeric_matrix(cost_matrix, "cost_matrix")
     if costs.ndim != 2:
         raise ValueError("cost_matrix must be two-dimensional")
     return np.nan_to_num(costs, nan=np.inf, posinf=np.inf, neginf=np.inf)
@@ -302,7 +331,7 @@ def _as_probability_matrix(
     probability_matrix: Any,
     shape: tuple[int, int],
 ) -> np.ndarray:
-    probabilities = np.asarray(probability_matrix, dtype=float)
+    probabilities = _as_numeric_matrix(probability_matrix, "probability_matrix")
     if probabilities.shape != shape:
         raise ValueError("probability_matrix must match cost_matrix shape")
     finite = np.isfinite(probabilities)

--- a/tests/test_candidate_pruning_matrix_validation.py
+++ b/tests/test_candidate_pruning_matrix_validation.py
@@ -1,0 +1,64 @@
+import unittest
+
+import numpy as np
+from pyrecest.utils import (
+    CandidatePruningConfig,
+    candidate_mask_from_costs,
+    prune_pairwise_cost_matrix,
+)
+
+
+class TestCandidatePruningMatrixValidation(unittest.TestCase):
+    def test_cost_matrix_rejects_boolean_entries(self):
+        invalid_matrices = (
+            [[True, False]],
+            np.array([[True, False]]),
+        )
+
+        for function in (candidate_mask_from_costs, prune_pairwise_cost_matrix):
+            for matrix in invalid_matrices:
+                with self.subTest(function=function.__name__, matrix=matrix):
+                    with self.assertRaisesRegex(
+                        ValueError,
+                        "cost_matrix must be numeric",
+                    ):
+                        function(matrix)
+
+    def test_cost_matrix_rejects_text_entries(self):
+        invalid_matrices = (
+            np.array([["1.0", "2.0"]]),
+            np.array([[b"1.0", b"2.0"]], dtype=object),
+        )
+
+        for function in (candidate_mask_from_costs, prune_pairwise_cost_matrix):
+            for matrix in invalid_matrices:
+                with self.subTest(function=function.__name__, dtype=str(matrix.dtype)):
+                    with self.assertRaisesRegex(
+                        ValueError,
+                        "cost_matrix must be numeric",
+                    ):
+                        function(matrix)
+
+    def test_probability_matrix_rejects_boolean_and_text_entries(self):
+        config = CandidatePruningConfig(probability_threshold=0.5)
+        invalid_probability_matrices = (
+            np.array([[True]]),
+            np.array([["0.75"]]),
+            np.array([[b"0.75"]], dtype=object),
+        )
+
+        for probabilities in invalid_probability_matrices:
+            with self.subTest(dtype=str(probabilities.dtype)):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "probability_matrix must be numeric",
+                ):
+                    candidate_mask_from_costs(
+                        np.array([[1.0]]),
+                        probability_matrix=probabilities,
+                        config=config,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a numeric-matrix normalization path for candidate pruning inputs before float coercion
- reject boolean and text-valued cost matrices instead of silently converting them to `0.0`/`1.0` or parsed floats
- reject boolean and text-valued probability matrices used by probability-threshold pruning
- add focused regression coverage for `candidate_mask_from_costs` and `prune_pairwise_cost_matrix`

## Bug
`candidate_mask_from_costs()` and `prune_pairwise_cost_matrix()` converted matrices with `np.asarray(..., dtype=float)`. That meant malformed inputs such as `[[True, False]]`, `np.array([["1.0"]])`, or a boolean `probability_matrix` were accepted silently as numeric values. For association pruning, that can turn data/configuration errors into valid candidate decisions.

## Validation
- Parsed the modified module and the new test file locally with `py_compile`.
- Ran a local targeted harness against the modified standalone `candidate_pruning.py` to confirm boolean/text matrices are rejected and ordinary numeric masks still work.

Full repository pytest was not run locally because this environment cannot clone the repository from GitHub; CI should run on the PR branch.