### PR TITLE
Fix JAX zero-sized choice for nonpositive populations

### DIFF
--- a/src/pyrecest/_backend/jax/random.py
+++ b/src/pyrecest/_backend/jax/random.py
@@ -445,11 +445,9 @@ def _choice(state, a, size=None, replace=True, p=None, shuffle=True, *args, **kw
     shuffle = _choice_bool(shuffle, "shuffle")
     population_size = _choice_population_size(a, kwargs)
     axis = kwargs.get("axis", 0)
-    if population_size == 0:
+    if population_size <= 0:
         if _shape_has_no_samples(shape):
             return state, _empty_choice_result(a, shape, axis)
-        raise ValueError("a must be a positive integer or a non-empty array")
-    if population_size < 0:
         raise ValueError("a must be a positive integer or a non-empty array")
     if p is not None:
         p = _validate_choice_probabilities(p, population_size)

--- a/tests/backend/test_jax_random_choice_empty_population.py
+++ b/tests/backend/test_jax_random_choice_empty_population.py
@@ -1,0 +1,14 @@
+import pytest
+
+jax = pytest.importorskip("jax")
+from pyrecest._backend.jax import random  # noqa: E402
+
+
+def test_zero_sized_choice_accepts_nonpositive_integer_population():
+    random.seed(0)
+
+    zero_sample = random.choice(0, size=(0,))
+    negative_sample = random.choice(-1, size=(0,))
+
+    assert zero_sample.shape == (0,)
+    assert negative_sample.shape == (0,)


### PR DESCRIPTION
## Summary
- allow the JAX random choice wrapper to return an empty result for zero-sized samples from nonpositive integer populations, matching NumPy/JAX behavior
- add regression coverage for zero and negative integer populations with `size=(0,)`

## Testing
- Not run locally (sandbox cannot clone the repository; outbound DNS to github.com is unavailable).