### PR TITLE
Reject non-real block particle filter inputs

### DIFF
--- a/src/pyrecest/filters/block_particle_filter.py
+++ b/src/pyrecest/filters/block_particle_filter.py
@@ -57,6 +57,9 @@ def _as_integer(value, name: str, minimum: int | None = None) -> int:
 def _as_real_numeric_array(value, name: str):
     """Return ``value`` as a backend float array without silent nonnumeric coercion."""
 
+    if _has_unsupported_numeric_leaf(value):
+        raise ValueError(f"{name} must contain real numeric values.")
+
     try:
         original = np.asarray(value)
     except (TypeError, ValueError) as exc:
@@ -109,6 +112,27 @@ def _as_real_numeric_array(value, name: str):
         return array(value, dtype=float)
     except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError(f"{name} must contain real numeric values.") from exc
+
+
+def _has_unsupported_numeric_leaf(value) -> bool:
+    if isinstance(
+        value,
+        (
+            bool,
+            np.bool_,
+            str,
+            bytes,
+            bytearray,
+            complex,
+            np.complexfloating,
+        ),
+    ):
+        return True
+    if isinstance(value, np.ndarray):
+        return False
+    if isinstance(value, Sequence):
+        return any(_has_unsupported_numeric_leaf(item) for item in value)
+    return False
 
 
 def validate_partition(

--- a/src/pyrecest/filters/block_particle_filter.py
+++ b/src/pyrecest/filters/block_particle_filter.py
@@ -4,6 +4,8 @@ from collections.abc import Callable, Sequence
 from numbers import Integral
 from typing import Any, Protocol
 
+import numpy as np
+
 # pylint: disable=no-name-in-module,no-member,too-many-positional-arguments
 from pyrecest.backend import (
     all,
@@ -50,6 +52,38 @@ def _as_integer(value, name: str, minimum: int | None = None) -> int:
     if minimum is not None and integer < minimum:
         raise ValueError(f"{name} must be at least {minimum}.")
     return integer
+
+
+def _as_real_numeric_array(value, name: str):
+    """Return ``value`` as a backend float array without silent nonnumeric coercion."""
+
+    try:
+        raw = np.asarray(to_numpy(array(value)))
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must contain real numeric values.") from exc
+
+    if raw.dtype == object:
+        for item in raw.reshape(-1):
+            if isinstance(
+                item,
+                (
+                    bool,
+                    np.bool_,
+                    str,
+                    bytes,
+                    bytearray,
+                    complex,
+                    np.complexfloating,
+                ),
+            ):
+                raise ValueError(f"{name} must contain real numeric values.")
+    elif raw.dtype.kind in "USbcmM" or not np.issubdtype(raw.dtype, np.number):
+        raise ValueError(f"{name} must contain real numeric values.")
+
+    try:
+        return array(value, dtype=float)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must contain real numeric values.") from exc
 
 
 def validate_partition(
@@ -231,7 +265,7 @@ class BlockParticleFilter:
 
     @staticmethod
     def _normalize_weights(weights):
-        weights = array(weights, dtype=float)
+        weights = _as_real_numeric_array(weights, "Particle weights")
         if ndim(weights) != 1:
             weights = reshape(weights, (-1,))
         if not all(isfinite(weights)):
@@ -245,7 +279,7 @@ class BlockParticleFilter:
 
     @staticmethod
     def _normalize_log_weights(log_weights):
-        log_weights = array(log_weights, dtype=float)
+        log_weights = _as_real_numeric_array(log_weights, "log weights")
         if ndim(log_weights) != 1:
             log_weights = reshape(log_weights, (-1,))
         if any(isnan(log_weights)):
@@ -258,7 +292,7 @@ class BlockParticleFilter:
         return BlockParticleFilter._normalize_weights(exp(log_weights - max_log_weight))
 
     def _normalize_block_weights(self, block_weights):
-        block_weights = array(block_weights, dtype=float)
+        block_weights = _as_real_numeric_array(block_weights, "block_weights")
         if ndim(block_weights) == 1:
             if block_weights.shape[0] != self.n_particles:
                 raise ValueError("block_weights must contain one value per particle.")
@@ -416,7 +450,7 @@ class BlockParticleFilter:
             )
         else:
             values = likelihood
-        values = array(values, dtype=float)
+        values = _as_real_numeric_array(values, "likelihood values")
         if values.shape != (self.n_particles,):
             raise ValueError("likelihood must return one value per particle.")
         if not all(values >= 0.0):
@@ -441,7 +475,7 @@ class BlockParticleFilter:
             )
         else:
             values = log_likelihood
-        values = array(values, dtype=float)
+        values = _as_real_numeric_array(values, "log_likelihood values")
         if values.shape != (self.n_particles,):
             raise ValueError("log_likelihood must return one value per particle.")
         return self.update_with_block_log_likelihoods(
@@ -466,7 +500,7 @@ class BlockParticleFilter:
             )
         else:
             values = likelihood
-        values = array(values, dtype=float)
+        values = _as_real_numeric_array(values, "block likelihood values")
         if values.shape != (self.n_blocks, self.n_particles):
             raise ValueError(
                 "block likelihoods must have shape "
@@ -481,7 +515,7 @@ class BlockParticleFilter:
     def _resampling_thresholds(self, ess_threshold):
         if ess_threshold is None:
             return [self.n_particles / 2.0 for _ in range(self.n_blocks)]
-        threshold_values = array(ess_threshold, dtype=float)
+        threshold_values = _as_real_numeric_array(ess_threshold, "ess_threshold")
         if not all(isfinite(threshold_values)) or any(threshold_values < 0.0):
             raise ValueError("ess_threshold values must be nonnegative and finite.")
         values = to_numpy(threshold_values).reshape(-1)
@@ -507,7 +541,7 @@ class BlockParticleFilter:
             )
         else:
             values = log_likelihood
-        values = array(values, dtype=float)
+        values = _as_real_numeric_array(values, "block log_likelihood values")
         if values.shape != (self.n_blocks, self.n_particles):
             raise ValueError(
                 "block log-likelihoods must have shape "
@@ -541,7 +575,7 @@ class BlockParticleFilter:
         ess_threshold=None,
     ):
         """Update from per-component likelihoods shaped ``(n_particles, K)``."""
-        values = array(component_likelihoods, dtype=float)
+        values = _as_real_numeric_array(component_likelihoods, "component_likelihoods")
         if values.shape != (self.n_particles, self._n_block_components):
             raise ValueError(
                 "component_likelihoods must have shape "
@@ -561,7 +595,9 @@ class BlockParticleFilter:
         ess_threshold=None,
     ):
         """Update from per-component log-likelihoods shaped ``(n_particles, K)``."""
-        values = array(component_log_likelihoods, dtype=float)
+        values = _as_real_numeric_array(
+            component_log_likelihoods, "component_log_likelihoods"
+        )
         if values.shape != (self.n_particles, self._n_block_components):
             raise ValueError(
                 "component_log_likelihoods must have shape "

--- a/src/pyrecest/filters/block_particle_filter.py
+++ b/src/pyrecest/filters/block_particle_filter.py
@@ -58,6 +58,31 @@ def _as_real_numeric_array(value, name: str):
     """Return ``value`` as a backend float array without silent nonnumeric coercion."""
 
     try:
+        original = np.asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must contain real numeric values.") from exc
+
+    if original.dtype == object:
+        for item in original.reshape(-1):
+            if isinstance(
+                item,
+                (
+                    bool,
+                    np.bool_,
+                    str,
+                    bytes,
+                    bytearray,
+                    complex,
+                    np.complexfloating,
+                ),
+            ):
+                raise ValueError(f"{name} must contain real numeric values.")
+    elif original.dtype.kind in "USbcmM" or not np.issubdtype(
+        original.dtype, np.number
+    ):
+        raise ValueError(f"{name} must contain real numeric values.")
+
+    try:
         raw = np.asarray(to_numpy(array(value)))
     except (TypeError, ValueError) as exc:
         raise ValueError(f"{name} must contain real numeric values.") from exc

--- a/tests/filters/test_block_particle_filter.py
+++ b/tests/filters/test_block_particle_filter.py
@@ -118,6 +118,28 @@ class BlockParticleFilterTest(unittest.TestCase):
                         block_weights=array([[1.0, invalid_weight], [1.0, 1.0]]),
                     )
 
+    def test_rejects_nonreal_weight_inputs(self):
+        invalid_weights = [
+            [True, False],
+            ["1.0", "0.0"],
+            [1.0 + 0.0j, 0.0],
+        ]
+
+        for weights in invalid_weights:
+            with self.subTest(weights=weights):
+                with self.assertRaisesRegex(ValueError, "real numeric"):
+                    DummyBlockParticleFilter(
+                        array([[0.0, 10.0], [1.0, 11.0]]),
+                        weights=weights,
+                    )
+
+                with self.assertRaisesRegex(ValueError, "real numeric"):
+                    DummyBlockParticleFilter(
+                        array([[0.0, 10.0], [1.0, 11.0]]),
+                        partition="singleton",
+                        block_weights=[weights, [1.0, 1.0]],
+                    )
+
     def test_global_log_likelihood_updates_all_blocks(self):
         filt = DummyBlockParticleFilter(
             array([[0.0, 10.0], [1.0, 11.0]]),
@@ -155,6 +177,55 @@ class BlockParticleFilterTest(unittest.TestCase):
                 )
             npt.assert_allclose(filt.block_weights, initial_block_weights)
             npt.assert_allclose(filt.weights, initial_weights)
+
+    def test_update_rejects_nonreal_ess_thresholds_before_mutating(self):
+        initial_block_weights = array([[0.5, 0.5], [0.5, 0.5]])
+        initial_weights = array([0.5, 0.5])
+        invalid_thresholds = [
+            True,
+            "0.0",
+            [0.0, "0.0"],
+            0.0 + 0.0j,
+        ]
+
+        for ess_threshold in invalid_thresholds:
+            filt = DummyBlockParticleFilter(
+                array([[0.0, 10.0], [1.0, 11.0]]),
+                partition="singleton",
+            )
+            with self.subTest(ess_threshold=ess_threshold), self.assertRaisesRegex(
+                ValueError, "real numeric"
+            ):
+                filt.update_with_log_likelihood(
+                    array([0.0, -1.0]),
+                    ess_threshold=ess_threshold,
+                    resample=False,
+                )
+            npt.assert_allclose(filt.block_weights, initial_block_weights)
+            npt.assert_allclose(filt.weights, initial_weights)
+
+    def test_update_rejects_nonreal_likelihoods(self):
+        invalid_likelihoods = [
+            [True, False],
+            ["1.0", "0.5"],
+            [1.0 + 0.0j, 0.5],
+        ]
+
+        for likelihood in invalid_likelihoods:
+            with self.subTest(likelihood=likelihood):
+                filt = DummyBlockParticleFilter(
+                    array([[0.0, 10.0], [1.0, 11.0]]),
+                    partition="singleton",
+                )
+                with self.assertRaisesRegex(ValueError, "real numeric"):
+                    filt.update_with_likelihood(likelihood, resample=False)
+
+                filt = DummyBlockParticleFilter(
+                    array([[0.0, 10.0], [1.0, 11.0]]),
+                    partition="singleton",
+                )
+                with self.assertRaisesRegex(ValueError, "real numeric"):
+                    filt.update_with_log_likelihood(likelihood, resample=False)
 
     def test_update_accepts_scalar_and_per_block_ess_thresholds(self):
         filt = DummyBlockParticleFilter(


### PR DESCRIPTION
## Summary
- reject boolean, text-like, complex, datetime/timedelta, and other non-real numeric values before block particle filter weights, likelihoods, log-likelihoods, and ESS thresholds are coerced to floats
- preserve existing finite/nonnegative checks for valid real numeric arrays
- add focused regression coverage for malformed weights, likelihoods, and ESS thresholds

## Bug
`BlockParticleFilter` used direct `array(..., dtype=float)` conversion in several public update and weight-normalization paths. That allowed boolean masks such as `[True, False]` or numeric-looking text such as `["1.0", "0.0"]` to be interpreted as real weights/likelihoods/thresholds instead of surfacing malformed caller input.

## Validation
- `python -m py_compile /tmp/block_particle_filter.py`
- `python -m py_compile /tmp/test_block_particle_filter.py`

Full repository tests were not run locally because this environment cannot resolve github.com; CI should run the focused block-particle filter tests and the full matrix.