### PR TITLE
Tighten track completion candidate validation

### DIFF
--- a/src/pyrecest/utils/track_completion.py
+++ b/src/pyrecest/utils/track_completion.py
@@ -10,6 +10,7 @@ path enumeration, duplicate-observation checks, and path bookkeeping.
 
 from __future__ import annotations
 
+import operator
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from typing import Any, Generic, Literal, TypeAlias, TypeVar
@@ -423,8 +424,8 @@ def _normalize_candidate_observation(value: Any) -> int:
         observation = int(scalar)
     else:
         try:
-            observation = int(scalar)
-        except (TypeError, ValueError, OverflowError) as exc:
+            observation = operator.index(scalar)
+        except TypeError as exc:
             raise ValueError(
                 "candidate observations must be non-negative integers"
             ) from exc

--- a/tests/test_track_completion_text_candidate_validation.py
+++ b/tests/test_track_completion_text_candidate_validation.py
@@ -1,8 +1,29 @@
+from decimal import Decimal
+from fractions import Fraction
+
 import numpy as np
 from pyrecest.utils.track_completion import (
     CompletionCandidate,
     enumerate_fragment_completion_paths,
 )
+
+
+def _provider_with(candidate):
+    def provider(*args):
+        return [candidate]
+
+    return provider
+
+
+def _assert_candidate_rejected(candidate):
+    try:
+        enumerate_fragment_completion_paths(
+            [[0, None]], direction="suffix", candidate_provider=_provider_with(candidate)
+        )
+    except ValueError as exc:
+        assert "candidate observations must be non-negative integers" in str(exc)
+    else:
+        raise AssertionError("candidate observation was accepted")
 
 
 def test_text_candidate_observations_are_rejected():
@@ -16,13 +37,19 @@ def test_text_candidate_observations_are_rejected():
         CompletionCandidate(np.array(candidate_text)),
     )
 
-    for invalid_candidate in invalid_candidates:
-        provider = lambda *_: [invalid_candidate]
-        try:
-            enumerate_fragment_completion_paths(
-                [[0, None]], direction="suffix", candidate_provider=provider
-            )
-        except ValueError as exc:
-            assert "candidate observations must be non-negative integers" in str(exc)
-        else:
-            raise AssertionError("text-valued candidate observation was accepted")
+    for candidate in invalid_candidates:
+        _assert_candidate_rejected(candidate)
+
+
+def test_fractional_object_candidate_observations_are_rejected():
+    fractional_candidates = (
+        Decimal("1.5"),
+        Fraction(3, 2),
+        np.array(Decimal("1.5"), dtype=object),
+        np.array(Fraction(3, 2), dtype=object),
+        CompletionCandidate(Decimal("1.5")),
+        CompletionCandidate(np.array(Fraction(3, 2), dtype=object)),
+    )
+
+    for candidate in fractional_candidates:
+        _assert_candidate_rejected(candidate)


### PR DESCRIPTION
## Summary
- Validate object-valued track-completion candidate observations with the integer-index protocol.
- Add focused regression coverage for fractional object-valued candidates.

## Bug fixed
Candidate observations must be non-negative integer indices. The previous fallback could accept some object-valued numeric candidates after integer conversion. The new validation rejects candidates that are not true integer-index objects.

## Validation
- Added focused regression coverage in `tests/test_track_completion_text_candidate_validation.py`.
- Full suite not run locally in this connector-only environment.