### PR TITLE
Fix PyTorch copy array-like contract

### DIFF
--- a/src/pyrecest/_backend_submodules.py
+++ b/src/pyrecest/_backend_submodules.py
@@ -202,6 +202,28 @@ def _adapt_pytorch_minmax_binary_contract(backend: ModuleType) -> None:
             setattr(backend, helper_name, current)
 
 
+def _adapt_raw_pytorch_copy_contract(backend: ModuleType) -> None:
+    """Adapt raw/public PyTorch ``copy`` to return backend tensors."""
+
+    try:
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch may be unavailable
+        return
+
+    copy = getattr(pytorch_backend, "copy", None)
+    if copy is None or getattr(copy, "_pyrecest_copy_contract", False):
+        return
+
+    @wraps(copy)
+    def wrapped_copy(x):
+        return pytorch_backend.array(x).clone()
+
+    wrapped_copy._pyrecest_copy_contract = True
+    setattr(pytorch_backend, "copy", wrapped_copy)
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        setattr(backend, "copy", wrapped_copy)
+
+
 def _pytorch_repeat_count(repetition) -> int:
     """Return one NumPy-style repeat count as a non-negative integer."""
     try:
@@ -663,6 +685,7 @@ def register_backend_submodules(backend: ModuleType | None = None) -> None:
     if backend is None:
         import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
 
+    _adapt_raw_pytorch_copy_contract(backend)
     _adapt_cumulative_out_contract(backend)
     _adapt_pytorch_allclose_keyword_contract(backend)
     _adapt_pytorch_isclose_keyword_contract(backend)

--- a/tests/backend_support/test_pytorch_copy_contract.py
+++ b/tests/backend_support/test_pytorch_copy_contract.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+from tests.support.backend_runner import run_backend_code
+
 
 def test_pytorch_copy_returns_backend_tensors_for_array_like_inputs():
     pytest.importorskip("torch")
@@ -22,3 +24,19 @@ def test_pytorch_copy_returns_backend_tensors_for_array_like_inputs():
     source[0] = 99.0
     assert raw_pytorch.is_array(array_copy)
     assert array_copy.tolist() == [1.0, 2.0]
+
+
+def test_public_pytorch_copy_returns_backend_tensor_for_array_like_inputs():
+    pytest.importorskip("torch")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import pyrecest.backend as backend
+
+copied = backend.copy([[1.0, 2.0], [3.0, 4.0]])
+assert backend.is_array(copied)
+assert copied.tolist() == [[1.0, 2.0], [3.0, 4.0]]
+""",
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Add an import-time adapter so raw PyTorch `copy()` returns PyTorch tensors for scalar, sequence, and NumPy array inputs instead of NumPy objects.
- Apply the same wrapper to the public backend when `PYRECEST_BACKEND=pytorch`.
- Extend the PyTorch copy contract test to cover the public backend path in a subprocess.

## Bug fixed
`pyrecest._backend.pytorch.copy([1.0, 2.0])` currently falls through to `np.copy(...)`, returning a NumPy object rather than a backend tensor. That violates the backend contract and leaves the existing raw PyTorch regression test failing for scalar/list/NumPy inputs.

## Validation
- Local syntax/AST check of the updated `_backend_submodules.py` content.
- GitHub diff check: branch is 2 commits ahead of `main`, 0 behind, with only the intended two files changed.
- Full CI should run on this PR.