### PR TITLE
Fix PyTorch equality helper device placement

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract/__init__.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract/__init__.py
@@ -34,6 +34,7 @@ def patch_pytorch_dtype_promotion_contract() -> None:
 
     _patch_pytorch_logical_device_contract(raw_pytorch, backend, torch)
     _patch_pytorch_binary_device_contract(raw_pytorch, backend, torch)
+    _patch_pytorch_equality_device_contract(raw_pytorch, backend, torch)
 
 
 def _preferred_pytorch_device(torch_module, *values):
@@ -150,6 +151,19 @@ def _wrap_binary_device_helper(original_helper, torch_module, *, box_x2):
     return binary_helper
 
 
+def _wrap_tensor_binary_device_helper(original_helper, torch_module):
+    def binary_helper(x1, x2, *args, **kwargs):
+        device = _preferred_pytorch_device(torch_module, x1, x2)
+        x1 = _as_pytorch_tensor_on_device(x1, torch_module, device=device)
+        x2 = _as_pytorch_tensor_on_device(x2, torch_module, device=device)
+        return original_helper(x1, x2, *args, **kwargs)
+
+    binary_helper.__name__ = getattr(original_helper, "__name__", "binary_helper")
+    binary_helper.__doc__ = getattr(original_helper, "__doc__", None)
+    binary_helper._pyrecest_device_contract = True
+    return binary_helper
+
+
 def _patch_pytorch_binary_device_contract(raw_pytorch, backend, torch) -> None:
     """Keep boxed PyTorch binary helper operands on an existing non-CPU device."""
     helpers = {
@@ -171,6 +185,28 @@ def _patch_pytorch_binary_device_contract(raw_pytorch, backend, torch) -> None:
             getattr(raw_pytorch, helper_name),
             torch,
             box_x2=box_x2,
+        )
+        setattr(raw_pytorch, helper_name, wrapped_helper)
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            setattr(backend, helper_name, wrapped_helper)
+
+
+def _patch_pytorch_equality_device_contract(raw_pytorch, backend, torch) -> None:
+    """Keep equality-style helpers on an existing non-CPU tensor device."""
+    helper_names = ("equal", "less_equal")
+    if all(
+        getattr(getattr(raw_pytorch, helper_name, None), "_pyrecest_device_contract", False)
+        for helper_name in helper_names
+    ):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            for helper_name in helper_names:
+                setattr(backend, helper_name, getattr(raw_pytorch, helper_name))
+        return
+
+    for helper_name in helper_names:
+        wrapped_helper = _wrap_tensor_binary_device_helper(
+            getattr(raw_pytorch, helper_name),
+            torch,
         )
         setattr(raw_pytorch, helper_name, wrapped_helper)
         if getattr(backend, "__backend_name__", None) == "pytorch":

--- a/tests/backend_support/test_pytorch_equality_device_contract.py
+++ b/tests/backend_support/test_pytorch_equality_device_contract.py
@@ -1,0 +1,69 @@
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+pytestmark = pytest.mark.backend_portable
+
+
+def _device_contract_code(target_module):
+    return f"""
+import torch
+import pyrecest  # noqa: F401  # triggers backend-support compatibility patches
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+def _non_cpu_device():
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    return torch.device("meta")
+
+target = {target_module}
+device = _non_cpu_device()
+
+cases = [
+    (
+        "equal",
+        torch.tensor([1.0, 2.0]),
+        lambda selected_device: torch.ones(2, device=selected_device),
+    ),
+    (
+        "less_equal",
+        torch.tensor([1.0, 2.0]),
+        lambda selected_device: torch.full((2,), 3.0, device=selected_device),
+    ),
+    (
+        "less_equal",
+        1.0,
+        lambda selected_device: torch.ones((), device=selected_device),
+    ),
+]
+
+for helper_name, left, right_factory in cases:
+    result = getattr(target, helper_name)(left, right_factory(device))
+    assert result.device.type == device.type
+    assert result.dtype == torch.bool
+
+print("ok")
+"""
+
+
+def test_raw_pytorch_equality_helpers_prefer_existing_non_cpu_device_after_import():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code("numpy", _device_contract_code("raw_pytorch"))
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_public_pytorch_equality_helpers_prefer_existing_non_cpu_device():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code("pytorch", _device_contract_code("backend"))
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- Extend the PyTorch backend compatibility patch to cover `equal` and `less_equal`.
- Move both operands onto an existing non-CPU tensor device before delegating to the original helper.
- Add backend-portable regression tests for raw PyTorch under the NumPy backend and for the public PyTorch backend.

## Bug fixed
`equal` and `less_equal` still used the raw helper paths after other device-placement compatibility fixes. With mixed CPU/non-CPU operands, e.g. a CPU tensor or scalar on the left and a CUDA/meta tensor on the right, the helpers could keep one operand on CPU and fail with a PyTorch device mismatch. The new wrapper chooses an existing non-CPU tensor device first and coerces both operands there.

## Validation
- Branch comparison against current `main`: 2 changed files, 105 additions, 0 deletions.
- Added focused regression tests in `tests/backend_support/test_pytorch_equality_device_contract.py`.
- Full test suite not run in this connector-only environment; CI should run on the PR.