### PR TITLE
Fix shared NumPy backend copy for scalar inputs

### DIFF
--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -9,6 +9,28 @@ from pyrecest.backend import copy  # noqa: F401
 _register_backend_submodules()
 
 
+def _patch_shared_numpy_copy_facade() -> None:
+    """Make shared NumPy backend copy accept scalar and array-like inputs."""
+
+    import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+
+    if getattr(backend, "__backend_name__", None) not in {"autograd", "numpy"}:
+        return
+
+    original_copy = backend.copy
+
+    def copy_arraylike(x):
+        return original_copy(backend.array(x))
+
+    copy_arraylike.__name__ = getattr(original_copy, "__name__", "copy")
+    copy_arraylike.__doc__ = getattr(original_copy, "__doc__", None)
+    backend.copy = copy_arraylike
+    globals()["copy"] = backend.copy
+
+
+_patch_shared_numpy_copy_facade()
+
+
 def _patch_pytorch_comparison_facade() -> None:
     """Make public PyTorch comparison helpers accept array-like inputs."""
 

--- a/tests/test_backend_contract.py
+++ b/tests/test_backend_contract.py
@@ -40,6 +40,16 @@ class BackendContractTest(unittest.TestCase):
         self.assertEqual(to_numpy(first).dtype, np.dtype("bool"))
         self.assertEqual(to_numpy(second).dtype, np.dtype("bool"))
 
+    def test_shared_numpy_copy_accepts_scalar_and_array_like_inputs(self):
+        if backend.__backend_name__ not in {"autograd", "numpy"}:
+            self.skipTest("shared NumPy copy regression test")
+
+        from pyrecest import copy as package_copy  # pylint: disable=import-outside-toplevel
+
+        npt.assert_allclose(to_numpy(backend.copy(5.0)), np.array(5.0))
+        npt.assert_allclose(to_numpy(backend.copy([1.0, 2.0])), np.array([1.0, 2.0]))
+        npt.assert_allclose(to_numpy(package_copy(6.0)), np.array(6.0))
+
     def test_assignment_with_empty_indices_is_a_noop(self):
         original = array([1.0, 2.0, 3.0])
 


### PR DESCRIPTION
## Summary
- patch the public shared NumPy/autograd backend facade so `copy` coerces scalar and array-like inputs through the active backend array constructor before copying
- refresh the package-level `pyrecest.copy` export after patching the facade
- add regression coverage for scalar, list, and package-level copy calls on the shared NumPy backend

## Bug fixed
`pyrecest.backend.copy(5.0)` failed for the shared NumPy backend because the backend implementation called `x.copy()` directly. Python scalars do not expose `.copy()`, despite `copy` being part of the public backend facade.

## Validation
- `python -m py_compile /tmp/pyrecest_init_new.py /tmp/test_backend_contract_new.py`
- local reproducer: old `x.copy()` raises `AttributeError` for `5.0`; coercing with `backend.array(x)` before copy accepts scalar and list inputs

Full repository tests were not run locally because this execution environment cannot resolve `github.com` for cloning/installing the repository.