### PR TITLE
Validate tracking numeric fields

### DIFF
--- a/src/pyrecest/tracking/event_records.py
+++ b/src/pyrecest/tracking/event_records.py
@@ -17,13 +17,61 @@ import numpy as np
 
 TrackingAction = Literal["predict", "update", "reject", "coast"] | str
 
+_REAL_NUMERIC_ARRAY_KINDS = {"i", "u", "f"}
+_INVALID_NUMERIC_SCALAR_TYPES = (
+    bool,
+    np.bool_,
+    str,
+    bytes,
+    bytearray,
+    complex,
+    np.complexfloating,
+)
+
+
+def _invalid_numeric_array_message(name: str) -> str:
+    return f"{name} must contain real-valued numeric entries"
+
+
+def _dtype_is_real_numeric(dtype: np.dtype) -> bool:
+    return np.dtype(dtype).kind in _REAL_NUMERIC_ARRAY_KINDS
+
+
+def _raw_item_is_invalid_numeric(value: Any) -> bool:
+    if isinstance(value, _INVALID_NUMERIC_SCALAR_TYPES):
+        return True
+    if isinstance(value, np.ndarray):
+        if value.dtype == object:
+            return any(_raw_item_is_invalid_numeric(item) for item in value.reshape(-1))
+        return not _dtype_is_real_numeric(value.dtype)
+    if isinstance(value, (list, tuple)):
+        return any(_raw_item_is_invalid_numeric(item) for item in value)
+    return False
+
+
+def _as_real_numeric_array(value: Any, *, name: str) -> np.ndarray:
+    if _raw_item_is_invalid_numeric(value):
+        raise ValueError(_invalid_numeric_array_message(name))
+
+    raw_array = np.asarray(value)
+    if raw_array.dtype == object:
+        if any(_raw_item_is_invalid_numeric(item) for item in raw_array.reshape(-1)):
+            raise ValueError(_invalid_numeric_array_message(name))
+    elif not _dtype_is_real_numeric(raw_array.dtype):
+        raise ValueError(_invalid_numeric_array_message(name))
+
+    try:
+        return raw_array.astype(float, copy=False)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(_invalid_numeric_array_message(name)) from exc
+
 
 def _array_or_none(
     value: Any, *, name: str, ndim: int | None = None
 ) -> np.ndarray | None:
     if value is None:
         return None
-    array = np.asarray(value, dtype=float)
+    array = _as_real_numeric_array(value, name=name)
     if ndim is not None and array.ndim != ndim:
         raise ValueError(f"{name} must have ndim={ndim}")
     if not np.isfinite(array).all():
@@ -32,7 +80,7 @@ def _array_or_none(
 
 
 def _vector(value: Any, *, name: str) -> np.ndarray:
-    array = np.asarray(value, dtype=float).reshape(-1)
+    array = _as_real_numeric_array(value, name=name).reshape(-1)
     if array.size == 0:
         raise ValueError(f"{name} must contain at least one element")
     if not np.isfinite(array).all():
@@ -41,7 +89,7 @@ def _vector(value: Any, *, name: str) -> np.ndarray:
 
 
 def _square_matrix(value: Any, *, name: str, dim: int | None = None) -> np.ndarray:
-    matrix = np.asarray(value, dtype=float)
+    matrix = _as_real_numeric_array(value, name=name)
     if matrix.ndim != 2 or matrix.shape[0] != matrix.shape[1]:
         raise ValueError(f"{name} must be a square matrix")
     if dim is not None and matrix.shape != (dim, dim):
@@ -330,7 +378,7 @@ def records_to_matrix(
     """Stack a vector-valued field from records into a matrix."""
 
     arrays = [
-        np.asarray(getattr(record, field), dtype=float).reshape(-1)
+        _as_real_numeric_array(getattr(record, field), name=field).reshape(-1)
         for record in records
     ]
     if not arrays:

--- a/tests/tracking/test_event_record_numeric_validation.py
+++ b/tests/tracking/test_event_record_numeric_validation.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from pyrecest.tracking import TrackingEvent, event_from_measurement, record_from_update
+
+_NUMERIC_BYTES = bytes.fromhex("312e30")
+
+
+@pytest.mark.parametrize(
+    "measurement",
+    ([True], ["1.0"], [_NUMERIC_BYTES], np.array([1.0 + 2.0j])),
+)
+def test_tracking_event_rejects_non_real_numeric_measurements(measurement) -> None:
+    with pytest.raises(
+        ValueError, match="measurement must contain real-valued numeric entries"
+    ):
+        TrackingEvent(time=0.0, source="rf", measurement=measurement)
+
+
+@pytest.mark.parametrize(
+    "covariance",
+    (
+        [[True]],
+        [["1.0"]],
+        [[_NUMERIC_BYTES]],
+        np.array([[1.0 + 2.0j]]),
+    ),
+)
+def test_tracking_event_rejects_non_real_numeric_covariances(covariance) -> None:
+    with pytest.raises(
+        ValueError, match="covariance must contain real-valued numeric entries"
+    ):
+        TrackingEvent(time=0.0, source="rf", measurement=[0.0], covariance=covariance)
+
+
+def test_tracking_record_rejects_non_real_numeric_state_fields() -> None:
+    event = event_from_measurement(time=0.0, source="rf")
+    base_kwargs = {
+        "event": event,
+        "prior_mean": [0.0, 0.0],
+        "prior_cov": np.eye(2),
+        "posterior_mean": [0.0, 0.0],
+        "posterior_cov": np.eye(2),
+    }
+
+    invalid_cases = (
+        ("prior_mean", [True, 0.0], "prior_mean"),
+        ("prior_cov", [["1.0", "0.0"], ["0.0", "1.0"]], "prior_cov"),
+        ("posterior_mean", np.array([1.0 + 2.0j, 0.0 + 0.0j]), "posterior_mean"),
+        (
+            "posterior_cov",
+            np.array([[1.0 + 2.0j, 0.0], [0.0, 1.0]]),
+            "posterior_cov",
+        ),
+        ("innovation", [_NUMERIC_BYTES], "innovation"),
+        ("innovation_cov", [[_NUMERIC_BYTES]], "innovation_cov"),
+    )
+
+    for field, value, message_name in invalid_cases:
+        kwargs = dict(base_kwargs)
+        kwargs[field] = value
+        with pytest.raises(
+            ValueError,
+            match=f"{message_name} must contain real-valued numeric entries",
+        ):
+            record_from_update(**kwargs)


### PR DESCRIPTION
Adds guarded real-numeric validation for tracking event records plus focused regression tests.

Validation: focused local pytest harness passed.