### PR TITLE
Support array-like PyTorch linalg tolerances

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -103,12 +103,43 @@ def _out_kwargs(out):
     return {} if out is None else {"out": out}
 
 
-def _normalize_linalg_tolerance(value):
-    """Return PyTorch-compatible scalar tolerances from NumPy scalar inputs."""
-    if isinstance(value, _np.ndarray) and value.ndim == 0:
-        return value.item()
+def _linalg_tolerance_dtype(reference):
+    """Return the real tolerance dtype matching a linalg input tensor."""
+    if not isinstance(reference, _torch.Tensor):
+        return None
+    if reference.dtype == _torch.complex64:
+        return _torch.float32
+    if reference.dtype == _torch.complex128:
+        return _torch.float64
+    if reference.dtype.is_floating_point:
+        return reference.dtype
+    return None
+
+
+def _normalize_linalg_tolerance(value, reference=None):
+    """Return PyTorch-compatible tolerances from NumPy scalar/array inputs."""
+    if value is None or _torch.is_tensor(value):
+        return value
     if isinstance(value, _np.generic):
         return value.item()
+    if isinstance(value, _np.ndarray):
+        if value.ndim == 0:
+            return value.item()
+        kwargs = {}
+        if isinstance(reference, _torch.Tensor):
+            kwargs["device"] = reference.device
+            dtype = _linalg_tolerance_dtype(reference)
+            if dtype is not None:
+                kwargs["dtype"] = dtype
+        return _torch.as_tensor(value, **kwargs)
+    if isinstance(value, (list, tuple)):
+        kwargs = {}
+        if isinstance(reference, _torch.Tensor):
+            kwargs["device"] = reference.device
+            dtype = _linalg_tolerance_dtype(reference)
+            if dtype is not None:
+                kwargs["dtype"] = dtype
+        return _torch.as_tensor(value, **kwargs)
     return value
 
 
@@ -159,8 +190,8 @@ def pinv(a, rcond=None, hermitian=False, *, atol=None, rtol=None, out=None):
             raise TypeError("pinv() got both 'rcond' and 'rtol'")
         rtol = rcond
     a = _as_linalg_tensor(a)
-    atol = _normalize_linalg_tolerance(atol)
-    rtol = _normalize_linalg_tolerance(rtol)
+    atol = _normalize_linalg_tolerance(atol, a)
+    rtol = _normalize_linalg_tolerance(rtol, a)
     return _torch.linalg.pinv(
         a,
         atol=atol,
@@ -270,8 +301,8 @@ def matrix_rank(a, tol=None, hermitian=False, *, rtol=None, atol=None, **kwargs)
         atol = tol
 
     a = _as_linalg_tensor(a)
-    atol = _normalize_linalg_tolerance(atol)
-    rtol = _normalize_linalg_tolerance(rtol)
+    atol = _normalize_linalg_tolerance(atol, a)
+    rtol = _normalize_linalg_tolerance(rtol, a)
     return _torch.linalg.matrix_rank(a, atol=atol, rtol=rtol, hermitian=hermitian)
 
 

--- a/tests/test_pytorch_linalg_tolerances.py
+++ b/tests/test_pytorch_linalg_tolerances.py
@@ -24,6 +24,19 @@ class TestPytorchLinalgToleranceContract(unittest.TestCase):
             1,
         )
 
+    def test_matrix_rank_accepts_numpy_vector_tolerances(self):
+        single = pytorch_backend.diag(
+            pytorch_backend.array([1.0, 1e-5], dtype=pytorch_backend.float64)
+        )
+        value = pytorch_backend.stack([single, single])
+
+        result = pytorch_backend.linalg.matrix_rank(
+            value,
+            rtol=np.array([1e-4, 1e-6]),
+        )
+
+        self.assertEqual(pytorch_backend.to_numpy(result).tolist(), [1, 2])
+
     def test_pinv_accepts_numpy_scalar_array_tolerances(self):
         value = pytorch_backend.diag(
             pytorch_backend.array([1.0, 1e-5], dtype=pytorch_backend.float64)
@@ -37,6 +50,32 @@ class TestPytorchLinalgToleranceContract(unittest.TestCase):
                 result = pytorch_backend.linalg.pinv(
                     value,
                     **{keyword: np.array(1e-4)},
+                )
+
+                self.assertEqual(result.dtype, pytorch_backend.float64)
+                self.assertTrue(pytorch_backend.allclose(result, expected))
+
+    def test_pinv_accepts_numpy_vector_tolerances(self):
+        single = pytorch_backend.diag(
+            pytorch_backend.array([1.0, 1e-5], dtype=pytorch_backend.float64)
+        )
+        value = pytorch_backend.stack([single, single])
+        expected = pytorch_backend.stack(
+            [
+                pytorch_backend.diag(
+                    pytorch_backend.array([1.0, 0.0], dtype=pytorch_backend.float64)
+                ),
+                pytorch_backend.diag(
+                    pytorch_backend.array([1.0, 1e5], dtype=pytorch_backend.float64)
+                ),
+            ]
+        )
+
+        for keyword in ("rcond", "rtol"):
+            with self.subTest(keyword=keyword):
+                result = pytorch_backend.linalg.pinv(
+                    value,
+                    **{keyword: np.array([1e-4, 1e-6])},
                 )
 
                 self.assertEqual(result.dtype, pytorch_backend.float64)


### PR DESCRIPTION
## Summary
- convert non-scalar NumPy/list linalg tolerances to PyTorch tensors on the input device/dtype
- preserve scalar NumPy tolerance handling for `pinv` and `matrix_rank`
- add regression coverage for vector-valued NumPy tolerances in PyTorch `pinv` and `matrix_rank`

## Rationale
PyTorch rejects non-scalar NumPy arrays passed as `rtol`, `atol`, or `rcond`, while the PyRecEst facade exposes NumPy-style linalg APIs where array-like tolerances can be used for stacked matrices. This caused valid NumPy-style calls to fail before dispatch.

## Validation
- Ran a local minimal PyTorch reproduction confirming PyTorch rejects raw NumPy vector tolerances and accepts the converted tensor tolerances.
- Syntax-compiled the modified linalg module and regression test file locally.