### PR TITLE
Validate online time-offset predict dt

### DIFF
--- a/src/pyrecest/filters/online_time_offset_estimator.py
+++ b/src/pyrecest/filters/online_time_offset_estimator.py
@@ -52,7 +52,9 @@ class OnlineTimeOffsetEstimator:
 
     def predict(self, dt: float = 0.0) -> None:
         """Apply random-walk process noise."""
-        del dt
+        dt_value = _as_finite_scalar(dt, "dt")
+        if dt_value < 0.0:
+            raise ValueError("dt must be nonnegative")
         self.variance = float(max(self.variance + self.process_variance, 1.0e-12))
 
     def update_from_position_residual(

--- a/tests/filters/test_online_time_offset_estimator.py
+++ b/tests/filters/test_online_time_offset_estimator.py
@@ -40,6 +40,29 @@ class OnlineTimeOffsetEstimatorTest(unittest.TestCase):
 
         self.assertAlmostEqual(estimator.variance, 1.25)
 
+    def test_predict_rejects_invalid_dt_without_state_change(self):
+        invalid_values = (
+            np.nan,
+            np.inf,
+            -np.inf,
+            -1.0,
+            True,
+            "1.0",
+            np.array("1.0"),
+            np.array([1.0]),
+        )
+        for value in invalid_values:
+            estimator = OnlineTimeOffsetEstimator(
+                offset=1.0,
+                variance=2.0,
+                process_variance=0.25,
+            )
+            with self.subTest(value=value):
+                with self.assertRaises(ValueError):
+                    estimator.predict(dt=value)
+                self.assertEqual(estimator.offset, 1.0)
+                self.assertEqual(estimator.variance, 2.0)
+
     def test_constructor_rejects_nonfinite_scalar_controls(self):
         invalid_values = (
             np.nan,


### PR DESCRIPTION
## Summary
- validate `OnlineTimeOffsetEstimator.predict(dt=...)` as a finite, nonnegative scalar before mutating state
- preserve the current one-step process-noise semantics for valid `dt` values
- add regression coverage that invalid `dt` values raise without changing the estimator state

## Bug fixed
`OnlineTimeOffsetEstimator.predict` exposed a `dt` argument but discarded it unconditionally. As a result, invalid values such as `np.nan`, negative durations, strings, booleans, or non-scalar arrays were silently accepted while still adding process variance. The method now rejects invalid time deltas before updating the posterior variance.

## Testing
- Not run locally; change made through GitHub contents API.