### PR TITLE
Validate scenario type registry keys

### DIFF
--- a/src/pyrecest/scenarios.py
+++ b/src/pyrecest/scenarios.py
@@ -35,12 +35,17 @@ ScenarioRunner = Callable[[str | Path], ScenarioResult]
 _SCENARIO_RUNNERS: dict[str, ScenarioRunner] = {}
 
 
+def _normalize_scenario_type(scenario_type: Any) -> str:
+    if not isinstance(scenario_type, str) or not scenario_type.strip():
+        raise ValueError("scenario_type must be a non-empty string")
+    return scenario_type.strip()
+
+
 def register_scenario_runner(
     scenario_type: str, runner: ScenarioRunner
 ) -> ScenarioRunner:
     """Register ``runner`` for a TOML ``scenario.type`` value."""
-    if not scenario_type:
-        raise ValueError("scenario_type must be a non-empty string")
+    scenario_type = _normalize_scenario_type(scenario_type)
     if scenario_type in _SCENARIO_RUNNERS:
         raise ValueError(f"Scenario type {scenario_type!r} is already registered")
     _SCENARIO_RUNNERS[scenario_type] = runner
@@ -49,6 +54,7 @@ def register_scenario_runner(
 
 def scenario_runner(scenario_type: str) -> Callable[[ScenarioRunner], ScenarioRunner]:
     """Decorator form of :func:`register_scenario_runner`."""
+    scenario_type = _normalize_scenario_type(scenario_type)
 
     def decorator(runner: ScenarioRunner) -> ScenarioRunner:
         return register_scenario_runner(scenario_type, runner)
@@ -344,13 +350,23 @@ def run_particle_resampling_scenario(path: str | Path) -> ScenarioResult:
 def run_scenario(path: str | Path) -> ScenarioResult:
     """Run the scenario described by ``path``."""
     config = load_scenario_config(path)
-    scenario_type = config.get("scenario", {}).get("type")
+    raw_scenario_type = config.get("scenario", {}).get("type")
+    available = ", ".join(available_scenario_types()) or "none"
+    try:
+        scenario_type = _normalize_scenario_type(raw_scenario_type)
+    except ValueError as exc:
+        message = (
+            f"Unsupported scenario type: {raw_scenario_type!r}. "
+            f"Available scenario types: {available}."
+        )
+        raise ValueError(message) from exc
     runner = _SCENARIO_RUNNERS.get(scenario_type)
     if runner is None:
-        available = ", ".join(available_scenario_types()) or "none"
-        raise ValueError(
-            f"Unsupported scenario type: {scenario_type!r}. Available scenario types: {available}."
+        message = (
+            f"Unsupported scenario type: {scenario_type!r}. "
+            f"Available scenario types: {available}."
         )
+        raise ValueError(message)
     return runner(path)
 
 

--- a/tests/test_scenario_type_validation.py
+++ b/tests/test_scenario_type_validation.py
@@ -1,0 +1,47 @@
+import pytest
+
+from pyrecest import scenarios
+
+
+@pytest.mark.parametrize(
+    "scenario_type",
+    [None, "", "   ", b"custom", 1, ["custom"]],
+)
+def test_register_scenario_runner_rejects_invalid_scenario_types(scenario_type):
+    with pytest.raises(ValueError, match="scenario_type must be a non-empty string"):
+        scenarios.register_scenario_runner(scenario_type, lambda _path: None)
+
+
+def test_scenario_runner_decorator_rejects_invalid_scenario_type():
+    with pytest.raises(ValueError, match="scenario_type must be a non-empty string"):
+        scenarios.scenario_runner("   ")
+
+
+def test_register_scenario_runner_strips_whitespace():
+    name = "temporary_scenario_type_for_validation"
+    scenarios._SCENARIO_RUNNERS.pop(name, None)  # pylint: disable=protected-access
+
+    def runner(_path):
+        raise AssertionError("runner should not be called")
+
+    try:
+        assert scenarios.register_scenario_runner(f"  {name}\t", runner) is runner
+        assert name in scenarios.available_scenario_types()
+        assert f"  {name}\t" not in scenarios._SCENARIO_RUNNERS  # pylint: disable=protected-access
+
+        with pytest.raises(ValueError, match="already registered"):
+            scenarios.register_scenario_runner(name, runner)
+    finally:
+        scenarios._SCENARIO_RUNNERS.pop(name, None)  # pylint: disable=protected-access
+
+
+def test_run_scenario_rejects_unhashable_scenario_type(tmp_path):
+    scenario_path = tmp_path / "bad_scenario.toml"
+    scenario_path.write_text(
+        "[scenario]\n"
+        'type = ["linear_gaussian"]\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Unsupported scenario type"):
+        scenarios.run_scenario(scenario_path)


### PR DESCRIPTION
## Summary
- Normalize and validate scenario registry keys before storing decorators/runners.
- Reject non-string, blank, and otherwise invalid scenario types before they reach registry lookups.
- Return a user-facing `ValueError` for unhashable TOML `scenario.type` values instead of leaking a raw dictionary `TypeError`.

## Tests
- `python -m py_compile src/pyrecest/scenarios.py tests/test_scenario_type_validation.py`
- Ran the new scenario-type validation tests against the patched module in an isolated local package (`9 passed`).

## Notes
- Full repository test suite was not run in this environment.