### PR TITLE
Validate measurement update diagnostic indices

### DIFF
--- a/src/pyrecest/filters/update_diagnostics.py
+++ b/src/pyrecest/filters/update_diagnostics.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from operator import index as operator_index
 from typing import Any
 
 
@@ -27,14 +28,16 @@ class MeasurementUpdateDiagnostics:
     metadata: Mapping[str, Any] | None = None
 
     def __post_init__(self):
-        indices = (
-            ()
-            if self.active_measurement_indices is None
-            else tuple(int(index) for index in self.active_measurement_indices)
+        indices = _normalize_active_measurement_indices(
+            self.active_measurement_indices
         )
         object.__setattr__(self, "active_measurement_indices", indices)
-        if self.measurement_count is not None and self.measurement_count < 0:
-            raise ValueError("measurement_count must be non-negative when provided")
+        if self.measurement_count is not None:
+            object.__setattr__(
+                self,
+                "measurement_count",
+                _as_nonnegative_integer(self.measurement_count, "measurement_count"),
+            )
         metadata = {} if self.metadata is None else dict(self.metadata)
         object.__setattr__(self, "metadata", metadata)
 
@@ -67,3 +70,33 @@ class MeasurementUpdateDiagnostics:
             skipped_reason=reason,
             metadata=metadata,
         )
+
+
+def _normalize_active_measurement_indices(
+    values: Sequence[int] | None,
+) -> tuple[int, ...]:
+    if values is None:
+        return ()
+    try:
+        iterator = iter(values)
+    except TypeError as exc:
+        raise ValueError(
+            "active_measurement_indices must be a sequence of non-negative integers"
+        ) from exc
+    return tuple(
+        _as_nonnegative_integer(value, "active_measurement_indices")
+        for value in iterator
+    )
+
+
+def _as_nonnegative_integer(value: Any, name: str) -> int:
+    message = f"{name} must be a non-negative integer"
+    if isinstance(value, bool):
+        raise ValueError(message)
+    try:
+        parsed = operator_index(value)
+    except TypeError as exc:
+        raise ValueError(message) from exc
+    if parsed < 0:
+        raise ValueError(message)
+    return int(parsed)

--- a/tests/filters/test_update_diagnostics_validation.py
+++ b/tests/filters/test_update_diagnostics_validation.py
@@ -1,0 +1,53 @@
+import numpy as np
+import pytest
+
+from pyrecest.filters.update_diagnostics import MeasurementUpdateDiagnostics
+
+
+def test_active_measurement_indices_reject_non_integer_values():
+    invalid_indices = (
+        True,
+        False,
+        "1",
+        b"1",
+        1.5,
+        -1,
+        np.bool_(True),
+        np.array([1]),
+    )
+
+    for invalid_index in invalid_indices:
+        with pytest.raises(ValueError, match="active_measurement_indices"):
+            MeasurementUpdateDiagnostics(active_measurement_indices=(invalid_index,))
+
+
+def test_active_measurement_indices_reject_non_sequence_values():
+    with pytest.raises(ValueError, match="active_measurement_indices"):
+        MeasurementUpdateDiagnostics(active_measurement_indices=1)  # type: ignore[arg-type]
+
+
+def test_measurement_count_rejects_non_integer_values():
+    invalid_counts = (
+        True,
+        False,
+        "3",
+        b"3",
+        2.0,
+        -1,
+        np.bool_(False),
+        np.array([1]),
+    )
+
+    for invalid_count in invalid_counts:
+        with pytest.raises(ValueError, match="measurement_count"):
+            MeasurementUpdateDiagnostics(measurement_count=invalid_count)
+
+
+def test_diagnostics_accept_integer_like_numpy_scalars():
+    diagnostics = MeasurementUpdateDiagnostics(
+        active_measurement_indices=(0, np.int64(2), np.array(3)),
+        measurement_count=np.int64(4),
+    )
+
+    assert diagnostics.active_measurement_indices == (0, 2, 3)
+    assert diagnostics.measurement_count == 4


### PR DESCRIPTION
## Summary
- validate `MeasurementUpdateDiagnostics.active_measurement_indices` as a sequence of non-negative integer-like scalars instead of coercing arbitrary values with `int(...)`
- validate and normalize `measurement_count` when provided
- add regression coverage for boolean, string, float, negative, and non-scalar values while keeping NumPy integer-like scalars accepted

## Bug
`MeasurementUpdateDiagnostics.__post_init__()` used `int(index)` for active measurement indices and only checked `measurement_count < 0`. That silently accepted malformed diagnostic values such as `True`, `"1"`, and `1.5` as valid indices/counts, which can make diagnostic metadata disagree with the measurement batch that was actually processed.

## Testing
- `python -m py_compile /mnt/data/update_diagnostics_patched.py /mnt/data/test_update_diagnostics_validation.py`
- `pytest -q /mnt/data/test_update_diagnostics_validation.py`

Full repository tests were not run locally because direct repository checkout/install is unavailable in this environment; CI should run the integrated test matrix.