### PR TITLE
Fix PyTorch log1p array-like backend contract

### DIFF
--- a/src/pyrecest/_backend_submodules.py
+++ b/src/pyrecest/_backend_submodules.py
@@ -97,6 +97,35 @@ def _adapt_pytorch_allclose_keyword_contract(backend: ModuleType) -> None:
     setattr(pytorch_backend, "allclose", wrapped_allclose)
 
 
+def _adapt_pytorch_log1p_contract(backend: ModuleType) -> None:
+    """Adapt PyTorch ``log1p`` to accept NumPy-style array-like inputs."""
+    try:
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - backend import fails first
+        return
+
+    log1p = getattr(pytorch_backend, "log1p", None)
+    if log1p is None:
+        return
+
+    if getattr(log1p, "_pyrecest_unary_arraylike_contract", False):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            setattr(backend, "log1p", log1p)
+        return
+
+    @wraps(log1p)
+    def wrapped_log1p(x, *args, out=None, **kwargs):
+        result = log1p(pytorch_backend.array(x), *args, **kwargs)
+        if out is not None:
+            return _copy_result_to_out(result, out)
+        return result
+
+    wrapped_log1p._pyrecest_unary_arraylike_contract = True
+    setattr(pytorch_backend, "log1p", wrapped_log1p)
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        setattr(backend, "log1p", wrapped_log1p)
+
+
 def _pytorch_repeat_count(repetition) -> int:
     """Return one NumPy-style repeat count as a non-negative integer."""
     try:
@@ -426,6 +455,7 @@ def register_backend_submodules(backend: ModuleType | None = None) -> None:
 
     _adapt_cumulative_out_contract(backend)
     _adapt_pytorch_allclose_keyword_contract(backend)
+    _adapt_pytorch_log1p_contract(backend)
     _adapt_pytorch_repeat_contract(backend)
     _adapt_pytorch_reshape_contract(backend)
     _adapt_pytorch_stack_helpers_contract(backend)

--- a/tests/backend_support/test_pytorch_linear_helpers_contract.py
+++ b/tests/backend_support/test_pytorch_linear_helpers_contract.py
@@ -1,3 +1,7 @@
+import importlib.util
+
+import numpy as np
+import numpy.testing as npt
 import pyrecest.backend as backend
 import pytest
 
@@ -37,3 +41,21 @@ def test_pytorch_backend_exposes_dot_and_matvec():
 
     assert _to_python(batched_matvec) == [[1.0, 2.0], [6.0, 12.0]]
     assert _to_python(shared_vector_matvec) == [[1.0, 2.0], [2.0, 6.0]]
+
+
+def test_raw_pytorch_log1p_accepts_array_like_inputs_and_out():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+
+    values = [0.0, 1.0, 3.0]
+    expected = np.log1p(values)
+
+    result = pytorch_backend.log1p(values)
+    npt.assert_allclose(pytorch_backend.to_numpy(result), expected)
+
+    out = pytorch_backend.zeros(3)
+    returned = pytorch_backend.log1p(values, out=out)
+    assert returned is out
+    npt.assert_allclose(pytorch_backend.to_numpy(out), expected)


### PR DESCRIPTION
## Summary
- Add an import-time PyTorch `log1p` adapter that coerces NumPy-style array-like inputs through the PyTorch backend before calling the raw helper.
- Preserve `out=` handling for tensor-like and mutable array outputs.
- Add regression coverage for raw PyTorch `log1p` with array-like inputs and `out=`.

## Bug fixed
`pyrecest._backend.pytorch.log1p` was still exposed as raw `torch.log1p`, unlike neighboring unary helpers such as `log`, `sqrt`, and `exp`. Direct raw-backend calls such as `pytorch_backend.log1p([0.0, 1.0, 3.0])` could therefore fail because Torch expects a tensor rather than a Python list. The wrapper keeps the raw backend and the public PyTorch facade aligned when PyTorch is selected.

## Testing
- Added `test_raw_pytorch_log1p_accepts_array_like_inputs_and_out` in `tests/backend_support/test_pytorch_linear_helpers_contract.py`.
- Not run locally in this connector session; CI should run the focused backend-portable regression.