### PR TITLE
Fix public API registry CLI argument ordering

### DIFF
--- a/scripts/check_public_api_registry.py
+++ b/scripts/check_public_api_registry.py
@@ -4,33 +4,50 @@
 from __future__ import annotations
 
 import argparse
-import importlib
+import ast
 import sys
 from pathlib import Path
 from typing import Any
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
-SRC_PATH = REPOSITORY_ROOT / "src"
+API_REGISTRY_PATH = REPOSITORY_ROOT / "src" / "pyrecest" / "api_registry.py"
+CAPABILITIES_PATH = (
+    REPOSITORY_ROOT / "src" / "pyrecest" / "_backend" / "capabilities.py"
+)
 
 
-def _ensure_src_on_path() -> None:
-    src_path = str(SRC_PATH)
-    if src_path not in sys.path:
-        sys.path.insert(0, src_path)
+def _load_literal_constant(path: Path, name: str) -> Any:
+    module_ast = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in module_ast.body:
+        value = None
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == name:
+                    value = node.value
+                    break
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == name
+        ):
+            value = node.value
+
+        if value is not None:
+            return ast.literal_eval(value)
+
+    raise RuntimeError(f"{name} is not defined in {path}")
 
 
 def _load_registry() -> tuple[dict[str, dict[str, str]], tuple[str, ...]]:
-    _ensure_src_on_path()
-    module = importlib.import_module("pyrecest.api_registry")
-    registry: Any = getattr(module, "PUBLIC_API_REGISTRY")
-    categories: Any = getattr(module, "PUBLIC_API_CATEGORIES")
+    registry: Any = _load_literal_constant(API_REGISTRY_PATH, "PUBLIC_API_REGISTRY")
+    categories: Any = _load_literal_constant(API_REGISTRY_PATH, "PUBLIC_API_CATEGORIES")
     return dict(registry), tuple(categories)
 
 
 def _load_backend_capabilities() -> dict[str, dict[str, str]]:
-    _ensure_src_on_path()
-    module = importlib.import_module("pyrecest._backend.capabilities")
-    capabilities: Any = getattr(module, "API_BACKEND_CAPABILITIES")
+    capabilities: Any = _load_literal_constant(
+        CAPABILITIES_PATH, "API_BACKEND_CAPABILITIES"
+    )
     return dict(capabilities)
 
 

--- a/scripts/check_public_api_registry.py
+++ b/scripts/check_public_api_registry.py
@@ -4,38 +4,32 @@
 from __future__ import annotations
 
 import argparse
-import importlib.util
+import importlib
 import sys
 from pathlib import Path
-from types import ModuleType
 from typing import Any
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
-API_REGISTRY_PATH = REPOSITORY_ROOT / "src" / "pyrecest" / "api_registry.py"
-CAPABILITIES_PATH = (
-    REPOSITORY_ROOT / "src" / "pyrecest" / "_backend" / "capabilities.py"
-)
+SRC_PATH = REPOSITORY_ROOT / "src"
 
 
-def _load_module(path: Path, name: str) -> ModuleType:
-    spec = importlib.util.spec_from_file_location(name, path)
-    if spec is None or spec.loader is None:
-        raise RuntimeError(f"Cannot load {path}")
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[name] = module
-    spec.loader.exec_module(module)
-    return module
+def _ensure_src_on_path() -> None:
+    src_path = str(SRC_PATH)
+    if src_path not in sys.path:
+        sys.path.insert(0, src_path)
 
 
 def _load_registry() -> tuple[dict[str, dict[str, str]], tuple[str, ...]]:
-    module = _load_module(API_REGISTRY_PATH, "_pyrecest_api_registry_for_docs")
+    _ensure_src_on_path()
+    module = importlib.import_module("pyrecest.api_registry")
     registry: Any = getattr(module, "PUBLIC_API_REGISTRY")
     categories: Any = getattr(module, "PUBLIC_API_CATEGORIES")
     return dict(registry), tuple(categories)
 
 
 def _load_backend_capabilities() -> dict[str, dict[str, str]]:
-    module = _load_module(CAPABILITIES_PATH, "_pyrecest_capabilities_for_registry")
+    _ensure_src_on_path()
+    module = importlib.import_module("pyrecest._backend.capabilities")
     capabilities: Any = getattr(module, "API_BACKEND_CAPABILITIES")
     return dict(capabilities)
 
@@ -133,13 +127,14 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
     errors = validate_registry()
     if errors:
         for error in errors:
             print(f"::error::{error}")
         return 1
 
-    args = build_parser().parse_args(argv)
     if args.check:
         return check_document(args.check)
 

--- a/tests/test_public_api_registry_script.py
+++ b/tests/test_public_api_registry_script.py
@@ -1,3 +1,5 @@
+import pytest
+
 from scripts import check_public_api_registry as registry_script
 
 
@@ -29,3 +31,16 @@ def test_render_markdown_sanitizes_table_cell_separators(monkeypatch):
     assert f"pyrecest.module{replacement}part" in data_row
     assert f"Contract{replacement}Name" in data_row
     assert f"first {replacement} second<br>continued" in data_row
+
+
+def test_main_help_does_not_load_registry(monkeypatch, capsys):
+    def fail_validate_registry():
+        raise AssertionError("--help should not require registry validation")
+
+    monkeypatch.setattr(registry_script, "validate_registry", fail_validate_registry)
+
+    with pytest.raises(SystemExit) as exc_info:
+        registry_script.main(["--help"])
+
+    assert exc_info.value.code == 0
+    assert "--output" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- Parse `scripts/check_public_api_registry.py` arguments before loading or validating the registry, so `--help` and argparse errors are not blocked by registry/import state.
- Load the registry and backend-capability constants via AST literal parsing instead of importing package modules during the script check.
- Add a regression test that `--help` does not call `validate_registry()`.

## Bug fixed
The script previously called `validate_registry()` before `argparse` parsed the CLI. That made `--help` and invalid-argument handling depend on the registry files being importable and valid, which violates normal CLI behavior and can mask the actual CLI response.

## Validation
- Local minimal-fixture sanity check: `validate_registry()`, `render_markdown()`, and `main(["--help"])` behaved as expected.
- Full repository tests were not run locally because the connector environment does not provide a checkout with dependencies.