### PR TITLE
Decode binary backend names in support errors

### DIFF
--- a/src/pyrecest/exceptions.py
+++ b/src/pyrecest/exceptions.py
@@ -11,6 +11,12 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 
+def _normalize_backend_name(backend: object) -> str:
+    if isinstance(backend, (bytes, bytearray)):
+        return backend.decode()
+    return str(backend)
+
+
 def _normalize_supported_backends(
     supported_backends: Iterable[str] | str | None,
 ) -> tuple[str, ...]:
@@ -20,7 +26,7 @@ def _normalize_supported_backends(
         return (supported_backends,)
     if isinstance(supported_backends, (bytes, bytearray)):
         return (supported_backends.decode(),)
-    return tuple(str(backend) for backend in supported_backends)
+    return tuple(_normalize_backend_name(backend) for backend in supported_backends)
 
 
 class PyRecEstError(Exception):

--- a/tests/test_backend_not_supported_error_binary_iterable.py
+++ b/tests/test_backend_not_supported_error_binary_iterable.py
@@ -1,0 +1,18 @@
+from pyrecest.exceptions import BackendNotSupportedError
+
+
+def test_backend_not_supported_error_decodes_binary_supported_backend_iterables():
+    error = BackendNotSupportedError(
+        "ExampleAPI.update",
+        "jax",
+        supported_backends=(
+            bytes("numpy", "utf-8"),
+            bytearray("pytorch", "utf-8"),
+        ),
+    )
+
+    assert error.supported_backends == ("numpy", "pytorch")
+    assert str(error) == (
+        "ExampleAPI.update is unavailable for backend 'jax'; "
+        "supported backends: numpy, pytorch"
+    )


### PR DESCRIPTION
## Summary
- decode bytes and bytearray backend names when they appear inside supported_backends iterables
- keep single string and single binary supported_backends handling unchanged
- add a focused regression covering mixed binary iterable backend names

## Bug fixed
`BackendNotSupportedError` already decoded a single bytes-like `supported_backends` value, but iterable bytes-like entries were normalized with `str(...)`. That produced user-facing support messages such as `b'numpy'` instead of `numpy`.

## Validation
- Added `tests/test_backend_not_supported_error_binary_iterable.py`
- Inspected the changed files on the branch through the GitHub connector
- Full test suite not run locally because this environment cannot clone GitHub (`github.com` DNS resolution failed).