### PR TITLE
Normalize invalid scenario numeric inputs

### DIFF
--- a/src/pyrecest/scenarios.py
+++ b/src/pyrecest/scenarios.py
@@ -154,7 +154,10 @@ def _to_float_list(
         raise ValueError(message)
     if isinstance(value, int | float):
         return [convert(value)]
-    return [convert(item) for item in value]
+    try:
+        return [convert(item) for item in value]
+    except TypeError as exc:
+        raise ValueError(message) from exc
 
 
 def _normalized_particle_weights(raw_weights: Any, particle_count: int, backend):

--- a/tests/test_scenario_input_validation.py
+++ b/tests/test_scenario_input_validation.py
@@ -1,0 +1,8 @@
+import pytest
+
+from pyrecest.scenarios import _to_float_list
+
+
+def test_to_float_list_rejects_noniterable_nonnumeric_values():
+    with pytest.raises(ValueError, match="measurement must contain numeric values"):
+        _to_float_list(object(), name="measurement", reject_text_or_bool=True)


### PR DESCRIPTION
## Summary
- Wrap non-iterable, nonnumeric scenario values in the helper's existing `ValueError` path.
- Preserve the standard scenario validation message instead of leaking a raw `TypeError`.
- Add a focused regression for an invalid scalar-like measurement value.

## Validation
- Inspected `main..fix-scenario-inputs` diff: 2 files changed, +12/-1.
- Not run: full local test suite in this connector session.