### PR TITLE
Reject non-real support point inputs

### DIFF
--- a/src/pyrecest/sampling/support_points.py
+++ b/src/pyrecest/sampling/support_points.py
@@ -4,9 +4,36 @@ from collections.abc import Sequence
 
 import numpy as np
 
+_TEXT_TYPES = (str, bytes, bytearray, np.str_, np.bytes_)
+_BOOLEAN_TYPES = (bool, np.bool_)
+_COMPLEX_TYPES = (complex, np.complexfloating)
+
+
+def _contains_values_of_type(value: object, types: tuple[type, ...]) -> bool:
+    if isinstance(value, types):
+        return True
+    try:
+        values = np.asarray(value, dtype=object).reshape(-1)
+    except (TypeError, ValueError, RuntimeError):
+        return False
+    return any(isinstance(item, types) for item in values)
+
+
+def _has_non_real_numeric_values(value: object) -> bool:
+    return (
+        _contains_values_of_type(value, _TEXT_TYPES)
+        or _contains_values_of_type(value, _BOOLEAN_TYPES)
+        or _contains_values_of_type(value, _COMPLEX_TYPES)
+    )
+
 
 def _as_real_array(name: str, value: np.ndarray | Sequence[float]) -> np.ndarray:
-    array = np.asarray(value, dtype=np.float64)
+    if _has_non_real_numeric_values(value):
+        raise ValueError(f"{name} must contain real numeric values.")
+    try:
+        array = np.asarray(value, dtype=np.float64)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must contain real numeric values.") from exc
     if not np.isfinite(array).all():
         raise ValueError(f"{name} must contain only finite values.")
     return array
@@ -14,6 +41,8 @@ def _as_real_array(name: str, value: np.ndarray | Sequence[float]) -> np.ndarray
 
 def _as_finite_nonnegative_scalar(name: str, value: float) -> float:
     message = f"{name} must be a finite non-negative scalar."
+    if _has_non_real_numeric_values(value):
+        raise ValueError(message)
     array = np.asarray(value)
     if array.shape != () or array.dtype == np.bool_:
         raise ValueError(message)

--- a/tests/sampling/test_support_points.py
+++ b/tests/sampling/test_support_points.py
@@ -91,6 +91,12 @@ def test_ellipsoid_axis_offsets_reject_nonfinite_radius(bad_radius: float) -> No
         ellipsoid_axis_offsets(np.eye(2), radius=bad_radius)
 
 
+@pytest.mark.parametrize("bad_radius", ["1.0", b"1.0", np.str_("1.0"), np.bytes_(b"1.0")])
+def test_ellipsoid_axis_offsets_reject_text_radius(bad_radius: object) -> None:
+    with pytest.raises(ValueError, match="radius"):
+        ellipsoid_axis_offsets(np.eye(2), radius=bad_radius)
+
+
 @pytest.mark.parametrize("bad_radius", [np.nan, np.inf, -np.inf])
 def test_ellipsoid_sigma_points_reject_nonfinite_radii(bad_radius: float) -> None:
     with pytest.raises(ValueError, match="finite"):
@@ -103,6 +109,33 @@ def test_mahalanobis_support_points_reject_nonfinite_radius(bad_radius: float) -
         mahalanobis_support_points(
             [0.0, 0.0], np.eye(2), [[1.0, 0.0]], radius=bad_radius
         )
+
+
+@pytest.mark.parametrize(
+    "bad_centers",
+    [
+        [True, False],
+        np.asarray([True, False]),
+        ["0.0", "1.0"],
+    ],
+)
+def test_support_points_reject_non_real_numeric_centers(bad_centers: object) -> None:
+    with pytest.raises(ValueError, match="centers"):
+        support_points_from_axis_offsets(bad_centers, np.eye(2))
+
+
+@pytest.mark.parametrize(
+    "bad_covariance",
+    [
+        [["1.0", "0.0"], ["0.0", "1.0"]],
+        [[True, False], [False, True]],
+    ],
+)
+def test_ellipsoid_axis_offsets_reject_non_real_numeric_covariance(
+    bad_covariance: object,
+) -> None:
+    with pytest.raises(ValueError, match="covariance"):
+        ellipsoid_axis_offsets(bad_covariance)
 
 
 def test_support_points_reject_shape_mismatch() -> None:


### PR DESCRIPTION
## Summary
- Reject text, boolean, and complex values before support-point helpers coerce inputs to `float64`.
- Preserve existing finite/non-negative scalar checks while preventing numeric-looking strings and boolean coordinate arrays from silently becoming floats.
- Add regression coverage for text radii, boolean/text centers, and text/boolean covariance matrices.

## Testing
- Local smoke check of the modified `support_points.py` helper behavior in an isolated Python process, including existing diagonal covariance behavior and the new invalid-input cases.
- Not run: full repository pytest suite (repository checkout is unavailable in this environment; changes were applied through the GitHub connector).