### PR TITLE
Reject non-integer NumPy randint bounds

### DIFF
--- a/src/pyrecest/_backend/numpy/random.py
+++ b/src/pyrecest/_backend/numpy/random.py
@@ -5,9 +5,43 @@ from numpy.random import default_rng as _default_rng
 from numpy.random import (  # For PyRecEst
     get_state,
     multinomial,
-    randint,
     seed,
     set_state,
 )
 
 from .._shared_numpy.random import choice, multivariate_normal, normal, rand, uniform
+
+_BOOLEAN_TYPES = (bool, _np.bool_)
+
+
+def _contains_boolean_value(value):
+    if isinstance(value, _BOOLEAN_TYPES):
+        return True
+    try:
+        values = _np.asarray(value, dtype=object).reshape(-1)
+    except (TypeError, ValueError, RuntimeError):
+        return False
+    return any(isinstance(item, _BOOLEAN_TYPES) for item in values)
+
+
+def _validate_randint_bound(bound, name):
+    if _contains_boolean_value(bound):
+        raise TypeError(f"{name} must contain integer values")
+    try:
+        bound_array = _np.asarray(bound)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(f"{name} must contain integer values") from exc
+    if bound_array.dtype.kind not in "iu":
+        raise TypeError(f"{name} must contain integer values")
+
+
+def randint(low, high=None, size=None, dtype=int):
+    """Draw integer samples after rejecting non-integer bounds."""
+
+    if high is None:
+        _validate_randint_bound(low, "high")
+        return _np.random.randint(low, high=None, size=size, dtype=dtype)
+
+    _validate_randint_bound(low, "low")
+    _validate_randint_bound(high, "high")
+    return _np.random.randint(low, high=high, size=size, dtype=dtype)

--- a/tests/backend/test_numpy_random_backend.py
+++ b/tests/backend/test_numpy_random_backend.py
@@ -33,7 +33,7 @@ def test_rand_rejects_ambiguous_positional_and_size_arguments():
         (0, True),
         (np.array([0.0, 10.0]), np.array([3, 13])),
         ([0, 10], [3.0, 13.0]),
-        (np.array([False, 0]), np.array([3, 13])),
+        (np.array([False, 0], dtype=object), np.array([3, 13])),
         (np.array([0, 10]), np.array([3, np.bool_(True)], dtype=object)),
         (np.array([0 + 0j, 10]), np.array([3, 13])),
     ],

--- a/tests/backend/test_numpy_random_backend.py
+++ b/tests/backend/test_numpy_random_backend.py
@@ -27,6 +27,52 @@ def test_rand_rejects_ambiguous_positional_and_size_arguments():
 @pytest.mark.parametrize(
     ("low", "high"),
     [
+        (0.2, 3),
+        (0, 3.7),
+        (False, 3),
+        (0, True),
+        (np.array([0.0, 10.0]), np.array([3, 13])),
+        ([0, 10], [3.0, 13.0]),
+        (np.array([False, 0]), np.array([3, 13])),
+        (np.array([0, 10]), np.array([3, np.bool_(True)], dtype=object)),
+        (np.array([0 + 0j, 10]), np.array([3, 13])),
+    ],
+)
+def test_randint_rejects_non_integer_bounds(low, high):
+    with pytest.raises(TypeError, match="integer"):
+        random.randint(low, high)
+
+
+@pytest.mark.parametrize(
+    "high",
+    [
+        3.0,
+        True,
+        np.array([3.0, 13.0]),
+        [3, 13.0],
+        np.array([True, False]),
+    ],
+)
+def test_randint_rejects_non_integer_high_only(high):
+    with pytest.raises(TypeError, match="integer"):
+        random.randint(high)
+
+
+def test_randint_accepts_integer_array_bounds():
+    random.seed(0)
+    low = np.array([0, 10])
+    high = np.array([3, 13])
+
+    samples = random.randint(low, high, size=(4, 2))
+
+    assert samples.shape == (4, 2)
+    assert np.all(samples >= low)
+    assert np.all(samples < high)
+
+
+@pytest.mark.parametrize(
+    ("low", "high"),
+    [
         (False, 1.0),
         (0.0, True),
         (np.array([False, False]), np.array([1.0, 2.0])),


### PR DESCRIPTION
## Summary
- Add a NumPy random-backend `randint` wrapper that validates integer low/high bounds before delegating to NumPy.
- Keep valid integer scalar and broadcasted integer array bounds working.
- Add regression tests for invalid scalar, high-only, and array-valued bounds.

## Tests
- Local smoke check of the new validator logic.
- Full repository pytest suite not run in this environment.