### PR TITLE
Fix BackendNotSupportedError supported_backends string handling

### DIFF
--- a/src/pyrecest/exceptions.py
+++ b/src/pyrecest/exceptions.py
@@ -11,6 +11,16 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 
+def _normalize_supported_backends(
+    supported_backends: Iterable[str] | str | None,
+) -> tuple[str, ...]:
+    if supported_backends is None:
+        return ()
+    if isinstance(supported_backends, str):
+        return (supported_backends,)
+    return tuple(supported_backends)
+
+
 class PyRecEstError(Exception):
     """Base class for PyRecEst-specific exceptions."""
 
@@ -27,12 +37,12 @@ class BackendNotSupportedError(BackendSupportError, NotImplementedError):
         api: str,
         backend: str | None = None,
         *,
-        supported_backends: Iterable[str] | None = None,
+        supported_backends: Iterable[str] | str | None = None,
         reason: str | None = None,
     ) -> None:
         self.api = api
         self.backend = backend
-        self.supported_backends = tuple(supported_backends or ())
+        self.supported_backends = _normalize_supported_backends(supported_backends)
         self.reason = reason
 
         if backend is None:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -23,6 +23,18 @@ def test_backend_not_supported_error_is_not_implemented_error():
     assert "numpy, pytorch" in str(error)
 
 
+def test_backend_not_supported_error_accepts_single_string_supported_backend():
+    error = BackendNotSupportedError(
+        "ExampleAPI.update",
+        "jax",
+        supported_backends="numpy",
+    )
+
+    assert error.supported_backends == ("numpy",)
+    assert "supported backends: numpy" in str(error)
+    assert "n, u, m, p, y" not in str(error)
+
+
 def test_backend_not_supported_error_keeps_backendless_context():
     error = BackendNotSupportedError(
         "ExampleAPI.batch_update",


### PR DESCRIPTION
## Summary
- Handle `supported_backends="numpy"` as one backend name, not as individual characters.
- Add a focused regression test in `tests/test_exceptions.py`.

## Validation
- Inspected the branch compare: only `src/pyrecest/exceptions.py` and `tests/test_exceptions.py` changed.
- Local pytest was not run in this session.