### PR TITLE
Fix Euclidean MTT target orientation handling

### DIFF
--- a/src/pyrecest/evaluation/get_distance_function.py
+++ b/src/pyrecest/evaluation/get_distance_function.py
@@ -189,19 +189,15 @@ def _validate_mtt_cutoff_distance(value: Any) -> float:
 
 
 def _euclidean_mtt_distance(x1, x2, *, cutoff_distance: float) -> float:
-    raw_first = _as_real_numeric_array(x1, "x1")
-    raw_second = _as_real_numeric_array(x2, "x2")
-    if raw_first.size == 0 and raw_first.ndim == 2 and raw_second.ndim == 2:
-        if raw_first.shape[1] != raw_second.shape[1]:
-            raise ValueError("MTT state sets must use the same target dimension")
-        return float(cutoff_distance * raw_second.shape[0])
-    if raw_second.size == 0 and raw_second.ndim == 2 and raw_first.ndim == 2:
-        if raw_first.shape[1] != raw_second.shape[1]:
-            raise ValueError("MTT state sets must use the same target dimension")
-        return float(cutoff_distance * raw_first.shape[0])
-    first = _as_target_matrix(raw_first, "x1")
-    second = _as_target_matrix(raw_second, "x2")
+    first = _as_target_matrix(x1, "x1")
+    second = _as_target_matrix(x2, "x2")
     if first.shape[0] == 0 or second.shape[0] == 0:
+        if (
+            first.shape[1] != 0
+            and second.shape[1] != 0
+            and first.shape[1] != second.shape[1]
+        ):
+            raise ValueError("MTT state sets must use the same target dimension")
         return float(cutoff_distance * abs(first.shape[0] - second.shape[0]))
     if first.shape[1] != second.shape[1]:
         raise ValueError("MTT state sets must use the same target dimension")

--- a/tests/evaluation/test_euclidean_mtt_distance_orientation.py
+++ b/tests/evaluation/test_euclidean_mtt_distance_orientation.py
@@ -18,3 +18,12 @@ def test_euclidean_mtt_distance_preserves_ambiguous_row_oriented_3d_targets():
     )
 
     np.testing.assert_allclose(distance(first, second), 5.0)
+
+
+def test_euclidean_mtt_distance_handles_empty_against_dim_first_targets():
+    distance = get_distance_function("euclidean_mtt", {"cutoff_distance": 7.0})
+    no_targets = np.empty((0, 2))
+    dim_first_targets = np.vstack((10.0 * np.arange(5), np.zeros(5)))
+
+    np.testing.assert_allclose(distance(no_targets, dim_first_targets), 35.0)
+    np.testing.assert_allclose(distance(dim_first_targets, no_targets), 35.0)


### PR DESCRIPTION
## Summary
- Normalize Euclidean MTT target arrays before the cardinality-only branch.
- Preserve dimension checks when both inputs provide a known target dimension.
- Add regression coverage for dim-first target arrays against a missing-target input.

## Testing
- Added coverage in `tests/evaluation/test_euclidean_mtt_distance_orientation.py`.
- Locally validated the old/new orientation logic with a minimal reproduction.