### PR TITLE
Fix NumPy boolean size axis validation

### DIFF
--- a/src/pyrecest/_backend/_common.py
+++ b/src/pyrecest/_backend/_common.py
@@ -5,7 +5,7 @@ import os as _os
 import numpy as _np
 from numpy import pi
 
-_AXIS_FLAG_TYPE = type(True)
+_AXIS_FLAG_TYPES = (bool, _np.bool_)
 
 
 def comb(n, k):
@@ -35,7 +35,7 @@ def outer(a, b):
 def _normalize_size_axis(axis):
     if axis is None:
         return None
-    if isinstance(axis, _AXIS_FLAG_TYPE):
+    if isinstance(axis, _AXIS_FLAG_TYPES):
         raise TypeError("an integer is required")
     try:
         return _operator.index(axis)

--- a/tests/test_common_size_axis_validation.py
+++ b/tests/test_common_size_axis_validation.py
@@ -1,0 +1,19 @@
+import numpy as np
+import pytest
+
+from pyrecest._backend import _common
+
+
+def test_common_size_rejects_boolean_axes():
+    values = np.arange(6).reshape(2, 3)
+
+    for axis in (True, False, np.bool_(True), np.bool_(False)):
+        with pytest.raises(TypeError, match="an integer is required"):
+            _common.size(values, axis=axis)
+
+
+def test_common_size_accepts_integer_like_axes():
+    values = np.arange(6).reshape(2, 3)
+
+    assert _common.size(values, axis=0) == 2
+    assert _common.size(values, axis=np.int64(1)) == 3


### PR DESCRIPTION
## Summary
- Reject NumPy boolean scalar axes in the shared backend `size` helper.
- Keep integer-like axes such as `np.int64(1)` accepted.
- Add focused regression coverage for boolean and integer-like axis handling.

## Bug fixed
`_common.size(..., axis=...)` explicitly rejected Python `bool` axes but not `np.bool_` axes. That made the size-axis validation less strict than the reduction-axis validation and could allow a NumPy boolean scalar through the integer-axis path depending on backend coercion.

## Validation
- Added `tests/test_common_size_axis_validation.py`.
- Full test suite not run in this connector-only environment.