### PR TITLE
Validate implicit surface protocol methods are callable

### DIFF
--- a/src/pyrecest/evaluation/implicit_surfaces.py
+++ b/src/pyrecest/evaluation/implicit_surfaces.py
@@ -22,25 +22,28 @@ _INVALID_NUMERIC_SCALAR_TYPES = (
 )
 
 
+def _surface_method(surface: Any, name: str) -> Callable[[Any], Any]:
+    """Return a callable scalar-field method or raise a clear protocol error."""
+
+    method = getattr(surface, name, None)
+    if not callable(method):
+        raise TypeError(f"surface must implement {name}(points).")
+    return method
+
+
 def surface_residuals(surface: Any, points: Any) -> Any:
     """Return scalar-field residuals for ``points`` via ``surface.value``."""
-    if not hasattr(surface, "value"):
-        raise TypeError("surface must implement value(points).")
-    return surface.value(points)
+    return _surface_method(surface, "value")(points)
 
 
 def surface_gradients(surface: Any, points: Any) -> Any:
     """Return scalar-field gradients for ``points`` via ``surface.gradient``."""
-    if not hasattr(surface, "gradient"):
-        raise TypeError("surface must implement gradient(points).")
-    return surface.gradient(points)
+    return _surface_method(surface, "gradient")(points)
 
 
 def surface_variances(surface: Any, points: Any) -> Any:
     """Return predictive field variances for ``points`` via ``surface.variance_at``."""
-    if not hasattr(surface, "variance_at"):
-        raise TypeError("surface must implement variance_at(points).")
-    return surface.variance_at(points)
+    return _surface_method(surface, "variance_at")(points)
 
 
 def surface_band_mask(values: Any, threshold: float) -> np.ndarray:

--- a/tests/evaluation/test_implicit_surfaces.py
+++ b/tests/evaluation/test_implicit_surfaces.py
@@ -35,6 +35,12 @@ class PlaneField:
         return np.full(points.shape[:-1], 0.04, dtype=np.float64)
 
 
+class NonCallableField:
+    value = 1.0
+    gradient = 1.0
+    variance_at = 1.0
+
+
 def test_scalar_field_protocols_are_structural() -> None:
     field = PlaneField()
 
@@ -53,6 +59,21 @@ def test_surface_residual_gradient_and_variance_helpers() -> None:
         [[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]],
     )
     assert np.allclose(surface_variances(field, points), [0.04, 0.04])
+
+
+@pytest.mark.parametrize(
+    ("helper", "method_name"),
+    [
+        (surface_residuals, "value"),
+        (surface_gradients, "gradient"),
+        (surface_variances, "variance_at"),
+    ],
+)
+def test_surface_helpers_reject_non_callable_protocol_members(helper, method_name) -> None:
+    points = np.asarray([[0.0, 0.0, 1.0]], dtype=np.float64)
+
+    with pytest.raises(TypeError, match=f"surface must implement {method_name}"):
+        helper(NonCallableField(), points)
 
 
 def test_surface_band_mask_and_inside_outside_classification() -> None:


### PR DESCRIPTION
## Summary
- require callable implicit-surface hooks before invoking them
- cover non-callable value, gradient, and variance_at attributes with regression tests

## Testing
- Not run locally in this connector-only environment.