### PR TITLE
Count empty file-backed measurements correctly

### DIFF
--- a/src/pyrecest/evaluation/evaluate_for_file.py
+++ b/src/pyrecest/evaluation/evaluate_for_file.py
@@ -44,10 +44,11 @@ def evaluate_for_file(
     n_meas_at_individual_time_step = np.zeros(data["measurements"].shape[1], dtype=int)
 
     for idx, inner_array in enumerate(data["measurements"][0]):
+        inner_array = np.asarray(inner_array)
         if inner_array.ndim == 2:
             n_meas_at_individual_time_step[idx] = inner_array.shape[0]
         elif inner_array.ndim == 1:
-            n_meas_at_individual_time_step[idx] = 1
+            n_meas_at_individual_time_step[idx] = 0 if inner_array.size == 0 else 1
 
     scenario_config.setdefault(
         "n_meas_at_individual_time_step", n_meas_at_individual_time_step

--- a/tests/test_evaluate_for_file_measurement_counts.py
+++ b/tests/test_evaluate_for_file_measurement_counts.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+
+
+def test_evaluate_for_file_counts_empty_1d_measurements_as_zero(tmp_path, monkeypatch):
+    module = importlib.import_module("pyrecest.evaluation.evaluate_for_file")
+    input_file = tmp_path / "scenario.npy"
+    measurements = np.empty((1, 3), dtype=object)
+    measurements[0, 0] = np.array([], dtype=float)
+    measurements[0, 1] = np.array([4.0, 5.0])
+    measurements[0, 2] = np.array([[1.0, 2.0], [3.0, 4.0]])
+    groundtruths = np.zeros((1, 3, 2), dtype=float)
+    np.save(input_file, {"groundtruths": groundtruths, "measurements": measurements})
+
+    captured = {}
+
+    def capture_call(groundtruths_arg, measurements_arg, filter_configs, scenario_config, **kwargs):
+        captured["scenario_config"] = dict(scenario_config)
+        return (
+            {},
+            [],
+            np.array([], dtype=bool),
+            groundtruths_arg,
+            measurements_arg,
+            scenario_config,
+            filter_configs,
+            kwargs,
+        )
+
+    monkeypatch.setattr(module, "evaluate_for_variables", capture_call)
+
+    module.evaluate_for_file(str(input_file), [], {}, save_folder=str(tmp_path))
+
+    np.testing.assert_array_equal(
+        captured["scenario_config"]["n_meas_at_individual_time_step"],
+        np.array([0, 1, 2], dtype=int),
+    )

--- a/tests/test_evaluate_for_file_measurement_counts.py
+++ b/tests/test_evaluate_for_file_measurement_counts.py
@@ -17,7 +17,13 @@ def test_evaluate_for_file_counts_empty_1d_measurements_as_zero(tmp_path, monkey
 
     captured = {}
 
-    def capture_call(groundtruths_arg, measurements_arg, filter_configs, scenario_config, **kwargs):
+    def capture_call(
+        groundtruths_arg,
+        measurements_arg,
+        filter_configs,
+        scenario_config,
+        **kwargs,
+    ):
         captured["scenario_config"] = dict(scenario_config)
         return (
             {},


### PR DESCRIPTION
## Summary
- Treat empty one-dimensional measurement arrays as zero detections when deriving file-backed `n_meas_at_individual_time_step`.
- Normalize per-step measurement payloads with `np.asarray` before dimension checks.
- Add a regression test covering empty 1-D, nonempty 1-D, and 2-D measurement payloads.

## Bug
`evaluate_for_file` previously counted every one-dimensional measurement array as one detection. An empty 1-D array such as `np.array([])` therefore produced a count of 1 instead of 0, which could misconfigure `scenario_config["n_meas_at_individual_time_step"]` for loaded scenarios with empty detection steps.

## Validation
- Not run locally; repository access here is through the GitHub connector, so CI should run the focused regression test and the existing suite.