### PR TITLE
Fix PyTorch cumulative out parameter

### DIFF
--- a/src/pyrecest/_backend_submodules.py
+++ b/src/pyrecest/_backend_submodules.py
@@ -3,15 +3,59 @@
 from __future__ import annotations
 
 import sys
+from functools import wraps
 from types import ModuleType
 
 from pyrecest._backend import BACKEND_ATTRIBUTES
+
+
+def _copy_result_to_out(result, out):
+    """Copy ``result`` into a backend ``out`` object and return that object."""
+    copy_ = getattr(out, "copy_", None)
+    if copy_ is not None:
+        copy_(result)
+        return out
+    try:
+        out[...] = result
+    except TypeError:
+        at = getattr(out, "at", None)
+        if at is None:
+            raise
+        return at[...].set(result)
+    return out
+
+
+def _cumulative_with_out(cumulative):
+    """Return a cumulative helper accepting NumPy's ``out`` keyword."""
+
+    @wraps(cumulative)
+    def wrapped_cumulative(x, axis=None, dtype=None, out=None):
+        result = cumulative(x, axis=axis, dtype=dtype)
+        if out is not None:
+            return _copy_result_to_out(result, out)
+        return result
+
+    wrapped_cumulative._pyrecest_out_contract = True
+    return wrapped_cumulative
+
+
+def _adapt_cumulative_out_contract(backend: ModuleType) -> None:
+    """Adapt PyTorch cumulative helpers to the public NumPy-style contract."""
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        return
+    for attribute_name in ("cumsum", "cumprod"):
+        cumulative = getattr(backend, attribute_name, None)
+        if cumulative is None or getattr(cumulative, "_pyrecest_out_contract", False):
+            continue
+        setattr(backend, attribute_name, _cumulative_with_out(cumulative))
 
 
 def register_backend_submodules(backend: ModuleType | None = None) -> None:
     """Register virtual backend submodules for standard import statements."""
     if backend is None:
         import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+
+    _adapt_cumulative_out_contract(backend)
 
     backend.__path__ = getattr(backend, "__path__", [])
     backend_spec = getattr(backend, "__spec__", None)

--- a/tests/test_backend_cumulative_contract.py
+++ b/tests/test_backend_cumulative_contract.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 
 import pyrecest.backend as backend
+from pyrecest.backend_tools import get_backend_name
 import pytest
 
 
@@ -15,6 +16,9 @@ def _to_python(value):
 
 
 def test_cumulative_out_contract_default_backend():
+    if get_backend_name() == "jax":
+        pytest.skip("JAX arrays do not support NumPy-style out mutation")
+
     values = backend.reshape(backend.arange(1, 7), (2, 3))
     out_sum = backend.zeros((2, 3), dtype=values.dtype)
     out_prod = backend.zeros((2, 3), dtype=values.dtype)

--- a/tests/test_backend_cumulative_contract.py
+++ b/tests/test_backend_cumulative_contract.py
@@ -1,0 +1,59 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pyrecest.backend as backend
+import pytest
+
+
+def _to_python(value):
+    value = backend.to_numpy(value)
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    return value
+
+
+def test_cumulative_out_contract_default_backend():
+    values = backend.reshape(backend.arange(1, 7), (2, 3))
+    out_sum = backend.zeros((2, 3), dtype=values.dtype)
+    out_prod = backend.zeros((2, 3), dtype=values.dtype)
+
+    result_sum = backend.cumsum(values, axis=1, out=out_sum)
+    result_prod = backend.cumprod(values, axis=1, out=out_prod)
+
+    assert result_sum is out_sum
+    assert result_prod is out_prod
+    assert _to_python(result_sum) == [[1, 3, 6], [4, 9, 15]]
+    assert _to_python(result_prod) == [[1, 2, 6], [4, 20, 120]]
+
+
+@pytest.mark.backend_portable
+def test_pytorch_cumulative_out_contract():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import pyrecest.backend as backend
+values = backend.reshape(backend.arange(1, 7), (2, 3))
+out_sum = backend.zeros((2, 3), dtype=values.dtype)
+out_prod = backend.zeros((2, 3), dtype=values.dtype)
+result_sum = backend.cumsum(values, axis=1, out=out_sum)
+result_prod = backend.cumprod(values, axis=1, out=out_prod)
+assert result_sum is out_sum
+assert result_prod is out_prod
+assert backend.to_numpy(result_sum).tolist() == [[1, 3, 6], [4, 9, 15]]
+assert backend.to_numpy(result_prod).tolist() == [[1, 2, 6], [4, 20, 120]]
+flat = backend.cumsum(values, out=backend.zeros((6,), dtype=values.dtype))
+assert backend.to_numpy(flat).tolist() == [1, 3, 6, 10, 15, 21]
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- adapt the public PyTorch backend facade so `cumsum` and `cumprod` accept NumPy-style `out`
- copy cumulative results into the provided output tensor/object and return it
- add regression coverage for default-backend and forced-PyTorch subprocess paths

## Bug fixed
`pyrecest.backend.cumsum(values, out=...)` and `pyrecest.backend.cumprod(values, out=...)` should follow the NumPy-style backend contract. Under `PYRECEST_BACKEND=pytorch`, the underlying cumulative helpers accepted `axis` and `dtype` but rejected `out`, so otherwise portable code failed on the PyTorch backend.

## Verification
- `python -m py_compile /mnt/data/backend_submodules_new.py /mnt/data/test_backend_cumulative_contract.py`
- local PyTorch smoke check for `cumsum`/`cumprod` writing into `out`
- compared branch against `main`: 2 commits ahead, 0 behind

Full pytest was not run locally because this sandbox cannot clone/install the repository via git; CI should validate the regression test.