### PR TITLE
Fix PyTorch bool dtype promotion

### DIFF
--- a/src/pyrecest/backend_support/__init__.py
+++ b/src/pyrecest/backend_support/__init__.py
@@ -9,6 +9,9 @@ from pyrecest._backend.capabilities import (
     BACKEND_SUPPORT_LEVELS,
     iter_api_backend_capabilities,
 )
+from pyrecest.backend_support._torch_dtype_promotion_contract import (
+    patch_pytorch_dtype_promotion_contract as _patch_pytorch_dtype_promotion_contract,
+)
 
 
 def _pytorch_scalar_tensor_index(index, torch_module):
@@ -338,6 +341,7 @@ def _patch_jax_outer_numpy_contract() -> None:
 
 
 _patch_raw_pytorch_assignment_scalar_tensor_indices()
+_patch_pytorch_dtype_promotion_contract()
 _patch_pytorch_dot_numpy_contract()
 _patch_pytorch_outer_numpy_contract()
 _patch_pytorch_tile_numpy_contract()

--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
@@ -1,0 +1,36 @@
+"""PyTorch dtype promotion compatibility helpers."""
+
+from __future__ import annotations
+
+
+def patch_pytorch_dtype_promotion_contract() -> None:
+    """Make PyTorch mixed-dtype helpers use Torch's promotion rules."""
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
+        return
+
+    original_convert = raw_pytorch.convert_to_wider_dtype
+    if getattr(original_convert, "_pyrecest_torch_promotion_contract", False):
+        return
+
+    def convert_to_wider_dtype(tensor_list):
+        tensors = list(tensor_list)
+        if not tensors:
+            return tensors
+
+        promoted_dtype = tensors[0].dtype
+        for tensor in tensors[1:]:
+            promoted_dtype = torch.promote_types(promoted_dtype, tensor.dtype)
+
+        if all(tensor.dtype == promoted_dtype for tensor in tensors):
+            return tensors
+        return [raw_pytorch.cast(tensor, dtype=promoted_dtype) for tensor in tensors]
+
+    convert_to_wider_dtype.__name__ = getattr(
+        original_convert, "__name__", "convert_to_wider_dtype"
+    )
+    convert_to_wider_dtype.__doc__ = getattr(original_convert, "__doc__", None)
+    convert_to_wider_dtype._pyrecest_torch_promotion_contract = True
+    raw_pytorch.convert_to_wider_dtype = convert_to_wider_dtype

--- a/tests/backend_support/test_pytorch_dtype_promotion_contract.py
+++ b/tests/backend_support/test_pytorch_dtype_promotion_contract.py
@@ -1,0 +1,17 @@
+import pytest
+
+pytorch_backend = pytest.importorskip("pyrecest._backend.pytorch")
+
+
+def test_pytorch_allclose_accepts_mixed_boolean_numeric_inputs():
+    left = pytorch_backend.array([True, False])
+    right = pytorch_backend.array([1, 0], dtype=pytorch_backend.uint8)
+
+    assert bool(pytorch_backend.allclose(left, right))
+
+
+def test_pytorch_isclose_accepts_mixed_boolean_numeric_inputs():
+    left = pytorch_backend.array([True, False])
+    right = pytorch_backend.array([1.0, 0.0], dtype=pytorch_backend.float32)
+
+    assert pytorch_backend.isclose(left, right).tolist() == [True, True]


### PR DESCRIPTION
## Summary
- Add a PyTorch backend compatibility shim that replaces `convert_to_wider_dtype` with a `torch.promote_types`-based implementation.
- Wire the shim into backend support initialization so raw PyTorch helpers use the corrected promotion behavior.
- Add regression tests for mixed boolean/numeric `allclose` and `isclose` inputs.

## Bug fixed
The PyTorch backend's promotion table did not include `bool`/`uint8` and other non-default numeric dtypes. Mixed boolean/numeric comparisons such as `allclose(bool_tensor, uint8_tensor)` and `isclose(bool_tensor, float_tensor)` could therefore leave incompatible dtypes unchanged and raise a Torch dtype mismatch, while NumPy promotes the operands and succeeds.

## Testing
- Added `tests/backend_support/test_pytorch_dtype_promotion_contract.py`.
- Not run locally in this connector environment; CI should execute the regression tests.