### PR TITLE
Use public track selection for MTT mean extraction

### DIFF
--- a/src/pyrecest/evaluation/get_extract_mean.py
+++ b/src/pyrecest/evaluation/get_extract_mean.py
@@ -52,16 +52,20 @@ def _point_estimate_or_mean(filter_state):
     return filter_state
 
 
+def _extract_track_collection_mean(tracks):
+    return [_point_estimate_or_mean(track) for track in tracks]
+
+
 def _extract_mtt_mean(filter_state):
+    get_tracks = getattr(filter_state, "get_tracks", None)
+    if callable(get_tracks):
+        return _extract_track_collection_mean(get_tracks())
     if hasattr(filter_state, "tracks"):
-        return [_point_estimate_or_mean(track) for track in filter_state.tracks]
+        return _extract_track_collection_mean(filter_state.tracks)
     if hasattr(filter_state, "single_target_filters"):
-        return [
-            _point_estimate_or_mean(track)
-            for track in filter_state.single_target_filters
-        ]
+        return _extract_track_collection_mean(filter_state.single_target_filters)
     if isinstance(filter_state, list | tuple):
-        return [_point_estimate_or_mean(track) for track in filter_state]
+        return _extract_track_collection_mean(filter_state)
     return _point_estimate_or_mean(filter_state)
 
 

--- a/tests/evaluation/test_evaluation_registries.py
+++ b/tests/evaluation/test_evaluation_registries.py
@@ -16,6 +16,25 @@ def _as_float(value):
     return float(to_numpy(value))
 
 
+class _PointEstimateTrack:
+    def __init__(self, value):
+        self.value = value
+
+    def get_point_estimate(self):
+        return self.value
+
+
+class _TrackManagerLikeState:
+    def __init__(self):
+        self.tracks = [
+            _PointEstimateTrack("raw-hidden"),
+            _PointEstimateTrack("selected"),
+        ]
+
+    def get_tracks(self):
+        return self.tracks[1:]
+
+
 def test_custom_distance_function_registry():
     register_distance_function(
         "unit-test-manifold", lambda _name, _params: lambda x, y: 42.0
@@ -159,6 +178,14 @@ def test_euclidean_extract_mean_preserves_raw_array_state():
     extracted = get_extract_mean("euclidean")(state)
 
     assert to_numpy(extracted).tolist() == pytest.approx([1.0, 2.0])
+
+
+def test_euclidean_mtt_extract_mean_uses_public_track_selection():
+    extracted = get_extract_mean("euclidean", mtt_scenario=True)(
+        _TrackManagerLikeState()
+    )
+
+    assert extracted == ["selected"]
 
 
 def test_symmetric_hypersphere_extract_mean_requires_custom_extractor():


### PR DESCRIPTION
## Summary
- Prefer a manager-like state's public `get_tracks()` selection when extracting Euclidean MTT means.
- Keep the existing `.tracks`, `.single_target_filters`, and list/tuple fallbacks for simpler states.
- Add a regression test showing that raw hidden tracks are not leaked when a filtered public track view is available.

## Bug
The Euclidean MTT mean extractor previously inspected a state object's raw `.tracks` attribute before any public selection API. For `TrackManager`-like states this can include tentative, deleted, or otherwise hidden tracks that `get_tracks()` intentionally filters out, contaminating evaluation summaries.

## Testing
- `python -m py_compile` on local copies of the modified source and test files.
- Exercised the new extraction path in a minimal local import harness.
- Full repository tests were not run because this environment cannot clone/install the GitHub repository directly.