### PR TITLE
Fix PyTorch array NumPy copy contract

### DIFF
--- a/src/pyrecest/_backend/pytorch/_common.py
+++ b/src/pyrecest/_backend/pytorch/_common.py
@@ -66,7 +66,7 @@ def array(val, dtype=None):
         if dtype is not None and tensor.dtype != dtype:
             tensor = cast(tensor, dtype=dtype)
 
-        return tensor
+        return tensor.clone()
 
     if isinstance(val, (list, tuple)) and len(val):
         tensors = [array(tensor, dtype=dtype) for tensor in val]

--- a/tests/backend_support/test_pytorch_numpy_view_conversion.py
+++ b/tests/backend_support/test_pytorch_numpy_view_conversion.py
@@ -37,3 +37,25 @@ assert backend.to_numpy(matrix_trace).item() == 6.0
     )
 
     assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.backend_portable
+def test_pytorch_array_copies_numpy_inputs():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import numpy as np
+import pyrecest.backend as backend
+
+source = np.arange(3.0)
+converted = backend.array(source)
+source[0] = 99.0
+
+assert backend.to_numpy(converted).tolist() == [0.0, 1.0, 2.0]
+""",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Make the PyTorch backend `array(np.ndarray)` return an independent tensor instead of aliasing NumPy memory through `torch.from_numpy`.
- Keep the existing negative-stride view support intact.
- Add a regression test that mutates the source NumPy array after conversion and verifies the backend tensor is unchanged.

## Bug fixed
`pyrecest.backend.array(source_numpy_array)` should behave like a NumPy-style array constructor and copy external mutable inputs. The PyTorch implementation currently routes NumPy arrays through `from_numpy()` and returns that tensor directly, so later mutations of the original NumPy array silently change the PyRecEst tensor.

## Testing
- Added focused backend-portable regression coverage in `tests/backend_support/test_pytorch_numpy_view_conversion.py`.
- Full CI should run on the PR.