### PR TITLE
Make backend support errors robust to non-text names

### DIFF
--- a/src/pyrecest/exceptions.py
+++ b/src/pyrecest/exceptions.py
@@ -11,9 +11,16 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 
+def _decode_text_bytes(value: bytes | bytearray) -> str:
+    try:
+        return bytes(value).decode()
+    except UnicodeDecodeError:
+        return repr(bytes(value))
+
+
 def _normalize_backend_name(backend: object) -> str:
     if isinstance(backend, (bytes, bytearray)):
-        return backend.decode()
+        return _decode_text_bytes(backend)
     return str(backend)
 
 
@@ -25,7 +32,7 @@ def _normalize_supported_backends(
     if isinstance(supported_backends, str):
         return (supported_backends,)
     if isinstance(supported_backends, (bytes, bytearray)):
-        return (supported_backends.decode(),)
+        return (_decode_text_bytes(supported_backends),)
     return tuple(_normalize_backend_name(backend) for backend in supported_backends)
 
 


### PR DESCRIPTION
## Summary
- centralize formatting of supported backend names
- keep error-message construction from failing when a backend label is not directly decodable

## Validation
- Branch diff inspected.
- Full test suite not run in this connector-only environment.