### PR TITLE
Validate evidence computation mode type

### DIFF
--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -61,7 +61,7 @@ class EvidenceComputationMode:
     metadata: dict[str, Any] | None = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        if self.mode not in {"full_smoothing", "evidence_only"}:
+        if not isinstance(self.mode, str) or self.mode not in {"full_smoothing", "evidence_only"}:
             raise ValueError(f"unknown evidence computation mode {self.mode!r}")
         return_smoothed = _coerce_bool_flag(self.return_smoothed, "return_smoothed")
         terminal_posterior = _coerce_bool_flag(

--- a/tests/test_evidence_only_mode.py
+++ b/tests/test_evidence_only_mode.py
@@ -48,6 +48,18 @@ def test_evidence_computation_mode_rejects_inconsistent_flags():
         resolve_evidence_computation_mode("posterior-only")
 
 
+def test_evidence_computation_mode_rejects_non_scalar_mode_values():
+    invalid_modes = (
+        ["evidence_only"],
+        {"mode": "evidence_only"},
+        np.array(["evidence_only"], dtype=object),
+    )
+
+    for mode in invalid_modes:
+        with pytest.raises(ValueError, match="unknown evidence computation mode"):
+            EvidenceComputationMode(mode=mode)
+
+
 def test_evidence_computation_mode_rejects_truthy_non_bool_return_smoothed():
     for return_smoothed in (
         "false",


### PR DESCRIPTION
## Summary
- Reject non-string `EvidenceComputationMode.mode` values before membership validation.
- Preserve the existing `ValueError` contract for malformed mode values instead of leaking a raw `TypeError` for unhashable inputs.
- Add a regression covering list, mapping, and object-array mode inputs.

## Bug
`EvidenceComputationMode(mode=["evidence_only"])` previously evaluated list membership in a set and raised `TypeError: unhashable type: 'list'`. Public validation should report invalid mode requests as deterministic `ValueError`s.

## Validation
- Ran a minimal local Python harness for the old/new mode-validation path.
- Full repository pytest was not run locally in this environment.