### PR TITLE
Accept NumPy boolean controls in PyTorch choice

### DIFF
--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -71,9 +71,15 @@ def _choice_size(size):
 
 
 def _choice_bool(value, name):
-    if isinstance(value, bool):
-        return value
+    if isinstance(value, _BOOLEAN_TYPES):
+        return bool(value)
     if _torch.is_tensor(value) and value.ndim == 0 and value.dtype == _torch.bool:
+        return bool(value.item())
+    if (
+        isinstance(value, _np.ndarray)
+        and value.shape == ()
+        and value.dtype.kind == "b"
+    ):
         return bool(value.item())
     raise TypeError(f"{name} must be a boolean")
 

--- a/tests/backend/test_pytorch_choice_boolean_controls.py
+++ b/tests/backend/test_pytorch_choice_boolean_controls.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from pyrecest._backend.pytorch import random  # noqa: E402
+
+
+@pytest.mark.parametrize("control", ["replace", "shuffle"])
+@pytest.mark.parametrize("value", [np.bool_(False), np.array(False)])
+def test_choice_accepts_numpy_scalar_boolean_controls(control, value):
+    kwargs = {control: value}
+    size = 2
+    if control == "shuffle":
+        kwargs["replace"] = False
+        size = 3
+
+    samples = random.choice(torch.arange(3), size=size, **kwargs)
+
+    assert samples.shape == (size,)
+
+
+@pytest.mark.parametrize("control", ["replace", "shuffle"])
+def test_choice_rejects_numpy_boolean_vector_controls(control):
+    kwargs = {control: np.array([False])}
+
+    with pytest.raises(TypeError, match=f"{control} must be a boolean"):
+        random.choice(torch.arange(3), size=2, **kwargs)


### PR DESCRIPTION
## Summary
- Accept NumPy scalar booleans for PyTorch `random.choice` control arguments `replace` and `shuffle`.
- Continue rejecting non-scalar NumPy boolean arrays as invalid controls.
- Add focused regression tests for the PyTorch backend.

## Testing
- Not run locally.