### PR TITLE
Reject None implicit surface numeric fields

### DIFF
--- a/src/pyrecest/evaluation/implicit_surfaces.py
+++ b/src/pyrecest/evaluation/implicit_surfaces.py
@@ -19,6 +19,7 @@ _INVALID_NUMERIC_SCALAR_TYPES = (
     np.bytes_,
     complex,
     np.complexfloating,
+    type(None),
 )
 
 

--- a/tests/evaluation/test_implicit_surface_numeric_validation.py
+++ b/tests/evaluation/test_implicit_surface_numeric_validation.py
@@ -12,6 +12,8 @@ from pyrecest.evaluation import (
     (
         [True, False],
         np.array([True, False]),
+        [None, 0.0],
+        np.array([None, 0.0], dtype=object),
         ["0.0", "1.0"],
         np.array(["0.0", "1.0"]),
         np.array([1.0 + 1.0j, 2.0 + 0.0j]),


### PR DESCRIPTION
## Summary
- reject `None` entries in implicit-surface numeric field inputs before float coercion
- add regression coverage for plain lists and object arrays containing `None`

## Bug
`_as_numpy_numeric_array()` guarded against booleans, text, bytes, complex, datetime, and timedelta values, but object arrays containing `None` still reached `astype(np.float64)`. NumPy converts `None` to `nan`, so helpers such as `surface_band_mask()`, `classify_inside_outside()`, and the signed-distance probability path could silently accept malformed nonnumeric data instead of raising a validation error.

## Validation
- connector diff check: only `src/pyrecest/evaluation/implicit_surfaces.py` and `tests/evaluation/test_implicit_surface_numeric_validation.py` changed
- focused regression cases added for `[None, 0.0]` and `np.array([None, 0.0], dtype=object)`
- full local pytest was not run because this execution environment cannot resolve `github.com` to clone/install the repository