### PR TITLE
Preserve sequence node type validation

### DIFF
--- a/src/pyrecest/filters/sequence_node_validation.py
+++ b/src/pyrecest/filters/sequence_node_validation.py
@@ -9,6 +9,4 @@ class SequenceAssociationNode(_SequenceAssociationNode):
     """Sequence-association node with consistent gap-node bookkeeping."""
 
     def __post_init__(self) -> None:
-        if self.is_missed_detection and self.candidate_index is not None:
-            raise ValueError("candidate_index must be None for explicit gap nodes")
         super().__post_init__()

--- a/tests/filters/test_public_sequence_node_flag_validation.py
+++ b/tests/filters/test_public_sequence_node_flag_validation.py
@@ -1,0 +1,11 @@
+import pytest
+from pyrecest.filters import SequenceAssociationNode
+
+
+def test_public_node_rejects_non_boolean_gap_flag_before_consistency_check():
+    with pytest.raises(ValueError, match="is_missed_detection must be a bool"):
+        SequenceAssociationNode(
+            frame_index=0,
+            candidate_index=1,
+            is_missed_detection="False",
+        )


### PR DESCRIPTION
## Summary
- simplify the public sequence node wrapper so base-class validation runs first
- add regression coverage for invalid public node flag input

## Validation
- Compared branch against current main: 2 commits ahead, 0 behind
- Full local test execution was not possible because this environment cannot resolve github.com for cloning/installing the repository.