### PR TITLE
Fix PyTorch comparison array-like/device contract

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
@@ -2,7 +2,18 @@
 
 from __future__ import annotations
 
-from operator import index as _operator_index
+from pyrecest.backend_support._torch_comparison_contract import (
+    patch_pytorch_comparison_arraylike_contract,
+)
+from pyrecest.backend_support._torch_diff_contract import (
+    patch_pytorch_diff_numpy_contract,
+)
+from pyrecest.backend_support._torch_pad_contract import (
+    patch_pytorch_pad_constant_values_contract,
+)
+from pyrecest.backend_support._torch_repeat_contract import (
+    patch_pytorch_repeat_numpy_contract,
+)
 
 
 def patch_pytorch_dtype_promotion_contract() -> None:
@@ -15,10 +26,14 @@ def patch_pytorch_dtype_promotion_contract() -> None:
     except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
         return
 
-    _patch_pytorch_repeat_numpy_contract(raw_pytorch, torch)
-    _patch_pytorch_diff_numpy_contract(raw_pytorch, torch)
-    _patch_pytorch_pad_constant_values_contract(raw_pytorch, torch, np)
+    patch_pytorch_repeat_numpy_contract(raw_pytorch, backend, torch, np)
+    patch_pytorch_diff_numpy_contract(raw_pytorch, backend, torch)
+    patch_pytorch_pad_constant_values_contract(raw_pytorch, backend, torch, np)
+    patch_pytorch_comparison_arraylike_contract(raw_pytorch, backend, torch)
+    _patch_pytorch_dtype_promotion(raw_pytorch, backend, torch)
 
+
+def _patch_pytorch_dtype_promotion(raw_pytorch, backend, torch) -> None:
     original_convert = raw_pytorch.convert_to_wider_dtype
     if getattr(original_convert, "_pyrecest_torch_promotion_contract", False):
         if getattr(backend, "__backend_name__", None) == "pytorch":
@@ -46,240 +61,3 @@ def patch_pytorch_dtype_promotion_contract() -> None:
     raw_pytorch.convert_to_wider_dtype = convert_to_wider_dtype
     if getattr(backend, "__backend_name__", None) == "pytorch":
         backend.convert_to_wider_dtype = convert_to_wider_dtype
