### PR TITLE
Reject nested unsupported covariance values

### DIFF
--- a/src/pyrecest/numerics.py
+++ b/src/pyrecest/numerics.py
@@ -28,13 +28,23 @@ _UNSUPPORTED_SCALAR_TYPES = (
 )
 
 
+def _object_item_contains_unsupported_numeric_values(item) -> bool:
+    if isinstance(item, _UNSUPPORTED_SCALAR_TYPES):
+        return True
+    if isinstance(item, np.ndarray):
+        return _contains_unsupported_numeric_values(item)
+    if isinstance(item, (list, tuple)):
+        return any(_object_item_contains_unsupported_numeric_values(subitem) for subitem in item)
+    return False
+
+
 def _contains_unsupported_numeric_values(value) -> bool:
     value_array = np.asarray(value)
     if value_array.dtype.kind in _UNSUPPORTED_NUMERIC_KINDS:
         return True
     if value_array.dtype.kind != "O":
         return False
-    return any(isinstance(item, _UNSUPPORTED_SCALAR_TYPES) for item in value_array.flat)
+    return any(_object_item_contains_unsupported_numeric_values(item) for item in value_array.flat)
 
 
 def _to_numpy_array(value, *, name: str = "matrix") -> np.ndarray:
@@ -42,9 +52,7 @@ def _to_numpy_array(value, *, name: str = "matrix") -> np.ndarray:
         import pyrecest.backend as backend
 
         raw = backend.to_numpy(value)
-    except (
-        Exception
-    ):  # pragma: no cover - fallback for source-tree bootstrap or unusual array objects
+    except Exception:  # pragma: no cover - fallback for source-tree bootstrap or unusual array objects
         raw = value
 
     try:

--- a/tests/test_numerics.py
+++ b/tests/test_numerics.py
@@ -54,6 +54,9 @@ def test_empty_square_matrix_is_symmetric_psd_covariance():
             ]
         ),
         np.array([[np.datetime64("2020-01-01"), 0.0], [0.0, 1.0]], dtype=object),
+        np.array([[np.array(True), 0.0], [0.0, 1.0]], dtype=object),
+        np.array([[np.array("1.0"), 0.0], [0.0, 1.0]], dtype=object),
+        np.array([[np.array(1.0 + 2.0j), 0.0], [0.0, 1.0]], dtype=object),
     ],
 )
 def test_covariance_helpers_reject_bool_text_temporal_and_none_matrices(matrix):


### PR DESCRIPTION
## Summary
- Recursively inspect object-dtype covariance inputs before float coercion.
- Reject nested ndarray/list/tuple values containing bool, text, complex, temporal, or None entries.
- Add regression cases for nested object scalars that previously could coerce into numeric covariance matrices.

## Testing
- Not run locally: cloning the repository in the execution container failed with `Could not resolve host: github.com`.
- No GitHub Actions workflow run was attached to the head commit before opening the PR.