### PR TITLE
Fix raw PyTorch reshape under non-PyTorch backends

### DIFF
--- a/src/pyrecest/_backend_submodules.py
+++ b/src/pyrecest/_backend_submodules.py
@@ -321,11 +321,13 @@ def _pytorch_reshape_shape(shape, torch_module) -> tuple[int, ...]:
 
 def _adapt_pytorch_reshape_contract(backend: ModuleType) -> None:
     """Adapt PyTorch reshape to accept array-like inputs and NumPy-style shapes."""
-    if getattr(backend, "__backend_name__", None) != "pytorch":
-        return
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
 
-    import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
-    import torch as torch_module  # pylint: disable=import-outside-toplevel
+    try:
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+        import torch as torch_module  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
 
     reshape = getattr(pytorch_backend, "reshape", None)
     if reshape is None or getattr(reshape, "_pyrecest_reshape_contract", False):
@@ -333,11 +335,15 @@ def _adapt_pytorch_reshape_contract(backend: ModuleType) -> None:
 
     @wraps(reshape)
     def wrapped_reshape(x, shape):
-        return reshape(backend.array(x), _pytorch_reshape_shape(shape, torch_module))
+        return reshape(
+            pytorch_backend.array(x),
+            _pytorch_reshape_shape(shape, torch_module),
+        )
 
     wrapped_reshape._pyrecest_reshape_contract = True
     setattr(pytorch_backend, "reshape", wrapped_reshape)
-    setattr(backend, "reshape", wrapped_reshape)
+    if active_pytorch_backend:
+        setattr(backend, "reshape", wrapped_reshape)
 
 
 def _adapt_pytorch_stack_helpers_contract(backend: ModuleType) -> None:

--- a/tests/backend_support/test_pytorch_reshape_contract.py
+++ b/tests/backend_support/test_pytorch_reshape_contract.py
@@ -6,19 +6,22 @@ import sys
 import pytest
 
 
-@pytest.mark.backend_portable
-def test_pytorch_reshape_array_like_inputs_match_numpy_contract():
-    if importlib.util.find_spec("torch") is None:
-        pytest.skip("torch is not installed")
-
+def _run_backend_subprocess(code, backend_name):
     env = os.environ.copy()
-    env["PYRECEST_BACKEND"] = "pytorch"
+    env["PYRECEST_BACKEND"] = backend_name
     src_path = os.path.abspath("src")
     env["PYTHONPATH"] = (
         src_path
         if not env.get("PYTHONPATH")
         else os.pathsep.join([src_path, env["PYTHONPATH"]])
     )
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)
+
+
+@pytest.mark.backend_portable
+def test_pytorch_reshape_array_like_inputs_match_numpy_contract():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
 
     code = """
 import numpy as np
@@ -47,4 +50,33 @@ except TypeError:
 else:
     raise AssertionError("reshape accepted a non-integer target shape")
 """
-    subprocess.run([sys.executable, "-c", code], check=True, env=env)
+    _run_backend_subprocess(code, "pytorch")
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_reshape_array_like_inputs_under_numpy_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import numpy as np
+
+import pyrecest  # noqa: F401
+import pyrecest._backend.pytorch as pytorch_backend
+
+matrix = pytorch_backend.reshape([1, 2, 3, 4], (2, 2))
+assert tuple(matrix.shape) == (2, 2)
+assert pytorch_backend.to_numpy(matrix).tolist() == [[1, 2], [3, 4]]
+
+shape_from_numpy = pytorch_backend.reshape([1, 2, 3, 4], np.array([4, 1]))
+assert tuple(shape_from_numpy.shape) == (4, 1)
+assert pytorch_backend.to_numpy(shape_from_numpy).tolist() == [[1], [2], [3], [4]]
+
+try:
+    pytorch_backend.reshape([1, 2], [1.5, 2])
+except TypeError:
+    pass
+else:
+    raise AssertionError("raw PyTorch reshape accepted a non-integer target shape")
+"""
+    _run_backend_subprocess(code, "numpy")


### PR DESCRIPTION
## Summary
- Patch the PyTorch `reshape` backend contract hook so it always patches raw `pyrecest._backend.pytorch.reshape`, even when the selected public backend is NumPy.
- Use `pyrecest._backend.pytorch.array` inside the wrapper rather than the active public backend's `array`, so raw PyTorch calls produce tensors under non-PyTorch public backends.
- Extend the reshape regression test to cover direct raw PyTorch usage after `PYRECEST_BACKEND=numpy`.

## Bug fixed
`_adapt_pytorch_reshape_contract()` returned early unless the active public backend was PyTorch. As a result, importing PyRecEst with `PYRECEST_BACKEND=numpy` and then calling `pyrecest._backend.pytorch.reshape([1, 2, 3, 4], (2, 2))` still exposed raw `torch.reshape`, which rejects array-like inputs instead of honoring the NumPy-style PyRecEst backend contract.

## Testing
- `python -m py_compile /tmp/_backend_submodules.py`
- `python -m py_compile /tmp/test_pytorch_reshape_contract.py`

Full test suite was not run locally because the execution container cannot reach GitHub to clone/install the repository dependencies; CI should run the focused regression.