### PR TITLE
Fix PyTorch array_equal equal_nan contract

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
@@ -1,6 +1,43 @@
-"""PyTorch dtype promotion compatibility helpers."""
+"""PyTorch backend compatibility helpers."""
 
 from __future__ import annotations
+
+
+def _sync_active_public_pytorch(name: str, helper) -> None:
+    """Expose a patched raw helper through the active public PyTorch facade."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        setattr(backend, name, helper)
+
+
+def _patch_pytorch_array_equal_numpy_contract(raw_pytorch, torch_module) -> None:
+    """Make PyTorch array_equal accept NumPy's equal_nan keyword."""
+    original_array_equal = raw_pytorch.array_equal
+    if getattr(original_array_equal, "_pyrecest_numpy_contract", False):
+        _sync_active_public_pytorch("array_equal", original_array_equal)
+        return
+
+    def array_equal(a, b, equal_nan=False):
+        a = raw_pytorch.array(a)
+        b = raw_pytorch.array(b)
+        if tuple(a.shape) != tuple(b.shape):
+            return False
+        if not equal_nan:
+            return torch_module.equal(a, b)
+        equal_or_both_nan = torch_module.eq(a, b) | (
+            torch_module.isnan(a) & torch_module.isnan(b)
+        )
+        return bool(torch_module.all(equal_or_both_nan))
+
+    array_equal.__name__ = getattr(original_array_equal, "__name__", "array_equal")
+    array_equal.__doc__ = getattr(original_array_equal, "__doc__", None)
+    array_equal._pyrecest_numpy_contract = True
+    raw_pytorch.array_equal = array_equal
+    _sync_active_public_pytorch("array_equal", array_equal)
 
 
 def patch_pytorch_dtype_promotion_contract() -> None:
@@ -10,6 +47,8 @@ def patch_pytorch_dtype_promotion_contract() -> None:
         import torch  # pylint: disable=import-outside-toplevel
     except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
         return
+
+    _patch_pytorch_array_equal_numpy_contract(raw_pytorch, torch)
 
     original_convert = raw_pytorch.convert_to_wider_dtype
     if getattr(original_convert, "_pyrecest_torch_promotion_contract", False):

--- a/tests/backend_support/test_pytorch_array_equal_contract.py
+++ b/tests/backend_support/test_pytorch_array_equal_contract.py
@@ -1,0 +1,72 @@
+"""Regression tests for PyTorch array_equal NumPy keyword semantics."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+def _skip_without_torch() -> None:
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_array_equal_accepts_equal_nan_under_numpy_backend():
+    _skip_without_torch()
+
+    result = run_backend_code(
+        "numpy",
+        """
+import importlib
+
+raw_pytorch = importlib.import_module("pyrecest._backend.pytorch")
+
+assert raw_pytorch.array_equal([1.0, 2.0], [1.0, 2.0])
+assert not raw_pytorch.array_equal([float("nan")], [float("nan")])
+assert raw_pytorch.array_equal(
+    [float("nan"), 1.0],
+    [float("nan"), 1.0],
+    equal_nan=True,
+)
+assert not raw_pytorch.array_equal(
+    [float("nan"), 1.0],
+    [float("nan"), 2.0],
+    equal_nan=True,
+)
+assert raw_pytorch.array_equal(
+    [complex(float("nan"), 1.0)],
+    [complex(2.0, float("nan"))],
+    equal_nan=True,
+)
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.backend_portable
+def test_public_pytorch_array_equal_accepts_equal_nan_keyword():
+    _skip_without_torch()
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import pyrecest.backend as backend
+
+assert backend.array_equal(
+    [float("nan"), 1.0],
+    [float("nan"), 1.0],
+    equal_nan=True,
+)
+assert not backend.array_equal(
+    [float("nan"), 1.0],
+    [float("nan"), 2.0],
+    equal_nan=True,
+)
+""",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Add a PyTorch compatibility shim for `array_equal(..., equal_nan=True)`.
- Patch both the raw PyTorch backend and the active public PyTorch facade.
- Add regression tests for the raw backend under NumPy selection and for the public PyTorch facade.

## Validation
- Python syntax check for the changed files.
- Local Torch smoke check for the new equality semantics.