### PR TITLE
Validate partially wrapped pdf truncation count

### DIFF
--- a/src/pyrecest/distributions/cart_prod/partially_wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/partially_wrapped_normal_distribution.py
@@ -63,6 +63,28 @@ def _validate_positive_sample_count(n) -> int:
     return count_int
 
 
+def _validate_nonnegative_wrap_count(m) -> int:
+    count_array = np.asarray(m)
+    if count_array.ndim != 0:
+        raise ValueError("m must be a scalar integer")
+
+    count = count_array.item()
+    if isinstance(count, (bool, np.bool_)):
+        raise ValueError("m must be an integer, not a boolean")
+
+    try:
+        count_int = int(count)
+        count_float = float(count)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("m must be an integer") from exc
+
+    if not np.isfinite(count_float) or not count_float.is_integer():
+        raise ValueError("m must be a finite integer")
+    if count_int < 0:
+        raise ValueError("m must be non-negative")
+    return count_int
+
+
 def _as_2d_query_points(xs, dim: int):
     """Normalize scalar/vector/matrix query inputs to shape ``(n_eval, dim)``."""
     xs = array(xs)
@@ -140,6 +162,7 @@ class PartiallyWrappedNormalDistribution(AbstractHypercylindricalDistribution):
         self.C = C
 
     def pdf(self, xs, m: Union[int, int32, int64] = 3):
+        m = _validate_nonnegative_wrap_count(m)
         xs = _as_2d_query_points(xs, self.input_dim)
         condition = (
             arange(xs.shape[1]) < self.bound_dim


### PR DESCRIPTION
## Summary
- add explicit validation for the `m` wrapping truncation argument in `PartiallyWrappedNormalDistribution.pdf`
- reject non-scalar, boolean, non-finite, non-integral, and negative values before they reach `range`/reshape logic

## Rationale
`pdf(..., m=...)` uses `m` as a non-negative wrap truncation count. Invalid values previously failed inconsistently, e.g. through Python `range` or downstream reshaping, and boolean `m=True` was silently treated as `1`.

## Tests
Not run locally; the execution environment here cannot clone GitHub. I attempted to add a small regression test file through the GitHub connector, but the write was blocked by the connector safety layer. The source change is intentionally narrow and follows the existing validation style used for `sample(n)`.