### PR TITLE
Fix circular uniform CDF angle wrapping

### DIFF
--- a/src/pyrecest/distributions/circle/circular_uniform_distribution.py
+++ b/src/pyrecest/distributions/circle/circular_uniform_distribution.py
@@ -1,4 +1,4 @@
-from pyrecest.backend import array, pi, where
+from pyrecest.backend import array, mod, pi
 
 from ..hypertorus.hypertoroidal_uniform_distribution import (
     HypertoroidalUniformDistribution,
@@ -42,7 +42,4 @@ class CircularUniformDistribution(
         """
 
         xa = array(xa)
-        val = (xa - starting_point) / (2 * pi)
-        val = where(val < 0, val + 1, val)
-
-        return val
+        return mod(xa - starting_point, 2.0 * pi) / (2.0 * pi)

--- a/tests/distributions/test_circular_uniform_cdf_wrapping.py
+++ b/tests/distributions/test_circular_uniform_cdf_wrapping.py
@@ -1,0 +1,20 @@
+import numpy.testing as npt
+
+from pyrecest.backend import array, pi
+from pyrecest.distributions.circle.circular_uniform_distribution import (
+    CircularUniformDistribution,
+)
+
+
+def test_circular_uniform_cdf_wraps_angles_relative_to_starting_point():
+    dist = CircularUniformDistribution()
+
+    x = array([0.0, 2.0 * pi, -pi, 3.0 * pi])
+    npt.assert_allclose(dist.cdf(x), array([0.0, 0.0, 0.5, 0.5]), atol=1e-12)
+
+    shifted_x = array([0.5 * pi, 2.5 * pi, 0.0, pi])
+    npt.assert_allclose(
+        dist.cdf(shifted_x, starting_point=0.5 * pi),
+        array([0.0, 0.0, 0.75, 0.25]),
+        atol=1e-12,
+    )


### PR DESCRIPTION
## Summary
- Compute `CircularUniformDistribution.cdf` with modulo-`2π` offsets relative to `starting_point`.
- Add a regression test covering `2π`, negative angles, angles beyond one period, and a shifted starting point.

## Bug fixed
The previous implementation only added `1` once for negative offsets and did not reduce angles modulo `2π`. As a result, circular CDF values could be outside the `[0, 1)` convention used by `cdf_numerical`, e.g. `cdf(2π)` returned `1` instead of `0`, and `cdf(3π)` returned `1.5` instead of `0.5`.

## Testing
- Not run locally in this connector session; added focused pytest coverage for the fixed behavior.