### PR TITLE
Validate NumPy random size arguments

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/random.py
+++ b/src/pyrecest/_backend/_shared_numpy/random.py
@@ -45,6 +45,8 @@ def _normalize_size(size):
         size_array = _np.asarray(size)
     except (TypeError, ValueError) as exc:
         raise _size_type_error() from exc
+    if size_array.ndim == 1 and size_array.size == 0:
+        return ()
     if size_array.dtype.kind not in "iu":
         raise _size_type_error()
     if size_array.ndim == 0:

--- a/src/pyrecest/_backend/_shared_numpy/random.py
+++ b/src/pyrecest/_backend/_shared_numpy/random.py
@@ -14,7 +14,7 @@ def _rand(*dims, size=None):
         if size is not None:
             raise TypeError("Specify either positional dimensions or size, not both.")
         size = dims[0] if len(dims) == 1 else dims
-    return _np.random.random(size)
+    return _np.random.random(_normalize_size(size))
 
 
 rand = _modify_func_default_dtype(
@@ -30,6 +30,34 @@ def _contains_boolean_value(value):
     except (TypeError, ValueError, RuntimeError):
         return False
     return any(isinstance(item, _BOOLEAN_TYPES) for item in values)
+
+
+def _size_type_error():
+    return TypeError("size must be None, an integer, or a sequence of integers")
+
+
+def _normalize_size(size):
+    if size is None:
+        return None
+    if _contains_boolean_value(size) or isinstance(size, (str, bytes)):
+        raise _size_type_error()
+    try:
+        size_array = _np.asarray(size)
+    except (TypeError, ValueError) as exc:
+        raise _size_type_error() from exc
+    if size_array.dtype.kind not in "iu":
+        raise _size_type_error()
+    if size_array.ndim == 0:
+        dimension = int(size_array.item())
+        if dimension < 0:
+            raise ValueError("size dimensions must be non-negative")
+        return dimension
+    if size_array.ndim != 1:
+        raise _size_type_error()
+    dimensions = tuple(int(dimension) for dimension in size_array.tolist())
+    if any(dimension < 0 for dimension in dimensions):
+        raise ValueError("size dimensions must be non-negative")
+    return dimensions
 
 
 def _validate_uniform_bound(bound, name):
@@ -52,7 +80,7 @@ def _validate_uniform_bounds(low, high):
 
 def _uniform(low=0.0, high=1.0, size=None):
     _validate_uniform_bounds(low, high)
-    return _np.random.uniform(low, high, size)
+    return _np.random.uniform(low, high, _normalize_size(size))
 
 
 uniform = _modify_func_default_dtype(
@@ -144,6 +172,7 @@ def choice(a, size=None, replace=True, p=None, axis=0, shuffle=True):
     """Draw samples from an integer or array population."""
     replace = _choice_bool(replace, "replace")
     shuffle = _choice_bool(shuffle, "shuffle")
+    size = _normalize_size(size)
     a_array = _np.asarray(a)
     _validate_choice_population(a_array)
     p = _validate_choice_probabilities(p)

--- a/tests/backend/test_numpy_random_backend.py
+++ b/tests/backend/test_numpy_random_backend.py
@@ -25,6 +25,53 @@ def test_rand_rejects_ambiguous_positional_and_size_arguments():
 
 
 @pytest.mark.parametrize(
+    "bad_size",
+    [
+        True,
+        False,
+        np.bool_(True),
+        np.array(True),
+        (True,),
+        [np.bool_(False), 2],
+        np.array([True, 2], dtype=object),
+    ],
+)
+@pytest.mark.parametrize(
+    "sampler",
+    [
+        lambda size: random.rand(size=size),
+        lambda size: random.uniform(size=size),
+        lambda size: random.choice(np.arange(5), size=size),
+    ],
+)
+def test_random_wrappers_reject_boolean_size_arguments(sampler, bad_size):
+    with pytest.raises(TypeError, match="size"):
+        sampler(bad_size)
+
+
+@pytest.mark.parametrize(
+    "dims",
+    [
+        (True,),
+        (np.bool_(True),),
+        (2, False),
+        ([True, 2],),
+    ],
+)
+def test_rand_rejects_boolean_positional_dimensions(dims):
+    with pytest.raises(TypeError, match="size"):
+        random.rand(*dims)
+
+
+def test_random_wrappers_accept_integer_array_size_arguments():
+    random.seed(0)
+
+    assert random.rand(size=np.array([2, 3], dtype=np.int64)).shape == (2, 3)
+    assert random.uniform(size=np.array(2, dtype=np.int64)).shape == (2,)
+    assert random.choice(np.arange(5), size=np.array([2], dtype=np.int64)).shape == (2,)
+
+
+@pytest.mark.parametrize(
     ("low", "high"),
     [
         (0.2, 3),


### PR DESCRIPTION
## Summary
- add shared validation for NumPy random `size` arguments
- reject boolean sizes and boolean positional `rand` dimensions instead of interpreting them as integer dimensions
- keep valid integer-like array sizes supported and add regression coverage

## Testing
- Not run locally in this session; GitHub CI should run on the PR.