### PR TITLE
Normalize sequence association top-k validation errors

### DIFF
--- a/src/pyrecest/filters/sequence_association.py
+++ b/src/pyrecest/filters/sequence_association.py
@@ -365,7 +365,10 @@ def _validate_cost(value: object, name: str) -> float:
 
 def _validate_positive_integer(value: object, name: str) -> int:
     message = f"{name} must be a positive integer"
-    value_array = np.asarray(value)
+    try:
+        value_array = np.asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(message) from exc
     if value_array.ndim != 0 or value_array.dtype == np.bool_:
         raise ValueError(message)
 

--- a/tests/filters/test_sequence_association_top_k_bad_input.py
+++ b/tests/filters/test_sequence_association_top_k_bad_input.py
@@ -1,0 +1,20 @@
+import pytest
+
+from pyrecest.filters import SequenceAssociationNode, solve_top_k_viterbi_sequence_associations
+
+
+class UncoercibleScalar:
+    def __array__(self, dtype=None):
+        del dtype
+        raise TypeError("cannot convert")
+
+
+def test_top_k_terminal_paths_reports_value_error_for_uncoercible_scalar():
+    frames = [[SequenceAssociationNode(0, 0)]]
+
+    with pytest.raises(ValueError, match="top_k_terminal_paths must be a positive integer"):
+        solve_top_k_viterbi_sequence_associations(
+            frames,
+            lambda _previous, _current, _context: 0.0,
+            top_k_terminal_paths=UncoercibleScalar(),
+        )


### PR DESCRIPTION
## Summary
- wrap `np.asarray` coercion failures in `_validate_positive_integer` as the stable PyRecEst `ValueError`
- add regression coverage for an array-like `top_k_terminal_paths` object whose conversion raises

## Bug fixed
`solve_top_k_viterbi_sequence_associations(..., top_k_terminal_paths=bad_array_like)` previously leaked the underlying `TypeError` from NumPy coercion instead of reporting the documented/stable `ValueError("top_k_terminal_paths must be a positive integer")`. The other scalar validators in this module already normalize coercion failures; this makes the top-k path consistent.

## Validation
- Inspected branch diff against current `main`: 2 commits, 2 files changed, only the validator and regression test.
- Full local test execution was not possible because this environment cannot resolve `github.com` for cloning/installing the repository.