### PR TITLE
Fix PyTorch assignment with NumPy boolean masks

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
@@ -15,6 +15,7 @@ def patch_pytorch_dtype_promotion_contract() -> None:
     except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
         return
 
+    _patch_pytorch_assignment_numpy_boolean_contract(raw_pytorch, torch, np)
     _patch_pytorch_diff_numpy_contract(raw_pytorch, torch)
     _patch_pytorch_pad_constant_values_contract(raw_pytorch, torch, np)
 
@@ -45,6 +46,42 @@ def patch_pytorch_dtype_promotion_contract() -> None:
     raw_pytorch.convert_to_wider_dtype = convert_to_wider_dtype
     if getattr(backend, "__backend_name__", None) == "pytorch":
         backend.convert_to_wider_dtype = convert_to_wider_dtype
+
+
+def _normalize_numpy_boolean_index(indices, torch, np):
+    """Convert NumPy boolean indices before PyTorch assignment normalization."""
+    if isinstance(indices, np.bool_):
+        return bool(indices)
+    if isinstance(indices, np.ndarray) and indices.dtype == np.bool_:
+        return torch.as_tensor(indices, dtype=torch.bool)
+    return indices
+
+
+def _patch_pytorch_assignment_numpy_boolean_contract(raw_pytorch, torch, np) -> None:
+    """Make PyTorch assignment helpers treat NumPy boolean arrays as masks."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        backend = None
+
+    def _wrap_assignment(original_assignment):
+        if getattr(original_assignment, "_pyrecest_numpy_boolean_index_contract", False):
+            return original_assignment
+
+        def assignment(x, values, indices, axis=0):
+            indices = _normalize_numpy_boolean_index(indices, torch, np)
+            return original_assignment(x, values, indices, axis=axis)
+
+        assignment.__name__ = getattr(original_assignment, "__name__", "assignment")
+        assignment.__doc__ = getattr(original_assignment, "__doc__", None)
+        assignment._pyrecest_numpy_boolean_index_contract = True
+        return assignment
+
+    raw_pytorch.assignment = _wrap_assignment(raw_pytorch.assignment)
+    raw_pytorch.assignment_by_sum = _wrap_assignment(raw_pytorch.assignment_by_sum)
+    if backend is not None and getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.assignment = raw_pytorch.assignment
+        backend.assignment_by_sum = raw_pytorch.assignment_by_sum
 
 
 def _patch_pytorch_diff_numpy_contract(raw_pytorch, torch) -> None:

--- a/tests/backend_support/test_pytorch_assignment_contract.py
+++ b/tests/backend_support/test_pytorch_assignment_contract.py
@@ -52,6 +52,7 @@ def test_pytorch_assignment_accepts_list_and_boolean_indices():
     result = run_backend_code(
         "pytorch",
         """
+import numpy as np
 import pyrecest.backend as backend
 
 vector = backend.zeros(3)
@@ -79,6 +80,18 @@ by_mask = backend.assignment(
         [False, False, False],
     ],
 )
+numpy_mask = np.array(
+    [
+        [True, False, False],
+        [False, True, False],
+        [False, False, True],
+    ],
+    dtype=bool,
+)
+by_numpy_mask = backend.assignment(backend.zeros((3, 3)), [3.0, 4.0, 5.0], numpy_mask)
+by_numpy_mask_sum = backend.assignment_by_sum(
+    backend.ones((3, 3)), [3.0, 4.0, 5.0], numpy_mask
+)
 
 logical = backend.logical_and(backend.asarray([1, 0]), backend.asarray([2, 3]))
 
@@ -94,8 +107,49 @@ assert backend.to_numpy(by_mask).tolist() == [
     [0.0, 2.0, 0.0],
     [0.0, 0.0, 0.0],
 ]
+assert backend.to_numpy(by_numpy_mask).tolist() == [
+    [3.0, 0.0, 0.0],
+    [0.0, 4.0, 0.0],
+    [0.0, 0.0, 5.0],
+]
+assert backend.to_numpy(by_numpy_mask_sum).tolist() == [
+    [4.0, 1.0, 1.0],
+    [1.0, 5.0, 1.0],
+    [1.0, 1.0, 6.0],
+]
 assert backend.to_numpy(logical).tolist() == [True, False]
 """,
     )
 
     assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_assignment_accepts_numpy_boolean_mask_after_import():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "numpy",
+        """
+import numpy as np
+import pyrecest  # noqa: F401  # triggers raw-backend compatibility patches
+import pyrecest._backend.pytorch as raw_pytorch_backend
+
+mask = np.array([True, False, True], dtype=bool)
+
+assigned = raw_pytorch_backend.assignment(
+    raw_pytorch_backend.zeros(3), [4.0, 5.0], mask
+)
+summed = raw_pytorch_backend.assignment_by_sum(
+    raw_pytorch_backend.ones(3), [4.0, 5.0], mask
+)
+
+assert raw_pytorch_backend.to_numpy(assigned).tolist() == [4.0, 0.0, 5.0]
+assert raw_pytorch_backend.to_numpy(summed).tolist() == [5.0, 1.0, 6.0]
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- Normalize NumPy boolean scalar/array indices before the PyTorch assignment helpers classify indices.
- Keep raw PyTorch assignment helpers and the active public PyTorch backend facade aligned after import.
- Add public and raw-backend regressions for NumPy boolean masks.

## Bug fixed
The PyTorch assignment helpers recognized Python/list and Torch boolean masks, but not NumPy boolean ndarrays. A call such as `backend.assignment(x, values, np.array([...], dtype=bool))` could be treated as integer-style indexing or rejected before mask assignment, while equivalent list-of-list masks already worked.

## Testing
- Not run locally; CI should run the new focused regressions.