### PR TITLE
Fix PyTorch backend logical helpers

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract/__init__.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract/__init__.py
@@ -1,0 +1,123 @@
+"""PyTorch backend logical-helper compatibility patch."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_base_contract_module():
+    module_path = Path(__file__).resolve().parent.parent / "_torch_dtype_promotion_contract.py"
+    spec = importlib.util.spec_from_file_location(
+        "_pyrecest_torch_dtype_promotion_contract_base",
+        module_path,
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load PyTorch dtype contract module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_BASE_CONTRACT = _load_base_contract_module()
+
+
+def patch_pytorch_dtype_promotion_contract() -> None:
+    """Apply the base PyTorch contract patch plus logical-helper device fixes."""
+    _BASE_CONTRACT.patch_pytorch_dtype_promotion_contract()
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
+        return
+
+    _patch_pytorch_logical_device_contract(raw_pytorch, backend, torch)
+
+
+def _preferred_pytorch_device(torch_module, *values):
+    """Return a non-CPU tensor device when mixed-device operands are present."""
+    for value in values:
+        if torch_module.is_tensor(value) and value.device.type != "cpu":
+            return value.device
+    for value in values:
+        if torch_module.is_tensor(value):
+            return value.device
+    return None
+
+
+def _as_pytorch_tensor_on_device(value, torch_module, *, device, dtype=None):
+    """Return ``value`` as a tensor on ``device``."""
+    if torch_module.is_tensor(value):
+        if device is not None and value.device != device:
+            value = value.to(device=device)
+        if dtype is not None and value.dtype != dtype:
+            value = value.to(dtype=dtype)
+        return value
+    return torch_module.as_tensor(value, dtype=dtype, device=device)
+
+
+def _patch_pytorch_logical_device_contract(raw_pytorch, backend, torch) -> None:
+    """Keep logical helpers on an existing non-CPU tensor device."""
+    helper_names = ("logical_and", "where")
+    if all(
+        getattr(
+            getattr(raw_pytorch, helper_name, None),
+            "_pyrecest_device_contract",
+            False,
+        )
+        for helper_name in helper_names
+    ):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            for helper_name in helper_names:
+                setattr(backend, helper_name, getattr(raw_pytorch, helper_name))
+        return
+
+    original_logical_and = raw_pytorch.logical_and
+    original_where = raw_pytorch.where
+
+    def logical_and(x, y):
+        device = _preferred_pytorch_device(torch, x, y)
+        return torch.logical_and(
+            _as_pytorch_tensor_on_device(x, torch, device=device),
+            _as_pytorch_tensor_on_device(y, torch, device=device),
+        )
+
+    def where(condition, x=None, y=None):
+        device = _preferred_pytorch_device(torch, condition, x, y)
+        condition = _as_pytorch_tensor_on_device(
+            condition,
+            torch,
+            device=device,
+            dtype=torch.bool,
+        )
+
+        if x is None and y is None:
+            return torch.where(condition)
+        if x is None or y is None:
+            raise ValueError("either both or neither of x and y should be given")
+
+        x = _as_pytorch_tensor_on_device(x, torch, device=device)
+        y = _as_pytorch_tensor_on_device(y, torch, device=device)
+        result_dtype = torch.result_type(x, y)
+        return torch.where(
+            condition,
+            x.to(dtype=result_dtype),
+            y.to(dtype=result_dtype),
+        )
+
+    logical_and.__name__ = getattr(original_logical_and, "__name__", "logical_and")
+    logical_and.__doc__ = getattr(original_logical_and, "__doc__", None)
+    logical_and._pyrecest_device_contract = True
+    where.__name__ = getattr(original_where, "__name__", "where")
+    where.__doc__ = getattr(original_where, "__doc__", None)
+    where._pyrecest_device_contract = True
+
+    raw_pytorch.logical_and = logical_and
+    raw_pytorch.where = where
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.logical_and = logical_and
+        backend.where = where
+
+
+__all__ = ["patch_pytorch_dtype_promotion_contract"]

--- a/tests/backend_support/test_pytorch_device_contract.py
+++ b/tests/backend_support/test_pytorch_device_contract.py
@@ -41,3 +41,37 @@ assert backend.to_numpy(sparse_array).tolist() == [[0.0, 5.0], [7.0, 0.0]]
     )
 
     assert result.returncode == 0, result.stderr
+
+
+def test_pytorch_logical_helpers_prefer_non_cpu_tensor_device():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import torch
+import pyrecest.backend as backend
+
+cpu_mask = torch.tensor([True, False], dtype=torch.bool)
+meta_mask = torch.ones(2, dtype=torch.bool, device="meta")
+
+logical_result = backend.logical_and(cpu_mask, meta_mask)
+
+assert logical_result.device.type == "meta"
+assert logical_result.dtype == torch.bool
+assert logical_result.shape == torch.Size([2])
+
+condition = torch.tensor([True, False], dtype=torch.bool)
+cpu_values = torch.tensor([1.0, 2.0])
+meta_values = torch.ones(2, device="meta")
+
+selected = backend.where(condition, cpu_values, meta_values)
+
+assert selected.device.type == "meta"
+assert selected.dtype == torch.float32
+assert selected.shape == torch.Size([2])
+""",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Patch PyTorch backend logical helpers to keep operands on an existing tensor device.
- Add focused regression coverage in `tests/backend_support/test_pytorch_device_contract.py`.

## Validation
- Regression added for the PyTorch backend helper path.
- Full suite not run locally; CI should validate the branch.