### PR TITLE
Patch raw PyTorch tile facade

### DIFF
--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -167,7 +167,7 @@ def _pytorch_tile_repetitions(reps, numpy_module, torch_module) -> tuple[int, ..
 
 
 def _patch_pytorch_tile_facade() -> None:
-    """Make public PyTorch ``tile`` follow NumPy repetition semantics."""
+    """Make public and raw PyTorch ``tile`` follow NumPy repetition semantics."""
 
     import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
 
@@ -177,6 +177,7 @@ def _patch_pytorch_tile_facade() -> None:
     try:
         import numpy as _np  # pylint: disable=import-outside-toplevel
         import torch as _torch  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as _pytorch_backend  # pylint: disable=import-outside-toplevel
     except (
         ModuleNotFoundError
     ):  # pragma: no cover - backend import fails first in practice
@@ -196,6 +197,7 @@ def _patch_pytorch_tile_facade() -> None:
     tile.__name__ = "tile"
     tile.__doc__ = getattr(_np.tile, "__doc__", None)
     backend.tile = tile
+    _pytorch_backend.tile = tile
 
 
 def _patch_jax_std_out_facade() -> None:

--- a/tests/backend_support/test_pytorch_tile_contract.py
+++ b/tests/backend_support/test_pytorch_tile_contract.py
@@ -22,28 +22,33 @@ def test_pytorch_tile_scalar_and_array_repetitions_match_numpy_contract():
 
     code = """
 import pyrecest.backend as backend
+from pyrecest._backend import pytorch as pytorch_backend
 
 values = backend.array([[1, 2], [3, 4]])
 
-scalar_result = backend.tile(values, 2)
-assert tuple(backend.shape(scalar_result)) == (2, 4)
-assert backend.to_numpy(scalar_result).tolist() == [[1, 2, 1, 2], [3, 4, 3, 4]]
+for tile_func, to_numpy in (
+    (backend.tile, backend.to_numpy),
+    (pytorch_backend.tile, pytorch_backend.to_numpy),
+):
+    scalar_result = tile_func(values, 2)
+    assert tuple(scalar_result.shape) == (2, 4)
+    assert to_numpy(scalar_result).tolist() == [[1, 2, 1, 2], [3, 4, 3, 4]]
 
-array_result = backend.tile(values, backend.array([2, 1]))
-assert tuple(backend.shape(array_result)) == (4, 2)
-assert backend.to_numpy(array_result).tolist() == [[1, 2], [3, 4], [1, 2], [3, 4]]
+    array_result = tile_func(values, backend.array([2, 1]))
+    assert tuple(array_result.shape) == (4, 2)
+    assert to_numpy(array_result).tolist() == [[1, 2], [3, 4], [1, 2], [3, 4]]
 
-empty_result = backend.tile(values, ())
-assert tuple(backend.shape(empty_result)) == (2, 2)
-assert backend.to_numpy(empty_result).tolist() == [[1, 2], [3, 4]]
-assert empty_result is not values
+    empty_result = tile_func(values, ())
+    assert tuple(empty_result.shape) == (2, 2)
+    assert to_numpy(empty_result).tolist() == [[1, 2], [3, 4]]
+    assert empty_result is not values
 
-for bad_reps in (1.5, [2.5, 1], "2", backend.array([2.5, 1.0])):
-    try:
-        backend.tile(values, bad_reps)
-    except TypeError:
-        pass
-    else:
-        raise AssertionError(f"tile accepted non-integer repetitions {bad_reps!r}")
+    for bad_reps in (1.5, [2.5, 1], "2", backend.array([2.5, 1.0])):
+        try:
+            tile_func(values, bad_reps)
+        except TypeError:
+            pass
+        else:
+            raise AssertionError(f"tile accepted non-integer repetitions {bad_reps!r}")
 """
     subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- patch the raw `pyrecest._backend.pytorch.tile` module attribute alongside the public `pyrecest.backend.tile` facade
- extend the PyTorch tile contract regression test to exercise both entry points

## Bug fixed
Direct users of `pyrecest._backend.pytorch.tile` could bypass the package-level `backend.tile` patch and still reach the old `Tensor.repeat` behavior. NumPy-style scalar, empty, or tensor repetition specifications could therefore fail or behave inconsistently depending on which PyTorch tile entry point was used.

## Testing
- Not run locally in this connector session; added focused backend-portable regression coverage in `tests/backend_support/test_pytorch_tile_contract.py`.