### PR TITLE
Validate NumPy normal sampler size arguments

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/random.py
+++ b/src/pyrecest/_backend/_shared_numpy/random.py
@@ -112,17 +112,24 @@ def _validate_normal_scale(scale):
 def _normal(loc=0.0, scale=1.0, size=None):
     loc = _validate_normal_parameter(loc, "loc")
     scale = _validate_normal_scale(scale)
-    return _np.random.normal(loc, scale, size)
+    return _np.random.normal(loc, scale, _normalize_size(size))
 
 
 normal = _modify_func_default_dtype(
     copy=False, kw_only=True, target=_allow_complex_dtype(target=_normal)
 )
 
+
+def _multivariate_normal(mean, cov, size=None, check_valid="warn", tol=1e-8):
+    return _np.random.multivariate_normal(
+        mean, cov, _normalize_size(size), check_valid, tol
+    )
+
+
 multivariate_normal = _modify_func_default_dtype(
     copy=False,
     kw_only=True,
-    target=_allow_complex_dtype(target=_np.random.multivariate_normal),
+    target=_allow_complex_dtype(target=_multivariate_normal),
 )
 
 

--- a/tests/backend/test_numpy_random_backend.py
+++ b/tests/backend/test_numpy_random_backend.py
@@ -41,6 +41,8 @@ def test_rand_rejects_ambiguous_positional_and_size_arguments():
     [
         lambda size: random.rand(size=size),
         lambda size: random.uniform(size=size),
+        lambda size: random.normal(size=size),
+        lambda size: random.multivariate_normal([0.0], [[1.0]], size=size),
         lambda size: random.choice(np.arange(5), size=size),
     ],
 )
@@ -68,6 +70,10 @@ def test_random_wrappers_accept_integer_array_size_arguments():
 
     assert random.rand(size=np.array([2, 3], dtype=np.int64)).shape == (2, 3)
     assert random.uniform(size=np.array(2, dtype=np.int64)).shape == (2,)
+    assert random.normal(size=np.array([2, 3], dtype=np.int64)).shape == (2, 3)
+    assert random.multivariate_normal(
+        [0.0], [[1.0]], size=np.array(2, dtype=np.int64)
+    ).shape == (2, 1)
     assert random.choice(np.arange(5), size=np.array([2], dtype=np.int64)).shape == (2,)
 
 


### PR DESCRIPTION
## Summary
- route NumPy `random.normal` and `random.multivariate_normal` through the shared `_normalize_size` helper
- make normal-family samplers reject boolean/object boolean `size` arguments consistently with `rand`, `uniform`, and `choice`
- extend NumPy random backend regression tests to cover the normal samplers for invalid and integer-array sizes

## Validation
- Inspected the patched branch contents via GitHub connector.
- Not run locally: the execution container could not clone the repository in this session.