### PR TITLE
Fix PyTorch outer NumPy contract

### DIFF
--- a/src/pyrecest/backend_support/__init__.py
+++ b/src/pyrecest/backend_support/__init__.py
@@ -53,7 +53,43 @@ def _patch_pytorch_dot_numpy_contract() -> None:
     raw_pytorch.dot = dot
 
 
+def _patch_pytorch_outer_numpy_contract() -> None:
+    """Make PyTorch outer flatten inputs like NumPy's outer."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        return
+
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
+        return
+
+    original_outer = raw_pytorch.outer
+    if getattr(original_outer, "_pyrecest_numpy_contract", False):
+        return
+
+    def outer(a, b):
+        a = backend.array(a)
+        b = backend.array(b)
+        dtype = torch.promote_types(a.dtype, b.dtype)
+        a = a.to(dtype=dtype)
+        b = b.to(dtype=dtype)
+        return torch.outer(a.reshape(-1), b.reshape(-1))
+
+    outer.__name__ = getattr(original_outer, "__name__", "outer")
+    outer.__doc__ = getattr(original_outer, "__doc__", None)
+    outer._pyrecest_numpy_contract = True
+    backend.outer = outer
+    raw_pytorch.outer = outer
+
+
 _patch_pytorch_dot_numpy_contract()
+_patch_pytorch_outer_numpy_contract()
 
 
 def get_backend_support(

--- a/tests/backend_support/test_pytorch_outer_contract.py
+++ b/tests/backend_support/test_pytorch_outer_contract.py
@@ -1,0 +1,45 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_pytorch_outer_matches_numpy_for_flattened_inputs():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import numpy as np
+import numpy.testing as npt
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+cases = [
+    (np.arange(6.0).reshape(2, 3), np.arange(4.0).reshape(2, 2)),
+    (2.0, [3.0, 4.0]),
+    ([[1, 2], [3, 4]], [[5, 6], [7, 8]]),
+]
+
+for left, right in cases:
+    expected = np.outer(np.asarray(left), np.asarray(right))
+    result = backend.outer(backend.array(left), backend.array(right))
+    raw_result = raw_pytorch.outer(raw_pytorch.array(left), raw_pytorch.array(right))
+
+    npt.assert_allclose(backend.to_numpy(result), expected)
+    npt.assert_allclose(backend.to_numpy(raw_result), expected)
+    assert tuple(result.shape) == expected.shape
+    assert tuple(raw_result.shape) == expected.shape
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- patch the PyTorch backend facade so `outer` flattens both inputs before forming the outer product, matching `numpy.outer`
- cover matrix, scalar, and integer inputs for both `pyrecest.backend.outer` and `pyrecest._backend.pytorch.outer`

## Bug
The raw PyTorch helper used an ellipsis einsum and a scalar multiply fast path, so non-1D inputs preserved leading dimensions and scalar inputs returned vector/scalar-shaped results instead of NumPy's flattened 2-D outer-product shape.

## Validation
- Added `tests/backend_support/test_pytorch_outer_contract.py`
- Locally sanity-checked the PyTorch/NumPy shape mismatch and the `torch.outer(a.reshape(-1), b.reshape(-1))` behavior in an isolated snippet; full repository tests were not run in this environment.