### PR TITLE
Fix PyTorch kron array-like backend contract

### DIFF
--- a/src/pyrecest/backend_support/__init__.py
+++ b/src/pyrecest/backend_support/__init__.py
@@ -148,6 +148,51 @@ def _patch_pytorch_outer_numpy_contract() -> None:
         backend.outer = outer
 
 
+def _patch_pytorch_kron_numpy_contract() -> None:
+    """Make PyTorch kron accept NumPy-style array-like inputs."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except (
+        ModuleNotFoundError
+    ):  # pragma: no cover - PyTorch backend import failed earlier
+        return
+
+    original_kron = raw_pytorch.kron
+    if getattr(original_kron, "_pyrecest_numpy_contract", False):
+        return
+
+    def kron(a, b, out=None):
+        a = raw_pytorch.array(a)
+        b = raw_pytorch.array(b)
+        dtype = torch.promote_types(a.dtype, b.dtype)
+        a = a.to(dtype=dtype)
+        b = b.to(dtype=dtype)
+        result = torch.kron(a, b)
+        if out is not None:
+            copy_ = getattr(out, "copy_", None)
+            if copy_ is not None:
+                copy_(result)
+                return out
+            out[...] = raw_pytorch.to_numpy(result)
+            return out
+        return result
+
+    kron.__name__ = getattr(original_kron, "__name__", "kron")
+    kron.__doc__ = getattr(original_kron, "__doc__", None)
+    kron._pyrecest_numpy_contract = True
+    raw_pytorch.kron = kron
+    if active_pytorch_backend:
+        backend.kron = kron
+
+
 def _pytorch_tile_repetition(repetition) -> int:
     """Return one NumPy-style tile repetition as an integer."""
 
@@ -569,6 +614,7 @@ _patch_raw_pytorch_assignment_scalar_tensor_indices()
 _patch_pytorch_dtype_promotion_contract()
 _patch_pytorch_dot_numpy_contract()
 _patch_pytorch_outer_numpy_contract()
+_patch_pytorch_kron_numpy_contract()
 _patch_pytorch_tile_numpy_contract()
 _patch_pytorch_copy_numpy_contract()
 _patch_pytorch_clip_numpy_contract()

--- a/tests/backend_support/test_pytorch_kron_contract.py
+++ b/tests/backend_support/test_pytorch_kron_contract.py
@@ -1,0 +1,61 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _backend_subprocess_env(backend_name):
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = backend_name
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    return env
+
+
+@pytest.mark.backend_portable
+@pytest.mark.parametrize("backend_name", ["numpy", "pytorch"])
+def test_pytorch_kron_accepts_array_like_inputs_under_public_backend(backend_name):
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = _backend_subprocess_env(backend_name)
+
+    code = f"""
+import numpy as np
+import numpy.testing as npt
+import pyrecest.backend as public_backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+assert public_backend.__backend_name__ == {backend_name!r}
+
+left = [[1, 2], [3, 4]]
+right = [0, 5]
+expected = np.kron(np.asarray(left), np.asarray(right))
+
+raw_result = raw_pytorch.kron(left, right)
+npt.assert_array_equal(raw_pytorch.to_numpy(raw_result), expected)
+
+mixed_result = raw_pytorch.kron(left, raw_pytorch.array(right))
+npt.assert_array_equal(raw_pytorch.to_numpy(mixed_result), expected)
+
+raw_out = raw_pytorch.empty_like(raw_result)
+raw_returned = raw_pytorch.kron(left, right, out=raw_out)
+assert raw_returned is raw_out
+npt.assert_array_equal(raw_pytorch.to_numpy(raw_out), expected)
+
+if public_backend.__backend_name__ == "pytorch":
+    public_result = public_backend.kron(left, right)
+    npt.assert_array_equal(public_backend.to_numpy(public_result), expected)
+
+    out = public_backend.empty_like(public_result)
+    returned = public_backend.kron(left, right, out=out)
+    assert returned is out
+    npt.assert_array_equal(public_backend.to_numpy(out), expected)
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- Patch raw `pyrecest._backend.pytorch.kron` so it accepts NumPy-style array-like inputs instead of exposing bare `torch.kron`.
- Keep the public PyTorch backend facade aligned when `PYRECEST_BACKEND=pytorch` is active.
- Add subprocess regression coverage for raw PyTorch `kron` under both NumPy and PyTorch public backend selections, including `out=` handling.

## Bug fixed
`torch.kron` rejects Python-list inputs, while the NumPy/PyRecEst backend contract accepts array-like operands. Direct raw PyTorch calls such as `pyrecest._backend.pytorch.kron([[1, 2]], [3, 4])` could therefore fail, and public PyTorch backend calls had the same issue.

## Validation
- Branch is current against `main` at compare time (`ahead_by=2`, `behind_by=0`).
- Syntax-checked the modified backend support module and new regression test with `python -m py_compile` in the container.
- Full pytest was not run locally because this execution environment cannot resolve `github.com` for cloning/installing repository dependencies; CI should run the focused backend-portable regression.