### PR TITLE
Normalize PyTorch matrix_power scalar exponents

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -130,9 +130,26 @@ def expm(a):
     return _torch.linalg.matrix_exp(_as_linalg_tensor(a))
 
 
+def _normalize_matrix_power_exponent(n):
+    """Return a Python integer exponent from scalar integer array inputs."""
+    if _torch.is_tensor(n):
+        if n.ndim != 0:
+            raise TypeError("exponent must be an integer")
+        n = n.detach().cpu().item()
+    elif isinstance(n, _np.ndarray):
+        if n.ndim != 0:
+            raise TypeError("exponent must be an integer")
+        n = n.item()
+    if isinstance(n, (bool, _np.bool_)):
+        raise TypeError("exponent must be an integer")
+    return _operator_index(n)
+
+
 def matrix_power(a, n):
     """Raise a matrix to an integer power after array-like input promotion."""
-    return _torch.linalg.matrix_power(_as_linalg_tensor(a), n)
+    return _torch.linalg.matrix_power(
+        _as_linalg_tensor(a), _normalize_matrix_power_exponent(n)
+    )
 
 
 def pinv(a, rcond=None, hermitian=False, *, atol=None, rtol=None, out=None):

--- a/tests/backend/test_pytorch_matrix_power_scalar_exponent.py
+++ b/tests/backend/test_pytorch_matrix_power_scalar_exponent.py
@@ -1,0 +1,27 @@
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_pytorch_matrix_power_accepts_scalar_array_exponents():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import numpy as np
+import torch
+
+import pyrecest.backend as backend
+from pyrecest.backend import linalg
+
+matrix = [[1.0, 1.0], [0.0, 1.0]]
+expected = [[1.0, 2.0], [0.0, 1.0]]
+
+assert backend.to_numpy(linalg.matrix_power(matrix, np.array(2))).tolist() == expected
+assert backend.to_numpy(linalg.matrix_power(matrix, torch.tensor(2))).tolist() == expected
+"""
+    result = run_backend_code("pytorch", code)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Normalize scalar NumPy array and scalar PyTorch tensor exponents before calling `torch.linalg.matrix_power`.
- Preserve the existing array-like matrix promotion behavior.
- Add a focused PyTorch backend regression for `np.array(2)` and `torch.tensor(2)` exponents.

## Bug fixed
`pyrecest.backend.linalg.matrix_power` already promotes array-like matrix inputs in the PyTorch backend, but it passed the exponent `n` through unchanged. Raw `torch.linalg.matrix_power` rejects scalar array/tensor exponent inputs even when they contain a valid integer value, so NumPy-style scalar array exponents failed despite being safely coercible to a Python integer.

## Validation
- Reproduced raw PyTorch failure locally for `torch.linalg.matrix_power(torch.eye(2), np.array(2))`.
- Verified locally that applying `operator.index(...)` after scalar extraction fixes NumPy scalar array and PyTorch scalar tensor exponents.
- Not run: full repository test suite in this connector session.