### PR TITLE
Fix PyTorch as_dtype coverage for non-floating aliases

### DIFF
--- a/src/pyrecest/_backend/pytorch/_dtype.py
+++ b/src/pyrecest/_backend/pytorch/_dtype.py
@@ -15,11 +15,28 @@ from pyrecest._backend._dtype_utils import (
 from pyrecest._backend._dtype_utils import (
     get_default_dtype as _shared_get_default_dtype,
 )
-from torch import complex64, complex128, float32, float64
+from torch import (
+    bool as torch_bool,
+    complex64,
+    complex128,
+    float32,
+    float64,
+    int8,
+    int16,
+    int32,
+    int64,
+    uint8,
+)
 
 from ._common import cast
 
 MAP_DTYPE = {
+    "bool": torch_bool,
+    "uint8": uint8,
+    "int8": int8,
+    "int16": int16,
+    "int32": int32,
+    "int64": int64,
     "float32": float32,
     "float64": float64,
     "complex64": complex64,

--- a/tests/test_pytorch_dtype_aliases.py
+++ b/tests/test_pytorch_dtype_aliases.py
@@ -11,6 +11,13 @@ def test_pytorch_as_dtype_accepts_dtype_like_aliases():
 
     original_dtype = backend.get_default_dtype()
     try:
+        assert backend.as_dtype(torch.bool) == torch.bool
+        assert backend.as_dtype(torch.uint8) == torch.uint8
+        assert backend.as_dtype(torch.int64) == torch.int64
+        assert backend.as_dtype(np.bool_) == torch.bool
+        assert backend.as_dtype(np.int64) == torch.int64
+        assert backend.as_dtype("int32") == torch.int32
+        assert backend.as_dtype("torch.uint8") == torch.uint8
         assert backend.as_dtype(torch.float64) == torch.float64
         assert backend.as_dtype(np.float64) == torch.float64
         assert backend.as_dtype(np.dtype("complex128")) == torch.complex128


### PR DESCRIPTION
## Summary
- extend PyTorch `as_dtype` alias mapping to cover bool, uint8, and integer dtypes exported by the backend
- keep `set_default_dtype` restricted to floating defaults
- add regression coverage for torch, NumPy, and string aliases such as `torch.int64`, `np.int64`, `"int32"`, and `"torch.uint8"`

## Testing
- Not run locally; container cannot resolve github.com to clone/install the repo in this environment.
