### PR TITLE
Fix PyTorch stack and concatenate backend contract

### DIFF
--- a/src/pyrecest/_backend_submodules.py
+++ b/src/pyrecest/_backend_submodules.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 from functools import wraps
+from operator import index as _operator_index
 from types import ModuleType
 
 from pyrecest._backend import BACKEND_ATTRIBUTES
@@ -66,7 +67,6 @@ def _adapt_pytorch_allclose_keyword_contract(backend: ModuleType) -> None:
         import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
     except ModuleNotFoundError:  # pragma: no cover - backend import fails first
         return
-
     missing_value_key = "equal_" + "na" + "n"
 
     @wraps(allclose)
@@ -98,6 +98,71 @@ def _adapt_pytorch_allclose_keyword_contract(backend: ModuleType) -> None:
     setattr(pytorch_backend, "allclose", wrapped_allclose)
 
 
+def _adapt_pytorch_stack_sequence_contract(backend: ModuleType) -> None:
+    """Adapt PyTorch stack/concatenate to NumPy-style sequence and axis inputs."""
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        return
+
+    stack_func = getattr(backend, "stack", None)
+    concatenate_func = getattr(backend, "concatenate", None)
+    if stack_func is None or concatenate_func is None:
+        return
+    if getattr(stack_func, "_pyrecest_sequence_contract", False) and getattr(
+        concatenate_func, "_pyrecest_sequence_contract", False
+    ):
+        return
+
+    try:
+        import torch as _torch  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - backend import fails first
+        return
+
+    def _tensor_sequence(seq):
+        tensors = tuple(backend.array(item) for item in seq)
+        if not tensors:
+            return tensors
+
+        device = next(
+            (tensor.device for tensor in tensors if _torch.is_tensor(tensor)),
+            None,
+        )
+        if device is not None:
+            tensors = tuple(tensor.to(device=device) for tensor in tensors)
+
+        dtype = tensors[0].dtype
+        for tensor in tensors[1:]:
+            dtype = _torch.promote_types(dtype, tensor.dtype)
+        return tuple(tensor.to(dtype=dtype) for tensor in tensors)
+
+    def _stack_axis(axis, dim):
+        axis = _operator_index(axis)
+        if dim is None:
+            return axis
+        dim = _operator_index(dim)
+        if axis not in (0, dim):
+            raise TypeError("stack() got both 'axis' and 'dim'")
+        return dim
+
+    @wraps(stack_func)
+    def wrapped_stack(seq, axis=0, out=None, *, dim=None):
+        axis = _stack_axis(axis, dim)
+        return _torch.stack(_tensor_sequence(seq), dim=axis, out=out)
+
+    @wraps(concatenate_func)
+    def wrapped_concatenate(seq, axis=0, out=None):
+        axis = _operator_index(axis)
+        return _torch.cat(_tensor_sequence(seq), dim=axis, out=out)
+
+    wrapped_stack._pyrecest_sequence_contract = True
+    wrapped_concatenate._pyrecest_sequence_contract = True
+
+    setattr(backend, "stack", wrapped_stack)
+    setattr(pytorch_backend, "stack", wrapped_stack)
+    setattr(backend, "concatenate", wrapped_concatenate)
+    setattr(pytorch_backend, "concatenate", wrapped_concatenate)
+
+
 def register_backend_submodules(backend: ModuleType | None = None) -> None:
     """Register virtual backend submodules for standard import statements."""
     if backend is None:
@@ -105,6 +170,7 @@ def register_backend_submodules(backend: ModuleType | None = None) -> None:
 
     _adapt_cumulative_out_contract(backend)
     _adapt_pytorch_allclose_keyword_contract(backend)
+    _adapt_pytorch_stack_sequence_contract(backend)
 
     backend.__path__ = getattr(backend, "__path__", [])
     backend_spec = getattr(backend, "__spec__", None)

--- a/tests/backend_support/test_pytorch_stack_helpers_contract.py
+++ b/tests/backend_support/test_pytorch_stack_helpers_contract.py
@@ -1,9 +1,7 @@
 import importlib.util
-import os
-import subprocess
-import sys
 
 import pytest
+from tests.support.backend_runner import run_backend_code
 
 
 @pytest.mark.backend_portable
@@ -11,17 +9,18 @@ def test_pytorch_stack_helpers_accept_array_like_sequences():
     if importlib.util.find_spec("torch") is None:
         pytest.skip("torch is not installed")
 
-    env = os.environ.copy()
-    env["PYRECEST_BACKEND"] = "pytorch"
-    src_path = os.path.abspath("src")
-    env["PYTHONPATH"] = (
-        src_path
-        if not env.get("PYTHONPATH")
-        else os.pathsep.join([src_path, env["PYTHONPATH"]])
-    )
-
-    code = """
+    result = run_backend_code(
+        "pytorch",
+        """
 import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_backend
+
+assert backend.to_numpy(backend.stack(([1, 2], [3, 4]), axis=1)).tolist() == [[1, 3], [2, 4]]
+assert backend.to_numpy(backend.stack(([1, 2], [3, 4]), dim=1)).tolist() == [[1, 3], [2, 4]]
+assert backend.to_numpy(backend.concatenate(([1, 2], [3, 4]), axis=0)).tolist() == [1, 2, 3, 4]
+assert backend.to_numpy(backend.concatenate(([[1], [2]], [[3], [4]]), axis=1)).tolist() == [[1, 3], [2, 4]]
+assert backend.to_numpy(raw_backend.stack(([1, 2], [3, 4]), axis=1)).tolist() == [[1, 3], [2, 4]]
+assert backend.to_numpy(raw_backend.concatenate(([1, 2], [3, 4]), axis=0)).tolist() == [1, 2, 3, 4]
 
 assert backend.to_numpy(backend.hstack(([1, 2], [3, 4]))).tolist() == [1, 2, 3, 4]
 assert backend.to_numpy(backend.vstack(([1, 2], [3, 4]))).tolist() == [[1, 2], [3, 4]]
@@ -31,5 +30,9 @@ assert backend.to_numpy(backend.dstack(([1, 2], [3, 4]))).tolist() == [[[1, 3], 
 values = backend.array([[1, 2], [3, 4]])
 assert backend.to_numpy(backend.hstack((values, [[5, 6], [7, 8]]))).tolist() == [[1, 2, 5, 6], [3, 4, 7, 8]]
 assert backend.to_numpy(backend.column_stack((values, [[5, 6], [7, 8]]))).tolist() == [[1, 2, 5, 6], [3, 4, 7, 8]]
-"""
-    subprocess.run([sys.executable, "-c", code], check=True, env=env)
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
Summary:
- Make PyTorch backend stack and concatenate accept NumPy-style array-like sequences.
- Support stack(axis=...) while preserving stack(dim=...).
- Add regression coverage for public and backend-module calls.

Validation:
- Syntax checked locally.
- Added focused regression test coverage.