### PR TITLE
Reject None entries in candidate pruning matrices

### DIFF
--- a/src/pyrecest/utils/candidate_pruning.py
+++ b/src/pyrecest/utils/candidate_pruning.py
@@ -18,6 +18,7 @@ import numpy as np
 _TEXT_TYPES = (str, bytes, bytearray, np.str_, np.bytes_)
 _BOOLEAN_TYPES = (bool, np.bool_)
 _COMPLEX_TYPES = (complex, np.complexfloating)
+_MISSING_TYPES = (type(None),)
 
 
 @dataclass(frozen=True)
@@ -181,6 +182,10 @@ def _contains_complex_values(value: Any) -> bool:
     return _contains_values_of_type(value, _COMPLEX_TYPES)
 
 
+def _contains_missing_values(value: Any) -> bool:
+    return _contains_values_of_type(value, _MISSING_TYPES)
+
+
 def _as_numeric_matrix(value: Any, name: str) -> np.ndarray:
     try:
         raw_values = np.asarray(value)
@@ -189,6 +194,8 @@ def _as_numeric_matrix(value: Any, name: str) -> np.ndarray:
 
     if raw_values.dtype == np.bool_:
         raise ValueError(f"{name} must be numeric, not boolean")
+    if _contains_missing_values(value) or _contains_missing_values(raw_values):
+        raise ValueError(f"{name} must be numeric")
     if _contains_boolean_values(value) or _contains_boolean_values(raw_values):
         raise ValueError(f"{name} must be numeric, not boolean")
     if (

--- a/tests/test_candidate_pruning.py
+++ b/tests/test_candidate_pruning.py
@@ -98,6 +98,17 @@ class TestCandidatePruning(unittest.TestCase):
 
         npt.assert_array_equal(mask, np.array([[False, True]]))
 
+    def test_numeric_matrices_reject_none_object_values(self):
+        with self.assertRaisesRegex(ValueError, "cost_matrix must be numeric"):
+            candidate_mask_from_costs(np.array([[1.0, None]], dtype=object))
+
+        with self.assertRaisesRegex(ValueError, "probability_matrix must be numeric"):
+            candidate_mask_from_costs(
+                np.array([[1.0, 2.0]]),
+                probability_matrix=np.array([[0.5, None]], dtype=object),
+                config=CandidatePruningConfig(probability_threshold=0.4),
+            )
+
     def test_percentile_rule_and_large_cost_replacement(self):
         costs = np.array([[1.0, 2.0, 100.0], [3.0, 4.0, 5.0]])
 


### PR DESCRIPTION
## Summary

- Reject `None` inside object-valued candidate-pruning cost/probability matrices before NumPy can coerce it to `nan`.
- Add regression coverage for `cost_matrix` and `probability_matrix` object arrays containing `None`.

## Notes

`np.asarray(..., dtype=float)` silently maps `None` to `nan`; for candidate pruning that could turn an invalid object entry into a missing/nonfinite candidate instead of failing validation.

## Testing

- Not run locally: outbound GitHub DNS resolution is unavailable in this sandbox, so the repository cannot be cloned or installed here.