### PR TITLE
Restore DensityTransitionModel particle alias

### DIFF
--- a/src/pyrecest/models/particle.py
+++ b/src/pyrecest/models/particle.py
@@ -5,9 +5,14 @@ This module keeps the historical import path ``pyrecest.models.particle`` from
 drifting away from the public model API.
 """
 
-from .likelihood import LikelihoodMeasurementModel, SampleableTransitionModel
+from .likelihood import (
+    DensityTransitionModel,
+    LikelihoodMeasurementModel,
+    SampleableTransitionModel,
+)
 
 __all__ = [
+    "DensityTransitionModel",
     "LikelihoodMeasurementModel",
     "SampleableTransitionModel",
 ]

--- a/tests/models/test_particle_aliases.py
+++ b/tests/models/test_particle_aliases.py
@@ -1,0 +1,13 @@
+import unittest
+
+from pyrecest.models.likelihood import DensityTransitionModel
+from pyrecest.models.particle import DensityTransitionModel as ParticleDensityTransitionModel
+
+
+class TestParticleAliases(unittest.TestCase):
+    def test_density_transition_alias_matches_canonical_model(self):
+        self.assertIs(ParticleDensityTransitionModel, DensityTransitionModel)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- re-export `DensityTransitionModel` from `pyrecest.models.particle`
- add a regression test that the compatibility alias points to the canonical likelihood-model class

## Why
`pyrecest.models.particle` is documented as a backward-compatible alias module that should not drift away from the public model API. `DensityTransitionModel` is exported from the public `pyrecest.models` API and implemented in `pyrecest.models.likelihood`, but the compatibility module only re-exported `LikelihoodMeasurementModel` and `SampleableTransitionModel`. As a result, users following the historical particle-model import path could not import `DensityTransitionModel`.

## Testing
- Added `tests/models/test_particle_aliases.py`
- Local full test execution was not possible from this sandbox, but the new regression is import-only and should be covered by CI.