### PR TITLE
Reject invalid adaptive process-noise ratios

### DIFF
--- a/src/pyrecest/filters/adaptive_process_noise.py
+++ b/src/pyrecest/filters/adaptive_process_noise.py
@@ -76,6 +76,27 @@ def _normalize_finite_scalar(value: float, name: str) -> float:
     return value_float
 
 
+def _normalize_nonnegative_finite_scalar(value: float, name: str) -> float:
+    message = f"{name} must be a nonnegative finite scalar"
+    value_array = np.asarray(value)
+    if (
+        value_array.shape != ()
+        or value_array.dtype == np.bool_
+        or value_array.dtype.kind in "USbcMm"
+    ):
+        raise ValueError(message)
+    value_scalar = value_array.item()
+    if isinstance(value_scalar, (bool, np.bool_, str, bytes, bytearray)):
+        raise ValueError(message)
+    try:
+        value_float = float(value_scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if value_float < 0.0 or not np.isfinite(value_float):
+        raise ValueError(message)
+    return value_float
+
+
 @dataclass
 class RollingNISProcessNoiseAdapter:
     """Maintain EWMA NIS ratios and return process-noise scale factors."""
@@ -152,7 +173,7 @@ def adaptive_scale_from_ratio(
     """Map a normalized NIS ratio to a bounded process-noise scale."""
 
     config = AdaptiveProcessNoiseConfig() if config is None else config
-    ratio = float(ratio)
+    ratio = _normalize_nonnegative_finite_scalar(ratio, "ratio")
     if ratio > float(config.high_nis_ratio):
         scale = 1.0 + float(config.scale_gain) * (ratio - float(config.high_nis_ratio))
     elif ratio < float(config.low_nis_ratio):

--- a/tests/filters/test_adaptive_process_noise.py
+++ b/tests/filters/test_adaptive_process_noise.py
@@ -19,6 +19,15 @@ def test_scale_increases_for_high_nis_ratio_and_decreases_for_low_ratio():
     assert adaptive_scale_from_ratio(0.0, config) < 1.0
 
 
+@pytest.mark.parametrize(
+    "ratio",
+    [np.nan, np.inf, -np.inf, -0.1, True, "1.0", np.array([1.0])],
+)
+def test_scale_rejects_invalid_ratios(ratio):
+    with pytest.raises(ValueError, match="ratio must be a nonnegative finite scalar"):
+        adaptive_scale_from_ratio(ratio)
+
+
 def test_rolling_adapter_updates_source_ratio_and_scales_covariance():
     adapter = RollingNISProcessNoiseAdapter(
         AdaptiveProcessNoiseConfig(ewma_alpha=1.0, high_nis_ratio=1.1)


### PR DESCRIPTION
## Summary
- Reject invalid NIS ratios in `adaptive_scale_from_ratio` instead of silently producing a neutral or clipped scale.
- Add regression coverage for NaN, infinities, negative values, booleans, text, and non-scalar arrays.

## Testing
- Not run locally; focused regression test added.