### PR TITLE
Preserve circular Dirac conversion type

### DIFF
--- a/src/pyrecest/distributions/circle/circular_dirac_distribution.py
+++ b/src/pyrecest/distributions/circle/circular_dirac_distribution.py
@@ -1,4 +1,4 @@
-from pyrecest.backend import reshape
+from pyrecest.backend import ones, reshape, sum
 
 from ..hypertorus.hypertoroidal_dirac_distribution import HypertoroidalDiracDistribution
 from .abstract_circular_distribution import AbstractCircularDistribution
@@ -21,6 +21,32 @@ class CircularDiracDistribution(
         self.d = reshape(self.d, (-1,))
         if self.d.shape != self.w.shape:
             raise ValueError("The shapes of d and w should match.")
+
+    @staticmethod
+    def from_distribution(
+        distribution: AbstractCircularDistribution, n_particles: int | None = None
+    ):
+        """Create a circular Dirac approximation from a circular distribution."""
+        if not isinstance(distribution, AbstractCircularDistribution):
+            raise ValueError(
+                "from_distribution: invalidObject: First argument has to be "
+                "a circular distribution."
+            )
+
+        get_grid = getattr(distribution, "get_grid", None)
+        if hasattr(distribution, "grid_values") and callable(get_grid):
+            weights = reshape(distribution.grid_values, (-1,))
+            weights = weights / sum(weights)
+            return CircularDiracDistribution(get_grid(), weights)
+
+        if n_particles is None:
+            raise ValueError("n_particles is required for sampling-based conversion.")
+        n_particles = HypertoroidalDiracDistribution._validate_particle_count(
+            n_particles
+        )
+        return CircularDiracDistribution(
+            distribution.sample(n_particles), ones(n_particles) / n_particles
+        )
 
     def plot_interpolated(self, _):
         """

--- a/tests/distributions/test_circular_dirac_distribution.py
+++ b/tests/distributions/test_circular_dirac_distribution.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy.testing as npt
 from pyrecest.backend import array, ones, pi
-from pyrecest.distributions import CircularDiracDistribution
+from pyrecest.distributions import CircularDiracDistribution, VonMisesDistribution
 
 
 class TestCircularDiracDistribution(unittest.TestCase):
@@ -28,6 +28,17 @@ class TestCircularDiracDistribution(unittest.TestCase):
     def test_rejects_multidimensional_locations_for_circular_dirac(self):
         with self.assertRaisesRegex(ValueError, "shapes of d and w"):
             CircularDiracDistribution(array([[0.0, pi / 2.0], [pi, 3.0 * pi / 2.0]]))
+
+    def test_from_distribution_preserves_circular_dirac_type(self):
+        n_particles = 5
+        vm = VonMisesDistribution(array(0.2), array(1.5))
+
+        wd = CircularDiracDistribution.from_distribution(vm, n_particles)
+
+        self.assertIsInstance(wd, CircularDiracDistribution)
+        self.assertEqual(wd.d.shape, (n_particles,))
+        self.assertEqual(wd.w.shape, (n_particles,))
+        npt.assert_allclose(wd.w, ones(n_particles) / n_particles)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a `CircularDiracDistribution.from_distribution` specialization so circular distributions convert to `CircularDiracDistribution` instead of the generic hypertoroidal Dirac type
- keep deterministic grid conversion and sampling-based conversion behavior while validating circular inputs and particle counts
- add a regression test covering the returned type, particle shape, and uniform weights

## Tests
- Not run locally; change was made through the GitHub connector.
