### PR TITLE
Guard EvidenceSupport support type validation

### DIFF
--- a/src/pyrecest/diagnostics.py
+++ b/src/pyrecest/diagnostics.py
@@ -243,7 +243,10 @@ class EvidenceSupport:
     diagnostics: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        if self.support_type not in _EVIDENCE_SUPPORT_TYPES:
+        if (
+            not isinstance(self.support_type, str)
+            or self.support_type not in _EVIDENCE_SUPPORT_TYPES
+        ):
             raise ValueError(
                 f"unsupported evidence support type {self.support_type!r}; "
                 f"expected one of {sorted(_EVIDENCE_SUPPORT_TYPES)}"

--- a/tests/test_evidence_support_invalid_values.py
+++ b/tests/test_evidence_support_invalid_values.py
@@ -1,0 +1,10 @@
+import pytest
+
+from pyrecest.diagnostics import EvidenceSupport
+
+
+def test_evidence_support_rejects_list_value() -> None:
+    bad_value = list(("unknown",))
+
+    with pytest.raises(ValueError, match="unsupported evidence support type"):
+        EvidenceSupport(bad_value)


### PR DESCRIPTION
## Summary
- Validate `EvidenceSupport.support_type` is a string before checking membership in the allowed support-type set.
- Convert unhashable invalid values such as lists into the documented `ValueError` path instead of leaking `TypeError`.
- Add a focused regression test for list-valued evidence support input.

## Validation
- Inspected the final `main..chatgpt-evidence-support-validation-fix` diff: 2 files changed, +14/-1.
- Local full test execution was not possible in this sandbox because direct GitHub cloning is unavailable here; the added test exercises the previously crashing path directly.