### PR TITLE
Harden candidate pruning numeric validation

### DIFF
--- a/src/pyrecest/utils/candidate_pruning.py
+++ b/src/pyrecest/utils/candidate_pruning.py
@@ -16,6 +16,8 @@ from typing import Any
 import numpy as np
 
 _TEXT_TYPES = (str, bytes, bytearray, np.str_, np.bytes_)
+_BOOLEAN_TYPES = (bool, np.bool_)
+_COMPLEX_TYPES = (complex, np.complexfloating)
 
 
 @dataclass(frozen=True)
@@ -157,14 +159,26 @@ def _normalize_bounded_scalar(
     return parsed
 
 
-def _contains_text_values(value: Any) -> bool:
-    if isinstance(value, _TEXT_TYPES):
+def _contains_values_of_type(value: Any, types: tuple[type, ...]) -> bool:
+    if isinstance(value, types):
         return True
     try:
         values = np.asarray(value, dtype=object).reshape(-1)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, RuntimeError):
         return False
-    return any(isinstance(item, _TEXT_TYPES) for item in values)
+    return any(isinstance(item, types) for item in values)
+
+
+def _contains_text_values(value: Any) -> bool:
+    return _contains_values_of_type(value, _TEXT_TYPES)
+
+
+def _contains_boolean_values(value: Any) -> bool:
+    return _contains_values_of_type(value, _BOOLEAN_TYPES)
+
+
+def _contains_complex_values(value: Any) -> bool:
+    return _contains_values_of_type(value, _COMPLEX_TYPES)
 
 
 def _as_numeric_matrix(value: Any, name: str) -> np.ndarray:
@@ -175,6 +189,14 @@ def _as_numeric_matrix(value: Any, name: str) -> np.ndarray:
 
     if raw_values.dtype == np.bool_:
         raise ValueError(f"{name} must be numeric, not boolean")
+    if _contains_boolean_values(value) or _contains_boolean_values(raw_values):
+        raise ValueError(f"{name} must be numeric, not boolean")
+    if (
+        raw_values.dtype.kind == "c"
+        or _contains_complex_values(value)
+        or _contains_complex_values(raw_values)
+    ):
+        raise ValueError(f"{name} must be real-valued numeric")
     if _contains_text_values(value) or _contains_text_values(raw_values):
         raise ValueError(f"{name} must be numeric")
 

--- a/tests/test_candidate_pruning_matrix_validation.py
+++ b/tests/test_candidate_pruning_matrix_validation.py
@@ -13,6 +13,8 @@ class TestCandidatePruningMatrixValidation(unittest.TestCase):
         invalid_matrices = (
             [[True, False]],
             np.array([[True, False]]),
+            np.array([[1.0, True]], dtype=object),
+            np.array([[False, 2.0]], dtype=object),
         )
 
         for function in (candidate_mask_from_costs, prune_pairwise_cost_matrix):
@@ -21,6 +23,21 @@ class TestCandidatePruningMatrixValidation(unittest.TestCase):
                     with self.assertRaisesRegex(
                         ValueError,
                         "cost_matrix must be numeric",
+                    ):
+                        function(matrix)
+
+    def test_cost_matrix_rejects_complex_entries(self):
+        invalid_matrices = (
+            np.array([[1.0 + 2.0j]]),
+            np.array([[1.0 + 2.0j]], dtype=object),
+        )
+
+        for function in (candidate_mask_from_costs, prune_pairwise_cost_matrix):
+            for matrix in invalid_matrices:
+                with self.subTest(function=function.__name__, dtype=str(matrix.dtype)):
+                    with self.assertRaisesRegex(
+                        ValueError,
+                        "cost_matrix must be real-valued numeric",
                     ):
                         function(matrix)
 
@@ -43,6 +60,7 @@ class TestCandidatePruningMatrixValidation(unittest.TestCase):
         config = CandidatePruningConfig(probability_threshold=0.5)
         invalid_probability_matrices = (
             np.array([[True]]),
+            np.array([[np.bool_(False)]], dtype=object),
             np.array([["0.75"]]),
             np.array([[b"0.75"]], dtype=object),
         )
@@ -52,6 +70,25 @@ class TestCandidatePruningMatrixValidation(unittest.TestCase):
                 with self.assertRaisesRegex(
                     ValueError,
                     "probability_matrix must be numeric",
+                ):
+                    candidate_mask_from_costs(
+                        np.array([[1.0]]),
+                        probability_matrix=probabilities,
+                        config=config,
+                    )
+
+    def test_probability_matrix_rejects_complex_entries(self):
+        config = CandidatePruningConfig(probability_threshold=0.5)
+        invalid_probability_matrices = (
+            np.array([[0.75 + 1.0j]]),
+            np.array([[0.75 + 1.0j]], dtype=object),
+        )
+
+        for probabilities in invalid_probability_matrices:
+            with self.subTest(dtype=str(probabilities.dtype)):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "probability_matrix must be real-valued numeric",
                 ):
                     candidate_mask_from_costs(
                         np.array([[1.0]]),


### PR DESCRIPTION
## Summary
- Reject object-dtype booleans in candidate-pruning cost/probability matrices instead of silently coercing them to `0.0`/`1.0`.
- Reject complex-valued cost/probability matrices before NumPy can discard imaginary parts during float conversion.
- Add focused regression coverage for cost and probability matrix validation.

## Validation
- Verified the branch diff against `main` with the GitHub compare API.
- Full test execution was not available from this connector-only environment.