### PR TITLE
Fix PyTorch set_diag array-like inputs

### DIFF
--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -198,6 +198,39 @@ def _patch_pytorch_tile_facade() -> None:
     backend.tile = tile
 
 
+def _patch_pytorch_set_diag_facade() -> None:
+    """Make public and raw PyTorch ``set_diag`` accept array-like matrices."""
+
+    import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        return
+
+    try:
+        import torch as _torch  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+    except (
+        ModuleNotFoundError
+    ):  # pragma: no cover - backend import fails first in practice
+        return
+
+    original_set_diag = pytorch_backend.set_diag
+
+    def set_diag(x, new_diag):
+        x = backend.array(x)
+        diag_len = min(x.shape[-2], x.shape[-1])
+        result = x.clone()
+        diag_indices = _torch.arange(diag_len, device=x.device)
+        values = _torch.as_tensor(new_diag, dtype=x.dtype, device=x.device)
+        result[..., diag_indices, diag_indices] = values
+        return result
+
+    set_diag.__name__ = getattr(original_set_diag, "__name__", "set_diag")
+    set_diag.__doc__ = getattr(original_set_diag, "__doc__", None)
+    backend.set_diag = set_diag
+    pytorch_backend.set_diag = set_diag
+
+
 def _patch_jax_std_out_facade() -> None:
     """Make public JAX ``std`` accept NumPy's ``out`` argument."""
 
@@ -231,6 +264,7 @@ def _patch_jax_std_out_facade() -> None:
 
 _patch_pytorch_comparison_facade()
 _patch_pytorch_tile_facade()
+_patch_pytorch_set_diag_facade()
 _patch_jax_std_out_facade()
 
 from pyrecest.backend_support import (  # noqa: E402,F401

--- a/tests/backend_support/test_pytorch_set_diag_array_like.py
+++ b/tests/backend_support/test_pytorch_set_diag_array_like.py
@@ -1,0 +1,26 @@
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+def test_pytorch_set_diag_accepts_array_like_matrix_and_raw_entrypoint():
+    pytest.importorskip("torch")
+
+    code = """
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_backend
+
+result = backend.set_diag([[1.0, 1.0], [1.0, 1.0]], [5.0, 6.0])
+assert backend.to_numpy(result).tolist() == [[5.0, 1.0], [1.0, 6.0]]
+
+raw_result = raw_backend.set_diag(
+    [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+    [7.0, 8.0],
+)
+assert backend.to_numpy(raw_result).tolist() == [
+    [7.0, 0.0, 0.0],
+    [0.0, 8.0, 0.0],
+]
+"""
+    result = run_backend_code("pytorch", code)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Coerce PyTorch `set_diag` matrix inputs through the backend array constructor before using tensor attributes.
- Apply the fix to the public backend facade and the raw PyTorch backend entry point.
- Add a focused subprocess regression test for Python-list matrix inputs.

## Testing
- Added `tests/backend_support/test_pytorch_set_diag_array_like.py`.
- Verified the branch diff only changes the patch site and the new test.