### PR TITLE
Fix PyTorch logical_or array-like inputs

### DIFF
--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -8,6 +8,35 @@ from pyrecest.backend import copy  # noqa: F401
 
 _register_backend_submodules()
 
+
+def _patch_pytorch_logical_or_arraylike():
+    """Make the public PyTorch backend logical_or accept array-like inputs."""
+    import pyrecest.backend as _backend  # pylint: disable=import-outside-toplevel
+
+    if getattr(_backend, "__backend_name__", None) != "pytorch":
+        return
+
+    try:
+        import torch as _torch  # pylint: disable=import-error,import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - inconsistent PyTorch backend env
+        return
+
+    def logical_or(x, y):
+        device = None
+        if _torch.is_tensor(x):
+            device = x.device
+        elif _torch.is_tensor(y):
+            device = y.device
+        return _torch.logical_or(
+            _torch.as_tensor(x, device=device),
+            _torch.as_tensor(y, device=device),
+        )
+
+    _backend.logical_or = logical_or
+
+
+_patch_pytorch_logical_or_arraylike()
+
 from pyrecest.backend_support import (  # noqa: E402,F401
     backend_support,
     format_backend_support_markdown,

--- a/src/pyrecest/_backend/jax/__init__.py
+++ b/src/pyrecest/_backend/jax/__init__.py
@@ -570,6 +570,10 @@ def is_bool(array):
     return _jnp.issubdtype(array.dtype, _jnp.bool_)
 
 
+def logical_or(x, y):
+    return _jnp.logical_or(_jnp.asarray(x), _jnp.asarray(y))
+
+
 def divide(a, b, ignore_div_zero=False):
     a_arr, b_arr = _jnp.asarray(a), _jnp.asarray(b)
     if ignore_div_zero is False:

--- a/tests/test_backend_logical_contract.py
+++ b/tests/test_backend_logical_contract.py
@@ -1,0 +1,47 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pyrecest.backend as backend
+import pytest
+
+
+def _to_python(value):
+    value = backend.to_numpy(value)
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    return value
+
+
+def test_logical_or_accepts_array_like_inputs():
+    result = backend.logical_or([True, False, False], [False, False, True])
+
+    assert _to_python(result) == [True, False, True]
+
+
+@pytest.mark.backend_portable
+def test_pytorch_logical_or_accepts_array_like_inputs():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import pyrecest.backend as backend
+
+result = backend.logical_or([True, False, False], [False, False, True])
+assert backend.to_numpy(result).tolist() == [True, False, True]
+
+tensor = backend.asarray([False, True, False])
+mixed = backend.logical_or(tensor, [True, False, False])
+assert backend.to_numpy(mixed).tolist() == [True, True, False]
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- patch the public PyTorch backend facade so `pyrecest.backend.logical_or` accepts NumPy-style array-like inputs
- preserve tensor-device handling when one operand is already a PyTorch tensor
- add regression coverage for generic backend and isolated PyTorch-subprocess imports

## Bug fixed
The PyTorch backend exported `logical_or` as raw `torch.logical_or`, unlike the custom `logical_and` wrapper. Public calls such as `pyrecest.backend.logical_or([True, False], [False, True])` therefore failed under `PYRECEST_BACKEND=pytorch` because Torch requires tensor operands. NumPy/JAX-style array-like inputs should work through the backend facade.

## Testing
- local syntax parsing of the modified `src/pyrecest/__init__.py` patch and new regression test
- full repository tests were not run locally because this sandbox cannot clone/install the repository dependencies