### PR TITLE
Report missing optional backend dependencies clearly

### DIFF
--- a/src/pyrecest/backends/__init__.py
+++ b/src/pyrecest/backends/__init__.py
@@ -12,7 +12,24 @@ from __future__ import annotations
 import importlib
 from types import ModuleType
 
+from pyrecest.exceptions import OptionalDependencyError
+
 SUPPORTED_BACKENDS: tuple[str, ...] = ("numpy", "pytorch", "jax", "autograd")
+_OPTIONAL_BACKEND_EXTRAS: dict[str, str] = {
+    "pytorch": "pytorch_support",
+    "jax": "jax_support",
+    "autograd": "jax_support",
+}
+
+
+def _normalize_backend_name(name: str) -> str:
+    if not isinstance(name, str):
+        raise ValueError("Backend name must be a string.")
+    normalized = name.lower().strip()
+    if normalized not in SUPPORTED_BACKENDS:
+        supported = ", ".join(SUPPORTED_BACKENDS)
+        raise ValueError(f"Unknown backend '{name}'. Supported backends: {supported}.")
+    return normalized
 
 
 def get_backend(name: str) -> ModuleType:
@@ -21,13 +38,26 @@ def get_backend(name: str) -> ModuleType:
     Parameters
     ----------
     name:
-        One of ``"numpy"``, ``"pytorch"``, or ``"jax"``.
+        One of ``"numpy"``, ``"pytorch"``, ``"jax"``, or ``"autograd"``.
     """
-    normalized = name.lower().strip()
-    if normalized not in SUPPORTED_BACKENDS:
-        supported = ", ".join(SUPPORTED_BACKENDS)
-        raise ValueError(f"Unknown backend '{name}'. Supported backends: {supported}.")
-    return importlib.import_module(f"pyrecest._backend.{normalized}")
+    normalized = _normalize_backend_name(name)
+    module_name = f"pyrecest._backend.{normalized}"
+    try:
+        return importlib.import_module(module_name)
+    except ModuleNotFoundError as exc:
+        if exc.name == module_name:
+            supported = ", ".join(SUPPORTED_BACKENDS)
+            raise ValueError(
+                f"Unknown backend '{name}'. Supported backends: {supported}."
+            ) from exc
+        extra = _OPTIONAL_BACKEND_EXTRAS.get(normalized)
+        if extra is None:
+            raise
+        missing = f" {exc.name!r}" if exc.name else ""
+        raise OptionalDependencyError(
+            f"Backend '{normalized}' requires optional dependency{missing}. "
+            f"Install it with `python -m pip install 'pyrecest[{extra}]'`."
+        ) from exc
 
 
 __all__ = ["SUPPORTED_BACKENDS", "get_backend"]

--- a/tests/test_explicit_backends.py
+++ b/tests/test_explicit_backends.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 from pyrecest.backends import SUPPORTED_BACKENDS, get_backend
+from pyrecest.exceptions import OptionalDependencyError
 
 
 def test_get_backend_imports_supported_backend():
@@ -23,6 +24,31 @@ def test_get_backend_accepts_autograd_backend(monkeypatch):
     assert "autograd" in SUPPORTED_BACKENDS
     assert get_backend("autograd") is fake_backend
     assert imported == ["pyrecest._backend.autograd"]
+
+
+def test_get_backend_reports_optional_dependency_install_hint(monkeypatch):
+    missing_dependency = ModuleNotFoundError("No module named 'torch'", name="torch")
+
+    def fake_import_module(module_name):
+        assert module_name == "pyrecest._backend.pytorch"
+        raise missing_dependency
+
+    monkeypatch.setattr("pyrecest.backends.importlib.import_module", fake_import_module)
+
+    with pytest.raises(OptionalDependencyError) as exc_info:
+        get_backend("pytorch")
+
+    assert exc_info.value.__cause__ is missing_dependency
+    message = str(exc_info.value)
+    assert "Backend 'pytorch'" in message
+    assert "torch" in message
+    assert "pyrecest[pytorch_support]" in message
+
+
+@pytest.mark.parametrize("name", [None, b"numpy", 1])
+def test_get_backend_rejects_non_string_names(name):
+    with pytest.raises(ValueError, match="Backend name must be a string"):
+        get_backend(name)
 
 
 def test_get_backend_rejects_unknown_backend():


### PR DESCRIPTION
## Summary
- Validate explicit backend names before normalization so non-string inputs raise a clear `ValueError`.
- Convert missing optional dependencies for explicit optional backends into `OptionalDependencyError` with the matching install-extra hint.
- Add regression coverage for the PyTorch optional dependency path and invalid backend-name types.

## Bug
`get_backend("pytorch")` called `importlib.import_module("pyrecest._backend.pytorch")` directly. When the backend implementation could not import an optional dependency such as `torch`, the raw `ModuleNotFoundError` leaked to callers instead of using PyRecEst's standardized optional-dependency error vocabulary and install guidance.

## Testing
- `python -m py_compile /mnt/data/backends_init_updated.py /mnt/data/test_explicit_backends_updated.py`
- Isolated local mock check for the optional dependency path and non-string name validation.

Full repository tests were not run locally because this execution environment cannot clone/install the repository from GitHub; CI should run the repository test matrix on this PR.