### PR TITLE
Fix empty EOT sampling array shape

### DIFF
--- a/src/pyrecest/evaluation/eot_shape_database.py
+++ b/src/pyrecest/evaluation/eot_shape_database.py
@@ -8,6 +8,12 @@ def _uniform_scalar(low: float = 0.0, high: float = 1.0) -> float:
     return float(to_numpy(random.uniform(size=()) * (high - low) + low))
 
 
+def _points_to_array(points):
+    if not points:
+        return array([]).reshape((0, 2))
+    return array([(point.x, point.y) for point in points])
+
+
 class PolygonWithSampling(Polygon):  # pylint: disable=abstract-method
     __slots__ = Polygon.__slots__
 
@@ -39,7 +45,7 @@ class PolygonWithSampling(Polygon):  # pylint: disable=abstract-method
                     break
                 distance -= line.length
 
-        return array([(point.x, point.y) for point in points])
+        return _points_to_array(points)
 
     def sample_within(self, num_points: int):
         min_x, min_y, max_x, max_y = self.bounds
@@ -62,7 +68,7 @@ class PolygonWithSampling(Polygon):  # pylint: disable=abstract-method
 
             points.append(random_point)
 
-        return array([(point.x, point.y) for point in points])
+        return _points_to_array(points)
 
 
 class StarShapedPolygon(PolygonWithSampling):  # pylint: disable=abstract-method

--- a/tests/test_eot_shape_database.py
+++ b/tests/test_eot_shape_database.py
@@ -48,6 +48,13 @@ class TestStarShapedPolygon(unittest.TestCase):
 
         self.assertEqual(samples.shape, (5, 2))
 
+    def test_zero_point_samples_keep_coordinate_dimension(self):
+        boundary_samples = self.square_star_convex_poly.sample_on_boundary(0)
+        within_samples = self.square_star_convex_poly.sample_within(0)
+
+        self.assertEqual(boundary_samples.shape, (0, 2))
+        self.assertEqual(within_samples.shape, (0, 2))
+
 
 class TestStar(unittest.TestCase):
     def test_compute_kernel_star_convex(self):


### PR DESCRIPTION
## Summary
- preserve the coordinate dimension when EOT polygon sampling is asked for zero points
- route both boundary and interior polygon samples through a shared point-to-array helper
- add regression coverage for zero-count boundary and interior samples

## Bug fixed
`PolygonWithSampling.sample_on_boundary(0)` and `sample_within(0)` previously converted an empty list of points with `array([])`, yielding shape `(0,)`. Downstream measurement code expects sampled 2-D point sets to keep the matrix shape `(n_points, 2)`, so zero-measurement EOT steps could produce a rank-inconsistent array.

## Validation
- `python -m ast`/`ast.parse` syntax check on the modified source and test file.
- Full pytest was not run locally because this sandbox cannot resolve `github.com` to clone/install the complete repository dependency set.