### PR TITLE
Handle scalar logistic association predictions

### DIFF
--- a/src/pyrecest/utils/__init__.py
+++ b/src/pyrecest/utils/__init__.py
@@ -168,7 +168,51 @@ def _patch_logistic_pairwise_backend_standardization() -> None:
     LogisticPairwiseAssociationModel._fit_standardization = _fit_standardization
 
 
+def _patch_logistic_pairwise_scalar_prediction() -> None:
+    """Make scalar prediction inputs valid for fitted one-feature models."""
+    original_prepare_prediction_features = (
+        LogisticPairwiseAssociationModel._prepare_prediction_features
+    )
+    if getattr(
+        original_prepare_prediction_features,
+        "_pyrecest_scalar_prediction_contract",
+        False,
+    ):
+        return
+
+    def _prepare_prediction_features(features, expected_feature_dimension):
+        import pyrecest.backend as _backend  # pylint: disable=import-outside-toplevel
+
+        features = _backend.asarray(features, dtype=_backend.float64)
+        if features.ndim == 0:
+            if expected_feature_dimension != 1:
+                raise ValueError(
+                    "A scalar prediction input is only valid for a fitted one-feature model"
+                )
+            flattened = features.reshape(1, 1)
+            if not _backend.all(_backend.isfinite(flattened)):
+                raise ValueError("features must be finite")
+            return flattened, ()
+        return original_prepare_prediction_features(features, expected_feature_dimension)
+
+    _prepare_prediction_features.__name__ = getattr(
+        original_prepare_prediction_features,
+        "__name__",
+        "_prepare_prediction_features",
+    )
+    _prepare_prediction_features.__doc__ = getattr(
+        original_prepare_prediction_features,
+        "__doc__",
+        None,
+    )
+    _prepare_prediction_features._pyrecest_scalar_prediction_contract = True
+    LogisticPairwiseAssociationModel._prepare_prediction_features = staticmethod(
+        _prepare_prediction_features
+    )
+
+
 _patch_logistic_pairwise_backend_standardization()
+_patch_logistic_pairwise_scalar_prediction()
 
 from .candidate_pruning import (
     CandidatePruningConfig,

--- a/tests/utils/test_logistic_association_scalar_prediction.py
+++ b/tests/utils/test_logistic_association_scalar_prediction.py
@@ -1,0 +1,43 @@
+import numpy as np
+import pytest
+
+from pyrecest.utils import LogisticPairwiseAssociationModel
+
+
+def test_one_feature_logistic_model_accepts_scalar_prediction_input():
+    model = LogisticPairwiseAssociationModel(
+        standardize=False,
+        class_weight=None,
+        l2_regularization=1.0,
+        max_iterations=25,
+    )
+    model.fit(np.array([-1.0, 0.0, 1.0, 2.0]), np.array([0, 0, 1, 1]))
+
+    scalar_probability = model.predict_match_probability(0.25)
+    vector_probability = model.predict_match_probability([0.25])
+
+    assert np.asarray(scalar_probability).shape == ()
+    assert np.allclose(float(np.asarray(scalar_probability)), float(np.asarray(vector_probability)))
+
+
+def test_multifeature_logistic_model_rejects_scalar_prediction_input_cleanly():
+    model = LogisticPairwiseAssociationModel(
+        standardize=False,
+        class_weight=None,
+        l2_regularization=1.0,
+        max_iterations=25,
+    )
+    model.fit(
+        np.array(
+            [
+                [0.0, 0.0],
+                [1.0, 0.0],
+                [0.0, 1.0],
+                [1.0, 1.0],
+            ]
+        ),
+        np.array([0, 0, 1, 1]),
+    )
+
+    with pytest.raises(ValueError, match="scalar prediction input"):
+        model.predict_match_probability(0.25)

--- a/tests/utils/test_logistic_association_scalar_prediction.py
+++ b/tests/utils/test_logistic_association_scalar_prediction.py
@@ -17,7 +17,10 @@ def test_one_feature_logistic_model_accepts_scalar_prediction_input():
     vector_probability = model.predict_match_probability([0.25])
 
     assert np.asarray(scalar_probability).shape == ()
-    assert np.allclose(float(np.asarray(scalar_probability)), float(np.asarray(vector_probability)))
+    assert np.allclose(
+        float(np.asarray(scalar_probability)),
+        float(np.asarray(vector_probability)),
+    )
 
 
 def test_multifeature_logistic_model_rejects_scalar_prediction_input_cleanly():


### PR DESCRIPTION
## Summary
- accept scalar prediction inputs for fitted one-feature logistic association models
- reject scalar prediction inputs for fitted multi-feature models with a clear ValueError
- add regression coverage for both scalar prediction paths

## Validation
- Inspected the branch diff.
- Not run: full local test suite in this connector session.