### PR TITLE
Preserve FFT dim with None axis aliases

### DIFF
--- a/src/pyrecest/_backend/pytorch/fft.py
+++ b/src/pyrecest/_backend/pytorch/fft.py
@@ -17,6 +17,8 @@ def _with_dim_alias(kwargs, alias, func_name):
 
     kwargs = dict(kwargs)
     alias_value = kwargs.pop(alias)
+    if alias_value is None:
+        return kwargs
     dim_value = kwargs.get("dim")
     if dim_value is not None and alias_value is not None and dim_value != alias_value:
         raise TypeError("conflicting FFT axis aliases")

--- a/tests/backend_support/test_pytorch_fft_axis_contract.py
+++ b/tests/backend_support/test_pytorch_fft_axis_contract.py
@@ -26,6 +26,10 @@ def test_raw_pytorch_fft_helpers_accept_numpy_axis_aliases():
         pytorch_fft.ifftn(pytorch_fft.fftn(matrix, axes=(0, 1)), axes=(0, 1)).numpy(),
         np.fft.ifftn(np.fft.fftn(matrix, axes=(0, 1)), axes=(0, 1)),
     )
+    npt.assert_allclose(
+        pytorch_fft.fftn(matrix, dim=0, axes=None).numpy(),
+        np.fft.fftn(matrix, axes=(0,)),
+    )
 
     npt.assert_array_equal(
         pytorch_fft.fftshift([0, 1, 2, 3], axes=0).numpy(),
@@ -34,6 +38,10 @@ def test_raw_pytorch_fft_helpers_accept_numpy_axis_aliases():
     npt.assert_array_equal(
         pytorch_fft.ifftshift([2, 3, 0, 1], axes=0).numpy(),
         np.fft.ifftshift(np.asarray([2, 3, 0, 1]), axes=0),
+    )
+    npt.assert_array_equal(
+        pytorch_fft.fftshift(matrix, dim=0, axes=None).numpy(),
+        np.fft.fftshift(matrix, axes=0),
     )
 
 


### PR DESCRIPTION
## Summary
- keep explicit PyTorch `dim` when `axis=None` or `axes=None` is forwarded
- add regression coverage for this edge case in the raw PyTorch FFT helper tests

## Testing
- Added/updated backend support regression assertions.