### PR TITLE
Reject non-real bias calibration values

### DIFF
--- a/src/pyrecest/calibration/bias.py
+++ b/src/pyrecest/calibration/bias.py
@@ -15,6 +15,18 @@ _FEATURE_ROW_COUNT_ERROR = (
     "features rows must match requested row count; "
     "features must produce one predicted bias row per measurement"
 )
+_REJECTED_NUMERIC_KINDS = frozenset("bUScMm")
+_REJECTED_OBJECT_VALUE_TYPES = (
+    bool,
+    np.bool_,
+    str,
+    bytes,
+    bytearray,
+    complex,
+    np.complexfloating,
+    np.datetime64,
+    np.timedelta64,
+)
 
 
 @dataclass(frozen=True)
@@ -324,7 +336,7 @@ def _as_numeric_array(values: Any, name: str) -> np.ndarray:
         raw = np.asarray(values)
     except (TypeError, ValueError) as exc:
         raise ValueError(f"{name} must contain numeric values") from exc
-    if _contains_bool_or_text(raw):
+    if _contains_invalid_numeric_values(raw):
         raise ValueError(f"{name} must contain numeric values")
     try:
         return np.asarray(values, dtype=float)
@@ -336,12 +348,12 @@ def _as_numeric_vector(values: Any, name: str) -> np.ndarray:
     return _as_numeric_array(values, name).reshape(-1)
 
 
-def _contains_bool_or_text(values: np.ndarray) -> bool:
-    if values.dtype.kind in "bUS":
+def _contains_invalid_numeric_values(values: np.ndarray) -> bool:
+    if values.dtype.kind in _REJECTED_NUMERIC_KINDS:
         return True
     if values.dtype == object:
         return any(
-            isinstance(item, (bool, np.bool_, str, bytes, bytearray))
+            isinstance(item, _REJECTED_OBJECT_VALUE_TYPES)
             for item in values.reshape(-1)
         )
     return False

--- a/tests/calibration/test_bias_numeric_validation.py
+++ b/tests/calibration/test_bias_numeric_validation.py
@@ -51,3 +51,37 @@ def test_make_bias_training_examples_rejects_text_times_before_float_coercion():
         )
 
     assert "measurement_times_s must contain numeric values" in str(exc_info.value)
+
+
+def test_make_bias_training_examples_rejects_non_real_measurements():
+    invalid_measurements = (
+        np.array([[1.0 + 2.0j]]),
+        np.array([[np.complex128(1.0 + 2.0j)]], dtype=object),
+        np.array([[np.datetime64("2026-01-01")]], dtype=object),
+        np.array([[np.timedelta64(1, "s")]], dtype=object),
+    )
+
+    for measurement_values in invalid_measurements:
+        with pytest.raises(ValueError) as exc_info:
+            make_bias_training_examples(
+                measurement_times_s=np.array([0.0]),
+                measurement_values=measurement_values,
+                reference_times_s=np.array([0.0]),
+                reference_values=np.array([[0.0]]),
+                max_time_delta_s=0.0,
+            )
+
+        assert "measurement_values must contain numeric values" in str(exc_info.value)
+
+
+def test_make_bias_training_examples_accepts_real_integer_measurements():
+    examples = make_bias_training_examples(
+        measurement_times_s=np.array([0.0]),
+        measurement_values=np.array([[2]], dtype=np.int64),
+        reference_times_s=np.array([0.0]),
+        reference_values=np.array([[1.0]]),
+        max_time_delta_s=0.0,
+    )
+
+    assert examples.measured.shape == (1, 1)
+    assert float(examples.residual[0, 0]) == 1.0


### PR DESCRIPTION
## Summary
- reject complex, datetime, and timedelta arrays in bias calibration numeric validation before float coercion
- cover direct complex dtype and object-dtype complex/datetime/timedelta measurement inputs
- keep real integer measurements accepted

## Bug
`make_bias_training_examples` and related bias calibration paths validated arrays by rejecting only bool/text before `np.asarray(..., dtype=float)`. Complex arrays could lose their imaginary components and datetime/timedelta values could be converted to numeric ordinals/durations, silently corrupting calibration inputs.

## Validation
- `python -m py_compile /tmp/bias.py`
- isolated local validator check for complex/datetime/timedelta rejection and float acceptance
- full repository tests not run locally because this sandbox cannot resolve `github.com`