### PR TITLE
Fix PyTorch moveaxis NumPy-style axes

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract/__init__.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+from operator import index as _operator_index
 
 
 def _load_base_contract_module():
@@ -37,6 +38,7 @@ def patch_pytorch_dtype_promotion_contract() -> None:
     _patch_pytorch_logical_device_contract(raw_pytorch, backend, torch)
     _patch_pytorch_binary_device_contract(raw_pytorch, backend, torch)
     _patch_pytorch_equality_device_contract(raw_pytorch, backend, torch)
+    _patch_pytorch_moveaxis_numpy_contract(raw_pytorch, backend, torch, np)
 
 
 def _pytorch_numpy_index_array(index, numpy_module, torch_module):
@@ -262,6 +264,39 @@ def _patch_pytorch_equality_device_contract(raw_pytorch, backend, torch) -> None
         setattr(raw_pytorch, helper_name, wrapped_helper)
         if getattr(backend, "__backend_name__", None) == "pytorch":
             setattr(backend, helper_name, wrapped_helper)
+
+
+def _pytorch_moveaxis_axis(axis, numpy_module, torch_module):
+    """Return NumPy-style moveaxis axes as Python ints or tuples of ints."""
+    if torch_module.is_tensor(axis):
+        axis = axis.detach().cpu().numpy()
+    axis_array = numpy_module.asarray(axis)
+    if axis_array.shape == ():
+        return _operator_index(axis_array.item())
+    return tuple(_operator_index(one_axis) for one_axis in axis_array.tolist())
+
+
+def _patch_pytorch_moveaxis_numpy_contract(raw_pytorch, backend, torch, np) -> None:
+    """Make PyTorch moveaxis accept array-like inputs and NumPy-style axes."""
+    original_moveaxis = raw_pytorch.moveaxis
+    if getattr(original_moveaxis, "_pyrecest_numpy_contract", False):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.moveaxis = original_moveaxis
+        return
+
+    def moveaxis(a, source, destination):
+        return torch.moveaxis(
+            raw_pytorch.array(a),
+            _pytorch_moveaxis_axis(source, np, torch),
+            _pytorch_moveaxis_axis(destination, np, torch),
+        )
+
+    moveaxis.__name__ = getattr(original_moveaxis, "__name__", "moveaxis")
+    moveaxis.__doc__ = getattr(np.moveaxis, "__doc__", None)
+    moveaxis._pyrecest_numpy_contract = True
+    raw_pytorch.moveaxis = moveaxis
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.moveaxis = moveaxis
 
 
 __all__ = ["patch_pytorch_dtype_promotion_contract"]

--- a/tests/backend_support/test_pytorch_moveaxis_contract.py
+++ b/tests/backend_support/test_pytorch_moveaxis_contract.py
@@ -1,0 +1,55 @@
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_pytorch_moveaxis_accepts_array_like_inputs_and_numpy_axes():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import numpy as np
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+values = np.arange(24).reshape(2, 3, 4)
+
+public_result = backend.moveaxis(values.tolist(), np.array(0), np.array(2))
+raw_result = raw_pytorch.moveaxis(values.tolist(), np.array([0, 1]), np.array([1, 2]))
+
+assert backend.to_numpy(public_result).tolist() == np.moveaxis(values, 0, 2).tolist()
+assert raw_pytorch.to_numpy(raw_result).tolist() == np.moveaxis(values, [0, 1], [1, 2]).tolist()
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_moveaxis_is_patched_under_default_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "numpy",
+        """
+import numpy as np
+import pyrecest  # noqa: F401 - triggers backend support patches
+import pyrecest._backend.pytorch as raw_pytorch
+
+values = np.arange(24).reshape(2, 3, 4)
+result = raw_pytorch.moveaxis(values.tolist(), np.array([0, 1]), np.array([1, 2]))
+
+assert raw_pytorch.to_numpy(result).tolist() == np.moveaxis(values, [0, 1], [1, 2]).tolist()
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- Patch the PyTorch backend support hook so `moveaxis` converts array-like inputs through the backend array helper before dispatching to `torch.moveaxis`.
- Normalize NumPy/PyTorch/list axis arguments to Python `int`/`tuple[int, ...]`, matching the NumPy-style backend contract.
- Add backend-portable regressions for the public PyTorch backend and for direct raw PyTorch backend use under the default backend.

## Bug fixed
`pyrecest._backend.pytorch.moveaxis` was still a direct `torch.moveaxis` export. Calls that are valid under NumPy/PyRecEst-style semantics, such as list inputs or NumPy scalar/vector axis arrays, failed with PyTorch argument-type errors.

## Validation
- `python -m py_compile /mnt/data/pytorch_dtype_contract_updated.py /mnt/data/test_pytorch_moveaxis_contract.py`
- Local isolated smoke check confirmed bare `torch.moveaxis` rejects list inputs and NumPy array axes before the compatibility wrapper.
- Full repository pytest was not run in this connector environment because the local container cannot clone/resolve `github.com`; CI should run the added focused regressions.