### PR TITLE
Handle negative-stride NumPy views in torch diagonal

### DIFF
--- a/src/pyrecest/_backend/_common.py
+++ b/src/pyrecest/_backend/_common.py
@@ -103,7 +103,7 @@ def diagonal(a, offset=0, axis1=0, axis2=1):
     torch = _torch_module_for_values(a)
     if torch is not None:
         return torch.diagonal(
-            torch.as_tensor(a),
+            _torch_as_tensor_compatible(a, torch),
             offset=offset,
             dim1=axis1,
             dim2=axis2,

--- a/tests/backend/test_common_torch_negative_strides.py
+++ b/tests/backend/test_common_torch_negative_strides.py
@@ -13,14 +13,17 @@ import torch
 import pyrecest.backend as backend
 
 values = np.arange(3.0)[::-1]
+matrix = np.arange(9.0).reshape(3, 3)[::-1]
 weights = torch.tensor([1.0, 2.0, 3.0], dtype=torch.float64)
 
 outer_result = backend.outer(values, weights)
 dot_result = backend.dot(values, weights)
 matvec_result = backend.matvec(np.eye(3, dtype=float)[::-1], weights)
+diagonal_result = backend.diagonal(matrix)
 
 assert backend.__backend_name__ == "pytorch"
 assert torch.is_tensor(outer_result)
+assert torch.is_tensor(diagonal_result)
 assert backend.to_numpy(outer_result).tolist() == [
     [2.0, 4.0, 6.0],
     [1.0, 2.0, 3.0],
@@ -28,6 +31,7 @@ assert backend.to_numpy(outer_result).tolist() == [
 ]
 assert float(dot_result) == 4.0
 assert backend.to_numpy(matvec_result).tolist() == [3.0, 2.0, 1.0]
+assert backend.to_numpy(diagonal_result).tolist() == [6.0, 4.0, 2.0]
 """
 
     result = run_backend_code("pytorch", code)


### PR DESCRIPTION
## Summary
- route the common PyTorch `diagonal` fallback through the existing compatible tensor conversion helper
- extend the negative-stride PyTorch fallback regression test to cover `backend.diagonal`

## Bug fixed
The previous negative-stride compatibility fix covered `outer`, `dot`, `matvec`, and `min`, but `backend.diagonal` still called `torch.as_tensor(a)` directly in the common fallback. Under `PYRECEST_BACKEND=pytorch`, passing a NumPy view with negative strides, e.g. `np.arange(9.0).reshape(3, 3)[::-1]`, still raises PyTorch's negative-stride conversion error before the diagonal can be computed.

## Testing
- Added focused regression coverage in `tests/backend/test_common_torch_negative_strides.py`.
- Verified the underlying failure mode in the execution sandbox with `torch.as_tensor(np.arange(9.0).reshape(3, 3)[::-1])`.
- Full test suite not run locally because this sandbox cannot clone from GitHub / resolve `github.com`.