### PR TITLE
Reject complex numeric values in time-offset validation

### DIFF
--- a/src/pyrecest/calibration/__init__.py
+++ b/src/pyrecest/calibration/__init__.py
@@ -6,22 +6,113 @@ from typing import Any
 import numpy as np
 
 from . import time_offset as _time_offset_module
-from .bias import (
+
+_REJECTED_REAL_SCALAR_TYPES = (
+    bool,
+    np.bool_,
+    str,
+    bytes,
+    bytearray,
+    complex,
+    np.complexfloating,
+)
+
+
+def _is_rejected_real_scalar(value: Any) -> bool:
+    return isinstance(value, _REJECTED_REAL_SCALAR_TYPES)
+
+
+def _as_finite_float(value: Any, name: str) -> float:
+    arr = np.asarray(value)
+    if arr.ndim != 0 or arr.dtype == np.bool_ or arr.dtype.kind in "USbcMm":
+        raise ValueError(f"{name} must be a finite scalar")
+    scalar = arr.item()
+    if _is_rejected_real_scalar(scalar):
+        raise ValueError(f"{name} must be a finite scalar")
+    try:
+        result = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be a finite scalar") from exc
+    if not np.isfinite(result):
+        raise ValueError(f"{name} must be a finite scalar")
+    return result
+
+
+def _as_nonnegative_time_delta(value: Any, name: str) -> float:
+    arr = np.asarray(value)
+    if arr.ndim != 0 or arr.dtype == np.bool_ or arr.dtype.kind in "USbcMm":
+        raise ValueError(f"{name} must be nonnegative")
+    scalar = arr.item()
+    if _is_rejected_real_scalar(scalar):
+        raise ValueError(f"{name} must be nonnegative")
+    try:
+        result = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be nonnegative") from exc
+    if result < 0.0 or np.isnan(result):
+        raise ValueError(f"{name} must be nonnegative")
+    return result
+
+
+def _as_real_numeric_array(value: Any, name: str) -> np.ndarray:
+    arr = np.asarray(value)
+    if arr.dtype == np.bool_ or arr.dtype.kind in "USbcMm":
+        raise ValueError(f"{name} must contain real numeric values")
+    if arr.dtype == object:
+        for item in arr.reshape(-1):
+            if _is_rejected_real_scalar(item):
+                raise ValueError(f"{name} must contain real numeric values")
+    try:
+        return np.asarray(value, dtype=float)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must contain real numeric values") from exc
+
+
+def _as_summary_scalar(value: Any, name: str, *, allow_nan: bool = False) -> float:
+    arr = np.asarray(value)
+    if arr.ndim != 0 or arr.dtype == np.bool_ or arr.dtype.kind in "USbcMm":
+        raise ValueError(f"{name} must be a real scalar")
+    scalar = arr.item()
+    if _is_rejected_real_scalar(scalar):
+        raise ValueError(f"{name} must be a real scalar")
+    try:
+        result = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be a real scalar") from exc
+    if np.isnan(result) and allow_nan:
+        return result
+    if not np.isfinite(result):
+        raise ValueError(f"{name} must be a finite real scalar")
+    return result
+
+
+def _as_nonnegative_summary_count(value: Any, name: str) -> float:
+    result = _as_summary_scalar(value, name)
+    if result < 0.0:
+        raise ValueError(f"{name} must be nonnegative")
+    return result
+
+
+_time_offset_module._as_finite_float = _as_finite_float
+_time_offset_module._as_nonnegative_time_delta = _as_nonnegative_time_delta
+_time_offset_module._as_real_numeric_array = _as_real_numeric_array
+_time_offset_module._as_summary_scalar = _as_summary_scalar
+_time_offset_module._as_nonnegative_summary_count = _as_nonnegative_summary_count
+
+from .bias import (  # noqa: E402
     BiasTrainingExamples,
     SensorBiasCorrectionModel,
     fit_sensor_bias_correction,
     fit_sensor_bias_correction_from_examples,
     make_bias_training_examples,
 )
-from .time_offset import (
+from .time_offset import (  # noqa: E402
     TimeOffsetFitResult,
     _aggregate_std_metric,
-    _as_nonnegative_summary_count,
-    _as_summary_scalar,
     _validate_error_metric,
 )
 from .time_offset import aggregate_time_offset_sweeps as _aggregate_time_offset_sweeps
-from .time_offset import (
+from .time_offset import (  # noqa: E402
     apply_time_offset,
     fit_time_offset,
     interpolate_reference_values,

--- a/tests/calibration/test_time_offset_real_numeric_validation.py
+++ b/tests/calibration/test_time_offset_real_numeric_validation.py
@@ -1,0 +1,26 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.calibration import apply_time_offset, make_offset_grid
+
+
+class TimeOffsetRealNumericValidationTest(unittest.TestCase):
+    def test_apply_time_offset_rejects_numpy_complex_scalar_inside_object_array(self):
+        times = np.array([np.complex128(complex(1.0, 2.0))], dtype=object)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "times_s must contain real numeric values",
+        ):
+            apply_time_offset(times, 0.0)
+
+    def test_make_offset_grid_rejects_numpy_complex_object_scalar(self):
+        min_s = np.array(np.complex128(complex(0.0, 1.0)), dtype=object)
+
+        with self.assertRaisesRegex(ValueError, "min_s must be a finite scalar"):
+            make_offset_grid(min_s, 1.0, 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
- tighten time-offset calibration validation for real-valued numeric inputs
- reject NumPy complex scalar values before conversion to float
- add regression coverage for timestamp and offset-grid inputs

Validation:
- Added tests/calibration/test_time_offset_real_numeric_validation.py
- Inspected the branch diff with the GitHub connector; local full-suite execution was not available in this runtime.