### PR TITLE
Reject boolean PyTorch normal parameters

### DIFF
--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -244,6 +244,11 @@ def _normal_device(*values):
     return None
 
 
+def _validate_normal_parameter(value, name):
+    if _contains_boolean_value(value):
+        raise TypeError(f"{name} must be real numeric, not boolean")
+
+
 def _normal_array_parameters(loc, scale):
     device = _normal_device(loc, scale)
     loc = _torch.as_tensor(loc, device=device)
@@ -413,6 +418,8 @@ def multinomial(n, pvals, size=None):
 
 @_allow_complex_dtype
 def normal(loc=0.0, scale=1.0, size=None):
+    _validate_normal_parameter(loc, "loc")
+    _validate_normal_parameter(scale, "scale")
     size = _normal_size(size)
     if not (_is_array_parameter(loc) or _is_array_parameter(scale)):
         return _torch.normal(mean=loc, std=scale, size=size or ())

--- a/tests/backend/test_pytorch_random_backend.py
+++ b/tests/backend/test_pytorch_random_backend.py
@@ -164,6 +164,29 @@ def test_uniform_rejects_boolean_bounds(low, high):
 
 
 @pytest.mark.parametrize(
+    ("loc", "scale"),
+    [
+        (False, 1.0),
+        (0.0, True),
+        (np.bool_(True), 1.0),
+        (0.0, np.bool_(True)),
+        (torch.tensor(True), 1.0),
+        (0.0, torch.tensor(True)),
+        (torch.tensor([False, False]), torch.tensor([1.0, 2.0])),
+        ([False, 0.0], [1.0, 2.0]),
+        ([0.0, 0.5], [1.0, np.bool_(True)]),
+        (
+            np.array([0.0, np.bool_(False)], dtype=object),
+            np.array([1.0, 2.0], dtype=object),
+        ),
+    ],
+)
+def test_normal_rejects_boolean_parameters(loc, scale):
+    with pytest.raises(TypeError, match="real numeric"):
+        random.normal(loc, scale)
+
+
+@pytest.mark.parametrize(
     ("low", "high"),
     [
         ("0.0", 1.0),


### PR DESCRIPTION
## Summary
- add PyTorch `random.normal` validation for boolean `loc` and `scale` parameters before dispatching to scalar or tensor sampling paths
- cover Python bools, NumPy bool scalars, torch bool tensors, and mixed object/list inputs in the existing PyTorch random backend regression tests

## Bug fixed
The PyTorch backend accepted boolean `loc`/`scale` values for `random.normal`, silently treating them as numeric 0/1. Other random parameter validators already reject booleans as non-numeric control values, so this was an inconsistent and error-prone sampling path.

## Validation
- Inspected the branch diff with GitHub compare: only `src/pyrecest/_backend/pytorch/random.py` and `tests/backend/test_pytorch_random_backend.py` changed.
- Ran `py_compile` locally on reconstructed edited files.
- Exercised the patched `random.normal` path in a small local harness against Python bools, NumPy bool scalars, torch bool tensors, boolean tensor arrays, and mixed boolean object/list inputs.
- Full repository pytest was not run locally because the execution environment cannot resolve `github.com` to clone/install the repository.