### PR TITLE
Validate discrete transition scalar inputs

### DIFF
--- a/src/pyrecest/filters/discrete_state/__init__.py
+++ b/src/pyrecest/filters/discrete_state/__init__.py
@@ -54,6 +54,32 @@ def _validated_state_vectors(state_vectors: Any) -> np.ndarray:
     return states
 
 
+def _validated_positive_scalar(
+    value: Any,
+    name: str,
+    *,
+    allow_infinite: bool = False,
+) -> float:
+    try:
+        raw_value = np.asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a positive real scalar") from exc
+    if raw_value.shape != () or raw_value.dtype.kind in _REJECTED_STATE_KINDS:
+        raise ValueError(f"{name} must be a positive real scalar")
+    scalar = raw_value.item()
+    if isinstance(scalar, _TEXT_TYPES + _BOOLEAN_TYPES + _COMPLEX_TYPES):
+        raise ValueError(f"{name} must be a positive real scalar")
+    try:
+        parsed = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be a positive real scalar") from exc
+    if parsed <= 0.0 or np.isnan(parsed):
+        raise ValueError(f"{name} must be a positive real scalar")
+    if not allow_infinite and not np.isfinite(parsed):
+        raise ValueError(f"{name} must be a positive real scalar")
+    return parsed
+
+
 def sparse_gaussian_transition_matrix(
     state_vectors,
     sigma,
@@ -62,6 +88,12 @@ def sparse_gaussian_transition_matrix(
     valid_state_mask=None,
 ):
     states = _validated_state_vectors(state_vectors)
+    sigma = _validated_positive_scalar(sigma, "sigma")
+    max_step_sigma = _validated_positive_scalar(
+        max_step_sigma,
+        "max_step_sigma",
+        allow_infinite=True,
+    )
     return _original_sparse_gaussian_transition_matrix(
         states,
         sigma,


### PR DESCRIPTION
## Summary
- Add explicit scalar validation for `sigma` and `max_step_sigma` in the `pyrecest.filters.discrete_state` compatibility wrapper.
- Reject text, boolean, complex, non-scalar, NaN, nonpositive, and nonfinite `sigma` values before they reach the core implementation.
- Preserve the existing documented behavior that `max_step_sigma=np.inf` is allowed for dense Gaussian support.

## Bug fixed
The wrapper already guarded `state_vectors`, but passed `sigma` and `max_step_sigma` straight through. The core implementation then used plain `float(...)`, so inputs such as text numerals or booleans could be silently accepted even though these parameters are part of the numerical model contract.

## Validation
- Inspected the branch diff via the GitHub connector.
- Not run locally; this environment cannot fetch the repository dependencies from GitHub.