### PR TITLE
Require finite discrete state grids

### DIFF
--- a/src/pyrecest/filters/discrete_state/__init__.py
+++ b/src/pyrecest/filters/discrete_state/__init__.py
@@ -1,0 +1,46 @@
+"""Compatibility wrapper for finite-state filtering utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import runpy
+
+import numpy as np
+
+_module_globals = runpy.run_path(
+    str(Path(__file__).resolve().parents[1] / "discrete_state.py"),
+    run_name=__name__,
+)
+_original_sparse_gaussian_transition_matrix = _module_globals[
+    "sparse_gaussian_transition_matrix"
+]
+
+
+def sparse_gaussian_transition_matrix(
+    state_vectors,
+    sigma,
+    max_step_sigma=4.0,
+    *,
+    valid_state_mask=None,
+):
+    states = np.asarray(state_vectors, dtype=float)
+    if states.ndim == 1:
+        finite_check_states = states[:, None]
+    elif states.ndim == 2:
+        finite_check_states = states
+    else:
+        finite_check_states = None
+    if finite_check_states is not None and np.any(~np.isfinite(finite_check_states)):
+        raise ValueError("state_vectors must contain only finite values")
+    return _original_sparse_gaussian_transition_matrix(
+        state_vectors,
+        sigma,
+        max_step_sigma=max_step_sigma,
+        valid_state_mask=valid_state_mask,
+    )
+
+
+_module_globals["sparse_gaussian_transition_matrix"] = sparse_gaussian_transition_matrix
+for name in _module_globals["__all__"]:
+    globals()[name] = _module_globals[name]
+__all__ = _module_globals["__all__"]

--- a/tests/filters/test_discrete_state_grid_validation.py
+++ b/tests/filters/test_discrete_state_grid_validation.py
@@ -1,0 +1,22 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.filters.discrete_state import sparse_gaussian_transition_matrix
+
+
+class TestDiscreteStateGridValidation(unittest.TestCase):
+    def test_sparse_gaussian_transition_matrix_requires_finite_states(self):
+        invalid_grids = (
+            np.array([0.0, np.nan, 2.0]),
+            np.array([[0.0], [np.inf], [2.0]]),
+        )
+
+        for grid in invalid_grids:
+            with self.subTest(grid=grid):
+                with self.assertRaisesRegex(ValueError, "state_vectors.*finite"):
+                    sparse_gaussian_transition_matrix(grid, sigma=1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add finite grid validation for the discrete Gaussian transition helper
- add focused coverage for invalid grid coordinates

## Validation
- Ran a focused local unittest harness for the new regression.
- Ran a finite-grid smoke check and verified transition columns still sum to one.

Full repository pytest was not run locally; CI should run the focused test and the existing suite.