### PR TITLE
Reject mixed boolean uniform bounds

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/random.py
+++ b/src/pyrecest/_backend/_shared_numpy/random.py
@@ -5,6 +5,7 @@ from ._dispatch import numpy as _np
 
 _modify_func_default_dtype = _common._modify_func_default_dtype
 _allow_complex_dtype = _common._allow_complex_dtype
+_BOOLEAN_TYPES = (bool, _np.bool_)
 
 
 def _rand(*dims, size=None):
@@ -21,26 +22,36 @@ rand = _modify_func_default_dtype(
 )
 
 
-def _validate_uniform_bound_array(bound, name):
-    if bound.dtype.kind == "b":
+def _contains_boolean_value(value):
+    if isinstance(value, _BOOLEAN_TYPES):
+        return True
+    try:
+        values = _np.asarray(value, dtype=object).reshape(-1)
+    except (TypeError, ValueError, RuntimeError):
+        return False
+    return any(isinstance(item, _BOOLEAN_TYPES) for item in values)
+
+
+def _validate_uniform_bound(bound, name):
+    if _contains_boolean_value(bound):
         raise TypeError(f"{name} must be real numeric, not boolean")
-    if bound.dtype.kind not in "iuf":
+    bound_array = _np.asarray(bound)
+    if bound_array.dtype.kind not in "iuf":
         raise TypeError(f"{name} must be real numeric")
-    if _np.any(~_np.isfinite(bound)):
+    if _np.any(~_np.isfinite(bound_array)):
         raise ValueError("uniform bounds must be finite")
+    return bound_array
 
 
 def _validate_uniform_bounds(low, high):
-    _validate_uniform_bound_array(low, "low")
-    _validate_uniform_bound_array(high, "high")
-    if _np.any(low > high):
+    low_array = _validate_uniform_bound(low, "low")
+    high_array = _validate_uniform_bound(high, "high")
+    if _np.any(low_array > high_array):
         raise ValueError("Upper bound must be greater than or equal to lower bound")
 
 
 def _uniform(low=0.0, high=1.0, size=None):
-    low_array = _np.asarray(low)
-    high_array = _np.asarray(high)
-    _validate_uniform_bounds(low_array, high_array)
+    _validate_uniform_bounds(low, high)
     return _np.random.uniform(low, high, size)
 
 
@@ -60,7 +71,7 @@ multivariate_normal = _modify_func_default_dtype(
 
 
 def _normalize_choice_axis(axis, ndim):
-    if isinstance(axis, (bool, _np.bool_)):
+    if isinstance(axis, _BOOLEAN_TYPES):
         raise TypeError("axis must be an integer")
     try:
         axis = _operator.index(axis)
@@ -72,7 +83,7 @@ def _normalize_choice_axis(axis, ndim):
 
 
 def _choice_bool(value, name):
-    if isinstance(value, (bool, _np.bool_)):
+    if isinstance(value, _BOOLEAN_TYPES):
         return bool(value)
     value_array = _np.asarray(value)
     if value_array.shape == () and value_array.dtype.kind == "b":
@@ -84,7 +95,7 @@ def _validate_choice_population(a_array):
     if a_array.ndim != 0:
         return
     scalar = a_array.item()
-    if isinstance(scalar, (bool, _np.bool_)):
+    if isinstance(scalar, _BOOLEAN_TYPES):
         raise ValueError("a must be a positive integer or a non-empty array")
 
 

--- a/tests/backend/test_numpy_random_backend.py
+++ b/tests/backend/test_numpy_random_backend.py
@@ -30,6 +30,12 @@ def test_rand_rejects_ambiguous_positional_and_size_arguments():
         (False, 1.0),
         (0.0, True),
         (np.array([False, False]), np.array([1.0, 2.0])),
+        ([False, 0.0], [1.0, 2.0]),
+        ([0.0, 0.5], [1.0, np.bool_(True)]),
+        (
+            np.array([0.0, np.bool_(False)], dtype=object),
+            np.array([1.0, 2.0], dtype=object),
+        ),
     ],
 )
 def test_uniform_rejects_boolean_bounds(low, high):


### PR DESCRIPTION
## Summary
- Detect boolean values in `random.uniform` bounds before NumPy can promote mixed boolean/float lists to floating arrays.
- Keep the existing numeric/text/finite bound checks unchanged after raw boolean detection.
- Add regression cases for mixed Python-list and object-array boolean bounds.

## Bug
`np.asarray([False, 0.0])` promotes the list to a floating array, so the previous dtype-only validation no longer saw that a boolean bound was supplied. This allowed malformed `random.uniform` bounds such as `[False, 0.0]` or `[1.0, np.bool_(True)]` to be treated as numeric limits.

## Validation
- `python -m py_compile /mnt/data/random.py /mnt/data/test_numpy_random_backend.py`
- Standalone smoke check that the new raw-value boolean detector flags mixed Python-list and object-array boolean bounds while leaving ordinary float lists valid.

Full repository pytest was not run locally because this environment cannot clone/install the repository from GitHub; CI should run the focused regression on the PR.