### PR TITLE
Fix virtual backend submodule imports

### DIFF
--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -1,23 +1,29 @@
 from importlib.metadata import PackageNotFoundError, version
 
 import pyrecest._backend  # noqa
+from pyrecest._backend_submodules import (  # noqa: F401
+    register_backend_submodules as _register_backend_submodules,
+)
 from pyrecest.backend import copy  # noqa: F401
-from pyrecest.backend_support import (  # noqa: F401
+
+_register_backend_submodules()
+
+from pyrecest.backend_support import (  # noqa: E402,F401
     backend_support,
     format_backend_support_markdown,
     get_backend_support,
 )
-from pyrecest.backend_tools import (  # noqa: F401
+from pyrecest.backend_tools import (  # noqa: E402,F401
     assert_backend,
     get_backend_name,
     is_backend,
     warn_if_backend_env_changed,
 )
-from pyrecest.evidence import (  # noqa: F401
+from pyrecest.evidence import (  # noqa: E402,F401
     EvidenceComputationMode,
     resolve_evidence_computation_mode,
 )
-from pyrecest.exceptions import (  # noqa: F401
+from pyrecest.exceptions import (  # noqa: E402,F401
     BackendNotSupportedError,
     BackendSupportError,
     DimensionMismatchError,
@@ -27,7 +33,7 @@ from pyrecest.exceptions import (  # noqa: F401
     ShapeError,
     ValidationError,
 )
-from pyrecest.stability import (  # noqa: F401
+from pyrecest.stability import (  # noqa: E402,F401
     get_public_api_status,
     iter_public_api_status,
     stability,

--- a/src/pyrecest/_backend_submodules.py
+++ b/src/pyrecest/_backend_submodules.py
@@ -1,0 +1,29 @@
+"""Utilities for exposing virtual backend submodules."""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+from pyrecest._backend import BACKEND_ATTRIBUTES
+
+
+def register_backend_submodules(backend: ModuleType | None = None) -> None:
+    """Register virtual backend submodules for standard import statements."""
+    if backend is None:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+
+    backend.__path__ = getattr(backend, "__path__", [])
+    backend_spec = getattr(backend, "__spec__", None)
+    if backend_spec is not None:
+        backend_spec.submodule_search_locations = (
+            getattr(backend_spec, "submodule_search_locations", None) or []
+        )
+
+    for submodule_name in BACKEND_ATTRIBUTES:
+        if not submodule_name:
+            continue
+        sys.modules.setdefault(
+            f"{backend.__name__}.{submodule_name}",
+            getattr(backend, submodule_name),
+        )

--- a/tests/test_backend_submodule_imports.py
+++ b/tests/test_backend_submodule_imports.py
@@ -1,0 +1,10 @@
+import importlib
+
+import pyrecest.backend as backend
+
+
+def test_backend_virtual_submodules_are_importable():
+    for submodule_name in ("linalg", "random"):
+        module = importlib.import_module(f"pyrecest.backend.{submodule_name}")
+
+        assert module is getattr(backend, submodule_name)


### PR DESCRIPTION
## Summary
- Register generated `pyrecest.backend` submodules in `sys.modules` so standard imports like `import pyrecest.backend.linalg` resolve.
- Mark the backend facade as package-like for importlib by providing submodule search locations.
- Add a regression test for direct backend submodule imports.

## Testing
- Not run locally; the execution sandbox cannot clone GitHub, so changes were made through the GitHub connector and validated by inspecting the branch diff.