-
-
-def _pytorch_repeat_count(repetition) -> int:
-    """Return one NumPy-style repeat count as a non-negative integer."""
-    try:
-        count = _operator_index(repetition)
-    except TypeError as exc:
-        raise TypeError("repeat counts must be integers") from exc
-    if count < 0:
-        raise ValueError("repeats may not contain negative values")
-    return count
-
-
-def _pytorch_repeat_counts(repeats, *, numpy_module, torch_module, device):
-    """Normalize NumPy-style repeat counts for ``torch.repeat_interleave``."""
-    if torch_module.is_tensor(repeats):
-        if repeats.ndim > 1:
-            raise ValueError("object too deep for desired array")
-        if repeats.dtype.is_floating_point or repeats.dtype.is_complex:
-            raise TypeError("repeat counts must be integers")
-        repeat_counts = repeats.to(device=device, dtype=torch_module.long)
-        if bool(torch_module.any(repeat_counts < 0)):
-            raise ValueError("repeats may not contain negative values")
-        return repeat_counts
-
-    repeats_array = numpy_module.asarray(repeats)
-    if repeats_array.shape == ():
-        return _pytorch_repeat_count(repeats_array.item())
-    if repeats_array.ndim > 1:
-        raise ValueError("object too deep for desired array")
-    if not numpy_module.can_cast(
-        repeats_array.dtype,
-        numpy_module.dtype("intp"),
-        casting="safe",
-    ):
-        raise TypeError("repeat counts must be integers")
-    repeat_counts = torch_module.as_tensor(
-        repeats_array,
-        dtype=torch_module.long,
-        device=device,
-    )
-    if bool(torch_module.any(repeat_counts < 0)):
-        raise ValueError("repeats may not contain negative values")
-    return repeat_counts
-
-
-def _patch_pytorch_repeat_numpy_contract(raw_pytorch, torch) -> None:
-    """Make raw/public PyTorch repeat follow the PyRecEst NumPy-style contract."""
-    try:
-        import numpy as np  # pylint: disable=import-outside-toplevel
-    except ModuleNotFoundError:  # pragma: no cover - NumPy is a core dependency
-        return
-
-    try:
-        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
-    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
-        backend = None
-
-    original_repeat = raw_pytorch.repeat
-    if getattr(original_repeat, "_pyrecest_numpy_contract", False):
-        return
-
-    def repeat(a, repeats, axis=None, *, dim=None, output_size=None):
-        if dim is not None:
-            if axis is not None and axis != dim:
-                raise TypeError("repeat() got both 'axis' and 'dim'")
-            axis = dim
-        if axis is not None:
-            axis = _operator_index(axis)
-
-        values = raw_pytorch.array(a)
-        repeat_counts = _pytorch_repeat_counts(
-            repeats,
-            numpy_module=np,
-            torch_module=torch,
-            device=values.device,
-        )
-        kwargs = {"dim": axis}
-        if output_size is not None:
-            kwargs["output_size"] = output_size
-        return original_repeat(values, repeat_counts, **kwargs)
-
-    repeat.__name__ = getattr(original_repeat, "__name__", "repeat")
-    repeat.__doc__ = getattr(original_repeat, "__doc__", None)
-    repeat._pyrecest_numpy_contract = True
-    raw_pytorch.repeat = repeat
-    if backend is not None and getattr(backend, "__backend_name__", None) == "pytorch":
-        backend.repeat = repeat
-
-
-def _patch_pytorch_diff_numpy_contract(raw_pytorch, torch) -> None:
-    """Make raw/public PyTorch diff follow the PyRecEst NumPy-style contract."""
-    try:
-        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
-    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
-        backend = None
-
-    original_diff = raw_pytorch.diff
-    if getattr(original_diff, "_pyrecest_numpy_contract", False):
-        return
-    no_boundary = object()
-
-    def _normalize_axis(axis, ndim):
-        axis = _operator_index(axis)
-        if axis < 0:
-            axis += ndim
-        if axis < 0 or axis >= ndim:
-            raise IndexError(f"axis {axis} is out of bounds for array of dimension {ndim}")
-        return axis
-
-    def _boundary(value, reference, axis):
-        boundary = raw_pytorch.array(value)
-        if boundary.device != reference.device:
-            boundary = boundary.to(device=reference.device)
-        if boundary.ndim == 0:
-            boundary_shape = list(reference.shape)
-            boundary_shape[axis] = 1
-            boundary = torch.broadcast_to(boundary, tuple(boundary_shape))
-        return boundary
-
-    def diff(a, n=1, axis=-1, prepend=no_boundary, append=no_boundary):
-        values = raw_pytorch.array(a)
-        order = _operator_index(n)
-        if order < 0:
-            raise ValueError(f"order must be non-negative but got {order}")
-        if order == 0:
-            return values.clone()
-        if values.ndim == 0:
-            raise ValueError("diff requires input that is at least one dimensional")
-
-        axis = _normalize_axis(axis, values.ndim)
-        diff_inputs = []
-        if prepend is not no_boundary:
-            diff_inputs.append(_boundary(prepend, values, axis))
-        diff_inputs.append(values)
-        if append is not no_boundary:
-            diff_inputs.append(_boundary(append, values, axis))
-        if len(diff_inputs) > 1:
-            diff_inputs = raw_pytorch.convert_to_wider_dtype(diff_inputs)
-            values = torch.cat(diff_inputs, dim=axis)
-        return torch.diff(values, n=order, dim=axis)
-
-    diff.__name__ = getattr(original_diff, "__name__", "diff")
-    diff.__doc__ = getattr(original_diff, "__doc__", None)
-    diff._pyrecest_numpy_contract = True
-    raw_pytorch.diff = diff
-    if backend is not None and getattr(backend, "__backend_name__", None) == "pytorch":
-        backend.diff = diff
-
-
-def _normalize_pad_pairs(pad_width, ndim, np):
-    """Return NumPy-style per-axis pad-width pairs as Python integers."""
-    try:
-        pad_pairs = np.broadcast_to(np.asarray(pad_width), (ndim, 2))
-    except ValueError as exc:
-        raise ValueError(f"pad_width must be broadcastable to shape ({ndim}, 2)") from exc
-    if np.any(pad_pairs < 0):
-        raise ValueError("index can't contain negative values")
-    try:
-        return tuple(
-            (_operator_index(before), _operator_index(after))
-            for before, after in pad_pairs.tolist()
-        )
-    except TypeError as exc:
-        raise TypeError("pad_width must be of integral type") from exc
-
-
-def _normalize_constant_value_pairs(constant_values, ndim, np):
-    """Return NumPy-style per-axis constant-value pairs."""
-    try:
-        constant_pairs = np.broadcast_to(np.asarray(constant_values), (ndim, 2))
-    except ValueError as exc:
-        raise ValueError(
-            f"constant_values must be broadcastable to shape ({ndim}, 2)"
-        ) from exc
-    return tuple(tuple(pair) for pair in constant_pairs.tolist())
-
-
-def _filled_pad_block(shape, value, reference, torch):
-    """Return a constant-filled block compatible with ``reference``."""
-    scalar_value = torch.as_tensor(value, dtype=reference.dtype, device=reference.device)
-    if scalar_value.ndim != 0:
-        raise ValueError("constant_values entries must be scalar")
-    block = torch.empty(tuple(shape), dtype=reference.dtype, device=reference.device)
-    block.fill_(scalar_value)
-    return block
-
-
-def _constant_pad(values, pad_width, constant_values, torch, np):
-    """Pad a tensor with NumPy-style per-axis constant values."""
-    pad_pairs = _normalize_pad_pairs(pad_width, values.ndim, np)
-    constant_pairs = _normalize_constant_value_pairs(constant_values, values.ndim, np)
-    result = values
-    for axis, ((before, after), (before_value, after_value)) in enumerate(
-        zip(pad_pairs, constant_pairs)
-    ):
-        if before:
-            before_shape = list(result.shape)
-            before_shape[axis] = before
-            before_block = _filled_pad_block(before_shape, before_value, result, torch)
-            result = torch.cat((before_block, result), dim=axis)
-        if after:
-            after_shape = list(result.shape)
-            after_shape[axis] = after
-            after_block = _filled_pad_block(after_shape, after_value, result, torch)
-            result = torch.cat((result, after_block), dim=axis)
-    return result
-
-
-def _patch_pytorch_pad_constant_values_contract(raw_pytorch, torch, np) -> None:
-    """Make raw/public PyTorch pad accept NumPy-style constant_values."""
-    try:
-        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
-    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
-        backend = None
-
-    original_pad = raw_pytorch.pad
-    if getattr(original_pad, "_pyrecest_constant_values_contract", False):
-        return
-
-    def pad(a, pad_width, mode="constant", constant_values=0.0):
-        values = raw_pytorch.array(a)
-        if mode != "constant":
-            return original_pad(
-                values,
-                pad_width,
-                mode=mode,
-                constant_values=constant_values,
-            )
-        return _constant_pad(values, pad_width, constant_values, torch, np)
-
-    pad.__name__ = getattr(original_pad, "__name__", "pad")
-    pad.__doc__ = getattr(original_pad, "__doc__", None)
-    pad._pyrecest_constant_values_contract = True
-    raw_pytorch.pad = pad
-    if backend is not None and getattr(backend, "__backend_name__", None) == "pytorch":
-        backend.pad = pad

