### PR TITLE
Fix progressive update for constant likelihoods

### DIFF
--- a/src/pyrecest/filters/wrapped_normal_filter.py
+++ b/src/pyrecest/filters/wrapped_normal_filter.py
@@ -122,23 +122,26 @@ class WrappedNormalFilter(AbstractFilter, CircularFilterMixin):
                     "Progressive update failed because likelihood is 0 everywhere"
                 )
 
-            w_min = min(wd.w)
-            w_max = max(wd.w)
+            if likelihood_vals_min == likelihood_vals_max:
+                current_lambda = lambda_
+            else:
+                w_min = min(wd.w)
+                w_max = max(wd.w)
 
-            if likelihood_vals_min == 0 or w_min == 0:
-                raise ZeroDivisionError("Cannot perform division by zero")
+                if likelihood_vals_min == 0 or w_min == 0:
+                    raise ZeroDivisionError("Cannot perform division by zero")
 
-            current_lambda = minimum(
-                log(tau * w_max / w_min)
-                / log(likelihood_vals_min / likelihood_vals_max),
-                lambda_,
-            )
+                current_lambda = minimum(
+                    log(tau * w_max / w_min)
+                    / log(likelihood_vals_min / likelihood_vals_max),
+                    lambda_,
+                )
 
-            if current_lambda <= 0:
-                raise ValueError("Progressive update with given threshold impossible")
+                if current_lambda <= 0:
+                    raise ValueError("Progressive update with given threshold impossible")
 
-            current_lambda = maximum(current_lambda, MINIMUM_LAMBDA)
-            current_lambda = minimum(current_lambda, lambda_)
+                current_lambda = maximum(current_lambda, MINIMUM_LAMBDA)
+                current_lambda = minimum(current_lambda, lambda_)
             wd_new = wd.reweigh(
                 lambda points, power=current_lambda: self._evaluate_likelihood_values(
                     likelihood, z, points, power=power

--- a/tests/filters/test_wrapped_normal_filter.py
+++ b/tests/filters/test_wrapped_normal_filter.py
@@ -71,6 +71,34 @@ class WrappedNormalFilterTest(unittest.TestCase):
         self.assertIsInstance(self.wn_filter.filter_state, WrappedNormalDistribution)
         self.assertTrue(math.isfinite(float(self.wn_filter.filter_state.sigma)))
 
+    def test_update_nonlinear_progressive_accepts_constant_nonzero_likelihood(self):
+        class FakeDiracDistribution:
+            def __init__(self):
+                self.d = array([0.0, 1.0])
+                self.w = array([1.0, 1.0])
+                self.reweigh_calls = 0
+
+            def reweigh(self, weight_fun):
+                self.reweigh_calls += 1
+                npt.assert_allclose(weight_fun(self.d), array([2.0, 2.0]), rtol=1e-12)
+                return self
+
+            @staticmethod
+            def to_wn():
+                return WrappedNormalDistribution(array(0.0), array(1.0))
+
+        fake_dirac = FakeDiracDistribution()
+
+        def constant_likelihood(_z, _x):
+            return 2.0
+
+        with patch.object(
+            WrappedNormalDistribution, "to_dirac5", return_value=fake_dirac
+        ):
+            self.wn_filter.update_nonlinear_progressive(constant_likelihood, z=0.0)
+
+        self.assertEqual(fake_dirac.reweigh_calls, 1)
+
     def test_update_nonlinear_progressive_rejects_invalid_tau(self):
         self.wn_filter.filter_state = WrappedNormalDistribution(array(0.0), array(0.5))
         invalid_taus = (


### PR DESCRIPTION
## Summary
- handle constant positive likelihoods in `WrappedNormalFilter.update_nonlinear_progressive()` by consuming the remaining progressive exponent directly instead of evaluating the adaptive log-ratio formula with `log(1)` in the denominator
- keep the existing zero-everywhere likelihood error path unchanged
- add a regression test for constant nonzero likelihood callbacks

## Rationale
A constant positive likelihood is a valid Bayesian update: it should leave normalized weights unchanged. Previously, the adaptive progressive-step calculation encountered a zero denominator when `likelihood_vals_min == likelihood_vals_max`, which could raise `ValueError("Progressive update with given threshold impossible")` for an otherwise valid no-information measurement.

## Testing
- Added `test_update_nonlinear_progressive_accepts_constant_nonzero_likelihood`
- Not run locally: the sandbox could not resolve `github.com` for cloning/installing the repository, so CI should be treated as the source of truth for execution.