### PR TITLE
Fix circular grid sinc interpolation

### DIFF
--- a/src/pyrecest/distributions/circle/circular_grid_distribution.py
+++ b/src/pyrecest/distributions/circle/circular_grid_distribution.py
@@ -62,7 +62,10 @@ class CircularGridDistribution(AbstractCircularDistribution, AbstractGridDistrib
 
     @staticmethod
     def _matlab_sinc(x):
-        return where(isclose(x, 0.0), 1.0, sin(x) / x)
+        zero_mask = isclose(x, 0.0)
+        scaled_x = pi * x
+        safe_scaled_x = where(zero_mask, 1.0, scaled_x)
+        return where(zero_mask, 1.0, sin(scaled_x) / safe_scaled_x)
 
     def _pdf_via_sinc(self, xs, sinc_repetitions):
         sinc_repetitions = _validate_no_of_gridpoints(sinc_repetitions)

--- a/tests/distributions/test_circular_grid_scalar_sinc_pdf.py
+++ b/tests/distributions/test_circular_grid_scalar_sinc_pdf.py
@@ -16,6 +16,14 @@ class CircularGridScalarSincPdfTest(unittest.TestCase):
 
         self.assertAlmostEqual(float(scalar_value), float(vector_value))
 
+    def test_sinc_interpolation_matches_knots(self):
+        values = array([0.05, 0.15, 0.35, 0.25, 0.2])
+        dist = CircularGridDistribution(values, enforce_pdf_nonnegative=False)
+        evaluated = dist.pdf(dist.get_grid(), use_sinc=True, sinc_repetitions=3)
+
+        for actual, expected in zip(evaluated, values):
+            self.assertAlmostEqual(float(actual), float(expected), delta=1e-7)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes the circular grid sinc helper to use normalized sinc interpolation and adds a regression test for exact grid-knot reconstruction.