### PR TITLE
Fix wrapped normal moment scalar inputs

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
@@ -266,7 +266,9 @@ class WrappedNormalDistribution(
 
     @staticmethod
     def from_moment(m) -> "WrappedNormalDistribution":
-        moment = m.squeeze()
+        moment = squeeze(array(m))
+        if ndim(moment) != 0:
+            raise ValueError("First trigonometric moment must be a scalar.")
         moment_abs = float(abs(moment))
         if not isfinite(moment_abs):
             raise ValueError("First trigonometric moment must be finite.")

--- a/tests/distributions/test_wrapped_normal_from_moment_input.py
+++ b/tests/distributions/test_wrapped_normal_from_moment_input.py
@@ -1,0 +1,30 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from pyrecest.backend import to_numpy
+from pyrecest.distributions.circle.wrapped_normal_distribution import (
+    WrappedNormalDistribution,
+)
+
+
+def _as_float(value):
+    return float(np.asarray(to_numpy(value)))
+
+
+@pytest.mark.parametrize("moment", [0.5 + 0.5j, [0.5 + 0.5j]])
+def test_from_moment_accepts_scalar_and_singleton_array_like_inputs(moment):
+    dist = WrappedNormalDistribution.from_moment(moment)
+    expected_moment = 0.5 + 0.5j
+
+    npt.assert_allclose(_as_float(dist.scalar_mu), np.pi / 4.0, atol=1e-7)
+    npt.assert_allclose(
+        _as_float(dist.sigma),
+        np.sqrt(-2.0 * np.log(abs(expected_moment))),
+        atol=1e-7,
+    )
+
+
+def test_from_moment_rejects_vector_moments_with_clear_error():
+    with pytest.raises(ValueError, match="First trigonometric moment must be a scalar"):
+        WrappedNormalDistribution.from_moment([0.25 + 0.0j, 0.5 + 0.0j])


### PR DESCRIPTION
## Summary
- Accept Python scalar and singleton array-like moments in `WrappedNormalDistribution.from_moment` by normalizing through the backend array/squeeze path.
- Add explicit scalar validation for vector-valued moments so invalid inputs fail with a clear `ValueError`.
- Add regression tests for Python complex moments, singleton array-like moments, and vector rejection.

## Bug fixed
`WrappedNormalDistribution.from_moment(0.5 + 0.5j)` previously failed with `AttributeError` because the implementation called `m.squeeze()` directly before backend normalization. Other distribution constructors and moment helpers accept scalar/array-like inputs, so this method should not require callers to pre-wrap scalar moments as backend arrays.

## Testing
- Not run in this environment; sandbox cloning from GitHub failed due DNS, so this was patched through the GitHub connector and validated by focused inspection.