### PR TITLE
Normalize NumPy array axes in PyTorch linalg norm

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -1,5 +1,7 @@
 """Pytorch based linear algebra backend."""
 
+import operator as _operator
+
 import numpy as _np
 import scipy as _scipy
 import torch as _torch
@@ -91,6 +93,13 @@ def _preferred_linalg_device(*values):
 
 def _out_kwargs(out):
     return {} if out is None else {"out": out}
+
+
+def _normalize_linalg_norm_axis(axis):
+    """Convert single-element NumPy axis arrays to Python integer axes."""
+    if isinstance(axis, _np.ndarray) and axis.size == 1:
+        return _operator.index(axis.item())
+    return axis
 
 
 def cholesky(a, upper=False, out=None):
@@ -208,6 +217,7 @@ def svd(x, full_matrices=True, compute_uv=True):
 
 def norm(x, ord=None, axis=None, keepdims=False):
     x = _as_linalg_tensor(x)
+    axis = _normalize_linalg_norm_axis(axis)
     return _torch.linalg.norm(x, ord=ord, dim=axis, keepdim=keepdims)
 
 

--- a/tests/backend_support/test_pytorch_linalg_norm_axis_contract.py
+++ b/tests/backend_support/test_pytorch_linalg_norm_axis_contract.py
@@ -8,20 +8,15 @@ except ModuleNotFoundError:
 
 
 @pytest.mark.skipif(pytorch_backend is None, reason="PyTorch is not installed")
-def test_linalg_norm_accepts_numpy_scalar_array_axis():
+@pytest.mark.parametrize(
+    "axis",
+    (np.array(0), np.array([0])),
+    ids=("zero_dim_array", "single_element_array"),
+)
+def test_linalg_norm_accepts_numpy_scalar_array_axis(axis):
     values = pytorch_backend.array([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]])
     expected = pytorch_backend.array([3.0, np.sqrt(17.0), np.sqrt(29.0)])
 
-    for axis in (np.array(0), np.array([0])):
-        with pytest.subtests.test(axis=repr(axis)) if hasattr(pytest, "subtests") else _nullcontext():
-            result = pytorch_backend.linalg.norm(values, axis=axis)
+    result = pytorch_backend.linalg.norm(values, axis=axis)
 
-            assert pytorch_backend.allclose(result, expected)
-
-
-class _nullcontext:
-    def __enter__(self):
-        return None
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        return False
+    assert pytorch_backend.allclose(result, expected)

--- a/tests/backend_support/test_pytorch_linalg_norm_axis_contract.py
+++ b/tests/backend_support/test_pytorch_linalg_norm_axis_contract.py
@@ -1,0 +1,27 @@
+import numpy as np
+import pytest
+
+try:
+    from pyrecest._backend import pytorch as pytorch_backend
+except ModuleNotFoundError:
+    pytorch_backend = None
+
+
+@pytest.mark.skipif(pytorch_backend is None, reason="PyTorch is not installed")
+def test_linalg_norm_accepts_numpy_scalar_array_axis():
+    values = pytorch_backend.array([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]])
+    expected = pytorch_backend.array([3.0, np.sqrt(17.0), np.sqrt(29.0)])
+
+    for axis in (np.array(0), np.array([0])):
+        with pytest.subtests.test(axis=repr(axis)) if hasattr(pytest, "subtests") else _nullcontext():
+            result = pytorch_backend.linalg.norm(values, axis=axis)
+
+            assert pytorch_backend.allclose(result, expected)
+
+
+class _nullcontext:
+    def __enter__(self):
+        return None
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False


### PR DESCRIPTION
## Summary
- Normalize single-element NumPy array axes before passing them to `torch.linalg.norm`.
- Preserve PyTorch handling for non-array axes and multi-element array axes.
- Add a focused PyTorch backend regression for `axis=np.array(0)` and `axis=np.array([0])`.

## Bug fixed
`pyrecest._backend.pytorch.linalg.norm(values, axis=np.array(0))` currently forwards the NumPy array directly as `dim`, which triggers a PyTorch argument-parser/internal error instead of behaving like a NumPy-style scalar axis.

## Validation
- Verified the minimal failure/fix locally against installed PyTorch by normalizing `np.array(0)` and `np.array([0])` before `torch.linalg.norm`.
- Not run: full PyRecEst test suite; repository checkout was not available in this execution environment.