### PR TITLE
Validate scenario expected estimate length

### DIFF
--- a/src/pyrecest/scenarios.py
+++ b/src/pyrecest/scenarios.py
@@ -245,9 +245,18 @@ def run_linear_gaussian_scenario(path: str | Path) -> ScenarioResult:
     expected = config.get("expected", {})
     metrics: dict[str, float] = {}
     if "final_estimate" in expected and final_estimate:
+        expected_final_estimate = _to_float_list(
+            expected["final_estimate"],
+            name="expected.final_estimate",
+            reject_text_or_bool=True,
+        )
+        if len(final_estimate) != len(expected_final_estimate):
+            raise ValueError(
+                "expected.final_estimate must have the same length as the final estimate"
+            )
         errors = [
-            abs(a - float(b))
-            for a, b in zip(final_estimate, expected["final_estimate"])
+            abs(actual - expected_value)
+            for actual, expected_value in zip(final_estimate, expected_final_estimate)
         ]
         metrics["max_abs_final_estimate_error"] = max(errors) if errors else 0.0
     if nis_values:

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from pyrecest.scenarios import load_scenario_config, run_scenario
 
 SCENARIO = Path("scenarios/linear_gaussian_cv_1d/config.toml")
@@ -17,6 +19,7 @@ def test_linear_gaussian_scenario_matches_golden_output():
     expected = json.loads(EXPECTED.read_text(encoding="utf-8"))
     result = run_scenario(SCENARIO)
     tolerance = float(expected["tolerance"])
+    assert len(result.final_estimate) == len(expected["final_estimate"])
     errors = [
         abs(a - b) for a, b in zip(result.final_estimate, expected["final_estimate"])
     ]
@@ -56,3 +59,39 @@ measurements = [[1.0, 2.0], [3.0, 4.0]]
     assert len(result.final_estimate) == 2
     assert len(result.estimates) == 2
     assert all(len(estimate) == 2 for estimate in result.estimates)
+
+
+def test_linear_gaussian_scenario_rejects_expected_length_mismatch(tmp_path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        """
+[scenario]
+type = "linear_gaussian"
+name = "expected length mismatch scenario"
+
+[model]
+system_matrix = [[1.0, 0.0], [0.0, 1.0]]
+system_noise_covariance = [[0.0, 0.0], [0.0, 0.0]]
+
+[measurement]
+measurement_matrix = [[1.0, 0.0], [0.0, 1.0]]
+measurement_noise_covariance = [[1.0, 0.0], [0.0, 1.0]]
+
+[initial]
+mean = [0.0, 0.0]
+covariance = [[1.0, 0.0], [0.0, 1.0]]
+
+[data]
+measurements = [[1.0, 2.0]]
+
+[expected]
+final_estimate = [1.0]
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="expected.final_estimate must have the same length",
+    ):
+        run_scenario(config_path)


### PR DESCRIPTION
## Summary
- reject `expected.final_estimate` entries whose length does not match the produced final estimate
- parse the expected vector once before computing the max absolute final-estimate error
- add a regression test for mismatched expected-vector length

## Testing
- Not run locally; repository access in this session is through the GitHub connector only, and the local environment could not clone/install the repo.