### PR TITLE
Reject temporal candidate pruning matrices

### DIFF
--- a/src/pyrecest/utils/candidate_pruning.py
+++ b/src/pyrecest/utils/candidate_pruning.py
@@ -18,6 +18,7 @@ import numpy as np
 _TEXT_TYPES = (str, bytes, bytearray, np.str_, np.bytes_)
 _BOOLEAN_TYPES = (bool, np.bool_)
 _COMPLEX_TYPES = (complex, np.complexfloating)
+_TEMPORAL_TYPES = (np.datetime64, np.timedelta64)
 _MISSING_TYPES = (type(None),)
 
 
@@ -182,6 +183,10 @@ def _contains_complex_values(value: Any) -> bool:
     return _contains_values_of_type(value, _COMPLEX_TYPES)
 
 
+def _contains_temporal_values(value: Any) -> bool:
+    return _contains_values_of_type(value, _TEMPORAL_TYPES)
+
+
 def _contains_missing_values(value: Any) -> bool:
     return _contains_values_of_type(value, _MISSING_TYPES)
 
@@ -194,10 +199,14 @@ def _as_numeric_matrix(value: Any, name: str) -> np.ndarray:
 
     if raw_values.dtype == np.bool_:
         raise ValueError(f"{name} must be numeric, not boolean")
+    if raw_values.dtype.kind in {"M", "m"}:
+        raise ValueError(f"{name} must be numeric")
     if _contains_missing_values(value) or _contains_missing_values(raw_values):
         raise ValueError(f"{name} must be numeric")
     if _contains_boolean_values(value) or _contains_boolean_values(raw_values):
         raise ValueError(f"{name} must be numeric, not boolean")
+    if _contains_temporal_values(value) or _contains_temporal_values(raw_values):
+        raise ValueError(f"{name} must be numeric")
     if (
         raw_values.dtype.kind == "c"
         or _contains_complex_values(value)

--- a/tests/test_candidate_pruning_matrix_validation.py
+++ b/tests/test_candidate_pruning_matrix_validation.py
@@ -41,6 +41,23 @@ class TestCandidatePruningMatrixValidation(unittest.TestCase):
                     ):
                         function(matrix)
 
+    def test_cost_matrix_rejects_temporal_entries(self):
+        invalid_matrices = (
+            np.array([["2026-06-25"]], dtype="datetime64[D]"),
+            np.array([[np.timedelta64(5, "s")]]),
+            np.array([[np.datetime64("2026-06-25")]], dtype=object),
+            np.array([[np.timedelta64(5, "s")]], dtype=object),
+        )
+
+        for function in (candidate_mask_from_costs, prune_pairwise_cost_matrix):
+            for matrix in invalid_matrices:
+                with self.subTest(function=function.__name__, dtype=str(matrix.dtype)):
+                    with self.assertRaisesRegex(
+                        ValueError,
+                        "cost_matrix must be numeric",
+                    ):
+                        function(matrix)
+
     def test_cost_matrix_rejects_negative_infinity(self):
         invalid_matrices = (
             [[0.0, -float("inf")]],
@@ -113,6 +130,27 @@ class TestCandidatePruningMatrixValidation(unittest.TestCase):
                 with self.assertRaisesRegex(
                     ValueError,
                     "probability_matrix must be real-valued numeric",
+                ):
+                    candidate_mask_from_costs(
+                        np.array([[1.0]]),
+                        probability_matrix=probabilities,
+                        config=config,
+                    )
+
+    def test_probability_matrix_rejects_temporal_entries(self):
+        config = CandidatePruningConfig(probability_threshold=0.5)
+        invalid_probability_matrices = (
+            np.array([["2026-06-25"]], dtype="datetime64[D]"),
+            np.array([[np.timedelta64(1, "s")]]),
+            np.array([[np.datetime64("2026-06-25")]], dtype=object),
+            np.array([[np.timedelta64(1, "s")]], dtype=object),
+        )
+
+        for probabilities in invalid_probability_matrices:
+            with self.subTest(dtype=str(probabilities.dtype)):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "probability_matrix must be numeric",
                 ):
                     candidate_mask_from_costs(
                         np.array([[1.0]]),


### PR DESCRIPTION
## Summary
- Reject temporal NumPy matrices before candidate-pruning helpers coerce inputs to float.
- Add regression coverage for temporal cost and probability matrices.

## Testing
- Regression test added in tests/test_candidate_pruning_temporal_validation.py.
- Not run locally because this environment cannot clone GitHub directly; CI should run on the PR.