### PR TITLE
Support PyTorch triangular helpers for array-like inputs

### DIFF
--- a/src/pyrecest/stability.py
+++ b/src/pyrecest/stability.py
@@ -10,7 +10,68 @@ from pyrecest.backend_support._pytorch_allclose_device_contract import (
     patch_pytorch_allclose_device_contract as _patch_pytorch_allclose_device_contract,
 )
 
+
+def _patch_pytorch_triangular_vector_helpers() -> None:
+    """Make PyTorch triangular-vector helpers accept array-like inputs."""
+
+    try:
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import torch as torch_module  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    originals = {
+        "vec_to_diag": getattr(pytorch_backend, "vec_to_diag", None),
+        "tril_to_vec": getattr(pytorch_backend, "tril_to_vec", None),
+        "triu_to_vec": getattr(pytorch_backend, "triu_to_vec", None),
+    }
+    if any(original is None for original in originals.values()):
+        return
+
+    if all(
+        getattr(original, "_pyrecest_triangular_vector_array_like_contract", False)
+        for original in originals.values()
+    ):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            for name, helper in originals.items():
+                setattr(backend, name, helper)
+        return
+
+    def vec_to_diag(vec):
+        values = pytorch_backend.array(vec)
+        return torch_module.diag_embed(values, offset=0)
+
+    def _triangular_to_vec(x, k, indices_func):
+        values = pytorch_backend.array(x)
+        rows, cols = indices_func(values.shape[-1], k=k)
+        rows = rows.to(device=values.device)
+        cols = cols.to(device=values.device)
+        return values[..., rows, cols]
+
+    def tril_to_vec(x, k=0):
+        return _triangular_to_vec(x, k, pytorch_backend.tril_indices)
+
+    def triu_to_vec(x, k=0):
+        return _triangular_to_vec(x, k, pytorch_backend.triu_indices)
+
+    patched = {
+        "vec_to_diag": vec_to_diag,
+        "tril_to_vec": tril_to_vec,
+        "triu_to_vec": triu_to_vec,
+    }
+    for name, helper in patched.items():
+        original = originals[name]
+        helper.__name__ = getattr(original, "__name__", name)
+        helper.__doc__ = getattr(original, "__doc__", None)
+        helper._pyrecest_triangular_vector_array_like_contract = True
+        setattr(pytorch_backend, name, helper)
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            setattr(backend, name, helper)
+
+
 _patch_pytorch_allclose_device_contract()
+_patch_pytorch_triangular_vector_helpers()
 
 P = ParamSpec("P")
 R = TypeVar("R")


### PR DESCRIPTION
## Summary
- Patch raw PyTorch `vec_to_diag`, `tril_to_vec`, and `triu_to_vec` so they coerce array-like inputs through the backend array constructor.
- Keep public PyTorch backend helpers synchronized when PyTorch is the active backend.
- Move generated triangular indices onto the input tensor device before indexing.

## Bug fixed
The raw PyTorch triangular-vector helpers assumed tensor inputs: `vec_to_diag([1.0, 2.0])` passed a Python list to `torch.diag_embed`, while `tril_to_vec([[...]])` and `triu_to_vec([[...]])` accessed `.shape` on a list. CUDA tensors could also be indexed with CPU-generated triangular indices. The wrapper normalizes inputs and index devices.

## Validation
- Inspected the branch diff against current `main`.
- Full test suite was not run because the repository could not be cloned in this environment.