### PR TITLE
Validate object score matrices in multi-session assignment

### DIFF
--- a/src/pyrecest/utils/multisession_assignment_score.py
+++ b/src/pyrecest/utils/multisession_assignment_score.py
@@ -71,6 +71,19 @@ def _raise_invalid_score_matrix() -> None:
     raise ValueError("pairwise_scores must contain real numeric score matrices.")
 
 
+def _validate_object_real_values(
+    raw_values: np.ndarray,
+    invalid_callback: Callable[[], None],
+) -> None:
+    for item in raw_values.reshape(-1):
+        if isinstance(item, _INVALID_SCORE_SCALAR_TYPES):
+            invalid_callback()
+        try:
+            float(item)
+        except (TypeError, ValueError, OverflowError):
+            invalid_callback()
+
+
 def _validate_real_score_matrix(value: Any) -> None:
     try:
         raw_values = np.asarray(value)
@@ -80,9 +93,7 @@ def _validate_real_score_matrix(value: Any) -> None:
     if raw_values.dtype.kind in _REJECTED_SCORE_ARRAY_KINDS:
         _raise_invalid_score_matrix()
     if raw_values.dtype == object:
-        for item in raw_values.reshape(-1):
-            if isinstance(item, _INVALID_SCORE_SCALAR_TYPES):
-                _raise_invalid_score_matrix()
+        _validate_object_real_values(raw_values, _raise_invalid_score_matrix)
 
 
 def _raise_invalid_score_to_cost_matrix() -> None:
@@ -98,9 +109,7 @@ def _validate_real_score_to_cost_matrix(value: Any) -> None:
     if raw_values.dtype.kind in _REJECTED_SCORE_ARRAY_KINDS:
         _raise_invalid_score_to_cost_matrix()
     if raw_values.dtype == object:
-        for item in raw_values.reshape(-1):
-            if isinstance(item, _INVALID_SCORE_SCALAR_TYPES):
-                _raise_invalid_score_to_cost_matrix()
+        _validate_object_real_values(raw_values, _raise_invalid_score_to_cost_matrix)
 
 
 def _validate_pairwise_score_inputs(pairwise_scores: PairwiseCostsInput) -> None:

--- a/tests/test_multisession_assignment_score_validation.py
+++ b/tests/test_multisession_assignment_score_validation.py
@@ -61,6 +61,8 @@ class TestMultiSessionAssignmentScoreValidation(unittest.TestCase):
             {(0, 1): np.array([["0.9"]])},
             {(0, 1): np.array([[0.9 + 0.0j]])},
             {(0, 1): np.array([[None]], dtype=object)},
+            {(0, 1): np.array([[object()]], dtype=object)},
+            {(0, 1): np.array([[{"score": 0.9}]], dtype=object)},
         )
 
         for pairwise_scores in invalid_pairwise_scores:
@@ -73,6 +75,26 @@ class TestMultiSessionAssignmentScoreValidation(unittest.TestCase):
                         pairwise_scores,
                         session_sizes=[1, 1],
                     )
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_similarity_wrapper_rejects_non_numeric_score_to_cost_object_entries(self):
+        pairwise_scores = {(0, 1): array([[0.9]], dtype=float)}
+
+        def score_to_cost(_scores):
+            return np.array([[object()]], dtype=object)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "score_to_cost must return real numeric cost matrices",
+        ):
+            solve_multisession_assignment_from_similarity(
+                pairwise_scores,
+                session_sizes=[1, 1],
+                score_to_cost=score_to_cost,
+            )
 
     @unittest.skipIf(
         __backend_name__ == "jax",


### PR DESCRIPTION
## Summary
- reject non-numeric object-dtype entries in pairwise score matrices before backend conversion
- apply the same object-entry validation to custom `score_to_cost` outputs
- add regression coverage for arbitrary object entries in score matrices and converted cost matrices

## Testing
- `python -m py_compile /mnt/data/multisession_assignment_score.py`
- `python -m py_compile /mnt/data/test_multisession_assignment_score_validation.py`

I could not run the full repository test suite locally because the container cannot clone or resolve `github.com` via git, so the patch was applied through the GitHub connector.