### PR TITLE
Fix PyTorch repeat axis handling

### DIFF
--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -250,6 +250,68 @@ def _patch_pytorch_tile_facade() -> None:
     backend.tile = tile
 
 
+def _pytorch_repeat_repeats(repeats, numpy_module, torch_module, *, device):
+    """Normalize NumPy-style repeat counts for ``torch.repeat_interleave``."""
+
+    if torch_module.is_tensor(repeats):
+        if repeats.ndim == 0:
+            return _pytorch_tile_repetition(repeats.detach().cpu().item())
+        return repeats.to(device=device, dtype=torch_module.long)
+
+    repeats_array = numpy_module.asarray(repeats)
+    if repeats_array.shape == ():
+        return _pytorch_tile_repetition(repeats_array.item())
+
+    if any(stride < 0 for stride in repeats_array.strides):
+        repeats_array = repeats_array.copy()
+    return torch_module.as_tensor(repeats_array, dtype=torch_module.long, device=device)
+
+
+def _patch_pytorch_repeat_facade() -> None:
+    """Make public and raw PyTorch ``repeat`` follow NumPy's axis contract."""
+
+    import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        return
+
+    try:
+        import numpy as _np  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+        import torch as _torch  # pylint: disable=import-outside-toplevel
+    except (
+        ModuleNotFoundError
+    ):  # pragma: no cover - backend import fails first in practice
+        return
+
+    def repeat(a, repeats, axis=None):
+        values = backend.array(a)
+        if axis is None:
+            values = values.reshape(-1)
+            dim = 0
+        else:
+            dim = _operator_index(axis)
+            if dim < 0:
+                dim += values.ndim
+            if dim < 0 or dim >= values.ndim:
+                raise IndexError(
+                    f"axis {axis} is out of bounds for array of dimension {values.ndim}"
+                )
+
+        repeat_counts = _pytorch_repeat_repeats(
+            repeats,
+            _np,
+            _torch,
+            device=values.device,
+        )
+        return _torch.repeat_interleave(values, repeat_counts, dim=dim)
+
+    repeat.__name__ = "repeat"
+    repeat.__doc__ = getattr(_np.repeat, "__doc__", None)
+    pytorch_backend.repeat = repeat
+    backend.repeat = repeat
+
+
 def _patch_pytorch_stack_helpers_facade() -> None:
     """Make public PyTorch stack helpers accept NumPy-style array-like inputs."""
 
@@ -396,6 +458,7 @@ def _patch_jax_matmul_out_facade() -> None:
 _patch_pytorch_comparison_facade()
 _patch_pytorch_clip_facade()
 _patch_pytorch_tile_facade()
+_patch_pytorch_repeat_facade()
 _patch_pytorch_stack_helpers_facade()
 _patch_jax_std_out_facade()
 _patch_jax_matmul_out_facade()

--- a/tests/backend_support/test_pytorch_repeat_contract.py
+++ b/tests/backend_support/test_pytorch_repeat_contract.py
@@ -1,0 +1,38 @@
+"""Regression tests for PyTorch backend repeat semantics."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_pytorch_repeat_accepts_numpy_axis_keyword_and_array_counts():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+from pyrecest.backend import asarray, repeat, to_numpy
+import pyrecest._backend.pytorch as pytorch_backend
+
+values = asarray([[1, 2], [3, 4]])
+
+axis_zero = repeat(values, 2, axis=0)
+assert to_numpy(axis_zero).tolist() == [[1, 2], [1, 2], [3, 4], [3, 4]]
+
+axis_last = repeat(values, [1, 2], axis=-1)
+assert to_numpy(axis_last).tolist() == [[1, 2, 2], [3, 4, 4]]
+
+flattened = repeat(values, [1, 2, 1, 0])
+assert to_numpy(flattened).tolist() == [1, 2, 2, 3]
+
+raw_backend_result = pytorch_backend.repeat([[1, 2]], 2, axis=1)
+assert to_numpy(raw_backend_result).tolist() == [[1, 1, 2, 2]]
+""",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Fixes PyTorch backend repeat so NumPy-style axis arguments work consistently with the backend facade. Adds a focused regression test for scalar repeats, per-element repeat counts, flattening behavior, and raw backend access.

Testing: added a focused regression test; full test suite was not run in this connector environment.