### PR TITLE
Reject nonnumeric time-offset arrays

### DIFF
--- a/src/pyrecest/calibration/time_offset.py
+++ b/src/pyrecest/calibration/time_offset.py
@@ -104,6 +104,23 @@ def _as_nonnegative_time_delta(value: Any, name: str) -> float:
     return result
 
 
+def _as_real_numeric_array(value: Any, name: str) -> np.ndarray:
+    """Return ``value`` as a real float array without silent text/bool coercion."""
+
+    arr = np.asarray(value)
+    if arr.dtype == np.bool_ or arr.dtype.kind in "USbcMm":
+        raise ValueError(f"{name} must contain real numeric values")
+    if arr.dtype == object:
+        flat = arr.reshape(-1)
+        for item in flat:
+            if isinstance(item, (bool, np.bool_, str, bytes, bytearray)):
+                raise ValueError(f"{name} must contain real numeric values")
+    try:
+        return np.asarray(value, dtype=float)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must contain real numeric values") from exc
+
+
 def make_offset_grid(min_s: float, max_s: float, step_s: float) -> np.ndarray:
     """Return an inclusive offset grid rounded to nanosecond precision."""
 
@@ -125,7 +142,7 @@ def apply_time_offset(times_s: np.ndarray, offset_s: float | None) -> np.ndarray
     """Return a copy of ``times_s`` shifted by ``offset_s`` seconds."""
 
     offset = 0.0 if offset_s is None else _as_finite_float(offset_s, "offset_s")
-    return np.asarray(times_s, dtype=float) + offset
+    return _as_real_numeric_array(times_s, "times_s") + offset
 
 
 def _validate_max_time_delta(max_time_delta_s: float | None) -> float | None:
@@ -140,10 +157,10 @@ def _finite_reference_rows(
 ) -> np.ndarray:
     """Return a mask selecting reference rows that are usable for matching."""
 
-    reference_times = np.asarray(reference_times_s, dtype=float).reshape(-1)
+    reference_times = _as_real_numeric_array(reference_times_s, "reference_times_s").reshape(-1)
     finite = np.isfinite(reference_times)
     if reference_values is not None:
-        values = np.asarray(reference_values, dtype=float)
+        values = _as_real_numeric_array(reference_values, "reference_values")
         if values.ndim == 1:
             values = values.reshape(-1, 1)
         finite &= np.isfinite(values).all(axis=1)
