### PR TITLE
Treat pandas NA track IDs as missing in diagnostics

### DIFF
--- a/src/pyrecest/evaluation/diagnostic_summaries.py
+++ b/src/pyrecest/evaluation/diagnostic_summaries.py
@@ -311,6 +311,11 @@ def _optional_float(value: Any) -> float | None:
 
 def _is_nan(value: Any) -> bool:
     try:
+        if bool(value != value):
+            return True
+    except (TypeError, ValueError):
+        return True
+    try:
         return bool(math.isnan(float(value)))
     except OverflowError:
         return True

--- a/tests/evaluation/test_diagnostic_summaries.py
+++ b/tests/evaluation/test_diagnostic_summaries.py
@@ -2,6 +2,7 @@ import math
 import unittest
 
 import numpy as np
+import pandas as pd
 from pyrecest.evaluation.diagnostic_summaries import (
     build_diagnostic_summary,
     covariance_inflation_summary,
@@ -61,6 +62,21 @@ class DiagnosticSummariesTest(unittest.TestCase):
     def test_track_switch_summary_counts_transitions(self):
         summary = track_switch_summary(self.records)
 
+        self.assertEqual(summary["count"], 1)
+        self.assertEqual(summary["top_transitions"][0]["from_track_id"], "A")
+        self.assertEqual(summary["top_transitions"][0]["to_track_id"], "B")
+
+    def test_track_switch_summary_treats_pandas_na_track_ids_as_missing(self):
+        records = [
+            {"time_s": 0.0, "track_id": "A"},
+            {"time_s": 1.0, "track_id": pd.NA},
+            {"time_s": 2.0, "track_id": "A"},
+            {"time_s": 3.0, "track_id": "B"},
+        ]
+
+        summary = track_switch_summary(records)
+
+        self.assertEqual(summary["updates_with_track_id"], 3)
         self.assertEqual(summary["count"], 1)
         self.assertEqual(summary["top_transitions"][0]["from_track_id"], "A")
         self.assertEqual(summary["top_transitions"][0]["to_track_id"], "B")


### PR DESCRIPTION
## Summary
- Treat missing-like track IDs whose equality is ambiguous, for example pandas `pd.NA`, as missing in diagnostic track-switch summaries.
- Add regression coverage so missing track IDs are skipped and do not trigger ambiguous boolean comparisons.

## Bug
`track_switch_summary()` previously only considered values missing when `math.isnan(float(value))` succeeded. `pd.NA` raises `TypeError` there, so it was retained as a track ID; later `current_id != previous_id` could produce `pd.NA`, and the `if` statement could raise `TypeError: boolean value of NA is ambiguous`.

## Testing
- Not run locally; the sandbox cannot clone/install the repository.