### PR TITLE
Fix PyTorch random choice empty-size handling

### DIFF
--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -339,12 +339,16 @@ def _integer_population_size(a):
     return None
 
 
+def _empty_choice_indices(size, device):
+    return _torch.empty(size or (0,), dtype=_torch.long, device=device)
+
+
 def _choice_indices(
     population_size, size, num_samples, replace, p, device, *, shuffle=True
 ):
     if population_size <= 0:
         if num_samples == 0:
-            return _torch.empty(size or (0,), dtype=_torch.long, device=device)
+            return _empty_choice_indices(size, device)
         raise ValueError("a must be greater than 0 unless no samples are taken")
 
     if p is not None:
@@ -353,10 +357,15 @@ def _choice_indices(
                 "Cannot take a larger sample than population when 'replace=False'."
             )
         p = _validate_choice_probabilities(p, population_size, device)
+        if num_samples == 0:
+            return _empty_choice_indices(size, p.device)
         indices = _torch.multinomial(p, num_samples=num_samples, replacement=replace)
         if size is None:
             return indices[0]
         return indices.reshape(size)
+
+    if num_samples == 0:
+        return _empty_choice_indices(size, device)
 
     if replace:
         return _torch.randint(0, population_size, size or (), device=device)

--- a/tests/backend/test_pytorch_choice_scalar_population.py
+++ b/tests/backend/test_pytorch_choice_scalar_population.py
@@ -35,6 +35,40 @@ def test_choice_allows_zero_sized_sample_from_zero_dimensional_numpy_zero_popula
     assert samples.shape == (0,)
 
 
+@pytest.mark.parametrize(
+    ("size", "expected_shape"),
+    [
+        (0, (0,)),
+        ((0,), (0,)),
+        ((2, 0), (2, 0)),
+    ],
+)
+@pytest.mark.parametrize("replace", [True, False])
+def test_choice_allows_empty_weighted_sample(size, expected_shape, replace):
+    random.seed(0)
+
+    samples = random.choice(
+        3,
+        size=size,
+        replace=replace,
+        p=np.array([0.2, 0.3, 0.5]),
+    )
+
+    assert samples.shape == expected_shape
+
+
+def test_choice_allows_empty_weighted_sample_from_array_population():
+    random.seed(0)
+
+    samples = random.choice(
+        torch.arange(3),
+        size=(0,),
+        p=torch.tensor([0.2, 0.3, 0.5]),
+    )
+
+    assert samples.shape == (0,)
+
+
 @pytest.mark.parametrize("population", [np.array(True), np.array(3.0)])
 def test_choice_rejects_zero_dimensional_numpy_non_integer_population(population):
     with pytest.raises(ValueError, match="positive integer or an array"):


### PR DESCRIPTION
## Summary
- fix PyTorch weighted choice when `size` requests zero samples
- keep probability validation before returning a correctly shaped empty tensor
- add regression tests for scalar and tensor populations

## Verification
- local focused check of patched choice logic
- full suite not run locally because the sandbox cannot clone GitHub