### PR TITLE
Validate support point boolean flags

### DIFF
--- a/src/pyrecest/sampling/support_points.py
+++ b/src/pyrecest/sampling/support_points.py
@@ -58,6 +58,18 @@ def _as_finite_nonnegative_scalar(name: str, value: float) -> float:
     return scalar_float
 
 
+def _as_bool_scalar(name: str, value: bool) -> bool:
+    if isinstance(value, (bool, np.bool_)):
+        return bool(value)
+    try:
+        array = np.asarray(value)
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise ValueError(f"{name} must be a boolean.") from exc
+    if array.shape == () and array.dtype == np.bool_:
+        return bool(array.item())
+    raise ValueError(f"{name} must be a boolean.")
+
+
 def _as_point_batch(
     name: str, points: np.ndarray | Sequence[float]
 ) -> tuple[np.ndarray, bool]:
@@ -151,6 +163,10 @@ def ellipsoid_axis_offsets(
     """
 
     radius = _as_finite_nonnegative_scalar("radius", radius)
+    sort_descending = _as_bool_scalar("sort_descending", sort_descending)
+    clip_negative_eigenvalues = _as_bool_scalar(
+        "clip_negative_eigenvalues", clip_negative_eigenvalues
+    )
     covariances, single = _as_covariance_batch("covariance", covariance)
     eigenvalues, eigenvectors = np.linalg.eigh(covariances)
     if sort_descending:
@@ -179,6 +195,7 @@ def support_points_from_axis_offsets(
     return ``(support_point_count, dim)``.
     """
 
+    include_center = _as_bool_scalar("include_center", include_center)
     point_batch, point_single = _as_point_batch("centers", centers)
     axis_batch, axis_single = _as_axis_offset_batch(
         axis_offsets, dim=point_batch.shape[1]
@@ -238,6 +255,11 @@ def ellipsoid_sigma_points(
     ``(count, support_point_count, dim)``.
     """
 
+    include_center = _as_bool_scalar("include_center", include_center)
+    sort_descending = _as_bool_scalar("sort_descending", sort_descending)
+    clip_negative_eigenvalues = _as_bool_scalar(
+        "clip_negative_eigenvalues", clip_negative_eigenvalues
+    )
     radii_tuple = tuple(
         _as_finite_nonnegative_scalar("radius", radius) for radius in radii
     )
@@ -299,6 +321,7 @@ def mahalanobis_support_points(
     """Map unit directions to a covariance ellipsoid's surface."""
 
     radius = _as_finite_nonnegative_scalar("radius", radius)
+    normalize_directions = _as_bool_scalar("normalize_directions", normalize_directions)
     centers, center_single = _as_point_batch("mean", mean)
     covariances, cov_single = _as_covariance_batch("covariance", covariance)
     directions_array = _as_real_array("directions", directions)

--- a/tests/sampling/test_support_points.py
+++ b/tests/sampling/test_support_points.py
@@ -51,6 +51,13 @@ def test_support_points_from_axis_offsets_supports_batches() -> None:
     )
 
 
+def test_support_points_from_axis_offsets_can_omit_center() -> None:
+    support = support_points_from_axis_offsets([0.0, 0.0], np.eye(2), include_center=False)
+
+    assert support.shape == (4, 2)
+    assert np.allclose(support, [[1.0, 0.0], [-1.0, 0.0], [0.0, 1.0], [0.0, -1.0]])
+
+
 def test_projected_linear_variance_from_axis_offsets() -> None:
     axis_offsets = np.broadcast_to(np.eye(2, dtype=np.float64), (2, 2, 2))
     coefficients = np.asarray([[3.0, 4.0], [1.0, 2.0]], dtype=np.float64)
@@ -97,6 +104,36 @@ def test_ellipsoid_axis_offsets_reject_nonfinite_radius(bad_radius: float) -> No
 def test_ellipsoid_axis_offsets_reject_text_radius(bad_radius: object) -> None:
     with pytest.raises(ValueError, match="radius"):
         ellipsoid_axis_offsets(np.eye(2), radius=bad_radius)
+
+
+@pytest.mark.parametrize(
+    "bad_flag",
+    ["False", 1, np.asarray([True]), None],
+)
+def test_support_points_reject_non_boolean_include_center(bad_flag: object) -> None:
+    with pytest.raises(ValueError, match="include_center"):
+        support_points_from_axis_offsets([0.0, 0.0], np.eye(2), include_center=bad_flag)
+
+
+@pytest.mark.parametrize(
+    "keyword",
+    ["sort_descending", "clip_negative_eigenvalues"],
+)
+def test_ellipsoid_axis_offsets_reject_non_boolean_flags(keyword: str) -> None:
+    with pytest.raises(ValueError, match=keyword):
+        ellipsoid_axis_offsets(np.eye(2), **{keyword: "False"})
+
+
+def test_ellipsoid_sigma_points_reject_non_boolean_include_center() -> None:
+    with pytest.raises(ValueError, match="include_center"):
+        ellipsoid_sigma_points([0.0, 0.0], np.eye(2), include_center="False")
+
+
+def test_mahalanobis_support_points_reject_non_boolean_normalize_flag() -> None:
+    with pytest.raises(ValueError, match="normalize_directions"):
+        mahalanobis_support_points(
+            [0.0, 0.0], np.eye(2), [[1.0, 0.0]], normalize_directions="False"
+        )
 
 
 @pytest.mark.parametrize("bad_radius", [np.nan, np.inf, -np.inf])


### PR DESCRIPTION
## Summary
- add strict boolean normalization for support-point helper keyword flags
- reject text, numeric, array, and `None` values for boolean-only parameters such as `include_center`, `sort_descending`, `clip_negative_eigenvalues`, and `normalize_directions`
- add regressions covering center omission and invalid boolean flag inputs

## Validation
- local targeted regression checks for the updated support-point helpers passed