### PR TITLE
Reject empty split-track edits

### DIFF
--- a/src/pyrecest/utils/track_edit_whatif.py
+++ b/src/pyrecest/utils/track_edit_whatif.py
@@ -376,6 +376,8 @@ def _apply_split_track(matrix: np.ndarray, edit: TrackEdit) -> TrackEditApplicat
         return TrackEditApplication(
             edit, output, False, "reject", "split_session_out_of_bounds"
         )
+    if not any(value is not None for value in output[row_index]):
+        return TrackEditApplication(edit, output, False, "reject", "empty_track")
     left = output[row_index].copy()
     right = output[row_index].copy()
     left[split_session:] = None

--- a/tests/test_track_edit_whatif_empty_split.py
+++ b/tests/test_track_edit_whatif_empty_split.py
@@ -1,0 +1,19 @@
+"""Regression tests for empty split-track edits."""
+
+from pyrecest.utils.track_edit_whatif import TrackEdit, apply_track_edit, score_track_edit_delta
+
+
+def test_split_track_rejects_empty_track() -> None:
+    predicted = [[None, None, None]]
+    edit = TrackEdit(kind="split_track", track_index=0, session_b=1)
+
+    application = apply_track_edit(predicted, edit)
+    delta = score_track_edit_delta(predicted, predicted, edit)
+
+    assert not application.applied
+    assert application.action == "reject"
+    assert application.reason == "empty_track"
+    assert application.track_matrix.tolist() == predicted
+    assert not delta.applied
+    assert delta.reason == "empty_track"
+    assert delta.pairwise_tp_delta == 0


### PR DESCRIPTION
## Summary
- Reject `split_track` edits that target an all-missing track row.
- Preserve the original matrix and return a deterministic `empty_track` rejection instead of allowing `np.vstack` to see an empty piece list or silently drop the empty row.
- Add a focused regression test covering `apply_track_edit` and `score_track_edit_delta`.

## Bug
`_apply_split_track` built its output from the non-empty split pieces. For an all-missing target row, both split halves are empty. If that row was the only row, the code could reach `np.vstack([])`; if other rows existed, the edit could silently delete the empty row. Both cases should be a rejected no-op edit.

## Tests
- Targeted behavior checked in an isolated Python harness.
- Full repository pytest not run in this environment.