### PR TITLE
Reject text-like measurement counts

### DIFF
--- a/src/pyrecest/evaluation/generate_measurements.py
+++ b/src/pyrecest/evaluation/generate_measurements.py
@@ -34,7 +34,7 @@ def _as_nonnegative_measurement_count(value, name="measurement count") -> int:
         raise ValueError(f"{name} must be a non-negative integer.")
 
     scalar = value_array.item()
-    if isinstance(scalar, (bool, np.bool_)):
+    if isinstance(scalar, (bool, np.bool_, str, bytes, bytearray, np.str_, np.bytes_)):
         raise ValueError(f"{name} must be a non-negative integer.")
     if isinstance(scalar, (int, np.integer)):
         count = int(scalar)

--- a/tests/evaluation/test_generate_measurements_validation.py
+++ b/tests/evaluation/test_generate_measurements_validation.py
@@ -1,5 +1,9 @@
+import numpy as np
 import pytest
-from pyrecest.evaluation.generate_measurements import generate_n_measurements_PPP
+from pyrecest.evaluation.generate_measurements import (
+    _as_nonnegative_measurement_count,
+    generate_n_measurements_PPP,
+)
 
 
 @pytest.mark.parametrize(
@@ -16,6 +20,22 @@ def test_generate_n_measurements_ppp_rejects_invalid_rate_inputs(
 ):
     with pytest.raises(ValueError, match=message):
         generate_n_measurements_PPP(area, intensity_lambda)
+
+
+@pytest.mark.parametrize(
+    "measurement_count",
+    [
+        "3",
+        b"3",
+        np.str_("3"),
+        np.bytes_(b"3"),
+        np.array("3"),
+        np.array(b"3"),
+    ],
+)
+def test_measurement_count_rejects_text_like_integer_scalars(measurement_count):
+    with pytest.raises(ValueError, match="measurement count"):
+        _as_nonnegative_measurement_count(measurement_count)
 
 
 def test_generate_n_measurements_ppp_returns_python_int_for_zero_rate():


### PR DESCRIPTION
## Summary
- Reject text-like scalar measurement counts such as `"3"` and `b"3"` instead of silently coercing them to integers.
- Add regression coverage for text-like scalar counts in measurement generation validation.

## Tests
- Not run locally in this connector-only environment; the added pytest regression is included for CI.