### PR TITLE
Normalize distance registry lookup names

### DIFF
--- a/src/pyrecest/evaluation/get_distance_function.py
+++ b/src/pyrecest/evaluation/get_distance_function.py
@@ -27,7 +27,7 @@ _UNSUPPORTED_NUMERIC_CONFIG_TYPES = (
 def _normalize_registry_name(manifold_name: str) -> str:
     if not isinstance(manifold_name, str) or not manifold_name.strip():
         raise ValueError("manifold_name must be a non-empty string")
-    return manifold_name.lower()
+    return manifold_name.strip().lower()
 
 
 def register_distance_function(
@@ -236,7 +236,7 @@ def _angular_distance_from_inner_product(inner_product):
 def get_distance_function(
     manifold_name, additional_params=None, nSymm=None, symmetryOffsets=None
 ):
-    normalized_name = str(manifold_name).lower()
+    normalized_name = _normalize_registry_name(manifold_name)
     registered_factory = _DISTANCE_FUNCTION_FACTORIES.get(normalized_name)
     if registered_factory is not None:
         return registered_factory(manifold_name, additional_params)

--- a/tests/evaluation/test_distance_registry_normalization.py
+++ b/tests/evaluation/test_distance_registry_normalization.py
@@ -1,0 +1,18 @@
+from pyrecest.backend import array
+from pyrecest.evaluation.get_distance_function import (
+    available_distance_functions,
+    get_distance_function,
+    register_distance_function,
+)
+
+
+def test_custom_distance_registry_strips_names_for_registration_and_lookup():
+    register_distance_function(
+        "  unit-test-distance-trimmed  ",
+        lambda _name, _params: lambda _x, _y: 13.0,
+    )
+
+    assert "unit-test-distance-trimmed" in available_distance_functions()
+    assert "  unit-test-distance-trimmed  " not in available_distance_functions()
+    assert get_distance_function("unit-test-distance-trimmed")(array([0.0]), array([1.0])) == 13.0
+    assert get_distance_function("  unit-test-distance-trimmed  ")(array([0.0]), array([1.0])) == 13.0


### PR DESCRIPTION
Summary:
- Normalize custom distance registry names consistently.
- Add regression coverage for padded registration and lookup.

Testing:
- Not run locally in this connector environment.