### PR TITLE
Support vector measurements in linear Gaussian scenarios

### DIFF
--- a/src/pyrecest/scenarios.py
+++ b/src/pyrecest/scenarios.py
@@ -218,10 +218,17 @@ def run_linear_gaussian_scenario(path: str | Path) -> ScenarioResult:
 
     estimates: list[list[float]] = []
     nis_values: list[float] = []
-    for scalar_measurement in data["measurements"]:
+    for measurement_value in data["measurements"]:
         kalman_filter.predict_linear(system_matrix, system_noise_cov)
+        measurement_vector = be.array(
+            _to_float_list(
+                measurement_value,
+                name="measurement",
+                reject_text_or_bool=True,
+            )
+        )
         diagnostics = kalman_filter.update_linear(
-            be.array([float(scalar_measurement)]),
+            measurement_vector,
             measurement_matrix,
             measurement_noise_cov,
             return_diagnostics=True,

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -22,3 +22,37 @@ def test_linear_gaussian_scenario_matches_golden_output():
     ]
     assert max(errors) <= tolerance
     assert result.metrics["max_abs_final_estimate_error"] <= tolerance
+
+
+def test_linear_gaussian_scenario_accepts_vector_measurements(tmp_path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        """
+[scenario]
+type = "linear_gaussian"
+name = "vector measurement scenario"
+
+[model]
+system_matrix = [[1.0, 0.0], [0.0, 1.0]]
+system_noise_covariance = [[0.0, 0.0], [0.0, 0.0]]
+
+[measurement]
+measurement_matrix = [[1.0, 0.0], [0.0, 1.0]]
+measurement_noise_covariance = [[1.0, 0.0], [0.0, 1.0]]
+
+[initial]
+mean = [0.0, 0.0]
+covariance = [[1.0, 0.0], [0.0, 1.0]]
+
+[data]
+measurements = [[1.0, 2.0], [3.0, 4.0]]
+""".strip(),
+        encoding="utf-8",
+    )
+
+    result = run_scenario(config_path)
+
+    assert result.name == "vector measurement scenario"
+    assert len(result.final_estimate) == 2
+    assert len(result.estimates) == 2
+    assert all(len(estimate) == 2 for estimate in result.estimates)


### PR DESCRIPTION
## Summary

- Fix `run_linear_gaussian_scenario` so each configured measurement may be either a scalar or a one-dimensional vector.
- Reuse the existing numeric validation helper so text and boolean measurement entries are rejected consistently.
- Add a regression test with a two-dimensional linear-Gaussian scenario whose measurement matrix and measurement covariance are 2x2.

## Notes

The previous implementation forced every entry in `data.measurements` through `float(...)` and wrapped it as a length-one vector, which made valid multi-dimensional linear-Gaussian scenarios fail before the Kalman update step.

## Testing

- Not run locally: the sandbox cannot clone or install the GitHub repository because outbound GitHub DNS resolution is unavailable here.