### PR TITLE
Fix hypertoroidal PF NumPy scalar validation

### DIFF
--- a/src/pyrecest/filters/hypertoroidal_particle_filter.py
+++ b/src/pyrecest/filters/hypertoroidal_particle_filter.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
-from numbers import Integral
 from typing import Union
+
+import numpy as np
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 # pylint: disable=no-name-in-module,no-member
@@ -23,12 +24,30 @@ from .manifold_mixins import HypertoroidalFilterMixin
 
 
 def _validate_positive_integer(value, name: str) -> int:
-    if isinstance(value, bool) or not isinstance(value, Integral):
-        raise ValueError(f"{name} must be a positive integer.")
-    value = int(value)
-    if value <= 0:
-        raise ValueError(f"{name} must be a positive integer.")
-    return value
+    message = f"{name} must be a positive integer."
+    value_array = np.asarray(value)
+    if value_array.shape != () or value_array.dtype == np.bool_:
+        raise ValueError(message)
+
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(message)
+    if isinstance(scalar, (str, bytes, bytearray, np.str_, np.bytes_)):
+        raise ValueError(message)
+    if isinstance(scalar, (complex, np.complexfloating)):
+        raise ValueError(message)
+
+    try:
+        scalar_float = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if not np.isfinite(scalar_float) or not scalar_float.is_integer():
+        raise ValueError(message)
+
+    integer = int(scalar_float)
+    if integer <= 0:
+        raise ValueError(message)
+    return integer
 
 
 class HypertoroidalParticleFilter(AbstractParticleFilter, HypertoroidalFilterMixin):

--- a/tests/filters/test_hypertoroidal_particle_filter_numpy_scalars.py
+++ b/tests/filters/test_hypertoroidal_particle_filter_numpy_scalars.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pytest
+
+from pyrecest.filters import HypertoroidalParticleFilter
+
+
+def test_constructor_accepts_numpy_integer_scalar_arrays():
+    hpf = HypertoroidalParticleFilter(
+        np.array(5, dtype=np.int64),
+        np.array(2, dtype=np.int64),
+    )
+
+    assert hpf.filter_state.d.shape == (5, 2)
+
+
+@pytest.mark.parametrize(
+    ("argument_name", "n_particles", "dim"),
+    [
+        ("n_particles", np.array(True), 3),
+        ("n_particles", np.array(0), 3),
+        ("n_particles", np.array(-1), 3),
+        ("n_particles", np.array(1.5), 3),
+        ("dim", 5, np.array(True)),
+        ("dim", 5, np.array(0)),
+        ("dim", 5, np.array(-1)),
+        ("dim", 5, np.array(1.5)),
+    ],
+)
+def test_constructor_rejects_invalid_numpy_scalar_arrays(
+    argument_name,
+    n_particles,
+    dim,
+):
+    with pytest.raises(ValueError, match=argument_name):
+        HypertoroidalParticleFilter(n_particles, dim)


### PR DESCRIPTION
## Summary
- Accept zero-dimensional NumPy integer scalar arrays for `HypertoroidalParticleFilter` particle counts and dimensions.
- Keep booleans, non-positive values, and non-integer scalar arrays rejected with the existing `ValueError` contract.
- Add a focused regression test for accepted/rejected NumPy scalar-array constructor arguments.

## Bug fixed
`HypertoroidalParticleFilter(np.array(5), np.array(2))` was rejected because the constructor validator only accepted `numbers.Integral` instances. This was inconsistent with the Euclidean particle filter's scalar-array validation and made config-derived NumPy scalar values fail before filter construction.

## Validation
- Not run locally; connector environment cannot clone GitHub repositories.
- Changes are limited to constructor argument normalization plus a focused pytest regression.