### PR TITLE
Handle dtype-like values in shared default dtype setup

### DIFF
--- a/src/pyrecest/_backend/_dtype_utils.py
+++ b/src/pyrecest/_backend/_dtype_utils.py
@@ -153,6 +153,17 @@ def _dyn_update_dtype(dtype_pos=None, target=None):
     return _decorator(target)
 
 
+def _dtype_name(value):
+    """Return a stable dtype name for backend dtype-like objects."""
+    name = getattr(value, "name", None) or getattr(value, "__name__", None)
+    if name is not None:
+        return str(name)
+    text = str(value)
+    if "." in text:
+        text = text.rsplit(".", maxsplit=1)[-1]
+    return text.strip("'>")
+
+
 def _pre_set_default_dtype(as_dtype):
     def set_default_dtype(value):
         """Set backend default dtype.
@@ -162,8 +173,17 @@ def _pre_set_default_dtype(as_dtype):
         value : str
             Possible values are "float32" as "float64".
         """
-        _config.DEFAULT_DTYPE = as_dtype(value)
-        _config.DEFAULT_COMPLEX_DTYPE = as_dtype(_MAP_FLOAT_TO_COMPLEX[value])
+        default_dtype = as_dtype(value)
+        dtype_name = _dtype_name(default_dtype)
+        try:
+            complex_dtype = as_dtype(_MAP_FLOAT_TO_COMPLEX[dtype_name])
+        except KeyError as exc:
+            raise ValueError(
+                "Default dtype must resolve to float32 or float64."
+            ) from exc
+
+        _config.DEFAULT_DTYPE = default_dtype
+        _config.DEFAULT_COMPLEX_DTYPE = complex_dtype
 
         _update_default_dtypes()
 

--- a/tests/test_numpy_default_dtype_objects.py
+++ b/tests/test_numpy_default_dtype_objects.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pytest
+
+
+def test_numpy_backend_set_default_dtype_accepts_dtype_like_values():
+    from pyrecest.backends import get_backend
+
+    numpy_backend = get_backend("numpy")
+    previous_dtype = numpy_backend.get_default_dtype()
+
+    try:
+        result = numpy_backend.set_default_dtype(np.dtype("float32"))
+        assert result == np.dtype("float32")
+        assert numpy_backend.get_default_dtype() == np.dtype("float32")
+        assert numpy_backend.get_default_cdtype() == np.dtype("complex64")
+
+        result = numpy_backend.set_default_dtype(np.float64)
+        assert result == np.dtype("float64")
+        assert numpy_backend.get_default_dtype() == np.dtype("float64")
+        assert numpy_backend.get_default_cdtype() == np.dtype("complex128")
+    finally:
+        numpy_backend.set_default_dtype(previous_dtype)
+
+
+def test_numpy_backend_set_default_dtype_rejects_nonfloating_dtype_without_mutation():
+    from pyrecest.backends import get_backend
+
+    numpy_backend = get_backend("numpy")
+    previous_dtype = numpy_backend.get_default_dtype()
+    previous_cdtype = numpy_backend.get_default_cdtype()
+
+    try:
+        with pytest.raises(ValueError, match="float32 or float64"):
+            numpy_backend.set_default_dtype(np.dtype("complex64"))
+
+        assert numpy_backend.get_default_dtype() == previous_dtype
+        assert numpy_backend.get_default_cdtype() == previous_cdtype
+    finally:
+        numpy_backend.set_default_dtype(previous_dtype)

--- a/tests/test_numpy_default_dtype_objects.py
+++ b/tests/test_numpy_default_dtype_objects.py
@@ -2,6 +2,16 @@ import numpy as np
 import pytest
 
 
+def _dtype_name(value):
+    name = getattr(value, "name", None) or getattr(value, "__name__", None)
+    if name is not None:
+        return str(name)
+    text = str(value)
+    if "." in text:
+        text = text.rsplit(".", maxsplit=1)[-1]
+    return text.strip("'>")
+
+
 def test_numpy_backend_set_default_dtype_accepts_dtype_like_values():
     from pyrecest.backends import get_backend
 
@@ -19,7 +29,7 @@ def test_numpy_backend_set_default_dtype_accepts_dtype_like_values():
         assert numpy_backend.get_default_dtype() == np.dtype("float64")
         assert numpy_backend.get_default_cdtype() == np.dtype("complex128")
     finally:
-        numpy_backend.set_default_dtype(previous_dtype)
+        numpy_backend.set_default_dtype(_dtype_name(previous_dtype))
 
 
 def test_numpy_backend_set_default_dtype_rejects_nonfloating_dtype_without_mutation():
@@ -36,4 +46,4 @@ def test_numpy_backend_set_default_dtype_rejects_nonfloating_dtype_without_mutat
         assert numpy_backend.get_default_dtype() == previous_dtype
         assert numpy_backend.get_default_cdtype() == previous_cdtype
     finally:
-        numpy_backend.set_default_dtype(previous_dtype)
+        numpy_backend.set_default_dtype(_dtype_name(previous_dtype))


### PR DESCRIPTION
## Summary
- Normalize resolved backend dtype objects before deriving the paired complex dtype in the shared default-dtype setter.
- Avoid mutating the global dtype state when a dtype resolves to a non-floating type such as `complex64`.
- Add NumPy backend regression tests for dtype-like inputs and invalid non-floating dtype values.

## Bug
The shared `_pre_set_default_dtype` helper used the raw user-supplied `value` as the key for `_MAP_FLOAT_TO_COMPLEX` after resolving `DEFAULT_DTYPE`. For dtype-like inputs accepted by the NumPy backend, such as `np.dtype("float32")` or `np.float64`, the key lookup could fail even though the dtype itself resolved correctly. Non-floating dtype inputs could also partially mutate `DEFAULT_DTYPE` before failing while setting `DEFAULT_COMPLEX_DTYPE`.

## Testing
- `python -m py_compile /mnt/data/_dtype_utils.py /mnt/data/test_numpy_default_dtype_objects.py`
- Minimal local harness for `_pre_set_default_dtype(np.dtype)` covering `np.dtype("float32")`, `np.float64`, and rejected `np.dtype("complex64")` without state mutation.

Full repository tests were not run locally because this environment cannot clone/install the repository from GitHub.