### PR TITLE
Fix PyTorch round backend contract

### DIFF
--- a/src/pyrecest/backend_tools.py
+++ b/src/pyrecest/backend_tools.py
@@ -275,12 +275,12 @@ def warn_if_backend_env_changed() -> None:
     already constructed backend facade.
     """
     active = get_backend_name()
-    current_env = os.environ.get("PYRECEST_BACKEND", "numpy")
-    if current_env != active:
+    requested = os.environ.get("PYRECEST_BACKEND", active)
+    if requested != active:
         warnings.warn(
-            "PYRECEST_BACKEND was changed after importing pyrecest; "
-            f"active backend remains {active!r}, while the environment requests "
-            f"{current_env!r}.",
+            "PYRECEST_BACKEND was changed after pyrecest was imported. "
+            f"The active backend remains {active!r}; the environment now requests "
+            f"{requested!r}. Start a new Python process to switch backends.",
             RuntimeWarning,
             stacklevel=2,
         )

--- a/src/pyrecest/backend_tools.py
+++ b/src/pyrecest/backend_tools.py
@@ -123,6 +123,41 @@ def _patch_pytorch_broadcast_arrays_numpy_contract() -> None:
     pytorch_backend.broadcast_arrays = broadcast_arrays
 
 
+def _patch_pytorch_round_numpy_contract() -> None:
+    """Make PyTorch round accept NumPy-style array-like inputs."""
+
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        return
+
+    try:
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+        import torch as _torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
+        return
+
+    if getattr(pytorch_backend.round, "_pyrecest_numpy_contract", False):
+        return
+
+    def round(a, decimals=0, out=None):  # pylint: disable=redefined-builtin
+        decimals = _operator_index(decimals)
+        result = _torch.round(pytorch_backend.array(a), decimals=decimals)
+        if out is not None:
+            out.copy_(result)
+            return out
+        return result
+
+    round.__name__ = getattr(_torch.round, "__name__", "round")
+    round.__doc__ = getattr(_torch.round, "__doc__", None)
+    round._pyrecest_numpy_contract = True
+    backend.round = round
+    pytorch_backend.round = round
+
+
 def _patch_pytorch_special_numpy_contract() -> None:
     """Make PyTorch special functions accept NumPy-style array-like inputs."""
 
@@ -180,6 +215,7 @@ def _patch_pytorch_special_numpy_contract() -> None:
 _patch_pytorch_assignment_scalar_tensor_indices()
 _patch_pytorch_diag_numpy_contract()
 _patch_pytorch_broadcast_arrays_numpy_contract()
+_patch_pytorch_round_numpy_contract()
 _patch_pytorch_special_numpy_contract()
 
 
@@ -239,12 +275,12 @@ def warn_if_backend_env_changed() -> None:
     already constructed backend facade.
     """
     active = get_backend_name()
-    requested = os.environ.get("PYRECEST_BACKEND", active)
-    if requested != active:
+    current_env = os.environ.get("PYRECEST_BACKEND", "numpy")
+    if current_env != active:
         warnings.warn(
-            "PYRECEST_BACKEND was changed after pyrecest was imported. "
-            f"The active backend remains {active!r}; the environment now requests "
-            f"{requested!r}. Start a new Python process to switch backends.",
+            "PYRECEST_BACKEND was changed after importing pyrecest; "
+            f"active backend remains {active!r}, while the environment requests "
+            f"{current_env!r}.",
             RuntimeWarning,
             stacklevel=2,
         )

--- a/tests/backend_support/test_pytorch_round_contract.py
+++ b/tests/backend_support/test_pytorch_round_contract.py
@@ -1,0 +1,47 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_pytorch_round_accepts_array_like_inputs_decimals_and_out():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_backend
+
+for round_backend in (backend, raw_backend):
+    result = round_backend.round([1.24, 2.76], decimals=1)
+    assert round_backend.to_numpy(result).tolist() == [1.2, 2.8]
+
+    tensor = backend.array([1.24, 2.76])
+    tensor_result = round_backend.round(tensor, decimals=1)
+    assert round_backend.to_numpy(tensor_result).tolist() == [1.2, 2.8]
+
+    out = round_backend.array([0.0, 0.0])
+    returned = round_backend.round([1.24, 2.76], decimals=1, out=out)
+    assert returned is out
+    assert round_backend.to_numpy(out).tolist() == [1.2, 2.8]
+
+try:
+    backend.round([1.0], decimals=1.5)
+except TypeError:
+    pass
+else:
+    raise AssertionError("round accepted a non-integer decimals argument")
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)

--- a/tests/backend_support/test_pytorch_round_contract.py
+++ b/tests/backend_support/test_pytorch_round_contract.py
@@ -24,18 +24,25 @@ def test_pytorch_round_accepts_array_like_inputs_decimals_and_out():
 import pyrecest.backend as backend
 import pyrecest._backend.pytorch as raw_backend
 
+
+def assert_close_list(actual, expected):
+    actual = [float(value) for value in actual]
+    assert len(actual) == len(expected)
+    assert all(abs(one_actual - one_expected) < 1e-6 for one_actual, one_expected in zip(actual, expected))
+
+
 for round_backend in (backend, raw_backend):
     result = round_backend.round([1.24, 2.76], decimals=1)
-    assert round_backend.to_numpy(result).tolist() == [1.2, 2.8]
+    assert_close_list(round_backend.to_numpy(result).tolist(), [1.2, 2.8])
 
     tensor = backend.array([1.24, 2.76])
     tensor_result = round_backend.round(tensor, decimals=1)
-    assert round_backend.to_numpy(tensor_result).tolist() == [1.2, 2.8]
+    assert_close_list(round_backend.to_numpy(tensor_result).tolist(), [1.2, 2.8])
 
     out = round_backend.array([0.0, 0.0])
     returned = round_backend.round([1.24, 2.76], decimals=1, out=out)
     assert returned is out
-    assert round_backend.to_numpy(out).tolist() == [1.2, 2.8]
+    assert_close_list(round_backend.to_numpy(out).tolist(), [1.2, 2.8])
 
 try:
     backend.round([1.0], decimals=1.5)


### PR DESCRIPTION
## Summary
- Patch PyTorch `round` so public and raw backends accept NumPy-style array-like inputs.
- Preserve `decimals` and `out` handling.
- Add a focused backend regression test.

## Testing
- Added `tests/backend_support/test_pytorch_round_contract.py`.
- Local full-suite execution was not possible in this environment; CI should validate the branch.