### PR TITLE
Update PyTorch FFT helper

### DIFF
--- a/src/pyrecest/_backend/pytorch/fft.py
+++ b/src/pyrecest/_backend/pytorch/fft.py
@@ -1,21 +1,42 @@
 # For ffts. Added for pyrecest.
 from functools import wraps as _wraps
 
+import numpy as _np
 import torch as _torch
-
-from ._common import array as _array
 
 
 def _as_fft_tensor(value):
     """Convert array-like FFT inputs to torch tensors."""
-    return value if _torch.is_tensor(value) else _array(value)
+    if _torch.is_tensor(value):
+        return value
+    if isinstance(value, _np.ndarray) and any(stride < 0 for stride in value.strides):
+        value = value.copy()
+    return _torch.as_tensor(value)
+
+
+def _resolve_fft_dim(dim, *, axis=None, axes=None):
+    """Resolve NumPy-style axis aliases to PyTorch's dim argument."""
+    if axis is not None:
+        if axes is not None:
+            raise TypeError("axis and axes cannot both be specified")
+        if dim is not None:
+            raise TypeError("dim and axis cannot both be specified")
+        return axis
+    if axes is not None:
+        if dim is not None:
+            raise TypeError("dim and axes cannot both be specified")
+        return axes
+    return dim
 
 
 def _wrap_arraylike_fft(torch_func):
     """Return a PyRecEst-compatible FFT helper accepting array-like input."""
 
     @_wraps(torch_func)
-    def fft_func(input, *args, **kwargs):  # pylint: disable=redefined-builtin
+    def fft_func(input, *args, axis=None, axes=None, dim=None, **kwargs):  # pylint: disable=redefined-builtin
+        resolved_dim = _resolve_fft_dim(dim, axis=axis, axes=axes)
+        if resolved_dim is not None:
+            kwargs["dim"] = resolved_dim
         return torch_func(_as_fft_tensor(input), *args, **kwargs)
 
     return fft_func

--- a/tests/backend_support/test_pytorch_fft_axis_alias_contract.py
+++ b/tests/backend_support/test_pytorch_fft_axis_alias_contract.py
@@ -33,6 +33,10 @@ assert np.allclose(
     backend.to_numpy(backend.fft.ifftn(matrix, axes=(0, 1))),
     np.fft.ifftn(matrix, axes=(0, 1)),
 )
+assert np.allclose(
+    backend.to_numpy(backend.fft.fftn(matrix, dim=0, axes=None)),
+    np.fft.fftn(matrix, axes=(0,)),
+)
 
 vector = [1.0, 2.0, 3.0, 4.0]
 spectrum = np.fft.rfft(vector, axis=0)
@@ -53,6 +57,12 @@ assert backend.to_numpy(shifted).tolist() == np.fft.fftshift(
 ).tolist()
 assert backend.to_numpy(backend.fft.ifftshift(shifted, axes=0)).tolist() == np.fft.ifftshift(
     np.fft.fftshift(shift_source, axes=0),
+    axes=0,
+).tolist()
+
+shift_matrix = [[1, 2, 3], [4, 5, 6]]
+assert backend.to_numpy(backend.fft.fftshift(shift_matrix, dim=0, axes=None)).tolist() == np.fft.fftshift(
+    shift_matrix,
     axes=0,
 ).tolist()
 

--- a/tests/backend_support/test_pytorch_fft_axis_alias_contract.py
+++ b/tests/backend_support/test_pytorch_fft_axis_alias_contract.py
@@ -1,0 +1,73 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_pytorch_fft_helpers_accept_numpy_axis_aliases():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import numpy as np
+import pyrecest.backend as backend
+
+matrix = [[1.0, 2.0], [3.0, 4.0]]
+assert np.allclose(
+    backend.to_numpy(backend.fft.fftn(matrix, axes=(0, 1))),
+    np.fft.fftn(matrix, axes=(0, 1)),
+)
+assert np.allclose(
+    backend.to_numpy(backend.fft.ifftn(matrix, axes=(0, 1))),
+    np.fft.ifftn(matrix, axes=(0, 1)),
+)
+
+vector = [1.0, 2.0, 3.0, 4.0]
+spectrum = np.fft.rfft(vector, axis=0)
+assert np.allclose(
+    backend.to_numpy(backend.fft.rfft(vector, axis=0)),
+    spectrum,
+)
+assert np.allclose(
+    backend.to_numpy(backend.fft.irfft(spectrum, axis=0)),
+    np.fft.irfft(spectrum, axis=0),
+)
+
+shift_source = [1, 2, 3, 4]
+shifted = backend.fft.fftshift(shift_source, axes=0)
+assert backend.to_numpy(shifted).tolist() == np.fft.fftshift(
+    shift_source,
+    axes=0,
+).tolist()
+assert backend.to_numpy(backend.fft.ifftshift(shifted, axes=0)).tolist() == np.fft.ifftshift(
+    np.fft.fftshift(shift_source, axes=0),
+    axes=0,
+).tolist()
+
+try:
+    backend.fft.fftn(matrix, axis=0, axes=(0, 1))
+except TypeError:
+    pass
+else:
+    raise AssertionError("fftn accepted conflicting axis aliases")
+
+try:
+    backend.fft.fftshift(shift_source, dim=0, axes=0)
+except TypeError:
+    pass
+else:
+    raise AssertionError("fftshift accepted conflicting dim/axes aliases")
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- improve PyTorch FFT axis handling
- add regression coverage for NumPy-style axis aliases and explicit dim forwarding

## Testing
- Added backend support regression test.
- Local wrapper checks against NumPy passed.