### PR TITLE
Validate association probability clip scalar input

### DIFF
--- a/src/pyrecest/utils/association_features.py
+++ b/src/pyrecest/utils/association_features.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
+from numbers import Real
 from types import MappingProxyType
 from typing import Any, Literal
+
+import numpy as np
 
 # pylint: disable=no-name-in-module,no-member,redefined-builtin
 from pyrecest.backend import (
@@ -24,6 +27,8 @@ from pyrecest.backend import (
 
 _COST_MODE = Literal["negative_log_probability", "one_minus_probability"]
 FeatureTransform = Callable[[Mapping[str, Any]], Any]
+_PROBABILITY_CLIP_ERROR = "probability_clip must be a finite real scalar in (0, 0.5)"
+_TEXT_SCALAR_TYPES = (str, bytes, bytearray, np.str_, np.bytes_)
 
 
 @dataclass(frozen=True, init=False)
@@ -123,12 +128,11 @@ class CalibratedPairwiseAssociationModel:
             if feature_names is None:
                 raise ValueError("feature_names or schema is required")
             schema = NamedPairwiseFeatureSchema(feature_names, transforms=transforms)
-        if not 0.0 < probability_clip < 0.5:
-            raise ValueError("probability_clip must lie in (0, 0.5)")
+        probability_clip = _normalize_probability_clip(probability_clip)
 
         object.__setattr__(self, "model", model)
         object.__setattr__(self, "schema", schema)
-        object.__setattr__(self, "probability_clip", float(probability_clip))
+        object.__setattr__(self, "probability_clip", probability_clip)
 
     @property
     def feature_names(self) -> tuple[str, ...]:
@@ -212,6 +216,26 @@ class CalibratedPairwiseAssociationModel:
             if _is_positive_binary_label(class_label):
                 return class_index
         return 1
+
+
+def _normalize_probability_clip(value: Any) -> float:
+    try:
+        value_array = np.asarray(value)
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise ValueError(_PROBABILITY_CLIP_ERROR) from exc
+    if value_array.shape != ():
+        raise ValueError(_PROBABILITY_CLIP_ERROR)
+
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_, complex, np.complexfloating, *_TEXT_SCALAR_TYPES)):
+        raise ValueError(_PROBABILITY_CLIP_ERROR)
+    if not isinstance(scalar, Real):
+        raise ValueError(_PROBABILITY_CLIP_ERROR)
+
+    probability_clip = float(scalar)
+    if not np.isfinite(probability_clip) or not 0.0 < probability_clip < 0.5:
+        raise ValueError(_PROBABILITY_CLIP_ERROR)
+    return probability_clip
 
 
 def _finite_probability_array(probabilities: Any) -> Any:

--- a/tests/test_association_probability_clip_validation.py
+++ b/tests/test_association_probability_clip_validation.py
@@ -1,0 +1,45 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.backend import array
+from pyrecest.utils import CalibratedPairwiseAssociationModel
+
+
+class ConstantProbabilityModel:
+    def predict_match_probability(self, features):
+        del features
+        return array([0.5])
+
+
+class TestAssociationProbabilityClipValidation(unittest.TestCase):
+    def test_rejects_malformed_probability_clip_values(self):
+        invalid_values = (
+            [1.0e-12],
+            np.array([1.0e-12]),
+            True,
+            np.nan,
+            np.inf,
+        )
+
+        for probability_clip in invalid_values:
+            with self.subTest(probability_clip=probability_clip):
+                with self.assertRaisesRegex(ValueError, "probability_clip"):
+                    CalibratedPairwiseAssociationModel(
+                        ConstantProbabilityModel(),
+                        feature_names=("distance",),
+                        probability_clip=probability_clip,
+                    )
+
+    def test_accepts_numpy_scalar_probability_clip(self):
+        model = CalibratedPairwiseAssociationModel(
+            ConstantProbabilityModel(),
+            feature_names=("distance",),
+            probability_clip=np.float64(1.0e-3),
+        )
+
+        self.assertEqual(model.probability_clip, 1.0e-3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- normalize `CalibratedPairwiseAssociationModel.probability_clip` through a dedicated scalar validator
- reject malformed non-scalar, boolean, NaN, and infinite values before they can be coerced by `float(...)`
- add focused regression coverage for malformed and accepted NumPy scalar clip values

## Bug
`probability_clip` is a scalar configuration value, but the previous chained-comparison validation could accept one-element arrays and then coerce them with `float(...)`. This made malformed configuration values look valid and could hide schema/input mistakes.

## Validation
- `python -m py_compile /tmp/pyrecest_patch/src/pyrecest/utils/association_features.py /tmp/pyrecest_patch/tests/test_calibrated_association_probability_bounds.py`
- Full repository tests were not run locally because the execution sandbox cannot resolve `github.com` for checkout/install; CI should run the integrated test matrix.