### PR TITLE
Fix PyTorch stack helper array-like inputs

### DIFF
--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -198,6 +198,58 @@ def _patch_pytorch_tile_facade() -> None:
     backend.tile = tile
 
 
+def _patch_pytorch_stack_helpers_facade() -> None:
+    """Make public PyTorch stack helpers accept NumPy-style array-like inputs."""
+
+    import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        return
+
+    try:
+        import numpy as _np  # pylint: disable=import-outside-toplevel
+        import torch as _torch  # pylint: disable=import-outside-toplevel
+    except (
+        ModuleNotFoundError
+    ):  # pragma: no cover - backend import fails first in practice
+        return
+
+    def _tensor_sequence(tup):
+        return [backend.array(item) for item in tup]
+
+    def hstack(tup):
+        tensors = [_torch.atleast_1d(tensor) for tensor in _tensor_sequence(tup)]
+        if not tensors:
+            return _torch.cat(tensors, dim=0)
+        return _torch.cat(tensors, dim=0 if tensors[0].ndim == 1 else 1)
+
+    def vstack(tup):
+        tensors = [_torch.atleast_2d(tensor) for tensor in _tensor_sequence(tup)]
+        return _torch.cat(tensors, dim=0)
+
+    def column_stack(tup):
+        tensors = []
+        for tensor in _tensor_sequence(tup):
+            if tensor.ndim < 2:
+                tensor = tensor.reshape(-1, 1)
+            tensors.append(tensor)
+        return _torch.cat(tensors, dim=1)
+
+    def dstack(tup):
+        tensors = [_torch.atleast_3d(tensor) for tensor in _tensor_sequence(tup)]
+        return _torch.cat(tensors, dim=2)
+
+    for helper_name, helper in {
+        "hstack": hstack,
+        "vstack": vstack,
+        "column_stack": column_stack,
+        "dstack": dstack,
+    }.items():
+        helper.__name__ = helper_name
+        helper.__doc__ = getattr(_np, helper_name).__doc__
+        setattr(backend, helper_name, helper)
+
+
 def _patch_jax_std_out_facade() -> None:
     """Make public JAX ``std`` accept NumPy's ``out`` argument."""
 
@@ -260,6 +312,7 @@ def _patch_jax_matmul_out_facade() -> None:
 
 _patch_pytorch_comparison_facade()
 _patch_pytorch_tile_facade()
+_patch_pytorch_stack_helpers_facade()
 _patch_jax_std_out_facade()
 _patch_jax_matmul_out_facade()
 

--- a/tests/backend_support/test_pytorch_stack_helpers_contract.py
+++ b/tests/backend_support/test_pytorch_stack_helpers_contract.py
@@ -1,0 +1,35 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_pytorch_stack_helpers_accept_array_like_sequences():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import pyrecest.backend as backend
+
+assert backend.to_numpy(backend.hstack(([1, 2], [3, 4]))).tolist() == [1, 2, 3, 4]
+assert backend.to_numpy(backend.vstack(([1, 2], [3, 4]))).tolist() == [[1, 2], [3, 4]]
+assert backend.to_numpy(backend.column_stack(([1, 2], [3, 4]))).tolist() == [[1, 3], [2, 4]]
+assert backend.to_numpy(backend.dstack(([1, 2], [3, 4]))).tolist() == [[[1, 3], [2, 4]]]
+
+values = backend.array([[1, 2], [3, 4]])
+assert backend.to_numpy(backend.hstack((values, [[5, 6], [7, 8]]))).tolist() == [[1, 2, 5, 6], [3, 4, 7, 8]]
+assert backend.to_numpy(backend.column_stack((values, [[5, 6], [7, 8]]))).tolist() == [[1, 2, 5, 6], [3, 4, 7, 8]]
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- patch the public PyTorch backend facade for `hstack`, `vstack`, `column_stack`, and `dstack`
- coerce NumPy-style array-like sequence elements before forwarding to `torch.cat`
- add a subprocess regression test covering list inputs and mixed tensor/list inputs

## Bug fixed
The public PyTorch backend exposed raw `torch.hstack`/`torch.vstack`/`torch.column_stack`/`torch.dstack`. Those helpers reject NumPy-style array-like sequences such as `([1, 2], [3, 4])` because the sequence elements are Python lists rather than tensors. NumPy and the other backend facades accept those inputs.

## Testing
- Added `tests/backend_support/test_pytorch_stack_helpers_contract.py`
- I could not run the full repository test suite in this environment because the runtime cannot clone GitHub repositories (`github.com` DNS resolution is unavailable).