### PR TITLE
Reject nonnumeric random uniform bounds

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/random.py
+++ b/src/pyrecest/_backend/_shared_numpy/random.py
@@ -27,9 +27,18 @@ rand = _modify_func_default_dtype(
 )
 
 
-def _validate_uniform_bounds(low, high):
-    if _np.any(~_np.isfinite(low)) or _np.any(~_np.isfinite(high)):
+def _validate_uniform_bound_array(bound, name):
+    if bound.dtype.kind == "b":
+        raise TypeError(f"{name} must be real numeric, not boolean")
+    if bound.dtype.kind not in "iuf":
+        raise TypeError(f"{name} must be real numeric")
+    if _np.any(~_np.isfinite(bound)):
         raise ValueError("uniform bounds must be finite")
+
+
+def _validate_uniform_bounds(low, high):
+    _validate_uniform_bound_array(low, "low")
+    _validate_uniform_bound_array(high, "high")
     if _np.any(low > high):
         raise ValueError("Upper bound must be greater than or equal to lower bound")
 
@@ -44,7 +53,6 @@ def _uniform(low=0.0, high=1.0, size=None):
 uniform = _modify_func_default_dtype(
     copy=False, kw_only=True, target=_allow_complex_dtype(target=_uniform)
 )
-
 
 normal = _modify_func_default_dtype(
     copy=False, kw_only=True, target=_allow_complex_dtype(target=_np.random.normal)

--- a/tests/backend/test_numpy_random_backend.py
+++ b/tests/backend/test_numpy_random_backend.py
@@ -24,6 +24,32 @@ def test_rand_rejects_ambiguous_positional_and_size_arguments():
         random.rand(2, size=(3,))
 
 
+@pytest.mark.parametrize(
+    ("low", "high"),
+    [
+        (False, 1.0),
+        (0.0, True),
+        (np.array([False, False]), np.array([1.0, 2.0])),
+    ],
+)
+def test_uniform_rejects_boolean_bounds(low, high):
+    with pytest.raises(TypeError, match="real numeric"):
+        random.uniform(low, high)
+
+
+@pytest.mark.parametrize(
+    ("low", "high"),
+    [
+        ("0.0", 1.0),
+        (0.0, "1.0"),
+        (np.array(["0.0", "0.5"]), np.array([1.0, 1.5])),
+    ],
+)
+def test_uniform_rejects_text_bounds(low, high):
+    with pytest.raises(TypeError, match="real numeric"):
+        random.uniform(low, high)
+
+
 def test_choice_without_replacement_shuffle_false_preserves_order():
     values = np.array([10, 20, 30, 40, 50])
     matrix = np.array([[10, 20, 30], [40, 50, 60]])


### PR DESCRIPTION
## Summary
- Reject boolean `random.uniform` bounds before NumPy silently coerces them to `0.0`/`1.0`.
- Reject text and other non-real-numeric bound dtypes with a consistent `TypeError` before the finiteness/order checks.
- Add regression coverage for boolean and text `low`/`high` inputs.

## Testing
- Not run locally; sandbox cannot resolve `github.com` to clone/install the repository. The change is limited to the NumPy shared random backend and targeted unit tests.