### PR TITLE
Add family caps to residual hypothesis MHT

### DIFF
--- a/src/pyrecest/tracking/__init__.py
+++ b/src/pyrecest/tracking/__init__.py
@@ -122,9 +122,11 @@ from .residual_hypothesis_mht import (
     ResidualEditCandidate,
     ResidualHypothesis,
     ResidualMHTConfig,
+    ResidualMHTPreset,
     enumerate_residual_hypotheses,
     hypotheses_to_dicts,
     hypothesis_to_dict,
+    residual_mht_config_for_preset,
     select_residual_hypothesis,
 )
 
@@ -132,10 +134,52 @@ __all__ += [
     "ResidualEditCandidate",
     "ResidualHypothesis",
     "ResidualMHTConfig",
+    "ResidualMHTPreset",
     "enumerate_residual_hypotheses",
     "hypotheses_to_dicts",
     "hypothesis_to_dict",
+    "residual_mht_config_for_preset",
     "select_residual_hypothesis",
+]
+
+from .residual_hypothesis_diagnostics import (
+    candidate_to_dict,
+    candidates_to_dicts,
+    hypotheses_to_diagnostic_dicts,
+    hypothesis_diagnostic_to_dict,
+    selection_ledger_to_dicts,
+)
+
+__all__ += [
+    "candidate_to_dict",
+    "candidates_to_dicts",
+    "hypotheses_to_diagnostic_dicts",
+    "hypothesis_diagnostic_to_dict",
+    "selection_ledger_to_dicts",
+]
+
+from .audit_guards import (
+    ForbiddenKeyAccessError,
+    GuardedMapping,
+    assert_selector_invariant_under_forbidden_key_changes,
+    guarded_mapping,
+    guarded_mappings,
+    poison_forbidden_keys,
+    poison_forbidden_keys_in_mappings,
+    strip_forbidden_keys,
+    strip_forbidden_keys_from_mappings,
+)
+
+__all__ += [
+    "ForbiddenKeyAccessError",
+    "GuardedMapping",
+    "assert_selector_invariant_under_forbidden_key_changes",
+    "guarded_mapping",
+    "guarded_mappings",
+    "poison_forbidden_keys",
+    "poison_forbidden_keys_in_mappings",
+    "strip_forbidden_keys",
+    "strip_forbidden_keys_from_mappings",
 ]
 
 from .ellipse_geometry import (

--- a/src/pyrecest/tracking/audit_guards.py
+++ b/src/pyrecest/tracking/audit_guards.py
@@ -1,0 +1,157 @@
+"""Generic audit/no-leakage guards for benchmarked selectors.
+
+The helpers in this module are intentionally domain-agnostic.  They are useful
+when a benchmark ledger contains both selection features and audit-only columns
+such as ground-truth labels or score deltas.  Selectors can be run against
+``GuardedMapping`` rows to fail fast if they access forbidden keys, and their
+outputs can be checked for invariance after forbidden columns are stripped or
+poisoned.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, TypeVar
+
+T = TypeVar("T")
+
+
+class ForbiddenKeyAccessError(KeyError):
+    """Raised when code accesses a forbidden audit-only key."""
+
+
+@dataclass(frozen=True)
+class GuardedMapping(Mapping[str, Any]):
+    """Read-only mapping that raises on access to forbidden keys."""
+
+    mapping: Mapping[str, Any]
+    forbidden_keys: frozenset[str]
+
+    def __getitem__(self, key: str) -> Any:
+        if str(key) in self.forbidden_keys:
+            raise ForbiddenKeyAccessError(str(key))
+        return self.mapping[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return (key for key in self.mapping if str(key) not in self.forbidden_keys)
+
+    def __len__(self) -> int:
+        return sum(1 for _ in iter(self))
+
+    def __contains__(self, key: object) -> bool:
+        if str(key) in self.forbidden_keys:
+            raise ForbiddenKeyAccessError(str(key))
+        return key in self.mapping
+
+    def get(self, key: str, default: Any = None) -> Any:
+        if str(key) in self.forbidden_keys:
+            raise ForbiddenKeyAccessError(str(key))
+        return self.mapping.get(key, default)
+
+
+def guarded_mapping(
+    mapping: Mapping[str, Any],
+    forbidden_keys: Iterable[str],
+) -> GuardedMapping:
+    """Wrap one mapping so forbidden audit keys fail on access."""
+
+    return GuardedMapping(mapping=mapping, forbidden_keys=frozenset(map(str, forbidden_keys)))
+
+
+def guarded_mappings(
+    rows: Iterable[Mapping[str, Any]],
+    forbidden_keys: Iterable[str],
+) -> tuple[GuardedMapping, ...]:
+    """Wrap a sequence of mapping rows with :class:`GuardedMapping`."""
+
+    frozen = frozenset(map(str, forbidden_keys))
+    return tuple(GuardedMapping(mapping=row, forbidden_keys=frozen) for row in rows)
+
+
+def strip_forbidden_keys(
+    mapping: Mapping[str, Any],
+    forbidden_keys: Iterable[str],
+) -> dict[str, Any]:
+    """Return a copy of ``mapping`` without forbidden audit-only keys."""
+
+    forbidden = frozenset(map(str, forbidden_keys))
+    return {str(key): value for key, value in mapping.items() if str(key) not in forbidden}
+
+
+def strip_forbidden_keys_from_mappings(
+    rows: Iterable[Mapping[str, Any]],
+    forbidden_keys: Iterable[str],
+) -> tuple[dict[str, Any], ...]:
+    """Return copies of rows with forbidden audit-only keys removed."""
+
+    forbidden = frozenset(map(str, forbidden_keys))
+    return tuple(strip_forbidden_keys(row, forbidden) for row in rows)
+
+
+def poison_forbidden_keys(
+    mapping: Mapping[str, Any],
+    forbidden_keys: Iterable[str],
+    *,
+    poison_value: Any = "__PYRECEST_FORBIDDEN_AUDIT_VALUE__",
+) -> dict[str, Any]:
+    """Return a copy with forbidden keys overwritten by a sentinel value."""
+
+    forbidden = frozenset(map(str, forbidden_keys))
+    output = {str(key): value for key, value in mapping.items()}
+    for key in forbidden:
+        if key in output:
+            output[key] = poison_value
+    return output
+
+
+def poison_forbidden_keys_in_mappings(
+    rows: Iterable[Mapping[str, Any]],
+    forbidden_keys: Iterable[str],
+    *,
+    poison_value: Any = "__PYRECEST_FORBIDDEN_AUDIT_VALUE__",
+) -> tuple[dict[str, Any], ...]:
+    """Return copies of rows with forbidden audit-only keys poisoned."""
+
+    forbidden = frozenset(map(str, forbidden_keys))
+    return tuple(
+        poison_forbidden_keys(row, forbidden, poison_value=poison_value) for row in rows
+    )
+
+
+def assert_selector_invariant_under_forbidden_key_changes(
+    selector: Callable[[Sequence[Mapping[str, Any]]], T],
+    rows: Sequence[Mapping[str, Any]],
+    forbidden_keys: Iterable[str],
+    *,
+    normalize: Callable[[T], Any] | None = None,
+    poison_value: Any = "__PYRECEST_FORBIDDEN_AUDIT_VALUE__",
+) -> None:
+    """Assert selector output is unchanged by removing/poisoning audit keys.
+
+    The selector is evaluated on the original rows, rows with forbidden columns
+    stripped, rows with forbidden columns poisoned, and guarded rows that raise
+    if forbidden columns are accessed.  ``normalize`` may be provided when the
+    selector returns a rich object and only a stable identifier should be
+    compared.
+    """
+
+    forbidden = frozenset(map(str, forbidden_keys))
+    normalize_result = normalize or (lambda result: result)
+    baseline = normalize_result(selector(rows))
+    stripped = normalize_result(selector(strip_forbidden_keys_from_mappings(rows, forbidden)))
+    poisoned = normalize_result(
+        selector(
+            poison_forbidden_keys_in_mappings(
+                rows,
+                forbidden,
+                poison_value=poison_value,
+            )
+        )
+    )
+    guarded = normalize_result(selector(guarded_mappings(rows, forbidden)))
+    if not (baseline == stripped == poisoned == guarded):
+        raise AssertionError(
+            "selector output changed when forbidden audit-only keys were removed, "
+            "poisoned, or guarded"
+        )

--- a/src/pyrecest/tracking/residual_hypothesis_diagnostics.py
+++ b/src/pyrecest/tracking/residual_hypothesis_diagnostics.py
@@ -1,0 +1,142 @@
+"""Diagnostic serialization helpers for residual hypothesis selection.
+
+The helpers in this module intentionally know nothing about any application
+specific tracking domain.  Domain-specific information can be stored in
+``ResidualEditCandidate.metadata`` and is flattened with a configurable prefix
+for CSV/JSON ledgers.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
+
+from .residual_hypothesis_mht import ResidualEditCandidate, ResidualHypothesis
+
+
+def candidate_to_dict(
+    candidate: ResidualEditCandidate,
+    *,
+    rank: int | None = None,
+    selected: bool = False,
+    applied: bool = False,
+    include_metadata: bool = True,
+    metadata_prefix: str = "metadata_",
+) -> dict[str, Any]:
+    """Return a CSV/JSON-friendly residual-edit candidate record."""
+
+    record: dict[str, Any] = {
+        "candidate_id": str(candidate.candidate_id),
+        "score": float(candidate.score),
+        "family": "" if candidate.family is None else str(candidate.family),
+        "conflict_keys": ";".join(sorted(str(key) for key in candidate.conflict_keys)),
+        "selected": int(bool(selected)),
+        "applied": int(bool(applied)),
+    }
+    if rank is not None:
+        record["rank"] = int(rank)
+    if include_metadata:
+        for key, value in candidate.metadata.items():
+            record[f"{metadata_prefix}{key}"] = value
+    return record
+
+
+def candidates_to_dicts(
+    candidates: Iterable[ResidualEditCandidate],
+    *,
+    selected_ids: Iterable[str] | None = None,
+    applied_ids: Iterable[str] | None = None,
+    include_metadata: bool = True,
+    metadata_prefix: str = "metadata_",
+) -> tuple[dict[str, Any], ...]:
+    """Serialize residual edit candidates with selected/applied flags."""
+
+    selected = {str(candidate_id) for candidate_id in selected_ids or ()}
+    applied = {str(candidate_id) for candidate_id in applied_ids or ()}
+    ordered = sorted(
+        tuple(candidates),
+        key=lambda candidate: (-float(candidate.score), str(candidate.candidate_id)),
+    )
+    return tuple(
+        candidate_to_dict(
+            candidate,
+            rank=index,
+            selected=str(candidate.candidate_id) in selected,
+            applied=str(candidate.candidate_id) in applied,
+            include_metadata=include_metadata,
+            metadata_prefix=metadata_prefix,
+        )
+        for index, candidate in enumerate(ordered, start=1)
+    )
+
+
+def hypothesis_diagnostic_to_dict(
+    hypothesis: ResidualHypothesis,
+    *,
+    rank: int | None = None,
+    selected: bool = False,
+) -> dict[str, Any]:
+    """Return a CSV/JSON-friendly residual hypothesis record."""
+
+    record: dict[str, Any] = {
+        "candidate_ids": ";".join(hypothesis.candidate_ids),
+        "n_edits": int(hypothesis.n_edits),
+        "score": float(hypothesis.score),
+        "candidate_scores": ";".join(
+            f"{score:.12g}" for score in hypothesis.candidate_scores
+        ),
+        "candidate_families": ";".join(hypothesis.candidate_families),
+        "selected": int(bool(selected)),
+    }
+    if rank is not None:
+        record["rank"] = int(rank)
+    return record
+
+
+def hypotheses_to_diagnostic_dicts(
+    hypotheses: Sequence[ResidualHypothesis],
+    *,
+    selected_hypothesis: ResidualHypothesis | None = None,
+) -> tuple[dict[str, Any], ...]:
+    """Serialize residual hypotheses and mark the selected hypothesis."""
+
+    selected_ids = None
+    if selected_hypothesis is not None:
+        selected_ids = tuple(selected_hypothesis.candidate_ids)
+    return tuple(
+        hypothesis_diagnostic_to_dict(
+            hypothesis,
+            rank=index,
+            selected=(selected_ids is not None and hypothesis.candidate_ids == selected_ids),
+        )
+        for index, hypothesis in enumerate(hypotheses, start=1)
+    )
+
+
+def selection_ledger_to_dicts(
+    candidates: Iterable[ResidualEditCandidate],
+    *,
+    hypotheses: Sequence[ResidualHypothesis] = (),
+    selected_hypothesis: ResidualHypothesis | None = None,
+    applied_ids: Iterable[str] | None = None,
+    include_metadata: bool = True,
+    metadata_prefix: str = "metadata_",
+) -> dict[str, tuple[dict[str, Any], ...]]:
+    """Serialize candidates and hypotheses for a residual-MHT selection ledger."""
+
+    selected_ids: tuple[str, ...] = ()
+    if selected_hypothesis is not None:
+        selected_ids = tuple(str(candidate_id) for candidate_id in selected_hypothesis.candidate_ids)
+    return {
+        "candidates": candidates_to_dicts(
+            candidates,
+            selected_ids=selected_ids,
+            applied_ids=applied_ids,
+            include_metadata=include_metadata,
+            metadata_prefix=metadata_prefix,
+        ),
+        "hypotheses": hypotheses_to_diagnostic_dicts(
+            hypotheses,
+            selected_hypothesis=selected_hypothesis,
+        ),
+    }

--- a/src/pyrecest/tracking/residual_hypothesis_mht.py
+++ b/src/pyrecest/tracking/residual_hypothesis_mht.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from itertools import combinations
-from typing import Any
+from typing import Any, Literal
+
+ResidualMHTPreset = Literal["conservative", "frontier", "multi_family"]
 
 
 @dataclass(frozen=True)
@@ -16,6 +18,11 @@ class ResidualEditCandidate:
     ``"merge"``, or ``"terminal_veto"``.  It has no intrinsic meaning to
     PyRecEst, but :class:`ResidualMHTConfig` can cap the number of edits selected
     from each family.
+
+    ``group_keys`` are softer grouping labels than ``conflict_keys``.  Conflicts
+    are hard mutual exclusions.  Group keys can be capped with
+    ``max_edits_per_group_key`` while still allowing more than one candidate from
+    the same group when the cap permits it.
     """
 
     candidate_id: str
@@ -23,6 +30,7 @@ class ResidualEditCandidate:
     conflict_keys: frozenset[str] = field(default_factory=frozenset)
     metadata: Mapping[str, Any] = field(default_factory=dict)
     family: str | None = None
+    group_keys: frozenset[str] = field(default_factory=frozenset)
 
 
 @dataclass(frozen=True)
@@ -33,6 +41,7 @@ class ResidualHypothesis:
     score: float
     candidate_scores: tuple[float, ...]
     candidate_families: tuple[str, ...] = ()
+    candidate_group_keys: tuple[str, ...] = ()
 
     @property
     def n_edits(self) -> int:
@@ -51,6 +60,60 @@ class ResidualMHTConfig:
     score_threshold: float = 1.0
     include_empty: bool = True
     max_edits_per_family: Mapping[str, int] = field(default_factory=dict)
+    max_edits_per_group_key: int | None = None
+    candidate_top_k: int | None = None
+    min_candidate_score: float | None = None
+
+
+def residual_mht_config_for_preset(
+    preset: ResidualMHTPreset,
+    *,
+    max_edits: int | None = None,
+    max_hypotheses: int | None = None,
+    score_threshold: float | None = None,
+) -> ResidualMHTConfig:
+    """Return a small generic preset for residual-MHT selection.
+
+    The presets are deliberately domain-agnostic.  They encode selector breadth,
+    not the meaning of candidates.
+    """
+
+    if preset == "conservative":
+        config = ResidualMHTConfig(
+            max_edits=1,
+            max_hypotheses=8,
+            edit_penalty=0.25,
+            score_threshold=1.0,
+            candidate_top_k=4,
+            max_edits_per_group_key=1,
+        )
+    elif preset == "frontier":
+        config = ResidualMHTConfig(
+            max_edits=2,
+            max_hypotheses=32,
+            edit_penalty=0.40,
+            score_threshold=1.4,
+            candidate_top_k=8,
+            max_edits_per_group_key=1,
+        )
+    elif preset == "multi_family":
+        config = ResidualMHTConfig(
+            max_edits=3,
+            max_hypotheses=64,
+            edit_penalty=0.25,
+            score_threshold=1.0,
+            candidate_top_k=12,
+            max_edits_per_group_key=1,
+        )
+    else:
+        raise ValueError(f"Unknown residual-MHT preset: {preset!r}")
+    if max_edits is not None:
+        config = replace(config, max_edits=int(max_edits))
+    if max_hypotheses is not None:
+        config = replace(config, max_hypotheses=int(max_hypotheses))
+    if score_threshold is not None:
+        config = replace(config, score_threshold=float(score_threshold))
+    return config
 
 
 def enumerate_residual_hypotheses(
@@ -61,19 +124,20 @@ def enumerate_residual_hypotheses(
     """Enumerate compatible bounded residual hypotheses."""
 
     cfg = config or ResidualMHTConfig()
-    ordered = sorted(
-        tuple(candidates),
-        key=lambda candidate: (-float(candidate.score), str(candidate.candidate_id)),
-    )
+    ordered = _candidate_frontier(candidates, cfg)
     max_edits = max(0, int(cfg.max_edits))
     max_hypotheses = max(1, int(cfg.max_hypotheses))
     hypotheses: list[ResidualHypothesis] = []
     if cfg.include_empty:
-        hypotheses.append(ResidualHypothesis((), 0.0, (), ()))
+        hypotheses.append(ResidualHypothesis((), 0.0, (), (), ()))
 
     for size in range(1, min(max_edits, len(ordered)) + 1):
         for group in combinations(ordered, size):
-            if not _compatible(group, max_edits_per_family=cfg.max_edits_per_family):
+            if not _compatible(
+                group,
+                max_edits_per_family=cfg.max_edits_per_family,
+                max_edits_per_group_key=cfg.max_edits_per_group_key,
+            ):
                 continue
             candidate_scores = tuple(float(candidate.score) for candidate in group)
             score = sum(candidate_scores) - float(cfg.edit_penalty) * float(size)
@@ -86,6 +150,10 @@ def enumerate_residual_hypotheses(
                     candidate_scores=candidate_scores,
                     candidate_families=tuple(
                         "" if candidate.family is None else str(candidate.family)
+                        for candidate in group
+                    ),
+                    candidate_group_keys=tuple(
+                        ";".join(sorted(str(key) for key in candidate.group_keys))
                         for candidate in group
                     ),
                 )
@@ -110,7 +178,7 @@ def select_residual_hypothesis(
 
     cfg = config or ResidualMHTConfig()
     hypotheses = enumerate_residual_hypotheses(candidates, config=cfg)
-    empty = ResidualHypothesis((), 0.0, (), ())
+    empty = ResidualHypothesis((), 0.0, (), (), ())
     if not hypotheses:
         return empty
     best = hypotheses[0]
@@ -132,6 +200,7 @@ def hypothesis_to_dict(hypothesis: ResidualHypothesis) -> dict[str, Any]:
             f"{score:.12g}" for score in hypothesis.candidate_scores
         ),
         "candidate_families": ";".join(hypothesis.candidate_families),
+        "candidate_group_keys": "|".join(hypothesis.candidate_group_keys),
     }
 
 
@@ -143,23 +212,48 @@ def hypotheses_to_dicts(
     return tuple(hypothesis_to_dict(hypothesis) for hypothesis in hypotheses)
 
 
+def _candidate_frontier(
+    candidates: Iterable[ResidualEditCandidate],
+    config: ResidualMHTConfig,
+) -> tuple[ResidualEditCandidate, ...]:
+    filtered = [
+        candidate
+        for candidate in candidates
+        if config.min_candidate_score is None
+        or float(candidate.score) >= float(config.min_candidate_score)
+    ]
+    filtered.sort(
+        key=lambda candidate: (-float(candidate.score), str(candidate.candidate_id))
+    )
+    if config.candidate_top_k is not None:
+        return tuple(filtered[: max(0, int(config.candidate_top_k))])
+    return tuple(filtered)
+
+
 def _compatible(
     candidates: Sequence[ResidualEditCandidate],
     *,
     max_edits_per_family: Mapping[str, int],
+    max_edits_per_group_key: int | None,
 ) -> bool:
     seen: set[str] = set()
     family_counts: dict[str, int] = {}
+    group_counts: dict[str, int] = {}
     for candidate in candidates:
         overlap = seen.intersection(set(candidate.conflict_keys))
         if overlap:
             return False
         seen.update(candidate.conflict_keys)
-        if candidate.family is None:
-            continue
-        family = str(candidate.family)
-        family_counts[family] = family_counts.get(family, 0) + 1
-        family_cap = max_edits_per_family.get(family)
-        if family_cap is not None and family_counts[family] > int(family_cap):
-            return False
+        if candidate.family is not None:
+            family = str(candidate.family)
+            family_counts[family] = family_counts.get(family, 0) + 1
+            family_cap = max_edits_per_family.get(family)
+            if family_cap is not None and family_counts[family] > int(family_cap):
+                return False
+        if max_edits_per_group_key is not None:
+            for group_key in candidate.group_keys:
+                group = str(group_key)
+                group_counts[group] = group_counts.get(group, 0) + 1
+                if group_counts[group] > int(max_edits_per_group_key):
+                    return False
     return True

--- a/src/pyrecest/tracking/residual_hypothesis_mht.py
+++ b/src/pyrecest/tracking/residual_hypothesis_mht.py
@@ -10,12 +10,19 @@ from typing import Any
 
 @dataclass(frozen=True)
 class ResidualEditCandidate:
-    """One discrete residual edit candidate."""
+    """One discrete residual edit candidate.
+
+    ``family`` is an optional generic grouping label, such as ``"split"``,
+    ``"merge"``, or ``"terminal_veto"``.  It has no intrinsic meaning to
+    PyRecEst, but :class:`ResidualMHTConfig` can cap the number of edits selected
+    from each family.
+    """
 
     candidate_id: str
     score: float
     conflict_keys: frozenset[str] = field(default_factory=frozenset)
     metadata: Mapping[str, Any] = field(default_factory=dict)
+    family: str | None = None
 
 
 @dataclass(frozen=True)
@@ -25,6 +32,7 @@ class ResidualHypothesis:
     candidate_ids: tuple[str, ...]
     score: float
     candidate_scores: tuple[float, ...]
+    candidate_families: tuple[str, ...] = ()
 
     @property
     def n_edits(self) -> int:
@@ -42,6 +50,7 @@ class ResidualMHTConfig:
     edit_penalty: float = 0.25
     score_threshold: float = 1.0
     include_empty: bool = True
+    max_edits_per_family: Mapping[str, int] = field(default_factory=dict)
 
 
 def enumerate_residual_hypotheses(
@@ -60,11 +69,11 @@ def enumerate_residual_hypotheses(
     max_hypotheses = max(1, int(cfg.max_hypotheses))
     hypotheses: list[ResidualHypothesis] = []
     if cfg.include_empty:
-        hypotheses.append(ResidualHypothesis((), 0.0, ()))
+        hypotheses.append(ResidualHypothesis((), 0.0, (), ()))
 
     for size in range(1, min(max_edits, len(ordered)) + 1):
         for group in combinations(ordered, size):
-            if not _compatible(group):
+            if not _compatible(group, max_edits_per_family=cfg.max_edits_per_family):
                 continue
             candidate_scores = tuple(float(candidate.score) for candidate in group)
             score = sum(candidate_scores) - float(cfg.edit_penalty) * float(size)
@@ -75,6 +84,10 @@ def enumerate_residual_hypotheses(
                     ),
                     score=float(score),
                     candidate_scores=candidate_scores,
+                    candidate_families=tuple(
+                        "" if candidate.family is None else str(candidate.family)
+                        for candidate in group
+                    ),
                 )
             )
 
@@ -97,7 +110,7 @@ def select_residual_hypothesis(
 
     cfg = config or ResidualMHTConfig()
     hypotheses = enumerate_residual_hypotheses(candidates, config=cfg)
-    empty = ResidualHypothesis((), 0.0, ())
+    empty = ResidualHypothesis((), 0.0, (), ())
     if not hypotheses:
         return empty
     best = hypotheses[0]
@@ -118,6 +131,7 @@ def hypothesis_to_dict(hypothesis: ResidualHypothesis) -> dict[str, Any]:
         "candidate_scores": ";".join(
             f"{score:.12g}" for score in hypothesis.candidate_scores
         ),
+        "candidate_families": ";".join(hypothesis.candidate_families),
     }
 
 
@@ -129,11 +143,23 @@ def hypotheses_to_dicts(
     return tuple(hypothesis_to_dict(hypothesis) for hypothesis in hypotheses)
 
 
-def _compatible(candidates: Sequence[ResidualEditCandidate]) -> bool:
+def _compatible(
+    candidates: Sequence[ResidualEditCandidate],
+    *,
+    max_edits_per_family: Mapping[str, int],
+) -> bool:
     seen: set[str] = set()
+    family_counts: dict[str, int] = {}
     for candidate in candidates:
         overlap = seen.intersection(set(candidate.conflict_keys))
         if overlap:
             return False
         seen.update(candidate.conflict_keys)
+        if candidate.family is None:
+            continue
+        family = str(candidate.family)
+        family_counts[family] = family_counts.get(family, 0) + 1
+        family_cap = max_edits_per_family.get(family)
+        if family_cap is not None and family_counts[family] > int(family_cap):
+            return False
     return True

--- a/tests/tracking/test_audit_guards.py
+++ b/tests/tracking/test_audit_guards.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import pytest
+
+from pyrecest.tracking import (
+    ForbiddenKeyAccessError,
+    assert_selector_invariant_under_forbidden_key_changes,
+    guarded_mapping,
+    guarded_mappings,
+    poison_forbidden_keys,
+    poison_forbidden_keys_in_mappings,
+    strip_forbidden_keys,
+    strip_forbidden_keys_from_mappings,
+)
+
+
+FORBIDDEN = {"audit_label", "audit_delta"}
+
+
+def test_guarded_mapping_raises_on_forbidden_key_access() -> None:
+    row = guarded_mapping({"score": 1.0, "audit_label": "x"}, FORBIDDEN)
+
+    assert row["score"] == 1.0
+    with pytest.raises(ForbiddenKeyAccessError):
+        _ = row["audit_label"]
+    with pytest.raises(ForbiddenKeyAccessError):
+        row.get("audit_label")
+    with pytest.raises(ForbiddenKeyAccessError):
+        "audit_label" in row
+    assert list(row) == ["score"]
+
+
+def test_strip_and_poison_forbidden_keys() -> None:
+    row = {"candidate_id": "a", "score": 1.0, "audit_delta": 99.0}
+
+    assert strip_forbidden_keys(row, FORBIDDEN) == {"candidate_id": "a", "score": 1.0}
+    assert poison_forbidden_keys(row, FORBIDDEN)["audit_delta"] == "__PYRECEST_FORBIDDEN_AUDIT_VALUE__"
+
+
+def test_sequence_helpers_strip_poison_and_guard_rows() -> None:
+    rows = [
+        {"candidate_id": "a", "score": 2.0, "audit_delta": 1.0},
+        {"candidate_id": "b", "score": 1.0, "audit_label": "x"},
+    ]
+
+    stripped = strip_forbidden_keys_from_mappings(rows, FORBIDDEN)
+    poisoned = poison_forbidden_keys_in_mappings(rows, FORBIDDEN, poison_value="SENTINEL")
+    guarded = guarded_mappings(rows, FORBIDDEN)
+
+    assert all("audit_delta" not in row for row in stripped)
+    assert poisoned[0]["audit_delta"] == "SENTINEL"
+    with pytest.raises(ForbiddenKeyAccessError):
+        guarded[0].get("audit_delta")
+
+
+def test_selector_invariance_helper_passes_for_allowed_feature_selector() -> None:
+    rows = [
+        {"candidate_id": "a", "score": 2.0, "audit_delta": -100.0},
+        {"candidate_id": "b", "score": 1.0, "audit_label": "x"},
+    ]
+
+    def selector(candidate_rows):
+        return max(candidate_rows, key=lambda row: row["score"])["candidate_id"]
+
+    assert_selector_invariant_under_forbidden_key_changes(selector, rows, FORBIDDEN)
+
+
+def test_selector_invariance_helper_catches_forbidden_feature_selector() -> None:
+    rows = [
+        {"candidate_id": "a", "score": 2.0, "audit_delta": -100.0},
+        {"candidate_id": "b", "score": 1.0, "audit_delta": 100.0},
+    ]
+
+    def selector(candidate_rows):
+        return max(candidate_rows, key=lambda row: row.get("audit_delta", 0.0))["candidate_id"]
+
+    with pytest.raises((AssertionError, ForbiddenKeyAccessError)):
+        assert_selector_invariant_under_forbidden_key_changes(selector, rows, FORBIDDEN)

--- a/tests/tracking/test_residual_hypothesis_diagnostics.py
+++ b/tests/tracking/test_residual_hypothesis_diagnostics.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from pyrecest.tracking import (
+    ResidualEditCandidate,
+    ResidualMHTConfig,
+    candidates_to_dicts,
+    enumerate_residual_hypotheses,
+    hypotheses_to_diagnostic_dicts,
+    select_residual_hypothesis,
+    selection_ledger_to_dicts,
+)
+
+
+def test_candidates_to_dicts_marks_selected_and_applied_candidates() -> None:
+    candidates = [
+        ResidualEditCandidate(
+            "b",
+            1.0,
+            conflict_keys=frozenset({"target:2"}),
+            metadata={"subject": "jm038"},
+            family="cell_gated",
+        ),
+        ResidualEditCandidate(
+            "a",
+            2.0,
+            conflict_keys=frozenset({"target:1"}),
+            metadata={"subject": "jm046"},
+            family="growth_veto",
+        ),
+    ]
+
+    rows = candidates_to_dicts(candidates, selected_ids={"a"}, applied_ids={"a"})
+
+    assert rows[0]["candidate_id"] == "a"
+    assert rows[0]["rank"] == 1
+    assert rows[0]["selected"] == 1
+    assert rows[0]["applied"] == 1
+    assert rows[0]["family"] == "growth_veto"
+    assert rows[0]["conflict_keys"] == "target:1"
+    assert rows[0]["metadata_subject"] == "jm046"
+    assert rows[1]["candidate_id"] == "b"
+    assert rows[1]["selected"] == 0
+
+
+def test_hypotheses_to_diagnostic_dicts_marks_selected_hypothesis() -> None:
+    candidates = [
+        ResidualEditCandidate("a", 2.0, family="growth_veto"),
+        ResidualEditCandidate("b", 1.0, family="cell_gated"),
+    ]
+    config = ResidualMHTConfig(max_edits=2, edit_penalty=0.0, score_threshold=0.0)
+    hypotheses = enumerate_residual_hypotheses(candidates, config=config)
+    selected = select_residual_hypothesis(candidates, config=config)
+
+    rows = hypotheses_to_diagnostic_dicts(hypotheses, selected_hypothesis=selected)
+
+    assert rows[0]["candidate_ids"] == "a;b"
+    assert rows[0]["candidate_families"] == "growth_veto;cell_gated"
+    assert rows[0]["selected"] == 1
+    assert any(row["selected"] == 0 for row in rows[1:])
+
+
+def test_selection_ledger_to_dicts_returns_candidate_and_hypothesis_tables() -> None:
+    candidates = [
+        ResidualEditCandidate("a", 2.0, family="growth_veto"),
+        ResidualEditCandidate("b", 1.0, family="cell_gated"),
+    ]
+    config = ResidualMHTConfig(max_edits=1, edit_penalty=0.0, score_threshold=0.0)
+    hypotheses = enumerate_residual_hypotheses(candidates, config=config)
+    selected = select_residual_hypothesis(candidates, config=config)
+
+    ledger = selection_ledger_to_dicts(
+        candidates,
+        hypotheses=hypotheses,
+        selected_hypothesis=selected,
+        applied_ids={"a"},
+    )
+
+    assert set(ledger) == {"candidates", "hypotheses"}
+    assert ledger["candidates"][0]["candidate_id"] == "a"
+    assert ledger["candidates"][0]["selected"] == 1
+    assert ledger["candidates"][0]["applied"] == 1
+    assert ledger["hypotheses"][0]["selected"] == 1

--- a/tests/tracking/test_residual_hypothesis_mht.py
+++ b/tests/tracking/test_residual_hypothesis_mht.py
@@ -53,3 +53,44 @@ def test_conflicting_candidates_are_not_combined():
     )
 
     assert all(len(hypothesis.candidate_ids) == 1 for hypothesis in hypotheses)
+
+
+def test_family_caps_prevent_overselecting_one_candidate_family():
+    candidates = [
+        ResidualEditCandidate("growth", 2.0, family="growth_veto"),
+        ResidualEditCandidate("cell_a", 1.9, family="cell_gated"),
+        ResidualEditCandidate("cell_b", 1.8, family="cell_gated"),
+    ]
+
+    selected = select_residual_hypothesis(
+        candidates,
+        config=ResidualMHTConfig(
+            max_edits=3,
+            edit_penalty=0.0,
+            score_threshold=0.0,
+            max_edits_per_family={"cell_gated": 1},
+        ),
+    )
+
+    assert selected.candidate_ids == ("growth", "cell_a")
+    assert selected.candidate_families == ("growth_veto", "cell_gated")
+
+
+def test_hypothesis_dict_serializes_candidate_families():
+    hypotheses = enumerate_residual_hypotheses(
+        [
+            ResidualEditCandidate("a", 1.0, family="alpha"),
+            ResidualEditCandidate("b", 0.9, family="beta"),
+        ],
+        config=ResidualMHTConfig(max_edits=2, edit_penalty=0.0, include_empty=False),
+    )
+
+    serialized = [
+        {
+            "candidate_ids": ";".join(hypothesis.candidate_ids),
+            "families": ";".join(hypothesis.candidate_families),
+        }
+        for hypothesis in hypotheses
+    ]
+
+    assert {"candidate_ids": "a;b", "families": "alpha;beta"} in serialized

--- a/tests/tracking/test_residual_hypothesis_mht.py
+++ b/tests/tracking/test_residual_hypothesis_mht.py
@@ -4,6 +4,7 @@ from pyrecest.tracking import (
     ResidualEditCandidate,
     ResidualMHTConfig,
     enumerate_residual_hypotheses,
+    residual_mht_config_for_preset,
     select_residual_hypothesis,
 )
 
@@ -94,3 +95,73 @@ def test_hypothesis_dict_serializes_candidate_families():
     ]
 
     assert {"candidate_ids": "a;b", "families": "alpha;beta"} in serialized
+
+
+def test_candidate_top_k_limits_frontier_before_hypothesis_enumeration():
+    hypotheses = enumerate_residual_hypotheses(
+        [
+            ResidualEditCandidate("a", 4.0),
+            ResidualEditCandidate("b", 3.0),
+            ResidualEditCandidate("c", 2.0),
+        ],
+        config=ResidualMHTConfig(
+            max_edits=3,
+            edit_penalty=0.0,
+            candidate_top_k=2,
+            include_empty=False,
+        ),
+    )
+
+    assert hypotheses[0].candidate_ids == ("a", "b")
+    assert all("c" not in hypothesis.candidate_ids for hypothesis in hypotheses)
+
+
+def test_min_candidate_score_filters_weak_candidates():
+    hypotheses = enumerate_residual_hypotheses(
+        [
+            ResidualEditCandidate("strong", 2.0),
+            ResidualEditCandidate("weak", 0.1),
+        ],
+        config=ResidualMHTConfig(
+            max_edits=2,
+            edit_penalty=0.0,
+            min_candidate_score=1.0,
+            include_empty=False,
+        ),
+    )
+
+    assert all("weak" not in hypothesis.candidate_ids for hypothesis in hypotheses)
+
+
+def test_group_key_caps_are_softer_than_conflict_keys():
+    candidates = [
+        ResidualEditCandidate("a", 3.0, group_keys=frozenset({"component:1"})),
+        ResidualEditCandidate("b", 2.0, group_keys=frozenset({"component:1"})),
+        ResidualEditCandidate("c", 1.0, group_keys=frozenset({"component:2"})),
+    ]
+
+    selected = select_residual_hypothesis(
+        candidates,
+        config=ResidualMHTConfig(
+            max_edits=3,
+            edit_penalty=0.0,
+            score_threshold=0.0,
+            max_edits_per_group_key=1,
+        ),
+    )
+
+    assert selected.candidate_ids == ("a", "c")
+    assert selected.candidate_group_keys == ("component:1", "component:2")
+
+
+def test_residual_mht_presets_are_generic_selector_breadth_controls():
+    conservative = residual_mht_config_for_preset("conservative")
+    frontier = residual_mht_config_for_preset("frontier")
+    multi_family = residual_mht_config_for_preset("multi_family", max_edits=4)
+
+    assert conservative.max_edits == 1
+    assert conservative.candidate_top_k == 4
+    assert frontier.max_edits == 2
+    assert frontier.candidate_top_k == 8
+    assert multi_family.max_edits == 4
+    assert multi_family.max_hypotheses == 64


### PR DESCRIPTION
## Summary

- extend generic residual-MHT candidates with an optional `family` label
- add `ResidualMHTConfig.max_edits_per_family` so bounded hypotheses can cap edits per family
- serialize candidate families in hypothesis diagnostics
- add regression tests for family-cap compatibility and diagnostics

## Motivation

BayesCaTrack now uses PyRecEst residual-MHT over multiple label-free edit families (for example growth-veto and high-overlap/cell-gated terminal-edge candidates). The family label and cap are generic and belong in PyRecEst rather than in the calcium-imaging domain layer.

## Notes

This is backward compatible for existing candidate construction: the new `family` field defaults to `None`, and `max_edits_per_family` defaults to an empty mapping.