### PR TITLE
Fix PyTorch backend diagonal fallback

### DIFF
--- a/src/pyrecest/_backend/_common.py
+++ b/src/pyrecest/_backend/_common.py
@@ -98,6 +98,19 @@ def ndim(x):
     return _np.ndim(x)
 
 
+def diagonal(a, offset=0, axis1=0, axis2=1):
+    """Return selected diagonals for NumPy arrays and PyTorch tensors."""
+    torch = _torch_module_for_values(a)
+    if torch is not None:
+        return torch.diagonal(
+            torch.as_tensor(a),
+            offset=offset,
+            dim1=axis1,
+            dim2=axis2,
+        )
+    return _np.diagonal(a, offset=offset, axis1=axis1, axis2=axis2)
+
+
 def _torch_module_for_values(*values):
     try:
         import torch as _torch

--- a/tests/backend/test_pytorch_backend_diagonal.py
+++ b/tests/backend/test_pytorch_backend_diagonal.py
@@ -1,0 +1,26 @@
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+def test_pytorch_backend_imports_and_exposes_diagonal_trace():
+    pytest.importorskip("torch")
+
+    code = """
+import pyrecest.backend as backend
+
+values = backend.asarray([
+    [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+    [[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]],
+])
+diag = backend.diagonal(values, offset=1, axis1=1, axis2=2)
+trace = backend.trace(values, offset=1, axis1=1, axis2=2)
+
+assert backend.__backend_name__ == "pytorch"
+assert backend.to_numpy(diag).tolist() == [[2.0, 6.0], [8.0, 12.0]]
+assert backend.to_numpy(trace).tolist() == [8.0, 20.0]
+"""
+
+    result = run_backend_code("pytorch", code)
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Summary:
- Add a common diagonal helper for the PyTorch public backend fallback.
- Add a subprocess regression test for PyTorch backend diagonal and trace behavior.

Testing: not run in this environment.