### PR TITLE
Fix PyTorch fftn empty axes no-op

### DIFF
--- a/src/pyrecest/_backend/pytorch/fft.py
+++ b/src/pyrecest/_backend/pytorch/fft.py
@@ -71,5 +71,15 @@ ifftshift = _wrap_arraylike_fft(
     dim_alias="axes",
     empty_dim_is_noop=True,
 )
-fftn = _wrap_arraylike_fft(_torch.fft.fftn, func_name="fftn", dim_alias="axes")
-ifftn = _wrap_arraylike_fft(_torch.fft.ifftn, func_name="ifftn", dim_alias="axes")
+fftn = _wrap_arraylike_fft(
+    _torch.fft.fftn,
+    func_name="fftn",
+    dim_alias="axes",
+    empty_dim_is_noop=True,
+)
+ifftn = _wrap_arraylike_fft(
+    _torch.fft.ifftn,
+    func_name="ifftn",
+    dim_alias="axes",
+    empty_dim_is_noop=True,
+)

--- a/tests/backend_support/test_pytorch_fftn_empty_axes_contract.py
+++ b/tests/backend_support/test_pytorch_fftn_empty_axes_contract.py
@@ -1,0 +1,46 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_pytorch_fftn_empty_axes_is_noop():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import numpy as np
+import numpy.testing as npt
+import pyrecest.backend as backend
+
+values_np = np.array([[0, 1], [2, 3]])
+values = backend.array(values_np)
+
+for axes in ((), []):
+    transformed = backend.fft.fftn(values, axes=axes)
+    inverse_transformed = backend.fft.ifftn(values, axes=axes)
+
+    expected_transformed = np.fft.fftn(values_np, axes=axes)
+    expected_inverse = np.fft.ifftn(values_np, axes=axes)
+
+    transformed_np = backend.to_numpy(transformed)
+    inverse_np = backend.to_numpy(inverse_transformed)
+
+    npt.assert_array_equal(transformed_np, expected_transformed)
+    npt.assert_array_equal(inverse_np, expected_inverse)
+    assert transformed_np.dtype == expected_transformed.dtype
+    assert inverse_np.dtype == expected_inverse.dtype
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- Make PyTorch `fftn` and `ifftn` treat empty `axes`/`dim` selections as NumPy-style no-ops.
- Preserve the input tensor and dtype for `axes=()` and `axes=[]`, matching `np.fft.fftn`/`np.fft.ifftn`.
- Add a focused PyTorch backend regression test that checks both values and dtype.

## Validation
- Added `tests/backend_support/test_pytorch_fftn_empty_axes_contract.py`.
- Performed a local minimal wrapper check against NumPy for `axes=()` and `axes=[]`; full repository tests were not run locally because this sandbox cannot clone GitHub.