### PR TITLE
Fix shared NumPy QR mode signatures

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/linalg.py
+++ b/src/pyrecest/_backend/_shared_numpy/linalg.py
@@ -74,10 +74,18 @@ def quadratic_assignment(a, b, options=None):
     return list(_scipy.optimize.quadratic_assignment(a, b, options=options).col_ind)
 
 
-def qr(*args, **kwargs):
-    return _np.vectorize(
-        _np.linalg.qr, signature="(n,m)->(n,k),(k,m)", excluded=["mode"]
-    )(*args, **kwargs)
+def qr(a, mode="reduced"):
+    if mode == "r":
+        signature = "(n,m)->(k,m)"
+    elif mode == "raw":
+        signature = "(n,m)->(m,n),(k)"
+    elif mode == "economic":
+        signature = "(n,m)->(n,m)"
+    else:
+        signature = "(n,m)->(n,k),(k,m)"
+    return _np.vectorize(_np.linalg.qr, signature=signature, excluded=["mode"])(
+        a, mode=mode
+    )
 
 
 def is_single_matrix_pd(mat):

--- a/tests/backend/test_numpy_linalg_qr_modes.py
+++ b/tests/backend/test_numpy_linalg_qr_modes.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+from pyrecest._backend.numpy import linalg
+
+
+def test_qr_mode_r_returns_single_batched_r_factor():
+    matrices = np.stack(
+        [
+            np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 7.0]]),
+            np.array([[2.0, 0.0], [0.0, 3.0], [1.0, 4.0]]),
+        ]
+    )
+
+    result = linalg.qr(matrices, mode="r")
+    expected = np.linalg.qr(matrices, mode="r")
+
+    assert isinstance(result, np.ndarray)
+    np.testing.assert_allclose(result, expected)
+
+
+def test_qr_mode_raw_preserves_batched_numpy_contract():
+    matrices = np.stack(
+        [
+            np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 7.0]]),
+            np.array([[2.0, 0.0], [0.0, 3.0], [1.0, 4.0]]),
+        ]
+    )
+
+    h, tau = linalg.qr(matrices, mode="raw")
+    expected_h, expected_tau = np.linalg.qr(matrices, mode="raw")
+
+    np.testing.assert_allclose(h, expected_h)
+    np.testing.assert_allclose(tau, expected_tau)


### PR DESCRIPTION
## Summary
- choose the vectorized `np.linalg.qr` output signature from the requested mode
- preserve single-output `mode="r"` and raw `(h, tau)` output shapes for batched inputs
- add focused NumPy backend regressions for `mode="r"` and `mode="raw"`

## Bug
The shared NumPy backend wrapped `np.linalg.qr` with a fixed two-output reduced/complete signature. Valid NumPy modes such as `mode="r"` return a single R factor, while `mode="raw"` returns raw-shaped `(h, tau)`. Those modes therefore failed in the backend wrapper even though NumPy supports them.

## Validation
- Ran a local minimal harness comparing the patched wrapper against `np.linalg.qr` for batched matrices in `reduced`, `complete`, `r`, and `raw` modes.
- Full repository pytest was not run locally because this environment cannot clone the repository from GitHub; CI should run on the PR branch.