### PR TITLE
Add residual MHT selector controls and presets

### DIFF
--- a/src/pyrecest/tracking/__init__.py
+++ b/src/pyrecest/tracking/__init__.py
@@ -122,9 +122,11 @@ from .residual_hypothesis_mht import (
     ResidualEditCandidate,
     ResidualHypothesis,
     ResidualMHTConfig,
+    ResidualMHTPreset,
     enumerate_residual_hypotheses,
     hypotheses_to_dicts,
     hypothesis_to_dict,
+    residual_mht_config_for_preset,
     select_residual_hypothesis,
 )
 
@@ -132,9 +134,11 @@ __all__ += [
     "ResidualEditCandidate",
     "ResidualHypothesis",
     "ResidualMHTConfig",
+    "ResidualMHTPreset",
     "enumerate_residual_hypotheses",
     "hypotheses_to_dicts",
     "hypothesis_to_dict",
+    "residual_mht_config_for_preset",
     "select_residual_hypothesis",
 ]
 

--- a/src/pyrecest/tracking/residual_hypothesis_mht.py
+++ b/src/pyrecest/tracking/residual_hypothesis_mht.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from itertools import combinations
-from typing import Any
+from typing import Any, Literal
+
+ResidualMHTPreset = Literal["conservative", "frontier", "multi_family"]
 
 
 @dataclass(frozen=True)
@@ -16,6 +18,11 @@ class ResidualEditCandidate:
     ``"merge"``, or ``"terminal_veto"``.  It has no intrinsic meaning to
     PyRecEst, but :class:`ResidualMHTConfig` can cap the number of edits selected
     from each family.
