### PR TITLE
Validate transition sampler counts

### DIFF
--- a/src/pyrecest/models/likelihood.py
+++ b/src/pyrecest/models/likelihood.py
@@ -20,7 +20,10 @@ compatibility.
 from __future__ import annotations
 
 from inspect import Parameter, signature
+from numbers import Integral
 from typing import Any, Callable
+
+import numpy as np
 
 from pyrecest.protocols.models import (
     SupportsLikelihood,
@@ -35,6 +38,21 @@ from .validation import _validate_bool_flag
 def _ensure_callable(value: Any, name: str) -> None:
     if not callable(value):
         raise TypeError(f"{name} must be callable")
+
+
+def _validate_sample_count(value: Any) -> int:
+    """Return ``value`` as a nonnegative integer sample count."""
+
+    value_array = np.asarray(value)
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError("n must be a nonnegative integer.")
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)) or not isinstance(scalar, Integral):
+        raise ValueError("n must be a nonnegative integer.")
+    count = int(scalar)
+    if count < 0:
+        raise ValueError("n must be a nonnegative integer.")
+    return count
 
 
 def _sample_count_call_mode(callback: Callable[..., Any]) -> str | None:
@@ -180,6 +198,7 @@ class SampleableTransitionModel:
     def sample_next(self, state: Any, n: int = 1) -> Any:
         """Draw ``n`` next-state samples conditioned on ``state``."""
 
+        n = _validate_sample_count(n)
         if self._sample_next_count_call_mode == "positional":
             return self._sample_next(state, n)
         if self._sample_next_count_call_mode == "keyword":
@@ -231,6 +250,7 @@ class DensityTransitionModel:
 
         if self._sample_next is None:
             raise NotImplementedError("No sample_next callback was provided.")
+        n = _validate_sample_count(n)
         if self._sample_next_count_call_mode == "positional":
             return self._sample_next(state, n)
         if self._sample_next_count_call_mode == "keyword":

--- a/tests/models/test_transition_sample_count_validation.py
+++ b/tests/models/test_transition_sample_count_validation.py
@@ -1,0 +1,73 @@
+"""Regression tests for transition-sampler sample-count validation."""
+
+import unittest
+
+import numpy as np
+from pyrecest.backend import array
+from pyrecest.models import DensityTransitionModel, SampleableTransitionModel, sample_next_state
+
+
+class TransitionSampleCountValidationTest(unittest.TestCase):
+    def test_sampleable_transition_model_rejects_invalid_sample_counts(self):
+        calls = []
+
+        def sample_next(state, n=1):
+            calls.append(n)
+            return state
+
+        model = SampleableTransitionModel(sample_next)
+        invalid_counts = (
+            True,
+            False,
+            -1,
+            1.5,
+            "2",
+            b"2",
+            np.array([2]),
+            np.array(True, dtype=object),
+            np.array("2"),
+        )
+
+        for n in invalid_counts:
+            with self.subTest(n=n):
+                with self.assertRaisesRegex(ValueError, "n must be"):
+                    sample_next_state(model, array([0.0]), n=n)
+
+        self.assertEqual(calls, [])
+
+    def test_sampleable_transition_model_normalizes_numpy_integer_count(self):
+        calls = []
+
+        def sample_next(state, n=1):
+            calls.append(n)
+            return state
+
+        model = SampleableTransitionModel(sample_next)
+
+        sample_next_state(model, array([0.0]), n=np.array(2, dtype=np.int64))
+
+        self.assertEqual(calls, [2])
+        self.assertIs(type(calls[0]), int)
+
+    def test_density_transition_model_rejects_invalid_sample_counts(self):
+        calls = []
+
+        def transition_density(state_next, state_previous):
+            return 1.0 if state_next is state_previous else 0.0
+
+        def sample_next(state, n=1):
+            calls.append(n)
+            return state
+
+        model = DensityTransitionModel(transition_density, sample_next=sample_next)
+
+        for n in (True, -1, "2", np.array([2])):
+            with self.subTest(n=n):
+                with self.assertRaisesRegex(ValueError, "n must be"):
+                    model.sample_next(array([0.0]), n=n)
+
+        self.assertEqual(calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- validate transition-sampler `n` arguments before forwarding them to wrapped callbacks
- reject booleans, text-like values, negative counts, non-integers, and non-scalar arrays
- add focused regression coverage for `SampleableTransitionModel`, `DensityTransitionModel`, and the `sample_next_state` adapter

## Bug
`SampleableTransitionModel.sample_next()` and `DensityTransitionModel.sample_next()` previously forwarded `n` directly to the wrapped sampler. Values such as `True`, `"2"`, negative integers, or non-scalar arrays could therefore be interpreted by user callbacks as valid sample counts, or fail later with callback-specific errors. The wrapper API now enforces a scalar nonnegative integer contract and normalizes NumPy integer scalars to plain `int`.

## Validation
- `python -m py_compile /mnt/data/likelihood.py`
- `python -m py_compile /mnt/data/tests/models/test_transition_sample_count_validation.py`

Full pytest was not run locally because this environment cannot clone/install the repository from GitHub; CI should run the new focused tests on the PR.