### PR TITLE
Fix shared NumPy trace keyword options

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/__init__.py
+++ b/src/pyrecest/_backend/_shared_numpy/__init__.py
@@ -410,7 +410,6 @@ def outer(a, b):
 
     if a.ndim > 1 and b.ndim > 1:
         return _np.einsum("...i,...j->...ij", a, b)
-
     if a.ndim == 1 and b.ndim > 1:
         return _np.einsum("i,...j->...ij", a, b)
     if a.ndim > 1 and b.ndim == 1:
@@ -444,8 +443,13 @@ def dot(a, b):
     return _np.einsum("...i,...i->...", a, b)
 
 
-def trace(a):
-    return _np.trace(a, axis1=-2, axis2=-1)
+def trace(a, offset=0, axis1=-2, axis2=-1, dtype=None, out=None):
+    kwargs = {"offset": offset, "axis1": axis1, "axis2": axis2}
+    if dtype is not None:
+        kwargs["dtype"] = dtype
+    if out is not None:
+        kwargs["out"] = out
+    return _np.trace(a, **kwargs)
 
 
 def scatter_add(input, dim, index, src):

--- a/tests/backend_support/test_shared_numpy_trace_contract.py
+++ b/tests/backend_support/test_shared_numpy_trace_contract.py
@@ -1,0 +1,34 @@
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+def test_autograd_trace_accepts_numpy_style_kwargs():
+    pytest.importorskip("autograd")
+
+    code = """
+import numpy as np
+import pyrecest.backend as backend
+
+values_np = np.array(
+    [
+        [[1, 2, 3], [4, 5, 6]],
+        [[7, 8, 9], [10, 11, 12]],
+    ]
+)
+values = backend.asarray(values_np)
+
+actual = backend.to_numpy(
+    backend.trace(values, offset=1, axis1=1, axis2=2, dtype=backend.float64)
+)
+expected = np.trace(values_np, offset=1, axis1=1, axis2=2, dtype=np.float64)
+assert actual.dtype == expected.dtype
+np.testing.assert_allclose(actual, expected)
+
+default_actual = backend.to_numpy(backend.trace(values))
+default_expected = np.trace(values_np, axis1=-2, axis2=-1)
+np.testing.assert_allclose(default_actual, default_expected)
+"""
+
+    result = run_backend_code("autograd", code)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- make the shared NumPy backend `trace` wrapper accept NumPy-style `offset`, `axis1`, `axis2`, `dtype`, and `out` keyword arguments
- preserve PyRecEst's last-two-axes trace default
- add an Autograd subprocess regression test, since the Autograd backend imports the shared NumPy wrapper

## Tests
- Not run locally; added focused regression coverage for CI.