### PR TITLE
Fix symmetric distance list inputs

### DIFF
--- a/src/pyrecest/evaluation/get_distance_function.py
+++ b/src/pyrecest/evaluation/get_distance_function.py
@@ -256,9 +256,11 @@ def get_distance_function(
     elif _is_hypersphere_symmetric_name(normalized_name):
 
         def distance_function(x1, x2):
+            x1_array = asarray(x1)
+            x2_array = asarray(x2)
             return min(
-                _angular_distance_from_inner_product(dot(x1, x2)),
-                _angular_distance_from_inner_product(dot(x1, -x2)),
+                _angular_distance_from_inner_product(dot(x1_array, x2_array)),
+                _angular_distance_from_inner_product(dot(x1_array, -x2_array)),
             )
 
     elif "hypersphere" in normalized_name:
@@ -284,9 +286,11 @@ def get_distance_function(
     elif "se3bounded" in normalized_name:
 
         def distance_function(x1, x2):
+            orientation1 = _state_slice(x1, 0, 4)
+            orientation2 = _state_slice(x2, 0, 4)
             return min(
-                _angular_distance_from_inner_product(dot(x1[:4], x2[:4])),
-                _angular_distance_from_inner_product(dot(x1[:4], -x2[:4])),
+                _angular_distance_from_inner_product(dot(orientation1, orientation2)),
+                _angular_distance_from_inner_product(dot(orientation1, -orientation2)),
             )
 
     elif "se3" in normalized_name or "se3linear" in normalized_name:

--- a/tests/evaluation/test_symmetric_distance_list_inputs.py
+++ b/tests/evaluation/test_symmetric_distance_list_inputs.py
@@ -1,0 +1,15 @@
+from pyrecest.evaluation.get_distance_function import get_distance_function
+
+
+def test_hypersphere_symmetric_accepts_list_values():
+    distance = get_distance_function("hypersphereSymmetric")
+
+    assert float(distance([1.0, 0.0], [-1.0, 0.0])) == 0.0
+
+
+def test_se3bounded_accepts_list_quaternions():
+    distance = get_distance_function("se3bounded")
+    estimate = [1.0, 0.0, 0.0, 0.0, 10.0, 20.0, 30.0]
+    expected = [-1.0, 0.0, 0.0, 0.0, -5.0, 3.0, 2.0]
+
+    assert float(distance(estimate, expected)) == 0.0


### PR DESCRIPTION
## Summary
- Convert hypersphere-symmetric distance inputs to backend arrays before applying the antipodal sign flip.
- Use the existing state-slice helper for SE(3)-bounded quaternion components before applying the antipodal sign flip.
- Add regressions for plain Python list inputs in hypersphere-symmetric and SE(3)-bounded distance functions.

## Bug fixed
Plain Python lists reached unary negation in the symmetric/hypersphere and SE(3)-bounded branches. Expressions like `-x2` and `-x2[:4]` fail for list inputs, even though nearby distance helpers already accept array-like values.

## Validation
- Reviewed the diff against `main`: 2 files changed, 12 source-line changes and 15 test lines.
- Local execution was not possible in this session because the container cannot resolve `github.com`; the regression tests are included for CI.