### PR TITLE
Fix PPP measurement count scalar validation

### DIFF
--- a/src/pyrecest/evaluation/generate_measurements.py
+++ b/src/pyrecest/evaluation/generate_measurements.py
@@ -1,7 +1,6 @@
 import copy
 
 import numpy as np
-from beartype import beartype
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 from pyrecest.backend import array, dot, get_backend_name, mod, pi, squeeze, tile, zeros
@@ -296,7 +295,6 @@ def generate_measurements(groundtruth, simulation_config):
     return measurements
 
 
-@beartype
 def generate_n_measurements_PPP(area: float, intensity_lambda: float) -> int:
     area = _as_nonnegative_finite_scalar(area, "area")
     intensity_lambda = _as_nonnegative_finite_scalar(

--- a/tests/evaluation/test_generate_measurements_validation.py
+++ b/tests/evaluation/test_generate_measurements_validation.py
@@ -67,6 +67,13 @@ def test_generate_n_measurements_ppp_returns_python_int_for_zero_rate():
     assert isinstance(count, int)
 
 
+def test_generate_n_measurements_ppp_accepts_numpy_scalar_like_inputs():
+    count = generate_n_measurements_PPP(np.array(0.0), np.float32(123.0))
+
+    assert count == 0
+    assert isinstance(count, int)
+
+
 def test_generate_measurements_eot_accepts_array_like_groundtruth_entries():
     simulation_config = {
         "n_timesteps": 1,


### PR DESCRIPTION
## Summary
- remove the runtime type decorator from `generate_n_measurements_PPP` so its explicit NumPy-based scalar validation can handle scalar-like inputs consistently
- add a regression test for NumPy 0-D array and NumPy scalar inputs at zero rate

## Rationale
`generate_n_measurements_PPP` already validates `area` and `intensity_lambda` with `_as_nonnegative_finite_scalar`, which accepts scalar-like NumPy inputs and returns clear `ValueError`s for invalid values. The `beartype` decorator intercepted some valid scalar-like inputs before the function's own validation ran.

## Testing
- Not run locally in this environment; patch is covered by the added regression test.