### PR TITLE
Ignore bool and text diagnostic numeric fields

### DIFF
--- a/src/pyrecest/evaluation/diagnostic_summaries.py
+++ b/src/pyrecest/evaluation/diagnostic_summaries.py
@@ -23,7 +23,9 @@ def _as_scalar_float(value: Any, name: str) -> float:
         scalar_value = value_array.item()
     except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError(f"{name} must be a scalar number") from exc
-    if isinstance(scalar_value, (bool, np.bool_, str, bytes, np.str_, np.bytes_)):
+    if isinstance(
+        scalar_value, (bool, np.bool_, str, bytes, bytearray, np.str_, np.bytes_)
+    ):
         raise ValueError(f"{name} must be a scalar number")
     try:
         scalar = float(scalar_value)
@@ -303,7 +305,21 @@ def _optional_float(value: Any) -> float | None:
     if value is None:
         return None
     try:
-        out = float(value)
+        value_array = np.asarray(value)
+    except (TypeError, ValueError):
+        return None
+    if value_array.shape != ():
+        return None
+    try:
+        scalar_value = value_array.item()
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if isinstance(
+        scalar_value, (bool, np.bool_, str, bytes, bytearray, np.str_, np.bytes_)
+    ):
+        return None
+    try:
+        out = float(scalar_value)
     except (TypeError, ValueError, OverflowError):
         return None
     return out if math.isfinite(out) else None

--- a/tests/evaluation/test_diagnostic_summaries.py
+++ b/tests/evaluation/test_diagnostic_summaries.py
@@ -111,6 +111,7 @@ class DiagnosticSummariesTest(unittest.TestCase):
             True,
             "2",
             b"2",
+            bytearray(b"2"),
             np.array("2"),
             np.array([1]),
         ):
@@ -135,6 +136,7 @@ class DiagnosticSummariesTest(unittest.TestCase):
             True,
             "5.0",
             b"5.0",
+            bytearray(b"5.0"),
             np.array("5.0"),
             np.array([1.0]),
         ):
@@ -174,6 +176,35 @@ class DiagnosticSummariesTest(unittest.TestCase):
         summary = build_diagnostic_summary(records, top_n=2, window_s=5.0)
         self.assertEqual(summary["top_residuals"], [])
         self.assertEqual(summary["track_switches"]["updates_with_track_id"], 0)
+        self.assertEqual(summary["covariance_inflation"]["count"], 0)
+        self.assertEqual(summary["worst_time_windows"], [])
+
+    def test_summary_treats_bool_and_text_optional_scalars_as_missing(self):
+        records = [
+            {
+                "time_s": "10.0",
+                "track_id": "A",
+                "source": "rf",
+                "residual_norm": True,
+                "covariance_scale": "3.0",
+                "error": "2.0",
+            },
+            {
+                "time_s": b"11.0",
+                "track_id": "B",
+                "source": "radar",
+                "residual_norm": bytearray(b"4.0"),
+                "covariance_scale": True,
+                "error": False,
+            },
+        ]
+
+        self.assertEqual(top_residuals(records), [])
+        self.assertEqual(covariance_inflation_summary(records)["count"], 0)
+        self.assertEqual(worst_time_windows(records), [])
+
+        summary = build_diagnostic_summary(records, top_n=2, window_s=5.0)
+        self.assertEqual(summary["top_residuals"], [])
         self.assertEqual(summary["covariance_inflation"]["count"], 0)
         self.assertEqual(summary["worst_time_windows"], [])
 


### PR DESCRIPTION
## Summary
- Treat boolean, text, bytes, bytearray, and non-scalar optional diagnostic numeric fields as missing instead of converting them to floats.
- Keep explicit scalar configuration validation consistent by rejecting bytearray values too.
- Add regression coverage for optional residual/error/time/covariance-scale fields.

## Bug
`_optional_float()` used `float(value)` directly. Values such as `True`, `"2.0"`, or `b"4.0"` were therefore interpreted as real residuals, errors, timestamps, or covariance scales in diagnostic summaries. That allowed malformed records to affect top-residual, covariance-inflation, and worst-window reports.

## Validation
- Local isolated syntax check for the modified helper and regression scenario.
- Local isolated behavior check for optional bool/text/bytes fields and accepted real scalar fields.
- Full repository test suite not run in this environment; CI should run the project tests on the PR.