### PR TITLE
Validate PyTorch fftconvolve non-axis shapes

### DIFF
--- a/src/pyrecest/_backend/pytorch/signal.py
+++ b/src/pyrecest/_backend/pytorch/signal.py
@@ -50,6 +50,14 @@ def _normalize_axes(axes, ndim):
     return tuple(normalized_axes)
 
 
+def _validate_non_convolved_shapes(shape1, shape2, axes):
+    axes_set = set(axes)
+    for axis, (first, second) in enumerate(zip(shape1, shape2, strict=True)):
+        if axis in axes_set or first == second or first == 1 or second == 1:
+            continue
+        raise ValueError(f"incompatible shapes for in1 and in2: {shape1} and {shape2}")
+
+
 def _as_tensor_pair(in1, in2):
     device = next(
         (value.device for value in (in1, in2) if _torch.is_tensor(value)), None
@@ -91,6 +99,9 @@ def fftconvolve(in1, in2, mode="full", axes=None):
         raise ValueError("in1 and in2 should have the same dimensionality")
 
     axes = _normalize_axes(axes, x.ndim)
+    x_shape = tuple(x.shape)
+    y_shape = tuple(y.shape)
+    _validate_non_convolved_shapes(x_shape, y_shape, axes)
     if mode == "valid":
         comparison_axes = tuple(
             axis for axis in axes if x.shape[axis] != 1 and y.shape[axis] != 1
@@ -115,7 +126,7 @@ def fftconvolve(in1, in2, mode="full", axes=None):
         result = result.real
 
     if mode == "same":
-        return result[_centered_slice(tuple(result.shape), tuple(x.shape))]
+        return result[_centered_slice(tuple(result.shape), x_shape)]
     if mode == "valid":
-        return result[_valid_slice(tuple(x.shape), tuple(y.shape), axes)]
+        return result[_valid_slice(x_shape, y_shape, axes)]
     return result

--- a/tests/backend_support/test_pytorch_fftconvolve_axes_validation.py
+++ b/tests/backend_support/test_pytorch_fftconvolve_axes_validation.py
@@ -37,3 +37,13 @@ def test_pytorch_fftconvolve_rejects_non_integer_axes(axes):
 
     with pytest.raises(TypeError, match="axes must be None"):
         backend.signal.fftconvolve(first, second, axes=axes)
+
+
+def test_pytorch_fftconvolve_rejects_incompatible_non_convolved_axes():
+    _skip_unless_pytorch()
+
+    first = backend.ones((3, 1))
+    second = backend.ones((2, 4))
+
+    with pytest.raises(ValueError, match="incompatible shapes"):
+        backend.signal.fftconvolve(first, second, axes=(1,))


### PR DESCRIPTION
## Summary
- add explicit validation for incompatible non-convolved dimensions in the PyTorch `fftconvolve` backend
- preserve SciPy-compatible broadcasting for singleton non-convolved dimensions
- add a regression test that expects a deterministic `ValueError` instead of a low-level Torch broadcasting error

## Bug fixed
When `backend.signal.fftconvolve(..., axes=...)` selected only some axes, incompatible dimensions outside the convolved axes could fall through to the pointwise FFT product and raise a Torch `RuntimeError`. SciPy rejects the same shape combination up front with a shape `ValueError`; the PyRecEst PyTorch backend advertises SciPy-compatible shape semantics, so this patch validates those dimensions before the FFT multiplication.

## Validation
- Compared branch against `main`: 2 commits, 2 files changed.
- Inspected the patched source and regression test through the GitHub connector.
- Local repository test execution was not available here because the environment could not clone GitHub due DNS/network restrictions.