### PR TITLE
Enable JAX solve_sylvester backend

### DIFF
--- a/src/pyrecest/_backend/capabilities.py
+++ b/src/pyrecest/_backend/capabilities.py
@@ -54,7 +54,6 @@ BACKEND_CAPABILITIES: Final = {
                 "fractional_matrix_power",
                 "logm",
                 "quadratic_assignment",
-                "solve_sylvester",
             ),
         },
         "bridged": {},

--- a/src/pyrecest/_backend/jax/linalg.py
+++ b/src/pyrecest/_backend/jax/linalg.py
@@ -79,6 +79,17 @@ def sqrtm(a, *args, **kwargs):
     return _jax_scipy_linalg.sqrtm(_as_linalg_array(a), *args, **kwargs)
 
 
+def solve_sylvester(a, b, q, *args, **kwargs):
+    """Solve ``A X + X B = Q`` using JAX arrays and JAX SciPy."""
+    return _jax_scipy_linalg.solve_sylvester(
+        _as_linalg_array(a),
+        _as_linalg_array(b),
+        _as_linalg_array(q),
+        *args,
+        **kwargs,
+    )
+
+
 def _unsupported_function(name):
     """Create an unsupported-function shim that preserves facade identity."""
 
@@ -95,7 +106,6 @@ def _unsupported_function(name):
 fractional_matrix_power = _unsupported_function("fractional_matrix_power")
 logm = _unsupported_function("logm")
 quadratic_assignment = _unsupported_function("quadratic_assignment")
-solve_sylvester = _unsupported_function("solve_sylvester")
 
 
 def is_single_matrix_pd(mat):

--- a/tests/backend_support/test_jax_solve_sylvester_contract.py
+++ b/tests/backend_support/test_jax_solve_sylvester_contract.py
@@ -1,0 +1,30 @@
+import pyrecest.backend as backend
+import pytest
+from pyrecest._backend.capabilities import get_unsupported_functions
+from pyrecest.backend import array, linalg
+
+
+def _to_python(value):
+    value = backend.to_numpy(value)
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    return value
+
+
+def test_jax_solve_sylvester_is_not_declared_unsupported():
+    assert "solve_sylvester" not in get_unsupported_functions("jax", "linalg")
+
+
+def test_jax_solve_sylvester_solves_sylvester_equation():
+    if backend.__backend_name__ != "jax":
+        pytest.skip("JAX-specific linalg regression test")
+
+    a = array([[2.0, 0.0], [0.0, 3.0]])
+    b = array([[5.0, 0.0], [0.0, 7.0]])
+    q = array([[1.0, 2.0], [3.0, 4.0]])
+
+    x = linalg.solve_sylvester(a, b, q)
+    residual = backend.matmul(a, x) + backend.matmul(x, b)
+
+    assert tuple(x.shape) == (2, 2)
+    assert bool(_to_python(backend.allclose(residual, q, atol=1e-6)))


### PR DESCRIPTION
## Summary
- implement the JAX backend `linalg.solve_sylvester` using `jax.scipy.linalg.solve_sylvester`
- remove `solve_sylvester` from the JAX unsupported-capabilities declaration
- add a regression test that verifies the Sylvester equation residual under the JAX backend

## Tests
- Added `tests/backend_support/test_jax_solve_sylvester_contract.py`
- Locally checked the JAX/SciPy solve path with a diagonal Sylvester system in the execution environment