### PR TITLE
Reject complex assignment costs

### DIFF
--- a/src/pyrecest/utils/assignment.py
+++ b/src/pyrecest/utils/assignment.py
@@ -26,6 +26,7 @@ from scipy.optimize import linear_sum_assignment
 
 _TEXT_TYPES = (str, bytes, bytearray, _np.str_, _np.bytes_)
 _BOOLEAN_TYPES = (bool, _np.bool_)
+_COMPLEX_TYPES = (complex, _np.complexfloating)
 _INVALID_SCALAR_TYPES = _BOOLEAN_TYPES + _TEXT_TYPES
 
 
@@ -74,6 +75,21 @@ def _has_boolean_dtype(value) -> bool:
     return dtype is not None and str(dtype).lower() in {"bool", "bool_", "torch.bool"}
 
 
+def _has_complex_dtype(value) -> bool:
+    dtype = getattr(value, "dtype", None)
+    if dtype is None:
+        return False
+    try:
+        return bool(_np.issubdtype(dtype, _np.complexfloating))
+    except TypeError:
+        return str(dtype).lower() in {
+            "complex64",
+            "complex128",
+            "torch.complex64",
+            "torch.complex128",
+        }
+
+
 def _contains_boolean_values(value) -> bool:
     if isinstance(value, _BOOLEAN_TYPES):
         return True
@@ -94,11 +110,23 @@ def _contains_text_values(value) -> bool:
     return any(isinstance(item, _TEXT_TYPES) for item in values)
 
 
+def _contains_complex_values(value) -> bool:
+    if isinstance(value, _COMPLEX_TYPES):
+        return True
+    try:
+        values = _np.asarray(value, dtype=object).reshape(-1)
+    except (TypeError, ValueError, RuntimeError):
+        return False
+    return any(isinstance(item, _COMPLEX_TYPES) for item in values)
+
+
 def _coerce_cost_matrix(cost_matrix):
     if _contains_boolean_values(cost_matrix):
         raise ValueError("cost_matrix must be numeric, not boolean")
     if _contains_text_values(cost_matrix):
         raise ValueError("cost_matrix must be numeric")
+    if _contains_complex_values(cost_matrix):
+        raise ValueError("cost_matrix must be real-valued")
     try:
         raw_cost_matrix = _asarray(cost_matrix)
     except (TypeError, ValueError, OverflowError, RuntimeError) as exc:
@@ -111,6 +139,8 @@ def _coerce_cost_matrix(cost_matrix):
         raise ValueError("cost_matrix must be numeric, not boolean")
     if _contains_text_values(cost_matrix) or _contains_text_values(raw_cost_matrix):
         raise ValueError("cost_matrix must be numeric")
+    if _has_complex_dtype(raw_cost_matrix) or _contains_complex_values(raw_cost_matrix):
+        raise ValueError("cost_matrix must be real-valued")
 
     try:
         coerced_cost_matrix = _asarray(raw_cost_matrix, dtype=float)
@@ -131,6 +161,8 @@ def _coerce_non_assignment_costs(costs, size: int, name: str):
     if costs is None:
         return _zeros(size, dtype=float)
 
+    if _contains_complex_values(costs):
+        raise ValueError(f"{name} must be real-valued")
     try:
         raw_costs_array = _asarray(costs)
     except (TypeError, ValueError, OverflowError, RuntimeError) as exc:
@@ -141,6 +173,8 @@ def _coerce_non_assignment_costs(costs, size: int, name: str):
         raise ValueError(f"{name} must be numeric and finite")
     if _contains_text_values(costs) or _contains_text_values(raw_costs_array):
         raise ValueError(f"{name} must be numeric and finite")
+    if _has_complex_dtype(raw_costs_array) or _contains_complex_values(raw_costs_array):
+        raise ValueError(f"{name} must be real-valued")
 
     try:
         costs_array = _asarray(raw_costs_array, dtype=float)

--- a/tests/utils/test_assignment.py
+++ b/tests/utils/test_assignment.py
@@ -275,6 +275,49 @@ class MurtyAssignmentTest(unittest.TestCase):
                         col_non_assignment_costs=invalid_cost,
                     )
 
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on the JAX backend",
+    )
+    def test_complex_assignment_costs_are_rejected(self):
+        invalid_cost_matrices = (
+            np.array([[1.0 + 2.0j]]),
+            [[1.0 + 2.0j]],
+        )
+
+        for invalid_cost_matrix in invalid_cost_matrices:
+            with self.subTest(invalid_cost_matrix=invalid_cost_matrix):
+                with self.assertRaisesRegex(ValueError, "cost_matrix must be real-valued"):
+                    murty_k_best_assignments(invalid_cost_matrix)
+
+        with self.assertRaisesRegex(ValueError, "cost_matrix must be real-valued"):
+            min_cost_max_cardinality_assignment(np.array([[1.0 + 2.0j]]))
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on the JAX backend",
+    )
+    def test_complex_non_assignment_costs_are_rejected(self):
+        cost_matrix = np.array([[1.0]])
+
+        for invalid_cost in (1.0 + 2.0j, np.array([1.0 + 2.0j])):
+            with self.subTest(kind="row", invalid_cost=invalid_cost):
+                with self.assertRaisesRegex(
+                    ValueError, "row_non_assignment_costs must be real-valued"
+                ):
+                    murty_k_best_assignments(
+                        cost_matrix,
+                        row_non_assignment_costs=invalid_cost,
+                    )
+            with self.subTest(kind="column", invalid_cost=invalid_cost):
+                with self.assertRaisesRegex(
+                    ValueError, "col_non_assignment_costs must be real-valued"
+                ):
+                    murty_k_best_assignments(
+                        cost_matrix,
+                        col_non_assignment_costs=invalid_cost,
+                    )
+
     def test_non_positive_k_returns_empty_list(self):
         self.assertEqual(murty_k_best_assignments(np.eye(2), k=0), [])
 


### PR DESCRIPTION
## Summary
- reject complex-valued assignment cost matrices before coercing to `float`
- reject complex row/column non-assignment costs instead of silently discarding imaginary parts
- add regression coverage for complex cost matrices and complex non-assignment costs

## Bug fixed
The assignment utilities previously coerced cost inputs with `dtype=float`. NumPy-style casting can silently drop imaginary parts from complex values, allowing invalid complex costs to influence Murty/min-cost assignment as if only their real parts were supplied.

## Testing
- Ran a local NumPy-backed stub of `tests/utils/test_assignment.py`; 14 tests passed.
- Did not run the full repository test suite locally because this environment cannot clone/install the GitHub repository over the network.