### PR TITLE
Fix PyTorch conj array-like backend contract

### DIFF
--- a/src/pyrecest/backend_tools.py
+++ b/src/pyrecest/backend_tools.py
@@ -326,6 +326,39 @@ def _patch_raw_pytorch_comparison_numpy_contract() -> None:
             setattr(backend, helper_name, helper)
 
 
+def _patch_raw_pytorch_conj_numpy_contract() -> None:
+    """Make raw PyTorch conj accept NumPy-style array-like inputs."""
+
+    try:
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import torch as _torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    original_conj = getattr(pytorch_backend, "conj", None)
+    if original_conj is None or getattr(original_conj, "_pyrecest_numpy_contract", False):
+        return
+
+    def conj(a, out=None):
+        result = _torch.conj(pytorch_backend.array(a))
+        if out is not None:
+            copy_ = getattr(out, "copy_", None)
+            if copy_ is not None:
+                copy_(result)
+                return out
+            out[...] = pytorch_backend.to_numpy(result)
+            return out
+        return result
+
+    conj.__name__ = getattr(original_conj, "__name__", "conj")
+    conj.__doc__ = getattr(original_conj, "__doc__", None)
+    conj._pyrecest_numpy_contract = True
+    pytorch_backend.conj = conj
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.conj = conj
+
+
 _patch_pytorch_assignment_scalar_tensor_indices()
 _patch_pytorch_diag_numpy_contract()
 _patch_pytorch_broadcast_arrays_numpy_contract()
@@ -333,6 +366,7 @@ _patch_pytorch_round_numpy_contract()
 _patch_pytorch_special_numpy_contract()
 _patch_pytorch_stack_helpers_numpy_contract()
 _patch_raw_pytorch_comparison_numpy_contract()
+_patch_raw_pytorch_conj_numpy_contract()
 
 
 def get_backend_name() -> str:

--- a/tests/backend_support/test_pytorch_conj_contract.py
+++ b/tests/backend_support/test_pytorch_conj_contract.py
@@ -1,0 +1,75 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _run_backend_snippet(backend_name, code):
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = backend_name
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_conj_accepts_array_like_inputs_with_numpy_public_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    _run_backend_snippet(
+        "numpy",
+        """
+import numpy as np
+
+import pyrecest  # noqa: F401
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+assert getattr(backend, "__backend_name__", None) == "numpy"
+
+result = raw_pytorch.conj([1.0 + 2.0j, 3.0 - 4.0j])
+assert raw_pytorch.is_array(result)
+assert result.tolist() == [1.0 - 2.0j, 3.0 + 4.0j]
+
+torch_out = raw_pytorch.empty(2, dtype=raw_pytorch.complex128)
+returned = raw_pytorch.conj([1.0 + 2.0j, 3.0 - 4.0j], out=torch_out)
+assert returned is torch_out
+assert torch_out.tolist() == [1.0 - 2.0j, 3.0 + 4.0j]
+
+numpy_out = np.empty(2, dtype=np.complex128)
+returned_numpy = raw_pytorch.conj([1.0 + 2.0j, 3.0 - 4.0j], out=numpy_out)
+assert returned_numpy is numpy_out
+assert numpy_out.tolist() == [1.0 - 2.0j, 3.0 + 4.0j]
+""",
+    )
+
+
+@pytest.mark.backend_portable
+def test_public_pytorch_conj_accepts_array_like_inputs():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    _run_backend_snippet(
+        "pytorch",
+        """
+import pyrecest.backend as backend
+
+assert getattr(backend, "__backend_name__", None) == "pytorch"
+
+result = backend.conj([1.0 + 2.0j, 3.0 - 4.0j])
+assert backend.is_array(result)
+assert result.tolist() == [1.0 - 2.0j, 3.0 + 4.0j]
+
+out = backend.empty(2, dtype=backend.complex128)
+returned = backend.conj([1.0 + 2.0j, 3.0 - 4.0j], out=out)
+assert returned is out
+assert out.tolist() == [1.0 - 2.0j, 3.0 + 4.0j]
+""",
+    )


### PR DESCRIPTION
## Summary
- Patch PyTorch `conj` compatibility handling so both raw `pyrecest._backend.pytorch.conj` and the public PyTorch backend accept NumPy-style array-like inputs.
- Preserve `out=` handling for both torch tensors and NumPy arrays.
- Add focused subprocess regressions for raw PyTorch under a NumPy public backend and for the public PyTorch backend.

## Bug fixed
`pyrecest._backend.pytorch.conj` still exposed bare `torch.conj`, so calls such as `raw_pytorch.conj([1.0 + 2.0j])` failed even though PyRecEst's backend facade generally accepts array-like inputs. The public PyTorch facade had the same issue for `backend.conj([...])`.

## Validation
- `python -m py_compile /tmp/backend_tools_new.py`
- Local standalone Torch smoke check confirmed bare `torch.conj` rejects Python lists, while the patched wrapper accepts list inputs and both torch/NumPy `out=` destinations.
- Full repository test suite was not run locally because this sandbox cannot clone GitHub via DNS; CI should run on GitHub.