### PR TITLE
Validate hyperrectangular integration PDF outputs

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/abstract_hyperrectangular_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/abstract_hyperrectangular_distribution.py
@@ -1,10 +1,17 @@
 # pylint: disable=no-name-in-module,no-member
+from math import isfinite as math_isfinite
+
 from pyrecest.backend import all as backend_all
 from pyrecest.backend import array, diff, isfinite, prod, reshape, to_numpy
 from scipy.integrate import nquad
 
 from ..abstract_bounded_nonperiodic_distribution import (
     AbstractBoundedNonPeriodicDistribution,
+)
+
+
+_ERROR_SCALAR_PDF_VALUE = (
+    "pdf must return one finite scalar value per integration point"
 )
 
 
@@ -21,6 +28,22 @@ def _require_increasing_bounds(bounds, name: str) -> None:
     widths = diff(bounds, axis=1)
     if not bool(backend_all(widths > 0.0)):
         raise ValueError(f"{name} must be strictly increasing in every dimension")
+
+
+def _require_scalar_pdf_value(values) -> float:
+    try:
+        flat_values = to_numpy(array(values)).reshape(-1)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(_ERROR_SCALAR_PDF_VALUE) from exc
+    if flat_values.size != 1:
+        raise ValueError(_ERROR_SCALAR_PDF_VALUE)
+    try:
+        value = float(flat_values[0])
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(_ERROR_SCALAR_PDF_VALUE) from exc
+    if not math_isfinite(value):
+        raise ValueError(_ERROR_SCALAR_PDF_VALUE)
+    return value
 
 
 class AbstractHyperrectangularDistribution(AbstractBoundedNonPeriodicDistribution):
@@ -80,6 +103,6 @@ class AbstractHyperrectangularDistribution(AbstractBoundedNonPeriodicDistributio
 
         def integrand(*args):
             values = self.pdf(reshape(array(args), (1, self.dim)))
-            return float(to_numpy(array(values)).reshape(-1)[0])
+            return _require_scalar_pdf_value(values)
 
         return nquad(integrand, ranges)[0]

--- a/tests/distributions/test_custom_hyperrectangular_distribution.py
+++ b/tests/distributions/test_custom_hyperrectangular_distribution.py
@@ -44,6 +44,22 @@ class TestCustomHyperrectangularDistribution(unittest.TestCase):
     def test_integrate_defaults_to_full_rectangular_bounds(self):
         self.assertAlmostEqual(float(self.hud.integrate()), 1.0, places=10)
 
+    def test_integrate_rejects_vector_pdf_values(self):
+        cd = CustomHyperrectangularDistribution(
+            lambda _xs: array([0.25, 0.75]), array([0.0, 1.0])
+        )
+
+        with self.assertRaisesRegex(ValueError, "one finite scalar"):
+            cd.integrate()
+
+    def test_integrate_rejects_nonfinite_pdf_values(self):
+        cd = CustomHyperrectangularDistribution(
+            lambda _xs: float("nan"), array([0.0, 1.0])
+        )
+
+        with self.assertRaisesRegex(ValueError, "one finite scalar"):
+            cd.integrate()
+
     def test_one_dimensional_bounds_are_supported(self):
         cd = CustomHyperrectangularDistribution(lambda _xs: 0.5, array([0.0, 2.0]))
 


### PR DESCRIPTION
## Summary
- Validate `AbstractHyperrectangularDistribution.integrate()` PDF evaluations before passing values to SciPy quadrature.
- Reject empty, vector/multi-value, non-real, and non-finite `pdf` outputs instead of flattening and integrating the first value.
- Add regression tests for vector and `NaN` custom hyperrectangular PDFs while preserving scalar-output integration behavior.

## Bug fixed
`integrate()` previously did `float(to_numpy(array(values)).reshape(-1)[0])` for each quadrature point. A malformed custom PDF returning multiple values for one point could therefore be silently reduced to its first value, producing a plausible but wrong integral. Non-finite values were also not rejected at the PyRecEst boundary.

## Validation
- Syntax-checked the modified source and test files locally with `ast.parse`.
- Full pytest was not run in this environment because the sandbox cannot resolve `github.com` to clone/install the repository dependency set.