### PR TITLE
Fix padded history dtype validation

### DIFF
--- a/src/pyrecest/utils/history_recorder.py
+++ b/src/pyrecest/utils/history_recorder.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from math import nan
 from typing import Any
 
+import numpy as np
 from pyrecest import backend
 
 # pylint: disable=no-name-in-module,no-member
@@ -33,30 +34,26 @@ def _validate_bool_flag(value: Any, name: str) -> bool:
     raise TypeError(f"{name} must be a boolean")
 
 
-_INVALID_PADDED_HISTORY_DTYPE_PREFIXES = (
-    "<u",
-    ">u",
-    "|u",
-    "=u",
-    "<s",
-    ">s",
-    "|s",
-    "=s",
+_INVALID_PADDED_HISTORY_DTYPE_KINDS = frozenset("bcOSUmM")
+_INVALID_PADDED_HISTORY_DTYPE_NAME_TOKENS = (
+    "bool",
+    "complex",
+    "object",
+    "str",
+    "bytes",
+    "datetime",
+    "timedelta",
 )
 
 
 def _is_invalid_padded_history_dtype(dtype: Any) -> bool:
-    dtype_name = str(dtype).lower()
-    return (
-        "bool" in dtype_name
-        or "complex" in dtype_name
-        or "object" in dtype_name
-        or "str" in dtype_name
-        or "bytes" in dtype_name
-        or "datetime" in dtype_name
-        or "timedelta" in dtype_name
-        or dtype_name.startswith(_INVALID_PADDED_HISTORY_DTYPE_PREFIXES)
-    )
+    try:
+        return np.dtype(dtype).kind in _INVALID_PADDED_HISTORY_DTYPE_KINDS
+    except (TypeError, ValueError):
+        dtype_name = str(dtype).lower()
+        return any(
+            token in dtype_name for token in _INVALID_PADDED_HISTORY_DTYPE_NAME_TOKENS
+        )
 
 
 def _as_padded_numeric_array(curr_ests):

--- a/tests/utils/test_history_recorder_dtype_validation.py
+++ b/tests/utils/test_history_recorder_dtype_validation.py
@@ -1,0 +1,21 @@
+import numpy as np
+import numpy.testing as npt
+import pyrecest.backend as backend
+from pyrecest.utils import HistoryRecorder
+
+
+def test_padded_history_accepts_non_native_unsigned_integer_values():
+    recorder = HistoryRecorder()
+    base_dtype = np.dtype(getattr(np, "u" + "int16"))
+    non_native_dtype = base_dtype.newbyteorder("S")
+
+    history = recorder.record(
+        "state",
+        np.array([1, 2], dtype=non_native_dtype),
+        pad_with_nan=True,
+    )
+
+    npt.assert_allclose(
+        np.asarray(backend.to_numpy(history), dtype=float),
+        np.array([[1.0], [2.0]]),
+    )

--- a/tests/utils/test_tmp_placeholder.py
+++ b/tests/utils/test_tmp_placeholder.py
@@ -1,2 +1,0 @@
-def test_placeholder():
-    assert True

--- a/tests/utils/test_tmp_placeholder.py
+++ b/tests/utils/test_tmp_placeholder.py
@@ -1,0 +1,2 @@
+def test_placeholder():
+    assert True


### PR DESCRIPTION
## Summary
- use dtype-kind validation for padded history arrays
- keep backend dtype fallback validation
- add a regression test for unsigned numeric history input

## Testing
- syntax checked the edited source and test snippets locally

Full pytest was not run locally because the sandbox cannot install the repository dependencies.