### PR TITLE
Fix PyTorch linalg QR modes

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -153,6 +153,29 @@ def block_diag(*arrs):
     return _torch.block_diag(*(array(arr) for arr in arrs))
 
 
+def qr(a, mode="reduced"):
+    """Compute QR decomposition with NumPy-compatible mode semantics."""
+    a = _as_linalg_tensor(a)
+
+    if mode in ("full", "f"):
+        mode = "reduced"
+    elif mode == "e":
+        mode = "economic"
+
+    if mode in ("reduced", "complete"):
+        return _torch.linalg.qr(a, mode=mode)
+    if mode == "r":
+        return _torch.linalg.qr(a, mode="r").R
+    if mode == "raw":
+        geqrf, tau = _torch.geqrf(a)
+        return geqrf.transpose(-2, -1), tau
+    if mode == "economic":
+        geqrf, _ = _torch.geqrf(a)
+        return geqrf
+
+    raise ValueError(f"Unrecognized mode {mode!r}")
+
+
 class _Logm(_torch.autograd.Function):
     """Torch autograd function for matrix logarithm."""
 
@@ -238,134 +261,3 @@ def solve(a, b):
     a = a.to(dtype=common_dtype)
     b = b.to(dtype=common_dtype)
     return _torch.linalg.solve(a, b)
-
-
-def quadratic_assignment(a, b, options=None):
-    return list(
-        _scipy.optimize.quadratic_assignment(
-            _as_numpy_no_grad(a), _as_numpy_no_grad(b), options=options
-        ).col_ind
-    )
-
-
-def qr(a, mode="reduced"):
-    """Compute QR decomposition with NumPy-compatible mode handling."""
-    a = _as_linalg_tensor(a)
-    if mode in {"reduced", "complete"}:
-        return _torch.linalg.qr(a, mode=mode)
-    if mode == "r":
-        return _torch.linalg.qr(a, mode=mode).R
-    if mode in {"raw", "economic"}:
-        result = _np.linalg.qr(_as_numpy_no_grad(a), mode=mode)
-        if mode == "raw":
-            h, tau = result
-            return _torch_as_like(h, a), _torch_as_like(tau, a)
-        return _torch_as_like(result, a)
-    raise ValueError(f"Unrecognized mode {mode!r}")
-
-
-def solve_sylvester(a, b, q):
-    a = _as_linalg_tensor(a)
-    b = _as_linalg_tensor(b)
-    q = _as_linalg_tensor(q)
-    common_dtype = _common_linalg_dtype(a, b, q)
-    a = a.to(dtype=common_dtype)
-    b = b.to(dtype=common_dtype)
-    q = q.to(dtype=common_dtype)
-    is_shared_factor = a.shape == b.shape and _torch.allclose(
-        a, b, atol=1e-6, rtol=1e-6
-    )
-    is_shared_hermitian_factor = is_shared_factor and _torch.all(
-        _torch.abs(a - a.transpose(-2, -1).conj()) < 1e-6
-    )
-    if is_shared_hermitian_factor:
-        eigvals, eigvecs = eigh(a)
-        if _torch.all(eigvals >= 1e-6):
-            adjoint_eigvecs = eigvecs.transpose(-2, -1).conj()
-            tilde_q = adjoint_eigvecs @ q @ eigvecs
-            tilde_x = tilde_q / (eigvals[..., :, None] + eigvals[..., None, :])
-            return eigvecs @ tilde_x @ adjoint_eigvecs
-
-    is_real_shared_symmetric_factor = (
-        is_shared_factor
-        and not is_complex(a)
-        and _torch.all(_torch.abs(a - a.transpose(-2, -1)) < 1e-6)
-    )
-    if is_real_shared_symmetric_factor:
-        eigvals, eigvecs = eigh(a)
-        conditions = _torch.all(eigvals >= 1e-6) or (
-            a.shape[-1] >= 2.0
-            and _torch.all(eigvals[..., 0] > -1e-6)
-            and _torch.all(eigvals[..., 1] >= 1e-6)
-            and _torch.all(_torch.abs(q + q.transpose(-2, -1)) < 1e-6)
-        )
-        if conditions:
-            tilde_q = eigvecs.transpose(-2, -1) @ q @ eigvecs
-            denominators = eigvals[..., :, None] + eigvals[..., None, :]
-            safe_denominators = _torch.where(
-                _torch.abs(denominators) < 1e-12,
-                _torch.ones((), dtype=denominators.dtype, device=denominators.device),
-                denominators,
-            )
-            tilde_x = tilde_q / safe_denominators
-            tilde_x = _torch.where(
-                _torch.abs(denominators) < 1e-12,
-                _torch.zeros((), dtype=tilde_x.dtype, device=tilde_x.device),
-                tilde_x,
-            )
-            return eigvecs @ tilde_x @ eigvecs.transpose(-2, -1)
-
-    solution = _np.vectorize(
-        _scipy.linalg.solve_sylvester, signature="(m,m),(n,n),(m,n)->(m,n)"
-    )(_as_numpy_no_grad(a), _as_numpy_no_grad(b), _as_numpy_no_grad(q))
-    return _torch_as_like(solution, q)
-
-
-# (TODO) (sait) _torch.linalg.cholesky_ex for even faster way
-def is_single_matrix_pd(mat):
-    """Check if 2D square matrix is positive definite."""
-    mat = _as_linalg_tensor(mat)
-    if mat.ndim != 2 or mat.shape[0] != mat.shape[1]:
-        return False
-    if mat.dtype in [_torch.complex64, _torch.complex128]:
-        is_hermitian = _torch.all(
-            _torch.abs(mat - _torch.conj(_torch.transpose(mat, 0, 1))) < atol
-        )
-        if not is_hermitian:
-            return False
-        eigvals = _torch.linalg.eigvalsh(mat)
-        return _torch.min(_torch.real(eigvals)) > 0
-    if not _torch.all(_torch.abs(mat - mat.transpose(-2, -1)) < atol):
-        return False
-    try:
-        _torch.linalg.cholesky(mat)
-        return True
-    except RuntimeError:
-        return False
-
-
-def fractional_matrix_power(A, t):
-    """Compute the fractional power of a matrix."""
-    A = _as_linalg_tensor(A)
-    A_np = _as_numpy_no_grad(A)
-    out = _np.vectorize(
-        lambda one_matrix: _scipy.linalg.fractional_matrix_power(one_matrix, t),
-        signature="(n,n)->(n,n)",
-    )(A_np)
-
-    if out.dtype.kind == "c":
-        target_complex_dtype = _COMPLEX_DTYPE_FOR_TENSOR_DTYPE.get(A.dtype)
-        if target_complex_dtype is not None:
-            out = out.astype(target_complex_dtype, copy=False)
-
-    return _torch_as_like(out, A)
-
-
-def polar(a, side="right"):
-    """Polar decomposition of a square or rectangular matrix."""
-    a = _as_linalg_tensor(a)
-    signature = "(m,n)->(m,n),(m,m)" if side == "left" else "(m,n)->(m,n),(n,n)"
-    func = _np.vectorize(_scipy.linalg.polar, signature=signature, excluded=["side"])
-    unitary, hermitian = func(_as_numpy_no_grad(a), side=side)
-
-    return _torch_as_like(unitary, a), _torch_as_like(hermitian, a)

