### PR TITLE
Fix record smoother callable arity handling

### DIFF
--- a/src/pyrecest/smoothers/record_smoother.py
+++ b/src/pyrecest/smoothers/record_smoother.py
@@ -8,6 +8,7 @@ that should be preserved while the state and covariance are smoothed.
 
 from __future__ import annotations
 
+import inspect
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Literal
@@ -358,19 +359,68 @@ def _predict_arrays(
 def _call_model(
     model: Callable[..., np.ndarray], dt: float, state_dim: int, name: str
 ) -> np.ndarray:
-    try:
+    arity = _preferred_model_call_arity(model)
+    if arity == 2:
         matrix = model(dt, state_dim)
-    except TypeError as exc:
-        try:
-            matrix = model(dt)
-        except TypeError:
-            raise exc
+    elif arity == 1:
+        matrix = model(dt)
+    else:
+        matrix = _call_model_with_fallback(model, dt, state_dim, name)
+
     array = np.asarray(matrix, dtype=float)
     if array.shape != (state_dim, state_dim):
         raise ValueError(f"{name} must return a ({state_dim}, {state_dim}) matrix")
     if not np.isfinite(array).all():
         raise ValueError(f"{name} must return finite values")
     return array
+
+
+def _preferred_model_call_arity(model: Callable[..., np.ndarray]) -> int | None:
+    try:
+        signature = inspect.signature(model)
+    except (TypeError, ValueError):
+        return None
+
+    if _accepts_positional_argument_count(signature, 2):
+        return 2
+    if _accepts_positional_argument_count(signature, 1):
+        return 1
+    return None
+
+
+def _accepts_positional_argument_count(
+    signature: inspect.Signature, argument_count: int
+) -> bool:
+    required_positional = 0
+    positional_capacity = 0
+    accepts_varargs = False
+    for parameter in signature.parameters.values():
+        if parameter.kind == inspect.Parameter.VAR_POSITIONAL:
+            accepts_varargs = True
+        elif parameter.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        ):
+            positional_capacity += 1
+            if parameter.default is inspect.Parameter.empty:
+                required_positional += 1
+    return required_positional <= argument_count and (
+        accepts_varargs or argument_count <= positional_capacity
+    )
+
+
+def _call_model_with_fallback(
+    model: Callable[..., np.ndarray], dt: float, state_dim: int, name: str
+) -> np.ndarray:
+    try:
+        return model(dt, state_dim)
+    except TypeError:
+        try:
+            return model(dt)
+        except TypeError as exc:
+            raise TypeError(
+                f"{name} must accept either (dt, state_dim) or (dt)"
+            ) from exc
 
 
 def _smoothing_gain(

--- a/tests/smoothers/test_record_smoother.py
+++ b/tests/smoothers/test_record_smoother.py
@@ -15,6 +15,14 @@ def _process_noise(dt: float, state_dim: int) -> np.ndarray:
     return 0.01 * max(dt, 0.0) * np.eye(2)
 
 
+def _transition_single_argument(dt: float) -> np.ndarray:
+    return _transition(dt, 2)
+
+
+def _process_noise_single_argument(dt: float) -> np.ndarray:
+    return _process_noise(dt, 2)
+
+
 def _records() -> list[dict[str, object]]:
     return [
         {
@@ -78,6 +86,45 @@ def test_rts_and_fixed_lag_match_when_lag_covers_all_future_records() -> None:
 
     assert np.allclose(full[0]["state"], lagged[0]["state"])
     assert np.allclose(full[0]["covariance"], lagged[0]["covariance"])
+
+
+def test_single_argument_models_are_supported() -> None:
+    out = smooth_records(
+        _records(),
+        method="rts",
+        transition_model=_transition_single_argument,
+        process_noise_model=_process_noise_single_argument,
+    )
+
+    assert len(out) == 3
+    assert out[0]["state"].shape == (2,)
+    assert out[0]["covariance"].shape == (2, 2)
+
+
+def test_single_argument_model_type_error_is_not_masked() -> None:
+    def bad_transition(_dt: float) -> np.ndarray:
+        raise TypeError("single-argument transition failure")
+
+    with pytest.raises(TypeError, match="single-argument transition failure"):
+        smooth_records(
+            _records(),
+            method="rts",
+            transition_model=bad_transition,
+            process_noise_model=_process_noise,
+        )
+
+
+def test_two_argument_model_type_error_is_not_masked() -> None:
+    def bad_transition(_dt: float, _state_dim: int) -> np.ndarray:
+        raise TypeError("two-argument transition failure")
+
+    with pytest.raises(TypeError, match="two-argument transition failure"):
+        smooth_records(
+            _records(),
+            method="rts",
+            transition_model=bad_transition,
+            process_noise_model=_process_noise,
+        )
 
 
 def test_none_returns_copied_records_with_metadata() -> None:


### PR DESCRIPTION
## Summary
- inspect transition/process-noise model signatures before choosing the `(dt, state_dim)` or `(dt)` call form
- avoid masking `TypeError`s raised inside one-argument record-smoother model callables
- add regression coverage for one-argument models and for preserving one- and two-argument model `TypeError`s

## Validation
- Added targeted regression tests in `tests/smoothers/test_record_smoother.py`
- Locally exercised the patched callable-dispatch logic in isolation