### PR TITLE
Fix PyTorch cov integer promotion

### DIFF
--- a/src/pyrecest/backend_support/__init__.py
+++ b/src/pyrecest/backend_support/__init__.py
@@ -310,6 +310,55 @@ def _patch_pytorch_clip_numpy_contract() -> None:
         backend.clip = clip
 
 
+def _patch_pytorch_cov_numpy_contract() -> None:
+    """Make PyTorch cov promote integer observations like NumPy's cov."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
+        return
+
+    original_cov = raw_pytorch.cov
+    if getattr(original_cov, "_pyrecest_numpy_contract", False):
+        return
+
+    def cov(input, correction=1, fweights=None, aweights=None, bias=False):
+        values = raw_pytorch.array(input)
+        if not (raw_pytorch.is_floating(values) or raw_pytorch.is_complex(values)):
+            values = raw_pytorch.cast(values, dtype=raw_pytorch.get_default_dtype())
+
+        if fweights is not None:
+            fweights = torch.as_tensor(fweights, device=values.device)
+        if aweights is not None:
+            aweights = torch.as_tensor(
+                aweights,
+                dtype=values.dtype,
+                device=values.device,
+            )
+        if bias:
+            correction = 0
+        return torch.cov(
+            values,
+            correction=correction,
+            fweights=fweights,
+            aweights=aweights,
+        )
+
+    cov.__name__ = getattr(original_cov, "__name__", "cov")
+    cov.__doc__ = getattr(original_cov, "__doc__", None)
+    cov._pyrecest_numpy_contract = True
+    raw_pytorch.cov = cov
+    if active_pytorch_backend:
+        backend.cov = cov
+
+
 def _patch_jax_outer_numpy_contract() -> None:
     """Make JAX outer flatten inputs like NumPy's outer."""
     try:
@@ -347,6 +396,7 @@ _patch_pytorch_outer_numpy_contract()
 _patch_pytorch_tile_numpy_contract()
 _patch_pytorch_copy_numpy_contract()
 _patch_pytorch_clip_numpy_contract()
+_patch_pytorch_cov_numpy_contract()
 _patch_jax_outer_numpy_contract()
 
 

--- a/tests/backend_support/test_pytorch_cov_contract.py
+++ b/tests/backend_support/test_pytorch_cov_contract.py
@@ -1,0 +1,38 @@
+"""Regression coverage for PyTorch covariance NumPy dtype semantics."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_pytorch_cov_promotes_integer_observations_for_public_and_raw_backends():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    code = """
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+values = raw_pytorch.array([[1, 2, 3], [2, 4, 8]], dtype=raw_pytorch.int64)
+expected = raw_pytorch.array(
+    [[2.0 / 3.0, 2.0], [2.0, 56.0 / 9.0]],
+    dtype=raw_pytorch.get_default_dtype(),
+)
+
+raw_result = raw_pytorch.cov(values, bias=True)
+assert raw_result.dtype == raw_pytorch.get_default_dtype()
+assert bool(raw_pytorch.allclose(raw_result, expected))
+
+if backend.__backend_name__ == "pytorch":
+    public_result = backend.cov([[1, 2, 3], [2, 4, 8]], bias=True)
+    assert public_result.dtype == backend.get_default_dtype()
+    assert bool(backend.allclose(public_result, expected))
+"""
+
+    for backend_name in ("numpy", "pytorch"):
+        result = run_backend_code(backend_name, code)
+        assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Patch the raw PyTorch backend `cov` wrapper so integer observations are promoted to the PyTorch default floating dtype before calling `torch.cov`.
- Preserve existing floating/complex behavior and continue to patch the public facade when `PYRECEST_BACKEND=pytorch`.
- Add backend-portable regression coverage for both raw PyTorch use under a NumPy public backend and the public PyTorch backend.

## Rationale
`torch.cov` rejects integer inputs, while NumPy-style covariance accepts integer observations by promoting them for floating-point covariance computation. The previous wrapper passed integer tensors through directly, so `raw_pytorch.cov(raw_pytorch.array(..., dtype=int64), bias=True)` failed.

## Tests
- Not run locally in this environment; added `tests/backend_support/test_pytorch_cov_contract.py` for CI.