### PR TITLE
Adjust PyTorch array-like helper contract

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract/__init__.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract/__init__.py
@@ -38,6 +38,7 @@ def patch_pytorch_dtype_promotion_contract() -> None:
     _patch_pytorch_binary_device_contract(raw_pytorch, backend, torch)
     _patch_pytorch_equality_device_contract(raw_pytorch, backend, torch)
     _patch_pytorch_linspace_integer_dtype_contract(raw_pytorch, backend, torch)
+    _patch_pytorch_arraylike_helper_contract(raw_pytorch, backend, torch)
 
 
 def _pytorch_numpy_index_array(index, numpy_module, torch_module):
@@ -310,6 +311,92 @@ def _patch_pytorch_linspace_integer_dtype_contract(raw_pytorch, backend, torch) 
     raw_pytorch.linspace = linspace
     if getattr(backend, "__backend_name__", None) == "pytorch":
         backend.linspace = linspace
+
+
+def _arraylike_tensor(value, raw_pytorch, torch):
+    """Return array-like helper input as a PyTorch tensor."""
+    if torch.is_tensor(value):
+        return value
+    return raw_pytorch.array(value)
+
+
+def _wrap_arraylike_unary_helper(original_helper, raw_pytorch, torch):
+    """Normalize NumPy-style array-like inputs before tensor-only helpers."""
+    if getattr(original_helper, "_pyrecest_arraylike_contract", False):
+        return original_helper
+
+    def unary_helper(input, *args, **kwargs):  # pylint: disable=redefined-builtin
+        return original_helper(
+            _arraylike_tensor(input, raw_pytorch, torch),
+            *args,
+            **kwargs,
+        )
+
+    unary_helper.__name__ = getattr(original_helper, "__name__", "unary_helper")
+    unary_helper.__doc__ = getattr(original_helper, "__doc__", None)
+    unary_helper._pyrecest_arraylike_contract = True
+    return unary_helper
+
+
+def _wrap_argsort_arraylike_helper(original_argsort, raw_pytorch, torch):
+    """Normalize NumPy-style array-like inputs before PyTorch argsort."""
+    if getattr(original_argsort, "_pyrecest_arraylike_contract", False):
+        return original_argsort
+
+    def argsort(input, axis=-1, descending=False, stable=False, *, dim=None):  # pylint: disable=redefined-builtin
+        if dim is not None:
+            if axis != -1 and axis != dim:
+                raise TypeError("argsort() got both 'axis' and 'dim'")
+            axis = dim
+        return original_argsort(
+            _arraylike_tensor(input, raw_pytorch, torch),
+            dim=axis,
+            descending=descending,
+            stable=stable,
+        )
+
+    argsort.__name__ = getattr(original_argsort, "__name__", "argsort")
+    argsort.__doc__ = getattr(original_argsort, "__doc__", None)
+    argsort._pyrecest_arraylike_contract = True
+    return argsort
+
+
+def _patch_pytorch_arraylike_helper_contract(raw_pytorch, backend, torch) -> None:
+    """Make tensor-like PyTorch helpers accept NumPy-style array-like inputs."""
+    helper_names = (
+        "empty_like",
+        "ones_like",
+        "zeros_like",
+        "full_like",
+        "isfinite",
+        "isinf",
+        "isnan",
+        "isreal",
+    )
+    all_helper_names = (*helper_names, "argsort")
+    if all(
+        getattr(getattr(raw_pytorch, helper_name, None), "_pyrecest_arraylike_contract", False)
+        for helper_name in all_helper_names
+    ):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            for helper_name in all_helper_names:
+                setattr(backend, helper_name, getattr(raw_pytorch, helper_name))
+        return
+
+    for helper_name in helper_names:
+        wrapped_helper = _wrap_arraylike_unary_helper(
+            getattr(raw_pytorch, helper_name),
+            raw_pytorch,
+            torch,
+        )
+        setattr(raw_pytorch, helper_name, wrapped_helper)
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            setattr(backend, helper_name, wrapped_helper)
+
+    wrapped_argsort = _wrap_argsort_arraylike_helper(raw_pytorch.argsort, raw_pytorch, torch)
+    raw_pytorch.argsort = wrapped_argsort
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.argsort = wrapped_argsort
 
 
 __all__ = ["patch_pytorch_dtype_promotion_contract"]

