### PR TITLE
Accept NumPy scalar expected-result values

### DIFF
--- a/src/pyrecest/cli.py
+++ b/src/pyrecest/cli.py
@@ -8,6 +8,7 @@ import math
 import platform
 import sys
 from importlib.metadata import PackageNotFoundError, version
+from numbers import Real
 from pathlib import Path
 from typing import Any
 
@@ -58,7 +59,7 @@ def _validate_tolerance(value: Any) -> float:
 
 def _is_finite_real_number(value: Any) -> bool:
     return (
-        isinstance(value, int | float)
+        isinstance(value, Real)
         and not isinstance(value, bool)
         and math.isfinite(float(value))
     )

--- a/tests/test_cli_tolerance_validation.py
+++ b/tests/test_cli_tolerance_validation.py
@@ -53,6 +53,19 @@ def test_expected_mapping_accepts_finite_numeric_actuals() -> None:
     )
 
 
+@pytest.mark.parametrize("actual_value", [np.float64(1.000001), np.int64(1)])
+def test_expected_mapping_accepts_numpy_scalar_actuals(actual_value) -> None:
+    assert (
+        _check_expected_mapping(
+            "metrics",
+            {"rmse": actual_value},
+            {"rmse": 1.0},
+            tolerance=1e-5,
+        )
+        == []
+    )
+
+
 @pytest.mark.parametrize("actual_value", [True, "1.0", math.nan, math.inf])
 def test_expected_mapping_rejects_malformed_numeric_actuals(actual_value) -> None:
     errors = _check_expected_mapping(


### PR DESCRIPTION
## Summary
- Treat finite NumPy scalar real numbers as numeric values in CLI expected-result mapping comparisons.
- Preserve rejection of boolean and non-finite values.
- Add regression coverage for `np.float64` and `np.int64` actual metric values.

## Bug
`_check_expected_mapping()` only recognized Python `int` and `float` values as finite real numbers. Scenario metrics and diagnostics produced by numerical code can naturally contain NumPy scalar values such as `np.float64` or `np.int64`; those were rejected as malformed instead of being compared numerically.

## Validation
- Ran an isolated local check for the patched numeric predicate behavior.
- Full repository pytest was not run locally because the sandbox cannot clone/install the full repository dependency set from GitHub.