### PR TITLE
Validate public API stability levels

### DIFF
--- a/src/pyrecest/stability.py
+++ b/src/pyrecest/stability.py
@@ -32,6 +32,10 @@ class PublicAPIStatus:
     replacement: str | None = None
     notes: str = ""
 
+    def __post_init__(self) -> None:
+        if self.level not in STABILITY_LEVELS:
+            raise ValueError(f"Unknown stability level: {self.level!r}")
+
     def to_dict(self) -> dict[str, str | None]:
         """Return a JSON-serializable representation."""
         return asdict(self)

--- a/tests/test_stability.py
+++ b/tests/test_stability.py
@@ -1,4 +1,11 @@
-from pyrecest.stability import get_public_api_status, iter_public_api_status, stability
+import pytest
+
+from pyrecest.stability import (
+    PublicAPIStatus,
+    get_public_api_status,
+    iter_public_api_status,
+    stability,
+)
 
 
 def test_registered_public_api_status():
@@ -8,6 +15,11 @@ def test_registered_public_api_status():
     assert list(iter_public_api_status())
 
 
+def test_public_api_status_rejects_unknown_stability_level():
+    with pytest.raises(ValueError, match="Unknown stability level"):
+        PublicAPIStatus("ExampleAPI", "public")  # type: ignore[arg-type]
+
+
 def test_stability_decorator_attaches_metadata():
     @stability("experimental", since="2.3.0", notes="test helper")
     def sample():
@@ -15,3 +27,25 @@ def test_stability_decorator_attaches_metadata():
 
     assert sample() == 1
     assert sample.__pyrecest_stability__.level == "experimental"
+
+
+def test_stability_decorator_attaches_public_api_status():
+    @stability("experimental", since="2.4.0", notes="example")
+    def example_function():
+        return None
+
+    status = example_function.__pyrecest_stability__
+
+    assert isinstance(status, PublicAPIStatus)
+    assert status.name.endswith("example_function")
+    assert status.level == "experimental"
+    assert status.since == "2.4.0"
+    assert status.notes == "example"
+
+
+def test_registered_public_api_status_rows_have_valid_levels():
+    rows = list(iter_public_api_status())
+
+    assert rows
+    assert get_public_api_status("KalmanFilter") in rows
+    assert all(isinstance(row, PublicAPIStatus) for row in rows)


### PR DESCRIPTION
## Summary
- Add `PublicAPIStatus.__post_init__` validation so direct metadata construction rejects unknown stability levels.
- Extend stability tests to cover direct `PublicAPIStatus` construction and decorator-produced metadata.

## Bug
The `stability(...)` decorator rejected unknown levels, but callers could instantiate `PublicAPIStatus` directly with an invalid level such as `"public"`. That produced inconsistent public-API metadata that would pass through `to_dict()` and status iteration despite being outside the declared `StabilityLevel` set.

## Validation
- Inspected the GitHub compare: only `src/pyrecest/stability.py` and `tests/test_stability.py` changed.
- Full pytest was not run locally in this connector-only environment; CI should run the focused regression tests.