### PR TITLE
Validate active measurement index sequences

### DIFF
--- a/src/pyrecest/filters/update_diagnostics.py
+++ b/src/pyrecest/filters/update_diagnostics.py
@@ -7,6 +7,11 @@ from dataclasses import dataclass
 from operator import index as operator_index
 from typing import Any
 
+_TEXT_SEQUENCE_TYPES = (str, bytes, bytearray)
+_ACTIVE_INDICES_MESSAGE = (
+    "active_measurement_indices must be a sequence of non-negative integers"
+)
+
 
 @dataclass(frozen=True)
 class MeasurementUpdateDiagnostics:
@@ -79,12 +84,12 @@ def _normalize_active_measurement_indices(
 ) -> tuple[int, ...]:
     if values is None:
         return ()
+    if isinstance(values, _TEXT_SEQUENCE_TYPES):
+        raise ValueError(_ACTIVE_INDICES_MESSAGE)
     try:
         iterator = iter(values)
     except TypeError as exc:
-        raise ValueError(
-            "active_measurement_indices must be a sequence of non-negative integers"
-        ) from exc
+        raise ValueError(_ACTIVE_INDICES_MESSAGE) from exc
     indices = tuple(
         _as_nonnegative_integer(value, "active_measurement_indices")
         for value in iterator

--- a/tests/filters/test_update_diagnostics_validation.py
+++ b/tests/filters/test_update_diagnostics_validation.py
@@ -25,6 +25,21 @@ def test_active_measurement_indices_reject_non_sequence_values():
         MeasurementUpdateDiagnostics(active_measurement_indices=1)  # type: ignore[arg-type]
 
 
+def test_active_measurement_indices_reject_text_like_top_level_sequences():
+    invalid_sequences = (
+        "01",
+        b"\x00\x01",
+        bytearray([0, 1]),
+    )
+
+    for invalid_sequence in invalid_sequences:
+        with pytest.raises(ValueError, match="active_measurement_indices"):
+            MeasurementUpdateDiagnostics(
+                active_measurement_indices=invalid_sequence,  # type: ignore[arg-type]
+                measurement_count=2,
+            )
+
+
 def test_active_measurement_indices_must_fit_measurement_count():
     with pytest.raises(
         ValueError,


### PR DESCRIPTION
## Summary
- Tighten active measurement index validation.
- Add a focused regression test for top-level text-like sequence inputs.

## Validation
- Syntax-compiled the changed diagnostics module.
- Ran a local smoke check for invalid text-like sequences and valid integer tuples.