### PR TITLE
Treat flat empty measurements as no-op updates

### DIFF
--- a/src/pyrecest/evaluation/perform_predict_update_cycles.py
+++ b/src/pyrecest/evaluation/perform_predict_update_cycles.py
@@ -128,13 +128,14 @@ def perform_predict_update_cycles(
             raise NotImplementedError("Cumulative updates not implemented yet.")
 
         all_meas_curr_time_step = atleast_2d(array(measurements[t]))
-        if _is_empty_measurement_set(all_meas_curr_time_step):
+        measurement_set_empty = _is_empty_measurement_set(all_meas_curr_time_step)
+        if measurement_set_empty:
             n_updates = 0
         else:
             n_updates = all_meas_curr_time_step.shape[0]
 
         if scenario_config.get("eot", False):
-            if n_updates > 0:
+            if not measurement_set_empty or all_meas_curr_time_step.shape[0] == 0:
                 meas_matrix = scenario_config.get("eot_meas_matrix")
                 filter_obj.update(
                     all_meas_curr_time_step.T, meas_matrix, meas_noise_for_filter

--- a/src/pyrecest/evaluation/perform_predict_update_cycles.py
+++ b/src/pyrecest/evaluation/perform_predict_update_cycles.py
@@ -49,6 +49,41 @@ def _last_stored_estimate(all_estimates):
         return all_estimates[-1]
 
 
+def _shape_has_zero_dimension(shape) -> bool:
+    """Return whether a shape-like object contains a zero dimension."""
+    try:
+        shape_iter = iter(shape)
+    except TypeError:
+        return False
+
+    for dimension in shape_iter:
+        try:
+            if int(dimension) == 0:
+                return True
+        except (TypeError, ValueError, OverflowError):
+            return False
+    return False
+
+
+def _is_empty_measurement_set(measurement) -> bool:
+    """Return whether ``measurement`` represents a zero-observation set."""
+    shape = getattr(measurement, "shape", None)
+    if shape is not None and _shape_has_zero_dimension(shape):
+        return True
+
+    size = getattr(measurement, "size", None)
+    if size is not None and not callable(size):
+        try:
+            return int(size) == 0
+        except (TypeError, ValueError, OverflowError):
+            pass
+
+    try:
+        return len(measurement) == 0
+    except TypeError:
+        return False
+
+
 # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-positional-arguments
 def perform_predict_update_cycles(
     scenario_config,
@@ -93,13 +128,17 @@ def perform_predict_update_cycles(
             raise NotImplementedError("Cumulative updates not implemented yet.")
 
         all_meas_curr_time_step = atleast_2d(array(measurements[t]))
-        n_updates = all_meas_curr_time_step.shape[0]
+        if _is_empty_measurement_set(all_meas_curr_time_step):
+            n_updates = 0
+        else:
+            n_updates = all_meas_curr_time_step.shape[0]
 
         if scenario_config.get("eot", False):
-            meas_matrix = scenario_config.get("eot_meas_matrix")
-            filter_obj.update(
-                all_meas_curr_time_step.T, meas_matrix, meas_noise_for_filter
-            )
+            if n_updates > 0:
+                meas_matrix = scenario_config.get("eot_meas_matrix")
+                filter_obj.update(
+                    all_meas_curr_time_step.T, meas_matrix, meas_noise_for_filter
+                )
         else:
             for m in range(n_updates):
                 curr_meas = all_meas_curr_time_step[m, :]

--- a/tests/evaluation/test_flat_empty_measurements.py
+++ b/tests/evaluation/test_flat_empty_measurements.py
@@ -1,0 +1,48 @@
+import numpy as np
+import numpy.testing as npt
+
+from pyrecest.backend import array
+from pyrecest.evaluation import perform_predict_update_cycles
+from pyrecest.evaluation.configure_for_filter import register_filter_factory
+
+
+class _NoUpdateFilter:
+    @property
+    def filter_state(self):
+        return self
+
+    def get_point_estimate(self):
+        return array([0.0])
+
+
+def _no_update_filter_factory(_filter_config, _scenario_config, _precalculated_params):
+    filter_obj = _NoUpdateFilter()
+
+    def prediction_routine():
+        return None
+
+    return filter_obj, prediction_routine, None, None
+
+
+def test_flat_empty_measurement_array_is_zero_updates():
+    filter_name = "flat_empty_measurement_zero_update_regression"
+    register_filter_factory(filter_name, _no_update_filter_factory)
+    scenario_config = {
+        "n_timesteps": 1,
+        "n_meas_at_individual_time_step": [0],
+        "apply_sys_noise_times": [False],
+        "mtt": False,
+        "eot": False,
+    }
+    groundtruth = np.array([[0.0]])
+    measurements = np.empty(1, dtype=object)
+    measurements[0] = np.array([])
+
+    _, _, last_estimate, _ = perform_predict_update_cycles(
+        scenario_config,
+        {"name": filter_name, "parameter": None},
+        groundtruth,
+        measurements,
+    )
+
+    npt.assert_allclose(last_estimate, array([0.0]))


### PR DESCRIPTION
## Summary
- detect zero-observation measurement containers after backend normalization in `perform_predict_update_cycles`
- skip non-EOT update calls for flat empty measurements such as `np.array([])` instead of treating them as one zero-dimensional update
- keep existing EOT empty-set behavior for two-dimensional empty measurement arrays
- add a regression test with a filter that intentionally has no update method, proving the empty measurement is not dispatched

## Bug fixed
`evaluate_for_file()` can mark a flat empty measurement array as zero measurements, but `perform_predict_update_cycles()` reshaped the same value with `atleast_2d`, yielding shape `(1, 0)`. The loop then attempted one update with an empty measurement vector. For filters that have no update to perform on an empty set, this raised instead of behaving as a no-op.

## Validation
- `python -m py_compile` on the changed source module and new regression test in a local scratch copy
- full pytest suite not run locally because the execution environment cannot resolve GitHub/package sources for a checkout/install