### PR TITLE
Reject boolean NumPy multinomial sizes

### DIFF
--- a/src/pyrecest/_backend/numpy/random.py
+++ b/src/pyrecest/_backend/numpy/random.py
@@ -73,7 +73,14 @@ def _validate_multinomial_pvals(pvals):
     return pvals_array
 
 
+def _validate_multinomial_size(size):
+    if size is not None and _contains_boolean_value(size):
+        raise TypeError("size must be None, an integer, or a sequence of integers")
+    return size
+
+
 def multinomial(n, pvals, size=None):
     n = _validate_multinomial_sample_count(n)
     pvals_array = _validate_multinomial_pvals(pvals)
+    size = _validate_multinomial_size(size)
     return _np.random.multinomial(n, pvals_array, size=size)

--- a/tests/backend/test_numpy_random_backend.py
+++ b/tests/backend/test_numpy_random_backend.py
@@ -102,6 +102,32 @@ def test_multinomial_accepts_integer_like_scalar_sample_counts():
 
 
 @pytest.mark.parametrize(
+    "bad_size",
+    [
+        True,
+        False,
+        np.bool_(True),
+        (True,),
+        [np.bool_(False), 2],
+        np.array(True),
+        np.array([True, 2], dtype=object),
+    ],
+)
+def test_multinomial_rejects_boolean_size_arguments(bad_size):
+    with pytest.raises(TypeError, match="size"):
+        random.multinomial(2, [0.25, 0.75], size=bad_size)
+
+
+def test_multinomial_accepts_integer_like_size_argument():
+    random.seed(0)
+
+    samples = random.multinomial(2, [0.25, 0.75], size=np.array(3, dtype=np.int64))
+
+    assert samples.shape == (3, 2)
+    assert np.all(samples.sum(axis=1) == 2)
+
+
+@pytest.mark.parametrize(
     ("low", "high"),
     [
         (False, 1.0),


### PR DESCRIPTION
## Summary
- add NumPy-backend validation for `random.multinomial(..., size=...)` so booleans are not silently treated as sample dimensions
- add regression coverage for Python, NumPy-scalar, tuple/list, and object-array boolean size inputs
- keep integer-like scalar size arguments accepted

## Bug fixed
`np.random.multinomial` accepts Python `True` and `False` for `size`, producing `(1, k)` or `(0, k)` output shapes. PyRecEst already rejects booleans for sample counts and most random-backend size dimensions; this patch closes the NumPy multinomial gap so boolean size values do not silently change the number of draws.

## Validation
- Inspected the branch diff with GitHub compare: only `src/pyrecest/_backend/numpy/random.py` and `tests/backend/test_numpy_random_backend.py` changed.
- Locally exercised the added size validator against the new boolean cases and an integer-like NumPy scalar size. The execution sandbox cannot resolve `github.com`, so I could not clone/install the full repository for a complete `pytest` run.