### PR TITLE
Normalize JAX FFT scalar array axes

### DIFF
--- a/src/pyrecest/_backend/jax/fft.py
+++ b/src/pyrecest/_backend/jax/fft.py
@@ -1,14 +1,18 @@
 """JAX FFT backend wrappers."""
 
-import numpy as _np
 import jax.numpy as _jnp
+import numpy as _np
 from jax.numpy import fft as _fft
 
 
 def _normalize_real_fft_axis(axis):
     """Return a Python ``int`` for NumPy integer scalar-array FFT axes."""
     if isinstance(axis, _np.ndarray):
-        if axis.size == 1 and _np.issubdtype(axis.dtype, _np.integer) and not _np.issubdtype(axis.dtype, _np.bool_):
+        if (
+            axis.size == 1
+            and _np.issubdtype(axis.dtype, _np.integer)
+            and not _np.issubdtype(axis.dtype, _np.bool_)
+        ):
             return int(axis.item())
         return axis
     if isinstance(axis, _np.integer) and not isinstance(axis, _np.bool_):

--- a/src/pyrecest/_backend/jax/fft.py
+++ b/src/pyrecest/_backend/jax/fft.py
@@ -1,15 +1,27 @@
 """JAX FFT backend wrappers."""
 
+import numpy as _np
 import jax.numpy as _jnp
 from jax.numpy import fft as _fft
 
 
+def _normalize_real_fft_axis(axis):
+    """Return a Python ``int`` for NumPy integer scalar-array FFT axes."""
+    if isinstance(axis, _np.ndarray):
+        if axis.size == 1 and _np.issubdtype(axis.dtype, _np.integer) and not _np.issubdtype(axis.dtype, _np.bool_):
+            return int(axis.item())
+        return axis
+    if isinstance(axis, _np.integer) and not isinstance(axis, _np.bool_):
+        return int(axis)
+    return axis
+
+
 def rfft(a, n=None, axis=-1, norm=None):
-    return _fft.rfft(_jnp.asarray(a), n=n, axis=axis, norm=norm)
+    return _fft.rfft(_jnp.asarray(a), n=n, axis=_normalize_real_fft_axis(axis), norm=norm)
 
 
 def irfft(a, n=None, axis=-1, norm=None):
-    return _fft.irfft(_jnp.asarray(a), n=n, axis=axis, norm=norm)
+    return _fft.irfft(_jnp.asarray(a), n=n, axis=_normalize_real_fft_axis(axis), norm=norm)
 
 
 def fftn(a, s=None, axes=None, norm=None):

--- a/tests/backend_support/test_jax_fft_scalar_array_axis_contract.py
+++ b/tests/backend_support/test_jax_fft_scalar_array_axis_contract.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pyrecest.backend as backend
+import pytest
+
+
+def _as_numpy(value):
+    return np.asarray(backend.to_numpy(value))
+
+
+def test_jax_real_fft_accepts_numpy_scalar_array_axes():
+    if backend.__backend_name__ != "jax":
+        pytest.skip("JAX-specific FFT backend contract")
+
+    samples = np.arange(6.0).reshape(2, 3)
+    backend_samples = backend.asarray(samples)
+    expected_spectrum = np.fft.rfft(samples, axis=1)
+
+    for axis in (np.array(1), np.array([1]), np.int64(1)):
+        actual_spectrum = _as_numpy(backend.fft.rfft(backend_samples, axis=axis))
+        assert np.allclose(actual_spectrum, expected_spectrum)
+
+        actual_roundtrip = _as_numpy(
+            backend.fft.irfft(actual_spectrum, n=samples.shape[1], axis=axis)
+        )
+        assert np.allclose(actual_roundtrip, samples)


### PR DESCRIPTION
## Summary
- Normalize NumPy integer scalar-array axes before dispatching JAX `rfft`/`irfft` wrappers.
- Preserve invalid non-integer and multi-element axis values by forwarding them to JAX unchanged.
- Add a focused JAX backend regression for `np.array(1)`, `np.array([1])`, and `np.int64(1)`.

## Bug fixed
`pyrecest._backend.jax.fft.rfft(..., axis=np.array(1))` and `irfft(..., axis=np.array([1]))` forwarded NumPy scalar arrays directly to JAX. JAX treats those array objects as unhashable/static-invalid axis values, even though they represent a single integer axis and are common when axis parameters come from NumPy-based configuration code.

## Validation
- Ran a local minimal JAX/NumPy reproduction of the new normalizer behavior for `rfft`/`irfft` with `np.array(1)`, `np.array([1])`, and `np.int64(1)`.
- Inspected the branch compare: 2 files changed, focused to JAX FFT wrapper plus regression test.
- Full repository test suite was not run because the container cannot resolve `github.com` for cloning.