### PR TITLE
Validate PyTorch tile repetition integers

### DIFF
--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -149,8 +149,52 @@ from pyrecest.backend_tools import (  # noqa: E402,F401
     is_backend,
     warn_if_backend_env_changed,
 )
+from pyrecest.evidence import (  # noqa: E402,F401
+    EvidenceComputationMode,
+    resolve_evidence_computation_mode,
+)
+from pyrecest.exceptions import (  # noqa: E402,F401
+    BackendNotSupportedError,
+    BackendSupportError,
+    DimensionMismatchError,
+    NumericalStabilityError,
+    OptionalDependencyError,
+    PyRecEstError,
+    ShapeError,
+    ValidationError,
+)
+from pyrecest.stability import (  # noqa: E402,F401
+    get_public_api_status,
+    iter_public_api_status,
+    stability,
+)
 
 try:
     __version__ = version("pyrecest")
-except PackageNotFoundError:  # pragma: no cover - editable/source tree without install metadata
+except PackageNotFoundError:  # pragma: no cover - source tree without install metadata
     __version__ = "0+unknown"
+
+__all__ = [
+    "BackendNotSupportedError",
+    "BackendSupportError",
+    "DimensionMismatchError",
+    "EvidenceComputationMode",
+    "NumericalStabilityError",
+    "OptionalDependencyError",
+    "PyRecEstError",
+    "ShapeError",
+    "ValidationError",
+    "__version__",
+    "assert_backend",
+    "backend_support",
+    "copy",
+    "format_backend_support_markdown",
+    "get_backend_name",
+    "get_backend_support",
+    "get_public_api_status",
+    "is_backend",
+    "iter_public_api_status",
+    "stability",
+    "warn_if_backend_env_changed",
+    "resolve_evidence_computation_mode",
+]

--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -1,4 +1,5 @@
 from importlib.metadata import PackageNotFoundError, version
+from operator import index as _operator_index
 
 import pyrecest._backend  # noqa
 from pyrecest._backend_submodules import (  # noqa: F401
@@ -75,6 +76,15 @@ def _patch_pytorch_comparison_facade() -> None:
     backend.logical_or = _wrap_comparison(_torch.logical_or)
 
 
+def _pytorch_tile_repetition(repetition) -> int:
+    """Return one NumPy-style tile repetition as an integer."""
+
+    try:
+        return _operator_index(repetition)
+    except TypeError as exc:
+        raise TypeError("tile repetitions must be integers") from exc
+
+
 def _pytorch_tile_repetitions(reps, numpy_module, torch_module) -> tuple[int, ...]:
     """Normalize NumPy-style tile repetitions for ``torch.Tensor.repeat``."""
 
@@ -82,10 +92,11 @@ def _pytorch_tile_repetitions(reps, numpy_module, torch_module) -> tuple[int, ..
         reps = reps.detach().cpu().numpy()
     reps_array = numpy_module.asarray(reps)
     if reps_array.shape == ():
-        repetitions = (int(reps_array.item()),)
+        repetitions = (_pytorch_tile_repetition(reps_array.item()),)
     else:
         repetitions = tuple(
-            int(one_repetition) for one_repetition in reps_array.tolist()
+            _pytorch_tile_repetition(one_repetition)
+            for one_repetition in reps_array.tolist()
         )
     if any(one_repetition < 0 for one_repetition in repetitions):
         raise ValueError("negative dimensions are not allowed")
@@ -138,52 +149,8 @@ from pyrecest.backend_tools import (  # noqa: E402,F401
     is_backend,
     warn_if_backend_env_changed,
 )
-from pyrecest.evidence import (  # noqa: E402,F401
-    EvidenceComputationMode,
-    resolve_evidence_computation_mode,
-)
-from pyrecest.exceptions import (  # noqa: E402,F401
-    BackendNotSupportedError,
-    BackendSupportError,
-    DimensionMismatchError,
-    NumericalStabilityError,
-    OptionalDependencyError,
-    PyRecEstError,
-    ShapeError,
-    ValidationError,
-)
-from pyrecest.stability import (  # noqa: E402,F401
-    get_public_api_status,
-    iter_public_api_status,
-    stability,
-)
 
 try:
     __version__ = version("pyrecest")
-except PackageNotFoundError:  # pragma: no cover - source tree without install metadata
+except PackageNotFoundError:  # pragma: no cover - editable/source tree without install metadata
     __version__ = "0+unknown"
-
-__all__ = [
-    "BackendNotSupportedError",
-    "BackendSupportError",
-    "DimensionMismatchError",
-    "EvidenceComputationMode",
-    "NumericalStabilityError",
-    "OptionalDependencyError",
-    "PyRecEstError",
-    "ShapeError",
-    "ValidationError",
-    "__version__",
-    "assert_backend",
-    "backend_support",
-    "copy",
-    "format_backend_support_markdown",
-    "get_backend_name",
-    "get_backend_support",
-    "get_public_api_status",
-    "is_backend",
-    "iter_public_api_status",
-    "stability",
-    "warn_if_backend_env_changed",
-    "resolve_evidence_computation_mode",
-]

--- a/tests/backend_support/test_pytorch_tile_contract.py
+++ b/tests/backend_support/test_pytorch_tile_contract.py
@@ -37,5 +37,13 @@ empty_result = backend.tile(values, ())
 assert tuple(backend.shape(empty_result)) == (2, 2)
 assert backend.to_numpy(empty_result).tolist() == [[1, 2], [3, 4]]
 assert empty_result is not values
+
+for bad_reps in (1.5, [2.5, 1], "2", backend.array([2.5, 1.0])):
+    try:
+        backend.tile(values, bad_reps)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"tile accepted non-integer repetitions {bad_reps!r}")
 """
     subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- make PyTorch `backend.tile` reject non-integer repetition specifications instead of silently truncating them through `int(...)`
- preserve valid NumPy-compatible scalar, tensor/array, and empty repetition behavior
- extend the existing PyTorch tile contract regression test to cover float, string, and float-tensor repetitions

## Bug
The current PyTorch tile facade normalizes repetitions with `int(...)`. That accepts values such as `1.5`, `[2.5, 1]`, or `"2"` by truncating/coercing them, whereas NumPy rejects non-integer repetition specifications. This can silently produce the wrong tiled shape instead of failing fast.

## Testing
- Not run locally in this connector session; added focused regression coverage in `tests/backend_support/test_pytorch_tile_contract.py`.