### PR TITLE
Accept array-like inputs in NumPy PD predicate

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/linalg.py
+++ b/src/pyrecest/_backend/_shared_numpy/linalg.py
@@ -125,6 +125,7 @@ def qr(a, mode="reduced"):
 
 def is_single_matrix_pd(mat):
     """Check if 2D square matrix is positive definite."""
+    mat = _np.asarray(mat)
     if mat.ndim != 2 or mat.shape[0] != mat.shape[1]:
         return False
     if mat.dtype in [_np.complex64, _np.complex128]:

--- a/tests/backend_support/test_linalg_pd_symmetry_contract.py
+++ b/tests/backend_support/test_linalg_pd_symmetry_contract.py
@@ -27,6 +27,12 @@ def test_is_single_matrix_pd_rejects_real_nonsymmetric_matrix():
 
 
 @pytest.mark.backend_portable
+def test_is_single_matrix_pd_accepts_array_like_inputs():
+    assert _as_bool(backend.linalg.is_single_matrix_pd([[2.0, 0.0], [0.0, 3.0]])) is True
+    assert _as_bool(backend.linalg.is_single_matrix_pd([1.0, 2.0])) is False
+
+
+@pytest.mark.backend_portable
 def test_jax_is_single_matrix_pd_rejects_real_nonsymmetric_matrix():
     if importlib.util.find_spec("jax") is None:
         pytest.skip("JAX is not installed")


### PR DESCRIPTION
## Summary
- convert inputs to arrays in the shared NumPy `linalg.is_single_matrix_pd` implementation before inspecting dimensions and dtype
- add portable regression coverage for Python-list positive-definite and non-matrix inputs

## Bug fixed
The shared NumPy/autograd linalg predicate assumed callers passed objects with `.ndim`, `.shape`, and `.dtype`. Plain Python lists therefore raised `AttributeError`, while the JAX and PyTorch implementations already accepted array-like inputs. The fix restores the backend contract by normalizing `mat` with `np.asarray` first.

## Testing
- Not run locally; the execution environment here cannot clone/install the repository dependencies.