### PR TITLE
Reject non-integer dtype for array randint

### DIFF
--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -218,6 +218,14 @@ def _normalize_random_dtype(dtype, *, default):
         return dtype
 
 
+def _normalize_randint_dtype(dtype):
+    """Return an integer dtype for randint outputs."""
+    dtype = _normalize_random_dtype(dtype, default=_torch.int64)
+    if dtype not in _INTEGER_DTYPES:
+        raise TypeError("dtype must be an integer dtype")
+    return dtype
+
+
 def _normalize_torch_dtype_kwargs(kwargs):
     if "dtype" not in kwargs:
         return kwargs
@@ -231,7 +239,7 @@ def _randint_array(low, high, size, *args, **kwargs):
         raise TypeError(
             "array-valued randint bounds do not support additional positional arguments"
         )
-    dtype = _normalize_random_dtype(kwargs.pop("dtype", None), default=_torch.int64)
+    dtype = _normalize_randint_dtype(kwargs.pop("dtype", None))
     device = kwargs.pop("device", None)
     generator = kwargs.pop("generator", None)
     out = kwargs.pop("out", None)

--- a/tests/backend/test_pytorch_random_dtype_aliases.py
+++ b/tests/backend/test_pytorch_random_dtype_aliases.py
@@ -60,3 +60,19 @@ def test_randint_array_bounds_accepts_numpy_dtype_alias():
     assert samples.dtype == torch.int32
     assert torch.all(samples >= low.to(dtype=torch.int32))
     assert torch.all(samples < high.to(dtype=torch.int32))
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        np.float32,
+        np.dtype("float64"),
+        torch.float32,
+    ],
+)
+def test_randint_array_bounds_rejects_noninteger_dtype(dtype):
+    low = torch.tensor([0, 10])
+    high = torch.tensor([4, 14])
+
+    with pytest.raises(TypeError, match="integer dtype"):
+        random.randint(low, high, dtype=dtype)


### PR DESCRIPTION
## Summary
- reject floating/complex/bool output dtypes for array-bounded PyTorch `random.randint`
- keep NumPy dtype aliases for integer array-bounded draws working
- add a regression test covering floating dtype aliases on array bounds

## Rationale
Scalar-bounded `torch.randint` only supports integer output dtypes, but PyRecEst's custom array-bounded randint path normalized arbitrary dtype aliases and could produce floating-point samples for integer random draws. This makes the array-bounded path consistent with the integer-sampling contract.

## Tests
- Not run locally; repository access was through the GitHub connector only.