### PR TITLE
Implement PyTorch searchsorted facade

### DIFF
--- a/docs/backend-compatibility.md
+++ b/docs/backend-compatibility.md
@@ -42,7 +42,7 @@ unless a focused backend test covers the exact helper being used.
 | Backend | Best fit                                                                                                                  | Main limitations                                                                                                                                                          |
 |---------|---------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | NumPy   | Default backend and broadest compatibility for examples, evaluation, plotting, tracking, and SciPy-based helpers.         | No automatic differentiation through `pyrecest.backend.autodiff`. Autodiff calls raise `AutodiffNotImplementedError`.                                                     |
-| PyTorch | Tensor workflows and automatic differentiation where the required API is implemented.                                     | Some backend helpers are placeholders or bridge through NumPy/SciPy. `pyrecest.backend.signal.fftconvolve` and `pyrecest.backend.searchsorted` are not implemented.       |
+| PyTorch | Tensor workflows and automatic differentiation where the required API is implemented.                                     | Some backend helpers are placeholders or bridge through NumPy/SciPy. `pyrecest.backend.signal.fftconvolve` is not implemented.                                            |
 | JAX     | JAX array and autodiff workflows for APIs that avoid unsupported mutable, assignment-heavy, or SciPy-specific operations. | Several package areas explicitly skip or reject JAX, including some sampling, tracking, assignment, evaluation, point-set registration, and manifold-specific operations. |
 
 ## Capability Metadata
@@ -78,8 +78,6 @@ Use the PyTorch backend when tensor operations or PyTorch autodiff are part of
 the workflow. Keep these caveats in mind:
 
 - `pyrecest.backend.signal.fftconvolve` is not implemented.
-- `pyrecest.backend.searchsorted` is a placeholder that raises
-  `NotImplementedError`.
 - Some linear algebra helpers use NumPy or SciPy internally, including matrix
   square root, fractional matrix powers, polar decomposition, quadratic
   assignment, and some Sylvester-equation paths. These helpers may copy data

--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -198,6 +198,74 @@ def _patch_pytorch_tile_facade() -> None:
     backend.tile = tile
 
 
+def _patch_pytorch_searchsorted_facade() -> None:
+    """Make public and raw PyTorch ``searchsorted`` use native Torch support."""
+
+    import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        return
+
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch as _torch  # pylint: disable=import-outside-toplevel
+    except (
+        ModuleNotFoundError
+    ):  # pragma: no cover - backend import fails first in practice
+        return
+
+    def _searchsorted_tensor(value, *, device=None, dtype=None):
+        if _torch.is_tensor(value):
+            target_device = device if device is not None else value.device
+            target_dtype = dtype if dtype is not None else value.dtype
+            if value.device != target_device or value.dtype != target_dtype:
+                return value.to(device=target_device, dtype=target_dtype)
+            return value
+        return _torch.as_tensor(value, device=device, dtype=dtype)
+
+    def searchsorted(
+        a,
+        v,
+        side="left",
+        sorter=None,
+        *,
+        out=None,
+        out_int32=False,
+        right=None,
+    ):
+        if side not in {"left", "right"}:
+            raise ValueError("side must be 'left' or 'right'")
+        if right is not None:
+            right_side = bool(right)
+            requested_side = "right" if right_side else "left"
+            if side != "left" and side != requested_side:
+                raise TypeError("searchsorted() got conflicting 'side' and 'right'")
+            side = requested_side
+
+        device = next(
+            (
+                value.device
+                for value in (a, v, sorter, out)
+                if _torch.is_tensor(value)
+            ),
+            None,
+        )
+        sequence = _searchsorted_tensor(a, device=device)
+        values = _searchsorted_tensor(v, device=device)
+        kwargs = {"right": side == "right", "out_int32": bool(out_int32)}
+        if sorter is not None:
+            kwargs["sorter"] = _searchsorted_tensor(
+                sorter, device=device, dtype=_torch.long
+            )
+        if out is not None:
+            kwargs["out"] = out
+        return _torch.searchsorted(sequence, values, **kwargs)
+
+    searchsorted.__name__ = "searchsorted"
+    searchsorted.__doc__ = getattr(_torch.searchsorted, "__doc__", None)
+    backend.searchsorted = raw_pytorch.searchsorted = searchsorted
+
+
 def _patch_jax_std_out_facade() -> None:
     """Make public JAX ``std`` accept NumPy's ``out`` argument."""
 
