### PR TITLE
Support JAX economic QR mode

### DIFF
--- a/src/pyrecest/_backend/jax/linalg.py
+++ b/src/pyrecest/_backend/jax/linalg.py
@@ -12,7 +12,6 @@ from jax.numpy.linalg import (  # NOQA
     matrix_rank,
     norm,
     pinv,
-    qr,
     solve,
     svd,
 )
@@ -44,6 +43,16 @@ def _unsupported_function(name):
     _raise_unsupported.__qualname__ = name
     _raise_unsupported.__doc__ = f"Unsupported JAX-backend placeholder for ``{name}``."
     return _raise_unsupported
+
+
+def qr(a, mode="reduced"):
+    """Compute QR decomposition with NumPy-compatible mode handling."""
+
+    a = _jnp.asarray(a)
+    if mode == "economic":
+        raw_result = _jnp.linalg.qr(a, mode="raw")
+        return _jnp.swapaxes(raw_result[0], -2, -1)
+    return _jnp.linalg.qr(a, mode=mode)
 
 
 def is_single_matrix_pd(mat):

--- a/tests/backend/test_jax_qr_economic.py
+++ b/tests/backend/test_jax_qr_economic.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pytest
+
+jnp = pytest.importorskip("jax.numpy")
+from pyrecest._backend.jax import linalg as jax_linalg  # noqa: E402
+
+
+def test_jax_linalg_qr_accepts_numpy_economic_mode():
+    values = jnp.array(
+        [
+            [1.0, 2.0],
+            [3.0, 4.0],
+            [5.0, 6.0],
+        ]
+    )
+
+    result = jax_linalg.qr(values, mode="economic")
+
+    assert result.shape == values.shape
+    assert np.isfinite(np.asarray(result)).all()


### PR DESCRIPTION
## Summary
- add a JAX `linalg.qr` wrapper so `mode="economic"` follows NumPy-compatible behavior
- keep the existing JAX QR modes delegated to `jax.numpy.linalg.qr`
- add a regression test that fails before the wrapper because JAX raises for `mode="economic"`

## Testing
- `PYTHONPATH=. pytest -q tests/backend/test_jax_qr_economic.py` in a minimal local harness containing the patched JAX linalg module

Note: I also noticed a separate direct-JAX `trace` duplicate-definition issue, but did not include it here to keep this PR small and low-risk.