### PR TITLE
Reject text-like model scalar parameters

### DIFF
--- a/src/pyrecest/models/motion_models.py
+++ b/src/pyrecest/models/motion_models.py
@@ -47,13 +47,33 @@ __all__ = [
     "white_noise_snap_covariance",
 ]
 
+_TEXT_OR_BOOL_SCALAR_TYPES = (
+    bool,
+    np.bool_,
+    str,
+    bytes,
+    bytearray,
+    np.str_,
+    np.bytes_,
+)
+_REJECTED_NUMERIC_ARRAY_KINDS = frozenset({"b", "c", "S", "U", "M", "m"})
+
+
+def _is_text_bool_or_complex(value: Any) -> bool:
+    return isinstance(value, _TEXT_OR_BOOL_SCALAR_TYPES) or isinstance(
+        value, (complex, np.complexfloating)
+    )
+
 
 def _as_scalar_float(value: Any, name: str) -> float:
     value_array = np.asarray(value)
-    if value_array.shape != () or np.issubdtype(value_array.dtype, np.bool_):
+    if value_array.shape != () or value_array.dtype.kind in _REJECTED_NUMERIC_ARRAY_KINDS:
+        raise ValueError(f"{name} must be a scalar number")
+    scalar_value = value_array.item()
+    if _is_text_bool_or_complex(scalar_value):
         raise ValueError(f"{name} must be a scalar number")
     try:
-        scalar = float(value_array.item())
+        scalar = float(scalar_value)
     except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError(f"{name} must be a scalar number") from exc
     if not np.isfinite(scalar):
@@ -98,11 +118,15 @@ def _as_nonnegative_integer(value: Any, name: str) -> int:
 
 def _as_nonnegative_vector(value: Any, length: int, name: str) -> np.ndarray:
     raw_value_array = np.asarray(value)
-    if np.issubdtype(raw_value_array.dtype, np.bool_):
+    if raw_value_array.dtype.kind in _REJECTED_NUMERIC_ARRAY_KINDS:
+        raise ValueError(f"{name} must be numeric")
+    if raw_value_array.dtype == object and any(
+        _is_text_bool_or_complex(item) for item in raw_value_array.flat
+    ):
         raise ValueError(f"{name} must be numeric")
     try:
         value_array = np.asarray(value, dtype=float)
-    except (TypeError, ValueError) as exc:
+    except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError(f"{name} must be numeric") from exc
     if value_array.shape == ():
         return np.repeat(_as_nonnegative_float(value_array, name), length)

--- a/src/pyrecest/models/sensor_models.py
+++ b/src/pyrecest/models/sensor_models.py
@@ -29,6 +29,17 @@ __all__ = [
     "tdoa_model",
 ]
 
+_TEXT_OR_BOOL_SCALAR_TYPES = (
+    bool,
+    np.bool_,
+    str,
+    bytes,
+    bytearray,
+    np.str_,
+    np.bytes_,
+)
+_REJECTED_SCALAR_ARRAY_KINDS = frozenset({"b", "c", "S", "U", "M", "m"})
+
 
 def _state_vector(state):
     return asarray(state)
@@ -36,10 +47,15 @@ def _state_vector(state):
 
 def _as_scalar_float(value: Any, name: str) -> float:
     value_array = np.asarray(value)
-    if value_array.shape != () or np.issubdtype(value_array.dtype, np.bool_):
+    if value_array.shape != () or value_array.dtype.kind in _REJECTED_SCALAR_ARRAY_KINDS:
+        raise ValueError(f"{name} must be a scalar number")
+    scalar_value = value_array.item()
+    if isinstance(scalar_value, _TEXT_OR_BOOL_SCALAR_TYPES) or isinstance(
+        scalar_value, (complex, np.complexfloating)
+    ):
         raise ValueError(f"{name} must be a scalar number")
     try:
-        scalar = float(value_array.item())
+        scalar = float(scalar_value)
     except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError(f"{name} must be a scalar number") from exc
     if not np.isfinite(scalar):

--- a/tests/test_dynamic_models.py
+++ b/tests/test_dynamic_models.py
@@ -100,11 +100,17 @@ class TestMotionModelCatalog(unittest.TestCase):
         invalid_cases = [
             {"dt": -1.0, "message": "dt"},
             {"dt": np.nan, "message": "dt"},
+            {"dt": "1.0", "message": "dt"},
             {"spatial_dim": 1.5, "message": "spatial_dim"},
+            {"spatial_dim": "2", "message": "spatial_dim"},
             {"derivative_order": 1.5, "message": "derivative_order"},
+            {"derivative_order": b"1", "message": "derivative_order"},
             {"spectral_density": -1.0, "message": "spectral_density"},
             {"spectral_density": np.nan, "message": "spectral_density"},
             {"spectral_density": True, "message": "spectral_density"},
+            {"spectral_density": "1.0", "message": "spectral_density"},
+            {"spectral_density": ["1.0", "2.0"], "message": "spectral_density"},
+            {"spectral_density": np.array([True, False], dtype=object), "message": "spectral_density"},
             {
                 "spectral_density": np.array([1.0, np.nan]),
                 "message": "spectral_density",
@@ -252,6 +258,8 @@ class TestSensorModelCatalog(unittest.TestCase):
         invalid_position_indices = (
             (0.5, 1),
             (True, 1),
+            ("0", 1),
+            (b"0", 1),
             (-1, 1),
             (0, 4),
             (0, 1, 2),
@@ -278,7 +286,7 @@ class TestSensorModelCatalog(unittest.TestCase):
         state = array([0.0, 4.0, 0.0, 1.0])
         sensors = array([[0.0, 0.0], [3.0, 0.0]])
 
-        for propagation_speed in (0.0, np.nan, np.inf, True):
+        for propagation_speed in (0.0, np.nan, np.inf, True, "1.0", b"1.0"):
             with self.subTest(propagation_speed=propagation_speed):
                 with self.assertRaisesRegex(ValueError, "propagation_speed"):
                     tdoa_measurement(
@@ -293,7 +301,7 @@ class TestSensorModelCatalog(unittest.TestCase):
                         propagation_speed=propagation_speed,
                     )
 
-        for reference_sensor in (1.5, True, -1, 2, np.array([0])):
+        for reference_sensor in (1.5, True, "0", b"0", -1, 2, np.array([0])):
             with self.subTest(reference_sensor=reference_sensor):
                 with self.assertRaisesRegex(ValueError, "reference_sensor"):
                     tdoa_measurement(


### PR DESCRIPTION
## Summary
- Reject numeric-looking text/bytes, complex values, and other non-real scalar kinds before motion-model scalar validation calls `float(...)`.
- Apply the same text-like scalar rejection to sensor-model index, reference-sensor, and propagation-speed validators.
- Add regression coverage for text-like motion/sensor model parameters and spectral-density vectors.

## Why
Several ready-made motion and sensor model helpers accepted values such as `dt="1.0"`, `spatial_dim="2"`, `reference_sensor="0"`, or `propagation_speed=b"1.0"` because their scalar validators called `float(...)` after only rejecting booleans. This silently converted malformed configuration inputs instead of failing early.

## Testing
- Not run locally in this connector environment.
- Added focused regression tests in `tests/test_dynamic_models.py`.