### PR TITLE
Reject duplicate active measurement indices

### DIFF
--- a/src/pyrecest/filters/update_diagnostics.py
+++ b/src/pyrecest/filters/update_diagnostics.py
@@ -85,10 +85,15 @@ def _normalize_active_measurement_indices(
         raise ValueError(
             "active_measurement_indices must be a sequence of non-negative integers"
         ) from exc
-    return tuple(
+    indices = tuple(
         _as_nonnegative_integer(value, "active_measurement_indices")
         for value in iterator
     )
+    if len(set(indices)) != len(indices):
+        raise ValueError(
+            "active_measurement_indices must not contain duplicate indices"
+        )
+    return indices
 
 
 def _as_nonnegative_integer(value: Any, name: str) -> int:

--- a/tests/filters/test_update_diagnostics_validation.py
+++ b/tests/filters/test_update_diagnostics_validation.py
@@ -35,6 +35,14 @@ def test_active_measurement_indices_must_fit_measurement_count():
         )
 
 
+def test_active_measurement_indices_reject_duplicates():
+    with pytest.raises(ValueError, match="active_measurement_indices.*duplicate"):
+        MeasurementUpdateDiagnostics(
+            active_measurement_indices=(0, np.int64(0)),
+            measurement_count=1,
+        )
+
+
 def test_measurement_count_rejects_non_integer_values():
     invalid_counts = (
         True,


### PR DESCRIPTION
## Summary
- Reject duplicate `active_measurement_indices` in `MeasurementUpdateDiagnostics` after integer normalization.
- Add a regression test covering duplicate integer-like indices.

## Rationale
Duplicate active measurement indices can make `active_measurement_count` over-count the number of distinct measurements that contributed to an update. That can make diagnostics/logging report an impossible active count for a given `measurement_count`.

## Testing
- `python -m py_compile /mnt/data/update_diagnostics.py /mnt/data/test_update_diagnostics_validation.py`
- Local targeted script checked that `(0, np.int64(0))` raises and integer-like scalar indices still normalize correctly.

Full repository tests were not run locally because this environment could not clone GitHub (`Could not resolve host: github.com`).