### PR TITLE
Guard stability status lookup against non-string names

### DIFF
--- a/src/pyrecest/stability.py
+++ b/src/pyrecest/stability.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable
 from dataclasses import asdict, dataclass
-from typing import Final, Literal, ParamSpec, TypeVar
+from typing import Any, Final, Literal, ParamSpec, TypeVar
 
 from pyrecest.backend_support._pytorch_allclose_device_contract import (
     patch_pytorch_allclose_device_contract as _patch_pytorch_allclose_device_contract,
@@ -101,6 +101,8 @@ def stability(
 
 def get_public_api_status(name: str) -> PublicAPIStatus | None:
     """Return registered stability metadata for a public API name."""
+    if not isinstance(name, str):
+        return None
     return _PUBLIC_API_STATUS.get(name)
 
 

--- a/tests/test_stability.py
+++ b/tests/test_stability.py
@@ -42,6 +42,10 @@ def test_stability_decorator_attaches_public_api_status():
     assert status.notes == "example"
 
 
+def test_get_public_api_status_returns_none_for_non_string_names():
+    assert get_public_api_status(["KalmanFilter"]) is None
+
+
 def test_registered_public_api_status_rows_have_valid_levels():
     rows = list(iter_public_api_status())
 


### PR DESCRIPTION
## Summary
- make `get_public_api_status()` return `None` for non-string lookup names before dictionary access
- avoid `TypeError` for unhashable values such as lists
- add a regression test covering non-string lookup input

## Bug fixed
`get_public_api_status()` represented a public metadata lookup where unknown names return `None`, but passing an unhashable non-string value such as `["KalmanFilter"]` reached `_PUBLIC_API_STATUS.get(...)` and raised `TypeError`. The helper now treats non-string names as unknown lookup keys.

## Testing
- Not run locally: the execution environment could not resolve `github.com` for cloning/installing the repository.