### PR TITLE
Reject boolean JAX normal scales

### DIFF
--- a/src/pyrecest/_backend/jax/random.py
+++ b/src/pyrecest/_backend/jax/random.py
@@ -237,6 +237,11 @@ def _validate_randint_bounds(low, high):
     return low, high
 
 
+def _validate_normal_parameter(value, name):
+    if _contains_boolean_value(value):
+        raise TypeError(f"{name} must be real numeric, not boolean")
+
+
 def _randint(state, size, low, high, *args, **kwargs):
     state, key = jax.random.split(state)
     return state, jax.random.randint(
@@ -305,6 +310,8 @@ def randint(low=None, high=None, size=None, *args, **kwargs):
 
 
 def _normal(state, loc=0.0, scale=1.0, size=None, *args, **kwargs):
+    _validate_normal_parameter(loc, "loc")
+    _validate_normal_parameter(scale, "scale")
     loc = _jnp.asarray(loc)
     scale = _jnp.asarray(scale)
     if bool(_jnp.any(scale < 0)):

--- a/src/pyrecest/_backend/jax/random.py
+++ b/src/pyrecest/_backend/jax/random.py
@@ -237,9 +237,9 @@ def _validate_randint_bounds(low, high):
     return low, high
 
 
-def _validate_normal_parameter(value, name):
-    if _contains_boolean_value(value):
-        raise TypeError(f"{name} must be real numeric, not boolean")
+def _validate_normal_scale(scale):
+    if _contains_boolean_value(scale):
+        raise TypeError("scale must be real numeric, not boolean")
 
 
 def _randint(state, size, low, high, *args, **kwargs):
@@ -310,8 +310,7 @@ def randint(low=None, high=None, size=None, *args, **kwargs):
 
 
 def _normal(state, loc=0.0, scale=1.0, size=None, *args, **kwargs):
-    _validate_normal_parameter(loc, "loc")
-    _validate_normal_parameter(scale, "scale")
+    _validate_normal_scale(scale)
     loc = _jnp.asarray(loc)
     scale = _jnp.asarray(scale)
     if bool(_jnp.any(scale < 0)):


### PR DESCRIPTION
## Summary
- validates the JAX `normal` scale argument before array conversion
- rejects boolean scale values instead of treating them as numeric 0/1

## Testing
Not run locally; GitHub Actions should run the JAX backend matrix on the PR.