### PR TITLE
Accept scalar array dimensions in model validation

### DIFF
--- a/src/pyrecest/models/validation.py
+++ b/src/pyrecest/models/validation.py
@@ -67,14 +67,26 @@ def _validate_expected_dim(
 ) -> None:
     if expected_dim is None:
         return
-    if isinstance(expected_dim, bool) or not isinstance(expected_dim, Integral):
-        raise TypeError(f"{dim_name} must be an integer or None.")
-    if int(expected_dim) <= 0:
+    expected_dim_value = _validate_expected_dim_scalar(expected_dim, dim_name)
+    if expected_dim_value <= 0:
         raise ValueError(f"{dim_name} must be positive.")
-    if actual_dim != int(expected_dim):
+    if actual_dim != expected_dim_value:
         raise ValueError(
-            f"{name} has dimension {actual_dim}, expected {int(expected_dim)}."
+            f"{name} has dimension {actual_dim}, expected {expected_dim_value}."
         )
+
+
+def _validate_expected_dim_scalar(value: Any, dim_name: str) -> int:
+    try:
+        value_array = np.asarray(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise TypeError(f"{dim_name} must be an integer or None.") from exc
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise TypeError(f"{dim_name} must be an integer or None.")
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)) or not isinstance(scalar, Integral):
+        raise TypeError(f"{dim_name} must be an integer or None.")
+    return int(scalar)
 
 
 def _to_python_bool(value: Any) -> bool:

--- a/tests/test_model_validation_scalar_dimensions.py
+++ b/tests/test_model_validation_scalar_dimensions.py
@@ -1,0 +1,35 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from pyrecest.models.validation import (
+    validate_covariance_matrix,
+    validate_matrix,
+    validate_vector,
+)
+
+
+def test_validation_accepts_zero_dimensional_numpy_integer_dimensions():
+    vector = validate_vector([1.0, 2.0], dim=np.array(2, dtype=np.int64))
+    matrix = validate_matrix(
+        [[1.0, 2.0], [3.0, 4.0]],
+        rows=np.array(2, dtype=np.int64),
+        cols=np.array(2, dtype=np.int64),
+    )
+    covariance = validate_covariance_matrix(
+        [[1.0, 0.0], [0.0, 2.0]],
+        dim=np.array(2, dtype=np.int64),
+    )
+
+    npt.assert_allclose(np.asarray(vector), [1.0, 2.0])
+    npt.assert_allclose(np.asarray(matrix), [[1.0, 2.0], [3.0, 4.0]])
+    npt.assert_allclose(np.asarray(covariance), [[1.0, 0.0], [0.0, 2.0]])
+
+
+@pytest.mark.parametrize(
+    "dim",
+    [np.array([2]), np.array(2.0), np.array(True), True, "2"],
+)
+def test_validate_vector_rejects_invalid_dimension_scalars(dim):
+    with pytest.raises((TypeError, ValueError), match="dim"):
+        validate_vector([1.0, 2.0], dim=dim)


### PR DESCRIPTION
Normalize expected dimension arguments before shape checks and add regression coverage for scalar array dimensions.