### PR TITLE
Preserve 1D particle matrix shape during prediction

### DIFF
--- a/src/pyrecest/filters/abstract_particle_filter.py
+++ b/src/pyrecest/filters/abstract_particle_filter.py
@@ -46,6 +46,13 @@ def _call_vectorized_sample_next(sample_next, particles, n_particles):
     return sample_next(particles)
 
 
+def _stack_particle_updates(updates, reference_particles):
+    """Stack scalar/one-dimensional particle updates without transposing matrices."""
+    if ndim(reference_particles) == 1:
+        return hstack(updates)
+    return vstack(updates)
+
+
 class AbstractParticleFilter(AbstractFilter):
     def __init__(
         self,
@@ -151,10 +158,9 @@ class AbstractParticleFilter(AbstractFilter):
             updated_particles = [
                 sample_next(particle) for particle in self.filter_state.d
             ]
-            if self.filter_state.dim == 1:
-                updated_particles = hstack(updated_particles)
-            else:
-                updated_particles = vstack(updated_particles)
+            updated_particles = _stack_particle_updates(
+                updated_particles, self.filter_state.d
+            )
 
         if updated_particles.shape != self.filter_state.d.shape:
             raise ValueError(
@@ -201,10 +207,9 @@ class AbstractParticleFilter(AbstractFilter):
                         noise_curr = shifted_noise
                     updated_particles.append(noise_curr.sample(1))
 
-            if self.filter_state.dim == 1:
-                updated_particles = hstack(updated_particles)
-            else:
-                updated_particles = vstack(updated_particles)
+            updated_particles = _stack_particle_updates(
+                updated_particles, self.filter_state.d
+            )
 
         self._filter_state.d = updated_particles
 

--- a/tests/filters/test_euclidean_particle_filter.py
+++ b/tests/filters/test_euclidean_particle_filter.py
@@ -61,6 +61,17 @@ class EuclideanParticleFilterTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "dimension"):
             self.pf.predict_nonlinear(lambda xs: xs, mismatched_noise)
 
+    def test_predict_identity_preserves_one_dimensional_particle_matrix_shape(self):
+        pf = EuclideanParticleFilter(n_particles=3, dim=1)
+        particles = array([[0.0], [1.0], [2.0]])
+        noise = LinearDiracDistribution(array([[0.5]]))
+        pf.filter_state = LinearDiracDistribution(particles)
+
+        pf.predict_identity(noise)
+
+        self.assertEqual(pf.filter_state.d.shape, particles.shape)
+        npt.assert_allclose(pf.filter_state.d, particles + 0.5)
+
     def test_update_identity_accepts_scalar_measurement_for_one_dimensional_noise(self):
         pf = EuclideanParticleFilter(n_particles=3, dim=1)
         particles = array([[0.0], [1.0], [2.0]])


### PR DESCRIPTION
## Summary
- fix per-particle prediction stacking so `(n, 1)` Euclidean particle matrices remain `(n, 1)` instead of being transposed to `(1, n)`
- apply the shared stacking helper to both reusable transition-model prediction and nonlinear prediction with sampled additive noise
- add a regression test for one-dimensional `predict_identity` with deterministic Dirac noise

## Testing
- Not run locally: the execution container could not resolve `github.com`, so I used the GitHub connector for inspection and commits.