### PR TITLE
Avoid ambiguous MeasurementScore activity checks

### DIFF
--- a/src/pyrecest/filters/measurement_scoring.py
+++ b/src/pyrecest/filters/measurement_scoring.py
@@ -34,4 +34,4 @@ class MeasurementScore:
     def is_active(self) -> bool:
         """Return whether the score contains at least one active measurement."""
 
-        return bool(self.active_measurement_indices)
+        return len(self.active_measurement_indices) > 0

--- a/tests/filters/test_measurement_scoring.py
+++ b/tests/filters/test_measurement_scoring.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+from pyrecest.filters.measurement_scoring import MeasurementScore
+
+
+def _score(active_measurement_indices):
+    return MeasurementScore(
+        measurement_jacobian=None,
+        predicted_measurements=None,
+        innovation_covariance=None,
+        residual=None,
+        active_measurement_indices=active_measurement_indices,
+    )
+
+
+def test_measurement_score_is_active_handles_numpy_index_arrays():
+    assert _score(np.array([0, 2])).is_active
+    assert not _score(np.array([], dtype=int)).is_active


### PR DESCRIPTION
## Summary
- Replace truthiness-based `MeasurementScore.is_active` evaluation with an explicit length check.
- Add regression coverage for NumPy arrays of active measurement indices.

## Bug fixed
`bool(self.active_measurement_indices)` raises `ValueError` for NumPy arrays with more than one element. Using `len(...) > 0` preserves the list behavior while also supporting array-like index containers.

## Testing
- `python -m py_compile /mnt/data/measurement_scoring.py /mnt/data/test_measurement_scoring.py`
- Local sanity check that NumPy index arrays return the expected `is_active` values and that the previous truthiness path raises `ValueError`.