### PR TITLE
Normalize manifold names for axis labels

### DIFF
--- a/src/pyrecest/evaluation/get_axis_label.py
+++ b/src/pyrecest/evaluation/get_axis_label.py
@@ -1,36 +1,40 @@
 def get_axis_label(manifold_name):
-    if "circleSymm" in manifold_name:
+    if not isinstance(manifold_name, str) or not manifold_name.strip():
+        raise ValueError("Mode not recognized")
+
+    normalized_name = manifold_name.strip().lower()
+
+    if "circlesymm" in normalized_name:
         error_label = "Error in radian"
 
-    elif "circle" in manifold_name or "hypertorus" in manifold_name:
+    elif "circle" in normalized_name or "hypertorus" in normalized_name:
         error_label = "Error in radian"
 
-    elif "hypersphereSymmetric" in manifold_name:
+    elif (
+        "hyperspheresymmetric" in normalized_name
+        or "hypersphere_symmetric" in normalized_name
+    ):
         error_label = "Angular error in radian"
 
-    elif "hypersphere" in manifold_name:
+    elif "hypersphere" in normalized_name:
         error_label = "Error (orthodromic distance) in radian"
 
-    elif "se2bounded" in manifold_name:
+    elif "se2bounded" in normalized_name:
         error_label = "Error in radian"
 
-    elif "se2" in manifold_name or "se2linear" in manifold_name:
+    elif "se2" in normalized_name or "se2linear" in normalized_name:
         error_label = "Error in meters"
 
-    elif "se3bounded" in manifold_name:
+    elif "se3bounded" in normalized_name:
         error_label = "Error in radian"
 
-    elif "se3" in manifold_name or "se3linear" in manifold_name:
+    elif "se3" in normalized_name or "se3linear" in normalized_name:
         error_label = "Error in meters"
 
-    elif (
-        "euclidean" in manifold_name or "Euclidean" in manifold_name
-    ) and "MTT" not in manifold_name:
+    elif "euclidean" in normalized_name and "mtt" not in normalized_name:
         error_label = "Error in meters"
 
-    elif (
-        "euclidean" in manifold_name or "Euclidean" in manifold_name
-    ) and "MTT" in manifold_name:
+    elif "euclidean" in normalized_name and "mtt" in normalized_name:
         error_label = "OSPA error in meters"
 
     else:

--- a/tests/test_axis_labels.py
+++ b/tests/test_axis_labels.py
@@ -26,3 +26,18 @@ def test_specific_manifolds_are_not_shadowed_by_generic_substrings(
 )
 def test_generic_manifold_axis_labels_are_preserved(manifold_name, expected_label):
     assert get_axis_label(manifold_name) == expected_label
+
+
+@pytest.mark.parametrize(
+    ("manifold_name", "expected_label"),
+    [
+        (" Circle ", "Error in radian"),
+        ("HYPERSPHERESYMMETRIC", "Angular error in radian"),
+        ("SE2", "Error in meters"),
+        ("EuclideanMTT", "OSPA error in meters"),
+    ],
+)
+def test_axis_labels_normalize_supported_manifold_names(
+    manifold_name, expected_label
+):
+    assert get_axis_label(manifold_name) == expected_label

--- a/tests/test_axis_labels.py
+++ b/tests/test_axis_labels.py
@@ -41,3 +41,9 @@ def test_axis_labels_normalize_supported_manifold_names(
     manifold_name, expected_label
 ):
     assert get_axis_label(manifold_name) == expected_label
+
+
+@pytest.mark.parametrize("manifold_name", ["", "   ", None, 42])
+def test_axis_labels_reject_invalid_manifold_names(manifold_name):
+    with pytest.raises(ValueError, match="Mode not recognized"):
+        get_axis_label(manifold_name)


### PR DESCRIPTION
## Summary
- Normalize `get_axis_label` inputs with `strip().lower()` before matching supported manifold names.
- Preserve the existing specific-before-generic matching order so bounded/symmetric manifolds are not shadowed.
- Add regression coverage for whitespace-padded and mixed-case supported names.

## Validation
- Ran a focused local syntax/behavior check for the patched `get_axis_label` cases.
- Inspected branch diff against `main`: two commits, two changed files, no unrelated changes.
- Full repository test suite not run locally because this sandbox cannot resolve `github.com` for cloning/installing the full repository.