### PR TITLE
Reject boolean PyTorch multivariate-normal parameters

### DIFF
--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -551,11 +551,35 @@ def _normal_sample_size(size):
     return _shape_from_size(size)
 
 
+def _validate_multivariate_normal_parameter(value, name, *, dtype, device):
+    if _contains_boolean_value(value):
+        raise TypeError(f"{name} must be real numeric, not boolean")
+    try:
+        parameter = _torch.as_tensor(value, device=device)
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise TypeError(f"{name} must be real numeric") from exc
+    if not _is_real_numeric_dtype(parameter.dtype):
+        raise TypeError(f"{name} must be real numeric")
+    if bool(_torch.any(~_torch.isfinite(parameter))):
+        raise ValueError(f"{name} must be finite")
+    return parameter.to(dtype=dtype)
+
+
 @_modify_func_default_dtype(copy=False, kw_only=True)
 @_allow_complex_dtype
 def multivariate_normal(mean, cov, size=None):
     device = _tensor_device(mean, cov)
     dtype = _floating_distribution_dtype(mean, cov)
-    mean = _torch.as_tensor(mean, dtype=dtype, device=device)
-    cov = _torch.as_tensor(cov, dtype=mean.dtype, device=mean.device)
+    mean = _validate_multivariate_normal_parameter(
+        mean,
+        "mean",
+        dtype=dtype,
+        device=device,
+    )
+    cov = _validate_multivariate_normal_parameter(
+        cov,
+        "cov",
+        dtype=mean.dtype,
+        device=mean.device,
+    )
     return _MultivariateNormal(mean, cov).sample(_normal_sample_size(size))

--- a/tests/backend/test_pytorch_random_scalar_inputs.py
+++ b/tests/backend/test_pytorch_random_scalar_inputs.py
@@ -58,3 +58,19 @@ def test_size_arguments_reject_zero_dimensional_non_integer_arrays_and_tensors(
 def test_choice_rejects_complex_probabilities(probabilities):
     with pytest.raises(TypeError, match="real numeric"):
         random.choice(2, size=1, p=probabilities)
+
+
+@pytest.mark.parametrize(
+    ("mean", "cov", "match"),
+    [
+        ([True], [[1.0]], "mean.*boolean"),
+        ([0.0], [[True]], "cov.*boolean"),
+        (np.array([True]), np.eye(1), "mean.*boolean"),
+        (np.zeros(1), np.array([[np.bool_(True)]], dtype=object), "cov.*boolean"),
+        (torch.tensor([True]), torch.eye(1), "mean.*boolean"),
+        (torch.zeros(1), torch.tensor([[True]]), "cov.*boolean"),
+    ],
+)
+def test_multivariate_normal_rejects_boolean_parameters(mean, cov, match):
+    with pytest.raises(TypeError, match=match):
+        random.multivariate_normal(mean, cov)


### PR DESCRIPTION
## Summary
- validate PyTorch backend `multivariate_normal` mean/covariance parameters before dtype casting
- reject boolean mean or covariance values instead of silently coercing them to numeric `0`/`1`
- add regression coverage for Python, NumPy, and Torch boolean inputs

## Bug fixed
`pyrecest._backend.pytorch.random.multivariate_normal([True], [[1.0]])` and boolean covariance variants were accepted because the wrapper chose a floating dtype first and then cast the parameters. That made malformed boolean configuration inputs indistinguishable from numeric parameters.

## Validation
- Inspected the branch diff against `main`: 2 commits, 2 files changed.
- Locally verified with an isolated PyTorch snippet that current casting turns boolean mean/covariance values into floating tensors accepted by `torch.distributions.MultivariateNormal`.
- Locally exercised the new validation helper on Python, NumPy, and Torch boolean mean/covariance cases.

Full repository tests were not run locally because this environment cannot clone GitHub due DNS/network restrictions.