### PR TITLE
Fix PyTorch conj array-like contract

### DIFF
--- a/src/pyrecest/backend_tools.py
+++ b/src/pyrecest/backend_tools.py
@@ -180,6 +180,35 @@ def _patch_pytorch_round_numpy_contract() -> None:
     pytorch_backend.round = round
 
 
+def _patch_raw_pytorch_conj_numpy_contract() -> None:
+    """Make raw and active public PyTorch conj accept array-like inputs."""
+
+    try:
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import torch as _torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    original_conj = getattr(pytorch_backend, "conj", None)
+    if original_conj is None:
+        return
+    if getattr(original_conj, "_pyrecest_numpy_contract", False):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.conj = original_conj
+        return
+
+    def conj(a):
+        return _torch.conj(pytorch_backend.array(a))
+
+    conj.__name__ = getattr(original_conj, "__name__", "conj")
+    conj.__doc__ = getattr(original_conj, "__doc__", None)
+    conj._pyrecest_numpy_contract = True
+    pytorch_backend.conj = conj
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.conj = conj
+
+
 def _patch_pytorch_special_numpy_contract() -> None:
     """Make PyTorch special functions accept NumPy-style array-like inputs."""
 
@@ -416,6 +445,7 @@ _patch_pytorch_assignment_scalar_tensor_indices()
 _patch_pytorch_diag_numpy_contract()
 _patch_pytorch_broadcast_arrays_numpy_contract()
 _patch_pytorch_round_numpy_contract()
+_patch_raw_pytorch_conj_numpy_contract()
 _patch_pytorch_special_numpy_contract()
 _patch_pytorch_stack_helpers_numpy_contract()
 _patch_raw_pytorch_comparison_numpy_contract()

--- a/tests/test_pytorch_conj_array_like_contract.py
+++ b/tests/test_pytorch_conj_array_like_contract.py
@@ -1,0 +1,31 @@
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+def test_public_pytorch_conj_accepts_array_like_inputs():
+    pytest.importorskip("torch")
+
+    code = """
+import pyrecest.backend as backend
+
+values = backend.conj([1.0 + 2.0j, 3.0 - 4.0j])
+converted = backend.to_numpy(values)
+assert converted.tolist() == [1.0 - 2.0j, 3.0 + 4.0j]
+"""
+    result = run_backend_code("pytorch", code)
+    assert result.returncode == 0, result.stderr
+
+
+def test_raw_pytorch_conj_accepts_array_like_under_default_backend():
+    pytest.importorskip("torch")
+
+    code = """
+import pyrecest
+import pyrecest._backend.pytorch as raw_pytorch
+
+result = raw_pytorch.conj([1.0 + 2.0j, 3.0 - 4.0j])
+assert raw_pytorch.to_numpy(result).tolist() == [1.0 - 2.0j, 3.0 + 4.0j]
+"""
+    result = run_backend_code("numpy", code)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- wrap raw and active public PyTorch `conj` so it normalizes NumPy-style array-like inputs through the PyTorch backend array constructor
- keep `pyrecest._backend.pytorch.conj` and `pyrecest.backend.conj` synchronized when the PyTorch backend is active
- add subprocess regressions for public PyTorch usage and raw PyTorch usage under the default NumPy backend

## Bug fixed
With `PYRECEST_BACKEND=pytorch`, `pyrecest.backend.conj([1+2j, ...])` reached `torch.conj` directly and raised `TypeError` for Python lists. NumPy/JAX accept those array-like inputs, and PyRecEst's backend helpers generally normalize NumPy-style array-like inputs.

## Validation
- `python -m py_compile /opt/pyvenv/lib/python3.13/site-packages/pyrecest/__init__.py`
- focused local smoke checks for public PyTorch `backend.conj([...])` and raw PyTorch `raw_pytorch.conj([...])` returning the expected conjugates
- connector inspection of the branch confirmed the shim and regression test are present

Full repository test execution was not possible in this sandbox because direct GitHub cloning is unavailable here.