### PR TITLE
Fix public sequence node flag validation

### DIFF
--- a/src/pyrecest/filters/sequence_node_validation.py
+++ b/src/pyrecest/filters/sequence_node_validation.py
@@ -7,8 +7,3 @@ from .sequence_association import SequenceAssociationNode as _SequenceAssociatio
 
 class SequenceAssociationNode(_SequenceAssociationNode):
     """Sequence-association node with consistent gap-node bookkeeping."""
-
-    def __post_init__(self) -> None:
-        if self.is_missed_detection and self.candidate_index is not None:
-            raise ValueError("candidate_index must be None for explicit gap nodes")
-        super().__post_init__()

--- a/tests/filters/test_sequence_node_validation_wrapper.py
+++ b/tests/filters/test_sequence_node_validation_wrapper.py
@@ -1,0 +1,13 @@
+import numpy as np
+import pytest
+
+from pyrecest.filters import SequenceAssociationNode
+
+
+def test_public_sequence_node_rejects_array_like_missed_detection_flag():
+    with pytest.raises(ValueError, match="is_missed_detection must be a bool"):
+        SequenceAssociationNode(
+            frame_index=0,
+            candidate_index=3,
+            is_missed_detection=np.array([True, False]),
+        )


### PR DESCRIPTION
## Summary
- remove the duplicate pre-validation in the public `SequenceAssociationNode` wrapper so malformed `is_missed_detection` values are handled by the base node validator
- add a regression test for array-like missed-detection flags, which should raise PyRecEst's stable `ValueError` instead of NumPy truth-value errors

## Bug fixed
The public wrapper previously evaluated `self.is_missed_detection` before scalar-bool validation. For array-like values such as `np.array([True, False])`, this can raise NumPy's ambiguous truth-value error before PyRecEst's intended validation path runs. Delegating to the base class keeps public import behavior consistent with the core implementation.

## Validation
- inspected branch diff with GitHub compare: 2 commits ahead of `main`, only 2 files changed
- local full tests were not run because this environment cannot resolve `github.com` for cloning/installing the repository