### PR TITLE
Accept scalar array distribution dimensions

### DIFF
--- a/src/pyrecest/models/validation.py
+++ b/src/pyrecest/models/validation.py
@@ -295,10 +295,16 @@ def _maybe_call(value: Any, *, allow_methods: bool) -> Any:
 
 
 def _positive_int_or_none(value: Any) -> int | None:
-    if isinstance(value, bool):
+    if isinstance(value, (bool, np.bool_)):
         return None
-    if isinstance(value, Integral) and int(value) > 0:
-        return int(value)
+    value_array = np.asarray(value)
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        return None
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        return None
+    if isinstance(scalar, Integral) and int(scalar) > 0:
+        return int(scalar)
     return None
 
 

--- a/tests/models/test_validation_dim_scalars.py
+++ b/tests/models/test_validation_dim_scalars.py
@@ -1,0 +1,11 @@
+from types import SimpleNamespace
+
+import numpy as np
+
+from pyrecest.models.validation import infer_state_dim_from_distribution
+
+
+def test_infer_state_dim_accepts_scalar_array_dim_attribute() -> None:
+    distribution = SimpleNamespace(dim=np.array(4))
+
+    assert infer_state_dim_from_distribution(distribution) == 4


### PR DESCRIPTION
## Summary
- Accept scalar array/tensor-like positive integer `dim` and `input_dim` attributes when inferring a distribution state dimension.
- Keep boolean and nonscalar dimension attributes ignored, matching the existing fallback semantics.
- Add a regression test for `np.array(4)` explicit dimension attributes.

## Tests
- `PYTHONPATH=/mnt/data/pyrecest_test_tree python -m pytest -q /mnt/data/pyrecest_test_tree/tests/models/test_validation_dim_scalars.py`