### PR TITLE
Fix PyTorch linear solve input coercion

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -14,10 +14,7 @@ from torch.linalg import (
     inv,
 )
 from torch.linalg import matrix_exp as expm
-from torch.linalg import (
-    matrix_power,
-    solve,
-)
+from torch.linalg import matrix_power
 
 from .._backend_config import np_atol as atol
 from ..numpy import linalg as _gsnplinalg
@@ -163,6 +160,20 @@ def matrix_rank(a, tol=None, hermitian=False, *, rtol=None, atol=None, **kwargs)
 
     a = _as_linalg_tensor(a)
     return _torch.linalg.matrix_rank(a, atol=atol, rtol=rtol, hermitian=hermitian)
+
+
+def solve(a, b):
+    """Solve a linear system with PyRecEst-compatible array-like inputs."""
+    device = next((value.device for value in (a, b) if _torch.is_tensor(value)), None)
+    a = _as_linalg_tensor(a)
+    b = _as_linalg_tensor(b)
+    if device is not None:
+        a = a.to(device=device)
+        b = b.to(device=device)
+    common_dtype = _common_linalg_dtype(a, b)
+    a = a.to(dtype=common_dtype)
+    b = b.to(dtype=common_dtype)
+    return _torch.linalg.solve(a, b)
 
 
 def quadratic_assignment(a, b, options=None):

--- a/tests/backend_support/test_pytorch_linalg_solve_contract.py
+++ b/tests/backend_support/test_pytorch_linalg_solve_contract.py
@@ -1,0 +1,36 @@
+"""Regression tests for PyTorch backend linear solve coercion."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+_CHECK = """
+import pyrecest.backend as backend
+
+solution = backend.linalg.solve([[2, 0], [0, 4]], [2, 8])
+assert tuple(backend.shape(solution)) == (2,)
+assert solution.dtype == backend.float64
+assert backend.to_numpy(solution).tolist() == [1.0, 2.0]
+
+matrix_rhs = backend.linalg.solve(
+    backend.array([[2.0, 0.0], [0.0, 4.0]], dtype=backend.float32),
+    backend.array([[2.0, 4.0], [8.0, 12.0]], dtype=backend.float64),
+)
+assert matrix_rhs.dtype == backend.float64
+assert backend.to_numpy(matrix_rhs).tolist() == [[1.0, 2.0], [2.0, 3.0]]
+print("ok")
+"""
+
+
+@pytest.mark.backend_portable
+def test_pytorch_linalg_solve_accepts_array_like_inputs_and_promotes_dtype():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code("pytorch", _CHECK)
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
Adds a small PyTorch backend wrapper for linear solve input coercion and a regression test covering list inputs, vector right-hand sides, and mixed floating dtypes.

Testing: added a backend regression test; full suite not run locally.