### PR TITLE
Fix hypertoroidal uniform pdf single-point shape

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_uniform_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_uniform_distribution.py
@@ -76,18 +76,18 @@ def _validate_pdf_inputs(xs, dim: int):
                 expected=f"({dim},) or (n, {dim})",
                 reason="scalar inputs are only valid for one-dimensional distributions",
             )
-        return xs, 1
+        return xs, 1, True
 
     if xs.ndim == 1:
         if dim == 1:
-            return xs, xs.shape[0]
+            return xs, xs.shape[0], False
         if xs.shape[0] != dim:
             raise ShapeError("xs", xs.shape, expected=f"({dim},) or (n, {dim})")
-        return xs, 1
+        return xs, 1, True
 
     if xs.shape[-1] != dim:
         raise ShapeError("xs", xs.shape, expected=f"last axis of length {dim}")
-    return xs, xs.shape[0]
+    return xs, xs.shape[0], False
 
 
 def _validate_vector(name: str, value, dim: int):
@@ -123,9 +123,10 @@ class HypertoroidalUniformDistribution(
         :param xs: Values at which to evaluate the PDF
         :returns: PDF evaluated at xs
         """
-        _, n_inputs = _validate_pdf_inputs(xs, self.dim)
+        _, n_inputs, single_input = _validate_pdf_inputs(xs, self.dim)
 
-        return 1.0 / self.get_manifold_size() * ones(n_inputs)
+        pdf_values = 1.0 / self.get_manifold_size() * ones(n_inputs)
+        return pdf_values[0] if single_input else pdf_values
 
     def trigonometric_moment(self, n: Union[int, int32, int64]):
         """

--- a/tests/distributions/test_hypertoroidal_uniform_distribution.py
+++ b/tests/distributions/test_hypertoroidal_uniform_distribution.py
@@ -3,7 +3,7 @@ import subprocess
 import sys
 
 import pytest
-from pyrecest.backend import array, ones, pi, zeros
+from pyrecest.backend import array, ndim, ones, pi, zeros
 from pyrecest.distributions.hypertorus.hypertoroidal_uniform_distribution import (
     HypertoroidalUniformDistribution,
 )
@@ -37,6 +37,24 @@ def test_pdf_keeps_legacy_shape_for_valid_inputs():
     values = dist.pdf(array([[0.1, 0.2], [0.3, 0.4]]))
 
     assert values.shape == (2,)
+
+
+def test_pdf_returns_scalar_for_one_dimensional_scalar_input():
+    dist = HypertoroidalUniformDistribution(1)
+
+    value = dist.pdf(array(0.1))
+
+    assert ndim(value) == 0
+    assert float(value) == pytest.approx(1.0 / (2.0 * pi))
+
+
+def test_pdf_returns_scalar_for_single_multidimensional_point():
+    dist = HypertoroidalUniformDistribution(2)
+
+    value = dist.pdf(array([0.1, 0.2]))
+
+    assert ndim(value) == 0
+    assert float(value) == pytest.approx(1.0 / (2.0 * pi) ** 2)
 
 
 def test_shift_validates_shape():


### PR DESCRIPTION
## Summary
- distinguish single evaluation points from batched inputs
- keep batched outputs unchanged
- add regression tests for one-dimensional and multidimensional single-point inputs

## Testing
Not run locally; the local container could not access GitHub.