### PR TITLE
Fix PyTorch isclose equal_nan contract

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
@@ -3,6 +3,52 @@
 from __future__ import annotations
 
 
+def _patch_pytorch_isclose_equal_nan_contract(raw_pytorch, torch_module) -> None:
+    """Make PyTorch isclose accept NumPy's equal_nan keyword."""
+
+    original_isclose = raw_pytorch.isclose
+    if getattr(original_isclose, "_pyrecest_equal_nan_contract", False):
+        return
+
+    default_atol = raw_pytorch.atol
+    default_rtol = raw_pytorch.rtol
+
+    def _as_isclose_tensor(value, *, device):
+        tensor = value if torch_module.is_tensor(value) else raw_pytorch.array(value)
+        if device is not None and tensor.device != device:
+            return tensor.to(device=device)
+        return tensor
+
+    def isclose(x, y, rtol=default_rtol, atol=default_atol, equal_nan=False):
+        device = next(
+            (value.device for value in (x, y) if torch_module.is_tensor(value)),
+            None,
+        )
+        x = _as_isclose_tensor(x, device=device)
+        y = _as_isclose_tensor(y, device=device)
+        x, y = raw_pytorch.convert_to_wider_dtype([x, y])
+        return torch_module.isclose(
+            x,
+            y,
+            atol=atol,
+            rtol=rtol,
+            equal_nan=equal_nan,
+        )
+
+    isclose.__name__ = getattr(original_isclose, "__name__", "isclose")
+    isclose.__doc__ = getattr(original_isclose, "__doc__", None)
+    isclose._pyrecest_equal_nan_contract = True
+    raw_pytorch.isclose = isclose
+
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.isclose = isclose
+
+
 def patch_pytorch_dtype_promotion_contract() -> None:
     """Make PyTorch mixed-dtype helpers use Torch's promotion rules."""
     try:
@@ -12,25 +58,26 @@ def patch_pytorch_dtype_promotion_contract() -> None:
         return
 
     original_convert = raw_pytorch.convert_to_wider_dtype
-    if getattr(original_convert, "_pyrecest_torch_promotion_contract", False):
-        return
+    if not getattr(original_convert, "_pyrecest_torch_promotion_contract", False):
 
-    def convert_to_wider_dtype(tensor_list):
-        tensors = list(tensor_list)
-        if not tensors:
-            return tensors
+        def convert_to_wider_dtype(tensor_list):
+            tensors = list(tensor_list)
+            if not tensors:
+                return tensors
 
-        promoted_dtype = tensors[0].dtype
-        for tensor in tensors[1:]:
-            promoted_dtype = torch.promote_types(promoted_dtype, tensor.dtype)
+            promoted_dtype = tensors[0].dtype
+            for tensor in tensors[1:]:
+                promoted_dtype = torch.promote_types(promoted_dtype, tensor.dtype)
 
-        if all(tensor.dtype == promoted_dtype for tensor in tensors):
-            return tensors
-        return [raw_pytorch.cast(tensor, dtype=promoted_dtype) for tensor in tensors]
+            if all(tensor.dtype == promoted_dtype for tensor in tensors):
+                return tensors
+            return [raw_pytorch.cast(tensor, dtype=promoted_dtype) for tensor in tensors]
 
-    convert_to_wider_dtype.__name__ = getattr(
-        original_convert, "__name__", "convert_to_wider_dtype"
-    )
-    convert_to_wider_dtype.__doc__ = getattr(original_convert, "__doc__", None)
-    convert_to_wider_dtype._pyrecest_torch_promotion_contract = True
-    raw_pytorch.convert_to_wider_dtype = convert_to_wider_dtype
+        convert_to_wider_dtype.__name__ = getattr(
+            original_convert, "__name__", "convert_to_wider_dtype"
+        )
+        convert_to_wider_dtype.__doc__ = getattr(original_convert, "__doc__", None)
+        convert_to_wider_dtype._pyrecest_torch_promotion_contract = True
+        raw_pytorch.convert_to_wider_dtype = convert_to_wider_dtype
+
+    _patch_pytorch_isclose_equal_nan_contract(raw_pytorch, torch)

--- a/tests/backend_support/test_pytorch_isclose_contract.py
+++ b/tests/backend_support/test_pytorch_isclose_contract.py
@@ -1,0 +1,51 @@
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_public_pytorch_isclose_accepts_equal_nan():
+    pytest.importorskip("torch")
+
+    result = run_backend_code(
+        "pytorch",
+        '''
+import pyrecest.backend as backend
+
+assert getattr(backend, "__backend_name__", None) == "pytorch"
+
+nan = float("nan")
+equal_nan = backend.isclose([nan, 1.0, 2.0], [nan, 1.0, 3.0], equal_nan=True)
+not_equal_nan = backend.isclose([nan, 1.0, 2.0], [nan, 1.0, 3.0], equal_nan=False)
+
+assert equal_nan.tolist() == [True, True, False]
+assert not_equal_nan.tolist() == [False, True, False]
+''',
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_isclose_accepts_equal_nan_with_numpy_public_backend():
+    pytest.importorskip("torch")
+
+    result = run_backend_code(
+        "numpy",
+        '''
+import pyrecest  # noqa: F401
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+assert getattr(backend, "__backend_name__", None) == "numpy"
+
+nan = float("nan")
+equal_nan = raw_pytorch.isclose([nan, 1.0, 2.0], [nan, 1.0, 3.0], equal_nan=True)
+not_equal_nan = raw_pytorch.isclose([nan, 1.0, 2.0], [nan, 1.0, 3.0], equal_nan=False)
+
+assert equal_nan.tolist() == [True, True, False]
+assert not_equal_nan.tolist() == [False, True, False]
+''',
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Patch the PyTorch backend `isclose` helper to accept NumPy/PyTorch's `equal_nan` keyword.
- Preserve array-like coercion, dtype promotion, and active public-backend replacement when PyTorch is selected.
- Add subprocess regression tests for both public PyTorch backend use and raw PyTorch backend use while NumPy is the active public backend.

## Bug
`pyrecest._backend.pytorch.isclose` exposed a wrapper without `equal_nan`, so NaN-aware comparisons raised `TypeError` instead of matching the NumPy/JAX backend contract.

## Tests
- Added `tests/backend_support/test_pytorch_isclose_contract.py`
- Not run locally in this environment; CI should exercise the added regression tests.