### PR TITLE
Fix circular mixture sampling order

### DIFF
--- a/src/pyrecest/distributions/abstract_mixture.py
+++ b/src/pyrecest/distributions/abstract_mixture.py
@@ -28,24 +28,25 @@ from .abstract_manifold_specific_distribution import (
 
 
 def _validate_positive_sample_count(n) -> int:
+    message = "n must be a positive integer"
     count_array = np.asarray(n)
     if count_array.ndim != 0:
-        raise ValueError("n must be a scalar integer")
+        raise ValueError(message)
 
     count = count_array.item()
     if isinstance(count, (bool, np.bool_)):
-        raise ValueError("n must be an integer, not a boolean")
+        raise ValueError(message)
 
     try:
         count_int = int(count)
         count_float = float(count)
     except (OverflowError, TypeError, ValueError) as exc:
-        raise ValueError("n must be an integer") from exc
+        raise ValueError(message) from exc
 
     if not np.isfinite(count_float) or not count_float.is_integer():
-        raise ValueError("n must be a finite integer")
+        raise ValueError(message)
     if count_int <= 0:
-        raise ValueError("n must be positive")
+        raise ValueError(message)
     return count_int
 
 

--- a/src/pyrecest/distributions/circle/circular_mixture.py
+++ b/src/pyrecest/distributions/circle/circular_mixture.py
@@ -1,6 +1,7 @@
 import collections
 import warnings
-from numbers import Integral
+
+import pyrecest.backend
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 # pylint: disable=no-name-in-module,no-member
@@ -8,7 +9,6 @@ from pyrecest.backend import (
     asarray,
     atleast_1d,
     concatenate,
-    empty,
     ndim,
     random,
     reshape,
@@ -16,6 +16,7 @@ from pyrecest.backend import (
     zeros,
 )
 
+from ..abstract_mixture import _validate_positive_sample_count
 from ..hypertorus.hypertoroidal_mixture import HypertoroidalMixture
 from .abstract_circular_distribution import AbstractCircularDistribution
 from .circular_dirac_distribution import CircularDiracDistribution
@@ -95,28 +96,21 @@ class CircularMixture(AbstractCircularDistribution, HypertoroidalMixture):
         return p
 
     def sample(self, n):
-        """Draw samples from the circular mixture.
+        """Draw ordered iid samples from the circular mixture.
 
-        The generic mixture sampler stores samples in an array of shape
-        ``(n, input_dim)``. For one-dimensional circular distributions, component
-        samplers conventionally return a flat angle vector with shape ``(n,)``.
-        Returning a flat vector here preserves that circular API and avoids
-        assigning ``(k,)`` component samples into ``(k, 1)`` slices.
+        Drawing only multinomial component counts and then concatenating
+        component-wise samples makes early output positions more likely to come
+        from earlier components. Instead, draw a component label for each output
+        position and sample the corresponding component in that order.
         """
-        if isinstance(n, bool) or not isinstance(n, Integral) or int(n) <= 0:
-            raise ValueError("n must be a positive integer.")
-        n = int(n)
+        n = _validate_positive_sample_count(n)
 
-        occurrences = random.multinomial(n, self.w)
+        component_indices = random.choice(len(self.dists), size=n, p=self.w)
+        component_indices = pyrecest.backend.to_numpy(component_indices).reshape(-1)
+
         samples = []
-
-        for i, occ in enumerate(occurrences):
-            occ_val = occ.item() if hasattr(occ, "item") else int(occ)
-            if occ_val != 0:
-                sample_i = self.dists[i].sample(occ_val)
-                samples.append(reshape(atleast_1d(sample_i), (-1,)))
-
-        if not samples:
-            return empty((0,))
+        for component_index in component_indices:
+            sample_i = self.dists[int(component_index)].sample(1)
+            samples.append(reshape(atleast_1d(sample_i), (-1,)))
 
         return concatenate(samples, axis=0)

--- a/tests/distributions/test_circular_mixture.py
+++ b/tests/distributions/test_circular_mixture.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy as np
 import numpy.testing as npt
+
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
@@ -92,7 +93,10 @@ class TestCircularMixture(unittest.TestCase):
         samples = mixture.sample(8)
 
         self.assertEqual(samples.shape, (8,))
-        npt.assert_allclose(samples, array([0.9, 0.9, 0.9, 0.9, 0.1, 0.9, 0.1, 0.9]))
+        npt.assert_allclose(
+            samples,
+            array([0.9, 0.9, 0.9, 0.9, 0.1, 0.9, 0.1, 0.9]),
+        )
 
     def test_sample_rejects_invalid_count(self):
         for n in (0, -1, 1.5, True):

--- a/tests/distributions/test_circular_mixture.py
+++ b/tests/distributions/test_circular_mixture.py
@@ -2,10 +2,26 @@ import unittest
 
 import numpy as np
 import numpy.testing as npt
+import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array
+from pyrecest.backend import array, zeros
 from pyrecest.distributions import CircularMixture, VonMisesDistribution
+from pyrecest.distributions.circle.abstract_circular_distribution import (
+    AbstractCircularDistribution,
+)
+
+
+class _ConstantCircularDistribution(AbstractCircularDistribution):
+    def __init__(self, value):
+        super().__init__()
+        self.value = value
+
+    def pdf(self, xs):
+        return zeros(array(xs).shape)
+
+    def sample(self, n):
+        return array([self.value] * int(n))
 
 
 class TestCircularMixture(unittest.TestCase):
@@ -62,6 +78,21 @@ class TestCircularMixture(unittest.TestCase):
         samples = mixture.sample(np.int64(4))
 
         self.assertEqual(samples.shape, (4,))
+
+    def test_sample_preserves_numpy_drawn_component_order(self):
+        if pyrecest.backend.__backend_name__ != "numpy":
+            self.skipTest("NumPy RNG regression test")
+
+        mixture = CircularMixture(
+            [_ConstantCircularDistribution(0.1), _ConstantCircularDistribution(0.9)],
+            array([0.5, 0.5]),
+        )
+
+        pyrecest.backend.random.seed(0)
+        samples = mixture.sample(8)
+
+        self.assertEqual(samples.shape, (8,))
+        npt.assert_allclose(samples, array([0.9, 0.9, 0.9, 0.9, 0.1, 0.9, 0.1, 0.9]))
 
     def test_sample_rejects_invalid_count(self):
         for n in (0, -1, 1.5, True):


### PR DESCRIPTION
## Summary
- Update circular-mixture sampling to draw component labels per output sample.
- Add a regression test for deterministic component ordering.

## Tests
- Not run locally.