### PR TITLE
Reject text dimensions in identity Gaussian models

### DIFF
--- a/src/pyrecest/models/linear_gaussian.py
+++ b/src/pyrecest/models/linear_gaussian.py
@@ -15,6 +15,8 @@ from pyrecest.backend import (
 )
 from pyrecest.distributions import GaussianDistribution
 
+_INVALID_DIMENSION_SCALAR_TYPES = (bool, str, bytes, bytearray)
+
 
 def _as_matrix(value, name):
     arr = asarray(value)
@@ -38,16 +40,19 @@ def _shape(value):
 
 def _as_positive_integer(value, name):
     message = f"{name} must be a positive integer"
-    if isinstance(value, bool):
+    if isinstance(value, _INVALID_DIMENSION_SCALAR_TYPES):
         raise ValueError(message)
-    arr = asarray(value)
+    try:
+        arr = asarray(value)
+    except (TypeError, ValueError, OverflowError, RuntimeError) as exc:
+        raise ValueError(message) from exc
     if ndim(arr) != 0:
         raise ValueError(message)
     try:
         scalar = arr.item()
     except AttributeError:
         scalar = arr
-    if isinstance(scalar, bool):
+    if isinstance(scalar, _INVALID_DIMENSION_SCALAR_TYPES):
         raise ValueError(message)
     if isinstance(scalar, Integral):
         parsed = int(scalar)

--- a/tests/models/test_linear_gaussian_models.py
+++ b/tests/models/test_linear_gaussian_models.py
@@ -70,7 +70,7 @@ class LinearGaussianModelsTest(unittest.TestCase):
         )
 
     def test_identity_models_reject_invalid_dimensions(self):
-        invalid_dims = (True, False, 0, -1, 1.5, float("inf"))
+        invalid_dims = (True, False, 0, -1, 1.5, float("inf"), "2", b"2", bytearray(b"2"))
 
         for dim in invalid_dims:
             with self.subTest(model="transition", dim=dim):


### PR DESCRIPTION
## Summary
- Reject text-like scalar dimensions before creating identity Gaussian transition/measurement models
- Normalize backend conversion failures in the dimension parser to the existing `ValueError` contract
- Add regression coverage for numeric-looking text and bytes dimensions

## Tests
- Not run locally: the sandbox cannot resolve `github.com`, so I could not install the repository dependencies from source. The new regression is limited to `tests/models/test_linear_gaussian_models.py`.