### PR TITLE
Fix fixed-lag Viterbi custom transition context

### DIFF
--- a/src/pyrecest/filters/tracklet_viterbi.py
+++ b/src/pyrecest/filters/tracklet_viterbi.py
@@ -332,6 +332,7 @@ def solve_fixed_lag_tracklet_viterbi(
             local_transition_cost = _transition_with_prefix_miss_streak(
                 transition_cost,
                 prefix_candidate,
+                previous_committed,
                 committed_miss_streak,
                 config,
             )
@@ -493,6 +494,7 @@ def _nodes_for_frame(
 def _transition_with_prefix_miss_streak(
     transition_cost: TransitionCost | None,
     prefix_candidate: TrackletAssociationCandidate,
+    prefix_previous: TrackletAssociationCandidate | None,
     committed_miss_streak: int,
     config: TrackletViterbiConfig,
 ) -> TransitionCost:
@@ -511,6 +513,7 @@ def _transition_with_prefix_miss_streak(
         miss_streak: int,
     ) -> float:
         if previous is prefix_candidate:
+            previous = prefix_previous
             miss_streak = int(committed_miss_streak)
         return float(transition(previous, current, miss_streak))
 
@@ -527,15 +530,6 @@ def _fixed_lag_committed_step_cost(
     """Score only the newly committed fixed-lag decision."""
 
     unary_cost = 0.0 if selected is None else float(selected.unary_cost)
-    if previous_committed is None:
-        if selected is None:
-            return float(
-                unary_cost
-                + config.missed_detection_cost
-                + (config.consecutive_miss_cost if committed_miss_streak > 0 else 0.0)
-            )
-        return float(unary_cost)
-
     transition = transition_cost or (
         lambda previous, current, miss_streak: default_tracklet_transition_cost(
             previous,
@@ -544,6 +538,12 @@ def _fixed_lag_committed_step_cost(
             config,
         )
     )
+    if previous_committed is None:
+        if committed_miss_streak > 0:
+            return float(unary_cost + transition(None, selected, committed_miss_streak))
+        if selected is None:
+            return float(unary_cost + config.missed_detection_cost)
+        return float(unary_cost)
     return float(
         unary_cost + transition(previous_committed, selected, committed_miss_streak)
     )

--- a/tests/filters/test_tracklet_viterbi.py
+++ b/tests/filters/test_tracklet_viterbi.py
@@ -179,3 +179,59 @@ def test_fixed_lag_consecutive_miss_after_detection_uses_committed_streak():
 
     assert fixed_lag.path == [frames[0][0], None, None]
     assert fixed_lag.total_cost == 9.0
+
+
+def test_fixed_lag_custom_transition_preserves_leading_gap_previous_none():
+    frames = [[], [TrackletAssociationCandidate("candidate", unary_cost=0.0)]]
+    config = TrackletViterbiConfig(missed_detection_cost=2.0)
+
+    def transition(previous, current, miss_streak):
+        del miss_streak
+        if current is None:
+            return 20.0
+        if previous is None:
+            return 0.0
+        return 100.0
+
+    full = solve_tracklet_viterbi(
+        frames,
+        config=config,
+        transition_cost=transition,
+    )
+    fixed_lag = solve_fixed_lag_tracklet_viterbi(
+        frames,
+        lag_s=0.1,
+        config=config,
+        transition_cost=transition,
+    )
+
+    assert fixed_lag.path == full.path == [None, frames[1][0]]
+    assert fixed_lag.total_cost == full.total_cost
+
+
+def test_fixed_lag_custom_transition_scores_recovery_after_leading_gap():
+    frames = [[], [TrackletAssociationCandidate("candidate", unary_cost=0.0)]]
+    config = TrackletViterbiConfig(missed_detection_cost=2.0)
+
+    def transition(previous, current, miss_streak):
+        if current is None:
+            return 100.0
+        if previous is None and miss_streak > 0:
+            return 7.0
+        return 0.0
+
+    full = solve_tracklet_viterbi(
+        frames,
+        config=config,
+        transition_cost=transition,
+    )
+    fixed_lag = solve_fixed_lag_tracklet_viterbi(
+        frames,
+        lag_s=0.1,
+        config=config,
+        transition_cost=transition,
+    )
+
+    assert fixed_lag.path == full.path == [None, frames[1][0]]
+    assert full.total_cost == 9.0
+    assert fixed_lag.total_cost == full.total_cost


### PR DESCRIPTION
## Summary
- preserve the logical previous state when fixed-lag Viterbi prepends a synthetic prefix after a leading missed-detection gap
- score committed fixed-lag decisions with custom transition costs after a leading gap, matching full Viterbi semantics
- add regressions for custom transition selection and total-cost consistency

## Bug
When `solve_fixed_lag_tracklet_viterbi(...)` had accumulated leading misses, it inserted a synthetic prefix candidate to carry missed-streak context into the local look-ahead window. Custom `transition_cost` callbacks then saw this synthetic candidate as `previous` instead of `None`, so fixed-lag selection could diverge from `solve_tracklet_viterbi(...)`. The committed total-cost path also skipped the custom transition when recovering from a leading gap.

## Testing
- `PYTHONPATH=/tmp/pyrectest pytest -q /tmp/pyrectest/tests/filters/test_tracklet_viterbi.py` in a minimal isolated reconstruction of the touched module: `14 passed`