### PR TITLE
Guard public API registry lookup names

### DIFF
--- a/src/pyrecest/api_registry.py
+++ b/src/pyrecest/api_registry.py
@@ -93,8 +93,10 @@ PUBLIC_API_REGISTRY: Final = {
 }
 
 
-def get_public_api_registry_entry(api_name: str) -> dict[str, str]:
+def get_public_api_registry_entry(api_name: object) -> dict[str, str]:
     """Return a copy of one public API registry row."""
+    if not isinstance(api_name, str):
+        return {}
     return dict(PUBLIC_API_REGISTRY.get(api_name, {}))
 
 

--- a/tests/test_api_registry.py
+++ b/tests/test_api_registry.py
@@ -31,6 +31,11 @@ def test_get_public_api_registry_entry_returns_copy():
     assert PUBLIC_API_REGISTRY["KalmanFilter"]["category"] == "stable"
 
 
+def test_get_public_api_registry_entry_returns_empty_for_non_string_lookup():
+    for value in (123, ("KalmanFilter",), ["KalmanFilter"], {"api": "KalmanFilter"}):
+        assert get_public_api_registry_entry(value) == {}
+
+
 def test_iter_public_api_registry_returns_row_copies():
     rows = dict(iter_public_api_registry())
     rows["KalmanFilter"]["category"] = "mutated"


### PR DESCRIPTION
## Summary
- Make `get_public_api_registry_entry()` return an empty row for non-string lookup values before dictionary access.
- Avoid `TypeError` for unhashable values such as lists or dictionaries.
- Add regression coverage for hashable and unhashable non-string lookup inputs.

## Bug fixed
`get_public_api_registry_entry()` already returned `{}` for unknown API names, but unhashable non-string inputs reached `PUBLIC_API_REGISTRY.get(...)` and raised `TypeError`. The helper now treats non-string inputs as unknown registry keys consistently.

## Validation
- Inspected the branch diff: `src/pyrecest/api_registry.py` and `tests/test_api_registry.py` only.
- Full test suite not run locally because the execution environment cannot resolve `github.com` for cloning/installing the repository.