### PR TITLE
Validate track completion scores

### DIFF
--- a/src/pyrecest/utils/track_completion.py
+++ b/src/pyrecest/utils/track_completion.py
@@ -281,16 +281,19 @@ def _extend_completion_path(
                 anchor_observation,
                 int(candidate_session),
                 int(candidate.observation),
-                float(candidate.score),
+                candidate.score,
                 candidate.payload,
             )
             raw_steps = (*steps, step)
             chronological_steps = _chronological_steps(direction, raw_steps)
-            score = (
-                float(score_path(chronological_steps))
-                if score_path is not None
-                else float(sum(item.score for item in chronological_steps))
-            )
+            if score_path is not None:
+                score = _as_finite_score(
+                    score_path(chronological_steps), "path scores"
+                )
+            else:
+                score = _as_finite_score(
+                    sum(item.score for item in chronological_steps), "path scores"
+                )
             out.append(
                 CompletionPath(
                     track_index=int(track_index),
@@ -398,7 +401,7 @@ def _coerce_candidate(
     if isinstance(value, CompletionCandidate):
         return CompletionCandidate(
             observation=_normalize_candidate_observation(value.observation),
-            score=value.score,
+            score=_as_finite_score(value.score, "candidate scores"),
             payload=value.payload,
         )
     return CompletionCandidate(observation=_normalize_candidate_observation(value))
@@ -430,6 +433,28 @@ def _normalize_candidate_observation(value: Any) -> int:
     if observation < 0:
         raise ValueError("candidate observations must be non-negative integers")
     return observation
+
+
+def _as_finite_score(value: Any, name: str) -> float:
+    message = f"{name} must be a finite real scalar"
+    value_array = np.asarray(value)
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError(message)
+
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(message)
+    if isinstance(scalar, (str, bytes, bytearray, np.str_, np.bytes_)):
+        raise ValueError(message)
+    if isinstance(scalar, (complex, np.complexfloating)):
+        raise ValueError(message)
+    try:
+        score = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if not np.isfinite(score):
+        raise ValueError(message)
+    return score
 
 
 def _as_positive_int(value: Any, name: str) -> int:

--- a/tests/test_track_completion_score_validation.py
+++ b/tests/test_track_completion_score_validation.py
@@ -1,0 +1,65 @@
+import numpy as np
+import pytest
+
+from pyrecest.utils.track_completion import (
+    CompletionCandidate,
+    enumerate_fragment_completion_paths,
+)
+
+
+def _candidate_provider_with_score(score):
+    def provider(session, observation, target_session):
+        del session, observation, target_session
+        return [CompletionCandidate(1, score=score)]
+
+    return provider
+
+
+def test_completion_candidate_scores_reject_non_real_values():
+    invalid_scores = (
+        True,
+        np.bool_(False),
+        "1.0",
+        b"1.0",
+        np.array("1.0"),
+        1.0 + 0.0j,
+        np.array(1.0 + 0.0j),
+        float("nan"),
+        float("inf"),
+        [1.0],
+    )
+
+    for invalid_score in invalid_scores:
+        with pytest.raises(
+            ValueError, match="candidate scores must be a finite real scalar"
+        ):
+            enumerate_fragment_completion_paths(
+                [[0, None]],
+                direction="suffix",
+                candidate_provider=_candidate_provider_with_score(invalid_score),
+            )
+
+
+def test_score_path_rejects_non_real_values():
+    invalid_scores = ("2.0", True, np.inf, [1.0])
+
+    for invalid_score in invalid_scores:
+        with pytest.raises(ValueError, match="path scores must be a finite real scalar"):
+            enumerate_fragment_completion_paths(
+                [[0, None]],
+                direction="suffix",
+                candidate_provider=_candidate_provider_with_score(0.25),
+                score_path=lambda steps, value=invalid_score: value,
+            )
+
+
+def test_completion_scores_accept_finite_real_numpy_scalars():
+    paths = enumerate_fragment_completion_paths(
+        [[0, None]],
+        direction="suffix",
+        candidate_provider=_candidate_provider_with_score(np.array(0.25)),
+        score_path=lambda steps: np.float64(sum(step.score for step in steps) + 0.5),
+    )
+
+    assert len(paths) == 1
+    assert paths[0].score == pytest.approx(0.75)


### PR DESCRIPTION
## Summary
- Validate fragment-completion candidate scores before constructing `CompletionStep` objects.
- Validate aggregate `score_path` outputs before storing `CompletionPath.score`.
- Add regression coverage for boolean, text-like, complex, non-finite, and non-scalar score values while keeping finite real NumPy scalar scores accepted.

## Bug
`enumerate_fragment_completion_paths(...)` converted candidate scores and `score_path` return values with `float(...)`. That silently accepted malformed values such as `True`, `"1.0"`, or `np.array(1.0 + 0.0j)` as ordinary path costs, and allowed `NaN`/`Inf` scores into completion-path sorting and downstream diagnostics. Scores are numeric cost/score quantities, so invalid non-real or non-finite provider outputs should fail at the completion boundary instead of being coerced.

## Validation
- `python -m py_compile /mnt/data/track_completion_patched.py`
- `python -m py_compile /mnt/data/test_track_completion_score_validation.py`
- isolated local harness for candidate-score and `score_path` validation paths passed

Full repository pytest was not run locally because direct repository checkout/install is unavailable in this environment; CI should run the integrated test matrix.