### PR TITLE
Validate MH scalar log-density outputs

### DIFF
--- a/src/pyrecest/distributions/abstract_manifold_specific_distribution.py
+++ b/src/pyrecest/distributions/abstract_manifold_specific_distribution.py
@@ -10,15 +10,52 @@ import pyrecest.backend
 # pylint: disable=no-name-in-module,no-member,redefined-builtin
 from pyrecest.backend import empty, int32, int64, log, random, squeeze
 
+_SCALAR_VALUE_ERROR = "Metropolis-Hastings scalar evaluations must return scalar values."
+
+
+def _shape_size(value) -> int | None:
+    shape = getattr(value, "shape", None)
+    if shape is None:
+        return None
+    try:
+        dimensions = tuple(shape)
+    except TypeError:
+        dimensions = (shape,)
+
+    size = 1
+    for dimension in dimensions:
+        try:
+            size *= int(dimension)
+        except (TypeError, ValueError):
+            return None
+    return size
+
 
 def _to_scalar(value):
     """Convert a backend scalar or length-one array to a Python float."""
+    value_size = _shape_size(value)
+    if value_size is not None and value_size != 1:
+        raise ValueError(_SCALAR_VALUE_ERROR)
     try:
         return float(value.item())
     except AttributeError:
-        return float(value)
-    except (TypeError, ValueError, RuntimeError):
-        return float(value.reshape(-1)[0])
+        try:
+            return float(value)
+        except (TypeError, ValueError, RuntimeError) as exc:
+            raise ValueError(_SCALAR_VALUE_ERROR) from exc
+    except (TypeError, ValueError, RuntimeError) as exc:
+        try:
+            flattened = value.reshape(-1)
+        except AttributeError as reshape_exc:
+            raise ValueError(_SCALAR_VALUE_ERROR) from reshape_exc
+
+        flattened_size = _shape_size(flattened)
+        if flattened_size is not None and flattened_size != 1:
+            raise ValueError(_SCALAR_VALUE_ERROR) from exc
+        try:
+            return float(flattened[0])
+        except (IndexError, TypeError, ValueError, RuntimeError) as flatten_exc:
+            raise ValueError(_SCALAR_VALUE_ERROR) from flatten_exc
 
 
 def _validate_integer_sample_parameter(value, name: str, minimum: int) -> int:
@@ -275,8 +312,11 @@ def sample_metropolis_hastings_jax(
     x = start_point
 
     def _to_scalar(val):
-        """Convert a JAX array of any shape to a Python float."""
-        return float(_jnp.asarray(val).ravel()[0])
+        """Convert a JAX scalar or length-one array to a Python float."""
+        arr = _jnp.asarray(val)
+        if arr.size != 1:
+            raise ValueError(_SCALAR_VALUE_ERROR)
+        return float(arr.reshape(-1)[0])
 
     log_px = _to_scalar(log_pdf(x))
 

--- a/tests/distributions/test_metropolis_hastings_scalar_validation.py
+++ b/tests/distributions/test_metropolis_hastings_scalar_validation.py
@@ -1,0 +1,55 @@
+import unittest
+
+import pyrecest.backend
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array
+from pyrecest.distributions.abstract_manifold_specific_distribution import (
+    AbstractManifoldSpecificDistribution,
+)
+
+
+class VectorLogDensityDistribution(AbstractManifoldSpecificDistribution):
+    def __init__(self):
+        super().__init__(dim=1)
+
+    @property
+    def input_dim(self):
+        return 1
+
+    def get_manifold_size(self):
+        return 1.0
+
+    def pdf(self, xs):
+        return array(1.0)
+
+    def ln_pdf(self, xs):
+        return array([0.0, -1.0])
+
+    def mean(self):
+        return array([0.0])
+
+
+class MetropolisHastingsScalarValidationTest(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="This regression test targets the non-JAX MH implementation.",
+    )
+    def test_sample_metropolis_hastings_rejects_vector_log_density(self):
+        distribution = VectorLogDensityDistribution()
+
+        def proposal(x):
+            return x
+
+        with self.assertRaisesRegex(ValueError, "scalar"):
+            distribution.sample_metropolis_hastings(
+                n=1,
+                burn_in=0,
+                skipping=1,
+                proposal=proposal,
+                start_point=array([0.0]),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Reject multi-element scalar conversions in Metropolis-Hastings log-density and proposal-correction paths instead of silently flattening and using the first element.
- Apply the same scalar-size validation to the JAX helper.
- Add a regression covering vector-valued `ln_pdf` output for the non-JAX sampler.

## Bug
`_to_scalar()` previously handled arrays whose `.item()` failed by returning `float(value.reshape(-1)[0])`. If `ln_pdf()` or `proposal_log_pdf()` returned a multi-element array, the sampler silently used only the first value, which could make acceptance decisions from malformed log densities instead of reporting the invalid shape.

## Validation
- Syntax-checked the modified source module and regression test locally with `ast.parse`.
- Full repository pytest was not run locally because this environment cannot resolve `github.com` to clone/install the repository dependencies.

Note: the branch is based on an earlier main commit, but the modified source file is unchanged on current `main`, so the diff should remain clean.