### PR TITLE
Normalize PyTorch linalg norm NumPy axes

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -1,5 +1,7 @@
 """Pytorch based linear algebra backend."""
 
+from operator import index as _operator_index
+
 import numpy as _np
 import scipy as _scipy
 import torch as _torch
@@ -206,8 +208,33 @@ def svd(x, full_matrices=True, compute_uv=True):
     return _torch.linalg.svdvals(x)
 
 
+def _normalize_norm_axis(axis):
+    """Return a PyTorch-compatible norm dimension from NumPy-style axis input."""
+    if axis is None:
+        return None
+    if _torch.is_tensor(axis):
+        if axis.ndim == 0:
+            return _operator_index(axis.item())
+        if axis.ndim != 1:
+            raise TypeError("axis must be None, an integer, or a tuple of integers")
+        axis = axis.detach().cpu().tolist()
+    elif isinstance(axis, _np.ndarray):
+        if axis.ndim == 0:
+            return _operator_index(axis.item())
+        if axis.ndim != 1:
+            raise TypeError("axis must be None, an integer, or a tuple of integers")
+        axis = axis.tolist()
+    elif isinstance(axis, (int, _np.integer)):
+        return int(axis)
+
+    if isinstance(axis, (list, tuple)):
+        return tuple(_operator_index(one_axis) for one_axis in axis)
+    return _operator_index(axis)
+
+
 def norm(x, ord=None, axis=None, keepdims=False):
     x = _as_linalg_tensor(x)
+    axis = _normalize_norm_axis(axis)
     return _torch.linalg.norm(x, ord=ord, dim=axis, keepdim=keepdims)
 
 

--- a/tests/backend_support/test_pytorch_linalg_norm_axis.py
+++ b/tests/backend_support/test_pytorch_linalg_norm_axis.py
@@ -1,0 +1,32 @@
+import unittest
+
+import numpy as np
+
+pytorch_backend = None
+try:
+    from pyrecest._backend import pytorch as pytorch_backend
+except ModuleNotFoundError:
+    pass
+
+
+@unittest.skipIf(pytorch_backend is None, "PyTorch is not installed")
+class TestPytorchLinalgNormAxis(unittest.TestCase):
+    def test_norm_accepts_numpy_scalar_axis(self):
+        values = pytorch_backend.array([[3.0, 4.0], [0.0, 5.0]])
+
+        result = pytorch_backend.linalg.norm(values, axis=np.array(1))
+
+        expected = pytorch_backend.array([5.0, 5.0])
+        self.assertTrue(pytorch_backend.allclose(result, expected))
+
+    def test_norm_accepts_singleton_numpy_array_axis(self):
+        values = pytorch_backend.array([[3.0, 4.0], [0.0, 5.0]])
+
+        result = pytorch_backend.linalg.norm(values, axis=np.array([0]))
+
+        expected = pytorch_backend.array([3.0, 41.0**0.5])
+        self.assertTrue(pytorch_backend.allclose(result, expected))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Normalize NumPy-style `axis` values before passing them to `torch.linalg.norm`.
- Handle scalar NumPy arrays such as `np.array(1)` and 1-D singleton arrays such as `np.array([0])` as valid norm axes.
- Add PyTorch backend regression coverage for both axis forms.

## Verification
- Locally reproduced the raw PyTorch failures for `dim=np.array(1)` and `dim=np.array([0])`.
- Locally checked that the normalization maps those inputs to `1` and `(0,)`, yielding the expected norm results.

Full repository tests were not run in this environment.