### PR TITLE
Reject text replay-grid proposal probabilities

### DIFF
--- a/src/pyrecest/filters/replay_grid_likelihood.py
+++ b/src/pyrecest/filters/replay_grid_likelihood.py
@@ -16,6 +16,8 @@ import numpy as np
 from scipy.spatial import cKDTree
 from scipy.special import logsumexp
 
+_TEXT_SCALAR_TYPES = (str, bytes, bytearray, np.str_, np.bytes_)
+
 
 @dataclass(frozen=True)
 class ReplayGridLikelihoodLookup:
@@ -434,10 +436,14 @@ def _nearest_bin_indices(positions: np.ndarray, bin_tree: cKDTree) -> np.ndarray
 
 def _validate_probability(probability: float, name: str) -> float:
     probability_array = np.asarray(probability)
-    if probability_array.shape != ():
+    if (
+        probability_array.shape != ()
+        or probability_array.dtype == np.bool_
+        or probability_array.dtype.kind in "SU"
+    ):
         raise ValueError(f"{name} must be a scalar probability in [0, 1]")
     probability_scalar = probability_array.item()
-    if isinstance(probability_scalar, (bool, np.bool_)):
+    if isinstance(probability_scalar, (bool, np.bool_) + _TEXT_SCALAR_TYPES):
         raise ValueError(f"{name} must be a scalar probability in [0, 1]")
     try:
         value = float(probability_scalar)

--- a/tests/filters/test_replay_grid_likelihood.py
+++ b/tests/filters/test_replay_grid_likelihood.py
@@ -111,6 +111,27 @@ class TestReplayGridLikelihood(unittest.TestCase):
         self.assertAlmostEqual(probability, 0.5)
         self.assertAlmostEqual(ess_fraction, 0.25)
 
+    def test_position_proposal_probability_rejects_text_scalars(self):
+        invalid_probabilities = (
+            "0.5",
+            b"0.5",
+            bytearray(b"0.5"),
+            np.str_("0.5"),
+            np.bytes_(b"0.5"),
+            np.array("0.5"),
+            np.array(b"0.5"),
+            np.array("0.5", dtype=object),
+            np.array(b"0.5", dtype=object),
+        )
+
+        for probability in invalid_probabilities:
+            with self.subTest(field="base_probability", probability=repr(probability)):
+                with self.assertRaisesRegex(ValueError, "base_probability"):
+                    adaptive_position_proposal_probability([1.0], probability, None)
+            with self.subTest(field="ess_threshold", probability=repr(probability)):
+                with self.assertRaisesRegex(ValueError, "ess_threshold"):
+                    adaptive_position_proposal_probability([1.0], 0.5, probability)
+
     def test_effective_sample_size_rejects_invalid_weights(self):
         for weights in ([1.0, -0.1], [1.0, np.nan], [1.0, np.inf]):
             with self.subTest(weights=weights):


### PR DESCRIPTION
## Summary
- reject string/byte scalar inputs in replay-grid proposal probability validation
- add regression coverage for text-like `base_probability` and `ess_threshold` inputs

## Bug fixed
`adaptive_position_proposal_probability(..., base_probability="0.5", ...)` and byte/object-array variants were silently accepted because `_validate_probability` converted scalar values with `float(...)`. This makes malformed configuration inputs indistinguishable from numeric probabilities and is inconsistent with the stricter scalar-validation policy used elsewhere in PyRecEst.

## Testing
- Not run locally; the available execution environment could not run a local checkout/tests during this session.
