### PR TITLE
Validate JAX random parameter finiteness

### DIFF
--- a/src/pyrecest/_backend/jax/random.py
+++ b/src/pyrecest/_backend/jax/random.py
@@ -313,6 +313,8 @@ def _validate_normal_parameter(value, name):
         raise TypeError(f"{name} must be real numeric") from exc
     if value.dtype.kind not in "iuf":
         raise TypeError(f"{name} must be real numeric")
+    if bool(_jnp.any(~_jnp.isfinite(value))):
+        raise ValueError(f"{name} must be finite")
     return value
 
 

--- a/tests/backend/test_jax_random_normal_scale_validation.py
+++ b/tests/backend/test_jax_random_normal_scale_validation.py
@@ -19,3 +19,31 @@ from pyrecest._backend.jax import random  # noqa: E402
 def test_normal_rejects_boolean_scale(scale):
     with pytest.raises(TypeError, match="scale must be real numeric, not boolean"):
         random.normal(scale=scale)
+
+
+@pytest.mark.parametrize(
+    "loc",
+    [
+        np.nan,
+        np.inf,
+        -np.inf,
+        jnp.array([0.0, np.nan]),
+    ],
+)
+def test_normal_rejects_nonfinite_loc(loc):
+    with pytest.raises(ValueError, match="loc must be finite"):
+        random.normal(loc=loc)
+
+
+@pytest.mark.parametrize(
+    "scale",
+    [
+        np.nan,
+        np.inf,
+        -np.inf,
+        jnp.array([1.0, np.inf]),
+    ],
+)
+def test_normal_rejects_nonfinite_scale(scale):
+    with pytest.raises(ValueError, match="scale must be finite"):
+        random.normal(scale=scale)


### PR DESCRIPTION
## Summary
- Add finite-value validation for JAX random.normal parameters.
- Add regression coverage for scalar and array-valued invalid parameters.

## Testing
- Syntax compilation passed for the patched source and test snippets.
- Full pytest was not run in this environment.