### PR TITLE
Add multi-session assignment problem containers

### DIFF
--- a/src/pyrecest/utils/multisession_assignment_problem.py
+++ b/src/pyrecest/utils/multisession_assignment_problem.py
@@ -1,0 +1,173 @@
+"""Stable problem/run containers for multi-session assignment.
+
+The containers in this module are intentionally domain-neutral: they carry
+pairwise cost matrices, session sizes, scalar solver knobs, optional metadata,
+and the resulting PyRecEst assignment result.  Dataset-specific code can convert
+its observations into these generic containers and then call PyRecEst's
+multi-session assignment solver without introducing domain-specific APIs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field, replace
+from typing import Any
+
+from .multisession_assignment import (
+    MultiSessionAssignmentResult,
+    PairwiseCostsInput,
+    SessionSizesInput,
+    solve_multisession_assignment,
+)
+
+SessionEdge = tuple[int, int]
+
+
+@dataclass(frozen=True)
+class MultiSessionAssignmentProblem:
+    """Domain-neutral input bundle for multi-session assignment.
+
+    Parameters mirror :func:`pyrecest.utils.solve_multisession_assignment` so the
+    object can be used as a lightweight, serializable boundary between
+    domain-specific preprocessing and PyRecEst's generic assignment solver.
+    """
+
+    pairwise_costs: PairwiseCostsInput
+    session_sizes: SessionSizesInput | None = None
+    start_cost: float = 0.0
+    end_cost: float = 0.0
+    gap_penalty: float = 0.0
+    cost_threshold: float | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def solve(self) -> MultiSessionAssignmentResult:
+        """Solve this assignment problem with PyRecEst's default solver."""
+
+        return solve_multisession_assignment(
+            self.pairwise_costs,
+            self.session_sizes,
+            start_cost=float(self.start_cost),
+            end_cost=float(self.end_cost),
+            gap_penalty=float(self.gap_penalty),
+            cost_threshold=self.cost_threshold,
+        )
+
+    def solved(self) -> "MultiSessionAssignmentRun":
+        """Return a run container containing this problem and its solved result."""
+
+        return MultiSessionAssignmentRun(problem=self, result=self.solve())
+
+    def with_pairwise_costs(
+        self,
+        pairwise_costs: PairwiseCostsInput,
+        *,
+        metadata_update: Mapping[str, Any] | None = None,
+    ) -> "MultiSessionAssignmentProblem":
+        """Return a copy with replaced pairwise costs and optional metadata update."""
+
+        metadata = dict(self.metadata)
+        if metadata_update:
+            metadata.update(dict(metadata_update))
+        return replace(self, pairwise_costs=pairwise_costs, metadata=metadata)
+
+
+@dataclass(frozen=True)
+class MultiSessionAssignmentRun:
+    """Assignment problem plus the corresponding solver result."""
+
+    problem: MultiSessionAssignmentProblem
+    result: MultiSessionAssignmentResult
+
+    @classmethod
+    def solve(
+        cls,
+        problem: MultiSessionAssignmentProblem,
+    ) -> "MultiSessionAssignmentRun":
+        """Solve ``problem`` and return the problem/result container."""
+
+        return cls(problem=problem, result=problem.solve())
+
+    @property
+    def n_tracks(self) -> int:
+        """Return the number of recovered tracks."""
+
+        return len(self.result.tracks)
+
+    @property
+    def n_matched_edges(self) -> int:
+        """Return the number of selected pairwise edges."""
+
+        return len(self.result.matched_edges)
+
+    def to_summary_dict(self) -> dict[str, Any]:
+        """Return a compact JSON/CSV-friendly run summary."""
+
+        return {
+            "n_tracks": int(self.n_tracks),
+            "n_matched_edges": int(self.n_matched_edges),
+            "total_cost": float(self.result.total_cost),
+            "start_cost": float(self.problem.start_cost),
+            "end_cost": float(self.problem.end_cost),
+            "gap_penalty": float(self.problem.gap_penalty),
+            "cost_threshold": (
+                None
+                if self.problem.cost_threshold is None
+                else float(self.problem.cost_threshold)
+            ),
+        }
+
+
+def session_edge_pairs(
+    num_sessions: int,
+    *,
+    max_gap: int = 1,
+) -> tuple[SessionEdge, ...]:
+    """Return forward session edges admitted by a max-gap policy.
+
+    ``max_gap=1`` yields consecutive edges only.  Larger values admit skip edges
+    up to that number of session steps.
+    """
+
+    num_sessions = _positive_or_zero_integer(num_sessions, name="num_sessions")
+    max_gap = _positive_integer(max_gap, name="max_gap")
+    return tuple(
+        (source, target)
+        for source in range(max(0, num_sessions - 1))
+        for target in range(source + 1, min(num_sessions, source + max_gap + 1))
+    )
+
+
+def _positive_or_zero_integer(value: Any, *, name: str) -> int:
+    parsed = _integer(value, name=name)
+    if parsed < 0:
+        raise ValueError(f"{name} must be non-negative")
+    return parsed
+
+
+def _positive_integer(value: Any, *, name: str) -> int:
+    parsed = _integer(value, name=name)
+    if parsed < 1:
+        raise ValueError(f"{name} must be positive")
+    return parsed
+
+
+def _integer(value: Any, *, name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be an integer")
+    if isinstance(value, int):
+        return int(value)
+    try:
+        value_float = float(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+    if not value_float.is_integer():
+        raise ValueError(f"{name} must be an integer")
+    return int(value_float)
+
+
+__all__ = (
+    "MultiSessionAssignmentProblem",
+    "MultiSessionAssignmentRun",
+    "SessionEdge",
+    "session_edge_pairs",
+)

--- a/tests/test_multisession_assignment_problem.py
+++ b/tests/test_multisession_assignment_problem.py
@@ -1,0 +1,93 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.utils.multisession_assignment_problem import (
+    MultiSessionAssignmentProblem,
+    MultiSessionAssignmentRun,
+    session_edge_pairs,
+)
+
+
+class TestMultiSessionAssignmentProblem(unittest.TestCase):
+    def test_problem_solves_and_keeps_metadata(self):
+        problem = MultiSessionAssignmentProblem(
+            pairwise_costs=[np.array([[0.1, 5.0], [5.0, 0.2]])],
+            start_cost=1.0,
+            end_cost=1.0,
+            metadata={"source": "synthetic"},
+        )
+
+        run = problem.solved()
+
+        self.assertIs(run.problem, problem)
+        self.assertEqual(run.problem.metadata["source"], "synthetic")
+        self.assertEqual(run.n_matched_edges, 2)
+        self.assertEqual(run.n_tracks, 2)
+        self.assertEqual(
+            run.result.matched_edges,
+            [((0, 0), (1, 0), 0.1), ((0, 1), (1, 1), 0.2)],
+        )
+
+    def test_run_solve_classmethod_and_summary(self):
+        problem = MultiSessionAssignmentProblem(
+            pairwise_costs={(0, 1): np.array([[0.25]])},
+            session_sizes=(1, 1),
+            start_cost=1.0,
+            end_cost=1.0,
+            gap_penalty=0.5,
+            cost_threshold=10.0,
+        )
+
+        run = MultiSessionAssignmentRun.solve(problem)
+        summary = run.to_summary_dict()
+
+        self.assertEqual(summary["n_tracks"], 1)
+        self.assertEqual(summary["n_matched_edges"], 1)
+        self.assertEqual(summary["start_cost"], 1.0)
+        self.assertEqual(summary["end_cost"], 1.0)
+        self.assertEqual(summary["gap_penalty"], 0.5)
+        self.assertEqual(summary["cost_threshold"], 10.0)
+        self.assertLess(summary["total_cost"], 2.0)
+
+    def test_with_pairwise_costs_replaces_costs_and_updates_metadata(self):
+        original = MultiSessionAssignmentProblem(
+            pairwise_costs=[np.array([[3.0]])],
+            metadata={"stage": "raw"},
+        )
+
+        updated = original.with_pairwise_costs(
+            [np.array([[0.1]])],
+            metadata_update={"stage": "adjusted", "adjustment": "triplet"},
+        )
+
+        self.assertEqual(original.metadata["stage"], "raw")
+        self.assertEqual(updated.metadata["stage"], "adjusted")
+        self.assertEqual(updated.metadata["adjustment"], "triplet")
+        self.assertIsNot(original, updated)
+        self.assertIs(updated.session_sizes, original.session_sizes)
+
+    def test_session_edge_pairs_supports_skip_edges(self):
+        self.assertEqual(session_edge_pairs(0), ())
+        self.assertEqual(session_edge_pairs(1), ())
+        self.assertEqual(session_edge_pairs(4), ((0, 1), (1, 2), (2, 3)))
+        self.assertEqual(
+            session_edge_pairs(4, max_gap=2),
+            ((0, 1), (0, 2), (1, 2), (1, 3), (2, 3)),
+        )
+
+    def test_session_edge_pairs_validates_inputs(self):
+        invalid_calls = (
+            lambda: session_edge_pairs(-1),
+            lambda: session_edge_pairs(3, max_gap=0),
+            lambda: session_edge_pairs(3.5),
+            lambda: session_edge_pairs(True),
+        )
+        for call in invalid_calls:
+            with self.subTest(call=call):
+                with self.assertRaises(ValueError):
+                    call()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_multisession_assignment_problem.py
+++ b/tests/test_multisession_assignment_problem.py
@@ -25,9 +25,11 @@ class TestMultiSessionAssignmentProblem(unittest.TestCase):
         self.assertEqual(run.n_matched_edges, 2)
         self.assertEqual(run.n_tracks, 2)
         self.assertEqual(
-            run.result.matched_edges,
-            [((0, 0), (1, 0), 0.1), ((0, 1), (1, 1), 0.2)],
+            [(edge[0], edge[1]) for edge in run.result.matched_edges],
+            [((0, 0), (1, 0)), ((0, 1), (1, 1))],
         )
+        self.assertAlmostEqual(run.result.matched_edges[0][2], 0.1)
+        self.assertAlmostEqual(run.result.matched_edges[1][2], 0.2)
 
     def test_run_solve_classmethod_and_summary(self):
         problem = MultiSessionAssignmentProblem(


### PR DESCRIPTION
## Summary
- add generic `MultiSessionAssignmentProblem` and `MultiSessionAssignmentRun` containers around the existing multi-session assignment solver
- add a generic `session_edge_pairs` helper for consecutive and skip-session edge policies
- add tests for solving through the problem container, run summaries, metadata-preserving cost replacement, and skip-edge enumeration

## Notes
- This is domain-neutral PyRecEst API surface. It carries only cost matrices, session sizes, solver knobs, and optional metadata.
- No Track2p, Suite2p, ROI, calcium-imaging, or HippoReplayIMM semantics are upstreamed.
- Downstream repositories can now use a stable PyRecEst boundary instead of local problem/run wrappers.

## Validation
- Not run locally; changes were prepared through the GitHub connector.