### PR TITLE
Reject boolean particle diagnostic weights

### DIFF
--- a/src/pyrecest/diagnostics.py
+++ b/src/pyrecest/diagnostics.py
@@ -12,6 +12,8 @@ from dataclasses import asdict, dataclass, field, fields
 from math import isfinite, log
 from typing import Any, Literal
 
+import numpy as np
+
 EvidenceSupportType = Literal[
     "exact_full_grid",
     "exact_sparse",
@@ -21,6 +23,7 @@ EvidenceSupportType = Literal[
 ]
 
 _EVIDENCE_SUPPORT_TYPES = set(EvidenceSupportType.__args__)
+_WEIGHT_TEXT_OR_BOOL_TYPES = (bool, np.bool_, str, bytes, bytearray)
 
 
 def _coerce_metadata_bool(value: Any, name: str) -> bool:
@@ -45,7 +48,7 @@ def _coerce_metadata_bool(value: Any, name: str) -> bool:
 
 def _coerce_weight_values(weights: Any) -> list[float]:
     """Return backend-independent Python floats from an array-like weight vector."""
-    if isinstance(weights, str | bytes | bytearray):
+    if isinstance(weights, _WEIGHT_TEXT_OR_BOOL_TYPES):
         raise ValueError("Particle weights must be numeric.")
     try:
         from pyrecest.backend import to_numpy
@@ -56,12 +59,17 @@ def _coerce_weight_values(weights: Any) -> list[float]:
 
     if hasattr(weights, "tolist"):
         weights = weights.tolist()
-    if isinstance(weights, str | bytes | bytearray):
+    if isinstance(weights, _WEIGHT_TEXT_OR_BOOL_TYPES):
         raise ValueError("Particle weights must be numeric.")
     if isinstance(weights, int | float):
         return [float(weights)]
     try:
-        return [float(weight) for weight in weights]
+        values = []
+        for weight in weights:
+            if isinstance(weight, _WEIGHT_TEXT_OR_BOOL_TYPES):
+                raise ValueError
+            values.append(float(weight))
+        return values
     except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError("Particle weights must be numeric.") from exc
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,5 +1,6 @@
 from math import isclose, log
 
+import numpy as np
 import pytest
 from pyrecest.diagnostics import (
     AssociationDiagnostics,
@@ -35,5 +36,12 @@ def test_particle_diagnostics_rejects_text_weight_sequences():
     text_bytes = bytes([49, 50])
     mutable_text_bytes = bytearray([49, 50])
     for weights in ("12", text_bytes, mutable_text_bytes):
+        with pytest.raises(ValueError, match="Particle weights must be numeric"):
+            ParticleDiagnostics.from_weights(weights)
+
+
+def test_particle_diagnostics_rejects_boolean_weights():
+    invalid_cases = (True, [True, False], np.array([True, False]))
+    for weights in invalid_cases:
         with pytest.raises(ValueError, match="Particle weights must be numeric"):
             ParticleDiagnostics.from_weights(weights)


### PR DESCRIPTION
## Summary
- Reject boolean scalar and sequence inputs in `ParticleDiagnostics.from_weights` instead of converting them to `1.0`/`0.0` weights.
- Keep numeric integer/float weights accepted after rejecting text-like and boolean values.
- Add regression coverage for Python boolean weights and NumPy boolean arrays.

## Testing
- Not run locally in this connector-only environment; focused regression coverage is included in `tests/test_diagnostics.py`.