### PR TITLE
Fix common backend env-change leakage

### DIFF
--- a/src/pyrecest/_backend/_common.py
+++ b/src/pyrecest/_backend/_common.py
@@ -111,15 +111,21 @@ def diagonal(a, offset=0, axis1=0, axis2=1):
     return _np.diagonal(a, offset=offset, axis1=axis1, axis2=axis2)
 
 
+def _active_backend_name():
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except Exception:  # pragma: no cover - only during backend bootstrap/failure paths
+        return _os.environ.get("PYRECEST_BACKEND")
+    return getattr(backend, "__backend_name__", _os.environ.get("PYRECEST_BACKEND"))
+
+
 def _torch_module_for_values(*values):
     try:
         import torch as _torch
     except ModuleNotFoundError:
         return None
 
-    if _os.environ.get("PYRECEST_BACKEND") == "pytorch" or any(
-        _torch.is_tensor(value) for value in values
-    ):
+    if _active_backend_name() == "pytorch" or any(_torch.is_tensor(value) for value in values):
         return _torch
     return None
 

--- a/tests/test_common_backend_env_contract.py
+++ b/tests/test_common_backend_env_contract.py
@@ -1,0 +1,17 @@
+import numpy as np
+import pytest
+
+import pyrecest.backend as backend
+
+
+def test_common_helpers_ignore_late_backend_env_change(monkeypatch):
+    if backend.__backend_name__ not in {"numpy", "autograd"}:
+        pytest.skip("NumPy-style backend regression test")
+    torch = pytest.importorskip("torch")
+
+    monkeypatch.setenv("PYRECEST_BACKEND", "pytorch")
+
+    result = backend.outer([1.0, 2.0], [3.0, 4.0])
+
+    assert not torch.is_tensor(result)
+    np.testing.assert_allclose(result, np.array([[3.0, 4.0], [6.0, 8.0]]))


### PR DESCRIPTION
## Summary
- make shared common backend helpers check the imported `pyrecest.backend` facade before falling back to `PYRECEST_BACKEND`
- prevent late environment changes from making NumPy/autograd backend helpers return PyTorch tensors for ordinary array-like inputs
- add regression coverage for the late-env-change contract

## Bug fixed
`pyrecest._backend._common._torch_module_for_values` previously consulted `os.environ["PYRECEST_BACKEND"]` directly. If a process imported PyRecEst with the NumPy/autograd backend and later changed `PYRECEST_BACKEND` to `pytorch`, common fallback helpers such as `backend.outer` could start routing plain list/NumPy inputs through PyTorch. That contradicts PyRecEst's import-time backend contract and the warning behavior in `backend_tools.warn_if_backend_env_changed()`.

The fix resolves the active imported backend first via `pyrecest.backend.__backend_name__`, and only falls back to the environment while the backend facade is unavailable.

## Validation
- Compared branch against `main`: 2 commits, 2 files changed
- Local full test execution was not available in this connector-only environment; the added regression test covers the failing contract.