### PR TITLE
Fix PyTorch diff backend contract

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from operator import index as _operator_index
+
 
 def patch_pytorch_dtype_promotion_contract() -> None:
     """Make PyTorch mixed-dtype helpers use Torch's promotion rules."""
@@ -10,6 +12,8 @@ def patch_pytorch_dtype_promotion_contract() -> None:
         import torch  # pylint: disable=import-outside-toplevel
     except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
         return
+
+    _patch_pytorch_diff_numpy_contract(raw_pytorch, torch)
 
     original_convert = raw_pytorch.convert_to_wider_dtype
     if getattr(original_convert, "_pyrecest_torch_promotion_contract", False):
@@ -34,3 +38,63 @@ def patch_pytorch_dtype_promotion_contract() -> None:
     convert_to_wider_dtype.__doc__ = getattr(original_convert, "__doc__", None)
     convert_to_wider_dtype._pyrecest_torch_promotion_contract = True
     raw_pytorch.convert_to_wider_dtype = convert_to_wider_dtype
+
+
+def _patch_pytorch_diff_numpy_contract(raw_pytorch, torch) -> None:
+    """Make raw/public PyTorch diff follow the PyRecEst NumPy-style contract."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        backend = None
+
+    original_diff = raw_pytorch.diff
+    if getattr(original_diff, "_pyrecest_numpy_contract", False):
+        return
+    no_boundary = object()
+
+    def _normalize_axis(axis, ndim):
+        axis = _operator_index(axis)
+        if axis < 0:
+            axis += ndim
+        if axis < 0 or axis >= ndim:
+            raise IndexError(f"axis {axis} is out of bounds for array of dimension {ndim}")
+        return axis
+
+    def _boundary(value, reference, axis):
+        boundary = raw_pytorch.array(value)
+        if boundary.device != reference.device:
+            boundary = boundary.to(device=reference.device)
+        if boundary.ndim == 0:
+            boundary_shape = list(reference.shape)
+            boundary_shape[axis] = 1
+            boundary = torch.broadcast_to(boundary, tuple(boundary_shape))
+        return boundary
+
+    def diff(a, n=1, axis=-1, prepend=no_boundary, append=no_boundary):
+        values = raw_pytorch.array(a)
+        order = _operator_index(n)
+        if order < 0:
+            raise ValueError(f"order must be non-negative but got {order}")
+        if order == 0:
+            return values.clone()
+        if values.ndim == 0:
+            raise ValueError("diff requires input that is at least one dimensional")
+
+        axis = _normalize_axis(axis, values.ndim)
+        diff_inputs = []
+        if prepend is not no_boundary:
+            diff_inputs.append(_boundary(prepend, values, axis))
+        diff_inputs.append(values)
+        if append is not no_boundary:
+            diff_inputs.append(_boundary(append, values, axis))
+        if len(diff_inputs) > 1:
+            diff_inputs = raw_pytorch.convert_to_wider_dtype(diff_inputs)
+            values = torch.cat(diff_inputs, dim=axis)
+        return torch.diff(values, n=order, dim=axis)
+
+    diff.__name__ = getattr(original_diff, "__name__", "diff")
+    diff.__doc__ = getattr(original_diff, "__doc__", None)
+    diff._pyrecest_numpy_contract = True
+    raw_pytorch.diff = diff
+    if backend is not None and getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.diff = diff

--- a/tests/backend_support/test_pytorch_diff_contract.py
+++ b/tests/backend_support/test_pytorch_diff_contract.py
@@ -1,0 +1,87 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+SCRIPT = """
+import pyrecest  # noqa: F401  # triggers raw-backend compatibility patches
+import torch
+import pyrecest._backend.pytorch as raw_pytorch_backend
+
+values = [[1.0, 3.0, 6.0], [0.0, 5.0, 9.0]]
+
+axis_result = raw_pytorch_backend.diff(values, axis=0)
+axis_expected = torch.tensor([[-1.0, 2.0, 3.0]])
+assert torch.allclose(axis_result, axis_expected)
+
+prepend_result = raw_pytorch_backend.diff(values, axis=1, prepend=0.0)
+prepend_expected = torch.tensor([[1.0, 2.0, 3.0], [0.0, 5.0, 4.0]])
+assert torch.allclose(prepend_result, prepend_expected)
+
+append_result = raw_pytorch_backend.diff(values, axis=-1, append=[[10.0], [12.0]])
+append_expected = torch.tensor([[2.0, 3.0, 4.0], [5.0, 4.0, 3.0]])
+assert torch.allclose(append_result, append_expected)
+
+zero_order = raw_pytorch_backend.diff(5.0, n=0)
+assert tuple(zero_order.shape) == ()
+assert float(zero_order) == 5.0
+
+try:
+    raw_pytorch_backend.diff(5.0)
+except ValueError as exc:
+    assert "at least one dimensional" in str(exc)
+else:  # pragma: no cover - exercised in subprocess
+    raise AssertionError("scalar diff with n > 0 should fail")
+
+print("ok")
+"""
+
+
+def test_raw_pytorch_diff_accepts_numpy_style_contract_after_import():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    env = os.environ.copy()
+    env.pop("PYRECEST_BACKEND", None)
+    completed = subprocess.run(
+        [sys.executable, "-c", SCRIPT],
+        capture_output=True,
+        env=env,
+        text=True,
+        timeout=30.0,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "ok" in completed.stdout
+
+
+def test_public_pytorch_diff_accepts_numpy_style_contract():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            """
+import pyrecest.backend as backend
+
+result = backend.diff([[1.0, 3.0, 6.0], [0.0, 5.0, 9.0]], axis=1, prepend=0.0)
+expected = backend.array([[1.0, 2.0, 3.0], [0.0, 5.0, 4.0]])
+assert backend.allclose(result, expected)
+print("ok")
+""",
+        ],
+        capture_output=True,
+        env=env,
+        text=True,
+        timeout=30.0,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "ok" in completed.stdout


### PR DESCRIPTION
## Summary
- Add a PyTorch backend-support wrapper for `diff` so array-like inputs work consistently.
- Cover scalar `prepend` and `append`, negative axes, `n=0`, and selected public PyTorch backend parity.
- Add focused regression tests.

## Testing
- `python -m py_compile` on the changed helper and new test file.