### PR TITLE
Accept vector states in SE distance functions

### DIFF
--- a/src/pyrecest/evaluation/get_distance_function.py
+++ b/src/pyrecest/evaluation/get_distance_function.py
@@ -156,6 +156,20 @@ def _euclidean_mtt_distance(x1, x2, *, cutoff_distance: float) -> float:
     return matched_cost + float(cutoff_distance) * missed_count
 
 
+def _state_component(value, index: int):
+    value = asarray(value)
+    if value.ndim == 1:
+        return value[index]
+    return value[index, :]
+
+
+def _state_slice(value, start: int, stop: int):
+    value = asarray(value)
+    if value.ndim == 1:
+        return value[start:stop]
+    return value[start:stop, :]
+
+
 def _angular_distance_from_inner_product(inner_product):
     return arccos(clip(inner_product, -1.0, 1.0))
 
@@ -197,13 +211,16 @@ def get_distance_function(
 
         def distance_function(xest, xtrue):
             return linalg.norm(
-                AbstractHypertoroidalDistribution.angular_error(xest[0, :], xtrue[0, :])
+                AbstractHypertoroidalDistribution.angular_error(
+                    _state_component(xest, 0),
+                    _state_component(xtrue, 0),
+                )
             )
 
     elif "se2" in normalized_name or "se2linear" in normalized_name:
 
         def distance_function(x1, x2):
-            return linalg.norm(x1[1:3, :] - x2[1:3, :])
+            return linalg.norm(_state_slice(x1, 1, 3) - _state_slice(x2, 1, 3))
 
     elif "se3bounded" in normalized_name:
 
@@ -216,7 +233,7 @@ def get_distance_function(
     elif "se3" in normalized_name or "se3linear" in normalized_name:
 
         def distance_function(x1, x2):
-            return linalg.norm(x1[4:7, :] - x2[4:7, :])
+            return linalg.norm(_state_slice(x1, 4, 7) - _state_slice(x2, 4, 7))
 
     elif "euclidean" in normalized_name and "mtt" not in normalized_name:
 

--- a/tests/evaluation/test_evaluation_registries.py
+++ b/tests/evaluation/test_evaluation_registries.py
@@ -75,6 +75,30 @@ def test_se2bounded_distance_uses_angular_component_before_linear_dispatch():
     assert _as_float(distance(x_estimate, x_true)) == pytest.approx(float(pi))
 
 
+def test_se2bounded_distance_accepts_vector_states():
+    distance = get_distance_function("se2bounded")
+
+    x_estimate = array([0.0, 1.0, 2.0])
+    x_true = array([pi, 1.0, 2.0])
+
+    assert _as_float(distance(x_estimate, x_true)) == pytest.approx(float(pi))
+
+
+def test_se2_and_se3_linear_distances_accept_vector_states():
+    se2_distance = get_distance_function("se2")
+    assert _as_float(
+        se2_distance(array([0.0, 1.0, 2.0]), array([0.0, 4.0, 6.0]))
+    ) == pytest.approx(5.0)
+
+    se3_distance = get_distance_function("se3")
+    assert _as_float(
+        se3_distance(
+            array([1.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0]),
+            array([1.0, 0.0, 0.0, 0.0, 4.0, 6.0, 3.0]),
+        )
+    ) == pytest.approx(5.0)
+
+
 def test_se3bounded_distance_uses_quaternion_component_before_linear_dispatch():
     distance = get_distance_function("se3bounded")
 


### PR DESCRIPTION
## Summary
- Fix SE(2), SE(2)-bounded, and SE(3) linear distance helpers so 1-D state vectors work in addition to column/state matrices.
- Add helper functions for state component/slice access that preserve existing 2-D behavior.
- Add regression tests for vector-valued SE(2)-bounded, SE(2), and SE(3) distance inputs.

## Bug
The SE distance helpers used matrix-only indexing for linear components. Ordinary 1-D state vectors therefore raised IndexError instead of returning the expected distance.

## Testing
- Syntax-checked modified sources with ast.parse.
- Full pytest not run locally; CI should run the focused regression tests.