### PR TITLE
Fix public PyTorch dtype promotion facade

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 def patch_pytorch_dtype_promotion_contract() -> None:
     """Make PyTorch mixed-dtype helpers use Torch's promotion rules."""
     try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
         import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
         import torch  # pylint: disable=import-outside-toplevel
     except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
@@ -13,6 +14,8 @@ def patch_pytorch_dtype_promotion_contract() -> None:
 
     original_convert = raw_pytorch.convert_to_wider_dtype
     if getattr(original_convert, "_pyrecest_torch_promotion_contract", False):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.convert_to_wider_dtype = original_convert
         return
 
     def convert_to_wider_dtype(tensor_list):
@@ -34,3 +37,5 @@ def patch_pytorch_dtype_promotion_contract() -> None:
     convert_to_wider_dtype.__doc__ = getattr(original_convert, "__doc__", None)
     convert_to_wider_dtype._pyrecest_torch_promotion_contract = True
     raw_pytorch.convert_to_wider_dtype = convert_to_wider_dtype
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.convert_to_wider_dtype = convert_to_wider_dtype

--- a/tests/backend_support/test_public_dtype_promotion_sync.py
+++ b/tests/backend_support/test_public_dtype_promotion_sync.py
@@ -1,0 +1,17 @@
+import pytest
+
+pytorch_backend = pytest.importorskip("pyrecest._backend.pytorch")
+
+
+def test_public_convert_to_wider_dtype_syncs_when_patch_is_reused(monkeypatch):
+    import pyrecest.backend as backend
+    from pyrecest.backend_support._torch_dtype_promotion_contract import (
+        patch_pytorch_dtype_promotion_contract,
+    )
+
+    monkeypatch.setattr(backend, "__backend_name__", "pytorch")
+    monkeypatch.setattr(backend, "convert_to_wider_dtype", None)
+
+    patch_pytorch_dtype_promotion_contract()
+
+    assert backend.convert_to_wider_dtype is pytorch_backend.convert_to_wider_dtype


### PR DESCRIPTION
## Summary
- Synchronize the active public PyTorch facade when the dtype-promotion compatibility patch replaces raw `pyrecest._backend.pytorch.convert_to_wider_dtype`.
- Preserve the early-return/idempotent path by also syncing `pyrecest.backend.convert_to_wider_dtype` when the raw PyTorch backend has already been patched.
- Add a focused regression covering the reused-patch synchronization path.

## Bug fixed
`patch_pytorch_dtype_promotion_contract()` updated the raw PyTorch backend implementation but left an already-created `pyrecest.backend.convert_to_wider_dtype` facade attribute stale when `PYRECEST_BACKEND=pytorch`. Public PyTorch users could therefore still hit the old dtype-order table instead of Torch's promotion rules.

## Testing
- Syntax-compiled the modified helper and new regression test locally with `py_compile`.
- Full repository test suite was not run locally because this environment could not clone GitHub repositories via DNS.