### PR TITLE
Reject string covariance feature control scalars

### DIFF
--- a/src/pyrecest/utils/pairwise_covariance_features.py
+++ b/src/pyrecest/utils/pairwise_covariance_features.py
@@ -186,6 +186,9 @@ def pairwise_covariance_shape_components(
 
 
 def _validate_control_scalar(value: Any, name: str, *, allow_zero: bool) -> float:
+    if isinstance(value, (str, bytes, bytearray)):
+        raise ValueError(f"{name} must be numeric")
+
     value_array = asarray(value)
     if value_array.shape != ():
         raise ValueError(f"{name} must be a scalar")
@@ -199,6 +202,8 @@ def _validate_control_scalar(value: Any, name: str, *, allow_zero: bool) -> floa
 
     if isinstance(scalar_value, bool):
         raise ValueError(f"{name} must be numeric, not boolean")
+    if isinstance(scalar_value, (str, bytes, bytearray)):
+        raise ValueError(f"{name} must be numeric")
 
     try:
         value_float = float(scalar_value)

--- a/tests/test_pairwise_covariance_features.py
+++ b/tests/test_pairwise_covariance_features.py
@@ -67,7 +67,7 @@ class TestPairwiseCovarianceFeatures(unittest.TestCase):
         means = array([[0.0], [0.0]])
         covariance = zeros((2, 2, 1))
 
-        for bad_regularization in (True, array([1.0])):
+        for bad_regularization in (True, "1.0", b"1.0", array([1.0])):
             with self.subTest(bad_regularization=bad_regularization):
                 with self.assertRaisesRegex(ValueError, "regularization"):
                     pairwise_mahalanobis_distances(
@@ -134,7 +134,7 @@ class TestPairwiseCovarianceFeatures(unittest.TestCase):
     def test_pairwise_covariance_shape_components_rejects_ambiguous_epsilon(self):
         covariances = zeros((2, 2, 1))
 
-        for bad_epsilon in (True, array([1e-6])):
+        for bad_epsilon in (True, "1e-6", b"1e-6", array([1e-6])):
             with self.subTest(bad_epsilon=bad_epsilon):
                 with self.assertRaisesRegex(ValueError, "epsilon"):
                     pairwise_covariance_shape_components(


### PR DESCRIPTION
## Summary
- reject string and byte-valued control scalars before float coercion in pairwise covariance feature helpers
- keep the existing boolean, nonscalar, negative, and zero checks unchanged
- extend the existing pairwise covariance feature tests for these inputs

## Validation
- Inspected the final `main..fix3650` diff
- Not run: full local test suite in this connector session