### PR TITLE
Accept dtype-like default dtype values

### DIFF
--- a/src/pyrecest/_backend/_dtype_utils.py
+++ b/src/pyrecest/_backend/_dtype_utils.py
@@ -26,6 +26,24 @@ _MAP_FLOAT_TO_COMPLEX = {
 }
 
 
+def _dtype_lookup_key(value):
+    """Return a backend-agnostic dtype name for shared dtype maps."""
+    name = getattr(value, "name", None)
+    if isinstance(name, str):
+        return name
+
+    name = getattr(value, "__name__", None)
+    if isinstance(name, str):
+        return name
+
+    text = str(value)
+    if text.startswith("torch."):
+        return text.split(".")[-1]
+    if text.endswith("'>") and "." in text:
+        return text.rsplit(".", maxsplit=1)[-1].removesuffix("'>")
+    return text
+
+
 def _copy_func(func):
     """Copy function."""
     new_func = types.FunctionType(
@@ -162,8 +180,17 @@ def _pre_set_default_dtype(as_dtype):
         value : str
             Possible values are "float32" as "float64".
         """
-        _config.DEFAULT_DTYPE = as_dtype(value)
-        _config.DEFAULT_COMPLEX_DTYPE = as_dtype(_MAP_FLOAT_TO_COMPLEX[value])
+        dtype = as_dtype(value)
+        dtype_key = _dtype_lookup_key(dtype)
+        try:
+            complex_dtype_name = _MAP_FLOAT_TO_COMPLEX[dtype_key]
+        except KeyError as exc:
+            raise ValueError(
+                "Default dtype must resolve to float32 or float64."
+            ) from exc
+
+        _config.DEFAULT_DTYPE = dtype
+        _config.DEFAULT_COMPLEX_DTYPE = as_dtype(complex_dtype_name)
 
         _update_default_dtypes()
 

--- a/src/pyrecest/_backend/jax/_dtype.py
+++ b/src/pyrecest/_backend/jax/_dtype.py
@@ -10,21 +10,28 @@ MAP_DTYPE = {
 }
 
 
+def _dtype_key(value):
+    try:
+        return str(_jnp.dtype(value))
+    except (TypeError, ValueError):
+        return str(value).rsplit(".", maxsplit=1)[-1].removesuffix("'>")
+
+
 def as_dtype(value):
     """
-    Transform string representing dtype into JAX dtype.
+    Transform string or dtype-like value into JAX dtype.
 
     Parameters
     ----------
-    value : str
-        String representing the dtype to be converted.
+    value : str or dtype-like
+        String or object representing the dtype to be converted.
 
     Returns
     -------
     dtype : jnp.dtype
-        JAX dtype object corresponding to the input string.
+        JAX dtype object corresponding to the input value.
     """
-    return MAP_DTYPE[value]
+    return MAP_DTYPE[_dtype_key(value)]
 
 
 set_default_dtype = _pre_set_default_dtype(as_dtype)

--- a/tests/test_backend_default_dtype_like_values.py
+++ b/tests/test_backend_default_dtype_like_values.py
@@ -1,0 +1,33 @@
+import numpy as np
+import pytest
+
+from pyrecest._backend import numpy as numpy_backend
+
+
+def test_numpy_set_default_dtype_accepts_dtype_like_values():
+    try:
+        returned_dtype = numpy_backend.set_default_dtype(np.dtype("float32"))
+
+        assert returned_dtype == np.dtype("float32")
+        assert numpy_backend.get_default_dtype() == np.dtype("float32")
+        assert numpy_backend.get_default_cdtype() == np.dtype("complex64")
+
+        returned_dtype = numpy_backend.set_default_dtype(np.float64)
+
+        assert returned_dtype == np.dtype("float64")
+        assert numpy_backend.get_default_dtype() == np.dtype("float64")
+        assert numpy_backend.get_default_cdtype() == np.dtype("complex128")
+    finally:
+        numpy_backend.set_default_dtype("float64")
+
+
+def test_numpy_set_default_dtype_rejects_non_float_without_state_mutation():
+    numpy_backend.set_default_dtype("float64")
+    previous_dtype = numpy_backend.get_default_dtype()
+    previous_cdtype = numpy_backend.get_default_cdtype()
+
+    with pytest.raises(ValueError, match="float32 or float64"):
+        numpy_backend.set_default_dtype(np.dtype("complex64"))
+
+    assert numpy_backend.get_default_dtype() == previous_dtype
+    assert numpy_backend.get_default_cdtype() == previous_cdtype

--- a/tests/test_jax_backend_dtype.py
+++ b/tests/test_jax_backend_dtype.py
@@ -24,3 +24,22 @@ def test_jax_set_default_dtype_invokes_shared_dtype_setter():
         assert get_default_cdtype() == jnp.complex64
     finally:
         jax_dtype.set_default_dtype(previous_name)
+
+
+def test_jax_set_default_dtype_accepts_dtype_like_values():
+    previous_name = _current_float_dtype_name()
+
+    try:
+        returned_dtype = jax_dtype.set_default_dtype(jnp.dtype("float32"))
+
+        assert returned_dtype == jnp.float32
+        assert get_default_dtype() == jnp.float32
+        assert get_default_cdtype() == jnp.complex64
+
+        returned_dtype = jax_dtype.set_default_dtype(jnp.float32)
+
+        assert returned_dtype == jnp.float32
+        assert get_default_dtype() == jnp.float32
+        assert get_default_cdtype() == jnp.complex64
+    finally:
+        jax_dtype.set_default_dtype(previous_name)


### PR DESCRIPTION
## Summary
- Normalize the dtype returned by each backend before looking up the matching complex default dtype.
- Allow the JAX backend dtype converter to accept dtype-like values such as `jnp.dtype("float32")` and `jnp.float32`, in addition to string names.
- Add regression coverage for NumPy and JAX dtype-like default-dtype inputs, and for rejecting non-floating dtype inputs without mutating default dtype state.

## Bug
The shared `set_default_dtype` helper converted the requested dtype with `as_dtype(value)`, but then used the original, unnormalized `value` to index `_MAP_FLOAT_TO_COMPLEX`. Dtype-like inputs that normalize cleanly, such as `np.dtype("float32")`, could therefore fail the complex-dtype lookup. Non-floating dtype-like inputs could also partially mutate `DEFAULT_DTYPE` before failing while deriving the paired complex dtype.

## Validation
- Added `tests/test_backend_default_dtype_like_values.py`.
- Extended `tests/test_jax_backend_dtype.py`.
- GitHub Actions should run the focused regression coverage and existing suite on the PR head.