### PR TITLE
Fix shared NumPy mixed dtype promotion

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/_common.py
+++ b/src/pyrecest/_backend/_shared_numpy/_common.py
@@ -84,7 +84,7 @@ _allow_complex_dtype = _pre_allow_complex_dtype(cast, _COMPLEX_DTYPES)
 
 
 def is_array(x):
-    return type(x) is _np.ndarray
+    return x.__class__ is _np.ndarray
 
 
 def to_ndarray(x, to_ndim, axis=0, dtype=None):
@@ -107,22 +107,14 @@ def _get_wider_dtype(tensor_list):
     if all(dtype == dtypes[0] for dtype in dtypes[1:]):
         return dtypes[0], True
 
-    dtype_ranks = [_DTYPES.get(dtype) for dtype in dtypes]
-    if any(rank is None for rank in dtype_ranks):
-        try:
-            return _np.result_type(*dtypes), False
-        except AttributeError as exc:
-            raise TypeError(
-                "Cannot determine a common dtype for unsupported dtype(s): "
-                f"{', '.join(str(dtype) for dtype in dtypes)}"
-            ) from exc
-
-    wider_dtype_rank = max(dtype_ranks)
-    wider_dtype = next(
-        dtype for dtype, rank in _DTYPES.items() if rank == wider_dtype_rank
-    )
-
-    return wider_dtype, False
+    try:
+        common_dtype = _np.result_type(*dtypes)
+    except (AttributeError, TypeError) as exc:
+        raise TypeError(
+            "Cannot determine a common dtype for unsupported dtype(s): "
+            f"{', '.join(str(dtype) for dtype in dtypes)}"
+        ) from exc
+    return common_dtype, False
 
 
 def convert_to_wider_dtype(tensor_list):
@@ -130,7 +122,8 @@ def convert_to_wider_dtype(tensor_list):
     if same:
         return tensor_list
 
-    return [cast(x, dtype=wider_dtype) for x in tensor_list]
+    converted = [cast(x, dtype=wider_dtype) for x in tensor_list]
+    return converted
 
 
 def _is_boolean(x):

--- a/tests/test_backend_sum_contract.py
+++ b/tests/test_backend_sum_contract.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import sys
 
+import numpy as np
 import pyrecest.backend as backend
 import pytest
 
@@ -16,6 +17,23 @@ def _to_python(value):
     if hasattr(value, "tolist"):
         return value.tolist()
     return value
+
+
+def test_convert_to_wider_dtype_matches_numpy_result_type_for_mixed_dtypes():
+    if backend.__backend_name__ not in {"autograd", "numpy"}:
+        pytest.skip("shared NumPy dtype promotion regression test")
+
+    first, second = backend.convert_to_wider_dtype(
+        [backend.array([1], dtype=np.int64), backend.array([1.5], dtype=np.float32)]
+    )
+
+    expected_dtype = np.result_type(np.dtype("int64"), np.dtype("float32"))
+    assert backend.to_numpy(first).dtype == expected_dtype
+    assert backend.to_numpy(second).dtype == expected_dtype
+    np.testing.assert_allclose(backend.to_numpy(first), np.array([1], dtype=expected_dtype))
+    np.testing.assert_allclose(
+        backend.to_numpy(second), np.array([1.5], dtype=expected_dtype)
+    )
 
 
 def test_sum_axis_none_keepdims_matches_numpy_contract():


### PR DESCRIPTION
## Summary
- Replace the hand-written shared NumPy dtype rank promotion path with NumPy's `result_type` for mixed dtypes.
- Add a regression covering `int64` plus `float32`, which should promote to NumPy's common dtype rather than truncating to `float32`.

## Bug
`convert_to_wider_dtype` previously ranked dtype families manually. For mixed integer/float inputs such as `int64` and `float32`, that ranking selected `float32`, while NumPy's safe common dtype is `float64`. This could silently lose integer precision when shared NumPy backends normalize arrays before downstream operations.

## Validation
- Added `test_convert_to_wider_dtype_matches_numpy_result_type_for_mixed_dtypes`.
- Local test execution was not run because the sandbox cannot resolve GitHub to clone/install the repository dependencies; CI should exercise the new regression.