### PR TITLE
Reject bool and text bias calibration arrays

### DIFF
--- a/src/pyrecest/calibration/bias.py
+++ b/src/pyrecest/calibration/bias.py
@@ -50,13 +50,13 @@ class SensorBiasCorrectionModel:
     def __post_init__(self) -> None:
         target_dim = _as_positive_int(self.target_dim, "target_dim")
         feature_dim = _as_nonnegative_int(self.feature_dim, "feature_dim")
-        intercept = np.asarray(self.intercept, dtype=float).reshape(target_dim)
-        coefficients = np.asarray(self.coefficients, dtype=float).reshape(
+        intercept = _as_numeric_array(self.intercept, "intercept").reshape(target_dim)
+        coefficients = _as_numeric_array(self.coefficients, "coefficients").reshape(
             feature_dim, target_dim
         )
-        feature_mean = np.asarray(self.feature_mean, dtype=float).reshape(feature_dim)
-        feature_scale = np.asarray(self.feature_scale, dtype=float).reshape(feature_dim)
-        residual_std = np.asarray(self.residual_std, dtype=float).reshape(target_dim)
+        feature_mean = _as_numeric_array(self.feature_mean, "feature_mean").reshape(feature_dim)
+        feature_scale = _as_numeric_array(self.feature_scale, "feature_scale").reshape(feature_dim)
+        residual_std = _as_numeric_array(self.residual_std, "residual_std").reshape(target_dim)
         feature_scale = np.where(
             np.isfinite(feature_scale) & (feature_scale > 0.0), feature_scale, 1.0
         )
@@ -152,11 +152,11 @@ class SensorBiasCorrectionModel:
         return cls(
             target_dim=payload["target_dim"],
             feature_dim=payload["feature_dim"],
-            intercept=np.asarray(payload["intercept"], dtype=float),
-            coefficients=np.asarray(payload["coefficients"], dtype=float),
-            feature_mean=np.asarray(payload["feature_mean"], dtype=float),
-            feature_scale=np.asarray(payload["feature_scale"], dtype=float),
-            residual_std=np.asarray(payload["residual_std"], dtype=float),
+            intercept=payload["intercept"],
+            coefficients=payload["coefficients"],
+            feature_mean=payload["feature_mean"],
+            feature_scale=payload["feature_scale"],
+            residual_std=payload["residual_std"],
             training_count=payload["training_count"],
             ridge_alpha=payload.get("ridge_alpha", 0.0),
             metadata=payload.get("metadata", {}),
@@ -175,9 +175,9 @@ def make_bias_training_examples(
     """Match measurements to nearest reference values and compute residual bias."""
 
     max_time_delta = _validate_max_time_delta(max_time_delta_s)
-    measurement_times = np.asarray(measurement_times_s, dtype=float).reshape(-1)
+    measurement_times = _as_numeric_vector(measurement_times_s, "measurement_times_s")
     measurements = _as_2d(measurement_values, "measurement_values")
-    reference_times = np.asarray(reference_times_s, dtype=float).reshape(-1)
+    reference_times = _as_numeric_vector(reference_times_s, "reference_times_s")
     references = _as_2d(reference_values, "reference_values")
     if measurement_times.size != measurements.shape[0]:
         raise ValueError(
@@ -319,8 +319,36 @@ def fit_sensor_bias_correction(
     )
 
 
+def _as_numeric_array(values: Any, name: str) -> np.ndarray:
+    try:
+        raw = np.asarray(values)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must contain numeric values") from exc
+    if _contains_bool_or_text(raw):
+        raise ValueError(f"{name} must contain numeric values")
+    try:
+        return np.asarray(values, dtype=float)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must contain numeric values") from exc
+
+
+def _as_numeric_vector(values: Any, name: str) -> np.ndarray:
+    return _as_numeric_array(values, name).reshape(-1)
+
+
+def _contains_bool_or_text(values: np.ndarray) -> bool:
+    if values.dtype.kind in "bUS":
+        return True
+    if values.dtype == object:
+        return any(
+            isinstance(item, (bool, np.bool_, str, bytes, bytearray))
+            for item in values.reshape(-1)
+        )
+    return False
+
+
 def _as_2d(values: np.ndarray, name: str) -> np.ndarray:
-    out = np.asarray(values, dtype=float)
+    out = _as_numeric_array(values, name)
     if out.ndim == 1:
         return out.reshape(-1, 1)
     if out.ndim != 2:

--- a/tests/calibration/test_bias_numeric_validation.py
+++ b/tests/calibration/test_bias_numeric_validation.py
@@ -1,0 +1,1 @@
+# placeholder

--- a/tests/calibration/test_bias_numeric_validation.py
+++ b/tests/calibration/test_bias_numeric_validation.py
@@ -1,1 +1,8 @@
-# placeholder
+import numpy as np
+import pytest
+
+from pyrecest.calibration.bias import SensorBiasCorrectionModel
+
+
+def test_placeholder():
+    assert True

--- a/tests/calibration/test_bias_numeric_validation.py
+++ b/tests/calibration/test_bias_numeric_validation.py
@@ -1,7 +1,10 @@
 import numpy as np
 import pytest
 
-from pyrecest.calibration.bias import SensorBiasCorrectionModel
+from pyrecest.calibration.bias import (
+    SensorBiasCorrectionModel,
+    make_bias_training_examples,
+)
 
 
 def _unit_feature_model_kwargs():
@@ -36,3 +39,15 @@ def test_model_rejects_boolean_array_field_before_float_coercion():
         SensorBiasCorrectionModel(**kwargs)
 
     assert "coefficients must contain numeric values" in str(exc_info.value)
+
+
+def test_make_bias_training_examples_rejects_text_times_before_float_coercion():
+    with pytest.raises(ValueError) as exc_info:
+        make_bias_training_examples(
+            measurement_times_s=np.array(["0.0", "1.0"]),
+            measurement_values=np.array([[1.0], [2.0]]),
+            reference_times_s=np.array([0.0, 1.0]),
+            reference_values=np.array([[1.5], [2.5]]),
+        )
+
+    assert "measurement_times_s must contain numeric values" in str(exc_info.value)

--- a/tests/calibration/test_bias_numeric_validation.py
+++ b/tests/calibration/test_bias_numeric_validation.py
@@ -4,5 +4,35 @@ import pytest
 from pyrecest.calibration.bias import SensorBiasCorrectionModel
 
 
-def test_placeholder():
-    assert True
+def _unit_feature_model_kwargs():
+    return {
+        "target_dim": 1,
+        "feature_dim": 1,
+        "intercept": np.array([0.0]),
+        "coefficients": np.array([[1.0]]),
+        "feature_mean": np.array([0.0]),
+        "feature_scale": np.array([1.0]),
+        "residual_std": np.array([0.0]),
+        "training_count": 2,
+        "ridge_alpha": 0.0,
+    }
+
+
+def test_model_rejects_text_array_field_before_float_coercion():
+    kwargs = _unit_feature_model_kwargs()
+    kwargs["intercept"] = np.array(["0.0"])
+
+    with pytest.raises(ValueError) as exc_info:
+        SensorBiasCorrectionModel(**kwargs)
+
+    assert "intercept must contain numeric values" in str(exc_info.value)
+
+
+def test_model_rejects_boolean_array_field_before_float_coercion():
+    kwargs = _unit_feature_model_kwargs()
+    kwargs["coefficients"] = np.array([[True]])
+
+    with pytest.raises(ValueError) as exc_info:
+        SensorBiasCorrectionModel(**kwargs)
+
+    assert "coefficients must contain numeric values" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- Validate bias calibration array inputs before float coercion.
- Reject boolean and text-like values in model array fields and timestamped training-example arrays.
- Add focused regression coverage for boolean/text array rejection in bias calibration.

## Bug
`src/pyrecest/calibration/bias.py` converted model and training arrays with `np.asarray(..., dtype=float)`. That silently accepted malformed inputs such as boolean arrays or numeric-looking text arrays, turning them into ordinary floating-point calibration data and hiding data/configuration errors.

## Validation
- `python -m py_compile /tmp/bias.py`
- `PYTHONPATH=/tmp python -m pytest -q /tmp/tests/calibration/test_bias.py /tmp/tests/calibration/test_bias_prediction_row_count.py /tmp/tests/calibration/test_bias_numeric_validation.py` — 33 passed