### PR TITLE
Forward additive-noise helper call arguments

### DIFF
--- a/src/pyrecest/models/additive_noise.py
+++ b/src/pyrecest/models/additive_noise.py
@@ -283,9 +283,9 @@ class AdditiveNoiseTransitionModel:
             else _distribution_covariance(self.noise_distribution)
         )
 
-    def mean(self, state):
+    def mean(self, state, dt=None, **kwargs):
         """Return ``f(state)`` plus the additive noise mean if available."""
-        propagated = self.transition_function(state)
+        propagated = self.evaluate(state, dt=dt, **kwargs)
         noise_mean = self.noise_mean
         return propagated if noise_mean is None else propagated + noise_mean
 
@@ -303,7 +303,7 @@ class AdditiveNoiseTransitionModel:
         """Return whether this model can provide transition Jacobians."""
         return self._jacobian is not None
 
-    def sample_next(self, state, n: int = 1):
+    def sample_next(self, state, n: int = 1, dt=None, **kwargs):
         """Draw ``n`` samples from ``p(x_next | state)``."""
         if self.noise_distribution is None or not hasattr(
             self.noise_distribution, "sample"
@@ -311,9 +311,9 @@ class AdditiveNoiseTransitionModel:
             raise NotImplementedError(
                 "The transition noise distribution does not provide sample(n)"
             )
-        return self.transition_function(state) + self.noise_distribution.sample(n)
+        return self.evaluate(state, dt=dt, **kwargs) + self.noise_distribution.sample(n)
 
-    def transition_density(self, next_state, state):
+    def transition_density(self, next_state, state, dt=None, **kwargs):
         """Evaluate ``p(next_state | state)`` from the additive noise density."""
         if self.noise_distribution is None or not hasattr(
             self.noise_distribution, "pdf"
@@ -321,7 +321,9 @@ class AdditiveNoiseTransitionModel:
             raise NotImplementedError(
                 "The transition noise distribution does not provide pdf(x)"
             )
-        return self.noise_distribution.pdf(next_state - self.transition_function(state))
+        return self.noise_distribution.pdf(
+            next_state - self.evaluate(state, dt=dt, **kwargs)
+        )
 
 
 class AdditiveNoiseMeasurementModel:
@@ -363,15 +365,15 @@ class AdditiveNoiseMeasurementModel:
         """Evaluate the noise-free measurement ``h(state)``."""
         return self.evaluate(state, **kwargs)
 
-    def predict_measurement(self, state):
+    def predict_measurement(self, state, **kwargs):
         """Return ``h(state)`` plus the additive noise mean if available."""
-        prediction = self.measurement_function(state)
+        prediction = self.measurement_function(state, **kwargs)
         noise_mean = self.noise_mean
         return prediction if noise_mean is None else prediction + noise_mean
 
-    def mean(self, state):
+    def mean(self, state, **kwargs):
         """Alias for :meth:`predict_measurement`."""
-        return self.predict_measurement(state)
+        return self.predict_measurement(state, **kwargs)
 
     @property
     def noise_mean(self):
@@ -402,11 +404,11 @@ class AdditiveNoiseMeasurementModel:
         """Return whether this model can provide measurement Jacobians."""
         return self._jacobian is not None
 
-    def measurement_residual(self, measurement, state):
+    def measurement_residual(self, measurement, state, **kwargs):
         """Return ``measurement - h(state)``."""
-        return measurement - self.measurement_function(state)
+        return measurement - self.measurement_function(state, **kwargs)
 
-    def sample_measurement(self, state, n: int = 1):
+    def sample_measurement(self, state, n: int = 1, **kwargs):
         """Draw ``n`` samples from ``p(measurement | state)``."""
         if self.noise_distribution is None or not hasattr(
             self.noise_distribution, "sample"
@@ -414,9 +416,9 @@ class AdditiveNoiseMeasurementModel:
             raise NotImplementedError(
                 "The measurement noise distribution does not provide sample(n)"
             )
-        return self.measurement_function(state) + self.noise_distribution.sample(n)
+        return self.measurement_function(state, **kwargs) + self.noise_distribution.sample(n)
 
-    def likelihood(self, measurement, state):
+    def likelihood(self, measurement, state, **kwargs):
         """Evaluate ``p(measurement | state)`` from the additive noise density."""
         if self.noise_distribution is None or not hasattr(
             self.noise_distribution, "pdf"
@@ -425,5 +427,5 @@ class AdditiveNoiseMeasurementModel:
                 "The measurement noise distribution does not provide pdf(x)"
             )
         return self.noise_distribution.pdf(
-            self.measurement_residual(measurement, state)
+            self.measurement_residual(measurement, state, **kwargs)
         )

--- a/tests/models/test_additive_noise_helper_kwargs.py
+++ b/tests/models/test_additive_noise_helper_kwargs.py
@@ -1,0 +1,87 @@
+import unittest
+
+from pyrecest.backend import allclose, array
+from pyrecest.models import AdditiveNoiseMeasurementModel, AdditiveNoiseTransitionModel
+
+
+class SimpleDist:
+    def __init__(self, mean, samples, value):
+        self._mean = mean
+        self._samples = samples
+        self.value = value
+        self.last_arg = None
+
+    def mean(self):
+        return self._mean
+
+    def sample(self, n):
+        return self._samples[:n]
+
+    def pdf(self, x):
+        self.last_arg = x
+        return self.value
+
+
+def assert_close(test_case, actual, expected):
+    test_case.assertTrue(bool(allclose(actual, expected)))
+
+
+class AdditiveNoiseHelperKwargsTest(unittest.TestCase):
+    def test_transition_helpers_forward_per_call_arguments(self):
+        dist = SimpleDist(array([0.25]), array([[0.5]]), array(13.0))
+        model = AdditiveNoiseTransitionModel(
+            lambda x, dt, scale: array([x[0] + dt * scale]),
+            noise_distribution=dist,
+            dt=1.0,
+            function_args={"scale": 2.0},
+        )
+        state = array([1.0])
+
+        assert_close(self, model.mean(state, dt=0.5, scale=4.0), array([3.25]))
+        assert_close(
+            self,
+            model.sample_next(state, n=1, dt=0.5, scale=4.0),
+            array([[3.5]]),
+        )
+        assert_close(
+            self,
+            model.transition_density(array([3.75]), state, dt=0.5, scale=4.0),
+            array(13.0),
+        )
+        assert_close(self, dist.last_arg, array([0.75]))
+
+    def test_measurement_helpers_forward_per_call_arguments(self):
+        dist = SimpleDist(array([0.25]), array([[0.5]]), array(17.0))
+        model = AdditiveNoiseMeasurementModel(
+            lambda x, scale, offset: array([scale * x[0] + offset]),
+            noise_distribution=dist,
+            function_args={"scale": 2.0, "offset": 0.0},
+        )
+        state = array([3.0])
+
+        assert_close(
+            self,
+            model.predict_measurement(state, scale=4.0, offset=1.0),
+            array([13.25]),
+        )
+        assert_close(self, model.mean(state, scale=4.0, offset=1.0), array([13.25]))
+        assert_close(
+            self,
+            model.measurement_residual(array([14.5]), state, scale=4.0, offset=1.0),
+            array([1.5]),
+        )
+        assert_close(
+            self,
+            model.sample_measurement(state, n=1, scale=4.0, offset=1.0),
+            array([[13.5]]),
+        )
+        assert_close(
+            self,
+            model.likelihood(array([14.5]), state, scale=4.0, offset=1.0),
+            array(17.0),
+        )
+        assert_close(self, dist.last_arg, array([1.5]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Forward per-call kwargs through additive-noise helper methods and add regression tests.