### PR TITLE
Fix PyTorch FFT axis aliases

### DIFF
--- a/src/pyrecest/_backend/pytorch/fft.py
+++ b/src/pyrecest/_backend/pytorch/fft.py
@@ -11,19 +11,32 @@ def _as_fft_tensor(value):
     return value if _torch.is_tensor(value) else _array(value)
 
 
-def _wrap_arraylike_fft(torch_func):
-    """Return a PyRecEst-compatible FFT helper accepting array-like input."""
+def _with_dim_alias(kwargs, alias, func_name):
+    if alias not in kwargs:
+        return kwargs
 
+    kwargs = dict(kwargs)
+    alias_value = kwargs.pop(alias)
+    dim_value = kwargs.get("dim")
+    if dim_value is not None and alias_value is not None and dim_value != alias_value:
+        raise TypeError("conflicting FFT axis aliases")
+    kwargs["dim"] = alias_value
+    return kwargs
+
+
+def _wrap_arraylike_fft(torch_func, *, func_name, dim_alias=None):
     @_wraps(torch_func)
-    def fft_func(input, *args, **kwargs):  # pylint: disable=redefined-builtin
-        return torch_func(_as_fft_tensor(input), *args, **kwargs)
+    def fft_func(value, *args, **kwargs):
+        if dim_alias is not None:
+            kwargs = _with_dim_alias(kwargs, dim_alias, func_name)
+        return torch_func(_as_fft_tensor(value), *args, **kwargs)
 
     return fft_func
 
 
-rfft = _wrap_arraylike_fft(_torch.fft.rfft)
-irfft = _wrap_arraylike_fft(_torch.fft.irfft)
-fftshift = _wrap_arraylike_fft(_torch.fft.fftshift)
-ifftshift = _wrap_arraylike_fft(_torch.fft.ifftshift)
-fftn = _wrap_arraylike_fft(_torch.fft.fftn)
-ifftn = _wrap_arraylike_fft(_torch.fft.ifftn)
+rfft = _wrap_arraylike_fft(_torch.fft.rfft, func_name="rfft", dim_alias="axis")
+irfft = _wrap_arraylike_fft(_torch.fft.irfft, func_name="irfft", dim_alias="axis")
+fftshift = _wrap_arraylike_fft(_torch.fft.fftshift, func_name="fftshift", dim_alias="axes")
+ifftshift = _wrap_arraylike_fft(_torch.fft.ifftshift, func_name="ifftshift", dim_alias="axes")
+fftn = _wrap_arraylike_fft(_torch.fft.fftn, func_name="fftn", dim_alias="axes")
+ifftn = _wrap_arraylike_fft(_torch.fft.ifftn, func_name="ifftn", dim_alias="axes")

--- a/tests/backend_support/test_pytorch_fft_axis_contract.py
+++ b/tests/backend_support/test_pytorch_fft_axis_contract.py
@@ -1,0 +1,42 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+pytest.importorskip("torch")
+
+import pyrecest._backend.pytorch.fft as pytorch_fft  # noqa: E402
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_fft_helpers_accept_numpy_axis_aliases():
+    vector = np.arange(4.0)
+    spectrum = pytorch_fft.rfft(vector.tolist(), axis=0)
+    npt.assert_allclose(spectrum.numpy(), np.fft.rfft(vector, axis=0))
+    npt.assert_allclose(
+        pytorch_fft.irfft(spectrum, axis=0).numpy(),
+        np.fft.irfft(np.fft.rfft(vector, axis=0), axis=0),
+    )
+
+    matrix = np.arange(6.0).reshape(2, 3)
+    npt.assert_allclose(
+        pytorch_fft.fftn(matrix.tolist(), axes=(0, 1)).numpy(),
+        np.fft.fftn(matrix, axes=(0, 1)),
+    )
+    npt.assert_allclose(
+        pytorch_fft.ifftn(pytorch_fft.fftn(matrix, axes=(0, 1)), axes=(0, 1)).numpy(),
+        np.fft.ifftn(np.fft.fftn(matrix, axes=(0, 1)), axes=(0, 1)),
+    )
+
+    npt.assert_array_equal(
+        pytorch_fft.fftshift([0, 1, 2, 3], axes=0).numpy(),
+        np.fft.fftshift(np.asarray([0, 1, 2, 3]), axes=0),
+    )
+    npt.assert_array_equal(
+        pytorch_fft.ifftshift([2, 3, 0, 1], axes=0).numpy(),
+        np.fft.ifftshift(np.asarray([2, 3, 0, 1]), axes=0),
+    )
+
+
+def test_raw_pytorch_fft_rejects_conflicting_axis_aliases():
+    with pytest.raises(TypeError):
+        pytorch_fft.rfft(np.arange(4.0), axis=0, dim=1)


### PR DESCRIPTION
## Summary
- Translate NumPy-style FFT axis keywords to Torch's `dim` parameter in the PyTorch FFT backend.
- Support `axis=` for `rfft` / `irfft` and `axes=` for `fftn` / `ifftn` / `fftshift` / `ifftshift`.
- Add raw PyTorch backend regression coverage for the alias behavior and conflicting alias errors.

## Bug fixed
The PyTorch FFT backend accepted array-like values but forwarded keyword arguments directly to `torch.fft`. As a result, NumPy-compatible calls such as `backend.fft.rfft(x, axis=0)` and `backend.fft.fftshift(x, axes=0)` failed under the PyTorch backend because Torch expects `dim=` instead.

## Validation
- Locally exercised the patched wrapper logic with NumPy/Torch comparisons for `rfft`, `irfft`, `fftn`, `ifftn`, `fftshift`, and `ifftshift`.
- CI should run the added regression test.