### PR TITLE
Reject nonfinite calibrated association probabilities

### DIFF
--- a/src/pyrecest/utils/association_features.py
+++ b/src/pyrecest/utils/association_features.py
@@ -9,10 +9,12 @@ from typing import Any, Literal
 
 # pylint: disable=no-name-in-module,no-member,redefined-builtin
 from pyrecest.backend import (
+    all,
     asarray,
     clip,
     exp,
     float64,
+    isfinite,
     isinf,
     isnan,
     log,
@@ -148,7 +150,7 @@ class CalibratedPairwiseAssociationModel:
             raise TypeError(
                 "model must expose predict_match_probability, predict_proba, or pairwise_cost_matrix"
             )
-        return clip(asarray(probabilities, dtype=float64), 0.0, 1.0)
+        return clip(_finite_probability_array(probabilities), 0.0, 1.0)
 
     def pairwise_probability_matrix_from_components(
         self, components: Mapping[str, Any]
@@ -210,6 +212,13 @@ class CalibratedPairwiseAssociationModel:
             if _is_positive_binary_label(class_label):
                 return class_index
         return 1
+
+
+def _finite_probability_array(probabilities: Any) -> Any:
+    probabilities = asarray(probabilities, dtype=float64)
+    if not all(isfinite(probabilities)):
+        raise ValueError("predicted probabilities must be finite")
+    return probabilities
 
 
 def _is_positive_binary_label(class_label: Any) -> bool:

--- a/tests/test_calibrated_association_nonfinite_probabilities.py
+++ b/tests/test_calibrated_association_nonfinite_probabilities.py
@@ -1,0 +1,53 @@
+import unittest
+
+from pyrecest.backend import array
+from pyrecest.utils import CalibratedPairwiseAssociationModel
+
+
+class NonfiniteMatchProbabilityModel:
+    def predict_match_probability(self, features):
+        del features
+        return array([0.2, float("nan")])
+
+
+class NonfinitePredictProbaModel:
+    classes_ = array([0, 1])
+
+    def predict_proba(self, features):
+        return array([[0.8, 0.2], [0.3, float("nan")]])[: features.shape[0]]
+
+
+class NonfiniteCostModel:
+    def pairwise_cost_matrix(self, features):
+        del features
+        return array([0.0, float("-inf")])
+
+
+class TestCalibratedAssociationNonfiniteProbabilities(unittest.TestCase):
+    def test_rejects_nonfinite_match_probabilities(self):
+        model = CalibratedPairwiseAssociationModel(
+            NonfiniteMatchProbabilityModel(), feature_names=("distance",)
+        )
+
+        with self.assertRaisesRegex(ValueError, "predicted probabilities must be finite"):
+            model.predict_match_probability(array([[0.1], [0.2]]))
+
+    def test_rejects_nonfinite_predict_proba_values(self):
+        model = CalibratedPairwiseAssociationModel(
+            NonfinitePredictProbaModel(), feature_names=("distance",)
+        )
+
+        with self.assertRaisesRegex(ValueError, "predicted probabilities must be finite"):
+            model.predict_match_probability(array([[0.1], [0.2]]))
+
+    def test_rejects_nonfinite_cost_derived_probabilities(self):
+        model = CalibratedPairwiseAssociationModel(
+            NonfiniteCostModel(), feature_names=("distance",)
+        )
+
+        with self.assertRaisesRegex(ValueError, "predicted probabilities must be finite"):
+            model.predict_match_probability(array([[0.1], [0.2]]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reject non-finite probabilities returned by calibrated association wrapper backends before clipping
- cover direct `predict_match_probability`, `predict_proba`, and cost-derived probability paths

## Bug
`CalibratedPairwiseAssociationModel.predict_match_probability()` converted external model outputs to floats and clipped them, but `NaN` survived clipping and `Inf` cost-derived probabilities could be silently clipped. This could propagate invalid association probabilities/costs into downstream assignment logic.

## Testing
- Not run locally; repository cloning/installing is unavailable in this sandbox. CI should run the added focused regression tests.