### PR TITLE
Reject unsupported transition sample counts

### DIFF
--- a/src/pyrecest/filters/abstract_particle_filter.py
+++ b/src/pyrecest/filters/abstract_particle_filter.py
@@ -26,6 +26,14 @@ from .abstract_filter import AbstractFilter
 
 def _call_vectorized_sample_next(sample_next, particles, n_particles):
     """Call vectorized sample_next, passing the batch size when supported."""
+    owner = getattr(sample_next, "__self__", None)
+    if (
+        getattr(owner, "function_is_vectorized", False)
+        and hasattr(owner, "_sample_next_count_call_mode")
+        and getattr(owner, "_sample_next_count_call_mode", None) is None
+    ):
+        return sample_next(particles)
+
     try:
         signature = inspect.signature(sample_next)
     except (TypeError, ValueError):

--- a/src/pyrecest/models/_sampleable_transition_validation.py
+++ b/src/pyrecest/models/_sampleable_transition_validation.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from .likelihood import SampleableTransitionModel
+from .likelihood import (
+    DensityTransitionModel,
+    SampleableTransitionModel,
+    _validate_sample_count,
+)
 from .validation import _validate_bool_flag
 
 
@@ -22,6 +26,26 @@ def _set_function_is_vectorized(
     )
 
 
+def _requested_sample_count(value: Any) -> int:
+    return _validate_sample_count(value)
+
+
+def _patch_sampler_count_check(model_cls) -> None:
+    original = model_cls.sample_next
+    if getattr(original, "_pyrecest_sampler_count_checked", False):
+        return
+
+    def checked_sample_next(self, state, n=1):
+        has_sampler = getattr(self, "_sample_next", None) is not None
+        has_count_argument = getattr(self, "_sample_next_count_call_mode", None) is not None
+        if has_sampler and not has_count_argument and _requested_sample_count(n) != 1:
+            raise TypeError("sample count is not supported by this sampler.")
+        return original(self, state, n=n)
+
+    checked_sample_next._pyrecest_sampler_count_checked = True
+    model_cls.sample_next = checked_sample_next
+
+
 def install_sampleable_transition_validation() -> None:
     """Validate ``function_is_vectorized`` after construction as well."""
 
@@ -30,3 +54,5 @@ def install_sampleable_transition_validation() -> None:
         _set_function_is_vectorized,
         doc="Whether ``sample_next`` accepts a batch of states.",
     )
+    _patch_sampler_count_check(SampleableTransitionModel)
+    _patch_sampler_count_check(DensityTransitionModel)

--- a/tests/models/test_transition_sample_count_unsupported.py
+++ b/tests/models/test_transition_sample_count_unsupported.py
@@ -1,0 +1,60 @@
+"""Regression tests for transition samplers without sample-count support."""
+
+import unittest
+
+import numpy as np
+from pyrecest.backend import array
+from pyrecest.models import (
+    DensityTransitionModel,
+    SampleableTransitionModel,
+    sample_next_state,
+)
+
+
+class UnsupportedTransitionSampleCountTest(unittest.TestCase):
+    def test_sampleable_transition_rejects_count_when_sampler_has_no_count_argument(self):
+        calls = []
+
+        def sample_next(state):
+            calls.append(state)
+            return state
+
+        model = SampleableTransitionModel(sample_next)
+        state = array([0.0])
+
+        with self.assertRaisesRegex(TypeError, "sample count is not supported"):
+            sample_next_state(model, state, n=2)
+
+        self.assertEqual(calls, [])
+        self.assertIsNotNone(sample_next_state(model, state, n=1))
+        self.assertEqual(len(calls), 1)
+
+    def test_density_transition_rejects_count_when_sampler_has_no_count_argument(self):
+        calls = []
+
+        def transition_density(state_next, state_previous):
+            return 1.0 if state_next is state_previous else 0.0
+
+        def sample_next(state):
+            calls.append(state)
+            return state
+
+        model = DensityTransitionModel(transition_density, sample_next=sample_next)
+        state = array([0.0])
+
+        with self.assertRaisesRegex(TypeError, "sample count is not supported"):
+            model.sample_next(state, n=2)
+
+        self.assertEqual(calls, [])
+        self.assertIsNotNone(model.sample_next(state, n=1))
+        self.assertEqual(len(calls), 1)
+
+    def test_sampler_without_count_still_rejects_invalid_counts_cleanly(self):
+        model = SampleableTransitionModel(lambda state: state)
+
+        with self.assertRaisesRegex(ValueError, "n must be a nonnegative integer"):
+            sample_next_state(model, array([0.0]), n=np.array([2]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a sample-count guard for transition sampler callbacks that do not accept an `n` argument
- preserve the existing invalid-count validation path before dispatching to samplers
- add regression coverage for both sampleable and density transition models

## Bug fixed
`SampleableTransitionModel(lambda state: state).sample_next(state, n=2)` previously accepted the request and silently called the sampler once, so the requested sample count was ignored. The same issue affected `DensityTransitionModel(..., sample_next=lambda state: state)`. These models now raise a clear `TypeError` when `n != 1` cannot be forwarded to the sampler.

## Validation
- Not run locally; this environment cannot clone GitHub repositories directly.
