### PR TITLE
Fix symmetric distance array-like inputs

### DIFF
--- a/src/pyrecest/evaluation/get_distance_function.py
+++ b/src/pyrecest/evaluation/get_distance_function.py
@@ -145,7 +145,8 @@ def _symmetric_distance_function(
         offsets = [0.0]
 
     def distance_function(xest, xtrue):
-        return min(base_distance(xest, xtrue + offset) for offset in offsets)
+        xtrue_array = asarray(xtrue)
+        return min(base_distance(xest, xtrue_array + offset) for offset in offsets)
 
     return distance_function
 

--- a/tests/evaluation/test_symmetric_distance_arraylike_inputs.py
+++ b/tests/evaluation/test_symmetric_distance_arraylike_inputs.py
@@ -1,0 +1,15 @@
+import unittest
+
+import numpy as np
+from pyrecest.evaluation.get_distance_function import get_distance_function
+
+
+class SymmetricDistanceArrayLikeInputTest(unittest.TestCase):
+    def test_symmetric_circle_accepts_array_like_truth_values(self):
+        distance = get_distance_function("circle", nSymm=2)
+
+        self.assertAlmostEqual(float(distance([0.0], [np.pi])), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closed after applying the regression test directly to `main` in commit ec3dadc510ac6b141259723eb48b8fb59e22fb68. The source-side fix is already present on current `main`.