### PR TITLE
Fix common reduction boolean axis validation

### DIFF
--- a/src/pyrecest/_backend/_common.py
+++ b/src/pyrecest/_backend/_common.py
@@ -50,10 +50,14 @@ def size(x, axis=None):
 
 
 def _normalize_reduction_axes(axis, ndim_value):
+    if isinstance(axis, (bool, _np.bool_)):
+        raise TypeError("axis must be an integer or a sequence of integers")
     if isinstance(axis, (int, _np.integer)):
         axes = (int(axis),)
     else:
         axes = tuple(axis)
+        if any(isinstance(axis_index, (bool, _np.bool_)) for axis_index in axes):
+            raise TypeError("axis must be an integer or a sequence of integers")
 
     normalized_axes = tuple(
         axis_index + ndim_value if axis_index < 0 else axis_index for axis_index in axes

--- a/tests/test_common_reduction_axis_validation.py
+++ b/tests/test_common_reduction_axis_validation.py
@@ -1,0 +1,18 @@
+import importlib.util
+
+import pytest
+
+from pyrecest._backend import _common
+
+
+@pytest.mark.backend_portable
+def test_common_torch_min_rejects_boolean_axes():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    import torch
+
+    values = torch.arange(6).reshape(2, 3)
+    for axis in (True, False, (True,), [False]):
+        with pytest.raises(TypeError):
+            _common.min(values, axis=axis)


### PR DESCRIPTION
## Summary
- Reject boolean scalar axes in the shared common reduction-axis normalizer.
- Reject boolean values nested inside sequence axes before they are treated as integer dimensions.
- Add a focused regression for `_common.min` on Torch tensors, where `True`/`False` previously reduced over axes 1/0 instead of failing like NumPy.

## Validation
- Regression test added.
- Full suite not run locally in this environment.