### PR TITLE
Validate complex covariances as Hermitian

### DIFF
--- a/src/pyrecest/models/validation.py
+++ b/src/pyrecest/models/validation.py
@@ -246,7 +246,7 @@ def validate_covariance_matrix(
     if check_symmetric and not _to_python_bool(
         backend.allclose(
             covariance,
-            backend.transpose(covariance),
+            backend.conj(backend.transpose(covariance)),
             rtol=symmetric_rtol,
             atol=symmetric_atol,
         )

--- a/tests/models/test_validation.py
+++ b/tests/models/test_validation.py
@@ -72,6 +72,21 @@ class TestModelValidation(unittest.TestCase):
                 array([[1.0, 2.0], [0.0, 1.0]]), check_symmetric=True
             )
 
+    def test_validate_covariance_matrix_accepts_complex_hermitian(self):
+        covariance = validate_covariance_matrix(
+            array([[1.0 + 0.0j, 2.0 + 3.0j], [2.0 - 3.0j, 4.0 + 0.0j]]),
+            check_symmetric=True,
+        )
+
+        self.assertEqual(covariance.shape, (2, 2))
+
+    def test_validate_covariance_matrix_rejects_complex_symmetric_non_hermitian(self):
+        with self.assertRaisesRegex(ValueError, "symmetric"):
+            validate_covariance_matrix(
+                array([[1.0 + 0.0j, 2.0 + 3.0j], [2.0 + 3.0j, 4.0 + 0.0j]]),
+                check_symmetric=True,
+            )
+
     def test_validate_noise_covariance_uses_covariance_rules(self):
         noise_covariance = validate_noise_covariance(
             array(0.5), dim=1, allow_scalar=True


### PR DESCRIPTION
# Pull request

## Summary

- fixes covariance validation for complex matrices by comparing against the conjugate transpose instead of a plain transpose
- preserves the existing real-valued symmetric covariance behavior
- adds regression coverage for valid Hermitian covariances and complex symmetric but non-Hermitian matrices

## Checklist

- [x] Tests were added or updated.
- [x] Shape, dtype, and measurement-set conventions were checked against `docs/conventions.md`.
- [x] New user-facing failures use clear messages or shared exceptions from `pyrecest.exceptions`.
- [ ] Backend limitations were documented or added to `src/pyrecest/_backend/capabilities.py`.
- [ ] Public examples and docs were updated when relevant.
- [ ] Performance-sensitive changes were checked against `benchmarks/basic_regressions.py` or a focused benchmark.
- [ ] `python scripts/check_release_consistency.py --local-only` passes when release metadata changed.
- [ ] The package smoke path still works: `python -m build`, `twine check dist/*`, install wheel, run a basic example.

Tests were not run locally in this environment.