### PR TITLE
Fix PyTorch tile behavior

### DIFF
--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -53,7 +53,57 @@ def _patch_pytorch_comparison_facade() -> None:
     backend.logical_or = _wrap_comparison(_torch.logical_or)
 
 
+def _pytorch_tile_repetitions(reps, numpy_module, torch_module) -> tuple[int, ...]:
+    """Normalize NumPy-style tile repetitions for ``torch.Tensor.repeat``."""
+
+    if torch_module.is_tensor(reps):
+        reps = reps.detach().cpu().numpy()
+    reps_array = numpy_module.asarray(reps)
+    if reps_array.shape == ():
+        repetitions = (int(reps_array.item()),)
+    else:
+        repetitions = tuple(
+            int(one_repetition) for one_repetition in reps_array.tolist()
+        )
+    if any(one_repetition < 0 for one_repetition in repetitions):
+        raise ValueError("negative dimensions are not allowed")
+    return repetitions
+
+
+def _patch_pytorch_tile_facade() -> None:
+    """Make public PyTorch ``tile`` follow NumPy repetition semantics."""
+
+    import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        return
+
+    try:
+        import numpy as _np  # pylint: disable=import-outside-toplevel
+        import torch as _torch  # pylint: disable=import-outside-toplevel
+    except (
+        ModuleNotFoundError
+    ):  # pragma: no cover - backend import fails first in practice
+        return
+
+    def tile(x, reps):
+        x = backend.array(x)
+        repetitions = _pytorch_tile_repetitions(reps, _np, _torch)
+        if not repetitions:
+            return x.clone()
+        if x.ndim < len(repetitions):
+            x = x.reshape((1,) * (len(repetitions) - x.ndim) + tuple(x.shape))
+        elif x.ndim > len(repetitions):
+            repetitions = (1,) * (x.ndim - len(repetitions)) + repetitions
+        return x.repeat(repetitions)
+
+    tile.__name__ = "tile"
+    tile.__doc__ = getattr(_np.tile, "__doc__", None)
+    backend.tile = tile
+
+
 _patch_pytorch_comparison_facade()
+_patch_pytorch_tile_facade()
 
 from pyrecest.backend_support import (  # noqa: E402,F401
     backend_support,

--- a/tests/backend_support/test_pytorch_tile_contract.py
+++ b/tests/backend_support/test_pytorch_tile_contract.py
@@ -1,0 +1,41 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_pytorch_tile_scalar_and_array_repetitions_match_numpy_contract():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import pyrecest.backend as backend
+
+values = backend.array([[1, 2], [3, 4]])
+
+scalar_result = backend.tile(values, 2)
+assert tuple(backend.shape(scalar_result)) == (2, 4)
+assert backend.to_numpy(scalar_result).tolist() == [[1, 2, 1, 2], [3, 4, 3, 4]]
+
+array_result = backend.tile(values, backend.array([2, 1]))
+assert tuple(backend.shape(array_result)) == (4, 2)
+assert backend.to_numpy(array_result).tolist() == [[1, 2], [3, 4], [1, 2], [3, 4]]
+
+empty_result = backend.tile(values, ())
+assert tuple(backend.shape(empty_result)) == (2, 2)
+assert backend.to_numpy(empty_result).tolist() == [[1, 2], [3, 4]]
+assert empty_result is not values
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- make public PyTorch `backend.tile` follow NumPy repetition semantics
- normalize scalar, array-like, tensor, and empty repetition specs before calling `Tensor.repeat`
- add a focused PyTorch regression test

## Verification
- compared branch with main: 2 commits, 2 files changed
- full test suite not run locally in this connector session