### PR TITLE
Validate NumPy normal scale values

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/random.py
+++ b/src/pyrecest/_backend/_shared_numpy/random.py
@@ -59,8 +59,28 @@ uniform = _modify_func_default_dtype(
     copy=False, kw_only=True, target=_allow_complex_dtype(target=_uniform)
 )
 
+
+def _validate_normal_scale(scale):
+    if _contains_boolean_value(scale):
+        raise TypeError("scale must be real numeric, not boolean")
+    try:
+        scale_array = _np.asarray(scale)
+    except (TypeError, ValueError) as exc:
+        raise TypeError("scale must be real numeric") from exc
+    if scale_array.dtype.kind not in "iuf":
+        raise TypeError("scale must be real numeric")
+    if _np.any(scale_array < 0):
+        raise ValueError("scale must be non-negative")
+    return scale_array
+
+
+def _normal(loc=0.0, scale=1.0, size=None):
+    scale = _validate_normal_scale(scale)
+    return _np.random.normal(loc, scale, size)
+
+
 normal = _modify_func_default_dtype(
-    copy=False, kw_only=True, target=_allow_complex_dtype(target=_np.random.normal)
+    copy=False, kw_only=True, target=_allow_complex_dtype(target=_normal)
 )
 
 multivariate_normal = _modify_func_default_dtype(

--- a/tests/backend/test_numpy_random_backend.py
+++ b/tests/backend/test_numpy_random_backend.py
@@ -159,6 +159,30 @@ def test_uniform_rejects_text_bounds(low, high):
         random.uniform(low, high)
 
 
+@pytest.mark.parametrize(
+    "scale",
+    [
+        True,
+        False,
+        np.bool_(True),
+        np.array(False),
+        [1.0, False],
+        np.array([1.0, np.bool_(True)], dtype=object),
+    ],
+)
+def test_normal_rejects_boolean_scale(scale):
+    with pytest.raises(TypeError, match="scale.*boolean"):
+        random.normal(scale=scale)
+
+
+def test_normal_rejects_negative_scale():
+    with pytest.raises(ValueError, match="non-negative"):
+        random.normal(scale=-1.0)
+
+    with pytest.raises(ValueError, match="non-negative"):
+        random.normal(scale=np.array([1.0, -0.1]))
+
+
 def test_choice_without_replacement_shuffle_false_preserves_order():
     values = np.array([10, 20, 30, 40, 50])
     matrix = np.array([[10, 20, 30], [40, 50, 60]])


### PR DESCRIPTION
## Summary
- validate NumPy-backend `random.normal(..., scale=...)` before dispatching to NumPy
- reject boolean scale values, including NumPy scalar booleans and boolean-containing arrays/lists, instead of silently coercing them to 0/1 standard deviations
- preserve negative-scale rejection with an explicit PyRecEst-side error and add regression coverage

## Bug fixed
The NumPy backend already rejects booleans for random uniform bounds, integer bounds, and multinomial arguments. However, `random.normal(scale=True)` and `random.normal(scale=False)` could still be passed through to NumPy, where they are interpreted as standard deviation `1` or `0`. That makes accidental boolean values silently change the distribution rather than failing fast.

## Validation
- Inspected the branch diff with GitHub compare: only `src/pyrecest/_backend/_shared_numpy/random.py` and `tests/backend/test_numpy_random_backend.py` changed.
- Locally exercised the new scale validator logic against Python booleans, NumPy boolean scalars, boolean-containing arrays/lists, valid positive numeric scales, and negative numeric scales.
- The execution sandbox cannot resolve `github.com`, so I could not clone/install the full repository for a complete `pytest` run.