### PR TITLE
Validate Autograd multinomial pvals

### DIFF
--- a/src/pyrecest/_backend/autograd/random.py
+++ b/src/pyrecest/_backend/autograd/random.py
@@ -1,6 +1,22 @@
 """Autograd based random backend."""
 
 import autograd.numpy as _np
-from autograd.numpy.random import get_state, multinomial, randint, seed, set_state
+from autograd.numpy.random import get_state, randint, seed, set_state
+from autograd.numpy.random import multinomial as _autograd_multinomial
 
 from .._shared_numpy.random import choice, multivariate_normal, normal, rand, uniform
+
+
+def _validate_multinomial_pvals(pvals):
+    try:
+        pvals_array = _np.asarray(pvals)
+    except (TypeError, ValueError) as exc:
+        raise TypeError("pvals must be real numeric") from exc
+    if pvals_array.dtype.kind not in "iuf":
+        raise TypeError("pvals must be real numeric")
+    return pvals_array
+
+
+def multinomial(n, pvals, size=None):
+    pvals_array = _validate_multinomial_pvals(pvals)
+    return _autograd_multinomial(n, pvals_array, size=size)

--- a/tests/backend/test_autograd_random_backend.py
+++ b/tests/backend/test_autograd_random_backend.py
@@ -12,3 +12,11 @@ def test_multinomial_accepts_real_probability_values():
 
     assert sample.shape == (2,)
     assert int(np.sum(sample)) == 4
+
+
+def test_multinomial_rejects_non_numeric_dtype_probability_values():
+    draw = getattr(random, "multinomial")
+    pvals = np.array([1, 0], dtype="?")
+
+    with pytest.raises(TypeError, match="real numeric"):
+        draw(4, pvals)

--- a/tests/backend/test_autograd_random_backend.py
+++ b/tests/backend/test_autograd_random_backend.py
@@ -1,0 +1,9 @@
+import pytest
+
+pytest.importorskip("autograd")
+
+from pyrecest._backend.autograd import random  # noqa: E402
+
+
+def test_autograd_random_backend_imports():
+    assert random is not None

--- a/tests/backend/test_autograd_random_backend.py
+++ b/tests/backend/test_autograd_random_backend.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 pytest.importorskip("autograd")
@@ -5,5 +6,9 @@ pytest.importorskip("autograd")
 from pyrecest._backend.autograd import random  # noqa: E402
 
 
-def test_autograd_random_backend_imports():
-    assert random is not None
+def test_multinomial_accepts_real_probability_values():
+    draw = getattr(random, "multinomial")
+    sample = draw(4, [0.25, 0.75])
+
+    assert sample.shape == (2,)
+    assert int(np.sum(sample)) == 4


### PR DESCRIPTION
## Summary
- stop re-exporting the Autograd backend's raw multinomial sampler directly
- validate `pvals` before dispatch so non-real probability vectors fail with a clear `TypeError`
- add focused Autograd backend regression coverage

## Bug fixed
The Autograd backend still exposed `autograd.numpy.random.multinomial` without the probability validation added for the NumPy backend. Inputs with non-real probability dtypes could therefore be passed through to the low-level sampler instead of being rejected consistently by PyRecEst's backend contract.

## Validation
- Syntax-checked the modified source and new test file with `ast.parse` locally.
- Full pytest was not run locally because the sandbox cannot resolve `github.com` to clone/install the repository dependency set.