### PR TITLE
Validate malformed Pareto constraint specs

### DIFF
--- a/src/pyrecest/evaluation/pareto.py
+++ b/src/pyrecest/evaluation/pareto.py
@@ -394,10 +394,16 @@ def _is_missing(value: Any) -> bool:
 
 
 def _parse_constraint_spec(spec: ConstraintSpec | Mapping[str, Any]) -> ConstraintSpec:
+    message = (
+        "Constraint specs must be ('op', value) pairs or mappings with "
+        "'op' and 'value' keys."
+    )
     if isinstance(spec, Mapping):
         op = spec.get("op")
         threshold = spec.get("value")
     else:
+        if _is_text_scalar(spec) or not isinstance(spec, Sequence):
+            raise ValueError(message)
         if len(spec) != 2:
             raise ValueError("Constraint tuple specs must have length 2.")
         op, threshold = spec

--- a/tests/evaluation/test_pareto_constraint_spec_validation.py
+++ b/tests/evaluation/test_pareto_constraint_spec_validation.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from pyrecest.evaluation import constraint_mask
+
+
+def test_constraint_mask_rejects_malformed_constraint_specs() -> None:
+    table = pd.DataFrame([{"name": "a", "score": 1.0}])
+    invalid_specs = (
+        1,
+        object(),
+        "<=",
+        np.array(["<=", 1.0, 2.0], dtype=object),
+    )
+
+    for spec in invalid_specs:
+        with pytest.raises(ValueError, match="Constraint"):
+            constraint_mask(table, {"score": spec})  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- Make Pareto constraint spec parsing reject malformed scalar/object/text specs with a stable `ValueError` instead of leaking a raw `TypeError` from `len(spec)`.
- Keep the existing tuple and mapping forms unchanged.
- Add a dedicated regression test for malformed specs passed to `constraint_mask`.

## Bug
`constraint_mask(table, {"score": 1})` previously reached `len(spec)` in `_parse_constraint_spec`, which raises `TypeError` for scalar specs. Public validation helpers should report invalid user inputs through deterministic `ValueError`s.

## Validation
- Ran an isolated local syntax/regression check against the modified Pareto helper module because the sandbox cannot resolve `github.com` to clone/install the full repository.
- Full repository test suite not run locally.