### PR TITLE
Preserve optional submodule import errors

### DIFF
--- a/src/pyrecest/optional_dependencies/__init__.py
+++ b/src/pyrecest/optional_dependencies/__init__.py
@@ -19,11 +19,7 @@ def _is_missing_requested_package(exc: ModuleNotFoundError, package: str) -> boo
     missing_name = exc.name
     if missing_name is None:
         return False
-    return (
-        missing_name == package
-        or package.startswith(f"{missing_name}.")
-        or missing_name.startswith(f"{package}.")
-    )
+    return missing_name == package or package.startswith(f"{missing_name}.")
 
 
 def require_optional_dependency(

--- a/tests/test_optional_dependencies_submodule.py
+++ b/tests/test_optional_dependencies_submodule.py
@@ -1,0 +1,14 @@
+from unittest import mock
+
+import pytest
+from pyrecest.optional_dependencies import require_optional_dependency
+
+
+def test_optional_dependency_preserves_requested_package_child_import_error():
+    import_error = ModuleNotFoundError(name="demo_package.child")
+
+    with mock.patch("importlib.import_module", side_effect=import_error):
+        with pytest.raises(ModuleNotFoundError) as exc_info:
+            require_optional_dependency("demo_package", "plot")
+
+    assert exc_info.value is import_error


### PR DESCRIPTION
## Summary
- Do not classify `ModuleNotFoundError` for a child module of an otherwise requested optional package as a missing optional dependency.
- Preserve the original nested import error so broken optional packages are not masked as install-extra guidance.
- Add a focused regression test for this case.

## Testing
- `python -m py_compile /mnt/data/optional_dependencies_init.py /mnt/data/test_optional_dependencies_submodule.py` locally for the edited file/test contents.

Note: `main` advanced while this branch was being prepared; the change is small and should rebase cleanly if GitHub asks for a branch update.