### PR TITLE
Fix PyTorch stack helper backend contract

### DIFF
--- a/src/pyrecest/backend_tools.py
+++ b/src/pyrecest/backend_tools.py
@@ -104,8 +104,7 @@ def _patch_pytorch_broadcast_arrays_numpy_contract() -> None:
     except ModuleNotFoundError:  # pragma: no cover - import fails before this module
         return
 
-    if getattr(backend, "__backend_name__", None) != "pytorch":
-        return
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
 
     try:
         import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
@@ -116,6 +115,8 @@ def _patch_pytorch_broadcast_arrays_numpy_contract() -> None:
         return
 
     if getattr(pytorch_backend.broadcast_arrays, "_pyrecest_numpy_contract", False):
+        if active_pytorch_backend:
+            backend.broadcast_arrays = pytorch_backend.broadcast_arrays
         return
 
     def broadcast_arrays(*arrays):
@@ -125,8 +126,9 @@ def _patch_pytorch_broadcast_arrays_numpy_contract() -> None:
     broadcast_arrays.__name__ = "broadcast_arrays"
     broadcast_arrays.__doc__ = getattr(_torch.broadcast_tensors, "__doc__", None)
     broadcast_arrays._pyrecest_numpy_contract = True
-    backend.broadcast_arrays = broadcast_arrays
     pytorch_backend.broadcast_arrays = broadcast_arrays
+    if active_pytorch_backend:
+        backend.broadcast_arrays = broadcast_arrays
 
 
 def _patch_pytorch_round_numpy_contract() -> None:
@@ -230,8 +232,7 @@ def _patch_pytorch_stack_helpers_numpy_contract() -> None:
     except ModuleNotFoundError:  # pragma: no cover - import fails before this module
         return
 
-    if getattr(backend, "__backend_name__", None) != "pytorch":
-        return
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
 
     try:
         import numpy as _np  # pylint: disable=import-outside-toplevel
@@ -240,6 +241,12 @@ def _patch_pytorch_stack_helpers_numpy_contract() -> None:
     except (
         ModuleNotFoundError
     ):  # pragma: no cover - PyTorch backend import failed earlier
+        return
+
+    if getattr(pytorch_backend.hstack, "_pyrecest_numpy_contract", False):
+        if active_pytorch_backend:
+            for helper_name in ("hstack", "vstack", "column_stack", "dstack"):
+                setattr(backend, helper_name, getattr(pytorch_backend, helper_name))
         return
 
     def _tensor_sequence(tup):
@@ -276,8 +283,9 @@ def _patch_pytorch_stack_helpers_numpy_contract() -> None:
         helper.__name__ = helper_name
         helper.__doc__ = getattr(_np, helper_name).__doc__
         helper._pyrecest_numpy_contract = True
-        setattr(backend, helper_name, helper)
         setattr(pytorch_backend, helper_name, helper)
+        if active_pytorch_backend:
+            setattr(backend, helper_name, helper)
 
 
 def _patch_raw_pytorch_comparison_numpy_contract() -> None:

--- a/tests/backend_support/test_pytorch_stack_helpers_contract.py
+++ b/tests/backend_support/test_pytorch_stack_helpers_contract.py
@@ -6,19 +6,22 @@ import sys
 import pytest
 
 
-@pytest.mark.backend_portable
-def test_pytorch_stack_helpers_accept_array_like_sequences():
-    if importlib.util.find_spec("torch") is None:
-        pytest.skip("torch is not installed")
-
+def _backend_test_env(backend_name):
     env = os.environ.copy()
-    env["PYRECEST_BACKEND"] = "pytorch"
+    env["PYRECEST_BACKEND"] = backend_name
     src_path = os.path.abspath("src")
     env["PYTHONPATH"] = (
         src_path
         if not env.get("PYTHONPATH")
         else os.pathsep.join([src_path, env["PYTHONPATH"]])
     )
+    return env
+
+
+@pytest.mark.backend_portable
+def test_pytorch_stack_helpers_accept_array_like_sequences():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
 
     code = """
 import pyrecest.backend as backend
@@ -44,4 +47,35 @@ raw_left, raw_right = raw_backend.broadcast_arrays([1, 2], 3.0)
 assert raw_backend.to_numpy(raw_left).tolist() == [1, 2]
 assert raw_backend.to_numpy(raw_right).tolist() == [3.0, 3.0]
 """
-    subprocess.run([sys.executable, "-c", code], check=True, env=env)
+    subprocess.run(
+        [sys.executable, "-c", code], check=True, env=_backend_test_env("pytorch")
+    )
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_stack_helpers_accept_array_like_sequences_with_numpy_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_backend
+
+assert getattr(backend, "__backend_name__", None) == "numpy"
+
+assert raw_backend.to_numpy(raw_backend.hstack(([1, 2], [3, 4]))).tolist() == [1, 2, 3, 4]
+assert raw_backend.to_numpy(raw_backend.vstack(([1, 2], [3, 4]))).tolist() == [[1, 2], [3, 4]]
+assert raw_backend.to_numpy(raw_backend.column_stack(([1, 2], [3, 4]))).tolist() == [[1, 3], [2, 4]]
+assert raw_backend.to_numpy(raw_backend.dstack(([1, 2], [3, 4]))).tolist() == [[[1, 3], [2, 4]]]
+
+values = raw_backend.array([[1, 2], [3, 4]])
+assert raw_backend.to_numpy(raw_backend.hstack((values, [[5, 6], [7, 8]]))).tolist() == [[1, 2, 5, 6], [3, 4, 7, 8]]
+assert raw_backend.to_numpy(raw_backend.column_stack((values, [[5, 6], [7, 8]]))).tolist() == [[1, 2, 5, 6], [3, 4, 7, 8]]
+
+raw_left, raw_right = raw_backend.broadcast_arrays([1, 2], 3.0)
+assert raw_backend.to_numpy(raw_left).tolist() == [1, 2]
+assert raw_backend.to_numpy(raw_right).tolist() == [3.0, 3.0]
+"""
+    subprocess.run(
+        [sys.executable, "-c", code], check=True, env=_backend_test_env("numpy")
+    )


### PR DESCRIPTION
Summary:
- Applies PyTorch broadcast and stack-helper compatibility wrappers to the PyTorch implementation even when NumPy is the selected public backend.
- Keeps public facade updates conditional on PYRECEST_BACKEND=pytorch.
- Adds regression coverage for this default-backend case.

Validation:
- Ran python -m py_compile on the modified file contents.