### PR TITLE
Reject nonnumeric pairwise covariance inputs

### DIFF
--- a/src/pyrecest/utils/pairwise_covariance_features.py
+++ b/src/pyrecest/utils/pairwise_covariance_features.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 import math
 from typing import Any
 
+import numpy as _np
+
 # pylint: disable=no-name-in-module,no-member,redefined-builtin
 from pyrecest.backend import (
     abs,
@@ -41,6 +43,9 @@ from pyrecest.backend import (
     where,
     zeros,
 )
+
+_TEXT_OR_BYTES_TYPES = (str, bytes, bytearray, _np.str_, _np.bytes_)
+_BOOL_TYPES = (bool, _np.bool_)
 
 
 def pairwise_mahalanobis_distances(
@@ -183,7 +188,10 @@ def pairwise_covariance_shape_components(
 
 
 def _validate_control_scalar(value: Any, name: str, *, allow_zero: bool) -> float:
-    value_array = asarray(value)
+    try:
+        value_array = asarray(value)
+    except (TypeError, ValueError, OverflowError, RuntimeError) as exc:
+        raise ValueError(f"{name} must be numeric") from exc
     if value_array.shape != ():
         raise ValueError(f"{name} must be a scalar")
 
@@ -194,8 +202,10 @@ def _validate_control_scalar(value: Any, name: str, *, allow_zero: bool) -> floa
     except (TypeError, ValueError) as exc:
         raise ValueError(f"{name} must be a scalar") from exc
 
-    if isinstance(scalar_value, bool):
+    if isinstance(scalar_value, _BOOL_TYPES):
         raise ValueError(f"{name} must be numeric, not boolean")
+    if isinstance(scalar_value, _TEXT_OR_BYTES_TYPES):
+        raise ValueError(f"{name} must be numeric, not text")
 
     try:
         value_float = float(scalar_value)
@@ -216,7 +226,7 @@ def _validate_mean_covariance_stack(
     covariance_name: str,
     covariances: Any,
 ) -> tuple[Any, Any]:
-    means = asarray(means, dtype=float64)
+    means = _as_real_numeric_array(means, mean_name)
     if means.ndim != 2:
         raise ValueError(f"{mean_name} must have shape (dim, n_items)")
     if not bool(backend_all(isfinite(means))):
@@ -235,12 +245,32 @@ def _validate_mean_covariance_stack(
 
 
 def _validate_covariance_stack(name: str, covariances: Any) -> Any:
-    covariances = asarray(covariances, dtype=float64)
+    covariances = _as_real_numeric_array(covariances, name)
     if covariances.ndim != 3 or covariances.shape[0] != covariances.shape[1]:
         raise ValueError(f"{name} must have shape (dim, dim, n_items)")
     if not bool(backend_all(isfinite(covariances))):
         raise ValueError(f"{name} must contain only finite values")
     return covariances
+
+
+def _as_real_numeric_array(value: Any, name: str) -> Any:
+    """Return ``value`` as a real float array without silent text/bool coercion."""
+
+    try:
+        value_array = asarray(value)
+    except (TypeError, ValueError, OverflowError, RuntimeError) as exc:
+        raise ValueError(f"{name} must contain real numeric values") from exc
+
+    dtype = getattr(value_array, "dtype", None)
+    dtype_kind = getattr(dtype, "kind", "")
+    dtype_name = str(dtype).lower()
+    if dtype_kind in "USbcmMO" or "bool" in dtype_name or "complex" in dtype_name:
+        raise ValueError(f"{name} must contain real numeric values")
+
+    try:
+        return asarray(value_array, dtype=float64)
+    except (TypeError, ValueError, OverflowError, RuntimeError) as exc:
+        raise ValueError(f"{name} must contain real numeric values") from exc
 
 
 def _symmetrized_covariance_batch(covariances: Any) -> Any:

--- a/tests/test_pairwise_covariance_features.py
+++ b/tests/test_pairwise_covariance_features.py
@@ -67,7 +67,7 @@ class TestPairwiseCovarianceFeatures(unittest.TestCase):
         means = array([[0.0], [0.0]])
         covariance = zeros((2, 2, 1))
 
-        for bad_regularization in (True, array([1.0])):
+        for bad_regularization in (True, "1.0", b"1.0", array([1.0])):
             with self.subTest(bad_regularization=bad_regularization):
                 with self.assertRaisesRegex(ValueError, "regularization"):
                     pairwise_mahalanobis_distances(
@@ -76,6 +76,26 @@ class TestPairwiseCovarianceFeatures(unittest.TestCase):
                         means,
                         covariance,
                         regularization=bad_regularization,
+                    )
+
+    def test_pairwise_mahalanobis_distances_rejects_text_and_boolean_data(self):
+        means = array([[0.0]])
+        covariance = array([[[1.0]]])
+        bad_cases = (
+            ("means_a", [["1.0"]], covariance, means, covariance),
+            ("means_a", [[True]], covariance, means, covariance),
+            ("covariances_a", means, [[["1.0"]]], means, covariance),
+            ("covariances_a", means, [[[True]]], means, covariance),
+        )
+
+        for expected_name, means_a, covariances_a, means_b, covariances_b in bad_cases:
+            with self.subTest(expected_name=expected_name):
+                with self.assertRaisesRegex(ValueError, expected_name):
+                    pairwise_mahalanobis_distances(
+                        means_a,
+                        covariances_a,
+                        means_b,
+                        covariances_b,
                     )
 
     def test_pairwise_covariance_shape_components_separate_shape_and_scale(self):
@@ -134,13 +154,24 @@ class TestPairwiseCovarianceFeatures(unittest.TestCase):
     def test_pairwise_covariance_shape_components_rejects_ambiguous_epsilon(self):
         covariances = zeros((2, 2, 1))
 
-        for bad_epsilon in (True, array([1e-6])):
+        for bad_epsilon in (True, "1.0", b"1.0", array([1e-6])):
             with self.subTest(bad_epsilon=bad_epsilon):
                 with self.assertRaisesRegex(ValueError, "epsilon"):
                     pairwise_covariance_shape_components(
                         covariances,
                         covariances,
                         epsilon=bad_epsilon,
+                    )
+
+    def test_pairwise_covariance_shape_components_rejects_text_and_boolean_covariances(self):
+        valid_covariances = array([[[1.0]]])
+
+        for bad_covariances in ([[["1.0"]]], [[[True]]]):
+            with self.subTest(bad_covariances=bad_covariances):
+                with self.assertRaisesRegex(ValueError, "covariances_a"):
+                    pairwise_covariance_shape_components(
+                        bad_covariances,
+                        valid_covariances,
                     )
 
     def test_invalid_inputs_raise(self):


### PR DESCRIPTION
## Summary
- reject numeric-looking text, bytes, booleans, complex arrays, and object-dtype arrays before pairwise covariance helpers coerce inputs to float64
- preserve existing finite and shape validation after safe numeric coercion
- add regression coverage for invalid regularization/epsilon controls, boolean/text mean inputs, and boolean/text covariance stacks

## Testing
- `python -m py_compile /mnt/data/pairwise_covariance_features.py /mnt/data/test_pairwise_covariance_features.py`
- Not run: full pytest suite. The execution environment cannot clone/install the repository from GitHub because `github.com` DNS resolution is unavailable here.