### PR TITLE
Fix raw PyTorch clip under non-PyTorch backends

### DIFF
--- a/src/pyrecest/backend_support/__init__.py
+++ b/src/pyrecest/backend_support/__init__.py
@@ -307,6 +307,7 @@ def _patch_pytorch_clip_numpy_contract() -> None:
         backend.clip = clip
 
 
+_patch_raw_pytorch_assignment_scalar_tensor_indices()
 _patch_pytorch_dot_numpy_contract()
 _patch_pytorch_outer_numpy_contract()
 _patch_pytorch_tile_numpy_contract()

--- a/src/pyrecest/backend_support/__init__.py
+++ b/src/pyrecest/backend_support/__init__.py
@@ -246,12 +246,72 @@ def _patch_pytorch_copy_numpy_contract() -> None:
         backend.copy = copy
 
 
-_patch_raw_pytorch_assignment_scalar_tensor_indices()
+def _patch_pytorch_clip_numpy_contract() -> None:
+    """Make PyTorch clip accept array-like inputs regardless of public backend."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
+        return
+
+    original_clip = raw_pytorch.clip
+    if getattr(original_clip, "_pyrecest_numpy_contract", False):
+        return
+
+    def _clip_bound(value, *, device):
+        if value is None:
+            return None
+        if torch.is_tensor(value):
+            return value.to(device=device)
+        return torch.as_tensor(value, device=device)
+
+    def clip(a, a_min=None, a_max=None, out=None, *, min=None, max=None):
+        if min is not None:
+            if a_min is not None:
+                raise TypeError("clip() got both 'a_min' and 'min'")
+            a_min = min
+        if max is not None:
+            if a_max is not None:
+                raise TypeError("clip() got both 'a_max' and 'max'")
+            a_max = max
+        if a_min is None and a_max is None:
+            raise ValueError("One of max or min must be given")
+
+        x = raw_pytorch.array(a)
+        result = torch.clip(
+            x,
+            min=_clip_bound(a_min, device=x.device),
+            max=_clip_bound(a_max, device=x.device),
+        )
+        if out is not None:
+            copy_ = getattr(out, "copy_", None)
+            if copy_ is not None:
+                copy_(result)
+                return out
+            out[...] = raw_pytorch.to_numpy(result)
+            return out
+        return result
+
+    clip.__name__ = getattr(original_clip, "__name__", "clip")
+    clip.__doc__ = getattr(original_clip, "__doc__", None)
+    clip._pyrecest_numpy_contract = True
+    raw_pytorch.clip = clip
+    if active_pytorch_backend:
+        backend.clip = clip
+
+
 _patch_pytorch_dot_numpy_contract()
 _patch_pytorch_outer_numpy_contract()
 _patch_pytorch_tile_numpy_contract()
 _patch_pytorch_copy_numpy_contract()
-_patch_pytorch_copy_numpy_contract()
+_patch_pytorch_clip_numpy_contract()
 
 
 def get_backend_support(

--- a/tests/backend_support/test_pytorch_clip_default_backend.py
+++ b/tests/backend_support/test_pytorch_clip_default_backend.py
@@ -1,0 +1,61 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_clip_array_like_inputs_with_non_pytorch_public_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "numpy"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import numpy as np
+
+import pyrecest  # noqa: F401
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+assert getattr(backend, "__backend_name__", None) == "numpy"
+
+result = raw_pytorch.clip([-2.0, 0.5, 3.0], -1.0, 2.0)
+assert raw_pytorch.is_array(result)
+assert result.tolist() == [-1.0, 0.5, 2.0]
+
+lower_bound_result = raw_pytorch.clip(
+    [[-2.0, 0.5], [3.0, 4.0]], min=np.array([-1.0, 1.0])
+)
+assert raw_pytorch.is_array(lower_bound_result)
+assert lower_bound_result.tolist() == [[-1.0, 1.0], [3.0, 4.0]]
+
+out = raw_pytorch.zeros(3, dtype=raw_pytorch.float64)
+returned = raw_pytorch.clip([-2.0, 0.5, 3.0], -1.0, 2.0, out=out)
+assert returned is out
+assert out.tolist() == [-1.0, 0.5, 2.0]
+
+try:
+    raw_pytorch.clip([1.0, 2.0])
+except ValueError:
+    pass
+else:
+    raise AssertionError("clip accepted missing bounds")
+
+try:
+    raw_pytorch.clip([1.0, 2.0], 0.0, min=0.0)
+except TypeError:
+    pass
+else:
+    raise AssertionError("clip accepted conflicting a_min/min aliases")
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- Patch `pyrecest.backend_support` so raw `pyrecest._backend.pytorch.clip` accepts NumPy-style array-like inputs even when the active public backend is not PyTorch.
- Preserve `a_min`/`a_max`, `min`/`max`, and `out=` handling while updating the active public PyTorch facade when applicable.
- Add a subprocess regression test for `PYRECEST_BACKEND=numpy` with direct raw PyTorch `clip` access.

## Bug fixed
With the default/NumPy public backend, importing `pyrecest` did not apply the PyTorch `clip` wrapper because the existing facade patch returns early unless `PYRECEST_BACKEND=pytorch`. Direct calls such as `pyrecest._backend.pytorch.clip([-2.0, 0.5, 3.0], -1.0, 2.0)` therefore reached `torch.clip` with a Python list and failed before backend conversion.

## Testing
- Added `tests/backend_support/test_pytorch_clip_default_backend.py`.
- Sanity-checked the wrapper behavior locally against the installed `torch` package; full repository tests were not run in this connector session.