### PR TITLE
Normalize PyTorch array device when stacking nested inputs

### DIFF
--- a/src/pyrecest/_backend/pytorch/_common.py
+++ b/src/pyrecest/_backend/pytorch/_common.py
@@ -60,6 +60,29 @@ def from_numpy(x):
     return _torch_from_numpy(x)
 
 
+def _iter_nested_tensors(value):
+    if _torch_is_tensor(value):
+        yield value
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            yield from _iter_nested_tensors(item)
+
+
+def _preferred_tensor_device(value):
+    for tensor in _iter_nested_tensors(value):
+        if tensor.device.type != "cpu":
+            return tensor.device
+    for tensor in _iter_nested_tensors(value):
+        return tensor.device
+    return None
+
+
+def _move_tensors_to_device(tensors, device):
+    if device is None:
+        return tensors
+    return [tensor.to(device=device) if tensor.device != device else tensor for tensor in tensors]
+
+
 def array(val, dtype=None):
     dtype = _normalize_dtype(dtype)
     if _torch_is_tensor(val):
@@ -76,7 +99,9 @@ def array(val, dtype=None):
         return tensor.clone()
 
     if isinstance(val, (list, tuple)) and len(val):
+        device = _preferred_tensor_device(val)
         tensors = [array(tensor, dtype=dtype) for tensor in val]
+        tensors = _move_tensors_to_device(tensors, device)
         return _torch_stack(tensors)
 
     return _torch_tensor(val, dtype=dtype)

--- a/tests/backend_support/test_pytorch_device_contract.py
+++ b/tests/backend_support/test_pytorch_device_contract.py
@@ -55,12 +55,12 @@ import torch
 import pyrecest._backend.pytorch as pytorch_backend
 
 cpu_row = torch.tensor([1.0, 2.0])
-accelerator_row = torch.ones(2, device="meta")
+accelerator_row = torch.ones(2, dtype=cpu_row.dtype, device="meta")
 
 stacked = pytorch_backend.array([cpu_row, accelerator_row])
 
 assert stacked.device.type == "meta"
-assert stacked.dtype == torch.float32
+assert stacked.dtype == cpu_row.dtype
 assert stacked.shape == torch.Size([2, 2])
 """,
     )

--- a/tests/backend_support/test_pytorch_device_contract.py
+++ b/tests/backend_support/test_pytorch_device_contract.py
@@ -41,3 +41,28 @@ assert backend.to_numpy(sparse_array).tolist() == [[0.0, 5.0], [7.0, 0.0]]
     )
 
     assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.backend_portable
+def test_pytorch_array_stacks_mixed_device_nested_inputs():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import torch
+import pyrecest._backend.pytorch as pytorch_backend
+
+cpu_row = torch.tensor([1.0, 2.0])
+accelerator_row = torch.ones(2, device="meta")
+
+stacked = pytorch_backend.array([cpu_row, accelerator_row])
+
+assert stacked.device.type == "meta"
+assert stacked.dtype == torch.float32
+assert stacked.shape == torch.Size([2, 2])
+""",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Normalize nested tensor devices before `pyrecest._backend.pytorch.array` stacks list/tuple inputs.
- Prefer an existing non-CPU tensor device, falling back to the first tensor device when all inputs are CPU.
- Add a focused PyTorch regression using a CPU row plus a meta-device row to cover mixed-device stacking without requiring CUDA.

## Bug fixed
`array([cpu_tensor, accelerator_tensor])` recursively converted each entry and then called `torch.stack` directly. When one nested entry was on an accelerator/non-CPU device and another was on CPU, Torch rejected the mixed-device stack. The patch chooses the existing non-CPU tensor device for the nested input and moves converted rows before stacking.

## Validation
- Added `test_pytorch_array_stacks_mixed_device_nested_inputs` in `tests/backend_support/test_pytorch_device_contract.py`.
- Full repository test suite not run in this environment; CI should run the new focused regression.