### PR TITLE
Fix raw JAX matmul out under NumPy backend

### DIFF
--- a/src/pyrecest/backend_support/__init__.py
+++ b/src/pyrecest/backend_support/__init__.py
@@ -310,6 +310,32 @@ def _patch_pytorch_clip_numpy_contract() -> None:
         backend.clip = clip
 
 
+def _patch_raw_jax_matmul_out_contract() -> None:
+    """Make raw JAX matmul honor ``out`` under any active public backend."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.jax as raw_jax  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - JAX may be unavailable
+        return
+
+    original_matmul = raw_jax.matmul
+    if getattr(original_matmul, "_pyrecest_out_contract", False):
+        return
+
+    def matmul(x, y, out=None):
+        result = original_matmul(x, y, out=None)
+        if out is None:
+            return result
+        return raw_jax.asarray(out).at[...].set(result)
+
+    matmul.__name__ = getattr(original_matmul, "__name__", "matmul")
+    matmul.__doc__ = getattr(original_matmul, "__doc__", None)
+    matmul._pyrecest_out_contract = True
+    raw_jax.matmul = matmul
+    if getattr(backend, "__backend_name__", None) == "jax":
+        backend.matmul = matmul
+
+
 def _patch_jax_outer_numpy_contract() -> None:
     """Make JAX outer flatten inputs like NumPy's outer."""
     try:
@@ -347,6 +373,7 @@ _patch_pytorch_outer_numpy_contract()
 _patch_pytorch_tile_numpy_contract()
 _patch_pytorch_copy_numpy_contract()
 _patch_pytorch_clip_numpy_contract()
+_patch_raw_jax_matmul_out_contract()
 _patch_jax_outer_numpy_contract()
 
 

--- a/tests/backend_support/test_raw_jax_matmul_out_contract.py
+++ b/tests/backend_support/test_raw_jax_matmul_out_contract.py
@@ -1,0 +1,40 @@
+"""Regression tests for raw JAX matmul out handling under another backend."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_raw_jax_matmul_honors_out_with_numpy_public_backend():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("JAX is not installed")
+
+    result = run_backend_code(
+        "numpy",
+        """
+import importlib
+
+raw_jax = importlib.import_module("pyrecest._backend.jax")
+
+left = [[1.0, 2.0], [3.0, 4.0]]
+right = [[1.0, 0.0], [0.0, 1.0]]
+
+out = raw_jax.zeros((2, 2))
+returned = raw_jax.matmul(left, right, out=out)
+assert raw_jax.to_numpy(returned).tolist() == [[1.0, 2.0], [3.0, 4.0]]
+
+bad_out = raw_jax.zeros((1, 1))
+try:
+    raw_jax.matmul(left, right, out=bad_out)
+except (TypeError, ValueError):
+    pass
+else:
+    raise AssertionError("raw JAX matmul ignored incompatible out shape")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Patch raw `pyrecest._backend.jax.matmul` from backend-support initialization so it honors `out` even when the active public backend is not JAX.
- Preserve the active JAX public facade update when JAX is selected.
- Add subprocess regression coverage for importing the raw JAX backend under the NumPy public backend.

## Bug fixed
A previous JAX `matmul(..., out=...)` fix only covered the active JAX public backend path. When `PYRECEST_BACKEND=numpy` and user code imports `pyrecest._backend.jax` directly, raw `matmul` still ignored `out`, so incompatible output shapes could silently succeed by returning the computed result. The new patch makes raw JAX `matmul` write through `.at[...].set(...)`, which also raises on incompatible `out` shapes.

## Testing
- Syntax-checked the changed source and added test content locally.
- Could not run the repository test suite locally because this container cannot resolve `github.com`; CI should execute the regression test.