### PR TITLE
Fix public PyTorch dtype promotion facade

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
@@ -9,6 +9,7 @@ def patch_pytorch_dtype_promotion_contract() -> None:
     """Make PyTorch mixed-dtype helpers use Torch's promotion rules."""
     try:
         import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
         import torch  # pylint: disable=import-outside-toplevel
     except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
         return
@@ -17,6 +18,8 @@ def patch_pytorch_dtype_promotion_contract() -> None:
 
     original_convert = raw_pytorch.convert_to_wider_dtype
     if getattr(original_convert, "_pyrecest_torch_promotion_contract", False):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.convert_to_wider_dtype = original_convert
         return
 
     def convert_to_wider_dtype(tensor_list):
@@ -38,6 +41,8 @@ def patch_pytorch_dtype_promotion_contract() -> None:
     convert_to_wider_dtype.__doc__ = getattr(original_convert, "__doc__", None)
     convert_to_wider_dtype._pyrecest_torch_promotion_contract = True
     raw_pytorch.convert_to_wider_dtype = convert_to_wider_dtype
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.convert_to_wider_dtype = convert_to_wider_dtype
 
 
 def _patch_pytorch_diff_numpy_contract(raw_pytorch, torch) -> None:

--- a/tests/backend_support/test_pytorch_dtype_promotion_contract.py
+++ b/tests/backend_support/test_pytorch_dtype_promotion_contract.py
@@ -1,4 +1,7 @@
+import importlib.util
+
 import pytest
+from tests.support.backend_runner import run_backend_code
 
 pytorch_backend = pytest.importorskip("pyrecest._backend.pytorch")
 
@@ -15,3 +18,22 @@ def test_pytorch_isclose_accepts_mixed_boolean_numeric_inputs():
     right = pytorch_backend.array([1.0, 0.0], dtype=pytorch_backend.float32)
 
     assert pytorch_backend.isclose(left, right).tolist() == [True, True]
+
+
+@pytest.mark.backend_portable
+def test_public_pytorch_convert_to_wider_dtype_uses_torch_promotion_contract():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        "import pyrecest.backend as backend\n"
+        "left = backend.array([True, False])\n"
+        "right = backend.array([1, 0], dtype=backend.uint8)\n"
+        "promoted_left, promoted_right = backend.convert_to_wider_dtype([left, right])\n"
+        "assert promoted_left.dtype == backend.uint8, promoted_left.dtype\n"
+        "assert promoted_right.dtype == backend.uint8, promoted_right.dtype\n"
+        "assert backend.to_numpy(promoted_left).tolist() == [1, 0]\n",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Synchronize the public `pyrecest.backend.convert_to_wider_dtype` facade with the raw PyTorch promotion shim when PyTorch is the active backend.
- Add a regression for public PyTorch promotion of `bool` and `uint8` tensors.

## Testing
- Not run locally; CI should run the added regression.