### PR TITLE
Fix PyTorch broadcast_to shape contract

### DIFF
--- a/src/pyrecest/backend_support/__init__.py
+++ b/src/pyrecest/backend_support/__init__.py
@@ -73,7 +73,6 @@ def _patch_pytorch_dot_numpy_contract() -> None:
         import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
     except ModuleNotFoundError:  # pragma: no cover - import fails before this module
         return
-
     active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
 
     try:
@@ -83,7 +82,6 @@ def _patch_pytorch_dot_numpy_contract() -> None:
         ModuleNotFoundError
     ):  # pragma: no cover - PyTorch backend import failed earlier
         return
-
     original_dot = raw_pytorch.dot
     if getattr(original_dot, "_pyrecest_numpy_contract", False):
         return
@@ -119,7 +117,6 @@ def _patch_pytorch_outer_numpy_contract() -> None:
         import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
     except ModuleNotFoundError:  # pragma: no cover - import fails before this module
         return
-
     active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
 
     try:
@@ -129,7 +126,6 @@ def _patch_pytorch_outer_numpy_contract() -> None:
         ModuleNotFoundError
     ):  # pragma: no cover - PyTorch backend import failed earlier
         return
-
     original_outer = raw_pytorch.outer
     if getattr(original_outer, "_pyrecest_numpy_contract", False):
         return
@@ -196,7 +192,6 @@ def _patch_pytorch_tile_numpy_contract() -> None:
         ModuleNotFoundError
     ):  # pragma: no cover - PyTorch backend import failed earlier
         return
-
     original_tile = raw_pytorch.tile
     if getattr(original_tile, "_pyrecest_numpy_contract", False):
         return
@@ -312,6 +307,57 @@ def _patch_pytorch_clip_numpy_contract() -> None:
         backend.clip = clip
 
 
+def _pytorch_broadcast_shape(shape, numpy_module, torch_module) -> tuple[int, ...]:
+    """Normalize NumPy-style broadcast shapes for ``torch.Tensor.expand``."""
+
+    if torch_module.is_tensor(shape):
+        shape = shape.detach().cpu().numpy()
+    shape_array = numpy_module.asarray(shape)
+    if shape_array.shape == ():
+        broadcast_shape = (_operator_index(shape_array.item()),)
+    else:
+        broadcast_shape = tuple(
+            _operator_index(one_dimension)
+            for one_dimension in shape_array.tolist()
+        )
+    if any(one_dimension < 0 for one_dimension in broadcast_shape):
+        raise ValueError("all elements of broadcast shape must be non-negative")
+    return broadcast_shape
+
+
+def _patch_pytorch_broadcast_to_numpy_contract() -> None:
+    """Make PyTorch broadcast_to normalize shapes like NumPy."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+
+    try:
+        import numpy as np  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
+        return
+
+    original_broadcast_to = raw_pytorch.broadcast_to
+    if getattr(original_broadcast_to, "_pyrecest_numpy_contract", False):
+        return
+
+    def broadcast_to(x, shape):
+        x = raw_pytorch.array(x)
+        result = x.expand(_pytorch_broadcast_shape(shape, np, torch))
+        return result
+
+    broadcast_to.__name__ = getattr(original_broadcast_to, "__name__", "broadcast_to")
+    broadcast_to.__doc__ = getattr(original_broadcast_to, "__doc__", None)
+    broadcast_to._pyrecest_numpy_contract = True
+    raw_pytorch.broadcast_to = broadcast_to
+    if active_pytorch_backend:
+        backend.broadcast_to = broadcast_to
+
+
 def _patch_jax_outer_numpy_contract() -> None:
     """Make JAX outer pair leading dimensions like the backend contract."""
     try:
@@ -353,6 +399,7 @@ _patch_pytorch_outer_numpy_contract()
 _patch_pytorch_tile_numpy_contract()
 _patch_pytorch_copy_numpy_contract()
 _patch_pytorch_clip_numpy_contract()
+_patch_pytorch_broadcast_to_numpy_contract()
 _patch_jax_outer_numpy_contract()
 
 

--- a/tests/backend_support/test_pytorch_broadcast_to_contract.py
+++ b/tests/backend_support/test_pytorch_broadcast_to_contract.py
@@ -1,0 +1,88 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _backend_test_env(backend_name):
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = backend_name
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    return env
+
+
+@pytest.mark.backend_portable
+def test_pytorch_broadcast_to_shape_inputs_match_numpy_contract():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import numpy as np
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as pytorch_backend
+
+values = backend.array([1, 2])
+
+for broadcast_to, to_numpy in (
+    (backend.broadcast_to, backend.to_numpy),
+    (pytorch_backend.broadcast_to, pytorch_backend.to_numpy),
+):
+    tensor_shape_result = broadcast_to(values, backend.array([2, 2]))
+    assert tuple(tensor_shape_result.shape) == (2, 2)
+    assert to_numpy(tensor_shape_result).tolist() == [[1, 2], [1, 2]]
+
+    numpy_shape_result = broadcast_to(values, np.array([2, 2]))
+    assert tuple(numpy_shape_result.shape) == (2, 2)
+    assert to_numpy(numpy_shape_result).tolist() == [[1, 2], [1, 2]]
+
+    scalar_result = broadcast_to(3, backend.array(2))
+    assert tuple(scalar_result.shape) == (2,)
+    assert to_numpy(scalar_result).tolist() == [3, 3]
+
+    try:
+        broadcast_to(values, (-1, 2))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("broadcast_to accepted a negative broadcast dimension")
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=_backend_test_env("pytorch"))
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_broadcast_to_shape_inputs_with_numpy_public_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import numpy as np
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as pytorch_backend
+
+assert getattr(backend, "__backend_name__", None) == "numpy"
+values = pytorch_backend.array([1, 2])
+
+for shape in (pytorch_backend.array([2, 2]), np.array([2, 2])):
+    result = pytorch_backend.broadcast_to(values, shape)
+    assert tuple(result.shape) == (2, 2)
+    assert pytorch_backend.to_numpy(result).tolist() == [[1, 2], [1, 2]]
+
+scalar_result = pytorch_backend.broadcast_to(3, pytorch_backend.array(2))
+assert tuple(scalar_result.shape) == (2,)
+assert pytorch_backend.to_numpy(scalar_result).tolist() == [3, 3]
+
+try:
+    pytorch_backend.broadcast_to(values, (-1, 2))
+except ValueError:
+    pass
+else:
+    raise AssertionError("raw broadcast_to accepted a negative broadcast dimension")
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=_backend_test_env("numpy"))


### PR DESCRIPTION
## Summary
- normalize PyTorch `broadcast_to` shape specifications before forwarding to `Tensor.expand`
- accept NumPy-style scalar, tensor, and NumPy-array shape arguments for both public and raw PyTorch backend calls
- reject negative broadcast dimensions instead of treating `-1` as Torch's expand sentinel
- add subprocess regressions for `PYRECEST_BACKEND=pytorch` and raw PyTorch use while the public backend is NumPy

## Bug fixed
The PyTorch backend implemented `broadcast_to` as a direct `x.expand(shape)` call. That diverges from NumPy in two directions: Torch accepts `-1` dimensions as a sentinel, while NumPy requires all broadcast shape entries to be non-negative; and Torch rejects tensor/NumPy-array shape specifications that NumPy accepts. This could silently keep an existing dimension when callers expected NumPy-compatible validation.

## Testing
- Not run locally in this connector session; added focused backend-portable subprocess coverage in `tests/backend_support/test_pytorch_broadcast_to_contract.py`.