### PR TITLE
Reject boolean PyTorch broadcast shapes

### DIFF
--- a/src/pyrecest/backend_support/__init__.py
+++ b/src/pyrecest/backend_support/__init__.py
@@ -532,13 +532,35 @@ def _markdown_table_cell(value: object) -> str:
     return str(value).replace("\r", " ").replace("\n", "<br>").replace(chr(124), escape)
 
 
+def _markdown_table_row(cells: list[str]) -> str:
+    separator = chr(124)
+    return f"{separator} " + f" {separator} ".join(cells) + f" {separator}"
+
+
 def format_backend_support_markdown() -> str:
-    """Render the backend support matrix as a Markdown table."""
-    headers = ["API", *BACKEND_SUPPORT_LEVELS]
-    rows = [headers, ["---", *["---"] * len(BACKEND_SUPPORT_LEVELS)]]
-    for api_name, support in iter_api_backend_capabilities():
-        rows.append(
-            [api_name]
-            + [_markdown_table_cell(support.get(backend, "")) for backend in BACKEND_SUPPORT_LEVELS]
+    """Render the public backend API matrix as a Markdown table."""
+    lines = [
+        _markdown_table_row(["API", "NumPy", "PyTorch", "JAX", "Notes"]),
+        _markdown_table_row(["-----", "-------", "---------", "-----", "-------"]),
+    ]
+    for api_name, row in iter_api_backend_capabilities():
+        lines.append(
+            _markdown_table_row(
+                [
+                    f"`{_markdown_table_cell(api_name)}`",
+                    _markdown_table_cell(row["numpy"]),
+                    _markdown_table_cell(row["pytorch"]),
+                    _markdown_table_cell(row["jax"]),
+                    _markdown_table_cell(row.get("notes", "")),
+                ]
+            )
         )
-    return "\n".join("| " + " | ".join(row) + " |" for row in rows)
+    return "\n".join(lines)
+
+
+__all__ = [
+    "BACKEND_SUPPORT_LEVELS",
+    "backend_support",
+    "format_backend_support_markdown",
+    "get_backend_support",
+]

--- a/src/pyrecest/backend_support/__init__.py
+++ b/src/pyrecest/backend_support/__init__.py
@@ -307,6 +307,17 @@ def _patch_pytorch_clip_numpy_contract() -> None:
         backend.clip = clip
 
 
+def _pytorch_broadcast_dimension(dimension, numpy_module) -> int:
+    """Return one NumPy-style broadcast dimension as a non-boolean integer."""
+
+    if isinstance(dimension, (bool, numpy_module.bool_)):
+        raise TypeError("broadcast shape entries must be integers")
+    try:
+        return _operator_index(dimension)
+    except TypeError as exc:
+        raise TypeError("broadcast shape entries must be integers") from exc
+
+
 def _pytorch_broadcast_shape(shape, numpy_module, torch_module) -> tuple[int, ...]:
     """Normalize NumPy-style broadcast shapes for ``torch.Tensor.expand``."""
 
@@ -314,10 +325,12 @@ def _pytorch_broadcast_shape(shape, numpy_module, torch_module) -> tuple[int, ..
         shape = shape.detach().cpu().numpy()
     shape_array = numpy_module.asarray(shape)
     if shape_array.shape == ():
-        broadcast_shape = (_operator_index(shape_array.item()),)
+        broadcast_shape = (
+            _pytorch_broadcast_dimension(shape_array.item(), numpy_module),
+        )
     else:
         broadcast_shape = tuple(
-            _operator_index(one_dimension)
+            _pytorch_broadcast_dimension(one_dimension, numpy_module)
             for one_dimension in shape_array.tolist()
         )
     if any(one_dimension < 0 for one_dimension in broadcast_shape):
@@ -519,35 +532,13 @@ def _markdown_table_cell(value: object) -> str:
     return str(value).replace("\r", " ").replace("\n", "<br>").replace(chr(124), escape)
 
 
-def _markdown_table_row(cells: list[str]) -> str:
-    separator = chr(124)
-    return f"{separator} " + f" {separator} ".join(cells) + f" {separator}"
-
-
 def format_backend_support_markdown() -> str:
-    """Render the public backend API matrix as a Markdown table."""
-    lines = [
-        _markdown_table_row(["API", "NumPy", "PyTorch", "JAX", "Notes"]),
-        _markdown_table_row(["-----", "-------", "---------", "-----", "-------"]),
-    ]
-    for api_name, row in iter_api_backend_capabilities():
-        lines.append(
-            _markdown_table_row(
-                [
-                    f"`{_markdown_table_cell(api_name)}`",
-                    _markdown_table_cell(row["numpy"]),
-                    _markdown_table_cell(row["pytorch"]),
-                    _markdown_table_cell(row["jax"]),
-                    _markdown_table_cell(row.get("notes", "")),
-                ]
-            )
+    """Render the backend support matrix as a Markdown table."""
+    headers = ["API", *BACKEND_SUPPORT_LEVELS]
+    rows = [headers, ["---", *["---"] * len(BACKEND_SUPPORT_LEVELS)]]
+    for api_name, support in iter_api_backend_capabilities():
+        rows.append(
+            [api_name]
+            + [_markdown_table_cell(support.get(backend, "")) for backend in BACKEND_SUPPORT_LEVELS]
         )
-    return "\n".join(lines)
-
-
-__all__ = [
-    "BACKEND_SUPPORT_LEVELS",
-    "backend_support",
-    "format_backend_support_markdown",
-    "get_backend_support",
-]
+    return "\n".join("| " + " | ".join(row) + " |" for row in rows)

--- a/tests/backend_support/test_pytorch_broadcast_to_contract.py
+++ b/tests/backend_support/test_pytorch_broadcast_to_contract.py
@@ -52,6 +52,14 @@ for broadcast_to, to_numpy in (
         pass
     else:
         raise AssertionError("broadcast_to accepted a negative broadcast dimension")
+
+    for invalid_shape in (True, (True,), np.array(True), np.array([True]), backend.array([True])):
+        try:
+            broadcast_to(values, invalid_shape)
+        except TypeError:
+            pass
+        else:
+            raise AssertionError(f"broadcast_to accepted boolean shape {invalid_shape!r}")
 """
     subprocess.run([sys.executable, "-c", code], check=True, env=_backend_test_env("pytorch"))
 
@@ -84,5 +92,13 @@ except ValueError:
     pass
 else:
     raise AssertionError("raw broadcast_to accepted a negative broadcast dimension")
+
+for invalid_shape in (True, (True,), np.array(True), np.array([True]), pytorch_backend.array([True])):
+    try:
+        pytorch_backend.broadcast_to(values, invalid_shape)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"raw broadcast_to accepted boolean shape {invalid_shape!r}")
 """
     subprocess.run([sys.executable, "-c", code], check=True, env=_backend_test_env("numpy"))


### PR DESCRIPTION
## Summary
- Reject boolean `broadcast_to` shape entries before forwarding PyTorch backend shapes to `Tensor.expand`.
- Preserve valid NumPy-style integer shape inputs for both public and raw PyTorch backend helpers.
- Add focused backend-portable regressions for scalar, tuple/list, NumPy, and Torch boolean shapes.

## Bug fixed
The PyTorch backend support shim normalized `broadcast_to` shape entries with `operator.index(...)`. Python booleans implement the integer index protocol, and boolean arrays/tensors are converted to Python booleans via `.tolist()`, so requests such as `broadcast_to(values, (True,))` could be interpreted as shape `(1,)`. NumPy rejects boolean shapes with `TypeError`, so backend-portable code could silently accept invalid shapes only under the PyTorch backend.

## Validation
- Branch comparison against current `main`: 2 changed files, 31 additions, 2 deletions.
- Added focused regression coverage in `tests/backend_support/test_pytorch_broadcast_to_contract.py`.
- Full suite not run in this connector-only environment.