### PR TITLE
Validate NumPy multivariate normal parameters

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/random.py
+++ b/src/pyrecest/_backend/_shared_numpy/random.py
@@ -122,7 +122,23 @@ normal = _modify_func_default_dtype(
 )
 
 
+def _validate_multivariate_normal_parameter(value, name):
+    if _contains_boolean_value(value):
+        raise TypeError(f"{name} must be real numeric, not boolean")
+    try:
+        value_array = _np.asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(f"{name} must be real numeric") from exc
+    if value_array.dtype.kind not in "iuf":
+        raise TypeError(f"{name} must be real numeric")
+    if _np.any(~_np.isfinite(value_array)):
+        raise ValueError(f"{name} must be finite")
+    return value_array
+
+
 def _multivariate_normal(mean, cov, size=None, check_valid="warn", tol=1e-8):
+    mean = _validate_multivariate_normal_parameter(mean, "mean")
+    cov = _validate_multivariate_normal_parameter(cov, "cov")
     return _np.random.multivariate_normal(
         mean, cov, _normalize_size(size), check_valid, tol
     )

--- a/tests/backend/test_numpy_multivariate_normal_validation.py
+++ b/tests/backend/test_numpy_multivariate_normal_validation.py
@@ -1,0 +1,45 @@
+import numpy as np
+import pytest
+
+from pyrecest._backend.numpy import random
+
+
+@pytest.mark.parametrize(
+    ("mean", "cov"),
+    [
+        ([True, False], np.eye(2)),
+        (np.array([0.0, np.bool_(True)], dtype=object), np.eye(2)),
+        ([0.0, 0.0], [[True, False], [False, True]]),
+        (
+            [0.0, 0.0],
+            np.array([[1.0, np.bool_(False)], [0.0, 1.0]], dtype=object),
+        ),
+    ],
+)
+def test_multivariate_normal_rejects_boolean_parameters(mean, cov):
+    with pytest.raises(TypeError, match="real numeric"):
+        random.multivariate_normal(mean, cov)
+
+
+@pytest.mark.parametrize(
+    ("mean", "cov"),
+    [
+        (["0.0", "1.0"], np.eye(2)),
+        ([0.0, 0.0], np.array([["1.0", "0.0"], ["0.0", "1.0"]])),
+    ],
+)
+def test_multivariate_normal_rejects_text_parameters(mean, cov):
+    with pytest.raises(TypeError, match="real numeric"):
+        random.multivariate_normal(mean, cov)
+
+
+@pytest.mark.parametrize(
+    ("mean", "cov"),
+    [
+        ([np.nan, 0.0], np.eye(2)),
+        ([0.0, 0.0], [[1.0, np.inf], [0.0, 1.0]]),
+    ],
+)
+def test_multivariate_normal_rejects_nonfinite_parameters(mean, cov):
+    with pytest.raises(ValueError, match="finite"):
+        random.multivariate_normal(mean, cov)


### PR DESCRIPTION
## Summary
- Validate NumPy-backed `random.multivariate_normal` mean and covariance inputs before sampling.
- Reject boolean, text-like, and non-finite parameters.
- Add regression tests for invalid `mean` and `cov` inputs.

## Verification
- Local syntax check for modified source and new test file.
- Compared branch against `main`: 2 commits ahead, 0 behind.