### PR TITLE
Reject boolean manifold EMA alpha values

### DIFF
--- a/src/pyrecest/filters/manifold_exponential_moving_average.py
+++ b/src/pyrecest/filters/manifold_exponential_moving_average.py
@@ -2,6 +2,8 @@
 
 from typing import Any, Callable
 
+import numpy as np
+
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import asarray
 
@@ -50,10 +52,25 @@ class ManifoldExponentialMovingAverage(AbstractFilter):
 
     @staticmethod
     def _validate_alpha(alpha: float) -> float:
-        alpha = float(alpha)
-        if alpha < 0.0 or alpha > 1.0:
+        message = "alpha must be a real scalar between 0 and 1"
+        try:
+            alpha_array = np.asarray(alpha)
+        except (TypeError, ValueError) as exc:
+            raise TypeError(message) from exc
+        if alpha_array.shape != () or alpha_array.dtype == np.bool_:
+            raise TypeError(message)
+
+        alpha_scalar = alpha_array.item()
+        if isinstance(alpha_scalar, (bool, np.bool_)):
+            raise TypeError(message)
+
+        try:
+            alpha_float = float(alpha_scalar)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise TypeError(message) from exc
+        if not np.isfinite(alpha_float) or alpha_float < 0.0 or alpha_float > 1.0:
             raise ValueError("alpha must be between 0 and 1")
-        return alpha
+        return alpha_float
 
     @property
     def alpha(self) -> float:

--- a/tests/filters/test_manifold_exponential_moving_average.py
+++ b/tests/filters/test_manifold_exponential_moving_average.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
@@ -81,6 +82,26 @@ class TestManifoldExponentialMovingAverage(unittest.TestCase):
         )
         with self.assertRaises(ValueError):
             ema.alpha = -0.1
+
+    def test_alpha_rejects_boolean_values(self):
+        for alpha in (True, False, np.bool_(True), np.array(False)):
+            with self.subTest(alpha=alpha):
+                with self.assertRaisesRegex(TypeError, "real scalar"):
+                    ManifoldExponentialMovingAverage(
+                        initial_state=0.0,
+                        alpha=alpha,
+                        phi=_phi_so2,
+                        phi_inv=_phi_inv_so2,
+                    )
+
+        ema = ManifoldExponentialMovingAverage(
+            initial_state=0.0,
+            alpha=0.5,
+            phi=_phi_so2,
+            phi_inv=_phi_inv_so2,
+        )
+        with self.assertRaisesRegex(TypeError, "real scalar"):
+            ema.alpha = True
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Reject boolean and boolean-array `alpha` values in `ManifoldExponentialMovingAverage` instead of accepting them through Python's `float(bool)` conversion.
- Keep finite real scalar `alpha` values in `[0, 1]` accepted for both construction and setter updates.
- Add regression coverage for Python, NumPy-scalar, and zero-dimensional NumPy boolean inputs.

## Bug
`ManifoldExponentialMovingAverage._validate_alpha` previously called `float(alpha)` directly. That allowed `True` and `False` to pass as `1.0` and `0.0`, turning the exponential moving average weight into an accidental hard switch rather than a real-valued smoothing parameter.

## Testing
- Not run locally; changes were made through the GitHub connector environment.