### PR TITLE
Fix tuple handling in backend predicate

### DIFF
--- a/src/pyrecest/backend_tools.py
+++ b/src/pyrecest/backend_tools.py
@@ -13,9 +13,10 @@ def get_backend_name() -> str:
     return backend.__backend_name__  # pylint: disable=no-member
 
 
-def is_backend(expected: str) -> bool:
-    """Return whether the active backend equals ``expected``."""
-    return get_backend_name() == expected
+def is_backend(expected: str | tuple[str, ...]) -> bool:
+    """Return whether the active backend matches one of the expected names."""
+    expected_names = _normalize_expected_backend_names(expected)
+    return get_backend_name() in expected_names
 
 
 def _normalize_expected_backend_names(

--- a/tests/test_backend_tools_tuple_predicate.py
+++ b/tests/test_backend_tools_tuple_predicate.py
@@ -1,0 +1,8 @@
+import pyrecest
+
+
+def test_is_backend_accepts_expected_name_tuples():
+    active = pyrecest.get_backend_name()
+    other = "jax" if active != "jax" else "numpy"
+
+    assert pyrecest.is_backend((other, active))


### PR DESCRIPTION
## Summary
- make `is_backend` normalize expected backend names through the same helper used by `assert_backend`
- allow tuple-valued expectations such as `(other_backend, active_backend)` to return `True` when the active backend is included
- add a regression test for tuple-valued `is_backend` inputs

## Bug
`assert_backend` accepted a tuple of allowed backend names, but `is_backend` compared the active backend string directly with the tuple object. As a result, `is_backend(("numpy", "jax"))` returned `False` even when the active backend was one of those names.

## Validation
- connector diff check: only `src/pyrecest/backend_tools.py` and a focused backend-tools regression test were changed
- local syntax check: `python -m py_compile` on the updated module and new test file
- full repository pytest was not run because this execution environment cannot resolve `github.com` to clone/install the repository