### PR TITLE
Honor wrapped normal PDF series order

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
@@ -29,6 +29,7 @@ from scipy.special import erf  # pylint: disable=no-name-in-module
 from ..hypertorus._input_validation import as_shift_vector
 from ..hypertorus.hypertoroidal_wrapped_normal_distribution import (
     HypertoroidalWrappedNormalDistribution,
+    _validate_series_order,
 )
 from .abstract_circular_distribution import AbstractCircularDistribution
 from .von_mises_distribution import VonMisesDistribution
@@ -80,7 +81,7 @@ class WrappedNormalDistribution(
 
     # pylint: disable=too-many-locals
     def pdf(self, xs, m: Union[int, int32, int64] = 3):
-        _ = m
+        m = _validate_series_order(m)
         sigma = self.sigma
         mu = self.scalar_mu
         if sigma <= 0:
@@ -94,7 +95,6 @@ class WrappedNormalDistribution(
         x = mod(xs, 2.0 * pi)
         x = where(x < 0, x + 2.0 * pi, x)
         x -= mu
-        max_iterations = 1000
         if pyrecest.backend.__backend_name__ != "jax":
             n_inputs = xs.shape[0]
             result = zeros(n_inputs)
@@ -105,7 +105,7 @@ class WrappedNormalDistribution(
             for i in range(n_inputs):
                 result[i] = squeeze(exp(x[i] * x[i] * tmp))
 
-                for k in range(1, max_iterations + 1):
+                for k in range(1, m + 1):
                     xp = x[i] + 2 * pi * k
                     xm = x[i] - 2 * pi * k
                     tp = xp * xp * tmp
@@ -141,7 +141,7 @@ class WrappedNormalDistribution(
                 # The accumulated density is positive and may keep changing by
                 # tiny floating-point amounts for a long time. Stop based on the
                 # latest wrapped contribution instead.
-                return logical_and(any(last_increment > 1e-10), i <= max_iterations)
+                return logical_and(any(last_increment > 1e-10), i <= m)
 
             initial_val = (
                 1,
@@ -290,5 +290,5 @@ class WrappedNormalDistribution(
 
     @staticmethod
     def sigma_to_kappa(sigma):
-        # Approximate conversion from sigma to kappa for a Von Mises distribution
+        # Approximate conversion from sigma to a Von Mises distribution
         return 1.0 / sigma**2

--- a/tests/distributions/test_wrapped_normal_distribution.py
+++ b/tests/distributions/test_wrapped_normal_distribution.py
@@ -52,6 +52,33 @@ class WrappedNormalDistributionTest(unittest.TestCase):
             )
         )
 
+    def test_pdf_honors_series_order(self):
+        wn = WrappedNormalDistribution(array(0.0), array(2.0))
+        x = array(2.0 * pi - 0.1)
+        norm_const = 1.0 / sqrt(2.0 * pi) / wn.sigma
+        central_term = norm_const * exp(-(x**2) / (2.0 * wn.sigma**2))
+        one_wrap_terms = norm_const * (
+            exp(-((x + 2.0 * pi) ** 2) / (2.0 * wn.sigma**2))
+            + exp(-((x - 2.0 * pi) ** 2) / (2.0 * wn.sigma**2))
+        )
+
+        self.assertTrue(allclose(wn.pdf(x, m=0), central_term, atol=1e-12, rtol=1e-10))
+        self.assertTrue(
+            allclose(
+                wn.pdf(x, m=1),
+                central_term + one_wrap_terms,
+                atol=1e-12,
+                rtol=1e-10,
+            )
+        )
+        self.assertFalse(allclose(wn.pdf(x, m=0), wn.pdf(x, m=1), rtol=1e-5))
+
+    def test_pdf_rejects_invalid_series_order(self):
+        for m in (-1, 1.5, True):
+            with self.subTest(m=m):
+                with self.assertRaisesRegex(ValueError, "non-negative integer"):
+                    self.wn.pdf(self.mu, m=m)
+
     def test_constructor_rejects_invalid_mu(self):
         for mu in (float("nan"), float("inf"), -float("inf")):
             with self.subTest(mu=mu):


### PR DESCRIPTION
## Summary
- Make `WrappedNormalDistribution.pdf(..., m=...)` validate and honor the requested wrapped-series order instead of ignoring it.
- Reuse the hypertoroidal wrapped-normal series-order validator for consistent `m` handling.
- Add regressions checking `m=0`, `m=1`, and invalid `m` values.

## Validation
- Syntax-compiled the modified implementation and test file locally with `python -m py_compile`.

## Bug fixed
The circular wrapped-normal `pdf` accepted an `m` argument but discarded it and summed until an internal hard-coded limit/convergence check. This made `m=0`, `m=1`, etc. indistinguishable for users and inconsistent with the hypertoroidal wrapped-normal implementation.