### PR TITLE
Validate malformed transition sample counts

### DIFF
--- a/src/pyrecest/models/likelihood.py
+++ b/src/pyrecest/models/likelihood.py
@@ -42,7 +42,10 @@ def _ensure_callable(value: Any, name: str) -> None:
 def _validate_sample_count(value: Any) -> int:
     """Return ``value`` as a nonnegative integer sample count."""
 
-    value_array = np.asarray(value)
+    try:
+        value_array = np.asarray(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("n must be a nonnegative integer.") from exc
     if value_array.shape != () or value_array.dtype == np.bool_:
         raise ValueError("n must be a nonnegative integer.")
     scalar = value_array.item()

--- a/tests/models/test_likelihood_sample_count_validation.py
+++ b/tests/models/test_likelihood_sample_count_validation.py
@@ -1,0 +1,30 @@
+import unittest
+
+from pyrecest.backend import array
+from pyrecest.models import DensityTransitionModel, SampleableTransitionModel
+
+
+class BrokenSampleCount:
+    def __array__(self, dtype=None):  # pragma: no cover - exercised by NumPy
+        raise TypeError("cannot coerce sample count")
+
+
+class TransitionModelSampleCountValidationTest(unittest.TestCase):
+    def test_sampleable_transition_rejects_uncoercible_sample_count_cleanly(self):
+        model = SampleableTransitionModel(lambda state, n=1: state)
+
+        with self.assertRaisesRegex(ValueError, "n must be a nonnegative integer"):
+            model.sample_next(array([1.0]), n=BrokenSampleCount())
+
+    def test_density_transition_rejects_uncoercible_sample_count_cleanly(self):
+        model = DensityTransitionModel(
+            lambda state_next, state_previous: 1.0,
+            sample_next=lambda state, n=1: state,
+        )
+
+        with self.assertRaisesRegex(ValueError, "n must be a nonnegative integer"):
+            model.sample_next(array([1.0]), n=BrokenSampleCount())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- catch NumPy coercion failures while validating transition sampler `n` values
- re-raise them as the stable PyRecEst `ValueError("n must be a nonnegative integer.")`
- add regression coverage for both `SampleableTransitionModel` and `DensityTransitionModel`

## Tests
- `python -m py_compile /tmp/likelihood.py /tmp/test_likelihood_sample_count_validation.py`

Note: I could not run the full repository test suite in the local execution sandbox because the repository/dependencies were not available there; CI should run the full suite on the PR.