### PR TITLE
Validate Gaussian marginalize_out dimensions

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
@@ -323,7 +323,13 @@ class GaussianDistribution(AbstractLinearDistribution):
             )
 
         dimensions = [int(dim) for dim in dimensions]
+        if len(set(dimensions)) != len(dimensions):
+            raise ValueError("dimensions must not contain duplicate indices.")
+
         remaining_dims = [i for i in range(self.dim) if i not in dimensions]
+        if not remaining_dims:
+            raise ValueError("marginalize_out must leave at least one dimension.")
+
         remaining_indices = pyrecest.backend.asarray(remaining_dims)
         new_mu = self.mu[remaining_indices]
         new_C = self.C[remaining_indices][

--- a/tests/distributions/test_gaussian_marginalize_out_validation.py
+++ b/tests/distributions/test_gaussian_marginalize_out_validation.py
@@ -1,0 +1,24 @@
+import unittest
+
+from pyrecest.backend import array
+from pyrecest.distributions import GaussianDistribution
+
+
+class GaussianMarginalizeOutValidationTest(unittest.TestCase):
+    def setUp(self):
+        self.distribution = GaussianDistribution(
+            array([1.0, 2.0]),
+            array([[1.1, 0.4], [0.4, 0.9]]),
+        )
+
+    def test_rejects_duplicate_dimensions(self):
+        with self.assertRaisesRegex(ValueError, "duplicate"):
+            self.distribution.marginalize_out([0, 0])
+
+    def test_rejects_empty_marginal(self):
+        with self.assertRaisesRegex(ValueError, "leave at least one dimension"):
+            self.distribution.marginalize_out([0, 1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Reject duplicate dimensions in `GaussianDistribution.marginalize_out`.
- Reject requests that remove every Gaussian dimension.
- Add regression coverage for both invalid cases.

## Testing
- Not run locally in this environment.
