### PR TITLE
Validate JAX multivariate normal parameters

### DIFF
--- a/src/pyrecest/_backend/jax/random.py
+++ b/src/pyrecest/_backend/jax/random.py
@@ -474,6 +474,30 @@ def choice(a, size=None, replace=True, p=None, shuffle=True, *args, **kwargs):
     return set_state_return(has_state, state, res)
 
 
+def _validate_multivariate_normal_mean(mean):
+    mean = _validate_normal_parameter(mean, "mean")
+    if mean.ndim != 1:
+        raise ValueError("mean must be 1-dimensional")
+    if mean.shape[0] == 0:
+        raise ValueError("mean must contain at least one entry")
+    return mean
+
+
+def _validate_multivariate_normal_cov(cov, mean_dim):
+    cov = _validate_normal_parameter(cov, "cov")
+    if cov.ndim != 2:
+        raise ValueError("cov must be a 2-dimensional square matrix")
+    if cov.shape != (mean_dim, mean_dim):
+        raise ValueError("cov must have shape (mean.size, mean.size)")
+    if not bool(_jnp.allclose(cov, cov.T)):
+        raise ValueError("cov must be symmetric")
+    cov_float = cov.astype(_jnp.result_type(cov, _jnp.float32))
+    eigenvalue_tolerance = 1e-8
+    if bool(_jnp.any(_jnp.linalg.eigvalsh(cov_float) < -eigenvalue_tolerance)):
+        raise ValueError("cov must be positive semidefinite")
+    return cov
+
+
 def _multivariate_normal(state, mean, cov, size=None, *args, **kwargs):
     state, key = jax.random.split(state)
     if "shape" in kwargs:
@@ -481,8 +505,11 @@ def _multivariate_normal(state, mean, cov, size=None, *args, **kwargs):
             raise TypeError("Specify only one of 'size' or 'shape'.")
         size = kwargs.pop("shape")
     shape = _shape_from_size(size)
-    mean = _jnp.asarray(mean)
-    cov = _jnp.asarray(cov)
+    mean = _validate_multivariate_normal_mean(mean)
+    cov = _validate_multivariate_normal_cov(cov, mean.shape[0])
+    dtype = _jnp.result_type(mean, cov, _jnp.float32)
+    mean = mean.astype(dtype)
+    cov = cov.astype(dtype)
     return state, jax.random.multivariate_normal(key, mean, cov, shape, *args, **kwargs)
 
 

--- a/tests/backend/test_jax_random_multivariate_normal_validation.py
+++ b/tests/backend/test_jax_random_multivariate_normal_validation.py
@@ -1,0 +1,82 @@
+import numpy as np
+import pytest
+
+jax = pytest.importorskip("jax")
+import jax.numpy as jnp  # noqa: E402
+from pyrecest._backend.jax import random  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "bad_mean",
+    [
+        True,
+        np.bool_(True),
+        jnp.array([True, False]),
+        [0.0, np.bool_(True)],
+        np.array([0.0, np.bool_(False)], dtype=object),
+    ],
+)
+def test_multivariate_normal_rejects_boolean_mean(bad_mean):
+    with pytest.raises(TypeError, match="mean must be real numeric, not boolean"):
+        random.multivariate_normal(bad_mean, jnp.eye(2))
+
+
+@pytest.mark.parametrize("bad_mean", [[0.0, np.nan], [0.0, np.inf]])
+def test_multivariate_normal_rejects_nonfinite_mean(bad_mean):
+    with pytest.raises(ValueError, match="mean must be finite"):
+        random.multivariate_normal(bad_mean, jnp.eye(2))
+
+
+def test_multivariate_normal_rejects_nonvector_mean():
+    with pytest.raises(ValueError, match="mean must be 1-dimensional"):
+        random.multivariate_normal(jnp.zeros((1, 2)), jnp.eye(2))
+
+
+@pytest.mark.parametrize(
+    "bad_cov",
+    [
+        True,
+        [[True, False], [False, True]],
+        [[1.0, np.bool_(False)], [0.0, 1.0]],
+        np.array([[1.0, 0.0], [0.0, np.bool_(True)]], dtype=object),
+    ],
+)
+def test_multivariate_normal_rejects_boolean_covariance(bad_cov):
+    with pytest.raises(TypeError, match="cov must be real numeric, not boolean"):
+        random.multivariate_normal(jnp.zeros(2), bad_cov)
+
+
+@pytest.mark.parametrize(
+    "bad_cov",
+    [
+        [[1.0, 0.0], [0.0, np.nan]],
+        [[1.0, 0.0], [0.0, np.inf]],
+    ],
+)
+def test_multivariate_normal_rejects_nonfinite_covariance(bad_cov):
+    with pytest.raises(ValueError, match="cov must be finite"):
+        random.multivariate_normal(jnp.zeros(2), bad_cov)
+
+
+@pytest.mark.parametrize(
+    ("bad_cov", "message"),
+    [
+        ([1.0, 1.0], "cov must be a 2-dimensional square matrix"),
+        (jnp.ones((2, 3)), "cov must have shape"),
+        ([[1.0, 0.1], [0.0, 1.0]], "cov must be symmetric"),
+        ([[1.0, 0.0], [0.0, -0.1]], "cov must be positive semidefinite"),
+    ],
+)
+def test_multivariate_normal_rejects_invalid_covariance_geometry(bad_cov, message):
+    with pytest.raises(ValueError, match=message):
+        random.multivariate_normal(jnp.zeros(2), bad_cov)
+
+
+@pytest.mark.parametrize("size", [None, 3, (2, 3)])
+def test_multivariate_normal_accepts_finite_positive_semidefinite_inputs(size):
+    random.seed(0)
+
+    sample = random.multivariate_normal([0, 1], [[2, 0], [0, 1]], size=size)
+
+    expected_shape = (2,) if size is None else (*np.atleast_1d(size), 2)
+    assert sample.shape == expected_shape


### PR DESCRIPTION
## Summary
- validate JAX-backed `random.multivariate_normal` `mean` and `cov` before sampling
- reject boolean, non-finite, non-vector mean, malformed covariance, non-symmetric covariance, and non-PSD covariance inputs with deterministic errors
- preserve valid NumPy-style `size`/`shape` behavior and add focused JAX regression tests

## Verification
- local syntax check for modified source and new test file
- local minimal pytest run for the new JAX validation test file: `21 passed`
- branch is based on current `main` and is 2 commits ahead / 0 behind