### PR TITLE
Fix NumPy trace keyword arguments

### DIFF
--- a/src/pyrecest/_backend/numpy/__init__.py
+++ b/src/pyrecest/_backend/numpy/__init__.py
@@ -192,6 +192,18 @@ linspace = _dyn_update_dtype(target=_np.linspace, dtype_pos=5)
 empty = _dyn_update_dtype(target=_np.empty, dtype_pos=1)
 
 
+def trace(a, offset=0, axis1=-2, axis2=-1, dtype=None, out=None):
+    """Return the trace while preserving PyRecEst's last-two-axes default."""
+    return _np.trace(
+        a,
+        offset=offset,
+        axis1=axis1,
+        axis2=axis2,
+        dtype=dtype,
+        out=out,
+    )
+
+
 def has_autodiff():
     """If allows for automatic differentiation.
 

--- a/tests/test_numpy_backend_trace.py
+++ b/tests/test_numpy_backend_trace.py
@@ -1,0 +1,49 @@
+import pyrecest.backend as backend
+import pytest
+from pyrecest.backend import array
+
+
+def _to_python(value):
+    value = backend.to_numpy(value)
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    return value
+
+
+def test_numpy_backend_trace_accepts_explicit_axes_offset_dtype_and_out():
+    if backend.__backend_name__ != "numpy":
+        pytest.skip("NumPy backend trace regression test")
+
+    values = array(
+        [
+            [[1, 2, 3], [4, 5, 6]],
+            [[7, 8, 9], [10, 11, 12]],
+        ]
+    )
+    out = backend.zeros((2,), dtype=backend.float64)
+
+    result = backend.trace(
+        values,
+        offset=1,
+        axis1=1,
+        axis2=2,
+        dtype=backend.float64,
+        out=out,
+    )
+
+    assert result is out
+    assert _to_python(result) == [8.0, 20.0]
+
+
+def test_numpy_backend_trace_defaults_to_last_two_axes():
+    if backend.__backend_name__ != "numpy":
+        pytest.skip("NumPy backend trace regression test")
+
+    values = array(
+        [
+            [[1.0, 2.0], [3.0, 4.0]],
+            [[5.0, 6.0], [7.0, 8.0]],
+        ]
+    )
+
+    assert _to_python(backend.trace(values)) == [5.0, 13.0]


### PR DESCRIPTION
## Summary
- Override the NumPy backend trace wrapper so valid NumPy keyword arguments are accepted.
- Preserve PyRecEst's last-two-axes default for batched matrix traces.
- Add focused regression tests for explicit trace kwargs and default batched trace behavior.

## Bug
The NumPy backend exposed the shared trace helper with a reduced single-argument signature. Calls such as `backend.trace(x, axis1=1, axis2=2, offset=1, dtype=..., out=...)` therefore failed under NumPy even though they are valid trace operations.

## Testing
- Not run locally because the sandbox cannot clone from github.com.
- GitHub Actions are expected to run on the PR.