### PR TITLE
Fix PyTorch fftconvolve negative-stride inputs

### DIFF
--- a/src/pyrecest/_backend/pytorch/signal.py
+++ b/src/pyrecest/_backend/pytorch/signal.py
@@ -58,12 +58,26 @@ def _validate_non_convolved_shapes(shape1, shape2, axes):
         raise ValueError(f"incompatible shapes for in1 and in2: {shape1} and {shape2}")
 
 
+def _as_torch_compatible(value):
+    if isinstance(value, _np.ndarray) and any(stride < 0 for stride in value.strides):
+        return value.copy()
+    return value
+
+
 def _as_tensor_pair(in1, in2):
     device = next(
         (value.device for value in (in1, in2) if _torch.is_tensor(value)), None
     )
-    x = in1 if _torch.is_tensor(in1) else _torch.as_tensor(in1, device=device)
-    y = in2 if _torch.is_tensor(in2) else _torch.as_tensor(in2, device=x.device)
+    x = (
+        in1
+        if _torch.is_tensor(in1)
+        else _torch.as_tensor(_as_torch_compatible(in1), device=device)
+    )
+    y = (
+        in2
+        if _torch.is_tensor(in2)
+        else _torch.as_tensor(_as_torch_compatible(in2), device=x.device)
+    )
     y = y.to(device=x.device)
 
     dtype = _torch.promote_types(x.dtype, y.dtype)

--- a/tests/backend_support/test_pytorch_fftconvolve_contract.py
+++ b/tests/backend_support/test_pytorch_fftconvolve_contract.py
@@ -38,6 +38,19 @@ def test_pytorch_fftconvolve_matches_scipy_selected_axes():
     assert np.allclose(actual, expected)
 
 
+def test_pytorch_fftconvolve_accepts_negative_stride_numpy_views():
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific signal backend contract")
+
+    first = np.arange(6.0).reshape(2, 3)[:, ::-1]
+    second = np.asarray([[1.0, -0.25], [0.5, 0.75]])[::-1, :]
+
+    actual = _as_numpy(backend.signal.fftconvolve(first, second, mode="same"))
+    expected = scipy_fftconvolve(first, second, mode="same")
+
+    assert np.allclose(actual, expected)
+
+
 def test_pytorch_fftconvolve_same_crops_broadcast_non_convolved_axes():
     if backend.__backend_name__ != "pytorch":
         pytest.skip("PyTorch-specific signal backend contract")


### PR DESCRIPTION
## Summary
- copy negative-stride NumPy views before converting PyTorch signal inputs with `torch.as_tensor`
- add a PyTorch `fftconvolve` regression matching SciPy for negative-stride NumPy views

## Bug fixed
`backend.signal.fftconvolve(np_arr[:, ::-1], ...)` under `PYRECEST_BACKEND=pytorch` reached `torch.as_tensor` directly, which rejects negative-stride NumPy views. SciPy accepts these views, so the PyTorch signal facade should accept them as array-like inputs.

## Testing
- Added `tests/backend_support/test_pytorch_fftconvolve_contract.py::test_pytorch_fftconvolve_accepts_negative_stride_numpy_views`
- Ran a standalone PyTorch/SciPy smoke test that reproduced the raw `torch.as_tensor` failure and verified the patched `fftconvolve` output matches SciPy
- Full repository tests were not run because this environment cannot clone GitHub repositories (`github.com` DNS resolution is unavailable)