### PR TITLE
Validate shared NumPy squeeze axis bounds

### DIFF
--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -28,7 +28,66 @@ def _patch_shared_numpy_copy_facade() -> None:
     globals()["copy"] = backend.copy
 
 
+def _patch_shared_numpy_squeeze_facade() -> None:
+    """Make shared NumPy squeeze reject out-of-bounds axes before shape access."""
+
+    import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+
+    if getattr(backend, "__backend_name__", None) not in {"autograd", "numpy"}:
+        return
+
+    import pyrecest._backend._shared_numpy as shared_numpy  # pylint: disable=import-outside-toplevel
+
+    original_squeeze = shared_numpy.squeeze
+    np_module = shared_numpy._np
+
+    def _axis_out_of_bounds_error(axis, ndim):
+        axis_error = getattr(getattr(np_module, "exceptions", None), "AxisError", None)
+        if axis_error is None:
+            axis_error = getattr(np_module, "AxisError", None)
+        if axis_error is None:
+            return ValueError(f"axis {axis} is out of bounds for array of dimension {ndim}")
+        try:
+            return axis_error(axis, ndim=ndim)
+        except TypeError:  # pragma: no cover - compatibility with older NumPy APIs
+            return axis_error(axis, ndim)
+
+    def squeeze(x, axis=None):
+        x_arr = np_module.asarray(x)
+        if axis is None:
+            return original_squeeze(x_arr, axis=None)
+
+        axes = shared_numpy._normalize_squeeze_axes(axis)
+        if not axes:
+            return x_arr
+
+        normalized_axes = []
+        for one_axis in axes:
+            if isinstance(one_axis, (int, np_module.integer)):
+                one_axis = int(one_axis)
+                normalized_axis = one_axis + x_arr.ndim if one_axis < 0 else one_axis
+                if normalized_axis < 0 or normalized_axis >= x_arr.ndim:
+                    raise _axis_out_of_bounds_error(one_axis, x_arr.ndim)
+                normalized_axes.append(normalized_axis)
+            else:
+                normalized_axes.append(one_axis)
+        normalized_axes = tuple(normalized_axes)
+
+        if len(set(normalized_axes)) != len(normalized_axes):
+            raise ValueError("duplicate value in 'axis'")
+        if any(x_arr.shape[one_axis] != 1 for one_axis in normalized_axes):
+            return x_arr
+        squeeze_axis = normalized_axes[0] if len(normalized_axes) == 1 else normalized_axes
+        return np_module.squeeze(x_arr, axis=squeeze_axis)
+
+    squeeze.__name__ = getattr(original_squeeze, "__name__", "squeeze")
+    squeeze.__doc__ = getattr(original_squeeze, "__doc__", None)
+    shared_numpy.squeeze = squeeze
+    backend.squeeze = squeeze
+
+
 _patch_shared_numpy_copy_facade()
+_patch_shared_numpy_squeeze_facade()
 
 
 def _patch_pytorch_comparison_facade() -> None:

--- a/tests/test_shared_numpy_squeeze.py
+++ b/tests/test_shared_numpy_squeeze.py
@@ -18,3 +18,14 @@ def test_shared_numpy_squeeze_accepts_tuple_axis():
 
     assert result.shape == (2,)
     assert _to_python(result) == [1, 2]
+
+
+@pytest.mark.parametrize("axis", [3, -4])
+def test_shared_numpy_squeeze_rejects_out_of_bounds_axis(axis):
+    if backend.__backend_name__ not in ("numpy", "autograd"):
+        pytest.skip("shared NumPy/autograd squeeze regression test")
+
+    with pytest.raises(Exception) as exc_info:
+        backend.squeeze(array([[[1], [2]]]), axis=axis)
+
+    assert "out of bounds" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- patch the NumPy/autograd backend squeeze facade so out-of-bounds axes are rejected before indexing `x.shape`
- keep existing tuple-axis behavior and non-singleton-axis no-op behavior
- add regression coverage for positive and negative out-of-bounds axes

## Tests
- Local minimal reproduction: verified the old implementation returns shape `(1, 2)` for `axis=-4` on a 3-D array and the patched logic raises an out-of-bounds axis error
- Full pytest not run locally because the execution environment cannot clone/install the GitHub repo dependencies; CI should run on the PR