### PR TITLE
Reject invalid multi-session scalar costs

### DIFF
--- a/src/pyrecest/utils/__init__.py
+++ b/src/pyrecest/utils/__init__.py
@@ -2,10 +2,14 @@
 
 import math as _math
 
+import numpy as _np
+
 from . import assignment as _assignment_module
 from . import multisession_assignment as _multisession_assignment_module
 from . import roi_assignment as _roi_assignment_module
 from ._multisession_assignment_labels import tracks_to_session_labels
+
+_TEXT_SCALAR_TYPES = (str, bytes, bytearray, _np.str_, _np.bytes_)
 
 
 def _murty_solution_with_full_assignment(solution, n_cols):
@@ -95,6 +99,30 @@ if not hasattr(
     _roi_assignment_module.assign_by_similarity_matrix = (
         _assign_by_similarity_matrix_with_unmatched_value_validation
     )
+
+
+def _validate_multisession_scalar_cost(name, value):
+    message = f"{name} must be a finite scalar."
+    try:
+        value_array = _np.asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(message) from exc
+    if (
+        value_array.shape != ()
+        or value_array.dtype == _np.bool_
+        or value_array.dtype.kind in {"S", "U"}
+    ):
+        raise ValueError(message)
+
+    scalar = value_array.item()
+    if isinstance(scalar, (bool, _np.bool_) + _TEXT_SCALAR_TYPES):
+        raise ValueError(message)
+    try:
+        scalar_float = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if not _math.isfinite(scalar_float):
+        raise ValueError(message)
 
 
 min_cost_max_cardinality_assignment = (
@@ -216,6 +244,7 @@ from .track_metrics import (
 )
 
 _multisession_assignment_module.tracks_to_session_labels = tracks_to_session_labels
+_multisession_assignment_module._validate_scalar_cost = _validate_multisession_scalar_cost
 
 __all__ = [
     "MultiSessionAssignmentResult",

--- a/tests/test_multisession_scalar_cost_validation.py
+++ b/tests/test_multisession_scalar_cost_validation.py
@@ -1,0 +1,49 @@
+"""Regression tests for multi-session scalar cost validation."""
+
+import unittest
+
+import numpy as np
+from pyrecest.backend import __backend_name__
+from pyrecest.utils import multisession_assignment as multisession_assignment_module
+from pyrecest.utils import solve_multisession_assignment
+
+
+class TestMultiSessionScalarCostValidation(unittest.TestCase):
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_boolean_scalar_costs_are_rejected(self):
+        invalid_costs = (
+            ("start_cost", True),
+            ("end_cost", np.bool_(True)),
+            ("gap_penalty", np.array(False, dtype=object)),
+            ("cost_threshold", np.array(True)),
+        )
+
+        for name, value in invalid_costs:
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(ValueError, f"{name} must be a finite scalar"):
+                    solve_multisession_assignment(
+                        {},
+                        session_sizes=[1],
+                        **{name: value},
+                    )
+                with self.assertRaisesRegex(ValueError, f"{name} must be a finite scalar"):
+                    multisession_assignment_module.solve_multisession_assignment(
+                        {},
+                        session_sizes=[1],
+                        **{name: value},
+                    )
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_text_scalar_costs_raise_value_error(self):
+        with self.assertRaisesRegex(ValueError, "start_cost must be a finite scalar"):
+            solve_multisession_assignment({}, session_sizes=[1], start_cost="1.0")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reject boolean scalar costs for `solve_multisession_assignment` instead of accepting them as numeric 0/1 values
- convert non-numeric scalar-cost failures such as text inputs into the existing `ValueError` validation path
- add focused regression coverage for public and module-level solver entry points

## Validation
- Inspected the `main..fix-multisession-scalar-cost-validation` diff
- Not run locally in this connector session