### PR TITLE
Fix empty padded history initialization

### DIFF
--- a/src/pyrecest/utils/history_recorder.py
+++ b/src/pyrecest/utils/history_recorder.py
@@ -183,6 +183,8 @@ class HistoryRecorder:
     @staticmethod
     def _ensure_2d(curr_ests):
         curr_ests = _as_padded_numeric_array(curr_ests)
+        if backend.size(curr_ests) == 0:
+            return array([[]])
         if curr_ests.ndim == 0:
             curr_ests = curr_ests.reshape(1, 1)
         elif curr_ests.ndim != 2 or curr_ests.shape[1] != 1:

--- a/tests/utils/test_history_recorder.py
+++ b/tests/utils/test_history_recorder.py
@@ -36,3 +36,14 @@ def test_padded_history_registers_array_like_initial_value():
     history = recorder.register("state", [1.0, 2.0], pad_with_nan=True)
 
     npt.assert_allclose(_to_numpy(history), np.array([[1.0], [2.0]]))
+
+
+def test_padded_history_empty_initial_value_does_not_add_nan_column():
+    recorder = HistoryRecorder()
+
+    history = recorder.register("state", [], pad_with_nan=True)
+    npt.assert_allclose(_to_numpy(history), np.empty((1, 0)))
+
+    history = recorder.record("state", [1.0, 2.0], pad_with_nan=True)
+
+    npt.assert_allclose(_to_numpy(history), np.array([[1.0], [2.0]]))


### PR DESCRIPTION
## Summary
- treat an empty initial value for padded histories as an empty history rather than as a first empty estimate column
- add a regression test showing the first real record is stored without a leading all-NaN column

## Testing
- Not run locally; this environment cannot resolve github.com for cloning/installing the repository, so CI should validate the regression test.