### PR TITLE
Fix JAX outer NumPy contract

### DIFF
--- a/src/pyrecest/backend_support/__init__.py
+++ b/src/pyrecest/backend_support/__init__.py
@@ -307,12 +307,42 @@ def _patch_pytorch_clip_numpy_contract() -> None:
         backend.clip = clip
 
 
-_patch_raw_pytorch_assignment_scalar_tensor_indices()
+def _patch_jax_outer_numpy_contract() -> None:
+    """Make JAX outer flatten inputs like NumPy's outer."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+
+    active_jax_backend = getattr(backend, "__backend_name__", None) == "jax"
+
+    try:
+        import jax.numpy as jnp  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.jax as raw_jax  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - JAX backend import failed earlier
+        return
+
+    original_outer = raw_jax.outer
+    if getattr(original_outer, "_pyrecest_numpy_contract", False):
+        return
+
+    def outer(a, b):
+        return jnp.outer(jnp.ravel(jnp.asarray(a)), jnp.ravel(jnp.asarray(b)))
+
+    outer.__name__ = getattr(original_outer, "__name__", "outer")
+    outer.__doc__ = getattr(jnp.outer, "__doc__", None)
+    outer._pyrecest_numpy_contract = True
+    raw_jax.outer = outer
+    if active_jax_backend:
+        backend.outer = outer
+
+
 _patch_pytorch_dot_numpy_contract()
 _patch_pytorch_outer_numpy_contract()
 _patch_pytorch_tile_numpy_contract()
 _patch_pytorch_copy_numpy_contract()
 _patch_pytorch_clip_numpy_contract()
+_patch_jax_outer_numpy_contract()
 
 
 def get_backend_support(

--- a/src/pyrecest/backend_support/__init__.py
+++ b/src/pyrecest/backend_support/__init__.py
@@ -337,6 +337,7 @@ def _patch_jax_outer_numpy_contract() -> None:
         backend.outer = outer
 
 
+_patch_raw_pytorch_assignment_scalar_tensor_indices()
 _patch_pytorch_dot_numpy_contract()
 _patch_pytorch_outer_numpy_contract()
 _patch_pytorch_tile_numpy_contract()

--- a/tests/backend_support/test_jax_outer_contract.py
+++ b/tests/backend_support/test_jax_outer_contract.py
@@ -1,0 +1,35 @@
+"""Regression coverage for JAX outer NumPy semantics."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_jax_outer_flattens_multidimensional_inputs_like_numpy():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("JAX is not installed")
+
+    result = run_backend_code(
+        "jax",
+        """
+import pyrecest  # noqa: F401
+import pyrecest.backend as backend
+import pyrecest._backend.jax as raw_jax
+
+expected = [[10, 20], [20, 40], [30, 60], [40, 80]]
+
+public_result = backend.outer([[1, 2], [3, 4]], [[10], [20]])
+assert tuple(public_result.shape) == (4, 2)
+assert backend.to_numpy(public_result).tolist() == expected
+
+raw_result = raw_jax.outer([[1, 2], [3, 4]], [[10], [20]])
+assert tuple(raw_result.shape) == (4, 2)
+assert raw_jax.to_numpy(raw_result).tolist() == expected
+""",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Patch the JAX backend `outer` helper from `pyrecest.backend_support` so it flattens both inputs before forming the outer product, matching NumPy semantics.
- Keep both the active public JAX facade and the raw `pyrecest._backend.jax.outer` helper on the same contract.
- Add subprocess regression coverage for multidimensional JAX inputs.

## Bug fixed
The current JAX backend `outer` implementation treats multidimensional inputs as batched outer products. NumPy's `outer` contract flattens both inputs first, so shapes such as `(2, 2)` and `(2, 1)` should produce `(4, 2)`, not a batched shape.

## Testing
- Not run locally in this connector session; the container cannot resolve github.com.
- Added `tests/backend_support/test_jax_outer_contract.py` for focused CI coverage.