### PR TITLE
Normalize JAX FFT scalar array axes

### DIFF
--- a/src/pyrecest/_backend/jax/fft.py
+++ b/src/pyrecest/_backend/jax/fft.py
@@ -6,12 +6,21 @@ from jax.numpy import fft as _fft
 
 
 def _normalize_real_fft_axis(axis):
-    """Return a Python ``int`` for NumPy integer scalar-array FFT axes."""
+    """Return a Python ``int`` for integer scalar-array FFT axes."""
     if isinstance(axis, _np.ndarray):
         if (
             axis.size == 1
             and _np.issubdtype(axis.dtype, _np.integer)
             and not _np.issubdtype(axis.dtype, _np.bool_)
+        ):
+            return int(axis.item())
+        return axis
+    if isinstance(axis, _jnp.ndarray):
+        axis_dtype = _np.asarray(axis).dtype
+        if (
+            axis.ndim == 0
+            and _np.issubdtype(axis_dtype, _np.integer)
+            and not _np.issubdtype(axis_dtype, _np.bool_)
         ):
             return int(axis.item())
         return axis

--- a/tests/test_jax_fft_scalar_array_axes.py
+++ b/tests/test_jax_fft_scalar_array_axes.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+def test_jax_fft_scalar_axis_smoke():
+    jnp = pytest.importorskip("jax.numpy")
+    from pyrecest._backend.jax import fft
+
+    values = jnp.arange(4.0)
+    axis = jnp.array(0)
+    assert fft.rfft(values, axis=axis).shape == fft.rfft(values, axis=0).shape

--- a/tests/test_jax_fft_scalar_array_axes.py
+++ b/tests/test_jax_fft_scalar_array_axes.py
@@ -7,4 +7,8 @@ def test_jax_fft_scalar_axis_smoke():
 
     values = jnp.arange(4.0)
     axis = jnp.array(0)
-    assert fft.rfft(values, axis=axis).shape == fft.rfft(values, axis=0).shape
+    expected = fft.rfft(values, axis=0)
+    actual = fft.rfft(values, axis=axis)
+
+    assert actual.shape == expected.shape
+    assert actual.tolist() == expected.tolist()


### PR DESCRIPTION
## Summary
- Normalize zero-dimensional JAX integer-array axes in the JAX real FFT wrappers.
- Preserve the existing NumPy integer scalar-array handling.
- Add a focused regression for `rfft` with a JAX scalar-array axis.

## Validation
- Added `tests/test_jax_fft_scalar_array_axes.py`.
- GitHub Actions are running on the PR.