### PR TITLE
Preserve one-dimensional multi-target groundtruth shape

### DIFF
--- a/src/pyrecest/evaluation/generate_groundtruth.py
+++ b/src/pyrecest/evaluation/generate_groundtruth.py
@@ -99,6 +99,7 @@ def generate_groundtruth(simulation_param, x0=None):
     if groundtruth[0].shape[1] != simulation_param["initial_prior"].dim:
         raise RuntimeError("Generated groundtruth has the wrong state dimension.")
     for t in range(simulation_param["n_timesteps"]):
-        groundtruth[t] = squeeze(groundtruth[t])
+        if simulation_param["n_targets"] == 1:
+            groundtruth[t] = squeeze(groundtruth[t])
 
     return groundtruth

--- a/tests/test_generate_groundtruth.py
+++ b/tests/test_generate_groundtruth.py
@@ -84,6 +84,27 @@ class TestGenerateGroundtruth(unittest.TestCase):
         npt.assert_allclose(groundtruth[2], expected_second_step)
         npt.assert_allclose(groundtruth[3], expected_third_step)
 
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
+    def test_preserves_matrix_shape_for_one_dimensional_multiple_targets(self):
+        x0 = array([[0.0], [2.0]])
+        step = array([1.0])
+        simulation_param = {
+            "initial_prior": GaussianDistribution(zeros(1), eye(1)),
+            "n_targets": 2,
+            "n_timesteps": 2,
+            "gen_next_state_with_noise": lambda state: state + step,
+        }
+
+        groundtruth = generate_groundtruth(simulation_param, x0)
+
+        self.assertEqual(groundtruth[0].shape, (2, 1))
+        self.assertEqual(groundtruth[1].shape, (2, 1))
+        npt.assert_allclose(groundtruth[0], x0)
+        npt.assert_allclose(groundtruth[1], array([[1.0], [3.0]]))
+
     def test_rejects_vector_initial_state_for_multiple_targets(self):
         x0 = array([0.0, 1.0])
         simulation_param = {


### PR DESCRIPTION
## Summary
- Keep generated ground-truth entries two-dimensional for multiple-target scenarios, even when the state dimension is one.
- Add a regression test covering two one-dimensional targets.

## Bug
`generate_groundtruth()` previously called `squeeze()` for every timestep. For MTT scenarios with `n_targets > 1` and `dim == 1`, this converted entries from `(n_targets, 1)` to `(n_targets,)`, losing the target/state axis separation expected by downstream MTT code such as `generate_measurements()`.

## Testing
- Not run locally; the execution environment has no direct network access to clone the repository.
- Added focused regression coverage in `tests/test_generate_groundtruth.py`.