### PR TITLE
Escape backend support Markdown table cells

### DIFF
--- a/src/pyrecest/backend_support.py
+++ b/src/pyrecest/backend_support.py
@@ -37,6 +37,11 @@ def backend_support(
     return get_backend_support(api_name, backend=backend)
 
 
+def _markdown_table_cell(value: object) -> str:
+    """Return ``value`` escaped for use inside a Markdown table cell."""
+    return str(value).replace("|", "\\|").replace("\n", "<br>")
+
+
 def format_backend_support_markdown() -> str:
     """Render the public backend API matrix as a Markdown table."""
     lines = [
@@ -44,9 +49,14 @@ def format_backend_support_markdown() -> str:
         "|-----|-------|---------|-----|-------|",
     ]
     for api_name, row in iter_api_backend_capabilities():
-        lines.append(
-            f"| `{api_name}` | {row['numpy']} | {row['pytorch']} | {row['jax']} | {row.get('notes', '')} |"
-        )
+        cells = [
+            f"`{_markdown_table_cell(api_name)}`",
+            _markdown_table_cell(row["numpy"]),
+            _markdown_table_cell(row["pytorch"]),
+            _markdown_table_cell(row["jax"]),
+            _markdown_table_cell(row.get("notes", "")),
+        ]
+        lines.append(f"| {' | '.join(cells)} |")
     return "\n".join(lines)
 
 

--- a/tests/test_backend_support_public.py
+++ b/tests/test_backend_support_public.py
@@ -1,3 +1,5 @@
+import importlib
+
 from pyrecest import (
     backend_support,
     format_backend_support_markdown,
@@ -19,3 +21,30 @@ def test_backend_support_markdown_contains_expected_rows():
     rendered = format_backend_support_markdown()
     assert "KalmanFilter" in rendered
     assert "BackendFacade" in rendered
+
+
+def test_backend_support_markdown_escapes_table_cells(monkeypatch):
+    backend_support_module = importlib.import_module("pyrecest.backend_support")
+    monkeypatch.setattr(
+        backend_support_module,
+        "iter_api_backend_capabilities",
+        lambda: (
+            (
+                "Escaped|API",
+                {
+                    "numpy": "supported|native",
+                    "pytorch": "partial",
+                    "jax": "unsupported",
+                    "notes": "contains | pipe\nand newline",
+                },
+            ),
+        ),
+    )
+
+    rendered = backend_support_module.format_backend_support_markdown()
+    rows = rendered.splitlines()
+
+    assert len(rows) == 3
+    assert r"`Escaped\|API`" in rows[2]
+    assert r"supported\|native" in rows[2]
+    assert r"contains \| pipe<br>and newline" in rows[2]


### PR DESCRIPTION
Superseded by #3134. The backend-support table changes were already covered by concurrent main changes, so this duplicate branch was closed to avoid a stale/conflicting PR.