### PR TITLE
Fix backend size axis validation

### DIFF
--- a/src/pyrecest/_backend/_common.py
+++ b/src/pyrecest/_backend/_common.py
@@ -1,8 +1,11 @@
 import math as _math
+import operator as _operator
 import os as _os
 
 import numpy as _np
 from numpy import pi
+
+_AXIS_FLAG_TYPE = type(True)
 
 
 def comb(n, k):
@@ -29,8 +32,20 @@ def outer(a, b):
     return a_expanded * b_expanded
 
 
+def _normalize_size_axis(axis):
+    if axis is None:
+        return None
+    if isinstance(axis, _AXIS_FLAG_TYPE):
+        raise TypeError("an integer is required")
+    try:
+        return _operator.index(axis)
+    except TypeError as exc:
+        raise TypeError("an integer is required") from exc
+
+
 def size(x, axis=None):
     """Return the total number of elements or the length of a given axis."""
+    axis = _normalize_size_axis(axis)
     if hasattr(x, "numel"):
         if axis is None:
             return x.numel()

--- a/tests/test_backend_size.py
+++ b/tests/test_backend_size.py
@@ -10,6 +10,12 @@ class TestBackendSize(unittest.TestCase):
     def test_size_returns_axis_length(self):
         self.assertEqual(size(array([[1, 2, 3], [4, 5, 6]]), axis=1), 3)
 
+    def test_size_rejects_logical_axis_value(self):
+        values = array([[1, 2, 3], [4, 5, 6]])
+
+        with self.assertRaises(TypeError):
+            size(values, axis=True)
+
     def test_size_handles_python_array_like_inputs(self):
         values = [[1, 2, 3], [4, 5, 6]]
 


### PR DESCRIPTION
## Summary
- Reject logical scalar axis values in the shared `backend.size` helper before indexing `shape`.
- Keep integer-like axis values routed through `operator.index`, matching NumPy's `size(..., axis=...)` behavior more closely.
- Add a regression test for `size(array, axis=True)` so it no longer silently returns the length of axis 1.

## Bug fixed
`pyrecest.backend.size(x, axis=True)` previously treated `True` as integer axis `1` because Python flags are tuple-indexable. NumPy rejects this input instead. The shared helper is used when a backend does not expose its own `size`, so the incorrect acceptance affected public backend code.

## Validation
- Reasoned regression: `axis=True` now raises `TypeError` before shape indexing.
- Added `tests/test_backend_size.py::TestBackendSize::test_size_rejects_logical_axis_value`.