### PR TITLE
Fix NumPy zeros dtype when active backend is non-NumPy

### DIFF
--- a/src/pyrecest/_backend/numpy/_common.py
+++ b/src/pyrecest/_backend/numpy/_common.py
@@ -2,8 +2,8 @@ import numpy as _np
 from pyrecest._backend._dtype_utils import (
     _dyn_update_dtype,
     _modify_func_default_dtype,
-    get_default_cdtype,
-    get_default_dtype,
+    get_default_cdtype as _shared_get_default_cdtype,
+    get_default_dtype as _shared_get_default_dtype,
 )
 
 from .._shared_numpy._common import (
@@ -30,6 +30,28 @@ from .._shared_numpy._common import (
     to_ndarray,
 )
 
+
+def _normalize_numpy_dtype(dtype, default):
+    if dtype is None:
+        dtype = default
+    try:
+        return _np.dtype(dtype)
+    except (TypeError, ValueError):
+        return _np.dtype(str(dtype).split(".")[-1])
+
+
+def get_default_dtype():
+    return _normalize_numpy_dtype(_shared_get_default_dtype(), _np.float64)
+
+
+def get_default_cdtype():
+    return _normalize_numpy_dtype(_shared_get_default_cdtype(), _np.complex128)
+
+
 array = _cast_out_from_dtype(target=_np.array, dtype_pos=1)
 eye = _modify_func_default_dtype(target=_np.eye)
-zeros = _dyn_update_dtype(target=_np.zeros, dtype_pos=1)
+
+
+def zeros(shape, dtype=None, *args, **kwargs):
+    dtype = _normalize_numpy_dtype(dtype, get_default_dtype())
+    return _np.zeros(shape, dtype, *args, **kwargs)

--- a/tests/test_numpy_backend_zeros_dtype.py
+++ b/tests/test_numpy_backend_zeros_dtype.py
@@ -1,0 +1,47 @@
+import importlib.util
+
+import numpy as np
+import pytest
+
+from pyrecest._backend import numpy as numpy_backend
+from tests.support.backend_runner import run_backend_code
+
+
+def test_numpy_zeros_preserves_explicit_positional_dtype():
+    result = numpy_backend.zeros((2,), np.float32)
+
+    assert result.dtype == np.dtype(np.float32)
+
+
+def test_numpy_zeros_uses_default_dtype_when_dtype_is_omitted():
+    result = numpy_backend.zeros((2,))
+
+    assert result.dtype == np.dtype(numpy_backend.get_default_dtype())
+
+
+@pytest.mark.backend_portable
+def test_numpy_zeros_uses_numpy_dtype_after_pytorch_backend_initialization():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import numpy as np
+import pyrecest.backend as backend
+from pyrecest._backend import numpy as numpy_backend
+
+result = numpy_backend.zeros((2,))
+assert result.dtype == np.dtype("float64"), (
+    backend.__backend_name__,
+    backend.get_default_dtype(),
+    numpy_backend.get_default_dtype(),
+    result.dtype,
+)
+assert numpy_backend.get_default_dtype() == np.dtype("float64")
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- Normalize explicit NumPy backend default dtypes back to NumPy dtypes when shared dtype state was initialized by another backend.
- Implement `numpy.zeros` through a small wrapper so omitted and explicit positional dtypes are normalized before calling NumPy.
- Add regressions for explicit positional dtype, omitted dtype, and importing the explicit NumPy backend after PyTorch backend initialization.

## Bug
The explicit `pyrecest._backend.numpy` module reused shared default dtype state directly. When `pyrecest.backend` was initialized as PyTorch, that shared state contained a `torch.dtype`. Passing that value through the NumPy backend's `zeros` wrapper as `dtype` can make NumPy reject the dtype or return inconsistent backend-specific dtype metadata. The fix keeps explicit NumPy backend defaults as NumPy dtypes even after another backend initialized the global dtype state.

## Validation
- Inspected the branch diff with GitHub compare: only `src/pyrecest/_backend/numpy/_common.py` and `tests/test_numpy_backend_zeros_dtype.py` changed.
- Full local pytest was not run because this environment cannot clone/install the repository from GitHub; CI should run the new focused regression tests on the PR.