### PR TITLE
Stabilize von Mises large-kappa evaluations

### DIFF
--- a/src/pyrecest/distributions/circle/von_mises_distribution.py
+++ b/src/pyrecest/distributions/circle/von_mises_distribution.py
@@ -200,7 +200,7 @@ class VonMisesDistribution(AbstractCircularDistribution):
         result = (
             -self.kappa * VonMisesDistribution.besselratio(0, self.kappa)
             + self.kappa
-            + log(2.0 * pi * ive(0, self.kappa))
+            + log(array(2.0 * pi * ive(0, self.kappa)))
         )
         return result
 

--- a/src/pyrecest/distributions/circle/von_mises_distribution.py
+++ b/src/pyrecest/distributions/circle/von_mises_distribution.py
@@ -61,7 +61,12 @@ class VonMisesDistribution(AbstractCircularDistribution):
 
     def pdf(self, xs):
         xs = array(xs)
-        p = exp(self.kappa * cos(xs - self.mu)) / self.norm_const
+        if self._norm_const is None:
+            p = exp(self.kappa * (cos(xs - self.mu) - 1.0)) / (
+                2.0 * pi * ive(0, self.kappa)
+            )
+        else:
+            p = exp(self.kappa * cos(xs - self.mu)) / self.norm_const
         return p
 
     def sample(self, n):
@@ -86,7 +91,7 @@ class VonMisesDistribution(AbstractCircularDistribution):
 
     @staticmethod
     def besselratio(nu, kappa):
-        return iv(nu + 1, kappa) / iv(nu, kappa)
+        return ive(nu + 1, kappa) / ive(nu, kappa)
 
     def cdf(self, xs, starting_point=0):
         """
@@ -192,8 +197,10 @@ class VonMisesDistribution(AbstractCircularDistribution):
         return VonMisesDistribution(mu_, kappa_)
 
     def entropy(self):
-        result = -self.kappa * VonMisesDistribution.besselratio(0, self.kappa) + log(
-            2.0 * pi * iv(0, self.kappa)
+        result = (
+            -self.kappa * VonMisesDistribution.besselratio(0, self.kappa)
+            + self.kappa
+            + log(2.0 * pi * ive(0, self.kappa))
         )
         return result
 

--- a/tests/distributions/test_von_mises_distribution.py
+++ b/tests/distributions/test_von_mises_distribution.py
@@ -24,6 +24,23 @@ class TestVonMisesDistribution(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     VonMisesDistribution(0.0, kappa)
 
+    def test_besselratio_remains_finite_for_large_concentration(self):
+        ratio = VonMisesDistribution.besselratio(0, 1000.0)
+
+        self.assertTrue(np.isfinite(float(ratio)))
+        self.assertGreater(float(ratio), 0.999)
+        self.assertLess(float(ratio), 1.0)
+
+    def test_large_concentration_pdf_and_entropy_are_finite(self):
+        dist = VonMisesDistribution(0.3, 1000.0)
+
+        mode_pdf = dist.pdf(array([0.3]))
+        entropy = dist.entropy()
+
+        self.assertTrue(np.isfinite(float(mode_pdf[0])))
+        self.assertGreater(float(mode_pdf[0]), 0.0)
+        self.assertTrue(np.isfinite(float(entropy)))
+
     def test_pdf(self):
         dist = VonMisesDistribution(2, 1)
         xs = linspace(1, 7, 7)


### PR DESCRIPTION
## Summary
- evaluate von Mises PDFs with the exponentially scaled modified Bessel function to avoid `inf / inf` at high concentration
- compute Bessel ratios with `ive` instead of direct `iv` ratios
- compute entropy through the scaled log normalizer
- add regression tests for large-`kappa` Bessel ratio, PDF, and entropy finiteness

## Testing
- Not run locally: repository checkout/network access is unavailable in this connector environment. The change is covered by the added regression tests and CI will run on the PR.