### PR TITLE
Keep von Mises pdf stable after norm_const access

### DIFF
--- a/src/pyrecest/distributions/circle/von_mises_distribution.py
+++ b/src/pyrecest/distributions/circle/von_mises_distribution.py
@@ -49,6 +49,7 @@ class VonMisesDistribution(AbstractCircularDistribution):
         self.mu = mu
         self.kappa = kappa
         self._norm_const = norm_const
+        self._norm_const_is_explicit = norm_const is not None
 
     def get_params(self):
         return self.mu, self.kappa
@@ -61,7 +62,7 @@ class VonMisesDistribution(AbstractCircularDistribution):
 
     def pdf(self, xs):
         xs = array(xs)
-        if self._norm_const is None:
+        if not self._norm_const_is_explicit:
             p = exp(self.kappa * (cos(xs - self.mu) - 1.0)) / (
                 2.0 * pi * ive(0, self.kappa)
             )

--- a/src/pyrecest/distributions/circle/von_mises_distribution.py
+++ b/src/pyrecest/distributions/circle/von_mises_distribution.py
@@ -62,7 +62,7 @@ class VonMisesDistribution(AbstractCircularDistribution):
 
     def pdf(self, xs):
         xs = array(xs)
-        if not self._norm_const_is_explicit:
+        if not getattr(self, "_norm_const_is_explicit", False):
             p = exp(self.kappa * (cos(xs - self.mu) - 1.0)) / (
                 2.0 * pi * ive(0, self.kappa)
             )

--- a/tests/distributions/test_von_mises_distribution.py
+++ b/tests/distributions/test_von_mises_distribution.py
@@ -41,6 +41,16 @@ class TestVonMisesDistribution(unittest.TestCase):
         self.assertGreater(float(mode_pdf[0]), 0.0)
         self.assertTrue(np.isfinite(float(entropy)))
 
+    def test_large_concentration_pdf_stays_stable_after_norm_const_access(self):
+        dist = VonMisesDistribution(0.3, 1000.0)
+        expected = VonMisesDistribution(0.3, 1000.0).pdf(array([0.3]))
+
+        _ = dist.norm_const
+        mode_pdf = dist.pdf(array([0.3]))
+
+        self.assertTrue(np.isfinite(float(mode_pdf[0])))
+        npt.assert_allclose(mode_pdf, expected)
+
     def test_pdf(self):
         dist = VonMisesDistribution(2, 1)
         xs = linspace(1, 7, 7)


### PR DESCRIPTION
## Summary
- keep automatically computed von Mises normalizers from changing `pdf()` to the unstable unscaled evaluation path
- preserve explicit `norm_const` behavior for callers that provide one
- add a regression test for large-concentration PDF evaluation after `norm_const` has been accessed

## Bug fixed
For large concentrations, `norm_const` can overflow because it uses the unscaled Bessel function `iv(0, kappa)`. Accessing `dist.norm_const` therefore cached `inf`; later `dist.pdf()` switched to `exp(kappa * cos(...)) / norm_const`, which evaluates to `inf / inf` at the mode and returns `nan`. The default `pdf()` path is already stable via `ive`, so the fix keeps auto-computed normalizers on that scaled path.

## Validation
- `python -m py_compile src/pyrecest/distributions/circle/von_mises_distribution.py tests/distributions/test_von_mises_distribution.py` on the patched files
- Reproduced the numerical failure locally with SciPy/NumPy formulas (`kappa=1000`, mode point): unscaled path produced `nan`, scaled path stayed finite
- Full repository test suite was not run because the execution sandbox cannot resolve `github.com` to clone/install the repository