### PR TITLE
Fix PyTorch matrix_power scalar exponent arrays

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -66,6 +66,14 @@ def _as_linalg_tensor(value):
     return tensor
 
 
+def _as_integer_scalar(value, name):
+    """Return a Python integer for Torch integer-scalar arguments."""
+    try:
+        return _operator_index(value)
+    except TypeError as exc:
+        raise TypeError(f"{name} must be an integer scalar") from exc
+
+
 def _common_linalg_dtype(*tensors):
     """Return a common floating/complex dtype for torch.linalg operations."""
     dtype = tensors[0].dtype
@@ -132,7 +140,7 @@ def expm(a):
 
 def matrix_power(a, n):
     """Raise a matrix to an integer power after array-like input promotion."""
-    return _torch.linalg.matrix_power(_as_linalg_tensor(a), n)
+    return _torch.linalg.matrix_power(_as_linalg_tensor(a), _as_integer_scalar(n, "n"))
 
 
 def pinv(a, rcond=None, hermitian=False, *, atol=None, rtol=None, out=None):

--- a/tests/test_pytorch_linalg_arraylike_inputs.py
+++ b/tests/test_pytorch_linalg_arraylike_inputs.py
@@ -21,6 +21,7 @@ def test_pytorch_linalg_helpers_accept_array_like_inputs():
     )
 
     code = """
+import numpy as np
 import pyrecest.backend as backend
 from pyrecest.backend import linalg
 
@@ -32,7 +33,9 @@ cholesky = linalg.cholesky([[4.0, 0.0], [0.0, 9.0]])
 assert backend.to_numpy(cholesky).tolist() == [[2.0, 0.0], [0.0, 3.0]]
 
 assert backend.to_numpy(linalg.eigvalsh([[2.0, 0.0], [0.0, 3.0]])).tolist() == [2.0, 3.0]
-assert backend.to_numpy(linalg.matrix_power([[1.0, 1.0], [0.0, 1.0]], 2)).tolist() == [[1.0, 2.0], [0.0, 1.0]]
+expected_power = [[1.0, 2.0], [0.0, 1.0]]
+assert backend.to_numpy(linalg.matrix_power([[1.0, 1.0], [0.0, 1.0]], 2)).tolist() == expected_power
+assert backend.to_numpy(linalg.matrix_power([[1.0, 1.0], [0.0, 1.0]], np.array(2))).tolist() == expected_power
 assert backend.to_numpy(linalg.pinv([[1.0, 0.0], [0.0, 0.0]])).tolist() == [[1.0, 0.0], [0.0, 0.0]]
 assert backend.to_numpy(linalg.expm([[0.0, 0.0], [0.0, 0.0]])).tolist() == identity
 assert backend.to_numpy(linalg.block_diag([[1.0]], [[2.0]])).tolist() == [[1.0, 0.0], [0.0, 2.0]]


### PR DESCRIPTION
## Summary
- Normalize the PyTorch `linalg.matrix_power` exponent through integer-scalar coercion before calling `torch.linalg.matrix_power`.
- Add a focused PyTorch backend regression for `np.array(2)` exponents.

## Bug fixed
`torch.linalg.matrix_power` rejects a 0-D NumPy integer array exponent with `TypeError: argument 'n' must be int, not numpy.ndarray`, while NumPy accepts `np.array(2)` as an integer scalar. PyRecEst's PyTorch backend forwarded `n` directly, so valid NumPy-style scalar exponent inputs failed under the PyTorch backend.

## Validation
- Verified a local minimal PyTorch reproduction: raw `torch.linalg.matrix_power(matrix, np.array(2))` fails, while converting with `operator.index(np.array(2))` produces `[[1.0, 2.0], [0.0, 1.0]]`.
- Inspected the branch compare against `main`: 2 commits, 2 changed files, focused to the PyTorch linalg wrapper and regression test.
- Not run: full repository test suite, because the execution environment cannot clone GitHub directly.