### PR TITLE
Fix PyTorch signal tensor alignment

### DIFF
--- a/src/pyrecest/_backend/pytorch/signal.py
+++ b/src/pyrecest/_backend/pytorch/signal.py
@@ -64,15 +64,25 @@ def _as_torch_compatible(value):
     return value
 
 
-def _as_tensor_pair(in1, in2):
-    device = next(
-        (value.device for value in (in1, in2) if _torch.is_tensor(value)), None
+def _preferred_tensor_device(*values):
+    tensor_devices = [value.device for value in values if _torch.is_tensor(value)]
+    if not tensor_devices:
+        return None
+    return next(
+        (device for device in tensor_devices if device.type != "cpu"),
+        tensor_devices[0],
     )
+
+
+def _as_tensor_pair(in1, in2):
+    device = _preferred_tensor_device(in1, in2)
     x = (
         in1
         if _torch.is_tensor(in1)
         else _torch.as_tensor(_as_torch_compatible(in1), device=device)
     )
+    if device is not None:
+        x = x.to(device=device)
     y = (
         in2
         if _torch.is_tensor(in2)

--- a/tests/backend_support/test_pytorch_fftconvolve_device_selection.py
+++ b/tests/backend_support/test_pytorch_fftconvolve_device_selection.py
@@ -1,0 +1,14 @@
+import pytest
+
+
+def test_pytorch_fftconvolve_uses_existing_accelerator_tensor_device():
+    torch = pytest.importorskip("torch")
+    from pyrecest._backend.pytorch import signal as pytorch_signal
+
+    cpu_input = torch.ones(3)
+    accelerator_input = torch.ones(3, device="meta")
+
+    first, second = pytorch_signal._as_tensor_pair(cpu_input, accelerator_input)
+
+    assert first.device.type == "meta"
+    assert second.device.type == "meta"


### PR DESCRIPTION
## Summary
- Align both PyTorch signal operands before dtype promotion.
- Add a focused regression for tensors that start on different placements.

## Validation
- Compared branch against main: 2 commits, 2 changed files.
- Ran a local smoke test for the updated helper logic.
- Full repository tests were not run because checkout was unavailable.