### PR TITLE
Validate sequence association node scalars

### DIFF
--- a/src/pyrecest/filters/sequence_association.py
+++ b/src/pyrecest/filters/sequence_association.py
@@ -48,11 +48,25 @@ class SequenceAssociationNode:
     metadata: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
-        if self.candidate_index is None and not self.is_missed_detection:
+        frame_index = _validate_integer(self.frame_index, "frame_index")
+        is_missed_detection = _validate_bool_flag(
+            self.is_missed_detection,
+            "is_missed_detection",
+        )
+        if self.candidate_index is None and not is_missed_detection:
             raise ValueError(
                 "candidate_index=None is reserved for missed-detection nodes"
             )
-        _validate_cost(self.unary_cost, "unary_cost")
+        candidate_index = (
+            None
+            if self.candidate_index is None
+            else _validate_integer(self.candidate_index, "candidate_index")
+        )
+        unary_cost = _validate_cost(self.unary_cost, "unary_cost")
+        object.__setattr__(self, "frame_index", frame_index)
+        object.__setattr__(self, "candidate_index", candidate_index)
+        object.__setattr__(self, "unary_cost", unary_cost)
+        object.__setattr__(self, "is_missed_detection", is_missed_detection)
         if self.metadata is not None:
             object.__setattr__(self, "metadata", dict(self.metadata))
 
@@ -281,6 +295,45 @@ def _reconstruct_path(
         nodes=tuple(path),
         transition_costs=tuple(transition_values),
     )
+
+
+def _validate_bool_flag(value: object, name: str) -> bool:
+    message = f"{name} must be a bool"
+    try:
+        value_array = np.asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(message) from exc
+    if value_array.ndim != 0 or value_array.dtype != np.bool_:
+        raise ValueError(message)
+    return bool(value_array.item())
+
+
+def _validate_integer(value: object, name: str) -> int:
+    message = f"{name} must be an integer"
+    try:
+        value_array = np.asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(message) from exc
+    if value_array.ndim != 0 or value_array.dtype == np.bool_:
+        raise ValueError(message)
+    if value_array.dtype.kind in {"S", "U", "c"}:
+        raise ValueError(message)
+
+    scalar = value_array.item()
+    if isinstance(
+        scalar,
+        (bool, np.bool_, str, bytes, bytearray, complex, np.complexfloating),
+    ):
+        raise ValueError(message)
+    if isinstance(scalar, (int, np.integer)):
+        return int(scalar)
+    if (
+        isinstance(scalar, (float, np.floating))
+        and np.isfinite(scalar)
+        and float(scalar).is_integer()
+    ):
+        return int(scalar)
+    raise ValueError(message)
 
 
 def _validate_cost(value: object, name: str) -> float:

--- a/tests/filters/test_sequence_association.py
+++ b/tests/filters/test_sequence_association.py
@@ -110,6 +110,49 @@ class SequenceAssociationTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             SequenceAssociationNode(0, None)
 
+    def test_validation_rejects_noninteger_node_indices(self):
+        invalid_frame_indices = (True, 1.5, np.nan, np.inf, "0", np.array([0]))
+        for frame_index in invalid_frame_indices:
+            with self.subTest(frame_index=frame_index):
+                with self.assertRaisesRegex(ValueError, "frame_index must be an integer"):
+                    SequenceAssociationNode(frame_index, 0)
+
+        invalid_candidate_indices = (False, 1.25, -np.inf, "1", np.array([1]))
+        for candidate_index in invalid_candidate_indices:
+            with self.subTest(candidate_index=candidate_index):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "candidate_index must be an integer",
+                ):
+                    SequenceAssociationNode(0, candidate_index)
+
+    def test_validation_rejects_nonbool_missed_detection_flags(self):
+        invalid_flags = (0, 1, "False", np.array([True]))
+        for is_missed_detection in invalid_flags:
+            with self.subTest(is_missed_detection=is_missed_detection):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "is_missed_detection must be a bool",
+                ):
+                    SequenceAssociationNode(
+                        0,
+                        None,
+                        is_missed_detection=is_missed_detection,
+                    )
+
+    def test_validation_normalizes_integer_like_node_scalars(self):
+        node = SequenceAssociationNode(
+            np.array(1.0),
+            np.float64(2.0),
+            unary_cost=np.float64(0.5),
+            is_missed_detection=np.bool_(False),
+        )
+
+        self.assertEqual(node.frame_index, 1)
+        self.assertEqual(node.candidate_index, 2)
+        self.assertEqual(node.unary_cost, 0.5)
+        self.assertIs(node.is_missed_detection, False)
+
     def test_validation_rejects_nonfinite_unary_costs(self):
         for invalid_cost in (np.nan, np.inf, -np.inf):
             with self.subTest(invalid_cost=invalid_cost):


### PR DESCRIPTION
## Summary
- Validate `SequenceAssociationNode` frame and candidate indices instead of accepting arbitrary scalar-like objects.
- Validate `is_missed_detection` explicitly as a boolean flag before using it in missed-detection logic.
- Normalize accepted integer-like scalar indices and unary costs to stable Python scalar values.
- Add regression coverage for invalid node indices, invalid missed-detection flags, and accepted integer-like scalar values.

## Testing
- `python -m py_compile src/pyrecest/filters/sequence_association.py tests/filters/test_sequence_association.py`
- Direct import-based smoke test for the new validation behavior and a simple Viterbi path.