### PR TITLE
Fix PyTorch array-like backend contracts

### DIFF
--- a/src/pyrecest/backend_tools.py
+++ b/src/pyrecest/backend_tools.py
@@ -123,9 +123,64 @@ def _patch_pytorch_broadcast_arrays_numpy_contract() -> None:
     pytorch_backend.broadcast_arrays = broadcast_arrays
 
 
+def _patch_pytorch_special_numpy_contract() -> None:
+    """Make PyTorch special functions accept NumPy-style array-like inputs."""
+
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        return
+
+    try:
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+        import torch as _torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
+        return
+
+    def _return_or_store_out(result, out):
+        if out is not None:
+            out.copy_(result)
+            return out
+        return result
+
+    def erf(a, out=None):
+        result = _torch.erf(pytorch_backend.array(a))
+        return _return_or_store_out(result, out)
+
+    def gammaln(a, out=None):
+        result = _torch.special.gammaln(pytorch_backend.array(a))
+        return _return_or_store_out(result, out)
+
+    def gamma(a, out=None):
+        result = _torch.exp(gammaln(a))
+        return _return_or_store_out(result, out)
+
+    def polygamma(n, a, out=None):
+        result = _torch.polygamma(n, pytorch_backend.array(a))
+        return _return_or_store_out(result, out)
+
+    for name, helper, target in (
+        ("erf", erf, _torch.erf),
+        ("gammaln", gammaln, _torch.special.gammaln),
+        ("gamma", gamma, pytorch_backend.gamma),
+        ("polygamma", polygamma, _torch.polygamma),
+    ):
+        helper.__name__ = name
+        helper.__doc__ = getattr(target, "__doc__", None)
+        helper._pyrecest_numpy_contract = True
+        setattr(backend, name, helper)
+        setattr(pytorch_backend, name, helper)
+
+    pytorch_backend._gammaln = gammaln  # pylint: disable=protected-access
+
+
 _patch_pytorch_assignment_scalar_tensor_indices()
 _patch_pytorch_diag_numpy_contract()
 _patch_pytorch_broadcast_arrays_numpy_contract()
+_patch_pytorch_special_numpy_contract()
 
 
 def get_backend_name() -> str:

--- a/src/pyrecest/backend_tools.py
+++ b/src/pyrecest/backend_tools.py
@@ -92,8 +92,40 @@ def _patch_pytorch_diag_numpy_contract() -> None:
     pytorch_backend.diag = diag
 
 
+def _patch_pytorch_broadcast_arrays_numpy_contract() -> None:
+    """Make PyTorch broadcast_arrays accept NumPy-style array-like inputs."""
+
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        return
+
+    try:
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+        import torch as _torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
+        return
+
+    if getattr(pytorch_backend.broadcast_arrays, "_pyrecest_numpy_contract", False):
+        return
+
+    def broadcast_arrays(*arrays):
+        tensors = tuple(pytorch_backend.array(array) for array in arrays)
+        return _torch.broadcast_tensors(*tensors)
+
+    broadcast_arrays.__name__ = "broadcast_arrays"
+    broadcast_arrays.__doc__ = getattr(_torch.broadcast_tensors, "__doc__", None)
+    broadcast_arrays._pyrecest_numpy_contract = True
+    backend.broadcast_arrays = broadcast_arrays
+    pytorch_backend.broadcast_arrays = broadcast_arrays
+
+
 _patch_pytorch_assignment_scalar_tensor_indices()
 _patch_pytorch_diag_numpy_contract()
+_patch_pytorch_broadcast_arrays_numpy_contract()
 
 
 def get_backend_name() -> str:

--- a/tests/backend_support/test_pytorch_special_contract.py
+++ b/tests/backend_support/test_pytorch_special_contract.py
@@ -1,0 +1,49 @@
+import importlib.util
+import math
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_pytorch_special_functions_accept_array_like_inputs():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import math
+
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_backend
+
+
+def assert_close(values, expected):
+    actual = backend.to_numpy(values).tolist()
+    if not isinstance(actual, list):
+        actual = [actual]
+    assert len(actual) == len(expected)
+    for actual_value, expected_value in zip(actual, expected):
+        assert abs(actual_value - expected_value) < 1e-6
+
+
+for special_backend in (backend, raw_backend):
+    assert_close(special_backend.erf([0.0, 1.0]), [0.0, math.erf(1.0)])
+    assert_close(special_backend.gammaln([1.0, 2.0, 4.0]), [0.0, 0.0, math.log(6.0)])
+    assert_close(special_backend.gamma([1.0, 2.0, 4.0]), [1.0, 1.0, 6.0])
+    assert_close(
+        special_backend.polygamma(1, [1.0, 2.0]),
+        [math.pi**2 / 6.0, math.pi**2 / 6.0 - 1.0],
+    )
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)

--- a/tests/backend_support/test_pytorch_stack_helpers_contract.py
+++ b/tests/backend_support/test_pytorch_stack_helpers_contract.py
@@ -35,5 +35,13 @@ for stack_backend in (backend, raw_backend):
     values = backend.array([[1, 2], [3, 4]])
     assert to_numpy(stack_backend.hstack((values, [[5, 6], [7, 8]]))).tolist() == [[1, 2, 5, 6], [3, 4, 7, 8]]
     assert to_numpy(stack_backend.column_stack((values, [[5, 6], [7, 8]]))).tolist() == [[1, 2, 5, 6], [3, 4, 7, 8]]
+
+left, right = backend.broadcast_arrays([1, 2, 3], [[10], [20]])
+assert backend.to_numpy(left).tolist() == [[1, 2, 3], [1, 2, 3]]
+assert backend.to_numpy(right).tolist() == [[10, 10, 10], [20, 20, 20]]
+
+raw_left, raw_right = raw_backend.broadcast_arrays([1, 2], 3.0)
+assert raw_backend.to_numpy(raw_left).tolist() == [1, 2]
+assert raw_backend.to_numpy(raw_right).tolist() == [3.0, 3.0]
 """
     subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- patch the PyTorch backend `broadcast_arrays` helper so public and raw backend calls coerce NumPy-style array-like inputs before calling Torch
- patch PyTorch special functions (`erf`, `gammaln`, `gamma`, `polygamma`) so public and raw backend calls accept Python lists / array-like values
- extend subprocess regression coverage for public and raw PyTorch `broadcast_arrays` and special-function calls

## Bugs fixed
The PyTorch backend exposed several raw Torch callables directly. Torch rejects Python lists/scalars in places where PyRecEst's NumPy-style backend facade should accept array-like inputs. Examples that failed before this PR include:

```python
pyrecest.backend.broadcast_arrays([1, 2, 3], [[10], [20]])
pyrecest._backend.pytorch.broadcast_arrays([1, 2], 3.0)
pyrecest.backend.gamma([1.0, 2.0, 4.0])
pyrecest._backend.pytorch.gammaln([1.0, 2.0, 4.0])
pyrecest.backend.polygamma(1, [1.0, 2.0])
```

## Validation
- Added subprocess regression coverage for public and raw PyTorch `broadcast_arrays` calls.
- Added subprocess regression coverage for public and raw PyTorch `erf`, `gammaln`, `gamma`, and `polygamma` array-like calls.
- Full test execution is not available in this connector-only environment; CI should run the backend-portable tests.