### PR TITLE
Fix scalar sinc PDF inputs for circular grids

### DIFF
--- a/src/pyrecest/distributions/circle/circular_grid_distribution.py
+++ b/src/pyrecest/distributions/circle/circular_grid_distribution.py
@@ -4,12 +4,15 @@ from numbers import Integral
 from pyrecest.backend import (
     arange,
     array,
+    atleast_1d,
     ceil,
     floor,
     isclose,
     linspace,
     mod,
+    ndim,
     pi,
+    reshape,
     round,
     sin,
     sqrt,
@@ -66,18 +69,23 @@ class CircularGridDistribution(AbstractCircularDistribution, AbstractGridDistrib
         if sinc_repetitions % 2 != 1:
             raise ValueError("sinc_repetitions must be a positive odd integer.")
 
+        scalar_input = ndim(xs) == 0
+        xs_eval = reshape(atleast_1d(xs), (-1,))
+
         grid_size = self.grid_values.shape[0]
         step_size = 2.0 * pi / grid_size
         lower = int(floor(sinc_repetitions / 2) * grid_size)
         upper = int(ceil(sinc_repetitions / 2) * grid_size)
         repetitions = arange(-lower, upper)
-        sinc_vals = self._matlab_sinc((xs / step_size)[:, None] - repetitions[None, :])
+        sinc_vals = self._matlab_sinc((xs_eval / step_size)[:, None] - repetitions[None, :])
         grid_values = (
             sqrt(self.grid_values) if self.enforce_pdf_nonnegative else self.grid_values
         )
         density = sum(tile(grid_values, sinc_repetitions) * sinc_vals, axis=1)
         if self.enforce_pdf_nonnegative:
-            return density**2
+            density = density**2
+        if scalar_input:
+            return density[0]
         return density
 
     def _pdf_via_fourier(self, xs):

--- a/tests/distributions/test_circular_grid_scalar_sinc_pdf.py
+++ b/tests/distributions/test_circular_grid_scalar_sinc_pdf.py
@@ -1,0 +1,21 @@
+import unittest
+
+from pyrecest.backend import array, pi
+from pyrecest.distributions.circle.circular_grid_distribution import CircularGridDistribution
+
+
+class CircularGridScalarSincPdfTest(unittest.TestCase):
+    def test_pdf_via_sinc_accepts_scalar_angle(self):
+        dist = CircularGridDistribution.from_function(
+            lambda xs: xs * 0.0 + 1.0 / (2.0 * pi),
+            9,
+        )
+
+        scalar_value = dist.pdf(0.0, use_sinc=True, sinc_repetitions=3)
+        vector_value = dist.pdf(array([0.0]), use_sinc=True, sinc_repetitions=3)[0]
+
+        self.assertAlmostEqual(float(scalar_value), float(vector_value))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
- Handle scalar inputs in `CircularGridDistribution.pdf(..., use_sinc=True)` by normalizing the evaluation points with `atleast_1d` before adding the sinc basis axis.
- Preserve scalar output for scalar input while keeping vector output shape unchanged.
- Add a regression test covering scalar sinc PDF evaluation against the equivalent one-element vector evaluation.

Tests: Not run locally; the environment cannot clone GitHub directly, so CI should be used as the validation source.