### PR TITLE
Reject complex covariance helper inputs

### DIFF
--- a/src/pyrecest/numerics.py
+++ b/src/pyrecest/numerics.py
@@ -11,17 +11,27 @@ from pyrecest.exceptions import (
     ShapeError,
 )
 
-_TEXT_OR_BOOL_KINDS = {"b", "S", "U"}
-_TEXT_OR_BOOL_SCALAR_TYPES = (bool, np.bool_, str, bytes, bytearray, np.str_, np.bytes_)
+_UNSUPPORTED_NUMERIC_KINDS = {"b", "S", "U", "c"}
+_UNSUPPORTED_SCALAR_TYPES = (
+    bool,
+    np.bool_,
+    str,
+    bytes,
+    bytearray,
+    np.str_,
+    np.bytes_,
+    complex,
+    np.complexfloating,
+)
 
 
-def _contains_text_or_bool_values(value) -> bool:
+def _contains_unsupported_numeric_values(value) -> bool:
     value_array = np.asarray(value)
-    if value_array.dtype.kind in _TEXT_OR_BOOL_KINDS:
+    if value_array.dtype.kind in _UNSUPPORTED_NUMERIC_KINDS:
         return True
     if value_array.dtype.kind != "O":
         return False
-    return any(isinstance(item, _TEXT_OR_BOOL_SCALAR_TYPES) for item in value_array.flat)
+    return any(isinstance(item, _UNSUPPORTED_SCALAR_TYPES) for item in value_array.flat)
 
 
 def _to_numpy_array(value, *, name: str = "matrix") -> np.ndarray:
@@ -35,7 +45,7 @@ def _to_numpy_array(value, *, name: str = "matrix") -> np.ndarray:
         raw = value
 
     try:
-        if _contains_text_or_bool_values(raw):
+        if _contains_unsupported_numeric_values(raw):
             raise ValueError
         return np.asarray(raw, dtype=float)
     except (TypeError, ValueError, OverflowError) as exc:

--- a/tests/test_numerics_complex_inputs.py
+++ b/tests/test_numerics_complex_inputs.py
@@ -1,0 +1,13 @@
+import numpy as np
+import pytest
+
+from pyrecest.numerics import assert_covariance_matrix, is_positive_semidefinite, is_symmetric
+
+
+def test_covariance_helpers_reject_complex_inputs():
+    matrix = np.array([[1.0 + 0.5j, 0.0], [0.0, 1.0]])
+
+    assert not is_symmetric(matrix)
+    assert not is_positive_semidefinite(matrix)
+    with pytest.raises(ValueError, match="covariance must contain numeric values"):
+        assert_covariance_matrix(matrix)


### PR DESCRIPTION
## Summary
- Reject complex-valued arrays before covariance helpers coerce inputs to `float`.
- Preserve the existing bool/text validation path.
- Add a focused regression test for complex covariance inputs.

## Validation
- Syntax-checked the changed module and test locally.
- Exercised the changed path in a minimal local harness.

Full pytest was not run locally; CI should cover the PR.