### PR TITLE
Fix backend device selection

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -261,7 +261,7 @@ def solve_sylvester(a, b, q):
             tilde_x = tilde_q / safe_denominators
             tilde_x = _torch.where(
                 _torch.abs(denominators) < 1e-12,
-                _torch.zeros((), dtype=tilde_x.dtype, device=tilte_x.device),
+                _torch.zeros((), dtype=tilde_x.dtype, device=tilde_x.device),
                 tilde_x,
             )
             return eigvecs @ tilde_x @ eigvecs.transpose(-2, -1)

--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -82,6 +82,21 @@ def _common_linalg_dtype(*tensors):
     return _default_linalg_dtype()
 
 
+def _preferred_linalg_device(*values):
+    """Return the non-CPU tensor device to preserve, falling back to any tensor."""
+    non_cpu_device = next(
+        (
+            value.device
+            for value in values
+            if _torch.is_tensor(value) and value.device.type != "cpu"
+        ),
+        None,
+    )
+    if non_cpu_device is not None:
+        return non_cpu_device
+    return next((value.device for value in values if _torch.is_tensor(value)), None)
+
+
 class _Logm(_torch.autograd.Function):
     """Torch autograd function for matrix logarithm.
 
@@ -164,7 +179,7 @@ def matrix_rank(a, tol=None, hermitian=False, *, rtol=None, atol=None, **kwargs)
 
 def solve(a, b):
     """Solve a linear system with PyRecEst-compatible array-like inputs."""
-    device = next((value.device for value in (a, b) if _torch.is_tensor(value)), None)
+    device = _preferred_linalg_device(a, b)
     a = _as_linalg_tensor(a)
     b = _as_linalg_tensor(b)
     if device is not None:
@@ -246,7 +261,7 @@ def solve_sylvester(a, b, q):
             tilde_x = tilde_q / safe_denominators
             tilde_x = _torch.where(
                 _torch.abs(denominators) < 1e-12,
-                _torch.zeros((), dtype=tilde_x.dtype, device=tilde_x.device),
+                _torch.zeros((), dtype=tilde_x.dtype, device=tilte_x.device),
                 tilde_x,
             )
             return eigvecs @ tilde_x @ eigvecs.transpose(-2, -1)

--- a/tests/backend_support/test_pytorch_solve_device_contract.py
+++ b/tests/backend_support/test_pytorch_solve_device_contract.py
@@ -1,0 +1,31 @@
+"""Regression tests for PyTorch linalg.solve device preservation."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_pytorch_linalg_solve_prefers_non_cpu_tensor_device():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import torch
+import pyrecest.backend as backend
+
+matrix = torch.eye(2)
+rhs = torch.ones(2, device="meta")
+solution = backend.linalg.solve(matrix, rhs)
+
+assert solution.device.type == "meta", solution.device
+assert tuple(solution.shape) == (2,)
+""",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- preserve tensor device selection in the PyTorch linear algebra wrapper
- add regression coverage using PyTorch's meta device

## Verification
- compared with main: 3 commits ahead, 0 behind; 2 files changed
- full test suite not run locally; CI should validate the new regression test