### PR TITLE
Fix PyTorch comparison device selection

### DIFF
--- a/src/pyrecest/backend_tools.py
+++ b/src/pyrecest/backend_tools.py
@@ -64,6 +64,18 @@ def _patch_pytorch_assignment_scalar_tensor_indices() -> None:
     )
 
 
+def _preferred_pytorch_device(torch_module, *values):
+    """Return a non-CPU tensor device when mixed-device operands are present."""
+
+    for value in values:
+        if torch_module.is_tensor(value) and value.device.type != "cpu":
+            return value.device
+    for value in values:
+        if torch_module.is_tensor(value):
+            return value.device
+    return None
+
+
 def _patch_pytorch_diag_numpy_contract() -> None:
     """Make PyTorch diag accept array-like inputs and NumPy's ``k`` keyword."""
 
@@ -299,10 +311,7 @@ def _patch_raw_pytorch_comparison_numpy_contract() -> None:
         return
 
     def _coerce_binary_args(x, y):
-        device = next(
-            (value.device for value in (x, y) if _torch.is_tensor(value)),
-            None,
-        )
+        device = _preferred_pytorch_device(_torch, x, y)
         if not _torch.is_tensor(x):
             x = _torch.as_tensor(x, device=device)
         elif device is not None and x.device != device:
@@ -351,10 +360,7 @@ def _patch_raw_pytorch_isclose_equal_nan_contract() -> None:
         atol=pytorch_backend.atol,
         equal_nan=False,
     ):
-        device = next(
-            (value.device for value in (x, y) if _torch.is_tensor(value)),
-            None,
-        )
+        device = _preferred_pytorch_device(_torch, x, y)
         if not _torch.is_tensor(x):
             x = _torch.as_tensor(x, device=device)
         elif device is not None and x.device != device:

--- a/tests/backend/test_pytorch_comparison_device_contract.py
+++ b/tests/backend/test_pytorch_comparison_device_contract.py
@@ -1,0 +1,65 @@
+import pytest
+
+
+torch = pytest.importorskip("torch")
+
+import pyrecest.backend_tools  # noqa: E402,F401
+import pyrecest._backend.pytorch as pytorch_backend  # noqa: E402
+
+
+def _non_cpu_device():
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    try:
+        torch.empty((), device="meta")
+    except Exception as exc:  # pragma: no cover - depends on PyTorch build
+        pytest.skip(f"no non-CPU PyTorch test device available: {exc}")
+    return torch.device("meta")
+
+
+@pytest.mark.parametrize(
+    ("helper_name", "left", "right_factory"),
+    [
+        (
+            "greater",
+            torch.tensor([1.0, 2.0]),
+            lambda device: torch.ones(2, device=device),
+        ),
+        (
+            "less",
+            torch.tensor([1.0, 2.0]),
+            lambda device: torch.full((2,), 3.0, device=device),
+        ),
+        (
+            "logical_or",
+            torch.tensor([True, False]),
+            lambda device: torch.tensor([False, True], device=device),
+        ),
+    ],
+)
+def test_raw_pytorch_comparison_helpers_prefer_existing_non_cpu_device(
+    helper_name,
+    left,
+    right_factory,
+):
+    device = _non_cpu_device()
+
+    result = getattr(pytorch_backend, helper_name)(left, right_factory(device))
+
+    assert result.device.type == device.type
+    assert result.dtype == torch.bool
+    assert tuple(result.shape) == (2,)
+
+
+def test_raw_pytorch_isclose_prefers_existing_non_cpu_device_for_right_operand():
+    device = _non_cpu_device()
+
+    result = pytorch_backend.isclose(
+        torch.tensor([1.0, 2.0]),
+        torch.ones(2, device=device),
+        equal_nan=True,
+    )
+
+    assert result.device.type == device.type
+    assert result.dtype == torch.bool
+    assert tuple(result.shape) == (2,)


### PR DESCRIPTION
## Summary
- Prefer an existing non-CPU tensor device when coercing raw PyTorch comparison helper operands.
- Apply the same device choice to the `isclose(equal_nan=...)` compatibility wrapper.
- Add regression coverage using CUDA when available and PyTorch meta tensors otherwise.

## Bug fixed
The `backend_tools` PyTorch comparison wrappers chose the first tensor operand's device. With a CPU left operand and a non-CPU right operand, helpers such as `greater`, `less`, `logical_or`, and `isclose` attempted to move the non-CPU operand back to CPU, which can fail or silently return results on the wrong device.

## Validation
- Added focused regression tests in `tests/backend/test_pytorch_comparison_device_contract.py`.
- Full test suite not run in this connector-only environment.