### PR TITLE
Reject text sigma-point scalar parameters

### DIFF
--- a/src/pyrecest/sampling/sigma_points.py
+++ b/src/pyrecest/sampling/sigma_points.py
@@ -10,6 +10,8 @@ import numpy as np
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import asarray, concatenate, float64, full, linalg, reshape, stack
 
+_TEXT_SCALAR_TYPES = (str, bytes, np.str_, np.bytes_)
+
 
 def _scalar_item(value, name: str):
     """Return a scalar value while rejecting arrays and booleans."""
@@ -40,6 +42,8 @@ def _validate_positive_integer(value, name: str) -> int:
 
 def _validate_finite_scalar(value, name: str) -> float:
     scalar = _scalar_item(value, name)
+    if isinstance(scalar, _TEXT_SCALAR_TYPES):
+        raise ValueError(f"{name} must be finite")
     try:
         result = float(scalar)
     except (TypeError, ValueError, OverflowError) as exc:

--- a/tests/test_sigma_points.py
+++ b/tests/test_sigma_points.py
@@ -68,6 +68,16 @@ class TestSigmaPoints(unittest.TestCase):
             ),
             (
                 MerweScaledSigmaPoints,
+                {"n": 2, "alpha": "0.5", "beta": 2.0, "kappa": 0.0},
+                "alpha must be finite",
+            ),
+            (
+                MerweScaledSigmaPoints,
+                {"n": 2, "alpha": 0.5, "beta": np.array("2.0"), "kappa": 0.0},
+                "beta must be finite",
+            ),
+            (
+                MerweScaledSigmaPoints,
                 {"n": 2, "alpha": 0.5, "beta": np.inf, "kappa": 0.0},
                 "beta must be finite",
             ),
@@ -84,6 +94,11 @@ class TestSigmaPoints(unittest.TestCase):
             (
                 JulierSigmaPoints,
                 {"n": 2, "kappa": np.nan},
+                "kappa must be finite",
+            ),
+            (
+                JulierSigmaPoints,
+                {"n": 2, "kappa": b"1.0"},
                 "kappa must be finite",
             ),
             (


### PR DESCRIPTION
## Summary
- reject text/bytes scalar values in sigma-point finite parameter validation
- preserve numeric scalar handling for valid NumPy/Python numeric values
- add regression coverage for string, NumPy string scalar, and bytes-valued `alpha`/`beta`/`kappa`

## Bug fixed
`MerweScaledSigmaPoints` and `JulierSigmaPoints` validated finite scalar parameters via `float(scalar)`. That silently accepted values such as `"0.5"`, `np.array("2.0")`, or `b"1.0"`, even though these are not real numeric scalar inputs. The validators now reject these text-like values with the existing finite-parameter error path.

## Verification
- local `python -m py_compile` on the modified sigma-point module
- local helper-level smoke check for text/bytes rejection and numeric scalar acceptance

Full pytest was not run in the sandbox because the repository dependencies are not installed there.