### PR TITLE
Accept scalar array boolean point metric flags

### DIFF
--- a/src/pyrecest/evaluation/point_set_metrics.py
+++ b/src/pyrecest/evaluation/point_set_metrics.py
@@ -365,6 +365,9 @@ def _validate_matching_dimension(query: np.ndarray, reference: np.ndarray) -> No
 def _validate_boolean_flag(value: Any, name: str) -> bool:
     if isinstance(value, (bool, np.bool_)):
         return bool(value)
+    value_array = np.asarray(value)
+    if value_array.shape == () and value_array.dtype == np.bool_:
+        return bool(value_array.item())
     raise TypeError(f"{name} must be a boolean.")
 
 

--- a/tests/evaluation/test_point_set_metrics.py
+++ b/tests/evaluation/test_point_set_metrics.py
@@ -147,7 +147,7 @@ def test_nonfinite_thresholds_raise_clear_errors():
         precision_recall_curve(points, points, (0.25, np.nan))
 
 
-@pytest.mark.parametrize("invalid_flag", ["False", "True", 0, 1, np.array(False)])
+@pytest.mark.parametrize("invalid_flag", ["False", "True", 0, 1, np.array([False])])
 def test_nearest_neighbor_distances_rejects_non_boolean_return_indices(invalid_flag):
     points = np.array([[0.0], [1.0]])
 
@@ -156,7 +156,7 @@ def test_nearest_neighbor_distances_rejects_non_boolean_return_indices(invalid_f
 
 
 @pytest.mark.parametrize("flag_name", ["squared", "symmetric"])
-@pytest.mark.parametrize("invalid_flag", ["False", "True", 0, 1, np.array(True)])
+@pytest.mark.parametrize("invalid_flag", ["False", "True", 0, 1, np.array([True])])
 def test_chamfer_distance_rejects_non_boolean_flags(flag_name, invalid_flag):
     points = np.array([[0.0], [1.0]])
 
@@ -167,12 +167,17 @@ def test_chamfer_distance_rejects_non_boolean_flags(flag_name, invalid_flag):
 def test_numpy_boolean_flags_remain_supported():
     points = np.array([[0.0], [1.0]])
 
-    distances, indices = nearest_neighbor_distances(
-        points, points, return_indices=np.bool_(True)
-    )
+    for return_indices in (np.bool_(True), np.array(True)):
+        distances, indices = nearest_neighbor_distances(
+            points, points, return_indices=return_indices
+        )
 
-    np.testing.assert_allclose(distances, [0.0, 0.0])
-    np.testing.assert_array_equal(indices, [0, 1])
+        np.testing.assert_allclose(distances, [0.0, 0.0])
+        np.testing.assert_array_equal(indices, [0, 1])
+
     assert chamfer_distance(
         points, points, squared=np.bool_(False), symmetric=np.bool_(True)
+    ) == pytest.approx(0.0)
+    assert chamfer_distance(
+        points, points, squared=np.array(False), symmetric=np.array(True)
     ) == pytest.approx(0.0)


### PR DESCRIPTION
## Summary
- Accept zero-dimensional NumPy boolean arrays for point-set metric boolean options such as `return_indices`, `squared`, and `symmetric`.
- Keep non-scalar boolean arrays rejected.
- Update regressions to cover both scalar array acceptance and vector-array rejection.

## Validation
- Inspected the `main..fix-point-metric-bool-flags` diff.
- Not run: full local test suite in this connector session.