### PR TITLE
Validate EOT shapely scalar inputs

### DIFF
--- a/src/pyrecest/evaluation/generate_measurements.py
+++ b/src/pyrecest/evaluation/generate_measurements.py
@@ -17,15 +17,21 @@ from shapely.affinity import rotate, translate
 from shapely.geometry import Polygon
 
 
-def _as_shapely_scalar(value):
-    if np.isscalar(value):
-        return float(value)
-    if hasattr(value, "item"):
-        try:
-            return float(value.item())
-        except (TypeError, ValueError):
-            pass
-    return float(np.asarray(value).reshape(-1)[0])
+def _as_shapely_scalar(value, name="groundtruth component"):
+    value_array = np.asarray(value)
+    if value_array.dtype == np.bool_ or value_array.size != 1:
+        raise ValueError(f"{name} must be a finite scalar.")
+
+    scalar = value_array.reshape(-1)[0]
+    if isinstance(scalar, (bool, np.bool_, str, bytes, bytearray, np.str_, np.bytes_)):
+        raise ValueError(f"{name} must be a finite scalar.")
+    try:
+        result = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be a finite scalar.") from exc
+    if not np.isfinite(result):
+        raise ValueError(f"{name} must be a finite scalar.")
+    return result
 
 
 def _as_nonnegative_measurement_count(value, name="measurement count") -> int:
@@ -136,13 +142,13 @@ def generate_measurements(groundtruth, simulation_config):
         for t in range(simulation_config["n_timesteps"]):
             curr_groundtruth = groundtruth[t]
             if curr_groundtruth.shape[-1] == 2:
-                x = _as_shapely_scalar(curr_groundtruth[..., 0])
-                y = _as_shapely_scalar(curr_groundtruth[..., 1])
+                x = _as_shapely_scalar(curr_groundtruth[..., 0], "groundtruth x")
+                y = _as_shapely_scalar(curr_groundtruth[..., 1], "groundtruth y")
                 curr_shape = translate(shape, xoff=x, yoff=y)
             elif curr_groundtruth.shape[-1] == 3:
-                angle = _as_shapely_scalar(curr_groundtruth[..., 0])
-                x = _as_shapely_scalar(curr_groundtruth[..., 1])
-                y = _as_shapely_scalar(curr_groundtruth[..., 2])
+                angle = _as_shapely_scalar(curr_groundtruth[..., 0], "groundtruth angle")
+                x = _as_shapely_scalar(curr_groundtruth[..., 1], "groundtruth x")
+                y = _as_shapely_scalar(curr_groundtruth[..., 2], "groundtruth y")
                 curr_shape = rotate(
                     translate(shape, xoff=x, yoff=y),
                     angle=angle,
@@ -155,7 +161,7 @@ def generate_measurements(groundtruth, simulation_config):
                 )
             if not isinstance(curr_shape, PolygonWithSampling):
                 curr_shape.__class__ = (
-                    PolygonWithSampling  # Evil class surgery to add sampling methods
+                    PolygonWithSampling  # Preserve existing subclass swap to add sampling methods
                 )
 
             if "n_meas_at_individual_time_step" in simulation_config:

--- a/tests/evaluation/test_generate_measurements_validation.py
+++ b/tests/evaluation/test_generate_measurements_validation.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 from pyrecest.evaluation.generate_measurements import (
     _as_nonnegative_measurement_count,
+    _as_shapely_scalar,
     generate_n_measurements_PPP,
 )
 
@@ -36,6 +37,25 @@ def test_generate_n_measurements_ppp_rejects_invalid_rate_inputs(
 def test_measurement_count_rejects_text_like_integer_scalars(measurement_count):
     with pytest.raises(ValueError, match="measurement count"):
         _as_nonnegative_measurement_count(measurement_count)
+
+
+def test_shapely_scalar_accepts_single_value_arrays():
+    assert _as_shapely_scalar(np.array([1.25]), "groundtruth x") == pytest.approx(1.25)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        np.array([1.0, 2.0]),
+        np.array([[1.0], [2.0]]),
+        True,
+        "1.0",
+        np.inf,
+    ],
+)
+def test_shapely_scalar_rejects_ambiguous_or_invalid_values(value):
+    with pytest.raises(ValueError, match="groundtruth x must be a finite scalar"):
+        _as_shapely_scalar(value, "groundtruth x")
 
 
 def test_generate_n_measurements_ppp_returns_python_int_for_zero_rate():


### PR DESCRIPTION
## Summary
- Make EOT shape-transform scalar conversion reject ambiguous multi-value arrays instead of silently taking the first element.
- Reject boolean, text-like, and non-finite scalar values before passing offsets/angles to Shapely.
- Preserve singleton-array support for existing single-target/singleton-axis inputs.
- Add regression coverage in the existing measurement-generation validation tests.

## Bug
`_as_shapely_scalar` previously fell back to `np.asarray(value).reshape(-1)[0]`, so malformed EOT ground-truth components with more than one value were silently truncated to the first entry. That can translate/rotate the target shape with the wrong coordinate instead of reporting invalid ground truth.

## Validation
- Inspected the branch diff: only `src/pyrecest/evaluation/generate_measurements.py` and `tests/evaluation/test_generate_measurements_validation.py` changed.
- Local pytest was not run because container execution failed in this environment.