### PR TITLE
Fix PyTorch asarray NumPy contract

### DIFF
--- a/src/pyrecest/backend_support/__init__.py
+++ b/src/pyrecest/backend_support/__init__.py
@@ -67,6 +67,93 @@ def _patch_raw_pytorch_assignment_scalar_tensor_indices() -> None:
         backend.assignment_by_sum = raw_pytorch.assignment_by_sum
 
 
+def _patch_pytorch_asarray_numpy_contract() -> None:
+    """Make PyTorch asarray accept NumPy dtype aliases and strided views."""
+    try:
+        import numpy as np  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+        from pyrecest._backend.pytorch._common import (  # pylint: disable=import-outside-toplevel
+            _normalize_dtype,
+        )
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    original_asarray = raw_pytorch.asarray
+    if getattr(original_asarray, "_pyrecest_numpy_contract", False):
+        return
+
+    def _asarray_kwargs(dtype, device, copy, requires_grad):
+        kwargs = {"requires_grad": requires_grad}
+        if dtype is not None:
+            kwargs["dtype"] = dtype
+        if device is not None:
+            kwargs["device"] = device
+        if copy is not None:
+            kwargs["copy"] = copy
+        return kwargs
+
+    def asarray(
+        a,
+        dtype=None,
+        order=None,
+        *,
+        device=None,
+        copy=None,
+        like=None,
+        requires_grad=False,
+    ):
+        if like is not None:
+            raise TypeError("The PyTorch backend does not support asarray(like=...).")
+        if order not in (None, "K", "A", "C"):
+            raise NotImplementedError(
+                "The PyTorch backend only supports C-contiguous asarray results."
+            )
+
+        dtype = _normalize_dtype(dtype)
+        if torch.is_tensor(a):
+            result = a
+            to_kwargs = {}
+            if dtype is not None:
+                to_kwargs["dtype"] = dtype
+            if device is not None:
+                to_kwargs["device"] = device
+            if to_kwargs:
+                result = result.to(**to_kwargs)
+            if copy is True:
+                result = result.clone()
+            if requires_grad and not result.requires_grad:
+                result = result.requires_grad_(True)
+            return result
+
+        if isinstance(a, np.ndarray):
+            source = a.copy() if copy is True else a
+            result = raw_pytorch.from_numpy(source)
+            to_kwargs = {}
+            if dtype is not None:
+                to_kwargs["dtype"] = dtype
+            if device is not None:
+                to_kwargs["device"] = device
+            if to_kwargs:
+                result = result.to(**to_kwargs)
+            if requires_grad and not result.requires_grad:
+                result = result.requires_grad_(True)
+            return result
+
+        return original_asarray(
+            a,
+            **_asarray_kwargs(dtype, device, copy, requires_grad),
+        )
+
+    asarray.__name__ = getattr(original_asarray, "__name__", "asarray")
+    asarray.__doc__ = getattr(original_asarray, "__doc__", None)
+    asarray._pyrecest_numpy_contract = True
+    raw_pytorch.asarray = asarray
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.asarray = asarray
+
+
 def _patch_pytorch_dot_numpy_contract() -> None:
     """Make PyTorch dot follow the backend batched inner-product contract."""
     try:
@@ -181,7 +268,6 @@ def _patch_pytorch_tile_numpy_contract() -> None:
         import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
     except ModuleNotFoundError:  # pragma: no cover - import fails before this module
         return
-
     active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
 
     try:
@@ -221,14 +307,12 @@ def _patch_pytorch_copy_numpy_contract() -> None:
         import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
     except ModuleNotFoundError:  # pragma: no cover - import fails before this module
         return
-
     active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
 
     try:
         import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
     except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
         return
-
     original_copy = raw_pytorch.copy
     if getattr(original_copy, "_pyrecest_numpy_contract", False):
         return
@@ -252,7 +336,6 @@ def _patch_pytorch_clip_numpy_contract() -> None:
         import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
     except ModuleNotFoundError:  # pragma: no cover - import fails before this module
         return
-
     active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
 
     try:
@@ -260,7 +343,6 @@ def _patch_pytorch_clip_numpy_contract() -> None:
         import torch  # pylint: disable=import-outside-toplevel
     except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
         return
-
     original_clip = raw_pytorch.clip
     if getattr(original_clip, "_pyrecest_numpy_contract", False):
         return
@@ -457,7 +539,6 @@ def _patch_jax_outer_numpy_contract() -> None:
         import pyrecest._backend.jax as raw_jax  # pylint: disable=import-outside-toplevel
     except ModuleNotFoundError:  # pragma: no cover - JAX backend import failed earlier
         return
-
     original_outer = raw_jax.outer
     if getattr(original_outer, "_pyrecest_numpy_contract", False):
         return
@@ -567,6 +648,7 @@ def _patch_jax_take_out_contract() -> None:
 
 _patch_raw_pytorch_assignment_scalar_tensor_indices()
 _patch_pytorch_dtype_promotion_contract()
+_patch_pytorch_asarray_numpy_contract()
 _patch_pytorch_dot_numpy_contract()
 _patch_pytorch_outer_numpy_contract()
 _patch_pytorch_tile_numpy_contract()

--- a/tests/backend_support/test_pytorch_numpy_view_conversion.py
+++ b/tests/backend_support/test_pytorch_numpy_view_conversion.py
@@ -93,3 +93,49 @@ assert backend.to_numpy(converted).tolist() == [0.0, 1.0, 2.0]
     )
 
     assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_asarray_accepts_numpy_dtype_and_negative_stride_views():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "numpy",
+        """
+import numpy as np
+import torch
+import pyrecest.backend_support  # noqa: F401
+import pyrecest._backend.pytorch as raw_pytorch
+
+view = np.arange(5.0)[::-1]
+converted = raw_pytorch.asarray(view, dtype=np.float64)
+assert converted.dtype is torch.float64
+assert raw_pytorch.to_numpy(converted).tolist() == [4.0, 3.0, 2.0, 1.0, 0.0]
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.backend_portable
+def test_public_pytorch_asarray_accepts_numpy_dtype_and_negative_stride_views():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import numpy as np
+import torch
+import pyrecest
+import pyrecest.backend as backend
+
+view = np.arange(4.0)[::-1]
+converted = backend.asarray(view, dtype=np.float64)
+assert converted.dtype is torch.float64
+assert backend.to_numpy(converted).tolist() == [3.0, 2.0, 1.0, 0.0]
+""",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Patch the PyTorch backend-support hook so `asarray` accepts NumPy dtype aliases such as `np.float64`.
- Route NumPy ndarray inputs through the backend's `from_numpy` helper so negative-stride views are handled consistently with `array()`.
- Keep the raw PyTorch backend and the active public PyTorch facade synchronized.

## Testing
- Added subprocess regressions for direct raw PyTorch backend use under the NumPy public backend.
- Added subprocess regressions for the public PyTorch facade.
- Full CI should run on GitHub.