### PR TITLE
Validate CircularUKF measurement inputs

### DIFF
--- a/src/pyrecest/filters/circular_ukf.py
+++ b/src/pyrecest/filters/circular_ukf.py
@@ -64,6 +64,32 @@ def _validate_bool_flag(value, name):
     return scalar
 
 
+def _has_invalid_real_numeric_value(value):
+    """Return whether ``value`` is not an unambiguous real numeric input."""
+    if isinstance(value, (bool, str, bytes, bytearray, complex)):
+        return True
+
+    dtype = getattr(value, "dtype", None)
+    dtype_kind = getattr(dtype, "kind", None)
+    if dtype_kind in {"b", "c", "S", "U"}:
+        return True
+    if dtype_kind == "O":
+        return any(_has_invalid_real_numeric_value(item) for item in value.flat)
+
+    dtype_name = str(dtype).lower() if dtype is not None else ""
+    if "bool" in dtype_name or "complex" in dtype_name:
+        return True
+
+    if isinstance(value, (list, tuple)):
+        return any(_has_invalid_real_numeric_value(item) for item in value)
+    return False
+
+
+def _validate_real_numeric_input(value, name):
+    if _has_invalid_real_numeric_value(value):
+        raise TypeError(f"{name} must contain real numeric values.")
+
+
 def _as_circular_gaussian(distribution, role):
     """Return a validated 1-D Gaussian for circular UKF state/noise."""
     if not isinstance(distribution, GaussianDistribution):
@@ -95,7 +121,11 @@ def _validate_backend_supported(operation):
 
 
 def _validate_circular_scalar_measurement(z):
-    measurement = array(z, dtype=float)
+    _validate_real_numeric_input(z, "measurement z")
+    try:
+        measurement = array(z, dtype=float)
+    except Exception as exc:  # pragma: no cover - backend-specific failures
+        raise TypeError("measurement z must contain real numeric values.") from exc
     if measurement.shape not in ((), (1,)):
         raise ValueError("measurement z must be scalar.")
     measurement = measurement[0] if measurement.shape == (1,) else measurement
@@ -106,7 +136,11 @@ def _validate_circular_scalar_measurement(z):
 
 def _measurement_vector(value):
     """Convert a scalar or vector-valued measurement to a flat 1-D array."""
-    measurement = atleast_1d(array(value, dtype=float)).flatten()
+    _validate_real_numeric_input(value, "measurement vector")
+    try:
+        measurement = atleast_1d(array(value, dtype=float)).flatten()
+    except Exception as exc:  # pragma: no cover - backend-specific failures
+        raise TypeError("measurement vector must contain real numeric values.") from exc
     if measurement.shape[0] == 0:
         raise ValueError("measurement vector must not be empty.")
     if not _to_python_bool(backend_all(isfinite(measurement))):

--- a/tests/filters/test_circular_ukf_measurement_validation.py
+++ b/tests/filters/test_circular_ukf_measurement_validation.py
@@ -1,0 +1,64 @@
+"""Regression tests for CircularUKF measurement numeric validation."""
+
+import numpy as np
+import pytest
+import pyrecest.backend
+from pyrecest.backend import array
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.filters.circular_ukf import CircularUKF
+
+
+def _measurement(angle):
+    return angle
+
+
+@pytest.fixture
+def circular_filter():
+    filt = CircularUKF()
+    filt.filter_state = GaussianDistribution(array([0.5]), array([[0.7]]))
+    return filt
+
+
+@pytest.fixture
+def measurement_noise():
+    return GaussianDistribution(array([0.0]), array([[0.7]]))
+
+
+@pytest.mark.parametrize("z", [True, "1.0", b"1.0", 1.0 + 0.0j])
+def test_update_identity_rejects_ambiguous_scalar_measurements(
+    circular_filter, measurement_noise, z
+):
+    with pytest.raises(TypeError, match="measurement z.*real numeric"):
+        circular_filter.update_identity(measurement_noise, z)
+
+
+@pytest.mark.skipif(
+    pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+    reason="Not supported on this backend",
+)
+@pytest.mark.parametrize(
+    "z",
+    [
+        [True],
+        ["1.0"],
+        [b"1.0"],
+        [1.0 + 0.0j],
+        np.asarray(["1.0"], dtype=object),
+    ],
+)
+def test_update_nonlinear_rejects_ambiguous_measurement_vectors(
+    circular_filter, measurement_noise, z
+):
+    with pytest.raises(TypeError, match="measurement vector.*real numeric"):
+        circular_filter.update_nonlinear(_measurement, measurement_noise, z)
+
+
+@pytest.mark.skipif(
+    pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+    reason="Not supported on this backend",
+)
+def test_update_nonlinear_rejects_ambiguous_measurement_function_outputs(
+    circular_filter, measurement_noise
+):
+    with pytest.raises(TypeError, match="measurement vector.*real numeric"):
+        circular_filter.update_nonlinear(lambda _angle: ["1.0"], measurement_noise, [0.5])


### PR DESCRIPTION
## Summary
- Reject boolean, text/bytes, and complex-valued CircularUKF measurements before backend float coercion.
- Apply the same validation to nonlinear measurement vectors and measurement-function outputs.
- Add focused regression tests for ambiguous scalar/vector inputs.

## Bug
`CircularUKF.update_identity()` and `CircularUKF.update_nonlinear()` converted public measurement inputs with `array(..., dtype=float)` before validation. That silently accepted malformed values such as `True`, `"1.0"`, `b"1.0"`, or complex values with zero imaginary part as ordinary numeric measurements, which can hide configuration/data errors.

## Validation
- Syntax-checked the patched module and new regression test locally with `python -m py_compile`.
- Full pytest was not run locally because this environment cannot clone/install the repository from GitHub; CI should run the focused regression tests.