### PR TITLE
Normalize PyTorch FFT NumPy axes

### DIFF
--- a/src/pyrecest/_backend/pytorch/fft.py
+++ b/src/pyrecest/_backend/pytorch/fft.py
@@ -35,6 +35,31 @@ def _normalize_single_fft_dim(dim):
         return dim
 
 
+def _normalize_fft_dim_sequence(dim):
+    """Return NumPy-style FFT dimension sequences in PyTorch-compatible form."""
+    if dim is None or isinstance(dim, (bool, str, bytes)):
+        return dim
+    try:
+        return _operator_index(dim)
+    except TypeError:
+        pass
+
+    try:
+        dim_entries = tuple(dim)
+    except TypeError:
+        return dim
+
+    normalized_entries = []
+    for entry in dim_entries:
+        if isinstance(entry, bool):
+            return dim
+        try:
+            normalized_entries.append(_operator_index(entry))
+        except TypeError:
+            return dim
+    return tuple(normalized_entries)
+
+
 def _with_dim_alias(kwargs, alias, func_name):
     if alias not in kwargs:
         return kwargs
@@ -59,6 +84,7 @@ def _wrap_arraylike_fft(
     dim_alias=None,
     empty_dim_is_noop=False,
     normalize_scalar_dim=False,
+    normalize_dim_sequence=False,
 ):
     @_wraps(torch_func)
     def fft_func(value, *args, **kwargs):
@@ -67,6 +93,9 @@ def _wrap_arraylike_fft(
         if normalize_scalar_dim and "dim" in kwargs:
             kwargs = dict(kwargs)
             kwargs["dim"] = _normalize_single_fft_dim(kwargs["dim"])
+        if normalize_dim_sequence and "dim" in kwargs:
+            kwargs = dict(kwargs)
+            kwargs["dim"] = _normalize_fft_dim_sequence(kwargs["dim"])
         value = _as_fft_tensor(value)
         if empty_dim_is_noop and _is_empty_dim(kwargs.get("dim")):
             return value
@@ -92,22 +121,26 @@ fftshift = _wrap_arraylike_fft(
     func_name="fftshift",
     dim_alias="axes",
     empty_dim_is_noop=True,
+    normalize_dim_sequence=True,
 )
 ifftshift = _wrap_arraylike_fft(
     _torch.fft.ifftshift,
     func_name="ifftshift",
     dim_alias="axes",
     empty_dim_is_noop=True,
+    normalize_dim_sequence=True,
 )
 fftn = _wrap_arraylike_fft(
     _torch.fft.fftn,
     func_name="fftn",
     dim_alias="axes",
     empty_dim_is_noop=True,
+    normalize_dim_sequence=True,
 )
 ifftn = _wrap_arraylike_fft(
     _torch.fft.ifftn,
     func_name="ifftn",
     dim_alias="axes",
     empty_dim_is_noop=True,
+    normalize_dim_sequence=True,
 )

--- a/tests/backend_support/test_pytorch_fft_numpy_axes_contract.py
+++ b/tests/backend_support/test_pytorch_fft_numpy_axes_contract.py
@@ -1,0 +1,55 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_pytorch_fft_axes_accept_numpy_integer_arrays():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import numpy as np
+import numpy.testing as npt
+import pyrecest.backend as backend
+
+values_np = np.array([[0, 1], [2, 3]])
+values = backend.array(values_np)
+axes_cases = (np.array([0]), np.array([0, 1]), [np.array(0)], (np.array(1),))
+
+for axes in axes_cases:
+    shifted = backend.fft.fftshift(values, axes=axes)
+    unshifted = backend.fft.ifftshift(values, axes=axes)
+    transformed = backend.fft.fftn(values, axes=axes)
+    inverse_transformed = backend.fft.ifftn(values, axes=axes)
+
+    npt.assert_array_equal(
+        backend.to_numpy(shifted),
+        np.fft.fftshift(values_np, axes=axes),
+    )
+    npt.assert_array_equal(
+        backend.to_numpy(unshifted),
+        np.fft.ifftshift(values_np, axes=axes),
+    )
+    npt.assert_allclose(
+        backend.to_numpy(transformed),
+        np.fft.fftn(values_np, axes=axes),
+    )
+    npt.assert_allclose(
+        backend.to_numpy(inverse_transformed),
+        np.fft.ifftn(values_np, axes=axes),
+    )
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- normalize NumPy-style FFT dimension sequences before dispatching to `torch.fft` for `fftshift`, `ifftshift`, `fftn`, and `ifftn`
- preserve the existing scalar `axis` normalization for `rfft`/`irfft`
- add a PyTorch backend regression test covering `axes=np.array([...])` and sequences containing scalar NumPy arrays through the public backend facade

## Testing
- Added `tests/backend_support/test_pytorch_fft_numpy_axes_contract.py`
- Ran an isolated torch/numpy smoke check for the new normalization logic in this execution environment; full repository tests should run in CI