### PR TITLE
Validate grid model callbacks

### DIFF
--- a/src/pyrecest/models/grid.py
+++ b/src/pyrecest/models/grid.py
@@ -20,6 +20,11 @@ GridLikelihoodFunction = Callable[[Any, Any], Any]
 GridTransitionDensityFactory = Callable[[Any], Any]
 
 
+def _ensure_callable(value: Any, name: str) -> None:
+    if not callable(value):
+        raise TypeError(f"{name} must be callable")
+
+
 @dataclass(frozen=True)
 class GridLikelihoodMeasurementModel:
     """Measurement model that evaluates likelihoods on a filter grid.
@@ -38,6 +43,9 @@ class GridLikelihoodMeasurementModel:
     """
 
     likelihood: GridLikelihoodFunction
+
+    def __post_init__(self) -> None:
+        _ensure_callable(self.likelihood, "likelihood")
 
     def likelihood_values(self, measurement: Any, grid: Any) -> Any:
         """Evaluate the measurement likelihood on ``grid``."""
@@ -81,6 +89,9 @@ class GridTransitionDensityFactoryModel:
     """
 
     transition_density_factory: GridTransitionDensityFactory
+
+    def __post_init__(self) -> None:
+        _ensure_callable(self.transition_density_factory, "transition_density_factory")
 
     def transition_density_for_filter(self, filter_instance: Any) -> Any:
         """Create a transition density compatible with ``filter_instance``."""

--- a/tests/models/test_grid_model_validation.py
+++ b/tests/models/test_grid_model_validation.py
@@ -1,0 +1,45 @@
+"""Regression tests for reusable grid-model callback validation."""
+
+import unittest
+
+from pyrecest.models.grid import (
+    GridLikelihoodMeasurementModel,
+    GridTransitionDensityFactoryModel,
+    GridTransitionDensityModel,
+)
+
+
+class TestGridModelValidation(unittest.TestCase):
+    def test_likelihood_model_rejects_noncallable_likelihood(self):
+        with self.assertRaisesRegex(TypeError, "likelihood must be callable"):
+            GridLikelihoodMeasurementModel(likelihood=object())
+
+    def test_transition_density_factory_model_rejects_noncallable_factory(self):
+        with self.assertRaisesRegex(
+            TypeError,
+            "transition_density_factory must be callable",
+        ):
+            GridTransitionDensityFactoryModel(transition_density_factory=object())
+
+    def test_valid_grid_model_callbacks_still_evaluate(self):
+        likelihood_model = GridLikelihoodMeasurementModel(
+            lambda measurement, grid: (measurement, grid)
+        )
+        self.assertEqual(likelihood_model.likelihood_values("z", "grid"), ("z", "grid"))
+
+        transition_density = object()
+        density_model = GridTransitionDensityModel(transition_density)
+        self.assertIs(density_model.transition_density_for_filter(object()), transition_density)
+
+        filter_instance = object()
+        factory_model = GridTransitionDensityFactoryModel(
+            lambda filter_arg: ("density", filter_arg)
+        )
+        self.assertEqual(
+            factory_model.transition_density_for_filter(filter_instance),
+            ("density", filter_instance),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds constructor validation for grid model callbacks and lightweight regression tests.