### PR TITLE
Fix PyTorch creation helper contract

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
@@ -12,11 +12,15 @@ def patch_pytorch_dtype_promotion_contract() -> None:
         import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
         import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
         import torch  # pylint: disable=import-outside-toplevel
+        from pyrecest._backend.pytorch._common import (  # pylint: disable=import-outside-toplevel
+            _normalize_dtype,
+        )
     except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
         return
 
     _patch_pytorch_diff_numpy_contract(raw_pytorch, torch)
     _patch_pytorch_pad_constant_values_contract(raw_pytorch, torch, np)
+    _patch_pytorch_creation_numpy_contract(raw_pytorch, torch, np, _normalize_dtype)
 
     original_convert = raw_pytorch.convert_to_wider_dtype
     if getattr(original_convert, "_pyrecest_torch_promotion_contract", False):
@@ -105,6 +109,88 @@ def _patch_pytorch_diff_numpy_contract(raw_pytorch, torch) -> None:
     raw_pytorch.diff = diff
     if backend is not None and getattr(backend, "__backend_name__", None) == "pytorch":
         backend.diff = diff
+
+
+def _normalize_creation_shape(shape, torch, np):
+    """Return a tuple of Python integers for NumPy-style shape inputs."""
+    if torch.is_tensor(shape):
+        shape = shape.detach().cpu().numpy()
+    shape_array = np.asarray(shape)
+    if shape_array.shape == ():
+        normalized_shape = (_operator_index(shape_array.item()),)
+    else:
+        normalized_shape = tuple(
+            _operator_index(one_dimension)
+            for one_dimension in shape_array.tolist()
+        )
+    if any(one_dimension < 0 for one_dimension in normalized_shape):
+        raise ValueError("negative dimensions are not allowed")
+    return normalized_shape
+
+
+def _patch_pytorch_creation_numpy_contract(
+    raw_pytorch,
+    torch,
+    np,
+    normalize_dtype,
+) -> None:
+    """Make raw/public PyTorch creation helpers accept NumPy shapes and dtypes."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        backend = None
+
+    active_pytorch_backend = (
+        backend is not None and getattr(backend, "__backend_name__", None) == "pytorch"
+    )
+
+    def _wrap_creation_helper(helper_name, torch_helper, *, has_fill_value=False):
+        original_helper = getattr(raw_pytorch, helper_name)
+        if getattr(original_helper, "_pyrecest_numpy_contract", False):
+            if active_pytorch_backend:
+                setattr(backend, helper_name, original_helper)
+            return original_helper
+
+        if has_fill_value:
+
+            def creation_helper(shape, fill_value, dtype=None, *args, **kwargs):
+                return torch_helper(
+                    _normalize_creation_shape(shape, torch, np),
+                    fill_value,
+                    *args,
+                    dtype=normalize_dtype(dtype),
+                    **kwargs,
+                )
+
+        else:
+
+            def creation_helper(shape, dtype=None, *args, **kwargs):
+                return torch_helper(
+                    _normalize_creation_shape(shape, torch, np),
+                    *args,
+                    dtype=normalize_dtype(dtype),
+                    **kwargs,
+                )
+
+        creation_helper.__name__ = getattr(original_helper, "__name__", helper_name)
+        creation_helper.__doc__ = getattr(original_helper, "__doc__", None)
+        creation_helper._pyrecest_numpy_contract = True
+        return creation_helper
+
+    for helper_name, torch_helper, has_fill_value in (
+        ("empty", torch.empty, False),
+        ("zeros", torch.zeros, False),
+        ("ones", torch.ones, False),
+        ("full", torch.full, True),
+    ):
+        helper = _wrap_creation_helper(
+            helper_name,
+            torch_helper,
+            has_fill_value=has_fill_value,
+        )
+        setattr(raw_pytorch, helper_name, helper)
+        if active_pytorch_backend:
+            setattr(backend, helper_name, helper)
 
 
 def _normalize_pad_pairs(pad_width, ndim, np):

--- a/tests/backend_support/test_pytorch_creation_contract.py
+++ b/tests/backend_support/test_pytorch_creation_contract.py
@@ -1,0 +1,102 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _backend_test_env(backend_name):
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = backend_name
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    return env
+
+
+@pytest.mark.backend_portable
+def test_pytorch_creation_helpers_accept_numpy_dtypes_and_shape_arrays():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import numpy as np
+import torch
+
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_backend
+
+assert getattr(backend, "__backend_name__", None) == "pytorch"
+
+for creation_backend in (backend, raw_backend):
+    zeros = creation_backend.zeros(np.array([2, 3]), dtype=np.float64)
+    assert tuple(zeros.shape) == (2, 3)
+    assert zeros.dtype == creation_backend.float64
+    assert creation_backend.to_numpy(zeros).tolist() == [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+
+    ones = creation_backend.ones(torch.tensor([2]), dtype=np.dtype("int64"))
+    assert tuple(ones.shape) == (2,)
+    assert ones.dtype == creation_backend.int64
+    assert creation_backend.to_numpy(ones).tolist() == [1, 1]
+
+    empty = creation_backend.empty(np.array(2), dtype=np.float32)
+    assert tuple(empty.shape) == (2,)
+    assert empty.dtype == creation_backend.float32
+
+    full = creation_backend.full(np.array([2]), 7, dtype=np.int64)
+    assert tuple(full.shape) == (2,)
+    assert full.dtype == creation_backend.int64
+    assert creation_backend.to_numpy(full).tolist() == [7, 7]
+
+    try:
+        creation_backend.zeros(np.array([-1]))
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("zeros accepted a negative dimension")
+"""
+    subprocess.run(
+        [sys.executable, "-c", code], check=True, env=_backend_test_env("pytorch")
+    )
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_creation_helpers_work_with_numpy_public_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import numpy as np
+import torch
+
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_backend
+
+assert getattr(backend, "__backend_name__", None) == "numpy"
+
+zeros = raw_backend.zeros(np.array([2]), dtype=np.float64)
+assert tuple(zeros.shape) == (2,)
+assert zeros.dtype == raw_backend.float64
+assert raw_backend.to_numpy(zeros).tolist() == [0.0, 0.0]
+
+ones = raw_backend.ones(torch.tensor([2, 1]), dtype=np.dtype("int64"))
+assert tuple(ones.shape) == (2, 1)
+assert ones.dtype == raw_backend.int64
+assert raw_backend.to_numpy(ones).tolist() == [[1], [1]]
+
+empty = raw_backend.empty(np.array(2), dtype=np.float32)
+assert tuple(empty.shape) == (2,)
+assert empty.dtype == raw_backend.float32
+
+full = raw_backend.full(torch.tensor([2]), 5, dtype=np.int64)
+assert tuple(full.shape) == (2,)
+assert full.dtype == raw_backend.int64
+assert raw_backend.to_numpy(full).tolist() == [5, 5]
+"""
+    subprocess.run(
+        [sys.executable, "-c", code], check=True, env=_backend_test_env("numpy")
+    )


### PR DESCRIPTION
## Summary
- normalize PyTorch creation-helper shape inputs before dispatching to Torch
- normalize dtype-like values such as NumPy dtype objects through the existing PyTorch dtype helper
- add subprocess regression coverage for public PyTorch backend calls and raw PyTorch helper calls with NumPy as the public backend

## Validation
- Added focused regression coverage in `tests/backend_support/test_pytorch_creation_contract.py`.
- Syntax-checked the edited helper and new test file with `python -m py_compile`.
- Ran a standalone Torch smoke check for the shape and dtype normalization behavior.