### PR TITLE
Add candidate pruning validation test

### DIFF
--- a/tests/test_candidate_pruning_timedelta_validation.py
+++ b/tests/test_candidate_pruning_timedelta_validation.py
@@ -1,0 +1,16 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.utils import candidate_mask_from_costs
+
+
+class TestCandidatePruningDurationValidation(unittest.TestCase):
+    def test_cost_matrix_rejects_duration_arrays(self):
+        matrix = np.array([[np.timedelta64(5, "s")]])
+        with self.assertRaisesRegex(ValueError, "cost_matrix must be numeric"):
+            candidate_mask_from_costs(matrix)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add regression coverage for candidate-pruning matrix validation.

## Testing
- Not run locally; CI should run on the PR.