### PR TITLE
Handle negative-stride NumPy views in torch fallbacks

### DIFF
--- a/src/pyrecest/_backend/_common.py
+++ b/src/pyrecest/_backend/_common.py
@@ -76,7 +76,7 @@ def min(a, axis=None):  # pylint: disable=redefined-builtin
     if torch is None:
         return _np.min(a, axis=axis)
 
-    tensor = torch.as_tensor(a)
+    tensor = _torch_as_tensor_compatible(a, torch)
     if axis is None:
         return torch.min(tensor)
 
@@ -111,6 +111,13 @@ def _torch_module_for_values(*values):
     return None
 
 
+def _torch_as_tensor_compatible(value, torch, *, device=None):
+    """Convert values to torch tensors, copying unsupported NumPy views first."""
+    if isinstance(value, _np.ndarray) and any(stride < 0 for stride in value.strides):
+        value = value.copy()
+    return torch.as_tensor(value, device=device)
+
+
 def _torch_promoted_pair(first, second):
     torch = _torch_module_for_values(first, second)
     if torch is None:
@@ -120,8 +127,8 @@ def _torch_promoted_pair(first, second):
         (value.device for value in (first, second) if torch.is_tensor(value)),
         None,
     )
-    first_tensor = torch.as_tensor(first, device=device)
-    second_tensor = torch.as_tensor(second, device=device)
+    first_tensor = _torch_as_tensor_compatible(first, torch, device=device)
+    second_tensor = _torch_as_tensor_compatible(second, torch, device=device)
     dtype = torch.promote_types(first_tensor.dtype, second_tensor.dtype)
     return first_tensor.to(dtype=dtype), second_tensor.to(dtype=dtype)
 

--- a/tests/backend/test_common_torch_negative_strides.py
+++ b/tests/backend/test_common_torch_negative_strides.py
@@ -1,0 +1,35 @@
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+def test_common_torch_fallbacks_accept_negative_stride_numpy_inputs():
+    pytest.importorskip("torch")
+
+    code = """
+import numpy as np
+import torch
+
+import pyrecest.backend as backend
+
+values = np.arange(3.0)[::-1]
+weights = torch.tensor([1.0, 2.0, 3.0], dtype=torch.float64)
+
+outer_result = backend.outer(values, weights)
+dot_result = backend.dot(values, weights)
+matvec_result = backend.matvec(np.eye(3, dtype=float)[::-1], weights)
+
+assert backend.__backend_name__ == "pytorch"
+assert torch.is_tensor(outer_result)
+assert backend.to_numpy(outer_result).tolist() == [
+    [2.0, 4.0, 6.0],
+    [1.0, 2.0, 3.0],
+    [0.0, 0.0, 0.0],
+]
+assert float(dot_result) == 4.0
+assert backend.to_numpy(matvec_result).tolist() == [3.0, 2.0, 1.0]
+"""
+
+    result = run_backend_code("pytorch", code)
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- copy negative-stride NumPy views before converting them through common PyTorch fallback helpers
- route common `min`, `dot`, `outer`, and `matvec` tensor coercion through the compatible conversion helper
- add a PyTorch subprocess regression test for negative-stride NumPy inputs in common fallback operations

## Testing
- Not run locally; verified the underlying `torch.as_tensor(np.arange(...)[::-1])` failure mode in the execution environment.