### PR TITLE
Fix PyTorch FFT None axis aliases

### DIFF
--- a/src/pyrecest/_backend/pytorch/fft.py
+++ b/src/pyrecest/_backend/pytorch/fft.py
@@ -17,6 +17,8 @@ def _with_dim_alias(kwargs, alias, func_name):
 
     kwargs = dict(kwargs)
     alias_value = kwargs.pop(alias)
+    if alias_value is None:
+        return kwargs
     dim_value = kwargs.get("dim")
     if dim_value is not None and alias_value is not None and dim_value != alias_value:
         raise TypeError("conflicting FFT axis aliases")


### PR DESCRIPTION
## Summary
- Preserve an explicit PyTorch FFT `dim` argument when the NumPy-style alias is present with value `None`.
- Prevent calls such as `fftn(x, dim=0, axes=None)` or `fftshift(x, dim=0, axes=None)` from being rewritten to `dim=None`.

## Bug fixed
The PyTorch FFT wrapper translated NumPy-style aliases (`axis` / `axes`) to Torch's `dim` argument. When callers supplied an explicit `dim` together with an alias value of `None`, the wrapper overwrote the explicit `dim` with `None`. That changed the requested one-axis transform/shift into Torch's default all-axis behavior.

## Validation
- Verified the wrapper logic locally with NumPy/Torch for `fftn(matrix, dim=0, axes=None)` against `np.fft.fftn(matrix, axes=(0,))`.
- I could not add the focused regression test in this connector session because repeated test-file write attempts were blocked by the connector safety filter, although the source patch commit succeeded.