### PR TITLE
Normalize scalar array squeeze axes

### DIFF
--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -42,6 +42,21 @@ def _patch_shared_numpy_squeeze_facade() -> None:
     original_squeeze = shared_numpy.squeeze
     np_module = shared_numpy._np
 
+    def _normalize_squeeze_axes(axis):
+        if isinstance(axis, (int, np_module.integer)):
+            return (int(axis),)
+        axis_array = np_module.asarray(axis)
+        if axis_array.shape == ():
+            try:
+                return (_operator_index(axis_array),)
+            except TypeError as exc:
+                raise TypeError(
+                    "only integer scalar arrays can be converted to a scalar index"
+                ) from exc
+        return tuple(axis)
+
+    shared_numpy._normalize_squeeze_axes = _normalize_squeeze_axes
+
     def _axis_out_of_bounds_error(axis, ndim):
         axis_error = getattr(getattr(np_module, "exceptions", None), "AxisError", None)
         if axis_error is None:
@@ -60,7 +75,7 @@ def _patch_shared_numpy_squeeze_facade() -> None:
         if axis is None:
             return original_squeeze(x_arr, axis=None)
 
-        axes = shared_numpy._normalize_squeeze_axes(axis)
+        axes = _normalize_squeeze_axes(axis)
         if not axes:
             return x_arr
 

--- a/tests/test_shared_numpy_squeeze.py
+++ b/tests/test_shared_numpy_squeeze.py
@@ -21,6 +21,34 @@ def test_shared_numpy_squeeze_accepts_tuple_axis():
     assert _to_python(result) == [1, 2]
 
 
+def test_shared_numpy_squeeze_accepts_scalar_array_axis():
+    if backend.__backend_name__ not in ("numpy", "autograd"):
+        pytest.skip("shared NumPy/autograd squeeze regression test")
+    np = pytest.importorskip("numpy")
+
+    result = backend.squeeze(array([[1], [2]]), axis=np.array(1))
+
+    assert result.shape == (2,)
+    assert _to_python(result) == [1, 2]
+
+
+def test_raw_numpy_squeeze_accepts_scalar_array_axis():
+    code = """
+import numpy as np
+import pyrecest  # noqa: F401
+import pyrecest._backend.numpy as raw_numpy
+
+result = raw_numpy.squeeze([[1], [2]], axis=np.array(1))
+assert result.shape == (2,)
+assert result.tolist() == [1, 2]
+print("ok")
+"""
+    result = run_backend_code("numpy", code)
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
 @pytest.mark.parametrize("axis", [3, -4])
 def test_shared_numpy_squeeze_rejects_out_of_bounds_axis(axis):
     if backend.__backend_name__ not in ("numpy", "autograd"):


### PR DESCRIPTION
## Summary
- Normalize 0-D NumPy array axes for shared NumPy/autograd squeeze handling.
- Update the shared raw squeeze normalizer during package initialization.
- Add public and raw NumPy regression coverage for `axis=np.array(1)`.

## Validation
- Inspected the compare diff.
- Full local tests were not run in this connector session.