### PR TITLE
Fix PyTorch expand_dims scalar axis

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
@@ -18,6 +18,7 @@ def patch_pytorch_dtype_promotion_contract() -> None:
     _patch_pytorch_repeat_numpy_contract(raw_pytorch, torch)
     _patch_pytorch_diff_numpy_contract(raw_pytorch, torch)
     _patch_pytorch_pad_constant_values_contract(raw_pytorch, torch, np)
+    _patch_pytorch_expand_dims_numpy_contract(raw_pytorch, backend, np)
 
     original_convert = raw_pytorch.convert_to_wider_dtype
     if getattr(original_convert, "_pyrecest_torch_promotion_contract", False):
@@ -90,6 +91,38 @@ def _pytorch_repeat_counts(repeats, *, numpy_module, torch_module, device):
     if bool(torch_module.any(repeat_counts < 0)):
         raise ValueError("repeats may not contain negative values")
     return repeat_counts
+
+
+def _pytorch_expand_dims_axes(axis, numpy_module):
+    """Normalize NumPy-style expand_dims axes for PyTorch."""
+    if isinstance(axis, (int, numpy_module.integer)):
+        return (axis,)
+    axis_array = numpy_module.asarray(axis)
+    if axis_array.shape == ():
+        return (axis_array.item(),)
+    return tuple(axis)
+
+
+def _patch_pytorch_expand_dims_numpy_contract(raw_pytorch, backend, numpy_module) -> None:
+    """Make raw/public PyTorch expand_dims accept NumPy scalar axes."""
+    original_expand_dims = raw_pytorch.expand_dims
+    if getattr(original_expand_dims, "_pyrecest_numpy_scalar_axis_contract", False):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.expand_dims = original_expand_dims
+        return
+
+    def expand_dims(x, axis=0):
+        return original_expand_dims(
+            x,
+            axis=_pytorch_expand_dims_axes(axis, numpy_module),
+        )
+
+    expand_dims.__name__ = getattr(original_expand_dims, "__name__", "expand_dims")
+    expand_dims.__doc__ = getattr(original_expand_dims, "__doc__", None)
+    expand_dims._pyrecest_numpy_scalar_axis_contract = True
+    raw_pytorch.expand_dims = expand_dims
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.expand_dims = expand_dims
 
 
 def _patch_pytorch_repeat_numpy_contract(raw_pytorch, torch) -> None:

--- a/tests/test_backend_contract.py
+++ b/tests/test_backend_contract.py
@@ -101,6 +101,16 @@ class BackendContractTest(unittest.TestCase):
             to_numpy(expanded), np.expand_dims(to_numpy(values), axis=(0, 2))
         )
 
+    def test_expand_dims_accepts_numpy_scalar_axis(self):
+        values = array([1.0, 2.0, 3.0])
+
+        expanded = backend.expand_dims(values, axis=np.array(0))
+
+        self.assertEqual(tuple(shape(expanded)), (1, 3))
+        npt.assert_allclose(
+            to_numpy(expanded), np.expand_dims(to_numpy(values), axis=np.array(0))
+        )
+
     def test_meshgrid_uses_numpy_default_xy_indexing(self):
         first, second = backend.meshgrid(array([1, 2]), array([3, 4]))
 


### PR DESCRIPTION
## Summary
- Normalize NumPy scalar axis arrays for the PyTorch expand_dims helper.
- Add regression coverage for axis=np.array(0).

## Validation
- Regression test added.
- Full suite not run locally here.