### PR TITLE
Fix PyTorch reshape array-like inputs

### DIFF
--- a/src/pyrecest/_backend_submodules.py
+++ b/src/pyrecest/_backend_submodules.py
@@ -188,6 +188,52 @@ def _adapt_pytorch_repeat_contract(backend: ModuleType) -> None:
     setattr(backend, "repeat", wrapped_repeat)
 
 
+def _pytorch_reshape_shape(shape, torch_module) -> tuple[int, ...]:
+    """Normalize NumPy-style reshape dimensions for ``torch.reshape``."""
+    if torch_module.is_tensor(shape):
+        if shape.ndim == 0:
+            return (_operator_index(shape.item()),)
+        shape = shape.detach().cpu().tolist()
+    elif getattr(shape, "ndim", None) == 0 and hasattr(shape, "item"):
+        return (_operator_index(shape.item()),)
+
+    try:
+        return (_operator_index(shape),)
+    except TypeError:
+        pass
+
+    if isinstance(shape, (str, bytes)):
+        raise TypeError("reshape shape must be an integer or a sequence of integers")
+
+    try:
+        return tuple(_operator_index(dimension) for dimension in shape)
+    except TypeError as exc:
+        raise TypeError(
+            "reshape shape must be an integer or a sequence of integers"
+        ) from exc
+
+
+def _adapt_pytorch_reshape_contract(backend: ModuleType) -> None:
+    """Adapt PyTorch reshape to accept array-like inputs and NumPy-style shapes."""
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        return
+
+    import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+    import torch as torch_module  # pylint: disable=import-outside-toplevel
+
+    reshape = getattr(pytorch_backend, "reshape", None)
+    if reshape is None or getattr(reshape, "_pyrecest_reshape_contract", False):
+        return
+
+    @wraps(reshape)
+    def wrapped_reshape(x, shape):
+        return reshape(pytorch_backend.array(x), _pytorch_reshape_shape(shape, torch_module))
+
+    wrapped_reshape._pyrecest_reshape_contract = True
+    setattr(pytorch_backend, "reshape", wrapped_reshape)
+    setattr(backend, "reshape", wrapped_reshape)
+
+
 def register_backend_submodules(backend: ModuleType | None = None) -> None:
     """Register virtual backend submodules for standard import statements."""
     if backend is None:
@@ -196,6 +242,7 @@ def register_backend_submodules(backend: ModuleType | None = None) -> None:
     _adapt_cumulative_out_contract(backend)
     _adapt_pytorch_allclose_keyword_contract(backend)
     _adapt_pytorch_repeat_contract(backend)
+    _adapt_pytorch_reshape_contract(backend)
 
     backend.__path__ = getattr(backend, "__path__", [])
     backend_spec = getattr(backend, "__spec__", None)

--- a/src/pyrecest/_backend_submodules.py
+++ b/src/pyrecest/_backend_submodules.py
@@ -227,7 +227,7 @@ def _adapt_pytorch_reshape_contract(backend: ModuleType) -> None:
 
     @wraps(reshape)
     def wrapped_reshape(x, shape):
-        return reshape(pytorch_backend.array(x), _pytorch_reshape_shape(shape, torch_module))
+        return reshape(backend.array(x), _pytorch_reshape_shape(shape, torch_module))
 
     wrapped_reshape._pyrecest_reshape_contract = True
     setattr(pytorch_backend, "reshape", wrapped_reshape)

--- a/tests/backend_support/test_pytorch_reshape_contract.py
+++ b/tests/backend_support/test_pytorch_reshape_contract.py
@@ -1,0 +1,50 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_pytorch_reshape_array_like_inputs_match_numpy_contract():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import numpy as np
+
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as pytorch_backend
+
+matrix = backend.reshape([1, 2, 3, 4], (2, 2))
+assert tuple(matrix.shape) == (2, 2)
+assert backend.to_numpy(matrix).tolist() == [[1, 2], [3, 4]]
+
+shape_from_numpy = backend.reshape([1, 2, 3, 4], np.array([4, 1]))
+assert tuple(shape_from_numpy.shape) == (4, 1)
+assert backend.to_numpy(shape_from_numpy).tolist() == [[1], [2], [3], [4]]
+
+shape_from_tensor = backend.reshape([1, 2, 3, 4], backend.array([2, 2]))
+assert backend.to_numpy(shape_from_tensor).tolist() == [[1, 2], [3, 4]]
+
+raw_result = pytorch_backend.reshape([1, 2, 3], 3)
+assert pytorch_backend.to_numpy(raw_result).tolist() == [1, 2, 3]
+
+try:
+    backend.reshape([1, 2], [1.5, 2])
+except TypeError:
+    pass
+else:
+    raise AssertionError("reshape accepted a non-integer target shape")
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- adapt the PyTorch backend `reshape` export so public `pyrecest.backend.reshape` and raw `pyrecest._backend.pytorch.reshape` coerce array-like inputs before calling Torch
- normalize NumPy-style target shapes from Python, NumPy, and Torch scalar/vector shape inputs
- add a backend-portable subprocess regression for the forced PyTorch backend

## Bug fixed
Under `PYRECEST_BACKEND=pytorch`, `backend.reshape([1, 2, 3, 4], (2, 2))` still forwarded the plain Python list directly to `torch.reshape`, which rejects non-tensor inputs. The same issue affected raw `pyrecest._backend.pytorch.reshape` after package import. This made the PyTorch backend inconsistent with the NumPy-style backend facade used elsewhere in PyRecEst.

## Validation
- Reproduced the underlying failure mode locally with the installed PyRecEst/PyTorch environment before applying the wrapper logic
- Smoke-tested the wrapper behavior locally for list inputs, tuple/NumPy/Torch shape arguments, raw backend access, and non-integer shape rejection
- Added `tests/backend_support/test_pytorch_reshape_contract.py`
- Full repository pytest was not run in this connector session because the execution container could not resolve `github.com` for cloning/installing the repository dependency set