### PR TITLE
Validate JAX normal scale parameters

### DIFF
--- a/src/pyrecest/_backend/jax/random.py
+++ b/src/pyrecest/_backend/jax/random.py
@@ -304,9 +304,21 @@ def randint(low=None, high=None, size=None, *args, **kwargs):
     return set_state_return(has_state, state, res)
 
 
+def _validate_normal_scale(scale):
+    if _contains_boolean_value(scale):
+        raise TypeError("scale must be real numeric, not boolean")
+    try:
+        scale = _jnp.asarray(scale)
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise TypeError("scale must be real numeric") from exc
+    if scale.dtype.kind not in "iuf":
+        raise TypeError("scale must be real numeric")
+    return scale
+
+
 def _normal(state, loc=0.0, scale=1.0, size=None, *args, **kwargs):
     loc = _jnp.asarray(loc)
-    scale = _jnp.asarray(scale)
+    scale = _validate_normal_scale(scale)
     if bool(_jnp.any(scale < 0)):
         raise ValueError("scale must be non-negative")
     sample_shape = _bounded_sampler_shape(size, loc, scale)

--- a/tests/backend/test_jax_random_normal_scale_validation.py
+++ b/tests/backend/test_jax_random_normal_scale_validation.py
@@ -1,0 +1,21 @@
+import numpy as np
+import pytest
+
+pytest.importorskip("jax")
+import jax.numpy as jnp  # noqa: E402
+from pyrecest._backend.jax import random  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "scale",
+    [
+        False,
+        np.bool_(True),
+        jnp.array([True, False]),
+        [1.0, False],
+        np.array([1.0, np.bool_(False)], dtype=object),
+    ],
+)
+def test_normal_rejects_boolean_scale(scale):
+    with pytest.raises(TypeError, match="scale must be real numeric, not boolean"):
+        random.normal(scale=scale)


### PR DESCRIPTION
## Summary
- add explicit JAX random-normal scale validation matching the NumPy/PyTorch backend contract
- reject boolean, non-real, and non-numeric scale inputs before sampling
- add regression coverage for boolean scalar, array, list, and object-array scales

## Bug fixed
The JAX backend converted `random.normal(..., scale=...)` directly with `jnp.asarray` and only checked for negative values. Boolean scales such as `True`, `False`, or arrays containing booleans were therefore silently accepted as numeric scale values, unlike the NumPy and PyTorch backends.

## Testing
- Added `tests/backend/test_jax_random_normal_scale_validation.py`
- Not run locally: this environment cannot clone GitHub over the network, so I validated the patch by inspection against the existing JAX random backend tests and backend contracts.