### PR TITLE
Validate sparse Gaussian grid coordinate dimension

### DIFF
--- a/src/pyrecest/filters/discrete_state.py
+++ b/src/pyrecest/filters/discrete_state.py
@@ -234,7 +234,30 @@ def sparse_gaussian_transition_matrix(
         destination rows receive zero probability.
     """
 
-    states = np.asarray(state_vectors, dtype=float)
+    try:
+        raw_states = np.asarray(state_vectors)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("state_vectors must contain real numeric values") from exc
+    if raw_states.dtype.kind in {"b", "c", "S", "U", "M", "m"}:
+        raise ValueError("state_vectors must contain real numeric values")
+    if raw_states.dtype == object:
+        rejected_types = (
+            bool,
+            np.bool_,
+            str,
+            bytes,
+            bytearray,
+            np.str_,
+            np.bytes_,
+            complex,
+            np.complexfloating,
+        )
+        if any(isinstance(value, rejected_types) for value in raw_states.ravel()):
+            raise ValueError("state_vectors must contain real numeric values")
+    try:
+        states = raw_states.astype(float, copy=False)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("state_vectors must contain real numeric values") from exc
     if states.ndim == 1:
         states = states[:, None]
     elif states.ndim != 2:
@@ -244,6 +267,10 @@ def sparse_gaussian_transition_matrix(
     n_states = states.shape[0]
     if n_states == 0:
         raise ValueError("state_vectors must contain at least one state")
+    if states.shape[1] == 0:
+        raise ValueError("state_vectors must contain at least one coordinate per state")
+    if np.any(~np.isfinite(states)):
+        raise ValueError("state_vectors must contain only finite values")
 
     sigma = float(sigma)
     if not np.isfinite(sigma) or sigma <= 0.0:


### PR DESCRIPTION
## Summary
- Harden `sparse_gaussian_transition_matrix` state-vector coercion in the core implementation.
- Reject non-real/non-numeric state grids before float coercion.
- Reject `(n_states, 0)` grids instead of silently treating all zero-dimensional states as mutually identical.

## Bug fixed
A grid with shape `(n_states, 0)` previously reached the distance computation with zero coordinate dimensions. That makes every squared distance zero, so the function can return a uniform column-stochastic transition matrix for an invalid state space. The function now raises `ValueError("state_vectors must contain at least one coordinate per state")`.

## Validation
- Standalone local validation of the updated coercion path for:
  - `np.zeros((3, 0))` -> raises the new coordinate-dimension error
  - ordinary 1D numeric grids -> accepted and reshaped to `(n_states, 1)`
  - boolean grids -> rejected as non-real numeric
  - NaN grids -> rejected as non-finite