### PR TITLE
Validate ROI unmatched sentinel

### DIFF
--- a/src/pyrecest/utils/__init__.py
+++ b/src/pyrecest/utils/__init__.py
@@ -1,7 +1,10 @@
 """Utility helpers for :mod:`pyrecest`."""
 
+import math as _math
+
 from . import assignment as _assignment_module
 from . import multisession_assignment as _multisession_assignment_module
+from . import roi_assignment as _roi_assignment_module
 from ._multisession_assignment_labels import tracks_to_session_labels
 
 
@@ -30,6 +33,65 @@ if not hasattr(_assignment_module, "_solve_subproblem_without_full_assignment"):
         _assignment_module._solve_subproblem
     )
     _assignment_module._solve_subproblem = _solve_subproblem_with_full_assignment
+
+
+def _normalize_roi_unmatched_value(unmatched_value):
+    value_array = _roi_assignment_module.asarray(unmatched_value)
+    if value_array.shape != ():
+        raise ValueError("unmatched_value must be an integer.")
+
+    scalar = value_array.item() if hasattr(value_array, "item") else value_array
+    if isinstance(scalar, bool):
+        raise ValueError("unmatched_value must be an integer.")
+    if isinstance(scalar, int):
+        return int(scalar)
+
+    try:
+        scalar_float = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("unmatched_value must be an integer.") from exc
+    if not _math.isfinite(scalar_float) or not scalar_float.is_integer():
+        raise ValueError("unmatched_value must be an integer.")
+    return int(scalar_float)
+
+
+def _assign_by_similarity_matrix_with_unmatched_value_validation(
+    similarity_matrix,
+    min_similarity=0.0,
+    num_dummy=None,
+    unmatched_value=-1,
+    *,
+    return_result=False,
+):
+    normalized_unmatched_value = _normalize_roi_unmatched_value(unmatched_value)
+    similarities = _roi_assignment_module.asarray(
+        similarity_matrix,
+        dtype=_roi_assignment_module.float64,
+    )
+    if similarities.ndim == 2 and 0 <= normalized_unmatched_value < similarities.shape[1]:
+        raise ValueError(
+            "unmatched_value must be outside the valid column index range."
+        )
+
+    return _roi_assignment_module._assign_by_similarity_matrix_without_unmatched_value_validation(
+        similarity_matrix,
+        min_similarity=min_similarity,
+        num_dummy=num_dummy,
+        unmatched_value=normalized_unmatched_value,
+        return_result=return_result,
+    )
+
+
+if not hasattr(
+    _roi_assignment_module,
+    "_assign_by_similarity_matrix_without_unmatched_value_validation",
+):
+    _roi_assignment_module._assign_by_similarity_matrix_without_unmatched_value_validation = (
+        _roi_assignment_module.assign_by_similarity_matrix
+    )
+    _roi_assignment_module.assign_by_similarity_matrix = (
+        _assign_by_similarity_matrix_with_unmatched_value_validation
+    )
 
 
 min_cost_max_cardinality_assignment = (

--- a/tests/test_roi_assignment_unmatched_value.py
+++ b/tests/test_roi_assignment_unmatched_value.py
@@ -1,0 +1,41 @@
+import unittest
+
+from pyrecest import backend
+from pyrecest.backend import array
+from pyrecest.utils.roi_assignment import assign_by_similarity_matrix
+
+
+class TestRoiAssignmentUnmatchedValue(unittest.TestCase):
+    @unittest.skipIf(
+        backend.__backend_name__ == "jax",
+        reason="Not supported on the jax backend",
+    )
+    def test_rejects_unmatched_value_colliding_with_columns(self):
+        similarity_matrix = array([[1.0, 0.5]])
+
+        for unmatched_value in (0, 1):
+            with self.subTest(unmatched_value=unmatched_value):
+                with self.assertRaisesRegex(ValueError, "unmatched_value"):
+                    assign_by_similarity_matrix(
+                        similarity_matrix,
+                        unmatched_value=unmatched_value,
+                    )
+
+    @unittest.skipIf(
+        backend.__backend_name__ == "jax",
+        reason="Not supported on the jax backend",
+    )
+    def test_rejects_noninteger_unmatched_value(self):
+        similarity_matrix = array([[1.0]])
+
+        for unmatched_value in (True, 1.5, float("nan"), [1]):
+            with self.subTest(unmatched_value=unmatched_value):
+                with self.assertRaisesRegex(ValueError, "unmatched_value"):
+                    assign_by_similarity_matrix(
+                        similarity_matrix,
+                        unmatched_value=unmatched_value,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Guard `assign_by_similarity_matrix(..., unmatched_value=...)` against non-integer sentinels.
- Reject unmatched sentinels that overlap valid column indices, preventing a real match to column `0`/`1` from being reported as unmatched in result bookkeeping.
- Add regression tests for sentinel collisions and invalid sentinel controls.

## Testing
- `python -m py_compile` on local copies of `src/pyrecest/utils/__init__.py` and `tests/test_roi_assignment_unmatched_value.py`