--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
@@ -1,63 +1,270 @@
-"""PyTorch backend compatibility helpers."""
-
-from __future__ import annotations
-
-from pyrecest.backend_support._torch_comparison_contract import (
-    patch_pytorch_comparison_arraylike_contract,
-)
-from pyrecest.backend_support._torch_diff_contract import (
-    patch_pytorch_diff_numpy_contract,
-)
-from pyrecest.backend_support._torch_pad_contract import (
-    patch_pytorch_pad_constant_values_contract,
-)
-from pyrecest.backend_support._torch_repeat_contract import (
-    patch_pytorch_repeat_numpy_contract,
-)
+from operator import index as _idx
 
 
-def patch_pytorch_dtype_promotion_contract() -> None:
-    """Make PyTorch backend helpers use PyRecEst compatibility contracts."""
+def patch_pytorch_dtype_promotion_contract():
     try:
-        import numpy as np  # pylint: disable=import-outside-toplevel
-        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
-        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
-        import torch  # pylint: disable=import-outside-toplevel
-    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
+        import numpy as np
+        import pyrecest._backend.pytorch as rp
+        import pyrecest.backend as be
+        import torch
+    except ModuleNotFoundError:
         return
+    _patch_repeat(rp, be, torch, np)
+    _patch_diff(rp, be, torch)
+    _patch_pad(rp, be, torch, np)
+    _patch_cmp(rp, be, torch)
+    _patch_dtype(rp, be, torch)
 
