### PR TITLE
Validate time-offset fit metric names

### DIFF
--- a/src/pyrecest/calibration/time_offset.py
+++ b/src/pyrecest/calibration/time_offset.py
@@ -9,6 +9,10 @@ from typing import Any
 import numpy as np
 
 
+_ERROR_METRIC_NAMES = frozenset({"max", "mean", "p95", "rmse", "std"})
+_ERROR_METRIC_MESSAGE = "metric must be one of 'max', 'mean', 'p95', 'rmse', or 'std'"
+
+
 @dataclass(frozen=True)
 class TimeOffsetFitResult:
     """Best timestamp correction selected from an offset sweep."""
@@ -66,6 +70,17 @@ def _best_metric_index(
         return int(candidates[int(np.nanargmin(values[candidates]))])
     candidates = np.flatnonzero(finite)
     return int(candidates[int(np.nanargmin(values[candidates]))])
+
+
+def _validate_error_metric(metric: Any) -> str:
+    """Return a normalized fit metric name with a deterministic validation error."""
+
+    if not isinstance(metric, str):
+        raise ValueError(_ERROR_METRIC_MESSAGE)
+    normalized = metric.strip().lower()
+    if normalized not in _ERROR_METRIC_NAMES:
+        raise ValueError(_ERROR_METRIC_MESSAGE)
+    return normalized
 
 
 def _as_finite_float(value: Any, name: str) -> float:
@@ -361,6 +376,7 @@ def fit_time_offset(
 ) -> TimeOffsetFitResult:
     """Fit a timestamp offset by minimizing a sweep metric."""
 
+    metric = _validate_error_metric(metric)
     summaries = time_offset_sweep(
         measurement_times_s,
         measurement_values,
@@ -370,7 +386,7 @@ def fit_time_offset(
         max_time_delta_s=max_time_delta_s,
     )
     offsets = np.array([row["time_offset_s"] for row in summaries], dtype=float)
-    values = np.array([row.get(metric, np.nan) for row in summaries], dtype=float)
+    values = np.array([row[metric] for row in summaries], dtype=float)
     counts = np.array([row.get("count", 0.0) for row in summaries], dtype=float)
     finite = np.isfinite(values) & (counts > 0)
     best = (
@@ -380,7 +396,7 @@ def fit_time_offset(
     )
     return TimeOffsetFitResult(
         best_offset_s=best,
-        metric=str(metric),
+        metric=metric,
         offsets_s=offsets,
         metric_values=values,
         counts=counts.astype(int),

--- a/tests/calibration/test_time_offset_metric_validation.py
+++ b/tests/calibration/test_time_offset_metric_validation.py
@@ -1,0 +1,39 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+from pyrecest.calibration.time_offset import fit_time_offset
+
+
+class TimeOffsetMetricValidationTest(unittest.TestCase):
+    def _fit_with_metric(self, metric):
+        reference_times = np.array([0.0, 1.0, 2.0])
+        reference_values = reference_times.reshape(-1, 1)
+        return fit_time_offset(
+            reference_times,
+            reference_values,
+            reference_times,
+            reference_values,
+            np.array([0.0]),
+            metric=metric,
+        )
+
+    def test_fit_time_offset_rejects_unknown_metric(self):
+        with self.assertRaisesRegex(ValueError, "metric must be one of"):
+            self._fit_with_metric("median")
+
+    def test_fit_time_offset_rejects_non_string_metric(self):
+        with self.assertRaisesRegex(ValueError, "metric must be one of"):
+            self._fit_with_metric(["rmse"])
+
+    def test_fit_time_offset_normalizes_metric_name(self):
+        result = self._fit_with_metric("RMSE")
+
+        self.assertEqual(result.metric, "rmse")
+        self.assertEqual(result.best_offset_s, 0.0)
+        npt.assert_allclose(result.metric_values, np.array([0.0]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Validate `fit_time_offset(metric=...)` before reading sweep summary rows.
- Normalize accepted metric names case-insensitively to the canonical summary keys.
- Add regression coverage for unknown, non-string, and mixed-case metric inputs.

## Bug
`fit_time_offset` previously used `row.get(metric, np.nan)` for each sweep row. A typo such as `metric="median"` therefore produced all-NaN metric values and `best_offset_s=None` instead of reporting invalid caller input. Unhashable metric values such as lists could also leak a raw `TypeError` from `dict.get`.

## Validation
- Ran a local isolated unittest harness for `tests/calibration/test_time_offset_metric_validation.py` against the patched `time_offset.py` content: 3 tests passed.
- Full repository pytest was not run locally because this environment cannot resolve `github.com` to clone/install the repository dependencies.