### PR TITLE
Backend shape compatibility fix

### DIFF
--- a/src/pyrecest/_backend_submodules.py
+++ b/src/pyrecest/_backend_submodules.py
@@ -179,7 +179,6 @@ def _adapt_pytorch_repeat_contract(backend: ModuleType) -> None:
     repeat = getattr(pytorch_backend, "repeat", None)
     if repeat is None or getattr(repeat, "_pyrecest_repeat_contract", False):
         return
-
     wrapped_repeat = _pytorch_repeat_with_arraylike_inputs(
         repeat,
         backend.array,
@@ -215,6 +214,14 @@ def _pytorch_reshape_shape(shape, torch_module) -> tuple[int, ...]:
         ) from exc
 
 
+def _pytorch_broadcast_shape(shape, torch_module) -> tuple[int, ...]:
+    """Normalize NumPy-style broadcast target shapes for PyTorch expand."""
+    target_shape = _pytorch_reshape_shape(shape, torch_module)
+    if any(dimension < 0 for dimension in target_shape):
+        raise ValueError("all elements of broadcast shape must be non-negative")
+    return target_shape
+
+
 def _adapt_pytorch_reshape_contract(backend: ModuleType) -> None:
     """Adapt PyTorch reshape to accept array-like inputs and NumPy-style shapes."""
     if getattr(backend, "__backend_name__", None) != "pytorch":
@@ -234,6 +241,34 @@ def _adapt_pytorch_reshape_contract(backend: ModuleType) -> None:
     wrapped_reshape._pyrecest_reshape_contract = True
     setattr(pytorch_backend, "reshape", wrapped_reshape)
     setattr(backend, "reshape", wrapped_reshape)
+
+
+def _adapt_pytorch_broadcast_to_contract(backend: ModuleType) -> None:
+    """Adapt PyTorch broadcast_to to accept NumPy-style array-like shapes."""
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        return
+
+    import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+    import torch as torch_module  # pylint: disable=import-outside-toplevel
+
+    broadcast_to = getattr(pytorch_backend, "broadcast_to", None)
+    if broadcast_to is None or getattr(
+        broadcast_to,
+        "_pyrecest_broadcast_to_contract",
+        False,
+    ):
+        return
+
+    @wraps(broadcast_to)
+    def wrapped_broadcast_to(x, shape):
+        return broadcast_to(
+            backend.array(x),
+            _pytorch_broadcast_shape(shape, torch_module),
+        )
+
+    wrapped_broadcast_to._pyrecest_broadcast_to_contract = True
+    setattr(pytorch_backend, "broadcast_to", wrapped_broadcast_to)
+    setattr(backend, "broadcast_to", wrapped_broadcast_to)
 
 
 def _adapt_pytorch_stack_helpers_contract(backend: ModuleType) -> None:
@@ -428,6 +463,7 @@ def register_backend_submodules(backend: ModuleType | None = None) -> None:
     _adapt_pytorch_allclose_keyword_contract(backend)
     _adapt_pytorch_repeat_contract(backend)
     _adapt_pytorch_reshape_contract(backend)
+    _adapt_pytorch_broadcast_to_contract(backend)
     _adapt_pytorch_stack_helpers_contract(backend)
     _adapt_pytorch_reduction_alias_contract(backend)
 

--- a/tests/backend_support/test_pytorch_broadcast_to_contract.py
+++ b/tests/backend_support/test_pytorch_broadcast_to_contract.py
@@ -1,0 +1,53 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_pytorch_broadcast_to_accepts_array_like_shapes():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import pyrecest.backend as backend
+from pyrecest._backend import pytorch as pytorch_backend
+
+values = backend.array([1, 2, 3])
+
+for broadcast_to, to_numpy in (
+    (backend.broadcast_to, backend.to_numpy),
+    (pytorch_backend.broadcast_to, pytorch_backend.to_numpy),
+):
+    result = broadcast_to(values, backend.array([2, 3]))
+    assert tuple(result.shape) == (2, 3)
+    assert to_numpy(result).tolist() == [[1, 2, 3], [1, 2, 3]]
+
+    scalar_shape = broadcast_to(7, backend.array(3))
+    assert tuple(scalar_shape.shape) == (3,)
+    assert to_numpy(scalar_shape).tolist() == [7, 7, 7]
+
+    empty_shape = broadcast_to(7, backend.array([]).to(dtype=backend.int64))
+    assert tuple(empty_shape.shape) == ()
+    assert to_numpy(empty_shape).tolist() == 7
+
+    for bad_shape in (backend.array([-1]), backend.array([2.0, 3.0])):
+        try:
+            broadcast_to(values, bad_shape)
+        except (TypeError, ValueError):
+            pass
+        else:
+            raise AssertionError(f"broadcast_to accepted invalid shape {bad_shape!r}")
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
Small backend compatibility fix with a focused regression test.

Testing: added a backend-portable subprocess regression; not run locally in this connector session.