### PR TITLE
Fix PyTorch linspace integer dtype flooring

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract/__init__.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract/__init__.py
@@ -37,6 +37,7 @@ def patch_pytorch_dtype_promotion_contract() -> None:
     _patch_pytorch_logical_device_contract(raw_pytorch, backend, torch)
     _patch_pytorch_binary_device_contract(raw_pytorch, backend, torch)
     _patch_pytorch_equality_device_contract(raw_pytorch, backend, torch)
+    _patch_pytorch_linspace_integer_dtype_contract(raw_pytorch, backend, torch)
 
 
 def _pytorch_numpy_index_array(index, numpy_module, torch_module):
@@ -262,6 +263,53 @@ def _patch_pytorch_equality_device_contract(raw_pytorch, backend, torch) -> None
         setattr(raw_pytorch, helper_name, wrapped_helper)
         if getattr(backend, "__backend_name__", None) == "pytorch":
             setattr(backend, helper_name, wrapped_helper)
+
+
+def _integer_torch_dtype(dtype, raw_pytorch, torch):
+    """Return an explicit integer torch dtype, or ``None`` for non-integers."""
+    if dtype is None:
+        return None
+    try:
+        torch_dtype = raw_pytorch.as_dtype(dtype)
+    except (KeyError, TypeError, ValueError):
+        return None
+    integer_dtypes = {
+        torch.uint8,
+        torch.int8,
+        torch.int16,
+        torch.int32,
+        torch.int64,
+    }
+    return torch_dtype if torch_dtype in integer_dtypes else None
+
+
+def _patch_pytorch_linspace_integer_dtype_contract(raw_pytorch, backend, torch) -> None:
+    """Make PyTorch linspace match NumPy flooring for explicit integer dtypes."""
+    original_linspace = raw_pytorch.linspace
+    if getattr(original_linspace, "_pyrecest_integer_dtype_contract", False):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.linspace = original_linspace
+        return
+
+    def linspace(start, stop, num=50, endpoint=True, dtype=None):
+        integer_dtype = _integer_torch_dtype(dtype, raw_pytorch, torch)
+        if integer_dtype is None:
+            return original_linspace(
+                start,
+                stop,
+                num=num,
+                endpoint=endpoint,
+                dtype=dtype,
+            )
+        values = original_linspace(start, stop, num=num, endpoint=endpoint, dtype=None)
+        return torch.floor(values).to(dtype=integer_dtype)
+
+    linspace.__name__ = getattr(original_linspace, "__name__", "linspace")
+    linspace.__doc__ = getattr(original_linspace, "__doc__", None)
+    linspace._pyrecest_integer_dtype_contract = True
+    raw_pytorch.linspace = linspace
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.linspace = linspace
 
 
 __all__ = ["patch_pytorch_dtype_promotion_contract"]

--- a/tests/backend_support/test_pytorch_linspace_integer_dtype_contract.py
+++ b/tests/backend_support/test_pytorch_linspace_integer_dtype_contract.py
@@ -1,0 +1,48 @@
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_pytorch_linspace_integer_dtype_floors_negative_fractional_values():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import numpy as np
+import pyrecest.backend as backend
+
+actual = backend.to_numpy(backend.linspace(-3, 3, num=5, dtype=backend.int64))
+expected = np.linspace(-3, 3, num=5, dtype=np.int64)
+
+assert actual.dtype == expected.dtype
+assert actual.tolist() == expected.tolist()
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_linspace_integer_dtype_floors_negative_fractional_values():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "numpy",
+        """
+import numpy as np
+import pyrecest._backend.pytorch as raw_pytorch
+
+actual = raw_pytorch.to_numpy(raw_pytorch.linspace(-3, 3, num=5, dtype=raw_pytorch.int64))
+expected = np.linspace(-3, 3, num=5, dtype=np.int64)
+
+assert actual.dtype == expected.dtype
+assert actual.tolist() == expected.tolist()
+""",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- wrap the PyTorch backend linspace helper so explicit integer dtypes match NumPy-style flooring before casting
- keep non-integer dtype behavior delegated to the existing implementation
- add public and raw-backend regression coverage

## Validation
- Inspected the branch diff and changed files
- Not run: local test suite is unavailable in this connector session