### PR TITLE
Validate Gaussian-mixture PHD component dimensions

### DIFF
--- a/src/pyrecest/filters/gaussian_mixture_phd_filter.py
+++ b/src/pyrecest/filters/gaussian_mixture_phd_filter.py
@@ -168,6 +168,13 @@ class GaussianMixturePHDFilter(
             )
 
         state = GaussianMixturePHDState(components, weights)
+        if state.dists and self.birth_components:
+            self._require_component_dimension(
+                self.birth_components,
+                state.dim,
+                "Birth",
+            )
+
         self._components = copy.deepcopy(state.dists)
         self._weights = array(state.w)
         if self._weights.ndim == 0:
@@ -188,6 +195,13 @@ class GaussianMixturePHDFilter(
             birth_weights = 0.05 * ones((len(birth_components),))
 
         birth_state = GaussianMixturePHDState(birth_components, birth_weights)
+        if birth_state.dists and self._dim is not None:
+            self._require_component_dimension(
+                birth_state.dists,
+                self._dim,
+                "Birth",
+            )
+
         self.birth_components = copy.deepcopy(birth_state.dists)
         self.birth_weights = array(birth_state.w)
 
@@ -264,6 +278,17 @@ class GaussianMixturePHDFilter(
             return float(clutter_as_array.reshape((-1,))[0])
         return float(clutter_as_array.reshape((-1,))[measurement_index])
 
+    @staticmethod
+    def _require_component_dimension(components, expected_dim, component_kind):
+        if not components:
+            return
+        component_dim = components[0].dim
+        if component_dim != expected_dim:
+            raise ValueError(
+                f"{component_kind} components must have dimension {expected_dim}, "
+                f"got {component_dim}."
+            )
+
     def _resolve_birth_arguments(self, birth_components, birth_weights):
         if birth_components is None:
             return self.birth_components, self.birth_weights
@@ -282,7 +307,8 @@ class GaussianMixturePHDFilter(
         birth_weights=None,
         survival_probability=None,
     ):
-        sys_noise_cov = _covariance_from_zero_mean_gaussian_noise(sys_noise)
+        system_matrix = array(system_matrix)
+        sys_noise_cov = array(_covariance_from_zero_mean_gaussian_noise(sys_noise))
 
         if survival_probability is None:
             survival_probability = self.survival_probability
@@ -311,6 +337,11 @@ class GaussianMixturePHDFilter(
 
         birth_components_resolved, birth_weights_resolved = (
             self._resolve_birth_arguments(birth_components, birth_weights)
+        )
+        self._require_component_dimension(
+            birth_components_resolved,
+            system_matrix.shape[0],
+            "Birth",
         )
         predicted_components.extend(copy.deepcopy(birth_components_resolved))
 

--- a/tests/filters/test_gaussian_mixture_phd_filter_dimensions.py
+++ b/tests/filters/test_gaussian_mixture_phd_filter_dimensions.py
@@ -1,0 +1,57 @@
+import unittest
+
+import pyrecest.backend
+from pyrecest.backend import array, eye
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.filters.gaussian_mixture_phd_filter import GaussianMixturePHDFilter
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ != "numpy",
+    reason="Currently only supported for the numpy backend",
+)
+class TestGaussianMixturePHDFilterDimensions(unittest.TestCase):
+    def test_constructor_rejects_mismatched_birth_dimension(self):
+        with self.assertRaisesRegex(ValueError, "Birth components must have dimension 2"):
+            GaussianMixturePHDFilter(
+                initial_components=[GaussianDistribution(array([0.0, 0.0]), eye(2))],
+                initial_weights=array([0.8]),
+                birth_components=[
+                    GaussianDistribution(array([5.0, 5.0, 0.0]), eye(3)),
+                ],
+                birth_weights=array([0.2]),
+                log_prior_estimates=False,
+                log_posterior_estimates=False,
+            )
+
+    def test_set_birth_model_rejects_mismatched_dimension(self):
+        tracker = GaussianMixturePHDFilter(
+            initial_components=[GaussianDistribution(array([0.0, 0.0]), eye(2))],
+            initial_weights=array([0.8]),
+            log_prior_estimates=False,
+            log_posterior_estimates=False,
+        )
+
+        with self.assertRaisesRegex(ValueError, "Birth components must have dimension 2"):
+            tracker.set_birth_model(
+                [GaussianDistribution(array([5.0, 5.0, 0.0]), eye(3))],
+                array([0.2]),
+            )
+
+    def test_predict_linear_rejects_mismatched_temporary_birth_dimension(self):
+        tracker = GaussianMixturePHDFilter(
+            initial_components=[GaussianDistribution(array([0.0, 0.0]), eye(2))],
+            initial_weights=array([0.8]),
+            log_prior_estimates=False,
+            log_posterior_estimates=False,
+        )
+
+        with self.assertRaisesRegex(ValueError, "Birth components must have dimension 2"):
+            tracker.predict_linear(
+                eye(2),
+                0.1 * eye(2),
+                birth_components=[
+                    GaussianDistribution(array([5.0, 5.0, 0.0]), eye(3)),
+                ],
+                birth_weights=array([0.2]),
+            )


### PR DESCRIPTION
## Summary
- Reject persistent birth components whose state dimension differs from an initialized Gaussian-mixture PHD filter.
- Reject constructor and per-call prediction configurations that would mix birth components with a different predicted state dimension.
- Add regression tests for constructor, `set_birth_model`, and temporary `predict_linear` birth-component dimension mismatches.

## Tests
- `python -m py_compile` on the modified source and added regression test file locally.

This prevents mixed-dimensional Gaussian-mixture PHD intensities from being accepted and failing later during point extraction or downstream prediction/update steps.