### PR TITLE
Fix PyTorch deg/rad array-like backend contract

### DIFF
--- a/src/pyrecest/backend_support/__init__.py
+++ b/src/pyrecest/backend_support/__init__.py
@@ -310,6 +310,68 @@ def _patch_pytorch_clip_numpy_contract() -> None:
         backend.clip = clip
 
 
+def _patch_pytorch_angle_unit_numpy_contract() -> None:
+    """Make PyTorch degree/radian helpers accept NumPy-style inputs."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
+        return
+
+    original_deg2rad = raw_pytorch.deg2rad
+    original_rad2deg = raw_pytorch.rad2deg
+    if getattr(original_deg2rad, "_pyrecest_numpy_contract", False) and getattr(
+        original_rad2deg,
+        "_pyrecest_numpy_contract",
+        False,
+    ):
+        return
+
+    def _angle_unit_input(x):
+        x = raw_pytorch.array(x)
+        if raw_pytorch.is_floating(x) or raw_pytorch.is_complex(x):
+            return x
+        return raw_pytorch.cast(x, dtype=raw_pytorch.get_default_dtype())
+
+    def _copy_result_to_out(result, out):
+        if out is None:
+            return result
+        copy_ = getattr(out, "copy_", None)
+        if copy_ is not None:
+            copy_(result)
+            return out
+        out[...] = result
+        return out
+
+    def deg2rad(x, out=None):
+        result = torch.deg2rad(_angle_unit_input(x))
+        return _copy_result_to_out(result, out)
+
+    def rad2deg(x, out=None):
+        result = torch.rad2deg(_angle_unit_input(x))
+        return _copy_result_to_out(result, out)
+
+    deg2rad.__name__ = getattr(original_deg2rad, "__name__", "deg2rad")
+    deg2rad.__doc__ = getattr(original_deg2rad, "__doc__", None)
+    deg2rad._pyrecest_numpy_contract = True
+    rad2deg.__name__ = getattr(original_rad2deg, "__name__", "rad2deg")
+    rad2deg.__doc__ = getattr(original_rad2deg, "__doc__", None)
+    rad2deg._pyrecest_numpy_contract = True
+
+    raw_pytorch.deg2rad = deg2rad
+    raw_pytorch.rad2deg = rad2deg
+    if active_pytorch_backend:
+        backend.deg2rad = deg2rad
+        backend.rad2deg = rad2deg
+
+
 def _patch_jax_outer_numpy_contract() -> None:
     """Make JAX outer flatten inputs like NumPy's outer."""
     try:
@@ -347,6 +409,7 @@ _patch_pytorch_outer_numpy_contract()
 _patch_pytorch_tile_numpy_contract()
 _patch_pytorch_copy_numpy_contract()
 _patch_pytorch_clip_numpy_contract()
+_patch_pytorch_angle_unit_numpy_contract()
 _patch_jax_outer_numpy_contract()
 
 

--- a/tests/backend_support/test_pytorch_angle_unit_contract.py
+++ b/tests/backend_support/test_pytorch_angle_unit_contract.py
@@ -1,0 +1,47 @@
+"""Regression coverage for PyTorch degree/radian helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+@pytest.mark.parametrize("public_backend", ["pytorch", "numpy"])
+def test_pytorch_degree_radian_helpers_accept_array_like_inputs(public_backend):
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        public_backend,
+        f"""
+import importlib
+import torch
+
+pt = importlib.import_module("pyrecest._backend.pytorch")
+
+degrees = [0, 90, 180]
+radians = pt.deg2rad(degrees)
+expected_radians = torch.tensor(
+    [0.0, torch.pi / 2, torch.pi], dtype=radians.dtype, device=radians.device
+)
+assert torch.allclose(radians, expected_radians)
+
+out = torch.empty_like(radians)
+returned = pt.rad2deg(radians, out=out)
+assert returned is out
+assert torch.allclose(
+    out, torch.tensor(degrees, dtype=out.dtype, device=out.device)
+)
+
+if {public_backend!r} == "pytorch":
+    import pyrecest.backend as backend
+
+    public_radians = backend.deg2rad(degrees)
+    assert torch.allclose(public_radians, expected_radians)
+""",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Patch raw PyTorch `deg2rad`/`rad2deg` to accept NumPy-style array-like inputs.
- Propagate the patched helpers to the public PyTorch backend when it is active.
- Add a subprocess regression that exercises raw PyTorch under both `PYRECEST_BACKEND=pytorch` and `PYRECEST_BACKEND=numpy`.

## Bug fixed
The PyTorch backend exposed `torch.deg2rad` and `torch.rad2deg` directly, so calls like `pt.deg2rad([0, 90, 180])` failed with `TypeError` even though the NumPy-style backend facade generally accepts array-like inputs. The patch normalizes inputs through the raw PyTorch backend array/cast path and preserves `out=` handling for `rad2deg`/`deg2rad`.

## Testing
- Added `tests/backend_support/test_pytorch_angle_unit_contract.py`.
- Local syntax check: `python -m py_compile` on the modified backend-support module and new test file.

Full CI should validate the complete backend matrix.