### PR TITLE
Validate NumPy choice probabilities

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/random.py
+++ b/src/pyrecest/_backend/_shared_numpy/random.py
@@ -109,12 +109,24 @@ def _maybe_preserve_choice_order(indices, *, replace, p, shuffle, size):
     return _np.sort(index_array.reshape(-1)).reshape(index_array.shape)
 
 
+def _validate_choice_probabilities(p):
+    if p is None:
+        return None
+    if _contains_boolean_value(p):
+        raise TypeError("p must be real numeric, not boolean")
+    p_array = _np.asarray(p)
+    if p_array.dtype.kind not in "iuf":
+        raise TypeError("p must be real numeric")
+    return p_array
+
+
 def choice(a, size=None, replace=True, p=None, axis=0, shuffle=True):
     """Draw samples from an integer or array population."""
     replace = _choice_bool(replace, "replace")
     shuffle = _choice_bool(shuffle, "shuffle")
     a_array = _np.asarray(a)
     _validate_choice_population(a_array)
+    p = _validate_choice_probabilities(p)
     if a_array.ndim == 0:
         return _maybe_preserve_choice_order(
             _np.random.choice(a, size=size, replace=replace, p=p),
@@ -135,9 +147,6 @@ def choice(a, size=None, replace=True, p=None, axis=0, shuffle=True):
             size=size,
         )
         return _np.take(a_array, indices, axis=0)
-
-    if p is not None:
-        p = _np.asarray(p)
 
     indices = _np.random.choice(a_array.shape[axis], size=size, replace=replace, p=p)
     indices = _maybe_preserve_choice_order(

--- a/tests/backend/test_numpy_random_backend.py
+++ b/tests/backend/test_numpy_random_backend.py
@@ -107,3 +107,29 @@ def test_choice_rejects_non_boolean_controls(control):
 
     with pytest.raises(TypeError, match=f"{control} must be a boolean"):
         random.choice(np.arange(3), size=2, **kwargs)
+
+
+@pytest.mark.parametrize(
+    "probabilities",
+    [
+        [True, False, False],
+        np.array([True, False, False]),
+        np.array([0.5, np.bool_(False), 0.5], dtype=object),
+    ],
+)
+def test_choice_rejects_boolean_probabilities(probabilities):
+    with pytest.raises(TypeError, match="real numeric"):
+        random.choice(np.arange(3), p=probabilities)
+
+
+@pytest.mark.parametrize(
+    "probabilities",
+    [
+        ["1.0", "0.0", "0.0"],
+        np.array(["0.2", "0.3", "0.5"]),
+        np.array([0.5, "0.5", 0.0], dtype=object),
+    ],
+)
+def test_choice_rejects_text_probabilities(probabilities):
+    with pytest.raises(TypeError, match="real numeric"):
+        random.choice(np.arange(3), p=probabilities)


### PR DESCRIPTION
## Summary
- Validate NumPy-backed `random.choice` probabilities before passing them to `np.random.choice`.
- Reject boolean and non-real/text probability inputs instead of allowing NumPy to coerce them to numeric weights.
- Add focused NumPy random backend regression coverage for boolean and text probability sequences.

## Testing
- `python -m py_compile /mnt/data/random_shared_numpy.py /mnt/data/test_numpy_random_backend.py`

Full repository tests were not run locally because the execution container cannot resolve `github.com`; CI should run the focused regression tests and full workflow.