### PR TITLE
Fix PyTorch FFT array-like inputs

### DIFF
--- a/src/pyrecest/_backend/pytorch/fft.py
+++ b/src/pyrecest/_backend/pytorch/fft.py
@@ -1,10 +1,60 @@
 # For ffts. Added for pyrecest.
 import torch as _torch
-from torch.fft import (
-    fftn,
-    fftshift,
-    ifftn,
-    ifftshift,
-    irfft,
-    rfft,
-)
+
+from ._common import array
+
+
+def _as_fft_tensor(x):
+    return x if _torch.is_tensor(x) else array(x)
+
+
+def _resolve_axis(axis, dim, func_name):
+    if dim is not None:
+        if axis != -1 and axis != dim:
+            raise TypeError(func_name + "() got both 'axis' and 'dim'")
+        axis = dim
+    return axis
+
+
+def _resolve_axes(axes, dim, func_name):
+    if dim is not None:
+        if axes is not None and axes != dim:
+            raise TypeError(func_name + "() got both 'axes' and 'dim'")
+        axes = dim
+    return axes
+
+
+def rfft(a, n=None, axis=-1, norm=None, *, dim=None):
+    """Compute a real FFT after coercing array-like inputs."""
+    axis = _resolve_axis(axis, dim, "rfft")
+    return _torch.fft.rfft(_as_fft_tensor(a), n=n, dim=axis, norm=norm)
+
+
+def irfft(a, n=None, axis=-1, norm=None, *, dim=None):
+    """Compute an inverse real FFT after coercing array-like inputs."""
+    axis = _resolve_axis(axis, dim, "irfft")
+    return _torch.fft.irfft(_as_fft_tensor(a), n=n, dim=axis, norm=norm)
+
+
+def fftn(a, s=None, axes=None, norm=None, *, dim=None):
+    """Compute an N-D FFT after coercing array-like inputs."""
+    axes = _resolve_axes(axes, dim, "fftn")
+    return _torch.fft.fftn(_as_fft_tensor(a), s=s, dim=axes, norm=norm)
+
+
+def ifftn(a, s=None, axes=None, norm=None, *, dim=None):
+    """Compute an inverse N-D FFT after coercing array-like inputs."""
+    axes = _resolve_axes(axes, dim, "ifftn")
+    return _torch.fft.ifftn(_as_fft_tensor(a), s=s, dim=axes, norm=norm)
+
+
+def fftshift(x, axes=None, *, dim=None):
+    """Shift zero-frequency components after coercing array-like inputs."""
+    axes = _resolve_axes(axes, dim, "fftshift")
+    return _torch.fft.fftshift(_as_fft_tensor(x), dim=axes)
+
+
+def ifftshift(x, axes=None, *, dim=None):
+    """Inverse-shift zero-frequency components after coercing array-like inputs."""
+    axes = _resolve_axes(axes, dim, "ifftshift")
+    return _torch.fft.ifftshift(_as_fft_tensor(x), dim=axes)

--- a/tests/backend/test_pytorch_fft_array_like.py
+++ b/tests/backend/test_pytorch_fft_array_like.py
@@ -1,0 +1,29 @@
+import pytest
+
+
+def test_pytorch_fft_helpers_accept_array_like_inputs():
+    torch = pytest.importorskip("torch")
+
+    from pyrecest._backend.pytorch import fft
+
+    spectrum = fft.rfft([1.0, 2.0, 3.0, 4.0])
+    expected_spectrum = torch.tensor(
+        [10.0 + 0.0j, -2.0 + 2.0j, -2.0 + 0.0j], dtype=spectrum.dtype
+    )
+    assert torch.allclose(spectrum, expected_spectrum)
+
+    reconstructed = fft.irfft(spectrum, n=4)
+    assert torch.allclose(
+        reconstructed,
+        torch.tensor([1.0, 2.0, 3.0, 4.0], dtype=reconstructed.dtype),
+    )
+
+    transformed = fft.fftn([[1.0, 2.0], [3.0, 4.0]], axes=(0, 1))
+    expected_transformed = torch.tensor(
+        [[10.0 + 0.0j, -2.0 + 0.0j], [-4.0 + 0.0j, 0.0 + 0.0j]],
+        dtype=transformed.dtype,
+    )
+    assert torch.allclose(transformed, expected_transformed)
+
+    assert fft.fftshift([0, 1, 2, 3]).tolist() == [2, 3, 0, 1]
+    assert fft.ifftshift([2, 3, 0, 1]).tolist() == [0, 1, 2, 3]


### PR DESCRIPTION
## Summary
- replace raw `torch.fft` re-exports in the PyTorch backend FFT module with thin PyRecEst-compatible wrappers
- coerce array-like inputs before calling `rfft`, `irfft`, `fftn`, `ifftn`, `fftshift`, and `ifftshift`
- keep NumPy-style `axis`/`axes` arguments while also accepting PyTorch-style `dim`
- add regression coverage for list inputs to the PyTorch FFT helpers

## Testing
- Added `tests/backend/test_pytorch_fft_array_like.py`
- Manually checked the patched wrapper behavior against local PyTorch for `rfft`, `irfft`, `fftn`, `fftshift`, and `ifftshift`

Full repository tests were not run in this environment.