### PR TITLE
Return bool from PyTorch matrix predicate

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -331,14 +331,16 @@ def is_single_matrix_pd(mat):
     if mat.ndim != 2 or mat.shape[0] != mat.shape[1]:
         return False
     if mat.dtype in [_torch.complex64, _torch.complex128]:
-        is_hermitian = _torch.all(
-            _torch.abs(mat - _torch.conj(_torch.transpose(mat, 0, 1))) < atol
+        is_hermitian = bool(
+            _torch.all(
+                _torch.abs(mat - _torch.conj(_torch.transpose(mat, 0, 1))) < atol
+            )
         )
         if not is_hermitian:
             return False
         eigvals = _torch.linalg.eigvalsh(mat)
-        return _torch.min(_torch.real(eigvals)) > 0
-    if not _torch.all(_torch.abs(mat - mat.transpose(-2, -1)) < atol):
+        return bool(_torch.min(_torch.real(eigvals)) > 0)
+    if not bool(_torch.all(_torch.abs(mat - mat.transpose(-2, -1)) < atol)):
         return False
     try:
         _torch.linalg.cholesky(mat)

--- a/tests/backend_support/test_pytorch_linalg_bool_contract.py
+++ b/tests/backend_support/test_pytorch_linalg_bool_contract.py
@@ -1,0 +1,28 @@
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_pytorch_complex_positive_definite_predicate_returns_python_bool():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import pyrecest.backend as backend
+
+matrix = backend.array(
+    [[2.0 + 0.0j, 0.0 + 0.0j], [0.0 + 0.0j, 3.0 + 0.0j]]
+)
+value = backend.linalg.is_single_matrix_pd(matrix)
+assert isinstance(value, bool), type(value)
+assert value is True
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- Normalize `pyrecest._backend.pytorch.linalg.is_single_matrix_pd` so its complex-input branch returns a plain Python `bool` instead of a scalar `torch.Tensor`.
- Keep the real-input branch on the same return contract.
- Add a PyTorch backend regression for the complex matrix case.

## Bug fixed
The PyTorch backend returned the result of a tensor comparison directly in one branch. That produced a zero-dimensional `torch.Tensor` rather than the plain boolean expected from this predicate-style helper.

## Testing
- Added `tests/backend_support/test_pytorch_linalg_bool_contract.py`.
- Full suite not run locally in this environment.