### PR TITLE
Fix raw PyTorch trace signature

### DIFF
--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -327,6 +327,46 @@ def _patch_pytorch_stack_helpers_facade() -> None:
         setattr(backend, helper_name, helper)
 
 
+def _patch_raw_pytorch_trace_facade() -> None:
+    """Make raw PyTorch ``trace`` follow NumPy's trace signature."""
+
+    try:
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - only relevant without PyTorch
+        return
+
+    original_trace = getattr(pytorch_backend, "trace", None)
+
+    def trace(a, offset=0, axis1=-2, axis2=-1, dtype=None, out=None):
+        values = pytorch_backend.array(a)
+        if values.ndim < 2:
+            raise ValueError("diag requires an array of at least two dimensions")
+        diagonal = pytorch_backend.diagonal(
+            values,
+            offset=_operator_index(offset),
+            axis1=_operator_index(axis1),
+            axis2=_operator_index(axis2),
+        )
+        result = pytorch_backend.sum(diagonal, axis=-1, dtype=dtype)
+        if out is not None:
+            copy_ = getattr(out, "copy_", None)
+            if copy_ is not None:
+                copy_(result)
+                return out
+            out[...] = result
+            return out
+        return result
+
+    trace.__name__ = getattr(original_trace, "__name__", "trace")
+    trace.__doc__ = getattr(original_trace, "__doc__", None)
+    pytorch_backend.trace = trace
+
+    import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.trace = trace
+
+
 def _patch_jax_std_out_facade() -> None:
     """Make public and raw JAX ``std`` accept NumPy's ``out`` argument."""
 
@@ -422,6 +462,7 @@ _patch_pytorch_comparison_facade()
 _patch_pytorch_clip_facade()
 _patch_pytorch_tile_facade()
 _patch_pytorch_stack_helpers_facade()
+_patch_raw_pytorch_trace_facade()
 _patch_jax_std_out_facade()
 _patch_jax_matmul_out_facade()
 

--- a/tests/backend_support/test_pytorch_trace_contract.py
+++ b/tests/backend_support/test_pytorch_trace_contract.py
@@ -1,0 +1,34 @@
+import importlib.util
+
+import pytest
+
+
+def test_raw_pytorch_trace_accepts_numpy_signature():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    import pyrecest  # noqa: F401  # triggers raw-backend compatibility patches
+    import torch
+    import pyrecest._backend.pytorch as raw_pytorch_backend
+
+    values = torch.arange(12.0, dtype=torch.float64).reshape(2, 2, 3)
+    expected = torch.tensor([6.0, 18.0], dtype=torch.float64)
+
+    result = raw_pytorch_backend.trace(values, offset=1, axis1=-2, axis2=-1)
+    assert torch.allclose(result, expected)
+
+    out = torch.empty(2, dtype=torch.float64)
+    returned = raw_pytorch_backend.trace(
+        values,
+        offset=1,
+        axis1=-2,
+        axis2=-1,
+        dtype=torch.float64,
+        out=out,
+    )
+    assert returned is out
+    assert torch.allclose(out, expected)
+
+    scalar_result = raw_pytorch_backend.trace([[1.0, 2.0], [3.0, 4.0]])
+    assert tuple(scalar_result.shape) == ()
+    assert float(scalar_result) == pytest.approx(5.0)

--- a/tests/backend_support/test_pytorch_trace_contract.py
+++ b/tests/backend_support/test_pytorch_trace_contract.py
@@ -1,4 +1,7 @@
 import importlib.util
+import os
+import subprocess
+import sys
 
 import pytest
 
@@ -7,28 +10,46 @@ def test_raw_pytorch_trace_accepts_numpy_signature():
     if importlib.util.find_spec("torch") is None:
         pytest.skip("PyTorch is not installed")
 
-    import pyrecest  # noqa: F401  # triggers raw-backend compatibility patches
-    import torch
-    import pyrecest._backend.pytorch as raw_pytorch_backend
+    env = os.environ.copy()
+    env.pop("PYRECEST_BACKEND", None)
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            """
+import pyrecest  # noqa: F401  # triggers raw-backend compatibility patches
+import torch
+import pyrecest._backend.pytorch as raw_pytorch_backend
 
-    values = torch.arange(12.0, dtype=torch.float64).reshape(2, 2, 3)
-    expected = torch.tensor([6.0, 18.0], dtype=torch.float64)
+values = torch.arange(12.0, dtype=torch.float64).reshape(2, 2, 3)
+expected = torch.tensor([6.0, 18.0], dtype=torch.float64)
 
-    result = raw_pytorch_backend.trace(values, offset=1, axis1=-2, axis2=-1)
-    assert torch.allclose(result, expected)
+result = raw_pytorch_backend.trace(values, offset=1, axis1=-2, axis2=-1)
+assert torch.allclose(result, expected)
 
-    out = torch.empty(2, dtype=torch.float64)
-    returned = raw_pytorch_backend.trace(
-        values,
-        offset=1,
-        axis1=-2,
-        axis2=-1,
-        dtype=torch.float64,
-        out=out,
+out = torch.empty(2, dtype=torch.float64)
+returned = raw_pytorch_backend.trace(
+    values,
+    offset=1,
+    axis1=-2,
+    axis2=-1,
+    dtype=torch.float64,
+    out=out,
+)
+assert returned is out
+assert torch.allclose(out, expected)
+
+scalar_result = raw_pytorch_backend.trace([[1.0, 2.0], [3.0, 4.0]])
+assert tuple(scalar_result.shape) == ()
+assert float(scalar_result) == 5.0
+print("ok")
+""",
+        ],
+        capture_output=True,
+        env=env,
+        text=True,
+        timeout=30.0,
     )
-    assert returned is out
-    assert torch.allclose(out, expected)
 
-    scalar_result = raw_pytorch_backend.trace([[1.0, 2.0], [3.0, 4.0]])
-    assert tuple(scalar_result.shape) == ()
-    assert float(scalar_result) == pytest.approx(5.0)
+    assert completed.returncode == 0, completed.stderr
+    assert "ok" in completed.stdout


### PR DESCRIPTION
## Summary
- Restore the raw PyTorch backend trace wrapper so `pyrecest._backend.pytorch.trace` accepts NumPy-style `offset`, `axis1`, `axis2`, `dtype`, and `out` arguments.
- Keep public `backend.trace` aligned when the active backend is PyTorch.
- Add focused regression coverage for the raw PyTorch entry point.

## Bug fixed
`pyrecest._backend.pytorch.trace` currently exposes the raw PyTorch-style helper, so calls with NumPy-compatible arguments such as `offset=`, `axis1=`, `axis2=`, `dtype=`, or `out=` fail even though PyRecEst's backend facade documents and tests a NumPy-style backend contract.

## Testing
- Restored `tests/backend_support/test_pytorch_trace_contract.py` from the validated raw-trace fix branch.
- The earlier branch passed MegaLinter; full CI should run on this PR.