### PR TITLE
Fix PyTorch arange dtype aliases

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract/__init__.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract/__init__.py
@@ -30,6 +30,9 @@ def patch_pytorch_dtype_promotion_contract() -> None:
         import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
         import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
         import torch  # pylint: disable=import-outside-toplevel
+        from pyrecest._backend.pytorch._common import (  # pylint: disable=import-outside-toplevel
+            _normalize_dtype,
+        )
     except ModuleNotFoundError:  # pragma: no cover - PyTorch backend import failed earlier
         return
 
@@ -37,6 +40,7 @@ def patch_pytorch_dtype_promotion_contract() -> None:
     _patch_pytorch_logical_device_contract(raw_pytorch, backend, torch)
     _patch_pytorch_binary_device_contract(raw_pytorch, backend, torch)
     _patch_pytorch_equality_device_contract(raw_pytorch, backend, torch)
+    _patch_pytorch_arange_dtype_contract(raw_pytorch, backend, _normalize_dtype)
 
 
 def _pytorch_numpy_index_array(index, numpy_module, torch_module):
@@ -86,6 +90,25 @@ def _patch_pytorch_assignment_numpy_index_contract(raw_pytorch, backend, torch, 
         setattr(raw_pytorch, helper_name, wrapped_helper)
         if getattr(backend, "__backend_name__", None) == "pytorch":
             setattr(backend, helper_name, wrapped_helper)
+
+
+def _patch_pytorch_arange_dtype_contract(raw_pytorch, backend, normalize_dtype) -> None:
+    """Make PyTorch arange accept NumPy-style dtype aliases."""
+    original_arange = raw_pytorch.arange
+    if getattr(original_arange, "_pyrecest_dtype_contract", False):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.arange = original_arange
+        return
+
+    def arange(*args, dtype=None, **kwargs):
+        return original_arange(*args, dtype=normalize_dtype(dtype), **kwargs)
+
+    arange.__name__ = getattr(original_arange, "__name__", "arange")
+    arange.__doc__ = getattr(original_arange, "__doc__", None)
+    arange._pyrecest_dtype_contract = True
+    raw_pytorch.arange = arange
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.arange = arange
 
 
 def _preferred_pytorch_device(torch_module, *values):

--- a/tests/backend_support/test_pytorch_arange_dtype_contract.py
+++ b/tests/backend_support/test_pytorch_arange_dtype_contract.py
@@ -1,0 +1,57 @@
+"""Regression tests for PyTorch arange dtype normalization."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_public_pytorch_arange_accepts_numpy_dtype_aliases():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import numpy as np
+import pyrecest.backend as backend
+
+from_numpy_type = backend.arange(3, dtype=np.float32)
+from_numpy_dtype = backend.arange(3, dtype=np.dtype("float64"))
+from_torch_string = backend.arange(3, dtype="torch.float64")
+
+assert from_numpy_type.dtype == backend.float32
+assert from_numpy_dtype.dtype == backend.float64
+assert from_torch_string.dtype == backend.float64
+assert backend.to_numpy(from_numpy_type).tolist() == [0.0, 1.0, 2.0]
+assert backend.to_numpy(from_numpy_dtype).tolist() == [0.0, 1.0, 2.0]
+assert backend.to_numpy(from_torch_string).tolist() == [0.0, 1.0, 2.0]
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_arange_is_patched_under_non_pytorch_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "numpy",
+        """
+import numpy as np
+import pyrecest  # noqa: F401
+import pyrecest._backend.pytorch as raw_pytorch
+
+values = raw_pytorch.arange(3, dtype=np.float64)
+
+assert values.dtype == raw_pytorch.float64
+assert values.tolist() == [0.0, 1.0, 2.0]
+""",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Summary:
- Normalize dtype aliases before forwarding PyTorch backend arange calls.
- Keep raw and public PyTorch backend arange behavior aligned.
- Add focused regression tests for NumPy dtype aliases and Torch-style dtype strings.

Testing:
- Added tests/backend_support/test_pytorch_arange_dtype_contract.py.
- Syntax-checked the modified module and new test content locally before committing.