### PR TITLE
Fix PyTorch reduction axis handling

### DIFF
--- a/src/pyrecest/backend_tools.py
+++ b/src/pyrecest/backend_tools.py
@@ -372,6 +372,97 @@ def _patch_pytorch_stack_helpers_numpy_contract() -> None:
             setattr(backend, helper_name, helper)
 
 
+def _normalize_pytorch_reduction_axis(axis):
+    """Return Python int axes for scalar integer array/tensor axes."""
+
+    if axis is None:
+        return None
+    try:
+        return _operator_index(axis)
+    except TypeError:
+        return axis
+
+
+def _wrap_pytorch_reduction_axis_helper(original_reduction):
+    """Normalize scalar array axes before PyTorch reduction helpers see them."""
+
+    if getattr(original_reduction, "_pyrecest_scalar_array_axis_contract", False):
+        return original_reduction
+
+    def reduction(a, axis=None, *args, **kwargs):
+        if "dim" in kwargs:
+            kwargs = dict(kwargs)
+            kwargs["dim"] = _normalize_pytorch_reduction_axis(kwargs["dim"])
+        axis = _normalize_pytorch_reduction_axis(axis)
+        return original_reduction(a, axis, *args, **kwargs)
+
+    reduction.__name__ = getattr(original_reduction, "__name__", "reduction")
+    reduction.__doc__ = getattr(original_reduction, "__doc__", None)
+    reduction._pyrecest_scalar_array_axis_contract = True
+    return reduction
+
+
+def _wrap_pytorch_quantile_axis_helper(original_quantile):
+    """Normalize scalar array axes before PyTorch quantile helpers see them."""
+
+    if getattr(original_quantile, "_pyrecest_scalar_array_axis_contract", False):
+        return original_quantile
+
+    def quantile(a, q, axis=None, *args, **kwargs):
+        if "dim" in kwargs:
+            kwargs = dict(kwargs)
+            kwargs["dim"] = _normalize_pytorch_reduction_axis(kwargs["dim"])
+        axis = _normalize_pytorch_reduction_axis(axis)
+        return original_quantile(a, q, axis, *args, **kwargs)
+
+    quantile.__name__ = getattr(original_quantile, "__name__", "quantile")
+    quantile.__doc__ = getattr(original_quantile, "__doc__", None)
+    quantile._pyrecest_scalar_array_axis_contract = True
+    return quantile
+
+
+def _patch_pytorch_reduction_axis_numpy_contract() -> None:
+    """Make PyTorch reductions accept NumPy-style scalar array axes."""
+
+    try:
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+    for helper_name in (
+        "all",
+        "amax",
+        "amin",
+        "any",
+        "argmax",
+        "argmin",
+        "count_nonzero",
+        "max",
+        "mean",
+        "min",
+        "prod",
+        "std",
+        "sum",
+    ):
+        helper = _wrap_pytorch_reduction_axis_helper(
+            getattr(pytorch_backend, helper_name)
+        )
+        setattr(pytorch_backend, helper_name, helper)
+        if active_pytorch_backend:
+            setattr(
+                backend,
+                helper_name,
+                _wrap_pytorch_reduction_axis_helper(getattr(backend, helper_name)),
+            )
+
+    quantile = _wrap_pytorch_quantile_axis_helper(pytorch_backend.quantile)
+    pytorch_backend.quantile = quantile
+    if active_pytorch_backend:
+        backend.quantile = _wrap_pytorch_quantile_axis_helper(backend.quantile)
+
+
 def _patch_raw_pytorch_comparison_numpy_contract() -> None:
     """Make raw PyTorch comparison helpers accept NumPy-style array-like inputs."""
 
@@ -470,6 +561,7 @@ _patch_pytorch_round_numpy_contract()
 _patch_raw_pytorch_conj_numpy_contract()
 _patch_pytorch_special_numpy_contract()
 _patch_pytorch_stack_helpers_numpy_contract()