@@ -158,8 +175,8 @@ def nearest_time_indices(
     Non-finite query times have no nearest reference time and are marked as ``-1``.
     """
 
-    reference = np.asarray(reference_times_s, dtype=float).reshape(-1)
-    query = np.asarray(query_times_s, dtype=float).reshape(-1)
+    reference = _as_real_numeric_array(reference_times_s, "reference_times_s").reshape(-1)
+    query = _as_real_numeric_array(query_times_s, "query_times_s").reshape(-1)
     finite_reference = _finite_reference_rows(reference)
     if not finite_reference.any():
         raise ValueError("reference_times_s must contain at least one finite value")
@@ -194,9 +211,9 @@ def interpolate_reference_values(
     """Interpolate reference values at query times and return a validity mask."""
 
     max_time_delta = _validate_max_time_delta(max_time_delta_s)
-    reference_times = np.asarray(reference_times_s, dtype=float).reshape(-1)
-    reference_values = np.asarray(reference_values, dtype=float)
-    query_times = np.asarray(query_times_s, dtype=float).reshape(-1)
+    reference_times = _as_real_numeric_array(reference_times_s, "reference_times_s").reshape(-1)
+    reference_values = _as_real_numeric_array(reference_values, "reference_values")
+    query_times = _as_real_numeric_array(query_times_s, "query_times_s").reshape(-1)
     if reference_values.ndim not in (1, 2):
         raise ValueError("reference_values must be one- or two-dimensional")
     if reference_values.ndim == 1:
@@ -243,7 +260,7 @@ def time_offset_error_summary(
 ) -> dict[str, float]:
     """Evaluate one candidate offset against a reference trajectory."""
 
-    measurement_values = np.asarray(measurement_values, dtype=float)
+    measurement_values = _as_real_numeric_array(measurement_values, "measurement_values")
     if measurement_values.ndim == 1:
         measurement_values = measurement_values.reshape(-1, 1)
     elif measurement_values.ndim != 2:
@@ -259,7 +276,7 @@ def time_offset_error_summary(
         query_times,
         max_time_delta_s=max_time_delta_s,
     )
-    if reference_at_query.shape[1] != measurement_values.shape[1]:
+    if measurement_values.shape[1] != reference_at_query.shape[1]:
         raise ValueError(
             "measurement_values and reference_values must have the same value dimension"
         )

--- a/tests/calibration/test_time_offset_numeric_arrays.py
+++ b/tests/calibration/test_time_offset_numeric_arrays.py
@@ -1,0 +1,149 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+from pyrecest.calibration.time_offset import (
+    apply_time_offset,
+    interpolate_reference_values,
+    nearest_time_indices,
+    time_offset_error_summary,
+)
+
+
+class TimeOffsetNumericArrayValidationTest(unittest.TestCase):
+    def assert_rejects_numeric_array(self, func, expected_name, *args):
+        with self.assertRaisesRegex(
+            ValueError,
+            f"{expected_name} must contain real numeric values",
+        ):
+            func(*args)
+
+    def test_apply_time_offset_rejects_bool_and_text_time_arrays(self):
+        invalid_times = (
+            np.array([False, True]),
+            np.array(["0.0", "1.0"]),
+            np.array([0.0, "1.0"], dtype=object),
+            np.array([0.0, b"1.0"], dtype=object),
+        )
+        for times_s in invalid_times:
+            with self.subTest(dtype=times_s.dtype, values=times_s):
+                self.assert_rejects_numeric_array(
+                    apply_time_offset,
+                    "times_s",
+                    times_s,
+                    0.0,
+                )
+
+    def test_nearest_time_indices_rejects_bool_and_text_time_arrays(self):
+        cases = (
+            (
+                np.array([False, True]),
+                np.array([0.25]),
+                "reference_times_s",
+            ),
+            (
+                np.array(["0.0", "1.0"]),
+                np.array([0.25]),
+                "reference_times_s",
+            ),
+            (
+                np.array([0.0, 1.0]),
+                np.array([False]),
+                "query_times_s",
+            ),
+            (
+                np.array([0.0, 1.0]),
+                np.array(["0.25"]),
+                "query_times_s",
+            ),
+        )
+        for reference_times_s, query_times_s, expected_name in cases:
+            with self.subTest(expected_name=expected_name):
+                self.assert_rejects_numeric_array(
+                    nearest_time_indices,
+                    expected_name,
+                    reference_times_s,
+                    query_times_s,
+                )
+
+    def test_interpolation_rejects_bool_and_text_data_arrays(self):
+        numeric_times = np.array([0.0, 1.0])
+        numeric_values = np.array([[0.0], [1.0]])
+        numeric_query = np.array([0.25])
+        cases = (
+            (
+                np.array([False, True]),
+                numeric_values,
+                numeric_query,
+                "reference_times_s",
+            ),
+            (
+                np.array(["0.0", "1.0"]),
+                numeric_values,
+                numeric_query,
+                "reference_times_s",
+            ),
+            (
+                numeric_times,
+                np.array([[False], [True]]),
+                numeric_query,
+                "reference_values",
+            ),
+            (
+                numeric_times,
+                np.array([["0.0"], ["1.0"]]),
+                numeric_query,
+                "reference_values",
+            ),
+            (
+                numeric_times,
+                numeric_values,
+                np.array([False]),
+                "query_times_s",
+            ),
+            (
+                numeric_times,
+                numeric_values,
+                np.array(["0.25"]),
+                "query_times_s",
+            ),
+        )
+        for reference_times_s, reference_values, query_times_s, expected_name in cases:
+            with self.subTest(expected_name=expected_name):
+                self.assert_rejects_numeric_array(
+                    interpolate_reference_values,
+                    expected_name,
+                    reference_times_s,
+                    reference_values,
+                    query_times_s,
+                )
+
+    def test_time_offset_summary_rejects_bool_and_text_measurement_values(self):
+        reference_times = np.array([0.0, 1.0])
+        reference_values = np.array([[0.0], [1.0]])
+        for measurement_values in (np.array([True]), np.array(["0.0"])):
+            with self.subTest(dtype=measurement_values.dtype):
+                self.assert_rejects_numeric_array(
+                    time_offset_error_summary,
+                    "measurement_values",
+                    np.array([0.0]),
+                    measurement_values,
+                    reference_times,
+                    reference_values,
+                    0.0,
+                )
+
+    def test_interpolation_accepts_numeric_object_arrays(self):
+        interpolated, valid = interpolate_reference_values(
+            np.array([0, 1], dtype=object),
+            np.array([[0.0], [1.0]], dtype=object),
+            np.array([0.25], dtype=object),
+        )
+
+        npt.assert_allclose(interpolated, np.array([[0.25]]))
+        npt.assert_array_equal(valid, np.array([True]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a shared real-numeric array validator for time-offset calibration inputs
- reject boolean, text, bytes, complex, datetime, and timedelta arrays before float coercion
- cover public time-offset APIs with regression tests while preserving numeric object arrays

## Bug
The time-offset calibration utilities converted public data arrays with `np.asarray(..., dtype=float)`. That silently accepted malformed inputs such as boolean arrays or numeric-looking text/bytes arrays, treating them as ordinary timestamps or measurement/reference values and hiding data/configuration errors.

This is separate from the open bias-calibration array validation PR; it hardens `calibration/time_offset.py` paths such as `apply_time_offset`, `nearest_time_indices`, `interpolate_reference_values`, and `time_offset_error_summary`.

## Validation
- `python -m py_compile /tmp/time_offset_patched.py`
- `PYTHONPATH=/tmp/testpkg python -m pytest -q /tmp/testpkg/tests/calibration/test_time_offset_numeric_arrays.py` — 5 passed, 16 subtests passed

Full repository test suite was not run locally because this environment cannot clone the repository directly; CI should run the full matrix on the PR.