### PR TITLE
Fix JAX one_hot keyword contract

### DIFF
--- a/src/pyrecest/backend_support/__init__.py
+++ b/src/pyrecest/backend_support/__init__.py
@@ -346,6 +346,44 @@ def _patch_jax_outer_numpy_contract() -> None:
         backend.outer = outer
 
 
+def _patch_jax_one_hot_backend_contract() -> None:
+    """Make JAX one_hot accept the shared labels/num_classes contract."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+
+    active_jax_backend = getattr(backend, "__backend_name__", None) == "jax"
+
+    try:
+        import jax.numpy as jnp  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.jax as raw_jax  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - JAX backend import failed earlier
+        return
+
+    original_one_hot = raw_jax.one_hot
+    if getattr(original_one_hot, "_pyrecest_backend_contract", False):
+        if active_jax_backend:
+            backend.one_hot = original_one_hot
+        return
+
+    def one_hot(labels, num_classes=None, *, depth=None):
+        if depth is not None:
+            if num_classes is not None and num_classes != depth:
+                raise TypeError("one_hot() got both 'num_classes' and 'depth'")
+            num_classes = depth
+        if num_classes is None:
+            raise TypeError("one_hot() missing required argument 'num_classes'")
+        return jnp.eye(num_classes, dtype=jnp.uint8)[jnp.asarray(labels)]
+
+    one_hot.__name__ = getattr(original_one_hot, "__name__", "one_hot")
+    one_hot.__doc__ = getattr(original_one_hot, "__doc__", None)
+    one_hot._pyrecest_backend_contract = True
+    raw_jax.one_hot = one_hot
+    if active_jax_backend:
+        backend.one_hot = one_hot
+
+
 _patch_raw_pytorch_assignment_scalar_tensor_indices()
 _patch_pytorch_dtype_promotion_contract()
 _patch_pytorch_dot_numpy_contract()
@@ -354,6 +392,7 @@ _patch_pytorch_tile_numpy_contract()
 _patch_pytorch_copy_numpy_contract()
 _patch_pytorch_clip_numpy_contract()
 _patch_jax_outer_numpy_contract()
+_patch_jax_one_hot_backend_contract()
 
 
 def get_backend_support(

--- a/tests/backend_support/test_jax_one_hot_contract.py
+++ b/tests/backend_support/test_jax_one_hot_contract.py
@@ -1,0 +1,43 @@
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+pytestmark = pytest.mark.backend_portable
+
+
+def test_public_jax_one_hot_accepts_shared_keyword_contract():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("JAX is not installed")
+
+    code = """
+import pyrecest.backend as backend
+
+result = backend.one_hot(labels=[1, 0], num_classes=3)
+assert result.shape == (2, 3)
+assert str(backend.to_numpy(result).dtype) == "uint8"
+assert backend.to_numpy(result).tolist() == [[0, 1, 0], [1, 0, 0]]
+print("ok")
+"""
+    result = run_backend_code("jax", code)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_raw_jax_one_hot_accepts_shared_keyword_contract_after_import():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("JAX is not installed")
+
+    code = """
+import pyrecest  # noqa: F401  # triggers raw-backend compatibility patches
+import pyrecest._backend.jax as raw_jax
+
+result = raw_jax.one_hot(labels=[2, 1], num_classes=4)
+assert result.shape == (2, 4)
+assert raw_jax.to_numpy(result).tolist() == [[0, 0, 1, 0], [0, 1, 0, 0]]
+print("ok")
+"""
+    result = run_backend_code("numpy", code)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- Patch raw/public JAX `one_hot` to accept the shared backend `labels`/`num_classes` keyword contract.
- Preserve `depth` as a compatibility alias for the previous raw JAX helper name.
- Add subprocess regressions for the public JAX backend and raw JAX backend after PyRecEst initialization.

## Bug fixed
The NumPy and PyTorch backends expose `one_hot(labels, num_classes)`, and the backend contract tests already exercise the positional form. The JAX backend used `one_hot(indices, depth)`, so calls using shared keywords such as `backend.one_hot(labels=[...], num_classes=...)` could fail only on JAX.

## Validation
- Inspected the changed backend-support patch and test file after committing.
- Full repository tests were not run locally in this connector session because the execution container cannot resolve `github.com` for cloning/installing the repository; CI should run the added focused regressions.