### PR TITLE
Return copies from API registry iterator

### DIFF
--- a/src/pyrecest/api_registry.py
+++ b/src/pyrecest/api_registry.py
@@ -100,4 +100,4 @@ def get_public_api_registry_entry(api_name: str) -> dict[str, str]:
 
 def iter_public_api_registry() -> tuple[tuple[str, dict[str, str]], ...]:
     """Return public API registry rows in stable name order."""
-    return tuple(sorted(PUBLIC_API_REGISTRY.items()))
+    return tuple((name, dict(row)) for name, row in sorted(PUBLIC_API_REGISTRY.items()))

--- a/tests/test_api_registry.py
+++ b/tests/test_api_registry.py
@@ -31,6 +31,12 @@ def test_get_public_api_registry_entry_returns_copy():
     assert PUBLIC_API_REGISTRY["KalmanFilter"]["category"] == "stable"
 
 
+def test_iter_public_api_registry_returns_row_copies():
+    rows = dict(iter_public_api_registry())
+    rows["KalmanFilter"]["category"] = "mutated"
+    assert PUBLIC_API_REGISTRY["KalmanFilter"]["category"] == "stable"
+
+
 def test_public_api_registry_document_contains_generated_table():
     document = Path("docs/public-api-registry.md").read_text(encoding="utf-8")
     assert render_markdown() in document


### PR DESCRIPTION
## Summary
- Return shallow copies from `iter_public_api_registry()` instead of exposing the live registry row dictionaries.
- Add regression coverage showing that mutating rows returned by the iterator does not mutate `PUBLIC_API_REGISTRY`.

## Bug
`get_public_api_registry_entry()` already returns a copied row, but `iter_public_api_registry()` returned the original mutable dictionaries from `PUBLIC_API_REGISTRY`. Callers that mutated an iterated row could therefore accidentally corrupt the module-level registry for the rest of the process.

## Validation
- `python -m py_compile /tmp/api_registry_patched.py`
- Targeted local harness verifying both `iter_public_api_registry()` and `get_public_api_registry_entry()` return rows that can be mutated without changing `PUBLIC_API_REGISTRY`.

Full pytest was not run locally because this environment cannot clone the repository from GitHub; CI should run on the PR.