### PR TITLE
Reject non-integer PyTorch randint array bounds

### DIFF
--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -109,6 +109,15 @@ def _randint_array_size(size, low, high):
     return sample_shape
 
 
+def _validate_randint_array_bound(name, bound):
+    if (
+        bound.dtype == _torch.bool
+        or bound.dtype.is_floating_point
+        or bound.dtype.is_complex
+    ):
+        raise TypeError(f"{name} must contain integer values")
+
+
 def _randint_array(low, high, size, *args, **kwargs):
     if args:
         raise TypeError(
@@ -128,6 +137,8 @@ def _randint_array(low, high, size, *args, **kwargs):
     device = _randint_device(low, high, device=device)
     low = _torch.as_tensor(low, device=device)
     high = _torch.as_tensor(high, device=device)
+    _validate_randint_array_bound("low", low)
+    _validate_randint_array_bound("high", high)
     sample_shape = _randint_array_size(size, low, high)
 
     try:

--- a/tests/backend/test_pytorch_random_backend.py
+++ b/tests/backend/test_pytorch_random_backend.py
@@ -104,6 +104,33 @@ def test_randint_rejects_invalid_array_bounds(low, high):
         random.randint(low, high)
 
 
+@pytest.mark.parametrize(
+    ("low", "high"),
+    [
+        (torch.tensor([0.0, 10.0]), torch.tensor([3.0, 13.0])),
+        ([0.2, 10.0], [3.0, 13.0]),
+        (torch.tensor([False, True]), torch.tensor([3, 13])),
+        (torch.tensor([0, 10]), torch.tensor([3.5, 13.0])),
+    ],
+)
+def test_randint_rejects_non_integer_array_bounds(low, high):
+    with pytest.raises(TypeError, match="integer"):
+        random.randint(low, high)
+
+
+@pytest.mark.parametrize(
+    "high",
+    [
+        torch.tensor([3.0, 13.0]),
+        [3.0, 13.0],
+        torch.tensor([True, False]),
+    ],
+)
+def test_randint_rejects_non_integer_array_high_only(high):
+    with pytest.raises(TypeError, match="integer"):
+        random.randint(high)
+
+
 @pytest.mark.parametrize("bad_size", [(), (3,), (3, 1)])
 def test_normal_rejects_array_parameters_incompatible_with_explicit_size(bad_size):
     with pytest.raises(ValueError, match="broadcast"):


### PR DESCRIPTION
## Summary
- Validate array-valued PyTorch `randint` low/high bounds before sampling.
- Reject floating, complex, and boolean bound tensors/lists instead of silently truncating them through output dtype conversion.
- Add regression coverage for array bounds and high-only array calls.

## Tests
- Not run in a full checkout here; the execution environment could not resolve `github.com` for cloning. CI should run the targeted PyTorch random backend tests and the full workflow.

## Bug fixed
The array-valued PyTorch `randint` path previously accepted non-integer bounds, converted them to tensors, and then produced integer results by flooring random samples and coercing the bounds to the output dtype. That could silently truncate invalid floating bounds such as `[0.2, 10.0]` / `[3.0, 13.0]`, unlike the scalar randint contract.