### PR TITLE
Allow unsigned padded history dtypes

### DIFF
--- a/src/pyrecest/utils/history_recorder.py
+++ b/src/pyrecest/utils/history_recorder.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from math import nan
 from typing import Any
 
+import numpy as np
+
 from pyrecest import backend
 
 # pylint: disable=no-name-in-module,no-member
@@ -46,6 +48,13 @@ _INVALID_PADDED_HISTORY_DTYPE_PREFIXES = (
 
 
 def _is_invalid_padded_history_dtype(dtype: Any) -> bool:
+    try:
+        dtype_kind = np.dtype(dtype).kind
+    except (TypeError, ValueError):
+        dtype_kind = None
+    if dtype_kind is not None:
+        return dtype_kind in {"b", "c", "O", "U", "S", "M", "m"}
+
     dtype_name = str(dtype).lower()
     return (
         "bool" in dtype_name

--- a/src/pyrecest/utils/history_recorder.py
+++ b/src/pyrecest/utils/history_recorder.py
@@ -68,12 +68,28 @@ def _is_invalid_padded_history_dtype(dtype: Any) -> bool:
     )
 
 
+def _padded_history_input_dtype(value: Any):
+    dtype = getattr(value, "dtype", None)
+    if dtype is not None:
+        return dtype
+    try:
+        return np.asarray(value).dtype
+    except (TypeError, ValueError):
+        return None
+
+
 def _as_padded_numeric_array(curr_ests):
     message = "padded history values must be real numeric"
+    if _is_invalid_padded_history_dtype(_padded_history_input_dtype(curr_ests)):
+        raise TypeError(message)
+
     try:
         raw_curr_ests = asarray(curr_ests)
-    except (TypeError, ValueError, RuntimeError) as exc:
-        raise TypeError(message) from exc
+    except (TypeError, ValueError, RuntimeError):
+        try:
+            raw_curr_ests = asarray(np.asarray(curr_ests, dtype=float))
+        except (TypeError, ValueError, RuntimeError) as fallback_exc:
+            raise TypeError(message) from fallback_exc
 
     if _is_invalid_padded_history_dtype(getattr(raw_curr_ests, "dtype", None)):
         raise TypeError(message)

--- a/tests/test_history_recorder_unsigned_dtype.py
+++ b/tests/test_history_recorder_unsigned_dtype.py
@@ -1,0 +1,34 @@
+import numpy as np
+import pytest
+
+from pyrecest import backend
+from pyrecest.utils.history_recorder import HistoryRecorder
+
+
+def _as_numpy(value):
+    return backend.to_numpy(value)
+
+
+def _swapped_uint16_dtype():
+    return np.dtype("uint16").newbyteorder("S")
+
+
+def test_padded_history_accepts_non_native_unsigned_integer_arrays():
+    recorder = HistoryRecorder()
+    initial = np.array([1, 2], dtype=_swapped_uint16_dtype())
+
+    history = recorder.register("counts", initial, pad_with_nan=True)
+
+    assert _as_numpy(history).tolist() == [[1.0], [2.0]]
+
+    updated = recorder.record("counts", np.array([3], dtype=_swapped_uint16_dtype()))
+
+    expected = np.array([[1.0, 3.0], [2.0, np.nan]])
+    assert np.allclose(_as_numpy(updated), expected, equal_nan=True)
+
+
+def test_padded_history_still_rejects_unicode_arrays():
+    recorder = HistoryRecorder()
+
+    with pytest.raises(TypeError, match="padded history values must be real numeric"):
+        recorder.register("bad", np.array(["1"], dtype=np.dtype("U1")), pad_with_nan=True)


### PR DESCRIPTION
## Summary
- Check NumPy dtype kinds before falling back to string-prefix dtype screening in padded histories.
- Allow byte-order-marked unsigned integer arrays to be converted to floating padded histories.
- Keep unicode/string history values rejected as non-real numeric.

## Validation
- Inspected the branch diff against main.
- Added targeted regression tests for swapped-byte-order unsigned arrays and unicode rejection.
- Not run: full local test suite in this connector session.