### PR TITLE
Fix PyTorch comparison backend contract

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
@@ -1,10 +1,76 @@
-"""PyTorch dtype promotion compatibility helpers."""
+"""PyTorch backend compatibility helpers."""
 
 from __future__ import annotations
 
 
+def _coerce_pytorch_binary_args(x, y, torch_module):
+    """Return tensor operands on a common device for binary PyTorch helpers."""
+
+    device = next(
+        (value.device for value in (x, y) if torch_module.is_tensor(value)),
+        None,
+    )
+    if not torch_module.is_tensor(x):
+        x = torch_module.as_tensor(x, device=device)
+    elif device is not None and x.device != device:
+        x = x.to(device=device)
+
+    if not torch_module.is_tensor(y):
+        y = torch_module.as_tensor(y, device=device)
+    elif device is not None and y.device != device:
+        y = y.to(device=device)
+
+    return x, y
+
+
+def _wrap_pytorch_binary_helper(original_helper, torch_function, torch_module, name):
+    """Wrap a binary PyTorch helper with NumPy-style array-like coercion."""
+
+    if getattr(original_helper, "_pyrecest_arraylike_binary_contract", False):
+        return original_helper
+
+    def helper(x, y, **kwargs):
+        x, y = _coerce_pytorch_binary_args(x, y, torch_module)
+        return torch_function(x, y, **kwargs)
+
+    helper.__name__ = getattr(original_helper, "__name__", name)
+    helper.__doc__ = getattr(original_helper, "__doc__", None)
+    helper._pyrecest_arraylike_binary_contract = True
+    return helper
+
+
+def _patch_pytorch_binary_arraylike_contract() -> None:
+    """Make raw PyTorch binary helpers accept array-like operands."""
+
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
+        return
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+    for helper_name, torch_function in {
+        "greater": torch.greater,
+        "less": torch.less,
+        "logical_or": torch.logical_or,
+    }.items():
+        helper = _wrap_pytorch_binary_helper(
+            getattr(raw_pytorch, helper_name),
+            torch_function,
+            torch,
+            helper_name,
+        )
+        setattr(raw_pytorch, helper_name, helper)
+        if active_pytorch_backend:
+            setattr(backend, helper_name, helper)
+
+
 def patch_pytorch_dtype_promotion_contract() -> None:
-    """Make PyTorch mixed-dtype helpers use Torch's promotion rules."""
+    """Make PyTorch backend import-time compatibility shims active."""
+
+    _patch_pytorch_binary_arraylike_contract()
+
     try:
         import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
         import torch  # pylint: disable=import-outside-toplevel

--- a/tests/backend_support/test_pytorch_raw_comparison_contract.py
+++ b/tests/backend_support/test_pytorch_raw_comparison_contract.py
@@ -8,27 +8,28 @@ import pytest
 from tests.support.backend_runner import run_backend_code
 
 
+_RAW_COMPARISON_CODE = """
+import pyrecest._backend.pytorch as raw_pytorch
+
+greater_result = raw_pytorch.greater([1, 2, 3], raw_pytorch.asarray([0, 2, 4]))
+less_result = raw_pytorch.less(raw_pytorch.asarray([1, 2, 3]), [0, 2, 4])
+logical_result = raw_pytorch.logical_or(
+    [True, False],
+    raw_pytorch.asarray([False, True]),
+)
+
+assert raw_pytorch.to_numpy(greater_result).tolist() == [True, False, False]
+assert raw_pytorch.to_numpy(less_result).tolist() == [False, False, True]
+assert raw_pytorch.to_numpy(logical_result).tolist() == [True, True]
+"""
+
+
 @pytest.mark.backend_portable
-def test_raw_pytorch_comparisons_accept_numpy_style_array_like_inputs():
+@pytest.mark.parametrize("backend_name", ["pytorch", "numpy"])
+def test_raw_pytorch_comparisons_accept_numpy_style_array_like_inputs(backend_name):
     if importlib.util.find_spec("torch") is None:
         pytest.skip("PyTorch is not installed")
 
-    result = run_backend_code(
-        "pytorch",
-        """
-import importlib
-from pyrecest.backend import asarray, to_numpy
-
-raw_pytorch = importlib.import_module("pyrecest._backend.pytorch")
-
-greater_result = raw_pytorch.greater([1, 2, 3], asarray([0, 2, 4]))
-less_result = raw_pytorch.less(asarray([1, 2, 3]), [0, 2, 4])
-logical_result = raw_pytorch.logical_or([True, False], asarray([False, True]))
-
-assert to_numpy(greater_result).tolist() == [True, False, False]
-assert to_numpy(less_result).tolist() == [False, False, True]
-assert to_numpy(logical_result).tolist() == [True, True]
-""",
-    )
+    result = run_backend_code(backend_name, _RAW_COMPARISON_CODE)
 
     assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Summary:
- Patch PyTorch comparison helper wrappers so array-like operands work under both public backend selections.
- Extend the regression to run under PyTorch and NumPy public backend selections.

Validation:
- Syntax-compiled the modified helper and test files locally with py_compile.
- Full suite not run locally because this environment cannot clone the repository via DNS; CI should run on GitHub.