--- a/tests/backend_support/test_pytorch_arraylike_helpers_contract.py
+++ b/tests/backend_support/test_pytorch_arraylike_helpers_contract.py
@@ -1,0 +1,93 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _backend_test_env(backend_name):
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = backend_name
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    return env
+
+
+@pytest.mark.backend_portable
+def test_pytorch_arraylike_helpers_accept_numpy_style_inputs():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import numpy as np
+import torch
+
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_backend
+
+assert getattr(backend, "__backend_name__", None) == "pytorch"
+
+for candidate in (backend, raw_backend):
+    ones = candidate.ones_like([1.0, 2.0])
+    assert torch.is_tensor(ones)
+    assert candidate.to_numpy(ones).tolist() == [1.0, 1.0]
+
+    zeros = candidate.zeros_like(np.array([1, 2], dtype=np.int64))
+    assert torch.is_tensor(zeros)
+    assert tuple(zeros.shape) == (2,)
+    assert zeros.dtype == candidate.int64
+    assert candidate.to_numpy(zeros).tolist() == [0, 0]
+
+    full = candidate.full_like([1, 2], 7)
+    assert torch.is_tensor(full)
+    assert candidate.to_numpy(full).tolist() == [7, 7]
+
+    empty = candidate.empty_like([1.0, 2.0])
+    assert torch.is_tensor(empty)
+    assert tuple(empty.shape) == (2,)
+
+    order = candidate.argsort([3.0, 1.0, 2.0], axis=0)
+    assert torch.is_tensor(order)
+    assert candidate.to_numpy(order).tolist() == [1, 2, 0]
+
+    assert candidate.to_numpy(candidate.isfinite([1.0, float("inf"), float("nan")])).tolist() == [True, False, False]
+    assert candidate.to_numpy(candidate.isinf([1.0, float("inf")])).tolist() == [False, True]
+    assert candidate.to_numpy(candidate.isnan([1.0, float("nan")])).tolist() == [False, True]
+    assert candidate.to_numpy(candidate.isreal([1.0, 2.0])).tolist() == [True, True]
+"""
+    subprocess.run(
+        [sys.executable, "-c", code], check=True, env=_backend_test_env("pytorch")
+    )
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_arraylike_helpers_work_under_numpy_public_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import torch
+
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_backend
+
+assert getattr(backend, "__backend_name__", None) == "numpy"
+
+ones = raw_backend.ones_like([1.0, 2.0])
+assert torch.is_tensor(ones)
+assert raw_backend.to_numpy(ones).tolist() == [1.0, 1.0]
+
+order = raw_backend.argsort([3.0, 1.0, 2.0], axis=0)
+assert torch.is_tensor(order)
+assert raw_backend.to_numpy(order).tolist() == [1, 2, 0]
+
+assert raw_backend.to_numpy(raw_backend.isfinite([1.0, float("inf")])).tolist() == [True, False]
+"""
+    subprocess.run(
+        [sys.executable, "-c", code], check=True, env=_backend_test_env("numpy")
+    )


### PR DESCRIPTION
## Summary
- normalize NumPy-style array-like inputs before PyTorch tensor-only helpers such as `ones_like`, `zeros_like`, `full_like`, `empty_like`, and finiteness predicates
- add a NumPy-style `axis` alias for the PyTorch `argsort` wrapper while keeping `dim` support
- keep raw `pyrecest._backend.pytorch` helpers and the active public PyTorch backend facade synchronized
- add backend-portable subprocess regressions for public PyTorch and raw PyTorch usage under the NumPy public backend

## Bug fixed
Several PyTorch backend helpers were imported directly from `torch`, so calls like `pyrecest.backend.ones_like([1.0, 2.0])` or `pyrecest.backend.argsort([3.0, 1.0, 2.0], axis=0)` failed under `PYRECEST_BACKEND=pytorch` even though the shared backend contract accepts NumPy-style array-like inputs in nearby helpers.

## Validation
- Reproduced the tensor-only TypeError locally against the installed PyRecEst package with Python 3.13, NumPy 2.3.5, and Torch 2.10.0.
- Verified the wrapper behavior locally with equivalent PyTorch helpers for `empty_like`, `ones_like`, `zeros_like`, `full_like`, `argsort`, `isfinite`, `isinf`, `isnan`, and `isreal`.
- Confirmed this branch is current against `main` and changes only the intended backend-support module plus the new regression test.