### PR TITLE
Reject nonnumeric reliability covariances

### DIFF
--- a/src/pyrecest/tracking/measurement_reliability.py
+++ b/src/pyrecest/tracking/measurement_reliability.py
@@ -17,6 +17,16 @@ from typing import Any, Literal
 import numpy as np
 
 ReliabilityMode = Literal["off", "inflate", "hard"] | str
+_BOOL_OR_TEXT_KINDS = {"b", "S", "U"}
+_BOOL_OR_TEXT_SCALAR_TYPES = (
+    bool,
+    np.bool_,
+    str,
+    bytes,
+    bytearray,
+    np.str_,
+    np.bytes_,
+)
 
 
 @dataclass(frozen=True)
@@ -302,8 +312,22 @@ def _bool_scalar(value: Any, name: str) -> bool:
     return bool(array.item())
 
 
+def _contains_bool_or_text_values(value: Any) -> bool:
+    array = np.asarray(value)
+    if array.dtype.kind in _BOOL_OR_TEXT_KINDS:
+        return True
+    if array.dtype.kind != "O":
+        return False
+    return any(isinstance(item, _BOOL_OR_TEXT_SCALAR_TYPES) for item in array.flat)
+
+
 def _covariance_matrix(value: Any, *, dim: int | None = None) -> np.ndarray:
-    covariance = np.asarray(value, dtype=float)
+    try:
+        if _contains_bool_or_text_values(value):
+            raise ValueError
+        covariance = np.asarray(value, dtype=float)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("covariance must contain only real numeric values") from exc
     if covariance.ndim != 2 or covariance.shape[0] != covariance.shape[1]:
         raise ValueError("covariance must be a square matrix")
     if dim is not None and covariance.shape != (dim, dim):

--- a/tests/tracking/test_measurement_reliability.py
+++ b/tests/tracking/test_measurement_reliability.py
@@ -62,6 +62,26 @@ def test_scale_covariance_by_reliability_returns_scaled_copy() -> None:
     assert np.allclose(cov, np.diag([4.0, 9.0]))
 
 
+def test_covariance_validation_rejects_bool_and_text_values() -> None:
+    invalid_covariances = (
+        [[True]],
+        [["1.0"]],
+        [[b"1.0"]],
+        np.array([[False]], dtype=object),
+        np.array([["1.0"]], dtype=object),
+    )
+
+    for covariance in invalid_covariances:
+        with pytest.raises(ValueError, match="real numeric values"):
+            scale_covariance_by_reliability(covariance, 0.5)
+        with pytest.raises(ValueError, match="real numeric values"):
+            ReliabilityWeightedMeasurement(
+                measurement=np.array([1.0]),
+                covariance=covariance,
+                reliability=0.5,
+            )
+
+
 def test_hard_mode_rejects_low_reliability_measurement() -> None:
     result = apply_measurement_reliability(
         np.eye(2),


### PR DESCRIPTION
## Summary
- reject boolean and text-valued covariance matrices in measurement-reliability helpers before float coercion
- preserve valid numeric covariance arrays and existing finite/square/dimension validation
- add regression coverage for direct covariance scaling and `ReliabilityWeightedMeasurement`

## Bug
`_covariance_matrix(...)` previously used `np.asarray(value, dtype=float)` directly. That silently accepted malformed covariance entries such as `True`, `"1.0"`, or `b"1.0"` as numeric values, which could turn caller/data bugs into plausible covariance matrices.

## Testing
- Not run locally; this environment cannot clone/install the repository because `github.com` DNS resolution is unavailable. The focused regression test is included for CI.