### PR TITLE
Stabilize wrapped exponential behavior for tiny rates

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
@@ -20,7 +20,7 @@ from pyrecest.backend import (
 
 from .abstract_circular_distribution import AbstractCircularDistribution
 
-_SMALL_ENTROPY_SERIES_THRESHOLD = 1e-4
+_SMALL_RATE_SERIES_THRESHOLD = 1e-4
 
 
 def _validate_positive_scalar(value, name):
@@ -32,6 +32,13 @@ def _validate_positive_scalar(value, name):
     if not bool(all(value > 0.0)):
         raise ValueError(f"{name} must be positive.")
     return value
+
+
+def _normalization_const_from_log_beta(log_beta):
+    if bool(all(log_beta < _SMALL_RATE_SERIES_THRESHOLD)):
+        # 1 / (1 - exp(-x)) = 1/x + 1/2 + x/12 - x**3/720 + O(x**5).
+        return 1.0 / log_beta + 0.5 + log_beta / 12.0 - log_beta**3 / 720.0
+    return 1.0 / (1.0 - exp(-log_beta))
 
 
 class WrappedExponentialDistribution(AbstractCircularDistribution):
@@ -47,7 +54,8 @@ class WrappedExponentialDistribution(AbstractCircularDistribution):
         AbstractCircularDistribution.__init__(self)
         lambda_ = _validate_positive_scalar(lambda_, "lambda_")
         self.lambda_ = lambda_
-        self._normalization_const = 1.0 / (1.0 - exp(-2.0 * pi * lambda_))
+        self._log_beta = 2.0 * pi * lambda_
+        self._normalization_const = _normalization_const_from_log_beta(self._log_beta)
 
     def pdf(self, xs):
         xs = asarray(xs)
@@ -68,8 +76,8 @@ class WrappedExponentialDistribution(AbstractCircularDistribution):
         return mod(-log(u) / self.lambda_, 2.0 * pi)
 
     def entropy(self):
-        log_beta = 2.0 * pi * self.lambda_
-        if bool(all(log_beta < _SMALL_ENTROPY_SERIES_THRESHOLD)):
+        log_beta = self._log_beta
+        if bool(all(log_beta < _SMALL_RATE_SERIES_THRESHOLD)):
             # As lambda approaches zero, the distribution approaches the uniform
             # distribution on [0, 2*pi).  The direct expression evaluates
             # log1p(-exp(-log_beta)) and divides by 1 - exp(-log_beta), which

--- a/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
@@ -20,6 +20,8 @@ from pyrecest.backend import (
 
 from .abstract_circular_distribution import AbstractCircularDistribution
 
+_SMALL_ENTROPY_SERIES_THRESHOLD = 1e-4
+
 
 def _validate_positive_scalar(value, name):
     value = asarray(value)
@@ -66,9 +68,20 @@ class WrappedExponentialDistribution(AbstractCircularDistribution):
         return mod(-log(u) / self.lambda_, 2.0 * pi)
 
     def entropy(self):
+        log_beta = 2.0 * pi * self.lambda_
+        if bool(all(log_beta < _SMALL_ENTROPY_SERIES_THRESHOLD)):
+            # As lambda approaches zero, the distribution approaches the uniform
+            # distribution on [0, 2*pi).  The direct expression evaluates
+            # log1p(-exp(-log_beta)) and divides by 1 - exp(-log_beta), which
+            # suffers catastrophic cancellation for tiny log_beta.
+            return (
+                log(2.0 * pi)
+                - log_beta**2 / 24.0
+                + log_beta**4 / 960.0
+            )
+
         # Use exp(-2*pi*lambda) to avoid overflowing exp(2*pi*lambda) for
         # concentrated wrapped exponentials.
-        log_beta = 2.0 * pi * self.lambda_
         exp_neg_log_beta = exp(-log_beta)
         return (
             1.0

--- a/tests/distributions/test_wrapped_exponential_distribution.py
+++ b/tests/distributions/test_wrapped_exponential_distribution.py
@@ -99,6 +99,14 @@ class WrappedExponentialDistributionTest(unittest.TestCase):
         self.assertTrue(np.isfinite(entropy).all())
         npt.assert_allclose(entropy, 1.0 - np.log(lambda_), rtol=5e-7, atol=5e-7)
 
+    def test_entropy_approaches_uniform_for_tiny_lambda(self):
+        we = WrappedExponentialDistribution(array(1e-18))
+
+        entropy = pyrecest.backend.to_numpy(we.entropy())
+
+        self.assertTrue(np.isfinite(entropy).all())
+        npt.assert_allclose(entropy, np.log(2.0 * np.pi), rtol=5e-7, atol=5e-7)
+
     def test_periodicity(self):
         npt.assert_allclose(
             self.we.pdf(linspace(-2.0 * pi, 0.0, 100)),

--- a/tests/distributions/test_wrapped_exponential_distribution.py
+++ b/tests/distributions/test_wrapped_exponential_distribution.py
@@ -42,6 +42,19 @@ class WrappedExponentialDistributionTest(unittest.TestCase):
             rtol=5e-7,
         )
 
+    def test_pdf_approaches_uniform_for_tiny_lambda(self):
+        we = WrappedExponentialDistribution(array(1e-18))
+
+        density = pyrecest.backend.to_numpy(we.pdf(array([0.0, pi])))
+
+        self.assertTrue(np.isfinite(density).all())
+        npt.assert_allclose(
+            density,
+            np.full(2, 1.0 / (2.0 * np.pi)),
+            rtol=5e-7,
+            atol=5e-7,
+        )
+
     def test_rejects_invalid_lambda(self):
         for lambda_ in (0.0, -0.5, float("inf"), array([1.0, 2.0])):
             with self.subTest(lambda_=lambda_):


### PR DESCRIPTION
## Summary
- stabilize the wrapped exponential normalizer when `lambda_` is extremely small
- use the small-rate entropy series so entropy approaches the uniform-circle limit instead of hitting cancellation
- add regression coverage for tiny-rate PDF and entropy values

## Testing
- Not run locally; added targeted regression tests under `tests/distributions/test_wrapped_exponential_distribution.py`.