### PR TITLE
Fix PyTorch arctan array-like backend contract

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
@@ -1,15 +1,10 @@
-"""PyTorch dtype promotion compatibility helpers."""
+"""PyTorch backend compatibility helpers."""
 
 from __future__ import annotations
 
 
-def patch_pytorch_dtype_promotion_contract() -> None:
+def _patch_convert_to_wider_dtype(raw_pytorch, torch) -> None:
     """Make PyTorch mixed-dtype helpers use Torch's promotion rules."""
-    try:
-        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
-        import torch  # pylint: disable=import-outside-toplevel
-    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
-        return
 
     original_convert = raw_pytorch.convert_to_wider_dtype
     if getattr(original_convert, "_pyrecest_torch_promotion_contract", False):
@@ -34,3 +29,41 @@ def patch_pytorch_dtype_promotion_contract() -> None:
     convert_to_wider_dtype.__doc__ = getattr(original_convert, "__doc__", None)
     convert_to_wider_dtype._pyrecest_torch_promotion_contract = True
     raw_pytorch.convert_to_wider_dtype = convert_to_wider_dtype
+
+
+def _patch_arctan_array_like_contract(raw_pytorch, torch) -> None:
+    """Make PyTorch arctan accept NumPy-style array-like inputs."""
+
+    original_arctan = raw_pytorch.arctan
+    if getattr(original_arctan, "_pyrecest_array_like_contract", False):
+        return
+
+    def arctan(x, *args, **kwargs):
+        if not torch.is_tensor(x):
+            x = raw_pytorch.array(x)
+        return original_arctan(x, *args, **kwargs)
+
+    arctan.__name__ = getattr(original_arctan, "__name__", "arctan")
+    arctan.__doc__ = getattr(original_arctan, "__doc__", None)
+    arctan._pyrecest_array_like_contract = True
+    raw_pytorch.arctan = arctan
+
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before backend setup
+        return
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.arctan = arctan
+
+
+def patch_pytorch_dtype_promotion_contract() -> None:
+    """Patch PyTorch backend compatibility contracts."""
+
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
+        return
+
+    _patch_convert_to_wider_dtype(raw_pytorch, torch)
+    _patch_arctan_array_like_contract(raw_pytorch, torch)

--- a/tests/backend_support/test_pytorch_arctan_contract.py
+++ b/tests/backend_support/test_pytorch_arctan_contract.py
@@ -1,0 +1,39 @@
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+@pytest.mark.parametrize("backend_name", ["pytorch", "numpy"])
+def test_pytorch_arctan_accepts_array_like_inputs(backend_name):
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    if backend_name == "pytorch":
+        code = """
+import pyrecest.backend as backend
+
+actual = backend.arctan([0.0, 1.0])
+expected = backend.array([0.0, 0.7853981633974483])
+
+assert tuple(actual.shape) == (2,)
+assert backend.allclose(actual, expected)
+print("ok")
+"""
+    else:
+        code = """
+import pyrecest._backend.pytorch as raw_pytorch
+
+actual = raw_pytorch.arctan([0.0, 1.0])
+expected = raw_pytorch.array([0.0, 0.7853981633974483])
+
+assert tuple(actual.shape) == (2,)
+assert raw_pytorch.allclose(actual, expected)
+print("ok")
+"""
+
+    result = run_backend_code(backend_name, code)
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- Patch the PyTorch backend-support hook so `arctan` accepts NumPy-style array-like inputs instead of exposing bare `torch.arctan`.
- Keep the raw PyTorch backend and active public PyTorch facade synchronized.
- Add focused subprocess regression coverage for both public PyTorch and raw PyTorch under a NumPy public backend.

## Bug fixed
`pyrecest._backend.pytorch.arctan` was still a direct `torch.arctan` export. Calls such as `raw_pytorch.arctan([0.0, 1.0])` failed with `TypeError`, while the NumPy/JAX-style backend contract accepts array-like inputs.

## Validation
- `python -m py_compile /tmp/_torch_dtype_promotion_contract.py /tmp/test_pytorch_arctan_contract.py`
- Local smoke check confirmed bare `torch.arctan([0.0, 1.0])` rejects lists and the patched wrapper accepts them.