### PR TITLE
Reject text values in circular sampler counts

### DIFF
--- a/src/pyrecest/sampling/hypertoroidal_sampler.py
+++ b/src/pyrecest/sampling/hypertoroidal_sampler.py
@@ -5,6 +5,8 @@ from pyrecest.distributions import CircularUniformDistribution
 
 from .abstract_sampler import AbstractSampler
 
+_TEXT_TYPES = (str, bytes, bytearray, np.str_, np.bytes_)
+
 
 def _validate_integral_scalar(value, name: str, *, minimum: int) -> int:
     scalar = np.asarray(value)
@@ -14,6 +16,8 @@ def _validate_integral_scalar(value, name: str, *, minimum: int) -> int:
     scalar_value = scalar.item()
     if isinstance(scalar_value, (bool, np.bool_)):
         raise ValueError(f"{name} must be an integer, not a boolean")
+    if isinstance(scalar_value, _TEXT_TYPES):
+        raise ValueError(f"{name} must be an integer")
 
     try:
         integer_value = int(scalar_value)

--- a/tests/test_hypertoroidal_sampler.py
+++ b/tests/test_hypertoroidal_sampler.py
@@ -30,13 +30,13 @@ class TestCircularUniformSampler(unittest.TestCase):
         self.assertEqual(samples.shape, (3, 1))
 
     def test_sample_stochastic_rejects_invalid_controls(self):
-        invalid_sample_counts = (-1, 1.5, True, [2])
+        invalid_sample_counts = (-1, 1.5, True, "3", b"3", [2])
         for n_samples in invalid_sample_counts:
             with self.subTest(n_samples=n_samples):
                 with self.assertRaises(ValueError):
                     self.sampler.sample_stochastic(n_samples)
 
-        invalid_dims = (0, 1.5, 2, True, [1])
+        invalid_dims = (0, 1.5, 2, True, "1", b"1", [1])
         for dim in invalid_dims:
             with self.subTest(dim=dim):
                 with self.assertRaises(ValueError):
@@ -68,7 +68,7 @@ class TestCircularUniformSampler(unittest.TestCase):
         self.assertEqual(grid_points.shape[0], 4)
 
     def test_get_grid_rejects_noninteger_density(self):
-        for density in (2.5, True, [3]):
+        for density in (2.5, True, "3", b"3", [3]):
             with self.subTest(density=density):
                 with self.assertRaises(ValueError):
                     self.sampler.get_grid(density)


### PR DESCRIPTION
## Summary
- Reject text values in the circular sampler's integral scalar validator.
- Preserve support for numeric integer-like scalar inputs.
- Add regression tests for text-valued sample counts, dimensions, and grid densities.

## Tests
Not run locally; the repository GitHub Actions matrix should run on this PR.