### PR TITLE
Fix pooled time-offset standard deviation

### DIFF
--- a/src/pyrecest/calibration/__init__.py
+++ b/src/pyrecest/calibration/__init__.py
@@ -25,7 +25,7 @@ from .time_offset import (
     time_offset_sweep,
 )
 from .time_offset import (
-    _aggregate_summary_metric,
+    _aggregate_std_metric,
     _as_nonnegative_summary_count,
     _as_summary_scalar,
     _validate_error_metric,
@@ -67,7 +67,14 @@ def aggregate_time_offset_sweeps(
             ],
             dtype=float,
         )
-        row["std"] = _aggregate_summary_metric("std", values, counts)
+        means = np.array(
+            [
+                _as_summary_scalar(part.get("mean", np.nan), "mean", allow_nan=True)
+                for part in parts
+            ],
+            dtype=float,
+        )
+        row["std"] = _aggregate_std_metric(values, means, counts)
     return rows
 
 

--- a/tests/calibration/test_time_offset_aggregate_validation.py
+++ b/tests/calibration/test_time_offset_aggregate_validation.py
@@ -37,12 +37,47 @@ class TimeOffsetAggregateValidationTest(unittest.TestCase):
         self.assertEqual(aggregated[0]["count"], 2.0)
         npt.assert_allclose(aggregated[0]["rmse"], 2.0)
 
+    def test_aggregate_time_offset_sweeps_pools_std_across_different_means(self):
+        sweeps = [
+            [
+                {
+                    "time_offset_s": 0.0,
+                    "count": 1.0,
+                    "mean": 0.0,
+                    "std": 0.0,
+                    "rmse": 0.0,
+                    "p95": 0.0,
+                    "max": 0.0,
+                }
+            ],
+            [
+                {
+                    "time_offset_s": 0.0,
+                    "count": 1.0,
+                    "mean": 2.0,
+                    "std": 0.0,
+                    "rmse": 2.0,
+                    "p95": 2.0,
+                    "max": 2.0,
+                }
+            ],
+        ]
+
+        for aggregate in (
+            aggregate_time_offset_sweeps,
+            aggregate_time_offset_sweeps_from_module,
+        ):
+            with self.subTest(aggregate=aggregate.__module__):
+                aggregated = aggregate(sweeps)
+
+                self.assertAlmostEqual(aggregated[0]["std"], 1.0)
+
     def test_aggregate_time_offset_sweeps_rejects_malformed_summary_scalars(self):
         invalid_cases = (
             ("time_offset_s", "0.0", "time_offset_s"),
             ("count", True, "count"),
             ("count", -1.0, "count"),
-            ("mean", 1.0 + 0.0j, "mean"),
+            ("mean", complex(1.0, 0.0), "mean"),
             ("rmse", "2.0", "rmse"),
             ("p95", np.array([2.5]), "p95"),
         )


### PR DESCRIPTION
## Summary
- use the pooled standard-deviation aggregator when preserving `std` in time-offset sweep aggregation
- pass per-sweep means into the pooled formula so between-sweep mean differences contribute to the aggregate variance
- add a regression test where individual sweep standard deviations are zero but the aggregate standard deviation is nonzero

## Bug fixed
`pyrecest.calibration.aggregate_time_offset_sweeps()` preserved `std` by taking a count-weighted average of per-sweep standard deviations. That underestimates the combined spread when the sweep means differ. The module already had `_aggregate_std_metric()`, which pools second moments correctly; the public wrapper now uses it.

## Testing
- Not run: full pytest suite in this environment because the container cannot resolve `github.com` to clone/install the repository.
- Inspected the generated GitHub commit diffs and added a focused regression test for the pooled-std case.