### PR TITLE
Reject temporal support-point inputs

### DIFF
--- a/src/pyrecest/sampling/support_points.py
+++ b/src/pyrecest/sampling/support_points.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from datetime import date, datetime, timedelta
 
 import numpy as np
 
 _TEXT_TYPES = (str, bytes, bytearray, np.str_, np.bytes_)
 _BOOLEAN_TYPES = (bool, np.bool_)
 _COMPLEX_TYPES = (complex, np.complexfloating)
+_TEMPORAL_TYPES = (date, datetime, timedelta, np.datetime64, np.timedelta64)
 
 
 def _contains_values_of_type(value: object, types: tuple[type, ...]) -> bool:
@@ -19,11 +21,20 @@ def _contains_values_of_type(value: object, types: tuple[type, ...]) -> bool:
     return any(isinstance(item, types) for item in values)
 
 
+def _has_temporal_dtype(value: object) -> bool:
+    try:
+        return np.asarray(value).dtype.kind in "Mm"
+    except (TypeError, ValueError, RuntimeError):
+        return False
+
+
 def _has_non_real_numeric_values(value: object) -> bool:
     return (
-        _contains_values_of_type(value, _TEXT_TYPES)
+        _has_temporal_dtype(value)
+        or _contains_values_of_type(value, _TEXT_TYPES)
         or _contains_values_of_type(value, _BOOLEAN_TYPES)
         or _contains_values_of_type(value, _COMPLEX_TYPES)
+        or _contains_values_of_type(value, _TEMPORAL_TYPES)
     )
 
 

--- a/tests/sampling/test_support_points.py
+++ b/tests/sampling/test_support_points.py
@@ -164,6 +164,18 @@ def test_support_points_reject_non_real_numeric_centers(bad_centers: object) -> 
 
 
 @pytest.mark.parametrize(
+    "bad_centers",
+    [
+        np.asarray([np.datetime64("2026-01-01")]),
+        np.asarray([np.datetime64("2026-01-01")], dtype=object),
+    ],
+)
+def test_support_points_reject_temporal_centers(bad_centers: object) -> None:
+    with pytest.raises(ValueError, match="centers"):
+        support_points_from_axis_offsets(bad_centers, np.eye(1))
+
+
+@pytest.mark.parametrize(
     "bad_covariance",
     [
         [["1.0", "0.0"], ["0.0", "1.0"]],
@@ -171,6 +183,20 @@ def test_support_points_reject_non_real_numeric_centers(bad_centers: object) -> 
     ],
 )
 def test_ellipsoid_axis_offsets_reject_non_real_numeric_covariance(
+    bad_covariance: object,
+) -> None:
+    with pytest.raises(ValueError, match="covariance"):
+        ellipsoid_axis_offsets(bad_covariance)
+
+
+@pytest.mark.parametrize(
+    "bad_covariance",
+    [
+        np.asarray([[np.timedelta64(3, "s")]]),
+        np.asarray([[np.timedelta64(3, "s")]], dtype=object),
+    ],
+)
+def test_ellipsoid_axis_offsets_reject_temporal_covariance(
     bad_covariance: object,
 ) -> None:
     with pytest.raises(ValueError, match="covariance"):


### PR DESCRIPTION
## Summary
- Reject NumPy/Python datetime and timedelta values before support-point helpers coerce inputs to float.
- Add regression coverage for temporal center and covariance inputs, including object arrays.

## Bug
NumPy can convert `datetime64` and `timedelta64` arrays to floating values such as day counts or time-unit counts. The existing support-point real-numeric validator rejected text, bool, and complex values, but allowed temporal values to reach `np.asarray(..., dtype=np.float64)`, so invalid model inputs could silently become coordinates or covariance entries.

## Testing
- `python -m py_compile /mnt/data/support_points_patched.py /mnt/data/test_support_points_patched.py`
- Targeted local smoke checks for temporal centers/covariances and a valid 1-D support-point call.

Full repository tests were not run locally because this environment cannot clone GitHub directly; CI should run on the PR.