### PR TITLE
Fix get_slice grouped index contract

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract/__init__.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract/__init__.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import importlib
 import importlib.util
 from operator import index as _operator_index
 from pathlib import Path
@@ -24,86 +23,9 @@ def _load_base_contract_module():
 _BASE_CONTRACT = _load_base_contract_module()
 
 
-def _normalize_get_slice_indices(indices):
-    """Return grouped get_slice indices in a backend-compatible form."""
-    if isinstance(indices, tuple):
-        return indices
-    if isinstance(indices, (str, bytes)):
-        return indices
-
-    ndim = getattr(indices, "ndim", None)
-    if ndim is not None:
-        return tuple(indices) if ndim > 1 else indices
-
-    if isinstance(indices, list):
-        if not indices:
-            return indices
-        first_index = indices[0]
-        if isinstance(first_index, (str, bytes)):
-            return indices
-        if hasattr(first_index, "__len__"):
-            return tuple(indices)
-
-    return indices
-
-
-def _wrap_get_slice_arraylike_contract(original_get_slice, array_func, is_array_func=None):
-    """Return a get_slice wrapper for array-like inputs and grouped indices."""
-    if getattr(original_get_slice, "_pyrecest_get_slice_contract", False):
-        return original_get_slice
-
-    def get_slice(x, indices):
-        if is_array_func is None or not is_array_func(x):
-            x = array_func(x)
-        return original_get_slice(x, _normalize_get_slice_indices(indices))
-
-    get_slice.__name__ = getattr(original_get_slice, "__name__", "get_slice")
-    get_slice.__doc__ = getattr(original_get_slice, "__doc__", None)
-    get_slice._pyrecest_get_slice_contract = True
-    return get_slice
-
-
-def _patch_one_get_slice_module(module) -> None:
-    original_get_slice = getattr(module, "get_slice", None)
-    array_func = getattr(module, "array", None) or getattr(module, "asarray", None)
-    if original_get_slice is None or array_func is None:
-        return
-
-    module.get_slice = _wrap_get_slice_arraylike_contract(
-        original_get_slice,
-        array_func,
-        getattr(module, "is_array", None),
-    )
-
-
-def _patch_backend_get_slice_contract() -> None:
-    """Make raw and public get_slice helpers honor their array-like contract."""
-    try:
-        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
-    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
-        backend = None
-
-    if backend is not None:
-        _patch_one_get_slice_module(backend)
-
-    for module_name in (
-        "pyrecest._backend._shared_numpy",
-        "pyrecest._backend.numpy",
-        "pyrecest._backend.autograd",
-        "pyrecest._backend.jax",
-        "pyrecest._backend.pytorch",
-    ):
-        try:
-            module = importlib.import_module(module_name)
-        except ModuleNotFoundError:  # pragma: no cover - optional backend unavailable
-            continue
-        _patch_one_get_slice_module(module)
-
-
 def patch_pytorch_dtype_promotion_contract() -> None:
     """Apply the base PyTorch contract patch plus device-placement fixes."""
     _BASE_CONTRACT.patch_pytorch_dtype_promotion_contract()
-    _patch_backend_get_slice_contract()
     try:
         import numpy as np  # pylint: disable=import-outside-toplevel
         import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel

--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract/__init__.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import importlib.util
 from operator import index as _operator_index
 from pathlib import Path
@@ -23,9 +24,86 @@ def _load_base_contract_module():
 _BASE_CONTRACT = _load_base_contract_module()
 
 
