### PR TITLE
Validate NumPy multinomial sample counts

### DIFF
--- a/src/pyrecest/_backend/numpy/random.py
+++ b/src/pyrecest/_backend/numpy/random.py
@@ -46,6 +46,21 @@ def randint(low, high=None, size=None, dtype=int):
     return _np.random.randint(low, high=high, size=size, dtype=dtype)
 
 
+def _validate_multinomial_sample_count(n):
+    if _contains_boolean_value(n):
+        raise TypeError("n must be a non-negative integer")
+    try:
+        n_array = _np.asarray(n)
+    except (TypeError, ValueError) as exc:
+        raise TypeError("n must be a non-negative integer") from exc
+    if n_array.shape != () or n_array.dtype.kind not in "iu":
+        raise TypeError("n must be a non-negative integer")
+    count = int(n_array.item())
+    if count < 0:
+        raise ValueError("n must be non-negative")
+    return count
+
+
 def _validate_multinomial_pvals(pvals):
     if _contains_boolean_value(pvals):
         raise TypeError("pvals must be real numeric, not boolean")
@@ -59,5 +74,6 @@ def _validate_multinomial_pvals(pvals):
 
 
 def multinomial(n, pvals, size=None):
+    n = _validate_multinomial_sample_count(n)
     pvals_array = _validate_multinomial_pvals(pvals)
     return _np.random.multinomial(n, pvals_array, size=size)

--- a/tests/backend/test_numpy_random_backend.py
+++ b/tests/backend/test_numpy_random_backend.py
@@ -71,6 +71,37 @@ def test_randint_accepts_integer_array_bounds():
 
 
 @pytest.mark.parametrize(
+    "n",
+    [
+        True,
+        False,
+        np.bool_(True),
+        np.array(True),
+        np.array([1]),
+        1.5,
+        "1",
+    ],
+)
+def test_multinomial_rejects_non_integer_or_boolean_sample_counts(n):
+    with pytest.raises(TypeError, match="non-negative integer"):
+        random.multinomial(n, [1.0])
+
+
+def test_multinomial_rejects_negative_sample_counts():
+    with pytest.raises(ValueError, match="non-negative"):
+        random.multinomial(-1, [1.0])
+
+
+def test_multinomial_accepts_integer_like_scalar_sample_counts():
+    random.seed(0)
+
+    samples = random.multinomial(np.array(2, dtype=np.int64), [0.25, 0.75], size=3)
+
+    assert samples.shape == (3, 2)
+    assert np.all(samples.sum(axis=1) == 2)
+
+
+@pytest.mark.parametrize(
     ("low", "high"),
     [
         (False, 1.0),


### PR DESCRIPTION
## Summary
- validate NumPy backend `random.multinomial(..., n=...)` before dispatching to NumPy
- reject boolean, non-scalar, fractional, text, and negative sample counts with explicit errors
- add regression coverage while preserving integer-like scalar counts

## Bug fixed
The NumPy backend already validated `pvals`, but passed `n` directly to `numpy.random.multinomial`. Because Python booleans are integer-like, calls such as `random.multinomial(True, [1.0])` were accepted as one draw instead of being rejected consistently with the JAX/PyTorch backend contract.

## Testing
- `python -m py_compile /mnt/data/random.py /mnt/data/test_numpy_random_backend.py`
- isolated validator check confirming boolean/fractional/text/non-scalar `n` inputs are rejected and an integer NumPy scalar is accepted

Full repository pytest was not run because this environment cannot clone the GitHub repository.