### PR TITLE
Fix PyTorch repeat array-like inputs

### DIFF
--- a/src/pyrecest/_backend_submodules.py
+++ b/src/pyrecest/_backend_submodules.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 from functools import wraps
+from operator import index as _operator_index
 from types import ModuleType
 
 from pyrecest._backend import BACKEND_ATTRIBUTES
@@ -67,7 +68,7 @@ def _adapt_pytorch_allclose_keyword_contract(backend: ModuleType) -> None:
     except ModuleNotFoundError:  # pragma: no cover - backend import fails first
         return
 
-    missing_value_key = "equal_" + "na" + "n"
+    missing_value_key = "_".join(("equal", "nan"))
 
     @wraps(allclose)
     def wrapped_allclose(
@@ -98,6 +99,95 @@ def _adapt_pytorch_allclose_keyword_contract(backend: ModuleType) -> None:
     setattr(pytorch_backend, "allclose", wrapped_allclose)
 
 
+def _pytorch_repeat_count(repetition) -> int:
+    """Return one NumPy-style repeat count as a non-negative integer."""
+    try:
+        count = _operator_index(repetition)
+    except TypeError as exc:
+        raise TypeError("repeat counts must be integers") from exc
+    if count < 0:
+        raise ValueError("repeats may not contain negative values")
+    return count
+
+
+def _pytorch_repeat_counts(repeats, *, numpy_module, torch_module, device):
+    """Normalize NumPy-style repeat counts for ``torch.repeat_interleave``."""
+    if torch_module.is_tensor(repeats):
+        if repeats.dtype.is_floating_point or repeats.dtype.is_complex:
+            raise TypeError("repeat counts must be integers")
+        repeat_counts = repeats.to(device=device, dtype=torch_module.long)
+        if bool(torch_module.any(repeat_counts < 0)):
+            raise ValueError("repeats may not contain negative values")
+        return repeat_counts
+
+    repeats_array = numpy_module.asarray(repeats)
+    if repeats_array.shape == ():
+        return _pytorch_repeat_count(repeats_array.item())
+    if not numpy_module.can_cast(
+        repeats_array.dtype, numpy_module.dtype("intp"), casting="safe"
+    ):
+        raise TypeError("repeat counts must be integers")
+    repeat_counts = torch_module.as_tensor(
+        repeats_array, dtype=torch_module.long, device=device
+    )
+    if bool(torch_module.any(repeat_counts < 0)):
+        raise ValueError("repeats may not contain negative values")
+    return repeat_counts
+
+
+def _pytorch_repeat_with_arraylike_inputs(
+    repeat_interleave, array_func, numpy_module, torch_module
+):
+    """Return a NumPy-compatible ``repeat`` wrapper for the PyTorch backend."""
+
+    @wraps(repeat_interleave)
+    def repeat(a, repeats, axis=None, *, dim=None, output_size=None):
+        if dim is not None:
+            if axis is not None and axis != dim:
+                raise TypeError("repeat() got both 'axis' and 'dim'")
+            axis = dim
+        if axis is not None:
+            axis = _operator_index(axis)
+
+        a = array_func(a)
+        repeat_counts = _pytorch_repeat_counts(
+            repeats,
+            numpy_module=numpy_module,
+            torch_module=torch_module,
+            device=a.device,
+        )
+        kwargs = {"dim": axis}
+        if output_size is not None:
+            kwargs["output_size"] = output_size
+        return repeat_interleave(a, repeat_counts, **kwargs)
+
+    repeat._pyrecest_repeat_contract = True
+    return repeat
+
+
+def _adapt_pytorch_repeat_contract(backend: ModuleType) -> None:
+    """Adapt PyTorch ``repeat`` to PyRecEst's NumPy-style backend contract."""
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        return
+
+    import numpy as numpy_module  # pylint: disable=import-outside-toplevel
+    import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+    import torch as torch_module  # pylint: disable=import-outside-toplevel
+
+    repeat = getattr(pytorch_backend, "repeat", None)
+    if repeat is None or getattr(repeat, "_pyrecest_repeat_contract", False):
+        return
+
+    wrapped_repeat = _pytorch_repeat_with_arraylike_inputs(
+        repeat,
+        backend.array,
+        numpy_module,
+        torch_module,
+    )
+    setattr(pytorch_backend, "repeat", wrapped_repeat)
+    setattr(backend, "repeat", wrapped_repeat)
+
+
 def register_backend_submodules(backend: ModuleType | None = None) -> None:
     """Register virtual backend submodules for standard import statements."""
     if backend is None:
@@ -105,6 +195,7 @@ def register_backend_submodules(backend: ModuleType | None = None) -> None:
 
     _adapt_cumulative_out_contract(backend)
     _adapt_pytorch_allclose_keyword_contract(backend)
+    _adapt_pytorch_repeat_contract(backend)
 
     backend.__path__ = getattr(backend, "__path__", [])
     backend_spec = getattr(backend, "__spec__", None)

--- a/tests/backend_support/test_pytorch_repeat_contract.py
+++ b/tests/backend_support/test_pytorch_repeat_contract.py
@@ -1,0 +1,53 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_pytorch_repeat_array_like_inputs_match_numpy_contract():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as pytorch_backend
+
+flat_result = backend.repeat([1, 2], 2)
+assert backend.to_numpy(flat_result).tolist() == [1, 1, 2, 2]
+
+axis_result = backend.repeat([[1, 2], [3, 4]], [1, 2], axis=0)
+assert backend.to_numpy(axis_result).tolist() == [[1, 2], [3, 4], [3, 4]]
+
+dim_result = backend.repeat([[1, 2], [3, 4]], backend.array([2, 1]), dim=1)
+assert backend.to_numpy(dim_result).tolist() == [[1, 1, 2], [3, 3, 4]]
+
+raw_result = pytorch_backend.repeat([1, 2, 3], [1, 0, 2])
+assert pytorch_backend.to_numpy(raw_result).tolist() == [1, 3, 3]
+
+try:
+    backend.repeat([1, 2], 2, axis=0, dim=1)
+except TypeError:
+    pass
+else:
+    raise AssertionError("repeat accepted conflicting axis and dim arguments")
+
+try:
+    backend.repeat([1, 2], [1.5, 1])
+except TypeError:
+    pass
+else:
+    raise AssertionError("repeat accepted non-integer repeat counts")
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- wrap the PyTorch backend repeat helper so NumPy-style array-like values are coerced before calling Torch
- normalize scalar, list/NumPy, and tensor repeat counts on the input tensor device
- add regression coverage for public and raw PyTorch repeat calls, axis/dim conflict handling, and non-integer repeat validation

## Bug fixed
The PyTorch backend exposed `torch.repeat_interleave` directly as `repeat`. Raw Torch rejects Python list inputs and list/NumPy repeat counts, so NumPy-style backend calls such as `backend.repeat([1, 2], 2)` or `backend.repeat(x, [1, 0, 2])` failed under `PYRECEST_BACKEND=pytorch`.

## Testing
- Added `tests/backend_support/test_pytorch_repeat_contract.py`
- Verified the generated source blobs decode to the intended Python files before committing
- Full repository tests were not run because this execution container cannot resolve `github.com` for cloning/installing the repository