### PR TITLE
Validate wrapped normal progressive tau

### DIFF
--- a/src/pyrecest/filters/wrapped_normal_filter.py
+++ b/src/pyrecest/filters/wrapped_normal_filter.py
@@ -1,3 +1,4 @@
+import math
 from collections.abc import Callable
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
@@ -6,6 +7,36 @@ from pyrecest.distributions import CircularDiracDistribution, WrappedNormalDistr
 
 from .abstract_filter import AbstractFilter
 from .manifold_mixins import CircularFilterMixin
+
+
+_PROGRESSIVE_TAU_MESSAGE = "tau must be a positive finite scalar"
+
+
+def _normalize_progressive_tau(tau, default: float) -> float:
+    """Normalize the progressive-update threshold without truthiness coercion."""
+    if tau is None:
+        return default
+    if isinstance(tau, (bool, str, bytes, bytearray)):
+        raise ValueError(_PROGRESSIVE_TAU_MESSAGE)
+    try:
+        tau_array = array(tau)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(_PROGRESSIVE_TAU_MESSAGE) from exc
+    if getattr(tau_array, "shape", ()) != ():
+        raise ValueError(_PROGRESSIVE_TAU_MESSAGE)
+    try:
+        scalar = tau_array.item()
+    except AttributeError:
+        scalar = tau_array
+    if isinstance(scalar, (bool, str, bytes, bytearray)):
+        raise ValueError(_PROGRESSIVE_TAU_MESSAGE)
+    try:
+        tau_value = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(_PROGRESSIVE_TAU_MESSAGE) from exc
+    if not math.isfinite(tau_value) or tau_value <= 0.0:
+        raise ValueError(_PROGRESSIVE_TAU_MESSAGE)
+    return tau_value
 
 
 class WrappedNormalFilter(AbstractFilter, CircularFilterMixin):
@@ -77,7 +108,7 @@ class WrappedNormalFilter(AbstractFilter, CircularFilterMixin):
         # pylint: disable=too-many-locals
         DEFAULT_TAU = 0.02
         MINIMUM_LAMBDA: float = 0.001
-        tau = tau if tau else DEFAULT_TAU
+        tau = _normalize_progressive_tau(tau, DEFAULT_TAU)
         lambda_ = 1.0
         steps = 0
 

--- a/tests/filters/test_wrapped_normal_filter.py
+++ b/tests/filters/test_wrapped_normal_filter.py
@@ -71,6 +71,26 @@ class WrappedNormalFilterTest(unittest.TestCase):
         self.assertIsInstance(self.wn_filter.filter_state, WrappedNormalDistribution)
         self.assertTrue(math.isfinite(float(self.wn_filter.filter_state.sigma)))
 
+    def test_update_nonlinear_progressive_rejects_invalid_tau(self):
+        self.wn_filter.filter_state = WrappedNormalDistribution(array(0.0), array(0.5))
+        invalid_taus = (
+            0.0,
+            -0.1,
+            float("nan"),
+            float("inf"),
+            True,
+            "0.02",
+            array([0.02]),
+        )
+
+        for tau in invalid_taus:
+            with self.subTest(tau=tau), self.assertRaisesRegex(
+                ValueError, "tau must be a positive finite scalar"
+            ):
+                self.wn_filter.update_nonlinear_progressive(
+                    _scalar_only_likelihood, 0.1, tau=tau
+                )
+
     def test_update_nonlinear_progressive_uses_adaptive_lambda(self):
         class FakeDiracDistribution:
             def __init__(self):


### PR DESCRIPTION
## Summary
- validate `WrappedNormalFilter.update_nonlinear_progressive(tau=...)` as a positive finite scalar
- stop treating falsey explicit values such as `tau=0` as if the default threshold had been requested
- add regression coverage for zero, negative, non-finite, boolean, text, and non-scalar tau inputs

## Bug fixed
`update_nonlinear_progressive()` used `tau = tau if tau else DEFAULT_TAU`, so an explicit `tau=0` was silently replaced by the default `0.02`. That can mask invalid progressive-update configuration instead of failing deterministically.

## Testing
- syntax-checked the edited source and test snippets locally with Python `compile(...)`
- full pytest was not run locally because the GitHub repository could not be cloned from this environment