### PR TITLE
Validate API backend capability keys

### DIFF
--- a/src/pyrecest/_backend/capabilities.py
+++ b/src/pyrecest/_backend/capabilities.py
@@ -150,6 +150,10 @@ API_BACKEND_CAPABILITIES: Final = {
 
 BACKEND_SUPPORT_LEVELS: Final = ("supported", "bridged", "partial", "unsupported")
 REQUIRED_BACKENDS: Final = ("numpy", "pytorch", "jax")
+_OPTIONAL_API_CAPABILITY_KEYS: Final = frozenset({"notes"})
+_ALLOWED_API_CAPABILITY_KEYS: Final = frozenset(
+    (*REQUIRED_BACKENDS, *_OPTIONAL_API_CAPABILITY_KEYS)
+)
 
 
 def get_unsupported_functions(
@@ -195,6 +199,12 @@ def validate_api_backend_capabilities() -> tuple[str, ...]:
     for api_name, row in iter_api_backend_capabilities():
         if not api_name:
             errors.append("Capability row has an empty API name.")
+
+        unknown_keys = sorted(set(row) - _ALLOWED_API_CAPABILITY_KEYS)
+        if unknown_keys:
+            errors.append(
+                f"{api_name}: unknown capability entries for {', '.join(unknown_keys)}."
+            )
 
         missing_backends = [
             backend for backend in REQUIRED_BACKENDS if backend not in row

--- a/tests/test_backend_capability_registry.py
+++ b/tests/test_backend_capability_registry.py
@@ -1,6 +1,24 @@
+from pyrecest._backend import capabilities
 from pyrecest._backend.capabilities import validate_api_backend_capabilities
 
 
 def test_api_backend_capability_registry_is_well_formed():
     errors = validate_api_backend_capabilities()
     assert errors == (), "\n".join(errors)
+
+
+def test_api_backend_capability_registry_rejects_unknown_keys(monkeypatch):
+    broken_registry = dict(capabilities.API_BACKEND_CAPABILITIES)
+    broken_registry["BrokenAPI"] = {
+        "numpy": "supported",
+        "pytorch": "supported",
+        "jax": "supported",
+        "tensorflow": "supported",
+        "notes": "Synthetic row with a misspelled backend key.",
+    }
+
+    monkeypatch.setattr(capabilities, "API_BACKEND_CAPABILITIES", broken_registry)
+
+    errors = capabilities.validate_api_backend_capabilities()
+
+    assert "BrokenAPI: unknown capability entries for tensorflow." in errors


### PR DESCRIPTION
## Summary
- reject unknown keys in API backend capability rows so misspelled backend names cannot pass registry validation silently
- add a regression test that injects a synthetic misspelled backend key and checks for a validation error

## Bug
`validate_api_backend_capabilities()` checked for missing required backends and invalid support levels, but it did not reject extra keys in `API_BACKEND_CAPABILITIES` rows. A typo such as `tensorflow` or `pytoch` could therefore remain in the registry without being reported by the well-formedness test.

## Validation
- `python -m py_compile /tmp/capabilities_patched.py`
- local targeted harness: current registry validates cleanly; synthetic `BrokenAPI` row with `tensorflow` key reports `BrokenAPI: unknown capability entries for tensorflow.`

Full repository pytest was not run locally because direct cloning from GitHub is unavailable in this environment.