### PR TITLE
Accept scalar array particle filter counts

### DIFF
--- a/src/pyrecest/filters/euclidean_particle_filter.py
+++ b/src/pyrecest/filters/euclidean_particle_filter.py
@@ -1,7 +1,8 @@
 import copy
 from collections.abc import Callable
-from numbers import Integral
 from typing import Union
+
+import numpy as np
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import int32, int64, zeros
@@ -69,10 +70,27 @@ class EuclideanParticleFilter(AbstractParticleFilter, EuclideanFilterMixin):
 
     @staticmethod
     def _validate_positive_int(value, name: str):
-        if (
-            isinstance(value, bool)
-            or not isinstance(value, Integral)
-            or int(value) <= 0
-        ):
-            raise ValueError(f"{name} must be a positive integer")
-        return int(value)
+        message = f"{name} must be a positive integer"
+        value_array = np.asarray(value)
+        if value_array.shape != () or value_array.dtype == np.bool_:
+            raise ValueError(message)
+
+        scalar = value_array.item()
+        if isinstance(scalar, (bool, np.bool_)):
+            raise ValueError(message)
+        if isinstance(scalar, (str, bytes, bytearray, np.str_, np.bytes_)):
+            raise ValueError(message)
+        if isinstance(scalar, (complex, np.complexfloating)):
+            raise ValueError(message)
+
+        try:
+            scalar_float = float(scalar)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(message) from exc
+        if not np.isfinite(scalar_float) or not scalar_float.is_integer():
+            raise ValueError(message)
+
+        integer = int(scalar_float)
+        if integer <= 0:
+            raise ValueError(message)
+        return integer

--- a/tests/filters/test_euclidean_particle_filter_validation.py
+++ b/tests/filters/test_euclidean_particle_filter_validation.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pytest
+
+from pyrecest.filters.euclidean_particle_filter import EuclideanParticleFilter
+
+
+@pytest.mark.parametrize(
+    "n_particles",
+    [np.int64(3), np.array(3, dtype=np.int64), np.array(3.0)],
+)
+@pytest.mark.parametrize(
+    "dim",
+    [np.int64(2), np.array(2, dtype=np.int64), np.array(2.0)],
+)
+def test_euclidean_particle_filter_accepts_integer_like_scalar_counts(n_particles, dim):
+    particle_filter = EuclideanParticleFilter(n_particles=n_particles, dim=dim)
+
+    assert particle_filter.filter_state.d.shape == (3, 2)
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [
+        True,
+        np.bool_(True),
+        np.array(True),
+        np.array([3]),
+        1.5,
+        np.array(1.5),
+        "3",
+        1 + 0j,
+    ],
+)
+def test_euclidean_particle_filter_rejects_invalid_scalar_counts(bad_value):
+    with pytest.raises(ValueError, match="n_particles must be a positive integer"):
+        EuclideanParticleFilter(n_particles=bad_value, dim=1)
+
+    with pytest.raises(ValueError, match="dim must be a positive integer"):
+        EuclideanParticleFilter(n_particles=1, dim=bad_value)


### PR DESCRIPTION
## Summary
- replace the Euclidean particle-filter count validator with scalar array-aware validation
- accept NumPy scalar and zero-dimensional integer-like values for `n_particles` and `dim`
- keep booleans, non-scalars, strings, complex values, non-integers, and non-positive counts rejected

## Bug fixed
`EuclideanParticleFilter` type hints allow backend integer scalar values, and related PyRecEst validators already normalize scalar NumPy arrays. The previous validator only accepted `numbers.Integral`, so valid scalar values such as `np.array(3, dtype=np.int64)` were rejected before the initial particle state could be constructed.

## Testing
- Added `tests/filters/test_euclidean_particle_filter_validation.py`
- Local syntax compile of patched source and regression test snippets
- Local isolated validation check for accepted and rejected scalar-count cases

Full repository pytest should run in CI.