### PR TITLE
Handle negative-stride arrays in PyTorch diagonal fallback

### DIFF
--- a/src/pyrecest/_backend/_common.py
+++ b/src/pyrecest/_backend/_common.py
@@ -103,7 +103,7 @@ def diagonal(a, offset=0, axis1=0, axis2=1):
     torch = _torch_module_for_values(a)
     if torch is not None:
         return torch.diagonal(
-            torch.as_tensor(a),
+            _torch_as_tensor_compatible(a, torch),
             offset=offset,
             dim1=axis1,
             dim2=axis2,

--- a/tests/backend_support/test_pytorch_numpy_view_conversion.py
+++ b/tests/backend_support/test_pytorch_numpy_view_conversion.py
@@ -27,6 +27,12 @@ assert backend.to_numpy(vector_tensor).tolist() == [4.0, 3.0, 2.0, 1.0, 0.0]
 matrix_view = np.arange(6.0).reshape(2, 3)[:, ::-1]
 matrix_tensor = backend.array(matrix_view)
 assert backend.to_numpy(matrix_tensor).tolist() == [[2.0, 1.0, 0.0], [5.0, 4.0, 3.0]]
+
+matrix_diagonal = backend.diagonal(matrix_view)
+assert backend.to_numpy(matrix_diagonal).tolist() == [2.0, 4.0]
+
+matrix_trace = backend.trace(matrix_view)
+assert backend.to_numpy(matrix_trace).item() == 6.0
 """,
     )
 


### PR DESCRIPTION
## Summary
- route the common PyTorch `diagonal` fallback through the existing negative-stride-safe tensor conversion helper
- extend the PyTorch negative-stride regression test to cover `backend.diagonal` and `backend.trace` on NumPy views

## Bug
`backend.diagonal(np_array[:, ::-1])` used `torch.as_tensor` directly when `PYRECEST_BACKEND=pytorch`. PyTorch rejects NumPy arrays with negative strides, so this still failed even after the common conversion helpers were fixed.

## Testing
- Not run against the full repository in this environment.
- Verified the underlying PyTorch failure mode manually: `torch.as_tensor(np.arange(...)[::-1])` raises the negative-stride `ValueError`, while copying the view before conversion produces the expected diagonal.