### PR TITLE
Fix EOT array-like ground truth handling

### DIFF
--- a/src/pyrecest/evaluation/generate_measurements.py
+++ b/src/pyrecest/evaluation/generate_measurements.py
@@ -140,7 +140,11 @@ def generate_measurements(groundtruth, simulation_config):
             )
 
         for t in range(simulation_config["n_timesteps"]):
-            curr_groundtruth = groundtruth[t]
+            curr_groundtruth = np.asarray(groundtruth[t])
+            if curr_groundtruth.ndim == 0:
+                raise ValueError(
+                    "Currently only R^2 and SE(2) scenarios are supported."
+                )
             if curr_groundtruth.shape[-1] == 2:
                 x = _as_shapely_scalar(curr_groundtruth[..., 0], "groundtruth x")
                 y = _as_shapely_scalar(curr_groundtruth[..., 1], "groundtruth y")

--- a/tests/evaluation/test_generate_measurements_validation.py
+++ b/tests/evaluation/test_generate_measurements_validation.py
@@ -1,8 +1,10 @@
 import numpy as np
 import pytest
+from pyrecest.evaluation.eot_shape_database import PolygonWithSampling
 from pyrecest.evaluation.generate_measurements import (
     _as_nonnegative_measurement_count,
     _as_shapely_scalar,
+    generate_measurements,
     generate_n_measurements_PPP,
 )
 
@@ -63,3 +65,20 @@ def test_generate_n_measurements_ppp_returns_python_int_for_zero_rate():
 
     assert count == 0
     assert isinstance(count, int)
+
+
+def test_generate_measurements_eot_accepts_array_like_groundtruth_entries():
+    simulation_config = {
+        "n_timesteps": 1,
+        "eot": True,
+        "target_shape": PolygonWithSampling(
+            [(0.0, 0.0), (1.0, 0.0), (0.0, 1.0)]
+        ),
+        "eot_sampling_style": "within",
+        "n_meas_at_individual_time_step": np.array([0]),
+    }
+
+    measurements = generate_measurements([[1.0, 2.0]], simulation_config)
+
+    assert measurements.shape == (1,)
+    assert measurements[0].shape == (0, 2)


### PR DESCRIPTION
## Summary
- Convert EOT ground-truth entries with `np.asarray` before checking their coordinate dimension.
- Preserve the existing R^2/SE(2) validation path for unsupported scalar entries.
- Add a regression test for Python-list ground truth in EOT measurement generation.

## Testing
- Added focused regression coverage in `tests/evaluation/test_generate_measurements_validation.py`.
- Full local pytest was not run in this environment; CI should cover the branch.