### PR TITLE
Preserve JAX choice shape for empty populations

### DIFF
--- a/src/pyrecest/_backend/jax/random.py
+++ b/src/pyrecest/_backend/jax/random.py
@@ -407,6 +407,15 @@ def _choice_population_size(a, kwargs):
     return a.shape[axis]
 
 
+def _empty_choice_result(a, shape, axis):
+    if a.ndim == 0:
+        return _jnp.empty(shape, dtype=a.dtype)
+    return _jnp.empty(
+        tuple(a.shape[:axis]) + tuple(shape) + tuple(a.shape[axis + 1 :]),
+        dtype=a.dtype,
+    )
+
+
 def _validate_choice_probabilities(p, population_size):
     if _contains_boolean_value(p):
         raise TypeError("p must be real numeric, not boolean")
@@ -435,9 +444,10 @@ def _choice(state, a, size=None, replace=True, p=None, shuffle=True, *args, **kw
     replace = _choice_bool(replace, "replace")
     shuffle = _choice_bool(shuffle, "shuffle")
     population_size = _choice_population_size(a, kwargs)
+    axis = kwargs.get("axis", 0)
     if population_size == 0:
         if _shape_has_no_samples(shape):
-            return state, _jnp.empty(shape, dtype=a.dtype)
+            return state, _empty_choice_result(a, shape, axis)
         raise ValueError("a must be a positive integer or a non-empty array")
     if population_size < 0:
         raise ValueError("a must be a positive integer or a non-empty array")
@@ -460,7 +470,7 @@ def _choice(state, a, size=None, replace=True, p=None, shuffle=True, *args, **kw
     )
     if a.ndim == 0:
         return state, indices
-    return state, _jnp.take(a, indices, axis=kwargs.get("axis", 0))
+    return state, _jnp.take(a, indices, axis=axis)
 
 
 def choice(a, size=None, replace=True, p=None, shuffle=True, *args, **kwargs):

--- a/tests/test_backend_random.py
+++ b/tests/test_backend_random.py
@@ -70,6 +70,21 @@ class TestBackendRandom(unittest.TestCase):
 
         self.assertEqual(samples.shape, (0,))
 
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ != "jax",
+        "JAX-specific empty multidimensional choice regression",
+    )
+    def test_jax_choice_preserves_unsampled_axes_for_empty_population(self):
+        axis0_values = pyrecest.backend.reshape(pyrecest.backend.array([]), (0, 2))
+        axis0_samples = random.choice(axis0_values, size=(0,), axis=0)
+
+        self.assertEqual(tuple(pyrecest.backend.shape(axis0_samples)), (0, 2))
+
+        axis1_values = pyrecest.backend.reshape(pyrecest.backend.array([]), (2, 0))
+        axis1_samples = random.choice(axis1_values, size=(0,), axis=1)
+
+        self.assertEqual(tuple(pyrecest.backend.shape(axis1_samples)), (2, 0))
+
     def test_choice_samples_matrix_values_along_requested_axis(self):
         values = pyrecest.backend.array([[0, 1, 2], [3, 4, 5]])
 


### PR DESCRIPTION
## Summary
- fix JAX `random.choice` so zero-sized samples from empty multidimensional populations preserve the non-sampled axes
- reuse the normalized axis when taking from non-scalar populations
- add a JAX regression test for empty populations along both axis 0 and axis 1

## Verification
- compared branch with main: 2 commits, 2 files changed
- full test suite not run locally in this connector session