### PR TITLE
Fix 1D numerical integration sequence bounds

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/abstract_linear_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/abstract_linear_distribution.py
@@ -307,7 +307,7 @@ class AbstractLinearDistribution(AbstractManifoldSpecificDistribution):
             return float(squeeze(f(array(args).reshape(-1, dim))))
 
         if dim == 1:
-            result, _ = quad(f_for_nquad, left, right)
+            result, _ = quad(f_for_nquad, left[0], right[0])
         elif dim == 2:
             result, _ = nquad(f_for_nquad, [(left[0], right[0]), (left[1], right[1])])
         elif dim == 3:

--- a/tests/distributions/test_abstract_linear_distribution.py
+++ b/tests/distributions/test_abstract_linear_distribution.py
@@ -35,6 +35,25 @@ class TestAbstractLinearDistribution(unittest.TestCase):
             integration_result, 1.0, rtol=1e-5
         ), f"Expected 1.0, but got {integration_result}"
 
+    def test_integrate_1d_accepts_sequence_bounds(self):
+        """Test that 1D integration accepts per-dimension sequence bounds."""
+        dist = GaussianDistribution(array([0.0]), array([[1.0]]))
+        integration_result = dist.integrate_numerically([-float("inf")], [float("inf")])
+        assert isclose(
+            integration_result, 1.0, rtol=1e-5
+        ), f"Expected 1.0, but got {integration_result}"
+
+    def test_integrate_fun_over_domain_1d_accepts_sequence_bounds(self):
+        dist = GaussianDistribution(array([0.0]), array([[1.0]]))
+
+        integration_result = AbstractLinearDistribution.integrate_fun_over_domain(
+            lambda x: dist.pdf(x), 1, [-float("inf")], [float("inf")]
+        )
+
+        assert isclose(
+            integration_result, 1.0, rtol=1e-5
+        ), f"Expected 1.0, but got {integration_result}"
+
     def test_integrate_fun_over_domain(self):
         dist = GaussianDistribution(array([1.0, 2.0]), diag(array([1.0, 2.0])))
 


### PR DESCRIPTION
## Summary
- Fix `AbstractLinearDistribution.integrate_fun_over_domain` for 1D per-dimension sequence bounds by passing scalar bounds to `scipy.integrate.quad`.
- Add regression coverage for 1D Gaussian integration with list bounds through both the public numerical integration path and the static helper.

## Validation
- Locally verified the 1D Gaussian integral over `[-inf, inf]` with list bounds returns approximately `1.0` after the change.

The previous 1D branch passed `left` and `right` directly to `quad`, which fails for Python list bounds such as `[-inf]` / `[inf]`. The 2D and 3D branches already index per-dimension bounds; this makes 1D consistent with them.