### PR TITLE
Normalize NumPy random size arguments

### DIFF
--- a/src/pyrecest/_backend/numpy/random.py
+++ b/src/pyrecest/_backend/numpy/random.py
@@ -8,7 +8,14 @@ from numpy.random import (  # For PyRecEst
     set_state,
 )
 
-from .._shared_numpy.random import choice, multivariate_normal, normal, rand, uniform
+from .._shared_numpy.random import (
+    _normalize_size,
+    choice,
+    multivariate_normal,
+    normal,
+    rand,
+    uniform,
+)
 
 _BOOLEAN_TYPES = (bool, _np.bool_)
 
@@ -37,6 +44,7 @@ def _validate_randint_bound(bound, name):
 def randint(low, high=None, size=None, dtype=int):
     """Draw integer samples after rejecting non-integer bounds."""
 
+    size = _normalize_size(size)
     if high is None:
         _validate_randint_bound(low, "high")
         return _np.random.randint(low, high=None, size=size, dtype=dtype)
@@ -84,9 +92,7 @@ def _validate_multinomial_pvals(pvals):
 
 
 def _validate_multinomial_size(size):
-    if size is not None and _contains_boolean_value(size):
-        raise TypeError("size must be None, an integer, or a sequence of integers")
-    return size
+    return _normalize_size(size)
 
 
 def multinomial(n, pvals, size=None):

--- a/tests/backend/test_numpy_random_size_validation.py
+++ b/tests/backend/test_numpy_random_size_validation.py
@@ -1,0 +1,54 @@
+import numpy as np
+import pytest
+
+from pyrecest._backend.numpy import random
+
+
+_INVALID_SIZE_ARGUMENTS = (
+    True,
+    np.bool_(True),
+    np.array(True),
+    (2, True),
+    1.5,
+    (2, 1.5),
+    "3",
+)
+
+
+@pytest.mark.parametrize("bad_size", _INVALID_SIZE_ARGUMENTS)
+@pytest.mark.parametrize(
+    "sampler",
+    (
+        lambda size: random.randint(0, 5, size=size),
+        lambda size: random.multinomial(2, [0.25, 0.75], size=size),
+    ),
+)
+def test_numpy_random_rejects_invalid_size_arguments_with_backend_message(
+    bad_size, sampler
+):
+    with pytest.raises(TypeError, match="size must be None"):
+        sampler(bad_size)
+
+
+@pytest.mark.parametrize(
+    "sampler",
+    (
+        lambda size: random.randint(0, 5, size=size),
+        lambda size: random.multinomial(2, [0.25, 0.75], size=size),
+    ),
+)
+def test_numpy_random_rejects_negative_size_dimensions(sampler):
+    with pytest.raises(ValueError, match="size dimensions must be non-negative"):
+        sampler((2, -1))
+
+
+def test_numpy_randint_normalizes_array_like_size_arguments():
+    samples = random.randint(0, 5, size=np.array([2, 3]))
+
+    assert samples.shape == (2, 3)
+
+
+def test_numpy_multinomial_normalizes_array_like_size_arguments():
+    samples = random.multinomial(2, [0.25, 0.75], size=np.array([2, 3]))
+
+    assert samples.shape == (2, 3, 2)


### PR DESCRIPTION
## Summary
- Reuse the shared NumPy backend size normalizer for `random.randint` and `random.multinomial`.
- Reject booleans, strings, non-integral values, and negative dimensions before dispatching to NumPy.
- Add focused NumPy random backend regression coverage for invalid and array-like size arguments.

## Bug fixed
`pyrecest._backend.numpy.random.randint` passed `size` straight through to `np.random.randint`, while other NumPy random helpers already use the shared backend size normalization path. This could surface backend-inconsistent errors for invalid inputs such as `size="3"` or negative shape components instead of PyRecEst's normalized `size` contract. `multinomial` only had a partial boolean guard, so it now shares the same path.

## Validation
- `python -m py_compile /tmp/numpy_random_size_validation.py /tmp/test_numpy_random_size_validation.py`
- Compared branch against `main`: 2 commits, 2 files changed.