### PR TITLE
Reject textual particle diagnostic weights

### DIFF
--- a/src/pyrecest/diagnostics.py
+++ b/src/pyrecest/diagnostics.py
@@ -54,9 +54,14 @@ def _coerce_weight_values(weights: Any) -> list[float]:
 
     if hasattr(weights, "tolist"):
         weights = weights.tolist()
+    if isinstance(weights, str | bytes | bytearray):
+        raise ValueError("Particle weights must be numeric.")
     if isinstance(weights, int | float):
         return [float(weights)]
-    return [float(weight) for weight in weights]
+    try:
+        return [float(weight) for weight in weights]
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("Particle weights must be numeric.") from exc
 
 
 def _coerce_numeric_values(values: Any) -> list[float]:

--- a/src/pyrecest/diagnostics.py
+++ b/src/pyrecest/diagnostics.py
@@ -45,6 +45,8 @@ def _coerce_metadata_bool(value: Any, name: str) -> bool:
 
 def _coerce_weight_values(weights: Any) -> list[float]:
     """Return backend-independent Python floats from an array-like weight vector."""
+    if isinstance(weights, str | bytes | bytearray):
+        raise ValueError("Particle weights must be numeric.")
     try:
         from pyrecest.backend import to_numpy
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -29,3 +29,11 @@ def test_particle_diagnostics_rejects_nonfinite_weights():
     for weights in ([float("nan"), 1.0], [float("inf"), 1.0]):
         with pytest.raises(ValueError, match="Particle weights must be finite"):
             ParticleDiagnostics.from_weights(weights)
+
+
+def test_particle_diagnostics_rejects_text_weight_sequences():
+    text_bytes = bytes([49, 50])
+    mutable_text_bytes = bytearray([49, 50])
+    for weights in ("12", text_bytes, mutable_text_bytes):
+        with pytest.raises(ValueError, match="Particle weights must be numeric"):
+            ParticleDiagnostics.from_weights(weights)


### PR DESCRIPTION
## Summary
- reject top-level text and byte sequences in `ParticleDiagnostics.from_weights`
- wrap non-numeric weight coercion failures in a clear `ValueError`
- add a regression test covering string, bytes, and bytearray inputs

## Rationale
`ParticleDiagnostics.from_weights("12")` previously iterated over the string and interpreted it as two weights (`1.0`, `2.0`). Byte sequences had a similar accidental sequence interpretation. These are textual inputs rather than numeric weight vectors and should fail fast.

## Testing
- `python -m pytest tests/test_diagnostics.py -q` in an isolated local package copy: 4 passed
- Full repository test suite not run here because the sandbox cannot clone GitHub directly