### PR TITLE
Fix PyTorch random dtype alias handling

### DIFF
--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -11,7 +11,11 @@ from torch.distributions.multivariate_normal import (
     MultivariateNormal as _MultivariateNormal,
 )
 
-from ._dtype import _allow_complex_dtype, _modify_func_default_dtype
+from ._dtype import (
+    _allow_complex_dtype,
+    _modify_func_default_dtype,
+    _normalize_torch_dtype,
+)
 
 _COMPLEX_TO_FLOAT_DTYPE = {
     _torch.complex64: _torch.float32,
@@ -191,14 +195,20 @@ def _validate_randint_array_bound(name, bound):
         raise TypeError(f"{name} must contain integer values")
 
 
+def _normalize_torch_dtype_kwargs(kwargs):
+    if "dtype" not in kwargs:
+        return kwargs
+    kwargs = dict(kwargs)
+    kwargs["dtype"] = _normalize_torch_dtype(kwargs["dtype"], default=None)
+    return kwargs
+
+
 def _randint_array(low, high, size, *args, **kwargs):
     if args:
         raise TypeError(
             "array-valued randint bounds do not support additional positional arguments"
         )
-    dtype = kwargs.pop("dtype", None)
-    if dtype is None:
-        dtype = _torch.int64
+    dtype = _normalize_torch_dtype(kwargs.pop("dtype", None), default=_torch.int64)
     device = kwargs.pop("device", None)
     generator = kwargs.pop("generator", None)
     out = kwargs.pop("out", None)
@@ -230,6 +240,7 @@ def _randint_array(low, high, size, *args, **kwargs):
 
 
 def randint(low, high=None, size=None, *args, **kwargs):
+    kwargs = _normalize_torch_dtype_kwargs(kwargs)
     if high is None:
         if low is None:
             raise TypeError("randint() missing required argument 'high'")
@@ -429,6 +440,7 @@ def seed(*args, **kwargs):
 
 
 def rand(*dims, size=None, dtype=None):
+    dtype = _normalize_torch_dtype(dtype, default=None)
     return _torch.rand(_shape_from_rand_args(dims, size), dtype=dtype)
 
 
@@ -526,6 +538,7 @@ def _validate_uniform_bounds(low, high):
 
 
 def uniform(low=0.0, high=1.0, size=None, dtype=None):
+    dtype = _normalize_torch_dtype(dtype, default=None)
     device = None
     if _torch.is_tensor(low):
         device = low.device

--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -29,6 +29,19 @@ _INTEGER_DTYPES = {
     _torch.int32,
     _torch.int64,
 }
+_TORCH_DTYPE_BY_NAME = {
+    "bool": _torch.bool,
+    "uint8": _torch.uint8,
+    "int8": _torch.int8,
+    "int16": _torch.int16,
+    "int32": _torch.int32,
+    "int64": _torch.int64,
+    "float16": _torch.float16,
+    "float32": _torch.float32,
+    "float64": _torch.float64,
+    "complex64": _torch.complex64,
+    "complex128": _torch.complex128,
+}
 
 
 def _size_type_error():
@@ -195,11 +208,21 @@ def _validate_randint_array_bound(name, bound):
         raise TypeError(f"{name} must contain integer values")
 
 
+def _normalize_random_dtype(dtype, *, default):
+    dtype = _normalize_torch_dtype(dtype, default=default)
+    if dtype is None or isinstance(dtype, _torch.dtype):
+        return dtype
+    try:
+        return _TORCH_DTYPE_BY_NAME[str(_np.dtype(dtype))]
+    except (KeyError, TypeError):
+        return dtype
+
+
 def _normalize_torch_dtype_kwargs(kwargs):
     if "dtype" not in kwargs:
         return kwargs
     kwargs = dict(kwargs)
-    kwargs["dtype"] = _normalize_torch_dtype(kwargs["dtype"], default=None)
+    kwargs["dtype"] = _normalize_random_dtype(kwargs["dtype"], default=None)
     return kwargs
 
 
@@ -208,7 +231,7 @@ def _randint_array(low, high, size, *args, **kwargs):
         raise TypeError(
             "array-valued randint bounds do not support additional positional arguments"
         )
-    dtype = _normalize_torch_dtype(kwargs.pop("dtype", None), default=_torch.int64)
+    dtype = _normalize_random_dtype(kwargs.pop("dtype", None), default=_torch.int64)
     device = kwargs.pop("device", None)
     generator = kwargs.pop("generator", None)
     out = kwargs.pop("out", None)
@@ -440,7 +463,7 @@ def seed(*args, **kwargs):
 
 
 def rand(*dims, size=None, dtype=None):
-    dtype = _normalize_torch_dtype(dtype, default=None)
+    dtype = _normalize_random_dtype(dtype, default=None)
     return _torch.rand(_shape_from_rand_args(dims, size), dtype=dtype)
 
 
@@ -538,7 +561,7 @@ def _validate_uniform_bounds(low, high):
 
 
 def uniform(low=0.0, high=1.0, size=None, dtype=None):
-    dtype = _normalize_torch_dtype(dtype, default=None)
+    dtype = _normalize_random_dtype(dtype, default=None)
     device = None
     if _torch.is_tensor(low):
         device = low.device

--- a/tests/backend/test_pytorch_random_dtype_aliases.py
+++ b/tests/backend/test_pytorch_random_dtype_aliases.py
@@ -1,0 +1,62 @@
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from pyrecest._backend.pytorch import random  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    ("dtype", "expected_dtype"),
+    [
+        (np.float32, torch.float32),
+        (np.dtype("float64"), torch.float64),
+    ],
+)
+def test_rand_accepts_numpy_dtype_aliases(dtype, expected_dtype):
+    samples = random.rand(size=(2,), dtype=dtype)
+
+    assert samples.shape == (2,)
+    assert samples.dtype == expected_dtype
+
+
+@pytest.mark.parametrize(
+    ("dtype", "expected_dtype"),
+    [
+        (np.float32, torch.float32),
+        (np.dtype("float64"), torch.float64),
+    ],
+)
+def test_uniform_accepts_numpy_dtype_aliases(dtype, expected_dtype):
+    samples = random.uniform(0.0, 1.0, size=(2,), dtype=dtype)
+
+    assert samples.shape == (2,)
+    assert samples.dtype == expected_dtype
+
+
+@pytest.mark.parametrize(
+    ("dtype", "expected_dtype"),
+    [
+        (np.int32, torch.int32),
+        (np.dtype("int64"), torch.int64),
+    ],
+)
+def test_randint_scalar_bounds_accepts_numpy_dtype_aliases(dtype, expected_dtype):
+    samples = random.randint(0, 4, size=(2,), dtype=dtype)
+
+    assert samples.shape == (2,)
+    assert samples.dtype == expected_dtype
+    assert torch.all(samples >= 0)
+    assert torch.all(samples < 4)
+
+
+def test_randint_array_bounds_accepts_numpy_dtype_alias():
+    low = torch.tensor([0, 10])
+    high = torch.tensor([4, 14])
+
+    samples = random.randint(low, high, dtype=np.dtype("int32"))
+
+    assert samples.shape == (2,)
+    assert samples.dtype == torch.int32
+    assert torch.all(samples >= low.to(dtype=torch.int32))
+    assert torch.all(samples < high.to(dtype=torch.int32))


### PR DESCRIPTION
## Summary
- normalize dtype aliases in the PyTorch random backend before forwarding them to Torch
- handle NumPy dtype/type aliases for `rand`, `uniform`, and both scalar-bound and array-bound `randint`
- add focused regression coverage for floating and integer NumPy dtype aliases

## Bug fixed
`pyrecest._backend.pytorch.random.rand(..., dtype=np.float64)`, `uniform(..., dtype=np.dtype("float64"))`, and `randint(..., dtype=np.int32)` forwarded NumPy dtype aliases directly into Torch APIs, which require `torch.dtype` objects. That made otherwise portable dtype arguments fail with `TypeError` under the PyTorch random backend.

This is intentionally scoped to the random backend so it does not conflict with the open general dtype-alias resolver PR.

## Testing
- Added `tests/backend/test_pytorch_random_dtype_aliases.py`
- Locally reproduced the raw PyTorch failure mode for `torch.rand`, `torch.as_tensor`, and `torch.randint` receiving NumPy dtype aliases
- Full repository tests were not run in this connector environment