### PR TITLE
Fix PyTorch stack helpers with NumPy backend

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
@@ -1,6 +1,53 @@
-"""PyTorch dtype promotion compatibility helpers."""
+"""PyTorch backend compatibility helpers."""
 
 from __future__ import annotations
+
+
+def _patch_stack_helpers(raw_pytorch, torch_module) -> None:
+    """Make low-level stack helpers accept NumPy-style array-like inputs."""
+    try:
+        import numpy as np  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - NumPy is a required dependency
+        return
+
+    def _tensor_sequence(tup):
+        return [raw_pytorch.array(item) for item in tup]
+
+    def hstack(tup):
+        tensors = [torch_module.atleast_1d(tensor) for tensor in _tensor_sequence(tup)]
+        if not tensors:
+            return torch_module.cat(tensors, dim=0)
+        return torch_module.cat(tensors, dim=0 if tensors[0].ndim == 1 else 1)
+
+    def vstack(tup):
+        tensors = [torch_module.atleast_2d(tensor) for tensor in _tensor_sequence(tup)]
+        return torch_module.cat(tensors, dim=0)
+
+    def column_stack(tup):
+        tensors = []
+        for tensor in _tensor_sequence(tup):
+            if tensor.ndim < 2:
+                tensor = tensor.reshape(-1, 1)
+            tensors.append(tensor)
+        return torch_module.cat(tensors, dim=1)
+
+    def dstack(tup):
+        tensors = [torch_module.atleast_3d(tensor) for tensor in _tensor_sequence(tup)]
+        return torch_module.cat(tensors, dim=2)
+
+    for helper_name, helper in {
+        "hstack": hstack,
+        "vstack": vstack,
+        "column_stack": column_stack,
+        "dstack": dstack,
+    }.items():
+        current_helper = getattr(raw_pytorch, helper_name)
+        if getattr(current_helper, "_pyrecest_numpy_contract", False):
+            continue
+        helper.__name__ = helper_name
+        helper.__doc__ = getattr(np, helper_name).__doc__
+        helper._pyrecest_numpy_contract = True
+        setattr(raw_pytorch, helper_name, helper)
 
 
 def patch_pytorch_dtype_promotion_contract() -> None:
@@ -12,25 +59,26 @@ def patch_pytorch_dtype_promotion_contract() -> None:
         return
 
     original_convert = raw_pytorch.convert_to_wider_dtype
-    if getattr(original_convert, "_pyrecest_torch_promotion_contract", False):
-        return
+    if not getattr(original_convert, "_pyrecest_torch_promotion_contract", False):
 
-    def convert_to_wider_dtype(tensor_list):
-        tensors = list(tensor_list)
-        if not tensors:
-            return tensors
+        def convert_to_wider_dtype(tensor_list):
+            tensors = list(tensor_list)
+            if not tensors:
+                return tensors
 
-        promoted_dtype = tensors[0].dtype
-        for tensor in tensors[1:]:
-            promoted_dtype = torch.promote_types(promoted_dtype, tensor.dtype)
+            promoted_dtype = tensors[0].dtype
+            for tensor in tensors[1:]:
+                promoted_dtype = torch.promote_types(promoted_dtype, tensor.dtype)
 
-        if all(tensor.dtype == promoted_dtype for tensor in tensors):
-            return tensors
-        return [raw_pytorch.cast(tensor, dtype=promoted_dtype) for tensor in tensors]
+            if all(tensor.dtype == promoted_dtype for tensor in tensors):
+                return tensors
+            return [raw_pytorch.cast(tensor, dtype=promoted_dtype) for tensor in tensors]
 
-    convert_to_wider_dtype.__name__ = getattr(
-        original_convert, "__name__", "convert_to_wider_dtype"
-    )
-    convert_to_wider_dtype.__doc__ = getattr(original_convert, "__doc__", None)
-    convert_to_wider_dtype._pyrecest_torch_promotion_contract = True
-    raw_pytorch.convert_to_wider_dtype = convert_to_wider_dtype
+        convert_to_wider_dtype.__name__ = getattr(
+            original_convert, "__name__", "convert_to_wider_dtype"
+        )
+        convert_to_wider_dtype.__doc__ = getattr(original_convert, "__doc__", None)
+        convert_to_wider_dtype._pyrecest_torch_promotion_contract = True
+        raw_pytorch.convert_to_wider_dtype = convert_to_wider_dtype
+
+    _patch_stack_helpers(raw_pytorch, torch)

--- a/tests/backend_support/test_pytorch_stack_helpers_raw_backend_contract.py
+++ b/tests/backend_support/test_pytorch_stack_helpers_raw_backend_contract.py
@@ -1,0 +1,36 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_pytorch_stack_helpers_accept_array_like_sequences_with_numpy_public_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "numpy"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import pyrecest  # noqa: F401
+import pyrecest.backend as public_backend
+import pyrecest._backend.pytorch as stack_backend
+
+assert public_backend.__backend_name__ == "numpy"
+to_numpy = stack_backend.to_numpy
+
+assert to_numpy(stack_backend.hstack(([1, 2], [3, 4]))).tolist() == [1, 2, 3, 4]
+assert to_numpy(stack_backend.vstack(([1, 2], [3, 4]))).tolist() == [[1, 2], [3, 4]]
+assert to_numpy(stack_backend.column_stack(([1, 2], [3, 4]))).tolist() == [[1, 3], [2, 4]]
+assert to_numpy(stack_backend.dstack(([1, 2], [3, 4]))).tolist() == [[[1, 3], [2, 4]]]
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- Patch the low-level PyTorch stack helper entry points from the backend support compatibility hook.
- Preserve NumPy-style array-like sequence support even when the selected public backend is NumPy.
- Add a subprocess regression for `hstack`, `vstack`, `column_stack`, and `dstack` with `PYRECEST_BACKEND=numpy`.

## Bug fixed
When the process selected the NumPy public backend, the PyTorch-specific stack-helper normalization path did not run. Direct PyTorch backend helper calls could therefore still reach Torch-native stack functions, which reject Python list elements such as `([1, 2], [3, 4])`.

## Testing
- Added `tests/backend_support/test_pytorch_stack_helpers_raw_backend_contract.py`.
- Not run locally in this connector-only session; CI should execute the focused backend-portable regression.