### PR TITLE
Fix raw PyTorch broadcast_arrays under NumPy backend

### DIFF
--- a/src/pyrecest/backend_support/__init__.py
+++ b/src/pyrecest/backend_support/__init__.py
@@ -246,6 +246,41 @@ def _patch_pytorch_copy_numpy_contract() -> None:
         backend.copy = copy
 
 
+def _patch_pytorch_broadcast_arrays_numpy_contract() -> None:
+    """Make PyTorch broadcast_arrays accept array-like inputs."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
+        return
+
+    original_broadcast_arrays = raw_pytorch.broadcast_arrays
+    if getattr(original_broadcast_arrays, "_pyrecest_numpy_contract", False):
+        return
+
+    def broadcast_arrays(*arrays):
+        tensors = tuple(raw_pytorch.array(array) for array in arrays)
+        return torch.broadcast_tensors(*tensors)
+
+    broadcast_arrays.__name__ = getattr(
+        original_broadcast_arrays,
+        "__name__",
+        "broadcast_arrays",
+    )
+    broadcast_arrays.__doc__ = getattr(torch.broadcast_tensors, "__doc__", None)
+    broadcast_arrays._pyrecest_numpy_contract = True
+    raw_pytorch.broadcast_arrays = broadcast_arrays
+    if active_pytorch_backend:
+        backend.broadcast_arrays = broadcast_arrays
+
+
 def _patch_pytorch_clip_numpy_contract() -> None:
     """Make PyTorch clip accept array-like inputs regardless of public backend."""
     try:
@@ -571,6 +606,7 @@ _patch_pytorch_dot_numpy_contract()
 _patch_pytorch_outer_numpy_contract()
 _patch_pytorch_tile_numpy_contract()
 _patch_pytorch_copy_numpy_contract()
+_patch_pytorch_broadcast_arrays_numpy_contract()
 _patch_pytorch_clip_numpy_contract()
 _patch_pytorch_isclose_device_contract()
 _patch_pytorch_broadcast_to_numpy_contract()

--- a/tests/backend_support/test_raw_pytorch_broadcast_arrays_default_backend.py
+++ b/tests/backend_support/test_raw_pytorch_broadcast_arrays_default_backend.py
@@ -1,0 +1,38 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_broadcast_arrays_accepts_array_like_with_numpy_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "numpy"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import pyrecest  # noqa: F401
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_backend
+
+assert backend.__backend_name__ == "numpy"
+
+left, right = raw_backend.broadcast_arrays([1, 2], raw_backend.array([[3], [4]]))
+assert raw_backend.to_numpy(left).tolist() == [[1, 2], [1, 2]]
+assert raw_backend.to_numpy(right).tolist() == [[3, 3], [4, 4]]
+
+scalar, matrix = raw_backend.broadcast_arrays(5, [[1, 2], [3, 4]])
+assert raw_backend.to_numpy(scalar).tolist() == [[5, 5], [5, 5]]
+assert raw_backend.to_numpy(matrix).tolist() == [[1, 2], [3, 4]]
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- Patch raw `pyrecest._backend.pytorch.broadcast_arrays` from backend-support initialization so it accepts NumPy-style array-like inputs even when the public backend is not PyTorch.
- Keep the active public PyTorch backend synchronized when `PYRECEST_BACKEND=pytorch`.
- Add a subprocess regression for `PYRECEST_BACKEND=numpy` followed by direct raw PyTorch `broadcast_arrays` calls with list/scalar inputs.

## Bug fixed
The raw PyTorch backend currently exposes `torch.broadcast_tensors` directly as `broadcast_arrays`. When the process selects the NumPy public backend and user code imports `pyrecest._backend.pytorch` directly, calls such as `raw_backend.broadcast_arrays([1, 2], raw_backend.array([[3], [4]]))` still reach Torch-native input validation and reject the list input. The patch normalizes all operands through the raw PyTorch backend array constructor before calling `torch.broadcast_tensors`.

## Testing
- Not run locally in this connector session; added focused regression coverage in `tests/backend_support/test_raw_pytorch_broadcast_arrays_default_backend.py`.