### PR TITLE
Use backend support error for PyTorch Rotation stub

### DIFF
--- a/src/pyrecest/_backend/pytorch/spatial.py
+++ b/src/pyrecest/_backend/pytorch/spatial.py
@@ -1,7 +1,14 @@
-def _unsupported_rotation_error(operation: str) -> RuntimeError:
-    return RuntimeError(
-        f"{operation} is not supported on the PyTorch backend. "
-        "Use a NumPy/JAX backend for this functionality."
+from pyrecest.exceptions import BackendNotSupportedError
+
+_SUPPORTED_ROTATION_BACKENDS = ("numpy", "jax")
+
+
+def _unsupported_rotation_error(operation: str) -> BackendNotSupportedError:
+    return BackendNotSupportedError(
+        operation,
+        "pytorch",
+        supported_backends=_SUPPORTED_ROTATION_BACKENDS,
+        reason="Use a NumPy/JAX backend for this functionality.",
     )
 
 

--- a/tests/backend_support/test_pytorch_rotation_stub_contract.py
+++ b/tests/backend_support/test_pytorch_rotation_stub_contract.py
@@ -6,6 +6,8 @@ import importlib.util
 
 import pytest
 
+from pyrecest.exceptions import BackendNotSupportedError
+
 
 @pytest.mark.backend_portable
 def test_pytorch_rotation_stub_exposes_matrix_methods_with_backend_error():
@@ -14,9 +16,15 @@ def test_pytorch_rotation_stub_exposes_matrix_methods_with_backend_error():
 
     from pyrecest._backend.pytorch.spatial import Rotation
 
-    with pytest.raises(RuntimeError, match="Rotation.from_matrix is not supported"):
+    with pytest.raises(
+        BackendNotSupportedError,
+        match="Rotation.from_matrix is unavailable for backend 'pytorch'",
+    ):
         Rotation.from_matrix([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
 
     rotation = object.__new__(Rotation)
-    with pytest.raises(RuntimeError, match="Rotation.as_matrix is not supported"):
+    with pytest.raises(
+        BackendNotSupportedError,
+        match="Rotation.as_matrix is unavailable for backend 'pytorch'",
+    ):
         rotation.as_matrix()

--- a/tests/backend_support/test_pytorch_rotation_stub_methods.py
+++ b/tests/backend_support/test_pytorch_rotation_stub_methods.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 import pytest
 
+from pyrecest.exceptions import BackendNotSupportedError
+
 
 def _rotation_stub_class():
     module_path = (
@@ -29,11 +31,23 @@ def _rotation_stub_class():
 def test_pytorch_rotation_stub_exposes_vector_methods_with_backend_errors():
     rotation_class = _rotation_stub_class()
 
-    with pytest.raises(RuntimeError, match="Rotation.from_rotvec is not supported"):
+    with pytest.raises(
+        BackendNotSupportedError,
+        match="Rotation.from_rotvec is unavailable for backend 'pytorch'",
+    ):
         rotation_class.from_rotvec([0.0, 0.0, 0.0])
-    with pytest.raises(RuntimeError, match="Rotation.from_euler is not supported"):
+    with pytest.raises(
+        BackendNotSupportedError,
+        match="Rotation.from_euler is unavailable for backend 'pytorch'",
+    ):
         rotation_class.from_euler("xyz", [0.0, 0.0, 0.0])
-    with pytest.raises(RuntimeError, match="Rotation.as_rotvec is not supported"):
+    with pytest.raises(
+        BackendNotSupportedError,
+        match="Rotation.as_rotvec is unavailable for backend 'pytorch'",
+    ):
         rotation_class.as_rotvec(None)
-    with pytest.raises(RuntimeError, match="Rotation.as_euler is not supported"):
+    with pytest.raises(
+        BackendNotSupportedError,
+        match="Rotation.as_euler is unavailable for backend 'pytorch'",
+    ):
         rotation_class.as_euler(None, "xyz")


### PR DESCRIPTION
## Summary
- Change the unsupported PyTorch `Rotation` stub to raise `BackendNotSupportedError` instead of a generic `RuntimeError`.
- Preserve the existing message guidance that NumPy/JAX backends should be used for Rotation functionality.
- Update focused Rotation-stub regressions to assert the PyRecEst-specific backend-support exception type.

## Bug fixed
The PyTorch backend already exposes `Rotation` as an unsupported API stub, but its failures used a generic `RuntimeError`. That made the failure harder to distinguish from actual runtime failures and bypassed PyRecEst's dedicated `BackendNotSupportedError`/`NotImplementedError` hierarchy for backend capability gaps.

## Validation
- Inspected the branch diff against `main`; only the Rotation stub and two focused tests are changed.
- Full test suite not run locally in this connector-only environment; GitHub Actions should validate the PR.