### PR TITLE
Validate reproducibility seed upper bound

### DIFF
--- a/src/pyrecest/reproducibility.py
+++ b/src/pyrecest/reproducibility.py
@@ -9,6 +9,8 @@ from contextlib import contextmanager
 from numbers import Integral
 from typing import Any
 
+_MAX_BACKEND_SEED = 2**32 - 1
+
 
 def _random_backend() -> Any:
     from pyrecest.backend import random
@@ -45,7 +47,7 @@ def _normalize_seed(seed: int | None) -> int | None:
             raise ValueError(message)
         normalized_seed = int(scalar_float)
 
-    if normalized_seed < 0:
+    if normalized_seed < 0 or normalized_seed > _MAX_BACKEND_SEED:
         raise ValueError(message)
     return normalized_seed
 

--- a/tests/test_reproducibility_seed.py
+++ b/tests/test_reproducibility_seed.py
@@ -17,6 +17,8 @@ class ReproducibilitySeedValidationTest(unittest.TestCase):
             True,
             False,
             -1,
+            2**32,
+            np.array(2**32, dtype=np.uint64),
             1.5,
             float("nan"),
             float("inf"),
@@ -38,6 +40,7 @@ class ReproducibilitySeedValidationTest(unittest.TestCase):
     def test_seed_all_accepts_integer_like_scalar_seed(self):
         self.assertIsNone(seed_all(None))
         self.assertEqual(seed_all(np.array(7.0)), 7)
+        self.assertEqual(seed_all(2**32 - 1), 2**32 - 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add an explicit upper-bound check for reproducibility seeds before backend seeding.
- Add regression coverage for values above the supported seed range.
- Keep the maximum supported seed accepted.

## Validation
- Local py_compile checks for the edited files.
- Local isolated validation check for valid and invalid seed values.

Full repository pytest was not run locally because the connector environment cannot clone the repository.