### PR TITLE
Fix PyTorch binary scalar boxing device placement

### DIFF
--- a/src/pyrecest/_backend/pytorch/_dtype.py
+++ b/src/pyrecest/_backend/pytorch/_dtype.py
@@ -107,6 +107,16 @@ def _dtype_as_str(dtype):
     return str(dtype).split(".")[-1]
 
 
+def _preferred_tensor_device(*values):
+    tensor_devices = [value.device for value in values if _torch.is_tensor(value)]
+    if not tensor_devices:
+        return None
+    return next(
+        (device for device in tensor_devices if device.type != "cpu"),
+        tensor_devices[0],
+    )
+
+
 def set_default_dtype(value):
     """Set backend default dtype.
 
@@ -281,10 +291,15 @@ def _box_binary_scalar(target=None, box_x1=True, box_x2=True):
     def _decorator(func):
         @functools.wraps(func)
         def _wrapped(x1, x2, *args, **kwargs):
+            device = _preferred_tensor_device(x1, x2)
             if box_x1 and not _torch.is_tensor(x1):
-                x1 = _torch.tensor(x1)
+                x1 = _torch.tensor(x1, device=device)
+            elif device is not None and _torch.is_tensor(x1) and x1.device != device:
+                x1 = x1.to(device=device)
             if box_x2 and not _torch.is_tensor(x2):
-                x2 = _torch.tensor(x2)
+                x2 = _torch.tensor(x2, device=device)
+            elif device is not None and _torch.is_tensor(x2) and x2.device != device:
+                x2 = x2.to(device=device)
 
             return func(x1, x2, *args, **kwargs)
 

--- a/tests/backend_support/test_pytorch_numpy_view_conversion.py
+++ b/tests/backend_support/test_pytorch_numpy_view_conversion.py
@@ -97,17 +97,15 @@ assert backend.to_numpy(converted).tolist() == [0.0, 1.0, 2.0]
 
 @pytest.mark.backend_portable
 def test_pytorch_boxed_binary_scalar_prefers_existing_cuda_tensor_device():
-    if importlib.util.find_spec("torch") is None:
-        pytest.skip("PyTorch is not installed")
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
 
     result = run_backend_code(
         "pytorch",
         """
 import pyrecest.backend as backend
 import torch
-
-if not torch.cuda.is_available():
-    raise SystemExit(0)
 
 tensor_operand = torch.ones(2, device="cuda")
 result = backend.arctan2([1.0, 2.0], tensor_operand)

--- a/tests/backend_support/test_pytorch_numpy_view_conversion.py
+++ b/tests/backend_support/test_pytorch_numpy_view_conversion.py
@@ -93,3 +93,28 @@ assert backend.to_numpy(converted).tolist() == [0.0, 1.0, 2.0]
     )
 
     assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.backend_portable
+def test_pytorch_boxed_binary_scalar_prefers_existing_cuda_tensor_device():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import pyrecest.backend as backend
+import torch
+
+if not torch.cuda.is_available():
+    raise SystemExit(0)
+
+tensor_operand = torch.ones(2, device="cuda")
+result = backend.arctan2([1.0, 2.0], tensor_operand)
+
+assert result.device.type == "cuda"
+assert tuple(result.shape) == (2,)
+""",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Preserve an existing tensor placement when PyTorch binary scalar wrappers box Python/list operands.
- Move already boxed tensor operands to the selected placement before calling the underlying PyTorch binary operation.
- Add a backend regression covering the non-CPU tensor operand path.

## Bug fixed
The previous wrapper implementation materialized Python/list operands with plain `torch.tensor(...)`. That could put the newly boxed operand somewhere different from an existing tensor operand, causing binary operations such as `arctan2` to fail with a placement mismatch.

## Validation
- Syntax-checked the changed module and regression test locally with `py_compile`.
- Reproduced the old placement mismatch locally and verified that the patched boxing path returns a result with the expected shape and placement.
- Full repository suite not run locally because direct repository cloning is unavailable in this execution environment.