### PR TITLE
Fix PyTorch predicate array-like backend contract

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
@@ -3,34 +3,79 @@
 from __future__ import annotations
 
 
+def _return_or_store_predicate_out(raw_pytorch, result, out):
+    """Return ``result`` or store it through a NumPy/PyTorch-style ``out``."""
+
+    if out is None:
+        return result
+    copy_ = getattr(out, "copy_", None)
+    if copy_ is not None:
+        copy_(result)
+        return out
+    out[...] = raw_pytorch.to_numpy(result)
+    return out
+
+
+def _patch_pytorch_predicate_numpy_contract(raw_pytorch, torch, backend) -> None:
+    """Make PyTorch predicate helpers accept NumPy-style array-like inputs."""
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+
+    def _make_predicate(helper_name, torch_func, original_helper):
+        def predicate(a, out=None):
+            result = torch_func(raw_pytorch.array(a))
+            return _return_or_store_predicate_out(raw_pytorch, result, out)
+
+        predicate.__name__ = getattr(original_helper, "__name__", helper_name)
+        predicate.__doc__ = getattr(original_helper, "__doc__", None)
+        predicate._pyrecest_numpy_contract = True
+        return predicate
+
+    for helper_name in ("isfinite", "isinf", "isnan", "isreal"):
+        original_helper = getattr(raw_pytorch, helper_name)
+        if getattr(original_helper, "_pyrecest_numpy_contract", False):
+            helper = original_helper
+        else:
+            helper = _make_predicate(
+                helper_name,
+                getattr(torch, helper_name),
+                original_helper,
+            )
+            setattr(raw_pytorch, helper_name, helper)
+        if active_pytorch_backend:
+            setattr(backend, helper_name, helper)
+
+
 def patch_pytorch_dtype_promotion_contract() -> None:
     """Make PyTorch mixed-dtype helpers use Torch's promotion rules."""
     try:
         import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
         import torch  # pylint: disable=import-outside-toplevel
     except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
         return
 
     original_convert = raw_pytorch.convert_to_wider_dtype
-    if getattr(original_convert, "_pyrecest_torch_promotion_contract", False):
-        return
+    if not getattr(original_convert, "_pyrecest_torch_promotion_contract", False):
 
-    def convert_to_wider_dtype(tensor_list):
-        tensors = list(tensor_list)
-        if not tensors:
-            return tensors
+        def convert_to_wider_dtype(tensor_list):
+            tensors = list(tensor_list)
+            if not tensors:
+                return tensors
 
-        promoted_dtype = tensors[0].dtype
-        for tensor in tensors[1:]:
-            promoted_dtype = torch.promote_types(promoted_dtype, tensor.dtype)
+            promoted_dtype = tensors[0].dtype
+            for tensor in tensors[1:]:
+                promoted_dtype = torch.promote_types(promoted_dtype, tensor.dtype)
 
-        if all(tensor.dtype == promoted_dtype for tensor in tensors):
-            return tensors
-        return [raw_pytorch.cast(tensor, dtype=promoted_dtype) for tensor in tensors]
+            if all(tensor.dtype == promoted_dtype for tensor in tensors):
+                return tensors
+            return [raw_pytorch.cast(tensor, dtype=promoted_dtype) for tensor in tensors]
 
-    convert_to_wider_dtype.__name__ = getattr(
-        original_convert, "__name__", "convert_to_wider_dtype"
-    )
-    convert_to_wider_dtype.__doc__ = getattr(original_convert, "__doc__", None)
-    convert_to_wider_dtype._pyrecest_torch_promotion_contract = True
-    raw_pytorch.convert_to_wider_dtype = convert_to_wider_dtype
+        convert_to_wider_dtype.__name__ = getattr(
+            original_convert, "__name__", "convert_to_wider_dtype"
+        )
+        convert_to_wider_dtype.__doc__ = getattr(original_convert, "__doc__", None)
+        convert_to_wider_dtype._pyrecest_torch_promotion_contract = True
+        raw_pytorch.convert_to_wider_dtype = convert_to_wider_dtype
+
+    _patch_pytorch_predicate_numpy_contract(raw_pytorch, torch, backend)

