### PR TITLE
Accept array-like Dirac reweigh outputs

### DIFF
--- a/src/pyrecest/distributions/abstract_dirac_distribution.py
+++ b/src/pyrecest/distributions/abstract_dirac_distribution.py
@@ -98,7 +98,7 @@ class AbstractDiracDistribution(AbstractDistributionType):
 
     def reweigh(self, f: Callable) -> "AbstractDiracDistribution":
         dist = copy.deepcopy(self)
-        w_new = f(dist.d)
+        w_new = asarray(f(dist.d))
 
         if w_new.shape != dist.w.shape:
             raise ValueError("Function returned wrong output dimensions.")

--- a/tests/distributions/test_abstract_dirac_distribution.py
+++ b/tests/distributions/test_abstract_dirac_distribution.py
@@ -167,6 +167,17 @@ class TestAbstractDiracDistribution(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "wrong output dimensions"):
             dist.reweigh(lambda _: array([[1.0, 1.0]]))
 
+    def test_reweigh_accepts_array_like_output_weights(self):
+        dist = LinearDiracDistribution(
+            array([[0.0], [1.0]]),
+            array([0.25, 0.75]),
+        )
+
+        reweighted = dist.reweigh(lambda _: [2.0, 1.0])
+
+        npt.assert_allclose(reweighted.w, array([0.4, 0.6]))
+        npt.assert_allclose(dist.w, array([0.25, 0.75]))
+
     def test_reweigh_rejects_zero_posterior_weight_mass(self):
         dist = LinearDiracDistribution(
             array(


### PR DESCRIPTION
## Summary
- Convert `AbstractDiracDistribution.reweigh()` outputs with the backend `asarray` helper before shape validation.
- Preserve existing wrong-shape validation while allowing natural array-like return values such as Python lists.
- Add a regression test covering list-valued reweighting outputs and verifying the original distribution is unchanged.

## Testing
- Not run locally; change was made through the GitHub connector. CI should run on this PR.