### PR TITLE
Validate DVS map count parameters

### DIFF
--- a/src/pyrecest/experimental/dvs/event_likelihood.py
+++ b/src/pyrecest/experimental/dvs/event_likelihood.py
@@ -449,8 +449,7 @@ def _as_event_xy(event_xy: np.ndarray) -> np.ndarray:
     if events.ndim == 1 and events.size == 0:
         return np.empty((0, 2), dtype=float)
     if events.ndim != 2 or events.shape[1] != 2:
-        raise ValueError("event_xy must have shape (n, 2)
-")
+        raise ValueError("event_xy must have shape (n, 2)")
     return events
 
 

--- a/src/pyrecest/experimental/dvs/event_likelihood.py
+++ b/src/pyrecest/experimental/dvs/event_likelihood.py
@@ -45,8 +45,7 @@ def _validate_nonnegative_finite(value: float, name: str) -> float:
     return value
 
 
-def _validate_integer_greater_than(value: int, name: str, lower_bound: int) -> int:
-    message = f"{name} must be greater than {lower_bound}"
+def _as_integer_scalar(value: int, message: str) -> int:
     try:
         value_array = np.asarray(value)
     except (TypeError, ValueError) as exc:
@@ -57,15 +56,26 @@ def _validate_integer_greater_than(value: int, name: str, lower_bound: int) -> i
     if isinstance(scalar, (*_BOOL_SCALAR_TYPES, *_TEXT_SCALAR_TYPES)):
         raise ValueError(message)
     if isinstance(scalar, (int, np.integer)):
-        parsed = int(scalar)
-    elif isinstance(scalar, (float, np.floating)):
+        return int(scalar)
+    if isinstance(scalar, (float, np.floating)):
         scalar_float = float(scalar)
-        if not np.isfinite(scalar_float) or not scalar_float.is_integer():
-            raise ValueError(message)
-        parsed = int(scalar_float)
-    else:
-        raise ValueError(message)
+        if np.isfinite(scalar_float) and scalar_float.is_integer():
+            return int(scalar_float)
+    raise ValueError(message)
+
+
+def _validate_integer_greater_than(value: int, name: str, lower_bound: int) -> int:
+    message = f"{name} must be greater than {lower_bound}"
+    parsed = _as_integer_scalar(value, message)
     if parsed <= int(lower_bound):
+        raise ValueError(message)
+    return parsed
+
+
+def _validate_integer_at_least(value: int, name: str, lower_bound: int) -> int:
+    message = f"{name} must be at least {lower_bound}"
+    parsed = _as_integer_scalar(value, message)
+    if parsed < int(lower_bound):
         raise ValueError(message)
     return parsed
 
@@ -155,10 +165,18 @@ class PointProcessUpdateConfig:
         object.__setattr__(self, "contour_samples", contour_samples)
         _validate_positive_finite(self.finite_difference_eps, "finite_difference_eps")
         _validate_nonnegative_finite(self.map_step_size, "map_step_size")
-        if self.max_map_iterations < 0:
-            raise ValueError("max_map_iterations must be non-negative")
-        if self.shape_update_modes < 0:
-            raise ValueError("shape_update_modes must be non-negative")
+        max_map_iterations = _validate_integer_at_least(
+            self.max_map_iterations,
+            "max_map_iterations",
+            0,
+        )
+        object.__setattr__(self, "max_map_iterations", max_map_iterations)
+        shape_update_modes = _validate_integer_at_least(
+            self.shape_update_modes,
+            "shape_update_modes",
+            0,
+        )
+        object.__setattr__(self, "shape_update_modes", shape_update_modes)
         covariance_damping = _validate_positive_finite(
             self.covariance_damping, "covariance_damping"
         )
@@ -431,7 +449,8 @@ def _as_event_xy(event_xy: np.ndarray) -> np.ndarray:
     if events.ndim == 1 and events.size == 0:
         return np.empty((0, 2), dtype=float)
     if events.ndim != 2 or events.shape[1] != 2:
-        raise ValueError("event_xy must have shape (n, 2)")
+        raise ValueError("event_xy must have shape (n, 2)
+")
     return events
 
 

--- a/tests/experimental/test_dvs_event_likelihood_counts.py
+++ b/tests/experimental/test_dvs_event_likelihood_counts.py
@@ -20,6 +20,34 @@ class TestDVSPointProcessCountValidation(unittest.TestCase):
         self.assertEqual(config.contour_samples, 5)
         self.assertIsInstance(config.contour_samples, int)
 
+    def test_rejects_invalid_map_count_parameters(self):
+        invalid_values = (2.5, "2", True)
+        for field_name in ("max_map_iterations", "shape_update_modes"):
+            for value in invalid_values:
+                with self.subTest(field_name=field_name, value=value):
+                    with self.assertRaisesRegex(ValueError, field_name):
+                        PointProcessUpdateConfig(**{field_name: value})
+
+    def test_normalizes_integer_like_map_count_parameters(self):
+        config = PointProcessUpdateConfig(
+            max_map_iterations=np.array(3.0),
+            shape_update_modes=np.int64(4),
+        )
+
+        self.assertEqual(config.max_map_iterations, 3)
+        self.assertIsInstance(config.max_map_iterations, int)
+        self.assertEqual(config.shape_update_modes, 4)
+        self.assertIsInstance(config.shape_update_modes, int)
+
+    def test_accepts_zero_map_count_parameters(self):
+        config = PointProcessUpdateConfig(
+            max_map_iterations=np.array(0.0),
+            shape_update_modes=0,
+        )
+
+        self.assertEqual(config.max_map_iterations, 0)
+        self.assertEqual(config.shape_update_modes, 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- validate `max_map_iterations` and `shape_update_modes` as non-negative integer-like scalar counts
- normalize accepted NumPy/Python integer-like values to plain `int`
- extend DVS point-process count regression tests for invalid and zero-valued map-count parameters

## Bug fixed

`PointProcessUpdateConfig` previously only checked `max_map_iterations < 0` and `shape_update_modes < 0`. That allowed fractional, text-like, and boolean values to enter the config, and could later fail inconsistently in `range(config.max_map_iterations)` or after `int(config.shape_update_modes)` truncation.

## Testing

- `python -m py_compile /mnt/data/event_likelihood_patched.py`
- focused local validation harness for accepted/rejected `PointProcessUpdateConfig` count values
- not run: full repository pytest; this environment cannot resolve `github.com` to clone/install the repo, so CI should run the full matrix
