### PR TITLE
Handle exact object observation IDs

### DIFF
--- a/src/pyrecest/utils/track_evaluation.py
+++ b/src/pyrecest/utils/track_evaluation.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from collections import Counter
 from collections.abc import Iterable, Sequence
+from decimal import Decimal
+from fractions import Fraction
 from typing import Any, TypeAlias
 
 import numpy as np
@@ -363,6 +365,8 @@ def _parse_optional_int(value: Any) -> int | None:
     candidate = _optional_int_candidate(value)
     if candidate is _MISSING:
         return None
+    if _fractional_exact_number(candidate):
+        return None
     if (
         isinstance(candidate, (float, np.floating))
         and not float(candidate).is_integer()
@@ -373,6 +377,14 @@ def _parse_optional_int(value: Any) -> int | None:
     except (TypeError, ValueError, OverflowError):
         return None
     return parsed if parsed >= 0 else None
+
+
+def _fractional_exact_number(value: Any) -> bool:
+    if isinstance(value, Decimal):
+        return value != value.to_integral_value()
+    if isinstance(value, Fraction):
+        return value.denominator != 1
+    return False
 
 
 def _optional_int_candidate(value: Any) -> Any:

--- a/src/pyrecest/utils/track_evaluation/__init__.py
+++ b/src/pyrecest/utils/track_evaluation/__init__.py
@@ -1,5 +1,3 @@
-from decimal import Decimal
-from fractions import Fraction
 import runpy
 from pathlib import Path
 
@@ -11,22 +9,12 @@ d = runpy.run_path(
 o = d["_optional_int_candidate"]
 
 
-def _fractional_exact_number(v):
-    if isinstance(v, Decimal):
-        return v != v.to_integral_value()
-    if isinstance(v, Fraction):
-        return v.denominator != 1
-    return False
-
-
 def f(v):
     if isinstance(v, np.ndarray):
         if v.ndim != 0:
             return d["_MISSING"]
         v = v.item()
     if isinstance(v, (bool, np.bool_)):
-        return d["_MISSING"]
-    if _fractional_exact_number(v):
         return d["_MISSING"]
     return o(v)
 

--- a/src/pyrecest/utils/track_evaluation/__init__.py
+++ b/src/pyrecest/utils/track_evaluation/__init__.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+from fractions import Fraction
 import runpy
 from pathlib import Path
 
@@ -9,12 +11,22 @@ d = runpy.run_path(
 o = d["_optional_int_candidate"]
 
 
+def _fractional_exact_number(v):
+    if isinstance(v, Decimal):
+        return v != v.to_integral_value()
+    if isinstance(v, Fraction):
+        return v.denominator != 1
+    return False
+
+
 def f(v):
     if isinstance(v, np.ndarray):
         if v.ndim != 0:
             return d["_MISSING"]
         v = v.item()
     if isinstance(v, (bool, np.bool_)):
+        return d["_MISSING"]
+    if _fractional_exact_number(v):
         return d["_MISSING"]
     return o(v)
 

--- a/tests/test_track_eval_ids.py
+++ b/tests/test_track_eval_ids.py
@@ -1,0 +1,31 @@
+from decimal import Decimal
+from fractions import Fraction
+
+import numpy as np
+from pyrecest.utils.track_evaluation import normalize_track_matrix, track_lengths
+
+
+def test_fractional_exact_observation_values_are_missing():
+    track_matrix = np.array(
+        [
+            [Decimal("1.5"), Fraction(3, 2)],
+            [
+                np.array(Decimal("2.5"), dtype=object),
+                np.array(Fraction(5, 2), dtype=object),
+            ],
+        ],
+        dtype=object,
+    )
+
+    normalized = normalize_track_matrix(track_matrix)
+
+    assert normalized.tolist() == [[None, None], [None, None]]
+    assert track_lengths(track_matrix).tolist() == [0, 0]
+
+
+def test_integral_exact_observation_values_are_preserved():
+    track_matrix = np.array([[Decimal("1"), Fraction(4, 2)]], dtype=object)
+
+    normalized = normalize_track_matrix(track_matrix)
+
+    assert normalized.tolist() == [[1, 2]]


### PR DESCRIPTION
## Summary
- Normalize object-valued exact numeric observation IDs without truncating non-integral values.
- Keep integral object-valued IDs unchanged.
- Add regression tests for scalar object values and scalar object arrays.

## Validation
- Compared branch against current main.
- MegaLinter had already passed on the earlier equivalent PR branch; full local suite was not run in this connector session.