### PR TITLE
Guard stability lookup against non-string names

### DIFF
--- a/src/pyrecest/stability.py
+++ b/src/pyrecest/stability.py
@@ -111,8 +111,10 @@ def stability(
     return decorator
 
 
-def get_public_api_status(name: str) -> PublicAPIStatus | None:
+def get_public_api_status(name: object) -> PublicAPIStatus | None:
     """Return registered stability metadata for a public API name."""
+    if not isinstance(name, str):
+        return None
     return _PUBLIC_API_STATUS.get(name)
 
 

--- a/tests/test_stability.py
+++ b/tests/test_stability.py
@@ -42,6 +42,11 @@ def test_stability_decorator_attaches_public_api_status():
     assert status.notes == "example"
 
 
+def test_get_public_api_status_returns_none_for_non_string_names():
+    assert get_public_api_status(["KalmanFilter"]) is None
+    assert get_public_api_status({"api": "KalmanFilter"}) is None
+
+
 def test_registered_public_api_status_rows_have_valid_levels():
     rows = list(iter_public_api_status())
 


### PR DESCRIPTION
## Summary
- make `get_public_api_status()` return `None` for non-string lookup names before dictionary access
- avoid `TypeError` for unhashable values such as lists or dictionaries
- add regression coverage for non-string lookup input

## Bug fixed
`get_public_api_status()` behaves like a metadata lookup where unknown names return `None`. Passing an unhashable non-string value such as `["KalmanFilter"]` previously reached `_PUBLIC_API_STATUS.get(...)` and raised `TypeError`; the helper now treats non-string names as unknown lookup keys.

## Validation
- Inspected the branch diff against current `main` (`ahead_by=2`, `behind_by=0`).
- Local full test execution was not possible because this environment cannot resolve `github.com` for cloning/installing the repository.