### PR TITLE
Fix PyTorch one_hot integer tensor labels

### DIFF
--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -108,9 +108,52 @@ def _patch_set_diag_arraylike_facade() -> None:
     backend.set_diag = set_diag
 
 
+def _patch_pytorch_one_hot_integer_label_facade() -> None:
+    """Make PyTorch one_hot accept all integer label tensor dtypes."""
+
+    try:
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import torch as _torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch may be unavailable
+        return
+
+    original_one_hot = getattr(pytorch_backend, "one_hot", None)
+    if original_one_hot is None:
+        return
+    if getattr(original_one_hot, "_pyrecest_integer_label_contract", False):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.one_hot = original_one_hot
+        return
+
+    def one_hot(labels, num_classes):
+        if _torch.is_tensor(labels):
+            if (
+                labels.dtype == _torch.bool
+                or labels.dtype.is_floating_point
+                or labels.dtype.is_complex
+            ):
+                return original_one_hot(labels, _operator_index(num_classes))
+            labels = labels.to(dtype=_torch.long)
+        else:
+            labels = _torch.LongTensor(labels)
+        return _torch.nn.functional.one_hot(
+            labels,
+            _operator_index(num_classes),
+        ).type(_torch.uint8)
+
+    one_hot.__name__ = getattr(original_one_hot, "__name__", "one_hot")
+    one_hot.__doc__ = getattr(original_one_hot, "__doc__", None)
+    one_hot._pyrecest_integer_label_contract = True
+    pytorch_backend.one_hot = one_hot
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.one_hot = one_hot
+
+
 _patch_shared_numpy_copy_facade()
 _patch_shared_numpy_squeeze_facade()
 _patch_set_diag_arraylike_facade()
+_patch_pytorch_one_hot_integer_label_facade()
 
 
 def _patch_pytorch_comparison_facade() -> None:

--- a/tests/backend_support/test_pytorch_one_hot_contract.py
+++ b/tests/backend_support/test_pytorch_one_hot_contract.py
@@ -1,0 +1,61 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _backend_test_env(backend_name):
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = backend_name
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    return env
+
+
+@pytest.mark.backend_portable
+def test_pytorch_one_hot_accepts_integer_label_tensors():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import pyrecest.backend as backend
+
+labels = backend.asarray([0, 2], dtype=backend.int32)
+result = backend.one_hot(labels, 3)
+
+assert result.shape == (2, 3)
+assert str(backend.to_numpy(result).dtype) == "uint8"
+assert backend.to_numpy(result).tolist() == [[1, 0, 0], [0, 0, 1]]
+"""
+    subprocess.run(
+        [sys.executable, "-c", code], check=True, env=_backend_test_env("pytorch")
+    )
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_one_hot_accepts_integer_label_tensors_with_numpy_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+assert getattr(backend, "__backend_name__", None) == "numpy"
+
+labels = raw_pytorch.asarray([0, 2], dtype=raw_pytorch.int32)
+result = raw_pytorch.one_hot(labels, 3)
+
+assert result.shape == (2, 3)
+assert str(raw_pytorch.to_numpy(result).dtype) == "uint8"
+assert raw_pytorch.to_numpy(result).tolist() == [[1, 0, 0], [0, 0, 1]]
+"""
+    subprocess.run(
+        [sys.executable, "-c", code], check=True, env=_backend_test_env("numpy")
+    )


### PR DESCRIPTION
## Summary
- Patch the PyTorch backend `one_hot` facade so integer label tensors with non-`long` dtypes are converted to `torch.long` before calling `torch.nn.functional.one_hot`.
- Apply the patch to both the public PyTorch backend and the raw PyTorch backend when PyRecEst is imported.
- Add subprocess regression coverage for public PyTorch and raw PyTorch under a NumPy public backend.

## Bug
`torch.nn.functional.one_hot` only accepts `LongTensor` inputs. The previous PyRecEst PyTorch backend wrapper passed tensor labels through unchanged, so valid integer label arrays such as `int32` tensors failed even though the backend contract already accepts integer label arrays.

## Testing
- Not run locally in this environment; added focused regression tests for CI.