### PR TITLE
Validate normal-flow helper inputs

### DIFF
--- a/src/pyrecest/experimental/dvs/normal_flow.py
+++ b/src/pyrecest/experimental/dvs/normal_flow.py
@@ -28,13 +28,88 @@ __all__ = [
     "signed_scalar_sign",
 ]
 
+_TEXT_TYPES = (str, bytes, bytearray, np.str_, np.bytes_)
+_BOOLEAN_TYPES = (bool, np.bool_)
+_COMPLEX_TYPES = (complex, np.complexfloating)
+_TEMPORAL_TYPES = (np.datetime64, np.timedelta64)
+
+
+def _contains_values_of_type(value: object, types: tuple[type, ...]) -> bool:
+    if isinstance(value, types):
+        return True
+    try:
+        values = np.asarray(value, dtype=object).reshape(-1)
+    except (TypeError, ValueError, RuntimeError):
+        return False
+    return any(isinstance(item, types) for item in values)
+
+
+def _has_non_real_numeric_values(value: object, *, allow_bool: bool = False) -> bool:
+    rejected_types = _TEXT_TYPES + _COMPLEX_TYPES + _TEMPORAL_TYPES
+    if not allow_bool:
+        rejected_types = rejected_types + _BOOLEAN_TYPES
+    if _contains_values_of_type(value, rejected_types):
+        return True
+    try:
+        array = np.asarray(value)
+    except (TypeError, ValueError, RuntimeError):
+        return False
+    return array.dtype.kind in {"M", "m"}
+
+
+def _as_finite_real_array(name: str, value: object, *, allow_bool: bool = False) -> np.ndarray:
+    message = f"{name} must contain finite real numeric values."
+    if _has_non_real_numeric_values(value, allow_bool=allow_bool):
+        raise ValueError(message)
+    try:
+        array = np.asarray(value, dtype=np.float64)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if not np.isfinite(array).all():
+        raise ValueError(message)
+    return array
+
+
+def _as_finite_real_scalar(name: str, value: object, *, allow_bool: bool = False) -> float:
+    message = f"{name} must be a finite real scalar."
+    try:
+        array = _as_finite_real_array(name, value, allow_bool=allow_bool)
+    except ValueError as exc:
+        raise ValueError(message) from exc
+    if array.shape != ():
+        raise ValueError(message)
+    return float(array.item())
+
+
+def _as_finite_nonnegative_scalar(name: str, value: object) -> float:
+    message = f"{name} must be a finite non-negative real scalar."
+    try:
+        scalar = _as_finite_real_scalar(name, value)
+    except ValueError as exc:
+        raise ValueError(message) from exc
+    if scalar < 0.0:
+        raise ValueError(message)
+    return scalar
+
+
+def _as_unit_interval_scalar(name: str, value: object) -> float:
+    message = f"{name} must be in [0, 1]"
+    try:
+        scalar = _as_finite_real_scalar(name, value)
+    except ValueError as exc:
+        raise ValueError(message) from exc
+    if scalar < 0.0 or scalar > 1.0:
+        raise ValueError(message)
+    return scalar
+
 
 def signed_scalar_sign(value, zero_tolerance=1e-12) -> float:
     """Return the sign of a scalar with a small zero dead-zone."""
-    value = float(value)
-    if value > float(zero_tolerance):
+    value = _as_finite_real_scalar("value", value)
+    tolerance = _as_finite_nonnegative_scalar("zero_tolerance", zero_tolerance)
+    if value > tolerance:
         return 1.0
-    if value < -float(zero_tolerance):
+    if value < -tolerance:
         return -1.0
     return 0.0
 
