### PR TITLE
Validate PyTorch normal parameter finiteness

### DIFF
--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -286,6 +286,14 @@ def _normal_device(*values):
 def _validate_normal_parameter(value, name):
     if _contains_boolean_value(value):
         raise TypeError(f"{name} must be real numeric, not boolean")
+    try:
+        parameter = _torch.as_tensor(value)
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise TypeError(f"{name} must be real numeric") from exc
+    if not _is_real_numeric_dtype(parameter.dtype):
+        raise TypeError(f"{name} must be real numeric")
+    if bool(_torch.any(~_torch.isfinite(parameter))):
+        raise ValueError(f"{name} must be finite")
 
 
 def _normal_array_parameters(loc, scale):

--- a/tests/backend_support/test_pytorch_random_normal_contract.py
+++ b/tests/backend_support/test_pytorch_random_normal_contract.py
@@ -40,6 +40,28 @@ print("ok")
 """
 
 
+_NONFINITE_PARAMETER_CHECK = """
+from pyrecest.backend import random
+
+bad_parameters = (
+    {"loc": float("inf"), "scale": 1.0},
+    {"loc": 0.0, "scale": float("inf")},
+    {"loc": [0.0, float("nan")], "scale": 1.0, "size": (2,)},
+    {"loc": [0.0, 1.0], "scale": [0.1, float("inf")]},
+)
+
+for kwargs in bad_parameters:
+    try:
+        random.normal(**kwargs)
+    except ValueError as exc:
+        assert "finite" in str(exc)
+    else:
+        raise AssertionError(f"normal accepted non-finite parameters: {kwargs}")
+
+print("ok")
+"""
+
+
 @pytest.mark.backend_portable
 def test_pytorch_normal_accepts_array_valued_parameters():
     if importlib.util.find_spec("torch") is None:
@@ -57,6 +79,17 @@ def test_pytorch_normal_rejects_negative_array_scale_with_size():
         pytest.skip("PyTorch is not installed")
 
     result = run_backend_code("pytorch", _ARRAY_PARAMETER_NEGATIVE_SCALE_CHECK)
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+@pytest.mark.backend_portable
+def test_pytorch_normal_rejects_nonfinite_parameters():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code("pytorch", _NONFINITE_PARAMETER_CHECK)
 
     assert result.returncode == 0, result.stderr
     assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- validate PyTorch `random.normal()` `loc` and `scale` values as real numeric tensors before sampling
- reject non-finite `loc`/`scale` inputs with a clear `ValueError`
- add backend-portable regression coverage for scalar and array-valued `inf`/`nan` parameters

## Bug fixed
The PyTorch backend previously only rejected boolean `normal()` parameters before sampling. Inputs such as `loc=float("inf")` or `scale=float("inf")` could be forwarded to `torch.normal()` or the array-valued sampling path, which can silently produce non-finite samples.

## Testing
- Inspected the branch diff: 2 files changed, production validation plus focused regression test.
- Local reproduction with installed PyTorch confirmed `torch.normal(mean=float("inf"), std=1.0, size=(3,))` returns `inf` samples and `std=float("inf")` returns non-finite samples.
- Full repository pytest not run in this environment because the sandbox cannot resolve `github.com` to clone/install the repository; CI should run the full backend matrix.