### PR TITLE
Validate OOSM buffer copy_values flag

### DIFF
--- a/src/pyrecest/filters/out_of_sequence.py
+++ b/src/pyrecest/filters/out_of_sequence.py
@@ -35,6 +35,21 @@ def _coerce_time(time):
     return time
 
 
+def _coerce_bool_flag(value, name):
+    if isinstance(value, bool):
+        return value
+    try:
+        value_array = asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a boolean scalar") from exc
+    if len(value_array.shape) != 0:
+        raise ValueError(f"{name} must be a boolean scalar")
+    scalar = value_array.item()
+    if isinstance(scalar, bool):
+        return bool(scalar)
+    raise ValueError(f"{name} must be a boolean scalar")
+
+
 def _coerce_diagnostic_accepted(value):
     if value is None:
         return False
@@ -106,7 +121,7 @@ class FixedLagBuffer:
         self.maxlen = None if maxlen is None else int(maxlen)
         if self.maxlen is not None and self.maxlen <= 0:
             raise ValueError("maxlen must be positive or None")
-        self.copy_values = bool(copy_values)
+        self.copy_values = _coerce_bool_flag(copy_values, "copy_values")
         self._items = []
         self._next_sequence = 0
 

--- a/tests/filters/test_out_of_sequence.py
+++ b/tests/filters/test_out_of_sequence.py
@@ -1,5 +1,7 @@
 import unittest
 
+import numpy as np
+
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import allclose, array
 from pyrecest.distributions.nonperiodic.linear_dirac_distribution import (
@@ -37,6 +39,24 @@ class OutOfSequenceMeasurementTest(unittest.TestCase):
         self.assertTrue(buffer.is_within_lag(2.0))
         self.assertFalse(buffer.is_within_lag(1.5))
         self.assertEqual(buffer.latest_at_or_before(2.5).value, "b")
+
+    def test_fixed_lag_buffer_rejects_nonboolean_copy_values(self):
+        for copy_values in ("False", 1, [True]):
+            with self.subTest(copy_values=copy_values):
+                with self.assertRaisesRegex(ValueError, "copy_values"):
+                    FixedLagBuffer(copy_values=copy_values)
+                with self.assertRaisesRegex(ValueError, "copy_values"):
+                    MeasurementTimeBuffer(copy_values=copy_values)
+
+    def test_fixed_lag_buffer_accepts_scalar_numpy_bool_copy_values(self):
+        buffer = FixedLagBuffer(copy_values=np.bool_(False))
+        stored_value = {"items": []}
+        buffer.append(0.0, stored_value)
+
+        stored_value["items"].append("updated")
+
+        self.assertFalse(buffer.copy_values)
+        self.assertEqual(buffer.items[0].value["items"], ["updated"])
 
     def test_measurement_time_buffer_reports_oosm(self):
         buffer = MeasurementTimeBuffer(max_lag=2.0)


### PR DESCRIPTION
## Summary
- add strict scalar-boolean validation for `FixedLagBuffer(copy_values=...)`
- reject string, integer, and non-scalar truthiness values instead of silently applying `bool(...)`
- add regression coverage for invalid values and NumPy boolean scalar support through both `FixedLagBuffer` and `MeasurementTimeBuffer`

## Testing
- `python -m py_compile /tmp/out_of_sequence_new.py /tmp/test_out_of_sequence_new.py` locally against the edited source text
- GitHub Actions should run the repository test matrix on this PR