### PR TITLE
Fix JAX buffer contract

### DIFF
--- a/src/pyrecest/backend_support/__init__.py
+++ b/src/pyrecest/backend_support/__init__.py
@@ -430,6 +430,58 @@ def _patch_jax_one_hot_backend_contract() -> None:
         backend.one_hot = one_hot
 
 
+def _patch_jax_take_out_contract() -> None:
+    """Make JAX take honor NumPy's out keyword without passing it to JAX."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+
+    active_jax_backend = getattr(backend, "__backend_name__", None) == "jax"
+
+    try:
+        import pyrecest._backend.jax as raw_jax  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - JAX backend import failed earlier
+        return
+
+    original_take = raw_jax.take
+    if getattr(original_take, "_pyrecest_out_contract", False):
+        if active_jax_backend:
+            backend.take = original_take
+        return
+
+    def take(
+        a,
+        indices,
+        axis=None,
+        out=None,
+        mode=None,
+        unique_indices=False,
+        indices_are_sorted=False,
+        fill_value=None,
+    ):
+        result = original_take(
+            a,
+            indices,
+            axis=axis,
+            out=None,
+            mode=mode,
+            unique_indices=unique_indices,
+            indices_are_sorted=indices_are_sorted,
+            fill_value=fill_value,
+        )
+        if out is None:
+            return result
+        return raw_jax.asarray(out).at[...].set(result)
+
+    take.__name__ = getattr(original_take, "__name__", "take")
+    take.__doc__ = getattr(original_take, "__doc__", None)
+    take._pyrecest_out_contract = True
+    raw_jax.take = take
+    if active_jax_backend:
+        backend.take = take
+
+
 _patch_raw_pytorch_assignment_scalar_tensor_indices()
 _patch_pytorch_dtype_promotion_contract()
 _patch_pytorch_dot_numpy_contract()
@@ -440,6 +492,7 @@ _patch_pytorch_clip_numpy_contract()
 _patch_pytorch_broadcast_to_numpy_contract()
 _patch_jax_outer_numpy_contract()
 _patch_jax_one_hot_backend_contract()
+_patch_jax_take_out_contract()
 
 
 def get_backend_support(

--- a/tests/backend_support/test_jax_take_out_contract.py
+++ b/tests/backend_support/test_jax_take_out_contract.py
@@ -1,0 +1,72 @@
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+def _skip_without_jax():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("JAX is not installed")
+
+
+@pytest.mark.backend_portable
+def test_raw_jax_take_honors_out_under_numpy_backend():
+    _skip_without_jax()
+
+    result = run_backend_code(
+        "numpy",
+        """
+import numpy as np
+import pyrecest  # noqa: F401 - triggers backend compatibility patches
+import pyrecest.backend as backend
+import pyrecest._backend.jax as raw_jax
+
+assert getattr(backend, "__backend_name__", None) == "numpy"
+values = raw_jax.arange(6).reshape(2, 3)
+out = raw_jax.zeros((2, 2), dtype=values.dtype)
+
+actual = raw_jax.take(values, [0, 2], axis=1, out=out)
+expected = np.array([[0, 2], [3, 5]])
+np.testing.assert_array_equal(raw_jax.to_numpy(actual), expected)
+
+try:
+    raw_jax.take(values, [0, 2], axis=1, out=raw_jax.zeros((2, 3), dtype=values.dtype))
+except ValueError:
+    pass
+else:
+    raise AssertionError("raw JAX take accepted an incompatible out shape")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.backend_portable
+def test_public_jax_take_honors_out_when_selected():
+    _skip_without_jax()
+
+    result = run_backend_code(
+        "jax",
+        """
+import numpy as np
+import pyrecest.backend as backend
+
+assert getattr(backend, "__backend_name__", None) == "jax"
+values = backend.arange(6).reshape(2, 3)
+out = backend.zeros((2, 2), dtype=values.dtype)
+
+actual = backend.take(values, [0, 2], axis=1, out=out)
+expected = np.array([[0, 2], [3, 5]])
+np.testing.assert_array_equal(backend.to_numpy(actual), expected)
+
+try:
+    backend.take(values, [0, 2], axis=1, out=backend.zeros((2, 3), dtype=values.dtype))
+except ValueError:
+    pass
+else:
+    raise AssertionError("public JAX take accepted an incompatible out shape")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Adds a JAX backend-support shim for the indexed selection helper.
- Handles caller-provided result buffers in PyRecEst before returning the JAX array.
- Adds regression coverage for raw JAX under NumPy selection and for the selected public JAX backend.

## Validation
- Local JAX smoke check for compatible and incompatible result-buffer shapes.
- CI should run the added focused regression tests.