### PR TITLE
Normalize PyTorch linalg scalar tolerances

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -95,6 +95,15 @@ def _out_kwargs(out):
     return {} if out is None else {"out": out}
 
 
+def _normalize_linalg_tolerance(value):
+    """Return PyTorch-compatible scalar tolerances from NumPy scalar inputs."""
+    if isinstance(value, _np.ndarray) and value.ndim == 0:
+        return value.item()
+    if isinstance(value, _np.generic):
+        return value.item()
+    return value
+
+
 def cholesky(a, upper=False, out=None):
     """Compute a Cholesky factor after PyRecEst-style array-like promotion."""
     return _torch.linalg.cholesky(_as_linalg_tensor(a), upper=upper, **_out_kwargs(out))
@@ -141,8 +150,11 @@ def pinv(a, rcond=None, hermitian=False, *, atol=None, rtol=None, out=None):
         if rtol is not None:
             raise TypeError("pinv() got both 'rcond' and 'rtol'")
         rtol = rcond
+    a = _as_linalg_tensor(a)
+    atol = _normalize_linalg_tolerance(atol)
+    rtol = _normalize_linalg_tolerance(rtol)
     return _torch.linalg.pinv(
-        _as_linalg_tensor(a),
+        a,
         atol=atol,
         rtol=rtol,
         hermitian=hermitian,
@@ -250,6 +262,8 @@ def matrix_rank(a, tol=None, hermitian=False, *, rtol=None, atol=None, **kwargs)
         atol = tol
 
     a = _as_linalg_tensor(a)
+    atol = _normalize_linalg_tolerance(atol)
+    rtol = _normalize_linalg_tolerance(rtol)
     return _torch.linalg.matrix_rank(a, atol=atol, rtol=rtol, hermitian=hermitian)
 
 

--- a/tests/test_pytorch_linalg_tolerances.py
+++ b/tests/test_pytorch_linalg_tolerances.py
@@ -1,0 +1,47 @@
+import unittest
+from typing import Any
+
+import numpy as np
+
+pytorch_backend: Any
+try:
+    from pyrecest._backend import pytorch as pytorch_backend
+except ModuleNotFoundError:
+    pytorch_backend = None
+
+
+@unittest.skipIf(pytorch_backend is None, "PyTorch is not installed")
+class TestPytorchLinalgToleranceContract(unittest.TestCase):
+    def test_matrix_rank_accepts_numpy_scalar_array_tolerances(self):
+        value = pytorch_backend.diag(pytorch_backend.array([1.0, 1e-5]))
+
+        self.assertEqual(
+            int(pytorch_backend.linalg.matrix_rank(value, tol=np.array(1e-4))),
+            1,
+        )
+        self.assertEqual(
+            int(pytorch_backend.linalg.matrix_rank(value, rtol=np.array(1e-4))),
+            1,
+        )
+
+    def test_pinv_accepts_numpy_scalar_array_tolerances(self):
+        value = pytorch_backend.diag(
+            pytorch_backend.array([1.0, 1e-5], dtype=pytorch_backend.float64)
+        )
+        expected = pytorch_backend.diag(
+            pytorch_backend.array([1.0, 0.0], dtype=pytorch_backend.float64)
+        )
+
+        for keyword in ("rcond", "rtol"):
+            with self.subTest(keyword=keyword):
+                result = pytorch_backend.linalg.pinv(
+                    value,
+                    **{keyword: np.array(1e-4)},
+                )
+
+                self.assertEqual(result.dtype, pytorch_backend.float64)
+                self.assertTrue(pytorch_backend.allclose(result, expected))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Normalize NumPy zero-dimensional scalar tolerance inputs before calling PyTorch `linalg.pinv` and `linalg.matrix_rank`.
- Keep non-scalar tolerance inputs delegated to PyTorch unchanged.
- Add focused PyTorch backend regressions for `np.array(1e-4)` tolerance values.

## Bug fixed
PyTorch rejects NumPy zero-dimensional array tolerances such as `np.array(1e-4)` for these functions, while NumPy accepts them as scalar tolerances. The PyRecEst PyTorch backend forwarded those values directly, so backend-portable code could fail when tolerances came from NumPy configuration or computations.

## Validation
- Reproduced the raw PyTorch failures locally.
- Verified the scalar-normalization behavior locally.
- Syntax-checked the updated module and new regression test locally.
- Full repository test suite not run in this connector session.