### PR TITLE
Reject nonnumeric weak measurement stds

### DIFF
--- a/src/pyrecest/models/weak_measurement.py
+++ b/src/pyrecest/models/weak_measurement.py
@@ -9,14 +9,21 @@ import numpy as np
 
 from .linear_gaussian import LinearGaussianMeasurementModel
 
+_BOOL_OR_TEXT_KINDS = {"b", "S", "U"}
+_BOOL_OR_TEXT_SCALAR_TYPES = (
+    bool,
+    np.bool_,
+    str,
+    bytes,
+    bytearray,
+    np.str_,
+    np.bytes_,
+)
+
 
 def diagonal_measurement_covariance(stds: Sequence[float] | np.ndarray) -> np.ndarray:
     'Return a diagonal covariance matrix from measurement standard deviations.'
-    values = np.asarray(stds, dtype=float).reshape(-1)
-    if values.size == 0:
-        raise ValueError("stds must contain at least one standard deviation")
-    if not np.isfinite(values).all() or np.any(values <= 0.0):
-        raise ValueError("stds must contain finite positive values")
+    values = _standard_deviations_array(stds)
     return np.diag(values**2)
 
 
@@ -58,11 +65,11 @@ def block_diag_measurement_covariance(
             [trusted_map[key] if key in trusted_map else weak_map[key] for key in order]
         )
 
-    stds: list[float] = []
+    stds: list[Any] = []
     if trusted_std is not None:
-        stds.extend(float(value) for value in trusted_std)
+        stds.extend(trusted_std)
     if weak_std is not None:
-        stds.extend(float(value) for value in weak_std)
+        stds.extend(weak_std)
     return diagonal_measurement_covariance(stds)
 
 
@@ -171,6 +178,29 @@ def weak_dimension_measurement_model(
 
 def _is_mapping(value: object) -> bool:
     return isinstance(value, Mapping)
+
+
+def _standard_deviations_array(stds: Sequence[float] | np.ndarray) -> np.ndarray:
+    try:
+        if _contains_bool_or_text_values(stds):
+            raise ValueError
+        values = np.asarray(stds, dtype=float).reshape(-1)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("stds must contain real numeric values") from exc
+    if values.size == 0:
+        raise ValueError("stds must contain at least one standard deviation")
+    if not np.isfinite(values).all() or np.any(values <= 0.0):
+        raise ValueError("stds must contain finite positive values")
+    return values
+
+
+def _contains_bool_or_text_values(value: Any) -> bool:
+    array = np.asarray(value)
+    if array.dtype.kind in _BOOL_OR_TEXT_KINDS:
+        return True
+    if array.dtype.kind != "O":
+        return False
+    return any(isinstance(item, _BOOL_OR_TEXT_SCALAR_TYPES) for item in array.flat)
 
 
 def _positive_int(value: int, name: str) -> int:

--- a/tests/models/test_weak_measurement.py
+++ b/tests/models/test_weak_measurement.py
@@ -18,6 +18,37 @@ def test_diagonal_measurement_covariance_from_stds() -> None:
     assert np.allclose(covariance, np.diag([4.0, 9.0]))
 
 
+def test_measurement_std_validation_rejects_bool_and_text_values() -> None:
+    invalid_stds = (
+        [True],
+        [np.bool_(False)],
+        ["1.0"],
+        [b"1.0"],
+        np.array([False], dtype=object),
+        np.array(["1.0"], dtype=object),
+    )
+
+    for stds in invalid_stds:
+        with pytest.raises(ValueError, match="real numeric values"):
+            diagonal_measurement_covariance(stds)
+        with pytest.raises(ValueError, match="real numeric values"):
+            block_diag_measurement_covariance(trusted_std=stds)
+        with pytest.raises(ValueError, match="real numeric values"):
+            MaskedLinearMeasurementModel(state_dim=1, observed_dims=[0], stds=stds)
+        with pytest.raises(ValueError, match="real numeric values"):
+            WeakDimensionMeasurementModel(np.eye(1), stds=stds)
+
+
+def test_measurement_std_mapping_validation_rejects_bool_and_text_values() -> None:
+    invalid_values = (True, np.bool_(False), "1.0", b"1.0")
+
+    for value in invalid_values:
+        with pytest.raises(ValueError, match="real numeric values"):
+            block_diag_measurement_covariance(trusted_std={"x": value})
+        with pytest.raises(ValueError, match="real numeric values"):
+            WeakDimensionMeasurementModel(np.eye(1), stds={"x": value})
+
+
 def test_block_diag_measurement_covariance_preserves_named_order() -> None:
     covariance = block_diag_measurement_covariance(
         trusted_std={"x": 1.0, "y": 2.0},


### PR DESCRIPTION
## Summary
- Reject boolean and text standard-deviation inputs in weak/masked measurement covariance helpers instead of silently converting them to floats.
- Route sequence-style `trusted_std` / `weak_std` values through the same validation path as direct `stds` inputs.
- Add regression tests covering list, NumPy scalar/object-array, and mapping inputs.

## Rationale
Standard deviations are numeric scale parameters. Accepting `True`, `False`, or numeric strings like `"1.0"` hides malformed caller inputs and can silently produce unintended measurement covariance matrices.

## Testing
- Not run locally: the execution sandbox cannot clone from GitHub (`Could not resolve host: github.com`).
- Verified the new validation helper behavior in an isolated NumPy snippet.