### PR TITLE
Improve calibration aggregation

### DIFF
--- a/src/pyrecest/calibration/time_offset.py
+++ b/src/pyrecest/calibration/time_offset.py
@@ -121,6 +121,35 @@ def _as_real_numeric_array(value: Any, name: str) -> np.ndarray:
         raise ValueError(f"{name} must contain real numeric values") from exc
 
 
+def _as_summary_scalar(value: Any, name: str, *, allow_nan: bool = False) -> float:
+    """Return a sweep-summary scalar without silent text, bool, or complex coercion."""
+
+    arr = np.asarray(value)
+    if arr.ndim != 0 or arr.dtype == np.bool_ or arr.dtype.kind in "USbcMm":
+        raise ValueError(f"{name} must be a real scalar")
+    scalar = arr.item()
+    if isinstance(scalar, (bool, np.bool_, str, bytes, bytearray)):
+        raise ValueError(f"{name} must be a real scalar")
+    try:
+        result = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be a real scalar") from exc
+    if np.isnan(result) and allow_nan:
+        return result
+    if not np.isfinite(result):
+        raise ValueError(f"{name} must be a finite real scalar")
+    return result
+
+
+def _as_nonnegative_summary_count(value: Any, name: str) -> float:
+    """Return a finite, nonnegative summary count."""
+
+    result = _as_summary_scalar(value, name)
+    if result < 0.0:
+        raise ValueError(f"{name} must be nonnegative")
+    return result
+
+
 def make_offset_grid(min_s: float, max_s: float, step_s: float) -> np.ndarray:
     """Return an inclusive offset grid rounded to nanosecond precision."""
 
@@ -370,17 +399,26 @@ def aggregate_time_offset_sweeps(
     by_offset: dict[float, list[Mapping[str, float]]] = {}
     for sweep in sweeps:
         for row in sweep:
-            by_offset.setdefault(float(row["time_offset_s"]), []).append(row)
+            offset = _as_summary_scalar(row["time_offset_s"], "time_offset_s")
+            by_offset.setdefault(offset, []).append(row)
     rows: list[dict[str, float]] = []
     for offset, parts in sorted(by_offset.items()):
         counts = np.array(
-            [float(part.get("count", 0.0)) for part in parts], dtype=float
+            [
+                _as_nonnegative_summary_count(part.get("count", 0.0), "count")
+                for part in parts
+            ],
+            dtype=float,
         )
         total = float(np.sum(counts))
         row = {"time_offset_s": float(offset), "count": total}
         for key in dict.fromkeys(("mean", "rmse", "p95", "max", metric)):
             values = np.array(
-                [float(part.get(key, np.nan)) for part in parts], dtype=float
+                [
+                    _as_summary_scalar(part.get(key, np.nan), str(key), allow_nan=True)
+                    for part in parts
+                ],
+                dtype=float,
             )
             row[key] = _aggregate_summary_metric(key, values, counts)
         rows.append(row)

--- a/tests/calibration/test_time_offset_aggregate_validation.py
+++ b/tests/calibration/test_time_offset_aggregate_validation.py
@@ -1,0 +1,54 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+from pyrecest.calibration.time_offset import aggregate_time_offset_sweeps
+
+
+class TimeOffsetAggregateValidationTest(unittest.TestCase):
+    def _summary_row(self) -> dict[str, float]:
+        return {
+            "time_offset_s": 0.0,
+            "count": 2.0,
+            "mean": 1.0,
+            "rmse": 2.0,
+            "p95": 2.5,
+            "max": 3.0,
+        }
+
+    def test_aggregate_time_offset_sweeps_accepts_scalar_numpy_values(self):
+        row = self._summary_row()
+        row.update(
+            {
+                "time_offset_s": np.array(0.0),
+                "count": np.float64(2.0),
+                "mean": np.array(1.0),
+                "rmse": np.float64(2.0),
+            }
+        )
+
+        aggregated = aggregate_time_offset_sweeps([[row]])
+
+        self.assertEqual(aggregated[0]["count"], 2.0)
+        npt.assert_allclose(aggregated[0]["rmse"], 2.0)
+
+    def test_aggregate_time_offset_sweeps_rejects_malformed_summary_scalars(self):
+        invalid_cases = (
+            ("time_offset_s", "0.0", "time_offset_s"),
+            ("count", True, "count"),
+            ("count", -1.0, "count"),
+            ("mean", 1.0 + 0.0j, "mean"),
+            ("rmse", "2.0", "rmse"),
+            ("p95", np.array([2.5]), "p95"),
+        )
+        for key, value, pattern in invalid_cases:
+            with self.subTest(key=key, value=value):
+                row = self._summary_row()
+                row[key] = value
+                with self.assertRaisesRegex(ValueError, pattern):
+                    aggregate_time_offset_sweeps([[row]])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add strict scalar handling for time-offset aggregation summary rows
- keep valid NumPy scalar inputs working while rejecting invalid text, boolean, complex, vector, and negative-count fields
- add focused regression coverage for the aggregation helper

## Validation
- `python -m py_compile /mnt/data/patch/src/pyrecest/calibration/time_offset.py`
- `PYTHONPATH=/mnt/data/patch/src python -m unittest tests/calibration/test_time_offset_aggregate_validation.py -v`

Full repository tests were not run locally because the sandbox cannot clone/install the repository from GitHub.