### PR TITLE
Fix raw PyTorch dot contract outside public backend

### DIFF
--- a/src/pyrecest/backend_support/__init__.py
+++ b/src/pyrecest/backend_support/__init__.py
@@ -16,8 +16,7 @@ def _patch_pytorch_dot_numpy_contract() -> None:
     except ModuleNotFoundError:  # pragma: no cover - import fails before this module
         return
 
-    if getattr(backend, "__backend_name__", None) != "pytorch":
-        return
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
 
     try:
         import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
@@ -30,8 +29,8 @@ def _patch_pytorch_dot_numpy_contract() -> None:
         return
 
     def dot(a, b):
-        a = backend.array(a)
-        b = backend.array(b)
+        a = raw_pytorch.array(a)
+        b = raw_pytorch.array(b)
         dtype = torch.promote_types(a.dtype, b.dtype)
         a = a.to(dtype=dtype)
         b = b.to(dtype=dtype)
@@ -49,8 +48,9 @@ def _patch_pytorch_dot_numpy_contract() -> None:
     dot.__name__ = getattr(original_dot, "__name__", "dot")
     dot.__doc__ = getattr(original_dot, "__doc__", None)
     dot._pyrecest_numpy_contract = True
-    backend.dot = dot
     raw_pytorch.dot = dot
+    if active_pytorch_backend:
+        backend.dot = dot
 
 
 _patch_pytorch_dot_numpy_contract()

--- a/tests/backend_support/test_pytorch_dot_contract.py
+++ b/tests/backend_support/test_pytorch_dot_contract.py
@@ -6,19 +6,24 @@ import sys
 import pytest
 
 
-@pytest.mark.backend_portable
-def test_pytorch_dot_matches_numpy_for_vector_matrix_and_high_rank_inputs():
-    if importlib.util.find_spec("torch") is None:
-        pytest.skip("torch is not installed")
-
+def _backend_subprocess_env(backend_name):
     env = os.environ.copy()
-    env["PYRECEST_BACKEND"] = "pytorch"
+    env["PYRECEST_BACKEND"] = backend_name
     src_path = os.path.abspath("src")
     env["PYTHONPATH"] = (
         src_path
         if not env.get("PYTHONPATH")
         else os.pathsep.join([src_path, env["PYTHONPATH"]])
     )
+    return env
+
+
+@pytest.mark.backend_portable
+def test_pytorch_dot_matches_numpy_for_vector_matrix_and_high_rank_inputs():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = _backend_subprocess_env("pytorch")
 
     code = """
 import numpy as np
@@ -36,6 +41,37 @@ for left, right in cases:
     expected = np.dot(np.asarray(left), np.asarray(right))
     result = backend.dot(backend.array(left), backend.array(right))
     npt.assert_allclose(backend.to_numpy(result), expected)
+    assert tuple(result.shape) == expected.shape
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_dot_matches_numpy_when_public_backend_is_numpy():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = _backend_subprocess_env("numpy")
+
+    code = """
+import numpy as np
+import numpy.testing as npt
+import pyrecest.backend as public_backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+assert public_backend.__backend_name__ == "numpy"
+
+cases = [
+    ([1.0, 2.0], [[5.0, 6.0], [7.0, 8.0]]),
+    ([[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]),
+    (np.arange(24, dtype=float).reshape(2, 3, 4), np.arange(120, dtype=float).reshape(5, 4, 6)),
+    (2.0, [[5.0, 6.0], [7.0, 8.0]]),
+]
+
+for left, right in cases:
+    expected = np.dot(np.asarray(left), np.asarray(right))
+    result = raw_pytorch.dot(raw_pytorch.array(left), raw_pytorch.array(right))
+    npt.assert_allclose(raw_pytorch.to_numpy(result), expected)
     assert tuple(result.shape) == expected.shape
 """
     subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- Patch the raw PyTorch backend `dot` implementation even when the active public backend is not PyTorch.
- Keep public `backend.dot` patched only for the active PyTorch backend.
- Add a subprocess regression that imports `pyrecest._backend.pytorch` while `PYRECEST_BACKEND=numpy` and checks vector-matrix, matrix-matrix, high-rank, and scalar cases against `numpy.dot`.

## Bug fixed
The existing PyTorch dot compatibility shim only ran when `pyrecest.backend` was configured as PyTorch. Importing `pyrecest._backend.pytorch` under the default/NumPy public backend left `raw_pytorch.dot` on the old implementation, which did not match NumPy's contraction axes for vector-matrix, matrix-matrix, and high-rank inputs.

## Testing
- Added `tests/backend_support/test_pytorch_dot_contract.py::test_raw_pytorch_dot_matches_numpy_when_public_backend_is_numpy`.
- Not run locally in this environment; CI should execute the regression test.