### PR TITLE
Fix raw JAX matmul out contract

### DIFF
--- a/src/pyrecest/backend_support/__init__.py
+++ b/src/pyrecest/backend_support/__init__.py
@@ -73,7 +73,6 @@ def _patch_pytorch_dot_numpy_contract() -> None:
         import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
     except ModuleNotFoundError:  # pragma: no cover - import fails before this module
         return
-
     active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
 
     try:
@@ -83,7 +82,6 @@ def _patch_pytorch_dot_numpy_contract() -> None:
         ModuleNotFoundError
     ):  # pragma: no cover - PyTorch backend import failed earlier
         return
-
     original_dot = raw_pytorch.dot
     if getattr(original_dot, "_pyrecest_numpy_contract", False):
         return
@@ -119,7 +117,6 @@ def _patch_pytorch_outer_numpy_contract() -> None:
         import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
     except ModuleNotFoundError:  # pragma: no cover - import fails before this module
         return
-
     active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
 
     try:
@@ -129,7 +126,6 @@ def _patch_pytorch_outer_numpy_contract() -> None:
         ModuleNotFoundError
     ):  # pragma: no cover - PyTorch backend import failed earlier
         return
-
     original_outer = raw_pytorch.outer
     if getattr(original_outer, "_pyrecest_numpy_contract", False):
         return
@@ -196,7 +192,6 @@ def _patch_pytorch_tile_numpy_contract() -> None:
         ModuleNotFoundError
     ):  # pragma: no cover - PyTorch backend import failed earlier
         return
-
     original_tile = raw_pytorch.tile
     if getattr(original_tile, "_pyrecest_numpy_contract", False):
         return
@@ -346,6 +341,38 @@ def _patch_jax_outer_numpy_contract() -> None:
         backend.outer = outer
 
 
+def _patch_jax_matmul_out_contract() -> None:
+    """Make JAX matmul honor the direct-backend ``out`` contract."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+
+    active_jax_backend = getattr(backend, "__backend_name__", None) == "jax"
+
+    try:
+        import pyrecest._backend.jax as raw_jax  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - JAX backend import failed earlier
+        return
+
+    original_matmul = raw_jax.matmul
+    if getattr(original_matmul, "_pyrecest_out_contract", False):
+        return
+
+    def matmul(x, y, out=None):
+        result = original_matmul(x, y)
+        if out is None:
+            return result
+        return raw_jax.asarray(out).at[...].set(result)
+
+    matmul.__name__ = getattr(original_matmul, "__name__", "matmul")
+    matmul.__doc__ = getattr(original_matmul, "__doc__", None)
+    matmul._pyrecest_out_contract = True
+    raw_jax.matmul = matmul
+    if active_jax_backend:
+        backend.matmul = matmul
+
+
 _patch_raw_pytorch_assignment_scalar_tensor_indices()
 _patch_pytorch_dtype_promotion_contract()
 _patch_pytorch_dot_numpy_contract()
@@ -354,6 +381,7 @@ _patch_pytorch_tile_numpy_contract()
 _patch_pytorch_copy_numpy_contract()
 _patch_pytorch_clip_numpy_contract()
 _patch_jax_outer_numpy_contract()
+_patch_jax_matmul_out_contract()
 
 
 def get_backend_support(

--- a/tests/backend/test_jax_matmul_out_contract.py
+++ b/tests/backend/test_jax_matmul_out_contract.py
@@ -1,0 +1,29 @@
+import numpy as np
+import pytest
+
+jnp = pytest.importorskip("jax.numpy")
+from pyrecest._backend import jax as jax_backend  # noqa: E402
+
+
+def _to_numpy(value):
+    return np.asarray(jax_backend.to_numpy(value))
+
+
+def test_direct_jax_matmul_out_controls_return_dtype():
+    left = jnp.array([[1, 2], [3, 4]], dtype=jnp.int32)
+    right = jnp.array([[5, 6], [7, 8]], dtype=jnp.int32)
+    out = jnp.zeros((2, 2), dtype=jnp.float32)
+
+    result = jax_backend.matmul(left, right, out=out)
+
+    assert _to_numpy(result).dtype == np.float32
+    assert _to_numpy(result).tolist() == [[19.0, 22.0], [43.0, 50.0]]
+
+
+def test_direct_jax_matmul_out_validates_shape():
+    left = jnp.array([[1, 2], [3, 4]], dtype=jnp.int32)
+    right = jnp.array([[5, 6], [7, 8]], dtype=jnp.int32)
+    out = jnp.zeros((3, 3), dtype=jnp.float32)
+
+    with pytest.raises(ValueError, match="Incompatible shapes|broadcast"):
+        jax_backend.matmul(left, right, out=out)


### PR DESCRIPTION
## Summary
- patch the raw JAX backend `matmul` wrapper so `out` is honored even when JAX is not the selected public backend
- keep the selected public JAX facade in sync when it is active
- add direct-backend regression coverage for `out` dtype/shape behavior

## Bug fixed
The current JAX backend implementation computes `result = jnp.matmul(x, y)` and returns `result` even when `out` is supplied. That means invalid `out` shapes can be silently ignored instead of following the backend contract used by the existing `trace`, `argmax`, and `argmin` wrappers, which write through `.at[...].set(...)` and raise on incompatible shapes.

## Validation
- Verified locally in an isolated JAX snippet that `out.at[...].set(result)` returns the expected values and raises `ValueError` for incompatible shapes.
- Existing focused regression coverage is included in this PR.