### PR TITLE
Validate multi-session similarity score matrices

### DIFF
--- a/src/pyrecest/utils/multisession_assignment_score.py
+++ b/src/pyrecest/utils/multisession_assignment_score.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import Any
 
 import numpy as np
@@ -35,6 +35,23 @@ from .multisession_assignment import (
 )
 
 
+_INVALID_SCORE_SCALAR_TYPES = (
+    type(None),
+    bool,
+    np.bool_,
+    str,
+    bytes,
+    bytearray,
+    np.str_,
+    np.bytes_,
+    complex,
+    np.complexfloating,
+    np.datetime64,
+    np.timedelta64,
+)
+_REJECTED_SCORE_ARRAY_KINDS = frozenset({"b", "c", "S", "U", "M", "m"})
+
+
 def _ensure_supported_backend(feature_name: str) -> None:
     if __backend_name__ == "jax":
         raise NotImplementedError(
@@ -48,6 +65,34 @@ def _default_score_to_cost(scores: Any) -> Any:
 
 def _is_text_scalar(value: Any) -> bool:
     return isinstance(value, (str, bytes, np.str_, np.bytes_))
+
+
+def _raise_invalid_score_matrix() -> None:
+    raise ValueError("pairwise_scores must contain real numeric score matrices.")
+
+
+def _validate_real_score_matrix(value: Any) -> None:
+    try:
+        raw_values = np.asarray(value)
+    except (TypeError, ValueError, RuntimeError):
+        return
+
+    if raw_values.dtype.kind in _REJECTED_SCORE_ARRAY_KINDS:
+        _raise_invalid_score_matrix()
+    if raw_values.dtype == object:
+        for item in raw_values.reshape(-1):
+            if isinstance(item, _INVALID_SCORE_SCALAR_TYPES):
+                _raise_invalid_score_matrix()
+
+
+def _validate_pairwise_score_inputs(pairwise_scores: PairwiseCostsInput) -> None:
+    if isinstance(pairwise_scores, Mapping):
+        score_matrices = pairwise_scores.values()
+    else:
+        score_matrices = pairwise_scores
+
+    for score_matrix in score_matrices:
+        _validate_real_score_matrix(score_matrix)
 
 
 def _normalize_min_score(min_score: Any) -> float:
@@ -171,6 +216,7 @@ def solve_multisession_assignment_from_similarity(  # pylint: disable=R0913,R091
     if max_gap is not None:
         max_gap = _normalize_max_gap(max_gap)
 
+    _validate_pairwise_score_inputs(pairwise_scores)
     normalized_pairwise_scores = _normalize_pairwise_costs(pairwise_scores)
     normalized_session_sizes = _normalize_session_sizes(session_sizes)
     session_sizes_map = _infer_and_validate_session_sizes(

--- a/tests/test_multisession_assignment_score_validation.py
+++ b/tests/test_multisession_assignment_score_validation.py
@@ -53,6 +53,31 @@ class TestMultiSessionAssignmentScoreValidation(unittest.TestCase):
         __backend_name__ == "jax",
         reason="Not supported on this backend",
     )
+    def test_similarity_wrapper_rejects_non_real_score_matrices(self):
+        invalid_pairwise_scores = (
+            {(0, 1): [[True]]},
+            {(0, 1): np.array([[True]], dtype=bool)},
+            {(0, 1): [["0.9"]]},
+            {(0, 1): np.array([["0.9"]])},
+            {(0, 1): np.array([[0.9 + 0.0j]])},
+            {(0, 1): np.array([[None]], dtype=object)},
+        )
+
+        for pairwise_scores in invalid_pairwise_scores:
+            with self.subTest(pairwise_scores=pairwise_scores):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "pairwise_scores must contain real numeric score matrices",
+                ):
+                    solve_multisession_assignment_from_similarity(
+                        pairwise_scores,
+                        session_sizes=[1, 1],
+                    )
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
     def test_tracks_to_index_matrix_rejects_text_scalar_fill_value(self):
         for fill_value in self._text_scalars("-1"):
             with self.subTest(fill_value=fill_value):


### PR DESCRIPTION
## Summary
- reject boolean, text-like, complex, datetime/timedelta, and missing values in multi-session similarity score matrices before backend float coercion
- keep existing finite-score handling for valid real numeric matrices
- add regression coverage for malformed pairwise similarity-score inputs

## Bug
`solve_multisession_assignment_from_similarity` accepted pairwise similarity matrices through the shared float-normalization path. Inputs such as `[[True]]` or `[["0.9"]]` could therefore be interpreted as numeric scores instead of invalid model outputs, silently changing association costs.

## Validation
- `python -m py_compile /mnt/data/multisession_assignment_score_patched.py /mnt/data/test_multisession_assignment_score_validation_patched.py`

Full repository tests were not run locally because the execution environment cannot resolve github.com to clone/install the repository and dependencies.