### PR TITLE
Fix cached point-estimate mean extraction

### DIFF
--- a/src/pyrecest/evaluation/get_extract_mean.py
+++ b/src/pyrecest/evaluation/get_extract_mean.py
@@ -39,9 +39,14 @@ def _is_array_state(filter_state) -> bool:
     return hasattr(filter_state, "ndim") and hasattr(filter_state, "shape")
 
 
+def _unsupported(message: str) -> None:
+    raise NotImplementedError(message)
+
+
 def _point_estimate_or_mean(filter_state):
-    if hasattr(filter_state, "get_point_estimate"):
-        return filter_state.get_point_estimate()
+    point_estimate = getattr(filter_state, "get_point_estimate", None)
+    if point_estimate is not None:
+        return point_estimate() if callable(point_estimate) else point_estimate
     if hasattr(filter_state, "mu"):
         return filter_state.mu
     if _is_array_state(filter_state):
@@ -64,7 +69,7 @@ def _extract_mtt_mean(filter_state):
         return _extract_track_collection_mean(filter_state.tracks)
     if hasattr(filter_state, "single_target_filters"):
         return _extract_track_collection_mean(filter_state.single_target_filters)
-    if isinstance(filter_state, list | tuple):
+    if isinstance(filter_state, (list, tuple)):
         return _extract_track_collection_mean(filter_state)
     return _point_estimate_or_mean(filter_state)
 
@@ -81,7 +86,7 @@ def get_extract_mean(manifold_name, mtt_scenario=False):
             return filter_state.mean_direction()
 
     elif _is_hypersphere_symmetric_name(normalized_name):
-        raise NotImplementedError(
+        _unsupported(
             "Symmetric hypersphere mean extraction needs an explicit convention via a custom extractor."
         )
 
@@ -91,15 +96,13 @@ def get_extract_mean(manifold_name, mtt_scenario=False):
             return filter_state.mean_direction()
 
     elif "symm" in normalized_name:
-        raise NotImplementedError(
-            "Symmetric mean extraction needs an explicit convention"
-        )
+        _unsupported("Symmetric mean extraction needs an explicit convention")
 
     elif "se2bounded" in normalized_name:
-        raise NotImplementedError("Not implemented yet")
+        _unsupported("Not implemented yet")
 
     elif "se2" in normalized_name or "se2linear" in normalized_name:
-        raise NotImplementedError("Not implemented yet")
+        _unsupported("Not implemented yet")
 
     elif "se3bounded" in normalized_name:
 

--- a/tests/evaluation/test_extract_mean_cached_point_estimate.py
+++ b/tests/evaluation/test_extract_mean_cached_point_estimate.py
@@ -1,0 +1,12 @@
+from pyrecest.evaluation.get_extract_mean import get_extract_mean
+
+
+class _CachedPointEstimateState:
+    def __init__(self, value):
+        self.get_point_estimate = value
+
+
+def test_euclidean_extract_mean_accepts_cached_point_estimate_attribute():
+    extractor = get_extract_mean("euclidean")
+
+    assert extractor(_CachedPointEstimateState("cached-estimate")) == "cached-estimate"


### PR DESCRIPTION
## Summary
- handle `get_point_estimate` values that are cached attributes as well as callable methods
- keep the existing fallback order for `mu`, raw array states, and `mean`
- add a focused regression test for Euclidean mean extraction from cached point-estimate adapter objects

## Bug fixed
`get_extract_mean("euclidean")` unconditionally called `filter_state.get_point_estimate()` whenever the attribute existed. Adapter or state objects that expose a cached point estimate under that public attribute therefore failed with `TypeError` even though the rest of the mean-extraction helper already supports callable-or-attribute style access for `mean`.

## Testing
- Added `tests/evaluation/test_extract_mean_cached_point_estimate.py`

I could not run the repository test suite locally because the execution container cannot resolve `github.com` for a clone/install; CI should run on this PR.