### PR TITLE
Validate piecewise numerical PDF outputs

### DIFF
--- a/src/pyrecest/distributions/circle/piecewise_constant_distribution.py
+++ b/src/pyrecest/distributions/circle/piecewise_constant_distribution.py
@@ -282,7 +282,20 @@ class PiecewiseConstantDistribution(AbstractCircularDistribution):
             )
 
         def _evaluate_pdf(x):
-            return float(array(pdf_func(array([x]))).reshape(-1)[0])
+            pdf_values = array(pdf_func(array([x])), dtype=float)
+            if pdf_values.shape == ():
+                scalar_value = pdf_values
+            else:
+                flat_values = pdf_values.reshape(-1)
+                if flat_values.shape[0] != 1:
+                    raise ValueError(
+                        "pdf_func must return a scalar or single value per integration point"
+                    )
+                scalar_value = flat_values[0]
+            scalar_float = float(scalar_value)
+            if not np.isfinite(scalar_float):
+                raise ValueError("pdf_func must return finite values")
+            return scalar_float
 
         n = _validate_positive_sample_count(n)
         w = zeros(n)

--- a/tests/distributions/test_piecewise_constant_distribution.py
+++ b/tests/distributions/test_piecewise_constant_distribution.py
@@ -162,6 +162,41 @@ class PiecewiseConstantDistributionTest(unittest.TestCase):
         pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
         reason="Not supported on JAX backend",
     )
+    def test_calculate_parameters_numerically_accepts_scalar_pdf_output(self):
+        weights = PiecewiseConstantDistribution.calculate_parameters_numerically(
+            lambda _xs: 1.0 / (2.0 * pi), 4
+        )
+
+        npt.assert_allclose(weights, array([0.25, 0.25, 0.25, 0.25]), rtol=1e-12)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on JAX backend",
+    )
+    def test_calculate_parameters_numerically_rejects_malformed_pdf_output(self):
+        malformed_outputs = [array([]), array([1.0, 2.0])]
+
+        for output in malformed_outputs:
+            with self.subTest(output=output):
+                with self.assertRaisesRegex(ValueError, "scalar or single value"):
+                    PiecewiseConstantDistribution.calculate_parameters_numerically(
+                        lambda _xs, output=output: output, 4
+                    )
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on JAX backend",
+    )
+    def test_calculate_parameters_numerically_rejects_nonfinite_pdf_output(self):
+        with self.assertRaisesRegex(ValueError, "finite"):
+            PiecewiseConstantDistribution.calculate_parameters_numerically(
+                lambda _xs: array([float("nan")]), 4
+            )
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on JAX backend",
+    )
     def test_calculate_parameters_numerically_rejects_invalid_count(self):
         for n in (0, -1, 1.5, True, [3], float("nan"), float("inf")):
             with self.subTest(n=n):


### PR DESCRIPTION
## Summary
- Validate each `pdf_func` value returned to `PiecewiseConstantDistribution.calculate_parameters_numerically` before passing it to SciPy quadrature.
- Accept scalar and single-element outputs, but reject empty or multi-element outputs instead of silently using the first flattened value.
- Reject non-finite numerical PDF outputs and add regression coverage for scalar, malformed, and non-finite returns.

## Bug fixed
`calculate_parameters_numerically()` previously evaluated `float(array(pdf_func(array([x]))).reshape(-1)[0])`. If a caller supplied a malformed `pdf_func` that returned an empty vector, the error was obscure; if it returned multiple values for one integration point, the routine silently integrated only the first value and ignored the rest. That can produce misleading discretized weights from an invalid PDF contract.

## Validation
- Syntax-checked the modified source and test module with `ast.parse` locally.
- Ran an isolated local harness for the new scalar-output validation behavior: scalar output integrates to uniform weights, empty/vector outputs raise `ValueError`, and NaN output raises `ValueError`.
- Full repository pytest was not run locally because the sandbox cannot resolve `github.com` to clone/install the full repository dependency set.