### PR TITLE
Patch raw PyTorch tile independent of public backend

### DIFF
--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -246,8 +246,7 @@ def _patch_pytorch_tile_facade() -> None:
 
     import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
 
-    if getattr(backend, "__backend_name__", None) != "pytorch":
-        return
+    selected_backend_is_pytorch = getattr(backend, "__backend_name__", None) == "pytorch"
 
     try:
         import numpy as _np  # pylint: disable=import-outside-toplevel
@@ -259,7 +258,7 @@ def _patch_pytorch_tile_facade() -> None:
         return
 
     def tile(x, reps):
-        x = backend.array(x)
+        x = _pytorch_backend.array(x)
         repetitions = _pytorch_tile_repetitions(reps, _np, _torch)
         if not repetitions:
             return x.clone()
@@ -271,7 +270,8 @@ def _patch_pytorch_tile_facade() -> None:
 
     tile.__name__ = "tile"
     tile.__doc__ = getattr(_np.tile, "__doc__", None)
-    backend.tile = tile
+    if selected_backend_is_pytorch:
+        backend.tile = tile
     _pytorch_backend.tile = tile
 
 

--- a/tests/backend_support/test_pytorch_tile_contract.py
+++ b/tests/backend_support/test_pytorch_tile_contract.py
@@ -6,19 +6,22 @@ import sys
 import pytest
 
 
-@pytest.mark.backend_portable
-def test_pytorch_tile_scalar_and_array_repetitions_match_numpy_contract():
-    if importlib.util.find_spec("torch") is None:
-        pytest.skip("torch is not installed")
-
+def _backend_test_env(backend_name):
     env = os.environ.copy()
-    env["PYRECEST_BACKEND"] = "pytorch"
+    env["PYRECEST_BACKEND"] = backend_name
     src_path = os.path.abspath("src")
     env["PYTHONPATH"] = (
         src_path
         if not env.get("PYTHONPATH")
         else os.pathsep.join([src_path, env["PYTHONPATH"]])
     )
+    return env
+
+
+@pytest.mark.backend_portable
+def test_pytorch_tile_scalar_and_array_repetitions_match_numpy_contract():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
 
     code = """
 import pyrecest.backend as backend
@@ -51,4 +54,40 @@ for tile_func, to_numpy in (
         else:
             raise AssertionError(f"tile accepted non-integer repetitions {bad_reps!r}")
 """
-    subprocess.run([sys.executable, "-c", code], check=True, env=env)
+    subprocess.run([sys.executable, "-c", code], check=True, env=_backend_test_env("pytorch"))
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_tile_matches_numpy_contract_with_numpy_public_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import pyrecest.backend as backend
+from pyrecest._backend import pytorch as pytorch_backend
+
+assert getattr(backend, "__backend_name__", None) == "numpy"
+values = pytorch_backend.array([[1, 2], [3, 4]])
+
+scalar_result = pytorch_backend.tile(values, 2)
+assert tuple(scalar_result.shape) == (2, 4)
+assert pytorch_backend.to_numpy(scalar_result).tolist() == [[1, 2, 1, 2], [3, 4, 3, 4]]
+
+array_result = pytorch_backend.tile(values, pytorch_backend.array([2, 1]))
+assert tuple(array_result.shape) == (4, 2)
+assert pytorch_backend.to_numpy(array_result).tolist() == [[1, 2], [3, 4], [1, 2], [3, 4]]
+
+empty_result = pytorch_backend.tile(values, ())
+assert tuple(empty_result.shape) == (2, 2)
+assert pytorch_backend.to_numpy(empty_result).tolist() == [[1, 2], [3, 4]]
+assert empty_result is not values
+
+for bad_reps in (1.5, [2.5, 1], "2", pytorch_backend.array([2.5, 1.0])):
+    try:
+        pytorch_backend.tile(values, bad_reps)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"raw tile accepted non-integer repetitions {bad_reps!r}")
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=_backend_test_env("numpy"))


### PR DESCRIPTION
## Duplicate
This PR duplicated the already-merged fix in #3430.

The bug was the raw `pyrecest._backend.pytorch.tile` shim only being patched when the selected public backend was PyTorch. #3430 already patched the raw backend independently of the public backend and added the `PYRECEST_BACKEND=numpy` regression coverage.

Closing to avoid a redundant open PR.