### PR TITLE
Reject text hypertoroidal sample counts

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_uniform_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_uniform_distribution.py
@@ -28,6 +28,8 @@ def _validate_positive_sample_count(n) -> int:
     count = count_array.item()
     if isinstance(count, (bool, np.bool_)):
         raise ValueError("n must be an integer, not a boolean")
+    if isinstance(count, (str, bytes)):
+        raise ValueError("n must be an integer, not text")
 
     try:
         count_int = int(count)

--- a/tests/distributions/test_hypertoroidal_uniform_distribution.py
+++ b/tests/distributions/test_hypertoroidal_uniform_distribution.py
@@ -10,6 +10,13 @@ from pyrecest.distributions.hypertorus.hypertoroidal_uniform_distribution import
 from pyrecest.exceptions import ShapeError
 
 
+def test_sample_rejects_text_count():
+    dist = HypertoroidalUniformDistribution(2)
+
+    with pytest.raises(ValueError, match="not text"):
+        dist.sample("3")
+
+
 def test_pdf_validates_dimension_mismatch():
     dist = HypertoroidalUniformDistribution(2)
 


### PR DESCRIPTION
## Summary
- reject string and byte-valued sample counts in `HypertoroidalUniformDistribution.sample`
- keep the existing scalar, integral, finite, and positive-count checks unchanged
- add a focused regression test for the text-count path

## Bug fixed
`HypertoroidalUniformDistribution.sample("3")` was accepted because `_validate_positive_sample_count` coerced scalar text through `int()`/`float()`. The public type contract accepts integer sample counts, so text inputs should be rejected before numeric coercion.

## Validation
- Inspected `main..fix-hypertoroidal-sample-count`: 2 files changed, +9/-0.
- Not run locally: this environment cannot resolve `github.com` for cloning the repository, so I could not execute the project test suite here.