@@ -231,6 +299,7 @@ def _patch_jax_std_out_facade() -> None:
 
 _patch_pytorch_comparison_facade()
 _patch_pytorch_tile_facade()
+_patch_pytorch_searchsorted_facade()
 _patch_jax_std_out_facade()
 
 from pyrecest.backend_support import (  # noqa: E402,F401

--- a/src/pyrecest/_backend/capabilities.py
+++ b/src/pyrecest/_backend/capabilities.py
@@ -18,9 +18,7 @@ BACKEND_CAPABILITIES: Final = {
         "partial": {},
     },
     "pytorch": {
-        "unsupported": {
-            "": ("searchsorted",),
-        },
+        "unsupported": {},
         "bridged": {
             "linalg": {
                 "sqrtm": "SciPy bridge; not differentiable through the bridge.",

--- a/tests/backend_support/test_pytorch_searchsorted_contract.py
+++ b/tests/backend_support/test_pytorch_searchsorted_contract.py
@@ -1,0 +1,61 @@
+"""Regression tests for PyTorch backend searchsorted support."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_pytorch_searchsorted_matches_numpy_style_contract():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import pyrecest.backend as backend
+from pyrecest._backend import pytorch as raw_pytorch
+
+boundaries = backend.asarray([1.0, 3.0, 5.0])
+values = backend.asarray([0.0, 1.0, 2.0, 5.0, 6.0])
+
+left = backend.searchsorted(boundaries, values)
+right = backend.searchsorted(boundaries, values, side="right")
+raw_result = raw_pytorch.searchsorted([1.0, 3.0, 5.0], [0.0, 1.0, 2.0, 5.0, 6.0])
+
+assert backend.to_numpy(left).tolist() == [0, 0, 1, 2, 3]
+assert backend.to_numpy(right).tolist() == [0, 1, 1, 3, 3]
+assert raw_pytorch.to_numpy(raw_result).tolist() == [0, 0, 1, 2, 3]
+
+unsorted_boundaries = backend.asarray([5.0, 1.0, 3.0])
+sorter = backend.argsort(unsorted_boundaries)
+sorted_result = backend.searchsorted(
+    unsorted_boundaries,
+    backend.asarray([2.0, 4.0]),
+    sorter=sorter,
+)
+assert backend.to_numpy(sorted_result).tolist() == [1, 2]
+
+out = backend.empty((2,), dtype=backend.int32)
+returned = backend.searchsorted(
+    boundaries,
+    backend.asarray([2.0, 4.0]),
+    out=out,
+    out_int32=True,
+)
+assert returned is out
+assert backend.to_numpy(out).tolist() == [1, 2]
+
+try:
+    backend.searchsorted(boundaries, values, side="middle")
+except ValueError as exc:
+    assert "side" in str(exc)
+else:
+    raise AssertionError("invalid searchsorted side should fail")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- replace the PyTorch backend `searchsorted` placeholder at import time with a native `torch.searchsorted` facade
- support array-like inputs, `side`, `right`, `sorter`, `out`, and `out_int32`, and patch both public `pyrecest.backend.searchsorted` and raw `pyrecest._backend.pytorch.searchsorted`
- update backend capability metadata and PyTorch backend compatibility docs

## Bug fixed
The PyTorch backend imported native `torch.searchsorted` but then overwrote the facade entry with a placeholder that always raised `NotImplementedError`. This made `pyrecest.backend.searchsorted(...)` fail under `PYRECEST_BACKEND=pytorch` despite the operation being natively available in PyTorch.

## Testing
- Added `tests/backend_support/test_pytorch_searchsorted_contract.py`
- Local syntax check of the edited Python files
- Local standalone Torch smoke check for `torch.searchsorted` left/right, sorter, and `out_int32` behavior

Full repository CI should run on this PR.