### PR TITLE
Validate measurement noise for empty batches

### DIFF
--- a/src/pyrecest/filters/measurement_reliability.py
+++ b/src/pyrecest/filters/measurement_reliability.py
@@ -254,9 +254,6 @@ def normalize_measurement_noise_covariances(
     n_measurements = _normalize_nonnegative_integer(n_measurements, "n_measurements")
     measurement_dim = _normalize_positive_integer(measurement_dim, "measurement_dim")
 
-    if n_measurements == 0:
-        return zeros((0, measurement_dim, measurement_dim))
-
     noise = array(measurement_noise)
     empty_shape = (0, measurement_dim, measurement_dim)
     if noise.ndim == 3:

--- a/tests/filters/test_measurement_reliability.py
+++ b/tests/filters/test_measurement_reliability.py
@@ -1,7 +1,7 @@
 import unittest
 
 import pyrecest.backend
-from pyrecest.backend import array, eye
+from pyrecest.backend import array, eye, zeros
 from pyrecest.filters import (
     normalize_active_measurement_mask,
     normalize_measurement_noise_covariances,
@@ -108,6 +108,25 @@ class TestMeasurementReliability(unittest.TestCase):
     def test_empty_measurement_covariances_have_batch_shape(self):
         covariances = normalize_measurement_noise_covariances(
             0.5,
+            0,
+            2,
+            as_covariance_matrix=_as_covariance_matrix,
+        )
+
+        self.assertEqual(covariances.shape, (0, 2, 2))
+
+    def test_empty_measurement_covariances_validate_shared_noise(self):
+        with self.assertRaisesRegex(ValueError, "R vector must have length 2"):
+            normalize_measurement_noise_covariances(
+                array([0.5, 0.25, 0.125]),
+                0,
+                2,
+                as_covariance_matrix=_as_covariance_matrix,
+            )
+
+    def test_empty_per_measurement_covariances_have_batch_shape(self):
+        covariances = normalize_measurement_noise_covariances(
+            zeros((0, 2, 2)),
             0,
             2,
             as_covariance_matrix=_as_covariance_matrix,


### PR DESCRIPTION
## Summary
- validate `measurement_noise` even when `n_measurements == 0` before returning an empty covariance stack
- preserve the `(0, measurement_dim, measurement_dim)` output shape for valid empty batches
- add regression coverage for invalid shared noise and valid empty per-measurement covariance arrays

## Tests
- Not run locally; this session's execution sandbox could not clone GitHub due DNS resolution, so validation is limited to code inspection and added regression tests.