### PR TITLE
Normalize complex diagnostic summary values

### DIFF
--- a/src/pyrecest/evaluation/diagnostic_summaries.py
+++ b/src/pyrecest/evaluation/diagnostic_summaries.py
@@ -360,6 +360,12 @@ def _json_value(value: Any) -> Any:
         value = float(value)
     if isinstance(value, float):
         return None if not math.isfinite(value) else value
+    if isinstance(value, (complex, np.complexfloating)):
+        real = float(np.real(value))
+        imag = float(np.imag(value))
+        if not math.isfinite(real) or not math.isfinite(imag):
+            return None
+        return {"real": real, "imag": imag}
     if isinstance(value, (bytes, bytearray, np.bytes_)):
         return bytes(value).decode("utf-8", errors="replace")
     if isinstance(value, np.str_):

--- a/tests/evaluation/test_diagnostic_summary_complex_json.py
+++ b/tests/evaluation/test_diagnostic_summary_complex_json.py
@@ -1,0 +1,34 @@
+import json
+import unittest
+
+import numpy as np
+from pyrecest.evaluation.diagnostic_summaries import top_residuals
+
+
+class DiagnosticSummaryComplexJsonTest(unittest.TestCase):
+    def test_top_residual_records_normalize_complex_payloads(self):
+        records = [
+            {
+                "time_s": 0.0,
+                "track_id": "A",
+                "source": "rf",
+                "residual_norm": 2.0,
+                "covariance_scale": 1.0,
+                "error": 1.0,
+                "phasor": 1.0 + 2.0j,
+                "complex_vector": np.array([3.0 + 4.0j, np.nan + 1.0j]),
+            }
+        ]
+
+        rows = top_residuals(records)
+
+        self.assertEqual(rows[0]["phasor"], {"real": 1.0, "imag": 2.0})
+        self.assertEqual(
+            rows[0]["complex_vector"],
+            [{"real": 3.0, "imag": 4.0}, None],
+        )
+        json.dumps(rows)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Normalize Python and NumPy complex diagnostic values to JSON-safe dictionaries with real and imaginary components.
- Return None for complex values with non-finite components, consistent with existing float handling.
- Add a regression test covering complex scalar and vector payloads in top residual records.

## Bug
Diagnostic summaries are documented as JSON-serializable. The existing record normalization handled arrays, NumPy real scalars, bytes, missing values, and NaNs, but complex values were returned unchanged. A diagnostic record containing a complex auxiliary value could therefore fail JSON serialization after top_residuals returned it.

## Validation
- py_compile on the modified source and new regression test in an isolated local copy.
- Isolated smoke check confirmed that top_residuals returns JSON-serializable rows for complex scalar and vector payloads.

Full repository pytest was not run locally because this environment cannot clone/import the complete repository; CI should run on the PR.