### PR TITLE
Reject out-of-range calibrated association probabilities

### DIFF
--- a/src/pyrecest/utils/association_features.py
+++ b/src/pyrecest/utils/association_features.py
@@ -218,6 +218,8 @@ def _finite_probability_array(probabilities: Any) -> Any:
     probabilities = asarray(probabilities, dtype=float64)
     if not all(isfinite(probabilities)):
         raise ValueError("predicted probabilities must be finite")
+    if not all(probabilities >= 0.0) or not all(probabilities <= 1.0):
+        raise ValueError("predicted probabilities must lie in [0, 1]")
     return probabilities
 
 

--- a/tests/test_calibrated_association_probability_bounds.py
+++ b/tests/test_calibrated_association_probability_bounds.py
@@ -1,0 +1,62 @@
+import unittest
+
+from pyrecest.backend import array
+from pyrecest.utils import CalibratedPairwiseAssociationModel
+
+
+class TestCalibratedAssociationProbabilityBounds(unittest.TestCase):
+    def test_rejects_direct_probabilities_outside_unit_interval(self):
+        class DirectProbabilityModel:
+            def __init__(self, probabilities):
+                self.probabilities = probabilities
+
+            def predict_match_probability(self, features):
+                del features
+                return array(self.probabilities)
+
+        features = array([[0.1], [0.2]])
+        invalid_probability_vectors = (
+            [-0.1, 0.5],
+            [0.5, 1.1],
+        )
+
+        for probabilities in invalid_probability_vectors:
+            with self.subTest(probabilities=probabilities):
+                model = CalibratedPairwiseAssociationModel(
+                    DirectProbabilityModel(probabilities), feature_names=("distance",)
+                )
+
+                with self.assertRaisesRegex(ValueError, r"\[0, 1\]"):
+                    model.predict_match_probability(features)
+
+    def test_rejects_predict_proba_probabilities_outside_unit_interval(self):
+        class PredictProbaModel:
+            classes_ = [0, 1]
+
+            def predict_proba(self, features):
+                del features
+                return array([[0.8, 1.2], [0.9, 0.1]])
+
+        model = CalibratedPairwiseAssociationModel(
+            PredictProbaModel(), feature_names=("distance",)
+        )
+
+        with self.assertRaisesRegex(ValueError, r"\[0, 1\]"):
+            model.predict_match_probability(array([[0.1], [0.2]]))
+
+    def test_rejects_negative_cost_derived_probabilities_above_one(self):
+        class NegativeCostModel:
+            def pairwise_cost_matrix(self, features):
+                del features
+                return array([-1.0, 0.0])
+
+        model = CalibratedPairwiseAssociationModel(
+            NegativeCostModel(), feature_names=("distance",)
+        )
+
+        with self.assertRaisesRegex(ValueError, r"\[0, 1\]"):
+            model.predict_match_probability(array([[0.1], [0.2]]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Reject calibrated association probabilities outside the probability interval `[0, 1]` instead of silently clipping invalid model outputs.
- Cover direct `predict_match_probability`, `predict_proba`, and negative-cost-derived probability paths with regression tests.

## Bug
`CalibratedPairwiseAssociationModel.predict_match_probability(...)` previously validated only finiteness before calling `clip(..., 0.0, 1.0)`. That allowed malformed model outputs such as `-0.1` or `1.2` to be turned into plausible probabilities, hiding model/data errors. The same issue affected `predict_proba` outputs and `pairwise_cost_matrix` models whose negative costs imply probabilities above one via `exp(-cost)`.

## Testing
- Not run locally: this environment cannot clone/install the repository from GitHub because `github.com` DNS resolution is unavailable.
- Added `tests/test_calibrated_association_probability_bounds.py` for CI coverage.