### PR TITLE
Fix PyTorch common dtype string aliases

### DIFF
--- a/src/pyrecest/_backend/pytorch/_common.py
+++ b/src/pyrecest/_backend/pytorch/_common.py
@@ -1,25 +1,44 @@
 import numpy as _np
-import torch as _torch
+from torch import (
+    bool as _torch_bool,
+    complex64 as _torch_complex64,
+    complex128 as _torch_complex128,
+    dtype as _torch_dtype,
+    float16 as _torch_float16,
+    float32 as _torch_float32,
+    float64 as _torch_float64,
+    from_numpy as _torch_from_numpy,
+    int8 as _torch_int8,
+    int16 as _torch_int16,
+    int32 as _torch_int32,
+    int64 as _torch_int64,
+    is_tensor as _torch_is_tensor,
+    stack as _torch_stack,
+    tensor as _torch_tensor,
+    uint8 as _torch_uint8,
+)
 
 _TORCH_DTYPE_BY_NAME = {
-    "bool": _torch.bool,
-    "uint8": _torch.uint8,
-    "int8": _torch.int8,
-    "int16": _torch.int16,
-    "int32": _torch.int32,
-    "int64": _torch.int64,
-    "float16": _torch.float16,
-    "float32": _torch.float32,
-    "float64": _torch.float64,
-    "complex64": _torch.complex64,
-    "complex128": _torch.complex128,
+    "bool": _torch_bool,
+    "uint8": _torch_uint8,
+    "int8": _torch_int8,
+    "int16": _torch_int16,
+    "int32": _torch_int32,
+    "int64": _torch_int64,
+    "float16": _torch_float16,
+    "float32": _torch_float32,
+    "float64": _torch_float64,
+    "complex64": _torch_complex64,
+    "complex128": _torch_complex128,
 }
 
 
 def _normalize_dtype(dtype):
-    """Return a torch dtype for dtype-like values understood by NumPy."""
-    if dtype is None or isinstance(dtype, _torch.dtype):
+    """Return a torch dtype for dtype-like values understood by PyTorch/NumPy."""
+    if dtype is None or isinstance(dtype, _torch_dtype):
         return dtype
+    if isinstance(dtype, str) and dtype.startswith("torch."):
+        dtype = dtype.split(".", 1)[1]
     try:
         return _TORCH_DTYPE_BY_NAME[str(_np.dtype(dtype))]
     except (KeyError, TypeError):
@@ -27,16 +46,16 @@ def _normalize_dtype(dtype):
 
 
 def from_numpy(x):
-    if _torch.is_tensor(x):
+    if _torch_is_tensor(x):
         return x
     if isinstance(x, _np.ndarray) and any(stride < 0 for stride in x.strides):
         x = x.copy()
-    return _torch.from_numpy(x)
+    return _torch_from_numpy(x)
 
 
 def array(val, dtype=None):
     dtype = _normalize_dtype(dtype)
-    if _torch.is_tensor(val):
+    if _torch_is_tensor(val):
         if dtype is None or val.dtype == dtype:
             return val.clone()
 
@@ -51,13 +70,13 @@ def array(val, dtype=None):
 
     if isinstance(val, (list, tuple)) and len(val):
         tensors = [array(tensor, dtype=dtype) for tensor in val]
-        return _torch.stack(tensors)
+        return _torch_stack(tensors)
 
-    return _torch.tensor(val, dtype=dtype)
+    return _torch_tensor(val, dtype=dtype)
 
 
 def cast(x, dtype):
     dtype = _normalize_dtype(dtype)
-    if _torch.is_tensor(x):
+    if _torch_is_tensor(x):
         return x.to(dtype=dtype)
     return array(x, dtype=dtype)

