### PR TITLE
Backend error validation

### DIFF
--- a/src/pyrecest/exceptions.py
+++ b/src/pyrecest/exceptions.py
@@ -9,6 +9,16 @@ validation helper to change at once. Existing ``ValueError`` and
 from __future__ import annotations
 
 from collections.abc import Iterable
+from typing import Any
+
+
+def _normalize_supported_backend_name(value: Any) -> str:
+    if not isinstance(value, str):
+        raise ValueError("supported_backends must contain backend names as strings")
+    backend = value.strip()
+    if not backend:
+        raise ValueError("supported_backends must contain non-empty backend names")
+    return backend
 
 
 def _normalize_supported_backends(
@@ -17,8 +27,14 @@ def _normalize_supported_backends(
     if supported_backends is None:
         return ()
     if isinstance(supported_backends, str):
-        return (supported_backends,)
-    return tuple(str(backend) for backend in supported_backends)
+        return (_normalize_supported_backend_name(supported_backends),)
+    try:
+        return tuple(
+            _normalize_supported_backend_name(backend)
+            for backend in supported_backends
+        )
+    except TypeError as exc:
+        raise ValueError("supported_backends must be an iterable of backend names") from exc
 
 
 class PyRecEstError(Exception):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -35,6 +35,32 @@ def test_backend_not_supported_error_accepts_single_string_supported_backend():
     assert "n, u, m, p, y" not in str(error)
 
 
+def test_backend_not_supported_error_strips_supported_backend_names():
+    error = BackendNotSupportedError(
+        "ExampleAPI.update",
+        "jax",
+        supported_backends=(" numpy ", "pytorch"),
+    )
+
+    assert error.supported_backends == ("numpy", "pytorch")
+    assert "supported backends: numpy, pytorch" in str(error)
+
+
+@pytest.mark.parametrize(
+    "supported_backends",
+    ["", "   ", ("numpy", ""), ("numpy", None), ("numpy", 123), 123],
+)
+def test_backend_not_supported_error_rejects_invalid_supported_backend_names(
+    supported_backends,
+):
+    with pytest.raises(ValueError, match="supported_backends"):
+        BackendNotSupportedError(
+            "ExampleAPI.update",
+            "jax",
+            supported_backends=supported_backends,
+        )
+
+
 def test_backend_not_supported_error_keeps_backendless_context():
     error = BackendNotSupportedError(
         "ExampleAPI.batch_update",


### PR DESCRIPTION
Small validation fix with regression tests.

Changes:
- normalize names in BackendNotSupportedError support lists
- reject empty or non-string entries instead of rendering misleading names
- extend exception tests

Validation: connector compare shows one commit ahead of main, two files changed.