### PR TITLE
Fix callable Dirac dimension inference

### DIFF
--- a/src/pyrecest/models/validation.py
+++ b/src/pyrecest/models/validation.py
@@ -340,8 +340,8 @@ def infer_state_dim_from_distribution(
     ``input_dim``.  If those are unavailable, it falls back to common storage
     attributes such as ``mu``/``m`` for means, ``C`` for covariance, and ``d``
     for row-oriented Dirac support locations.  Method calls such as
-    ``mean()``/``covariance()`` are allowed by default but can be disabled with
-    ``allow_methods=False`` to avoid expensive numerical fallbacks.
+    ``mean()``/``covariance()``/``d()`` are allowed by default but can be disabled
+    with ``allow_methods=False`` to avoid expensive numerical fallbacks.
     """
     allow_methods = _validate_bool_flag(allow_methods, "allow_methods")
     for attr_name in ("dim", "input_dim"):
@@ -384,7 +384,8 @@ def infer_state_dim_from_distribution(
 
     if hasattr(distribution, "d"):
         try:
-            support = validate_matrix(getattr(distribution, "d"), name="distribution.d")
+            support = _maybe_call(getattr(distribution, "d"), allow_methods=allow_methods)
+            support = validate_matrix(support, name="distribution.d")
             return _shape_tuple(support)[1]
         except (TypeError, ValueError):
             pass

--- a/tests/models/test_validation_callable_dirac_dim.py
+++ b/tests/models/test_validation_callable_dirac_dim.py
@@ -1,0 +1,29 @@
+import unittest
+
+from pyrecest.backend import zeros
+from pyrecest.models.validation import infer_state_dim_from_distribution
+
+
+class TestCallableDiracDimensionInference(unittest.TestCase):
+    def test_infer_state_dim_from_callable_dirac_locations(self):
+        class DistributionWithCallableDiracs:
+            def d(self):
+                return zeros((4, 2))
+
+        self.assertEqual(
+            infer_state_dim_from_distribution(DistributionWithCallableDiracs()), 2
+        )
+
+    def test_disabled_methods_do_not_call_callable_dirac_locations(self):
+        class DistributionWithCallableDiracs:
+            def d(self):
+                raise RuntimeError("unexpected d call")
+
+        with self.assertRaisesRegex(ValueError, "Could not infer"):
+            infer_state_dim_from_distribution(
+                DistributionWithCallableDiracs(), allow_methods=False
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Call `d()` when method calls are allowed and Dirac support is used for state-dimension inference.
- Add focused regression tests for callable Dirac support.

## Validation
- Not run locally; patched via GitHub connector.