### PR TITLE
Reject non-real point-set coordinates

### DIFF
--- a/src/pyrecest/evaluation/point_set_metrics.py
+++ b/src/pyrecest/evaluation/point_set_metrics.py
@@ -29,15 +29,26 @@ def as_point_set(
         Optional required point dimensionality.
     """
 
-    array = np.asarray(points, dtype=np.float64)
+    try:
+        array = np.asarray(points)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must have shape (N, D).") from exc
     if array.ndim != 2:
         raise ValueError(f"{name} must have shape (N, D).")
     if expected_dim is not None and array.shape[1] != expected_dim:
         raise ValueError(f"{name} must have shape (N, {expected_dim}).")
     if array.shape[0] == 0:
         raise ValueError(f"{name} must contain at least one point.")
+    if array.dtype.kind not in "iuf":
+        raise ValueError(f"{name} must contain only finite real numeric values.")
+    try:
+        array = array.astype(np.float64, copy=False)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(
+            f"{name} must contain only finite real numeric values."
+        ) from exc
     if not np.all(np.isfinite(array)):
-        raise ValueError(f"{name} must contain only finite values.")
+        raise ValueError(f"{name} must contain only finite real numeric values.")
     return array
 
 

--- a/tests/evaluation/test_point_set_metric_validation.py
+++ b/tests/evaluation/test_point_set_metric_validation.py
@@ -1,0 +1,29 @@
+import numpy as np
+import pytest
+
+from pyrecest.evaluation.point_set_metrics import nearest_neighbor_distances
+
+
+@pytest.mark.parametrize(
+    "invalid_points",
+    [
+        [["0.0"], ["1.0"]],
+        np.array([[True], [False]], dtype=np.bool_),
+        np.array([[1.0 + 0.0j], [2.0 + 0.0j]], dtype=np.complex128),
+        np.array([[1.0], [2.0]], dtype=object),
+    ],
+)
+def test_point_set_metrics_rejects_nonreal_coordinate_dtypes(invalid_points):
+    reference = np.array([[0.0]])
+
+    with pytest.raises(ValueError, match="finite real numeric"):
+        nearest_neighbor_distances(invalid_points, reference)
+
+
+def test_point_set_metrics_still_accepts_numeric_integer_coordinates():
+    distances = nearest_neighbor_distances(
+        np.array([[0], [2]], dtype=np.int64),
+        np.array([[1]], dtype=np.uint64),
+    )
+
+    np.testing.assert_allclose(distances, [1.0, 1.0])


### PR DESCRIPTION
## Summary
- Reject non-real or non-numeric point-set coordinate dtypes before converting point sets to `float64`.
- Prevent boolean, complex, text, and object-dtype coordinates from being silently interpreted by nearest-neighbor/Chamfer/precision-recall metrics.
- Add regression tests that keep numeric integer coordinate arrays accepted.

## Testing
- `python -m py_compile /mnt/data/point_set_metrics.py /mnt/data/test_point_set_metric_validation.py` locally against the patched files
- CI should run the repository test suite on GitHub