### PR TITLE
Validate diagnostic active measurement index bounds

### DIFF
--- a/src/pyrecest/filters/update_diagnostics.py
+++ b/src/pyrecest/filters/update_diagnostics.py
@@ -31,11 +31,15 @@ class MeasurementUpdateDiagnostics:
         indices = _normalize_active_measurement_indices(self.active_measurement_indices)
         object.__setattr__(self, "active_measurement_indices", indices)
         if self.measurement_count is not None:
-            object.__setattr__(
-                self,
+            measurement_count = _as_nonnegative_integer(
+                self.measurement_count,
                 "measurement_count",
-                _as_nonnegative_integer(self.measurement_count, "measurement_count"),
             )
+            if indices and max(indices) >= measurement_count:
+                raise ValueError(
+                    "active_measurement_indices must be smaller than measurement_count"
+                )
+            object.__setattr__(self, "measurement_count", measurement_count)
         metadata = {} if self.metadata is None else dict(self.metadata)
         object.__setattr__(self, "metadata", metadata)
 

--- a/tests/filters/test_update_diagnostics_validation.py
+++ b/tests/filters/test_update_diagnostics_validation.py
@@ -25,6 +25,14 @@ def test_active_measurement_indices_reject_non_sequence_values():
         MeasurementUpdateDiagnostics(active_measurement_indices=1)  # type: ignore[arg-type]
 
 
+def test_active_measurement_indices_must_fit_measurement_count():
+    with pytest.raises(
+        ValueError,
+        match="active_measurement_indices.*measurement_count",
+    ):
+        MeasurementUpdateDiagnostics(active_measurement_indices=(0, 2), measurement_count=2)
+
+
 def test_measurement_count_rejects_non_integer_values():
     invalid_counts = (
         True,


### PR DESCRIPTION
## Summary
- Validate that `active_measurement_indices` cannot refer past `measurement_count` when both are provided.
- Preserve existing normalization for integer-like scalar indices and counts.
- Add a regression test for an out-of-range active measurement index.

## Bug
`MeasurementUpdateDiagnostics(active_measurement_indices=(0, 2), measurement_count=2)` previously constructed an inconsistent diagnostic object even though valid measurement indices for a count of 2 are only `0` and `1`. The fix rejects that impossible state during construction.

## Validation
- Added `test_active_measurement_indices_must_fit_measurement_count` in `tests/filters/test_update_diagnostics_validation.py`.
- Changes were made through the GitHub connector; CI should run the focused regression test and existing suite on the PR.