### PR TITLE
Reject complex assignment costs

### DIFF
--- a/src/pyrecest/utils/assignment.py
+++ b/src/pyrecest/utils/assignment.py
@@ -26,6 +26,7 @@ from scipy.optimize import linear_sum_assignment
 
 _TEXT_TYPES = (str, bytes, bytearray, _np.str_, _np.bytes_)
 _BOOLEAN_TYPES = (bool, _np.bool_)
+_COMPLEX_TYPES = (complex, _np.complexfloating)
 _INVALID_SCALAR_TYPES = _BOOLEAN_TYPES + _TEXT_TYPES
 
 
@@ -74,6 +75,18 @@ def _has_boolean_dtype(value) -> bool:
     return dtype is not None and str(dtype).lower() in {"bool", "bool_", "torch.bool"}
 
 
+def _has_complex_dtype(value) -> bool:
+    dtype = getattr(value, "dtype", None)
+    if dtype is None:
+        return False
+    try:
+        if _np.issubdtype(dtype, _np.complexfloating):
+            return True
+    except TypeError:
+        pass
+    return str(dtype).lower() in {"complex", "complex64", "complex128", "torch.complex64", "torch.complex128"}
+
+
 def _contains_boolean_values(value) -> bool:
     if isinstance(value, _BOOLEAN_TYPES):
         return True
@@ -94,11 +107,23 @@ def _contains_text_values(value) -> bool:
     return any(isinstance(item, _TEXT_TYPES) for item in values)
 
 
+def _contains_complex_values(value) -> bool:
+    if isinstance(value, _COMPLEX_TYPES):
+        return True
+    try:
+        values = _np.asarray(value, dtype=object).reshape(-1)
+    except (TypeError, ValueError, RuntimeError):
+        return False
+    return any(isinstance(item, _COMPLEX_TYPES) for item in values)
+
+
 def _coerce_cost_matrix(cost_matrix):
     if _contains_boolean_values(cost_matrix):
         raise ValueError("cost_matrix must be numeric, not boolean")
     if _contains_text_values(cost_matrix):
         raise ValueError("cost_matrix must be numeric")
+    if _contains_complex_values(cost_matrix):
+        raise ValueError("cost_matrix must be real-valued numeric")
     try:
         raw_cost_matrix = _asarray(cost_matrix)
     except (TypeError, ValueError, OverflowError, RuntimeError) as exc:
@@ -111,6 +136,8 @@ def _coerce_cost_matrix(cost_matrix):
         raise ValueError("cost_matrix must be numeric, not boolean")
     if _contains_text_values(cost_matrix) or _contains_text_values(raw_cost_matrix):
         raise ValueError("cost_matrix must be numeric")
+    if _has_complex_dtype(raw_cost_matrix) or _contains_complex_values(raw_cost_matrix):
+        raise ValueError("cost_matrix must be real-valued numeric")
 
     try:
         coerced_cost_matrix = _asarray(raw_cost_matrix, dtype=float)
@@ -141,6 +168,8 @@ def _coerce_non_assignment_costs(costs, size: int, name: str):
         raise ValueError(f"{name} must be numeric and finite")
     if _contains_text_values(costs) or _contains_text_values(raw_costs_array):
         raise ValueError(f"{name} must be numeric and finite")
+    if _has_complex_dtype(raw_costs_array) or _contains_complex_values(costs) or _contains_complex_values(raw_costs_array):
+        raise ValueError(f"{name} must be real-valued numeric and finite")
 
     try:
         costs_array = _asarray(raw_costs_array, dtype=float)

--- a/tests/utils/test_assignment_complex_cost_validation.py
+++ b/tests/utils/test_assignment_complex_cost_validation.py
@@ -1,0 +1,51 @@
+import unittest
+
+import numpy as np
+import pyrecest.backend
+from pyrecest.utils import (
+    min_cost_max_cardinality_assignment,
+    murty_k_best_assignments,
+)
+
+
+class AssignmentComplexCostValidationTest(unittest.TestCase):
+    @staticmethod
+    def _solvers():
+        return (
+            ("murty", lambda matrix: murty_k_best_assignments(matrix, k=1)),
+            ("max_cardinality", min_cost_max_cardinality_assignment),
+        )
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on the JAX backend",
+    )
+    def test_complex_cost_matrix_entries_are_rejected(self):
+        complex_matrices = (
+            np.array([[1.0 + 2.0j, 2.0 + 0.0j]]),
+            np.array([[1.0, 2.0 + 0.0j]], dtype=object),
+        )
+        for solver_name, solver in self._solvers():
+            for matrix in complex_matrices:
+                with self.subTest(solver=solver_name, dtype=str(matrix.dtype)):
+                    with self.assertRaisesRegex(ValueError, "real-valued"):
+                        solver(matrix)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on the JAX backend",
+    )
+    def test_complex_non_assignment_costs_are_rejected(self):
+        matrix = np.array([[1.0]])
+        invalid_costs = (
+            {"row_non_assignment_costs": np.array([1.0 + 2.0j])},
+            {"col_non_assignment_costs": np.array([1.0 + 0.0j], dtype=object)},
+        )
+        for kwargs in invalid_costs:
+            with self.subTest(kwargs=tuple(kwargs)):
+                with self.assertRaisesRegex(ValueError, "real-valued"):
+                    murty_k_best_assignments(matrix, k=1, **kwargs)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Reject complex-valued assignment cost matrices before NumPy can discard imaginary parts during float coercion.
- Reject complex row/column non-assignment costs with the same real-valued cost contract.
- Add regression coverage for complex dtype and object-dtype complex inputs.
- Refreshed the branch onto current `main` so the PR is mergeable again.

## Bug
`murty_k_best_assignments` and `min_cost_max_cardinality_assignment` validate assignment costs as real-valued costs, but complex NumPy arrays can be cast to `float` by discarding the imaginary component. That lets invalid model/output costs silently change the optimization objective. The new guards reject complex dtype and object-dtype complex values before coercion.

## Validation
- Not run locally in this connector environment.
- Added focused regression coverage in `tests/utils/test_assignment_complex_cost_validation.py`; CI should run the repository test matrix.