### PR TITLE
Fix PyTorch clip array-like inputs

### DIFF
--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -139,6 +139,58 @@ def _patch_pytorch_comparison_facade() -> None:
     backend.logical_or = _wrap_comparison(_torch.logical_or)
 
 
+def _patch_pytorch_clip_facade() -> None:
+    """Make public and raw PyTorch ``clip`` accept array-like inputs."""
+
+    import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        return
+
+    try:
+        import torch as _torch  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+    except (
+        ModuleNotFoundError
+    ):  # pragma: no cover - backend import fails first in practice
+        return
+
+    def _clip_bound(value, *, device):
+        if value is None:
+            return None
+        if _torch.is_tensor(value):
+            return value.to(device=device)
+        return _torch.as_tensor(value, device=device)
+
+    def clip(a, a_min=None, a_max=None, out=None, *, min=None, max=None):
+        if min is not None:
+            if a_min is not None:
+                raise TypeError("clip() got both 'a_min' and 'min'")
+            a_min = min
+        if max is not None:
+            if a_max is not None:
+                raise TypeError("clip() got both 'a_max' and 'max'")
+            a_max = max
+        if a_min is None and a_max is None:
+            raise ValueError("One of max or min must be given")
+
+        x = backend.array(a)
+        result = _torch.clip(
+            x,
+            min=_clip_bound(a_min, device=x.device),
+            max=_clip_bound(a_max, device=x.device),
+        )
+        if out is not None:
+            out.copy_(result)
+            return out
+        return result
+
+    clip.__name__ = getattr(_torch.clip, "__name__", "clip")
+    clip.__doc__ = getattr(_torch.clip, "__doc__", None)
+    pytorch_backend.clip = clip
+    backend.clip = clip
+
+
 def _pytorch_tile_repetition(repetition) -> int:
     """Return one NumPy-style tile repetition as an integer."""
 
@@ -259,6 +311,7 @@ def _patch_jax_matmul_out_facade() -> None:
 
 
 _patch_pytorch_comparison_facade()
+_patch_pytorch_clip_facade()
 _patch_pytorch_tile_facade()
 _patch_jax_std_out_facade()
 _patch_jax_matmul_out_facade()

--- a/tests/backend_support/test_pytorch_clip_contract.py
+++ b/tests/backend_support/test_pytorch_clip_contract.py
@@ -1,0 +1,57 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_pytorch_clip_accepts_array_like_inputs_and_numpy_bounds():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as pytorch_backend
+
+values = [-2.0, 0.5, 3.0]
+
+clipped = backend.clip(values, -1.0, 2.0)
+assert backend.to_numpy(clipped).tolist() == [-1.0, 0.5, 2.0]
+
+alias_clipped = backend.clip(values, min=-0.5, max=1.5)
+assert backend.to_numpy(alias_clipped).tolist() == [-0.5, 0.5, 1.5]
+
+array_bound_clipped = backend.clip(
+    values,
+    [-1.0, 0.0, 2.5],
+    [0.0, 1.0, 2.75],
+)
+assert backend.to_numpy(array_bound_clipped).tolist() == [-1.0, 0.5, 2.75]
+
+raw_clipped = pytorch_backend.clip(values, -1.0, 2.0)
+assert backend.to_numpy(raw_clipped).tolist() == [-1.0, 0.5, 2.0]
+
+out = backend.empty_like(clipped)
+returned = backend.clip(values, -1.0, 2.0, out=out)
+assert returned is out
+assert backend.to_numpy(out).tolist() == [-1.0, 0.5, 2.0]
+
+try:
+    backend.clip(values, -1.0, 2.0, min=-1.0)
+except TypeError:
+    pass
+else:
+    raise AssertionError("clip accepted both a_min and min")
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- patch the PyTorch backend facade so `backend.clip` accepts NumPy-style array-like inputs
- keep the raw `pyrecest._backend.pytorch.clip` entry point aligned after package import
- support scalar and per-element array-like clip bounds, `min`/`max` aliases, and `out=`
- add focused backend-portable regression coverage

## Bug fixed
The PyTorch backend exported `torch.clip` directly. Under `PYRECEST_BACKEND=pytorch`, calls such as `backend.clip([-2.0, 0.5, 3.0], -1.0, 2.0)` therefore reached `torch.clip` with a Python list as input and failed instead of following the backend facade's NumPy-compatible array-like input contract.

## Testing
- Added `tests/backend_support/test_pytorch_clip_contract.py` with a subprocess regression test for public and raw PyTorch clip entry points.
- Sanity-checked the wrapper behavior locally against the installed `torch` package in this session.
- Full repository test suite was not run in this connector session.