### PR TITLE
Patch raw PyTorch comparisons across backends

### DIFF
--- a/src/pyrecest/stability.py
+++ b/src/pyrecest/stability.py
@@ -20,6 +20,69 @@ from pyrecest.backend_support._pytorch_minmax_device_contract import (
 )
 
 
+def _patch_pytorch_raw_comparison_arraylike_contract() -> None:
+    """Patch raw/public PyTorch comparisons to accept array-like operands."""
+
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+    helper_names = ("greater", "less", "logical_or")
+    if all(
+        getattr(getattr(raw_pytorch, helper_name, None), "_pyrecest_arraylike_contract", False)
+        for helper_name in helper_names
+    ):
+        if active_pytorch_backend:
+            for helper_name in helper_names:
+                setattr(backend, helper_name, getattr(raw_pytorch, helper_name))
+        return
+
+    def _preferred_pytorch_device(*values):
+        for value in values:
+            if torch.is_tensor(value) and value.device.type != "cpu":
+                return value.device
+        for value in values:
+            if torch.is_tensor(value):
+                return value.device
+        return None
+
+    def _coerce_binary_args(x, y):
+        device = _preferred_pytorch_device(x, y)
+        if not torch.is_tensor(x):
+            x = torch.as_tensor(x, device=device)
+        elif device is not None and x.device != device:
+            x = x.to(device=device)
+        if not torch.is_tensor(y):
+            y = torch.as_tensor(y, device=device)
+        elif device is not None and y.device != device:
+            y = y.to(device=device)
+        return x, y
+
+    def _wrap_comparison(helper_name, torch_func):
+        def comparison(x, y, **kwargs):
+            x, y = _coerce_binary_args(x, y)
+            return torch_func(x, y, **kwargs)
+
+        comparison.__name__ = helper_name
+        comparison.__doc__ = getattr(torch_func, "__doc__", None)
+        comparison._pyrecest_arraylike_contract = True
+        return comparison
+
+    helpers = {
+        "greater": _wrap_comparison("greater", torch.greater),
+        "less": _wrap_comparison("less", torch.less),
+        "logical_or": _wrap_comparison("logical_or", torch.logical_or),
+    }
+    for helper_name, helper in helpers.items():
+        setattr(raw_pytorch, helper_name, helper)
+        if active_pytorch_backend:
+            setattr(backend, helper_name, helper)
+
+
 def _patch_pytorch_diag_numpy_contract() -> None:
     """Patch raw/public PyTorch ``diag`` to accept NumPy-style inputs."""
     try:
@@ -50,6 +113,7 @@ def _patch_pytorch_diag_numpy_contract() -> None:
 
 _patch_pytorch_allclose_device_contract()
 _patch_pytorch_diag_numpy_contract()
+_patch_pytorch_raw_comparison_arraylike_contract()
 _patch_pytorch_dot_outer_device_contract()
 _patch_pytorch_matmul_device_contract()
 _patch_pytorch_minmax_device_contract()

--- a/tests/backend_support/test_pytorch_raw_comparison_contract.py
+++ b/tests/backend_support/test_pytorch_raw_comparison_contract.py
@@ -9,25 +9,26 @@ from tests.support.backend_runner import run_backend_code
 
 
 @pytest.mark.backend_portable
-def test_raw_pytorch_comparisons_accept_numpy_style_array_like_inputs():
+@pytest.mark.parametrize("backend_name", ["numpy", "pytorch"])
+def test_raw_pytorch_comparisons_accept_numpy_style_array_like_inputs(backend_name):
     if importlib.util.find_spec("torch") is None:
         pytest.skip("PyTorch is not installed")
 
     result = run_backend_code(
-        "pytorch",
+        backend_name,
         """
 import importlib
-from pyrecest.backend import asarray, to_numpy
 
 raw_pytorch = importlib.import_module("pyrecest._backend.pytorch")
 
-greater_result = raw_pytorch.greater([1, 2, 3], asarray([0, 2, 4]))
-less_result = raw_pytorch.less(asarray([1, 2, 3]), [0, 2, 4])
-logical_result = raw_pytorch.logical_or([True, False], asarray([False, True]))
+right = raw_pytorch.asarray([0, 2, 4])
+greater_result = raw_pytorch.greater([1, 2, 3], right)
+less_result = raw_pytorch.less(right, [1, 2, 3])
+logical_result = raw_pytorch.logical_or([True, False], raw_pytorch.asarray([False, True]))
 
-assert to_numpy(greater_result).tolist() == [True, False, False]
-assert to_numpy(less_result).tolist() == [False, False, True]
-assert to_numpy(logical_result).tolist() == [True, True]
+assert raw_pytorch.to_numpy(greater_result).tolist() == [True, False, False]
+assert raw_pytorch.to_numpy(less_result).tolist() == [True, False, False]
+assert raw_pytorch.to_numpy(logical_result).tolist() == [True, True]
 """,
     )
 


### PR DESCRIPTION
## Summary
- patch raw PyTorch `greater`, `less`, and `logical_or` during stability initialization even when the selected public backend is not PyTorch
- preserve existing-device behavior when one operand is already a non-CPU tensor
- extend the raw PyTorch comparison regression test to run under both `numpy` and `pytorch` public backend modes

## Testing
- Not run locally; changes were validated by code inspection through the GitHub connector.
