### PR TITLE
Fix PyTorch roll NumPy-style backend contract

### DIFF
--- a/src/pyrecest/backend_support/__init__.py
+++ b/src/pyrecest/backend_support/__init__.py
@@ -310,6 +310,39 @@ def _patch_pytorch_clip_numpy_contract() -> None:
         backend.clip = clip
 
 
+def _patch_pytorch_roll_numpy_contract() -> None:
+    """Make PyTorch roll accept NumPy-style array-like inputs and axis."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
+        return
+
+    original_roll = raw_pytorch.roll
+    if getattr(original_roll, "_pyrecest_numpy_contract", False):
+        return
+
+    def roll(a, shift, axis=None):
+        values = raw_pytorch.array(a)
+        if axis is None:
+            return torch.roll(values.reshape(-1), shifts=shift, dims=0).reshape(values.shape)
+        return torch.roll(values, shifts=shift, dims=axis)
+
+    roll.__name__ = getattr(original_roll, "__name__", "roll")
+    roll.__doc__ = getattr(original_roll, "__doc__", None)
+    roll._pyrecest_numpy_contract = True
+    raw_pytorch.roll = roll
+    if active_pytorch_backend:
+        backend.roll = roll
+
+
 def _patch_jax_outer_numpy_contract() -> None:
     """Make JAX outer flatten inputs like NumPy's outer."""
     try:
@@ -347,6 +380,7 @@ _patch_pytorch_outer_numpy_contract()
 _patch_pytorch_tile_numpy_contract()
 _patch_pytorch_copy_numpy_contract()
 _patch_pytorch_clip_numpy_contract()
+_patch_pytorch_roll_numpy_contract()
 _patch_jax_outer_numpy_contract()
 
 

--- a/tests/backend_support/test_pytorch_roll_contract.py
+++ b/tests/backend_support/test_pytorch_roll_contract.py
@@ -1,0 +1,67 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _subprocess_env(backend_name):
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = backend_name
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    return env
+
+
+@pytest.mark.backend_portable
+def test_pytorch_roll_accepts_array_like_inputs_and_numpy_axis_keyword():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import pyrecest.backend as backend
+
+assert getattr(backend, "__backend_name__", None) == "pytorch"
+
+axis_result = backend.roll([[1, 2, 3], [4, 5, 6]], 1, axis=1)
+assert tuple(axis_result.shape) == (2, 3)
+assert backend.to_numpy(axis_result).tolist() == [[3, 1, 2], [6, 4, 5]]
+
+flat_result = backend.roll([[1, 2, 3], [4, 5, 6]], 2)
+assert tuple(flat_result.shape) == (2, 3)
+assert backend.to_numpy(flat_result).tolist() == [[5, 6, 1], [2, 3, 4]]
+
+multi_axis_result = backend.roll([[1, 2, 3], [4, 5, 6]], (1, -1), axis=(0, 1))
+assert backend.to_numpy(multi_axis_result).tolist() == [[5, 6, 4], [2, 3, 1]]
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=_subprocess_env("pytorch"))
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_roll_matches_numpy_contract_with_numpy_public_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import pyrecest.backend as backend
+from pyrecest._backend import pytorch as pytorch_backend
+
+assert getattr(backend, "__backend_name__", None) == "numpy"
+
+axis_result = pytorch_backend.roll([[1, 2, 3], [4, 5, 6]], 1, axis=1)
+assert tuple(axis_result.shape) == (2, 3)
+assert pytorch_backend.to_numpy(axis_result).tolist() == [[3, 1, 2], [6, 4, 5]]
+
+flat_result = pytorch_backend.roll([[1, 2, 3], [4, 5, 6]], 2)
+assert tuple(flat_result.shape) == (2, 3)
+assert pytorch_backend.to_numpy(flat_result).tolist() == [[5, 6, 1], [2, 3, 4]]
+
+multi_axis_result = pytorch_backend.roll([[1, 2, 3], [4, 5, 6]], (1, -1), axis=(0, 1))
+assert pytorch_backend.to_numpy(multi_axis_result).tolist() == [[5, 6, 4], [2, 3, 1]]
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=_subprocess_env("numpy"))


### PR DESCRIPTION
## Summary
- Patch PyTorch `roll` so it accepts array-like inputs.
- Add NumPy-style `axis` handling, including flattening when no axis is provided.
- Add subprocess regressions for both the public PyTorch facade and direct PyTorch backend imports while the public backend is NumPy.

## Testing
- Added `tests/backend_support/test_pytorch_roll_contract.py`.
- Observed passing GitHub Actions: CodeQL, Security checks, Documentation examples, MegaLinter, Dependency review, and Release notes preview. The main test workflow is still running.