### PR TITLE
Reject malformed implicit-surface numeric inputs

### DIFF
--- a/src/pyrecest/evaluation/implicit_surfaces.py
+++ b/src/pyrecest/evaluation/implicit_surfaces.py
@@ -8,8 +8,18 @@ from typing import Any
 import numpy as np
 from scipy.special import ndtr
 
-_TEXT_OR_BOOL_KINDS = {"b", "S", "U"}
-_TEXT_OR_BOOL_SCALAR_TYPES = (bool, np.bool_, str, bytes, bytearray, np.str_, np.bytes_)
+_INVALID_NUMERIC_KINDS = {"b", "S", "U", "c", "M", "m"}
+_INVALID_NUMERIC_SCALAR_TYPES = (
+    bool,
+    np.bool_,
+    str,
+    bytes,
+    bytearray,
+    np.str_,
+    np.bytes_,
+    complex,
+    np.complexfloating,
+)
 
 
 def surface_residuals(surface: Any, points: Any) -> Any:
@@ -95,11 +105,11 @@ def _boolean_flag(name: str, value: bool) -> bool:
 def _positive_float(name: str, value: float) -> float:
     message = f"{name} must be finite and positive."
     value_array = np.asarray(value)
-    if value_array.shape != () or value_array.dtype.kind in _TEXT_OR_BOOL_KINDS:
+    if value_array.shape != () or value_array.dtype.kind in _INVALID_NUMERIC_KINDS:
         raise ValueError(message)
 
     scalar = value_array.item()
-    if isinstance(scalar, _TEXT_OR_BOOL_SCALAR_TYPES):
+    if isinstance(scalar, _INVALID_NUMERIC_SCALAR_TYPES):
         raise ValueError(message)
     try:
         parsed = float(scalar)
@@ -139,9 +149,9 @@ def _as_numpy_numeric_array(values: Any, name: str) -> np.ndarray:
         array = np.asarray(values)
     except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError(f"{name} must contain numeric values.") from exc
