### PR TITLE
Fix Gaussian conversion error import

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/conversion/__init__.py
+++ b/src/pyrecest/distributions/nonperiodic/conversion/__init__.py
@@ -1,0 +1,3 @@
+from pyrecest.distributions.conversion import ConversionError
+
+__all__ = ["ConversionError"]


### PR DESCRIPTION
## Summary
- add a nonperiodic conversion shim so `GaussianDistribution.from_distribution()` can resolve its existing `.conversion` import
- re-export the canonical `ConversionError` from `pyrecest.distributions.conversion`

## Rationale
`GaussianDistribution.from_distribution()` currently imports `ConversionError` via `from .conversion import ConversionError`, but no `pyrecest.distributions.nonperiodic.conversion` module exists on `main`. This can raise `ModuleNotFoundError` before the intended conversion or conversion-error handling runs.

## Tests
- Not run locally; the execution sandbox cannot clone GitHub.
- Existing `tests/distributions/test_gaussian_conversion_contract.py` covers the affected conversion-error path.