### PR TITLE
Reject non-real CLI tolerances

### DIFF
--- a/src/pyrecest/cli.py
+++ b/src/pyrecest/cli.py
@@ -11,7 +11,18 @@ from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Any
 
+import numpy as np
+
 _INVALID_TOLERANCE_MESSAGE = "tolerance must be a non-negative finite number"
+_INVALID_TOLERANCE_SCALAR_TYPES = (
+    bool,
+    str,
+    bytes,
+    bytearray,
+    np.bool_,
+    np.str_,
+    np.bytes_,
+)
 
 
 def _package_version(name: str) -> str | None:
@@ -24,10 +35,20 @@ def _package_version(name: str) -> str | None:
 def _validate_tolerance(value: Any) -> float:
     """Return a validated comparison tolerance for expected-result checks."""
 
-    if isinstance(value, (bool, str, bytes, bytearray)):
-        raise ValueError(_INVALID_TOLERANCE_MESSAGE)
     try:
-        tolerance = float(value)
+        value_array = np.asarray(value)
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise ValueError(_INVALID_TOLERANCE_MESSAGE) from exc
+
+    if value_array.shape != ():
+        raise ValueError(_INVALID_TOLERANCE_MESSAGE)
+
+    scalar = value_array.item()
+    if isinstance(scalar, _INVALID_TOLERANCE_SCALAR_TYPES):
+        raise ValueError(_INVALID_TOLERANCE_MESSAGE)
+
+    try:
+        tolerance = float(scalar)
     except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError(_INVALID_TOLERANCE_MESSAGE) from exc
     if not math.isfinite(tolerance) or tolerance < 0.0:

--- a/tests/test_cli_tolerance_validation.py
+++ b/tests/test_cli_tolerance_validation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 
+import numpy as np
 import pytest
 from pyrecest.cli import _check_expected_mapping, _validate_tolerance
 
@@ -9,10 +10,23 @@ from pyrecest.cli import _check_expected_mapping, _validate_tolerance
 def test_validate_tolerance_accepts_finite_nonnegative_numbers() -> None:
     assert _validate_tolerance(0.0) == 0.0
     assert _validate_tolerance(1e-8) == 1e-8
+    assert _validate_tolerance(np.float64(1e-8)) == 1e-8
+    assert _validate_tolerance(np.array(1e-8)) == 1e-8
 
 
 def test_validate_tolerance_rejects_invalid_values() -> None:
-    for tolerance in (math.nan, math.inf, -1.0, True, "0.1"):
+    invalid_tolerances = (
+        math.nan,
+        math.inf,
+        -1.0,
+        True,
+        "0.1",
+        np.bool_(True),
+        np.array(True, dtype=object),
+        np.array("0.1", dtype=object),
+        np.array([0.1]),
+    )
+    for tolerance in invalid_tolerances:
         with pytest.raises(ValueError, match="tolerance"):
             _validate_tolerance(tolerance)
 


### PR DESCRIPTION
## Summary
- Tighten CLI expected-result tolerance validation by normalizing through NumPy scalars before calling `float`.
- Reject boolean, text-like, object-scalar, and non-scalar array tolerances instead of silently accepting values such as `np.bool_(True)` as `1.0`.
- Keep finite nonnegative Python numbers, NumPy scalar numbers, and 0-D numeric arrays supported.

## Bug
`_validate_tolerance` explicitly rejected plain Python booleans and strings, but then passed other scalar-like inputs directly to `float(...)`. NumPy boolean scalars and object scalar arrays can therefore be accepted as ordinary numeric tolerances, which weakens expected-result checks.

## Testing
- `python -m py_compile /mnt/data/cli.py /mnt/data/test_cli_tolerance_validation.py`
- Direct local harness for `_validate_tolerance` accepted finite numeric scalar/0-D NumPy inputs and rejected boolean/text/object-array/non-scalar tolerances.

Full repository tests were not run locally because this execution environment cannot clone/install the repository from GitHub; CI should run the repository test matrix on this PR.