### PR TITLE
Reject negative infinity candidate costs

### DIFF
--- a/src/pyrecest/utils/candidate_pruning.py
+++ b/src/pyrecest/utils/candidate_pruning.py
@@ -346,7 +346,11 @@ def _as_cost_matrix(cost_matrix: Any) -> np.ndarray:
     costs = _as_numeric_matrix(cost_matrix, "cost_matrix")
     if costs.ndim != 2:
         raise ValueError("cost_matrix must be two-dimensional")
-    return np.nan_to_num(costs, nan=np.inf, posinf=np.inf, neginf=np.inf)
+    if np.any(np.isneginf(costs)):
+        raise ValueError(
+            "cost_matrix may only contain finite values or positive infinity"
+        )
+    return np.nan_to_num(costs, nan=np.inf, posinf=np.inf)
 
 
 def _as_probability_matrix(

--- a/tests/test_candidate_pruning_matrix_validation.py
+++ b/tests/test_candidate_pruning_matrix_validation.py
@@ -41,6 +41,30 @@ class TestCandidatePruningMatrixValidation(unittest.TestCase):
                     ):
                         function(matrix)
 
+    def test_cost_matrix_rejects_negative_infinity(self):
+        invalid_matrices = (
+            [[0.0, -float("inf")]],
+            np.array([[0.0, -np.inf]]),
+        )
+
+        for function in (candidate_mask_from_costs, prune_pairwise_cost_matrix):
+            for matrix in invalid_matrices:
+                with self.subTest(function=function.__name__, matrix=matrix):
+                    with self.assertRaisesRegex(
+                        ValueError,
+                        "positive infinity",
+                    ):
+                        function(matrix)
+
+    def test_cost_matrix_keeps_positive_infinity_as_missing_candidate(self):
+        costs = np.array([[1.0, np.inf]])
+
+        np.testing.assert_array_equal(
+            candidate_mask_from_costs(costs),
+            np.array([[True, False]]),
+        )
+        np.testing.assert_array_equal(prune_pairwise_cost_matrix(costs), costs)
+
     def test_cost_matrix_rejects_text_entries(self):
         invalid_matrices = (
             np.array([["1.0", "2.0"]]),


### PR DESCRIPTION
## Summary
- Reject negative-infinity cost-matrix entries before candidate pruning normalizes missing candidates.
- Preserve existing positive-infinity handling as a missing/impossible candidate sentinel.
- Add regression coverage for candidate masks and pruned matrices.

## Bug
`_as_cost_matrix()` converted `-inf` to `+inf` through `np.nan_to_num(..., neginf=np.inf)`, silently discarding a malformed/impossibly-low cost by treating it as a missing candidate. Cost matrices already use positive infinity as the impossible-candidate sentinel, so negative infinity should fail validation instead of being inverted.

## Validation
- `python -m py_compile /tmp/candidate_pruning.py /tmp/test_candidate_pruning_matrix_validation.py`
- Isolated behavior check for negative-infinity rejection and positive-infinity mask preservation.
- Full repository tests were not run locally because this environment cannot resolve `github.com`; CI should run the full test matrix.