### PR TITLE
Validate NumPy vmap scalar arguments

### DIFF
--- a/src/pyrecest/_backend/numpy/__init__.py
+++ b/src/pyrecest/_backend/numpy/__init__.py
@@ -223,7 +223,9 @@ def vmap(pyfunc, randomness="error"):
         if not args:
             raise ValueError("vmap requires at least one positional argument")
         mapped_args = [_np.asarray(arg) for arg in args]
-        if not all([arg.shape[0] == mapped_args[0].shape[0] for arg in mapped_args]):
+        if any(arg.ndim == 0 for arg in mapped_args):
+            raise ValueError("vmap arguments must have at least one dimension")
+        if not all(arg.shape[0] == mapped_args[0].shape[0] for arg in mapped_args):
             raise ValueError(
                 "All arguments must have the same size in the first dimension"
             )

--- a/tests/test_numpy_vmap_validation.py
+++ b/tests/test_numpy_vmap_validation.py
@@ -1,0 +1,17 @@
+import numpy as np
+import pytest
+from pyrecest._backend import numpy as numpy_backend
+
+
+def test_numpy_vmap_rejects_scalar_arguments():
+    mapped = numpy_backend.vmap(lambda x: x)
+
+    with pytest.raises(ValueError, match="at least one dimension"):
+        mapped(np.array(1.0))
+
+
+def test_numpy_vmap_rejects_mixed_scalar_arguments():
+    mapped = numpy_backend.vmap(lambda x, y: x + y)
+
+    with pytest.raises(ValueError, match="at least one dimension"):
+        mapped(np.array([1.0]), np.array(2.0))


### PR DESCRIPTION
## Summary
- reject scalar arguments in the NumPy backend `vmap` before reading `shape[0]`
- add regression coverage for single-scalar and mixed vector/scalar calls

## Bug fixed
`numpy_backend.vmap(...)` converted inputs with `np.asarray` and immediately compared `arg.shape[0]` across arguments. A scalar/0-D argument therefore raised a low-level `IndexError: tuple index out of range` instead of a deterministic validation error. The new check rejects 0-D arguments with a clear `ValueError`.

## Validation
- Locally reproduced the old scalar path raising `IndexError: tuple index out of range` in an isolated NumPy snippet.
- Locally verified the patched logic raises `ValueError: vmap arguments must have at least one dimension` for the same scalar input.
- Inspected the branch diff against `main`: 2 commits, 2 files changed.

Full repository tests were not run locally because this execution environment could not clone GitHub due DNS/network restrictions.