### PR TITLE
Normalize diagnostic summary JSON values

### DIFF
--- a/src/pyrecest/evaluation/diagnostic_summaries.py
+++ b/src/pyrecest/evaluation/diagnostic_summaries.py
@@ -344,20 +344,28 @@ def _json_record(record: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _json_value(value: Any) -> Any:
-    if isinstance(value, np.integer):
-        return int(value)
-    if isinstance(value, np.floating):
-        value = float(value)
-    if isinstance(value, float):
-        return None if not math.isfinite(value) else value
-    if isinstance(value, np.bool_):
-        return bool(value)
+    if value is None:
+        return None
     if isinstance(value, np.ndarray):
         return [_json_value(item) for item in value.tolist()]
     if isinstance(value, Mapping):
         return _json_record(value)
     if isinstance(value, (list, tuple)):
         return [_json_value(item) for item in value]
+    if isinstance(value, np.bool_):
+        return bool(value)
+    if isinstance(value, np.integer):
+        return int(value)
+    if isinstance(value, np.floating):
+        value = float(value)
+    if isinstance(value, float):
+        return None if not math.isfinite(value) else value
+    if isinstance(value, (bytes, bytearray, np.bytes_)):
+        return bytes(value).decode("utf-8", errors="replace")
+    if isinstance(value, np.str_):
+        return str(value)
+    if not isinstance(value, str) and _is_nan(value):
+        return None
     return value
 
 

--- a/tests/evaluation/test_diagnostic_summaries.py
+++ b/tests/evaluation/test_diagnostic_summaries.py
@@ -1,3 +1,4 @@
+import json
 import math
 import unittest
 
@@ -207,6 +208,28 @@ class DiagnosticSummariesTest(unittest.TestCase):
         self.assertEqual(summary["top_residuals"], [])
         self.assertEqual(summary["covariance_inflation"]["count"], 0)
         self.assertEqual(summary["worst_time_windows"], [])
+
+    def test_summary_json_records_normalize_missing_and_bytes_payloads(self):
+        records = [
+            {
+                "time_s": 0.0,
+                "track_id": "A",
+                "source": "rf",
+                "residual_norm": 2.0,
+                "covariance_scale": 1.0,
+                "error": 1.0,
+                "note": pd.NA,
+                "payload": b"ok",
+                "vector": np.array([1.0, np.nan]),
+            }
+        ]
+
+        rows = top_residuals(records)
+
+        self.assertIsNone(rows[0]["note"])
+        self.assertEqual(rows[0]["payload"], "ok")
+        self.assertEqual(rows[0]["vector"], [1.0, None])
+        json.dumps(rows)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Normalize diagnostic-summary record values recursively before returning JSON-friendly rows.
- Convert missing scalar values to `None`.
- Decode byte payloads to text.
- Add regression coverage for missing scalar values, bytes, nested NaN values, and JSON serialization.

## Validation
- Validated the patched conversion logic locally for the new regression case.
- Full repository tests were not run in this environment.