### PR TITLE
Validate circular association PDF scalar outputs

### DIFF
--- a/src/pyrecest/filters/abstract_circular_filter.py
+++ b/src/pyrecest/filters/abstract_circular_filter.py
@@ -8,6 +8,16 @@ from .abstract_filter import AbstractFilter
 from .manifold_mixins import CircularFilterMixin
 
 
+def _scalar_pdf_value(value, owner: str):
+    """Return one PDF value and reject ambiguous vector outputs."""
+    flattened = asarray(value).reshape(-1)
+    if flattened.shape[0] != 1:
+        raise ValueError(
+            f"{owner}.pdf must return exactly one value for one integration angle."
+        )
+    return flattened[0]
+
+
 class AbstractCircularFilter(AbstractFilter, CircularFilterMixin):
     """Abstract base class for filters on S1/SO(2)."""
 
@@ -29,8 +39,14 @@ class AbstractCircularFilter(AbstractFilter, CircularFilterMixin):
 
         def integrand(angle):
             angle_array = array([angle])
-            estimate_pdf = asarray(estimate.pdf(angle_array)).reshape(-1)[0]
-            likelihood_pdf = asarray(likelihood.pdf(angle_array)).reshape(-1)[0]
+            estimate_pdf = _scalar_pdf_value(
+                estimate.pdf(angle_array),
+                "filter_state",
+            )
+            likelihood_pdf = _scalar_pdf_value(
+                likelihood.pdf(angle_array),
+                "likelihood",
+            )
             return float(estimate_pdf * likelihood_pdf)
 
         likelihood_val, _ = quad(integrand, 0.0, 2.0 * pi)

--- a/tests/filters/test_abstract_circular_filter.py
+++ b/tests/filters/test_abstract_circular_filter.py
@@ -1,0 +1,60 @@
+"""Regression tests for circular association likelihood validation."""
+
+import math
+
+import pytest
+from pyrecest.backend import array
+from pyrecest.filters.abstract_circular_filter import AbstractCircularFilter
+
+
+class _TestCircularFilter(AbstractCircularFilter):
+    @property
+    def filter_state(self):
+        return self._filter_state
+
+    @filter_state.setter
+    def filter_state(self, new_state):
+        self._filter_state = new_state
+
+
+class _PdfDistribution:
+    def __init__(self, pdf_value):
+        self._pdf_value = pdf_value
+
+    def pdf(self, _angle):
+        return self._pdf_value
+
+    def mean(self):
+        return array([0.0])
+
+    @property
+    def dim(self):
+        return 1
+
+
+def test_association_likelihood_accepts_single_element_pdf_values():
+    filt = _TestCircularFilter(_PdfDistribution(array([1.0])))
+    likelihood = _PdfDistribution(array(0.5))
+
+    result = filt.association_likelihood_numerical(likelihood)
+
+    assert float(result) == pytest.approx(0.5 * math.tau)
+
+
+@pytest.mark.parametrize(
+    ("state_pdf", "likelihood_pdf", "message"),
+    [
+        (array([1.0, 2.0]), array([1.0]), r"filter_state\.pdf"),
+        (array([1.0]), array([1.0, 2.0]), r"likelihood\.pdf"),
+    ],
+)
+def test_association_likelihood_rejects_vector_pdf_values(
+    state_pdf,
+    likelihood_pdf,
+    message,
+):
+    filt = _TestCircularFilter(_PdfDistribution(state_pdf))
+    likelihood = _PdfDistribution(likelihood_pdf)
+
+    with pytest.raises(ValueError, match=message):
+        filt.association_likelihood_numerical(likelihood)


### PR DESCRIPTION
## Summary
- Add scalar-size validation for `AbstractCircularFilter.association_likelihood_numerical` PDF evaluations.
- Keep scalar and single-element PDF outputs valid, but reject empty or multi-element outputs instead of flattening and using the first entry.
- Add focused regression coverage for valid single-element outputs and malformed state/likelihood PDF vectors.

## Bug
`association_likelihood_numerical()` previously converted each `pdf(...)` result with `asarray(...).reshape(-1)[0]`. If a distribution returned an empty or multi-element PDF vector for one integration angle, the integration either failed obscurely or silently used only the first value. That can hide invalid distribution/likelihood implementations and produce a wrong association likelihood.

## Validation
- Syntax-checked the modified source and new regression test with `ast.parse` locally.
- Full repository pytest was not run locally because this environment cannot resolve `github.com` to clone/install repository dependencies.