### PR TITLE
Validate active measurement diagnostic index bounds

### DIFF
--- a/src/pyrecest/filters/update_diagnostics.py
+++ b/src/pyrecest/filters/update_diagnostics.py
@@ -31,11 +31,15 @@ class MeasurementUpdateDiagnostics:
         indices = _normalize_active_measurement_indices(self.active_measurement_indices)
         object.__setattr__(self, "active_measurement_indices", indices)
         if self.measurement_count is not None:
-            object.__setattr__(
-                self,
+            measurement_count = _as_nonnegative_integer(
+                self.measurement_count,
                 "measurement_count",
-                _as_nonnegative_integer(self.measurement_count, "measurement_count"),
             )
+            if indices and max(indices) >= measurement_count:
+                raise ValueError(
+                    "active_measurement_indices must be smaller than measurement_count"
+                )
+            object.__setattr__(self, "measurement_count", measurement_count)
         metadata = {} if self.metadata is None else dict(self.metadata)
         object.__setattr__(self, "metadata", metadata)
 

--- a/tests/filters/test_update_diagnostics_validation.py
+++ b/tests/filters/test_update_diagnostics_validation.py
@@ -25,6 +25,14 @@ def test_active_measurement_indices_reject_non_sequence_values():
         MeasurementUpdateDiagnostics(active_measurement_indices=1)  # type: ignore[arg-type]
 
 
+def test_active_measurement_indices_must_fit_measurement_count():
+    with pytest.raises(
+        ValueError,
+        match="active_measurement_indices.*measurement_count",
+    ):
+        MeasurementUpdateDiagnostics(active_measurement_indices=(0, 2), measurement_count=2)
+
+
 def test_measurement_count_rejects_non_integer_values():
     invalid_counts = (
         True,


### PR DESCRIPTION
## Summary
- Validate that `active_measurement_indices` are within `measurement_count` when both are provided.
- Preserve normalized integer-like scalar handling for valid indices/counts.
- Add a regression test for out-of-range active measurement indices.

## Rationale
`MeasurementUpdateDiagnostics(active_measurement_indices=(0, 2), measurement_count=2)` previously constructed inconsistent diagnostics: index `2` is outside the valid range for two measurements. The constructor now rejects this state instead of allowing downstream diagnostics to report impossible active-measurement selections.

## Tests
- Added `test_active_measurement_indices_must_fit_measurement_count` in `tests/filters/test_update_diagnostics_validation.py`.
- Not run locally; changes were made through the GitHub connector without a local checkout.