### PR TITLE
Tighten reproducibility seed validation

### DIFF
--- a/src/pyrecest/reproducibility.py
+++ b/src/pyrecest/reproducibility.py
@@ -9,7 +9,18 @@ from contextlib import contextmanager
 from numbers import Integral
 from typing import Any
 
+import numpy as np
+
 _MAX_BACKEND_SEED = 2**32 - 1
+_UNSUPPORTED_SEED_SCALAR_TYPES = (
+    bool,
+    str,
+    bytes,
+    bytearray,
+    np.bool_,
+    np.str_,
+    np.bytes_,
+)
 
 
 def _random_backend() -> Any:
@@ -34,7 +45,7 @@ def _normalize_seed(seed: int | None) -> int | None:
     except (TypeError, ValueError, RuntimeError, OverflowError) as exc:
         raise ValueError(message) from exc
 
-    if isinstance(scalar, bool | str | bytes):
+    if isinstance(scalar, _UNSUPPORTED_SEED_SCALAR_TYPES):
         raise ValueError(message)
     if isinstance(scalar, Integral):
         normalized_seed = int(scalar)

--- a/tests/test_reproducibility.py
+++ b/tests/test_reproducibility.py
@@ -6,7 +6,16 @@ from pyrecest.reproducibility import _normalize_seed
 
 class ReproducibilityValidationTest(unittest.TestCase):
     def test_normalize_seed_rejects_text_values(self):
-        for value in ("1", np.array("1")):
+        for value in ("1", np.array("1"), bytes([49]), bytearray([49]), np.bytes_(bytes([49]))):
+            with self.subTest(value=repr(value)):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "seed must be a non-negative integer or None",
+                ):
+                    _normalize_seed(value)
+
+    def test_normalize_seed_rejects_boolean_values(self):
+        for value in (True, np.bool_(True), np.array(True)):
             with self.subTest(value=repr(value)):
                 with self.assertRaisesRegex(
                     ValueError,


### PR DESCRIPTION
## Summary
- Reject additional nonnumeric scalar seed inputs before numeric coercion.
- Preserve existing integer-like numeric seed support.
- Add focused regression coverage in `tests/test_reproducibility.py`.

## Testing
- Not run locally in this connector-only environment.