### PR TITLE
Tighten CLI expected numeric checks

### DIFF
--- a/src/pyrecest/cli.py
+++ b/src/pyrecest/cli.py
@@ -35,6 +35,14 @@ def _validate_tolerance(value: Any) -> float:
     return tolerance
 
 
+def _is_finite_real_number(value: Any) -> bool:
+    return (
+        isinstance(value, int | float)
+        and not isinstance(value, bool)
+        and math.isfinite(float(value))
+    )
+
+
 def _cmd_info(_args: argparse.Namespace) -> int:
     import pyrecest
     import pyrecest.backend as backend
@@ -91,17 +99,15 @@ def _check_expected_mapping(
             errors.append(f"{section_name}.{key} missing from scenario result")
             continue
         actual_value = actual[key]
-        if isinstance(expected_value, int | float) and not isinstance(
-            expected_value, bool
-        ):
-            try:
-                actual_numeric = float(actual_value)
-                expected_numeric = float(expected_value)
-            except (TypeError, ValueError, OverflowError):
+        if _is_finite_real_number(expected_value):
+            if not _is_finite_real_number(actual_value):
                 errors.append(
-                    f"{section_name}.{key} mismatch: expected numeric {expected_value!r}, got {actual_value!r}"
+                    f"{section_name}.{key} mismatch: expected finite numeric "
+                    f"{expected_value!r}, got {actual_value!r}"
                 )
                 continue
+            actual_numeric = float(actual_value)
+            expected_numeric = float(expected_value)
             delta = abs(actual_numeric - expected_numeric)
             if delta > tolerance:
                 errors.append(

--- a/tests/test_cli_expected_mapping.py
+++ b/tests/test_cli_expected_mapping.py
@@ -11,7 +11,7 @@ def test_expected_mapping_reports_nonnumeric_actual_instead_of_raising():
         tolerance=1e-8,
     )
 
-    assert errors == ["metrics.rmse mismatch: expected numeric 1.0, got 'not-a-number'"]
+    assert errors == ["metrics.rmse mismatch: expected finite numeric 1.0, got 'not-a-number'"]
 
 
 def test_expected_mapping_compares_boolean_expected_values_exactly():

--- a/tests/test_cli_tolerance_validation.py
+++ b/tests/test_cli_tolerance_validation.py
@@ -25,3 +25,28 @@ def test_expected_mapping_rejects_nan_tolerance() -> None:
             {"rmse": 2.0},
             tolerance=math.nan,
         )
+
+
+def test_expected_mapping_accepts_finite_numeric_actuals() -> None:
+    assert (
+        _check_expected_mapping(
+            "metrics",
+            {"rmse": 1.000001},
+            {"rmse": 1.0},
+            tolerance=1e-5,
+        )
+        == []
+    )
+
+
+@pytest.mark.parametrize("actual_value", [True, "1.0", math.nan, math.inf])
+def test_expected_mapping_rejects_malformed_numeric_actuals(actual_value) -> None:
+    errors = _check_expected_mapping(
+        "metrics",
+        {"rmse": actual_value},
+        {"rmse": 1.0},
+        tolerance=0.0,
+    )
+
+    assert errors
+    assert "metrics.rmse mismatch" in errors[0]


### PR DESCRIPTION
## Summary
- require expected-result numeric comparisons to use finite real numeric actual values instead of accepting booleans, strings, NaN, or infinity through `float(...)`
- add regression coverage for valid finite numeric comparisons and malformed numeric actual values

## Testing
- `python -m py_compile /mnt/data/cli2.py /mnt/data/test_cli_tolerance_validation.py`
- targeted local helper smoke checks for valid numeric values and malformed actual values (`True`, `"1.0"`, `NaN`, `inf`)

Full repository tests were not run locally because this environment cannot clone/install the repository from GitHub.