### PR TITLE
Fix raw PyTorch diag under non-PyTorch backends

### DIFF
--- a/src/pyrecest/backend_support/__init__.py
+++ b/src/pyrecest/backend_support/__init__.py
@@ -310,6 +310,36 @@ def _patch_pytorch_clip_numpy_contract() -> None:
         backend.clip = clip
 
 
+def _patch_pytorch_diag_numpy_contract() -> None:
+    """Make PyTorch diag accept array-like inputs and NumPy's ``k`` keyword."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
+        return
+
+    original_diag = raw_pytorch.diag
+    if getattr(original_diag, "_pyrecest_numpy_contract", False):
+        return
+
+    def diag(v, k=0):
+        return torch.diag(raw_pytorch.array(v), diagonal=_operator_index(k))
+
+    diag.__name__ = getattr(original_diag, "__name__", "diag")
+    diag.__doc__ = getattr(original_diag, "__doc__", None)
+    diag._pyrecest_numpy_contract = True
+    raw_pytorch.diag = diag
+    if active_pytorch_backend:
+        backend.diag = diag
+
+
 def _patch_jax_outer_numpy_contract() -> None:
     """Make JAX outer flatten inputs like NumPy's outer."""
     try:
@@ -347,6 +377,7 @@ _patch_pytorch_outer_numpy_contract()
 _patch_pytorch_tile_numpy_contract()
 _patch_pytorch_copy_numpy_contract()
 _patch_pytorch_clip_numpy_contract()
+_patch_pytorch_diag_numpy_contract()
 _patch_jax_outer_numpy_contract()
 
 

--- a/tests/backend_support/test_raw_pytorch_diag_default_backend.py
+++ b/tests/backend_support/test_raw_pytorch_diag_default_backend.py
@@ -1,0 +1,47 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def test_raw_pytorch_diag_accepts_numpy_contract_under_numpy_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "numpy"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            """
+import pyrecest  # noqa: F401  # triggers raw-backend compatibility patches
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch_backend
+
+assert getattr(backend, "__backend_name__", None) == "numpy"
+
+upper = raw_pytorch_backend.diag([1, 2, 3], k=1)
+assert raw_pytorch_backend.to_numpy(upper).tolist() == [
+    [0, 1, 0, 0],
+    [0, 0, 2, 0],
+    [0, 0, 0, 3],
+    [0, 0, 0, 0],
+]
+
+matrix = [[0, 4, 0], [1, 0, 5], [0, 2, 0]]
+lower = raw_pytorch_backend.diag(matrix, k=-1)
+assert raw_pytorch_backend.to_numpy(lower).tolist() == [1, 2]
+print("ok")
+""",
+        ],
+        capture_output=True,
+        env=env,
+        text=True,
+        timeout=30.0,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "ok" in completed.stdout


### PR DESCRIPTION
## Summary
- Patch raw `pyrecest._backend.pytorch.diag` from `pyrecest.backend_support` so it is fixed even when the active public backend is not PyTorch.
- Preserve the public PyTorch facade update when `PYRECEST_BACKEND=pytorch` is active.
- Add a regression covering `PYRECEST_BACKEND=numpy` followed by direct raw PyTorch `diag` usage with NumPy-style list inputs and `k=`.

## Bug fixed
`backend_tools._patch_pytorch_diag_numpy_contract()` only ran when the selected public backend was PyTorch. With `PYRECEST_BACKEND=numpy`, importing `pyrecest` and then using `pyrecest._backend.pytorch.diag([1, 2, 3], k=1)` still exposed raw `torch.diag`, which rejects the NumPy-style `k=` keyword/list-input contract.

## Testing
- Added `tests/backend_support/test_raw_pytorch_diag_default_backend.py`.
- Syntax-checked the modified Python content before committing; full test suite not run in this environment.