### PR TITLE
Validate PyTorch repeat count dimensions

### DIFF
--- a/src/pyrecest/_backend_submodules.py
+++ b/src/pyrecest/_backend_submodules.py
@@ -113,6 +113,8 @@ def _pytorch_repeat_count(repetition) -> int:
 def _pytorch_repeat_counts(repeats, *, numpy_module, torch_module, device):
     """Normalize NumPy-style repeat counts for ``torch.repeat_interleave``."""
     if torch_module.is_tensor(repeats):
+        if repeats.ndim > 1:
+            raise ValueError("object too deep for desired array")
         if repeats.dtype.is_floating_point or repeats.dtype.is_complex:
             raise TypeError("repeat counts must be integers")
         repeat_counts = repeats.to(device=device, dtype=torch_module.long)
@@ -123,6 +125,8 @@ def _pytorch_repeat_counts(repeats, *, numpy_module, torch_module, device):
     repeats_array = numpy_module.asarray(repeats)
     if repeats_array.shape == ():
         return _pytorch_repeat_count(repeats_array.item())
+    if repeats_array.ndim > 1:
+        raise ValueError("object too deep for desired array")
     if not numpy_module.can_cast(
         repeats_array.dtype, numpy_module.dtype("intp"), casting="safe"
     ):

--- a/tests/backend_support/test_pytorch_repeat_count_validation.py
+++ b/tests/backend_support/test_pytorch_repeat_count_validation.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from pyrecest._backend_submodules import _pytorch_repeat_counts  # noqa: E402
+
+
+@pytest.mark.backend_portable
+def test_pytorch_repeat_rejects_nested_numpy_repeat_counts_before_torch_call():
+    with pytest.raises(ValueError, match="object too deep"):
+        _pytorch_repeat_counts(
+            [[1, 2]],
+            numpy_module=np,
+            torch_module=torch,
+            device=torch.device("cpu"),
+        )
+
+
+@pytest.mark.backend_portable
+def test_pytorch_repeat_rejects_nested_tensor_repeat_counts_before_torch_call():
+    with pytest.raises(ValueError, match="object too deep"):
+        _pytorch_repeat_counts(
+            torch.tensor([[1, 2]], dtype=torch.long),
+            numpy_module=np,
+            torch_module=torch,
+            device=torch.device("cpu"),
+        )


### PR DESCRIPTION
## Summary
- reject nested PyTorch repeat count arrays/tensors before calling `torch.repeat_interleave`
- align the PyTorch backend `repeat` wrapper with NumPy/PyRecEst repeat-count shape validation by raising `ValueError` for repeat counts deeper than 1-D
- add regression coverage for nested NumPy-style and tensor repeat-count inputs

## Bug fixed
`backend.repeat(..., repeats=[[...]])` under `PYRECEST_BACKEND=pytorch` allowed nested repeat counts to reach Torch directly. Torch then raised a low-level `RuntimeError` (`repeats must be 0-dim or 1-dim tensor`) instead of the backend rejecting the invalid NumPy-style repeat-count shape itself.

## Testing
- Added `tests/backend_support/test_pytorch_repeat_count_validation.py`
- Reproduced the contract mismatch locally with NumPy 2.3.5 and Torch 2.10.0+cpu
- Full repository test suite was not run in this connector environment