### PR TITLE
Fix raw PyTorch stack helper array-like inputs

### DIFF
--- a/src/pyrecest/_backend_submodules.py
+++ b/src/pyrecest/_backend_submodules.py
@@ -234,6 +234,63 @@ def _adapt_pytorch_reshape_contract(backend: ModuleType) -> None:
     setattr(backend, "reshape", wrapped_reshape)
 
 
+def _adapt_pytorch_stack_helpers_contract(backend: ModuleType) -> None:
+    """Adapt raw PyTorch stack helpers to accept NumPy-style sequences."""
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        return
+
+    try:
+        import numpy as numpy_module  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+        import torch as torch_module  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - backend import fails first
+        return
+
+    helper_names = ("hstack", "vstack", "column_stack", "dstack")
+    if all(
+        getattr(getattr(pytorch_backend, helper_name, None), "_pyrecest_stack_contract", False)
+        for helper_name in helper_names
+    ):
+        return
+
+    def _tensor_sequence(tup):
+        return [backend.array(item) for item in tup]
+
+    def hstack(tup):
+        tensors = [torch_module.atleast_1d(tensor) for tensor in _tensor_sequence(tup)]
+        if not tensors:
+            return torch_module.cat(tensors, dim=0)
+        return torch_module.cat(tensors, dim=0 if tensors[0].ndim == 1 else 1)
+
+    def vstack(tup):
+        tensors = [torch_module.atleast_2d(tensor) for tensor in _tensor_sequence(tup)]
+        return torch_module.cat(tensors, dim=0)
+
+    def column_stack(tup):
+        tensors = []
+        for tensor in _tensor_sequence(tup):
+            if tensor.ndim < 2:
+                tensor = tensor.reshape(-1, 1)
+            tensors.append(tensor)
+        return torch_module.cat(tensors, dim=1)
+
+    def dstack(tup):
+        tensors = [torch_module.atleast_3d(tensor) for tensor in _tensor_sequence(tup)]
+        return torch_module.cat(tensors, dim=2)
+
+    for helper_name, helper in {
+        "hstack": hstack,
+        "vstack": vstack,
+        "column_stack": column_stack,
+        "dstack": dstack,
+    }.items():
+        helper.__name__ = helper_name
+        helper.__doc__ = getattr(numpy_module, helper_name).__doc__
+        helper._pyrecest_stack_contract = True
+        setattr(pytorch_backend, helper_name, helper)
+        setattr(backend, helper_name, helper)
+
+
 def register_backend_submodules(backend: ModuleType | None = None) -> None:
     """Register virtual backend submodules for standard import statements."""
     if backend is None:
@@ -243,6 +300,7 @@ def register_backend_submodules(backend: ModuleType | None = None) -> None:
     _adapt_pytorch_allclose_keyword_contract(backend)
     _adapt_pytorch_repeat_contract(backend)
     _adapt_pytorch_reshape_contract(backend)
+    _adapt_pytorch_stack_helpers_contract(backend)
 
     backend.__path__ = getattr(backend, "__path__", [])
     backend_spec = getattr(backend, "__spec__", None)

--- a/tests/backend_support/test_pytorch_stack_helpers_contract.py
+++ b/tests/backend_support/test_pytorch_stack_helpers_contract.py
@@ -22,14 +22,18 @@ def test_pytorch_stack_helpers_accept_array_like_sequences():
 
     code = """
 import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_backend
 
-assert backend.to_numpy(backend.hstack(([1, 2], [3, 4]))).tolist() == [1, 2, 3, 4]
-assert backend.to_numpy(backend.vstack(([1, 2], [3, 4]))).tolist() == [[1, 2], [3, 4]]
-assert backend.to_numpy(backend.column_stack(([1, 2], [3, 4]))).tolist() == [[1, 3], [2, 4]]
-assert backend.to_numpy(backend.dstack(([1, 2], [3, 4]))).tolist() == [[[1, 3], [2, 4]]]
+for stack_backend in (backend, raw_backend):
+    to_numpy = stack_backend.to_numpy
 
-values = backend.array([[1, 2], [3, 4]])
-assert backend.to_numpy(backend.hstack((values, [[5, 6], [7, 8]]))).tolist() == [[1, 2, 5, 6], [3, 4, 7, 8]]
-assert backend.to_numpy(backend.column_stack((values, [[5, 6], [7, 8]]))).tolist() == [[1, 2, 5, 6], [3, 4, 7, 8]]
+    assert to_numpy(stack_backend.hstack(([1, 2], [3, 4]))).tolist() == [1, 2, 3, 4]
+    assert to_numpy(stack_backend.vstack(([1, 2], [3, 4]))).tolist() == [[1, 2], [3, 4]]
+    assert to_numpy(stack_backend.column_stack(([1, 2], [3, 4]))).tolist() == [[1, 3], [2, 4]]
+    assert to_numpy(stack_backend.dstack(([1, 2], [3, 4]))).tolist() == [[[1, 3], [2, 4]]]
+
+    values = backend.array([[1, 2], [3, 4]])
+    assert to_numpy(stack_backend.hstack((values, [[5, 6], [7, 8]]))).tolist() == [[1, 2, 5, 6], [3, 4, 7, 8]]
+    assert to_numpy(stack_backend.column_stack((values, [[5, 6], [7, 8]]))).tolist() == [[1, 2, 5, 6], [3, 4, 7, 8]]
 """
     subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- patch raw `pyrecest._backend.pytorch` stack helper entry points for `hstack`, `vstack`, `column_stack`, and `dstack`
- keep the public PyTorch backend facade aligned with the same NumPy-style array-like sequence behavior during backend submodule registration
- extend the PyTorch stack helper regression to cover both `pyrecest.backend` and raw `pyrecest._backend.pytorch`

## Bug fixed
The public PyTorch facade had been patched to accept NumPy-style sequence inputs such as `([1, 2], [3, 4])`, but the raw `pyrecest._backend.pytorch` helpers still exposed Torch's native `hstack`/`vstack`/`column_stack`/`dstack`. Those native helpers reject list elements with `TypeError: expected Tensor as element 0`, so users could get inconsistent behavior depending on whether they used the public facade or the raw backend module.

## Validation
- Reproduced the raw Torch failure mode locally with `torch.hstack(([1, 2], [3, 4]))` and the corresponding helpers
- Smoke-tested the replacement helper semantics locally against the expected NumPy-style results
- Added focused regression coverage in `tests/backend_support/test_pytorch_stack_helpers_contract.py`
- Full repository pytest was not run in this connector session because the execution container cannot resolve `github.com` for cloning/installing the repository dependency set