### PR TITLE
Reject scalar hypersphere uniform pdf inputs cleanly

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/abstract_hypersphere_subset_uniform_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/abstract_hypersphere_subset_uniform_distribution.py
@@ -25,7 +25,7 @@ class AbstractHypersphereSubsetUniformDistribution(
             : Probability density at the given data points.
         """
         xs = array(xs)
-        if xs.shape[-1] != self.input_dim:
+        if xs.ndim == 0 or xs.shape[-1] != self.input_dim:
             raise ValueError("Invalid shape of input data points.")
         manifold_size = self.get_manifold_size()
         if manifold_size == 0:

--- a/tests/distributions/test_hypersphere_uniform_scalar_pdf.py
+++ b/tests/distributions/test_hypersphere_uniform_scalar_pdf.py
@@ -1,0 +1,17 @@
+"""Regression tests for hyperspherical uniform input validation."""
+
+import unittest
+
+from pyrecest.distributions import HypersphericalUniformDistribution
+
+
+class HypersphericalUniformScalarPdfTest(unittest.TestCase):
+    def test_pdf_rejects_scalar_input_with_value_error(self):
+        dist = HypersphericalUniformDistribution(2)
+
+        with self.assertRaisesRegex(ValueError, "Invalid shape"):
+            dist.pdf(1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Guard rank-0 hypersphere uniform `pdf` inputs before reading `shape[-1]`.
- Add a regression test showing scalar inputs now raise the intended `ValueError` instead of leaking `IndexError`.

## Bug fixed
`AbstractHypersphereSubsetUniformDistribution.pdf()` accessed `xs.shape[-1]` unconditionally. For scalar inputs such as `1.0`, NumPy arrays have shape `()`, so the validator raised `IndexError` before PyRecEst could report the documented invalid-shape `ValueError`.

## Validation
- Inspected `main..bugfix/hyperspherical-scalar-shape`: 2 files changed, +18/-1.
- Added `tests/distributions/test_hypersphere_uniform_scalar_pdf.py`.
- Full tests were not run locally because this execution environment cannot resolve `github.com` for cloning/installing the repository.