### PR TITLE
Reject non-real weak measurement inputs

### DIFF
--- a/src/pyrecest/models/weak_measurement.py
+++ b/src/pyrecest/models/weak_measurement.py
@@ -3,14 +3,15 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from datetime import date, datetime, timedelta
 from typing import Any
 
 import numpy as np
 
 from .linear_gaussian import LinearGaussianMeasurementModel
 
-_BOOL_OR_TEXT_KINDS = {"b", "S", "U"}
-_BOOL_OR_TEXT_SCALAR_TYPES = (
+_NON_REAL_NUMERIC_KINDS = {"b", "c", "m", "M", "S", "U"}
+_NON_REAL_NUMERIC_SCALAR_TYPES = (
     bool,
     np.bool_,
     str,
@@ -18,6 +19,13 @@ _BOOL_OR_TEXT_SCALAR_TYPES = (
     bytearray,
     np.str_,
     np.bytes_,
+    complex,
+    np.complexfloating,
+    date,
+    datetime,
+    timedelta,
+    np.datetime64,
+    np.timedelta64,
 )
 
 
@@ -107,7 +115,9 @@ class MaskedLinearMeasurementModel(LinearGaussianMeasurementModel):
         covariance = (
             diagonal_measurement_covariance(stds)
             if stds is not None
-            else np.asarray(measurement_noise_cov, dtype=float)
+            else _real_numeric_array(
+                measurement_noise_cov, name="measurement_noise_cov"
+            )
         )
         super().__init__(matrix, covariance)
         self.observed_dims = tuple(
@@ -143,7 +153,9 @@ class WeakDimensionMeasurementModel(LinearGaussianMeasurementModel):
         if stds is not None and (trusted_std is not None or weak_std is not None):
             raise ValueError("stds cannot be combined with trusted_std or weak_std")
         if measurement_noise_cov is not None:
-            covariance = np.asarray(measurement_noise_cov, dtype=float)
+            covariance = _real_numeric_array(
+                measurement_noise_cov, name="measurement_noise_cov"
+            )
         elif stds is not None and _is_mapping(stds):
             covariance = block_diag_measurement_covariance(
                 trusted_std=stds, dimension_order=dimension_order
@@ -182,13 +194,17 @@ def _is_mapping(value: object) -> bool:
     return isinstance(value, Mapping)
 
 
-def _standard_deviations_array(stds: Sequence[float] | np.ndarray) -> np.ndarray:
+def _real_numeric_array(value: Any, *, name: str) -> np.ndarray:
     try:
-        if _contains_bool_or_text_values(stds):
+        if _contains_non_real_numeric_values(value):
             raise ValueError
-        values = np.asarray(stds, dtype=float).reshape(-1)
+        return np.asarray(value, dtype=float)
     except (TypeError, ValueError, OverflowError) as exc:
-        raise ValueError("stds must contain real numeric values") from exc
+        raise ValueError(f"{name} must contain real numeric values") from exc
+
+
+def _standard_deviations_array(stds: Sequence[float] | np.ndarray) -> np.ndarray:
+    values = _real_numeric_array(stds, name="stds").reshape(-1)
     if values.size == 0:
         raise ValueError("stds must contain at least one standard deviation")
     if not np.isfinite(values).all() or np.any(values <= 0.0):
@@ -196,13 +212,15 @@ def _standard_deviations_array(stds: Sequence[float] | np.ndarray) -> np.ndarray
     return values
 
 
-def _contains_bool_or_text_values(value: Any) -> bool:
+def _contains_non_real_numeric_values(value: Any) -> bool:
     array = np.asarray(value)
-    if array.dtype.kind in _BOOL_OR_TEXT_KINDS:
+    if array.dtype.kind in _NON_REAL_NUMERIC_KINDS:
         return True
     if array.dtype.kind != "O":
         return False
-    return any(isinstance(item, _BOOL_OR_TEXT_SCALAR_TYPES) for item in array.flat)
+    return any(
+        isinstance(item, _NON_REAL_NUMERIC_SCALAR_TYPES) for item in array.flat
+    )
 
 
 def _positive_int(value: int, name: str) -> int:

--- a/tests/models/test_weak_measurement_nonreal_inputs.py
+++ b/tests/models/test_weak_measurement_nonreal_inputs.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+
+import numpy as np
+import pytest
+
+from pyrecest.models import (
+    MaskedLinearMeasurementModel,
+    WeakDimensionMeasurementModel,
+    block_diag_measurement_covariance,
+    diagonal_measurement_covariance,
+)
+
+
+_NON_REAL_STD_CASES = (
+    [1.0 + 0.0j],
+    [np.complex128(1.0 + 0.0j)],
+    [np.datetime64("2024-01-01")],
+    [np.timedelta64(1, "D")],
+    [date(2024, 1, 1)],
+    [datetime(2024, 1, 1, 12, 0, 0)],
+    [timedelta(days=1)],
+)
+
+
+@pytest.mark.parametrize("stds", _NON_REAL_STD_CASES)
+def test_measurement_stds_reject_non_real_values(stds) -> None:
+    with pytest.raises(ValueError, match="real numeric values"):
+        diagonal_measurement_covariance(stds)
+    with pytest.raises(ValueError, match="real numeric values"):
+        block_diag_measurement_covariance(trusted_std=stds)
+    with pytest.raises(ValueError, match="real numeric values"):
+        MaskedLinearMeasurementModel(state_dim=1, observed_dims=[0], stds=stds)
+    with pytest.raises(ValueError, match="real numeric values"):
+        WeakDimensionMeasurementModel(np.eye(1), stds=stds)
+
+
+@pytest.mark.parametrize("std_value", tuple(case[0] for case in _NON_REAL_STD_CASES))
+def test_measurement_std_mappings_reject_non_real_values(std_value) -> None:
+    with pytest.raises(ValueError, match="real numeric values"):
+        block_diag_measurement_covariance(trusted_std={"x": std_value})
+    with pytest.raises(ValueError, match="real numeric values"):
+        WeakDimensionMeasurementModel(np.eye(1), stds={"x": std_value})
+
+
+@pytest.mark.parametrize(
+    "measurement_noise_cov",
+    (
+        np.array([[1.0 + 0.0j]]),
+        np.array([[np.complex128(1.0 + 0.0j)]], dtype=object),
+        np.array([[np.datetime64("2024-01-01")]]),
+        np.array([[np.timedelta64(1, "D")]]),
+        np.array([[date(2024, 1, 1)]], dtype=object),
+        np.array([[datetime(2024, 1, 1, 12, 0, 0)]], dtype=object),
+        np.array([[timedelta(days=1)]], dtype=object),
+    ),
+)
+def test_measurement_noise_cov_rejects_non_real_values(measurement_noise_cov) -> None:
+    with pytest.raises(ValueError, match="measurement_noise_cov"):
+        MaskedLinearMeasurementModel(
+            state_dim=1,
+            observed_dims=[0],
+            measurement_noise_cov=measurement_noise_cov,
+        )
+    with pytest.raises(ValueError, match="measurement_noise_cov"):
+        WeakDimensionMeasurementModel(
+            np.eye(1),
+            measurement_noise_cov=measurement_noise_cov,
+        )


### PR DESCRIPTION
## Summary
- Reject complex, datetime, timedelta, boolean, and text-like values before weak/masked measurement standard-deviation and covariance coercion.
- Route direct `measurement_noise_cov` inputs through the same real-numeric validation used for standard deviations.
- Add regression coverage for non-real std sequences, std mappings, and measurement-noise covariance matrices.

## Bug
The weak-measurement helpers used `np.asarray(..., dtype=float)` on several user-provided numeric inputs. NumPy can silently discard complex imaginary parts and convert datetime/timedelta units into numeric values, so invalid measurement standard deviations or covariance entries could pass validation and produce misleading noise models.

## Validation
- `python -m py_compile /tmp/weak_measurement.py /tmp/test_weak_measurement_nonreal_inputs.py`
- Full pytest was not run locally because this environment cannot clone/import the complete repository.