### PR TITLE
Validate PyTorch random array sizes

### DIFF
--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -167,6 +167,36 @@ def _normal_size(size):
     return _shape_from_size(size)
 
 
+def _broadcasted_parameter_shape(*parameters, message):
+    try:
+        return tuple(_torch.broadcast_shapes(*(parameter.shape for parameter in parameters)))
+    except RuntimeError as exc:
+        raise ValueError(message) from exc
+
+
+def _sample_shape_from_size_and_parameters(size, parameters, message):
+    parameter_shape = _broadcasted_parameter_shape(*parameters, message=message)
+    if size is None:
+        return parameter_shape
+
+    sample_shape = _shape_from_size(size)
+    try:
+        broadcast_shape = tuple(_torch.broadcast_shapes(sample_shape, parameter_shape))
+    except RuntimeError as exc:
+        raise ValueError(message) from exc
+    if broadcast_shape != sample_shape:
+        raise ValueError(message)
+    return sample_shape
+
+
+def _normal_array_size(size, loc, scale):
+    return _sample_shape_from_size_and_parameters(
+        size,
+        (loc, scale),
+        "size, loc, and scale could not be broadcast together",
+    )
+
+
 def _normal_device(*values):
     for value in values:
         if _torch.is_tensor(value):
@@ -349,23 +379,19 @@ def normal(loc=0.0, scale=1.0, size=None):
         return _torch.normal(mean=loc, std=scale, size=size or ())
 
     loc, scale = _normal_array_parameters(loc, scale)
-    if size is None:
-        return _torch.normal(mean=loc, std=scale)
-
     if bool(_torch.any(scale < 0)):
         raise ValueError("scale must be non-negative")
+    size = _normal_array_size(size, loc, scale)
     dtype = _torch.result_type(loc, scale)
     return _torch.empty(size, dtype=dtype, device=loc.device).normal_() * scale + loc
 
 
 def _uniform_size(size, low, high):
-    if size is not None:
-        return _shape_from_size(size)
-
-    try:
-        return tuple(_torch.broadcast_shapes(low.shape, high.shape))
-    except RuntimeError as exc:
-        raise ValueError("low and high could not be broadcast together") from exc
+    return _sample_shape_from_size_and_parameters(
+        size,
+        (low, high),
+        "size, low, and high could not be broadcast together",
+    )
 
 
 def _validate_uniform_bounds(low, high):

--- a/tests/backend/test_pytorch_random_backend.py
+++ b/tests/backend/test_pytorch_random_backend.py
@@ -104,6 +104,36 @@ def test_randint_rejects_invalid_array_bounds(low, high):
         random.randint(low, high)
 
 
+@pytest.mark.parametrize("bad_size", [(), (3,), (3, 1)])
+def test_normal_rejects_array_parameters_incompatible_with_explicit_size(bad_size):
+    with pytest.raises(ValueError, match="broadcast"):
+        random.normal(torch.tensor([1.0, 2.0]), 1.0, size=bad_size)
+
+
+@pytest.mark.parametrize("bad_size", [(), (3,), (3, 1)])
+def test_uniform_rejects_array_parameters_incompatible_with_explicit_size(bad_size):
+    with pytest.raises(ValueError, match="broadcast"):
+        random.uniform(torch.tensor([1.0, 2.0]), 3.0, size=bad_size)
+
+
+def test_normal_accepts_array_parameters_with_compatible_explicit_size():
+    random.seed(0)
+
+    samples = random.normal(torch.tensor([1.0, 2.0]), 1.0, size=(4, 2))
+
+    assert samples.shape == (4, 2)
+
+
+def test_uniform_accepts_array_parameters_with_compatible_explicit_size():
+    random.seed(0)
+
+    samples = random.uniform(torch.tensor([1.0, 2.0]), 3.0, size=(4, 2))
+
+    assert samples.shape == (4, 2)
+    assert torch.all(samples >= torch.tensor([1.0, 2.0]))
+    assert torch.all(samples <= 3.0)
+
+
 def test_scalar_and_empty_tuple_sizes_keep_scalar_shape():
     assert random.rand().shape == ()
     assert random.rand(size=()).shape == ()


### PR DESCRIPTION
## Summary
- validate explicit `size` against broadcasted array-valued parameters in the PyTorch `normal` and `uniform` random helpers
- preserve NumPy-compatible behavior by rejecting requested sizes that would otherwise broadcast to a different output shape
- add focused PyTorch random backend regression tests for incompatible and compatible array-parameter sizes

## Validation
- Not run locally; changes were made through the GitHub connector.