+_patch_pytorch_reduction_axis_numpy_contract()
 _patch_raw_pytorch_comparison_numpy_contract()
 _patch_raw_pytorch_isclose_equal_nan_contract()
 

--- a/tests/test_backend_reduction_keepdims_contract.py
+++ b/tests/test_backend_reduction_keepdims_contract.py
@@ -1,5 +1,6 @@
 import importlib.util
 
+import numpy as np
 import pyrecest.backend as backend
 import pytest
 from tests.support.backend_runner import run_backend_code
@@ -29,6 +30,20 @@ def test_reductions_accept_keepdims_keyword():
     ]
 
 
+def test_reductions_accept_numpy_scalar_array_axis():
+    if backend.__backend_name__ == "jax":
+        pytest.skip("PyTorch-specific scalar array axis contract")
+
+    values = backend.array([[1, 2, 3], [4, 5, 6]])
+    axis = np.array(1)
+
+    assert _to_python(backend.sum(values, axis=axis)) == [6, 15]
+    assert _to_python(backend.mean(values, axis=axis)) == [2.0, 5.0]
+    assert _to_python(backend.max(values, axis=axis)) == [3, 6]
+    assert _to_python(backend.prod(values, axis=axis)) == [6, 120]
+    assert _to_python(backend.quantile(values, 0.5, axis=axis)) == [2.0, 5.0]
+
+
 @pytest.mark.backend_portable
 def test_pytorch_reductions_accept_keepdims_keyword():
     if importlib.util.find_spec("torch") is None:
@@ -46,6 +61,58 @@ assert backend.to_numpy(backend.max(values, axis=(0, 2), keepdims=True)).tolist(
 assert backend.to_numpy(backend.amin(values, axis=(0, 2), keepdims=True)).tolist() == [[[0], [0]]]
 assert backend.to_numpy(backend.min(values, axis=(0, 2), keepdims=True)).tolist() == [[[0], [0]]]
 assert backend.to_numpy(backend.prod(values + 1, axis=(0, 2), keepdims=True)).tolist() == [[[40], [3]]]
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+@pytest.mark.backend_portable
+def test_pytorch_reductions_accept_numpy_scalar_array_axis():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import numpy as np
+import pyrecest.backend as backend
+
+values = backend.array([[1, 2, 3], [4, 5, 6]])
+axis = np.array(1)
+assert backend.to_numpy(backend.sum(values, axis=axis)).tolist() == [6, 15]
+assert backend.to_numpy(backend.mean(values, axis=axis)).tolist() == [2.0, 5.0]
+assert backend.to_numpy(backend.max(values, axis=axis)).tolist() == [3, 6]
+assert backend.to_numpy(backend.prod(values, axis=axis)).tolist() == [6, 120]
+assert backend.to_numpy(backend.quantile(values, 0.5, axis=axis)).tolist() == [2.0, 5.0]
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_reductions_accept_numpy_scalar_array_axis_after_import():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import numpy as np
+import pyrecest  # noqa: F401 - triggers import-time backend compatibility patches
+import pyrecest._backend.pytorch as raw_pytorch
+
+values = raw_pytorch.array([[1, 2, 3], [4, 5, 6]])
+axis = np.array(1)
+assert raw_pytorch.to_numpy(raw_pytorch.sum(values, axis=axis)).tolist() == [6, 15]
+assert raw_pytorch.to_numpy(raw_pytorch.sum(values, dim=axis)).tolist() == [6, 15]
+assert raw_pytorch.to_numpy(raw_pytorch.max(values, axis=axis)).tolist() == [3, 6]
+assert raw_pytorch.to_numpy(raw_pytorch.quantile(values, 0.5, axis=axis)).tolist() == [2.0, 5.0]
 print("ok")
 """,
     )


### PR DESCRIPTION
## Summary
- Normalize scalar NumPy array axes for PyTorch reductions.
- Cover public and internal PyTorch backend calls in regression tests.

## Testing
- Not run in this session.