-    patch_pytorch_repeat_numpy_contract(raw_pytorch, backend, torch, np)
-    patch_pytorch_diff_numpy_contract(raw_pytorch, backend, torch)
-    patch_pytorch_pad_constant_values_contract(raw_pytorch, backend, torch, np)
-    patch_pytorch_comparison_arraylike_contract(raw_pytorch, backend, torch)
-    _patch_pytorch_dtype_promotion(raw_pytorch, backend, torch)
+
+def _active(be):
+    return getattr(be, "__backend_name__", None) == "pytorch"
 
 
-def _patch_pytorch_dtype_promotion(raw_pytorch, backend, torch) -> None:
-    original_convert = raw_pytorch.convert_to_wider_dtype
-    if getattr(original_convert, "_pyrecest_torch_promotion_contract", False):
-        if getattr(backend, "__backend_name__", None) == "pytorch":
-            backend.convert_to_wider_dtype = original_convert
+def _pub(be, name, value):
+    if _active(be):
+        setattr(be, name, value)
+
+
+def _patch_dtype(rp, be, torch):
+    old = rp.convert_to_wider_dtype
+    if getattr(old, "_pyrecest_torch_promotion_contract", False):
+        _pub(be, "convert_to_wider_dtype", old)
         return
 
     def convert_to_wider_dtype(tensor_list):
-        tensors = list(tensor_list)
-        if not tensors:
-            return tensors
+        xs = list(tensor_list)
+        if not xs:
+            return xs
+        dtype = xs[0].dtype
+        for x in xs[1:]:
+            dtype = torch.promote_types(dtype, x.dtype)
+        if all(x.dtype == dtype for x in xs):
+            return xs
+        return [rp.cast(x, dtype=dtype) for x in xs]
 
-        promoted_dtype = tensors[0].dtype
-        for tensor in tensors[1:]:
-            promoted_dtype = torch.promote_types(promoted_dtype, tensor.dtype)
-
-        if all(tensor.dtype == promoted_dtype for tensor in tensors):
-            return tensors
-        return [raw_pytorch.cast(tensor, dtype=promoted_dtype) for tensor in tensors]
-
-    convert_to_wider_dtype.__name__ = getattr(
-        original_convert, "__name__", "convert_to_wider_dtype"
-    )
-    convert_to_wider_dtype.__doc__ = getattr(original_convert, "__doc__", None)
+    convert_to_wider_dtype.__name__ = getattr(old, "__name__", "convert_to_wider_dtype")
+    convert_to_wider_dtype.__doc__ = getattr(old, "__doc__", None)
     convert_to_wider_dtype._pyrecest_torch_promotion_contract = True
