### PR TITLE
Patch raw PyTorch comparison helpers

### DIFF
--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -96,7 +96,7 @@ _patch_shared_numpy_squeeze_facade()
 
 
 def _patch_pytorch_comparison_facade() -> None:
-    """Make public PyTorch comparison helpers accept array-like inputs."""
+    """Make public and raw PyTorch comparison helpers accept array-like inputs."""
 
     import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
 
@@ -104,6 +104,7 @@ def _patch_pytorch_comparison_facade() -> None:
         return
 
     try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
         import torch as _torch  # pylint: disable=import-outside-toplevel
     except (
         ModuleNotFoundError
@@ -134,9 +135,13 @@ def _patch_pytorch_comparison_facade() -> None:
         comparison.__doc__ = getattr(torch_func, "__doc__", None)
         return comparison
 
-    backend.greater = _wrap_comparison(_torch.greater)
-    backend.less = _wrap_comparison(_torch.less)
-    backend.logical_or = _wrap_comparison(_torch.logical_or)
+    greater = _wrap_comparison(_torch.greater)
+    less = _wrap_comparison(_torch.less)
+    logical_or = _wrap_comparison(_torch.logical_or)
+
+    backend.greater = raw_pytorch.greater = greater
+    backend.less = raw_pytorch.less = less
+    backend.logical_or = raw_pytorch.logical_or = logical_or
 
 
 def _pytorch_tile_repetition(repetition) -> int:

--- a/tests/backend_support/test_pytorch_raw_comparison_contract.py
+++ b/tests/backend_support/test_pytorch_raw_comparison_contract.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import importlib
 import importlib.util
 
 import pytest

--- a/tests/backend_support/test_pytorch_raw_comparison_contract.py
+++ b/tests/backend_support/test_pytorch_raw_comparison_contract.py
@@ -1,0 +1,35 @@
+"""Regression tests for raw PyTorch backend comparison helpers."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_comparisons_accept_numpy_style_array_like_inputs():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import importlib
+from pyrecest.backend import asarray, to_numpy
+
+raw_pytorch = importlib.import_module("pyrecest._backend.pytorch")
+
+greater_result = raw_pytorch.greater([1, 2, 3], asarray([0, 2, 4]))
+less_result = raw_pytorch.less(asarray([1, 2, 3]), [0, 2, 4])
+logical_result = raw_pytorch.logical_or([True, False], asarray([False, True]))
+
+assert to_numpy(greater_result).tolist() == [True, False, False]
+assert to_numpy(less_result).tolist() == [False, False, True]
+assert to_numpy(logical_result).tolist() == [True, True]
+""",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- patch the raw `pyrecest._backend.pytorch` comparison entry points alongside the public `pyrecest.backend` facade
- keep `greater`, `less`, and `logical_or` NumPy-style for array-like/tensor mixed inputs
- add a backend-portable regression test that imports the raw PyTorch backend directly

## Bug fixed
The public PyTorch backend facade already coerced comparison operands to tensors, but direct users of `pyrecest._backend.pytorch.greater`, `less`, or `logical_or` still reached Torch's stricter functions. Mixed NumPy-style array-like/tensor inputs could therefore raise `TypeError` depending on which entry point was used.

## Testing
- local wrapper smoke test with Torch 2.10.0+cpu for `greater`, `less`, and `logical_or`
- repository CI should run the new `tests/backend_support/test_pytorch_raw_comparison_contract.py` regression test