### PR TITLE
Reject None in bias calibration numeric inputs

### DIFF
--- a/src/pyrecest/calibration/bias.py
+++ b/src/pyrecest/calibration/bias.py
@@ -22,6 +22,7 @@ _REJECTED_OBJECT_VALUE_TYPES = (
     str,
     bytes,
     bytearray,
+    type(None),
     complex,
     np.complexfloating,
     np.datetime64,


### PR DESCRIPTION
## Summary
- Treat `None` as an invalid object value in bias-calibration numeric input validation.
- Prevent NumPy from silently converting `None` payloads to `nan` in bias model parameters and training inputs.

## Bug fixed
`np.asarray(None, dtype=float)` and object arrays containing `None` can produce `nan` values instead of raising. The bias calibration helper rejected booleans, text, complex values, and datetime-like payloads, but not `None`, so malformed inputs could be accepted and later filtered or serialized as invalid numeric state.

## Validation
- Not run locally in this connector session; the environment cannot clone the GitHub repository.
- Attempted to add focused regression coverage, but test-file writes were blocked by the connector safety layer. The runtime fix is limited to the shared object-value rejection tuple.