### PR TITLE
Fix PyTorch gamma array-like inputs

### DIFF
--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -198,6 +198,31 @@ def _patch_pytorch_tile_facade() -> None:
     backend.tile = tile
 
 
+def _patch_pytorch_gamma_facade() -> None:
+    """Make PyTorch ``gamma`` accept scalar and array-like inputs."""
+
+    import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        return
+
+    try:
+        import torch as _torch  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+    except (
+        ModuleNotFoundError
+    ):  # pragma: no cover - backend import fails first in practice
+        return
+
+    def gamma(a):
+        return _torch.exp(_torch.special.gammaln(backend.array(a)))
+
+    gamma.__name__ = "gamma"
+    gamma.__doc__ = "Gamma function for PyTorch tensors and array-like inputs."
+    backend.gamma = gamma
+    pytorch_backend.gamma = gamma
+
+
 def _patch_jax_std_out_facade() -> None:
     """Make public JAX ``std`` accept NumPy's ``out`` argument."""
 
@@ -231,6 +256,7 @@ def _patch_jax_std_out_facade() -> None:
 
 _patch_pytorch_comparison_facade()
 _patch_pytorch_tile_facade()
+_patch_pytorch_gamma_facade()
 _patch_jax_std_out_facade()
 
 from pyrecest.backend_support import (  # noqa: E402,F401

--- a/tests/backend_support/test_pytorch_gamma_contract.py
+++ b/tests/backend_support/test_pytorch_gamma_contract.py
@@ -1,0 +1,36 @@
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_pytorch_gamma_accepts_array_like_inputs():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import math
+import torch
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch_backend
+
+scalar = backend.gamma(5.0)
+assert torch.is_tensor(scalar)
+assert tuple(scalar.shape) == ()
+assert backend.allclose(scalar, backend.array(24.0))
+
+values = backend.gamma([0.5, 1.0, 5.0])
+expected = backend.array([math.sqrt(math.pi), 1.0, 24.0])
+assert backend.allclose(values, expected)
+
+raw_values = raw_pytorch_backend.gamma([1.0, 2.0, 3.0])
+assert backend.allclose(raw_values, backend.array([1.0, 1.0, 2.0]))
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- patch the PyTorch `gamma` backend entry point so scalar and array-like inputs are first coerced through the active backend array constructor
- update both the public `pyrecest.backend.gamma` facade and the raw `pyrecest._backend.pytorch.gamma` entry point
- add a subprocess regression test for scalar, list, and raw-backend gamma calls

## Bug fixed
The PyTorch backend exported `gamma`, but its implementation called `torch.special.gammaln` directly. That function only accepts tensors, so calls such as `backend.gamma(5.0)` or `backend.gamma([0.5, 1.0, 5.0])` failed under `PYRECEST_BACKEND=pytorch` even though other unary backend functions accept scalar and array-like inputs.

## Testing
- Added `tests/backend_support/test_pytorch_gamma_contract.py`
- Locally syntax-checked the modified `src/pyrecest/__init__.py` and the new regression test with `python -m py_compile`

Full test execution was not possible in this execution environment because the repository cannot be cloned or installed from GitHub here.