### PR TITLE
Fix backend support table formatting

### DIFF
--- a/src/pyrecest/backend_support.py
+++ b/src/pyrecest/backend_support.py
@@ -37,15 +37,32 @@ def backend_support(
     return get_backend_support(api_name, backend=backend)
 
 
+def _markdown_table_cell(value: object) -> str:
+    return str(value).replace("\r", " ").replace("\n", "<br>").replace(chr(124), chr(0xFF5C))
+
+
+def _markdown_table_row(cells: list[str]) -> str:
+    separator = chr(124)
+    return f"{separator} " + f" {separator} ".join(cells) + f" {separator}"
+
+
 def format_backend_support_markdown() -> str:
     """Render the public backend API matrix as a Markdown table."""
     lines = [
-        "| API | NumPy | PyTorch | JAX | Notes |",
-        "|-----|-------|---------|-----|-------|",
+        _markdown_table_row(["API", "NumPy", "PyTorch", "JAX", "Notes"]),
+        _markdown_table_row(["-----", "-------", "---------", "-----", "-------"]),
     ]
     for api_name, row in iter_api_backend_capabilities():
         lines.append(
-            f"| `{api_name}` | {row['numpy']} | {row['pytorch']} | {row['jax']} | {row.get('notes', '')} |"
+            _markdown_table_row(
+                [
+                    f"`{_markdown_table_cell(api_name)}`",
+                    _markdown_table_cell(row["numpy"]),
+                    _markdown_table_cell(row["pytorch"]),
+                    _markdown_table_cell(row["jax"]),
+                    _markdown_table_cell(row.get("notes", "")),
+                ]
+            )
         )
     return "\n".join(lines)
 

--- a/tests/test_backend_support_public.py
+++ b/tests/test_backend_support_public.py
@@ -1,9 +1,14 @@
+from importlib import import_module
+
 from pyrecest import (
     backend_support,
     format_backend_support_markdown,
     get_backend_support,
 )
 from pyrecest._backend.capabilities import BACKEND_SUPPORT_LEVELS
+
+
+backend_support_module = import_module("pyrecest.backend_support")
 
 
 def test_public_backend_support_lookup():
@@ -19,3 +24,35 @@ def test_backend_support_markdown_contains_expected_rows():
     rendered = format_backend_support_markdown()
     assert "KalmanFilter" in rendered
     assert "BackendFacade" in rendered
+
+
+def test_backend_support_markdown_handles_table_separators(monkeypatch):
+    separator = chr(124)
+    replacement = chr(0xFF5C)
+
+    def fake_backend_capabilities():
+        return (
+            (
+                f"Pipe{separator}API",
+                {
+                    "numpy": "supported",
+                    "pytorch": f"partial{separator}bridged",
+                    "jax": "unsupported",
+                    "notes": f"first {separator} second\ncontinued",
+                },
+            ),
+        )
+
+    monkeypatch.setattr(
+        backend_support_module,
+        "iter_api_backend_capabilities",
+        fake_backend_capabilities,
+    )
+
+    rendered = backend_support_module.format_backend_support_markdown()
+    data_row = rendered.splitlines()[-1]
+
+    assert data_row.count(separator) == 6
+    assert f"Pipe{replacement}API" in data_row
+    assert f"partial{replacement}bridged" in data_row
+    assert f"first {replacement} second<br>continued" in data_row


### PR DESCRIPTION
## Summary
- Route generated backend support rows through a small cell formatter.
- Normalize embedded newlines in rendered cells.
- Add regression coverage for metadata values that would otherwise change the rendered column count.

## Testing
- Not run locally because the execution sandbox cannot clone GitHub.
- Verified by connector compare: only backend support rendering and its focused test changed.