### PR TITLE
Fix backend trace NumPy signature

### DIFF
--- a/src/pyrecest/_backend/__init__.py
+++ b/src/pyrecest/_backend/__init__.py
@@ -445,6 +445,30 @@ def _sum_with_numpy_signature(sum_func, asarray_func, reshape_func):
     return sum
 
 
+def _trace_with_numpy_signature(diagonal_func, sum_func):
+    """Return a trace wrapper with PyRecEst's NumPy-style contract."""
+
+    def trace(a, offset=0, axis1=-2, axis2=-1, dtype=None, out=None):
+        diagonal = diagonal_func(a, offset=offset, axis1=axis1, axis2=axis2)
+        result = sum_func(diagonal, axis=-1, dtype=dtype)
+        if out is not None:
+            copy_ = getattr(out, "copy_", None)
+            if copy_ is not None:
+                copy_(result)
+                return out
+            try:
+                out[...] = result
+            except TypeError:
+                at = getattr(out, "at", None)
+                if at is None:
+                    raise
+                return at[...].set(result)
+            return out
+        return result
+
+    return trace
+
+
 def _std_with_numpy_input(
     std_func,
     asarray_func,
@@ -700,6 +724,15 @@ class BackendImporter(importlib.abc.MetaPathFinder, importlib.abc.Loader):
                         attribute = _quantile_with_numpy_axis(
                             attribute,
                             getattr(backend, "asarray"),
+                        )
+                    if (
+                        module_name == ""
+                        and attribute_name == "trace"
+                        and backend_name in {"jax", "pytorch"}
+                    ):
+                        attribute = _trace_with_numpy_signature(
+                            getattr(backend, "diagonal"),
+                            getattr(backend, "sum"),
                         )
                     if module_name == "" and attribute_name in {
                         "assignment",

--- a/tests/test_backend_trace_signature_contract.py
+++ b/tests/test_backend_trace_signature_contract.py
@@ -1,0 +1,34 @@
+import pyrecest.backend as backend
+from pyrecest.backend import array
+
+
+def _to_python(value):
+    value = backend.to_numpy(value)
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    return value
+
+
+def test_trace_accepts_numpy_signature_offset_axes_dtype_and_out():
+    values = array(
+        [
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+            [[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]],
+        ],
+        dtype=backend.float32,
+    )
+    out = backend.zeros((2,), dtype=backend.float32)
+
+    result = backend.trace(
+        values,
+        offset=1,
+        axis1=1,
+        axis2=2,
+        dtype=backend.float32,
+        out=out,
+    )
+
+    if backend.__backend_name__ != "jax":
+        assert result is out
+    assert _to_python(result) == [8.0, 20.0]
+    assert str(backend.to_numpy(result).dtype) == "float32"


### PR DESCRIPTION
## Summary
- make JAX and PyTorch backend.trace follow the NumPy-style PyRecEst contract
- use trailing matrix axes by default for batched inputs
- add a regression test for offset, axes, dtype, and out handling

## Verification
- compared branch with main: 2 commits, 2 files changed
- full test suite not run locally in this connector session