### PR TITLE
Fix PyTorch concatenate axis None contract

### DIFF
--- a/src/pyrecest/backend_support/_torch_dtype_promotion_contract/__init__.py
+++ b/src/pyrecest/backend_support/_torch_dtype_promotion_contract/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+from operator import index as _operator_index
 from pathlib import Path
 
 
@@ -39,6 +40,7 @@ def patch_pytorch_dtype_promotion_contract() -> None:
     _patch_pytorch_equality_device_contract(raw_pytorch, backend, torch)
     _patch_pytorch_linspace_integer_dtype_contract(raw_pytorch, backend, torch)
     _patch_pytorch_arraylike_helper_contract(raw_pytorch, backend, torch)
+    _patch_pytorch_concatenate_axis_none_contract(raw_pytorch, backend, torch)
 
 
 def _pytorch_numpy_index_array(index, numpy_module, torch_module):
@@ -397,6 +399,32 @@ def _patch_pytorch_arraylike_helper_contract(raw_pytorch, backend, torch) -> Non
     raw_pytorch.argsort = wrapped_argsort
     if getattr(backend, "__backend_name__", None) == "pytorch":
         backend.argsort = wrapped_argsort
+
+
+def _patch_pytorch_concatenate_axis_none_contract(raw_pytorch, backend, torch) -> None:
+    """Make PyTorch concatenate flatten inputs when axis is ``None``."""
+    original_concatenate = raw_pytorch.concatenate
+    if getattr(original_concatenate, "_pyrecest_axis_none_contract", False):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.concatenate = original_concatenate
+        return
+
+    def concatenate(seq, axis=0, out=None):
+        tensors = [raw_pytorch.array(item) for item in seq]
+        if axis is None:
+            tensors = [tensor.reshape(-1) for tensor in tensors]
+            axis_arg = 0
+        else:
+            axis_arg = _operator_index(axis)
+        tensors = raw_pytorch.convert_to_wider_dtype(tensors)
+        return torch.cat(tensors, dim=axis_arg, out=out)
+
+    concatenate.__name__ = getattr(original_concatenate, "__name__", "concatenate")
+    concatenate.__doc__ = getattr(original_concatenate, "__doc__", None)
+    concatenate._pyrecest_axis_none_contract = True
+    raw_pytorch.concatenate = concatenate
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.concatenate = concatenate
 
 
 __all__ = ["patch_pytorch_dtype_promotion_contract"]

--- a/tests/backend_support/test_pytorch_pad_contract.py
+++ b/tests/backend_support/test_pytorch_pad_contract.py
@@ -123,3 +123,42 @@ print("ok")
     result = run_backend_code("pytorch", code)
     assert result.returncode == 0, result.stderr
     assert "ok" in result.stdout
+
+
+def test_raw_pytorch_concatenate_axis_none_flattens_after_import():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    code = """
+import pyrecest  # noqa: F401  # triggers raw-backend compatibility patches
+import pyrecest._backend.pytorch as raw_pytorch_backend
+
+result = raw_pytorch_backend.concatenate(
+    (raw_pytorch_backend.array([[1, 2]]), raw_pytorch_backend.array([[3], [4]])),
+    axis=None,
+)
+assert raw_pytorch_backend.to_numpy(result).tolist() == [1, 2, 3, 4]
+print("ok")
+"""
+    result = run_backend_code("numpy", code)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_public_pytorch_concatenate_axis_none_flattens_inputs():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    code = """
+import pyrecest.backend as backend
+
+result = backend.concatenate(
+    (backend.array([[1, 2]]), backend.array([[3], [4]])),
+    axis=None,
+)
+assert backend.to_numpy(result).tolist() == [1, 2, 3, 4]
+print("ok")
+"""
+    result = run_backend_code("pytorch", code)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- Patch the PyTorch backend compatibility layer so `concatenate(..., axis=None)` flattens each input and concatenates along axis 0, matching NumPy semantics instead of forwarding `None` to `torch.cat`.
- Apply the patch to both the raw PyTorch backend and the public backend when `PYRECEST_BACKEND=pytorch`.
- Add regression coverage for the raw PyTorch backend after `pyrecest` import and the public PyTorch backend.

Fixes #3677.

## Tests
- CI passed for the PR head commit, including the main test workflow, security checks, dependency review, documentation examples, CodeQL, release notes preview, and MegaLinter.