### PR TITLE
Fix Pareto front eligibility for missing objectives

### DIFF
--- a/src/pyrecest/evaluation/pareto.py
+++ b/src/pyrecest/evaluation/pareto.py
@@ -260,6 +260,12 @@ def _pareto_front_position_mask(
     front = np.zeros(len(candidates), dtype=bool)
     rows = [row for _, row in candidates.iterrows()]
     for position, row in enumerate(rows):
+        if not _has_front_eligible_objectives(
+            row,
+            objectives,
+            allow_missing=allow_missing,
+        ):
+            continue
         dominated = False
         for other_position, other in enumerate(rows):
             if position == other_position:
@@ -276,6 +282,19 @@ def _pareto_front_position_mask(
                 break
         front[position] = not dominated
     return front
+
+
+def _has_front_eligible_objectives(
+    record: Mapping[str, Any] | pd.Series,
+    objectives: Sequence[str],
+    *,
+    allow_missing: bool,
+) -> bool:
+    present = [
+        not _is_missing(_lookup_numeric(record, objective))
+        for objective in objectives
+    ]
+    return any(present) if allow_missing else all(present)
 
 
 def _validate_objectives(objectives: Sequence[str]) -> tuple[str, ...]:

--- a/src/pyrecest/evaluation/pareto.py
+++ b/src/pyrecest/evaluation/pareto.py
@@ -290,11 +290,15 @@ def _has_front_eligible_objectives(
     *,
     allow_missing: bool,
 ) -> bool:
-    present = [
+    if allow_missing:
+        return any(
+            not _is_missing(record.get(objective, np.nan))
+            for objective in objectives
+        )
+    return all(
         not _is_missing(_lookup_numeric(record, objective))
         for objective in objectives
-    ]
-    return any(present) if allow_missing else all(present)
+    )
 
 
 def _validate_objectives(objectives: Sequence[str]) -> tuple[str, ...]:

--- a/tests/evaluation/test_pareto_missing_front_eligibility.py
+++ b/tests/evaluation/test_pareto_missing_front_eligibility.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from pyrecest.evaluation import is_pareto_front, pareto_front_indices
+
+
+def test_pareto_front_excludes_rows_without_comparable_objectives() -> None:
+    table = pd.DataFrame(
+        [
+            {"name": "valid", "error": 1.0, "runtime": 1.0},
+            {"name": "unknown", "error": np.nan, "runtime": np.nan},
+        ]
+    )
+
+    indices = pareto_front_indices(
+        table,
+        ["error", "runtime"],
+        directions={"error": "min", "runtime": "min"},
+    )
+    mask = is_pareto_front(
+        table,
+        ["error", "runtime"],
+        directions={"error": "min", "runtime": "min"},
+    )
+
+    assert table.loc[indices, "name"].tolist() == ["valid"]
+    assert mask.tolist() == [True, False]
+
+
+def test_strict_pareto_front_requires_complete_objectives() -> None:
+    table = pd.DataFrame(
+        [
+            {"name": "complete", "error": 1.0, "runtime": 1.0},
+            {"name": "partial", "error": 0.5, "runtime": np.nan},
+        ]
+    )
+
+    indices = pareto_front_indices(
+        table,
+        ["error", "runtime"],
+        directions={"error": "min", "runtime": "min"},
+        allow_missing=False,
+    )
+    mask = is_pareto_front(
+        table,
+        ["error", "runtime"],
+        directions={"error": "min", "runtime": "min"},
+        allow_missing=False,
+    )
+
+    assert table.loc[indices, "name"].tolist() == ["complete"]
+    assert mask.tolist() == [True, False]


### PR DESCRIPTION
## Summary
- exclude candidates with no comparable objective values from Pareto-front membership when missing values are allowed
- require complete objective values for front eligibility when `allow_missing=False`
- add regression coverage for both `pareto_front_indices` and `is_pareto_front`

## Testing
- Validated the changed Pareto helper logic locally with a minimal pandas/NumPy reproduction
- Full repository test suite not run in this environment