### PR TITLE
Reject non-real time-offset estimator inputs

### DIFF
--- a/src/pyrecest/filters/online_time_offset_estimator.py
+++ b/src/pyrecest/filters/online_time_offset_estimator.py
@@ -8,6 +8,23 @@ from typing import Any
 import numpy as np
 
 
+_UNSUPPORTED_NUMERIC_KINDS = {"b", "S", "U", "c", "M", "m"}
+_UNSUPPORTED_SCALAR_TYPES = (
+    type(None),
+    bool,
+    np.bool_,
+    str,
+    bytes,
+    bytearray,
+    np.str_,
+    np.bytes_,
+    complex,
+    np.complexfloating,
+    np.datetime64,
+    np.timedelta64,
+)
+
+
 @dataclass
 class OnlineTimeOffsetEstimator:
     """Scalar online timestamp-offset estimator with a Gaussian state."""
@@ -46,8 +63,8 @@ class OnlineTimeOffsetEstimator:
         measurement_variance: float,
     ) -> float:
         """Update the offset from a position residual and return innovation NIS."""
-        residual = np.asarray(residual, dtype=float).reshape(-1)
-        velocity = np.asarray(velocity, dtype=float).reshape(-1)
+        residual = _as_real_numeric_array(residual, "residual").reshape(-1)
+        velocity = _as_real_numeric_array(velocity, "velocity").reshape(-1)
         if residual.size != velocity.size:
             raise ValueError("residual and velocity must have the same dimension")
         if not np.isfinite(residual).all() or not np.isfinite(velocity).all():
@@ -77,8 +94,31 @@ class OnlineTimeOffsetEstimator:
         return float(np.sqrt(max(self.variance, 0.0)))
 
 
-def _as_finite_scalar(value: Any, name: str) -> float:
+def _contains_unsupported_numeric_values(value: Any) -> bool:
     value_array = np.asarray(value)
+    if value_array.dtype.kind in _UNSUPPORTED_NUMERIC_KINDS:
+        return True
+    if value_array.dtype.kind != "O":
+        return False
+    return any(isinstance(item, _UNSUPPORTED_SCALAR_TYPES) for item in value_array.flat)
+
+
+def _as_real_numeric_array(value: Any, name: str) -> np.ndarray:
+    try:
+        if _contains_unsupported_numeric_values(value):
+            raise ValueError
+        return np.asarray(value, dtype=float)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be real-valued numeric") from exc
+
+
+def _as_finite_scalar(value: Any, name: str) -> float:
+    try:
+        if _contains_unsupported_numeric_values(value):
+            raise ValueError
+        value_array = np.asarray(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be a finite scalar") from exc
     if value_array.shape != () or value_array.dtype == np.bool_:
         raise ValueError(f"{name} must be a finite scalar")
     scalar = value_array.item()

--- a/tests/filters/test_online_time_offset_estimator.py
+++ b/tests/filters/test_online_time_offset_estimator.py
@@ -41,7 +41,15 @@ class OnlineTimeOffsetEstimatorTest(unittest.TestCase):
         self.assertAlmostEqual(estimator.variance, 1.25)
 
     def test_constructor_rejects_nonfinite_scalar_controls(self):
-        invalid_values = (np.nan, np.inf, -np.inf, True, np.array([1.0]))
+        invalid_values = (
+            np.nan,
+            np.inf,
+            -np.inf,
+            True,
+            "1.0",
+            np.array("1.0"),
+            np.array([1.0]),
+        )
         for field_name in ("offset", "variance", "process_variance", "min_speed"):
             for value in invalid_values:
                 with self.subTest(field_name=field_name, value=value):
@@ -56,10 +64,16 @@ class OnlineTimeOffsetEstimatorTest(unittest.TestCase):
             {"measurement_variance": np.nan},
             {"measurement_variance": np.inf},
             {"measurement_variance": True},
+            {"measurement_variance": "1.0"},
+            {"measurement_variance": np.array("1.0")},
             {"measurement_variance": np.array([1.0])},
             {"measurement_variance": -1.0},
             {"residual": np.array([np.nan])},
+            {"residual": np.array([True])},
+            {"residual": np.array(["1.0"])},
             {"velocity": np.array([np.inf])},
+            {"velocity": np.array([False])},
+            {"velocity": np.array(["2.0"])},
         )
 
         for override in invalid_updates:


### PR DESCRIPTION
## Summary
- Add explicit real-numeric input validation for `OnlineTimeOffsetEstimator` residual, velocity, and scalar control inputs.
- Reject booleans, numeric-looking strings, complex values, temporal values, and missing values before NumPy can coerce them to floats.
- Extend the online time-offset estimator regressions to cover malformed scalar controls and update inputs while preserving the no-state-change guarantee on rejected updates.

## Bug
`OnlineTimeOffsetEstimator` used direct `np.asarray(..., dtype=float)` and `float(...)` coercions for residuals, velocities, and scalar controls. That allowed malformed inputs such as `True`, `"1.0"`, or `np.array([False])` to be interpreted as numeric measurements/configuration instead of surfacing caller/data errors.

## Validation
- `python -m py_compile /mnt/data/online_time_offset_estimator.py /mnt/data/test_online_time_offset_estimator.py`
- Local focused smoke check of valid updates and newly rejected malformed inputs.

Full repository tests were not run locally because this environment cannot clone/install the repository from GitHub.