### PR TITLE
Reject boolean scalar dimensions in linear Gaussian models

### DIFF
--- a/src/pyrecest/models/linear_gaussian.py
+++ b/src/pyrecest/models/linear_gaussian.py
@@ -18,6 +18,11 @@ from pyrecest.distributions import GaussianDistribution
 _INVALID_DIMENSION_SCALAR_TYPES = (bool, str, bytes, bytearray)
 
 
+def _has_boolean_dtype(value):
+    dtype = getattr(value, "dtype", None)
+    return dtype is not None and str(dtype).lower() in {"bool", "bool_", "torch.bool"}
+
+
 def _as_matrix(value, name):
     arr = asarray(value)
     if ndim(arr) != 2:
@@ -46,7 +51,7 @@ def _as_positive_integer(value, name):
         arr = asarray(value)
     except (TypeError, ValueError, OverflowError, RuntimeError) as exc:
         raise ValueError(message) from exc
-    if ndim(arr) != 0:
+    if ndim(arr) != 0 or _has_boolean_dtype(arr):
         raise ValueError(message)
     try:
         scalar = arr.item()

--- a/tests/models/test_linear_gaussian_models.py
+++ b/tests/models/test_linear_gaussian_models.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 from pyrecest.backend import array, diag, eye, to_numpy
 from pyrecest.distributions import GaussianDistribution
@@ -70,7 +71,19 @@ class LinearGaussianModelsTest(unittest.TestCase):
         )
 
     def test_identity_models_reject_invalid_dimensions(self):
-        invalid_dims = (True, False, 0, -1, 1.5, float("inf"), "2", b"2", bytearray(b"2"))
+        invalid_dims = (
+            True,
+            False,
+            np.asarray(True),
+            np.asarray(False),
+            0,
+            -1,
+            1.5,
+            float("inf"),
+            "2",
+            b"2",
+            bytearray(b"2"),
+        )
 
         for dim in invalid_dims:
             with self.subTest(model="transition", dim=dim):


### PR DESCRIPTION
## Summary
- reject backend and NumPy boolean scalar values when validating identity-model dimensions
- extend linear Gaussian model regression coverage with NumPy boolean scalar dimensions

## Tests
- Not run locally; focused regression coverage was added in tests/models/test_linear_gaussian_models.py.