### PR TITLE
Handle zero weights in piecewise entropy

### DIFF
--- a/src/pyrecest/distributions/circle/piecewise_constant_distribution.py
+++ b/src/pyrecest/distributions/circle/piecewise_constant_distribution.py
@@ -164,7 +164,12 @@ class PiecewiseConstantDistribution(AbstractCircularDistribution):
             Entropy of the distribution.
         """
         n = len(self.w)
-        return float(-2.0 * pi / n * sum(self.w * log(self.w)))
+        positive_weights = self.w > 0.0
+        safe_weights = pyrecest.backend.where(positive_weights, self.w, 1.0)
+        entropy_terms = pyrecest.backend.where(
+            positive_weights, self.w * log(safe_weights), 0.0
+        )
+        return float(-2.0 * pi / n * sum(entropy_terms))
 
     def sample(self, n):
         """Draw n random samples from the distribution.

--- a/tests/distributions/test_piecewise_constant_distribution.py
+++ b/tests/distributions/test_piecewise_constant_distribution.py
@@ -177,6 +177,14 @@ class PiecewiseConstantDistributionTest(unittest.TestCase):
         expected = -2.0 * pi / n * sum(w * log(w))
         npt.assert_allclose(self.dist.entropy(), expected, rtol=1e-10)
 
+    def test_entropy_handles_zero_weight_intervals(self):
+        dist = PiecewiseConstantDistribution(array([1.0, 0.0, 1.0]))
+
+        entropy = dist.entropy()
+
+        self.assertTrue(np.isfinite(entropy))
+        npt.assert_allclose(entropy, np.log(4.0 * np.pi / 3.0), rtol=1e-12)
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
         reason="Not supported on JAX backend",


### PR DESCRIPTION
## Summary
- Avoid `0 * log(0)` in `PiecewiseConstantDistribution.entropy()` by replacing zero-density bins with neutral safe values before the logarithm.
- Add a regression test for a piecewise-constant circular density with a zero-weight interval.

## Test
- Not run locally; the execution environment here cannot clone/install the repository dependencies.
- Added targeted regression coverage in `tests/distributions/test_piecewise_constant_distribution.py`.