--- a/tests/backend_support/test_pytorch_predicate_contract.py
+++ b/tests/backend_support/test_pytorch_predicate_contract.py
@@ -1,0 +1,105 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _run_with_backend(backend_name, code):
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = backend_name
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)
+
+
+@pytest.mark.backend_portable
+def test_pytorch_predicates_accept_array_like_inputs_and_out():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import numpy as np
+import torch
+
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+assert getattr(backend, "__backend_name__", None) == "pytorch"
+
+values = [0.0, float("nan"), float("inf"), -float("inf")]
+expected = {
+    "isfinite": [True, False, False, False],
+    "isinf": [False, False, True, True],
+    "isnan": [False, True, False, False],
+}
+
+for module in (backend, raw_pytorch):
+    for helper_name, expected_values in expected.items():
+        result = getattr(module, helper_name)(values)
+        assert module.is_array(result)
+        assert module.to_numpy(result).tolist() == expected_values
+
+complex_values = [1.0 + 0.0j, 2.0 + 3.0j]
+for module in (backend, raw_pytorch):
+    result = module.isreal(complex_values)
+    assert module.is_array(result)
+    assert module.to_numpy(result).tolist() == [True, False]
+
+out = torch.empty(len(values), dtype=torch.bool)
+returned = backend.isfinite(values, out=out)
+assert returned is out
+assert out.tolist() == expected["isfinite"]
+
+np_out = np.empty(len(values), dtype=bool)
+returned = raw_pytorch.isinf(values, out=np_out)
+assert returned is np_out
+assert np_out.tolist() == expected["isinf"]
+"""
+    _run_with_backend("pytorch", code)
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_predicates_work_with_numpy_public_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import numpy as np
+import torch
+
+import pyrecest  # noqa: F401
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+assert getattr(backend, "__backend_name__", None) == "numpy"
+
+values = [0.0, float("nan"), float("inf")]
+finite = raw_pytorch.isfinite(values)
+assert raw_pytorch.is_array(finite)
+assert finite.tolist() == [True, False, False]
+
+nan_values = raw_pytorch.isnan(values)
+assert raw_pytorch.is_array(nan_values)
+assert nan_values.tolist() == [False, True, False]
+
+real = raw_pytorch.isreal([1.0 + 0.0j, 2.0 + 3.0j])
+assert raw_pytorch.is_array(real)
+assert real.tolist() == [True, False]
+
+np_out = np.empty(len(values), dtype=bool)
+returned = raw_pytorch.isinf(values, out=np_out)
+assert returned is np_out
+assert np_out.tolist() == [False, False, True]
+
+torch_out = torch.empty(len(values), dtype=torch.bool)
+returned = raw_pytorch.isfinite(values, out=torch_out)
+assert returned is torch_out
+assert torch_out.tolist() == [True, False, False]
+"""
+    _run_with_backend("numpy", code)


### PR DESCRIPTION
## Summary
- Patch raw PyTorch predicate helpers `isfinite`, `isinf`, `isnan`, and `isreal` so they accept NumPy-style array-like inputs.
- Preserve active public PyTorch backend parity by syncing the patched helpers onto `pyrecest.backend` when `PYRECEST_BACKEND=pytorch`.
- Add regression coverage for public PyTorch and raw PyTorch usage under the NumPy public backend, including `out=` handling for Torch and NumPy outputs.

## Bug fixed
The PyTorch backend still exposed bare Torch predicate helpers. Calls that are valid for NumPy-style backend-portable code, such as `pyrecest._backend.pytorch.isfinite([0.0, float("inf")])` or `backend.isnan([...], out=...)`, could fail under PyTorch because Torch requires tensor input and these helpers do not accept NumPy's `out=` keyword.

## Validation
- `python -m py_compile /tmp/_torch_dtype_promotion_contract.py /tmp/test_pytorch_predicate_contract.py`
- Standalone local Torch smoke test for list inputs plus Torch/NumPy `out=` destinations.