### PR TITLE
Restore raw PyTorch repeat default-backend contract

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
@@ -1,15 +1,111 @@
-"""PyTorch dtype promotion compatibility helpers."""
+"""PyTorch backend compatibility helpers."""
 
 from __future__ import annotations
 
+from operator import index as _operator_index
+
+
+def _pytorch_repeat_count(repetition) -> int:
+    """Return one NumPy-style repeat count as a non-negative integer."""
+    try:
+        count = _operator_index(repetition)
+    except TypeError as exc:
+        raise TypeError("repeat counts must be integers") from exc
+    if count < 0:
+        raise ValueError("repeats may not contain negative values")
+    return count
+
+
+def _pytorch_repeat_counts(repeats, *, numpy_module, torch_module, device):
+    """Normalize NumPy-style repeat counts for ``torch.repeat_interleave``."""
+    if torch_module.is_tensor(repeats):
+        if repeats.ndim > 1:
+            raise ValueError("object too deep for desired array")
+        if repeats.dtype.is_floating_point or repeats.dtype.is_complex:
+            raise TypeError("repeat counts must be integers")
+        repeat_counts = repeats.to(device=device, dtype=torch_module.long)
+        if bool(torch_module.any(repeat_counts < 0)):
+            raise ValueError("repeats may not contain negative values")
+        return repeat_counts
+
+    repeats_array = numpy_module.asarray(repeats)
+    if repeats_array.shape == ():
+        return _pytorch_repeat_count(repeats_array.item())
+    if repeats_array.ndim > 1:
+        raise ValueError("object too deep for desired array")
+    if not numpy_module.can_cast(
+        repeats_array.dtype,
+        numpy_module.dtype("intp"),
+        casting="safe",
+    ):
+        raise TypeError("repeat counts must be integers")
+    repeat_counts = torch_module.as_tensor(
+        repeats_array,
+        dtype=torch_module.long,
+        device=device,
+    )
+    if bool(torch_module.any(repeat_counts < 0)):
+        raise ValueError("repeats may not contain negative values")
+    return repeat_counts
+
+
+def _patch_raw_pytorch_repeat_contract(raw_pytorch, torch_module) -> None:
+    """Make raw PyTorch repeat follow PyRecEst's NumPy-style contract."""
+    try:
+        import numpy as numpy_module  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - NumPy is a core dependency
+        return
+
+    original_repeat = getattr(raw_pytorch, "repeat", None)
+    if original_repeat is None or getattr(
+        original_repeat,
+        "_pyrecest_repeat_contract",
+        False,
+    ):
+        return
+
+    def repeat(a, repeats, axis=None, *, dim=None, output_size=None):
+        if dim is not None:
+            if axis is not None and axis != dim:
+                raise TypeError("repeat() got both 'axis' and 'dim'")
+            axis = dim
+        if axis is not None:
+            axis = _operator_index(axis)
+
+        values = raw_pytorch.array(a)
+        repeat_counts = _pytorch_repeat_counts(
+            repeats,
+            numpy_module=numpy_module,
+            torch_module=torch_module,
+            device=values.device,
+        )
+        kwargs = {"dim": axis}
+        if output_size is not None:
+            kwargs["output_size"] = output_size
+        return original_repeat(values, repeat_counts, **kwargs)
+
+    repeat.__name__ = getattr(original_repeat, "__name__", "repeat")
+    repeat.__doc__ = getattr(original_repeat, "__doc__", None)
+    repeat._pyrecest_repeat_contract = True
+    raw_pytorch.repeat = repeat
+
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before backend exists
+        return
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.repeat = repeat
+
 
 def patch_pytorch_dtype_promotion_contract() -> None:
-    """Make PyTorch mixed-dtype helpers use Torch's promotion rules."""
+    """Make PyTorch backend helpers follow PyRecEst compatibility contracts."""
     try:
         import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
         import torch  # pylint: disable=import-outside-toplevel
     except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
         return
+
+    _patch_raw_pytorch_repeat_contract(raw_pytorch, torch)
 
     original_convert = raw_pytorch.convert_to_wider_dtype
     if getattr(original_convert, "_pyrecest_torch_promotion_contract", False):

--- a/tests/backend_support/test_raw_pytorch_repeat_default_backend.py
+++ b/tests/backend_support/test_raw_pytorch_repeat_default_backend.py
@@ -1,0 +1,64 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_repeat_accepts_array_like_with_numpy_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "numpy"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import pyrecest  # noqa: F401
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as pytorch_backend
+
+assert backend.__backend_name__ == "numpy"
+
+flat_result = pytorch_backend.repeat([1, 2], 2)
+assert pytorch_backend.to_numpy(flat_result).tolist() == [1, 1, 2, 2]
+
+axis_result = pytorch_backend.repeat([[1, 2], [3, 4]], [1, 2], axis=0)
+assert pytorch_backend.to_numpy(axis_result).tolist() == [[1, 2], [3, 4], [3, 4]]
+
+dim_result = pytorch_backend.repeat([[1, 2], [3, 4]], pytorch_backend.array([2, 1]), dim=1)
+assert pytorch_backend.to_numpy(dim_result).tolist() == [[1, 1, 2], [3, 3, 4]]
+
+public_result = backend.repeat([1, 2], 2)
+assert public_result.tolist() == [1, 1, 2, 2]
+assert type(public_result).__module__.startswith("numpy")
+
+try:
+    pytorch_backend.repeat([1, 2], 2, axis=0, dim=1)
+except TypeError:
+    pass
+else:
+    raise AssertionError("raw repeat accepted conflicting axis and dim arguments")
+
+try:
+    pytorch_backend.repeat([1, 2], [[1, 0]])
+except ValueError:
+    pass
+else:
+    raise AssertionError("raw repeat accepted nested repeat counts")
+
+try:
+    pytorch_backend.repeat([1, 2], [1.5, 1])
+except TypeError:
+    pass
+else:
+    raise AssertionError("raw repeat accepted non-integer repeat counts")
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- patch raw `pyrecest._backend.pytorch.repeat` from the backend-support compatibility path
- keep NumPy-style array-like inputs, repeat counts, and `axis`/`dim` handling available even when the public backend is NumPy
- add a subprocess regression for direct raw PyTorch `repeat` under `PYRECEST_BACKEND=numpy`

## Bug fixed
`pyrecest._backend.pytorch.repeat` was only adapted by the backend-submodule compatibility layer when the active public backend was PyTorch. Under the default/NumPy public backend, direct raw PyTorch backend users could still reach bare `torch.repeat_interleave`, which rejects list inputs / NumPy-style repeat counts and does not accept PyRecEst's `axis=` alias.

## Testing
- Not run locally in this connector session; added `tests/backend_support/test_raw_pytorch_repeat_default_backend.py` for the failing import/backend combination.