-    raw_pytorch.convert_to_wider_dtype = convert_to_wider_dtype
-    if getattr(backend, "__backend_name__", None) == "pytorch":
-        backend.convert_to_wider_dtype = convert_to_wider_dtype
+    rp.convert_to_wider_dtype = convert_to_wider_dtype
+    _pub(be, "convert_to_wider_dtype", convert_to_wider_dtype)
+
+
+def _patch_cmp(rp, be, torch):
+    funcs = {
+        "greater": torch.greater,
+        "less": torch.less,
+        "less_equal": torch.less_equal,
+        "logical_or": torch.logical_or,
+    }
+    if all(
+        getattr(getattr(rp, name, None), "_pyrecest_arraylike_contract", False)
+        for name in funcs
+    ):
+        for name in funcs:
+            _pub(be, name, getattr(rp, name))
+        return
+
+    def coerce(x, y):
+        dev = next((v.device for v in (x, y) if torch.is_tensor(v)), None)
+        if not torch.is_tensor(x):
+            x = torch.as_tensor(x, device=dev)
+        elif dev is not None and x.device != dev:
+            x = x.to(device=dev)
+        if not torch.is_tensor(y):
+            y = torch.as_tensor(y, device=dev)
+        elif dev is not None and y.device != dev:
+            y = y.to(device=dev)
+        return x, y
+
+    def wrap(fn, name):
+        def comparison(x, y, **kw):
+            x, y = coerce(x, y)
+            return fn(x, y, **kw)
+
+        comparison.__name__ = name
+        comparison.__doc__ = getattr(fn, "__doc__", None)
+        comparison._pyrecest_arraylike_contract = True
+        return comparison
+
+    for name, fn in funcs.items():
+        helper = wrap(fn, name)
+        setattr(rp, name, helper)
+        _pub(be, name, helper)
+
+
+def _repeat_count(repetition):
+    try:
+        count = _idx(repetition)
+    except TypeError as exc:
+        raise TypeError("repeat counts must be integers") from exc
+    if count < 0:
+        raise ValueError("repeats may not contain negative values")
+    return count
+
+
+def _repeat_counts(repeats, *, np, torch, device):
+    if torch.is_tensor(repeats):
+        if repeats.ndim > 1:
+            raise ValueError("object too deep for desired array")
+        if repeats.dtype.is_floating_point or repeats.dtype.is_complex:
+            raise TypeError("repeat counts must be integers")
+        counts = repeats.to(device=device, dtype=torch.long)
+        if bool(torch.any(counts < 0)):
+            raise ValueError("repeats may not contain negative values")
+        return counts
+    arr = np.asarray(repeats)
+    if arr.shape == ():
+        return _repeat_count(arr.item())
+    if arr.ndim > 1:
+        raise ValueError("object too deep for desired array")
+    if not np.can_cast(arr.dtype, np.dtype("intp"), casting="safe"):
+        raise TypeError("repeat counts must be integers")
+    counts = torch.as_tensor(arr, dtype=torch.long, device=device)
+    if bool(torch.any(counts < 0)):
+        raise ValueError("repeats may not contain negative values")
+    return counts
+
+
+def _patch_repeat(rp, be, torch, np):
+    old = rp.repeat
+    if getattr(old, "_pyrecest_numpy_contract", False):
+        return
+
+    def repeat(a, repeats, axis=None, *, dim=None, output_size=None):
+        if dim is not None:
+            if axis is not None and axis != dim:
+                raise TypeError("repeat() got both 'axis' and 'dim'")
+            axis = dim
+        if axis is not None:
+            axis = _idx(axis)
+        values = rp.array(a)
+        counts = _repeat_counts(repeats, np=np, torch=torch, device=values.device)
+        kw = {"dim": axis}
+        if output_size is not None:
+            kw["output_size"] = output_size
+        return old(values, counts, **kw)
+
+    repeat.__name__ = getattr(old, "__name__", "repeat")
+    repeat.__doc__ = getattr(old, "__doc__", None)
+    repeat._pyrecest_numpy_contract = True
+    rp.repeat = repeat
+    _pub(be, "repeat", repeat)
+
+
+def _patch_diff(rp, be, torch):
+    old = rp.diff
+    if getattr(old, "_pyrecest_numpy_contract", False):
+        return
+    none = object()
+
+    def norm_axis(axis, ndim):
+        axis = _idx(axis)
+        if axis < 0:
+            axis += ndim
+        if axis < 0 or axis >= ndim:
+            raise IndexError(f"axis {axis} is out of bounds for array of dimension {ndim}")
+        return axis
+
+    def boundary(value, ref, axis):
+        out = rp.array(value)
+        if out.device != ref.device:
+            out = out.to(device=ref.device)
+        if out.ndim == 0:
+            shape = list(ref.shape)
+            shape[axis] = 1
+            out = torch.broadcast_to(out, tuple(shape))
+        return out
+
+    def diff(a, n=1, axis=-1, prepend=none, append=none):
+        values = rp.array(a)
+        order = _idx(n)
+        if order < 0:
+            raise ValueError(f"order must be non-negative but got {order}")
+        if order == 0:
+            return values.clone()
+        if values.ndim == 0:
+            raise ValueError("diff requires input that is at least one dimensional")
+        axis = norm_axis(axis, values.ndim)
+        parts = []
+        if prepend is not none:
+            parts.append(boundary(prepend, values, axis))
+        parts.append(values)
+        if append is not none:
+            parts.append(boundary(append, values, axis))
+        if len(parts) > 1:
+            values = torch.cat(rp.convert_to_wider_dtype(parts), dim=axis)
+        return torch.diff(values, n=order, dim=axis)
+
+    diff.__name__ = getattr(old, "__name__", "diff")
+    diff.__doc__ = getattr(old, "__doc__", None)
+    diff._pyrecest_numpy_contract = True
+    rp.diff = diff
+    _pub(be, "diff", diff)
+
+
+def _pad_pairs(pad_width, ndim, np):
+    try:
+        pairs = np.broadcast_to(np.asarray(pad_width), (ndim, 2))
+    except ValueError as exc:
+        raise ValueError(f"pad_width must be broadcastable to shape ({ndim}, 2)") from exc
+    if np.any(pairs < 0):
+        raise ValueError("index can't contain negative values")
+    try:
+        return tuple((_idx(before), _idx(after)) for before, after in pairs.tolist())
+    except TypeError as exc:
+        raise TypeError("pad_width must be of integral type") from exc
+
+
+def _constant_pairs(constant_values, ndim, np):
+    try:
+        pairs = np.broadcast_to(np.asarray(constant_values), (ndim, 2))
+    except ValueError as exc:
+        raise ValueError(
+            f"constant_values must be broadcastable to shape ({ndim}, 2)"
+        ) from exc
+    return tuple(tuple(pair) for pair in pairs.tolist())
+
+
+def _block(shape, value, ref, torch):
+    value = torch.as_tensor(value, dtype=ref.dtype, device=ref.device)
+    if value.ndim != 0:
+        raise ValueError("constant_values entries must be scalar")
+    out = torch.empty(tuple(shape), dtype=ref.dtype, device=ref.device)
+    out.fill_(value)
+    return out
+
+
+def _constant_pad(values, pad_width, constant_values, torch, np):
+    pads = _pad_pairs(pad_width, values.ndim, np)
+    constants = _constant_pairs(constant_values, values.ndim, np)
+    out = values
+    for axis, ((before, after), (before_value, after_value)) in enumerate(
+        zip(pads, constants)
+    ):
+        if before:
+            shape = list(out.shape)
+            shape[axis] = before
+            out = torch.cat((_block(shape, before_value, out, torch), out), dim=axis)
+        if after:
+            shape = list(out.shape)
+            shape[axis] = after
+            out = torch.cat((out, _block(shape, after_value, out, torch)), dim=axis)
+    return out
+
+
+def _patch_pad(rp, be, torch, np):
+    old = rp.pad
+    if getattr(old, "_pyrecest_constant_values_contract", False):
+        return
+
+    def pad(a, pad_width, mode="constant", constant_values=0.0):
+        values = rp.array(a)
+        if mode != "constant":
+            return old(values, pad_width, mode=mode, constant_values=constant_values)
+        return _constant_pad(values, pad_width, constant_values, torch, np)
+
+    pad.__name__ = getattr(old, "__name__", "pad")
+    pad.__doc__ = getattr(old, "__doc__", None)
+    pad._pyrecest_constant_values_contract = True
+    rp.pad = pad
+    _pub(be, "pad", pad)

