### PR TITLE
Fix PyTorch FFT None axis alias handling

### DIFF
--- a/src/pyrecest/_backend/pytorch/fft.py
+++ b/src/pyrecest/_backend/pytorch/fft.py
@@ -18,8 +18,10 @@ def _with_dim_alias(kwargs, alias, func_name):
     kwargs = dict(kwargs)
     alias_value = kwargs.pop(alias)
     dim_value = kwargs.get("dim")
-    if dim_value is not None and alias_value is not None and dim_value != alias_value:
-        raise TypeError("conflicting FFT axis aliases")
+    if dim_value is not None:
+        if alias_value is not None and dim_value != alias_value:
+            raise TypeError("conflicting FFT axis aliases")
+        return kwargs
     kwargs["dim"] = alias_value
     return kwargs
 

--- a/tests/backend_support/test_pytorch_fft_axis_contract.py
+++ b/tests/backend_support/test_pytorch_fft_axis_contract.py
@@ -37,6 +37,24 @@ def test_raw_pytorch_fft_helpers_accept_numpy_axis_aliases():
     )
 
 
+@pytest.mark.backend_portable
+def test_raw_pytorch_fft_none_axis_alias_preserves_explicit_dim():
+    matrix = np.arange(6.0).reshape(2, 3)
+
+    npt.assert_allclose(
+        pytorch_fft.fftn(matrix.tolist(), axes=None, dim=(0,)).numpy(),
+        np.fft.fftn(matrix, axes=(0,)),
+    )
+    npt.assert_allclose(
+        pytorch_fft.ifftn(
+            pytorch_fft.fftn(matrix, dim=(0,)),
+            axes=None,
+            dim=(0,),
+        ).numpy(),
+        np.fft.ifftn(np.fft.fftn(matrix, axes=(0,)), axes=(0,)),
+    )
+
+
 def test_raw_pytorch_fft_rejects_conflicting_axis_aliases():
     with pytest.raises(TypeError):
         pytorch_fft.rfft(np.arange(4.0), axis=0, dim=1)


### PR DESCRIPTION
## Summary
- preserve an explicit PyTorch `dim` argument when the NumPy-style FFT axis alias is provided as `None`
- keep conflicting non-`None` `axis`/`axes` and `dim` arguments rejected
- add a regression test covering `axes=None, dim=(0,)` for `fftn`/`ifftn`

## Bug
The PyTorch FFT wrapper translated `axis`/`axes` aliases by always assigning `kwargs["dim"] = alias_value`. When `axes=None` was passed together with an explicit `dim`, this overwrote the requested dimension with `None`, so transforms were evaluated over the default axes instead of the caller-specified axes.

## Testing
- Validated the specific alias-normalization behavior with a local Torch/NumPy snippet.
- Full GitHub Actions CI is queued on the PR.