### PR TITLE
Fix scalar Gaussian log-pdf backend shape

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
@@ -185,9 +185,12 @@ class GaussianDistribution(AbstractLinearDistribution):
         """
         xs = self._validate_evaluation_points(xs)
         scalar_input = self.dim == 1 and ndim(xs) == 0
+        one_dimensional_batch_input = self.dim == 1 and ndim(xs) == 1
         if pyrecest.backend.__backend_name__ == "numpy":
             from scipy.stats import multivariate_normal as mvn
 
+            if ndim(xs) <= 1 and self.dim == 1:
+                xs = reshape(xs, (-1, 1))
             log_pdf_vals = mvn.logpdf(xs, self.mu, self.C)
         elif pyrecest.backend.__backend_name__ == "pytorch":
             # Disable import errors for megalinter
@@ -213,6 +216,8 @@ class GaussianDistribution(AbstractLinearDistribution):
 
         if scalar_input:
             log_pdf_vals = reshape(log_pdf_vals, ())
+        elif one_dimensional_batch_input:
+            log_pdf_vals = reshape(log_pdf_vals, (-1,))
         return log_pdf_vals
 
     log_pdf = ln_pdf

--- a/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
@@ -184,6 +184,7 @@ class GaussianDistribution(AbstractLinearDistribution):
         many likelihoods are accumulated or when densities may underflow.
         """
         xs = self._validate_evaluation_points(xs)
+        scalar_input = self.dim == 1 and ndim(xs) == 0
         if pyrecest.backend.__backend_name__ == "numpy":
             from scipy.stats import multivariate_normal as mvn
 
@@ -210,6 +211,8 @@ class GaussianDistribution(AbstractLinearDistribution):
         else:
             raise NotImplementedError("Backend not supported")
 
+        if scalar_input:
+            log_pdf_vals = reshape(log_pdf_vals, ())
         return log_pdf_vals
 
     log_pdf = ln_pdf

--- a/tests/backend_support/test_gaussian_scalar_logpdf_contract.py
+++ b/tests/backend_support/test_gaussian_scalar_logpdf_contract.py
@@ -1,0 +1,36 @@
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+pytestmark = pytest.mark.backend_portable
+
+
+@pytest.mark.parametrize("backend_name", ["numpy", "pytorch", "jax"])
+def test_one_dimensional_gaussian_scalar_logpdf_preserves_scalar_shape(backend_name):
+    if backend_name == "pytorch" and importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+    if backend_name == "jax" and importlib.util.find_spec("jax") is None:
+        pytest.skip("JAX is not installed")
+
+    code = """
+import pyrecest.backend as backend
+from pyrecest.distributions import GaussianDistribution
+
+
+distribution = GaussianDistribution(backend.array(0.0), backend.array(1.0))
+log_density = distribution.ln_pdf(backend.array(0.0))
+density = distribution.pdf(backend.array(0.0))
+batch_log_density = distribution.ln_pdf(backend.array([0.0]))
+
+assert tuple(backend.shape(backend.asarray(log_density))) == ()
+assert tuple(backend.shape(backend.asarray(density))) == ()
+assert tuple(backend.shape(backend.asarray(batch_log_density))) == (1,)
+assert float(backend.to_numpy(log_density)) < 0.0
+assert float(backend.to_numpy(density)) > 0.0
+print("ok")
+"""
+    result = run_backend_code(backend_name, code)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- preserve scalar output shape for one-dimensional `GaussianDistribution.ln_pdf` scalar inputs after PyTorch/JAX event-dimension reshaping
- keep one-dimensional array inputs as a batch of scalar evaluation points
- add a backend-portable regression covering scalar `ln_pdf`, scalar `pdf`, and one-element batch `ln_pdf` across NumPy, PyTorch, and JAX

## Bug fixed
For a one-dimensional Gaussian, scalar inputs are valid evaluation points. The NumPy/SciPy path returns a scalar log-density, but the PyTorch and JAX paths reshape scalar inputs to `(-1, 1)` for their multivariate-normal APIs and previously returned the resulting length-1 batch unchanged. The fix records scalar input shape before reshaping and reshapes the returned log-density back to `()`.

## Validation
- `python -m py_compile src/pyrecest/distributions/nonperiodic/gaussian_distribution.py tests/backend_support/test_gaussian_scalar_logpdf_contract.py`
- Checked the underlying NumPy/PyTorch/JAX scalar-shape behavior in an isolated local snippet.
- Full repository tests were not run locally because this environment could not clone/resolve `github.com`; CI should run the backend-portable regression.