### PR TITLE
JAX FFT arraylike inputs

### DIFF
--- a/src/pyrecest/_backend/jax/fft.py
+++ b/src/pyrecest/_backend/jax/fft.py
@@ -1,8 +1,28 @@
-from jax.numpy.fft import (
-    fftn,
-    fftshift,
-    ifftn,
-    ifftshift,
-    irfft,
-    rfft,
-)
+"""JAX FFT backend wrappers."""
+
+import jax.numpy as _jnp
+from jax.numpy import fft as _fft
+
+
+def rfft(a, n=None, axis=-1, norm=None):
+    return _fft.rfft(_jnp.asarray(a), n=n, axis=axis, norm=norm)
+
+
+def irfft(a, n=None, axis=-1, norm=None):
+    return _fft.irfft(_jnp.asarray(a), n=n, axis=axis, norm=norm)
+
+
+def fftn(a, s=None, axes=None, norm=None):
+    return _fft.fftn(_jnp.asarray(a), s=s, axes=axes, norm=norm)
+
+
+def ifftn(a, s=None, axes=None, norm=None):
+    return _fft.ifftn(_jnp.asarray(a), s=s, axes=axes, norm=norm)
+
+
+def fftshift(x, axes=None):
+    return _fft.fftshift(_jnp.asarray(x), axes=axes)
+
+
+def ifftshift(x, axes=None):
+    return _fft.ifftshift(_jnp.asarray(x), axes=axes)

--- a/tests/backend_support/test_jax_fft_arraylike_contract.py
+++ b/tests/backend_support/test_jax_fft_arraylike_contract.py
@@ -1,0 +1,31 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_jax_fft_helpers_accept_python_lists():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("jax is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "jax"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = src_path if not env.get("PYTHONPATH") else os.pathsep.join([src_path, env["PYTHONPATH"]])
+
+    code = """
+import pyrecest.backend as backend
+
+values = [1.0, 2.0, 3.0, 4.0]
+spectrum = backend.fft.rfft(values)
+expected = backend.fft.rfft(backend.array(values))
+assert tuple(backend.shape(spectrum)) == (3,)
+assert bool(backend.to_numpy(backend.allclose(spectrum, expected)))
+
+shifted = backend.fft.fftshift(values)
+assert backend.to_numpy(shifted).tolist() == [3.0, 4.0, 1.0, 2.0]
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
Summary:
- Coerce list-like inputs in JAX FFT helpers before dispatching to jax.numpy.fft.
- Add backend-portable regression coverage for JAX rfft and fftshift list inputs.

Testing: not run locally in this connector session; focused test added.