### PR TITLE
Fix raw PyTorch cumulative out contract

### DIFF
--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -460,6 +460,43 @@ def _patch_pytorch_linear_helpers_facade() -> None:
     backend.outer = pytorch_backend.outer = outer
 
 
+def _patch_raw_pytorch_cumulative_facade() -> None:
+    """Make raw PyTorch cumulative helpers accept NumPy's ``out`` argument."""
+
+    try:
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+        from pyrecest._backend_submodules import _copy_result_to_out  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - only relevant without PyTorch
+        return
+
+    def _wrap_cumulative(cumulative):
+        if getattr(cumulative, "_pyrecest_out_contract", False):
+            return cumulative
+
+        def wrapped_cumulative(x, axis=None, dtype=None, out=None):
+            result = cumulative(x, axis=axis, dtype=dtype)
+            if out is not None:
+                return _copy_result_to_out(result, out)
+            return result
+
+        wrapped_cumulative.__name__ = getattr(cumulative, "__name__", "cumulative")
+        wrapped_cumulative.__doc__ = getattr(cumulative, "__doc__", None)
+        wrapped_cumulative._pyrecest_out_contract = True
+        return wrapped_cumulative
+
+    import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+
+    selected_backend_is_pytorch = getattr(backend, "__backend_name__", None) == "pytorch"
+    for helper_name in ("cumsum", "cumprod"):
+        cumulative = getattr(pytorch_backend, helper_name, None)
+        if cumulative is None:
+            continue
+        wrapped_cumulative = _wrap_cumulative(cumulative)
+        setattr(pytorch_backend, helper_name, wrapped_cumulative)
+        if selected_backend_is_pytorch:
+            setattr(backend, helper_name, wrapped_cumulative)
+
+
 def _patch_raw_pytorch_trace_facade() -> None:
     """Make raw PyTorch ``trace`` follow NumPy's trace signature."""
 
@@ -596,6 +633,7 @@ _patch_pytorch_clip_facade()
 _patch_pytorch_tile_facade()
 _patch_pytorch_stack_helpers_facade()
 _patch_pytorch_linear_helpers_facade()
+_patch_raw_pytorch_cumulative_facade()
 _patch_raw_pytorch_trace_facade()
 _patch_jax_std_out_facade()
 _patch_jax_matmul_out_facade()

--- a/tests/backend_support/test_raw_pytorch_cumulative_contract.py
+++ b/tests/backend_support/test_raw_pytorch_cumulative_contract.py
@@ -1,0 +1,34 @@
+import importlib.util
+
+import pytest
+
+import pyrecest.backend as backend
+from pyrecest.backend_tools import get_backend_name
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_cumulative_out_contract_with_numpy_public_backend():
+    if get_backend_name() != "numpy":
+        pytest.skip("raw PyTorch/non-PyTorch public backend contract needs NumPy")
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    from pyrecest._backend import pytorch as pytorch_backend
+
+    values = pytorch_backend.reshape(pytorch_backend.arange(1, 7), (2, 3))
+    out_sum = pytorch_backend.zeros((2, 3), dtype=values.dtype)
+    out_prod = pytorch_backend.zeros((2, 3), dtype=values.dtype)
+
+    result_sum = pytorch_backend.cumsum(values, axis=1, out=out_sum)
+    result_prod = pytorch_backend.cumprod(values, axis=1, out=out_prod)
+
+    assert result_sum is out_sum
+    assert result_prod is out_prod
+    assert pytorch_backend.to_numpy(result_sum).tolist() == [[1, 3, 6], [4, 9, 15]]
+    assert pytorch_backend.to_numpy(result_prod).tolist() == [[1, 2, 6], [4, 20, 120]]
+
+    flat = pytorch_backend.cumsum(
+        values,
+        out=pytorch_backend.zeros((6,), dtype=values.dtype),
+    )
+    assert pytorch_backend.to_numpy(flat).tolist() == [1, 3, 6, 10, 15, 21]


### PR DESCRIPTION
## Summary
- Add an import-time adapter so raw `pyrecest._backend.pytorch.cumsum` and `cumprod` accept NumPy-style `out=`.
- Keep the active public PyTorch backend aligned when PyTorch is selected.
- Add regression coverage for direct raw PyTorch cumulative calls while the selected public backend is NumPy.

## Bug fixed
The public PyTorch backend had been adapted so `cumsum(..., out=...)` and `cumprod(..., out=...)` work, but direct raw PyTorch backend imports could still expose helpers without the `out` keyword when the selected public backend was NumPy. That made otherwise portable backend code fail with `TypeError` depending on import path and selected backend.

## Testing
- Not run locally in this connector session; added focused backend-portable regression coverage in `tests/backend_support/test_raw_pytorch_cumulative_contract.py`.