### PR TITLE
Reject non-finite covariance validation inputs

### DIFF
--- a/src/pyrecest/models/validation.py
+++ b/src/pyrecest/models/validation.py
@@ -98,6 +98,16 @@ def _to_python_bool(value: Any) -> bool:
     return bool(value)
 
 
+def _validate_finite_entries(value: Any, name: str) -> None:
+    """Raise if a backend array contains NaN or infinite entries."""
+    try:
+        finite = backend.all(backend.isfinite(value))
+    except Exception as exc:  # pragma: no cover - backend-specific exception type
+        raise ValueError(f"{name} must contain only finite values.") from exc
+    if not _to_python_bool(finite):
+        raise ValueError(f"{name} must contain only finite values.")
+
+
 def validate_vector(
     vector: Any,
     *,
@@ -242,6 +252,7 @@ def validate_covariance_matrix(
         )
 
     _validate_expected_dim(rows, dim, name, "dim")
+    _validate_finite_entries(covariance, name)
 
     if check_symmetric and not _to_python_bool(
         backend.allclose(

--- a/tests/models/test_validation.py
+++ b/tests/models/test_validation.py
@@ -66,6 +66,14 @@ class TestModelValidation(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "expected 3"):
             validate_covariance_matrix(eye(2), dim=3)
 
+    def test_validate_covariance_matrix_rejects_nonfinite_values(self):
+        for value in (float("nan"), float("inf"), -float("inf")):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(ValueError, "finite"):
+                    validate_covariance_matrix(array([[value]]))
+                with self.assertRaisesRegex(ValueError, "finite"):
+                    validate_noise_covariance(array([[value]]))
+
     def test_validate_covariance_matrix_can_check_symmetry(self):
         with self.assertRaisesRegex(ValueError, "symmetric"):
             validate_covariance_matrix(


### PR DESCRIPTION
## Summary
- reject NaN and infinite entries in reusable covariance/noise-covariance validation
- keep the existing shape, dimension, and optional Hermitian symmetry checks unchanged
- add regression coverage for NaN and +/-Inf covariance inputs

## Bug fixed
`validate_covariance_matrix` and `validate_noise_covariance` accepted square arrays containing `NaN` or infinite values. Those values can then pass model-shape validation and fail later inside filtering/update algebra. The validator now fails fast with a deterministic `ValueError` before optional symmetry checks.

## Validation
- Added `test_validate_covariance_matrix_rejects_nonfinite_values` in `tests/models/test_validation.py`.
- Inspected the branch diff against `main`: 2 files changed, +19/-0.
- Full test suite was not run locally in this connector-only environment.