### PR TITLE
Fix PyTorch comparison array-like inputs

### DIFF
--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -8,6 +8,50 @@ from pyrecest.backend import copy  # noqa: F401
 
 _register_backend_submodules()
 
+
+def _patch_pytorch_comparison_facade() -> None:
+    """Make public PyTorch comparison helpers accept array-like inputs."""
+
+    import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        return
+
+    try:
+        import torch as _torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - backend import fails first in practice
+        return
+
+    def _coerce_binary_args(x, y):
+        device = next(
+            (value.device for value in (x, y) if _torch.is_tensor(value)),
+            None,
+        )
+        if not _torch.is_tensor(x):
+            x = _torch.as_tensor(x, device=device)
+        elif device is not None and x.device != device:
+            x = x.to(device=device)
+        if not _torch.is_tensor(y):
+            y = _torch.as_tensor(y, device=device)
+        elif device is not None and y.device != device:
+            y = y.to(device=device)
+        return x, y
+
+    def _wrap_comparison(torch_func):
+        def comparison(x, y, **kwargs):
+            x, y = _coerce_binary_args(x, y)
+            return torch_func(x, y, **kwargs)
+
+        comparison.__name__ = getattr(torch_func, "__name__", "comparison")
+        comparison.__doc__ = getattr(torch_func, "__doc__", None)
+        return comparison
+
+    backend.greater = _wrap_comparison(_torch.greater)
+    backend.less = _wrap_comparison(_torch.less)
+
+
+_patch_pytorch_comparison_facade()
+
 from pyrecest.backend_support import (  # noqa: E402,F401
     backend_support,
     format_backend_support_markdown,

--- a/tests/backend_support/test_pytorch_comparison_contract.py
+++ b/tests/backend_support/test_pytorch_comparison_contract.py
@@ -1,0 +1,31 @@
+"""Regression tests for PyTorch backend comparison helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_pytorch_comparisons_accept_numpy_style_array_like_inputs():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+from pyrecest.backend import asarray, greater, less, to_numpy
+
+greater_result = greater([1, 2, 3], [0, 2, 4])
+less_result = less([1, 2, 3], [0, 2, 4])
+mixed_result = greater(asarray([1.0, 2.0, 3.0]), [0.5, 2.0, 5.0])
+
+assert to_numpy(greater_result).tolist() == [True, False, False]
+assert to_numpy(less_result).tolist() == [False, False, True]
+assert to_numpy(mixed_result).tolist() == [True, False, False]
+""",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- patch the public PyTorch backend facade so `greater` and `less` accept NumPy-style array-like inputs
- preserve tensor-device handling when one operand is already a PyTorch tensor
- add subprocess regression coverage for the PyTorch backend facade

## Bug fixed
`pyrecest.backend.greater([1, 2], [0, 3])` and `pyrecest.backend.less([1, 2], [0, 3])` failed under `PYRECEST_BACKEND=pytorch` because the public facade exposed raw `torch.greater`/`torch.less`, which require tensor operands. NumPy-style array-like inputs should work through the backend facade, consistent with other wrapped helpers such as `logical_and`.

## Testing
- Not run locally: this execution sandbox cannot clone/install the repository because DNS resolution for `github.com` fails.
- Added `tests/backend_support/test_pytorch_comparison_contract.py` for CI coverage.