### PR TITLE
Fix PyTorch assignment scalar tensor indices

### DIFF
--- a/src/pyrecest/backend_tools.py
+++ b/src/pyrecest/backend_tools.py
@@ -4,6 +4,65 @@ from __future__ import annotations
 
 import os
 import warnings
+from operator import index as _operator_index
+
+
+def _pytorch_scalar_tensor_index(index, torch_module):
+    """Return Python int indices for scalar integer tensors."""
+
+    if not torch_module.is_tensor(index) or index.ndim != 0:
+        return index
+    if (
+        index.dtype in {torch_module.bool, torch_module.uint8}
+        or index.dtype.is_floating_point
+        or index.dtype.is_complex
+    ):
+        return index
+    return _operator_index(index)
+
+
+def _wrap_pytorch_assignment_helper(original_assignment, torch_module):
+    """Normalize scalar tensor indices before assignment helper len() checks."""
+
+    def assignment(x, values, indices, axis=0):
+        indices = _pytorch_scalar_tensor_index(indices, torch_module)
+        return original_assignment(x, values, indices, axis=axis)
+
+    assignment.__name__ = getattr(original_assignment, "__name__", "assignment")
+    assignment.__doc__ = getattr(original_assignment, "__doc__", None)
+    return assignment
+
+
+def _patch_pytorch_assignment_scalar_tensor_indices() -> None:
+    """Make PyTorch assignment helpers accept scalar integer tensor indices."""
+
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        return
+
+    try:
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+        import torch as _torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
+        return
+
+    backend.assignment = _wrap_pytorch_assignment_helper(backend.assignment, _torch)
+    backend.assignment_by_sum = _wrap_pytorch_assignment_helper(
+        backend.assignment_by_sum, _torch
+    )
+    pytorch_backend.assignment = _wrap_pytorch_assignment_helper(
+        pytorch_backend.assignment, _torch
+    )
+    pytorch_backend.assignment_by_sum = _wrap_pytorch_assignment_helper(
+        pytorch_backend.assignment_by_sum, _torch
+    )
+
+
+_patch_pytorch_assignment_scalar_tensor_indices()
 
 
 def get_backend_name() -> str:

--- a/tests/backend_support/test_pytorch_scalar_tensor_assignment_contract.py
+++ b/tests/backend_support/test_pytorch_scalar_tensor_assignment_contract.py
@@ -1,0 +1,45 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_pytorch_assignment_accepts_scalar_tensor_indices():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import torch
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as pytorch_backend
+
+
+def as_list(value):
+    return backend.to_numpy(value).tolist()
+
+
+original = backend.array([1.0, 2.0, 3.0])
+
+assigned = backend.assignment(original, 9.0, torch.tensor(1))
+added = backend.assignment_by_sum(original, 5.0, torch.tensor(2))
+raw_assigned = pytorch_backend.assignment(original, -4.0, torch.tensor(0))
+raw_added = pytorch_backend.assignment_by_sum(original, 10.0, torch.tensor(1))
+
+assert as_list(assigned) == [1.0, 9.0, 3.0]
+assert as_list(added) == [1.0, 2.0, 8.0]
+assert as_list(raw_assigned) == [-4.0, 2.0, 3.0]
+assert as_list(raw_added) == [1.0, 12.0, 3.0]
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- normalize scalar integer `torch.Tensor` indices before the PyTorch assignment helpers reach their `len(indices)` vectorization checks
- patch both the public `pyrecest.backend` facade and the raw `pyrecest._backend.pytorch` assignment entry points
- add a subprocess regression test under `PYRECEST_BACKEND=pytorch`

## Bug fixed
`assignment` and `assignment_by_sum` already treat 0-D tensor indices as scalar indices later in their implementation, but they first evaluate `len(indices)`. For a scalar tensor such as `torch.tensor(1)`, that raises `TypeError` before the intended scalar-index path is reachable.

## Testing
- Added `tests/backend_support/test_pytorch_scalar_tensor_assignment_contract.py`
- Not run locally in this connector environment; CI should exercise the focused PyTorch regression test.