### PR TITLE
Fix PyTorch real FFT scalar axis arrays

### DIFF
--- a/src/pyrecest/_backend/pytorch/fft.py
+++ b/src/pyrecest/_backend/pytorch/fft.py
@@ -1,5 +1,6 @@
 # For ffts. Added for pyrecest.
 from functools import wraps as _wraps
+from operator import index as _operator_index
 
 import torch as _torch
 
@@ -19,6 +20,19 @@ def _is_empty_dim(dim):
         return len(tuple(dim)) == 0
     except TypeError:
         return False
+
+
+def _normalize_single_fft_dim(dim):
+    """Return scalar-array FFT dimensions as Python integers when possible."""
+    if dim is None or isinstance(dim, (bool, str, bytes)):
+        return dim
+    ndim = getattr(dim, "ndim", None)
+    if ndim is not None and ndim != 0:
+        return dim
+    try:
+        return _operator_index(dim)
+    except TypeError:
+        return dim
 
 
 def _with_dim_alias(kwargs, alias, func_name):
@@ -44,11 +58,15 @@ def _wrap_arraylike_fft(
     func_name,
     dim_alias=None,
     empty_dim_is_noop=False,
+    normalize_scalar_dim=False,
 ):
     @_wraps(torch_func)
     def fft_func(value, *args, **kwargs):
         if dim_alias is not None:
             kwargs = _with_dim_alias(kwargs, dim_alias, func_name)
+        if normalize_scalar_dim and "dim" in kwargs:
+            kwargs = dict(kwargs)
+            kwargs["dim"] = _normalize_single_fft_dim(kwargs["dim"])
         value = _as_fft_tensor(value)
         if empty_dim_is_noop and _is_empty_dim(kwargs.get("dim")):
             return value
@@ -57,8 +75,18 @@ def _wrap_arraylike_fft(
     return fft_func
 
 
-rfft = _wrap_arraylike_fft(_torch.fft.rfft, func_name="rfft", dim_alias="axis")
-irfft = _wrap_arraylike_fft(_torch.fft.irfft, func_name="irfft", dim_alias="axis")
+rfft = _wrap_arraylike_fft(
+    _torch.fft.rfft,
+    func_name="rfft",
+    dim_alias="axis",
+    normalize_scalar_dim=True,
+)
+irfft = _wrap_arraylike_fft(
+    _torch.fft.irfft,
+    func_name="irfft",
+    dim_alias="axis",
+    normalize_scalar_dim=True,
+)
 fftshift = _wrap_arraylike_fft(
     _torch.fft.fftshift,
     func_name="fftshift",

--- a/tests/backend_support/test_pytorch_fft_scalar_axis_contract.py
+++ b/tests/backend_support/test_pytorch_fft_scalar_axis_contract.py
@@ -1,0 +1,30 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+pytest.importorskip("torch")
+
+import pyrecest._backend.pytorch.fft as pytorch_fft  # noqa: E402
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_real_fft_accepts_numpy_scalar_array_axis_alias():
+    vector = np.arange(4.0)
+    scalar_axes = [np.array(0), np.int64(0)]
+
+    for axis in scalar_axes:
+        spectrum = pytorch_fft.rfft(vector.tolist(), axis=axis)
+        npt.assert_allclose(spectrum.numpy(), np.fft.rfft(vector, axis=axis))
+
+        reconstructed = pytorch_fft.irfft(spectrum, n=vector.size, axis=axis)
+        expected = np.fft.irfft(np.fft.rfft(vector, axis=axis), n=vector.size, axis=axis)
+        npt.assert_allclose(reconstructed.numpy(), expected)
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_real_fft_accepts_numpy_scalar_array_dim():
+    vector = np.arange(4.0)
+    axis = np.array(0)
+
+    spectrum = pytorch_fft.rfft(vector.tolist(), dim=axis)
+    npt.assert_allclose(spectrum.numpy(), np.fft.rfft(vector, axis=int(axis)))


### PR DESCRIPTION
## Summary
- Normalize scalar-array FFT dimensions for the PyTorch `rfft`/`irfft` wrappers before dispatching to `torch.fft`.
- Keep non-scalar axis-like inputs unchanged so PyTorch still rejects invalid list/array axes for the single-axis real FFT helpers.
- Add focused regression coverage for `np.array(0)` and `np.int64(0)` passed through both NumPy-style `axis=` and direct `dim=` paths.

## Bug fixed
`pyrecest._backend.pytorch.fft.rfft(..., axis=np.array(0))` and the corresponding `irfft` call previously forwarded the 0-D NumPy array directly as Torch's `dim` argument. NumPy accepts this scalar-array axis, but Torch rejects it with `TypeError: argument 'dim' must be int, not numpy.ndarray`. The wrapper now converts scalar array/integer dimensions to Python `int` while leaving non-scalar inputs untouched.

## Validation
- Added `tests/backend_support/test_pytorch_fft_scalar_axis_contract.py`.
- Ran a local minimal Torch/NumPy check of the new scalar-axis normalization behavior. Full repository tests were not run locally because this sandbox cannot resolve `github.com` for cloning.