### PR TITLE
Fix raw PyTorch outer and tile contracts

### DIFF
--- a/src/pyrecest/backend_support/__init__.py
+++ b/src/pyrecest/backend_support/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from operator import index as _operator_index
+
 from pyrecest._backend.capabilities import (
     API_BACKEND_CAPABILITIES,
     BACKEND_SUPPORT_LEVELS,
@@ -60,8 +62,7 @@ def _patch_pytorch_outer_numpy_contract() -> None:
     except ModuleNotFoundError:  # pragma: no cover - import fails before this module
         return
 
-    if getattr(backend, "__backend_name__", None) != "pytorch":
-        return
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
 
     try:
         import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
@@ -74,8 +75,8 @@ def _patch_pytorch_outer_numpy_contract() -> None:
         return
 
     def outer(a, b):
-        a = backend.array(a)
-        b = backend.array(b)
+        a = raw_pytorch.array(a)
+        b = raw_pytorch.array(b)
         dtype = torch.promote_types(a.dtype, b.dtype)
         a = a.to(dtype=dtype)
         b = b.to(dtype=dtype)
@@ -84,12 +85,80 @@ def _patch_pytorch_outer_numpy_contract() -> None:
     outer.__name__ = getattr(original_outer, "__name__", "outer")
     outer.__doc__ = getattr(original_outer, "__doc__", None)
     outer._pyrecest_numpy_contract = True
-    backend.outer = outer
     raw_pytorch.outer = outer
+    if active_pytorch_backend:
+        backend.outer = outer
+
+
+def _pytorch_tile_repetition(repetition) -> int:
+    """Return one NumPy-style tile repetition as an integer."""
+
+    try:
+        return _operator_index(repetition)
+    except TypeError as exc:
+        raise TypeError("tile repetitions must be integers") from exc
+
+
+def _pytorch_tile_repetitions(reps, numpy_module, torch_module) -> tuple[int, ...]:
+    """Normalize NumPy-style tile repetitions for ``torch.Tensor.repeat``."""
+
+    if torch_module.is_tensor(reps):
+        reps = reps.detach().cpu().numpy()
+    reps_array = numpy_module.asarray(reps)
+    if reps_array.shape == ():
+        repetitions = (_pytorch_tile_repetition(reps_array.item()),)
+    else:
+        repetitions = tuple(
+            _pytorch_tile_repetition(one_repetition)
+            for one_repetition in reps_array.tolist()
+        )
+    if any(one_repetition < 0 for one_repetition in repetitions):
+        raise ValueError("negative dimensions are not allowed")
+    return repetitions
+
+
+def _patch_pytorch_tile_numpy_contract() -> None:
+    """Make PyTorch tile follow NumPy repetition semantics."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+
+    try:
+        import numpy as np  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
+        return
+
+    original_tile = raw_pytorch.tile
+    if getattr(original_tile, "_pyrecest_numpy_contract", False):
+        return
+
+    def tile(x, reps):
+        x = raw_pytorch.array(x)
+        repetitions = _pytorch_tile_repetitions(reps, np, torch)
+        if not repetitions:
+            return x.clone()
+        if x.ndim < len(repetitions):
+            x = x.reshape((1,) * (len(repetitions) - x.ndim) + tuple(x.shape))
+        elif x.ndim > len(repetitions):
+            repetitions = (1,) * (x.ndim - len(repetitions)) + repetitions
+        return x.repeat(repetitions)
+
+    tile.__name__ = getattr(original_tile, "__name__", "tile")
+    tile.__doc__ = getattr(np.tile, "__doc__", None)
+    tile._pyrecest_numpy_contract = True
+    raw_pytorch.tile = tile
+    if active_pytorch_backend:
+        backend.tile = tile
 
 
 _patch_pytorch_dot_numpy_contract()
 _patch_pytorch_outer_numpy_contract()
+_patch_pytorch_tile_numpy_contract()
 
 
 def get_backend_support(

--- a/src/pyrecest/backend_support/__init__.py
+++ b/src/pyrecest/backend_support/__init__.py
@@ -53,7 +53,43 @@ def _patch_pytorch_dot_numpy_contract() -> None:
     raw_pytorch.dot = dot
 
 
+def _patch_pytorch_outer_numpy_contract() -> None:
+    """Make PyTorch outer flatten inputs like NumPy's outer."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        return
+
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
+        return
+
+    original_outer = raw_pytorch.outer
+    if getattr(original_outer, "_pyrecest_numpy_contract", False):
+        return
+
+    def outer(a, b):
+        a = backend.array(a)
+        b = backend.array(b)
+        dtype = torch.promote_types(a.dtype, b.dtype)
+        a = a.to(dtype=dtype)
+        b = b.to(dtype=dtype)
+        return torch.outer(a.reshape(-1), b.reshape(-1))
+
+    outer.__name__ = getattr(original_outer, "__name__", "outer")
+    outer.__doc__ = getattr(original_outer, "__doc__", None)
+    outer._pyrecest_numpy_contract = True
+    backend.outer = outer
+    raw_pytorch.outer = outer
+
+
 _patch_pytorch_dot_numpy_contract()
+_patch_pytorch_outer_numpy_contract()
 
 
 def get_backend_support(

--- a/tests/backend_support/test_pytorch_outer_contract.py
+++ b/tests/backend_support/test_pytorch_outer_contract.py
@@ -6,19 +6,24 @@ import sys
 import pytest
 
 
-@pytest.mark.backend_portable
-def test_pytorch_outer_matches_numpy_for_flattened_inputs():
-    if importlib.util.find_spec("torch") is None:
-        pytest.skip("torch is not installed")
-
+def _backend_subprocess_env(backend_name):
     env = os.environ.copy()
-    env["PYRECEST_BACKEND"] = "pytorch"
+    env["PYRECEST_BACKEND"] = backend_name
     src_path = os.path.abspath("src")
     env["PYTHONPATH"] = (
         src_path
         if not env.get("PYTHONPATH")
         else os.pathsep.join([src_path, env["PYTHONPATH"]])
     )
+    return env
+
+
+@pytest.mark.backend_portable
+def test_pytorch_outer_matches_numpy_for_flattened_inputs():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = _backend_subprocess_env("pytorch")
 
     code = """
 import numpy as np
@@ -38,8 +43,39 @@ for left, right in cases:
     raw_result = raw_pytorch.outer(raw_pytorch.array(left), raw_pytorch.array(right))
 
     npt.assert_allclose(backend.to_numpy(result), expected)
-    npt.assert_allclose(backend.to_numpy(raw_result), expected)
+    npt.assert_allclose(raw_pytorch.to_numpy(raw_result), expected)
     assert tuple(result.shape) == expected.shape
+    assert tuple(raw_result.shape) == expected.shape
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_outer_matches_numpy_when_public_backend_is_numpy():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = _backend_subprocess_env("numpy")
+
+    code = """
+import numpy as np
+import numpy.testing as npt
+import pyrecest.backend as public_backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+assert public_backend.__backend_name__ == "numpy"
+
+cases = [
+    (np.arange(6.0).reshape(2, 3), np.arange(4.0).reshape(2, 2)),
+    (2.0, [3.0, 4.0]),
+    ([[1, 2], [3, 4]], [[5, 6], [7, 8]]),
+]
+
+for left, right in cases:
+    expected = np.outer(np.asarray(left), np.asarray(right))
+    raw_result = raw_pytorch.outer(raw_pytorch.array(left), raw_pytorch.array(right))
+
+    npt.assert_allclose(raw_pytorch.to_numpy(raw_result), expected)
     assert tuple(raw_result.shape) == expected.shape
 """
     subprocess.run([sys.executable, "-c", code], check=True, env=env)

--- a/tests/backend_support/test_pytorch_outer_contract.py
+++ b/tests/backend_support/test_pytorch_outer_contract.py
@@ -1,0 +1,45 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_pytorch_outer_matches_numpy_for_flattened_inputs():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import numpy as np
+import numpy.testing as npt
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+cases = [
+    (np.arange(6.0).reshape(2, 3), np.arange(4.0).reshape(2, 2)),
+    (2.0, [3.0, 4.0]),
+    ([[1, 2], [3, 4]], [[5, 6], [7, 8]]),
+]
+
+for left, right in cases:
+    expected = np.outer(np.asarray(left), np.asarray(right))
+    result = backend.outer(backend.array(left), backend.array(right))
+    raw_result = raw_pytorch.outer(raw_pytorch.array(left), raw_pytorch.array(right))
+
+    npt.assert_allclose(backend.to_numpy(result), expected)
+    npt.assert_allclose(backend.to_numpy(raw_result), expected)
+    assert tuple(result.shape) == expected.shape
+    assert tuple(raw_result.shape) == expected.shape
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)

--- a/tests/backend_support/test_raw_pytorch_tile_contract.py
+++ b/tests/backend_support/test_raw_pytorch_tile_contract.py
@@ -1,0 +1,61 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _backend_subprocess_env(backend_name):
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = backend_name
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    return env
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_tile_matches_numpy_when_public_backend_is_numpy():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = _backend_subprocess_env("numpy")
+
+    code = """
+import numpy as np
+import numpy.testing as npt
+import pyrecest.backend as public_backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+assert public_backend.__backend_name__ == "numpy"
+
+cases = [
+    ([[1, 2], [3, 4]], 2),
+    ([[1, 2], [3, 4]], [2, 1]),
+    ([[1, 2], [3, 4]], ()),
+    ([1, 2, 3], [2, 3]),
+]
+
+for values, repetitions in cases:
+    expected = np.tile(np.asarray(values), repetitions)
+    result = raw_pytorch.tile(raw_pytorch.array(values), repetitions)
+    npt.assert_array_equal(raw_pytorch.to_numpy(result), expected)
+    assert tuple(result.shape) == expected.shape
+
+values = raw_pytorch.array([[1, 2], [3, 4]])
+empty_result = raw_pytorch.tile(values, ())
+assert empty_result is not values
+
+for bad_reps in (1.5, [2.5, 1], "2", raw_pytorch.array([2.5, 1.0])):
+    try:
+        raw_pytorch.tile(values, bad_reps)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"tile accepted non-integer repetitions {bad_reps!r}")
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- Patch raw PyTorch `outer` when the public backend is NumPy.
- Add a raw PyTorch `tile` NumPy-contract patch.
- Add subprocess regressions for raw PyTorch with `PYRECEST_BACKEND=numpy`.

Supersedes #3423.