### PR TITLE
Expose matrix methods on PyTorch Rotation stub

### DIFF
--- a/src/pyrecest/_backend/pytorch/spatial.py
+++ b/src/pyrecest/_backend/pytorch/spatial.py
@@ -14,9 +14,22 @@ class Rotation:
             "Use a NumPy/JAX backend for this functionality."
         )
 
+    @classmethod
+    def from_matrix(cls, *args, **kwargs):
+        raise RuntimeError(
+            "Rotation.from_matrix is not supported on the PyTorch backend. "
+            "Use a NumPy/JAX backend for this functionality."
+        )
+
     def as_quat(self, *args, **kwargs):
         raise RuntimeError(
             "Rotation.as_quat is not supported on the PyTorch backend. "
+            "Use a NumPy/JAX backend for this functionality."
+        )
+
+    def as_matrix(self, *args, **kwargs):
+        raise RuntimeError(
+            "Rotation.as_matrix is not supported on the PyTorch backend. "
             "Use a NumPy/JAX backend for this functionality."
         )
 

--- a/tests/backend_support/test_pytorch_rotation_stub_contract.py
+++ b/tests/backend_support/test_pytorch_rotation_stub_contract.py
@@ -1,0 +1,24 @@
+"""Regression tests for the PyTorch Rotation stub API surface."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_pytorch_rotation_stub_exposes_matrix_methods_with_backend_error():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    from pyrecest._backend.pytorch.spatial import Rotation
+
+    with pytest.raises(RuntimeError, match="Rotation.from_matrix is not supported"):
+        Rotation.from_matrix(
+            [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+        )
+
+    rotation = object.__new__(Rotation)
+    with pytest.raises(RuntimeError, match="Rotation.as_matrix is not supported"):
+        rotation.as_matrix()


### PR DESCRIPTION
## Summary
- add `Rotation.from_matrix` and `Rotation.as_matrix` to the PyTorch backend's dummy `Rotation` class
- keep the behavior explicitly unsupported, but return the same backend-specific `RuntimeError` style as the existing quaternion methods
- add a regression test that checks the matrix methods are present and fail with explicit backend errors

## Notes
- The bug was an inconsistent PyTorch backend API surface: code paths that probe `spatial.Rotation.from_matrix` could see a missing method instead of the intended explicit unsupported-backend failure.
- I did not run the full test suite in this connector-only environment; the added test is focused on the patched contract.