--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -261,3 +261,118 @@ def solve(a, b):
     a = a.to(dtype=common_dtype)
     b = b.to(dtype=common_dtype)
     return _torch.linalg.solve(a, b)
+
+
+def quadratic_assignment(a, b, options=None):
+    return list(
+        _scipy.optimize.quadratic_assignment(
+            _as_numpy_no_grad(a), _as_numpy_no_grad(b), options=options
+        ).col_ind
+    )
+
+
+def solve_sylvester(a, b, q):
+    a = _as_linalg_tensor(a)
+    b = _as_linalg_tensor(b)
+    q = _as_linalg_tensor(q)
+    common_dtype = _common_linalg_dtype(a, b, q)
+    a = a.to(dtype=common_dtype)
+    b = b.to(dtype=common_dtype)
+    q = q.to(dtype=common_dtype)
+    is_shared_factor = a.shape == b.shape and _torch.allclose(
+        a, b, atol=1e-6, rtol=1e-6
+    )
+    is_shared_hermitian_factor = is_shared_factor and _torch.all(
+        _torch.abs(a - a.transpose(-2, -1).conj()) < 1e-6
+    )
+    if is_shared_hermitian_factor:
+        eigvals, eigvecs = eigh(a)
+        if _torch.all(eigvals >= 1e-6):
+            adjoint_eigvecs = eigvecs.transpose(-2, -1).conj()
+            tilde_q = adjoint_eigvecs @ q @ eigvecs
+            tilde_x = tilde_q / (eigvals[..., :, None] + eigvals[..., None, :])
+            return eigvecs @ tilde_x @ adjoint_eigvecs
+
+    is_real_shared_symmetric_factor = (
+        is_shared_factor
+        and not is_complex(a)
+        and _torch.all(_torch.abs(a - a.transpose(-2, -1)) < 1e-6)
+    )
+    if is_real_shared_symmetric_factor:
+        eigvals, eigvecs = eigh(a)
+        conditions = _torch.all(eigvals >= 1e-6) or (
+            a.shape[-1] >= 2.0
+            and _torch.all(eigvals[..., 0] > -1e-6)
+            and _torch.all(eigvals[..., 1] >= 1e-6)
+            and _torch.all(_torch.abs(q + q.transpose(-2, -1)) < 1e-6)
+        )
+        if conditions:
+            tilde_q = eigvecs.transpose(-2, -1) @ q @ eigvecs
+            denominators = eigvals[..., :, None] + eigvals[..., None, :]
+            safe_denominators = _torch.where(
+                _torch.abs(denominators) < 1e-12,
+                _torch.ones((), dtype=denominators.dtype, device=denominators.device),
+                denominators,
+            )
+            tilde_x = tilde_q / safe_denominators
+            tilde_x = _torch.where(
+                _torch.abs(denominators) < 1e-12,
+                _torch.zeros((), dtype=tilde_x.dtype, device=tilde_x.device),
+                tilde_x,
+            )
+            return eigvecs @ tilde_x @ eigvecs.transpose(-2, -1)
+
+    solution = _np.vectorize(
+        _scipy.linalg.solve_sylvester, signature="(m,m),(n,n),(m,n)->(m,n)"
+    )(_as_numpy_no_grad(a), _as_numpy_no_grad(b), _as_numpy_no_grad(q))
+    return _torch_as_like(solution, q)
+
+
+# (TODO) (sait) _torch.linalg.cholesky_ex for even faster way
+def is_single_matrix_pd(mat):
+    """Check if 2D square matrix is positive definite."""
+    mat = _as_linalg_tensor(mat)
+    if mat.ndim != 2 or mat.shape[0] != mat.shape[1]:
+        return False
+    if mat.dtype in [_torch.complex64, _torch.complex128]:
+        is_hermitian = _torch.all(
+            _torch.abs(mat - _torch.conj(_torch.transpose(mat, 0, 1))) < atol
+        )
+        if not is_hermitian:
+            return False
+        eigvals = _torch.linalg.eigvalsh(mat)
+        return _torch.min(_torch.real(eigvals)) > 0
+    if not _torch.all(_torch.abs(mat - mat.transpose(-2, -1)) < atol):
+        return False
+    try:
+        _torch.linalg.cholesky(mat)
+        return True
+    except RuntimeError:
+        return False
+
+
+def fractional_matrix_power(A, t):
+    """Compute the fractional power of a matrix."""
+    A = _as_linalg_tensor(A)
+    A_np = _as_numpy_no_grad(A)
+    out = _np.vectorize(
+        lambda one_matrix: _scipy.linalg.fractional_matrix_power(one_matrix, t),
+        signature="(n,n)->(n,n)",
+    )(A_np)
+
+    if out.dtype.kind == "c":
+        target_complex_dtype = _COMPLEX_DTYPE_FOR_TENSOR_DTYPE.get(A.dtype)
+        if target_complex_dtype is not None:
+            out = out.astype(target_complex_dtype, copy=False)
+
+    return _torch_as_like(out, A)
+
+
+def polar(a, side="right"):
+    """Polar decomposition of a square or rectangular matrix."""
+    a = _as_linalg_tensor(a)
+    signature = "(m,n)->(m,n),(m,m)" if side == "left" else "(m,n)->(m,n),(n,n)"
+    func = _np.vectorize(_scipy.linalg.polar, signature=signature, excluded=["side"])
+    unitary, hermitian = func(_as_numpy_no_grad(a), side=side)
+
+    return _torch_as_like(unitary, a), _torch_as_like(hermitian, a)

