### PR TITLE
Validate score_to_cost output matrices

### DIFF
--- a/src/pyrecest/utils/multisession_assignment_score.py
+++ b/src/pyrecest/utils/multisession_assignment_score.py
@@ -50,6 +50,7 @@ _INVALID_SCORE_SCALAR_TYPES = (
     np.timedelta64,
 )
 _REJECTED_SCORE_ARRAY_KINDS = frozenset({"b", "c", "S", "U", "M", "m"})
+_SCORE_TO_COST_ERROR = "score_to_cost must return real numeric cost matrices."
 
 
 def _ensure_supported_backend(feature_name: str) -> None:
@@ -83,6 +84,24 @@ def _validate_real_score_matrix(value: Any) -> None:
         for item in raw_values.reshape(-1):
             if isinstance(item, _INVALID_SCORE_SCALAR_TYPES):
                 _raise_invalid_score_matrix()
+
+
+def _raise_invalid_score_to_cost_matrix() -> None:
+    raise ValueError(_SCORE_TO_COST_ERROR)
+
+
+def _validate_real_score_to_cost_matrix(value: Any) -> None:
+    try:
+        raw_values = np.asarray(value)
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise ValueError(_SCORE_TO_COST_ERROR) from exc
+
+    if raw_values.dtype.kind in _REJECTED_SCORE_ARRAY_KINDS:
+        _raise_invalid_score_to_cost_matrix()
+    if raw_values.dtype == object:
+        for item in raw_values.reshape(-1):
+            if isinstance(item, _INVALID_SCORE_SCALAR_TYPES):
+                _raise_invalid_score_to_cost_matrix()
 
 
 def _validate_pairwise_score_inputs(pairwise_scores: PairwiseCostsInput) -> None:
@@ -242,7 +261,9 @@ def solve_multisession_assignment_from_similarity(  # pylint: disable=R0913,R091
             admissible_mask &= score_matrix_array >= min_score
 
         safe_scores = where(score_finite_mask, score_matrix_array, 0.0)
-        cost_matrix = asarray(score_to_cost(safe_scores), dtype=float)
+        raw_cost_matrix = score_to_cost(safe_scores)
+        _validate_real_score_to_cost_matrix(raw_cost_matrix)
+        cost_matrix = asarray(raw_cost_matrix, dtype=float)
         if cost_matrix.shape != score_matrix_array.shape:
             raise ValueError("score_to_cost must preserve the input matrix shape.")
 

--- a/tests/test_multisession_assignment_similarity_score_to_cost.py
+++ b/tests/test_multisession_assignment_similarity_score_to_cost.py
@@ -1,0 +1,63 @@
+"""Regression tests for score_to_cost output validation."""
+
+import unittest
+
+import numpy as np
+from pyrecest.backend import __backend_name__, array
+from pyrecest.utils import solve_multisession_assignment_from_similarity
+
+
+class TestMultiSessionAssignmentSimilarityScoreToCost(unittest.TestCase):
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_accepts_numeric_cost_matrix_from_score_to_cost(self):
+        result = solve_multisession_assignment_from_similarity(
+            [array([[0.25]], dtype=float)],
+            start_cost=1.0,
+            end_cost=1.0,
+            score_to_cost=lambda scores: 1.0 - np.asarray(scores),
+        )
+
+        self.assertEqual(result.tracks, [{0: 0, 1: 0}])
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_rejects_boolean_cost_matrix_from_score_to_cost(self):
+        pairwise_scores = [array([[0.25]], dtype=float)]
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "score_to_cost must return real numeric cost matrices",
+        ):
+            solve_multisession_assignment_from_similarity(
+                pairwise_scores,
+                start_cost=1.0,
+                end_cost=1.0,
+                score_to_cost=lambda scores: np.asarray(scores) > 0.0,
+            )
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_rejects_text_cost_matrix_from_score_to_cost(self):
+        pairwise_scores = [array([[0.25]], dtype=float)]
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "score_to_cost must return real numeric cost matrices",
+        ):
+            solve_multisession_assignment_from_similarity(
+                pairwise_scores,
+                start_cost=1.0,
+                end_cost=1.0,
+                score_to_cost=lambda scores: np.asarray([["bad"]]),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- validate custom `score_to_cost` outputs before converting them to backend float arrays
- reject boolean, text, complex, and otherwise non-real cost matrices with a clear `ValueError`
- add regression coverage for valid numeric converters and invalid boolean/text converter outputs

## Bug fixed
`solve_multisession_assignment_from_similarity()` used to pass custom `score_to_cost` results directly into `asarray(..., dtype=float)`. Boolean matrices were therefore silently coerced to numeric costs, and text/non-real outputs could fail with backend-level conversion errors instead of the wrapper's validation contract.

## Testing
- `python -m py_compile /mnt/data/multisession_assignment_score.py /mnt/data/test_multisession_assignment_similarity_score_to_cost.py`

Full pytest was not run locally in this connector environment.