### PR TITLE
Validate PyTorch tile repetition counts

### DIFF
--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -1,3 +1,4 @@
+import operator as _operator
 from importlib.metadata import PackageNotFoundError, version
 
 import pyrecest._backend  # noqa
@@ -75,6 +76,18 @@ def _patch_pytorch_comparison_facade() -> None:
     backend.logical_or = _wrap_comparison(_torch.logical_or)
 
 
+def _pytorch_tile_repetition_as_index(repetition) -> int:
+    """Return one validated repetition count for ``torch.Tensor.repeat``."""
+
+    try:
+        repetition = _operator.index(repetition)
+    except TypeError as exc:
+        raise TypeError("tile repetitions must be integers") from exc
+    if repetition < 0:
+        raise ValueError("negative dimensions are not allowed")
+    return repetition
+
+
 def _pytorch_tile_repetitions(reps, numpy_module, torch_module) -> tuple[int, ...]:
     """Normalize NumPy-style tile repetitions for ``torch.Tensor.repeat``."""
 
@@ -82,14 +95,13 @@ def _pytorch_tile_repetitions(reps, numpy_module, torch_module) -> tuple[int, ..
         reps = reps.detach().cpu().numpy()
     reps_array = numpy_module.asarray(reps)
     if reps_array.shape == ():
-        repetitions = (int(reps_array.item()),)
+        raw_repetitions = (reps_array.item(),)
     else:
-        repetitions = tuple(
-            int(one_repetition) for one_repetition in reps_array.tolist()
-        )
-    if any(one_repetition < 0 for one_repetition in repetitions):
-        raise ValueError("negative dimensions are not allowed")
-    return repetitions
+        raw_repetitions = tuple(reps_array.tolist())
+    return tuple(
+        _pytorch_tile_repetition_as_index(one_repetition)
+        for one_repetition in raw_repetitions
+    )
 
 
 def _patch_pytorch_tile_facade() -> None:

--- a/tests/backend_support/test_pytorch_tile_contract.py
+++ b/tests/backend_support/test_pytorch_tile_contract.py
@@ -37,5 +37,18 @@ empty_result = backend.tile(values, ())
 assert tuple(backend.shape(empty_result)) == (2, 2)
 assert backend.to_numpy(empty_result).tolist() == [[1, 2], [3, 4]]
 assert empty_result is not values
+
+
+def assert_tile_repetitions_rejected(repetitions):
+    try:
+        backend.tile(values, repetitions)
+    except TypeError:
+        return
+    raise AssertionError(f"backend.tile accepted invalid repetitions {repetitions!r}")
+
+
+assert_tile_repetitions_rejected(2.5)
+assert_tile_repetitions_rejected([2.5, 1])
+assert_tile_repetitions_rejected(backend.array([2.5, 1.0]))
 """
     subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- validate public PyTorch `backend.tile` repetition counts with Python index semantics instead of `int(...)`
- reject fractional scalar, list, and tensor repetitions instead of silently truncating them
- extend the existing PyTorch tile backend-portable regression test

## Bug fixed
The public PyTorch `tile` facade normalized repetition counts through `int(...)`. Values such as `2.5` therefore became `2`, producing a plausible but wrong tiled tensor instead of failing fast.

## Testing
- Not run locally in this connector session; added focused regression coverage in `tests/backend_support/test_pytorch_tile_contract.py`.