### PR TITLE
Accept JAX matrix_rank hermitian argument

### DIFF
--- a/src/pyrecest/_backend/jax/linalg.py
+++ b/src/pyrecest/_backend/jax/linalg.py
@@ -95,8 +95,7 @@ def _unsupported_function(name):
     """Create an unsupported-function shim that preserves facade identity."""
 
     def _raise_unsupported(*args, **kwargs):
-        unused_args = args
-        unused_kwargs = kwargs
+        _ = (args, kwargs)
         raise NotImplementedError(f"{name} is not supported in this JAX backend.")
 
     _raise_unsupported.__name__ = name

--- a/src/pyrecest/_backend/jax/linalg.py
+++ b/src/pyrecest/_backend/jax/linalg.py
@@ -39,7 +39,8 @@ def matrix_power(a, n):
     return _jnp.linalg.matrix_power(_as_linalg_array(a), n)
 
 
-def matrix_rank(a, *args, **kwargs):
+def matrix_rank(a, *args, hermitian=False, **kwargs):
+    _ = hermitian
     return _jnp.linalg.matrix_rank(_as_linalg_array(a), *args, **kwargs)
 
 
@@ -94,7 +95,8 @@ def _unsupported_function(name):
     """Create an unsupported-function shim that preserves facade identity."""
 
     def _raise_unsupported(*args, **kwargs):
-        del args, kwargs
+        unused_args = args
+        unused_kwargs = kwargs
         raise NotImplementedError(f"{name} is not supported in this JAX backend.")
 
     _raise_unsupported.__name__ = name

--- a/tests/backend_support/test_jax_matrix_rank_contract.py
+++ b/tests/backend_support/test_jax_matrix_rank_contract.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_jax_matrix_rank_accepts_hermitian_argument():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("JAX is not installed")
+
+    from pyrecest._backend.jax import linalg
+
+    rank = linalg.matrix_rank([[1.0, 0.0], [0.0, 0.0]], hermitian=True)
+
+    assert rank.item() == 1


### PR DESCRIPTION
## Summary
- Accept `hermitian=` in the JAX `linalg.matrix_rank` wrapper.
- Add a focused JAX backend regression test.

## Validation
- Not run locally; CI should run on this PR.