### PR TITLE
Flatten Dirac constructor weights

### DIFF
--- a/src/pyrecest/distributions/abstract_dirac_distribution.py
+++ b/src/pyrecest/distributions/abstract_dirac_distribution.py
@@ -20,6 +20,7 @@ from pyrecest.backend import (
     log,
     ones,
     random,
+    reshape,
     stack,
     sum,
 )
@@ -44,7 +45,7 @@ class AbstractDiracDistribution(AbstractDistributionType):
         if w is None:
             self.w = ones(d.shape[0]) / d.shape[0]
         else:
-            w = asarray(w)
+            w = reshape(asarray(w), (-1,))
             if d.shape[0] != w.shape[0]:
                 raise ValueError("Number of Diracs and weights must match.")
             self.w = copy.copy(w)

--- a/tests/distributions/test_dirac_weight_shapes.py
+++ b/tests/distributions/test_dirac_weight_shapes.py
@@ -1,0 +1,29 @@
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array
+from pyrecest.distributions import LinearDiracDistribution
+
+
+def test_linear_dirac_distribution_flattens_column_weights_for_sampling():
+    dist = LinearDiracDistribution(
+        array(
+            [
+                [0.0],
+                [1.0],
+            ]
+        ),
+        array([[0.0], [1.0]]),
+    )
+
+    npt.assert_allclose(dist.w, array([0.0, 1.0]))
+    npt.assert_allclose(
+        dist.sample(3),
+        array(
+            [
+                [1.0],
+                [1.0],
+                [1.0],
+            ]
+        ),
+    )


### PR DESCRIPTION
## Summary
- flatten explicit Dirac weight inputs during construction
- preserve existing count, finite, nonnegative, and normalization validation after flattening
- add regression coverage for column-shaped weights that previously broke sampling

## Bug
`AbstractDiracDistribution.__init__` stored explicit weights with their original shape. Passing natural column-shaped weights such as `[[0.0], [1.0]]` passed the length check because `shape[0]` matched the number of Diracs, but left `self.w` two-dimensional. Later `sample()` passes `self.w` to the backend random choice as a probability vector, where NumPy expects a one-dimensional `p` array.

## Validation
- Not run locally; this environment cannot clone/install the repository because `github.com` DNS resolution is unavailable. The focused regression test is included for CI.