### PR TITLE
Validate sparse second-order weights

### DIFF
--- a/src/pyrecest/filters/sparse_second_order_grid.py
+++ b/src/pyrecest/filters/sparse_second_order_grid.py
@@ -27,6 +27,8 @@ SparsePairTransitionRowBuilder = Callable[
     [int, int, int], tuple[np.ndarray, np.ndarray]
 ]
 SparsePairTransitionCacheKeyBuilder = Callable[[int, int, int], Hashable | None]
+_TEXT_TYPES = (str, bytes, bytearray, np.str_, np.bytes_)
+_BOOLEAN_TYPES = (bool, np.bool_)
 
 
 @dataclass(frozen=True)
@@ -121,7 +123,7 @@ def sparse_second_order_grid_evidence(
     prev_raw, curr_raw, alpha, initial_edge_counts = initial_pair_initializer(scaled)
     prev_raw = np.asarray(prev_raw)
     curr_raw = np.asarray(curr_raw)
-    alpha = np.asarray(alpha, dtype=float)
+    alpha = _coerce_real_weight_array(alpha, "initial pair weights")
     if (
         prev_raw.ndim != 1
         or curr_raw.ndim != 1
@@ -312,7 +314,7 @@ def _advance_sparse_pair_alpha(
                 int(src_prev), int(src_curr), int(transition_index)
             )
             dst_raw = np.asarray(dst)
-            weights = np.asarray(weights, dtype=float)
+            weights = _coerce_real_weight_array(weights, "transition row weights")
             if dst_raw.ndim != 1 or weights.shape != dst_raw.shape:
                 raise ValueError(
                     "transition rows must return one-dimensional dst and weights arrays with matching shapes"
@@ -367,6 +369,31 @@ def _advance_sparse_pair_alpha(
         cache_hits,
         cache_misses,
     )
+
+
+def _contains_values_of_type(value: Any, types: tuple[type, ...]) -> bool:
+    if isinstance(value, types):
+        return True
+    try:
+        values = np.asarray(value, dtype=object).reshape(-1)
+    except (TypeError, ValueError, RuntimeError):
+        return False
+    return any(isinstance(item, types) for item in values)
+
+
+def _coerce_real_weight_array(values: Any, message_prefix: str) -> np.ndarray:
+    message = f"{message_prefix} must be finite and nonnegative"
+    if _contains_values_of_type(values, _TEXT_TYPES) or _contains_values_of_type(
+        values, _BOOLEAN_TYPES
+    ):
+        raise ValueError(message)
+    try:
+        weights = np.asarray(values, dtype=float)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if np.any(~np.isfinite(weights)) or np.any(weights < 0.0):
+        raise ValueError(message)
+    return weights
 
 
 def _coerce_grid_index_array(

--- a/tests/test_sparse_second_order_grid_weight_validation.py
+++ b/tests/test_sparse_second_order_grid_weight_validation.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pytest
+
+from pyrecest.filters.sparse_second_order_grid import sparse_second_order_grid_evidence
+
+
+def test_sparse_second_order_grid_rejects_boolean_initial_pair_weights():
+    def init(scaled):
+        del scaled
+        return np.array([0]), np.array([0]), np.array([True]), [1]
+
+    def row(prev, curr, transition_index):
+        del prev, curr, transition_index
+        return np.array([0]), np.array([1.0])
+
+    with pytest.raises(ValueError, match="initial pair weights"):
+        sparse_second_order_grid_evidence(np.zeros((3, 2)), init, row)
+
+
+def test_sparse_second_order_grid_rejects_boolean_transition_row_weights():
+    def init(scaled):
+        del scaled
+        return np.array([0]), np.array([0]), np.array([1.0]), [1]
+
+    def row(prev, curr, transition_index):
+        del prev, curr, transition_index
+        return np.array([0]), np.array([True])
+
+    with pytest.raises(ValueError, match="transition row weights"):
+        sparse_second_order_grid_evidence(np.zeros((3, 2)), init, row)

--- a/tests/test_sparse_second_order_grid_weight_validation.py
+++ b/tests/test_sparse_second_order_grid_weight_validation.py
@@ -28,3 +28,33 @@ def test_sparse_second_order_grid_rejects_boolean_transition_row_weights():
 
     with pytest.raises(ValueError, match="transition row weights"):
         sparse_second_order_grid_evidence(np.zeros((3, 2)), init, row)
+
+
+def test_sparse_second_order_grid_rejects_text_initial_pair_weights():
+    numeric_text = "".join(("1", ".", "0"))
+
+    def init(scaled):
+        del scaled
+        return np.array([0]), np.array([0]), np.array([numeric_text], dtype=object), [1]
+
+    def row(prev, curr, transition_index):
+        del prev, curr, transition_index
+        return np.array([0]), np.array([1.0])
+
+    with pytest.raises(ValueError, match="initial pair weights"):
+        sparse_second_order_grid_evidence(np.zeros((3, 2)), init, row)
+
+
+def test_sparse_second_order_grid_rejects_text_transition_row_weights():
+    numeric_text = "".join(("1", ".", "0"))
+
+    def init(scaled):
+        del scaled
+        return np.array([0]), np.array([0]), np.array([1.0]), [1]
+
+    def row(prev, curr, transition_index):
+        del prev, curr, transition_index
+        return np.array([0]), np.array([numeric_text], dtype=object)
+
+    with pytest.raises(ValueError, match="transition row weights"):
+        sparse_second_order_grid_evidence(np.zeros((3, 2)), init, row)


### PR DESCRIPTION
## Summary
- add explicit validation for sparse pair and transition weights before numeric coercion
- add regression tests for invalid sparse weight inputs

## Testing
- Not run locally in this connector-only environment.