### PR TITLE
Refresh backend virtual submodule registrations

### DIFF
--- a/src/pyrecest/_backend_submodules.py
+++ b/src/pyrecest/_backend_submodules.py
@@ -23,7 +23,6 @@ def register_backend_submodules(backend: ModuleType | None = None) -> None:
     for submodule_name in BACKEND_ATTRIBUTES:
         if not submodule_name:
             continue
-        sys.modules.setdefault(
-            f"{backend.__name__}.{submodule_name}",
-            getattr(backend, submodule_name),
+        sys.modules[f"{backend.__name__}.{submodule_name}"] = getattr(
+            backend, submodule_name
         )


### PR DESCRIPTION
## Summary
- Replace stale virtual backend submodule entries in `sys.modules` when backend submodules are registered again.
- This avoids keeping an old submodule object after a backend facade is re-registered under the same module name.

## Testing
- Not run locally: repository checkout is unavailable in this connector environment.
- I attempted to add a focused regression test, but the connector safety layer blocked the test-file branch update after creating the intermediate tree/commit object.