### PR TITLE
Validate PyTorch pad_width integral type

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
@@ -284,19 +284,19 @@ def _patch_pytorch_creation_numpy_contract(
 
 def _normalize_pad_pairs(pad_width, ndim, np):
     """Return NumPy-style per-axis pad-width pairs as Python integers."""
+    pad_width_array = np.asarray(pad_width)
+    if not np.issubdtype(pad_width_array.dtype, np.signedinteger):
+        raise TypeError("pad_width must be of integral type")
     try:
-        pad_pairs = np.broadcast_to(np.asarray(pad_width), (ndim, 2))
+        pad_pairs = np.broadcast_to(pad_width_array, (ndim, 2))
     except ValueError as exc:
         raise ValueError(f"pad_width must be broadcastable to shape ({ndim}, 2)") from exc
     if np.any(pad_pairs < 0):
         raise ValueError("index can't contain negative values")
-    try:
-        return tuple(
-            (_operator_index(before), _operator_index(after))
-            for before, after in pad_pairs.tolist()
-        )
-    except TypeError as exc:
-        raise TypeError("pad_width must be of integral type") from exc
+    return tuple(
+        (_operator_index(before), _operator_index(after))
+        for before, after in pad_pairs.tolist()
+    )
 
 
 def _normalize_constant_value_pairs(constant_values, ndim, np):
@@ -355,6 +355,7 @@ def _patch_pytorch_pad_constant_values_contract(raw_pytorch, torch, np) -> None:
     def pad(a, pad_width, mode="constant", constant_values=0.0):
         values = raw_pytorch.array(a)
         if mode != "constant":
+            _normalize_pad_pairs(pad_width, values.ndim, np)
             return original_pad(
                 values,
                 pad_width,

--- a/tests/backend_support/test_pytorch_pad_contract.py
+++ b/tests/backend_support/test_pytorch_pad_contract.py
@@ -13,6 +13,14 @@ EXPECTED_PADDED = [
     [7, 6, 6, 8],
 ]
 
+BAD_PAD_WIDTHS = [
+    "1.5",
+    "((0, 1.25),)",
+    "True",
+    "[True, False]",
+    "np.array([1, 2], dtype=np.uint8)",
+]
+
 
 def test_raw_pytorch_pad_accepts_numpy_style_constant_values_after_import():
     if importlib.util.find_spec("torch") is None:
@@ -60,6 +68,56 @@ result = backend.pad(
     constant_values=((5, 6), (7, 8)),
 )
 assert backend.to_numpy(result).tolist() == {EXPECTED_PADDED!r}
+print("ok")
+"""
+    result = run_backend_code("pytorch", code)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_raw_pytorch_pad_rejects_non_integral_pad_width_after_import():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    code = f"""
+import numpy as np
+import pyrecest  # noqa: F401  # triggers raw-backend compatibility patches
+import pyrecest._backend.pytorch as raw_pytorch_backend
+
+bad_pad_widths = [{", ".join(BAD_PAD_WIDTHS)}]
+for bad_pad_width in bad_pad_widths:
+    try:
+        raw_pytorch_backend.pad([1, 2], bad_pad_width, mode="constant")
+    except TypeError as exc:
+        assert "pad_width" in str(exc)
+        assert "integral" in str(exc)
+    else:
+        raise AssertionError(f"accepted invalid pad_width: {{bad_pad_width!r}}")
+print("ok")
+"""
+    result = run_backend_code("numpy", code)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_public_pytorch_pad_rejects_non_integral_pad_width():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    code = f"""
+import numpy as np
+import pyrecest.backend as backend
+
+values = backend.array([1, 2], dtype=backend.int64)
+bad_pad_widths = [{", ".join(BAD_PAD_WIDTHS)}]
+for bad_pad_width in bad_pad_widths:
+    try:
+        backend.pad(values, bad_pad_width, mode="constant")
+    except TypeError as exc:
+        assert "pad_width" in str(exc)
+        assert "integral" in str(exc)
+    else:
+        raise AssertionError(f"accepted invalid pad_width: {{bad_pad_width!r}}")
 print("ok")
 """
     result = run_backend_code("pytorch", code)


### PR DESCRIPTION
## Summary
- Reject non-integral PyTorch `pad_width` inputs before normalizing NumPy-style pad pairs.
- Match NumPy's behavior for booleans and unsigned integer pad widths instead of coercing them to Python integers.
- Add raw-backend-after-import and public PyTorch backend regression coverage.

## Bug fixed
`_normalize_pad_pairs` used `_operator_index` after broadcasting pad widths, which allowed boolean and unsigned integer pad widths to be silently interpreted as valid padding counts. NumPy rejects these with `TypeError`. The patched helper now requires a signed integer dtype before broadcasting and also validates non-constant PyTorch padding requests before delegating to the original helper.

## Validation
- Added focused regression tests in `tests/backend_support/test_pytorch_pad_contract.py`.
- Full suite not run in this connector-only environment.