### PR TITLE
Fix PyTorch argsort NumPy-style contract

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
@@ -1,15 +1,12 @@
-"""PyTorch dtype promotion compatibility helpers."""
+"""PyTorch backend compatibility helpers."""
 
 from __future__ import annotations
 
+from operator import index as _operator_index
 
-def patch_pytorch_dtype_promotion_contract() -> None:
+
+def _patch_convert_to_wider_dtype_contract(raw_pytorch, torch) -> None:
     """Make PyTorch mixed-dtype helpers use Torch's promotion rules."""
-    try:
-        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
-        import torch  # pylint: disable=import-outside-toplevel
-    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
-        return
 
     original_convert = raw_pytorch.convert_to_wider_dtype
     if getattr(original_convert, "_pyrecest_torch_promotion_contract", False):
@@ -34,3 +31,81 @@ def patch_pytorch_dtype_promotion_contract() -> None:
     convert_to_wider_dtype.__doc__ = getattr(original_convert, "__doc__", None)
     convert_to_wider_dtype._pyrecest_torch_promotion_contract = True
     raw_pytorch.convert_to_wider_dtype = convert_to_wider_dtype
+
+
+def _resolve_argsort_axis(axis, dim):
+    """Resolve NumPy's ``axis`` and PyTorch's ``dim`` aliases."""
+
+    if dim is not None:
+        if axis != -1 and axis != dim:
+            raise TypeError("argsort() got both 'axis' and 'dim'")
+        axis = dim
+    if axis is None:
+        return None
+    return _operator_index(axis)
+
+
+def _resolve_argsort_stability(kind, stable) -> bool:
+    """Resolve NumPy-style sorting stability arguments for ``torch.argsort``."""
+
+    if kind is not None:
+        valid_kinds = {"quicksort", "heapsort", "mergesort", "stable"}
+        if kind not in valid_kinds:
+            raise ValueError(f"sort kind must be one of {sorted(valid_kinds)!r}")
+        if kind in {"mergesort", "stable"} and stable is None:
+            stable = True
+    return bool(stable) if stable is not None else False
+
+
+def _patch_argsort_numpy_contract(raw_pytorch, torch, backend) -> None:
+    """Make PyTorch argsort accept NumPy-style array-like inputs and axis."""
+
+    original_argsort = raw_pytorch.argsort
+    if getattr(original_argsort, "_pyrecest_numpy_contract", False):
+        return
+
+    def argsort(
+        a,
+        axis=-1,
+        kind=None,
+        order=None,
+        stable=None,
+        *,
+        dim=None,
+        descending=False,
+    ):
+        if order is not None:
+            raise TypeError("argsort() got an unsupported 'order' argument")
+
+        values = raw_pytorch.array(a)
+        resolved_axis = _resolve_argsort_axis(axis, dim)
+        if resolved_axis is None:
+            values = values.reshape(-1)
+            resolved_axis = -1
+        return torch.argsort(
+            values,
+            dim=resolved_axis,
+            descending=descending,
+            stable=_resolve_argsort_stability(kind, stable),
+        )
+
+    argsort.__name__ = getattr(original_argsort, "__name__", "argsort")
+    argsort.__doc__ = getattr(original_argsort, "__doc__", None)
+    argsort._pyrecest_numpy_contract = True
+    raw_pytorch.argsort = argsort
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.argsort = argsort
+
+
+def patch_pytorch_dtype_promotion_contract() -> None:
+    """Apply PyTorch backend compatibility patches used during package import."""
+
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
+        return
+
+    _patch_convert_to_wider_dtype_contract(raw_pytorch, torch)
+    _patch_argsort_numpy_contract(raw_pytorch, torch, backend)

--- a/tests/backend_support/test_pytorch_argsort_contract.py
+++ b/tests/backend_support/test_pytorch_argsort_contract.py
@@ -1,0 +1,69 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _backend_test_env(backend_name):
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = backend_name
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    return env
+
+
+@pytest.mark.backend_portable
+def test_pytorch_argsort_accepts_array_like_inputs_and_numpy_axis_keyword():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import pyrecest.backend as backend
+
+assert getattr(backend, "__backend_name__", None) == "pytorch"
+
+axis_result = backend.argsort([[3, 1, 2], [6, 4, 5]], axis=1)
+assert tuple(axis_result.shape) == (2, 3)
+assert backend.to_numpy(axis_result).tolist() == [[1, 2, 0], [1, 2, 0]]
+
+flat_result = backend.argsort([[3, 1, 2], [6, 4, 5]], axis=None)
+assert tuple(flat_result.shape) == (6,)
+assert backend.to_numpy(flat_result).tolist() == [1, 2, 0, 4, 5, 3]
+
+dim_result = backend.argsort([[3, 1, 2], [6, 4, 5]], dim=0, descending=True)
+assert backend.to_numpy(dim_result).tolist() == [[1, 1, 1], [0, 0, 0]]
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=_backend_test_env("pytorch"))
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_argsort_matches_numpy_contract_with_numpy_public_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import pyrecest.backend as backend
+from pyrecest._backend import pytorch as pytorch_backend
+
+assert getattr(backend, "__backend_name__", None) == "numpy"
+
+axis_result = pytorch_backend.argsort([[3, 1, 2], [6, 4, 5]], axis=1)
+assert tuple(axis_result.shape) == (2, 3)
+assert pytorch_backend.to_numpy(axis_result).tolist() == [[1, 2, 0], [1, 2, 0]]
+
+flat_result = pytorch_backend.argsort([[3, 1, 2], [6, 4, 5]], axis=None)
+assert tuple(flat_result.shape) == (6,)
+assert pytorch_backend.to_numpy(flat_result).tolist() == [1, 2, 0, 4, 5, 3]
+
+dim_result = pytorch_backend.argsort(
+    [[3, 1, 2], [6, 4, 5]], dim=0, descending=True
+)
+assert pytorch_backend.to_numpy(dim_result).tolist() == [[1, 1, 1], [0, 0, 0]]
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=_backend_test_env("numpy"))


### PR DESCRIPTION
## Summary
- Patch PyTorch `argsort` during backend initialization so it accepts array-like inputs and NumPy-style `axis`, including `axis=None` flattening.
- Preserve PyTorch-style `dim` and `descending` arguments while mapping stability-related NumPy options onto `torch.argsort`.
- Add subprocess regression tests for both the active public PyTorch backend and raw PyTorch backend when the public backend is NumPy.

## Bug
`pyrecest._backend.pytorch.argsort` was exposed directly from `torch.argsort`, so calls that are valid for the NumPy backend, for example `argsort([[3, 1, 2]], axis=1)` or `axis=None`, failed instead of following the backend facade contract.

## Validation
- Ran an isolated local check of the new wrapper logic against installed PyTorch.
- Full repository tests were not run locally because the GitHub repository could not be cloned from this environment.