### PR TITLE
Fix PyTorch take axis validation

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
@@ -18,6 +18,7 @@ def patch_pytorch_dtype_promotion_contract() -> None:
     _patch_pytorch_repeat_numpy_contract(raw_pytorch, torch)
     _patch_pytorch_diff_numpy_contract(raw_pytorch, torch)
     _patch_pytorch_pad_constant_values_contract(raw_pytorch, torch, np)
+    _patch_pytorch_take_axis_contract(raw_pytorch, torch, np)
 
     original_convert = raw_pytorch.convert_to_wider_dtype
     if getattr(original_convert, "_pyrecest_torch_promotion_contract", False):
@@ -283,3 +284,59 @@ def _patch_pytorch_pad_constant_values_contract(raw_pytorch, torch, np) -> None:
     raw_pytorch.pad = pad
     if backend is not None and getattr(backend, "__backend_name__", None) == "pytorch":
         backend.pad = pad
+
+
+def _is_logical_axis(axis, torch, np) -> bool:
+    """Return whether ``axis`` is a logical scalar, not an integer axis."""
+    if isinstance(axis, (bool, np.bool_)):
+        return True
+    return bool(torch.is_tensor(axis) and axis.dtype == torch.bool)
+
+
+def _normalize_take_axis(axis, ndim, torch, np):
+    """Normalize NumPy-style take axes without accepting non-integer scalars."""
+    if axis is None:
+        return None
+    if _is_logical_axis(axis, torch, np):
+        raise TypeError("an integer is required for the axis")
+    try:
+        axis = _operator_index(axis)
+    except TypeError as exc:
+        raise TypeError("an integer is required for the axis") from exc
+    if axis < 0:
+        axis += ndim
+    if axis < 0 or axis >= ndim:
+        raise IndexError(f"axis {axis} is out of bounds for array of dimension {ndim}")
+    return axis
+
+
+def _patch_pytorch_take_axis_contract(raw_pytorch, torch, np) -> None:
+    """Make raw/public PyTorch take reject non-integer NumPy-style axes."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        backend = None
+
+    original_take = raw_pytorch.take
+    if getattr(original_take, "_pyrecest_take_axis_contract", False):
+        if backend is not None and getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.take = original_take
+        return
+
+    def take(a, indices, axis=None, out=None, mode=None):
+        values = raw_pytorch.array(a)
+        normalized_axis = _normalize_take_axis(axis, values.ndim, torch, np)
+        return original_take(
+            values,
+            indices,
+            axis=normalized_axis,
+            out=out,
+            mode=mode,
+        )
+
+    take.__name__ = getattr(original_take, "__name__", "take")
+    take.__doc__ = getattr(original_take, "__doc__", None)
+    take._pyrecest_take_axis_contract = True
+    raw_pytorch.take = take
+    if backend is not None and getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.take = take

--- a/tests/backend_support/test_pytorch_take_axis_contract.py
+++ b/tests/backend_support/test_pytorch_take_axis_contract.py
@@ -1,0 +1,50 @@
+"""Regression tests for PyTorch backend take-axis validation."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_pytorch_take_rejects_non_integer_axes_like_numpy():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import numpy as np
+import torch
+
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+
+def assert_axis_type_error(take_func, values, axis):
+    try:
+        take_func(values, [0], axis=axis)
+    except TypeError:
+        return
+    raise AssertionError(f"take accepted non-integer axis {axis!r}")
+
+
+values = backend.asarray([[0, 1], [2, 3]])
+raw_values = raw_pytorch.array([[0, 1], [2, 3]])
+
+for invalid_axis in (True, 1.0, "1", np.array(True), torch.tensor(True)):
+    assert_axis_type_error(backend.take, values, invalid_axis)
+    assert_axis_type_error(raw_pytorch.take, raw_values, invalid_axis)
+
+assert backend.to_numpy(backend.take(values, [0], axis=np.array(0))).tolist() == [[0, 1]]
+assert raw_pytorch.to_numpy(raw_pytorch.take(raw_values, [0], axis=np.array(1))).tolist() == [
+    [0],
+    [2],
+]
+""",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Patch the PyTorch backend compatibility layer so `take(..., axis=...)` uses integer-index semantics instead of `int(axis)` coercion.
- Reject logical and non-integer axes such as `True`, `1.0`, `"1"`, `np.array(True)`, and `torch.tensor(True)` for both public and raw PyTorch `take`.
- Add subprocess regression coverage while preserving 0-D NumPy integer scalar axis support.

## Bug fixed
The raw PyTorch `take` helper normalized `axis` through `int(axis)`, so castable non-integer values could be silently accepted as dimensions. NumPy rejects those values, so a call such as `backend.take(values, [0], axis=1.0)` could incorrectly behave as `axis=1` under the PyTorch backend.

## Validation
- `python -m py_compile /mnt/data/_torch_dtype_promotion_contract.py`
- `python -m py_compile /mnt/data/test_pytorch_take_axis_contract.py`
- Full repository tests were not run locally because this execution container cannot resolve `github.com` to clone/install the repository; CI should run the added focused regression.