### PR TITLE
Preserve pipes in backend support markdown

### DIFF
--- a/src/pyrecest/backend_support.py
+++ b/src/pyrecest/backend_support.py
@@ -38,7 +38,8 @@ def backend_support(
 
 
 def _markdown_table_cell(value: object) -> str:
-    return str(value).replace("\r", " ").replace("\n", "<br>").replace(chr(124), chr(0xFF5C))
+    escape = chr(92) + chr(124)
+    return str(value).replace("\r", " ").replace("\n", "<br>").replace(chr(124), escape)
 
 
 def _markdown_table_row(cells: list[str]) -> str:

--- a/tests/test_backend_support_public.py
+++ b/tests/test_backend_support_public.py
@@ -26,9 +26,9 @@ def test_backend_support_markdown_contains_expected_rows():
     assert "BackendFacade" in rendered
 
 
-def test_backend_support_markdown_handles_table_separators(monkeypatch):
+def test_backend_support_markdown_preserves_table_separators(monkeypatch):
     separator = chr(124)
-    replacement = chr(0xFF5C)
+    escaped_separator = chr(92) + separator
 
     def fake_backend_capabilities():
         return (
@@ -52,7 +52,7 @@ def test_backend_support_markdown_handles_table_separators(monkeypatch):
     rendered = backend_support_module.format_backend_support_markdown()
     data_row = rendered.splitlines()[-1]
 
-    assert data_row.count(separator) == 6
-    assert f"Pipe{replacement}API" in data_row
-    assert f"partial{replacement}bridged" in data_row
-    assert f"first {replacement} second<br>continued" in data_row
+    assert data_row.count(separator) == 9
+    assert f"Pipe{escaped_separator}API" in data_row
+    assert f"partial{escaped_separator}bridged" in data_row
+    assert f"first {escaped_separator} second<br>continued" in data_row


### PR DESCRIPTION
## Summary
- Preserve literal pipe characters in backend support Markdown table cells by escaping them instead of replacing them with a fullwidth lookalike.
- Keep newline normalization for Markdown table cells.
- Update the regression test to verify escaped separators remain in rendered text while the table structure stays stable.

## Testing
- Not run locally in this connector-only environment.
- Added focused regression coverage in `tests/test_backend_support_public.py`.