### PR TITLE
Fix PyTorch one_hot integer tensor labels

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
@@ -18,6 +18,7 @@ def patch_pytorch_dtype_promotion_contract() -> None:
     _patch_pytorch_repeat_numpy_contract(raw_pytorch, torch)
     _patch_pytorch_diff_numpy_contract(raw_pytorch, torch)
     _patch_pytorch_pad_constant_values_contract(raw_pytorch, torch, np)
+    _patch_pytorch_one_hot_index_dtype_contract(raw_pytorch, torch)
 
     original_convert = raw_pytorch.convert_to_wider_dtype
     if getattr(original_convert, "_pyrecest_torch_promotion_contract", False):
@@ -283,3 +284,45 @@ def _patch_pytorch_pad_constant_values_contract(raw_pytorch, torch, np) -> None:
     raw_pytorch.pad = pad
     if backend is not None and getattr(backend, "__backend_name__", None) == "pytorch":
         backend.pad = pad
+
+
+def _is_pytorch_integer_label_dtype(dtype, torch) -> bool:
+    """Return whether ``dtype`` is an integer index dtype accepted as labels."""
+    return dtype in {
+        torch.uint8,
+        torch.int8,
+        torch.int16,
+        torch.int32,
+        torch.int64,
+    }
+
+
+def _patch_pytorch_one_hot_index_dtype_contract(raw_pytorch, torch) -> None:
+    """Make raw/public PyTorch one_hot accept integer tensor label dtypes."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        backend = None
+
+    original_one_hot = raw_pytorch.one_hot
+    if getattr(original_one_hot, "_pyrecest_index_dtype_contract", False):
+        return
+
+    def one_hot(labels, num_classes):
+        if torch.is_tensor(labels):
+            if (
+                labels.dtype != torch.long
+                and _is_pytorch_integer_label_dtype(labels.dtype, torch)
+            ):
+                labels = labels.to(dtype=torch.long)
+        else:
+            labels = torch.LongTensor(labels)
+        result = torch.nn.functional.one_hot(labels, num_classes)
+        return result.to(dtype=torch.uint8)
+
+    one_hot.__name__ = getattr(original_one_hot, "__name__", "one_hot")
+    one_hot.__doc__ = getattr(original_one_hot, "__doc__", None)
+    one_hot._pyrecest_index_dtype_contract = True
+    raw_pytorch.one_hot = one_hot
+    if backend is not None and getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.one_hot = one_hot

--- a/tests/backend_support/test_pytorch_one_hot_contract.py
+++ b/tests/backend_support/test_pytorch_one_hot_contract.py
@@ -1,0 +1,39 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_pytorch_one_hot_accepts_integer_tensor_labels():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import torch
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+labels = torch.tensor([0, 2], dtype=torch.int32)
+expected = [[1, 0, 0], [0, 0, 1]]
+
+result = backend.one_hot(labels, 3)
+assert backend.to_numpy(result).tolist() == expected
+assert str(backend.to_numpy(result).dtype) == "uint8"
+
+raw_result = raw_pytorch.one_hot(torch.tensor([1], dtype=torch.int16), 3)
+assert backend.to_numpy(raw_result).tolist() == [[0, 1, 0]]
+assert str(backend.to_numpy(raw_result).dtype) == "uint8"
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- Patch the PyTorch backend compatibility layer so `one_hot` casts integer tensor label dtypes to `torch.long` before calling `torch.nn.functional.one_hot`.
- Keep the public `pyrecest.backend` facade and raw `pyrecest._backend.pytorch` helper in sync.
- Add subprocess regression coverage for `torch.int32`/`torch.int16` tensor labels while preserving `uint8` indicators.

## Bug fixed
The PyTorch backend accepted Python list labels because it converted them with `torch.LongTensor`, but it rejected integer tensors such as `torch.tensor([0, 2], dtype=torch.int32)`. This made valid integer-label inputs fail only when they were already tensors, even though the shared backend contract accepts integer label arrays.

## Testing
- `python -m py_compile /tmp/_torch_dtype_promotion_contract.py /tmp/test_pytorch_one_hot_contract.py`
- Local torch smoke check confirmed `torch.nn.functional.one_hot(torch.tensor([0], dtype=torch.int32), 3)` raises before casting and succeeds after casting to `torch.long`.

Full repository tests were not run locally in this connector-driven session.