### PR TITLE
Normalize scalar tuple states in Euclidean UKF

### DIFF
--- a/src/pyrecest/filters/unscented_kalman_filter.py
+++ b/src/pyrecest/filters/unscented_kalman_filter.py
@@ -21,6 +21,16 @@ def _assert_supported_backend():
         )
 
 
+def _coerce_gaussian_state(state, name):
+    if isinstance(state, GaussianDistribution):
+        return state
+    if isinstance(state, tuple) and len(state) == 2:
+        return GaussianDistribution(state[0], state[1])
+    raise ValueError(
+        f"{name} must be a GaussianDistribution or a tuple of (mean, covariance)"
+    )
+
+
 class UnscentedKalmanFilter(AbstractFilter, EuclideanFilterMixin):
     # pylint: disable=too-many-positional-arguments
     def __init__(
@@ -32,14 +42,8 @@ class UnscentedKalmanFilter(AbstractFilter, EuclideanFilterMixin):
         points=None,
         dim_z: int | None = None,
     ):
-        if isinstance(initial_state, GaussianDistribution):
-            dim_x = initial_state.dim
-        elif isinstance(initial_state, tuple) and len(initial_state) == 2:
-            dim_x = len(initial_state[0])
-        else:
-            raise ValueError(
-                "initial_state must be a GaussianDistribution or a tuple of (mean, covariance)"
-            )
+        initial_state = _coerce_gaussian_state(initial_state, "initial_state")
+        dim_x = initial_state.dim
 
         if points is None:
             # Standard settings for Gaussian approximations
@@ -52,12 +56,8 @@ class UnscentedKalmanFilter(AbstractFilter, EuclideanFilterMixin):
         AbstractFilter.__init__(self, bfukf)
 
         # Set initial state
-        if isinstance(initial_state, GaussianDistribution):
-            self._filter_state.x = initial_state.mu
-            self._filter_state.P = initial_state.C
-        else:
-            self._filter_state.x = initial_state[0]
-            self._filter_state.P = initial_state[1]
+        self._filter_state.x = initial_state.mu
+        self._filter_state.P = initial_state.C
         # Track whether predict() has been called before update()
         self._predicted = False
 
@@ -69,16 +69,10 @@ class UnscentedKalmanFilter(AbstractFilter, EuclideanFilterMixin):
 
     @filter_state.setter
     def filter_state(self, new_state: "GaussianDistribution | tuple"):
-        if isinstance(new_state, GaussianDistribution):
-            self._filter_state.x = new_state.mu
-            self._filter_state.P = new_state.C
-        elif isinstance(new_state, tuple) and len(new_state) == 2:
-            self._filter_state.x = new_state[0]
-            self._filter_state.P = new_state[1]
-        else:
-            raise ValueError(
-                "new_state must be a GaussianDistribution or a tuple of (mean, covariance)"
-            )
+        new_state = _coerce_gaussian_state(new_state, "new_state")
+        self._filter_state.x = new_state.mu
+        self._filter_state.P = new_state.C
+        self._predicted = False
 
     def _ensure_predicted(self):
         """Run a zero-noise predict to populate sigma points if needed."""

--- a/tests/filters/test_unscented_kalman_filter_scalar_tuple.py
+++ b/tests/filters/test_unscented_kalman_filter_scalar_tuple.py
@@ -1,0 +1,40 @@
+import unittest
+
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+import pyrecest.backend
+from pyrecest.backend import array
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.filters.unscented_kalman_filter import UnscentedKalmanFilter
+
+
+class UnscentedKalmanFilterScalarTupleStateTest(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
+    def test_initialization_accepts_scalar_tuple_state(self):
+        kf = UnscentedKalmanFilter((1.0, 10000.0))
+
+        npt.assert_allclose(kf.get_point_estimate(), array([1.0]))
+        self.assertEqual(kf.filter_state.mu.shape, (1,))
+        self.assertEqual(kf.filter_state.C.shape, (1, 1))
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
+    def test_filter_state_setter_accepts_scalar_tuple_state(self):
+        kf = UnscentedKalmanFilter(GaussianDistribution(array([0.0]), array([[1.0]])))
+
+        kf.filter_state = (2.0, 3.0)
+
+        npt.assert_allclose(kf.filter_state.mu, array([2.0]))
+        npt.assert_allclose(kf.filter_state.C, array([[3.0]]))
+        kf.update_identity(meas_noise=array([[1.0]]), measurement=array([4.0]))
+        npt.assert_allclose(kf.get_point_estimate(), array([3.5]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Coerce Euclidean UKF tuple states through `GaussianDistribution` in both the constructor and `filter_state` setter.
- Preserve the existing GaussianDistribution path while giving scalar `(mean, covariance)` tuples canonical `(1,)` / `(1, 1)` internal shapes.
- Add focused regression coverage for scalar tuple initialization and state replacement.

## Bug
`UnscentedKalmanFilter((1.0, 1.0))` previously reached `len(initial_state[0])`, which fails for scalar means despite `GaussianDistribution` and `KalmanFilter` treating scalar states as one-dimensional. The `filter_state` setter also assigned tuple elements directly, so scalar tuples could leave scalar-shaped internals and fail during later prediction/update code that expects vector-shaped state arrays.

## Validation
- Not run locally; this environment cannot clone GitHub. Added `tests/filters/test_unscented_kalman_filter_scalar_tuple.py` to exercise the regression in CI.