### PR TITLE
Reject unsupported unary transition sample counts

### DIFF
--- a/src/pyrecest/models/_sampleable_transition_validation.py
+++ b/src/pyrecest/models/_sampleable_transition_validation.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 
 from typing import Any
 
-from .likelihood import SampleableTransitionModel
+from .likelihood import (
+    DensityTransitionModel,
+    SampleableTransitionModel,
+    _validate_sample_count,
+)
 from .validation import _validate_bool_flag
+
+_SAMPLEABLE_SAMPLE_NEXT = SampleableTransitionModel.sample_next
+_DENSITY_SAMPLE_NEXT = DensityTransitionModel.sample_next
 
 
 def _get_function_is_vectorized(model: SampleableTransitionModel) -> bool:
@@ -22,11 +29,33 @@ def _set_function_is_vectorized(
     )
 
 
+def _validated_sampler_count(model: Any, n: Any) -> int:
+    n = _validate_sample_count(n)
+    if model._sample_next_count_call_mode is None and n != 1:
+        raise ValueError(
+            "sample_next callback does not accept an n argument; only n=1 is supported."
+        )
+    return n
+
+
+def _sampleable_sample_next(model: SampleableTransitionModel, state: Any, n: int = 1) -> Any:
+    n = _validated_sampler_count(model, n)
+    return _SAMPLEABLE_SAMPLE_NEXT(model, state, n=n)
+
+
+def _density_sample_next(model: DensityTransitionModel, state: Any, n: int = 1) -> Any:
+    if model._sample_next is not None:
+        n = _validated_sampler_count(model, n)
+    return _DENSITY_SAMPLE_NEXT(model, state, n=n)
+
+
 def install_sampleable_transition_validation() -> None:
-    """Validate ``function_is_vectorized`` after construction as well."""
+    """Install runtime validation hooks for transition-model capabilities."""
 
     SampleableTransitionModel.function_is_vectorized = property(
         _get_function_is_vectorized,
         _set_function_is_vectorized,
         doc="Whether ``sample_next`` accepts a batch of states.",
     )
+    SampleableTransitionModel.sample_next = _sampleable_sample_next
+    DensityTransitionModel.sample_next = _density_sample_next

--- a/tests/models/test_transition_unary_sampler_count_contract.py
+++ b/tests/models/test_transition_unary_sampler_count_contract.py
@@ -1,0 +1,38 @@
+import unittest
+
+from pyrecest.backend import allclose, array
+from pyrecest.models import DensityTransitionModel, SampleableTransitionModel
+
+
+class UnaryTransitionSamplerCountContractTest(unittest.TestCase):
+    def test_sampleable_unary_sampler_allows_default_count(self):
+        model = SampleableTransitionModel(lambda state: state + array([1.0]))
+
+        self.assertTrue(allclose(model.sample_next(array([10.0])), array([11.0])))
+
+    def test_sampleable_unary_sampler_rejects_multiple_samples(self):
+        model = SampleableTransitionModel(lambda state: state + array([1.0]))
+
+        with self.assertRaisesRegex(ValueError, "does not accept an n argument"):
+            model.sample_next(array([10.0]), n=2)
+
+    def test_density_unary_sampler_allows_default_count(self):
+        model = DensityTransitionModel(
+            lambda state_next, state_previous: state_next + state_previous,
+            sample_next=lambda state: state + array([1.0]),
+        )
+
+        self.assertTrue(allclose(model.sample_next(array([4.0])), array([5.0])))
+
+    def test_density_unary_sampler_rejects_multiple_samples(self):
+        model = DensityTransitionModel(
+            lambda state_next, state_previous: state_next + state_previous,
+            sample_next=lambda state: state + array([1.0]),
+        )
+
+        with self.assertRaisesRegex(ValueError, "does not accept an n argument"):
+            model.sample_next(array([4.0]), n=2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Validate transition sampler count requests for callbacks that only accept `state`.
- Allow the default count of one.
- Raise `ValueError` for larger requested counts instead of ignoring the request.
- Add regression tests for `SampleableTransitionModel` and `DensityTransitionModel`.

## Validation
- `python -m py_compile /tmp/_sampleable_transition_validation.py /tmp/test_transition_unary_sampler_count_contract.py`