### PR TITLE
Validate GNN pairwise cost matrices

### DIFF
--- a/src/pyrecest/filters/global_nearest_neighbor.py
+++ b/src/pyrecest/filters/global_nearest_neighbor.py
@@ -1,6 +1,7 @@
 # pylint: disable=redefined-builtin,no-name-in-module,no-member,duplicate-code
 import warnings
 
+import numpy as np
 from pyrecest.backend import (
     all,
     any,
@@ -72,11 +73,26 @@ class GlobalNearestNeighbor(AbstractNearestNeighborTracker):
     def _validate_pairwise_cost_matrix(pairwise_cost_matrix, n_targets, n_meas):
         if pairwise_cost_matrix is None:
             return None
+        try:
+            raw_pairwise_cost_matrix = np.asarray(pairwise_cost_matrix)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "pairwise_cost_matrix must contain real numeric costs."
+            ) from exc
+        if raw_pairwise_cost_matrix.dtype.kind in {"b", "c", "S", "U"}:
+            raise ValueError("pairwise_cost_matrix must contain real numeric costs.")
         pairwise_cost_matrix = asarray(pairwise_cost_matrix, dtype=float)
         if pairwise_cost_matrix.shape != (n_targets, n_meas):
             raise ValueError(
                 "pairwise_cost_matrix must have shape "
                 f"({n_targets}, {n_meas}), got {pairwise_cost_matrix.shape}."
+            )
+        pairwise_cost_values = np.asarray(pairwise_cost_matrix, dtype=float)
+        if np.any(np.isnan(pairwise_cost_values)) or np.any(
+            np.isneginf(pairwise_cost_values)
+        ):
+            raise ValueError(
+                "pairwise_cost_matrix may only contain finite values or positive infinity."
             )
         return pairwise_cost_matrix
 

--- a/tests/filters/test_gnn_pairwise_cost_validation.py
+++ b/tests/filters/test_gnn_pairwise_cost_validation.py
@@ -1,0 +1,54 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.filters.global_nearest_neighbor import GlobalNearestNeighbor
+
+
+class GlobalNearestNeighborPairwiseCostValidationTest(unittest.TestCase):
+    def test_rejects_non_real_pairwise_cost_matrix_dtypes(self):
+        invalid_matrices = (
+            np.array([[True]], dtype=bool),
+            np.array([[1.0 + 1.0j]], dtype=complex),
+            np.array([["1.0"]], dtype=str),
+        )
+
+        for invalid_matrix in invalid_matrices:
+            with self.subTest(dtype=invalid_matrix.dtype):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "pairwise_cost_matrix must contain real numeric costs",
+                ):
+                    GlobalNearestNeighbor._validate_pairwise_cost_matrix(
+                        invalid_matrix,
+                        1,
+                        1,
+                    )
+
+    def test_rejects_nan_and_negative_infinite_pairwise_costs(self):
+        invalid_matrices = (np.array([[np.nan]]), np.array([[-np.inf]]))
+
+        for invalid_matrix in invalid_matrices:
+            with self.subTest(invalid_matrix=invalid_matrix):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "finite values or positive infinity",
+                ):
+                    GlobalNearestNeighbor._validate_pairwise_cost_matrix(
+                        invalid_matrix,
+                        1,
+                        1,
+                    )
+
+    def test_accepts_positive_infinity_as_pairwise_gate(self):
+        pairwise_cost_matrix = GlobalNearestNeighbor._validate_pairwise_cost_matrix(
+            np.array([[np.inf]]),
+            1,
+            1,
+        )
+
+        self.assertTrue(np.isposinf(np.asarray(pairwise_cost_matrix)[0, 0]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- validate `GlobalNearestNeighbor` pairwise cost matrices before fusing them with geometric association distances
- reject boolean, complex, string, NaN, and negative-infinite pairwise costs
- preserve positive infinity as an explicit gating sentinel and add focused regression coverage

## Bug
`GlobalNearestNeighbor._validate_pairwise_cost_matrix` previously coerced `pairwise_cost_matrix` directly to `float` and then only checked its shape. That could silently reinterpret invalid pairwise costs, for example boolean matrices becoming 0/1 costs, or let invalid non-finite costs propagate into the assignment objective.

## Validation
- Added `tests/filters/test_gnn_pairwise_cost_validation.py` for invalid dtype/non-finite validation and positive-infinity gating support.
- Not run locally in this connector environment.