### PR TITLE
Validate DVS likelihood numeric inputs

### DIFF
--- a/src/pyrecest/experimental/dvs/event_likelihood.py
+++ b/src/pyrecest/experimental/dvs/event_likelihood.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 import numpy as np
 
 
-def _as_finite_scalar(value: float, name: str, message: str) -> float:
+def _as_finite_scalar(value: float, message: str) -> float:
     value_array = np.asarray(value)
     if value_array.shape != () or value_array.dtype == np.bool_:
         raise ValueError(message)
@@ -25,7 +25,7 @@ def _as_finite_scalar(value: float, name: str, message: str) -> float:
 
 def _validate_positive_finite(value: float, name: str) -> float:
     message = f"{name} must be finite and positive"
-    value = _as_finite_scalar(value, name, message)
+    value = _as_finite_scalar(value, message)
     if value <= 0.0:
         raise ValueError(message)
     return value
@@ -33,7 +33,7 @@ def _validate_positive_finite(value: float, name: str) -> float:
 
 def _validate_nonnegative_finite(value: float, name: str) -> float:
     message = f"{name} must be finite and non-negative"
-    value = _as_finite_scalar(value, name, message)
+    value = _as_finite_scalar(value, message)
     if value < 0.0:
         raise ValueError(message)
     return value

--- a/src/pyrecest/experimental/dvs/event_likelihood.py
+++ b/src/pyrecest/experimental/dvs/event_likelihood.py
@@ -7,18 +7,41 @@ from dataclasses import dataclass, field
 import numpy as np
 
 
+def _as_finite_scalar(value: float, name: str, message: str) -> float:
+    value_array = np.asarray(value)
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError(message)
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_, str, bytes, bytearray)):
+        raise ValueError(message)
+    try:
+        result = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if not np.isfinite(result):
+        raise ValueError(message)
+    return result
+
+
 def _validate_positive_finite(value: float, name: str) -> float:
-    value = float(value)
-    if not np.isfinite(value) or value <= 0.0:
-        raise ValueError(f"{name} must be finite and positive")
+    message = f"{name} must be finite and positive"
+    value = _as_finite_scalar(value, name, message)
+    if value <= 0.0:
+        raise ValueError(message)
     return value
 
 
 def _validate_nonnegative_finite(value: float, name: str) -> float:
-    value = float(value)
-    if not np.isfinite(value) or value < 0.0:
-        raise ValueError(f"{name} must be finite and non-negative")
+    message = f"{name} must be finite and non-negative"
+    value = _as_finite_scalar(value, name, message)
+    if value < 0.0:
+        raise ValueError(message)
     return value
+
+
+def _validate_finite_array(values: np.ndarray, name: str) -> None:
+    if np.any(~np.isfinite(values)):
+        raise ValueError(f"{name} must contain only finite values")
 
 
 @dataclass(frozen=True)
@@ -41,12 +64,16 @@ class ContourSample:
             raise ValueError("normals must have the same shape as points")
         if weights.shape != (points.shape[0],):
             raise ValueError("weights must have shape (n,)")
+        _validate_finite_array(points, "points")
+        _validate_finite_array(normals, "normals")
+        _validate_finite_array(weights, "weights")
         if np.any(weights < 0.0):
             raise ValueError("weights must be non-negative")
         if self.angles is not None:
             angles = np.asarray(self.angles, dtype=float)
             if angles.shape != (points.shape[0],):
                 raise ValueError("angles must have shape (n,)")
+            _validate_finite_array(angles, "angles")
         object.__setattr__(self, "points", points)
         object.__setattr__(self, "normals", normals)
         object.__setattr__(self, "weights", weights)
@@ -97,8 +124,8 @@ class PointProcessUpdateConfig:
             raise ValueError("max_map_iterations must be non-negative")
         if self.shape_update_modes < 0:
             raise ValueError("shape_update_modes must be non-negative")
-        covariance_damping = float(self.covariance_damping)
-        if not np.isfinite(covariance_damping) or not 0.0 < covariance_damping <= 1.0:
+        covariance_damping = _validate_positive_finite(self.covariance_damping, "covariance_damping")
+        if covariance_damping > 1.0:
             raise ValueError("covariance_damping must be finite and in (0, 1]")
         _validate_positive_finite(self.max_state_update_norm, "max_state_update_norm")
 
