### PR TITLE
Fix PyTorch squeeze tuple-axis contract

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
@@ -2,9 +2,85 @@
 
 from __future__ import annotations
 
+from operator import index as _operator_index
+
+
+def _normalize_pytorch_squeeze_axes(axis, ndim: int) -> tuple[int, ...]:
+    """Normalize NumPy-style squeeze axes for the PyTorch backend."""
+
+    try:
+        axes = (_operator_index(axis),)
+    except TypeError:
+        if isinstance(axis, (str, bytes)):
+            raise TypeError(
+                "squeeze axis must be an integer or a sequence of integers"
+            ) from None
+        try:
+            axes = tuple(_operator_index(one_axis) for one_axis in axis)
+        except TypeError as exc:
+            raise TypeError(
+                "squeeze axis must be an integer or a sequence of integers"
+            ) from exc
+
+    normalized_axes = []
+    for one_axis in axes:
+        normalized_axis = one_axis + ndim if one_axis < 0 else one_axis
+        if normalized_axis < 0 or normalized_axis >= ndim:
+            raise IndexError(
+                f"axis {one_axis} is out of bounds for array of dimension {ndim}"
+            )
+        normalized_axes.append(normalized_axis)
+
+    if len(set(normalized_axes)) != len(normalized_axes):
+        raise ValueError("duplicate value in 'axis'")
+    return tuple(normalized_axes)
+
+
+def _patch_pytorch_squeeze_axis_contract() -> None:
+    """Make PyTorch squeeze accept NumPy-style tuple axes."""
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
+        return
+
+    original_squeeze = raw_pytorch.squeeze
+    if getattr(original_squeeze, "_pyrecest_squeeze_axis_contract", False):
+        return
+
+    def squeeze(x, axis=None):
+        x = raw_pytorch.array(x)
+        if axis is None:
+            return torch.squeeze(x)
+
+        axes = _normalize_pytorch_squeeze_axes(axis, x.ndim)
+        if not axes:
+            return x
+        if any(x.shape[one_axis] != 1 for one_axis in axes):
+            return x
+
+        result = x
+        for one_axis in sorted(axes, reverse=True):
+            result = torch.squeeze(result, dim=one_axis)
+        return result
+
+    squeeze.__name__ = getattr(original_squeeze, "__name__", "squeeze")
+    squeeze.__doc__ = getattr(original_squeeze, "__doc__", None)
+    squeeze._pyrecest_squeeze_axis_contract = True
+    raw_pytorch.squeeze = squeeze
+
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.squeeze = squeeze
+
 
 def patch_pytorch_dtype_promotion_contract() -> None:
     """Make PyTorch mixed-dtype helpers use Torch's promotion rules."""
+    _patch_pytorch_squeeze_axis_contract()
+
     try:
         import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
         import torch  # pylint: disable=import-outside-toplevel

--- a/tests/backend_support/test_pytorch_reshape_contract.py
+++ b/tests/backend_support/test_pytorch_reshape_contract.py
@@ -6,19 +6,22 @@ import sys
 import pytest
 
 
-@pytest.mark.backend_portable
-def test_pytorch_reshape_array_like_inputs_match_numpy_contract():
-    if importlib.util.find_spec("torch") is None:
-        pytest.skip("torch is not installed")
-
+def _backend_test_env(backend_name):
     env = os.environ.copy()
-    env["PYRECEST_BACKEND"] = "pytorch"
+    env["PYRECEST_BACKEND"] = backend_name
     src_path = os.path.abspath("src")
     env["PYTHONPATH"] = (
         src_path
         if not env.get("PYTHONPATH")
         else os.pathsep.join([src_path, env["PYTHONPATH"]])
     )
+    return env
+
+
+@pytest.mark.backend_portable
+def test_pytorch_reshape_array_like_inputs_match_numpy_contract():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
 
     code = """
 import numpy as np
@@ -47,4 +50,71 @@ except TypeError:
 else:
     raise AssertionError("reshape accepted a non-integer target shape")
 """
-    subprocess.run([sys.executable, "-c", code], check=True, env=env)
+    subprocess.run([sys.executable, "-c", code], check=True, env=_backend_test_env("pytorch"))
+
+
+@pytest.mark.backend_portable
+def test_pytorch_squeeze_accepts_tuple_axes_for_public_and_raw_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import pyrecest.backend as backend
+from pyrecest._backend import pytorch as pytorch_backend
+
+values = backend.array([[[1], [2]]])
+
+for squeeze_func, to_numpy in (
+    (backend.squeeze, backend.to_numpy),
+    (pytorch_backend.squeeze, pytorch_backend.to_numpy),
+):
+    result = squeeze_func(values, axis=(0, 2))
+    assert tuple(result.shape) == (2,)
+    assert to_numpy(result).tolist() == [1, 2]
+
+    negative_axis_result = squeeze_func(values, axis=(-3, -1))
+    assert tuple(negative_axis_result.shape) == (2,)
+    assert to_numpy(negative_axis_result).tolist() == [1, 2]
+
+    tensor_axis_result = squeeze_func(values, axis=backend.array([0, 2]))
+    assert tuple(tensor_axis_result.shape) == (2,)
+    assert to_numpy(tensor_axis_result).tolist() == [1, 2]
+
+    empty_axis_result = squeeze_func(values, axis=())
+    assert tuple(empty_axis_result.shape) == (1, 2, 1)
+    assert to_numpy(empty_axis_result).tolist() == [[[1], [2]]]
+
+    try:
+        squeeze_func(values, axis=(0, -3))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("squeeze accepted duplicate axes")
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=_backend_test_env("pytorch"))
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_squeeze_tuple_axes_with_numpy_public_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import pyrecest.backend as backend
+from pyrecest._backend import pytorch as pytorch_backend
+
+assert getattr(backend, "__backend_name__", None) == "numpy"
+values = pytorch_backend.array([[[1], [2]]])
+
+result = pytorch_backend.squeeze(values, axis=(0, 2))
+assert tuple(result.shape) == (2,)
+assert pytorch_backend.to_numpy(result).tolist() == [1, 2]
+
+axis_tensor_result = pytorch_backend.squeeze(
+    values,
+    axis=pytorch_backend.array([0, 2]),
+)
+assert tuple(axis_tensor_result.shape) == (2,)
+assert pytorch_backend.to_numpy(axis_tensor_result).tolist() == [1, 2]
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=_backend_test_env("numpy"))


### PR DESCRIPTION
Fix PyTorch backend squeeze handling for tuple axes and add regression coverage.