### PR TITLE
Fix binary supported backend normalization

### DIFF
--- a/src/pyrecest/exceptions.py
+++ b/src/pyrecest/exceptions.py
@@ -18,6 +18,8 @@ def _normalize_supported_backends(
         return ()
     if isinstance(supported_backends, str):
         return (supported_backends,)
+    if isinstance(supported_backends, (bytes, bytearray)):
+        return (supported_backends.decode(),)
     return tuple(str(backend) for backend in supported_backends)
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -35,6 +35,18 @@ def test_backend_not_supported_error_accepts_single_string_supported_backend():
     assert "n, u, m, p, y" not in str(error)
 
 
+def test_backend_not_supported_error_accepts_single_binary_supported_backend():
+    error = BackendNotSupportedError(
+        "ExampleAPI.update",
+        "jax",
+        supported_backends=bytes("numpy", "utf-8"),
+    )
+
+    assert error.supported_backends == ("numpy",)
+    assert "supported backends: numpy" in str(error)
+    assert "n, u, m, p, y" not in str(error)
+
+
 def test_backend_not_supported_error_keeps_backendless_context():
     error = BackendNotSupportedError(
         "ExampleAPI.batch_update",


### PR DESCRIPTION
## Summary
- Treat `bytes` and `bytearray` backend names as single textual backend names when normalizing `BackendNotSupportedError.supported_backends`.
- Add a regression test covering the binary-single-name case.

## Bug fixed
`BackendNotSupportedError` already special-cased `str` so that `supported_backends="numpy"` is displayed as one backend instead of being split into characters. The same scalar-text issue affected `bytes` and `bytearray`: `supported_backends=bytes("numpy", "utf-8")` was treated as an iterable of byte values, producing a misleading supported-backends tuple/message instead of `("numpy",)`.

## Validation
- Local Python smoke test for `_normalize_supported_backends("numpy")`, `_normalize_supported_backends(bytes("numpy", "utf-8"))`, and tuple input.
- Added `tests/test_exceptions.py::test_backend_not_supported_error_accepts_single_binary_supported_backend`.