### PR TITLE
Fix PyTorch trace backend contract

### DIFF
--- a/src/pyrecest/_backend_submodules.py
+++ b/src/pyrecest/_backend_submodules.py
@@ -234,6 +234,48 @@ def _adapt_pytorch_reshape_contract(backend: ModuleType) -> None:
     setattr(backend, "reshape", wrapped_reshape)
 
 
+def _pytorch_trace_with_numpy_signature(trace, array_func, torch_module):
+    """Return a NumPy-compatible ``trace`` wrapper for the PyTorch backend."""
+
+    @wraps(trace)
+    def wrapped_trace(a, offset=0, axis1=-2, axis2=-1, dtype=None, out=None):
+        a = array_func(a)
+        diagonal_values = torch_module.diagonal(
+            a,
+            offset=offset,
+            dim1=axis1,
+            dim2=axis2,
+        )
+        result = torch_module.sum(diagonal_values, dim=-1, dtype=dtype)
+        if out is not None:
+            return _copy_result_to_out(result, out)
+        return result
+
+    wrapped_trace._pyrecest_trace_contract = True
+    return wrapped_trace
+
+
+def _adapt_pytorch_trace_contract(backend: ModuleType) -> None:
+    """Adapt PyTorch trace to PyRecEst's NumPy-style backend contract."""
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        return
+
+    import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+    import torch as torch_module  # pylint: disable=import-outside-toplevel
+
+    trace = getattr(pytorch_backend, "trace", None)
+    if trace is None or getattr(trace, "_pyrecest_trace_contract", False):
+        return
+
+    wrapped_trace = _pytorch_trace_with_numpy_signature(
+        trace,
+        backend.array,
+        torch_module,
+    )
+    setattr(pytorch_backend, "trace", wrapped_trace)
+    setattr(backend, "trace", wrapped_trace)
+
+
 def register_backend_submodules(backend: ModuleType | None = None) -> None:
     """Register virtual backend submodules for standard import statements."""
     if backend is None:
@@ -243,6 +285,7 @@ def register_backend_submodules(backend: ModuleType | None = None) -> None:
     _adapt_pytorch_allclose_keyword_contract(backend)
     _adapt_pytorch_repeat_contract(backend)
     _adapt_pytorch_reshape_contract(backend)
+    _adapt_pytorch_trace_contract(backend)
 
     backend.__path__ = getattr(backend, "__path__", [])
     backend_spec = getattr(backend, "__spec__", None)

--- a/tests/backend_support/test_pytorch_trace_contract.py
+++ b/tests/backend_support/test_pytorch_trace_contract.py
@@ -1,0 +1,69 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_pytorch_trace_accepts_numpy_signature_and_last_axis_default():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as pytorch_backend
+
+values = backend.array(
+    [
+        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+        [[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]],
+    ],
+    dtype=backend.float32,
+)
+
+# PyRecEst's backend trace contract uses the last two axes by default.
+default_result = backend.trace(values)
+assert backend.to_numpy(default_result).tolist() == [6.0, 18.0]
+
+out = backend.zeros((2,), dtype=backend.float32)
+result = backend.trace(
+    values,
+    offset=1,
+    axis1=1,
+    axis2=2,
+    dtype=backend.float32,
+    out=out,
+)
+
+assert result is out
+assert backend.to_numpy(result).tolist() == [8.0, 20.0]
+assert str(backend.to_numpy(result).dtype) == "float32"
+
+raw_out = pytorch_backend.zeros((2,), dtype=pytorch_backend.float64)
+raw_result = pytorch_backend.trace(
+    [
+        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+        [[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]],
+    ],
+    offset=1,
+    axis1=1,
+    axis2=2,
+    dtype=pytorch_backend.float64,
+    out=raw_out,
+)
+assert raw_result is raw_out
+assert pytorch_backend.to_numpy(raw_result).tolist() == [8.0, 20.0]
+assert str(pytorch_backend.to_numpy(raw_result).dtype) == "float64"
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
Summary:
- Adapt PyTorch backend trace to accept offset, axis1, axis2, dtype, and out.
- Preserve the last-two-axes default used by the NumPy and JAX backend contracts.
- Add a PyTorch subprocess regression test for the public backend facade and the raw PyTorch backend module.

Validation:
- Compared branch against main; only the trace adapter and regression test are changed.
- Full local test-suite execution was not available in this environment, so CI should validate the new backend_portable test.