### PR TITLE
Validate camera projection matrix shapes

### DIFF
--- a/src/pyrecest/models/sensor_models.py
+++ b/src/pyrecest/models/sensor_models.py
@@ -126,6 +126,13 @@ def _as_vector(value, length: int, name: str):
     return vector
 
 
+def _as_matrix(value, shape: tuple[int, int], name: str):
+    matrix = asarray(value)
+    if tuple(matrix.shape) != shape:
+        raise ValueError(f"{name} must have shape {shape}")
+    return matrix
+
+
 def _as_sensor_positions(value, position_dim: int = 2):
     sensors = asarray(value)
     sensor_shape = tuple(sensors.shape)
@@ -334,7 +341,7 @@ def camera_projection_measurement(
     are returned.
     """
     position = _select(state, position_indices, 3, "position_indices")
-    rotation = asarray(rotation) if rotation is not None else None
+    rotation = None if rotation is None else _as_matrix(rotation, (3, 3), "rotation")
     translation = _as_vector(translation, 3, "translation")
     camera_position = position if rotation is None else matvec(rotation, position)
     camera_position = camera_position + translation
@@ -348,7 +355,7 @@ def camera_projection_measurement(
     )
     if camera_matrix is None:
         return stack([normalized[0], normalized[1]])
-    homogeneous = matvec(asarray(camera_matrix), normalized)
+    homogeneous = matvec(_as_matrix(camera_matrix, (3, 3), "camera_matrix"), normalized)
     _validate_nonzero_scalar(homogeneous[2], "homogeneous camera scale")
     return stack([homogeneous[0] / homogeneous[2], homogeneous[1] / homogeneous[2]])
 

--- a/tests/test_camera_projection_validation.py
+++ b/tests/test_camera_projection_validation.py
@@ -1,0 +1,48 @@
+"""Regression tests for camera projection geometry validation."""
+
+import unittest
+
+from pyrecest.backend import array, eye
+from pyrecest.models import camera_projection_measurement
+
+
+class TestCameraProjectionValidation(unittest.TestCase):
+    def test_camera_projection_rejects_malformed_rotation_shape(self):
+        state = array([1.0, 2.0, 4.0])
+
+        invalid_rotations = (
+            array([1.0, 0.0, 0.0]),
+            array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]),
+        )
+        for rotation in invalid_rotations:
+            with self.subTest(rotation_shape=tuple(rotation.shape)):
+                with self.assertRaisesRegex(ValueError, "rotation"):
+                    camera_projection_measurement(state, rotation=rotation)
+
+    def test_camera_projection_rejects_malformed_camera_matrix_shape(self):
+        state = array([1.0, 2.0, 4.0])
+
+        invalid_camera_matrices = (
+            array([1.0, 0.0, 0.0]),
+            array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]),
+        )
+        for camera_matrix in invalid_camera_matrices:
+            with self.subTest(camera_matrix_shape=tuple(camera_matrix.shape)):
+                with self.assertRaisesRegex(ValueError, "camera_matrix"):
+                    camera_projection_measurement(state, camera_matrix=camera_matrix)
+
+    def test_camera_projection_accepts_well_formed_rotation_and_camera_matrix(self):
+        state = array([2.0, 4.0, 2.0])
+        camera_matrix = array([[2.0, 0.0, 10.0], [0.0, 3.0, 20.0], [0.0, 0.0, 1.0]])
+
+        projected = camera_projection_measurement(
+            state,
+            rotation=eye(3),
+            camera_matrix=camera_matrix,
+        )
+
+        self.assertEqual(tuple(projected.shape), (2,))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- validate `camera_projection_measurement(..., rotation=...)` as a 3x3 matrix before applying it
- validate `camera_projection_measurement(..., camera_matrix=...)` as a 3x3 projective camera matrix before homogeneous projection
- add regression coverage for malformed camera geometry shapes while preserving a valid projection case

## Bug fixed
Malformed camera geometry inputs were not validated deterministically. A length-3 `rotation` vector could be treated as a vector dot product and then broadcast with translation, producing silently wrong camera coordinates. Malformed camera matrices could also surface as low-level matmul or index errors. The helper now rejects these cases with explicit `ValueError`s naming `rotation` or `camera_matrix`.

## Testing
- GitHub compare verified only `src/pyrecest/models/sensor_models.py` and `tests/test_camera_projection_validation.py` changed.
- Full local pytest was not run because the execution sandbox cannot resolve `github.com` to clone/install the repository.