### PR TITLE
Patch raw PyTorch round under NumPy backend

### DIFF
--- a/src/pyrecest/backend_support/__init__.py
+++ b/src/pyrecest/backend_support/__init__.py
@@ -83,7 +83,6 @@ def _patch_pytorch_dot_numpy_contract() -> None:
         ModuleNotFoundError
     ):  # pragma: no cover - PyTorch backend import failed earlier
         return
-
     original_dot = raw_pytorch.dot
     if getattr(original_dot, "_pyrecest_numpy_contract", False):
         return
@@ -129,7 +128,6 @@ def _patch_pytorch_outer_numpy_contract() -> None:
         ModuleNotFoundError
     ):  # pragma: no cover - PyTorch backend import failed earlier
         return
-
     original_outer = raw_pytorch.outer
     if getattr(original_outer, "_pyrecest_numpy_contract", False):
         return
@@ -194,7 +192,6 @@ def _patch_pytorch_tile_numpy_contract() -> None:
         ModuleNotFoundError
     ):  # pragma: no cover - PyTorch backend import failed earlier
         return
-
     original_tile = raw_pytorch.tile
     if getattr(original_tile, "_pyrecest_numpy_contract", False):
         return
@@ -310,6 +307,45 @@ def _patch_pytorch_clip_numpy_contract() -> None:
         backend.clip = clip
 
 
+def _patch_pytorch_round_numpy_contract() -> None:
+    """Make PyTorch round accept NumPy-style array-like inputs."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
+        return
+
+    original_round = raw_pytorch.round
+    if getattr(original_round, "_pyrecest_numpy_contract", False):
+        return
+
+    def round(a, decimals=0, out=None):  # pylint: disable=redefined-builtin
+        decimals = _operator_index(decimals)
+        result = torch.round(raw_pytorch.array(a), decimals=decimals)
+        if out is not None:
+            copy_ = getattr(out, "copy_", None)
+            if copy_ is not None:
+                copy_(result)
+                return out
+            out[...] = raw_pytorch.to_numpy(result)
+            return out
+        return result
+
+    round.__name__ = getattr(original_round, "__name__", "round")
+    round.__doc__ = getattr(original_round, "__doc__", None)
+    round._pyrecest_numpy_contract = True
+    raw_pytorch.round = round
+    if active_pytorch_backend:
+        backend.round = round
+
+
 def _patch_jax_outer_numpy_contract() -> None:
     """Make JAX outer flatten inputs like NumPy's outer."""
     try:
@@ -347,6 +383,7 @@ _patch_pytorch_outer_numpy_contract()
 _patch_pytorch_tile_numpy_contract()
 _patch_pytorch_copy_numpy_contract()
 _patch_pytorch_clip_numpy_contract()
+_patch_pytorch_round_numpy_contract()
 _patch_jax_outer_numpy_contract()
 
 

--- a/tests/backend_support/test_raw_pytorch_round_default_backend.py
+++ b/tests/backend_support/test_raw_pytorch_round_default_backend.py
@@ -1,0 +1,30 @@
+import importlib.util
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_round_accepts_array_like_inputs_under_numpy_backend(monkeypatch):
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    monkeypatch.setenv("PYRECEST_BACKEND", "numpy")
+
+    import pyrecest  # noqa: F401
+    import pyrecest._backend.pytorch as raw_backend
+
+    def assert_close_list(actual, expected):
+        actual = [float(value) for value in actual]
+        assert len(actual) == len(expected)
+        assert all(abs(one_actual - one_expected) < 1e-6 for one_actual, one_expected in zip(actual, expected))
+
+    result = raw_backend.round([1.24, 2.76], decimals=1)
+    assert_close_list(raw_backend.to_numpy(result).tolist(), [1.2, 2.8])
+
+    out = raw_backend.array([0.0, 0.0])
+    returned = raw_backend.round([1.24, 2.76], decimals=1, out=out)
+    assert returned is out
+    assert_close_list(raw_backend.to_numpy(out).tolist(), [1.2, 2.8])
+
+    with pytest.raises(TypeError):
+        raw_backend.round([1.0], decimals=1.5)


### PR DESCRIPTION
## Summary
- Move the PyTorch `round` NumPy-compatibility wrapper into the backend-support import hook so the raw PyTorch backend is patched even when the selected public backend is NumPy.
- Preserve active public PyTorch facade behavior when `PYRECEST_BACKEND=pytorch`.
- Add regression coverage for importing PyRecEst with `PYRECEST_BACKEND=numpy` and then calling `pyrecest._backend.pytorch.round` with list inputs, `decimals`, and `out`.

## Bug fixed
The earlier PyTorch `round` compatibility patch only covered the active PyTorch backend path. With `PYRECEST_BACKEND=numpy`, importing `pyrecest` and then using `pyrecest._backend.pytorch.round([1.24, 2.76], decimals=1)` still exposed raw `torch.round`, which rejects NumPy-style array-like inputs.

## Testing
- Syntax-checked the modified backend-support module and the new regression test locally.
- Full test suite not run in this environment; CI should validate the complete matrix.