### PR TITLE
Reject text mixture sample counts

### DIFF
--- a/src/pyrecest/distributions/abstract_mixture.py
+++ b/src/pyrecest/distributions/abstract_mixture.py
@@ -34,7 +34,10 @@ def _validate_positive_sample_count(n) -> int:
         raise ValueError(message)
 
     count = count_array.item()
-    if isinstance(count, (bool, np.bool_)):
+    if isinstance(
+        count,
+        (bool, np.bool_, str, bytes, bytearray, np.str_, np.bytes_),
+    ):
         raise ValueError(message)
 
     try:

--- a/tests/distributions/test_abstract_mixture_sample_validation.py
+++ b/tests/distributions/test_abstract_mixture_sample_validation.py
@@ -1,0 +1,15 @@
+import numpy as np
+import pytest
+
+from pyrecest.backend import array, eye
+from pyrecest.distributions.hypertorus.hypertoroidal_mixture import HypertoroidalMixture
+from pyrecest.distributions.hypertorus.toroidal_wrapped_normal_distribution import ToroidalWrappedNormalDistribution
+
+
+@pytest.mark.parametrize("count", ["3", np.str_("3")])
+def test_mixture_sample_rejects_text_count(count):
+    vmf = ToroidalWrappedNormalDistribution(array([1.0, 0.0]), eye(2))
+    mixture = HypertoroidalMixture([vmf, vmf.shift(array([1.0, 1.0]))], array([0.5, 0.5]))
+
+    with pytest.raises(ValueError, match="n must be a positive integer"):
+        mixture.sample(count)


### PR DESCRIPTION
## Summary
- tighten AbstractMixture sample-count validation so textual scalar counts are rejected instead of being silently coerced
- add a regression test covering string and NumPy string sample counts

## Testing
- Not run locally; repository was inspected and modified through the GitHub connector, and the execution sandbox cannot resolve github.com for cloning.