### PR TITLE
Reject non-finite wrapped-normal means

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_wrapped_normal_distribution.py
@@ -33,6 +33,12 @@ def _as_1d_mu(mu):
         mu = mu.reshape((1,))
     if mu.ndim != 1:
         raise ValueError(f"mu must be one-dimensional, but got shape {mu.shape}")
+    try:
+        finite_mu = backend_all(isfinite(mu))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("mu must contain only finite real values") from exc
+    if not bool(finite_mu):
+        raise ValueError("mu must contain only finite real values")
     return mu
 
 

--- a/tests/distributions/test_wrapped_normal_distribution.py
+++ b/tests/distributions/test_wrapped_normal_distribution.py
@@ -52,6 +52,18 @@ class WrappedNormalDistributionTest(unittest.TestCase):
             )
         )
 
+    def test_constructor_rejects_invalid_mu(self):
+        for mu in (float("nan"), float("inf"), -float("inf")):
+            with self.subTest(mu=mu):
+                with self.assertRaisesRegex(ValueError, "finite real values"):
+                    WrappedNormalDistribution(array(mu), array(1.0))
+
+    def test_set_mean_rejects_invalid_mu(self):
+        for mu in (float("nan"), float("inf"), -float("inf")):
+            with self.subTest(mu=mu):
+                with self.assertRaisesRegex(ValueError, "finite real values"):
+                    self.wn.set_mean(array(mu))
+
     def test_constructor_rejects_invalid_sigma(self):
         for sigma in (-1.0, 0.0, float("nan"), float("inf")):
             with self.subTest(sigma=sigma):


### PR DESCRIPTION
## Summary
- validate wrapped-normal mean vectors for finite real values before storing/wrapping them
- cover both constructor and `set_mean` rejection paths for `nan`, `inf`, and `-inf` circular wrapped-normal means

## Bug
`HypertoroidalWrappedNormalDistribution` validated covariance finiteness but accepted non-finite mean angles. Those values were wrapped with `mod(...)`, leaving distributions with `nan` means that could later poison PDFs, samples, moments, and shifted distributions.

## Validation
- `python -m py_compile` on the edited source and regression test files in a local scratch copy
- GitHub diff check: branch is 2 commits ahead of `main`, 0 behind, touching only the intended source and test files