### PR TITLE
Validate time-offset aggregate metric names

### DIFF
--- a/src/pyrecest/calibration/__init__.py
+++ b/src/pyrecest/calibration/__init__.py
@@ -9,7 +9,7 @@ from .bias import (
 )
 from .time_offset import (
     TimeOffsetFitResult,
-    aggregate_time_offset_sweeps,
+    aggregate_time_offset_sweeps as _aggregate_time_offset_sweeps,
     apply_time_offset,
     fit_time_offset,
     interpolate_reference_values,
@@ -17,7 +17,16 @@ from .time_offset import (
     nearest_time_indices,
     time_offset_error_summary,
     time_offset_sweep,
+    _validate_error_metric,
 )
+
+
+def aggregate_time_offset_sweeps(sweeps, *, metric="rmse"):
+    """Aggregate same-offset sweeps after normalizing the selected metric."""
+
+    metric = _validate_error_metric(metric)
+    return _aggregate_time_offset_sweeps(sweeps, metric=metric)
+
 
 __all__ = [
     "BiasTrainingExamples",

--- a/tests/calibration/test_time_offset_aggregate_validation.py
+++ b/tests/calibration/test_time_offset_aggregate_validation.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 import numpy.testing as npt
 
-from pyrecest.calibration.time_offset import aggregate_time_offset_sweeps
+from pyrecest.calibration import aggregate_time_offset_sweeps
 
 
 class TimeOffsetAggregateValidationTest(unittest.TestCase):

--- a/tests/calibration/test_time_offset_aggregate_validation.py
+++ b/tests/calibration/test_time_offset_aggregate_validation.py
@@ -12,6 +12,7 @@ class TimeOffsetAggregateValidationTest(unittest.TestCase):
             "time_offset_s": 0.0,
             "count": 2.0,
             "mean": 1.0,
+            "std": 0.5,
             "rmse": 2.0,
             "p95": 2.5,
             "max": 3.0,
@@ -48,6 +49,22 @@ class TimeOffsetAggregateValidationTest(unittest.TestCase):
                 row[key] = value
                 with self.assertRaisesRegex(ValueError, pattern):
                     aggregate_time_offset_sweeps([[row]])
+
+    def test_aggregate_time_offset_sweeps_rejects_invalid_metric_names(self):
+        invalid_metrics = (None, 1, "", "median", "coverage")
+        for metric in invalid_metrics:
+            with self.subTest(metric=metric):
+                with self.assertRaisesRegex(ValueError, "metric must be one of"):
+                    aggregate_time_offset_sweeps([[self._summary_row()]], metric=metric)
+
+    def test_aggregate_time_offset_sweeps_normalizes_metric_names(self):
+        aggregated = aggregate_time_offset_sweeps(
+            [[self._summary_row()]],
+            metric=" STD ",
+        )
+
+        self.assertEqual(aggregated[0]["std"], 0.5)
+        self.assertNotIn(" STD ", aggregated[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- validate and normalize the exported `aggregate_time_offset_sweeps` metric argument before aggregation
- add regression coverage for invalid metric names and whitespace/case normalization
- include `std` in the aggregate validation fixture so the normalized metric path is exercised

## Testing
- `PYTHONPATH=/mnt/data/patch_check/src python -m pytest -q /mnt/data/patch_check/tests/calibration/test_time_offset_aggregate_validation.py`
- `python -m py_compile /mnt/data/patch_check/src/pyrecest/calibration/__init__.py`

Note: full repository pytest was not run locally because the sandbox cannot resolve github.com to clone/install the full repository dependency set.