### PR TITLE
Reject boolean distribution weights

### DIFF
--- a/src/pyrecest/distributions/abstract_dirac_distribution.py
+++ b/src/pyrecest/distributions/abstract_dirac_distribution.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from numbers import Integral
 from typing import Union
 
+import numpy as np
 from beartype import beartype
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
@@ -26,6 +27,10 @@ from pyrecest.backend import (
 )
 
 from .abstract_distribution_type import AbstractDistributionType
+
+
+def _is_boolean_array(values) -> bool:
+    return np.asarray(values).dtype == np.bool_
 
 
 class AbstractDiracDistribution(AbstractDistributionType):
@@ -56,6 +61,9 @@ class AbstractDiracDistribution(AbstractDistributionType):
         """
         Validate Dirac weights and return their total mass.
         """
+        if _is_boolean_array(w):
+            raise ValueError("Dirac weights must be numeric, not boolean.")
+
         if not bool(all(isfinite(w))):
             raise ValueError("Dirac weights must be finite.")
 

--- a/src/pyrecest/distributions/abstract_mixture.py
+++ b/src/pyrecest/distributions/abstract_mixture.py
@@ -27,6 +27,10 @@ from .abstract_manifold_specific_distribution import (
 )
 
 
+def _is_boolean_array(values) -> bool:
+    return np.asarray(values).dtype == np.bool_
+
+
 def _validate_positive_sample_count(n) -> int:
     count_array = np.asarray(n)
     if count_array.ndim != 0:
@@ -68,6 +72,8 @@ class AbstractMixture(AbstractDistributionType):
         if weights is None:
             weights = ones(num_distributions) / num_distributions
         else:
+            if _is_boolean_array(weights):
+                raise ValueError("Mixture weights must be numeric, not boolean")
             weights = reshape(asarray(weights), (-1,))
 
         if num_distributions != weights.shape[0]:

--- a/tests/distributions/test_dirac_weight_shapes.py
+++ b/tests/distributions/test_dirac_weight_shapes.py
@@ -1,4 +1,5 @@
 import numpy.testing as npt
+import pytest
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import array
@@ -27,3 +28,31 @@ def test_linear_dirac_distribution_flattens_column_weights_for_sampling():
             ]
         ),
     )
+
+
+def test_linear_dirac_distribution_rejects_boolean_weights():
+    with pytest.raises(ValueError, match="boolean"):
+        LinearDiracDistribution(
+            array(
+                [
+                    [0.0],
+                    [1.0],
+                ]
+            ),
+            array([False, True]),
+        )
+
+
+def test_linear_dirac_distribution_rejects_boolean_reweighing_factors():
+    dist = LinearDiracDistribution(
+        array(
+            [
+                [0.0],
+                [1.0],
+            ]
+        ),
+        array([0.5, 0.5]),
+    )
+
+    with pytest.raises(ValueError, match="boolean"):
+        dist.reweigh(lambda _: array([False, True]))

--- a/tests/distributions/test_linear_mixture.py
+++ b/tests/distributions/test_linear_mixture.py
@@ -66,6 +66,15 @@ class LinearMixtureTest(unittest.TestCase):
             with self.assertRaises(ValueError):
                 LinearMixture([gm1, gm2], array([0.0, 0.0]))
 
+    def test_rejects_boolean_weights(self):
+        gm1 = GaussianDistribution(array([1.0]), array([[1.0]]))
+        gm2 = GaussianDistribution(array([50.0]), array([[1.0]]))
+
+        with catch_warnings():
+            simplefilter("ignore", category=UserWarning)
+            with self.assertRaisesRegex(ValueError, "boolean"):
+                LinearMixture([gm1, gm2], array([True, False]))
+
     def test_pdf(self):
         gm1 = GaussianDistribution(array([1.0, 1.0]), diag(array([2.0, 3.0])))
         gm2 = GaussianDistribution(-array([3.0, 1.0]), diag(array([2.0, 3.0])))


### PR DESCRIPTION
## Summary
- Reject boolean Dirac weights and boolean Dirac reweighting outputs.
- Reject boolean mixture weights before normalization.
- Add focused regression tests for Dirac and linear mixture weight validation.

## Testing
- Not run locally because the execution sandbox cannot resolve github.com.
- Added CI regression coverage in the touched test files.