### PR TITLE
Accept NumPy scalar populations in PyTorch choice

### DIFF
--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -304,6 +304,12 @@ def _integer_population_size(a):
         return None
     if isinstance(a, _Integral):
         return int(a)
+    if isinstance(a, _np.ndarray) and a.ndim == 0:
+        if _np.issubdtype(a.dtype, _np.integer) and not _np.issubdtype(
+            a.dtype, _np.bool_
+        ):
+            return int(a.item())
+        return None
     if (
         _torch.is_tensor(a)
         and a.ndim == 0

--- a/tests/backend/test_pytorch_choice_scalar_population.py
+++ b/tests/backend/test_pytorch_choice_scalar_population.py
@@ -37,6 +37,6 @@ def test_choice_allows_zero_sized_sample_from_zero_dimensional_numpy_zero_popula
 
 
 @pytest.mark.parametrize("population", [np.array(True), np.array(3.0)])
-def test_choice_rejects_zero_dimimensional_numpy_non_integer_population(population):
+def test_choice_rejects_zero_dimensional_numpy_non_integer_population(population):
     with pytest.raises(ValueError, match="positive integer or an array"):
         random.choice(population)

--- a/tests/backend/test_pytorch_choice_scalar_population.py
+++ b/tests/backend/test_pytorch_choice_scalar_population.py
@@ -1,0 +1,42 @@
+import numpy as np
+import pytest
+
+
+torch = pytest.importorskip("torch")
+
+from pyrecest._backend.pytorch import random  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "population",
+    [np.array(3, dtype=np.int32), np.array(3, dtype=np.int64)],
+)
+def test_choice_accepts_zero_dimensional_numpy_integer_population(population):
+    random.seed(0)
+
+    samples = random.choice(population, size=16)
+
+    assert samples.shape == (16,)
+    assert torch.all(samples >= 0)
+    assert torch.all(samples < int(population.item()))
+
+
+def test_choice_accepts_zero_dimensional_numpy_integer_population_without_replacement():
+    random.seed(0)
+
+    samples = random.choice(np.array(3, dtype=np.int64), size=3, replace=False)
+
+    assert samples.shape == (3,)
+    assert torch.equal(torch.sort(samples).values, torch.arange(3))
+
+
+def test_choice_allows_zero_sized_sample_from_zero_dimensional_numpy_zero_population():
+    samples = random.choice(np.array(0, dtype=np.int64), size=(0,))
+
+    assert samples.shape == (0,)
+
+
+@pytest.mark.parametrize("population", [np.array(True), np.array(3.0)])
+def test_choice_rejects_zero_dimimensional_numpy_non_integer_population(population):
+    with pytest.raises(ValueError, match="positive integer or an array"):
+        random.choice(population)


### PR DESCRIPTION
## Summary
- Treat zero-dimensional NumPy integer arrays as scalar integer populations in the PyTorch random backend.
- Keep boolean and floating zero-dimensional NumPy populations rejected.
- Add focused PyTorch regression tests for scalar NumPy populations.

## Testing
- Not run locally; connector-based patch only.
