### PR TITLE
Fix Murty full-assignment bookkeeping

### DIFF
--- a/src/pyrecest/utils/__init__.py
+++ b/src/pyrecest/utils/__init__.py
@@ -1,8 +1,35 @@
 """Utility helpers for :mod:`pyrecest`."""
 
+from . import assignment as _assignment_module
 from . import multisession_assignment as _multisession_assignment_module
 from ._multisession_assignment_labels import tracks_to_session_labels
-from .assignment import min_cost_max_cardinality_assignment, murty_k_best_assignments
+
+
+def _murty_solution_with_full_assignment(solution, n_cols):
+    if solution is None or "_full_assignment" in solution:
+        return solution
+    full_assignment = _assignment_module._array(solution["assignment"])
+    for row_index, col_index in enumerate(full_assignment):
+        if int(col_index) < 0:
+            full_assignment[row_index] = n_cols + row_index
+    patched_solution = dict(solution)
+    patched_solution["_full_assignment"] = full_assignment
+    return patched_solution
+
+
+def _solve_subproblem_with_full_assignment(*args, **kwargs):
+    solution = _assignment_module._solve_subproblem_without_full_assignment(*args, **kwargs)
+    n_cols = args[2] if len(args) > 2 else kwargs["n_cols"]
+    return _murty_solution_with_full_assignment(solution, n_cols)
+
+
+if not hasattr(_assignment_module, "_solve_subproblem_without_full_assignment"):
+    _assignment_module._solve_subproblem_without_full_assignment = _assignment_module._solve_subproblem
+    _assignment_module._solve_subproblem = _solve_subproblem_with_full_assignment
+
+
+min_cost_max_cardinality_assignment = _assignment_module.min_cost_max_cardinality_assignment
+murty_k_best_assignments = _assignment_module.murty_k_best_assignments
 from .association_features import (
     CalibratedPairwiseAssociationModel,
     NamedPairwiseFeatureSchema,


### PR DESCRIPTION
## Summary
- patch Murty subproblem solutions to retain the augmented full-assignment vector needed for branching
- keep the public `murty_k_best_assignments()` result payload unchanged
- rely on the existing k-best assignment brute-force regression coverage for multi-solution cases

## Bug fixed
`murty_k_best_assignments()` branches on `solution["_full_assignment"]` when enumerating additional ranked hypotheses, but `_solve_subproblem()` did not expose that bookkeeping entry. For non-trivial `k > 1` calls, the first solution could be emitted and then branching could fail with `KeyError("_full_assignment")` instead of returning the remaining k-best assignments.

## Testing
- Local focused reproduction: the current bookkeeping path raises `KeyError("_full_assignment")`; the patched path returns ranked assignments for a 2x2 problem.
- Not run: full repository pytest in this environment because the sandbox cannot resolve `github.com` to clone/install the repository. CI should run the full matrix.