### PR TITLE
Normalize ragged uniform bound validation errors

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/random.py
+++ b/src/pyrecest/_backend/_shared_numpy/random.py
@@ -65,7 +65,10 @@ def _normalize_size(size):
 def _validate_uniform_bound(bound, name):
     if _contains_boolean_value(bound):
         raise TypeError(f"{name} must be real numeric, not boolean")
-    bound_array = _np.asarray(bound)
+    try:
+        bound_array = _np.asarray(bound)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(f"{name} must be real numeric") from exc
     if bound_array.dtype.kind not in "iuf":
         raise TypeError(f"{name} must be real numeric")
     if _np.any(~_np.isfinite(bound_array)):

--- a/tests/backend/test_numpy_random_uniform_validation.py
+++ b/tests/backend/test_numpy_random_uniform_validation.py
@@ -1,0 +1,17 @@
+import pytest
+
+from pyrecest._backend.numpy import random
+
+
+@pytest.mark.parametrize(
+    ("low", "high", "expected_message"),
+    [
+        ([[0.0], [0.5, 0.75]], 1.0, "low must be real numeric"),
+        (0.0, [[1.0], [1.5, 1.75]], "high must be real numeric"),
+    ],
+)
+def test_uniform_rejects_ragged_bounds_with_normalized_type_error(
+    low, high, expected_message
+):
+    with pytest.raises(TypeError, match=expected_message):
+        random.uniform(low, high)


### PR DESCRIPTION
## Summary
- Wrap NumPy conversion failures in `_validate_uniform_bound` so ragged `low`/`high` inputs raise PyRecEst-facing `TypeError` messages.
- Add regression coverage for ragged lower and upper uniform bounds.

Fixes #3591.

## Testing
- Not run locally; repository dependencies were not available in this environment.