### PR TITLE
Fix main CI validation failures

### DIFF
--- a/src/pyrecest/_backend/numpy/__init__.py
+++ b/src/pyrecest/_backend/numpy/__init__.py
@@ -1,5 +1,7 @@
 """Numpy based computation backend."""
 
+import builtins as _builtins
+
 import numpy as _np
 from numpy import (  # The ones below are for pyrecest; For Riemannian score-based SDE
     all,
@@ -223,9 +225,11 @@ def vmap(pyfunc, randomness="error"):
         if not args:
             raise ValueError("vmap requires at least one positional argument")
         mapped_args = [_np.asarray(arg) for arg in args]
-        if any(arg.ndim == 0 for arg in mapped_args):
+        if _builtins.any(arg.ndim == 0 for arg in mapped_args):
             raise ValueError("vmap arguments must have at least one dimension")
-        if not all(arg.shape[0] == mapped_args[0].shape[0] for arg in mapped_args):
+        if not _builtins.all(
+            arg.shape[0] == mapped_args[0].shape[0] for arg in mapped_args
+        ):
             raise ValueError(
                 "All arguments must have the same size in the first dimension"
             )

--- a/src/pyrecest/filters/sequence_node_validation.py
+++ b/src/pyrecest/filters/sequence_node_validation.py
@@ -10,5 +10,5 @@ class SequenceAssociationNode(_SequenceAssociationNode):
 
     def __post_init__(self) -> None:
         if self.is_missed_detection and self.candidate_index is not None:
-            raise ValueError("gap nodes must use candidate_index=None")
+            raise ValueError("candidate_index must be None for explicit gap nodes")
         super().__post_init__()


### PR DESCRIPTION
Closed as redundant: `main` already advanced to `f69b4fa829c4e586e67c1ff745fcbef1bda4263c` with the same fix family (`Fix backend vmap validation and gap node message`).