### PR TITLE
Fix PyTorch QR mode contract

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -16,7 +16,6 @@ from torch.linalg import (
 from torch.linalg import matrix_exp as expm
 from torch.linalg import (
     matrix_power,
-    qr,
     solve,
 )
 

--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -174,6 +174,22 @@ def quadratic_assignment(a, b, options=None):
     )
 
 
+def qr(a, mode="reduced"):
+    """Compute QR decomposition with NumPy-compatible mode handling."""
+    a = _as_linalg_tensor(a)
+    if mode in {"reduced", "complete"}:
+        return _torch.linalg.qr(a, mode=mode)
+    if mode == "r":
+        return _torch.linalg.qr(a, mode=mode).R
+    if mode in {"raw", "economic"}:
+        result = _np.linalg.qr(_as_numpy_no_grad(a), mode=mode)
+        if mode == "raw":
+            h, tau = result
+            return _torch_as_like(h, a), _torch_as_like(tau, a)
+        return _torch_as_like(result, a)
+    raise ValueError(f"Unrecognized mode {mode!r}")
+
+
 def solve_sylvester(a, b, q):
     a = _as_linalg_tensor(a)
     b = _as_linalg_tensor(b)

--- a/tests/backend_support/test_pytorch_linalg_qr_contract.py
+++ b/tests/backend_support/test_pytorch_linalg_qr_contract.py
@@ -1,0 +1,56 @@
+import unittest
+from typing import Any
+
+import numpy as np
+
+pytorch_backend: Any
+try:
+    from pyrecest._backend import pytorch as pytorch_backend
+except ModuleNotFoundError:
+    pytorch_backend = None
+
+
+@unittest.skipIf(pytorch_backend is None, "PyTorch is not installed")
+class TestPytorchLinalgQrContract(unittest.TestCase):
+    def test_mode_r_returns_numpy_style_r_factor(self):
+        matrices_np = np.stack(
+            [
+                np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 7.0]]),
+                np.array([[2.0, 0.0], [0.0, 3.0], [1.0, 4.0]]),
+            ]
+        )
+        matrices = pytorch_backend.array(matrices_np, dtype=pytorch_backend.float64)
+
+        result = pytorch_backend.linalg.qr(matrices, mode="r")
+        expected = np.linalg.qr(matrices_np, mode="r")
+
+        self.assertEqual(tuple(result.shape), expected.shape)
+        self.assertTrue(
+            pytorch_backend.allclose(
+                result, pytorch_backend.array(expected, dtype=pytorch_backend.float64)
+            )
+        )
+
+    def test_mode_raw_returns_numpy_style_h_tau_tuple(self):
+        matrix_np = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 7.0]])
+        matrix = pytorch_backend.array(matrix_np, dtype=pytorch_backend.float64)
+
+        h, tau = pytorch_backend.linalg.qr(matrix, mode="raw")
+        expected_h, expected_tau = np.linalg.qr(matrix_np, mode="raw")
+
+        self.assertEqual(tuple(h.shape), expected_h.shape)
+        self.assertEqual(tuple(tau.shape), expected_tau.shape)
+        self.assertTrue(
+            pytorch_backend.allclose(
+                h, pytorch_backend.array(expected_h, dtype=pytorch_backend.float64)
+            )
+        )
+        self.assertTrue(
+            pytorch_backend.allclose(
+                tau, pytorch_backend.array(expected_tau, dtype=pytorch_backend.float64)
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fix the PyTorch backend QR wrapper so its return values match the NumPy backend for QR modes. Adds focused regression coverage.