### PR TITLE
Validate JAX normal location parameters

### DIFF
--- a/src/pyrecest/_backend/jax/random.py
+++ b/src/pyrecest/_backend/jax/random.py
@@ -304,20 +304,24 @@ def randint(low=None, high=None, size=None, *args, **kwargs):
     return set_state_return(has_state, state, res)
 
 
-def _validate_normal_scale(scale):
-    if _contains_boolean_value(scale):
-        raise TypeError("scale must be real numeric, not boolean")
+def _validate_normal_parameter(value, name):
+    if _contains_boolean_value(value):
+        raise TypeError(f"{name} must be real numeric, not boolean")
     try:
-        scale = _jnp.asarray(scale)
+        value = _jnp.asarray(value)
     except (TypeError, ValueError, RuntimeError) as exc:
-        raise TypeError("scale must be real numeric") from exc
-    if scale.dtype.kind not in "iuf":
-        raise TypeError("scale must be real numeric")
-    return scale
+        raise TypeError(f"{name} must be real numeric") from exc
+    if value.dtype.kind not in "iuf":
+        raise TypeError(f"{name} must be real numeric")
+    return value
+
+
+def _validate_normal_scale(scale):
+    return _validate_normal_parameter(scale, "scale")
 
 
 def _normal(state, loc=0.0, scale=1.0, size=None, *args, **kwargs):
-    loc = _jnp.asarray(loc)
+    loc = _validate_normal_parameter(loc, "loc")
     scale = _validate_normal_scale(scale)
     if bool(_jnp.any(scale < 0)):
         raise ValueError("scale must be non-negative")

--- a/tests/backend/test_jax_random_backend.py
+++ b/tests/backend/test_jax_random_backend.py
@@ -186,10 +186,19 @@ def test_normal_legacy_shape_detection_accepts_numpy_integer_dimensions():
     assert random.normal((np.int64(2), 3)).shape == (2, 3)
 
 
-def test_normal_bool_location_is_not_interpreted_as_legacy_shape():
-    random.seed(0)
-
-    assert random.normal(True).shape == ()
+@pytest.mark.parametrize(
+    "loc",
+    [
+        False,
+        np.bool_(True),
+        jnp.array([True, False]),
+        [False, 0.0],
+        np.array([0.0, np.bool_(True)], dtype=object),
+    ],
+)
+def test_normal_rejects_boolean_location(loc):
+    with pytest.raises(TypeError, match="loc must be real numeric, not boolean"):
+        random.normal(loc=loc)
 
 
 def test_normal_integer_tuple_location_with_array_scale_is_not_legacy_shape():


### PR DESCRIPTION
## Summary
- validate JAX `random.normal(..., loc=...)` before sampling
- reject boolean and non-real location values instead of silently coercing them
- add regression coverage for scalar, array, list, and object-array boolean locations

## Bug fixed
The JAX backend validated `scale` but converted `loc` directly with `jnp.asarray`, so boolean locations were accepted as 0/1. That made JAX inconsistent with the NumPy and PyTorch normal backends.

## Testing
- `python -m py_compile /mnt/data/jax_random_patched.py /mnt/data/test_jax_random_backend_patched.py`
- not run: full pytest suite; the execution container cannot resolve github.com, so repository clone/install is unavailable here