### PR TITLE
Reject non-real padded history values

### DIFF
--- a/src/pyrecest/utils/history_recorder.py
+++ b/src/pyrecest/utils/history_recorder.py
@@ -33,6 +33,39 @@ def _validate_bool_flag(value: Any, name: str) -> bool:
     raise TypeError(f"{name} must be a boolean")
 
 
+_INVALID_PADDED_HISTORY_DTYPE_PREFIXES = ("<u", ">u", "|u", "=u", "<s", ">s", "|s", "=s")
+
+
+def _is_invalid_padded_history_dtype(dtype: Any) -> bool:
+    dtype_name = str(dtype).lower()
+    return (
+        "bool" in dtype_name
+        or "complex" in dtype_name
+        or "object" in dtype_name
+        or "str" in dtype_name
+        or "bytes" in dtype_name
+        or "datetime" in dtype_name
+        or "timedelta" in dtype_name
+        or dtype_name.startswith(_INVALID_PADDED_HISTORY_DTYPE_PREFIXES)
+    )
+
+
+def _as_padded_numeric_array(curr_ests):
+    message = "padded history values must be real numeric"
+    try:
+        raw_curr_ests = asarray(curr_ests)
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise TypeError(message) from exc
+
+    if _is_invalid_padded_history_dtype(getattr(raw_curr_ests, "dtype", None)):
+        raise TypeError(message)
+
+    try:
+        return asarray(raw_curr_ests, dtype=float)
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise TypeError(message) from exc
+
+
 class HistoryRecorder:
     """Record and retrieve named histories.
 
@@ -140,7 +173,7 @@ class HistoryRecorder:
 
     @staticmethod
     def _ensure_2d(curr_ests):
-        curr_ests = asarray(curr_ests, dtype=float)
+        curr_ests = _as_padded_numeric_array(curr_ests)
         if curr_ests.ndim == 0:
             curr_ests = curr_ests.reshape(1, 1)
         elif curr_ests.ndim != 2 or curr_ests.shape[1] != 1:

--- a/tests/utils/test_history_recorder_padded_validation.py
+++ b/tests/utils/test_history_recorder_padded_validation.py
@@ -1,0 +1,37 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.utils import HistoryRecorder
+
+
+class HistoryRecorderPaddedValidationTest(unittest.TestCase):
+    def test_padded_history_rejects_boolean_values(self):
+        recorder = HistoryRecorder()
+
+        for value in ([True], np.array([False]), np.array([1.0, True], dtype=object)):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(TypeError, "padded history values"):
+                    recorder.record("state", value, pad_with_nan=True)
+
+    def test_padded_history_rejects_text_values(self):
+        recorder = HistoryRecorder()
+
+        for value in (["1.0"], np.array(["2.0"]), np.array([1.0, "2.0"], dtype=object)):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(TypeError, "padded history values"):
+                    recorder.record("state", value, pad_with_nan=True)
+
+    def test_padded_history_rejects_complex_initial_values(self):
+        recorder = HistoryRecorder()
+
+        with self.assertRaisesRegex(TypeError, "padded history values"):
+            recorder.register(
+                "state",
+                np.array([1.0 + 2.0j]),
+                pad_with_nan=True,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- validate padded numeric history values before converting them with `dtype=float`
- reject boolean, text/bytes, complex, datetime/timedelta, and object-dtype padded history entries instead of silently coercing them
- add regression coverage for boolean/text records and complex initial padded values

## Bug
`HistoryRecorder._ensure_2d` converted padded history values via `asarray(curr_ests, dtype=float)`. That allowed malformed numeric histories such as `True` or `"1.0"` to be stored as ordinary numeric values, and complex values could lose their imaginary component during float conversion. Padded histories are documented as numeric histories, so invalid non-real inputs should fail before they pollute logged state/estimate histories.

## Validation
- `python -m py_compile /tmp/pyrecest_patch/src/pyrecest/utils/history_recorder.py /tmp/pyrecest_patch/tests/utils/test_history_recorder_padded_validation.py`
- targeted stubbed NumPy-backend run of the new regression test: `3 tests OK`

Full repository pytest was not run locally because this environment cannot resolve `github.com` to clone/install the repository; CI should run the repository test matrix on this PR.