### PR TITLE
Fix PyTorch QR full mode alias

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -251,6 +251,9 @@ def quadratic_assignment(a, b, options=None):
 def qr(a, mode="reduced"):
     """Compute QR decomposition with NumPy-compatible mode handling."""
     a = _as_linalg_tensor(a)
+    if mode == "full":
+        # NumPy still accepts the deprecated ``full`` alias for ``reduced``.
+        mode = "reduced"
     if mode in {"reduced", "complete"}:
         return _torch.linalg.qr(a, mode=mode)
     if mode == "r":

--- a/tests/backend_support/test_pytorch_qr_mode_contract.py
+++ b/tests/backend_support/test_pytorch_qr_mode_contract.py
@@ -1,0 +1,47 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_pytorch_qr_accepts_numpy_full_mode_alias():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import numpy as np
+
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch.linalg as raw_pytorch_linalg
+from pyrecest.backend import linalg
+
+matrix = [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]
+
+for qr in (linalg.qr, raw_pytorch_linalg.qr):
+    q_full, r_full = qr(matrix, mode="full")
+    q_reduced, r_reduced = qr(matrix, mode="reduced")
+
+    assert tuple(q_full.shape) == tuple(q_reduced.shape) == (3, 2)
+    assert tuple(r_full.shape) == tuple(r_reduced.shape) == (2, 2)
+
+    np.testing.assert_allclose(backend.to_numpy(q_full), backend.to_numpy(q_reduced))
+    np.testing.assert_allclose(backend.to_numpy(r_full), backend.to_numpy(r_reduced))
+    np.testing.assert_allclose(
+        backend.to_numpy(q_full @ r_full),
+        np.asarray(matrix),
+        atol=1e-6,
+    )
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- map PyTorch backend `linalg.qr(..., mode="full")` to NumPy's deprecated `"full"` alias semantics
- keep existing native Torch paths for `"reduced"`, `"complete"`, and `"r"`
- add regression coverage for both public `pyrecest.backend.linalg.qr` and raw `pyrecest._backend.pytorch.linalg.qr`

## Bug fixed
The PyTorch linalg backend advertised NumPy-compatible QR mode handling, but it rejected `mode="full"` with `ValueError`. NumPy still accepts `"full"` as a deprecated alias for the reduced QR result, so backend-portable code using the shared NumPy backend could fail when switching to `PYRECEST_BACKEND=pytorch`.

## Testing
- Added `tests/backend_support/test_pytorch_qr_mode_contract.py`
- Verified the branch diff through the GitHub connector
- Full repository tests were not run locally because this execution container cannot resolve `github.com` for cloning/installing the repository