### PR TITLE
Validate abstract grid coordinate dimensionality

### DIFF
--- a/src/pyrecest/distributions/abstract_grid_distribution.py
+++ b/src/pyrecest/distributions/abstract_grid_distribution.py
@@ -33,12 +33,20 @@ class AbstractGridDistribution(AbstractDistributionType):
                     f"grid values. Expected {expected_grid_points}, got "
                     f"{grid.shape[0]}."
                 )
-            if grid.ndim != 1 and grid.shape[1] != dim:
+            if grid.ndim == 1:
+                actual_dim = 1
+            elif grid.ndim == 2:
+                actual_dim = grid.shape[1]
+            else:
+                raise ValueError(
+                    "Grid coordinates must be a one- or two-dimensional array."
+                )
+            if dim is not None and actual_dim != dim:
                 raise ValueError(
                     f"Grid coordinates must have dimension {dim}, got "
-                    f"{grid.shape[1]}."
+                    f"{actual_dim}."
                 )
-        if grid is None or grid.ndim > 1 and grid.shape[0] < grid.shape[1]:
+        if grid is None or (grid.ndim > 1 and grid.shape[0] < grid.shape[1]):
             warnings.warn(
                 "Warning: Dimension is higher than number of grid points. Verify that this is really intended."
             )

--- a/tests/distributions/test_abstract_grid_distribution.py
+++ b/tests/distributions/test_abstract_grid_distribution.py
@@ -47,6 +47,18 @@ class AbstractGridDistributionTest(unittest.TestCase):
                 array([1.0, 1.0]), grid=array([[0.0, 0.0], [1.0, 1.0]])
             )
 
+    def test_constructor_rejects_one_dimensional_grid_for_multidimensional_space(self):
+        with self.assertRaisesRegex(ValueError, "dimension 2"):
+            DummyGridDistribution(
+                array([1.0, 1.0]), grid=array([0.0, 1.0]), dim=2
+            )
+
+    def test_constructor_rejects_higher_rank_grid_coordinates(self):
+        with self.assertRaisesRegex(ValueError, "one- or two-dimensional"):
+            DummyGridDistribution(
+                array([1.0, 1.0]), grid=array([[[0.0]], [[1.0]]])
+            )
+
     def test_integrate_rejects_custom_boundaries(self):
         dist = DummyGridDistribution(array([1.0, 1.0]))
 


### PR DESCRIPTION
## Summary
- Fix `AbstractGridDistribution` coordinate validation so 1-D grid coordinates are treated as one-dimensional coordinates, not silently accepted for higher-dimensional distributions.
- Reject rank > 2 coordinate tensors instead of accepting them when `shape[1]` happens to match `dim`.
- Add regression coverage for both malformed coordinate cases.

## Bug fixed
Before this change, `DummyGridDistribution(array([1.0, 1.0]), grid=array([0.0, 1.0]), dim=2)` passed constructor validation even though the stored coordinates are one-dimensional. Similarly, rank-3 coordinate arrays could pass validation accidentally.

## Testing
- `python -m py_compile /tmp/abstract_grid_distribution.py /tmp/test_abstract_grid_distribution.py`

Full project tests are expected to run in GitHub Actions on the PR.