### PR TITLE
Reject non-integer JAX randint bounds

### DIFF
--- a/src/pyrecest/_backend/jax/random.py
+++ b/src/pyrecest/_backend/jax/random.py
@@ -215,6 +215,18 @@ def uniform(low=0.0, high=1.0, size=None, *args, **kwargs):
     return set_state_return(has_state, state, res)
 
 
+def _validate_randint_bound(bound, name):
+    if _contains_boolean_value(bound):
+        raise TypeError(f"{name} must contain integer values")
+    try:
+        bound_array = _jnp.asarray(bound)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(f"{name} must contain integer values") from exc
+    if bound_array.dtype.kind not in "iu":
+        raise TypeError(f"{name} must contain integer values")
+    return bound_array
+
+
 def _validate_randint_bounds(low, high):
     try:
         low, high = _jnp.broadcast_arrays(low, high)
@@ -283,8 +295,8 @@ def randint(low=None, high=None, size=None, *args, **kwargs):
         high = low
         low = 0
 
-    low = _jnp.asarray(low)
-    high = _jnp.asarray(high)
+    low = _validate_randint_bound(low, "low")
+    high = _validate_randint_bound(high, "high")
     low, high = _validate_randint_bounds(low, high)
     shape = _bounded_sampler_shape(size, low, high)
     state, has_state, kwargs = _get_state(**kwargs)

--- a/tests/backend/test_jax_randint_bounds.py
+++ b/tests/backend/test_jax_randint_bounds.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 jax = pytest.importorskip("jax")
@@ -16,6 +17,40 @@ def test_randint_accepts_sequence_bounds_with_explicit_size(bounds_type):
     assert samples.shape == (4, 2)
     assert jnp.all(samples >= jnp.array([0, 10]))
     assert jnp.all(samples < jnp.array([3, 13]))
+
+
+@pytest.mark.parametrize(
+    ("low", "high"),
+    [
+        (0.2, 3),
+        (0, 3.7),
+        (False, 3),
+        (0, True),
+        (jnp.array([0.0, 10.0]), jnp.array([3, 13])),
+        ([0, 10], [3.0, 13.0]),
+        ([False, 0], [3, 13]),
+        (np.array([0, 10]), np.array([3, np.bool_(True)], dtype=object)),
+        (np.array([0 + 0j, 10]), np.array([3, 13])),
+    ],
+)
+def test_randint_rejects_non_integer_bounds(low, high):
+    with pytest.raises(TypeError, match="integer"):
+        random.randint(low, high)
+
+
+@pytest.mark.parametrize(
+    "high",
+    [
+        3.0,
+        True,
+        jnp.array([3.0, 13.0]),
+        [3, 13.0],
+        jnp.array([True, False]),
+    ],
+)
+def test_randint_rejects_non_integer_high_only(high):
+    with pytest.raises(TypeError, match="integer"):
+        random.randint(high)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Add JAX `randint` bound validation so float, complex, and boolean bounds are rejected before JAX silently coerces them.
- Keep integer scalar, sequence, and broadcasted array bounds supported.
- Extend the focused JAX randint regression tests for NumPy/PyTorch backend parity.

## Testing
- `PYTHONPATH=/tmp pytest -q /tmp/tests/backend/test_jax_randint_bounds.py` in a minimal local package scaffold with the patched `random.py`: 19 passed.
- Direct local reproduction confirmed that unpatched JAX accepts/coerces bounds such as `0.2` and `3.7`; patched code raises `TypeError` with an integer-bound message.