### PR TITLE
Fix Euclidean MTT mean extraction dispatch

### DIFF
--- a/src/pyrecest/evaluation/get_extract_mean.py
+++ b/src/pyrecest/evaluation/get_extract_mean.py
@@ -71,9 +71,10 @@ def _extract_mtt_mean(filter_state):
 
 def get_extract_mean(manifold_name, mtt_scenario=False):
     normalized_name = _normalize_registry_name(manifold_name)
+    is_mtt_scenario = bool(mtt_scenario) or "mtt" in normalized_name
     registered_factory = _EXTRACT_MEAN_FACTORIES.get(normalized_name)
     if registered_factory is not None:
-        return registered_factory(manifold_name, mtt_scenario)
+        return registered_factory(manifold_name, is_mtt_scenario)
 
     if "circle" in normalized_name or "hypertorus" in normalized_name:
 
@@ -111,12 +112,12 @@ def get_extract_mean(manifold_name, mtt_scenario=False):
         def extract_mean(filter_state):
             return filter_state.hybrid_mean()
 
-    elif "euclidean" in normalized_name and not mtt_scenario:
+    elif "euclidean" in normalized_name and not is_mtt_scenario:
 
         def extract_mean(filter_state):
             return _point_estimate_or_mean(filter_state)
 
-    elif "euclidean" in normalized_name and mtt_scenario:
+    elif "euclidean" in normalized_name and is_mtt_scenario:
 
         def extract_mean(filter_state):
             return _extract_mtt_mean(filter_state)

--- a/tests/evaluation/test_evaluation_registries.py
+++ b/tests/evaluation/test_evaluation_registries.py
@@ -194,6 +194,12 @@ def test_euclidean_mtt_extract_mean_uses_public_track_selection():
     assert extracted == ["selected"]
 
 
+def test_named_euclidean_mtt_extract_mean_uses_public_track_selection():
+    extracted = get_extract_mean("euclideanMTT")(_TrackManagerLikeState())
+
+    assert extracted == ["selected"]
+
+
 def test_symmetric_hypersphere_extract_mean_requires_custom_extractor():
     with pytest.raises(NotImplementedError, match="custom extractor"):
         get_extract_mean("hypersphereSymmetric")


### PR DESCRIPTION
## Summary
- Treat manifold names containing `mtt` as multi-target tracking scenarios in `get_extract_mean`.
- Keep explicit `mtt_scenario=True` behavior unchanged.
- Add regression coverage for `get_extract_mean("euclideanMTT")` selecting public tracks through `get_tracks()`.

## Bug
`get_distance_function("euclideanMTT")` already dispatches to the MTT-specific path based on the manifold name, but `get_extract_mean("euclideanMTT")` previously stayed on the single-target Euclidean path unless the caller also passed `mtt_scenario=True`. For tracker-manager-like states, that could return the raw state object instead of the selected track means.

## Testing
- Not run locally; changes were made through the GitHub connector.