### PR TITLE
Fix PyTorch diag backend contract

### DIFF
--- a/src/pyrecest/backend_tools.py
+++ b/src/pyrecest/backend_tools.py
@@ -62,7 +62,38 @@ def _patch_pytorch_assignment_scalar_tensor_indices() -> None:
     )
 
 
+def _patch_pytorch_diag_numpy_contract() -> None:
+    """Make PyTorch diag accept array-like inputs and NumPy's ``k`` keyword."""
+
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        return
+
+    try:
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+        import torch as _torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
+        return
+
+    if getattr(pytorch_backend.diag, "_pyrecest_numpy_contract", False):
+        return
+
+    def diag(v, k=0):
+        return _torch.diag(pytorch_backend.array(v), diagonal=k)
+
+    diag.__name__ = getattr(_torch.diag, "__name__", "diag")
+    diag.__doc__ = getattr(_torch.diag, "__doc__", None)
+    diag._pyrecest_numpy_contract = True
+    backend.diag = diag
+    pytorch_backend.diag = diag
+
+
 _patch_pytorch_assignment_scalar_tensor_indices()
+_patch_pytorch_diag_numpy_contract()
 
 
 def get_backend_name() -> str:

--- a/tests/backend_support/test_pytorch_diag_contract.py
+++ b/tests/backend_support/test_pytorch_diag_contract.py
@@ -1,0 +1,56 @@
+import importlib.util
+import sys
+from contextlib import contextmanager
+
+import pytest
+
+
+@contextmanager
+def _isolated_pytorch_backend(monkeypatch):
+    previous_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if name == "pyrecest" or name.startswith("pyrecest.")
+    }
+    for name in previous_modules:
+        sys.modules.pop(name, None)
+
+    monkeypatch.setenv("PYRECEST_BACKEND", "pytorch")
+    try:
+        import pyrecest.backend as backend
+        import pyrecest._backend.pytorch as raw_pytorch_backend
+
+        yield backend, raw_pytorch_backend
+    finally:
+        for name in list(sys.modules):
+            if name == "pyrecest" or name.startswith("pyrecest."):
+                sys.modules.pop(name, None)
+        sys.modules.update(previous_modules)
+
+
+@pytest.mark.backend_portable
+def test_pytorch_diag_accepts_arraylike_and_numpy_k_keyword(monkeypatch):
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    with _isolated_pytorch_backend(monkeypatch) as (backend, raw_pytorch_backend):
+        vector = [1, 2, 3]
+        upper = backend.diag(vector, k=1)
+        assert backend.to_numpy(upper).tolist() == [
+            [0, 1, 0, 0],
+            [0, 0, 2, 0],
+            [0, 0, 0, 3],
+            [0, 0, 0, 0],
+        ]
+
+        lower = raw_pytorch_backend.diag(vector, k=-1)
+        assert raw_pytorch_backend.to_numpy(lower).tolist() == [
+            [0, 0, 0, 0],
+            [1, 0, 0, 0],
+            [0, 2, 0, 0],
+            [0, 0, 3, 0],
+        ]
+
+        matrix = [[0, 4, 0], [1, 0, 5], [0, 2, 0]]
+        assert backend.to_numpy(backend.diag(matrix, k=-1)).tolist() == [1, 2]
+        assert raw_pytorch_backend.to_numpy(raw_pytorch_backend.diag(matrix, k=1)).tolist() == [4, 5]


### PR DESCRIPTION
## Summary
- patch the PyTorch backend `diag` helper so it accepts NumPy-style array-like inputs
- support NumPy's `k=` diagonal-offset keyword while forwarding to Torch's `diagonal=` argument
- add backend-portable regression coverage for public and raw PyTorch backend calls

## Bug fixed
The PyTorch backend exposed `torch.diag` directly. Raw Torch rejects Python list inputs and does not accept NumPy's `k=` keyword, so calls such as `backend.diag([1, 2, 3], k=1)` failed under `PYRECEST_BACKEND=pytorch` even though the NumPy-style backend contract should accept array-like inputs and `k` offsets.

## Validation
- Syntax-checked the updated `backend_tools.py` content locally with `py_compile` before committing.
- Syntax-checked the regression test locally with `py_compile` before committing.
- Compared `fix-pytorch-diag` against `main`: 2 commits, 2 changed files.