### PR TITLE
Fix Dirac sample count validation

### DIFF
--- a/src/pyrecest/distributions/abstract_dirac_distribution.py
+++ b/src/pyrecest/distributions/abstract_dirac_distribution.py
@@ -1,7 +1,7 @@
 import copy
 import warnings
 from collections.abc import Callable
-from numbers import Integral
+from operator import index as _operator_index
 from typing import Union
 
 from beartype import beartype
@@ -27,6 +27,30 @@ from pyrecest.backend import (
 )
 
 from .abstract_distribution_type import AbstractDistributionType
+
+
+def _validate_positive_sample_count(n) -> int:
+    """Return ``n`` as a positive Python int after scalar-count validation."""
+    message = "n must be a positive integer."
+    if isinstance(n, bool):
+        raise ValueError(message)
+
+    ndim = getattr(n, "ndim", None)
+    if ndim not in (None, 0):
+        raise ValueError(message)
+
+    dtype = getattr(n, "dtype", None)
+    if getattr(dtype, "kind", None) == "b" or str(dtype) == "torch.bool":
+        raise ValueError(message)
+
+    try:
+        count = _operator_index(n)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError(message) from exc
+
+    if count <= 0:
+        raise ValueError(message)
+    return int(count)
 
 
 class AbstractDiracDistribution(AbstractDistributionType):
@@ -113,9 +137,8 @@ class AbstractDiracDistribution(AbstractDistributionType):
         return dist
 
     def sample(self, n: Union[int, int32, int64]):
-        if isinstance(n, bool) or not isinstance(n, Integral) or int(n) <= 0:
-            raise ValueError("n must be a positive integer.")
-        indices = random.choice(arange(self.d.shape[0]), int(n), p=self.w)
+        n = _validate_positive_sample_count(n)
+        indices = random.choice(arange(self.d.shape[0]), n, p=self.w)
         samples = self.d[indices]
         return samples
 

--- a/tests/distributions/test_se2_dirac_distribution.py
+++ b/tests/distributions/test_se2_dirac_distribution.py
@@ -113,6 +113,18 @@ class TestSE2DiracDistribution(unittest.TestCase):
         npt.assert_allclose(m[0], wd.trigonometric_moment(1).real, rtol=1e-10)
         npt.assert_allclose(m[1], wd.trigonometric_moment(1).imag, rtol=1e-10)
 
+    def test_sampling_accepts_scalar_array_count(self):
+        random.seed(0)
+        samples = self.dist.sample(np.array(3, dtype=np.int64))
+
+        self.assertEqual(samples.shape, (3, 3))
+
+    def test_sampling_rejects_invalid_count_values(self):
+        for n in (np.array([3], dtype=np.int64), np.array(True), True, 1.5, 0, -1):
+            with self.subTest(n=n):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
+                    self.dist.sample(n)
+
     def test_sampling(self):
         random.seed(0)
         n = 20


### PR DESCRIPTION
## Summary
- Normalize Dirac sampler counts before calling `random.choice`.
- Accept scalar integer count objects such as 0-D NumPy arrays while rejecting booleans, non-scalar arrays, non-integers, and non-positive counts with the existing `ValueError` contract.
- Add SE2 Dirac regression coverage for accepted scalar-array counts and invalid count values.

## Bug fixed
`AbstractDiracDistribution.sample` validated `n` with `isinstance(n, Integral)`, so valid scalar integer array/backend count objects such as `np.array(3, dtype=np.int64)` were rejected before sampling, even though they represent the same count as a Python or NumPy integer scalar.

## Validation
- `python -m py_compile` on the patched source and test files in the sandbox.
- Full test suite not run locally because this environment cannot clone GitHub directly; CI should run the focused regression.