### PR TITLE
Validate manifold EMA alpha text inputs

### DIFF
--- a/src/pyrecest/filters/manifold_exponential_moving_average.py
+++ b/src/pyrecest/filters/manifold_exponential_moving_average.py
@@ -61,7 +61,10 @@ class ManifoldExponentialMovingAverage(AbstractFilter):
             raise TypeError(message)
 
         alpha_scalar = alpha_array.item()
-        if isinstance(alpha_scalar, (bool, np.bool_)):
+        if isinstance(
+            alpha_scalar,
+            (bool, np.bool_, str, bytes, bytearray, np.str_, np.bytes_),
+        ):
             raise TypeError(message)
 
         try:

--- a/tests/evaluation/zzz_math_probe.py
+++ b/tests/evaluation/zzz_math_probe.py
@@ -1,3 +1,0 @@
-import math
-
-x = math.pi

--- a/tests/evaluation/zzz_math_probe.py
+++ b/tests/evaluation/zzz_math_probe.py
@@ -1,0 +1,3 @@
+import math
+
+x = math.pi

--- a/tests/filters/test_manifold_exponential_moving_average.py
+++ b/tests/filters/test_manifold_exponential_moving_average.py
@@ -8,16 +8,20 @@ from pyrecest.backend import array, pi
 from pyrecest.filters import ManifoldExponentialMovingAverage
 
 
+
 def _phi_euclidean(state, xi):
     return state + xi
+
 
 
 def _phi_inv_euclidean(state_ref, state):
     return state - state_ref
 
 
+
 def _phi_so2(state, xi):
     return state + xi[0]
+
 
 
 def _phi_inv_so2(state_ref, state):
@@ -102,6 +106,26 @@ class TestManifoldExponentialMovingAverage(unittest.TestCase):
         )
         with self.assertRaisesRegex(TypeError, "real scalar"):
             ema.alpha = True
+
+    def test_alpha_rejects_text_values(self):
+        for alpha in ("0.5", b"0.5", np.array("0.5")):
+            with self.subTest(alpha=alpha):
+                with self.assertRaisesRegex(TypeError, "real scalar"):
+                    ManifoldExponentialMovingAverage(
+                        initial_state=0.0,
+                        alpha=alpha,
+                        phi=_phi_so2,
+                        phi_inv=_phi_inv_so2,
+                    )
+
+        ema = ManifoldExponentialMovingAverage(
+            initial_state=0.0,
+            alpha=0.5,
+            phi=_phi_so2,
+            phi_inv=_phi_inv_so2,
+        )
+        with self.assertRaisesRegex(TypeError, "real scalar"):
+            ema.alpha = "0.25"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Reject text and byte-like alpha values in ManifoldExponentialMovingAverage.
- Add regression coverage for constructor and setter validation.

## Testing
- Not run locally; repository dependencies are not available in this environment.