### PR TITLE
Fix constant wrapped normal progressive likelihood updates

### DIFF
--- a/src/pyrecest/filters/wrapped_normal_filter.py
+++ b/src/pyrecest/filters/wrapped_normal_filter.py
@@ -121,6 +121,8 @@ class WrappedNormalFilter(AbstractFilter, CircularFilterMixin):
                 raise ValueError(
                     "Progressive update failed because likelihood is 0 everywhere"
                 )
+            if likelihood_vals_min == likelihood_vals_max:
+                return
 
             w_min = min(wd.w)
             w_max = max(wd.w)

--- a/src/pyrecest/filters/wrapped_normal_filter.py
+++ b/src/pyrecest/filters/wrapped_normal_filter.py
@@ -121,7 +121,7 @@ class WrappedNormalFilter(AbstractFilter, CircularFilterMixin):
                 raise ValueError(
                     "Progressive update failed because likelihood is 0 everywhere"
                 )
-            if likelihood_vals_min == likelihood_vals_max:
+            if likelihood_vals_min == likelihood_vals_max and likelihood_vals_max > 0:
                 return
 
             w_min = min(wd.w)

--- a/tests/filters/test_wrapped_normal_filter_constant_likelihood.py
+++ b/tests/filters/test_wrapped_normal_filter_constant_likelihood.py
@@ -1,0 +1,20 @@
+import numpy.testing as npt
+
+from pyrecest.backend import array
+from pyrecest.distributions import WrappedNormalDistribution
+from pyrecest.filters.wrapped_normal_filter import WrappedNormalFilter
+
+
+def _constant_positive_likelihood(_z, _x):
+    return 3.0
+
+
+def test_update_nonlinear_progressive_constant_likelihood_is_noop():
+    filt = WrappedNormalFilter(WrappedNormalDistribution(array(0.4), array(0.7)))
+    initial_mu = filt.filter_state.mu
+    initial_sigma = filt.filter_state.sigma
+
+    filt.update_nonlinear_progressive(_constant_positive_likelihood, 0.1)
+
+    npt.assert_allclose(filt.filter_state.mu, initial_mu, rtol=0.0, atol=0.0)
+    npt.assert_allclose(filt.filter_state.sigma, initial_sigma, rtol=0.0, atol=0.0)


### PR DESCRIPTION
## Summary
- Treat positive constant likelihoods in `WrappedNormalFilter.update_nonlinear_progressive()` as a no-op Bayesian update.
- Avoid the `log(1) == 0` adaptive-step denominator that previously raised `Progressive update with given threshold impossible`.
- Add regression coverage for constant nonzero progressive likelihood callbacks.

## Validation
- Syntax-compiled the modified filter and regression test locally.
- Full test suite not run in this connector-only session.