### PR TITLE
Reject nonnumeric discrete state grids

### DIFF
--- a/src/pyrecest/filters/discrete_state/__init__.py
+++ b/src/pyrecest/filters/discrete_state/__init__.py
@@ -4,8 +4,14 @@ from __future__ import annotations
 
 from pathlib import Path
 import runpy
+from typing import Any
 
 import numpy as np
+
+_TEXT_TYPES = (str, bytes, bytearray, np.str_, np.bytes_)
+_BOOLEAN_TYPES = (bool, np.bool_)
+_COMPLEX_TYPES = (complex, np.complexfloating)
+_REJECTED_STATE_KINDS = frozenset({"b", "c", "S", "U", "M", "m"})
 
 _module_globals = runpy.run_path(
     str(Path(__file__).resolve().parents[1] / "discrete_state.py"),
@@ -16,14 +22,27 @@ _original_sparse_gaussian_transition_matrix = _module_globals[
 ]
 
 
-def sparse_gaussian_transition_matrix(
-    state_vectors,
-    sigma,
-    max_step_sigma=4.0,
-    *,
-    valid_state_mask=None,
-):
-    states = np.asarray(state_vectors, dtype=float)
+def _validated_state_vectors(state_vectors: Any) -> np.ndarray:
+    try:
+        raw_states = np.asarray(state_vectors)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("state_vectors must contain real numeric values") from exc
+
+    if raw_states.dtype.kind in _REJECTED_STATE_KINDS:
+        raise ValueError("state_vectors must contain real numeric values")
+    if raw_states.dtype == object:
+        for value in raw_states.ravel():
+            if isinstance(
+                value,
+                _TEXT_TYPES + _BOOLEAN_TYPES + _COMPLEX_TYPES,
+            ):
+                raise ValueError("state_vectors must contain real numeric values")
+
+    try:
+        states = np.asarray(state_vectors, dtype=float)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("state_vectors must contain real numeric values") from exc
+
     if states.ndim == 1:
         finite_check_states = states[:, None]
     elif states.ndim == 2:
@@ -32,8 +51,19 @@ def sparse_gaussian_transition_matrix(
         finite_check_states = None
     if finite_check_states is not None and np.any(~np.isfinite(finite_check_states)):
         raise ValueError("state_vectors must contain only finite values")
+    return states
+
+
+def sparse_gaussian_transition_matrix(
+    state_vectors,
+    sigma,
+    max_step_sigma=4.0,
+    *,
+    valid_state_mask=None,
+):
+    states = _validated_state_vectors(state_vectors)
     return _original_sparse_gaussian_transition_matrix(
-        state_vectors,
+        states,
         sigma,
         max_step_sigma=max_step_sigma,
         valid_state_mask=valid_state_mask,

--- a/tests/filters/test_discrete_state_grid_validation.py
+++ b/tests/filters/test_discrete_state_grid_validation.py
@@ -17,6 +17,19 @@ class TestDiscreteStateGridValidation(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, "state_vectors.*finite"):
                     sparse_gaussian_transition_matrix(grid, sigma=1.0)
 
+    def test_sparse_gaussian_transition_matrix_rejects_non_real_numeric_states(self):
+        invalid_grids = (
+            np.array([True, False]),
+            np.array([True, 1.0], dtype=object),
+            np.array(["0.0", "1.0"]),
+            np.array([1.0 + 0.0j, 2.0 + 0.0j]),
+        )
+
+        for grid in invalid_grids:
+            with self.subTest(grid=grid):
+                with self.assertRaisesRegex(ValueError, "state_vectors.*real numeric"):
+                    sparse_gaussian_transition_matrix(grid, sigma=1.0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- reject boolean, text-like, complex, datetime/timedelta, and other non-real state-grid coordinates before `sparse_gaussian_transition_matrix` can coerce them to floats
- preserve the existing finite-coordinate guard and pass validated float grids into the underlying transition builder
- add regression coverage for boolean, object-bool, numeric-looking text, and complex grid inputs

## Testing
- local syntax/validation check of the modified helper and regression cases
- not run full pytest locally because the execution environment cannot clone/install the repository from GitHub

## Bug
Malformed grid coordinates such as booleans or numeric-looking strings were accepted as `0.0`/`1.0` after NumPy coercion. That can silently build a transition matrix for an invalid finite-state grid instead of rejecting the input.