### PR TITLE
Validate raw shared NumPy squeeze axes

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/__init__.py
+++ b/src/pyrecest/_backend/_shared_numpy/__init__.py
@@ -89,6 +89,18 @@ def _normalize_squeeze_axes(axis):
     return tuple(axis)
 
 
+def _axis_out_of_bounds_error(axis, ndim):
+    axis_error = getattr(getattr(_np, "exceptions", None), "AxisError", None)
+    if axis_error is None:
+        axis_error = getattr(_np, "AxisError", None)
+    if axis_error is None:
+        return ValueError(f"axis {axis} is out of bounds for array of dimension {ndim}")
+    try:
+        return axis_error(axis, ndim=ndim)
+    except TypeError:  # pragma: no cover - compatibility with older NumPy APIs
+        return axis_error(axis, ndim)
+
+
 def squeeze(x, axis=None):
     x = _np.asarray(x)
     if axis is None:
@@ -98,9 +110,14 @@ def squeeze(x, axis=None):
     if not axes:
         return x
 
-    normalized_axes = tuple(
-        one_axis + x.ndim if one_axis < 0 else one_axis for one_axis in axes
-    )
+    normalized_axes = []
+    for one_axis in axes:
+        normalized_axis = one_axis + x.ndim if one_axis < 0 else one_axis
+        if normalized_axis < 0 or normalized_axis >= x.ndim:
+            raise _axis_out_of_bounds_error(one_axis, x.ndim)
+        normalized_axes.append(normalized_axis)
+    normalized_axes = tuple(normalized_axes)
+
     if len(set(normalized_axes)) != len(normalized_axes):
         raise ValueError("duplicate value in 'axis'")
     if any(x.shape[one_axis] != 1 for one_axis in normalized_axes):

--- a/tests/test_shared_numpy_squeeze.py
+++ b/tests/test_shared_numpy_squeeze.py
@@ -1,6 +1,7 @@
 import pyrecest.backend as backend
 import pytest
 from pyrecest.backend import array
+from tests.support.backend_runner import run_backend_code
 
 
 def _to_python(value):
@@ -29,3 +30,23 @@ def test_shared_numpy_squeeze_rejects_out_of_bounds_axis(axis):
         backend.squeeze(array([[[1], [2]]]), axis=axis)
 
     assert "out of bounds" in str(exc_info.value)
+
+
+def test_raw_numpy_squeeze_rejects_out_of_bounds_axis():
+    code = """
+import pyrecest  # noqa: F401
+import pyrecest._backend.numpy as raw_numpy
+
+for axis in (3, -4):
+    try:
+        raw_numpy.squeeze([[[1], [2]]], axis=axis)
+    except Exception as exc:
+        assert "out of bounds" in str(exc), str(exc)
+    else:
+        raise AssertionError("expected an out-of-bounds axis failure")
+print("ok")
+"""
+    result = run_backend_code("numpy", code)
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- Validate shared NumPy squeeze axes before indexing `shape`.
- Keep duplicate-axis handling and existing non-singleton no-op behavior.
- Add a raw NumPy backend regression for out-of-bounds squeeze axes.

## Validation
- Syntax-checked the edited source and test content locally.
- Full test suite not run in this connector-only session; CI should run the focused regression.