### PR TITLE
Normalize PyTorch transpose numpy axes

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract.py
@@ -21,6 +21,7 @@ def patch_pytorch_dtype_promotion_contract() -> None:
 
     _patch_pytorch_repeat_numpy_contract(raw_pytorch, torch)
     _patch_pytorch_diff_numpy_contract(raw_pytorch, torch)
+    _patch_pytorch_transpose_numpy_axes_contract(raw_pytorch, np)
     _patch_pytorch_pad_constant_values_contract(raw_pytorch, torch, np)
     _patch_pytorch_creation_numpy_contract(raw_pytorch, torch, np, _normalize_dtype)
     _patch_pytorch_randint_empty_size_contract(raw_pytorch_random, torch)
@@ -200,6 +201,41 @@ def _patch_pytorch_diff_numpy_contract(raw_pytorch, torch) -> None:
     raw_pytorch.diff = diff
     if backend is not None and getattr(backend, "__backend_name__", None) == "pytorch":
         backend.diff = diff
+
+
+def _normalize_transpose_axes(axes, np):
+    """Return PyTorch ``permute`` axes from NumPy-style transpose axes."""
+    axes_array = np.asarray(axes)
+    if axes_array.shape == () or axes_array.ndim != 1:
+        raise ValueError("axes don't match array")
+    return tuple(_operator_index(axis) for axis in axes_array.tolist())
+
+
+def _patch_pytorch_transpose_numpy_axes_contract(raw_pytorch, np) -> None:
+    """Make raw/public PyTorch transpose accept NumPy-style axes arrays."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        backend = None
+
+    original_transpose = raw_pytorch.transpose
+    if getattr(original_transpose, "_pyrecest_numpy_axes_contract", False):
+        if backend is not None and getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.transpose = original_transpose
+        return
+
+    def transpose(x, axes=None):
+        values = raw_pytorch.array(x)
+        if axes is None:
+            return original_transpose(values, axes=None)
+        return values.permute(_normalize_transpose_axes(axes, np))
+
+    transpose.__name__ = getattr(original_transpose, "__name__", "transpose")
+    transpose.__doc__ = getattr(original_transpose, "__doc__", None)
+    transpose._pyrecest_numpy_axes_contract = True
+    raw_pytorch.transpose = transpose
+    if backend is not None and getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.transpose = transpose
 
 
 def _normalize_creation_shape(shape, torch, np):

--- a/tests/backend_support/test_pytorch_linear_helpers_contract.py
+++ b/tests/backend_support/test_pytorch_linear_helpers_contract.py
@@ -1,3 +1,5 @@
+import numpy as np
+import numpy.testing as npt
 import pyrecest.backend as backend
 import pytest
 
@@ -37,3 +39,28 @@ def test_pytorch_backend_exposes_dot_and_matvec():
 
     assert _to_python(batched_matvec) == [[1.0, 2.0], [6.0, 12.0]]
     assert _to_python(shared_vector_matvec) == [[1.0, 2.0], [2.0, 6.0]]
+
+
+def test_raw_pytorch_transpose_accepts_numpy_axes_array():
+    pytest.importorskip("torch")
+    import pyrecest  # noqa: F401
+    import pyrecest._backend.pytorch as raw_pytorch
+
+    values = np.arange(24.0).reshape(2, 3, 4)
+    axes = np.array([2, 0, 1])
+
+    result = raw_pytorch.transpose(values, axes=axes)
+
+    npt.assert_allclose(result.numpy(), np.transpose(values, axes=axes))
+
+
+def test_pytorch_backend_transpose_accepts_numpy_axes_array():
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific backend helper contract")
+
+    values = np.arange(24.0).reshape(2, 3, 4)
+    axes = np.array([2, 0, 1])
+
+    result = backend.transpose(backend.array(values), axes=axes)
+
+    npt.assert_allclose(backend.to_numpy(result), np.transpose(values, axes=axes))


### PR DESCRIPTION
## Summary
- patch the PyTorch backend support layer so `transpose(..., axes=np.array([...]))` normalizes NumPy-style axes before calling `torch.Tensor.permute`
- keep the raw PyTorch backend and selected public PyTorch backend in sync
- add regression coverage for raw and public PyTorch transpose handling of NumPy axes arrays

## Bug fixed
PyTorch accepts tuple/list axes for `permute`, but rejects NumPy array axes directly. The PyRecEst backend exposes a NumPy-like `transpose` contract, so callers using NumPy-generated axes arrays could fail in the PyTorch backend even though `np.transpose` accepts the same axes object.

## Testing
- Local targeted check: reproduced the raw `torch.Tensor.permute(np.array([...]))` TypeError and verified normalized axes produce the same result as `np.transpose`.
- Added regression tests in `tests/backend_support/test_pytorch_linear_helpers_contract.py`.