### PR TITLE
Add generic cost matrix adjustment utilities

### DIFF
--- a/src/pyrecest/utils/cost_matrix_adjustments.py
+++ b/src/pyrecest/utils/cost_matrix_adjustments.py
@@ -1,0 +1,219 @@
+"""Composable cost-matrix adjustment helpers.
+
+These helpers provide a small domain-neutral interface for applying priors,
+uncertainty corrections, consistency penalties, or other transformations to
+pairwise association cost matrices before assignment.  Domain-specific projects
+should construct the matrices and any metadata themselves, then expose only a
+matrix-shaped adjustment to PyRecEst.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from numbers import Real
+from typing import Any, Protocol
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class CostMatrixAdjustmentResult:
+    """Result of applying one or more shape-preserving cost adjustments."""
+
+    adjusted_cost_matrix: np.ndarray
+    diagnostics: Mapping[str, Any] = field(default_factory=dict)
+
+
+class CostMatrixAdjustment(Protocol):
+    """Protocol for domain-neutral cost-matrix adjustments."""
+
+    name: str
+
+    def apply(
+        self,
+        cost_matrix: Any,
+        *,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> CostMatrixAdjustmentResult | Any:
+        """Return an adjusted matrix or a ``CostMatrixAdjustmentResult``."""
+
+
+AdjustmentFunction = Callable[[np.ndarray, Mapping[str, Any]], Any]
+
+
+@dataclass(frozen=True)
+class CallableCostMatrixAdjustment:
+    """Cost adjustment backed by a callable.
+
+    The callable receives a validated numeric matrix and merged metadata.  It may
+    return either an adjusted matrix, a ``(matrix, diagnostics)`` tuple, or a
+    ``CostMatrixAdjustmentResult``.
+    """
+
+    name: str
+    function: AdjustmentFunction
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str) or not self.name:
+            raise ValueError("name must be a non-empty string")
+        if not callable(self.function):
+            raise ValueError("function must be callable")
+
+    def apply(
+        self,
+        cost_matrix: Any,
+        *,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> CostMatrixAdjustmentResult:
+        """Apply the wrapped callable to ``cost_matrix``."""
+
+        matrix = _as_cost_matrix(cost_matrix)
+        merged_metadata = dict(self.metadata)
+        if metadata:
+            merged_metadata.update(dict(metadata))
+        return _coerce_adjustment_output(
+            self.function(matrix.copy(), merged_metadata),
+            expected_shape=matrix.shape,
+        )
+
+
+def apply_cost_matrix_adjustment(
+    cost_matrix: Any,
+    adjustment: CostMatrixAdjustment | Callable[[np.ndarray], Any] | CallableCostMatrixAdjustment,
+    *,
+    metadata: Mapping[str, Any] | None = None,
+) -> CostMatrixAdjustmentResult:
+    """Apply one shape-preserving adjustment to a cost matrix.
+
+    ``adjustment`` may be an object exposing ``apply(cost_matrix, metadata=...)``
+    or a simple callable that accepts a validated matrix.  The adjusted matrix is
+    validated to have the same shape as the input.
+    """
+
+    matrix = _as_cost_matrix(cost_matrix)
+    if hasattr(adjustment, "apply"):
+        output = adjustment.apply(matrix.copy(), metadata=metadata)  # type: ignore[attr-defined]
+    elif callable(adjustment):
+        output = adjustment(matrix.copy())
+    else:
+        raise ValueError("adjustment must be callable or expose an apply method")
+    return _coerce_adjustment_output(output, expected_shape=matrix.shape)
+
+
+def compose_cost_matrix_adjustments(
+    cost_matrix: Any,
+    adjustments: Sequence[
+        CostMatrixAdjustment | Callable[[np.ndarray], Any] | CallableCostMatrixAdjustment
+    ],
+    *,
+    metadata: Mapping[str, Any] | None = None,
+) -> CostMatrixAdjustmentResult:
+    """Apply cost-matrix adjustments in order and collect diagnostics."""
+
+    matrix = _as_cost_matrix(cost_matrix)
+    diagnostics: dict[str, Any] = {"adjustment_order": []}
+    current = matrix
+    for index, adjustment in enumerate(adjustments):
+        name = _adjustment_name(adjustment, index=index)
+        result = apply_cost_matrix_adjustment(
+            current,
+            adjustment,
+            metadata=metadata,
+        )
+        current = result.adjusted_cost_matrix
+        diagnostics["adjustment_order"].append(name)
+        diagnostics[name] = dict(result.diagnostics)
+    return CostMatrixAdjustmentResult(current, diagnostics)
+
+
+def additive_cost_matrix_adjustment(
+    penalty_matrix: Any,
+    *,
+    name: str = "additive_penalty",
+    diagnostics: Mapping[str, Any] | None = None,
+) -> CallableCostMatrixAdjustment:
+    """Return an adjustment that adds a same-shaped penalty matrix."""
+
+    penalty = _as_cost_matrix(penalty_matrix)
+    stored_diagnostics = dict(diagnostics or {})
+
+    def _add(matrix: np.ndarray, _metadata: Mapping[str, Any]) -> CostMatrixAdjustmentResult:
+        if matrix.shape != penalty.shape:
+            raise ValueError(
+                f"penalty_matrix shape {penalty.shape} does not match cost_matrix shape {matrix.shape}"
+            )
+        return CostMatrixAdjustmentResult(matrix + penalty, stored_diagnostics)
+
+    return CallableCostMatrixAdjustment(name=name, function=_add)
+
+
+def _adjustment_name(adjustment: Any, *, index: int) -> str:
+    name = getattr(adjustment, "name", None)
+    if isinstance(name, str) and name:
+        return name
+    callable_name = getattr(adjustment, "__name__", None)
+    if isinstance(callable_name, str) and callable_name:
+        return callable_name
+    return f"adjustment_{index}"
+
+
+def _coerce_adjustment_output(
+    output: Any,
+    *,
+    expected_shape: tuple[int, int],
+) -> CostMatrixAdjustmentResult:
+    if isinstance(output, CostMatrixAdjustmentResult):
+        adjusted = _as_cost_matrix(output.adjusted_cost_matrix)
+        diagnostics = dict(output.diagnostics)
+    elif isinstance(output, tuple) and len(output) == 2:
+        adjusted = _as_cost_matrix(output[0])
+        diagnostics = dict(output[1])
+    else:
+        adjusted = _as_cost_matrix(output)
+        diagnostics = {}
+    if adjusted.shape != expected_shape:
+        raise ValueError(
+            f"adjusted cost matrix has shape {adjusted.shape}, expected {expected_shape}"
+        )
+    return CostMatrixAdjustmentResult(adjusted, diagnostics)
+
+
+def _as_cost_matrix(value: Any) -> np.ndarray:
+    try:
+        matrix = np.asarray(value, dtype=float)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("cost_matrix must be real-valued numeric") from exc
+    if matrix.ndim != 2:
+        raise ValueError("cost_matrix must be two-dimensional")
+    if matrix.dtype == np.bool_ or _contains_invalid_values(value):
+        raise ValueError("cost_matrix must be real-valued numeric")
+    if np.any(np.isneginf(matrix)):
+        raise ValueError("cost_matrix may not contain negative infinity")
+    return np.nan_to_num(matrix, nan=np.inf, posinf=np.inf)
+
+
+def _contains_invalid_values(value: Any) -> bool:
+    try:
+        flat = np.asarray(value, dtype=object).reshape(-1)
+    except (TypeError, ValueError, RuntimeError):
+        return True
+    for item in flat:
+        if item is None or isinstance(item, (bool, np.bool_, str, bytes, bytearray)):
+            return True
+        if isinstance(item, complex):
+            return True
+        if not isinstance(item, Real) and not np.isscalar(item):
+            return True
+    return False
+
+
+__all__ = (
+    "CallableCostMatrixAdjustment",
+    "CostMatrixAdjustment",
+    "CostMatrixAdjustmentResult",
+    "additive_cost_matrix_adjustment",
+    "apply_cost_matrix_adjustment",
+    "compose_cost_matrix_adjustments",
+)

--- a/tests/test_cost_matrix_adjustments.py
+++ b/tests/test_cost_matrix_adjustments.py
@@ -1,0 +1,137 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+from pyrecest.utils.cost_matrix_adjustments import (
+    CallableCostMatrixAdjustment,
+    CostMatrixAdjustmentResult,
+    additive_cost_matrix_adjustment,
+    apply_cost_matrix_adjustment,
+    compose_cost_matrix_adjustments,
+)
+
+
+class _ObjectAdjustment:
+    name = "object_adjustment"
+
+    def apply(self, cost_matrix, *, metadata=None):
+        scale = float((metadata or {}).get("scale", 1.0))
+        return CostMatrixAdjustmentResult(
+            np.asarray(cost_matrix, dtype=float) + scale,
+            {"scale": scale},
+        )
+
+
+class TestCostMatrixAdjustments(unittest.TestCase):
+    def test_callable_adjustment_returns_matrix_and_preserves_shape(self):
+        adjustment = CallableCostMatrixAdjustment(
+            name="add_one",
+            function=lambda matrix, metadata: matrix + float(metadata["offset"]),
+            metadata={"offset": 1.0},
+        )
+
+        result = apply_cost_matrix_adjustment(
+            np.array([[1.0, 2.0], [3.0, np.inf]]),
+            adjustment,
+        )
+
+        npt.assert_allclose(
+            result.adjusted_cost_matrix,
+            np.array([[2.0, 3.0], [4.0, np.inf]]),
+        )
+        self.assertEqual(dict(result.diagnostics), {})
+
+    def test_callable_adjustment_metadata_override_and_diagnostics_tuple(self):
+        def adjustment(matrix, metadata):
+            return matrix * float(metadata["scale"]), {"used_scale": metadata["scale"]}
+
+        wrapped = CallableCostMatrixAdjustment(
+            name="scale",
+            function=adjustment,
+            metadata={"scale": 2.0},
+        )
+
+        result = wrapped.apply(np.array([[1.0]]), metadata={"scale": 3.0})
+
+        npt.assert_allclose(result.adjusted_cost_matrix, np.array([[3.0]]))
+        self.assertEqual(dict(result.diagnostics), {"used_scale": 3.0})
+
+    def test_object_adjustment_receives_metadata(self):
+        result = apply_cost_matrix_adjustment(
+            np.array([[0.0, 1.0]]),
+            _ObjectAdjustment(),
+            metadata={"scale": 2.5},
+        )
+
+        npt.assert_allclose(result.adjusted_cost_matrix, np.array([[2.5, 3.5]]))
+        self.assertEqual(dict(result.diagnostics), {"scale": 2.5})
+
+    def test_compose_adjustments_collects_ordered_diagnostics(self):
+        add = additive_cost_matrix_adjustment(
+            np.array([[1.0, 0.0]]),
+            name="prior",
+            diagnostics={"kind": "prior"},
+        )
+        scale = CallableCostMatrixAdjustment(
+            name="scale",
+            function=lambda matrix, _metadata: CostMatrixAdjustmentResult(
+                matrix * 2.0,
+                {"factor": 2.0},
+            ),
+        )
+
+        result = compose_cost_matrix_adjustments(
+            np.array([[2.0, 3.0]]),
+            [add, scale],
+        )
+
+        npt.assert_allclose(result.adjusted_cost_matrix, np.array([[6.0, 6.0]]))
+        self.assertEqual(result.diagnostics["adjustment_order"], ["prior", "scale"])
+        self.assertEqual(result.diagnostics["prior"], {"kind": "prior"})
+        self.assertEqual(result.diagnostics["scale"], {"factor": 2.0})
+
+    def test_additive_adjustment_rejects_shape_mismatch(self):
+        adjustment = additive_cost_matrix_adjustment(np.ones((2, 2)))
+
+        with self.assertRaisesRegex(ValueError, "penalty_matrix shape"):
+            apply_cost_matrix_adjustment(np.ones((1, 2)), adjustment)
+
+    def test_adjustment_rejects_shape_change(self):
+        adjustment = CallableCostMatrixAdjustment(
+            name="bad",
+            function=lambda _matrix, _metadata: np.ones((1, 3)),
+        )
+
+        with self.assertRaisesRegex(ValueError, "expected \(1, 2\)"):
+            apply_cost_matrix_adjustment(np.ones((1, 2)), adjustment)
+
+    def test_simple_callable_without_apply_is_supported(self):
+        result = apply_cost_matrix_adjustment(
+            np.array([[1.0, 2.0]]),
+            lambda matrix: matrix + 4.0,
+        )
+
+        npt.assert_allclose(result.adjusted_cost_matrix, np.array([[5.0, 6.0]]))
+
+    def test_numeric_validation(self):
+        invalid_inputs = (
+            [[True]],
+            [["not-a-number"]],
+            [1.0, 2.0],
+            [[-np.inf]],
+        )
+        for value in invalid_inputs:
+            with self.subTest(value=value):
+                with self.assertRaises(ValueError):
+                    apply_cost_matrix_adjustment(value, lambda matrix: matrix)
+
+    def test_named_adjustment_validation(self):
+        with self.assertRaises(ValueError):
+            CallableCostMatrixAdjustment(name="", function=lambda matrix, metadata: matrix)
+        with self.assertRaises(ValueError):
+            CallableCostMatrixAdjustment(name="bad", function=None)  # type: ignore[arg-type]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a domain-neutral cost-matrix adjustment interface for pairwise association costs
- provide callable/object adjustment support, composition with diagnostics, and a same-shape additive penalty helper
- add regression coverage for metadata propagation, diagnostic collection, shape preservation, and numeric validation

## Notes
- This is the upstream #3 boundary: PyRecEst owns the generic mechanism for composing cost-matrix adjustments; downstream projects keep domain-specific ROI, Track2p, HippoReplayIMM, or neuroscience semantics outside PyRecEst.
- The API operates only on numeric cost matrices, adjustment callables/objects, and optional metadata.

## Validation
- Not run locally; changes were prepared through the GitHub connector.