### PR TITLE
Validate Daum-Huang flow scalar parameters

### DIFF
--- a/src/pyrecest/filters/daum_huang_particle_filter.py
+++ b/src/pyrecest/filters/daum_huang_particle_filter.py
@@ -350,15 +350,52 @@ def _validate_flow_type(flow_type) -> FlowType:
 
 
 def _validate_positive_int(value, name: str) -> int:
-    if isinstance(value, bool) or int(value) != value or int(value) <= 0:
-        raise ValueError(f"{name} must be a positive integer.")
-    return int(value)
+    message = f"{name} must be a positive integer."
+    value_array = np.asarray(value)
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError(message)
+
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(message)
+    if isinstance(scalar, (str, bytes, bytearray, np.str_, np.bytes_)):
+        raise ValueError(message)
+    if isinstance(scalar, (complex, np.complexfloating)):
+        raise ValueError(message)
+
+    try:
+        scalar_float = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if not np.isfinite(scalar_float) or not scalar_float.is_integer():
+        raise ValueError(message)
+
+    parsed = int(scalar_float)
+    if parsed <= 0:
+        raise ValueError(message)
+    return parsed
 
 
 def _validate_nonnegative_float(value, name: str) -> float:
-    value = float(value)
+    message = f"{name} must be finite and nonnegative."
+    value_array = np.asarray(value)
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError(message)
+
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(message)
+    if isinstance(scalar, (str, bytes, bytearray, np.str_, np.bytes_)):
+        raise ValueError(message)
+    if isinstance(scalar, (complex, np.complexfloating)):
+        raise ValueError(message)
+
+    try:
+        value = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
     if not np.isfinite(value) or value < 0.0:
-        raise ValueError(f"{name} must be finite and nonnegative.")
+        raise ValueError(message)
     return value
 
 


### PR DESCRIPTION
## Summary
- harden Daum-Huang particle-flow scalar validators against silent NumPy/Python coercions
- reject boolean, text-like, complex, non-scalar, non-finite, and non-integer values for positive integer parameters
- reject boolean, text-like, complex, non-scalar, non-finite, and negative values for nonnegative float parameters

## Bug fixed
`_validate_positive_int` previously used `int(value) != value`, which silently accepted `np.bool_(True)` as `1`. `_validate_nonnegative_float` directly called `float(value)`, so boolean and text-like values such as `True` or `"1e-8"` could be accepted as valid algorithm parameters. This could make Daum-Huang particle-flow configuration accept semantically invalid `n_steps` or `jitter` inputs instead of failing with a clear validation error.

## Testing
- Reasoned regression: `n_steps=np.bool_(True)` now raises `ValueError` instead of being accepted as one step.
- Reasoned regression: boolean/text/complex/non-scalar `jitter` values now raise `ValueError` before float coercion.
- Full pytest not run in this environment; GitHub Actions should run the repository matrix.

Note: I attempted to add a focused regression test file, but the connector guard blocked both the file-create and tree-update calls for the test file during this session. The source fix itself is committed.