### PR TITLE
Validate hyperrectangular integration boundaries

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/abstract_hyperrectangular_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/abstract_hyperrectangular_distribution.py
@@ -8,6 +8,21 @@ from ..abstract_bounded_nonperiodic_distribution import (
 )
 
 
+def _require_finite_bounds(bounds, name: str) -> None:
+    try:
+        finite = bool(backend_all(isfinite(bounds)))
+    except TypeError as exc:
+        raise ValueError(f"{name} must contain only finite values") from exc
+    if not finite:
+        raise ValueError(f"{name} must contain only finite values")
+
+
+def _require_increasing_bounds(bounds, name: str) -> None:
+    widths = diff(bounds, axis=1)
+    if not bool(backend_all(widths > 0.0)):
+        raise ValueError(f"{name} must be strictly increasing in every dimension")
+
+
 class AbstractHyperrectangularDistribution(AbstractBoundedNonPeriodicDistribution):
     def __init__(self, bounds):
         bounds = array(bounds)
@@ -17,11 +32,8 @@ class AbstractHyperrectangularDistribution(AbstractBoundedNonPeriodicDistributio
             bounds = reshape(bounds, (1, 2))
         if bounds.ndim != 2 or bounds.shape[1] != 2:
             raise ValueError("bounds must have shape (dim, 2)")
-        if not bool(backend_all(isfinite(bounds))):
-            raise ValueError("bounds must contain only finite values")
-        widths = diff(bounds, axis=1)
-        if not bool(backend_all(widths > 0.0)):
-            raise ValueError("bounds must be strictly increasing in every dimension")
+        _require_finite_bounds(bounds, "bounds")
+        _require_increasing_bounds(bounds, "bounds")
         AbstractBoundedNonPeriodicDistribution.__init__(self, int(bounds.shape[0]))
         self.bounds = bounds
 
@@ -49,9 +61,16 @@ class AbstractHyperrectangularDistribution(AbstractBoundedNonPeriodicDistributio
         if integration_boundaries is None:
             integration_boundaries = self.bounds
 
-        integration_boundaries = reshape(array(integration_boundaries), (-1, 2))
+        try:
+            integration_boundaries = reshape(array(integration_boundaries), (-1, 2))
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"integration_boundaries must have shape ({self.dim}, 2)"
+            ) from exc
         if integration_boundaries.shape[0] != self.dim:
             raise ValueError(f"integration_boundaries must have shape ({self.dim}, 2)")
+        _require_finite_bounds(integration_boundaries, "integration_boundaries")
+        _require_increasing_bounds(integration_boundaries, "integration_boundaries")
         left = integration_boundaries[:, 0]
         right = integration_boundaries[:, 1]
         ranges = [

--- a/tests/distributions/test_hyperrectangular_integration_validation.py
+++ b/tests/distributions/test_hyperrectangular_integration_validation.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pyrecest.distributions.nonperiodic.hyperrectangular_uniform_distribution import (
+    HyperrectangularUniformDistribution,
+)
+
+
+def _unit_square_distribution() -> HyperrectangularUniformDistribution:
+    return HyperrectangularUniformDistribution([[0.0, 1.0], [0.0, 1.0]])
+
+
+def test_integrate_rejects_nonfinite_integration_boundaries() -> None:
+    distribution = _unit_square_distribution()
+
+    with pytest.raises(ValueError, match="finite"):
+        distribution.integrate([[0.0, np.inf], [0.0, 1.0]])
+
+
+def test_integrate_rejects_reversed_integration_boundaries() -> None:
+    distribution = _unit_square_distribution()
+
+    with pytest.raises(ValueError, match="strictly increasing"):
+        distribution.integrate([[1.0, 0.0], [0.0, 1.0]])
+
+
+def test_integrate_preserves_flat_boundary_input_contract() -> None:
+    distribution = _unit_square_distribution()
+
+    assert distribution.integrate([0.0, 0.5, 0.0, 0.5]) == pytest.approx(0.25)


### PR DESCRIPTION
## Summary
- Validate `integration_boundaries` in `AbstractHyperrectangularDistribution.integrate` before forwarding them to SciPy integration.
- Reuse the constructor-style finite and strictly increasing checks for both stored bounds and ad-hoc integration bounds.
- Add regression coverage for non-finite, reversed, and flat-form integration boundaries.

## Bug
`integrate()` previously reshaped user-supplied boundaries and only checked the number of rows. Reversed ranges such as `[[1.0, 0.0], [0.0, 1.0]]` could be passed to `scipy.integrate.nquad`, producing an invalid signed result instead of a clear validation error; non-finite bounds were also not rejected at the PyRecEst API boundary.

## Validation
- Syntax-checked the modified module and new regression test content locally.
- Full repository pytest was not run locally because this environment cannot resolve `github.com` to clone/install the repository dependencies.