### PR TITLE
Reject text-valued replay controls

### DIFF
--- a/src/pyrecest/tracking/hypothesis_replay.py
+++ b/src/pyrecest/tracking/hypothesis_replay.py
@@ -20,6 +20,8 @@ try:  # Optional only so this module can be used without event_records imports a
 except Exception:  # pragma: no cover - defensive for partial downstream copies
     TrackingRecord = object  # type: ignore[misc,assignment]
 
+_TEXT_TYPES = (str, bytes, bytearray, np.str_, np.bytes_)
+
 
 @dataclass(frozen=True)
 class InnovationConsistencyScoreConfig:
@@ -360,7 +362,7 @@ def _finite_float(value: Any, name: str) -> float:
     if value_array.shape != () or value_array.dtype == np.bool_:
         raise ValueError(f"{name} must be finite")
     scalar = value_array.item()
-    if isinstance(scalar, (bool, np.bool_)):
+    if isinstance(scalar, (bool, np.bool_)) or isinstance(scalar, _TEXT_TYPES):
         raise ValueError(f"{name} must be finite")
     try:
         parsed = float(scalar)
@@ -390,7 +392,7 @@ def _nonnegative_int(value: Any, name: str) -> int:
     if value_array.shape != () or value_array.dtype == np.bool_:
         raise ValueError(f"{name} must be a nonnegative integer")
     scalar = value_array.item()
-    if isinstance(scalar, (bool, np.bool_)):
+    if isinstance(scalar, (bool, np.bool_)) or isinstance(scalar, _TEXT_TYPES):
         raise ValueError(f"{name} must be a nonnegative integer")
     if isinstance(scalar, (int, np.integer)):
         parsed = int(scalar)

--- a/tests/tracking/test_hypothesis_replay.py
+++ b/tests/tracking/test_hypothesis_replay.py
@@ -81,12 +81,34 @@ def test_score_config_rejects_invalid_scalar_controls() -> None:
             InnovationConsistencyScoreConfig(**{field_name: value})
 
 
+def test_score_config_rejects_text_scalar_controls() -> None:
+    invalid_cases = (
+        ("residual_weight", "1.0", "residual_weight must be finite"),
+        ("nis_clip", b"50", "nis_clip must be finite"),
+    )
+
+    for field_name, value, message in invalid_cases:
+        with pytest.raises(ValueError, match=message):
+            InnovationConsistencyScoreConfig(**{field_name: value})
+
+
 def test_hypothesis_replay_rejects_fractional_count_fields() -> None:
     with pytest.raises(
         ValueError,
         match="track_switches must be a nonnegative integer",
     ):
         HypothesisReplay(hypothesis_id="bad-count", records=[], track_switches=1.5)
+
+
+def test_hypothesis_replay_rejects_text_count_fields() -> None:
+    invalid_cases = (
+        ("track_switches", "1", "track_switches must be a nonnegative integer"),
+        ("coverage_count", b"2", "coverage_count must be a nonnegative integer"),
+    )
+
+    for field_name, value, message in invalid_cases:
+        with pytest.raises(ValueError, match=message):
+            HypothesisReplay(hypothesis_id="bad-count", records=[], **{field_name: value})
 
 
 def test_rank_replayed_hypotheses_calls_replay_function() -> None:
@@ -98,5 +120,4 @@ def test_rank_replayed_hypotheses_calls_replay_function() -> None:
         )
 
     scores = rank_replayed_hypotheses([3, 1, 2], replay_fn)
-
     assert [score.hypothesis_id for score in scores] == [1, 2, 3]


### PR DESCRIPTION
## Summary
- reject string/bytes scalar values in hypothesis replay numeric controls instead of accepting them through `float()` coercion
- apply the same guard to nonnegative count fields
- add focused regressions for score config controls and replay count fields

## Validation
- Inspected `main..fix-replay-text-controls` diff
- Not run: full local test suite in this connector session