### PR TITLE
Scale online time-offset process noise by dt

### DIFF
--- a/src/pyrecest/filters/online_time_offset_estimator.py
+++ b/src/pyrecest/filters/online_time_offset_estimator.py
@@ -49,12 +49,14 @@ class OnlineTimeOffsetEstimator:
         if self.min_speed < 0.0:
             raise ValueError("min_speed must be nonnegative")
 
-    def predict(self, dt: float = 0.0) -> None:
-        """Apply random-walk process noise."""
+    def predict(self, dt: float = 1.0) -> None:
+        """Apply elapsed-time-scaled random-walk process noise."""
         dt_value = _as_finite_scalar(dt, "dt")
         if dt_value < 0.0:
             raise ValueError("dt must be nonnegative")
-        self.variance = float(max(self.variance + self.process_variance, 1.0e-12))
+        self.variance = float(
+            max(self.variance + self.process_variance * dt_value, 1.0e-12)
+        )
 
     def update_from_position_residual(
         self,

--- a/tests/filters/test_online_time_offset_estimator.py
+++ b/tests/filters/test_online_time_offset_estimator.py
@@ -33,12 +33,21 @@ class OnlineTimeOffsetEstimatorTest(unittest.TestCase):
         self.assertEqual(estimator.offset, 1.0)
         self.assertEqual(estimator.variance, 2.0)
 
-    def test_predict_adds_process_variance(self):
+    def test_predict_adds_process_variance_for_default_step(self):
+        estimator = OnlineTimeOffsetEstimator(variance=1.0, process_variance=0.25)
+
+        estimator.predict()
+
+        self.assertAlmostEqual(estimator.variance, 1.25)
+
+    def test_predict_scales_process_variance_by_elapsed_time(self):
         estimator = OnlineTimeOffsetEstimator(variance=1.0, process_variance=0.25)
 
         estimator.predict(dt=3.0)
+        self.assertAlmostEqual(estimator.variance, 1.75)
 
-        self.assertAlmostEqual(estimator.variance, 1.25)
+        estimator.predict(dt=0.0)
+        self.assertAlmostEqual(estimator.variance, 1.75)
 
     def test_predict_rejects_invalid_dt_without_state_change(self):
         invalid_values = (


### PR DESCRIPTION
## Summary
- Scale `OnlineTimeOffsetEstimator.predict(dt=...)` variance inflation by elapsed time.
- Keep `predict()` as a one-step prediction by defaulting `dt` to `1.0`.
- Add regression coverage for `dt=3.0` and `dt=0.0`.

## Tests
- Added focused unit test coverage.