### PR TITLE
Fix PyTorch extrema out contract

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_minmax_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_minmax_device_contract.py
@@ -34,6 +34,16 @@ def _binary_operands(raw_pytorch, torch_module, left, right):
 _minmax_operands = _binary_operands
 
 
+def _copy_to_out(result, out):
+    """Store ``result`` in ``out`` and return the output buffer."""
+    copy_ = getattr(out, "copy_", None)
+    if copy_ is not None:
+        copy_(result)
+        return out
+    out[...] = result
+    return out
+
+
 def _raw_pytorch_module():
     """Return the raw PyTorch backend module, importing it when available."""
     try:
@@ -42,7 +52,15 @@ def _raw_pytorch_module():
         return None
 
 
-def _patch_binary_helpers(raw_pytorch, backend, torch_module, helpers, contract_attr):
+def _patch_binary_helpers(
+    raw_pytorch,
+    backend,
+    torch_module,
+    helpers,
+    contract_attr,
+    *,
+    supports_out=False,
+):
     """Patch raw/public binary helpers to share dtype and preserve device."""
     if all(
         getattr(
@@ -60,9 +78,20 @@ def _patch_binary_helpers(raw_pytorch, backend, torch_module, helpers, contract_
     for helper_name, torch_helper in helpers.items():
         original_helper = getattr(raw_pytorch, helper_name)
 
-        def binary_helper(left, right, _torch_helper=torch_helper):
-            left, right = _binary_operands(raw_pytorch, torch_module, left, right)
-            return _torch_helper(left, right)
+        if supports_out:
+
+            def binary_helper(left, right, out=None, _torch_helper=torch_helper):
+                left, right = _binary_operands(raw_pytorch, torch_module, left, right)
+                result = _torch_helper(left, right)
+                if out is None:
+                    return result
+                return _copy_to_out(result, out)
+
+        else:
+
+            def binary_helper(left, right, _torch_helper=torch_helper):
+                left, right = _binary_operands(raw_pytorch, torch_module, left, right)
+                return _torch_helper(left, right)
 
         binary_helper.__name__ = getattr(original_helper, "__name__", helper_name)
         binary_helper.__doc__ = getattr(original_helper, "__doc__", None)
@@ -94,6 +123,7 @@ def patch_pytorch_minmax_device_contract() -> None:
             "minimum": torch.minimum,
         },
         "_pyrecest_minmax_device_contract",
+        supports_out=True,
     )
     _patch_binary_helpers(
         raw_pytorch,

--- a/tests/backend_support/test_pytorch_extrema_out_contract.py
+++ b/tests/backend_support/test_pytorch_extrema_out_contract.py
@@ -1,0 +1,41 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_pytorch_maximum_minimum_accept_out_keyword():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import pyrecest.backend as backend
+from pyrecest._backend import pytorch as pytorch_backend
+
+left = backend.array([1.0, 4.0])
+right = backend.array([2.0, 3.0])
+
+for func, expected in (
+    (backend.maximum, [2.0, 4.0]),
+    (pytorch_backend.maximum, [2.0, 4.0]),
+    (backend.minimum, [1.0, 3.0]),
+    (pytorch_backend.minimum, [1.0, 3.0]),
+):
+    out = backend.empty_like(left)
+    returned = func(left, right, out=out)
+    assert returned is out
+    assert backend.to_numpy(out).tolist() == expected
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- Add an import-time PyTorch adapter so `maximum` and `minimum` accept NumPy-style `out=`.
- Keep both the public `pyrecest.backend` functions and raw `pyrecest._backend.pytorch` helpers aligned when PyTorch is selected.
- Add a focused subprocess regression covering `backend.maximum`, `backend.minimum`, `pytorch_backend.maximum`, and `pytorch_backend.minimum` with `out=`.

## Bug fixed
The NumPy backend exposes `maximum`/`minimum` as NumPy ufuncs, which accept `out=`. The PyTorch backend helpers only accepted two positional operands, so code using the backend abstraction with an output buffer failed with `TypeError` under `PYRECEST_BACKEND=pytorch` even though the same call is valid for NumPy.

## Testing
- Not run locally in this connector session.
- Added `tests/backend_support/test_pytorch_extrema_out_contract.py` as regression coverage.