### PR TITLE
Fix PyTorch FFT empty-axes shape validation

### DIFF
--- a/src/pyrecest/_backend/pytorch/fft.py
+++ b/src/pyrecest/_backend/pytorch/fft.py
@@ -22,6 +22,19 @@ def _is_empty_dim(dim):
         return False
 
 
+def _empty_dim_noop_is_valid(args, kwargs):
+    """Return whether an empty FFT dimension tuple can safely no-op."""
+    shape = args[0] if args else kwargs.get("s", None)
+    if shape is None:
+        return True
+    if isinstance(shape, (str, bytes)):
+        return False
+    try:
+        return len(tuple(shape)) == 0
+    except TypeError:
+        return False
+
+
 def _normalize_single_fft_dim(dim):
     """Return scalar-array FFT dimensions as Python integers when possible."""
     if dim is None or isinstance(dim, (bool, str, bytes)):
@@ -99,7 +112,11 @@ def _wrap_arraylike_fft(
             kwargs = dict(kwargs)
             kwargs["dim"] = _normalize_fft_dim_sequence(kwargs["dim"])
         value = _as_fft_tensor(value)
-        if empty_dim_is_noop and _is_empty_dim(kwargs.get("dim")):
+        if (
+            empty_dim_is_noop
+            and _is_empty_dim(kwargs.get("dim"))
+            and _empty_dim_noop_is_valid(args, kwargs)
+        ):
             return value
         return torch_func(value, *args, **kwargs)
 

--- a/tests/backend_support/test_pytorch_fftn_empty_axes_contract.py
+++ b/tests/backend_support/test_pytorch_fftn_empty_axes_contract.py
@@ -44,3 +44,44 @@ for axes in ((), []):
     assert inverse_np.dtype == expected_inverse.dtype
 """
     subprocess.run([sys.executable, "-c", code], check=True, env=env)
+
+
+@pytest.mark.backend_portable
+def test_pytorch_fftn_empty_axes_rejects_nonempty_shape():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch.fft as raw_fft
+
+values = backend.array([[0.0, 1.0], [2.0, 3.0]])
+
+for fft_func in (backend.fft.fftn, backend.fft.ifftn, raw_fft.fftn, raw_fft.ifftn):
+    for kwargs in ({"s": (2,), "axes": ()}, {"s": [2], "axes": []}):
+        try:
+            fft_func(values, **kwargs)
+        except Exception as exc:
+            assert "length" in str(exc)
+        else:
+            raise AssertionError(f"{fft_func.__name__} accepted {kwargs!r}")
+
+    try:
+        fft_func(values, (2,), axes=())
+    except Exception as exc:
+        assert "length" in str(exc)
+    else:
+        raise AssertionError(
+            f"{fft_func.__name__} accepted positional shape with empty axes"
+        )
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- Preserve the PyTorch FFT empty-axes no-op only when no transform shape, `None`, or an empty transform shape is supplied.
- Let `torch.fft.fftn`/`ifftn` validate non-empty `s` with empty `axes` instead of silently returning the input.
- Add public and raw PyTorch backend regression coverage for `fftn`/`ifftn`.

## Testing
- Not run against the full repository in this connector session.
- Locally validated the wrapper behavior with PyTorch for empty axes, empty shape, and non-empty shape/axis length mismatch.