### PR TITLE
Restore PyTorch allclose equal_nan contract

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
@@ -14,11 +14,10 @@ def _patch_pytorch_allclose_equal_nan_contract(raw_pytorch, torch_module) -> Non
     default_rtol = raw_pytorch.rtol
 
     def _as_allclose_tensor(value, *, device):
-        if torch_module.is_tensor(value):
-            if device is not None and value.device != device:
-                return value.to(device=device)
-            return value
-        return torch_module.as_tensor(value, device=device)
+        tensor = value if torch_module.is_tensor(value) else raw_pytorch.array(value)
+        if device is not None and tensor.device != device:
+            return tensor.to(device=device)
+        return tensor
 
     def allclose(a, b, atol=default_atol, rtol=default_rtol, equal_nan=False):
         device = next(

--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
@@ -1,6 +1,54 @@
-"""PyTorch dtype promotion compatibility helpers."""
+"""PyTorch backend compatibility helpers."""
 
 from __future__ import annotations
+
+
+def _patch_pytorch_allclose_equal_nan_contract(raw_pytorch, torch_module) -> None:
+    """Make PyTorch allclose accept the NumPy/PyTorch equal_nan keyword."""
+
+    original_allclose = raw_pytorch.allclose
+    if getattr(original_allclose, "_pyrecest_equal_nan_contract", False):
+        return
+
+    default_atol = raw_pytorch.atol
+    default_rtol = raw_pytorch.rtol
+
+    def _as_allclose_tensor(value, *, device):
+        if torch_module.is_tensor(value):
+            if device is not None and value.device != device:
+                return value.to(device=device)
+            return value
+        return torch_module.as_tensor(value, device=device)
+
+    def allclose(a, b, atol=default_atol, rtol=default_rtol, equal_nan=False):
+        device = next(
+            (value.device for value in (a, b) if torch_module.is_tensor(value)),
+            None,
+        )
+        a = _as_allclose_tensor(a, device=device)
+        b = _as_allclose_tensor(b, device=device)
+        a, b = raw_pytorch.convert_to_wider_dtype([a, b])
+        a, b = torch_module.broadcast_tensors(a, b)
+        return torch_module.allclose(
+            a,
+            b,
+            atol=atol,
+            rtol=rtol,
+            equal_nan=equal_nan,
+        )
+
+    allclose.__name__ = getattr(original_allclose, "__name__", "allclose")
+    allclose.__doc__ = getattr(original_allclose, "__doc__", None)
+    allclose._pyrecest_equal_nan_contract = True
+    raw_pytorch.allclose = allclose
+
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.allclose = allclose
 
 
 def patch_pytorch_dtype_promotion_contract() -> None:
@@ -12,25 +60,26 @@ def patch_pytorch_dtype_promotion_contract() -> None:
         return
 
     original_convert = raw_pytorch.convert_to_wider_dtype
-    if getattr(original_convert, "_pyrecest_torch_promotion_contract", False):
-        return
+    if not getattr(original_convert, "_pyrecest_torch_promotion_contract", False):
 
-    def convert_to_wider_dtype(tensor_list):
-        tensors = list(tensor_list)
-        if not tensors:
-            return tensors
+        def convert_to_wider_dtype(tensor_list):
+            tensors = list(tensor_list)
+            if not tensors:
+                return tensors
 
-        promoted_dtype = tensors[0].dtype
-        for tensor in tensors[1:]:
-            promoted_dtype = torch.promote_types(promoted_dtype, tensor.dtype)
+            promoted_dtype = tensors[0].dtype
+            for tensor in tensors[1:]:
+                promoted_dtype = torch.promote_types(promoted_dtype, tensor.dtype)
 
-        if all(tensor.dtype == promoted_dtype for tensor in tensors):
-            return tensors
-        return [raw_pytorch.cast(tensor, dtype=promoted_dtype) for tensor in tensors]
+            if all(tensor.dtype == promoted_dtype for tensor in tensors):
+                return tensors
+            return [raw_pytorch.cast(tensor, dtype=promoted_dtype) for tensor in tensors]
 
-    convert_to_wider_dtype.__name__ = getattr(
-        original_convert, "__name__", "convert_to_wider_dtype"
-    )
-    convert_to_wider_dtype.__doc__ = getattr(original_convert, "__doc__", None)
-    convert_to_wider_dtype._pyrecest_torch_promotion_contract = True
-    raw_pytorch.convert_to_wider_dtype = convert_to_wider_dtype
+        convert_to_wider_dtype.__name__ = getattr(
+            original_convert, "__name__", "convert_to_wider_dtype"
+        )
+        convert_to_wider_dtype.__doc__ = getattr(original_convert, "__doc__", None)
+        convert_to_wider_dtype._pyrecest_torch_promotion_contract = True
+        raw_pytorch.convert_to_wider_dtype = convert_to_wider_dtype
+
+    _patch_pytorch_allclose_equal_nan_contract(raw_pytorch, torch)

--- a/tests/backend_support/test_pytorch_allclose_contract.py
+++ b/tests/backend_support/test_pytorch_allclose_contract.py
@@ -1,0 +1,25 @@
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_pytorch_allclose_accepts_equal_nan_after_backend_support_patch():
+    pytest.importorskip("torch")
+
+    import pyrecest._backend.pytorch as pytorch_backend
+    from pyrecest.backend_support._torch_dtype_promotion_contract import (
+        patch_pytorch_dtype_promotion_contract,
+    )
+
+    patch_pytorch_dtype_promotion_contract()
+
+    assert pytorch_backend.allclose(
+        [float("nan"), 1.0],
+        [float("nan"), 1.0],
+        equal_nan=True,
+    )
+    assert not pytorch_backend.allclose(
+        [float("nan"), 1.0],
+        [float("nan"), 1.0],
+        equal_nan=False,
+    )
+    assert pytorch_backend.allclose([[1.0]], [1.0], atol=0.0, rtol=0.0)


### PR DESCRIPTION
## Summary
- restore the PyTorch backend `allclose(..., equal_nan=...)` compatibility contract
- patch both raw `pyrecest._backend.pytorch.allclose` and the active public PyTorch facade through the backend-support hook
- add a focused backend-support regression for NaN handling and broadcasted array-like inputs

## Bug fixed
Current `main` still exposes the PyTorch backend `allclose` wrapper with only `(a, b, atol, rtol)`. Backend-portable code using the NumPy/PyTorch missing-value comparison keyword, for example `backend.allclose([nan], [nan], equal_nan=True)`, therefore raises under PyTorch instead of matching the expected contract.

## Validation
- `python -m py_compile /tmp/_torch_dtype_promotion_contract_new.py /tmp/test_pytorch_allclose_contract.py`
- local Torch smoke check of the wrapper logic for `equal_nan=True`, `equal_nan=False`, and broadcasted array-like inputs
- verified changed files by fetching the branch contents from GitHub

Full repository tests were not run in this connector environment; CI should run the focused regression.