### PR TITLE
Validate DVS count likelihood inputs

### DIFF
--- a/src/pyrecest/experimental/dvs/synthetic.py
+++ b/src/pyrecest/experimental/dvs/synthetic.py
@@ -9,6 +9,17 @@ import numpy as np
 from .active_contour import activity_profile, rectangle_contour_samples
 
 EDGE_ORDER = ("left", "right", "top", "bottom")
+_INVALID_REAL_SCALAR_TYPES = (
+    bool,
+    np.bool_,
+    str,
+    bytes,
+    bytearray,
+    np.str_,
+    np.bytes_,
+    complex,
+    np.complexfloating,
+)
 
 
 @dataclass(frozen=True)
@@ -71,12 +82,12 @@ def count_negative_log_likelihood(
     probability_floor: float = 1e-12,
 ) -> float:
     """Return multinomial count NLL up to the count-dependent constant."""
-    if probability_floor <= 0.0:
-        raise ValueError("probability_floor must be positive")
+    probability_floor = _validate_probability_floor(probability_floor)
     nll = 0.0
     for edge in EDGE_ORDER:
-        probability = max(float(probabilities[edge]), probability_floor)
-        nll -= int(observed_counts[edge]) * float(np.log(probability))
+        count = _edge_count(observed_counts, edge)
+        probability = _edge_probability(probabilities, edge, probability_floor)
+        nll -= count * float(np.log(probability))
     return nll
 
 
@@ -121,3 +132,55 @@ def simulate_rectangle_event_counts(
         normal_flow_probabilities=true_probabilities,
         uniform_probabilities=uniform_edge_probabilities(contour.edge_labels),
     )
+
+
+def _mapping_value(mapping: dict[str, float], edge: str, name: str):
+    try:
+        return mapping[edge]
+    except KeyError as exc:
+        raise ValueError(f"{name} must include an entry for edge {edge!r}") from exc
+
+
+def _as_finite_real_scalar(value, name: str) -> float:
+    value_array = np.asarray(value)
+    if value_array.shape != () or value_array.dtype.kind in "bcSU":
+        raise ValueError(f"{name} must be a finite real scalar")
+    scalar = value_array.item()
+    if isinstance(scalar, _INVALID_REAL_SCALAR_TYPES):
+        raise ValueError(f"{name} must be a finite real scalar")
+    try:
+        value_float = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be a finite real scalar") from exc
+    if not np.isfinite(value_float):
+        raise ValueError(f"{name} must be a finite real scalar")
+    return value_float
+
+
+def _validate_probability_floor(probability_floor: float) -> float:
+    value = _as_finite_real_scalar(probability_floor, "probability_floor")
+    if value <= 0.0 or value > 1.0:
+        raise ValueError("probability_floor must be finite and in (0, 1]")
+    return value
+
+
+def _edge_count(observed_counts: dict[str, int], edge: str) -> int:
+    value = _as_finite_real_scalar(
+        _mapping_value(observed_counts, edge, "observed_counts"),
+        "observed_counts values",
+    )
+    if value < 0.0 or not value.is_integer():
+        raise ValueError("observed_counts values must be non-negative integers")
+    return int(value)
+
+
+def _edge_probability(
+    probabilities: dict[str, float], edge: str, probability_floor: float
+) -> float:
+    value = _as_finite_real_scalar(
+        _mapping_value(probabilities, edge, "probabilities"),
+        "probabilities values",
+    )
+    if value < 0.0 or value > 1.0:
+        raise ValueError("probabilities values must lie in [0, 1]")
+    return max(value, probability_floor)

--- a/tests/experimental/test_dvs_synthetic.py
+++ b/tests/experimental/test_dvs_synthetic.py
@@ -6,6 +6,8 @@ from pyrecest.experimental.dvs import (
     uniform_edge_probabilities,
 )
 
+_EDGES = ("left", "right", "top", "bottom")
+
 
 def test_motion_gated_counts_concentrate_on_vertical_edges():
     simulation = simulate_rectangle_event_counts(
@@ -45,3 +47,36 @@ def test_uniform_edge_probabilities_sum_to_one():
     )
 
     assert sum(probabilities.values()) == pytest.approx(1.0)
+
+
+def test_count_nll_rejects_invalid_observed_counts():
+    probabilities = {edge: 0.25 for edge in _EDGES}
+
+    for bad_count in (-1, 1.5, np.nan, np.inf, True, "2", np.array([2])):
+        observed_counts = {edge: 1 for edge in _EDGES}
+        observed_counts["left"] = bad_count
+        with pytest.raises(ValueError, match="observed_counts"):
+            count_negative_log_likelihood(observed_counts, probabilities)
+
+
+def test_count_nll_rejects_invalid_probabilities():
+    observed_counts = {edge: 1 for edge in _EDGES}
+
+    for bad_probability in (-0.1, 1.1, np.nan, np.inf, True, "0.25", 0.25 + 0.1j):
+        probabilities = {edge: 0.25 for edge in _EDGES}
+        probabilities["left"] = bad_probability
+        with pytest.raises(ValueError, match="probabilities"):
+            count_negative_log_likelihood(observed_counts, probabilities)
+
+
+def test_count_nll_rejects_invalid_probability_floor():
+    observed_counts = {edge: 1 for edge in _EDGES}
+    probabilities = {edge: 0.25 for edge in _EDGES}
+
+    for probability_floor in (0.0, -1e-3, 1.1, np.nan, np.inf, True, "1e-12"):
+        with pytest.raises(ValueError, match="probability_floor"):
+            count_negative_log_likelihood(
+                observed_counts,
+                probabilities,
+                probability_floor=probability_floor,
+            )


### PR DESCRIPTION
## Summary
- Validate DVS count-likelihood inputs before evaluation.
- Reject invalid non-real, boolean, negative, and non-finite count/rate inputs.
- Add regression coverage for invalid DVS count likelihood inputs.

## Testing
- CI-covered PR change.