### PR TITLE
Support JAX QR economic mode

### DIFF
--- a/src/pyrecest/_backend/jax/linalg.py
+++ b/src/pyrecest/_backend/jax/linalg.py
@@ -52,7 +52,24 @@ def pinv(a, *args, **kwargs):
 
 
 def qr(a, *args, **kwargs):
-    return _jnp.linalg.qr(_as_linalg_array(a), *args, **kwargs)
+    """Compute QR decomposition with NumPy-compatible legacy mode handling."""
+    a = _as_linalg_array(a)
+    if args:
+        mode = args[0]
+        if len(args) != 1 or "mode" in kwargs or mode != "economic":
+            return _jnp.linalg.qr(a, *args, **kwargs)
+        raw_qr = _jnp.linalg.qr(a, "raw", **kwargs)
+    else:
+        mode = kwargs.get("mode", "reduced")
+        if mode != "economic":
+            return _jnp.linalg.qr(a, **kwargs)
+        kwargs = dict(kwargs)
+        kwargs["mode"] = "raw"
+        raw_qr = _jnp.linalg.qr(a, **kwargs)
+
+    # NumPy's deprecated ``economic`` mode returns the transposed raw Householder
+    # reflector matrix. JAX exposes that matrix as ``Q`` for ``mode="raw"``.
+    return _jnp.swapaxes(raw_qr.Q, -1, -2)
 
 
 def solve(a, b, *args, **kwargs):

--- a/tests/backend_support/test_jax_linalg_contract.py
+++ b/tests/backend_support/test_jax_linalg_contract.py
@@ -61,3 +61,36 @@ def test_jax_linalg_accepts_array_like_inputs_directly():
 
     root = linalg.sqrtm([[4.0, 0.0], [0.0, 9.0]])
     assert bool(jnp.allclose(root, jnp.array([[2.0, 0.0], [0.0, 3.0]]), atol=1e-5))
+
+
+@pytest.mark.backend_portable
+def test_jax_qr_accepts_numpy_economic_mode():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("JAX is not installed")
+
+    result = run_backend_code(
+        "jax",
+        """
+import numpy as np
+import pyrecest.backend as backend
+
+values = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+economic = backend.linalg.qr(backend.array(values), mode="economic")
+expected = np.linalg.qr(values, mode="raw")[0].swapaxes(-1, -2)
+np.testing.assert_allclose(np.asarray(economic), expected, rtol=1e-5, atol=1e-5)
+
+batched_values = np.stack([values, values + 1.0])
+batched_economic = backend.linalg.qr(backend.array(batched_values), mode="economic")
+batched_expected = np.linalg.qr(batched_values, mode="raw")[0].swapaxes(-1, -2)
+np.testing.assert_allclose(
+    np.asarray(batched_economic),
+    batched_expected,
+    rtol=1e-5,
+    atol=1e-5,
+)
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- Teach the JAX linalg `qr` wrapper to support NumPy's legacy `mode="economic"` contract.
- Implement the mode via JAX raw QR and swap the raw Householder matrix axes, including batched inputs.
- Add a focused backend regression comparing against NumPy raw-mode output.

## Bug fixed
`backend.linalg.qr(..., mode="economic")` works under the NumPy backend and the PyTorch wrapper, but the JAX wrapper delegated straight to `jax.numpy.linalg.qr`, which rejects `"economic"` with `ValueError: Unsupported QR decomposition mode 'economic'`.

## Validation
- Reproduced the raw JAX rejection locally.
- Verified the implementation against NumPy raw QR for 2-D and batched inputs in an isolated local check.
- Syntax-checked the updated module and regression test locally.
- Full repository test suite not run in this connector session because the sandbox cannot clone GitHub directly.