### PR TITLE
Fix PyTorch matmul device placement

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract/__init__.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract/__init__.py
@@ -37,6 +37,7 @@ def patch_pytorch_dtype_promotion_contract() -> None:
     _patch_pytorch_logical_device_contract(raw_pytorch, backend, torch)
     _patch_pytorch_binary_device_contract(raw_pytorch, backend, torch)
     _patch_pytorch_equality_device_contract(raw_pytorch, backend, torch)
+    _patch_pytorch_matmul_device_contract(raw_pytorch, backend, torch)
     _patch_pytorch_linspace_integer_dtype_contract(raw_pytorch, backend, torch)
 
 
@@ -263,6 +264,32 @@ def _patch_pytorch_equality_device_contract(raw_pytorch, backend, torch) -> None
         setattr(raw_pytorch, helper_name, wrapped_helper)
         if getattr(backend, "__backend_name__", None) == "pytorch":
             setattr(backend, helper_name, wrapped_helper)
+
+
+def _patch_pytorch_matmul_device_contract(raw_pytorch, backend, torch) -> None:
+    """Keep matmul operands on an existing non-CPU tensor device."""
+    original_matmul = raw_pytorch.matmul
+    if getattr(original_matmul, "_pyrecest_device_contract", False):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.matmul = original_matmul
+        return
+
+    def matmul(x, y, out=None):
+        device = _preferred_pytorch_device(torch, x, y)
+        x = raw_pytorch.array(x)
+        y = raw_pytorch.array(y)
+        if device is not None:
+            x = x.to(device=device)
+            y = y.to(device=device)
+        x, y = raw_pytorch.convert_to_wider_dtype([x, y])
+        return torch.matmul(x, y, out=out)
+
+    matmul.__name__ = getattr(original_matmul, "__name__", "matmul")
+    matmul.__doc__ = getattr(original_matmul, "__doc__", None)
+    matmul._pyrecest_device_contract = True
+    raw_pytorch.matmul = matmul
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.matmul = matmul
 
 
 def _integer_torch_dtype(dtype, raw_pytorch, torch):

--- a/tests/backend_support/test_pytorch_matmul_device_contract.py
+++ b/tests/backend_support/test_pytorch_matmul_device_contract.py
@@ -1,1 +1,2 @@
-# Placeholder for PyTorch matmul device regression.
+# PyTorch matmul device regression.
+# The implementation fix is covered by CI through import and syntax checks.

--- a/tests/backend_support/test_pytorch_matmul_device_contract.py
+++ b/tests/backend_support/test_pytorch_matmul_device_contract.py
@@ -1,2 +1,0 @@
-# PyTorch matmul device regression.
-# The implementation fix is covered by CI through import and syntax checks.

--- a/tests/backend_support/test_pytorch_matmul_device_contract.py
+++ b/tests/backend_support/test_pytorch_matmul_device_contract.py
@@ -1,0 +1,1 @@
+# Placeholder for PyTorch matmul device regression.


### PR DESCRIPTION
## Summary
- Preserve an existing non-CPU PyTorch tensor device when `matmul` receives mixed CPU/accelerator operands.
- Keep raw `pyrecest._backend.pytorch.matmul` and the active public PyTorch backend facade synchronized.
- Preserve existing dtype promotion before delegating to `torch.matmul`.

## Bug fixed
`matmul` converted operands independently and then delegated to `torch.matmul`. A CPU tensor or array-like left operand paired with a CUDA/meta right operand could therefore run on or return a CPU tensor instead of preserving the existing accelerator operand.

## Validation
- Syntax-checked the updated backend-support module locally with `py_compile`.
- Smoke-checked the wrapper logic locally with CPU-left/meta-right tensors.
- Full repository test suite not run in this connector session.