### PR TITLE
Reject text Gaussian sample counts

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
@@ -61,7 +61,10 @@ def _validate_positive_sample_count(n) -> int:
         raise ValueError(message)
 
     count = count_array.item()
-    if isinstance(count, (bool, np.bool_)):
+    if isinstance(
+        count,
+        (bool, np.bool_, str, bytes, bytearray, np.str_, np.bytes_),
+    ):
         raise ValueError(message)
 
     try:

--- a/tests/distributions/test_gaussian_distribution_sample_validation.py
+++ b/tests/distributions/test_gaussian_distribution_sample_validation.py
@@ -1,0 +1,13 @@
+import numpy as np
+import pytest
+
+from pyrecest.backend import array, eye
+from pyrecest.distributions.nonperiodic.gaussian_distribution import GaussianDistribution
+
+
+@pytest.mark.parametrize("count", ["3", b"3", np.str_("3"), np.bytes_(b"3")])
+def test_gaussian_sample_rejects_text_count(count):
+    gaussian = GaussianDistribution(array([0.0]), eye(1))
+
+    with pytest.raises(ValueError, match="n must be a positive integer"):
+        gaussian.sample(count)


### PR DESCRIPTION
## Summary
- Reject string/bytes scalar values before coercing Gaussian sample counts with `int()`/`float()`.
- Keep existing positive integral numeric count handling unchanged.
- Add regression coverage for string-like count inputs.

## Bug fixed
`GaussianDistribution.sample("3")` and bytes/string scalar variants could be accepted because `_validate_positive_sample_count()` only rejected bool before coercing with `int()`/`float()`. These text counts now raise the documented `ValueError` instead.

## Validation
- Syntax-compiled patched source and regression test in local scratch copies:
  - `python -m py_compile /tmp/gaussian_distribution.py /tmp/test_gaussian_distribution_sample_validation.py`
- Inspected `main..fix-gaussian-sample-text-count`: 2 files changed, +17/-1.
- Not run: full test suite; this environment cannot resolve `github.com` for cloning/installing the repository.