### PR TITLE
Accept array-like inputs in sine PDFs

### DIFF
--- a/src/pyrecest/distributions/circle/sine_skewed_distributions.py
+++ b/src/pyrecest/distributions/circle/sine_skewed_distributions.py
@@ -53,6 +53,7 @@ class GeneralizedKSineSkewedVonMisesDistribution(AbstractCircularDistribution):
         self.m = _validate_sine_power(self.m, "m")
 
     def pdf(self, xs):
+        xs = array(xs)
         # Evaluate the von Mises distribution and multiply by (1 + lambda_ * sin(xa - mu))
         if self.k != 1:
             raise NotImplementedError("Currently, only k=1 is supported")
@@ -170,6 +171,8 @@ class AbstractSineSkewedDistribution(AbstractCircularDistribution):
         """
         Compute the skewed probability density function (PDF) for the distribution.
         """
+        xs = array(xs)
+
         # Calculate the base pdf from the wrapped distribution
         base_pdf = self.base_pdf(xs)
 
@@ -237,6 +240,7 @@ class GeneralizedKSineSkewedWrappedCauchyDistribution(AbstractCircularDistributi
         self.m = _validate_sine_power(self.m, "m")
 
     def pdf(self, xs):
+        xs = array(xs)
         if self.k != 1:
             raise NotImplementedError("Currently, only k=1 is supported")
         # Use the WC pdf formula directly to ensure correct centering at mu

--- a/tests/distributions/test_sine_skewed_arraylike_pdf.py
+++ b/tests/distributions/test_sine_skewed_arraylike_pdf.py
@@ -1,0 +1,40 @@
+import numpy as np
+import pyrecest.backend
+from pyrecest.backend import pi
+from pyrecest.distributions.circle.sine_skewed_distributions import (
+    GeneralizedKSineSkewedVonMisesDistribution,
+    GeneralizedKSineSkewedWrappedCauchyDistribution,
+    SineSkewedWrappedNormalDistribution,
+)
+
+
+def _to_numpy(values):
+    return np.asarray(pyrecest.backend.to_numpy(values))
+
+
+def _assert_pdf_pair(values):
+    values = _to_numpy(values)
+    assert values.shape == (2,)
+    assert np.all(values >= 0.0)
+
+
+def test_generalized_k_sine_skewed_von_mises_pdf_accepts_list_input():
+    dist = GeneralizedKSineSkewedVonMisesDistribution(
+        mu=pi, kappa=1.0, lambda_=0.5, k=1, m=1
+    )
+
+    _assert_pdf_pair(dist.pdf([0.0, float(pi / 2)]))
+
+
+def test_sine_skewed_wrapped_normal_pdf_accepts_list_input():
+    dist = SineSkewedWrappedNormalDistribution(mu=0.0, sigma=1.0, lambda_=0.5)
+
+    _assert_pdf_pair(dist.pdf([0.0, float(pi / 2)]))
+
+
+def test_generalized_k_sine_skewed_wrapped_cauchy_pdf_accepts_list_input():
+    dist = GeneralizedKSineSkewedWrappedCauchyDistribution(
+        mu=pi, gamma=0.5, lambda_=0.5, k=1, m=1
+    )
+
+    _assert_pdf_pair(dist.pdf([0.0, float(pi / 2)]))


### PR DESCRIPTION
Summary:
- Convert xs with the active backend array helper before sine factor arithmetic.
- Cover generalized von Mises, shared wrapped normal/Cauchy path, and generalized wrapped Cauchy.
- Add focused regression tests for Python list inputs.

Tests: added regression tests; not run locally here because the container cannot access GitHub.