### PR TITLE
Validate scalar PyTorch normal scales

### DIFF
--- a/src/pyrecest/_backend/pytorch/_dtype.py
+++ b/src/pyrecest/_backend/pytorch/_dtype.py
@@ -126,7 +126,66 @@ def _add_default_dtype_by_casting(target=None):
 _cast_out_to_input_dtype = _pre_cast_out_to_input_dtype(
     cast, is_floating, is_complex, as_dtype, _dtype_as_str
 )
-_allow_complex_dtype = _pre_allow_complex_dtype(cast, _COMPLEX_DTYPES)
+_base_allow_complex_dtype = _pre_allow_complex_dtype(cast, _COMPLEX_DTYPES)
+
+
+def _is_random_array_parameter(value):
+    return (
+        _torch.is_tensor(value)
+        or isinstance(value, (list, tuple))
+        or (not isinstance(value, (str, bytes)) and hasattr(value, "__array__"))
+    )
+
+
+def _is_real_numeric_dtype(dtype):
+    return dtype.is_floating_point or dtype in {
+        _torch.uint8,
+        _torch.int8,
+        _torch.int16,
+        _torch.int32,
+        _torch.int64,
+    }
+
+
+def _normal_scale_from_call(args, kwargs):
+    if "scale" in kwargs:
+        return kwargs["scale"]
+    if len(args) >= 2:
+        return args[1]
+    return 1.0
+
+
+def _validate_scalar_normal_scale(scale):
+    if _is_random_array_parameter(scale):
+        return
+
+    try:
+        scale = _torch.as_tensor(scale)
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise TypeError("scale must be real numeric") from exc
+    if scale.ndim != 0 or not _is_real_numeric_dtype(scale.dtype):
+        raise TypeError("scale must be real numeric")
+    if bool(scale < 0):
+        raise ValueError("scale must be non-negative")
+
+
+def _allow_complex_dtype(target=None):
+    def _decorator(func):
+        wrapped = _base_allow_complex_dtype(func)
+        if getattr(func, "__name__", "") != "normal":
+            return wrapped
+
+        @functools.wraps(wrapped)
+        def _wrapped(*args, **kwargs):
+            _validate_scalar_normal_scale(_normal_scale_from_call(args, kwargs))
+            return wrapped(*args, **kwargs)
+
+        return _wrapped
+
+    if target is None:
+        return _decorator
+
+    return _decorator(target)
 
 
 def _preserve_input_dtype(target=None):

--- a/tests/backend/test_pytorch_random_normal_scalar_scale.py
+++ b/tests/backend/test_pytorch_random_normal_scalar_scale.py
@@ -1,0 +1,11 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from pyrecest._backend.pytorch import random  # noqa: E402
+
+
+@pytest.mark.parametrize("scale", [-1.0, -1])
+def test_normal_rejects_negative_scalar_scale(scale):
+    with pytest.raises(ValueError, match="scale"):
+        random.normal(0.0, scale)


### PR DESCRIPTION
## Summary
- validate scalar Python `scale` values before PyTorch `random.normal` dispatch
- keep array-valued scale handling delegated to the existing random backend path
- add a focused regression test for negative scalar scales

## Bug fixed
The PyTorch backend already rejected negative array-valued `scale` inputs through the backend validation path, but Python scalar negative scales were forwarded to `torch.normal`, which raises a backend-specific `RuntimeError`. This makes `random.normal(0.0, -1.0)` inconsistent with the array-valued path and the expected NumPy-style `ValueError` behavior.

## Testing
- Local syntax compile of the patched helper module and focused regression file.
- Local focused harness confirmed `random.normal(0.0, -1.0)` and `random.normal(0.0, -1)` now raise `ValueError("scale must be non-negative")`.
- Not run: full repository pytest; this execution environment cannot resolve `github.com` to clone/install the repo, so CI should run the full matrix.