### PR TITLE
Fix CLI expected mapping comparisons for NumPy values

### DIFF
--- a/src/pyrecest/cli.py
+++ b/src/pyrecest/cli.py
@@ -65,6 +65,27 @@ def _is_finite_real_number(value: Any) -> bool:
     )
 
 
+def _comparison_value(value: Any) -> Any:
+    if isinstance(value, np.ndarray):
+        return _comparison_value(value.tolist())
+    if isinstance(value, np.generic):
+        return _comparison_value(value.item())
+    if isinstance(value, dict):
+        return {str(key): _comparison_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_comparison_value(item) for item in value]
+    return value
+
+
+def _values_equal(actual_value: Any, expected_value: Any) -> bool:
+    actual_value = _comparison_value(actual_value)
+    expected_value = _comparison_value(expected_value)
+    try:
+        return bool(actual_value == expected_value)
+    except (TypeError, ValueError):
+        return False
+
+
 def _cmd_info(_args: argparse.Namespace) -> int:
     import pyrecest
     import pyrecest.backend as backend
@@ -136,11 +157,12 @@ def _check_expected_mapping(
                     f"{section_name}.{key} mismatch: abs_error={delta:.6g} > tolerance={tolerance:.6g}"
                 )
         elif isinstance(expected_value, bool):
-            if not isinstance(actual_value, bool) or actual_value is not expected_value:
+            actual_bool = _comparison_value(actual_value)
+            if not isinstance(actual_bool, bool) or actual_bool is not expected_value:
                 errors.append(
                     f"{section_name}.{key} mismatch: expected {expected_value!r}, got {actual_value!r}"
                 )
-        elif actual_value != expected_value:
+        elif not _values_equal(actual_value, expected_value):
             errors.append(
                 f"{section_name}.{key} mismatch: expected {expected_value!r}, got {actual_value!r}"
             )

--- a/tests/test_cli_expected_mapping_arrays.py
+++ b/tests/test_cli_expected_mapping_arrays.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import numpy as np
+
+from pyrecest.cli import _check_expected_mapping
+
+
+def test_expected_mapping_accepts_numpy_array_equal_to_json_list() -> None:
+    errors = _check_expected_mapping(
+        "diagnostics",
+        {"indices": np.array([2, 0, 1])},
+        {"indices": [2, 0, 1]},
+        tolerance=0.0,
+    )
+    assert errors == []
+
+
+def test_expected_mapping_reports_numpy_array_mismatches() -> None:
+    errors = _check_expected_mapping(
+        "diagnostics",
+        {"indices": np.array([2, 0, 1])},
+        {"indices": [2, 1, 0]},
+        tolerance=0.0,
+    )
+    assert len(errors) == 1
+    assert errors[0].startswith("diagnostics.indices mismatch:")
+
+
+def test_expected_mapping_accepts_numpy_boolean_scalars() -> None:
+    errors = _check_expected_mapping(
+        "diagnostics",
+        {"resampled": np.bool_(True)},
+        {"resampled": True},
+        tolerance=0.0,
+    )
+    assert errors == []


### PR DESCRIPTION
## Summary
- normalize NumPy arrays and scalars before non-numeric CLI expected-result comparisons
- accept NumPy boolean scalars for boolean expected diagnostics
- add regression coverage for array/list equality, mismatch reporting, and NumPy boolean scalars

## Bug fixed
Expected-result checks for `metrics` or `diagnostics` could crash when a scenario returned a NumPy array and the expected JSON used the equivalent list. The fallback comparison now normalizes array-like values first, so equal values pass and unequal values produce a normal mismatch message.

## Validation
- py-compiled the patched CLI file and new regression test
- locally exercised the patched helper for array equality, array mismatch, and `np.bool_` equality