### PR TITLE
Reject text hypertoroidal uniform sample counts

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_uniform_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_uniform_distribution.py
@@ -28,6 +28,8 @@ def _validate_positive_sample_count(n) -> int:
     count = count_array.item()
     if isinstance(count, (bool, np.bool_)):
         raise ValueError("n must be an integer, not a boolean")
+    if isinstance(count, (str, np.str_)):
+        raise ValueError("n must be an integer, not text")
 
     try:
         count_int = int(count)
@@ -126,7 +128,7 @@ class HypertoroidalUniformDistribution(
     def mean_direction(self):
         """
         Returns the mean of the circular uniform distribution.
-        Since it doesn't have a unique mean, this function always raises a ValueError.
+        Since it does not have a unique mean, this function always raises a ValueError.
 
         :raises ValueError: Circular uniform distribution does not have a unique mean
         """

--- a/tests/distributions/test_hypertoroidal_uniform_distribution.py
+++ b/tests/distributions/test_hypertoroidal_uniform_distribution.py
@@ -55,6 +55,13 @@ def test_integrate_accepts_scalar_boundaries_for_one_dimension():
     assert dist.integrate((array(0.0), 2.0 * pi)) == pytest.approx(1.0)
 
 
+def test_sample_rejects_text_count():
+    dist = HypertoroidalUniformDistribution(2)
+
+    with pytest.raises(ValueError, match="integer"):
+        dist.sample("3")
+
+
 def test_validation_survives_optimized_python():
     env = os.environ.copy()
     src_path = os.path.abspath("src")


### PR DESCRIPTION
## Summary
- reject textual sample counts in `HypertoroidalUniformDistribution.sample`
- add a regression test that `sample("3")` raises instead of silently drawing three samples

## Rationale
`np.asarray("3").item()` produces a scalar string and the previous validation accepted it via `int()`/`float()` conversion. That is inconsistent with the stricter sample-count validation used elsewhere and lets an invalid API type pass silently.

## Testing
- Not run locally: the execution environment cannot clone GitHub directly, so I used the GitHub connector for the patch.