### PR TITLE
Fix PyTorch diff NumPy-style contract

### DIFF
--- a/src/pyrecest/backend_tools.py
+++ b/src/pyrecest/backend_tools.py
@@ -280,6 +280,83 @@ def _patch_pytorch_stack_helpers_numpy_contract() -> None:
         setattr(pytorch_backend, helper_name, helper)
 
 
+def _patch_pytorch_diff_numpy_contract() -> None:
+    """Make PyTorch diff accept NumPy-style array-like inputs and ``axis``."""
+
+    try:
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import torch as _torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    if getattr(pytorch_backend.diff, "_pyrecest_numpy_contract", False):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.diff = pytorch_backend.diff
+        return
+
+    def _boundary(value, x, axis):
+        boundary = pytorch_backend.array(value)
+        if _torch.is_tensor(boundary):
+            boundary = boundary.to(device=x.device)
+        if boundary.ndim == 0:
+            shape = list(x.shape)
+            shape[axis] = 1
+            boundary = boundary.expand(tuple(shape))
+        return boundary
+
+    def diff(a, n=1, axis=-1, prepend=None, append=None, out=None, *, dim=None):
+        if dim is not None:
+            if axis != -1 and axis != dim:
+                raise TypeError("diff() got both 'axis' and 'dim'")
+            axis = dim
+
+        n = _operator_index(n)
+        if n < 0:
+            raise ValueError("order must be non-negative")
+
+        x = pytorch_backend.array(a)
+        axis = _operator_index(axis)
+        normalized_axis = axis + x.ndim if axis < 0 else axis
+        if normalized_axis < 0 or normalized_axis >= x.ndim:
+            raise IndexError(
+                f"axis {axis} is out of bounds for array of dimension {x.ndim}"
+            )
+
+        tensors = [x]
+        prepend_tensor = None
+        append_tensor = None
+        if prepend is not None:
+            prepend_tensor = _boundary(prepend, x, normalized_axis)
+            tensors.append(prepend_tensor)
+        if append is not None:
+            append_tensor = _boundary(append, x, normalized_axis)
+            tensors.append(append_tensor)
+
+        promoted = pytorch_backend.convert_to_wider_dtype(tensors)
+        x = promoted[0]
+        cursor = 1
+        kwargs = {"n": n, "dim": normalized_axis}
+        if prepend_tensor is not None:
+            kwargs["prepend"] = promoted[cursor]
+            cursor += 1
+        if append_tensor is not None:
+            kwargs["append"] = promoted[cursor]
+
+        result = _torch.diff(x, **kwargs)
+        if out is not None:
+            out.copy_(result)
+            return out
+        return result
+
+    diff.__name__ = getattr(_torch.diff, "__name__", "diff")
+    diff.__doc__ = getattr(_torch.diff, "__doc__", None)
+    diff._pyrecest_numpy_contract = True
+    pytorch_backend.diff = diff
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.diff = diff
+
+
 def _patch_raw_pytorch_comparison_numpy_contract() -> None:
     """Make raw PyTorch comparison helpers accept NumPy-style array-like inputs."""
 
@@ -372,6 +449,7 @@ _patch_pytorch_broadcast_arrays_numpy_contract()
 _patch_pytorch_round_numpy_contract()
 _patch_pytorch_special_numpy_contract()
 _patch_pytorch_stack_helpers_numpy_contract()
+_patch_pytorch_diff_numpy_contract()
 _patch_raw_pytorch_comparison_numpy_contract()
 _patch_raw_pytorch_isclose_equal_nan_contract()
 

--- a/tests/backend_support/test_pytorch_diff_contract.py
+++ b/tests/backend_support/test_pytorch_diff_contract.py
@@ -1,0 +1,78 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _backend_test_env(backend_name):
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = backend_name
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    return env
+
+
+@pytest.mark.backend_portable
+def test_pytorch_diff_matches_numpy_axis_and_boundary_contract():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import pyrecest
+import pyrecest.backend as backend
+from pyrecest._backend import pytorch as pytorch_backend
+
+values = [[1, 3, 6], [10, 15, 21]]
+
+for diff_func, to_numpy in (
+    (backend.diff, backend.to_numpy),
+    (pytorch_backend.diff, pytorch_backend.to_numpy),
+):
+    second = diff_func(values, n=2, axis=1)
+    assert tuple(second.shape) == (2, 1)
+    assert to_numpy(second).tolist() == [[1], [1]]
+
+    prepended = diff_func(values, axis=1, prepend=0)
+    assert tuple(prepended.shape) == (2, 3)
+    assert to_numpy(prepended).tolist() == [[1, 2, 3], [10, 5, 6]]
+
+    appended = diff_func(values, dim=0, append=[[20, 30, 42]])
+    assert tuple(appended.shape) == (2, 3)
+    assert to_numpy(appended).tolist() == [[9, 12, 15], [10, 15, 21]]
+
+    out = backend.empty((2, 3), dtype=backend.int64)
+    returned = diff_func(values, axis=1, prepend=0, out=out)
+    assert returned is out
+    assert to_numpy(out).tolist() == [[1, 2, 3], [10, 5, 6]]
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=_backend_test_env("pytorch"))
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_diff_is_patched_with_numpy_public_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import pyrecest
+import pyrecest.backend as backend
+from pyrecest._backend import pytorch as pytorch_backend
+
+assert getattr(backend, "__backend_name__", None) == "numpy"
+values = [[1, 3, 6], [10, 15, 21]]
+
+result = pytorch_backend.diff(values, axis=1, prepend=0)
+assert tuple(result.shape) == (2, 3)
+assert pytorch_backend.to_numpy(result).tolist() == [[1, 2, 3], [10, 5, 6]]
+
+second = pytorch_backend.diff(values, n=2, axis=1)
+assert tuple(second.shape) == (2, 1)
+assert pytorch_backend.to_numpy(second).tolist() == [[1], [1]]
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=_backend_test_env("numpy"))


### PR DESCRIPTION
## Summary
- patch raw `pyrecest._backend.pytorch.diff` so it accepts array-like inputs and NumPy-style `axis`, while preserving PyTorch `dim`
- support scalar `prepend`/`append` broadcasting and `out=` handling
- keep the public PyTorch facade synchronized and add regressions for public PyTorch plus raw PyTorch under a NumPy public backend

## Bug fixed
`pyrecest._backend.pytorch.diff` was still exposed as raw `torch.diff`. That rejects Python-list inputs and does not accept NumPy-style `axis`, so backend-portable code that works with the NumPy facade could fail when switching to PyTorch or when using the raw PyTorch backend after normal PyRecEst import.

## Validation
- `python -m py_compile /tmp/backend_tools_new.py /tmp/test_pytorch_diff_contract.py`
- local PyTorch smoke check for list input, `axis=`, scalar `prepend`, `dim=` alias, and `append=`

Full repository tests were not run in this connector environment; CI should run the focused regression.