### PR TITLE
Fix get_slice array-like backend contract

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
@@ -3,6 +3,83 @@
 from __future__ import annotations
 
 
+def _wrap_get_slice_arraylike_contract(original_get_slice, array_func, is_array_func=None):
+    """Return a get_slice wrapper that accepts documented array-like inputs."""
+
+    if getattr(original_get_slice, "_pyrecest_arraylike_contract", False):
+        return original_get_slice
+
+    def get_slice(x, indices):
+        if is_array_func is None or not is_array_func(x):
+            x = array_func(x)
+        return original_get_slice(x, indices)
+
+    get_slice.__name__ = getattr(original_get_slice, "__name__", "get_slice")
+    get_slice.__doc__ = getattr(original_get_slice, "__doc__", None)
+    get_slice._pyrecest_arraylike_contract = True
+    return get_slice
+
+
+def _patch_one_get_slice_module(module) -> None:
+    original_get_slice = getattr(module, "get_slice", None)
+    array_func = getattr(module, "array", None)
+    if original_get_slice is None or array_func is None:
+        return
+
+    module.get_slice = _wrap_get_slice_arraylike_contract(
+        original_get_slice,
+        array_func,
+        getattr(module, "is_array", None),
+    )
+
+
+def _patch_backend_get_slice_arraylike_contract() -> None:
+    """Make public and raw backend get_slice helpers accept array-like inputs."""
+
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        backend = None
+
+    if backend is not None:
+        _patch_one_get_slice_module(backend)
+
+    try:
+        import pyrecest._backend._shared_numpy as shared_numpy  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - unavailable backend module
+        pass
+    else:
+        _patch_one_get_slice_module(shared_numpy)
+
+    try:
+        import pyrecest._backend.numpy as raw_numpy  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - unavailable backend module
+        pass
+    else:
+        _patch_one_get_slice_module(raw_numpy)
+
+    try:
+        import pyrecest._backend.autograd as raw_autograd  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - optional backend unavailable
+        pass
+    else:
+        _patch_one_get_slice_module(raw_autograd)
+
+    try:
+        import pyrecest._backend.jax as raw_jax  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - optional backend unavailable
+        pass
+    else:
+        _patch_one_get_slice_module(raw_jax)
+
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - optional backend unavailable
+        pass
+    else:
+        _patch_one_get_slice_module(raw_pytorch)
+
+
 def patch_pytorch_dtype_promotion_contract() -> None:
     """Make PyTorch mixed-dtype helpers use Torch's promotion rules."""
     try:
@@ -34,3 +111,6 @@ def patch_pytorch_dtype_promotion_contract() -> None:
     convert_to_wider_dtype.__doc__ = getattr(original_convert, "__doc__", None)
     convert_to_wider_dtype._pyrecest_torch_promotion_contract = True
     raw_pytorch.convert_to_wider_dtype = convert_to_wider_dtype
+
+
+_patch_backend_get_slice_arraylike_contract()

--- a/tests/backend_support/test_get_slice_arraylike_contract.py
+++ b/tests/backend_support/test_get_slice_arraylike_contract.py
@@ -1,0 +1,14 @@
+import pyrecest.backend as backend
+
+
+def _to_python(value):
+    value = backend.to_numpy(value)
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    return value
+
+
+def test_get_slice_accepts_array_like_inputs():
+    result = backend.get_slice([[0, 1, 2], [3, 4, 5]], ((0, 1), (2, 0)))
+
+    assert _to_python(result) == [2, 3]


### PR DESCRIPTION
## Summary
- Patch backend `get_slice` helpers to coerce documented array-like inputs before grouped indexing.
- Preserve existing backend array behavior.
- Add a focused regression for slicing a nested Python list.

## Validation
- Added `tests/backend_support/test_get_slice_arraylike_contract.py`.
- Full CI should run on GitHub.