-    if array.dtype.kind in _TEXT_OR_BOOL_KINDS or (
+    if array.dtype.kind in _INVALID_NUMERIC_KINDS or (
         array.dtype.kind == "O"
-        and any(isinstance(item, _TEXT_OR_BOOL_SCALAR_TYPES) for item in array.flat)
+        and any(isinstance(item, _INVALID_NUMERIC_SCALAR_TYPES) for item in array.flat)
     ):
         raise ValueError(f"{name} must contain numeric values.")
     try:

--- a/src/pyrecest/evaluation/implicit_surfaces.py
+++ b/src/pyrecest/evaluation/implicit_surfaces.py
@@ -8,6 +8,9 @@ from typing import Any
 import numpy as np
 from scipy.special import ndtr
 
+_TEXT_OR_BOOL_KINDS = {"b", "S", "U"}
+_TEXT_OR_BOOL_SCALAR_TYPES = (bool, np.bool_, str, bytes, bytearray, np.str_, np.bytes_)
+
 
 def surface_residuals(surface: Any, points: Any) -> Any:
     """Return scalar-field residuals for ``points`` via ``surface.value``."""
@@ -33,7 +36,7 @@ def surface_variances(surface: Any, points: Any) -> Any:
 def surface_band_mask(values: Any, threshold: float) -> np.ndarray:
     """Return a mask for values within ``[-threshold, threshold]``."""
     threshold = _positive_float("threshold", threshold)
-    array = np.asarray(values, dtype=np.float64)
+    array = _as_numpy_numeric_array(values, "values")
     return np.isfinite(array) & (np.abs(array) <= threshold)
 
 
@@ -45,7 +48,7 @@ def classify_inside_outside(values: Any, *, negative_inside: bool = True) -> np.
     convention.
     """
     negative_inside = _boolean_flag("negative_inside", negative_inside)
-    array = np.asarray(values, dtype=np.float64)
+    array = _as_numpy_numeric_array(values, "values")
     labels = np.zeros(array.shape, dtype=np.int8)
     finite = np.isfinite(array)
     if negative_inside:
@@ -69,7 +72,7 @@ def surface_band_probability_from_signed_distance(
     epsilon = _positive_float("epsilon", epsilon)
     min_std = _positive_float("min_std", min_std)
     cdf = ndtr if normal_cdf is None else normal_cdf
-    distance = _as_numeric_field(distance)
+    distance = _as_numeric_field(distance, "distance")
     distance_std = _nonnegative_finite_numeric_field(distance_std, "distance_std")
     std = _maximum(distance_std, min_std)
     upper = (epsilon - distance) / std
@@ -92,11 +95,11 @@ def _boolean_flag(name: str, value: bool) -> bool:
 def _positive_float(name: str, value: float) -> float:
     message = f"{name} must be finite and positive."
     value_array = np.asarray(value)
-    if value_array.shape != () or value_array.dtype == np.bool_:
+    if value_array.shape != () or value_array.dtype.kind in _TEXT_OR_BOOL_KINDS:
         raise ValueError(message)
 
     scalar = value_array.item()
-    if isinstance(scalar, (bool, np.bool_)):
+    if isinstance(scalar, _TEXT_OR_BOOL_SCALAR_TYPES):
         raise ValueError(message)
     try:
         parsed = float(scalar)
@@ -107,10 +110,10 @@ def _positive_float(name: str, value: float) -> float:
     return parsed
 
 
-def _as_numeric_field(values: Any) -> Any:
+def _as_numeric_field(values: Any, name: str) -> Any:
     if hasattr(values, "clamp"):
         return values
-    return np.asarray(values, dtype=np.float64)
+    return _as_numpy_numeric_array(values, name)
 
 
 def _nonnegative_finite_numeric_field(values: Any, name: str) -> Any:
@@ -123,12 +126,28 @@ def _nonnegative_finite_numeric_field(values: Any, name: str) -> Any:
             raise ValueError(f"{name} must be non-negative.")
         return values
 
-    array = np.asarray(values, dtype=np.float64)
+    array = _as_numpy_numeric_array(values, name)
     if np.any(~np.isfinite(array)):
         raise ValueError(f"{name} must contain only finite values.")
     if np.any(array < 0.0):
         raise ValueError(f"{name} must be non-negative.")
     return array
+
+
+def _as_numpy_numeric_array(values: Any, name: str) -> np.ndarray:
+    try:
+        array = np.asarray(values)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must contain numeric values.") from exc
+    if array.dtype.kind in _TEXT_OR_BOOL_KINDS or (
+        array.dtype.kind == "O"
+        and any(isinstance(item, _TEXT_OR_BOOL_SCALAR_TYPES) for item in array.flat)
+    ):
+        raise ValueError(f"{name} must contain numeric values.")
+    try:
+        return array.astype(np.float64, copy=False)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must contain numeric values.") from exc
 
 
 def _maximum(values: Any, minimum: float) -> Any:

--- a/tests/evaluation/test_implicit_surface_numeric_validation.py
+++ b/tests/evaluation/test_implicit_surface_numeric_validation.py
@@ -1,0 +1,27 @@
+import numpy as np
+import pytest
+from pyrecest.evaluation import (
+    classify_inside_outside,
+    surface_band_mask,
+    surface_band_probability_from_signed_distance,
+)
+
+
+@pytest.mark.parametrize(
+    "values",
+    (
+        [True, False],
+        np.array([True, False]),
+        ["0.0", "1.0"],
+        np.array(["0.0", "1.0"]),
+    ),
+)
+def test_surface_numeric_fields_reject_bool_and_text_array_likes(values) -> None:
+    with pytest.raises(ValueError, match="values"):
+        surface_band_mask(values, 0.1)
+    with pytest.raises(ValueError, match="values"):
+        classify_inside_outside(values)
+    with pytest.raises(ValueError, match="distance"):
+        surface_band_probability_from_signed_distance(values, [0.1, 0.1], 0.1)
+    with pytest.raises(ValueError, match="distance_std"):
+        surface_band_probability_from_signed_distance([0.0, 0.1], values, 0.1)

--- a/tests/evaluation/test_implicit_surface_numeric_validation.py
+++ b/tests/evaluation/test_implicit_surface_numeric_validation.py
@@ -14,9 +14,10 @@ from pyrecest.evaluation import (
         np.array([True, False]),
         ["0.0", "1.0"],
         np.array(["0.0", "1.0"]),
+        np.array([1.0 + 1.0j, 2.0 + 0.0j]),
     ),
 )
-def test_surface_numeric_fields_reject_bool_and_text_array_likes(values) -> None:
+def test_surface_numeric_fields_reject_malformed_array_likes(values) -> None:
     with pytest.raises(ValueError, match="values"):
         surface_band_mask(values, 0.1)
     with pytest.raises(ValueError, match="values"):

--- a/tests/evaluation/test_implicit_surface_scale_validation.py
+++ b/tests/evaluation/test_implicit_surface_scale_validation.py
@@ -6,8 +6,8 @@ from pyrecest.evaluation import (
 )
 
 
-def test_surface_band_scale_controls_reject_bools_and_non_scalars() -> None:
-    invalid_values = (True, np.array([0.1]))
+def test_surface_band_scale_controls_reject_bools_text_and_non_scalars() -> None:
+    invalid_values = (True, "0.1", b"0.1", np.array("0.1"), np.array([0.1]))
 
     for invalid_value in invalid_values:
         with pytest.raises(ValueError, match="threshold"):


### PR DESCRIPTION
## Summary
- Reject boolean, text-like, bytes, complex, datetime, and timedelta NumPy/plain array inputs in implicit-surface numeric fields before float coercion.
- Reject text-like and complex scalar scale controls for surface-band thresholds and standard-deviation floors.
- Add focused regression tests for malformed field arrays and scale parameters.

## Bug
`surface_band_mask()`, `classify_inside_outside()`, and `surface_band_probability_from_signed_distance()` converted plain array-like values with `np.asarray(..., dtype=np.float64)` or `astype(np.float64)`. That silently accepted malformed values such as boolean arrays or numeric-looking text arrays, and complex arrays could be coerced with information loss. Scale controls such as `threshold="0.1"` were also accepted by `float(...)`.

## Validation
- Inspected the branch with GitHub compare: only `src/pyrecest/evaluation/implicit_surfaces.py`, `tests/evaluation/test_implicit_surface_numeric_validation.py`, and `tests/evaluation/test_implicit_surface_scale_validation.py` changed.
- Full pytest was not run locally; CI should run the new focused regressions.