### PR TITLE
Fix raw PyTorch diag backend contract

### DIFF
--- a/src/pyrecest/stability.py
+++ b/src/pyrecest/stability.py
@@ -19,7 +19,37 @@ from pyrecest.backend_support._pytorch_minmax_device_contract import (
     patch_pytorch_minmax_device_contract as _patch_pytorch_minmax_device_contract,
 )
 
+
+def _patch_pytorch_diag_numpy_contract() -> None:
+    """Patch raw/public PyTorch ``diag`` to accept NumPy-style inputs."""
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    original_diag = getattr(raw_pytorch, "diag", None)
+    if original_diag is None:
+        return
+    if getattr(original_diag, "_pyrecest_numpy_contract", False):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.diag = original_diag
+        return
+
+    def diag(v, k=0):
+        return torch.diag(raw_pytorch.array(v), diagonal=k)
+
+    diag.__name__ = getattr(original_diag, "__name__", "diag")
+    diag.__doc__ = getattr(original_diag, "__doc__", None)
+    diag._pyrecest_numpy_contract = True
+    raw_pytorch.diag = diag
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.diag = diag
+
+
 _patch_pytorch_allclose_device_contract()
+_patch_pytorch_diag_numpy_contract()
 _patch_pytorch_dot_outer_device_contract()
 _patch_pytorch_matmul_device_contract()
 _patch_pytorch_minmax_device_contract()

--- a/tests/test_backend_tools.py
+++ b/tests/test_backend_tools.py
@@ -1,4 +1,7 @@
+import importlib.util
 import os
+import subprocess
+import sys
 
 import pyrecest
 import pytest
@@ -47,3 +50,35 @@ def test_warn_if_backend_env_changed(monkeypatch):
 
     monkeypatch.setenv("PYRECEST_BACKEND", active)
     pyrecest.warn_if_backend_env_changed()
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_diag_accepts_arraylike_when_public_backend_is_numpy():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "numpy"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import torch
+import pyrecest
+import pyrecest._backend.pytorch as raw_pytorch
+
+result = raw_pytorch.diag([1, 2, 3], k=1)
+expected = torch.diag(torch.tensor([1, 2, 3]), diagonal=1)
+assert torch.equal(result, expected)
+"""
+    subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        check=True,
+        env=env,
+        text=True,
+    )


### PR DESCRIPTION
## Summary
- Patch raw `pyrecest._backend.pytorch.diag` even when the active public backend is not PyTorch.
- Keep the public PyTorch facade synchronized when PyTorch is the active backend.
- Add regression coverage showing raw PyTorch `diag` accepts array-like input and NumPy-style `k=` under the default NumPy public backend.

## Bug fixed
Importing PyRecEst with `PYRECEST_BACKEND=numpy` left the raw PyTorch backend's `diag` helper as `torch.diag`. That raw helper rejected NumPy-style usage such as `raw_pytorch.diag([1, 2, 3], k=1)`, even though PyRecEst's backend compatibility layer should normalize array-like inputs and expose NumPy-style arguments consistently.

## Validation
- Syntax-checked the patched source and updated test module locally.
- Verified the minimal old behavior (`torch.diag([1, 2, 3], ...)`) raises `TypeError` and the patched wrapper produces the expected tensor.
- Inspected the final branch diff against `main`: two commits, two modified files, branch is 2 ahead / 0 behind.
- Full repository test suite not run locally because this sandbox cannot clone/install from `github.com`.