### PR TITLE
Reject byte fill values in multisession labels

### DIFF
--- a/src/pyrecest/utils/_multisession_assignment_labels.py
+++ b/src/pyrecest/utils/_multisession_assignment_labels.py
@@ -19,7 +19,7 @@ from .multisession_assignment import (  # pylint: disable=protected-access
     _validate_track_session_sizes,
 )
 
-_TEXT_TYPES = (str, np.str_)
+_TEXT_TYPES = (str, bytes, np.str_, np.bytes_)
 
 
 def _normalize_fill_value(fill_value: Any, track_count: int) -> int:

--- a/tests/test_multisession_assignment_labels.py
+++ b/tests/test_multisession_assignment_labels.py
@@ -66,9 +66,17 @@ class TestMultiSessionAssignmentLabels(unittest.TestCase):
         __backend_name__ == "jax",
         reason="Not supported on this backend",
     )
-    def test_text_fill_values_are_rejected(self):
+    def test_text_and_bytes_fill_values_are_rejected(self):
         tracks = [{0: 0}]
-        invalid_fill_values = ("-1", np.str_("-2"), np.array("-3"))
+        invalid_fill_values = (
+            "-1",
+            b"-1",
+            np.str_("-2"),
+            np.bytes_(b"-2"),
+            np.array("-3"),
+            np.array(b"-4"),
+            np.array(b"-5", dtype=object),
+        )
 
         for fill_value in invalid_fill_values:
             for name, converter in self._converters():


### PR DESCRIPTION
## Summary
- treat byte/NumPy byte scalar fill values as text-like input in multi-session label conversion
- extend the label-conversion regression test to cover bytes, NumPy bytes, byte arrays, and object-dtype byte scalars

## Bug fixed
`tracks_to_session_labels(..., fill_value=np.array(b"-5", dtype=object))` previously bypassed the text-scalar guard because object-dtype byte scalars reached `float(...)` and were silently parsed as an integer. This is inconsistent with the existing validation policy that rejects text-like `fill_value` inputs instead of accepting string/byte encodings of integers.

## Testing
- Not run locally; the execution sandbox cannot resolve github.com to clone/install the repository.
