### PR TITLE
Validate sequence association cost scalars

### DIFF
--- a/src/pyrecest/filters/sequence_association.py
+++ b/src/pyrecest/filters/sequence_association.py
@@ -284,7 +284,26 @@ def _reconstruct_path(
 
 
 def _validate_cost(value: object, name: str) -> float:
-    cost = float(value)
+    numeric_message = f"{name} must be a scalar numeric cost"
+    try:
+        value_array = np.asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(numeric_message) from exc
+
+    if value_array.ndim != 0 or value_array.dtype.kind in {"b", "S", "U", "c"}:
+        raise ValueError(numeric_message)
+
+    scalar = value_array.item()
+    if isinstance(
+        scalar,
+        (bool, np.bool_, str, bytes, bytearray, complex, np.complexfloating),
+    ):
+        raise ValueError(numeric_message)
+
+    try:
+        cost = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(numeric_message) from exc
     if not np.isfinite(cost):
         raise ValueError(f"{name} must be finite")
     return cost

--- a/tests/filters/test_sequence_association_cost_validation.py
+++ b/tests/filters/test_sequence_association_cost_validation.py
@@ -8,6 +8,11 @@ def test_sequence_association_rejects_boolean_unary_cost():
         SequenceAssociationNode(frame_index=0, candidate_index=0, unary_cost=True)
 
 
+def test_sequence_association_rejects_text_unary_cost():
+    with pytest.raises(ValueError, match="unary_cost must be a scalar numeric cost"):
+        SequenceAssociationNode(frame_index=0, candidate_index=0, unary_cost="1.0")
+
+
 def test_sequence_association_rejects_boolean_transition_cost():
     frames = [
         [SequenceAssociationNode(frame_index=0, candidate_index=0)],
@@ -16,6 +21,19 @@ def test_sequence_association_rejects_boolean_transition_cost():
 
     def transition_cost(_previous, _current, _context):
         return True
+
+    with pytest.raises(ValueError, match="transition_cost must be a scalar numeric cost"):
+        solve_viterbi_sequence_association(frames, transition_cost)
+
+
+def test_sequence_association_rejects_text_transition_cost():
+    frames = [
+        [SequenceAssociationNode(frame_index=0, candidate_index=0)],
+        [SequenceAssociationNode(frame_index=1, candidate_index=0)],
+    ]
+
+    def transition_cost(_previous, _current, _context):
+        return "1.0"
 
     with pytest.raises(ValueError, match="transition_cost must be a scalar numeric cost"):
         solve_viterbi_sequence_association(frames, transition_cost)

--- a/tests/filters/test_sequence_association_cost_validation.py
+++ b/tests/filters/test_sequence_association_cost_validation.py
@@ -1,0 +1,8 @@
+import pytest
+
+from pyrecest.filters import SequenceAssociationNode
+
+
+def test_sequence_association_rejects_boolean_unary_cost():
+    with pytest.raises(ValueError, match="unary_cost must be a scalar numeric cost"):
+        SequenceAssociationNode(frame_index=0, candidate_index=0, unary_cost=True)

--- a/tests/filters/test_sequence_association_cost_validation.py
+++ b/tests/filters/test_sequence_association_cost_validation.py
@@ -1,8 +1,21 @@
 import pytest
 
-from pyrecest.filters import SequenceAssociationNode
+from pyrecest.filters import SequenceAssociationNode, solve_viterbi_sequence_association
 
 
 def test_sequence_association_rejects_boolean_unary_cost():
     with pytest.raises(ValueError, match="unary_cost must be a scalar numeric cost"):
         SequenceAssociationNode(frame_index=0, candidate_index=0, unary_cost=True)
+
+
+def test_sequence_association_rejects_boolean_transition_cost():
+    frames = [
+        [SequenceAssociationNode(frame_index=0, candidate_index=0)],
+        [SequenceAssociationNode(frame_index=1, candidate_index=0)],
+    ]
+
+    def transition_cost(_previous, _current, _context):
+        return True
+
+    with pytest.raises(ValueError, match="transition_cost must be a scalar numeric cost"):
+        solve_viterbi_sequence_association(frames, transition_cost)


### PR DESCRIPTION
## Summary
- Reject boolean and text-like sequence-association costs instead of allowing `float(...)` to coerce them to numeric costs.
- Keep existing finite numeric scalar behavior for unary and transition costs.
- Add regression tests covering malformed unary and transition costs.

## Bug
`SequenceAssociationNode.__post_init__` and the Viterbi transition-cost path both called `_validate_cost`, which previously used `float(value)` directly. This allowed malformed values such as `True` and `"1.0"` to be silently interpreted as valid costs (`1.0`) rather than surfacing an invalid model/bookkeeping output.

## Testing
- Not run locally: this environment cannot clone/install the repository from GitHub because `github.com` DNS resolution is unavailable.
- Added `tests/filters/test_sequence_association_cost_validation.py` for CI coverage.