### PR TITLE
Reject malformed measurement reliability arrays

### DIFF
--- a/src/pyrecest/tracking/measurement_reliability.py
+++ b/src/pyrecest/tracking/measurement_reliability.py
@@ -17,6 +17,8 @@ from typing import Any, Literal
 import numpy as np
 
 ReliabilityMode = Literal["off", "inflate", "hard"] | str
+_TEXT_OR_BOOL_SCALAR_TYPES = (bool, np.bool_, str, bytes, bytearray, np.str_, np.bytes_)
+_REJECTED_NUMERIC_ARRAY_KINDS = frozenset({"b", "c", "S", "U", "M", "m"})
 
 
 @dataclass(frozen=True)
@@ -92,7 +94,7 @@ class ReliabilityWeightedMeasurement:
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        measurement = np.asarray(self.measurement, dtype=float).reshape(-1)
+        measurement = _real_numeric_array(self.measurement, "measurement").reshape(-1)
         if measurement.size == 0:
             raise ValueError("measurement must contain at least one value")
         if not np.isfinite(measurement).all():
@@ -281,10 +283,7 @@ def _finite_scalar(value: Any, name: str) -> float:
     if array.shape != () or array.dtype == np.bool_:
         raise ValueError(f"{name} must be a finite scalar")
     scalar = array.item()
-    if isinstance(
-        scalar,
-        (bool, np.bool_, str, bytes, bytearray, np.str_, np.bytes_),
-    ):
+    if isinstance(scalar, _TEXT_OR_BOOL_SCALAR_TYPES):
         raise ValueError(f"{name} must be a finite scalar")
     try:
         parsed = float(scalar)
@@ -295,6 +294,22 @@ def _finite_scalar(value: Any, name: str) -> float:
     return parsed
 
 
+def _real_numeric_array(value: Any, name: str) -> np.ndarray:
+    raw = np.asarray(value)
+    if raw.dtype.kind in _REJECTED_NUMERIC_ARRAY_KINDS:
+        raise ValueError(f"{name} must contain real numeric values")
+    if raw.dtype == object:
+        for item in raw.ravel():
+            if isinstance(item, _TEXT_OR_BOOL_SCALAR_TYPES) or isinstance(
+                item, (complex, np.complexfloating)
+            ):
+                raise ValueError(f"{name} must contain real numeric values")
+    try:
+        return np.asarray(value, dtype=float)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must contain real numeric values") from exc
+
+
 def _bool_scalar(value: Any, name: str) -> bool:
     array = np.asarray(value)
     if array.shape != () or array.dtype != np.bool_:
@@ -303,7 +318,7 @@ def _bool_scalar(value: Any, name: str) -> bool:
 
 
 def _covariance_matrix(value: Any, *, dim: int | None = None) -> np.ndarray:
-    covariance = np.asarray(value, dtype=float)
+    covariance = _real_numeric_array(value, "covariance")
     if covariance.ndim != 2 or covariance.shape[0] != covariance.shape[1]:
         raise ValueError("covariance must be a square matrix")
     if dim is not None and covariance.shape != (dim, dim):

--- a/tests/tracking/test_measurement_reliability.py
+++ b/tests/tracking/test_measurement_reliability.py
@@ -53,6 +53,38 @@ def test_reliability_config_rejects_text_and_object_boolean_scalars() -> None:
             MeasurementReliabilityConfig(**kwargs)
 
 
+def test_reliability_weighted_measurement_rejects_malformed_measurements() -> None:
+    invalid_measurements = (
+        np.array([True]),
+        np.array(["1.0"]),
+        np.array([True], dtype=object),
+        np.array([1.0 + 0.0j]),
+    )
+
+    for measurement in invalid_measurements:
+        with pytest.raises(ValueError, match="measurement must contain real numeric values"):
+            ReliabilityWeightedMeasurement(
+                measurement=measurement,
+                covariance=np.eye(1),
+                reliability=0.5,
+            )
+
+
+def test_reliability_helpers_reject_malformed_covariance_arrays() -> None:
+    invalid_covariances = (
+        np.array([[True]]),
+        np.array([["1.0"]]),
+        np.array([[True]], dtype=object),
+        np.array([[1.0 + 0.0j]]),
+    )
+
+    for covariance in invalid_covariances:
+        with pytest.raises(ValueError, match="covariance must contain real numeric values"):
+            scale_covariance_by_reliability(covariance, 0.5)
+        with pytest.raises(ValueError, match="covariance must contain real numeric values"):
+            apply_measurement_reliability(covariance, reliability=0.5)
+
+
 def test_scale_covariance_by_reliability_returns_scaled_copy() -> None:
     cov = np.diag([4.0, 9.0])
     scaled, scale = scale_covariance_by_reliability(cov, 0.25)


### PR DESCRIPTION
## Summary
- Reject boolean, text/bytes, datetime/timedelta, and complex-valued measurement and covariance arrays before NumPy float coercion.
- Keep numeric object arrays supported when their elements are real-numeric.
- Add regression coverage for malformed measurement vectors and covariance matrices in the measurement-reliability helpers.

## Bug
`ReliabilityWeightedMeasurement`, `scale_covariance_by_reliability()`, and `apply_measurement_reliability()` previously converted measurement/covariance arrays with `np.asarray(..., dtype=float)` directly. That silently accepted malformed arrays such as boolean masks or numeric-looking text as ordinary numeric measurement/covariance data.

## Validation
- Syntax-checked the updated module and test file locally.
- Ran a focused local harness that verifies bool/text/complex measurement and covariance arrays are rejected while numeric covariance scaling still works.