### PR TITLE
Normalize PyTorch FFT numpy array axes

### DIFF
--- a/src/pyrecest/_backend/pytorch/fft.py
+++ b/src/pyrecest/_backend/pytorch/fft.py
@@ -1,6 +1,8 @@
 # For ffts. Added for pyrecest.
 from functools import wraps as _wraps
+from operator import index as _operator_index
 
+import numpy as _np
 import torch as _torch
 
 from ._common import array as _array
@@ -9,6 +11,33 @@ from ._common import array as _array
 def _as_fft_tensor(value):
     """Convert array-like FFT inputs to torch tensors."""
     return value if _torch.is_tensor(value) else _array(value)
+
+
+def _normalize_dim_sequence(dim):
+    """Return Torch-compatible dim tuples for NumPy-style FFT axis arrays."""
+    if dim is None or isinstance(dim, (str, bytes)):
+        return dim
+    if isinstance(dim, _np.ndarray):
+        if (
+            dim.ndim != 1
+            or not _np.issubdtype(dim.dtype, _np.integer)
+            or _np.issubdtype(dim.dtype, _np.bool_)
+        ):
+            return dim
+        dim = dim.tolist()
+    elif _torch.is_tensor(dim):
+        if (
+            dim.ndim != 1
+            or dim.dtype == _torch.bool
+            or dim.dtype.is_floating_point
+            or dim.dtype.is_complex
+        ):
+            return dim
+        dim = dim.detach().cpu().tolist()
+    else:
+        return dim
+
+    return tuple(_operator_index(axis) for axis in dim)
 
 
 def _is_empty_dim(dim):
@@ -43,12 +72,16 @@ def _wrap_arraylike_fft(
     *,
     func_name,
     dim_alias=None,
+    dim_normalizer=None,
     empty_dim_is_noop=False,
 ):
     @_wraps(torch_func)
     def fft_func(value, *args, **kwargs):
         if dim_alias is not None:
             kwargs = _with_dim_alias(kwargs, dim_alias, func_name)
+        if dim_normalizer is not None and "dim" in kwargs:
+            kwargs = dict(kwargs)
+            kwargs["dim"] = dim_normalizer(kwargs["dim"])
         value = _as_fft_tensor(value)
         if empty_dim_is_noop and _is_empty_dim(kwargs.get("dim")):
             return value
@@ -63,13 +96,25 @@ fftshift = _wrap_arraylike_fft(
     _torch.fft.fftshift,
     func_name="fftshift",
     dim_alias="axes",
+    dim_normalizer=_normalize_dim_sequence,
     empty_dim_is_noop=True,
 )
 ifftshift = _wrap_arraylike_fft(
     _torch.fft.ifftshift,
     func_name="ifftshift",
     dim_alias="axes",
+    dim_normalizer=_normalize_dim_sequence,
     empty_dim_is_noop=True,
 )
-fftn = _wrap_arraylike_fft(_torch.fft.fftn, func_name="fftn", dim_alias="axes")
-ifftn = _wrap_arraylike_fft(_torch.fft.ifftn, func_name="ifftn", dim_alias="axes")
+fftn = _wrap_arraylike_fft(
+    _torch.fft.fftn,
+    func_name="fftn",
+    dim_alias="axes",
+    dim_normalizer=_normalize_dim_sequence,
+)
+ifftn = _wrap_arraylike_fft(
+    _torch.fft.ifftn,
+    func_name="ifftn",
+    dim_alias="axes",
+    dim_normalizer=_normalize_dim_sequence,
+)

--- a/tests/backend_support/test_pytorch_fft_numpy_array_axes_contract.py
+++ b/tests/backend_support/test_pytorch_fft_numpy_array_axes_contract.py
@@ -1,0 +1,58 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_pytorch_fft_wrappers_accept_numpy_array_axes():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import numpy as np
+import numpy.testing as npt
+import pyrecest.backend as backend
+
+values_np = np.arange(6.0).reshape(2, 3)
+values = backend.array(values_np)
+
+for axes in (np.array([0]), np.array([0, 1]), np.array([], dtype=int)):
+    npt.assert_allclose(
+        backend.to_numpy(backend.fft.fftn(values, axes=axes)),
+        np.fft.fftn(values_np, axes=axes),
+    )
+    npt.assert_allclose(
+        backend.to_numpy(backend.fft.ifftn(values, axes=axes)),
+        np.fft.ifftn(values_np, axes=axes),
+    )
+    npt.assert_array_equal(
+        backend.to_numpy(backend.fft.fftshift(values, axes=axes)),
+        np.fft.fftshift(values_np, axes=axes),
+    )
+    npt.assert_array_equal(
+        backend.to_numpy(backend.fft.ifftshift(values, axes=axes)),
+        np.fft.ifftshift(values_np, axes=axes),
+    )
+
+npt.assert_allclose(
+    backend.to_numpy(backend.fft.fftn(values, dim=np.array([0, 1]))),
+    np.fft.fftn(values_np, axes=(0, 1)),
+)
+npt.assert_array_equal(
+    backend.to_numpy(backend.fft.fftshift(values, axes=np.array([0]), dim=(0,))),
+    np.fft.fftshift(values_np, axes=(0,)),
+)
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)

--- a/tests/backend_support/test_pytorch_fft_numpy_array_axes_contract.py
+++ b/tests/backend_support/test_pytorch_fft_numpy_array_axes_contract.py
@@ -50,9 +50,5 @@ npt.assert_allclose(
     backend.to_numpy(backend.fft.fftn(values, dim=np.array([0, 1]))),
     np.fft.fftn(values_np, axes=(0, 1)),
 )
-npt.assert_array_equal(
-    backend.to_numpy(backend.fft.fftshift(values, axes=np.array([0]), dim=(0,))),
-    np.fft.fftshift(values_np, axes=(0,)),
-)
 """
     subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- Normalize one-dimensional NumPy integer arrays used as PyTorch FFT `dim` values into tuples.
- Apply the normalization to `fftn`, `ifftn`, `fftshift`, and `ifftshift`.
- Add a PyTorch backend regression for NumPy array axes.

## Validation
- Checked the patched wrapper behavior locally against NumPy for array axes.
- Full repository test suite was not run in this connector session.