### PR TITLE
Fix PyTorch unary predicate array-like contract

### DIFF
--- a/src/pyrecest/backend_support/__init__.py
+++ b/src/pyrecest/backend_support/__init__.py
@@ -312,6 +312,46 @@ def _patch_pytorch_clip_numpy_contract() -> None:
         backend.clip = clip
 
 
+def _patch_pytorch_unary_predicate_numpy_contract() -> None:
+    """Make PyTorch unary predicates accept NumPy-style array-like inputs."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
+        return
+
+    def _wrap_predicate(helper_name, torch_func):
+        original_helper = getattr(raw_pytorch, helper_name)
+        if getattr(original_helper, "_pyrecest_numpy_contract", False):
+            return original_helper
+
+        def predicate(a):
+            return torch_func(raw_pytorch.array(a))
+
+        predicate.__name__ = getattr(original_helper, "__name__", helper_name)
+        predicate.__doc__ = getattr(original_helper, "__doc__", None)
+        predicate._pyrecest_numpy_contract = True
+        return predicate
+
+    for helper_name, torch_func in (
+        ("isfinite", torch.isfinite),
+        ("isinf", torch.isinf),
+        ("isnan", torch.isnan),
+        ("isreal", torch.isreal),
+    ):
+        helper = _wrap_predicate(helper_name, torch_func)
+        setattr(raw_pytorch, helper_name, helper)
+        if active_pytorch_backend:
+            setattr(backend, helper_name, helper)
+
+
 def _patch_jax_outer_numpy_contract() -> None:
     """Make JAX outer pair leading dimensions like the backend contract."""
     try:
@@ -353,6 +393,7 @@ _patch_pytorch_outer_numpy_contract()
 _patch_pytorch_tile_numpy_contract()
 _patch_pytorch_copy_numpy_contract()
 _patch_pytorch_clip_numpy_contract()
+_patch_pytorch_unary_predicate_numpy_contract()
 _patch_jax_outer_numpy_contract()
 
 

--- a/tests/backend_support/test_pytorch_unary_predicate_contract.py
+++ b/tests/backend_support/test_pytorch_unary_predicate_contract.py
@@ -1,0 +1,63 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _env_with_backend(backend_name):
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = backend_name
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    return env
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_unary_predicates_accept_array_like_with_numpy_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import numpy as np
+
+import pyrecest  # noqa: F401
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+assert getattr(backend, "__backend_name__", None) == "numpy"
+
+assert raw_pytorch.isfinite([1.0, float("inf"), float("nan")]).tolist() == [True, False, False]
+assert raw_pytorch.isinf([-float("inf"), 0.0, float("inf"), float("nan")]).tolist() == [True, False, True, False]
+assert raw_pytorch.isnan([1.0, float("nan")]).tolist() == [False, True]
+assert raw_pytorch.isreal(np.array([1.0 + 0.0j, 1.0 + 2.0j])).tolist() == [True, False]
+
+numpy_result = backend.isfinite([1.0, float("nan")])
+assert numpy_result.tolist() == [True, False]
+assert type(numpy_result).__module__.startswith("numpy")
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=_env_with_backend("numpy"))
+
+
+@pytest.mark.backend_portable
+def test_public_pytorch_unary_predicates_accept_array_like_inputs():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import pyrecest  # noqa: F401
+import pyrecest.backend as backend
+
+assert getattr(backend, "__backend_name__", None) == "pytorch"
+
+assert backend.isfinite([1.0, float("nan")]).tolist() == [True, False]
+assert backend.isinf([-float("inf"), 0.0, float("inf")]).tolist() == [True, False, True]
+assert backend.isnan([1.0, float("nan")]).tolist() == [False, True]
+assert backend.isreal([1.0 + 0.0j, 1.0 + 2.0j]).tolist() == [True, False]
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=_env_with_backend("pytorch"))


### PR DESCRIPTION
## Summary
- Patch raw PyTorch `isfinite`, `isinf`, `isnan`, and `isreal` so they accept PyRecEst/NumPy-style array-like inputs.
- Keep the active public PyTorch facade aligned while leaving the NumPy public backend untouched.
- Add subprocess regressions for raw PyTorch under the NumPy public backend and for the public PyTorch backend.

## Bug fixed
The PyTorch backend exposed these unary predicate helpers directly from `torch`. Calls such as `pyrecest._backend.pytorch.isfinite([1.0, float("nan")])` therefore raised `TypeError`, even though PyRecEst backend helpers generally accept array-like inputs.

## Testing
- Local sanity check: bare Torch rejects list inputs for `isfinite`, `isinf`, `isnan`, and `isreal`.
- Local syntax check: `python -m py_compile` on the modified backend-support module and new test file.
- Full repository test suite not run in this connector session; CI should run the focused regressions.