### PR TITLE
Normalize PyTorch diagonal scalar integer arguments

### DIFF
--- a/src/pyrecest/_backend/_common.py
+++ b/src/pyrecest/_backend/_common.py
@@ -43,6 +43,14 @@ def _normalize_size_axis(axis):
         raise TypeError("an integer is required") from exc
 
 
+def _normalize_diagonal_integer(value):
+    """Return NumPy-style integer scalar arguments for stricter tensor APIs."""
+    try:
+        return _operator.index(value)
+    except TypeError:
+        return value
+
+
 def size(x, axis=None):
     """Return the total number of elements or the length of a given axis."""
     axis = _normalize_size_axis(axis)
@@ -127,9 +135,9 @@ def diagonal(a, offset=0, axis1=0, axis2=1):
     if torch is not None:
         return torch.diagonal(
             _torch_as_tensor_compatible(a, torch),
-            offset=offset,
-            dim1=axis1,
-            dim2=axis2,
+            offset=_normalize_diagonal_integer(offset),
+            dim1=_normalize_diagonal_integer(axis1),
+            dim2=_normalize_diagonal_integer(axis2),
         )
     return _np.diagonal(a, offset=offset, axis1=axis1, axis2=axis2)
 

--- a/tests/backend_support/test_pytorch_diagonal_numpy_scalar_args.py
+++ b/tests/backend_support/test_pytorch_diagonal_numpy_scalar_args.py
@@ -1,0 +1,24 @@
+import numpy as np
+import pytest
+
+from pyrecest._backend import _common as common
+
+
+def test_common_diagonal_accepts_numpy_scalar_integer_arguments_for_torch():
+    torch = pytest.importorskip("torch")
+
+    values = torch.tensor(
+        [
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]],
+            [[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]],
+        ]
+    )
+
+    diag = common.diagonal(
+        values,
+        offset=np.array(1),
+        axis1=np.array(1),
+        axis2=np.array(2),
+    )
+
+    assert diag.cpu().numpy().tolist() == [[2.0, 6.0], [8.0, 12.0]]


### PR DESCRIPTION
## Summary
- Normalize NumPy-style scalar integer arguments before dispatching `backend.diagonal()` to PyTorch.
- Covers `offset`, `axis1`, and `axis2`, which PyTorch rejects when they are zero-dimensional NumPy arrays even though NumPy accepts them.
- Add a focused PyTorch regression for the shared diagonal fallback.

## Bug fixed
`backend.diagonal(torch_tensor, offset=np.array(1), axis1=np.array(1), axis2=np.array(2))` raised `TypeError` from `torch.diagonal()` because the shared backend fallback forwarded zero-dimensional NumPy arrays directly. `backend.trace()` is affected through its diagonal-based implementation.

## Validation
- Syntax-checked the modified shared backend module locally.
- Exercised the patched helper directly with a PyTorch tensor and NumPy scalar integer arguments locally.
- Full repository tests were not run in this connector/container session.