### PR TITLE
Support JAX std out argument

### DIFF
--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -124,8 +124,38 @@ def _patch_pytorch_tile_facade() -> None:
     backend.tile = tile
 
 
+def _patch_jax_std_out_facade() -> None:
+    """Make public JAX ``std`` accept NumPy's ``out`` argument."""
+
+    import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+
+    if getattr(backend, "__backend_name__", None) != "jax":
+        return
+
+    original_std = backend.std
+
+    def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False, *, correction=0):
+        result = original_std(
+            a,
+            axis=axis,
+            dtype=dtype,
+            out=None,
+            ddof=ddof,
+            keepdims=keepdims,
+            correction=correction,
+        )
+        if out is None:
+            return result
+        return backend.asarray(out).at[...].set(result)
+
+    std.__name__ = getattr(original_std, "__name__", "std")
+    std.__doc__ = getattr(original_std, "__doc__", None)
+    backend.std = std
+
+
 _patch_pytorch_comparison_facade()
 _patch_pytorch_tile_facade()
+_patch_jax_std_out_facade()
 
 from pyrecest.backend_support import (  # noqa: E402,F401
     backend_support,

--- a/tests/test_backend_std_contract.py
+++ b/tests/test_backend_std_contract.py
@@ -36,3 +36,27 @@ print("ok")
 
     assert result.returncode == 0, result.stderr
     assert "ok" in result.stdout
+
+
+@pytest.mark.backend_portable
+def test_jax_std_accepts_out_argument():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("JAX is not installed")
+
+    result = run_backend_code(
+        "jax",
+        """
+import pyrecest.backend as backend
+
+values = backend.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+out = backend.zeros((1, 3), dtype=backend.float64)
+result = backend.std(values, axis=0, dtype=backend.float64, out=out, ddof=1, keepdims=True)
+expected = backend.array([[2.1213203435596424, 2.1213203435596424, 2.1213203435596424]])
+assert tuple(result.shape) == (1, 3)
+assert backend.allclose(result, expected)
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- patch the public JAX backend `std` facade so NumPy-style `out=` calls do not forward `out` into `jax.numpy.std`, which rejects it
- preserve existing `axis`, `dtype`, `ddof`, `keepdims`, and `correction` behavior while returning an updated JAX array for `out=`
- add a backend-portable subprocess regression test for `PYRECEST_BACKEND=jax`

## Bug
The generic `std` wrapper currently keeps NumPy's `out` keyword in its call to the backend function. JAX exposes an `out` parameter for NumPy API compatibility but raises `NotImplementedError` when it is not `None`, so `backend.std(..., out=...)` fails under the JAX backend.

## Testing
- Isolated local JAX check reproducing the pre-patch `NotImplementedError` and verifying the patched wrapper result/shape.
- Full repository tests were not run in this connector environment.