### PR TITLE
Fix low-level PyTorch tile contract

### DIFF
--- a/src/pyrecest/backend_support/__init__.py
+++ b/src/pyrecest/backend_support/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from operator import index as _operator_index
+
 from pyrecest._backend.capabilities import (
     API_BACKEND_CAPABILITIES,
     BACKEND_SUPPORT_LEVELS,
@@ -20,12 +22,12 @@ def _patch_pytorch_dot_numpy_contract() -> None:
         return
 
     try:
-        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
         import torch  # pylint: disable=import-outside-toplevel
     except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
         return
 
-    original_dot = raw_pytorch.dot
+    original_dot = pytorch_backend.dot
     if getattr(original_dot, "_pyrecest_numpy_contract", False):
         return
 
@@ -50,10 +52,77 @@ def _patch_pytorch_dot_numpy_contract() -> None:
     dot.__doc__ = getattr(original_dot, "__doc__", None)
     dot._pyrecest_numpy_contract = True
     backend.dot = dot
-    raw_pytorch.dot = dot
+    pytorch_backend.dot = dot
+
+
+def _pytorch_tile_repetition(repetition) -> int:
+    """Return one NumPy-style tile repetition as an integer."""
+
+    try:
+        return _operator_index(repetition)
+    except TypeError as exc:
+        raise TypeError("tile repetitions must be integers") from exc
+
+
+def _pytorch_tile_repetitions(reps, numpy_module, torch_module) -> tuple[int, ...]:
+    """Normalize NumPy-style tile repetitions for ``torch.Tensor.repeat``."""
+
+    if torch_module.is_tensor(reps):
+        reps = reps.detach().cpu().numpy()
+    reps_array = numpy_module.asarray(reps)
+    if reps_array.shape == ():
+        repetitions = (_pytorch_tile_repetition(reps_array.item()),)
+    else:
+        repetitions = tuple(
+            _pytorch_tile_repetition(one_repetition)
+            for one_repetition in reps_array.tolist()
+        )
+    if any(one_repetition < 0 for one_repetition in repetitions):
+        raise ValueError("negative dimensions are not allowed")
+    return repetitions
+
+
+def _patch_pytorch_tile_numpy_contract() -> None:
+    """Make low-level PyTorch tile follow NumPy semantics for any public backend."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+
+    try:
+        import numpy as _np  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch is optional
+        return
+
+    original_tile = pytorch_backend.tile
+    if getattr(original_tile, "_pyrecest_numpy_contract", False):
+        return
+
+    def tile(x, reps):
+        x = pytorch_backend.array(x)
+        repetitions = _pytorch_tile_repetitions(reps, _np, torch)
+        if not repetitions:
+            return x.clone()
+        if x.ndim < len(repetitions):
+            x = x.reshape((1,) * (len(repetitions) - x.ndim) + tuple(x.shape))
+        elif x.ndim > len(repetitions):
+            repetitions = (1,) * (x.ndim - len(repetitions)) + repetitions
+        return x.repeat(repetitions)
+
+    tile.__name__ = getattr(original_tile, "__name__", "tile")
+    tile.__doc__ = getattr(_np.tile, "__doc__", None)
+    tile._pyrecest_numpy_contract = True
+    pytorch_backend.tile = tile
+    if active_pytorch_backend:
+        backend.tile = tile
 
 
 _patch_pytorch_dot_numpy_contract()
+_patch_pytorch_tile_numpy_contract()
 
 
 def get_backend_support(

--- a/tests/backend_support/test_pytorch_tile_low_level_contract.py
+++ b/tests/backend_support/test_pytorch_tile_low_level_contract.py
@@ -1,0 +1,56 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _backend_subprocess_env(backend_name):
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = backend_name
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    return env
+
+
+@pytest.mark.backend_portable
+def test_low_level_pytorch_tile_uses_numpy_repetitions_with_numpy_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = _backend_subprocess_env("numpy")
+
+    code = """
+import pyrecest.backend as public_backend
+from pyrecest._backend import pytorch as pytorch_backend
+
+assert public_backend.__backend_name__ == "numpy"
+values = pytorch_backend.array([[1, 2], [3, 4]])
+
+scalar_result = pytorch_backend.tile(values, 2)
+assert tuple(scalar_result.shape) == (2, 4)
+assert pytorch_backend.to_numpy(scalar_result).tolist() == [[1, 2, 1, 2], [3, 4, 3, 4]]
+
+array_result = pytorch_backend.tile(values, pytorch_backend.array([2, 1]))
+assert tuple(array_result.shape) == (4, 2)
+assert pytorch_backend.to_numpy(array_result).tolist() == [[1, 2], [3, 4], [1, 2], [3, 4]]
+
+empty_result = pytorch_backend.tile(values, ())
+assert tuple(empty_result.shape) == (2, 2)
+assert pytorch_backend.to_numpy(empty_result).tolist() == [[1, 2], [3, 4]]
+assert empty_result is not values
+
+for bad_reps in (1.5, [2.5, 1], "2", pytorch_backend.array([2.5, 1.0])):
+    try:
+        pytorch_backend.tile(values, bad_reps)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"tile accepted non-integer repetitions {bad_reps!r}")
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- Patch `pyrecest._backend.pytorch.tile` so direct backend imports get NumPy-compatible repetition handling even when the active public backend is NumPy.
- Keep the public PyTorch backend facade aligned with the same implementation.
- Add a subprocess regression covering scalar, tensor/list, empty, and invalid non-integer repetition specifications under `PYRECEST_BACKEND=numpy`.

## Bug fixed
The previous PyTorch tile compatibility patch only ran when `pyrecest.backend` was configured as PyTorch. Direct users of `pyrecest._backend.pytorch.tile` under the default NumPy backend could still reach `Tensor.repeat` semantics, so NumPy-style scalar repetitions, empty repetitions, tensor repetitions, and invalid non-integer repetitions could fail or behave differently depending on import path.

## Testing
- Added `tests/backend_support/test_pytorch_tile_low_level_contract.py`.
- Not run locally in this connector session; CI should execute the focused subprocess regression.