### PR TITLE
Return copied backend capability rows

### DIFF
--- a/src/pyrecest/_backend/capabilities.py
+++ b/src/pyrecest/_backend/capabilities.py
@@ -215,7 +215,9 @@ def get_api_backend_support(api_name: str) -> dict[str, str]:
 
 def iter_api_backend_capabilities() -> tuple[tuple[str, dict[str, str]], ...]:
     """Return public API backend support rows in a stable order."""
-    return tuple(sorted(API_BACKEND_CAPABILITIES.items()))
+    return tuple(
+        (api_name, dict(row)) for api_name, row in sorted(API_BACKEND_CAPABILITIES.items())
+    )
 
 
 def validate_api_backend_capabilities() -> tuple[str, ...]:

--- a/src/pyrecest/_backend/capabilities/__init__.py
+++ b/src/pyrecest/_backend/capabilities/__init__.py
@@ -156,7 +156,9 @@ def get_api_backend_support(api_name: str) -> dict[str, str]:
 
 def iter_api_backend_capabilities() -> tuple[tuple[str, dict[str, str]], ...]:
     """Return public API backend support rows in a stable order."""
-    return tuple(sorted(API_BACKEND_CAPABILITIES.items()))
+    return tuple(
+        (api_name, dict(row)) for api_name, row in sorted(API_BACKEND_CAPABILITIES.items())
+    )
 
 
 def validate_api_backend_capabilities() -> tuple[str, ...]:

--- a/tests/test_backend_capabilities.py
+++ b/tests/test_backend_capabilities.py
@@ -20,6 +20,15 @@ def test_api_backend_capability_rows_have_valid_support_levels() -> None:
         assert support.get("notes")
 
 
+def test_iter_api_backend_capabilities_returns_row_copies() -> None:
+    api_name, support = iter_api_backend_capabilities()[0]
+    original_notes = API_BACKEND_CAPABILITIES[api_name]["notes"]
+
+    support["notes"] = "mutated by caller"
+
+    assert API_BACKEND_CAPABILITIES[api_name]["notes"] == original_notes
+
+
 def test_cli_backends_reports_machine_readable_capabilities(capsys) -> None:
     assert cli_main(["backends"]) == 0
     payload = json.loads(capsys.readouterr().out)


### PR DESCRIPTION
## Summary
- return copied row dictionaries from `iter_api_backend_capabilities()` instead of exposing live registry rows
- add a regression test that mutating an iterator row does not mutate `API_BACKEND_CAPABILITIES`

## Bug fixed
`iter_api_backend_capabilities()` previously returned the dictionaries stored in `API_BACKEND_CAPABILITIES` directly. Any caller that adjusted a returned row could accidentally mutate the process-global backend capability registry, unlike the other public capability accessors that already return copies.

## Validation
- Inspected `main..bugfix/copy-backend-capability-rows`: 2 files changed, +12/-1.
- Added `test_iter_api_backend_capabilities_returns_row_copies` in `tests/test_backend_capabilities.py`.
- Full tests were not run locally because this environment could not clone/install from GitHub.