### PR TITLE
Fix summarize_filter_results last_estimates-only path

### DIFF
--- a/src/pyrecest/evaluation/summarize_filter_results.py
+++ b/src/pyrecest/evaluation/summarize_filter_results.py
@@ -27,6 +27,8 @@ def summarize_filter_results(
             "Provided both last_filter_states and last_estimates. Using last_estimates."
         )
         filter_results = last_estimates
+    elif last_estimates is not None:
+        filter_results = last_estimates
     elif last_filter_states is not None:
         filter_results = last_filter_states
     else:

--- a/tests/test_evaluation_summarize_filter_results.py
+++ b/tests/test_evaluation_summarize_filter_results.py
@@ -26,6 +26,33 @@ class TestSummarizeFilterResultsWarnings(unittest.TestCase):
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
         reason="Not supported on this backend",
     )
+    def test_accepts_last_estimates_without_last_filter_states(self):
+        groundtruths = np.empty((1, 1), dtype=object)
+        groundtruths[0, 0] = np.array([1.0, 2.0])
+        last_estimates = np.array([[[1.0, 4.0]]])
+        filter_configs = [{"name": "estimate-only"}]
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            summarized = summarize_filter_results(
+                scenario_config={"manifold": "Euclidean", "mtt": False},
+                filter_configs=filter_configs,
+                runtimes=np.array([[0.25]]),
+                groundtruths=groundtruths,
+                run_failed=np.array([[False]]),
+                last_estimates=last_estimates,
+            )
+
+        self.assertIs(summarized, filter_configs)
+        self.assertAlmostEqual(summarized[0]["error_mean"], 2.0)
+        self.assertAlmostEqual(summarized[0]["error_std"], 0.0)
+        self.assertAlmostEqual(summarized[0]["time_mean"], 0.25)
+        self.assertAlmostEqual(summarized[0]["failure_rate"], 0.0)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
     def test_run_count_warning_uses_run_axis(self):
         n_runs = 1000
         n_timesteps = 2


### PR DESCRIPTION
## Summary
- Accept `last_estimates` when `last_filter_states` is omitted in `summarize_filter_results`.
- Add a regression test covering estimate-only summaries.

## Bug fixed
`summarize_filter_results()` documents and errors as though either `last_filter_states` or `last_estimates` may be supplied. However, the control flow only accepted `last_estimates` when `last_filter_states` was also present, so valid estimate-only calls raised `ValueError`.

## Validation
- `python -m py_compile /tmp/summarize_filter_results.py /tmp/test_evaluation_summarize_filter_results.py`
- Verified branch diff against `main` (`ahead_by=2`, `behind_by=0`).
- Full test suite not run locally; the container cannot resolve `github.com` for cloning dependencies.