--- a/tests/backend_support/test_pytorch_dtype_argument_contract.py
+++ b/tests/backend_support/test_pytorch_dtype_argument_contract.py
@@ -1,0 +1,43 @@
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_pytorch_public_helpers_accept_numpy_dtype_aliases():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import numpy as np
+import pyrecest.backend as backend
+
+values = backend.array([[1, 2, 3], [4, 5, 6]])
+
+sum_result = backend.sum(values, axis=0, dtype=np.float64)
+assert sum_result.dtype == backend.float64
+assert backend.to_numpy(sum_result).tolist() == [5.0, 7.0, 9.0]
+
+prod_out = backend.empty((3,), dtype=backend.int64)
+prod_result = backend.prod(values, axis=0, dtype=np.dtype("int64"), out=prod_out)
+assert prod_result is prod_out
+assert prod_out.dtype == backend.int64
+assert backend.to_numpy(prod_out).tolist() == [4, 10, 18]
+
+line = backend.linspace(0, 1, num=3, dtype=np.dtype("float32"))
+assert line.dtype == backend.float32
+assert backend.to_numpy(line).tolist() == [0.0, 0.5, 1.0]
+
+column = backend.to_ndarray([1, 2], 2, axis=1, dtype=np.float64)
+assert column.dtype == backend.float64
+assert tuple(column.shape) == (2, 1)
+
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout

--- a/tests/backend_support/test_pytorch_dtype_argument_contract.py
+++ b/tests/backend_support/test_pytorch_dtype_argument_contract.py
@@ -5,35 +5,26 @@ from tests.support.backend_runner import run_backend_code
 
 
 @pytest.mark.backend_portable
-def test_pytorch_public_helpers_accept_numpy_dtype_aliases():
+def test_pytorch_array_and_cast_accept_torch_dtype_string_aliases():
     if importlib.util.find_spec("torch") is None:
         pytest.skip("PyTorch is not installed")
 
     result = run_backend_code(
         "pytorch",
         """
-import numpy as np
 import pyrecest.backend as backend
 
-values = backend.array([[1, 2, 3], [4, 5, 6]])
+values = backend.array([1, 2, 3], dtype="torch.float64")
+assert values.dtype == backend.float64
+assert backend.to_numpy(values).tolist() == [1.0, 2.0, 3.0]
 
-sum_result = backend.sum(values, axis=0, dtype=np.float64)
-assert sum_result.dtype == backend.float64
-assert backend.to_numpy(sum_result).tolist() == [5.0, 7.0, 9.0]
+cast_values = backend.cast(values, "torch.float32")
+assert cast_values.dtype == backend.float32
+assert backend.to_numpy(cast_values).tolist() == [1.0, 2.0, 3.0]
 
-prod_out = backend.empty((3,), dtype=backend.int64)
-prod_result = backend.prod(values, axis=0, dtype=np.dtype("int64"), out=prod_out)
-assert prod_result is prod_out
-assert prod_out.dtype == backend.int64
-assert backend.to_numpy(prod_out).tolist() == [4, 10, 18]
-
-line = backend.linspace(0, 1, num=3, dtype=np.dtype("float32"))
-assert line.dtype == backend.float32
-assert backend.to_numpy(line).tolist() == [0.0, 0.5, 1.0]
-
-column = backend.to_ndarray([1, 2], 2, axis=1, dtype=np.float64)
-assert column.dtype == backend.float64
-assert tuple(column.shape) == (2, 1)
+complex_values = backend.array([1, 2], dtype="torch.complex128")
+assert complex_values.dtype == backend.complex128
+assert tuple(complex_values.shape) == (2,)
 
 print("ok")
 """,


### PR DESCRIPTION
## Summary
- normalize `"torch.*"` dtype string aliases in the PyTorch common dtype resolver before NumPy dtype parsing
- preserve the existing NumPy dtype object/type and `torch.dtype` handling for `array()` and `cast()`
- add a forced-PyTorch subprocess regression for `backend.array(..., dtype="torch.float64")`, `backend.cast(..., "torch.float32")`, and complex aliases

## Bug fixed
The PyTorch common helper accepted NumPy dtype objects/types and actual `torch.dtype` objects, but string aliases such as `"torch.float64"` fell through unchanged after `np.dtype(...)` rejected them. Passing that unresolved string to Torch then raised `TypeError` in public array/cast paths.

## Testing
- Added `tests/backend_support/test_pytorch_dtype_argument_contract.py`
- Locally sanity-checked the resolver logic in an isolated PyTorch snippet
- Full repository tests should run in CI