### PR TITLE
Fix shared backend dot NumPy contraction

### DIFF
--- a/src/pyrecest/_backend/_common.py
+++ b/src/pyrecest/_backend/_common.py
@@ -188,20 +188,12 @@ def dot(a, b):
         if a.ndim == 1 and b.ndim == 1:
             return torch.dot(a, b)
         if b.ndim == 1:
-            return torch.einsum("...i,i->...", a, b)
+            return torch.tensordot(a, b, dims=([-1], [0]))
         if a.ndim == 1:
-            return torch.einsum("i,...i->...", a, b)
-        return torch.einsum("...i,...i->...", a, b)
+            return torch.tensordot(a, b, dims=([0], [-2]))
+        return torch.tensordot(a, b, dims=([-1], [-2]))
 
-    a = _np.asarray(a)
-    b = _np.asarray(b)
-    if a.ndim == 0 or b.ndim == 0:
-        return _np.multiply(a, b)
-    if b.ndim == 1:
-        return _np.einsum("...i,i->...", a, b)
-    if a.ndim == 1:
-        return _np.einsum("i,...i->...", a, b)
-    return _np.einsum("...i,...i->...", a, b)
+    return _np.dot(_np.asarray(a), _np.asarray(b))
 
 
 def matvec(matrix, vector):

--- a/tests/backend_support/test_common_dot_contract.py
+++ b/tests/backend_support/test_common_dot_contract.py
@@ -1,0 +1,30 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from pyrecest._backend import _common as common
+
+
+def _to_numpy(value):
+    detach = getattr(value, "detach", None)
+    if detach is not None:
+        return detach().cpu().numpy()
+    return np.asarray(value)
+
+
+@pytest.mark.backend_portable
+@pytest.mark.parametrize(
+    ("left", "right"),
+    [
+        ([1.0, 2.0], [[5.0, 6.0, 7.0], [8.0, 9.0, 10.0]]),
+        ([[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0, 7.0], [8.0, 9.0, 10.0]]),
+        (np.arange(24.0).reshape(2, 3, 4), np.arange(20.0).reshape(4, 5)),
+        (2.0, [[5.0, 6.0], [7.0, 8.0]]),
+    ],
+)
+def test_common_dot_matches_numpy_contract(left, right):
+    expected = np.dot(np.asarray(left), np.asarray(right))
+
+    result = common.dot(left, right)
+
+    npt.assert_allclose(_to_numpy(result), expected)


### PR DESCRIPTION
## Summary
- update the shared backend `dot` helper to use NumPy-compatible contraction axes
- keep scalar and vector-vector behavior unchanged
- add regression coverage for non-square vector-matrix, matrix-matrix, batched, and scalar dot products

## Bug fixed
`pyrecest._backend._common.dot` documents a NumPy-compatible dot contract, but its fallback implementation used rowwise `einsum` contractions for matrix/matrix and vector/matrix inputs. This returned incorrect shapes/values for square matrices and failed for ordinary non-square NumPy-compatible cases such as `(2,) dot (2, 3)`.

## Testing
- Not run locally in this environment; added focused pytest regression coverage for the corrected contract.