### PR TITLE
Reject textual fill values in session labels

### DIFF
--- a/src/pyrecest/utils/_multisession_assignment_labels.py
+++ b/src/pyrecest/utils/_multisession_assignment_labels.py
@@ -19,6 +19,8 @@ from .multisession_assignment import (  # pylint: disable=protected-access
     _validate_track_session_sizes,
 )
 
+_TEXT_TYPES = (str, np.str_)
+
 
 def _normalize_fill_value(fill_value: Any, track_count: int) -> int:
     fill_value_array = np.asarray(fill_value)
@@ -26,7 +28,7 @@ def _normalize_fill_value(fill_value: Any, track_count: int) -> int:
         raise ValueError("fill_value must be an integer.")
 
     fill_value_value = fill_value_array.item()
-    if isinstance(fill_value_value, (bool, np.bool_)):
+    if isinstance(fill_value_value, (bool, np.bool_) + _TEXT_TYPES):
         raise ValueError("fill_value must be an integer.")
 
     if isinstance(fill_value_value, Integral):

--- a/src/pyrecest/utils/_multisession_assignment_labels.py
+++ b/src/pyrecest/utils/_multisession_assignment_labels.py
@@ -24,7 +24,11 @@ _TEXT_TYPES = (str, np.str_)
 
 def _normalize_fill_value(fill_value: Any, track_count: int) -> int:
     fill_value_array = np.asarray(fill_value)
-    if fill_value_array.shape != () or fill_value_array.dtype == np.bool_:
+    if (
+        fill_value_array.shape != ()
+        or fill_value_array.dtype == np.bool_
+        or fill_value_array.dtype.kind in "SU"
+    ):
         raise ValueError("fill_value must be an integer.")
 
     fill_value_value = fill_value_array.item()

--- a/tests/test_multisession_assignment_labels.py
+++ b/tests/test_multisession_assignment_labels.py
@@ -66,6 +66,23 @@ class TestMultiSessionAssignmentLabels(unittest.TestCase):
         __backend_name__ == "jax",
         reason="Not supported on this backend",
     )
+    def test_text_fill_values_are_rejected(self):
+        tracks = [{0: 0}]
+        invalid_fill_values = ("-1", np.str_("-2"), np.array("-3"))
+
+        for fill_value in invalid_fill_values:
+            for name, converter in self._converters():
+                with self.subTest(converter=name, fill_value=repr(fill_value)):
+                    with self.assertRaisesRegex(
+                        ValueError,
+                        "fill_value must be an integer",
+                    ):
+                        converter(tracks, session_sizes=[2], fill_value=fill_value)
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
     def test_fill_value_cannot_collide_with_track_labels(self):
         tracks = [{0: 0}, {0: 1}]
 


### PR DESCRIPTION
## Summary

This PR tightens multi-session label conversion validation. String-like scalar fill values are now rejected instead of being accepted as integer sentinels. Numeric integer-like fill values remain supported.

A regression test covers the public utility, the module-level utility, and `MultiSessionAssignmentResult.to_session_labels()`.

## Tests

Not run locally; patch was made through the GitHub connector.