### PR TITLE
Tighten PyTorch fftconvolve axis validation

### DIFF
--- a/src/pyrecest/_backend/pytorch/signal.py
+++ b/src/pyrecest/_backend/pytorch/signal.py
@@ -1,15 +1,36 @@
 import numpy as _np
 import torch as _torch
 
+_AXIS_TYPE_ERROR = "axes must be None, an integer, or a sequence of integers"
+
+
+def _coerce_axis(axis):
+    try:
+        axis_array = _np.asarray(axis)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(_AXIS_TYPE_ERROR) from exc
+    if axis_array.shape != () or axis_array.dtype.kind not in "iu":
+        raise TypeError(_AXIS_TYPE_ERROR)
+    return int(axis_array.item())
+
+
+def _is_scalar_axis_argument(value):
+    if isinstance(value, (int, _np.integer, bool, _np.bool_)):
+        return True
+    return getattr(value, "shape", None) == ()
+
 
 def _normalize_axes(axes, ndim):
     axes_were_provided = axes is not None
     if axes is None:
         axes = tuple(range(ndim))
-    elif isinstance(axes, (int, _np.integer)):
-        axes = (int(axes),)
+    elif _is_scalar_axis_argument(axes):
+        axes = (_coerce_axis(axes),)
     else:
-        axes = tuple(int(axis) for axis in axes)
+        try:
+            axes = tuple(_coerce_axis(axis) for axis in axes)
+        except TypeError as exc:
+            raise TypeError(_AXIS_TYPE_ERROR) from exc
 
     if axes_were_provided and len(axes) == 0 and ndim > 0:
         raise ValueError("when provided, axes cannot be empty")

--- a/tests/backend_support/test_pytorch_fftconvolve_axes_validation.py
+++ b/tests/backend_support/test_pytorch_fftconvolve_axes_validation.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pyrecest.backend as backend
+import pytest
+from scipy.signal import fftconvolve as scipy_fftconvolve
+
+
+def _skip_unless_pytorch():
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific signal backend contract")
+
+
+def test_pytorch_fftconvolve_accepts_scalar_array_axis():
+    _skip_unless_pytorch()
+
+    first = backend.asarray([[1.0, 2.0], [3.0, 4.0]])
+    second = backend.asarray([[0.5, 1.5]])
+
+    actual = backend.to_numpy(
+        backend.signal.fftconvolve(first, second, mode="same", axes=np.array(0))
+    )
+    expected = scipy_fftconvolve(
+        backend.to_numpy(first), backend.to_numpy(second), mode="same", axes=0
+    )
+
+    assert np.allclose(actual, expected)
+
+
+@pytest.mark.parametrize(
+    "axes",
+    [True, np.bool_(False), np.array(True), (True,), "0", np.array(0.0)],
+)
+def test_pytorch_fftconvolve_rejects_non_integer_axes(axes):
+    _skip_unless_pytorch()
+
+    first = backend.asarray([1.0, 2.0])
+    second = backend.asarray([3.0, 4.0])
+
+    with pytest.raises(TypeError, match="axes must be None"):
+        backend.signal.fftconvolve(first, second, axes=axes)


### PR DESCRIPTION
## Summary
- normalize PyTorch `signal.fftconvolve` axes through an explicit scalar/sequence integer coercion path
- accept scalar NumPy integer axes such as `np.array(0)`
- reject boolean, text, and non-integer scalar axes instead of silently coercing them or failing with an unclear iteration error
- add focused PyTorch backend regression tests for scalar-array axes and invalid axes

## Validation
- Not run locally; changes were made through the GitHub connector without a local checkout/runtime.