@@ -123,12 +150,13 @@ def normal_flow_activities(
     """Return normalized normal-flow activity for sampled contour normals."""
     normals = np.asarray(normals, dtype=float)
     velocity = np.asarray(velocity, dtype=float)
+    activity_floor = _validate_nonnegative_finite(activity_floor, "activity_floor")
     if normals.ndim != 2 or normals.shape[1] != 2:
         raise ValueError("normals must have shape (n, 2)")
     if velocity.shape != (2,):
         raise ValueError("velocity must have shape (2,)")
-    if activity_floor < 0.0:
-        raise ValueError("activity_floor must be non-negative")
+    _validate_finite_array(normals, "normals")
+    _validate_finite_array(velocity, "velocity")
 
     velocity_norm = float(np.linalg.norm(velocity))
     if velocity_norm <= 1e-12:
@@ -202,9 +230,8 @@ def expected_event_count(
     )
     expected_background = 0.0
     if image_area is not None:
-        if image_area < 0.0:
-            raise ValueError("image_area must be non-negative")
-        expected_background = duration * config.background_rate * float(image_area)
+        image_area = _validate_nonnegative_finite(image_area, "image_area")
+        expected_background = duration * config.background_rate * image_area
     return expected_foreground, expected_background
 
 
@@ -375,7 +402,5 @@ def _duration_from_argument(
     if batch_duration is None:
         duration = config.batch_duration
     else:
-        duration = float(batch_duration)
-    if not np.isfinite(duration) or duration < 0.0:
-        raise ValueError("batch_duration must be finite and non-negative")
-    return duration
+        duration = batch_duration
+    return _validate_nonnegative_finite(duration, "batch_duration")

--- a/tests/experimental/test_dvs_event_likelihood.py
+++ b/tests/experimental/test_dvs_event_likelihood.py
@@ -73,6 +73,28 @@ def test_contour_sample_converts_sequence_inputs_to_arrays():
 @pytest.mark.parametrize(
     ("keyword", "value"),
     [
+        ("points", np.array([[0.0, 0.0], [np.nan, 0.0]])),
+        ("normals", np.array([[0.0, 1.0], [np.inf, 0.0]])),
+        ("weights", np.array([1.0, np.nan])),
+        ("angles", np.array([0.0, -np.inf])),
+    ],
+)
+def test_contour_sample_rejects_nonfinite_geometry(keyword, value):
+    kwargs = {
+        "points": np.array([[0.0, 0.0], [1.0, 0.0]]),
+        "normals": np.array([[0.0, 1.0], [0.0, 1.0]]),
+        "weights": np.array([1.0, 2.0]),
+        "angles": np.array([0.0, np.pi]),
+    }
+    kwargs[keyword] = value
+
+    with pytest.raises(ValueError, match=f"{keyword} must contain only finite values"):
+        ContourSample(**kwargs)
+
+
+@pytest.mark.parametrize(
+    ("keyword", "value"),
+    [
         ("spatial_sigma_px", float("nan")),
         ("spatial_sigma_px", float("inf")),
         ("foreground_rate", float("nan")),
@@ -90,6 +112,22 @@ def test_event_likelihood_config_rejects_nonfinite_numeric_values(keyword, value
 @pytest.mark.parametrize(
     ("keyword", "value"),
     [
+        ("spatial_sigma_px", "1.0"),
+        ("foreground_rate", True),
+        ("background_rate", b"0.1"),
+        ("activity_floor", np.array(True, dtype=object)),
+        ("min_intensity", "1e-12"),
+        ("batch_duration", np.array("1.0")),
+    ],
+)
+def test_event_likelihood_config_rejects_text_and_boolean_scalars(keyword, value):
+    with pytest.raises(ValueError, match=keyword):
+        EventLikelihoodConfig(**{keyword: value})
+
+
+@pytest.mark.parametrize(
+    ("keyword", "value"),
+    [
         ("finite_difference_eps", float("nan")),
         ("finite_difference_eps", float("inf")),
         ("map_step_size", float("nan")),
@@ -98,6 +136,20 @@ def test_event_likelihood_config_rejects_nonfinite_numeric_values(keyword, value
     ],
 )
 def test_point_process_update_config_rejects_nonfinite_numeric_values(keyword, value):
+    with pytest.raises(ValueError, match=keyword):
+        PointProcessUpdateConfig(**{keyword: value})
+
+
+@pytest.mark.parametrize(
+    ("keyword", "value"),
+    [
+        ("finite_difference_eps", "0.01"),
+        ("map_step_size", True),
+        ("covariance_damping", "0.98"),
+        ("max_state_update_norm", np.array(True, dtype=object)),
+    ],
+)
+def test_point_process_update_config_rejects_text_and_boolean_scalars(keyword, value):
     with pytest.raises(ValueError, match=keyword):
         PointProcessUpdateConfig(**{keyword: value})
 
@@ -118,6 +170,17 @@ def test_activity_floor_applies_without_motion():
     )
 
     np.testing.assert_allclose(activities, np.full(4, 0.05))
+
+
+def test_normal_flow_activities_rejects_nonfinite_inputs():
+    normals = np.array([[1.0, 0.0]], dtype=float)
+
+    with pytest.raises(ValueError, match="normals must contain only finite values"):
+        normal_flow_activities(np.array([[np.nan, 0.0]]), np.array([1.0, 0.0]))
+    with pytest.raises(ValueError, match="velocity must contain only finite values"):
+        normal_flow_activities(normals, np.array([np.inf, 0.0]))
+    with pytest.raises(ValueError, match="activity_floor"):
+        normal_flow_activities(normals, np.array([0.0, 0.0]), activity_floor=np.nan)
 
 
 def test_active_edge_events_have_higher_intensity():
@@ -151,6 +214,14 @@ def test_inactive_side_length_does_not_change_expected_count():
     wide_foreground, _ = expected_event_count(wide, np.array([1.0, 0.0]), config)
 
     assert narrow_foreground == pytest.approx(wide_foreground)
+
+
+@pytest.mark.parametrize("image_area", [np.nan, np.inf, -1.0, "4.0", True])
+def test_expected_event_count_rejects_invalid_image_area(image_area):
+    contour = _rectangle_contour(width=1.0, height=2.0)
+
+    with pytest.raises(ValueError, match="image_area"):
+        expected_event_count(contour, np.array([1.0, 0.0]), image_area=image_area)
 
 
 def test_likelihood_prefers_correct_width_for_two_sided_support():


### PR DESCRIPTION
## Summary
- reject non-finite DVS contour geometry, normals, weights, angles, and normal-flow velocity inputs before they can produce NaN likelihoods
- reject text and boolean scalar values for DVS likelihood/update numeric configuration parameters instead of accepting them during dataclass construction and failing later in arithmetic
- validate `image_area`, explicit `batch_duration`, and direct `activity_floor` inputs with the same finite non-negative scalar contract

## Bug
The DVS point-process likelihood path converted many values with `float(...)` during validation but did not store those converted values in the frozen dataclasses. As a result, text-like values such as `EventLikelihoodConfig(spatial_sigma_px="1.0")` passed validation while leaving a string in the config, causing later TypeErrors in kernel arithmetic. Non-finite contour geometry, weights, velocity, and image-area inputs could also propagate NaN/Inf through intensities and log-likelihood terms instead of failing deterministically.

## Validation
- `PYTHONPATH=/tmp/pyrecest_patch/src python -m py_compile /tmp/pyrecest_patch/src/pyrecest/experimental/dvs/event_likelihood.py /tmp/pyrecest_patch/tests/experimental/test_dvs_event_likelihood.py`
- `PYTHONPATH=/tmp/pyrecest_patch/src python -m pytest -q /tmp/pyrecest_patch/tests/experimental/test_dvs_event_likelihood.py` — 39 passed

Note: validation was run in a temporary focused checkout reconstructed from the fetched files because the sandbox cannot clone GitHub directly.