### PR TITLE
Normalize JAX linalg norm array axes

### DIFF
--- a/src/pyrecest/_backend/jax/linalg.py
+++ b/src/pyrecest/_backend/jax/linalg.py
@@ -1,5 +1,6 @@
 """JAX-based linear algebra backend."""
 
+import numpy as _np
 import jax.numpy as _jnp
 import jax.scipy.linalg as _jax_scipy_linalg
 
@@ -9,6 +10,29 @@ from .._backend_config import jax_atol as atol
 def _as_linalg_array(value):
     """Convert PyRecEst array-like inputs before calling raw JAX linalg."""
     return _jnp.asarray(value)
+
+
+def _normalize_norm_axis(axis):
+    """Convert NumPy scalar-array axes to hashable values accepted by JAX."""
+    if axis is None or isinstance(axis, (int, _np.integer)):
+        return axis
+
+    axis_array = _np.asarray(axis)
+    if axis_array.ndim == 0:
+        return int(axis_array.item())
+    if axis_array.ndim == 1 and axis_array.size == 1:
+        return int(axis_array.reshape(()).item())
+    return axis
+
+
+def _normalize_norm_arguments(args, kwargs):
+    if len(args) >= 2:
+        args = tuple(args)
+        args = args[:1] + (_normalize_norm_axis(args[1]),) + args[2:]
+    if "axis" in kwargs:
+        kwargs = dict(kwargs)
+        kwargs["axis"] = _normalize_norm_axis(kwargs["axis"])
+    return args, kwargs
 
 
 def cholesky(a, *args, **kwargs):
@@ -44,6 +68,7 @@ def matrix_rank(a, *args, **kwargs):
 
 
 def norm(x, *args, **kwargs):
+    args, kwargs = _normalize_norm_arguments(args, kwargs)
     return _jnp.linalg.norm(_as_linalg_array(x), *args, **kwargs)
 
 

--- a/tests/backend_support/test_jax_linalg_norm_axis_contract.py
+++ b/tests/backend_support/test_jax_linalg_norm_axis_contract.py
@@ -1,0 +1,15 @@
+import numpy as np
+import pytest
+
+pytest.importorskip("jax")
+from pyrecest._backend import jax as jax_backend  # noqa: E402
+
+
+def test_linalg_norm_accepts_numpy_array_axes():
+    values = jax_backend.array([[3.0, 4.0], [0.0, 5.0]])
+    expected = jax_backend.array([5.0, 5.0])
+
+    for axis in (np.array(1), np.array([1])):
+        result = jax_backend.linalg.norm(values, axis=axis)
+
+        assert jax_backend.allclose(result, expected)


### PR DESCRIPTION
## Summary
- Normalize NumPy scalar and one-element array `axis` values before delegating `pyrecest._backend.jax.linalg.norm` to JAX.
- Add a focused regression covering `axis=np.array(1)` and `axis=np.array([1])`.

## Bug fixed
`jax.numpy.linalg.norm` treats `axis` as a static argument and rejects non-hashable NumPy arrays before it can apply NumPy-compatible scalar-axis coercion. That made the PyRecEst JAX backend fail for NumPy-style scalar-array axes even though the NumPy contract accepts them.

## Validation
- Reproduced the raw JAX failure locally with `jnp.linalg.norm(..., axis=np.array(1))` and `axis=np.array([1])`.
- Verified the normalizer returns the expected `[5, 5]` result in an isolated JAX snippet.
- Not run: full pytest suite in this connector session.