### PR TITLE
Fix raw JAX std out contract

### DIFF
--- a/src/pyrecest/backend_support/__init__.py
+++ b/src/pyrecest/backend_support/__init__.py
@@ -340,6 +340,54 @@ def _patch_jax_outer_numpy_contract() -> None:
         backend.outer = outer
 
 
+def _patch_jax_std_out_numpy_contract() -> None:
+    """Make raw JAX std honor NumPy's ``out`` contract."""
+
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.jax as raw_jax  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - JAX backend may be unavailable
+        return
+
+    original_std = raw_jax.std
+    if getattr(original_std, "_pyrecest_numpy_contract", False):
+        return
+
+    def _return_or_store_out(result, out):
+        if out is None:
+            return result
+        return raw_jax.asarray(out).at[...].set(result)
+
+    def std(
+        a,
+        axis=None,
+        dtype=None,
+        out=None,
+        ddof=0,
+        keepdims=False,
+        *,
+        correction=0,
+    ):
+        kwargs = {
+            "axis": axis,
+            "dtype": dtype,
+            "out": None,
+            "ddof": ddof,
+            "keepdims": keepdims,
+        }
+        if correction != 0:
+            kwargs["correction"] = correction
+        result = original_std(a, **kwargs)
+        return _return_or_store_out(result, out)
+
+    std.__name__ = getattr(original_std, "__name__", "std")
+    std.__doc__ = getattr(original_std, "__doc__", None)
+    std._pyrecest_numpy_contract = True
+    raw_jax.std = std
+    if getattr(backend, "__backend_name__", None) == "jax":
+        backend.std = std
+
+
 _patch_raw_pytorch_assignment_scalar_tensor_indices()
 _patch_pytorch_dtype_promotion_contract()
 _patch_pytorch_dot_numpy_contract()
@@ -348,6 +396,7 @@ _patch_pytorch_tile_numpy_contract()
 _patch_pytorch_copy_numpy_contract()
 _patch_pytorch_clip_numpy_contract()
 _patch_jax_outer_numpy_contract()
+_patch_jax_std_out_numpy_contract()
 
 
 def get_backend_support(

--- a/tests/backend_support/test_raw_jax_std_out_default_backend.py
+++ b/tests/backend_support/test_raw_jax_std_out_default_backend.py
@@ -1,0 +1,41 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_raw_jax_std_out_works_under_numpy_backend():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("jax is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "numpy"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import pyrecest  # noqa: F401
+import pyrecest._backend.jax as raw_jax
+
+values = raw_jax.asarray([[1.0, 3.0], [5.0, 7.0]])
+out = raw_jax.zeros((2,), dtype=values.dtype)
+returned = raw_jax.std(values, axis=0, out=out, ddof=0)
+
+assert raw_jax.to_numpy(returned).tolist() == [2.0, 2.0]
+
+bad_out = raw_jax.zeros((3,), dtype=values.dtype)
+try:
+    raw_jax.std(values, axis=0, out=bad_out, ddof=0)
+except ValueError:
+    pass
+else:
+    raise AssertionError("raw JAX std accepted incompatible out shape")
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- patch raw `pyrecest._backend.jax.std` from backend-support initialization so `out=` is handled even when the public backend is not JAX
- keep the public JAX facade aligned when JAX is the active backend
- add a subprocess regression for `PYRECEST_BACKEND=numpy` followed by direct raw JAX `std(..., out=...)`

## Bug fixed
The existing JAX `std(..., out=...)` compatibility patch only ran through the active public JAX facade path. With `PYRECEST_BACKEND=numpy`, importing `pyrecest` and then using `pyrecest._backend.jax.std(values, out=...)` could still expose `jax.numpy.std`, which rejects non-`None` `out` values. The raw backend now computes with `out=None` and returns the JAX `.at[...]` updated output array.

## Testing
- Not run locally in this connector session; added focused regression coverage in `tests/backend_support/test_raw_jax_std_out_default_backend.py`.