### PR TITLE
Reject boolean JAX normal scales

### DIFF
--- a/src/pyrecest/_backend/jax/random.py
+++ b/src/pyrecest/_backend/jax/random.py
@@ -304,11 +304,23 @@ def randint(low=None, high=None, size=None, *args, **kwargs):
     return set_state_return(has_state, state, res)
 
 
+def _validate_normal_scale(scale):
+    if _contains_boolean_value(scale):
+        raise TypeError("scale must be real numeric, not boolean")
+    try:
+        scale_array = _jnp.asarray(scale)
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise TypeError("scale must be real numeric") from exc
+    if scale_array.dtype.kind not in "iuf":
+        raise TypeError("scale must be real numeric")
+    if bool(_jnp.any(scale_array < 0)):
+        raise ValueError("scale must be non-negative")
+    return scale_array
+
+
 def _normal(state, loc=0.0, scale=1.0, size=None, *args, **kwargs):
     loc = _jnp.asarray(loc)
-    scale = _jnp.asarray(scale)
-    if bool(_jnp.any(scale < 0)):
-        raise ValueError("scale must be non-negative")
+    scale = _validate_normal_scale(scale)
     sample_shape = _bounded_sampler_shape(size, loc, scale)
     state, key = jax.random.split(state)
     samples = jax.random.normal(key, sample_shape, *args, **kwargs)


### PR DESCRIPTION
## Summary
- add a JAX `random.normal` scale validator that rejects boolean-valued scales before converting to JAX arrays
- preserve the existing negative-scale validation and NumPy-compatible sample-shape handling
- align the JAX backend with the existing NumPy/PyTorch normal-scale validation behavior

## Validation
- Compared `fix-jax-normal-boolean-scale` against `main`: one file changed, 15 additions / 3 deletions in `src/pyrecest/_backend/jax/random.py`.
- Locally imported the patched JAX random backend and verified boolean scales such as `True`, `False`, `[1.0, False]`, and JAX boolean arrays now raise `TypeError`.
- Verified `scale=-1.0` still raises `ValueError` and numeric array scales with `size=(3, 2)` still produce samples of shape `(3, 2)`.

Note: I attempted to add a regression test, but the GitHub connector safety layer blocked test-file writes for the executable test payload. The runtime fix itself is committed on this branch.