### PR TITLE
NumPy zeros dtype fix

### DIFF
--- a/src/pyrecest/_backend/numpy/_common.py
+++ b/src/pyrecest/_backend/numpy/_common.py
@@ -1,5 +1,6 @@
 import numpy as _np
 from pyrecest._backend._dtype_utils import (
+    _dyn_update_dtype,
     _modify_func_default_dtype,
     get_default_cdtype,
     get_default_dtype,

--- a/src/pyrecest/_backend/numpy/_common.py
+++ b/src/pyrecest/_backend/numpy/_common.py
@@ -1,6 +1,5 @@
 import numpy as _np
 from pyrecest._backend._dtype_utils import (
-    _dyn_update_dtype,
     _modify_func_default_dtype,
     get_default_cdtype,
     get_default_dtype,
@@ -32,4 +31,9 @@ from .._shared_numpy._common import (
 
 array = _cast_out_from_dtype(target=_np.array, dtype_pos=1)
 eye = _modify_func_default_dtype(target=_np.eye)
-zeros = _dyn_update_dtype(target=_np.zeros, dtype_pos=1)
+
+
+def zeros(shape, dtype=None, *args, **kwargs):
+    if dtype is None:
+        dtype = get_default_dtype()
+    return _np.zeros(shape, dtype, *args, **kwargs)

--- a/tests/test_numpy_backend_zeros_dtype.py
+++ b/tests/test_numpy_backend_zeros_dtype.py
@@ -1,0 +1,1 @@
+# Regression coverage for NumPy zeros dtype handling.

--- a/tests/test_numpy_backend_zeros_dtype.py
+++ b/tests/test_numpy_backend_zeros_dtype.py
@@ -1,1 +1,15 @@
-# Regression coverage for NumPy zeros dtype handling.
+import numpy as np
+
+from pyrecest._backend import numpy as numpy_backend
+
+
+def test_numpy_zeros_preserves_explicit_positional_dtype():
+    result = numpy_backend.zeros((2,), np.float32)
+
+    assert result.dtype == np.dtype(np.float32)
+
+
+def test_numpy_zeros_uses_default_dtype_when_dtype_is_omitted():
+    result = numpy_backend.zeros((2,))
+
+    assert result.dtype == numpy_backend.get_default_dtype()


### PR DESCRIPTION
Preserve explicit positional dtype in the NumPy backend zeros wrapper and add regression coverage.