### PR TITLE
Reject text registration tolerance values

### DIFF
--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -219,12 +219,18 @@ def _validate_max_cost(max_cost) -> float:
 
 
 def _validate_tolerance(tolerance) -> float:
-    tolerance_array = asarray(tolerance)
+    if isinstance(tolerance, (str, bytes, bytearray)):
+        raise ValueError("tolerance must be a finite non-negative scalar.")
+
+    try:
+        tolerance_array = asarray(tolerance)
+    except (TypeError, ValueError, OverflowError, RuntimeError) as exc:
+        raise ValueError("tolerance must be a finite non-negative scalar.") from exc
     if tolerance_array.shape != ():
         raise ValueError("tolerance must be a finite non-negative scalar.")
 
     tolerance_scalar = tolerance_array.item()
-    if isinstance(tolerance_scalar, bool):
+    if isinstance(tolerance_scalar, (bool, str, bytes, bytearray)):
         raise ValueError("tolerance must be a finite non-negative scalar.")
 
     try:

--- a/tests/test_registration_loop_control_validation.py
+++ b/tests/test_registration_loop_control_validation.py
@@ -49,6 +49,24 @@ class TestRegistrationLoopControlValidation(unittest.TestCase):
         pyrecest.backend.__backend_name__ == "jax",
         reason="Not supported on this backend",
     )
+    def test_joint_registration_assignment_rejects_text_tolerance(self):
+        reference = array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+        moving = reference + array([1.0, -1.0])
+
+        for bad_value in ("0.1", b"0.1"):
+            with self.subTest(bad_value=bad_value):
+                with self.assertRaisesRegex(ValueError, "tolerance"):
+                    joint_registration_assignment(
+                        reference,
+                        moving,
+                        model="translation",
+                        tolerance=bad_value,
+                    )
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
     def test_joint_tps_registration_assignment_rejects_invalid_max_iterations(self):
         reference = array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
         moving = reference + array([0.5, -0.25])


### PR DESCRIPTION
## Summary
- Reject text and bytes values for registration-loop tolerance instead of accepting them through float coercion.
- Keep the existing finite non-negative numeric tolerance contract unchanged.
- Add regression coverage for text and bytes tolerance in joint_registration_assignment.

## Validation
- Inspected the branch diff: 2 files changed, +19/-1.
- Not run: full local test suite in this connector session.