### PR TITLE
Validate track latency missed values

### DIFF
--- a/src/pyrecest/utils/track_metrics.py
+++ b/src/pyrecest/utils/track_metrics.py
@@ -219,6 +219,7 @@ def track_latencies(
     )
     predicted_lookup = _single_observation_lookup(predicted)
     times = _session_times(reference.shape[1], session_times)
+    missed_latency = _validate_missed_value(missed_value)
     values: list[float] = []
     for observations in _observations_by_track(reference):
         if not observations:
@@ -230,7 +231,7 @@ def track_latencies(
             if (session, observation) in predicted_lookup
         ]
         if not detected_sessions:
-            values.append(float(missed_value))
+            values.append(missed_latency)
             continue
         values.append(
             float(times[min(detected_sessions)] - times[first_reference_session])
@@ -341,6 +342,22 @@ def _session_times(
     if np.any(np.diff(times) < 0):
         raise ValueError("session_times must be nondecreasing")
     return times
+
+
+def _validate_missed_value(value: Any) -> float:
+    value_array = np.asarray(value, dtype=object)
+    if value_array.shape != ():
+        raise ValueError("missed_value must be a scalar numeric value")
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_, str, bytes, bytearray, np.str_, np.bytes_)):
+        raise ValueError("missed_value must be a scalar numeric value")
+    try:
+        parsed = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("missed_value must be a scalar numeric value") from exc
+    if np.isinf(parsed):
+        raise ValueError("missed_value must be finite or NaN")
+    return parsed
 
 
 def _contains_bool_or_text(values: np.ndarray) -> bool:

--- a/tests/test_track_latency_missed_value.py
+++ b/tests/test_track_latency_missed_value.py
@@ -1,0 +1,37 @@
+"""Regression tests for track-latency missed-value validation."""
+
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+from pyrecest.utils.track_metrics import track_latencies
+
+
+class TestTrackLatencyMissedValue(unittest.TestCase):
+    def test_track_latency_rejects_invalid_missed_values(self):
+        invalid_missed_values = (
+            True,
+            "1.0",
+            b"1.0",
+            np.inf,
+            -np.inf,
+            np.array([np.nan]),
+        )
+
+        for missed_value in invalid_missed_values:
+            with self.subTest(missed_value=missed_value):
+                with self.assertRaisesRegex(ValueError, "missed_value"):
+                    track_latencies([[None]], [[0]], missed_value=missed_value)
+
+    def test_track_latency_accepts_numeric_missed_values(self):
+        npt.assert_allclose(
+            track_latencies([[None]], [[0]], missed_value=7.0), np.array([7.0])
+        )
+        values = track_latencies([[None]], [[0]], missed_value=np.array(np.nan))
+
+        self.assertEqual(values.shape, (1,))
+        self.assertTrue(np.isnan(values[0]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Validate `track_latencies(..., missed_value=...)` before converting the sentinel to a float.
- Reject boolean, text-like, infinite, and nonscalar values.
- Add focused regression coverage for invalid sentinels and accepted numeric/NaN sentinels.

## Testing
- `python -m py_compile /mnt/data/track_metrics.py /mnt/data/test_track_latency_missed_value.py`
- Full pytest was not run in this sandbox.