### PR TITLE
Fix PyTorch linalg array-like inputs

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -3,18 +3,6 @@
 import numpy as _np
 import scipy as _scipy
 import torch as _torch
-from torch import block_diag  # For PyRecEst
-from torch.linalg import pinv  # For PyRecEst
-from torch.linalg import (
-    cholesky,
-    det,
-    eig,
-    eigh,
-    eigvalsh,
-    inv,
-)
-from torch.linalg import matrix_exp as expm
-from torch.linalg import matrix_power
 
 from .._backend_config import np_atol as atol
 from ..numpy import linalg as _gsnplinalg
@@ -24,6 +12,11 @@ from ._dtype import (
     is_complex,
     is_floating,
 )
+
+
+# The public backend facade exposes NumPy-style helpers. Keep array-like
+# coercion local to this module instead of re-exporting raw torch.linalg
+# functions, because raw torch.linalg rejects Python lists and integer arrays.
 
 
 def _as_numpy_no_grad(value):
@@ -82,6 +75,70 @@ def _common_linalg_dtype(*tensors):
     return _default_linalg_dtype()
 
 
+def _out_kwargs(out):
+    return {} if out is None else {"out": out}
+
+
+def cholesky(a, upper=False, out=None):
+    """Compute a Cholesky factor after PyRecEst-style array-like promotion."""
+    return _torch.linalg.cholesky(_as_linalg_tensor(a), upper=upper, **_out_kwargs(out))
+
+
+def det(a, out=None):
+    """Compute a determinant after PyRecEst-style array-like promotion."""
+    return _torch.linalg.det(_as_linalg_tensor(a), **_out_kwargs(out))
+
+
+def eig(a, out=None):
+    """Compute eigenvalues/eigenvectors after array-like input promotion."""
+    return _torch.linalg.eig(_as_linalg_tensor(a), **_out_kwargs(out))
+
+
+def eigh(a, UPLO="L", out=None):
+    """Compute Hermitian eigenpairs after array-like input promotion."""
+    return _torch.linalg.eigh(_as_linalg_tensor(a), UPLO=UPLO, **_out_kwargs(out))
+
+
+def eigvalsh(a, UPLO="L", out=None):
+    """Compute Hermitian eigenvalues after array-like input promotion."""
+    return _torch.linalg.eigvalsh(_as_linalg_tensor(a), UPLO=UPLO, **_out_kwargs(out))
+
+
+def inv(a, out=None):
+    """Invert a matrix after PyRecEst-style array-like promotion."""
+    return _torch.linalg.inv(_as_linalg_tensor(a), **_out_kwargs(out))
+
+
+def expm(a):
+    """Compute the matrix exponential after array-like input promotion."""
+    return _torch.linalg.matrix_exp(_as_linalg_tensor(a))
+
+
+def matrix_power(a, n):
+    """Raise a matrix to an integer power after array-like input promotion."""
+    return _torch.linalg.matrix_power(_as_linalg_tensor(a), n)
+
+
+def pinv(a, rcond=None, hermitian=False, *, atol=None, rtol=None, out=None):
+    """Compute the Moore-Penrose pseudoinverse after array-like input promotion."""
+    if rcond is not None:
+        if rtol is not None:
+            raise TypeError("pinv() got both 'rcond' and 'rtol'")
+        rtol = rcond
+    return _torch.linalg.pinv(
+        _as_linalg_tensor(a),
+        atol=atol,
+        rtol=rtol,
+        hermitian=hermitian,
+        **_out_kwargs(out),
+    )
+
+
+def block_diag(*arrs):
+    """Build a block diagonal tensor from PyRecEst-style array-like inputs."""
+    return _torch.block_diag(*(array(arr) for arr in arrs))
+
+
 class _Logm(_torch.autograd.Function):
     """Torch autograd function for matrix logarithm.
 
@@ -120,14 +177,11 @@ logm = _Logm.apply
 
 
 def sqrtm(x):
+    x = _as_linalg_tensor(x)
     x_np = _as_numpy_no_grad(x)
     np_sqrtm = _np.vectorize(_scipy.linalg.sqrtm, signature="(n,m)->(n,m)")(x_np)
     if np_sqrtm.dtype.kind == "c":
-        target_complex_dtype = (
-            _COMPLEX_DTYPE_FOR_TENSOR_DTYPE.get(x.dtype)
-            if isinstance(x, _torch.Tensor)
-            else None
-        )
+        target_complex_dtype = _COMPLEX_DTYPE_FOR_TENSOR_DTYPE.get(x.dtype)
         if target_complex_dtype is not None:
             np_sqrtm = np_sqrtm.astype(target_complex_dtype, copy=False)
 

--- a/tests/test_pytorch_linalg_arraylike_inputs.py
+++ b/tests/test_pytorch_linalg_arraylike_inputs.py
@@ -1,0 +1,40 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_pytorch_linalg_helpers_accept_array_like_inputs():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import pyrecest.backend as backend
+from pyrecest.backend import linalg
+
+identity = [[1.0, 0.0], [0.0, 1.0]]
+assert backend.to_numpy(linalg.inv(identity)).tolist() == identity
+assert float(backend.to_numpy(linalg.det(identity))) == 1.0
+
+cholesky = linalg.cholesky([[4.0, 0.0], [0.0, 9.0]])
+assert backend.to_numpy(cholesky).tolist() == [[2.0, 0.0], [0.0, 3.0]]
+
+assert backend.to_numpy(linalg.eigvalsh([[2.0, 0.0], [0.0, 3.0]])).tolist() == [2.0, 3.0]
+assert backend.to_numpy(linalg.matrix_power([[1.0, 1.0], [0.0, 1.0]], 2)).tolist() == [[1.0, 2.0], [0.0, 1.0]]
+assert backend.to_numpy(linalg.pinv([[1.0, 0.0], [0.0, 0.0]])).tolist() == [[1.0, 0.0], [0.0, 0.0]]
+assert backend.to_numpy(linalg.expm([[0.0, 0.0], [0.0, 0.0]])).tolist() == identity
+assert backend.to_numpy(linalg.block_diag([[1.0]], [[2.0]])).tolist() == [[1.0, 0.0], [0.0, 2.0]]
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- wrap PyTorch `backend.linalg` exports that were still raw `torch.linalg`/`torch.block_diag` functions
- promote NumPy-style array-like and integer inputs before calling PyTorch linear-algebra kernels
- add subprocess regression coverage for the PyTorch backend linalg facade

## Bug fixed
Several public `pyrecest.backend.linalg` helpers under `PYRECEST_BACKEND=pytorch` still pointed directly at raw PyTorch functions. Calls such as `linalg.inv([[1.0, 0.0], [0.0, 1.0]])`, `linalg.det(...)`, `linalg.cholesky(...)`, `linalg.matrix_power(...)`, `linalg.pinv(...)`, `linalg.expm(...)`, and `linalg.block_diag(...)` therefore rejected Python lists instead of following the PyRecEst backend facade's NumPy-style array-like input contract.

## Verification
- `python -m py_compile /tmp/linalg_patched.py`
- `python -m py_compile /tmp/test_pytorch_linalg_arraylike_inputs.py`
- compared branch against `main`: 2 commits ahead; `main` advanced by 1 commit after the branch was created, but GitHub currently reports the PR as mergeable

Full repository pytest was not run locally because this environment cannot clone/install from GitHub; CI should validate the added backend-portable regression test.