### PR TITLE
Validate evidence mode input type

### DIFF
--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -178,8 +178,10 @@ def resolve_evidence_computation_mode(
         return EvidenceComputationMode.from_return_smoothed(
             True if return_smoothed is None else return_smoothed
         )
+    if not isinstance(mode, str):
+        raise ValueError(f"unknown evidence computation mode {mode!r}")
 
-    key = str(mode).strip().lower().replace("-", "_")
+    key = mode.strip().lower().replace("-", "_")
     if key in {"full", "full_smoothing", "smoothed", "smoothing"}:
         return _require_return_smoothed_agreement(
             EvidenceComputationMode.full_smoothing(), return_smoothed

--- a/tests/test_evidence_mode_validation.py
+++ b/tests/test_evidence_mode_validation.py
@@ -1,0 +1,19 @@
+import pytest
+
+from pyrecest.evidence import resolve_evidence_computation_mode
+
+
+class StringifyingMode:
+    def __str__(self):
+        return "evidence"
+
+
+def test_resolver_rejects_non_string_modes_before_stringification():
+    with pytest.raises(ValueError, match="unknown evidence computation mode"):
+        resolve_evidence_computation_mode(StringifyingMode())
+
+
+def test_resolver_accepts_documented_string_aliases():
+    mode = resolve_evidence_computation_mode("evidence")
+
+    assert mode.evidence_only_requested


### PR DESCRIPTION
Summary:
- Reject non-string mode values in resolve_evidence_computation_mode before alias normalization.
- Keep documented string aliases working.
- Add a focused regression test.

Validation:
- Inspected the branch diff.
- Full test suite not run in this connector session.