### PR TITLE
Align PyTorch solve_sylvester tensor devices

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -295,9 +295,14 @@ def qr(a, mode="reduced"):
 
 
 def solve_sylvester(a, b, q):
+    device = _preferred_linalg_device(a, b, q)
     a = _as_linalg_tensor(a)
     b = _as_linalg_tensor(b)
     q = _as_linalg_tensor(q)
+    if device is not None:
+        a = a.to(device=device)
+        b = b.to(device=device)
+        q = q.to(device=device)
     common_dtype = _common_linalg_dtype(a, b, q)
     a = a.to(dtype=common_dtype)
     b = b.to(dtype=common_dtype)

--- a/tests/backend_support/test_pytorch_solve_sylvester_device.py
+++ b/tests/backend_support/test_pytorch_solve_sylvester_device.py
@@ -1,0 +1,53 @@
+import unittest
+from typing import Any
+
+pytorch_backend: Any
+torch: Any
+try:
+    import torch
+
+    from pyrecest._backend import pytorch as pytorch_backend
+except ModuleNotFoundError:
+    torch = None
+    pytorch_backend = None
+
+
+@unittest.skipIf(pytorch_backend is None, "PyTorch is not installed")
+class TestPytorchSolveSylvesterDevice(unittest.TestCase):
+    def test_solve_sylvester_keeps_common_dtype_for_mixed_array_like_inputs(self):
+        a = pytorch_backend.array(
+            [[2.0, 0.0], [0.0, 3.0]], dtype=pytorch_backend.float32
+        )
+        b = [[2.0, 0.0], [0.0, 3.0]]
+        q = pytorch_backend.array(
+            [[8.0, 10.0], [10.0, 12.0]], dtype=pytorch_backend.float64
+        )
+
+        result = pytorch_backend.linalg.solve_sylvester(a, b, q)
+
+        expected = pytorch_backend.array(
+            [[2.0, 2.0], [2.0, 2.0]], dtype=pytorch_backend.float64
+        )
+        self.assertEqual(result.dtype, pytorch_backend.float64)
+        self.assertTrue(pytorch_backend.allclose(result, expected))
+
+    @unittest.skipIf(torch is None or not torch.cuda.is_available(), "CUDA is not available")
+    def test_solve_sylvester_aligns_mixed_tensor_devices(self):
+        a = torch.tensor(
+            [[2.0, 0.0], [0.0, 3.0]], dtype=torch.float32, device="cuda"
+        )
+        b = torch.tensor([[2.0, 0.0], [0.0, 3.0]], dtype=torch.float32)
+        q = torch.tensor([[8.0, 10.0], [10.0, 12.0]], dtype=torch.float64)
+
+        result = pytorch_backend.linalg.solve_sylvester(a, b, q)
+
+        expected = torch.tensor(
+            [[2.0, 2.0], [2.0, 2.0]], dtype=torch.float64, device="cuda"
+        )
+        self.assertEqual(result.device.type, "cuda")
+        self.assertEqual(result.dtype, torch.float64)
+        self.assertTrue(torch.allclose(result, expected))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Align `linalg.solve_sylvester` inputs to a preferred tensor device before common dtype promotion.
- Preserve the existing common-dtype behavior and symmetric-factor fast paths.
- Add regression coverage for mixed array-like inputs and CUDA mixed-device tensors when CUDA is available.

## Bug fixed
The PyTorch backend `linalg.solve` already chooses a preferred tensor device before calling PyTorch linear algebra. `linalg.solve_sylvester` promoted `a`, `b`, and `q` to a common dtype but did not move them to a common device first. If one operand was on CUDA and another on CPU, the shared-factor checks and subsequent matmul/eigh paths could fail with a cross-device tensor error. The fallback SciPy bridge also needed `q` aligned first so `_torch_as_like(..., q)` returns the solution on the selected device.

## Validation
- Inspected the branch compare: 2 commits, 2 changed files.
- Added a CPU regression for mixed array-like inputs.
- Added a CUDA regression that exercises the original mixed-device failure when CUDA is available.
- Not run locally: full suite, because this environment cannot clone GitHub directly.