### PR TITLE
Reject bool and text Gaussian hypothesis inputs

### DIFF
--- a/src/pyrecest/filters/gaussian_hypothesis_mixture.py
+++ b/src/pyrecest/filters/gaussian_hypothesis_mixture.py
@@ -7,6 +7,9 @@ from typing import Any
 
 import numpy as np
 
+_TEXT_OR_BOOL_KINDS = {"b", "S", "U"}
+_TEXT_OR_BOOL_SCALAR_TYPES = (bool, np.bool_, str, bytes, bytearray, np.str_, np.bytes_)
+
 
 @dataclass(frozen=True)
 class WeightedGaussianHypothesis:
@@ -18,17 +21,15 @@ class WeightedGaussianHypothesis:
     metadata: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
-        mean = np.asarray(self.mean, dtype=float).reshape(-1)
-        covariance = np.asarray(self.covariance, dtype=float)
+        mean = _as_float_array(self.mean, "mean").reshape(-1)
+        covariance = _as_float_array(self.covariance, "covariance")
         if not np.all(np.isfinite(mean)):
             raise ValueError("mean must contain only finite values")
         if covariance.shape != (mean.size, mean.size):
             raise ValueError("covariance must match mean dimension")
         if not np.all(np.isfinite(covariance)):
             raise ValueError("covariance must contain only finite values")
-        log_weight = float(self.log_weight)
-        if np.isnan(log_weight):
-            raise ValueError("log_weight must not be NaN")
+        log_weight = _as_log_weight(self.log_weight)
         object.__setattr__(self, "mean", mean)
         object.__setattr__(self, "covariance", _symmetrized(covariance))
         object.__setattr__(self, "log_weight", log_weight)
@@ -64,7 +65,7 @@ def moment_match_gaussian_hypotheses(
 
 def normalize_log_weights(log_weights: list[float] | np.ndarray) -> np.ndarray:
     """Normalize log weights to probabilities in a numerically stable way."""
-    values = np.asarray(log_weights, dtype=float).reshape(-1)
+    values = _as_float_array(log_weights, "log_weights").reshape(-1)
     if values.size == 0:
         raise ValueError("log_weights must not be empty")
     if np.any(np.isnan(values)):
@@ -86,6 +87,32 @@ def normalize_log_weights(log_weights: list[float] | np.ndarray) -> np.ndarray:
     return weights / total
 
 
+def _as_float_array(value: Any, name: str) -> np.ndarray:
+    try:
+        array = np.asarray(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must contain numeric values") from exc
+    if array.dtype.kind in _TEXT_OR_BOOL_KINDS or (
+        array.dtype.kind == "O"
+        and any(isinstance(item, _TEXT_OR_BOOL_SCALAR_TYPES) for item in array.flat)
+    ):
+        raise ValueError(f"{name} must contain numeric values")
+    try:
+        return array.astype(float, copy=False)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must contain numeric values") from exc
+
+
+def _as_log_weight(value: Any) -> float:
+    array = _as_float_array(value, "log_weight")
+    if array.shape != ():
+        raise ValueError("log_weight must be a scalar number")
+    log_weight = float(array.item())
+    if np.isnan(log_weight):
+        raise ValueError("log_weight must not be NaN")
+    return log_weight
+
+
 def _symmetrized(matrix: np.ndarray) -> np.ndarray:
-    array = np.asarray(matrix, dtype=float)
+    array = _as_float_array(matrix, "matrix")
     return 0.5 * (array + array.T)

--- a/tests/filters/test_gaussian_hypothesis_mixture.py
+++ b/tests/filters/test_gaussian_hypothesis_mixture.py
@@ -40,6 +40,18 @@ class GaussianHypothesisMixtureTest(unittest.TestCase):
                 ]
             )
 
+    def test_log_weights_reject_bool_and_text_inputs(self):
+        invalid_log_weights = (
+            [True, False],
+            np.array([True, False]),
+            ["0.0", "1.0"],
+            np.array(["0.0", "1.0"]),
+        )
+        for log_weights in invalid_log_weights:
+            with self.subTest(log_weights=log_weights):
+                with self.assertRaisesRegex(ValueError, "log_weights"):
+                    normalize_log_weights(log_weights)
+
     def test_hypotheses_reject_nonfinite_mean_and_covariance(self):
         with self.assertRaisesRegex(ValueError, "mean"):
             WeightedGaussianHypothesis(np.array([np.nan]), np.array([[1.0]]))
@@ -52,6 +64,52 @@ class GaussianHypothesisMixtureTest(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "covariance"):
             WeightedGaussianHypothesis(np.array([0.0]), np.array([[np.inf]]))
+
+    def test_hypotheses_reject_bool_and_text_numeric_fields(self):
+        invalid_cases = [
+            {
+                "mean": np.array([True]),
+                "covariance": np.array([[1.0]]),
+                "log_weight": 0.0,
+                "message": "mean",
+            },
+            {
+                "mean": np.array(["0.0"]),
+                "covariance": np.array([[1.0]]),
+                "log_weight": 0.0,
+                "message": "mean",
+            },
+            {
+                "mean": np.array([0.0]),
+                "covariance": np.array([[True]]),
+                "log_weight": 0.0,
+                "message": "covariance",
+            },
+            {
+                "mean": np.array([0.0]),
+                "covariance": np.array([["1.0"]]),
+                "log_weight": 0.0,
+                "message": "covariance",
+            },
+            {
+                "mean": np.array([0.0]),
+                "covariance": np.array([[1.0]]),
+                "log_weight": True,
+                "message": "log_weight",
+            },
+            {
+                "mean": np.array([0.0]),
+                "covariance": np.array([[1.0]]),
+                "log_weight": "0.0",
+                "message": "log_weight",
+            },
+        ]
+        for case in invalid_cases:
+            with self.subTest(case=case):
+                with self.assertRaisesRegex(ValueError, case["message"]):
+                    WeightedGaussianHypothesis(
+                        case["mean"], case["covariance"], log_weight=case["log_weight"]
+                    )
 
     def test_moment_matching_rejects_mixed_state_dimensions(self):
         with self.assertRaisesRegex(ValueError, "same dimension"):


### PR DESCRIPTION
## Summary
- Reject boolean and text-valued inputs before converting Gaussian hypothesis means, covariances, and log weights to floats.
- Reuse the guarded conversion path for `normalize_log_weights()` so malformed log-weight sequences no longer become ordinary numeric weights.
- Add regression tests for boolean and numeric-looking text inputs.

## Bug
`WeightedGaussianHypothesis` and `normalize_log_weights()` previously used `np.asarray(..., dtype=float)` / `float(...)` directly. Inputs such as `[True, False]`, `['0.0', '1.0']`, `log_weight=True`, or `log_weight='0.0'` were silently accepted as numeric Gaussian hypothesis data, which can hide malformed configuration or serialization errors in mixture scoring.

## Validation
- Inspected the branch with GitHub compare: only `src/pyrecest/filters/gaussian_hypothesis_mixture.py` and `tests/filters/test_gaussian_hypothesis_mixture.py` changed.
- Full pytest was not run locally; CI should run the focused regression tests.