### PR TITLE
Fix PyTorch predicate array-like inputs

### DIFF
--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -139,6 +139,38 @@ def _patch_pytorch_comparison_facade() -> None:
     backend.logical_or = _wrap_comparison(_torch.logical_or)
 
 
+def _patch_pytorch_finiteness_predicate_facade() -> None:
+    """Make PyTorch finite predicates accept scalar and array-like inputs."""
+
+    import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        return
+
+    try:
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+        import torch as _torch  # pylint: disable=import-outside-toplevel
+    except (
+        ModuleNotFoundError
+    ):  # pragma: no cover - backend import fails first in practice
+        return
+
+    def _wrap_predicate(torch_func):
+        def predicate(x):
+            if not _torch.is_tensor(x):
+                x = backend.array(x)
+            return torch_func(x)
+
+        predicate.__name__ = getattr(torch_func, "__name__", "predicate")
+        predicate.__doc__ = getattr(torch_func, "__doc__", None)
+        return predicate
+
+    for predicate_name in ("isfinite", "isinf", "isnan", "isreal"):
+        predicate = _wrap_predicate(getattr(_torch, predicate_name))
+        setattr(pytorch_backend, predicate_name, predicate)
+        setattr(backend, predicate_name, predicate)
+
+
 def _pytorch_tile_repetition(repetition) -> int:
     """Return one NumPy-style tile repetition as an integer."""
 
@@ -230,6 +262,7 @@ def _patch_jax_std_out_facade() -> None:
 
 
 _patch_pytorch_comparison_facade()
+_patch_pytorch_finiteness_predicate_facade()
 _patch_pytorch_tile_facade()
 _patch_jax_std_out_facade()
 

--- a/tests/backend_support/test_pytorch_finiteness_predicate_contract.py
+++ b/tests/backend_support/test_pytorch_finiteness_predicate_contract.py
@@ -1,0 +1,40 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_pytorch_finiteness_predicates_accept_array_like_inputs():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_backend
+
+values = [1.0, float("inf"), float("nan")]
+assert backend.to_numpy(backend.isfinite(values)).tolist() == [True, False, False]
+assert backend.to_numpy(backend.isinf(values)).tolist() == [False, True, False]
+assert backend.to_numpy(backend.isnan(values)).tolist() == [False, False, True]
+
+complex_values = [1.0 + 0.0j, 1.0 + 2.0j]
+assert backend.to_numpy(backend.isreal(complex_values)).tolist() == [True, False]
+
+assert backend.to_numpy(raw_backend.isfinite(values)).tolist() == [True, False, False]
+assert backend.to_numpy(raw_backend.isinf(values)).tolist() == [False, True, False]
+assert backend.to_numpy(raw_backend.isnan(values)).tolist() == [False, False, True]
+assert backend.to_numpy(raw_backend.isreal(complex_values)).tolist() == [True, False]
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
Patch PyTorch backend predicate helpers so ordinary scalar and array-like inputs are accepted. Adds a focused backend regression test. Local syntax checks passed; full test execution should run in CI.