### PR TITLE
Validate uniform moment order

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_uniform_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_uniform_distribution.py
@@ -44,6 +44,28 @@ def _validate_positive_sample_count(n) -> int:
     return count_int
 
 
+def _validate_trigonometric_moment_order(n: Union[int, int32, int64]) -> int:
+    order_array = np.asarray(n)
+    if order_array.ndim != 0:
+        raise ValueError("n must be a scalar integer")
+
+    order = order_array.item()
+    if isinstance(order, (bool, np.bool_)):
+        raise ValueError("n must be an integer, not a boolean")
+    if isinstance(order, (str, bytes)):
+        raise ValueError("n must be an integer, not text")
+
+    try:
+        order_int = int(order)
+        order_float = float(order)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("n must be an integer") from exc
+
+    if not np.isfinite(order_float) or not order_float.is_integer():
+        raise ValueError("n must be a finite integer")
+    return order_int
+
+
 def _validate_pdf_inputs(xs, dim: int):
     xs = asarray(xs)
     if xs.ndim == 0:
@@ -112,6 +134,7 @@ class HypertoroidalUniformDistribution(
         :param n: Moment order
         :returns: n-th trigonometric moment
         """
+        n = _validate_trigonometric_moment_order(n)
         if n == 0:
             return ones(self.dim) + 0j
 

--- a/tests/distributions/test_uniform_order_validation.py
+++ b/tests/distributions/test_uniform_order_validation.py
@@ -1,0 +1,12 @@
+import pytest
+
+from pyrecest.backend import array
+from pyrecest.distributions.hypertorus.hypertoroidal_uniform_distribution import HypertoroidalUniformDistribution
+
+
+def test_uniform_moment_rejects_invalid_order():
+    dist = HypertoroidalUniformDistribution(2)
+
+    for order in ("0", True, array([0]), 1.5):
+        with pytest.raises(ValueError):
+            dist.trigonometric_moment(order)


### PR DESCRIPTION
Summary:
- Add scalar integer validation for hypertoroidal uniform trigonometric moment order inputs.
- Add regression coverage for invalid order inputs.

Validation:
- Inspected main..uniform-order-check: 2 files changed, +35/-0.
- Full tests not run locally in this connector session.