### PR TITLE
Reject bool and text covariance matrices

### DIFF
--- a/src/pyrecest/numerics.py
+++ b/src/pyrecest/numerics.py
@@ -11,16 +11,35 @@ from pyrecest.exceptions import (
     ShapeError,
 )
 
+_TEXT_OR_BOOL_KINDS = {"b", "S", "U"}
+_TEXT_OR_BOOL_SCALAR_TYPES = (bool, np.bool_, str, bytes, bytearray, np.str_, np.bytes_)
 
-def _to_numpy_array(value) -> np.ndarray:
+
+def _contains_text_or_bool_values(value) -> bool:
+    value_array = np.asarray(value)
+    if value_array.dtype.kind in _TEXT_OR_BOOL_KINDS:
+        return True
+    if value_array.dtype.kind != "O":
+        return False
+    return any(isinstance(item, _TEXT_OR_BOOL_SCALAR_TYPES) for item in value_array.flat)
+
+
+def _to_numpy_array(value, *, name: str = "matrix") -> np.ndarray:
     try:
         import pyrecest.backend as backend
 
-        return np.asarray(backend.to_numpy(value), dtype=float)
+        raw = backend.to_numpy(value)
     except (
         Exception
     ):  # pragma: no cover - fallback for source-tree bootstrap or unusual array objects
-        return np.asarray(value, dtype=float)
+        raw = value
+
+    try:
+        if _contains_text_or_bool_values(raw):
+            raise ValueError
+        return np.asarray(raw, dtype=float)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must contain numeric values.") from exc
 
 
 def _from_numpy_array(value: np.ndarray):
@@ -103,7 +122,10 @@ def symmetrize_matrix(matrix):
 def is_symmetric(matrix, *, atol: float = 1e-10) -> bool:
     """Return whether a matrix is symmetric within an absolute tolerance."""
     atol = _validate_nonnegative_finite("atol", atol)
-    arr = _to_numpy_array(matrix)
+    try:
+        arr = _to_numpy_array(matrix)
+    except ValueError:
+        return False
     return bool(
         arr.ndim == 2
         and arr.shape[0] == arr.shape[1]
@@ -115,7 +137,10 @@ def is_symmetric(matrix, *, atol: float = 1e-10) -> bool:
 def is_positive_semidefinite(matrix, *, atol: float = 1e-10) -> bool:
     """Return whether a symmetric matrix is positive semidefinite within tolerance."""
     atol = _validate_nonnegative_finite("atol", atol)
-    arr = _to_numpy_array(matrix)
+    try:
+        arr = _to_numpy_array(matrix)
+    except ValueError:
+        return False
     if (
         arr.ndim != 2
         or arr.shape[0] != arr.shape[1]
@@ -180,7 +205,7 @@ def assert_covariance_matrix(
     """Validate a covariance matrix and return it in the active backend representation."""
     atol = _validate_nonnegative_finite("atol", atol)
     dim = _validate_optional_dimension("dim", dim)
-    arr = _to_numpy_array(matrix)
+    arr = _to_numpy_array(matrix, name=name)
     if arr.ndim != 2 or arr.shape[0] != arr.shape[1]:
         raise ShapeError(f"{name} must be a square matrix, got shape {arr.shape}.")
     if dim is not None and arr.shape[0] != dim:

--- a/tests/test_numerics.py
+++ b/tests/test_numerics.py
@@ -34,6 +34,28 @@ def test_empty_square_matrix_is_symmetric_psd_covariance():
     assert validated.shape == (0, 0)
 
 
+@pytest.mark.parametrize(
+    "matrix",
+    [
+        np.array([[True, False], [False, True]]),
+        np.array([["1.0", "0.0"], ["0.0", "1.0"]]),
+        np.array([[1.0, False], [0.0, 1.0]], dtype=object),
+    ],
+)
+def test_covariance_helpers_reject_bool_and_text_matrices(matrix):
+    assert not is_symmetric(matrix)
+    assert not is_positive_semidefinite(matrix)
+
+    with pytest.raises(ValueError, match="covariance must contain numeric values"):
+        assert_covariance_matrix(matrix)
+    with pytest.raises(ValueError, match="matrix must contain numeric values"):
+        symmetrize_matrix(matrix)
+    with pytest.raises(ValueError, match="matrix must contain numeric values"):
+        nearest_symmetric_psd(matrix)
+    with pytest.raises(ValueError, match="matrix must contain numeric values"):
+        jittered_cholesky(matrix)
+
+
 def test_covariance_helpers_reject_nonfinite_matrices():
     matrix = np.array([[np.inf, 0.0], [0.0, 1.0]])
 


### PR DESCRIPTION
## Summary
- Reject boolean and text-like covariance matrix inputs before float coercion in numerics helpers.
- Keep predicate helpers conservative by returning `False` for these invalid matrix inputs.
- Add regression coverage across covariance validation and matrix repair helpers.

## Bug
`pyrecest.numerics` converted covariance-like inputs with `np.asarray(..., dtype=float)`, so boolean matrices became `0.0`/`1.0` and numeric-looking text matrices could be accepted as valid covariance matrices. That could let malformed covariance inputs pass validation or enter numerical repair routines silently.

## Testing
- `PYTHONPATH=src python -m pytest tests/test_numerics.py -q` on a focused local source-tree copy: 13 passed.