### PR TITLE
Reject non-finite NumPy normal parameters

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/random.py
+++ b/src/pyrecest/_backend/_shared_numpy/random.py
@@ -99,6 +99,8 @@ def _validate_normal_parameter(value, name):
         raise TypeError(f"{name} must be real numeric") from exc
     if value_array.dtype.kind not in "iuf":
         raise TypeError(f"{name} must be real numeric")
+    if _np.any(~_np.isfinite(value_array)):
+        raise ValueError(f"{name} must be finite")
     return value_array
 
 

--- a/tests/backend/test_numpy_random_normal_parameter_validation.py
+++ b/tests/backend/test_numpy_random_normal_parameter_validation.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pytest
+
+from pyrecest._backend.numpy import random
+
+
+@pytest.mark.parametrize(
+    "loc",
+    [
+        np.nan,
+        np.inf,
+        -np.inf,
+        np.array([0.0, np.inf]),
+    ],
+)
+def test_normal_rejects_nonfinite_loc(loc):
+    with pytest.raises(ValueError, match="loc must be finite"):
+        random.normal(loc=loc)
+
+
+@pytest.mark.parametrize(
+    "scale",
+    [
+        np.nan,
+        np.inf,
+        -np.inf,
+        np.array([1.0, np.inf]),
+    ],
+)
+def test_normal_rejects_nonfinite_scale(scale):
+    with pytest.raises(ValueError, match="scale must be finite"):
+        random.normal(scale=scale)


### PR DESCRIPTION
## Summary
- reject `NaN`/`Inf` `loc` and `scale` values in the shared NumPy `random.normal` backend before sampling
- keep the existing boolean/type and negative-scale validation behavior
- add regression coverage for scalar and array-valued non-finite `loc`/`scale`

## Bug fixed
The shared NumPy normal sampler accepted non-finite distribution parameters and forwarded them to `np.random.normal`, which can silently produce non-finite samples. The uniform sampler already rejects non-finite bounds; this makes the normal sampler fail early with a clear `ValueError` as well.

## Testing
- `python -m py_compile /tmp/shared_numpy_random.py /tmp/test_numpy_random_normal_parameter_validation.py`

Not run: full repository pytest in this environment.