### PR TITLE
Handle missing grouped gate counts

### DIFF
--- a/src/pyrecest/evaluation/model_comparison.py
+++ b/src/pyrecest/evaluation/model_comparison.py
@@ -719,15 +719,29 @@ def grouped_claim_gate_summary(
             f"min {claim_fraction_col} > {float(min_claim_fraction):g}",
         )
         if forbidden_claims_col:
-            max_forbidden = int(
-                pd.to_numeric(summary[forbidden_claims_col], errors="coerce")
-                .fillna(np.inf)
-                .max()
+            forbidden_values = pd.to_numeric(
+                summary[forbidden_claims_col], errors="coerce"
             )
+            missing_forbidden = bool(forbidden_values.isna().any())
+            max_forbidden_value = (
+                float(forbidden_values.max())
+                if not forbidden_values.dropna().empty
+                else np.nan
+            )
+            if missing_forbidden or not np.isfinite(max_forbidden_value):
+                observed_forbidden: object = "missing"
+            elif float(max_forbidden_value).is_integer():
+                observed_forbidden = int(max_forbidden_value)
+            else:
+                observed_forbidden = f"{max_forbidden_value:.6g}"
             add(
                 "all_groups_no_forbidden_claims",
-                max_forbidden == 0,
-                max_forbidden,
+                (
+                    not missing_forbidden
+                    and np.isfinite(max_forbidden_value)
+                    and max_forbidden_value == 0.0
+                ),
+                observed_forbidden,
                 f"max {forbidden_claims_col} == 0",
             )
         if mean_delta_col:

--- a/tests/test_model_comparison_missing_forbidden_counts.py
+++ b/tests/test_model_comparison_missing_forbidden_counts.py
@@ -1,0 +1,29 @@
+import numpy as np
+import pandas as pd
+
+from pyrecest.evaluation.model_comparison import grouped_claim_gate_summary
+
+
+def test_grouped_claim_gate_summary_treats_missing_forbidden_counts_as_failed_gate():
+    summary = pd.DataFrame(
+        [
+            {
+                "rat": "Rat1",
+                "positive_claim_fraction": 1.0,
+                "reference_model_claims": np.nan,
+            }
+        ]
+    )
+
+    gates = grouped_claim_gate_summary(
+        summary,
+        group_col="rat",
+        claim_fraction_col="positive_claim_fraction",
+        forbidden_claims_col="reference_model_claims",
+        min_claim_fraction=0.5,
+    )
+
+    by_gate = gates.set_index("gate")
+    assert by_gate.loc["all_groups_no_forbidden_claims", "observed"] == "missing"
+    assert not bool(by_gate.loc["all_groups_no_forbidden_claims", "passed"])
+    assert not bool(by_gate.loc["overall", "passed"])


### PR DESCRIPTION
## Summary
- handle missing grouped gate count values without raising during gate summarization
- add regression coverage for the missing-count case

## Validation
- Inspected the branch diff through the GitHub connector. Changes are limited to the helper and one new regression test.
- Local test execution was not available because this environment could not clone GitHub due DNS/network restrictions.