+def _normalize_get_slice_indices(indices):
+    """Return grouped get_slice indices in a backend-compatible form."""
+    if isinstance(indices, tuple):
+        return indices
+    if isinstance(indices, (str, bytes)):
+        return indices
+
+    ndim = getattr(indices, "ndim", None)
+    if ndim is not None:
+        return tuple(indices) if ndim > 1 else indices
+
+    if isinstance(indices, list):
+        if not indices:
+            return indices
+        first_index = indices[0]
+        if isinstance(first_index, (str, bytes)):
+            return indices
+        if hasattr(first_index, "__len__"):
+            return tuple(indices)
+
+    return indices
+
+
+def _wrap_get_slice_arraylike_contract(original_get_slice, array_func, is_array_func=None):
+    """Return a get_slice wrapper for array-like inputs and grouped indices."""
+    if getattr(original_get_slice, "_pyrecest_get_slice_contract", False):
+        return original_get_slice
+
+    def get_slice(x, indices):
+        if is_array_func is None or not is_array_func(x):
+            x = array_func(x)
+        return original_get_slice(x, _normalize_get_slice_indices(indices))
+
+    get_slice.__name__ = getattr(original_get_slice, "__name__", "get_slice")
+    get_slice.__doc__ = getattr(original_get_slice, "__doc__", None)
+    get_slice._pyrecest_get_slice_contract = True
+    return get_slice
+
+
+def _patch_one_get_slice_module(module) -> None:
+    original_get_slice = getattr(module, "get_slice", None)
+    array_func = getattr(module, "array", None) or getattr(module, "asarray", None)
+    if original_get_slice is None or array_func is None:
+        return
+
+    module.get_slice = _wrap_get_slice_arraylike_contract(
+        original_get_slice,
+        array_func,
+        getattr(module, "is_array", None),
+    )
+
+
+def _patch_backend_get_slice_contract() -> None:
+    """Make raw and public get_slice helpers honor their array-like contract."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        backend = None
+
+    if backend is not None:
+        _patch_one_get_slice_module(backend)
+
+    for module_name in (
+        "pyrecest._backend._shared_numpy",
+        "pyrecest._backend.numpy",
+        "pyrecest._backend.autograd",
+        "pyrecest._backend.jax",
+        "pyrecest._backend.pytorch",
+    ):
+        try:
+            module = importlib.import_module(module_name)
+        except ModuleNotFoundError:  # pragma: no cover - optional backend unavailable
+            continue
+        _patch_one_get_slice_module(module)
+
+
 def patch_pytorch_dtype_promotion_contract() -> None:
     """Apply the base PyTorch contract patch plus device-placement fixes."""
     _BASE_CONTRACT.patch_pytorch_dtype_promotion_contract()
+    _patch_backend_get_slice_contract()
     try:
         import numpy as np  # pylint: disable=import-outside-toplevel
         import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel

--- a/src/pyrecest/backend_tools.py
+++ b/src/pyrecest/backend_tools.py
@@ -463,6 +463,53 @@ def _patch_raw_pytorch_isclose_equal_nan_contract() -> None:
         backend.isclose = isclose
 
 
+def _normalize_get_slice_indices(indices):
+    """Return grouped get_slice indices in a backend-compatible form."""
+    if isinstance(indices, tuple):
+        return indices
+    if isinstance(indices, (str, bytes)):
+        return indices
+
+    ndim = getattr(indices, "ndim", None)
+    if ndim is not None:
+        return tuple(indices) if ndim > 1 else indices
+
+    if isinstance(indices, list):
+        if not indices:
+            return indices
+        first_index = indices[0]
+        if isinstance(first_index, (str, bytes)):
+            return indices
+        if hasattr(first_index, "__len__"):
+            return tuple(indices)
+
+    return indices
+
+
+def _patch_get_slice_arraylike_contract() -> None:
+    """Make public get_slice accept array-like inputs and grouped list indices."""
+    import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+
+    original_get_slice = getattr(backend, "get_slice", None)
+    array_func = getattr(backend, "array", None) or getattr(backend, "asarray", None)
+    if original_get_slice is None or array_func is None:
+        return
+    if getattr(original_get_slice, "_pyrecest_get_slice_contract", False):
+        return
+
+    is_array_func = getattr(backend, "is_array", None)
+
+    def get_slice(x, indices):
+        if is_array_func is None or not is_array_func(x):
+            x = array_func(x)
+        return original_get_slice(x, _normalize_get_slice_indices(indices))
+
+    get_slice.__name__ = getattr(original_get_slice, "__name__", "get_slice")
+    get_slice.__doc__ = getattr(original_get_slice, "__doc__", None)
+    get_slice._pyrecest_get_slice_contract = True
+    backend.get_slice = get_slice
+
+
 _patch_pytorch_assignment_scalar_tensor_indices()
 _patch_pytorch_diag_numpy_contract()
 _patch_pytorch_broadcast_arrays_numpy_contract()
@@ -472,6 +519,7 @@ _patch_pytorch_special_numpy_contract()
 _patch_pytorch_stack_helpers_numpy_contract()
 _patch_raw_pytorch_comparison_numpy_contract()
 _patch_raw_pytorch_isclose_equal_nan_contract()
+_patch_get_slice_arraylike_contract()
 
 
 def get_backend_name() -> str:

--- a/tests/backend_support/test_get_slice_contract.py
+++ b/tests/backend_support/test_get_slice_contract.py
@@ -1,0 +1,22 @@
+import pyrecest.backend as backend
+
+
+def _to_python(value):
+    value = backend.to_numpy(value)
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    return value
+
+
+def test_get_slice_accepts_array_like_inputs():
+    result = backend.get_slice([[0, 1, 2], [3, 4, 5]], ((0, 1), (2, 0)))
+
+    assert _to_python(result) == [2, 3]
+
+
+def test_get_slice_accepts_grouped_list_indices():
+    values = backend.reshape(backend.arange(30), (3, 10))
+
+    result = backend.get_slice(values, [[0, 2], [8, 9]])
+
+    assert _to_python(result) == [8, 29]


### PR DESCRIPTION
## Summary
- Normalize grouped `get_slice` indices supplied as lists or backend arrays before dispatching to raw backend indexing.
- Coerce array-like `x` inputs before slicing so the documented array-like contract works through the public backend facade.
- Cover both array-like inputs and grouped list-index regressions.

This supersedes the stale/non-mergeable direction in #3478 with a clean branch from current `main`.

## Validation
- Added `tests/backend_support/test_get_slice_contract.py`.
- Full CI should run on GitHub for all configured backends.