### PR TITLE
Fix PyTorch flip axis facade

### DIFF
--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -198,6 +198,43 @@ def _patch_pytorch_tile_facade() -> None:
     backend.tile = tile
 
 
+def _pytorch_flip_axes(axis, ndim) -> tuple[int, ...]:
+    """Normalize NumPy-style ``flip`` axes for ``torch.flip``."""
+
+    if axis is None:
+        return tuple(range(ndim))
+    try:
+        return (_operator_index(axis),)
+    except TypeError:
+        return tuple(_operator_index(one_axis) for one_axis in axis)
+
+
+def _patch_pytorch_flip_facade() -> None:
+    """Make public PyTorch ``flip`` follow NumPy axis semantics."""
+
+    import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        return
+
+    try:
+        import torch as _torch  # pylint: disable=import-outside-toplevel
+    except (
+        ModuleNotFoundError
+    ):  # pragma: no cover - backend import fails first in practice
+        return
+
+    original_flip = backend.flip
+
+    def flip(x, axis=None):
+        x = backend.array(x)
+        return _torch.flip(x, dims=_pytorch_flip_axes(axis, x.ndim))
+
+    flip.__name__ = getattr(original_flip, "__name__", "flip")
+    flip.__doc__ = getattr(original_flip, "__doc__", None)
+    backend.flip = flip
+
+
 def _patch_jax_std_out_facade() -> None:
     """Make public JAX ``std`` accept NumPy's ``out`` argument."""
 
@@ -231,6 +268,7 @@ def _patch_jax_std_out_facade() -> None:
 
 _patch_pytorch_comparison_facade()
 _patch_pytorch_tile_facade()
+_patch_pytorch_flip_facade()
 _patch_jax_std_out_facade()
 
 from pyrecest.backend_support import (  # noqa: E402,F401

--- a/tests/backend/test_pytorch_flip_facade.py
+++ b/tests/backend/test_pytorch_flip_facade.py
@@ -1,24 +1,25 @@
+import pytest
+
 from tests.support.backend_runner import run_backend_code
 
 
 def test_pytorch_flip_matches_numpy_default_and_scalar_axis_contracts():
-    code = """
-import numpy as np
-import pyrecest.backend as backend
+    pytest.importorskip("torch")
 
-values = backend.reshape(backend.arange(6), (2, 3))
-
-def as_list(value):
-    converted = backend.to_numpy(value)
-    if hasattr(converted, "tolist"):
-        return converted.tolist()
-    return converted
-
-assert as_list(backend.flip(values)) == [[5, 4, 3], [2, 1, 0]]
-assert as_list(backend.flip(values, axis=None)) == [[5, 4, 3], [2, 1, 0]]
-assert as_list(backend.flip(values, axis=np.int64(0))) == [[3, 4, 5], [0, 1, 2]]
-assert as_list(backend.flip(values, axis=(0, 1))) == [[5, 4, 3], [2, 1, 0]]
-assert as_list(backend.flip(values, axis=())) == [[0, 1, 2], [3, 4, 5]]
-"""
+    code = (
+        "import numpy as np\n"
+        "import pyrecest.backend as backend\n"
+        "values = backend.reshape(backend.arange(6), (2, 3))\n"
+        "def as_list(value):\n"
+        "    converted = backend.to_numpy(value)\n"
+        "    if hasattr(converted, 'tolist'):\n"
+        "        return converted.tolist()\n"
+        "    return converted\n"
+        "assert as_list(backend.flip(values)) == [[5, 4, 3], [2, 1, 0]]\n"
+        "assert as_list(backend.flip(values, axis=None)) == [[5, 4, 3], [2, 1, 0]]\n"
+        "assert as_list(backend.flip(values, axis=np.int64(0))) == [[3, 4, 5], [0, 1, 2]]\n"
+        "assert as_list(backend.flip(values, axis=(0, 1))) == [[5, 4, 3], [2, 1, 0]]\n"
+        "assert as_list(backend.flip(values, axis=())) == [[0, 1, 2], [3, 4, 5]]\n"
+    )
     result = run_backend_code("pytorch", code)
     assert result.returncode == 0, result.stderr

--- a/tests/backend/test_pytorch_flip_facade.py
+++ b/tests/backend/test_pytorch_flip_facade.py
@@ -1,0 +1,24 @@
+from tests.support.backend_runner import run_backend_code
+
+
+def test_pytorch_flip_matches_numpy_default_and_scalar_axis_contracts():
+    code = """
+import numpy as np
+import pyrecest.backend as backend
+
+values = backend.reshape(backend.arange(6), (2, 3))
+
+def as_list(value):
+    converted = backend.to_numpy(value)
+    if hasattr(converted, "tolist"):
+        return converted.tolist()
+    return converted
+
+assert as_list(backend.flip(values)) == [[5, 4, 3], [2, 1, 0]]
+assert as_list(backend.flip(values, axis=None)) == [[5, 4, 3], [2, 1, 0]]
+assert as_list(backend.flip(values, axis=np.int64(0))) == [[3, 4, 5], [0, 1, 2]]
+assert as_list(backend.flip(values, axis=(0, 1))) == [[5, 4, 3], [2, 1, 0]]
+assert as_list(backend.flip(values, axis=())) == [[0, 1, 2], [3, 4, 5]]
+"""
+    result = run_backend_code("pytorch", code)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- patch the public PyTorch backend `flip` facade to accept NumPy's default `axis=None`
- normalize scalar axis objects such as `np.int64(0)` before passing them to `torch.flip`
- add a subprocess regression test for PyTorch backend import-time behavior

## Bug fixed
The PyTorch backend implementation required `axis` and forwarded scalar NumPy integer axes directly to `torch.flip`. That diverged from NumPy/JAX `flip` semantics and made calls like `backend.flip(values)` or `backend.flip(values, axis=np.int64(0))` fail under the PyTorch public facade.

## Testing
- Added `tests/backend/test_pytorch_flip_facade.py`
- Local syntax check of the modified/new files only; full repository tests were not run in this environment.