### PR TITLE
Fix overwritten association probability gate regression

### DIFF
--- a/tests/filters/test_association_hypotheses.py
+++ b/tests/filters/test_association_hypotheses.py
@@ -128,7 +128,7 @@ class AssociationHypothesesTest(unittest.TestCase):
 
         self.assertEqual(gate.k, 2)
 
-    def test_probability_likelihood_gate_rejects_zero_threshold(self):
+    def test_probability_likelihood_gate_rejects_zero_threshold_and_allows_zero_probability_threshold(self):
         with self.assertRaises(ValueError):
             ProbabilityThresholdGate(0.0, use_likelihood=True)
 


### PR DESCRIPTION
## Summary
- rename the duplicated probability-gate test method so Python no longer overwrites the earlier regression in `AssociationHypothesesTest`
- restores coverage that zero likelihood thresholds are rejected while zero probability thresholds remain valid

## Tests
- Not run locally.
