### PR TITLE
Reject boolean PyTorch creation shapes

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract/__init__.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract/__init__.py
@@ -33,6 +33,7 @@ def patch_pytorch_dtype_promotion_contract() -> None:
         return
 
     _patch_pytorch_logical_device_contract(raw_pytorch, backend, torch)
+    _patch_pytorch_creation_shape_bool_contract(raw_pytorch, backend, torch)
 
 
 def _preferred_pytorch_device(torch_module, *values):
@@ -118,6 +119,81 @@ def _patch_pytorch_logical_device_contract(raw_pytorch, backend, torch) -> None:
     if getattr(backend, "__backend_name__", None) == "pytorch":
         backend.logical_and = logical_and
         backend.where = where
+
+
+def _shape_contains_boolean_dimension(shape, torch_module):
+    """Return whether ``shape`` contains a boolean dimension value."""
+    try:
+        import numpy as np  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - NumPy is a core dependency
+        np = None
+
+    boolean_types = (bool,) if np is None else (bool, np.bool_)
+    if isinstance(shape, boolean_types):
+        return True
+    if torch_module.is_tensor(shape):
+        return shape.dtype == torch_module.bool
+    if np is None:
+        return False
+
+    try:
+        shape_values = np.asarray(shape, dtype=object).reshape(-1)
+    except (TypeError, ValueError, RuntimeError):
+        return False
+    return any(isinstance(one_dimension, boolean_types) for one_dimension in shape_values)
+
+
+def _validate_creation_shape_not_boolean(shape, torch_module) -> None:
+    """Reject boolean shape values before the base PyTorch creation wrapper runs."""
+    if _shape_contains_boolean_dimension(shape, torch_module):
+        raise TypeError("shape dimensions must be integers, not booleans")
+
+
+def _patch_pytorch_creation_shape_bool_contract(raw_pytorch, backend, torch) -> None:
+    """Keep PyTorch creation helpers from treating booleans as dimensions."""
+    helper_specs = (
+        ("empty", False),
+        ("zeros", False),
+        ("ones", False),
+        ("full", True),
+    )
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+    if all(
+        getattr(getattr(raw_pytorch, helper_name, None), "_pyrecest_rejects_bool_shape", False)
+        for helper_name, _ in helper_specs
+    ):
+        if active_pytorch_backend:
+            for helper_name, _ in helper_specs:
+                setattr(backend, helper_name, getattr(raw_pytorch, helper_name))
+        return
+
+    def _wrap_creation_helper(helper_name, *, has_fill_value=False):
+        original_helper = getattr(raw_pytorch, helper_name)
+        if getattr(original_helper, "_pyrecest_rejects_bool_shape", False):
+            return original_helper
+
+        if has_fill_value:
+
+            def creation_helper(shape, fill_value, *args, **kwargs):
+                _validate_creation_shape_not_boolean(shape, torch)
+                return original_helper(shape, fill_value, *args, **kwargs)
+
+        else:
+
+            def creation_helper(shape, *args, **kwargs):
+                _validate_creation_shape_not_boolean(shape, torch)
+                return original_helper(shape, *args, **kwargs)
+
+        creation_helper.__name__ = getattr(original_helper, "__name__", helper_name)
+        creation_helper.__doc__ = getattr(original_helper, "__doc__", None)
+        creation_helper._pyrecest_rejects_bool_shape = True
+        return creation_helper
+
+    for helper_name, has_fill_value in helper_specs:
+        helper = _wrap_creation_helper(helper_name, has_fill_value=has_fill_value)
+        setattr(raw_pytorch, helper_name, helper)
+        if active_pytorch_backend:
+            setattr(backend, helper_name, helper)
 
 
 __all__ = ["patch_pytorch_dtype_promotion_contract"]

--- a/tests/backend_support/test_pytorch_creation_shape_contract.py
+++ b/tests/backend_support/test_pytorch_creation_shape_contract.py
@@ -1,0 +1,102 @@
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+pytestmark = pytest.mark.backend_portable
+
+
+def test_raw_pytorch_creation_helpers_reject_boolean_shapes_after_import():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    code = """
+import numpy as np
+import torch
+import pyrecest  # noqa: F401  # triggers raw-backend compatibility patches
+import pyrecest._backend.pytorch as raw_pytorch_backend
+
+invalid_shapes = [
+    True,
+    False,
+    np.bool_(True),
+    [True],
+    (True, 2),
+    np.array(True),
+    np.array([True]),
+    torch.tensor(True),
+    torch.tensor([True]),
+]
+
+for helper_name in ("empty", "zeros", "ones"):
+    helper = getattr(raw_pytorch_backend, helper_name)
+    for shape in invalid_shapes:
+        try:
+            helper(shape)
+        except TypeError:
+            pass
+        else:
+            raise AssertionError(f"{helper_name} accepted boolean shape {shape!r}")
+
+for shape in invalid_shapes:
+    try:
+        raw_pytorch_backend.full(shape, 1)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"full accepted boolean shape {shape!r}")
+
+assert tuple(raw_pytorch_backend.zeros((2,)).shape) == (2,)
+print("ok")
+"""
+    result = run_backend_code("numpy", code)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_public_pytorch_creation_helpers_reject_boolean_shapes():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    code = """
+import numpy as np
+import torch
+import pyrecest.backend as backend
+
+invalid_shapes = [
+    True,
+    False,
+    np.bool_(True),
+    [True],
+    (True, 2),
+    np.array(True),
+    np.array([True]),
+    torch.tensor(True),
+    torch.tensor([True]),
+]
+
+for helper_name in ("empty", "zeros", "ones"):
+    helper = getattr(backend, helper_name)
+    for shape in invalid_shapes:
+        try:
+            helper(shape)
+        except TypeError:
+            pass
+        else:
+            raise AssertionError(f"{helper_name} accepted boolean shape {shape!r}")
+
+for shape in invalid_shapes:
+    try:
+        backend.full(shape, 1)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"full accepted boolean shape {shape!r}")
+
+assert tuple(backend.zeros((2,)).shape) == (2,)
+print("ok")
+"""
+    result = run_backend_code("pytorch", code)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- Add a PyTorch creation-helper compatibility layer that rejects boolean shape values before the base NumPy-style wrapper normalizes them.
- Cover `empty`, `zeros`, `ones`, and `full` for raw PyTorch backend imports and the public PyTorch backend.
- Keep valid integer shapes unchanged.

## Bug fixed
The PyTorch backend support wrapper normalized creation-helper shapes with `operator.index(...)`. Because Python booleans implement the integer index protocol, calls such as `backend.zeros(True)` or `raw_pytorch_backend.full([True], 1)` were accepted as shape `(1,)`. NumPy and raw PyTorch both reject boolean dimensions, so backend-portable code could silently allocate an unintended shape instead of surfacing a bad configuration.

## Validation
- Inspected the branch diff with `compare_commits`.
- Added focused backend-portable regression tests.
- Full suite not run locally because this connector environment cannot clone GitHub directly.