### PR TITLE
Validate JAX random size broadcasting

### DIFF
--- a/src/pyrecest/_backend/jax/random.py
+++ b/src/pyrecest/_backend/jax/random.py
@@ -100,9 +100,24 @@ def _broadcast_shape_from_values(*values):
 
 def _bounded_sampler_shape(size, *parameters):
     """Return the NumPy-compatible output shape for bounded random samplers."""
-    if size is not None:
-        return _shape_from_size(size)
-    return _broadcast_shape_from_values(*parameters)
+    try:
+        parameter_shape = _broadcast_shape_from_values(*parameters)
+    except ValueError as exc:
+        raise ValueError("parameter arrays could not be broadcast together") from exc
+
+    if size is None:
+        return parameter_shape
+
+    sample_shape = _shape_from_size(size)
+    try:
+        broadcast_shape = _np.broadcast_shapes(sample_shape, parameter_shape)
+    except ValueError as exc:
+        raise ValueError(
+            "size and parameter arrays could not be broadcast together"
+        ) from exc
+    if broadcast_shape != sample_shape:
+        raise ValueError("size and parameter arrays could not be broadcast together")
+    return sample_shape
 
 
 def _looks_like_shape(value):

--- a/tests/backend/test_jax_random_backend.py
+++ b/tests/backend/test_jax_random_backend.py
@@ -69,6 +69,51 @@ def test_uniform_and_randint_reject_incompatible_bounds_without_explicit_size():
         )
 
 
+@pytest.mark.parametrize("bad_size", [(), (3,), (3, 1)])
+def test_normal_rejects_array_parameters_incompatible_with_explicit_size(bad_size):
+    with pytest.raises(ValueError, match="broadcast"):
+        random.normal(jnp.array([1.0, 2.0]), 1.0, size=bad_size)
+
+
+@pytest.mark.parametrize("bad_size", [(), (3,), (3, 1)])
+def test_uniform_rejects_array_parameters_incompatible_with_explicit_size(bad_size):
+    with pytest.raises(ValueError, match="broadcast"):
+        random.uniform(jnp.array([1.0, 2.0]), 3.0, size=bad_size)
+
+
+def test_randint_rejects_array_bounds_incompatible_with_explicit_size():
+    with pytest.raises(ValueError, match="broadcast"):
+        random.randint(jnp.array([0, 10]), jnp.array([3, 13]), size=(3,))
+
+
+def test_normal_accepts_array_parameters_with_compatible_explicit_size():
+    random.seed(0)
+
+    samples = random.normal(jnp.array([1.0, 2.0]), 1.0, size=(4, 2))
+
+    assert samples.shape == (4, 2)
+
+
+def test_uniform_accepts_array_parameters_with_compatible_explicit_size():
+    random.seed(0)
+
+    samples = random.uniform(jnp.array([1.0, 2.0]), 3.0, size=(4, 2))
+
+    assert samples.shape == (4, 2)
+    assert jnp.all(samples >= jnp.array([1.0, 2.0]))
+    assert jnp.all(samples <= 3.0)
+
+
+def test_randint_accepts_array_bounds_with_compatible_explicit_size():
+    random.seed(0)
+
+    samples = random.randint(jnp.array([0, 10]), jnp.array([3, 13]), size=(4, 2))
+
+    assert samples.shape == (4, 2)
+    assert jnp.all(samples >= jnp.array([0, 10]))
+    assert jnp.all(samples < jnp.array([3, 13]))
+
+
 def _size_aware_samplers():
     values = jnp.array([0, 1, 2])
     mean = jnp.array([0.0])


### PR DESCRIPTION
## Summary
- validate JAX random sampler output sizes against broadcasted array parameter shapes
- raise a clear `ValueError` when explicit `size` cannot contain array-valued `low`/`high`/`loc`/`scale`
- add JAX backend regression tests for incompatible and compatible explicit-size broadcasting

## Validation
- `python -m py_compile /mnt/data/jax_random_new.py /mnt/data/test_jax_random_backend_new.py`
- targeted local import check of patched JAX random helper for incompatible and compatible `normal`, `uniform`, and `randint` array-parameter cases