### PR TITLE
Accept array-like Euclidean distance inputs

### DIFF
--- a/src/pyrecest/evaluation/get_distance_function.py
+++ b/src/pyrecest/evaluation/get_distance_function.py
@@ -293,7 +293,7 @@ def get_distance_function(
     elif "euclidean" in normalized_name and "mtt" not in normalized_name:
 
         def distance_function(x1, x2):
-            return linalg.norm(x1 - x2)
+            return linalg.norm(asarray(x1) - asarray(x2))
 
     elif "euclidean" in normalized_name and "mtt" in normalized_name:
         params = additional_params or {}

--- a/tests/evaluation/test_evaluation_registries.py
+++ b/tests/evaluation/test_evaluation_registries.py
@@ -85,6 +85,12 @@ def test_euclidean_mtt_distance_uses_assignment_with_cutoff():
     assert distance(array([[0.0], [10.0]]), array([[0.0], [12.0]])) == 2.0
 
 
+def test_euclidean_distance_accepts_array_like_inputs():
+    distance = get_distance_function("euclidean")
+
+    assert _as_float(distance([1.0, 2.0], (4.0, 6.0))) == pytest.approx(5.0)
+
+
 def test_underscored_symmetric_hypersphere_distance_is_antipodal_invariant():
     distance = get_distance_function("hypersphere_symmetric")
 


### PR DESCRIPTION
## Summary
- coerce plain Euclidean distance inputs through the active backend before subtraction
- add a regression test for list/tuple inputs to `get_distance_function("euclidean")`

## Bug fixed
`get_distance_function("euclidean")` previously returned a distance function that evaluated `x1 - x2` directly. Python lists and tuples therefore raised `TypeError` before the backend could coerce them, unlike other distance helpers that already normalize array-like state inputs.

## Testing
- Inspected the branch diff and patched source via the GitHub connector.
- Not run locally: repository clone/install is unavailable in this connector-only session.