@@ -46,7 +121,8 @@ def event_polarity_sign(event_polarity) -> float:
     ``-1/+1``. Positive values are treated as ``+1`` and all non-positive
     values as ``-1``.
     """
-    return 1.0 if float(event_polarity) > 0.0 else -1.0
+    polarity = _as_finite_real_scalar("event_polarity", event_polarity, allow_bool=True)
+    return 1.0 if polarity > 0.0 else -1.0
 
 
 def normalize_polarity_contrast_sign(
@@ -69,7 +145,7 @@ def normalize_polarity_contrast_sign(
                 f"polarity_contrast_sign must be {infer_sentinel!r}, None, or non-zero"
             )
         return infer_sentinel
-    value = float(polarity_contrast_sign)
+    value = _as_finite_real_scalar("polarity_contrast_sign", polarity_contrast_sign)
     if value == 0.0:
         raise ValueError(
             f"polarity_contrast_sign must be {infer_sentinel!r}, None, or non-zero"
@@ -95,17 +171,18 @@ def infer_polarity_contrast_sign(
     if normalized != infer_sentinel:
         return normalized
 
-    flows = np.asarray(signed_normal_flows, dtype=float).reshape((-1,))
-    polarities = np.asarray(event_polarities, dtype=float).reshape((-1,))
+    tolerance = _as_finite_nonnegative_scalar("zero_tolerance", zero_tolerance)
+    flows = _as_finite_real_array("signed_normal_flows", signed_normal_flows).reshape((-1,))
+    polarities = _as_finite_real_array("event_polarities", event_polarities, allow_bool=True).reshape((-1,))
     if flows.shape != polarities.shape:
         raise ValueError("event_polarities must have one value per signed normal flow")
 
     score = 0.0
     for signed_flow, event_polarity in zip(flows, polarities, strict=True):
-        if signed_scalar_sign(signed_flow, zero_tolerance=zero_tolerance) == 0.0:
+        if signed_scalar_sign(signed_flow, zero_tolerance=tolerance) == 0.0:
             continue
         score += event_polarity_sign(event_polarity) * float(signed_flow)
-    if abs(score) <= float(zero_tolerance):
+    if abs(score) <= tolerance:
         return 1.0
     return 1.0 if score > 0.0 else -1.0
 
@@ -135,9 +212,10 @@ def polarity_consistency_for_signed_flow(
             f"polarity_contrast_sign={infer_sentinel!r} must be resolved at batch level"
         )
 
+    tolerance = _as_finite_nonnegative_scalar("zero_tolerance", zero_tolerance)
     flow_sign = signed_scalar_sign(
         signed_normal_flow_value,
-        zero_tolerance=zero_tolerance,
+        zero_tolerance=tolerance,
     )
     if flow_sign == 0.0:
         return None
@@ -156,9 +234,7 @@ def polarity_weight_for_signed_flow(
     zero_tolerance=1e-12,
 ) -> float:
     """Return a multiplicative reliability weight from polarity consistency."""
-    mismatch_weight = float(polarity_mismatch_weight)
-    if mismatch_weight < 0.0 or mismatch_weight > 1.0:
-        raise ValueError("polarity_mismatch_weight must be in [0, 1]")
+    mismatch_weight = _as_unit_interval_scalar("polarity_mismatch_weight", polarity_mismatch_weight)
     consistency = polarity_consistency_for_signed_flow(
         signed_normal_flow_value,
         event_polarity,
@@ -181,8 +257,9 @@ def polarity_weights_for_signed_flows(
     zero_tolerance=1e-12,
 ) -> np.ndarray:
     """Return polarity reliability weights for a batch of signed-flow samples."""
-    flows = np.asarray(signed_normal_flows, dtype=float).reshape((-1,))
-    polarities = np.asarray(event_polarities, dtype=float).reshape((-1,))
+    mismatch_weight = _as_unit_interval_scalar("polarity_mismatch_weight", polarity_mismatch_weight)
+    flows = _as_finite_real_array("signed_normal_flows", signed_normal_flows).reshape((-1,))
+    polarities = _as_finite_real_array("event_polarities", event_polarities, allow_bool=True).reshape((-1,))
     resolved_sign = infer_polarity_contrast_sign(
         flows,
         polarities,
@@ -198,7 +275,7 @@ def polarity_weights_for_signed_flows(
                 signed_flow,
                 event_polarity,
                 polarity_contrast_sign=resolved_sign,
-                polarity_mismatch_weight=polarity_mismatch_weight,
+                polarity_mismatch_weight=mismatch_weight,
                 infer_sentinel=infer_sentinel,
                 zero_tolerance=zero_tolerance,
             )

--- a/tests/experimental/test_dvs_normal_flow.py
+++ b/tests/experimental/test_dvs_normal_flow.py
@@ -18,10 +18,30 @@ def test_signed_scalar_sign_uses_dead_zone():
     assert signed_scalar_sign(1e-13) == 0.0
 
 
+@pytest.mark.parametrize("bad_value", [np.nan, np.inf, "1.0", 1.0 + 0.0j, True])
+def test_signed_scalar_sign_rejects_invalid_values(bad_value):
+    with pytest.raises(ValueError, match="value"):
+        signed_scalar_sign(bad_value)
+
+
+@pytest.mark.parametrize("bad_tolerance", [-1e-12, np.nan, np.inf, "1e-12", 1e-12 + 0.0j])
+def test_signed_scalar_sign_rejects_invalid_zero_tolerance(bad_tolerance):
+    with pytest.raises(ValueError, match="zero_tolerance"):
+        signed_scalar_sign(1.0, zero_tolerance=bad_tolerance)
+
+
 def test_event_polarity_sign_supports_zero_one_and_signed_conventions():
     assert event_polarity_sign(1) == 1.0
     assert event_polarity_sign(0) == -1.0
     assert event_polarity_sign(-1) == -1.0
+    assert event_polarity_sign(True) == 1.0
+    assert event_polarity_sign(False) == -1.0
+
+
+@pytest.mark.parametrize("bad_polarity", [np.nan, np.inf, "1", 1.0 + 0.0j])
+def test_event_polarity_sign_rejects_invalid_polarities(bad_polarity):
+    with pytest.raises(ValueError, match="event_polarity"):
+        event_polarity_sign(bad_polarity)
 
 
 def test_normalize_polarity_contrast_sign():
@@ -35,6 +55,12 @@ def test_normalize_polarity_contrast_sign():
         normalize_polarity_contrast_sign(0.0)
 
 
+@pytest.mark.parametrize("bad_sign", [np.nan, np.inf, True, 1.0 + 0.0j])
+def test_normalize_polarity_contrast_sign_rejects_invalid_numeric_values(bad_sign):
+    with pytest.raises(ValueError, match="polarity_contrast_sign"):
+        normalize_polarity_contrast_sign(bad_sign)
+
+
 def test_infer_polarity_contrast_sign_from_batch():
     signed_flows = np.array([1.0, -0.5, 0.0])
     polarities = np.array([1.0, 0.0, 1.0])
@@ -43,6 +69,13 @@ def test_infer_polarity_contrast_sign_from_batch():
     assert infer_polarity_contrast_sign(-signed_flows, polarities, "infer") == -1.0
     assert infer_polarity_contrast_sign(signed_flows, polarities, None) is None
     assert infer_polarity_contrast_sign(signed_flows, polarities, -1.0) == -1.0
+
+
+def test_infer_polarity_contrast_sign_rejects_invalid_batches():
+    with pytest.raises(ValueError, match="signed_normal_flows"):
+        infer_polarity_contrast_sign([1.0, np.nan], [1.0, 0.0], "infer")
+    with pytest.raises(ValueError, match="event_polarities"):
+        infer_polarity_contrast_sign([1.0, -1.0], ["1", "0"], "infer")
 
 
 def test_polarity_consistency_and_weight_for_signed_flow():
@@ -72,6 +105,12 @@ def test_polarity_consistency_and_weight_for_signed_flow():
         polarity_weight_for_signed_flow(1.0, 1.0, 1.0, polarity_mismatch_weight=1.5)
 
 
+@pytest.mark.parametrize("bad_weight", [np.nan, np.inf, "0.5", 0.5 + 0.0j, -0.1, 1.1])
+def test_polarity_weight_rejects_invalid_mismatch_weight(bad_weight):
+    with pytest.raises(ValueError, match="polarity_mismatch_weight"):
+        polarity_weight_for_signed_flow(1.0, 0.0, 1.0, polarity_mismatch_weight=bad_weight)
+
+
 def test_polarity_weights_for_signed_flows_resolves_batch_sign():
     weights = polarity_weights_for_signed_flows(
         np.array([1.0, -1.0, 0.0]),
@@ -79,3 +118,8 @@ def test_polarity_weights_for_signed_flows_resolves_batch_sign():
         polarity_mismatch_weight=0.2,
     )
     np.testing.assert_allclose(weights, np.array([1.0, 1.0, 1.0]))
+
+
+def test_polarity_weights_for_signed_flows_rejects_invalid_mismatch_weight_when_disabled():
+    with pytest.raises(ValueError, match="polarity_mismatch_weight"):
+        polarity_weights_for_signed_flows([1.0], [1.0], None, polarity_mismatch_weight=np.nan)


### PR DESCRIPTION
Summary:
- Adds finite numeric input checks in normal-flow helper functions.
- Adds regression tests for invalid scalar and batch values.

Validation:
- PYTHONPATH=. pytest -q tests/experimental/test_dvs_normal_flow.py (32 passed in isolated checkout).