### PR TITLE
Fix symmetric distance array-like inputs

### DIFF
--- a/src/pyrecest/evaluation/get_distance_function.py
+++ b/src/pyrecest/evaluation/get_distance_function.py
@@ -145,8 +145,9 @@ def _symmetric_distance_function(
         offsets = [0.0]
 
     def distance_function(xest, xtrue):
+        xest_array = asarray(xest)
         xtrue_array = asarray(xtrue)
-        return min(base_distance(xest, xtrue_array + offset) for offset in offsets)
+        return min(base_distance(xest_array, xtrue_array + offset) for offset in offsets)
 
     return distance_function
 

--- a/src/pyrecest/evaluation/get_distance_function.py
+++ b/src/pyrecest/evaluation/get_distance_function.py
@@ -145,7 +145,8 @@ def _symmetric_distance_function(
         offsets = [0.0]
 
     def distance_function(xest, xtrue):
-        return min(base_distance(xest, xtrue + offset) for offset in offsets)
+        xtrue_array = asarray(xtrue)
+        return min(base_distance(xest, xtrue_array + offset) for offset in offsets)
 
     return distance_function
 

--- a/tests/evaluation/test_symmetric_distance_array_like_input.py
+++ b/tests/evaluation/test_symmetric_distance_array_like_input.py
@@ -1,0 +1,14 @@
+import unittest
+from math import pi
+
+from pyrecest.evaluation.get_distance_function import get_distance_function
+
+
+class SymmetricDistanceArrayLikeInputTest(unittest.TestCase):
+    def test_symmetric_circle_accepts_python_lists(self):
+        distance = get_distance_function("circle", nSymm=2)
+        self.assertAlmostEqual(float(distance([0.0], [pi])), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- coerce symmetric-distance reference inputs to backend arrays before applying symmetry offsets
- add a regression test for Python-list inputs on circle distances with symmetry

## Bug fixed
`get_distance_function("circle", nSymm=...)` wrapped the base distance by evaluating `xtrue + offset` before the base distance function could coerce inputs. For Python lists or tuples, this raises a `TypeError` because scalar addition is attempted on the raw sequence. Converting `xtrue` via `asarray` in the wrapper preserves the existing backend-compatible behavior for array-like inputs.

## Testing
- Added `tests/evaluation/test_symmetric_distance_array_like_input.py`
- Not run locally in this chat environment; change is covered by the new focused regression test.