--- a/tests/backend_support/test_pytorch_pad_contract.py
+++ b/tests/backend_support/test_pytorch_pad_contract.py
@@ -65,3 +65,62 @@ print("ok")
     result = run_backend_code("pytorch", code)
     assert result.returncode == 0, result.stderr
     assert "ok" in result.stdout
+
+
+@pytest.mark.parametrize("backend_name", ["numpy", "pytorch"])
+def test_raw_pytorch_comparison_helpers_accept_array_like_inputs(backend_name):
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    code = """
+import numpy as np
+import pyrecest._backend.pytorch as pt
+
+np.testing.assert_array_equal(
+    pt.to_numpy(pt.greater([2, 1, 3], [1, 1, 4])),
+    np.array([True, False, False]),
+)
+np.testing.assert_array_equal(
+    pt.to_numpy(pt.less([2, 1, 3], [1, 2, 3])),
+    np.array([False, True, False]),
+)
+np.testing.assert_array_equal(
+    pt.to_numpy(pt.less_equal([2, 1, 3], [2, 0, 4])),
+    np.array([True, False, True]),
+)
+np.testing.assert_array_equal(
+    pt.to_numpy(pt.logical_or([0, 1, 0], [0, 0, 2])),
+    np.array([False, True, True]),
+)
+"""
+
+    result = run_backend_code(backend_name, code)
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize("backend_name", ["numpy", "pytorch"])
+def test_raw_pytorch_less_equal_uses_tensor_operand_device(backend_name):
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    code = """
+import torch
+import pyrecest._backend.pytorch as pt
+import pyrecest.backend as backend
+
+raw_left = torch.empty(3, device="meta")
+raw_result = pt.less_equal(raw_left, [1.0, 2.0, 3.0])
+assert raw_result.device.type == "meta"
+assert tuple(raw_result.shape) == (3,)
+assert raw_result.dtype == torch.bool
+
+if backend.__backend_name__ == "pytorch":
+    public_left = torch.empty(3, device="meta")
+    public_result = backend.less_equal(public_left, [1.0, 2.0, 3.0])
+    assert public_result.device.type == "meta"
+    assert tuple(public_result.shape) == (3,)
+    assert public_result.dtype == torch.bool
+"""
+
+    result = run_backend_code(backend_name, code)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Patch raw PyTorch comparison helpers `greater`, `less`, `less_equal`, and `logical_or` to coerce NumPy-style array-like operands before calling Torch.
- Keep the public PyTorch backend facade aligned when `PYRECEST_BACKEND=pytorch` is active.
- Add subprocess regression coverage under both NumPy and PyTorch backend selections.

## Bug fixed
`less_equal` could leave array-like operands on CPU when the other operand was already a tensor on another device. The new wrapper normalizes operands onto the tensor operand's device before calling Torch.

## Validation
- Added comparison contract coverage to `tests/backend_support/test_pytorch_pad_contract.py`.
- Added a `meta`-device regression for `less_equal`.
- Full repository test suite not run locally in this environment.