### PR TITLE
Reject whitespace-padded backend names

### DIFF
--- a/src/pyrecest/backend_tools.py
+++ b/src/pyrecest/backend_tools.py
@@ -27,7 +27,9 @@ def _normalize_expected_backend_names(expected: str | tuple[str, ...]) -> tuple[
             names = tuple(expected)
         except TypeError as exc:
             raise ValueError(message) from exc
-    if not names or any(not isinstance(name, str) or not name for name in names):
+    if not names or any(
+        not isinstance(name, str) or not name or name.strip() != name for name in names
+    ):
         raise ValueError(message)
     return names
 

--- a/tests/test_backend_tools.py
+++ b/tests/test_backend_tools.py
@@ -19,7 +19,7 @@ def test_assert_backend_rejects_unexpected_backend():
         pyrecest.assert_backend(unexpected)
 
 
-@pytest.mark.parametrize("expected", [(), ("",), ("numpy", 1), 1])
+@pytest.mark.parametrize("expected", [(), ("",), " ", (" numpy",), ("numpy ",), ("numpy", 1), 1])
 def test_assert_backend_rejects_invalid_expected_names(expected):
     with pytest.raises(ValueError, match="expected"):
         pyrecest.assert_backend(expected)


### PR DESCRIPTION
## Summary
- Reject whitespace-padded backend names in `assert_backend()` input validation.
- Add regression coverage for whitespace-only and padded expected backend names.

## Bug
`assert_backend()` accepted malformed names such as `" "`, `" numpy"`, and `"numpy "` as syntactically valid expected backend names, then reported them as unexpected backends. These should fail in the existing validation path with `ValueError`, matching the behavior for empty and non-string backend names.

## Testing
- Not run locally; repository access in this environment is through the GitHub connector, and direct clone/test execution was not available. CI should run on the PR branch.