### PR TITLE
Fix PyTorch dtype alias resolution

### DIFF
--- a/src/pyrecest/_backend/pytorch/_dtype.py
+++ b/src/pyrecest/_backend/pytorch/_dtype.py
@@ -34,6 +34,19 @@ _FLOAT_TO_COMPLEX_DTYPE = {
 _COMPLEX_DTYPES = (complex64, complex128)
 
 
+def _dtype_key(value):
+    """Return the canonical PyTorch dtype-map key for dtype-like values."""
+    try:
+        return str(_np.dtype(value))
+    except (TypeError, ValueError):
+        text = str(value)
+        if text.startswith("torch."):
+            return text.split(".")[-1]
+        if text.endswith("'>") and "." in text:
+            return text.rsplit(".", maxsplit=1)[-1].removesuffix("'>")
+        return text
+
+
 def _normalize_torch_dtype(dtype, *, default):
     """Return a torch dtype for dtype-like values from other backends."""
     if dtype is None:
@@ -41,8 +54,8 @@ def _normalize_torch_dtype(dtype, *, default):
     if isinstance(dtype, _torch.dtype):
         return dtype
     try:
-        return MAP_DTYPE[str(_np.dtype(dtype))]
-    except (KeyError, TypeError):
+        return MAP_DTYPE[_dtype_key(dtype)]
+    except KeyError:
         return dtype
 
 
@@ -69,8 +82,8 @@ def is_bool(x):
 
 
 def as_dtype(value):
-    """Transform string representing dtype in dtype."""
-    return MAP_DTYPE[value]
+    """Transform string or dtype-like value into a PyTorch dtype."""
+    return MAP_DTYPE[_dtype_key(value)]
 
 
 def _dtype_as_str(dtype):

--- a/tests/test_pytorch_dtype_aliases.py
+++ b/tests/test_pytorch_dtype_aliases.py
@@ -10,15 +10,19 @@ def test_pytorch_as_dtype_accepts_dtype_like_aliases():
 
     torch = pytest.importorskip("torch")
 
-    assert backend.as_dtype(torch.float64) == torch.float64
-    assert backend.as_dtype(np.float64) == torch.float64
-    assert backend.as_dtype(np.dtype("complex128")) == torch.complex128
-    assert backend.as_dtype("torch.float32") == torch.float32
+    original_dtype = backend.get_default_dtype()
+    try:
+        assert backend.as_dtype(torch.float64) == torch.float64
+        assert backend.as_dtype(np.float64) == torch.float64
+        assert backend.as_dtype(np.dtype("complex128")) == torch.complex128
+        assert backend.as_dtype("torch.float32") == torch.float32
 
-    assert backend.set_default_dtype(np.dtype("float32")) == torch.float32
-    assert backend.get_default_dtype() == torch.float32
-    assert backend.get_default_cdtype() == torch.complex64
+        assert backend.set_default_dtype(np.dtype("float32")) == torch.float32
+        assert backend.get_default_dtype() == torch.float32
+        assert backend.get_default_cdtype() == torch.complex64
 
-    assert backend.set_default_dtype("torch.float64") == torch.float64
-    assert backend.get_default_dtype() == torch.float64
-    assert backend.get_default_cdtype() == torch.complex128
+        assert backend.set_default_dtype("torch.float64") == torch.float64
+        assert backend.get_default_dtype() == torch.float64
+        assert backend.get_default_cdtype() == torch.complex128
+    finally:
+        backend.set_default_dtype(original_dtype)

--- a/tests/test_pytorch_dtype_aliases.py
+++ b/tests/test_pytorch_dtype_aliases.py
@@ -1,0 +1,24 @@
+import numpy as np
+import pytest
+
+import pyrecest.backend as backend
+
+
+def test_pytorch_as_dtype_accepts_dtype_like_aliases():
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific dtype alias regression test")
+
+    torch = pytest.importorskip("torch")
+
+    assert backend.as_dtype(torch.float64) == torch.float64
+    assert backend.as_dtype(np.float64) == torch.float64
+    assert backend.as_dtype(np.dtype("complex128")) == torch.complex128
+    assert backend.as_dtype("torch.float32") == torch.float32
+
+    assert backend.set_default_dtype(np.dtype("float32")) == torch.float32
+    assert backend.get_default_dtype() == torch.float32
+    assert backend.get_default_cdtype() == torch.complex64
+
+    assert backend.set_default_dtype("torch.float64") == torch.float64
+    assert backend.get_default_dtype() == torch.float64
+    assert backend.get_default_cdtype() == torch.complex128


### PR DESCRIPTION
## Summary
- normalize PyTorch backend dtype-like inputs through the same canonical dtype key resolver used by `as_dtype`
- allow `torch.float*`, NumPy dtype objects/types, and `"torch.float*"` string aliases where PyTorch dtype arguments are accepted
- add a regression test covering `backend.as_dtype` and `set_default_dtype` alias handling

## Bug fixed
The PyTorch backend exposed `as_dtype`, but it only looked up exact keys such as `"float64"` in `MAP_DTYPE`. Dtype-like values accepted elsewhere, including `torch.float64`, `np.float64`, `np.dtype("complex128")`, and `"torch.float32"`, could therefore fail with `KeyError` or propagate as unresolved values.

## Tests
- Added `tests/test_pytorch_dtype_aliases.py`
- Could not run the test suite locally because the execution environment cannot clone or install from GitHub; inspected the changed files through the GitHub connector.