### PR TITLE
Validate Euclidean MTT distance inputs

### DIFF
--- a/src/pyrecest/evaluation/get_distance_function.py
+++ b/src/pyrecest/evaluation/get_distance_function.py
@@ -68,6 +68,12 @@ def _contains_unsupported_numeric_config_values(value: Any) -> bool:
     if isinstance(value, _UNSUPPORTED_NUMERIC_CONFIG_TYPES):
         return True
     try:
+        raw_values = np.asarray(value, dtype=object).reshape(-1)
+    except (TypeError, ValueError, RuntimeError):
+        raw_values = ()
+    if any(isinstance(item, _UNSUPPORTED_NUMERIC_CONFIG_TYPES) for item in raw_values):
+        return True
+    try:
         values = np.asarray(to_numpy(value), dtype=object).reshape(-1)
     except (TypeError, ValueError, RuntimeError):
         return False

--- a/src/pyrecest/evaluation/get_distance_function.py
+++ b/src/pyrecest/evaluation/get_distance_function.py
@@ -74,6 +74,19 @@ def _contains_unsupported_numeric_config_values(value: Any) -> bool:
     return any(isinstance(item, _UNSUPPORTED_NUMERIC_CONFIG_TYPES) for item in values)
 
 
+def _as_real_numeric_array(value: Any, name: str) -> np.ndarray:
+    message = f"{name} must contain only finite real numeric values"
+    if _contains_unsupported_numeric_config_values(value):
+        raise ValueError(message)
+    try:
+        values = np.asarray(to_numpy(value), dtype=float)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if not np.all(np.isfinite(values)):
+        raise ValueError(message)
+    return values
+
+
 def _validate_symmetry_count(nSymm: Any) -> int:
     count_array = np.asarray(to_numpy(nSymm))
     if (
@@ -131,8 +144,8 @@ def _symmetric_distance_function(
     return distance_function
 
 
-def _as_target_matrix(value) -> np.ndarray:
-    value = np.asarray(to_numpy(value), dtype=float)
+def _as_target_matrix(value, name: str) -> np.ndarray:
+    value = _as_real_numeric_array(value, name)
     if value.size == 0:
         if value.ndim == 2:
             return value
@@ -150,7 +163,12 @@ def _as_target_matrix(value) -> np.ndarray:
 
 def _validate_mtt_cutoff_distance(value: Any) -> float:
     value_array = np.asarray(to_numpy(value))
-    if value_array.shape != () or np.issubdtype(value_array.dtype, np.bool_):
+    if (
+        value_array.shape != ()
+        or np.issubdtype(value_array.dtype, np.bool_)
+        or _contains_unsupported_numeric_config_values(value)
+        or _contains_unsupported_numeric_config_values(value_array)
+    ):
         raise ValueError("cutoff_distance must be a finite nonnegative scalar")
     scalar = value_array.item()
     if isinstance(scalar, (bool, np.bool_)):
@@ -165,8 +183,8 @@ def _validate_mtt_cutoff_distance(value: Any) -> float:
 
 
 def _euclidean_mtt_distance(x1, x2, *, cutoff_distance: float) -> float:
-    raw_first = np.asarray(to_numpy(x1), dtype=float)
-    raw_second = np.asarray(to_numpy(x2), dtype=float)
+    raw_first = _as_real_numeric_array(x1, "x1")
+    raw_second = _as_real_numeric_array(x2, "x2")
     if raw_first.size == 0 and raw_first.ndim == 2 and raw_second.ndim == 2:
         if raw_first.shape[1] != raw_second.shape[1]:
             raise ValueError("MTT state sets must use the same target dimension")
@@ -175,8 +193,8 @@ def _euclidean_mtt_distance(x1, x2, *, cutoff_distance: float) -> float:
         if raw_first.shape[1] != raw_second.shape[1]:
             raise ValueError("MTT state sets must use the same target dimension")
         return float(cutoff_distance * raw_first.shape[0])
-    first = _as_target_matrix(x1)
-    second = _as_target_matrix(x2)
+    first = _as_target_matrix(raw_first, "x1")
+    second = _as_target_matrix(raw_second, "x2")
     if first.shape[0] == 0 or second.shape[0] == 0:
         return float(cutoff_distance * abs(first.shape[0] - second.shape[0]))
     if first.shape[1] != second.shape[1]:

--- a/tests/evaluation/test_mtt_distance_input_validation.py
+++ b/tests/evaluation/test_mtt_distance_input_validation.py
@@ -1,0 +1,49 @@
+import unittest
+
+import numpy as np
+from pyrecest.evaluation.get_distance_function import get_distance_function
+
+
+class EuclideanMttDistanceInputValidationTest(unittest.TestCase):
+    def test_rejects_text_cutoff_distances(self):
+        for cutoff_distance in ("2.5", np.array("2.5", dtype=object)):
+            with self.subTest(cutoff_distance=cutoff_distance):
+                with self.assertRaisesRegex(ValueError, "cutoff_distance.*finite"):
+                    get_distance_function(
+                        "euclidean_mtt",
+                        {"cutoff_distance": cutoff_distance},
+                    )
+
+    def test_rejects_invalid_state_values(self):
+        distance = get_distance_function(
+            "euclidean_mtt",
+            {"cutoff_distance": 2.5},
+        )
+        valid_state = np.array([[0.0, 0.0]])
+        invalid_states = (
+            np.array([[1.0 + 2.0j, 0.0]]),
+            [[True, 0.0]],
+            [["1.0", 0.0]],
+            [[np.nan, 0.0]],
+            [[np.inf, 0.0]],
+        )
+
+        for state in invalid_states:
+            with self.subTest(state=state, argument="x1"):
+                with self.assertRaisesRegex(ValueError, "x1.*finite real"):
+                    distance(state, valid_state)
+            with self.subTest(state=state, argument="x2"):
+                with self.assertRaisesRegex(ValueError, "x2.*finite real"):
+                    distance(valid_state, state)
+
+    def test_valid_empty_target_behavior_is_preserved(self):
+        distance = get_distance_function(
+            "euclidean_mtt",
+            {"cutoff_distance": 2.5},
+        )
+
+        self.assertEqual(distance(np.empty((0, 2)), np.array([[1.0, 2.0]])), 2.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/evaluation/test_tmp_validation_smoke.py
+++ b/tests/evaluation/test_tmp_validation_smoke.py
@@ -1,2 +1,0 @@
-def test_placeholder():
-    assert True

--- a/tests/evaluation/test_tmp_validation_smoke.py
+++ b/tests/evaluation/test_tmp_validation_smoke.py
@@ -1,0 +1,2 @@
+def test_placeholder():
+    assert True


### PR DESCRIPTION
## Summary
- validate Euclidean MTT state sets before float coercion so boolean, text, complex, and non-finite values fail fast
- reject text-like `cutoff_distance` values instead of accepting them through `float(...)`
- add focused regression coverage for invalid MTT distance inputs while preserving the existing empty-target cutoff behavior

## Bug
The Euclidean MTT distance implementation converted target-state inputs with `np.asarray(..., dtype=float)` before validation. That allowed malformed values to be silently coerced, including complex arrays whose imaginary components could be discarded. The cutoff-distance parser also accepted numeric-looking text values via `float(...)`.

## Validation
- `python -m py_compile /tmp/get_distance_function.py /tmp/test_get_distance_function_mtt.py`
- isolated local smoke test with PyRecEst backend/distribution stubs covering valid empty-target behavior plus invalid state/cutoff rejection

Full repository pytest was not run locally because this sandbox cannot resolve `github.com`, so I could not clone/install the full dependency environment here.