### PR TITLE
Reject fractional exact track observations

### DIFF
--- a/src/pyrecest/utils/track_evaluation/__init__.py
+++ b/src/pyrecest/utils/track_evaluation/__init__.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+from fractions import Fraction
 import runpy
 from pathlib import Path
 
@@ -9,12 +11,22 @@ d = runpy.run_path(
 o = d["_optional_int_candidate"]
 
 
+def _fractional_exact_number(v):
+    if isinstance(v, Decimal):
+        return v != v.to_integral_value()
+    if isinstance(v, Fraction):
+        return v.denominator != 1
+    return False
+
+
 def f(v):
     if isinstance(v, np.ndarray):
         if v.ndim != 0:
             return d["_MISSING"]
         v = v.item()
     if isinstance(v, (bool, np.bool_)):
+        return d["_MISSING"]
+    if _fractional_exact_number(v):
         return d["_MISSING"]
     return o(v)
 

--- a/tests/test_track_eval_ids.py
+++ b/tests/test_track_eval_ids.py
@@ -1,0 +1,31 @@
+from decimal import Decimal
+from fractions import Fraction
+
+import numpy as np
+from pyrecest.utils.track_evaluation import normalize_track_matrix, track_lengths
+
+
+def test_fractional_exact_observation_values_are_missing():
+    track_matrix = np.array(
+        [
+            [Decimal("1.5"), Fraction(3, 2)],
+            [
+                np.array(Decimal("2.5"), dtype=object),
+                np.array(Fraction(5, 2), dtype=object),
+            ],
+        ],
+        dtype=object,
+    )
+
+    normalized = normalize_track_matrix(track_matrix)
+
+    assert normalized.tolist() == [[None, None], [None, None]]
+    assert track_lengths(track_matrix).tolist() == [0, 0]
+
+
+def test_integral_exact_observation_values_are_preserved():
+    track_matrix = np.array([[Decimal("1"), Fraction(4, 2)]], dtype=object)
+
+    normalized = normalize_track_matrix(track_matrix)
+
+    assert normalized.tolist() == [[1, 2]]


### PR DESCRIPTION
Superseded by #3687, which carries the same fix rebased onto the current `main` branch.