### PR TITLE
Fix PyTorch allclose mixed-device operands

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_allclose_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_allclose_device_contract.py
@@ -1,0 +1,68 @@
+"""PyTorch ``allclose`` compatibility hook."""
+
+from __future__ import annotations
+
+
+def _preferred_pytorch_device(torch_module, *values):
+    """Return a non-CPU tensor device when mixed-device operands are present."""
+
+    for value in values:
+        if torch_module.is_tensor(value) and value.device.type != "cpu":
+            return value.device
+    for value in values:
+        if torch_module.is_tensor(value):
+            return value.device
+    return None
+
+
+def _coerce_binary_args(torch_module, x, y):
+    """Move array-like PyTorch binary operands to a preferred existing device."""
+
+    device = _preferred_pytorch_device(torch_module, x, y)
+    if not torch_module.is_tensor(x):
+        x = torch_module.as_tensor(x, device=device)
+    elif device is not None and x.device != device:
+        x = x.to(device=device)
+    if not torch_module.is_tensor(y):
+        y = torch_module.as_tensor(y, device=device)
+    elif device is not None and y.device != device:
+        y = y.to(device=device)
+    return x, y
+
+
+def patch_pytorch_allclose_device_contract() -> None:
+    """Patch raw/public PyTorch ``allclose`` to preserve non-CPU operands."""
+
+    try:
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import torch as torch_module  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    original_allclose = getattr(pytorch_backend, "allclose", None)
+    if original_allclose is None:
+        return
+    if getattr(original_allclose, "_pyrecest_equal_nan_device_contract", False):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.allclose = original_allclose
+        return
+
+    def allclose(
+        a,
+        b,
+        atol=pytorch_backend.atol,
+        rtol=pytorch_backend.rtol,
+        equal_nan=False,
+    ):
+        a, b = _coerce_binary_args(torch_module, a, b)
+        a, b = pytorch_backend.convert_to_wider_dtype([a, b])
+        a, b = torch_module.broadcast_tensors(a, b)
+        return torch_module.allclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan)
+
+    allclose.__name__ = getattr(original_allclose, "__name__", "allclose")
+    allclose.__doc__ = getattr(original_allclose, "__doc__", None)
+    allclose._pyrecest_equal_nan_device_contract = True
+    pytorch_backend.allclose = allclose
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.allclose = allclose

--- a/src/pyrecest/stability.py
+++ b/src/pyrecest/stability.py
@@ -6,6 +6,12 @@ from collections.abc import Callable, Iterable
 from dataclasses import asdict, dataclass
 from typing import Final, Literal, ParamSpec, TypeVar
 
+from pyrecest.backend_support._pytorch_allclose_device_contract import (
+    patch_pytorch_allclose_device_contract as _patch_pytorch_allclose_device_contract,
+)
+
+_patch_pytorch_allclose_device_contract()
+
 P = ParamSpec("P")
 R = TypeVar("R")
 

--- a/tests/backend/test_pytorch_comparison_device_contract.py
+++ b/tests/backend/test_pytorch_comparison_device_contract.py
@@ -63,3 +63,12 @@ def test_raw_pytorch_isclose_prefers_existing_non_cpu_device_for_right_operand()
     assert result.device.type == device.type
     assert result.dtype == torch.bool
     assert tuple(result.shape) == (2,)
+
+
+def test_raw_pytorch_allclose_accepts_arraylike_against_cuda_operand():
+    if not torch.cuda.is_available():
+        pytest.skip("allclose returns a host bool and cannot be exercised on meta tensors")
+
+    right = torch.tensor([1.0, float("nan")], device="cuda")
+
+    assert pytorch_backend.allclose([1.0, float("nan")], right, equal_nan=True)


### PR DESCRIPTION
## Summary
- Add a PyTorch `allclose` compatibility hook that keeps array-like operands on an existing non-CPU tensor device instead of materializing them on CPU.
- Load the hook during normal package initialization.
- Add CUDA-only regression coverage for `allclose(..., equal_nan=True)` with an array-like operand against a CUDA tensor; CPU-only environments skip this case because `allclose` returns a host bool and cannot be exercised on meta tensors.

## Bug fixed
The existing PyTorch `allclose(equal_nan=...)` wrapper coerced array-like operands with `torch.tensor(...)`, which always materializes them on CPU. Calls such as `pyrecest._backend.pytorch.allclose([1.0], torch.ones(1, device="cuda"))` therefore mix CPU and CUDA tensors and fail instead of preserving the existing non-CPU device, unlike the recently fixed comparison and `isclose` wrappers.

## Validation
- Verified branch diff against `main`.
- Full test suite not run in this connector-only environment; the focused regression is CUDA-gated and will skip on CPU-only CI.