### PR TITLE
Validate NumPy multinomial pvals

### DIFF
--- a/src/pyrecest/_backend/numpy/random.py
+++ b/src/pyrecest/_backend/numpy/random.py
@@ -4,7 +4,6 @@ import numpy as _np
 from numpy.random import default_rng as _default_rng
 from numpy.random import (  # For PyRecEst
     get_state,
-    multinomial,
     seed,
     set_state,
 )
@@ -45,3 +44,20 @@ def randint(low, high=None, size=None, dtype=int):
     _validate_randint_bound(low, "low")
     _validate_randint_bound(high, "high")
     return _np.random.randint(low, high=high, size=size, dtype=dtype)
+
+
+def _validate_multinomial_pvals(pvals):
+    if _contains_boolean_value(pvals):
+        raise TypeError("pvals must be real numeric, not boolean")
+    try:
+        pvals_array = _np.asarray(pvals)
+    except (TypeError, ValueError) as exc:
+        raise TypeError("pvals must be real numeric") from exc
+    if pvals_array.dtype.kind not in "iuf":
+        raise TypeError("pvals must be real numeric")
+    return pvals_array
+
+
+def multinomial(n, pvals, size=None):
+    pvals_array = _validate_multinomial_pvals(pvals)
+    return _np.random.multinomial(n, pvals_array, size=size)

--- a/tests/backend/test_numpy_multinomial_real_pvals.py
+++ b/tests/backend/test_numpy_multinomial_real_pvals.py
@@ -1,4 +1,11 @@
+import pytest
+
 from pyrecest._backend.numpy import random
+
+
+def test_multinomial_rejects_text_pvals():
+    with pytest.raises(TypeError, match="real numeric"):
+        random.multinomial(1, ["1.0"])
 
 
 def test_multinomial_accepts_real_pvals():

--- a/tests/backend/test_numpy_multinomial_real_pvals.py
+++ b/tests/backend/test_numpy_multinomial_real_pvals.py
@@ -1,0 +1,8 @@
+from pyrecest._backend.numpy import random
+
+
+def test_multinomial_accepts_real_pvals():
+    result = random.multinomial(1, [1.0])
+
+    assert result.shape == (1,)
+    assert result.sum() == 1

--- a/tests/backend/test_numpy_multinomial_real_pvals.py
+++ b/tests/backend/test_numpy_multinomial_real_pvals.py
@@ -1,6 +1,12 @@
+import numpy as np
 import pytest
 
 from pyrecest._backend.numpy import random
+
+
+def test_multinomial_rejects_boolean_pvals():
+    with pytest.raises(TypeError, match="real numeric"):
+        random.multinomial(1, np.ones(1, dtype=bool))
 
 
 def test_multinomial_rejects_text_pvals():


### PR DESCRIPTION
## Summary
- replace the direct NumPy multinomial re-export with a small wrapper
- validate `pvals` before dispatching to NumPy
- add focused NumPy backend tests for invalid and valid pvals

## Validation
- Syntax-checked the modified source and test snippets locally with `ast.parse`.
- Ran a local isolated helper harness: invalid pvals raise `TypeError`; real-valued pvals still sample successfully.
- Full pytest was not run in this sandbox because the repository cannot be cloned from GitHub here.