--- a/tests/backend_support/test_pytorch_linalg_qr_legacy_modes.py
+++ b/tests/backend_support/test_pytorch_linalg_qr_legacy_modes.py
@@ -1,0 +1,57 @@
+import unittest
+from typing import Any
+
+import numpy as np
+
+pytorch_backend: Any
+try:
+    from pyrecest._backend import pytorch as pytorch_backend
+except ModuleNotFoundError:
+    pytorch_backend = None
+
+
+@unittest.skipIf(pytorch_backend is None, "PyTorch is not installed")
+class TestPytorchLinalgQrLegacyModes(unittest.TestCase):
+    def test_mode_full_alias_matches_reduced_numpy_result(self):
+        matrix_np = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 7.0]])
+        matrix = pytorch_backend.array(matrix_np, dtype=pytorch_backend.float64)
+
+        q, r = pytorch_backend.linalg.qr(matrix, mode="full")
+        expected_q, expected_r = np.linalg.qr(matrix_np, mode="reduced")
+
+        self.assertEqual(tuple(q.shape), expected_q.shape)
+        self.assertEqual(tuple(r.shape), expected_r.shape)
+        self.assertTrue(
+            pytorch_backend.allclose(
+                q, pytorch_backend.array(expected_q, dtype=pytorch_backend.float64)
+            )
+        )
+        self.assertTrue(
+            pytorch_backend.allclose(
+                r, pytorch_backend.array(expected_r, dtype=pytorch_backend.float64)
+            )
+        )
+
+    def test_mode_economic_returns_numpy_style_geqrf_storage(self):
+        matrices_np = np.stack(
+            [
+                np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 7.0]]),
+                np.array([[2.0, 0.0], [0.0, 3.0], [1.0, 4.0]]),
+            ]
+        )
+        matrices = pytorch_backend.array(matrices_np, dtype=pytorch_backend.float64)
+
+        result = pytorch_backend.linalg.qr(matrices, mode="economic")
+        expected_h, _ = np.linalg.qr(matrices_np, mode="raw")
+        expected = np.swapaxes(expected_h, -1, -2)
+
+        self.assertEqual(tuple(result.shape), expected.shape)
+        self.assertTrue(
+            pytorch_backend.allclose(
+                result, pytorch_backend.array(expected, dtype=pytorch_backend.float64)
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a PyTorch backend `linalg.qr` wrapper with NumPy-compatible mode handling and regression tests for legacy QR modes.