+
+    ``group_keys`` are softer grouping labels than ``conflict_keys``.  Conflicts
+    are hard mutual exclusions.  Group keys can be capped with
+    ``max_edits_per_group_key`` while still allowing more than one candidate from
+    the same group when the cap permits it.
     """
 
     candidate_id: str
@@ -23,6 +30,7 @@ class ResidualEditCandidate:
     conflict_keys: frozenset[str] = field(default_factory=frozenset)
     metadata: Mapping[str, Any] = field(default_factory=dict)
     family: str | None = None
+    group_keys: frozenset[str] = field(default_factory=frozenset)
 
 
 @dataclass(frozen=True)
@@ -33,6 +41,7 @@ class ResidualHypothesis:
     score: float
     candidate_scores: tuple[float, ...]
     candidate_families: tuple[str, ...] = ()
+    candidate_group_keys: tuple[str, ...] = ()
 
     @property
     def n_edits(self) -> int:
@@ -51,6 +60,60 @@ class ResidualMHTConfig:
     score_threshold: float = 1.0
     include_empty: bool = True
     max_edits_per_family: Mapping[str, int] = field(default_factory=dict)
+    max_edits_per_group_key: int | None = None
+    candidate_top_k: int | None = None
+    min_candidate_score: float | None = None
+
+
+def residual_mht_config_for_preset(
+    preset: ResidualMHTPreset,
+    *,
+    max_edits: int | None = None,
+    max_hypotheses: int | None = None,
+    score_threshold: float | None = None,
+) -> ResidualMHTConfig:
+    """Return a small generic preset for residual-MHT selection.
+
+    The presets are deliberately domain-agnostic.  They encode selector breadth,
+    not the meaning of candidates.
+    """
+
+    if preset == "conservative":
+        config = ResidualMHTConfig(
+            max_edits=1,
+            max_hypotheses=8,
+            edit_penalty=0.25,
+            score_threshold=1.0,
+            candidate_top_k=4,
+            max_edits_per_group_key=1,
+        )
+    elif preset == "frontier":
+        config = ResidualMHTConfig(
+            max_edits=2,
+            max_hypotheses=32,
+            edit_penalty=0.40,
+            score_threshold=1.4,
+            candidate_top_k=8,
+            max_edits_per_group_key=1,
+        )
+    elif preset == "multi_family":
+        config = ResidualMHTConfig(
+            max_edits=3,
+            max_hypotheses=64,
+            edit_penalty=0.25,
+            score_threshold=1.0,
+            candidate_top_k=12,
+            max_edits_per_group_key=1,
+        )
+    else:
+        raise ValueError(f"Unknown residual-MHT preset: {preset!r}")
+    if max_edits is not None:
+        config = replace(config, max_edits=int(max_edits))
+    if max_hypotheses is not None:
+        config = replace(config, max_hypotheses=int(max_hypotheses))
+    if score_threshold is not None:
+        config = replace(config, score_threshold=float(score_threshold))
+    return config
 
 
 def enumerate_residual_hypotheses(
@@ -61,19 +124,20 @@ def enumerate_residual_hypotheses(
     """Enumerate compatible bounded residual hypotheses."""
 
     cfg = config or ResidualMHTConfig()
-    ordered = sorted(
-        tuple(candidates),
-        key=lambda candidate: (-float(candidate.score), str(candidate.candidate_id)),
-    )
+    ordered = _candidate_frontier(candidates, cfg)
     max_edits = max(0, int(cfg.max_edits))
     max_hypotheses = max(1, int(cfg.max_hypotheses))
     hypotheses: list[ResidualHypothesis] = []
     if cfg.include_empty:
-        hypotheses.append(ResidualHypothesis((), 0.0, (), ()))
+        hypotheses.append(ResidualHypothesis((), 0.0, (), (), ()))
 
     for size in range(1, min(max_edits, len(ordered)) + 1):
         for group in combinations(ordered, size):
-            if not _compatible(group, max_edits_per_family=cfg.max_edits_per_family):
+            if not _compatible(
+                group,
+                max_edits_per_family=cfg.max_edits_per_family,
+                max_edits_per_group_key=cfg.max_edits_per_group_key,
+            ):
                 continue
             candidate_scores = tuple(float(candidate.score) for candidate in group)
             score = sum(candidate_scores) - float(cfg.edit_penalty) * float(size)
@@ -86,6 +150,10 @@ def enumerate_residual_hypotheses(
                     candidate_scores=candidate_scores,
                     candidate_families=tuple(
                         "" if candidate.family is None else str(candidate.family)
+                        for candidate in group
+                    ),
+                    candidate_group_keys=tuple(
+                        ";".join(sorted(str(key) for key in candidate.group_keys))
                         for candidate in group
                     ),
                 )
@@ -110,7 +178,7 @@ def select_residual_hypothesis(
 
     cfg = config or ResidualMHTConfig()
     hypotheses = enumerate_residual_hypotheses(candidates, config=cfg)
-    empty = ResidualHypothesis((), 0.0, (), ())
+    empty = ResidualHypothesis((), 0.0, (), (), ())
     if not hypotheses:
         return empty
     best = hypotheses[0]
@@ -132,6 +200,7 @@ def hypothesis_to_dict(hypothesis: ResidualHypothesis) -> dict[str, Any]:
             f"{score:.12g}" for score in hypothesis.candidate_scores
         ),
         "candidate_families": ";".join(hypothesis.candidate_families),
+        "candidate_group_keys": "|".join(hypothesis.candidate_group_keys),
     }
 
 
@@ -143,23 +212,48 @@ def hypotheses_to_dicts(
     return tuple(hypothesis_to_dict(hypothesis) for hypothesis in hypotheses)
 
 
+def _candidate_frontier(
+    candidates: Iterable[ResidualEditCandidate],
+    config: ResidualMHTConfig,
+) -> tuple[ResidualEditCandidate, ...]:
+    filtered = [
+        candidate
+        for candidate in candidates
+        if config.min_candidate_score is None
+        or float(candidate.score) >= float(config.min_candidate_score)
+    ]
+    filtered.sort(
+        key=lambda candidate: (-float(candidate.score), str(candidate.candidate_id))
+    )
+    if config.candidate_top_k is not None:
+        return tuple(filtered[: max(0, int(config.candidate_top_k))])
+    return tuple(filtered)
+
+
 def _compatible(
     candidates: Sequence[ResidualEditCandidate],
     *,
     max_edits_per_family: Mapping[str, int],
+    max_edits_per_group_key: int | None,
 ) -> bool:
     seen: set[str] = set()
     family_counts: dict[str, int] = {}
+    group_counts: dict[str, int] = {}
     for candidate in candidates:
         overlap = seen.intersection(set(candidate.conflict_keys))
         if overlap:
             return False
         seen.update(candidate.conflict_keys)
-        if candidate.family is None:
-            continue
-        family = str(candidate.family)
-        family_counts[family] = family_counts.get(family, 0) + 1
-        family_cap = max_edits_per_family.get(family)
-        if family_cap is not None and family_counts[family] > int(family_cap):
-            return False
+        if candidate.family is not None:
+            family = str(candidate.family)
+            family_counts[family] = family_counts.get(family, 0) + 1
+            family_cap = max_edits_per_family.get(family)
+            if family_cap is not None and family_counts[family] > int(family_cap):
+                return False
+        if max_edits_per_group_key is not None:
+            for group_key in candidate.group_keys:
+                group = str(group_key)
+                group_counts[group] = group_counts.get(group, 0) + 1
+                if group_counts[group] > int(max_edits_per_group_key):
+                    return False
     return True

--- a/tests/tracking/test_residual_hypothesis_mht.py
+++ b/tests/tracking/test_residual_hypothesis_mht.py
@@ -4,6 +4,7 @@ from pyrecest.tracking import (
     ResidualEditCandidate,
     ResidualMHTConfig,
     enumerate_residual_hypotheses,
+    residual_mht_config_for_preset,
     select_residual_hypothesis,
 )
 
@@ -94,3 +95,73 @@ def test_hypothesis_dict_serializes_candidate_families():
     ]
 
     assert {"candidate_ids": "a;b", "families": "alpha;beta"} in serialized
+
+
+def test_candidate_top_k_limits_frontier_before_hypothesis_enumeration():
+    hypotheses = enumerate_residual_hypotheses(
+        [
+            ResidualEditCandidate("a", 4.0),
+            ResidualEditCandidate("b", 3.0),
+            ResidualEditCandidate("c", 2.0),
+        ],
+        config=ResidualMHTConfig(
+            max_edits=3,
+            edit_penalty=0.0,
+            candidate_top_k=2,
+            include_empty=False,
+        ),
+    )
+
+    assert hypotheses[0].candidate_ids == ("a", "b")
+    assert all("c" not in hypothesis.candidate_ids for hypothesis in hypotheses)
+
+
+def test_min_candidate_score_filters_weak_candidates():
+    hypotheses = enumerate_residual_hypotheses(
+        [
+            ResidualEditCandidate("strong", 2.0),
+            ResidualEditCandidate("weak", 0.1),
+        ],
+        config=ResidualMHTConfig(
+            max_edits=2,
+            edit_penalty=0.0,
+            min_candidate_score=1.0,
+            include_empty=False,
+        ),
+    )
+
+    assert all("weak" not in hypothesis.candidate_ids for hypothesis in hypotheses)
+
+
+def test_group_key_caps_are_softer_than_conflict_keys():
+    candidates = [
+        ResidualEditCandidate("a", 3.0, group_keys=frozenset({"component:1"})),
+        ResidualEditCandidate("b", 2.0, group_keys=frozenset({"component:1"})),
+        ResidualEditCandidate("c", 1.0, group_keys=frozenset({"component:2"})),
+    ]
+
+    selected = select_residual_hypothesis(
+        candidates,
+        config=ResidualMHTConfig(
+            max_edits=3,
+            edit_penalty=0.0,
+            score_threshold=0.0,
+            max_edits_per_group_key=1,
+        ),
+    )
+
+    assert selected.candidate_ids == ("a", "c")
+    assert selected.candidate_group_keys == ("component:1", "component:2")
+
+
+def test_residual_mht_presets_are_generic_selector_breadth_controls():
+    conservative = residual_mht_config_for_preset("conservative")
+    frontier = residual_mht_config_for_preset("frontier")
+    multi_family = residual_mht_config_for_preset("multi_family", max_edits=4)
+
+    assert conservative.max_edits == 1
+    assert conservative.candidate_top_k == 4
+    assert frontier.max_edits == 2
+    assert frontier.candidate_top_k == 8
+    assert multi_family.max_edits == 4
+    assert multi_family.max_hypotheses == 64


### PR DESCRIPTION
## Summary

- add generic residual-MHT selector controls:
  - `candidate_top_k`
  - `min_candidate_score`
  - `max_edits_per_group_key`
  - optional candidate `group_keys`
- add generic selector breadth presets via `residual_mht_config_for_preset(...)`
- serialize candidate group keys in hypothesis records
- export the new preset API through `pyrecest.tracking`
- extend tests for top-k filtering, minimum score filtering, group-key caps, and presets

## Motivation

BayesCaTrack uses residual-MHT over several bounded candidate frontiers. The generic breadth controls should live in PyRecEst, while BayesCaTrack keeps calcium-imaging-specific candidate generation and scoring. The controls are intentionally domain-agnostic: they express how large and diverse a residual hypothesis frontier may be, not what a candidate means.

## Stacking

Base branch: `codex/residual-mht-audit-guards-final` / PyRecEst#3737.

This completes the current PyRecEst residual-MHT infrastructure stack:

- #3733 candidate families / family caps
- #3734 diagnostics schema
- #3737 audit guards
- this PR: selector controls / presets

## Validation

Not run here. Expected local checks:

```bash
python -m pytest \
  tests/tracking/test_residual_hypothesis_mht.py \
  tests/tracking/test_residual_hypothesis_diagnostics.py \
  tests/tracking/test_audit_guards.py \
  -q
python -m ruff check \
  src/pyrecest/tracking/residual_hypothesis_mht.py \
  tests/tracking/test_residual_hypothesis_mht.py
```