### PR TITLE
Validate JAX choice probability types

### DIFF
--- a/src/pyrecest/_backend/jax/random.py
+++ b/src/pyrecest/_backend/jax/random.py
@@ -380,7 +380,15 @@ def _choice_population_size(a, kwargs):
 
 
 def _validate_choice_probabilities(p, population_size):
-    p = _jnp.asarray(p, dtype=_jnp.float32)
+    if _contains_boolean_value(p):
+        raise TypeError("p must be real numeric, not boolean")
+    try:
+        p = _jnp.asarray(p)
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise TypeError("p must be real numeric") from exc
+    if p.dtype.kind not in "iuf":
+        raise TypeError("p must be real numeric")
+    p = p.astype(_jnp.float32)
     if p.ndim != 1 or p.shape[0] != population_size:
         raise ValueError("p must be 1-dimensional with one entry per population item")
 

--- a/tests/test_jax_choice_probability_validation.py
+++ b/tests/test_jax_choice_probability_validation.py
@@ -25,6 +25,24 @@ class JaxChoiceProbabilityValidationTest(unittest.TestCase):
         result = run_backend_code("jax", code)
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
 
+    def assert_choice_raises_type_error(self, call_source):
+        code = textwrap.dedent(f"""
+            from pyrecest.backend import array, random
+
+            try:
+                {call_source}
+            except TypeError:
+                raise SystemExit(0)
+            except Exception as exc:
+                raise AssertionError(
+                    f"expected TypeError, got {{type(exc).__name__}}: {{exc}}"
+                ) from exc
+            else:
+                raise AssertionError("expected TypeError")
+            """)
+        result = run_backend_code("jax", code)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
     def test_choice_rejects_negative_probabilities(self):
         self.assert_choice_raises_value_error(
             "random.choice(array([0, 1, 2]), size=2, p=array([0.5, -0.1, 0.6]))"
@@ -43,6 +61,19 @@ class JaxChoiceProbabilityValidationTest(unittest.TestCase):
     def test_choice_rejects_wrong_probability_length(self):
         self.assert_choice_raises_value_error(
             "random.choice(array([0, 1, 2]), size=2, p=array([0.5, 0.5]))"
+        )
+
+    def test_choice_rejects_boolean_probabilities(self):
+        for call_source in (
+            "random.choice(array([0, 1, 2]), size=2, p=[True, False, False])",
+            "random.choice(array([0, 1, 2]), size=2, p=array([True, False, False]))",
+        ):
+            with self.subTest(call_source=call_source):
+                self.assert_choice_raises_type_error(call_source)
+
+    def test_choice_rejects_text_probabilities(self):
+        self.assert_choice_raises_type_error(
+            "random.choice(array([0, 1, 2]), size=2, p=['1.0', '0.0', '0.0'])"
         )
 
 


### PR DESCRIPTION
Summary:
- Reject boolean probability vectors before the JAX backend casts p to floating point in random.choice.
- Reject non-real probability vectors with a clear TypeError.
- Add JAX regression coverage for boolean and text p inputs.

Tests:
- Python compile check on the modified source and test file.
- Local JAX smoke check for boolean/text rejection, numeric probability acceptance, and wrong-length probability ValueError behavior.