### PR TITLE
Validate evidence metadata mappings

### DIFF
--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -8,6 +8,7 @@ consistent diagnostics.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -34,6 +35,16 @@ def _coerce_bool_flag(value: bool, name: str) -> bool:
     if value_array.shape == () and np.issubdtype(value_array.dtype, np.bool_):
         return bool(value_array.item())
     raise ValueError(f"{name} must be a bool")
+
+
+def _coerce_metadata(metadata: Any) -> dict[str, Any]:
+    """Return a plain metadata dictionary without sequence-to-dict surprises."""
+
+    if metadata is None:
+        return {}
+    if not isinstance(metadata, Mapping):
+        raise ValueError("metadata must be a mapping or None")
+    return dict(metadata)
 
 
 @dataclass(frozen=True, slots=True)
@@ -74,7 +85,7 @@ class EvidenceComputationMode:
             raise ValueError("evidence_only mode cannot return smoothed posteriors")
         if self.mode == "full_smoothing" and not return_smoothed:
             raise ValueError("full_smoothing mode must return smoothed posteriors")
-        metadata = {} if self.metadata is None else dict(self.metadata)
+        metadata = _coerce_metadata(self.metadata)
         conflicting_metadata_keys = _RESERVED_DIAGNOSTIC_METADATA_KEYS.intersection(
             metadata
         )

--- a/tests/test_evidence_metadata_validation.py
+++ b/tests/test_evidence_metadata_validation.py
@@ -1,0 +1,13 @@
+import pytest
+
+from pyrecest.evidence import EvidenceComputationMode
+
+
+def test_evidence_computation_mode_rejects_text_metadata():
+    with pytest.raises(ValueError, match="metadata must be a mapping or None"):
+        EvidenceComputationMode(metadata="ab")
+
+
+def test_evidence_computation_mode_rejects_sequence_metadata():
+    with pytest.raises(ValueError, match="metadata must be a mapping or None"):
+        EvidenceComputationMode(metadata=["ab"])


### PR DESCRIPTION
## Summary
- Require `EvidenceComputationMode.metadata` to be a mapping or `None` before copying it into diagnostics metadata.
- Prevent sequence-to-dict surprises such as text or list inputs being silently converted into unintended metadata entries.
- Add focused regression coverage for text and sequence metadata inputs.

## Bug fixed
`EvidenceComputationMode.__post_init__()` previously used `dict(self.metadata)` directly. Python's `dict(...)` accepts some non-mapping sequences, so invalid metadata such as `["ab"]` could be silently interpreted as `{ "a": "b" }` and then emitted as diagnostics. The new helper rejects non-mapping metadata with a stable `ValueError`.

## Validation
- Inspected `main..fix-evidence-metadata-validation`: 2 files changed, +25/-1.
- Full test suite not run locally; this environment cannot clone/install the repository from GitHub directly.