### PR TITLE
Fix linear slice in bounded Dirac products

### DIFF
--- a/src/pyrecest/distributions/cart_prod/lin_bounded_cart_prod_dirac_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/lin_bounded_cart_prod_dirac_distribution.py
@@ -15,9 +15,8 @@ class LinBoundedCartProdDiracDistribution(
     AbstractDiracDistribution, AbstractLinBoundedCartProdDistribution
 ):
     def marginalize_periodic(self):
-        return LinearDiracDistribution(
-            self.d[:, self.bound_dim :], self.w  # noqa: E203
-        )
+        linear_start = self.d.shape[-1] - self.lin_dim
+        return LinearDiracDistribution(self.d[:, linear_start:], self.w)
 
     def linear_mean(self):
         return self.marginalize_periodic().mean()

--- a/tests/distributions/test_se3_dirac_distribution.py
+++ b/tests/distributions/test_se3_dirac_distribution.py
@@ -53,6 +53,22 @@ class SE3DiracDistributionTest(unittest.TestCase):
         npt.assert_allclose(dist.w, array(weights))
         self.assertEqual(dist.d.shape, (2, 7))
 
+    def test_linear_marginal_starts_after_full_quaternion_coordinates(self):
+        particles = array(
+            [
+                [0.0, 0.0, 0.0, 1.0, 1.0, 2.0, 3.0],
+                [1.0, 0.0, 0.0, 0.0, 4.0, 5.0, 6.0],
+            ]
+        )
+        weights = array([0.25, 0.75])
+
+        dist = SE3DiracDistribution(particles, weights)
+        linear_marginal = dist.marginalize_periodic()
+
+        self.assertEqual(linear_marginal.d.shape, (2, 3))
+        npt.assert_allclose(linear_marginal.d, particles[:, 4:])
+        npt.assert_allclose(dist.linear_mean(), array([3.25, 4.25, 5.25]))
+
     def test_constructor_rejects_unnormalized_hypersphere_particles(self):
         particles = array([[2.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0]])
 


### PR DESCRIPTION
## Summary
- Split linear Dirac components using `d.shape[-1] - lin_dim` instead of `bound_dim`.
- Add an SE(3) regression for quaternion-plus-linear particles.

## Validation
- Added focused regression coverage.
- Full suite not run in this connector-only environment.