### PR TITLE
Fix direct JAX trace signature

### DIFF
--- a/src/pyrecest/_backend/jax/__init__.py
+++ b/src/pyrecest/_backend/jax/__init__.py
@@ -243,15 +243,18 @@ def squeeze(a, axis=None):
     return _jnp.squeeze(_jnp.asarray(a), axis=axis)
 
 
-def trace(a, offset=0, axis1=0, axis2=1, dtype=None, out=None):
-    return _jnp.trace(
+def trace(a, offset=0, axis1=-2, axis2=-1, dtype=None, out=None):
+    """Return the trace while preserving PyRecEst's last-two-axes default."""
+    result = _jnp.trace(
         _jnp.asarray(a),
         offset=offset,
         axis1=axis1,
         axis2=axis2,
         dtype=dtype,
-        out=out,
     )
+    if out is not None:
+        return out.at[...].set(result)
+    return result
 
 
 def tril(m, k=0):
@@ -626,10 +629,6 @@ def matvec(matrix, vector):
     if matrix.ndim == 2:
         return _jnp.einsum("ij,...j->...i", matrix, vector)
     return _jnp.einsum("...ij,...j->...i", matrix, vector)
-
-
-def trace(a):
-    return _jnp.trace(_jnp.asarray(a), axis1=-2, axis2=-1)
 
 
 # One-hot encoding

--- a/tests/backend/test_jax_direct_trace.py
+++ b/tests/backend/test_jax_direct_trace.py
@@ -1,0 +1,42 @@
+import numpy as np
+import pytest
+
+jnp = pytest.importorskip("jax.numpy")
+from pyrecest._backend import jax as jax_backend  # noqa: E402
+
+
+def _to_numpy(value):
+    return np.asarray(jax_backend.to_numpy(value))
+
+
+def test_direct_jax_trace_accepts_explicit_axes_offset_dtype_and_out():
+    values = jnp.array(
+        [
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+            [[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]],
+        ],
+        dtype=jnp.float32,
+    )
+    out = jnp.zeros((2,), dtype=jnp.float32)
+
+    result = jax_backend.trace(
+        values,
+        offset=1,
+        axis1=1,
+        axis2=2,
+        dtype=jnp.float32,
+        out=out,
+    )
+
+    assert _to_numpy(result).tolist() == [8.0, 20.0]
+
+
+def test_direct_jax_trace_defaults_to_last_two_axes():
+    values = jnp.array(
+        [
+            [[1.0, 2.0], [3.0, 4.0]],
+            [[5.0, 6.0], [7.0, 8.0]],
+        ]
+    )
+
+    assert _to_numpy(jax_backend.trace(values)).tolist() == [5.0, 13.0]


### PR DESCRIPTION
## Summary
- remove the duplicate direct-JAX `trace(a)` definition that overwrote the full backend signature
- preserve PyRecEst's last-two-axes default on the remaining direct-JAX trace implementation
- support `out=` for direct JAX trace through JAX's immutable `.at[...].set(...)` update path
- add regression tests for explicit `offset`/`axis1`/`axis2`/`dtype`/`out` arguments and the default last-two-axes behavior

## Testing
- Minimal local JAX semantics check for `jnp.trace(..., offset=1, axis1=1, axis2=2)` returning `[8.0, 20.0]`
- Full repository pytest not run locally because this runtime cannot clone GitHub over DNS; CI should run the added regression test