### PR TITLE
Fix PyTorch flip default axis

### DIFF
--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -198,6 +198,55 @@ def _patch_pytorch_tile_facade() -> None:
     backend.tile = tile
 
 
+def _pytorch_flip_axes(axis, ndim) -> tuple[int, ...]:
+    """Normalize NumPy-style flip axes for ``torch.flip``."""
+
+    if axis is None:
+        return tuple(range(ndim))
+    try:
+        axes = (_operator_index(axis),)
+    except TypeError:
+        axes = tuple(_operator_index(one_axis) for one_axis in axis)
+
+    normalized_axes = tuple(one_axis + ndim if one_axis < 0 else one_axis for one_axis in axes)
+    if len(set(normalized_axes)) != len(normalized_axes):
+        raise ValueError("duplicate value in 'axis'")
+    for original_axis, normalized_axis in zip(axes, normalized_axes):
+        if normalized_axis < 0 or normalized_axis >= ndim:
+            raise IndexError(
+                f"axis {original_axis} is out of bounds for array of dimension {ndim}"
+            )
+    return normalized_axes
+
+
+def _patch_pytorch_flip_facade() -> None:
+    """Make public PyTorch ``flip`` follow NumPy's default-axis contract."""
+
+    import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        return
+
+    try:
+        import numpy as _np  # pylint: disable=import-outside-toplevel
+        import torch as _torch  # pylint: disable=import-outside-toplevel
+    except (
+        ModuleNotFoundError
+    ):  # pragma: no cover - backend import fails first in practice
+        return
+
+    def flip(x, axis=None):
+        x = backend.array(x)
+        axes = _pytorch_flip_axes(axis, x.ndim)
+        if not axes:
+            return x.clone()
+        return _torch.flip(x, dims=axes)
+
+    flip.__name__ = "flip"
+    flip.__doc__ = getattr(_np.flip, "__doc__", None)
+    backend.flip = flip
+
+
 def _patch_jax_std_out_facade() -> None:
     """Make public JAX ``std`` accept NumPy's ``out`` argument."""
 
@@ -231,6 +280,7 @@ def _patch_jax_std_out_facade() -> None:
 
 _patch_pytorch_comparison_facade()
 _patch_pytorch_tile_facade()
+_patch_pytorch_flip_facade()
 _patch_jax_std_out_facade()
 
 from pyrecest.backend_support import (  # noqa: E402,F401

--- a/tests/test_pytorch_flip_facade.py
+++ b/tests/test_pytorch_flip_facade.py
@@ -1,0 +1,19 @@
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+def test_pytorch_flip_defaults_to_all_axes():
+    pytest.importorskip("torch")
+
+    code = """
+import pyrecest.backend as backend
+
+values = backend.asarray([[1, 2], [3, 4]])
+flipped = backend.flip(values)
+assert backend.to_numpy(flipped).tolist() == [[4, 3], [2, 1]]
+"""
+
+    result = run_backend_code("pytorch", code)
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- patch the PyTorch backend facade so `backend.flip(x)` follows NumPy/JAX semantics and flips all axes when `axis` is omitted
- normalize scalar, tuple, negative, duplicate, and empty axis inputs before calling `torch.flip`
- add a PyTorch subprocess regression test for the default-axis case

## Validation
- `python -m py_compile` on the modified package init and new test file locally
- local semantic check of the axis normalizer against `torch.flip`

This fixes a backend contract mismatch where the PyTorch backend required `axis`, unlike NumPy/JAX `flip`.