### PR TITLE
Fix JAX custom gradient VJP contraction

### DIFF
--- a/src/pyrecest/_backend/jax/autodiff.py
+++ b/src/pyrecest/_backend/jax/autodiff.py
@@ -44,16 +44,26 @@ def elementwise_grad(func):
     return _elementwise_grad
 
 
-def _apply_custom_gradient(cotangent, grads):
+def _shape_tuple(value):
+    """Return a plain Python shape tuple for array-like values."""
+    return tuple(int(dim) for dim in getattr(value, "shape", ()))
+
+
+def _apply_custom_gradient(cotangent, grads, argument):
     """Apply a user-supplied Jacobian/VJP factor to an upstream cotangent."""
-    if isinstance(grads, float):
+    cotangent = anp.asarray(cotangent)
+    grads = anp.asarray(grads)
+    argument_shape = _shape_tuple(argument)
+    cotangent_shape = _shape_tuple(cotangent)
+
+    if argument_shape and grads.shape == argument_shape:
         return cotangent * grads
 
-    ndim = getattr(grads, "ndim", None)
-    if ndim == 2:
-        return cotangent[..., None] * grads
-    if ndim == 3:
-        return cotangent[..., None, None] * grads
+    if grads.shape == cotangent_shape + argument_shape:
+        if cotangent.ndim == 0:
+            return cotangent * grads
+        return anp.tensordot(cotangent, grads, axes=cotangent.ndim)
+
     return cotangent * grads
 
 
@@ -110,7 +120,9 @@ def custom_gradient(*grad_funcs):
             for arg_index in range(len(values)):
                 if arg_index < len(grad_funcs):
                     grads = call_with_bound_values(grad_funcs[arg_index], values)
-                    gradients.append(_apply_custom_gradient(cotangent, grads))
+                    gradients.append(
+                        _apply_custom_gradient(cotangent, grads, values[arg_index])
+                    )
                 else:
                     gradients.append(None)
             return tuple(gradients)

--- a/tests/test_jax_autodiff_backend.py
+++ b/tests/test_jax_autodiff_backend.py
@@ -67,6 +67,30 @@ def test_custom_gradient_supports_multiple_arguments_and_keyword_calls():
     assert jnp.allclose(grad_scale, -1.0)
 
 
+def test_custom_gradient_contracts_vector_output_for_scalar_argument():
+    @autodiff.custom_gradient(lambda x: jnp.array([2.0, 3.0]))
+    def affine_pair(x):
+        return jnp.array([2.0 * x, 3.0 * x])
+
+    _, pullback = jax.vjp(affine_pair, 4.0)
+    (gradient,) = pullback(jnp.array([10.0, 1.0]))
+
+    assert jnp.allclose(gradient, 23.0)
+
+
+def test_custom_gradient_contracts_full_jacobian_with_cotangent():
+    jacobian_matrix = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+
+    @autodiff.custom_gradient(lambda x: jacobian_matrix)
+    def linear_map(x):
+        return jacobian_matrix @ x
+
+    _, pullback = jax.vjp(linear_map, jnp.array([1.0, 1.0]))
+    (gradient,) = pullback(jnp.array([5.0, 7.0]))
+
+    assert jnp.allclose(gradient, jnp.array([26.0, 38.0]))
+
+
 @pytest.mark.parametrize(
     "function_name",
     [


### PR DESCRIPTION
## Summary
- Fix JAX `custom_gradient` VJP handling so vector-output Jacobians are contracted with the upstream cotangent.
- Preserve the existing elementwise-gradient behavior for scalar-output/vector-argument use cases.
- Add focused JAX autodiff regressions for scalar-argument vector outputs and full-Jacobian cotangent contraction.

## Bug fixed
The JAX backend's `custom_gradient` wrapper multiplied custom gradients by the upstream cotangent unconditionally. That works for elementwise scalar-output patterns, but it is not a valid VJP for vector-output functions whose custom gradient is a Jacobian. For example, a vector-output function of a scalar argument should contract `[10, 1]` with `[2, 3]` to produce scalar gradient `23`, not return a length-2 gradient.

## Validation
- `python -m py_compile /mnt/data/autodiff.py /mnt/data/test_jax_autodiff_backend.py`
- Local JAX smoke checks for the existing elementwise-gradient behavior, scalar-argument vector-output VJP, and full-Jacobian VJP contraction.
- Full repository test suite was not run locally because this environment cannot clone GitHub repositories via DNS; CI should run the complete matrix.