### PR TITLE
Use backend std for association model standardization

### DIFF
--- a/src/pyrecest/utils/__init__.py
+++ b/src/pyrecest/utils/__init__.py
@@ -135,6 +135,41 @@ from .association_features import (
     pairwise_feature_tensor,
 )
 from .association_models import LogisticPairwiseAssociationModel
+
+
+def _patch_logistic_pairwise_backend_standardization() -> None:
+    """Make association-model standardization use backend reduction contracts."""
+    original_fit_standardization = LogisticPairwiseAssociationModel._fit_standardization
+    if getattr(original_fit_standardization, "_pyrecest_backend_std_contract", False):
+        return
+
+    def _fit_standardization(self, features):
+        import pyrecest.backend as _backend  # pylint: disable=import-outside-toplevel
+
+        if self.standardize:
+            feature_mean = _backend.mean(features, axis=0)
+            feature_scale = _backend.std(features, axis=0)
+            feature_scale = _backend.where(feature_scale > 0.0, feature_scale, 1.0)
+        else:
+            feature_mean = _backend.zeros(features.shape[1], dtype=_backend.float64)
+            feature_scale = _backend.ones(features.shape[1], dtype=_backend.float64)
+
+        self.feature_mean_ = feature_mean
+        self.feature_scale_ = feature_scale
+        return (features - feature_mean) / feature_scale
+
+    _fit_standardization.__name__ = getattr(
+        original_fit_standardization,
+        "__name__",
+        "_fit_standardization",
+    )
+    _fit_standardization.__doc__ = getattr(original_fit_standardization, "__doc__", None)
+    _fit_standardization._pyrecest_backend_std_contract = True
+    LogisticPairwiseAssociationModel._fit_standardization = _fit_standardization
+
+
+_patch_logistic_pairwise_backend_standardization()
+
 from .candidate_pruning import (
     CandidatePruningConfig,
     candidate_mask_from_costs,

--- a/tests/utils/test_association_model_backend_standardization.py
+++ b/tests/utils/test_association_model_backend_standardization.py
@@ -1,0 +1,44 @@
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_logistic_pairwise_standardization_uses_backend_std_contract():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import numpy as np
+
+import pyrecest.backend as backend
+from pyrecest.utils import LogisticPairwiseAssociationModel
+
+features_np = np.asarray(
+    [
+        [1.0, 2.0],
+        [3.0, 8.0],
+        [5.0, 14.0],
+        [7.0, 20.0],
+    ],
+    dtype=float,
+)
+features = backend.asarray(features_np, dtype=backend.float64)
+model = LogisticPairwiseAssociationModel()
+model._fit_standardization(features)
+
+actual_scale = backend.to_numpy(model.feature_scale_)
+expected_population_scale = features_np.std(axis=0)
+unbiased_torch_scale = features_np.std(axis=0, ddof=1)
+
+np.testing.assert_allclose(actual_scale, expected_population_scale, rtol=1e-12, atol=1e-12)
+assert not np.allclose(actual_scale, unbiased_torch_scale)
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- Use active backend reductions during association model standardization.
- Add a focused PyTorch backend regression for feature scaling.

## Testing
- Not run locally in this connector-only session; added targeted regression coverage for CI.