### PR TITLE
Fix PyTorch multivariate_normal validation keywords

### DIFF
--- a/src/pyrecest/_backend/pytorch/random/__init__.py
+++ b/src/pyrecest/_backend/pytorch/random/__init__.py
@@ -1,0 +1,72 @@
+"""Compatibility shim for the PyTorch random backend module."""
+
+from __future__ import annotations
+
+import importlib.util as _importlib_util
+import sys as _sys
+from pathlib import Path as _Path
+
+import numpy as _np
+
+_LEGACY_MODULE_NAME = __name__.rsplit(".", 1)[0] + "._random_legacy"
+_LEGACY_PATH = _Path(__file__).resolve().parent.parent / "random.py"
+_LEGACY_SPEC = _importlib_util.spec_from_file_location(_LEGACY_MODULE_NAME, _LEGACY_PATH)
+if _LEGACY_SPEC is None or _LEGACY_SPEC.loader is None:  # pragma: no cover
+    raise ImportError(f"Cannot load legacy PyTorch random backend from {_LEGACY_PATH}")
+_LEGACY = _importlib_util.module_from_spec(_LEGACY_SPEC)
+_sys.modules[_LEGACY_MODULE_NAME] = _LEGACY
+_LEGACY_SPEC.loader.exec_module(_LEGACY)
+
+
+def _validate_multivariate_normal_check_valid(check_valid):
+    if check_valid not in {"warn", "raise", "ignore"}:
+        raise ValueError("check_valid must be one of 'warn', 'raise', or 'ignore'")
+    return check_valid
+
+
+def _validate_multivariate_normal_tol(tol):
+    message = "tol must be a finite non-negative scalar"
+    try:
+        tol_array = _np.asarray(tol)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(message) from exc
+    if tol_array.shape != () or _np.issubdtype(tol_array.dtype, _np.bool_):
+        raise ValueError(message)
+    scalar = tol_array.item()
+    if isinstance(scalar, (bool, _np.bool_)):
+        raise ValueError(message)
+    try:
+        tol_value = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if not _np.isfinite(tol_value) or tol_value < 0.0:
+        raise ValueError(message)
+    return tol_value
+
+
+def multivariate_normal(mean, cov, size=None, *args, **kwargs):
+    """Draw samples with NumPy-compatible validation keyword handling."""
+
+    check_valid = kwargs.pop("check_valid", "warn")
+    tol = kwargs.pop("tol", 1e-8)
+    _validate_multivariate_normal_check_valid(check_valid)
+    _validate_multivariate_normal_tol(tol)
+    return _LEGACY.multivariate_normal(mean, cov, size=size, *args, **kwargs)
+
+
+__all__ = sorted(
+    {
+        name
+        for name in dir(_LEGACY)
+        if not (name.startswith("__") and name.endswith("__"))
+    }
+    | {"multivariate_normal"}
+)
+
+
+def __getattr__(name):
+    return getattr(_LEGACY, name)
+
+
+def __dir__():
+    return sorted(set(globals()) | set(dir(_LEGACY)))

--- a/src/pyrecest/_backend/pytorch/random/__init__.py
+++ b/src/pyrecest/_backend/pytorch/random/__init__.py
@@ -33,7 +33,7 @@ def _validate_multivariate_normal_tol(tol):
     if tol_array.shape != () or _np.issubdtype(tol_array.dtype, _np.bool_):
         raise ValueError(message)
     scalar = tol_array.item()
-    if isinstance(scalar, (bool, _np.bool_)):
+    if isinstance(scalar, (bool, _np.bool_, str, bytes, _np.str_, _np.bytes_)):
         raise ValueError(message)
     try:
         tol_value = float(scalar)

--- a/tests/backend/test_pytorch_random_multivariate_normal_keywords.py
+++ b/tests/backend/test_pytorch_random_multivariate_normal_keywords.py
@@ -1,0 +1,42 @@
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+from pyrecest._backend.pytorch import random  # noqa: E402
+
+
+def test_multivariate_normal_accepts_numpy_validation_keywords():
+    random.seed(0)
+
+    sample = random.multivariate_normal(
+        [0.0, 1.0],
+        [[2.0, 0.0], [0.0, 1.0]],
+        size=3,
+        check_valid="raise",
+        tol=np.float64(1e-8),
+    )
+
+    assert sample.shape == (3, 2)
+
+
+@pytest.mark.parametrize("bad_check_valid", ["error", None, 1])
+def test_multivariate_normal_rejects_invalid_check_valid_keyword(bad_check_valid):
+    with pytest.raises(ValueError, match="check_valid"):
+        random.multivariate_normal(
+            [0.0, 1.0],
+            [[1.0, 0.0], [0.0, 1.0]],
+            check_valid=bad_check_valid,
+        )
+
+
+@pytest.mark.parametrize(
+    "bad_tol",
+    [-1.0, np.nan, np.inf, True, [1e-8], "1e-8"],
+)
+def test_multivariate_normal_rejects_invalid_tol_keyword(bad_tol):
+    with pytest.raises(ValueError, match="tol"):
+        random.multivariate_normal(
+            [0.0, 1.0],
+            [[1.0, 0.0], [0.0, 1.0]],
+            tol=bad_tol,
+        )


### PR DESCRIPTION
Summary:
- Add a PyTorch random-backend compatibility shim that consumes and validates NumPy-style `multivariate_normal(..., check_valid=..., tol=...)` keywords before delegating to the existing implementation.
- Add focused regression coverage for accepted validation keywords and invalid `check_valid`/`tol` values.

Bug fixed:
The NumPy random backend accepts `check_valid` and `tol` for `multivariate_normal`, while the PyTorch backend rejected those keywords by signature. Backend-portable code that passed NumPy-style validation options therefore failed under the PyTorch backend even for valid covariance inputs. This patch preserves the existing PyTorch sampling path while making those validation keyword arguments explicit and validated.

Validation:
- Added regression tests.
- Full suite not run locally in this connector-only environment.