### PR TITLE
Reject temporal covariance helper inputs

### DIFF
--- a/src/pyrecest/numerics.py
+++ b/src/pyrecest/numerics.py
@@ -11,7 +11,7 @@ from pyrecest.exceptions import (
     ShapeError,
 )
 
-_UNSUPPORTED_NUMERIC_KINDS = {"b", "S", "U", "c"}
+_UNSUPPORTED_NUMERIC_KINDS = {"b", "S", "U", "c", "M", "m"}
 _UNSUPPORTED_SCALAR_TYPES = (
     bool,
     np.bool_,
@@ -22,6 +22,8 @@ _UNSUPPORTED_SCALAR_TYPES = (
     np.bytes_,
     complex,
     np.complexfloating,
+    np.datetime64,
+    np.timedelta64,
 )
 
 

--- a/tests/test_numerics.py
+++ b/tests/test_numerics.py
@@ -40,9 +40,22 @@ def test_empty_square_matrix_is_symmetric_psd_covariance():
         np.array([[True, False], [False, True]]),
         np.array([["1.0", "0.0"], ["0.0", "1.0"]]),
         np.array([[1.0, False], [0.0, 1.0]], dtype=object),
+        np.array(
+            [
+                [np.datetime64("2020-01-01"), np.datetime64("2020-01-02")],
+                [np.datetime64("2020-01-02"), np.datetime64("2020-01-03")],
+            ]
+        ),
+        np.array(
+            [
+                [np.timedelta64(1, "D"), np.timedelta64(0, "D")],
+                [np.timedelta64(0, "D"), np.timedelta64(1, "D")],
+            ]
+        ),
+        np.array([[np.datetime64("2020-01-01"), 0.0], [0.0, 1.0]], dtype=object),
     ],
 )
-def test_covariance_helpers_reject_bool_and_text_matrices(matrix):
+def test_covariance_helpers_reject_bool_text_and_temporal_matrices(matrix):
     assert not is_symmetric(matrix)
     assert not is_positive_semidefinite(matrix)
 


### PR DESCRIPTION
## Summary
- reject NumPy datetime and timedelta arrays in covariance/numerical helper input coercion instead of silently converting them to floats
- cover temporal dtypes and object arrays in `tests/test_numerics.py`

## Validation
- targeted local check that the revised numeric-type guard rejects `datetime64`, `timedelta64`, and temporal object arrays while still accepting ordinary numeric matrices
- full repository tests were not run locally because this environment cannot clone GitHub directly