### PR TITLE
Handle Markdown fence variants in doc example runner

### DIFF
--- a/scripts/run_doc_examples.py
+++ b/scripts/run_doc_examples.py
@@ -12,7 +12,12 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
-PYTHON_FENCE_RE = re.compile(r"```(?:python|py)\n(?P<code>.*?)\n```", re.DOTALL)
+PYTHON_FENCE_RE = re.compile(
+    r"^[ \t]{0,3}```[ \t]*(?:python|py)(?:[ \t][^\r\n]*)?\r?\n"
+    r"(?P<code>.*?)"
+    r"\r?\n[ \t]{0,3}```[ \t]*\r?$",
+    re.DOTALL | re.IGNORECASE | re.MULTILINE,
+)
 SKIP_MARKERS = ("# pyrecest: skip", "# doctest: +SKIP")
 
 

--- a/tests/test_doc_example_runner.py
+++ b/tests/test_doc_example_runner.py
@@ -12,3 +12,19 @@ def test_doc_example_runner_skips_marked_blocks(tmp_path: Path):
     blocks = list(iter_python_blocks(doc))
     assert len(blocks) == 1
     assert "run" in blocks[0].code
+
+
+def test_doc_example_runner_accepts_common_markdown_fence_variants(tmp_path: Path):
+    doc = tmp_path / "doc.md"
+    doc.write_text(
+        "```python title=\"demo\"\nprint('with attrs')\n```   \n\n"
+        "   ```PY \r\nprint('indented uppercase crlf')\r\n   ```\r\n",
+        encoding="utf-8",
+    )
+
+    blocks = list(iter_python_blocks(doc))
+
+    assert [block.code for block in blocks] == [
+        "print('with attrs')",
+        "print('indented uppercase crlf')",
+    ]


### PR DESCRIPTION
## Summary
- make the documentation example runner recognize common Markdown fence variants: leading indentation, trailing fence attributes/spaces, uppercase `PY`/`python`, and CRLF line endings
- keep existing skip-marker and ellipsis filtering behavior
- add regression coverage for attribute-bearing and indented CRLF code fences

## Bug fixed
`scripts/run_doc_examples.py` only matched fences of the exact form ` ```python\n...\n``` ` or ` ```py\n...\n``` `. Valid/common Markdown code fences such as ` ```python title="demo" ` or indented uppercase `PY` fences were silently ignored, so examples could escape the documentation-example CI workflow.

## Testing
- Added `tests/test_doc_example_runner.py` regression coverage for the new fence variants.
- I validated the regex behavior against the new examples, but did not run the full repository test suite locally in this environment.