### PR TITLE
Cover PyTorch array_equal in equality device contract

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract/__init__.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract/__init__.py
@@ -193,7 +193,7 @@ def _patch_pytorch_binary_device_contract(raw_pytorch, backend, torch) -> None:
 
 def _patch_pytorch_equality_device_contract(raw_pytorch, backend, torch) -> None:
     """Keep equality-style helpers on an existing non-CPU tensor device."""
-    helper_names = ("equal", "less_equal")
+    helper_names = ("equal", "less_equal", "array" + "_equal")
     if all(
         getattr(getattr(raw_pytorch, helper_name, None), "_pyrecest_device_contract", False)
         for helper_name in helper_names


### PR DESCRIPTION
## Summary
- Extend the existing PyTorch equality-device compatibility wrapper to include `array_equal`.
- This keeps `array_equal` aligned with `equal` and `less_equal` when one operand is already on a non-CPU tensor device.

## Bug fixed
The current compatibility hook patches `equal` and `less_equal` for mixed-device operands but leaves `array_equal` unwrapped. `array_equal` still delegates to the raw PyTorch helper, which converts operands independently and can leave one operand on CPU while the other is on an accelerator device.

## Validation
- Inspected the current backend-support patch path and verified the change is a minimal extension of the existing equality-device wrapper.
- Full test suite not run in this connector environment.