### PR TITLE
Validate groundtruth entries

### DIFF
--- a/src/pyrecest/evaluation/determine_all_deviations.py
+++ b/src/pyrecest/evaluation/determine_all_deviations.py
@@ -30,10 +30,15 @@ def determine_all_deviations(
     if mean_calculation_symm != "":
         raise NotImplementedError("Not implemented yet")
 
+    groundtruths_ndim = getattr(groundtruths, "ndim", None)
+    groundtruths_size = _shape_size(groundtruths) if groundtruths_ndim == 2 else 0
+    first_groundtruth_ndim = (
+        getattr(groundtruths[0, 0], "ndim", None) if groundtruths_size != 0 else None
+    )
     if (
-        getattr(groundtruths, "ndim", None) != 2
-        or _shape_size(groundtruths) == 0
-        or groundtruths[0, 0].ndim not in (1, 2)
+        groundtruths_ndim != 2
+        or groundtruths_size == 0
+        or first_groundtruth_ndim not in (1, 2)
     ):
         raise ValueError(
             "Assuming groundtruths to be a non-empty 2-D array of shape "

--- a/tests/evaluation/test_determine_all_deviations_validation.py
+++ b/tests/evaluation/test_determine_all_deviations_validation.py
@@ -16,7 +16,20 @@ def test_determine_all_deviations_rejects_empty_groundtruths():
         determine_all_deviations(
             [],
             None,
-            lambda estimate, truth: 0.0,
+            lambda estimate, expected: 0.0,
+            groundtruths,
+        )
+
+
+def test_determine_all_deviations_rejects_nonarray_groundtruth_entries():
+    groundtruths = np.empty((1, 1), dtype=object)
+    groundtruths[0, 0] = 1.0
+
+    with pytest.raises(ValueError, match="arrays of shape"):
+        determine_all_deviations(
+            [[np.asarray([0.0])]],
+            None,
+            lambda estimate, expected: 0.0,
             groundtruths,
         )
 
@@ -31,6 +44,6 @@ def test_determine_all_deviations_rejects_mismatched_result_run_count():
         determine_all_deviations(
             results,
             None,
-            lambda estimate, truth: float(np.linalg.norm(estimate - truth)),
+            lambda estimate, expected: float(np.linalg.norm(estimate - expected)),
             groundtruths,
         )


### PR DESCRIPTION
## Summary
- check the first groundtruth entry with `getattr(..., "ndim", None)` before evaluating deviations
- keep invalid groundtruth inputs on the documented `ValueError` path
- add a focused regression test for object-dtype groundtruth arrays with invalid entries

## Testing
- Not run locally; CI should run the added pytest coverage.