### PR TITLE
Normalize extract-mean registry lookup names

### DIFF
--- a/src/pyrecest/evaluation/get_extract_mean.py
+++ b/src/pyrecest/evaluation/get_extract_mean.py
@@ -10,7 +10,7 @@ _EXTRACT_MEAN_FACTORIES: dict[str, MeanExtractorFactory] = {}
 def _normalize_registry_name(manifold_name: str) -> str:
     if not isinstance(manifold_name, str) or not manifold_name.strip():
         raise ValueError("manifold_name must be a non-empty string")
-    return manifold_name.lower()
+    return manifold_name.strip().lower()
 
 
 def register_extract_mean(
@@ -66,7 +66,7 @@ def _extract_mtt_mean(filter_state):
 
 
 def get_extract_mean(manifold_name, mtt_scenario=False):
-    normalized_name = str(manifold_name).lower()
+    normalized_name = _normalize_registry_name(manifold_name)
     registered_factory = _EXTRACT_MEAN_FACTORIES.get(normalized_name)
     if registered_factory is not None:
         return registered_factory(manifold_name, mtt_scenario)

--- a/tests/evaluation/test_evaluation_registries.py
+++ b/tests/evaluation/test_evaluation_registries.py
@@ -4,7 +4,11 @@ from pyrecest.evaluation.get_distance_function import (
     get_distance_function,
     register_distance_function,
 )
-from pyrecest.evaluation.get_extract_mean import get_extract_mean, register_extract_mean
+from pyrecest.evaluation.get_extract_mean import (
+    available_extract_mean_functions,
+    get_extract_mean,
+    register_extract_mean,
+)
 
 
 def _as_float(value):
@@ -114,6 +118,18 @@ def test_custom_extract_mean_registry():
     )
 
     assert get_extract_mean("unit-test-mean")({"mean": 3}) == 3
+
+
+def test_custom_extract_mean_registry_strips_names_for_registration_and_lookup():
+    register_extract_mean(
+        "  unit-test-mean-trimmed  ",
+        lambda _name, _mtt: lambda state: state["mean"],
+    )
+
+    assert "unit-test-mean-trimmed" in available_extract_mean_functions()
+    assert "  unit-test-mean-trimmed  " not in available_extract_mean_functions()
+    assert get_extract_mean("unit-test-mean-trimmed")({"mean": 7}) == 7
+    assert get_extract_mean("  unit-test-mean-trimmed  ")({"mean": 8}) == 8
 
 
 def test_euclidean_extract_mean_preserves_raw_array_state():


### PR DESCRIPTION
## Summary
- Strip custom extract-mean registry names before storing them.
- Use the same normalization during lookup so padded names resolve consistently.
- Add a regression test that registers a padded name and verifies both padded and unpadded lookups.

## Testing
- Not run locally; validated by code inspection and a focused regression test in `tests/evaluation/test_evaluation_registries.py`.