### PR TITLE
Stabilize circular entropy calculation

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
@@ -11,6 +11,7 @@ from pyrecest.backend import (
     int64,
     isfinite,
     log,
+    log1p,
     mod,
     ndim,
     pi,
@@ -65,7 +66,13 @@ class WrappedExponentialDistribution(AbstractCircularDistribution):
         return mod(-log(u) / self.lambda_, 2.0 * pi)
 
     def entropy(self):
-        # log(exp(2*pi*lambda)) = 2*pi*lambda, avoiding redundant exp/log
+        # Use exp(-2*pi*lambda) to avoid overflowing exp(2*pi*lambda) for
+        # concentrated wrapped exponentials.
         log_beta = 2.0 * pi * self.lambda_
-        beta = exp(log_beta)
-        return 1.0 + log((beta - 1.0) / self.lambda_) - beta / (beta - 1.0) * log_beta
+        exp_neg_log_beta = exp(-log_beta)
+        return (
+            1.0
+            - log(self.lambda_)
+            + log1p(-exp_neg_log_beta)
+            - log_beta * exp_neg_log_beta / (1.0 - exp_neg_log_beta)
+        )

--- a/tests/distributions/test_wrapped_exponential_distribution.py
+++ b/tests/distributions/test_wrapped_exponential_distribution.py
@@ -90,6 +90,15 @@ class WrappedExponentialDistributionTest(unittest.TestCase):
     def test_entropy(self):
         npt.assert_allclose(self.we.entropy(), self.we.entropy_numerical(), rtol=5e-7)
 
+    def test_entropy_stays_finite_for_large_lambda(self):
+        lambda_ = 200.0
+        we = WrappedExponentialDistribution(array(lambda_))
+
+        entropy = pyrecest.backend.to_numpy(we.entropy())
+
+        self.assertTrue(np.isfinite(entropy).all())
+        npt.assert_allclose(entropy, 1.0 - np.log(lambda_), rtol=5e-7, atol=5e-7)
+
     def test_periodicity(self):
         npt.assert_allclose(
             self.we.pdf(linspace(-2.0 * pi, 0.0, 100)),


### PR DESCRIPTION
## Summary
- rewrite the circular wrapped-rate entropy calculation to use `exp(-2πλ)` and `log1p` instead of forming the reciprocal large-scale term directly
- add a regression test for large `lambda_` values where the previous expression returned `nan`

## Bug
The previous entropy formula constructed a term that grows as `exp(2πλ)`. For concentrated distributions, for example `lambda_=200`, that term becomes non-finite and the following ratio makes the entropy `nan`. The new expression is algebraically equivalent but evaluates the correction through the bounded `exp(-2πλ)` quantity.

## Validation
- connector diff check: only the circular distribution implementation and its distribution test changed
- local scalar formula check confirmed the old expression gives `nan` at `lambda_=200` while the new expression is finite and matches the large-rate limit `1 - log(lambda_)`
- full repository pytest was not run because this execution environment cannot resolve `github.com` to clone/install the repository