### PR TITLE
Reject infinite probability pruning entries

### DIFF
--- a/src/pyrecest/utils/candidate_pruning.py
+++ b/src/pyrecest/utils/candidate_pruning.py
@@ -376,6 +376,8 @@ def _as_probability_matrix(
     probabilities = _as_numeric_matrix(probability_matrix, "probability_matrix")
     if probabilities.shape != shape:
         raise ValueError("probability_matrix must match cost_matrix shape")
+    if np.any(np.isinf(probabilities)):
+        raise ValueError("probability_matrix may only contain finite probabilities or NaN")
     finite = np.isfinite(probabilities)
     if np.any(finite & ((probabilities < 0.0) | (probabilities > 1.0))):
         raise ValueError("finite probability_matrix entries must lie in [0, 1]")

--- a/tests/test_candidate_pruning.py
+++ b/tests/test_candidate_pruning.py
@@ -87,7 +87,7 @@ class TestCandidatePruning(unittest.TestCase):
                         config=config,
                     )
 
-    def test_probability_matrix_ignores_nonfinite_values(self):
+    def test_probability_matrix_ignores_nan_values(self):
         config = CandidatePruningConfig(probability_threshold=0.5)
 
         mask = candidate_mask_from_costs(
@@ -97,6 +97,21 @@ class TestCandidatePruning(unittest.TestCase):
         )
 
         npt.assert_array_equal(mask, np.array([[False, True]]))
+
+    def test_probability_matrix_rejects_infinite_values(self):
+        config = CandidatePruningConfig(probability_threshold=0.5)
+
+        for probabilities in (np.array([[np.inf, 0.75]]), np.array([[-np.inf, 0.75]])):
+            with self.subTest(probabilities=probabilities):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "probability_matrix may only contain finite probabilities or NaN",
+                ):
+                    candidate_mask_from_costs(
+                        np.array([[1.0, 2.0]]),
+                        probability_matrix=probabilities,
+                        config=config,
+                    )
 
     def test_numeric_matrices_reject_none_object_values(self):
         with self.assertRaisesRegex(ValueError, "cost_matrix must be numeric"):


### PR DESCRIPTION
## Summary
- Reject infinite values in `probability_matrix` for candidate pruning while preserving NaN-as-missing behavior.
- Rename the existing NaN regression to make that contract explicit.
- Add focused coverage for positive and negative infinite probability entries.

## Bug fixed
`candidate_mask_from_costs(..., probability_matrix=...)` previously treated `+/-inf` probability entries like missing values because validation only checked finite entries against `[0, 1]`. Infinite probabilities are not valid probabilities, so this could silently hide malformed pruning inputs instead of failing early.

## Validation
- Added targeted unit coverage in `tests/test_candidate_pruning.py`.
- Inspected the branch diff against current `main`.
- Full repository tests were not run locally because this connector environment cannot clone GitHub.