### PR TITLE
Reject non-finite PyTorch normal parameters

### DIFF
--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -286,6 +286,14 @@ def _normal_device(*values):
 def _validate_normal_parameter(value, name):
     if _contains_boolean_value(value):
         raise TypeError(f"{name} must be real numeric, not boolean")
+    try:
+        value_tensor = _torch.as_tensor(value)
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise TypeError(f"{name} must be real numeric") from exc
+    if not _is_real_numeric_dtype(value_tensor.dtype):
+        raise TypeError(f"{name} must be real numeric")
+    if bool(_torch.any(~_torch.isfinite(value_tensor))):
+        raise ValueError(f"{name} must be finite")
 
 
 def _normal_array_parameters(loc, scale):

--- a/tests/backend/test_pytorch_random_normal_finiteness.py
+++ b/tests/backend/test_pytorch_random_normal_finiteness.py
@@ -1,0 +1,23 @@
+import math
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from pyrecest._backend.pytorch import random  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    ("loc", "scale", "message"),
+    [
+        (math.inf, 1.0, "loc"),
+        (math.nan, 1.0, "loc"),
+        (torch.tensor([0.0, math.inf]), 1.0, "loc"),
+        (0.0, math.inf, "scale"),
+        (0.0, math.nan, "scale"),
+        (0.0, torch.tensor([1.0, math.inf]), "scale"),
+    ],
+)
+def test_normal_rejects_non_finite_parameters(loc, scale, message):
+    with pytest.raises(ValueError, match=message):
+        random.normal(loc, scale)


### PR DESCRIPTION
## Summary
- Validate PyTorch `random.normal` `loc` and `scale` inputs as finite real numeric parameters.
- Reject `NaN`/`inf` parameters before sampling, instead of allowing non-finite samples to propagate.
- Add focused PyTorch backend regression coverage for scalar and tensor-valued non-finite parameters.

## Validation
- `python -m py_compile /mnt/data/pytorch_random_patched.py /mnt/data/test_pytorch_random_normal_finiteness.py`

Full repository pytest was not run locally because this runtime cannot clone GitHub directly.