### PR TITLE
Fix PyTorch logical helper device contract

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract/__init__.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract/__init__.py
@@ -1,0 +1,123 @@
+"""PyTorch backend logical-helper compatibility patch."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_base_contract_module():
+    module_path = Path(__file__).resolve().parent.parent / "_torch_dtype_promotion_contract.py"
+    spec = importlib.util.spec_from_file_location(
+        "_pyrecest_torch_dtype_promotion_contract_base",
+        module_path,
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load PyTorch dtype contract module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_BASE_CONTRACT = _load_base_contract_module()
+
+
+def patch_pytorch_dtype_promotion_contract() -> None:
+    """Apply the base PyTorch contract patch plus logical-helper device fixes."""
+    _BASE_CONTRACT.patch_pytorch_dtype_promotion_contract()
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
+        return
+
+    _patch_pytorch_logical_device_contract(raw_pytorch, backend, torch)
+
+
+def _preferred_pytorch_device(torch_module, *values):
+    """Return a non-CPU tensor device when mixed-device operands are present."""
+    for value in values:
+        if torch_module.is_tensor(value) and value.device.type != "cpu":
+            return value.device
+    for value in values:
+        if torch_module.is_tensor(value):
+            return value.device
+    return None
+
+
+def _as_pytorch_tensor_on_device(value, torch_module, *, device, dtype=None):
+    """Return ``value`` as a tensor on ``device``."""
+    if torch_module.is_tensor(value):
+        if device is not None and value.device != device:
+            value = value.to(device=device)
+        if dtype is not None and value.dtype != dtype:
+            value = value.to(dtype=dtype)
+        return value
+    return torch_module.as_tensor(value, dtype=dtype, device=device)
+
+
+def _patch_pytorch_logical_device_contract(raw_pytorch, backend, torch) -> None:
+    """Keep logical helpers on an existing non-CPU tensor device."""
+    helper_names = ("logical_and", "where")
+    if all(
+        getattr(
+            getattr(raw_pytorch, helper_name, None),
+            "_pyrecest_device_contract",
+            False,
+        )
+        for helper_name in helper_names
+    ):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            for helper_name in helper_names:
+                setattr(backend, helper_name, getattr(raw_pytorch, helper_name))
+        return
+
+    original_logical_and = raw_pytorch.logical_and
+    original_where = raw_pytorch.where
+
+    def logical_and(x, y):
+        device = _preferred_pytorch_device(torch, x, y)
+        return torch.logical_and(
+            _as_pytorch_tensor_on_device(x, torch, device=device),
+            _as_pytorch_tensor_on_device(y, torch, device=device),
+        )
+
+    def where(condition, x=None, y=None):
+        device = _preferred_pytorch_device(torch, condition, x, y)
+        condition = _as_pytorch_tensor_on_device(
+            condition,
+            torch,
+            device=device,
+            dtype=torch.bool,
+        )
+
+        if x is None and y is None:
+            return torch.where(condition)
+        if x is None or y is None:
+            raise ValueError("either both or neither of x and y should be given")
+
+        x = _as_pytorch_tensor_on_device(x, torch, device=device)
+        y = _as_pytorch_tensor_on_device(y, torch, device=device)
+        result_dtype = torch.result_type(x, y)
+        return torch.where(
+            condition,
+            x.to(dtype=result_dtype),
+            y.to(dtype=result_dtype),
+        )
+
+    logical_and.__name__ = getattr(original_logical_and, "__name__", "logical_and")
+    logical_and.__doc__ = getattr(original_logical_and, "__doc__", None)
+    logical_and._pyrecest_device_contract = True
+    where.__name__ = getattr(original_where, "__name__", "where")
+    where.__doc__ = getattr(original_where, "__doc__", None)
+    where._pyrecest_device_contract = True
+
+    raw_pytorch.logical_and = logical_and
+    raw_pytorch.where = where
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.logical_and = logical_and
+        backend.where = where
+
+
+__all__ = ["patch_pytorch_dtype_promotion_contract"]


### PR DESCRIPTION
## Summary
- Add a PyTorch backend-support compatibility package that delegates to the existing dtype-promotion patch and then patches `logical_and` and `where`.
- Prefer an existing non-CPU tensor device when logical-helper operands are mixed across CPU and accelerator devices.
- Keep the raw PyTorch backend and the public `pyrecest.backend` facade synchronized when `PYRECEST_BACKEND=pytorch` is active.

## Bug fixed
The current PyTorch `logical_and` and `where` helpers choose the device from the first tensor operand. For calls such as a CPU condition/left operand with a CUDA right operand, the helper attempts to move the CUDA tensor back to CPU, which fails or breaks device locality. The new wrapper selects a non-CPU tensor device when present and moves CPU/array-like operands to that device before dispatching to Torch.

## Validation
- Inspected the backend implementation and confirmed `logical_and`/`where` used first-tensor device selection.
- GitHub connector source patch created against current `main` (`281bfcdd48b5f1fc61ba7a6d8693f225890b1671`).
- I could not add the focused regression test file because the connector safety layer blocked writes under `tests/backend_support` during this session.