### PR TITLE
Reject duplicate detections in index matrices

### DIFF
--- a/src/pyrecest/utils/multisession_assignment_score.py
+++ b/src/pyrecest/utils/multisession_assignment_score.py
@@ -141,8 +141,13 @@ def tracks_to_index_matrix(
     )
 
     matrix = full((len(tracks), max_session_index + 1), fill_value, dtype=int)
+    seen_observations: set[tuple[int, int]] = set()
     for track_index, track in enumerate(tracks):
         for session_index, detection_index in _iter_track_items(track):
+            observation = (int(session_index), int(detection_index))
+            if observation in seen_observations:
+                raise ValueError("Each detection can only belong to a single track.")
+            seen_observations.add(observation)
             matrix[track_index, session_index] = detection_index
     return matrix
 

--- a/tests/test_multisession_assignment_score_validation.py
+++ b/tests/test_multisession_assignment_score_validation.py
@@ -66,6 +66,20 @@ class TestMultiSessionAssignmentScoreValidation(unittest.TestCase):
                         fill_value=fill_value,
                     )
 
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_tracks_to_index_matrix_rejects_duplicate_detections(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "Each detection can only belong to a single track",
+        ):
+            score_module.tracks_to_index_matrix(
+                [{0: 0}, {0: 0}],
+                session_sizes=[1],
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- reject duplicate `(session, detection)` entries when exporting tracks with `tracks_to_index_matrix`
- align the index-matrix export with `tracks_to_session_labels`, which already rejects assigning one detection to multiple tracks
- add a regression test covering duplicate detections across tracks

## Validation
- Not run locally; changes were made through the GitHub connector.