### PR TITLE
Fix PyTorch repeat axis contract

### DIFF
--- a/src/pyrecest/_backend_submodules.py
+++ b/src/pyrecest/_backend_submodules.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 from functools import wraps
+from operator import index as _operator_index
 from types import ModuleType
 
 from pyrecest._backend import BACKEND_ATTRIBUTES
@@ -98,6 +99,78 @@ def _adapt_pytorch_allclose_keyword_contract(backend: ModuleType) -> None:
     setattr(pytorch_backend, "allclose", wrapped_allclose)
 
 
+def _pytorch_repeat_count(repeat) -> int:
+    """Return one NumPy-style repeat count as an integer."""
+    try:
+        return _operator_index(repeat)
+    except TypeError as exc:
+        raise TypeError("repeat counts must be integers") from exc
+
+
+def _pytorch_repeat_repeats(repeats, numpy_module, torch_module, *, device):
+    """Normalize NumPy-style repeat counts for ``torch.repeat_interleave``."""
+    if torch_module.is_tensor(repeats):
+        if repeats.ndim == 0:
+            return _pytorch_repeat_count(repeats.detach().cpu().item())
+        repeats_array = repeats.detach().cpu().numpy()
+    else:
+        repeats_array = numpy_module.asarray(repeats)
+
+    if repeats_array.shape == ():
+        return _pytorch_repeat_count(repeats_array.item())
+
+    repeat_counts = numpy_module.asarray(
+        [_pytorch_repeat_count(one_repeat) for one_repeat in repeats_array.tolist()],
+        dtype=numpy_module.int64,
+    )
+    return torch_module.as_tensor(repeat_counts, dtype=torch_module.long, device=device)
+
+
+def _adapt_pytorch_repeat_axis_contract(backend: ModuleType) -> None:
+    """Adapt PyTorch repeat to accept NumPy's ``axis`` keyword."""
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        return
+
+    repeat = getattr(backend, "repeat", None)
+    if repeat is None or getattr(repeat, "_pyrecest_axis_contract", False):
+        return
+
+    try:
+        import numpy as _np  # pylint: disable=import-outside-toplevel
+        import torch as _torch  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - backend import fails first
+        return
+
+    def wrapped_repeat(a, repeats, axis=None):
+        values = backend.array(a)
+        if axis is None:
+            values = values.reshape(-1)
+            dim = 0
+        else:
+            dim = _operator_index(axis)
+            if dim < 0:
+                dim += values.ndim
+            if dim < 0 or dim >= values.ndim:
+                raise IndexError(
+                    f"axis {axis} is out of bounds for array of dimension {values.ndim}"
+                )
+
+        repeat_counts = _pytorch_repeat_repeats(
+            repeats,
+            _np,
+            _torch,
+            device=values.device,
+        )
+        return _torch.repeat_interleave(values, repeat_counts, dim=dim)
+
+    wrapped_repeat.__name__ = "repeat"
+    wrapped_repeat.__doc__ = getattr(_np.repeat, "__doc__", None)
+    wrapped_repeat._pyrecest_axis_contract = True
+    setattr(backend, "repeat", wrapped_repeat)
+    setattr(pytorch_backend, "repeat", wrapped_repeat)
+
+
 def register_backend_submodules(backend: ModuleType | None = None) -> None:
     """Register virtual backend submodules for standard import statements."""
     if backend is None:
@@ -105,6 +178,7 @@ def register_backend_submodules(backend: ModuleType | None = None) -> None:
 
     _adapt_cumulative_out_contract(backend)
     _adapt_pytorch_allclose_keyword_contract(backend)
+    _adapt_pytorch_repeat_axis_contract(backend)
 
     backend.__path__ = getattr(backend, "__path__", [])
     backend_spec = getattr(backend, "__spec__", None)

--- a/tests/backend_support/test_pytorch_repeat_contract.py
+++ b/tests/backend_support/test_pytorch_repeat_contract.py
@@ -1,0 +1,38 @@
+"""Regression tests for PyTorch backend repeat semantics."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_pytorch_repeat_accepts_numpy_axis_keyword_and_array_counts():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+from pyrecest.backend import asarray, repeat, to_numpy
+import pyrecest._backend.pytorch as pytorch_backend
+
+values = asarray([[1, 2], [3, 4]])
+
+axis_zero = repeat(values, 2, axis=0)
+assert to_numpy(axis_zero).tolist() == [[1, 2], [1, 2], [3, 4], [3, 4]]
+
+axis_last = repeat(values, [1, 2], axis=-1)
+assert to_numpy(axis_last).tolist() == [[1, 2, 2], [3, 4, 4]]
+
+flattened = repeat(values, [1, 2, 1, 0])
+assert to_numpy(flattened).tolist() == [1, 2, 2, 3]
+
+raw_backend_result = pytorch_backend.repeat([[1, 2]], 2, axis=1)
+assert to_numpy(raw_backend_result).tolist() == [[1, 1, 2, 2]]
+""",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Fixes PyTorch backend repeat so NumPy-style axis arguments work consistently with the backend facade. The patch lives in the backend-submodule adaptation layer and updates both the public facade and raw PyTorch backend binding.

Testing: added a focused regression test for scalar repeats, per-element repeat counts, flattening behavior, and raw backend access. Full test suite was not run in this connector environment.