### PR TITLE
Guard zero-speed online offset updates

### DIFF
--- a/src/pyrecest/filters/online_time_offset_estimator.py
+++ b/src/pyrecest/filters/online_time_offset_estimator.py
@@ -80,7 +80,7 @@ class OnlineTimeOffsetEstimator:
             raise ValueError("measurement_variance must be nonnegative")
 
         speed2 = float(velocity @ velocity)
-        if speed2 < float(self.min_speed) ** 2:
+        if speed2 <= 0.0 or speed2 < float(self.min_speed) ** 2:
             return float("nan")
         measured_offset = float((residual @ velocity) / speed2)
         variance = max(float(measurement_variance) / speed2, 1.0e-12)

--- a/tests/filters/test_online_time_offset_estimator.py
+++ b/tests/filters/test_online_time_offset_estimator.py
@@ -33,6 +33,19 @@ class OnlineTimeOffsetEstimatorTest(unittest.TestCase):
         self.assertEqual(estimator.offset, 1.0)
         self.assertEqual(estimator.variance, 2.0)
 
+    def test_zero_velocity_with_zero_min_speed_returns_nan_without_update(self):
+        estimator = OnlineTimeOffsetEstimator(offset=1.0, variance=2.0, min_speed=0.0)
+
+        nis = estimator.update_from_position_residual(
+            residual=np.array([10.0]),
+            velocity=np.array([0.0]),
+            measurement_variance=1.0,
+        )
+
+        self.assertTrue(math.isnan(nis))
+        self.assertEqual(estimator.offset, 1.0)
+        self.assertEqual(estimator.variance, 2.0)
+
     def test_predict_adds_process_variance_for_default_step(self):
         estimator = OnlineTimeOffsetEstimator(variance=1.0, process_variance=0.25)
 


### PR DESCRIPTION
## Summary
- return an uninformative NaN NIS when online offset updates see exactly zero velocity
- keep estimator offset/variance unchanged in that zero-speed case
- add a regression for `min_speed=0.0` with zero velocity

## Validation
- Focused local regression: zero-speed update returns NaN and leaves state unchanged
- Compared branch against `main`: 2 changed files, +14/-1 lines