### PR TITLE
Normalize PyTorch assignment NumPy indices

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract/__init__.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract/__init__.py
@@ -26,15 +26,66 @@ def patch_pytorch_dtype_promotion_contract() -> None:
     """Apply the base PyTorch contract patch plus device-placement fixes."""
     _BASE_CONTRACT.patch_pytorch_dtype_promotion_contract()
     try:
+        import numpy as np  # pylint: disable=import-outside-toplevel
         import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
         import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
         import torch  # pylint: disable=import-outside-toplevel
     except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
         return
 
+    _patch_pytorch_assignment_numpy_index_contract(raw_pytorch, backend, torch, np)
     _patch_pytorch_logical_device_contract(raw_pytorch, backend, torch)
     _patch_pytorch_binary_device_contract(raw_pytorch, backend, torch)
     _patch_pytorch_equality_device_contract(raw_pytorch, backend, torch)
+
+
+def _pytorch_numpy_index_array(index, numpy_module, torch_module):
+    """Return tensor indices for NumPy index arrays before helper len() checks."""
+    if not isinstance(index, numpy_module.ndarray):
+        return index
+    if numpy_module.issubdtype(index.dtype, numpy_module.bool_):
+        return torch_module.as_tensor(index, dtype=torch_module.bool)
+    if numpy_module.issubdtype(index.dtype, numpy_module.integer):
+        return torch_module.as_tensor(index, dtype=torch_module.long)
+    return index
+
+
+def _wrap_assignment_numpy_index_helper(original_helper, torch_module, numpy_module):
+    """Normalize NumPy index arrays before assignment helper len() checks."""
+    if getattr(original_helper, "_pyrecest_numpy_index_contract", False):
+        return original_helper
+
+    def assignment(x, values, indices, axis=0):
+        indices = _pytorch_numpy_index_array(indices, numpy_module, torch_module)
+        return original_helper(x, values, indices, axis=axis)
+
+    assignment.__name__ = getattr(original_helper, "__name__", "assignment")
+    assignment.__doc__ = getattr(original_helper, "__doc__", None)
+    assignment._pyrecest_numpy_index_contract = True
+    return assignment
+
+
+def _patch_pytorch_assignment_numpy_index_contract(raw_pytorch, backend, torch, np) -> None:
+    """Make PyTorch assignment helpers accept NumPy integer and boolean indices."""
+    helper_names = ("assignment", "assignment_by_sum")
+    if all(
+        getattr(getattr(raw_pytorch, helper_name, None), "_pyrecest_numpy_index_contract", False)
+        for helper_name in helper_names
+    ):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            for helper_name in helper_names:
+                setattr(backend, helper_name, getattr(raw_pytorch, helper_name))
+        return
+
+    for helper_name in helper_names:
+        wrapped_helper = _wrap_assignment_numpy_index_helper(
+            getattr(raw_pytorch, helper_name),
+            torch,
+            np,
+        )
+        setattr(raw_pytorch, helper_name, wrapped_helper)
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            setattr(backend, helper_name, wrapped_helper)
 
 
 def _preferred_pytorch_device(torch_module, *values):

--- a/tests/backend/test_pytorch_backend_assignment.py
+++ b/tests/backend/test_pytorch_backend_assignment.py
@@ -1,0 +1,36 @@
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+def test_pytorch_assignment_accepts_numpy_index_arrays():
+    pytest.importorskip("torch")
+
+    code = """
+import numpy as np
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+assert backend.__backend_name__ == "pytorch"
+
+indices = np.array([0, 2])
+mask = np.array([True, False, True, False])
+base = backend.zeros(4)
+
+updated = backend.assignment(base, [1.0, 2.0], indices)
+summed = backend.assignment_by_sum(base, [1.0, 2.0], indices)
+masked = backend.assignment(base, [3.0, 4.0], mask)
+masked_sum = backend.assignment_by_sum(base, [3.0, 4.0], mask)
+raw_updated = raw_pytorch.assignment(raw_pytorch.zeros(4), [5.0, 6.0], indices)
+raw_masked = raw_pytorch.assignment(raw_pytorch.zeros(4), [7.0, 8.0], mask)
+
+assert backend.to_numpy(updated).tolist() == [1.0, 0.0, 2.0, 0.0]
+assert backend.to_numpy(summed).tolist() == [1.0, 0.0, 2.0, 0.0]
+assert backend.to_numpy(masked).tolist() == [3.0, 0.0, 4.0, 0.0]
+assert backend.to_numpy(masked_sum).tolist() == [3.0, 0.0, 4.0, 0.0]
+assert raw_pytorch.to_numpy(raw_updated).tolist() == [5.0, 0.0, 6.0, 0.0]
+assert raw_pytorch.to_numpy(raw_masked).tolist() == [7.0, 0.0, 8.0, 0.0]
+"""
+
+    result = run_backend_code("pytorch", code)
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- patch the PyTorch backend-support layer so `assignment` and `assignment_by_sum` accept NumPy integer index arrays and NumPy boolean masks
- keep the raw PyTorch backend and selected public PyTorch backend helper bindings in sync after the wrapper is applied
- add a subprocess regression test for public and raw PyTorch assignment helpers with NumPy index arrays

## Bug fixed
The PyTorch assignment helpers perform iterable/boolean checks before converting indices. NumPy index arrays therefore reached the existing helper as non-tensor, non-list objects: integer arrays could be counted as one index and reject multi-value assignments, and boolean masks could miss the mask branch. The wrapper converts NumPy integer/boolean index arrays to PyTorch index tensors before the existing helper performs its contract checks.

## Testing
- Local syntax check: `python -m py_compile` on the updated backend-support module and the new regression test.
- Local targeted reproduction: simulated the current PyTorch helper path and confirmed NumPy index arrays trigger the erroneous value-count path before normalization.