### PR TITLE
Fix PyTorch NumPy byte order conversion

### DIFF
--- a/src/pyrecest/_backend/pytorch/_common.py
+++ b/src/pyrecest/_backend/pytorch/_common.py
@@ -43,11 +43,19 @@ def _normalize_dtype(dtype):
         return dtype
 
 
+def _as_torch_compatible_numpy_array(x):
+    if not x.dtype.isnative:
+        x = x.astype(x.dtype.newbyteorder("="), copy=False)
+    if any(stride < 0 for stride in x.strides):
+        x = x.copy()
+    return x
+
+
 def from_numpy(x):
     if _torch_is_tensor(x):
         return x
-    if isinstance(x, _np.ndarray) and any(stride < 0 for stride in x.strides):
-        x = x.copy()
+    if isinstance(x, _np.ndarray):
+        x = _as_torch_compatible_numpy_array(x)
     return _torch_from_numpy(x)
 
 

--- a/tests/backend_support/test_pytorch_numpy_view_conversion.py
+++ b/tests/backend_support/test_pytorch_numpy_view_conversion.py
@@ -40,6 +40,40 @@ assert backend.to_numpy(matrix_trace).item() == 6.0
 
 
 @pytest.mark.backend_portable
+def test_pytorch_backend_accepts_non_native_byte_order_numpy_arrays():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import sys
+
+import numpy as np
+import pyrecest.backend as backend
+from pyrecest._backend.pytorch._common import from_numpy
+
+non_native_prefix = ">" if sys.byteorder == "little" else "<"
+source = np.array([1.25, 2.5], dtype=f"{non_native_prefix}f8")
+assert not source.dtype.isnative
+
+converted_from_numpy = from_numpy(source)
+converted_array = backend.array(source)
+assert converted_from_numpy.dtype == backend.float64
+assert converted_array.dtype == backend.float64
+assert backend.to_numpy(converted_from_numpy).tolist() == [1.25, 2.5]
+assert backend.to_numpy(converted_array).tolist() == [1.25, 2.5]
+
+source[0] = 99.0
+assert backend.to_numpy(converted_from_numpy).tolist() == [1.25, 2.5]
+assert backend.to_numpy(converted_array).tolist() == [1.25, 2.5]
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.backend_portable
 def test_pytorch_array_copies_numpy_inputs():
     if importlib.util.find_spec("torch") is None:
         pytest.skip("PyTorch is not installed")


### PR DESCRIPTION
Summary:
- Convert non-native-endian NumPy arrays to native byte order before PyTorch conversion.
- Keep the existing negative-stride view handling.
- Add a focused regression for raw conversion and public backend.array.

Testing:
- Local smoke test reproduced the old conversion failure and verified the patched helper preserves values, returns float64, avoids sharing the original non-native array, and still handles negative-stride views.