### PR TITLE
Reject text scalar ellipse floors

### DIFF
--- a/src/pyrecest/tracking/ellipse_geometry.py
+++ b/src/pyrecest/tracking/ellipse_geometry.py
@@ -30,7 +30,7 @@ from pyrecest.backend import (
     sqrt,
 )
 
-_TEXT_TYPES = (str, bytes, bytearray)
+_INVALID_SCALAR_TYPES = (bool, str, bytes, bytearray)
 
 
 def symmetrize(matrix):
@@ -77,7 +77,7 @@ def _coerce_bool_flag(value, name: str) -> bool:
 
 def _coerce_nonnegative_finite_scalar(value, name: str) -> float:
     message = f"{name} must be a finite non-negative scalar"
-    if isinstance(value, (bool, *_TEXT_TYPES)):
+    if isinstance(value, _INVALID_SCALAR_TYPES):
         raise ValueError(message)
     try:
         value_array = asarray(value)
@@ -86,7 +86,7 @@ def _coerce_nonnegative_finite_scalar(value, name: str) -> float:
     if value_array.shape != ():
         raise ValueError(message)
     scalar = value_array.item()
-    if isinstance(scalar, (bool, *_TEXT_TYPES)):
+    if isinstance(scalar, _INVALID_SCALAR_TYPES):
         raise ValueError(message)
     try:
         scalar_float = float(scalar)
@@ -130,8 +130,8 @@ def ellipse_angle_delta(reference, theta):
     """Return the axial orientation residual ``theta - reference``.
 
     Ellipse orientations are pi-periodic: ``theta`` and ``theta + pi`` describe
-the same physical extent.  The returned residual lies in the principal axial
-interval ``[-pi/2, pi/2]`` up to floating-point boundary effects.
+    the same physical extent.  The returned residual lies in the principal axial
+    interval ``[-pi/2, pi/2]`` up to floating-point boundary effects.
     """
 
     return 0.5 * arctan2(sin(2.0 * (theta - reference)), cos(2.0 * (theta - reference)))

--- a/src/pyrecest/tracking/ellipse_geometry.py
+++ b/src/pyrecest/tracking/ellipse_geometry.py
@@ -30,6 +30,8 @@ from pyrecest.backend import (
     sqrt,
 )
 
+_TEXT_TYPES = (str, bytes, bytearray)
+
 
 def symmetrize(matrix):
     """Return the symmetric part of ``matrix``."""
@@ -75,7 +77,7 @@ def _coerce_bool_flag(value, name: str) -> bool:
 
 def _coerce_nonnegative_finite_scalar(value, name: str) -> float:
     message = f"{name} must be a finite non-negative scalar"
-    if isinstance(value, bool):
+    if isinstance(value, (bool, *_TEXT_TYPES)):
         raise ValueError(message)
     try:
         value_array = asarray(value)
@@ -84,7 +86,7 @@ def _coerce_nonnegative_finite_scalar(value, name: str) -> float:
     if value_array.shape != ():
         raise ValueError(message)
     scalar = value_array.item()
-    if isinstance(scalar, bool):
+    if isinstance(scalar, (bool, *_TEXT_TYPES)):
         raise ValueError(message)
     try:
         scalar_float = float(scalar)
@@ -128,8 +130,8 @@ def ellipse_angle_delta(reference, theta):
     """Return the axial orientation residual ``theta - reference``.
 
     Ellipse orientations are pi-periodic: ``theta`` and ``theta + pi`` describe
-    the same physical extent.  The returned residual lies in the principal axial
-    interval ``[-pi/2, pi/2]`` up to floating-point boundary effects.
+the same physical extent.  The returned residual lies in the principal axial
+interval ``[-pi/2, pi/2]`` up to floating-point boundary effects.
     """
 
     return 0.5 * arctan2(sin(2.0 * (theta - reference)), cos(2.0 * (theta - reference)))

--- a/tests/tracking/test_ellipse_geometry_text_validation.py
+++ b/tests/tracking/test_ellipse_geometry_text_validation.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+from pyrecest.tracking import (
+    canonicalize_ellipse_axes,
+    project_symmetric_covariance,
+    shape_from_extent_matrix,
+)
+
+
+@pytest.mark.parametrize("floor_value", ["0.0", np.array("0.0")])
+def test_ellipse_numeric_floors_reject_text_scalars(floor_value) -> None:
+    with pytest.raises(ValueError, match="minimum_eigenvalue"):
+        project_symmetric_covariance(
+            np.eye(2),
+            minimum_eigenvalue=floor_value,
+        )
+
+    with pytest.raises(ValueError, match="minimum_axis_length"):
+        shape_from_extent_matrix(
+            np.eye(2),
+            minimum_axis_length=floor_value,
+        )
+
+    with pytest.raises(ValueError, match="minimum_axis_length"):
+        canonicalize_ellipse_axes(
+            np.array([1.0, 2.0]),
+            minimum_axis_length=floor_value,
+        )


### PR DESCRIPTION
## Summary
- reject text-like scalar values in ellipse geometry nonnegative finite scalar validation
- add regression coverage for string and scalar string-array values passed as ellipse floor parameters

## Rationale
`project_symmetric_covariance`, `shape_from_extent_matrix`, and `canonicalize_ellipse_axes` accepted values such as `"0.0"` for numeric floor parameters because validation converted scalar strings through `float(...)`. That is inconsistent with the existing validation contract for invalid scalar controls and can hide configuration errors.

## Tests
- Added `tests/tracking/test_ellipse_geometry_text_validation.py`

I could not run the test suite in this connector environment; this PR relies on GitHub CI.