### PR TITLE
Validate euclidean MTT distance params

### DIFF
--- a/src/pyrecest/evaluation/get_distance_function.py
+++ b/src/pyrecest/evaluation/get_distance_function.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from math import pi
 from typing import Any
 
@@ -192,6 +192,14 @@ def _validate_mtt_cutoff_distance(value: Any) -> float:
     return cutoff_distance
 
 
+def _coerce_additional_params(additional_params: Any) -> Mapping[str, Any]:
+    if additional_params is None:
+        return {}
+    if not isinstance(additional_params, Mapping):
+        raise ValueError("additional_params must be a mapping or None")
+    return additional_params
+
+
 def _euclidean_mtt_distance(x1, x2, *, cutoff_distance: float) -> float:
     first = _as_target_matrix(x1, "x1")
     second = _as_target_matrix(x2, "x2")
@@ -304,7 +312,7 @@ def get_distance_function(
             return linalg.norm(asarray(x1) - asarray(x2))
 
     elif "euclidean" in normalized_name and "mtt" in normalized_name:
-        params = additional_params or {}
+        params = _coerce_additional_params(additional_params)
         cutoff_distance = _validate_mtt_cutoff_distance(
             params.get("cutoff_distance", 1000000.0)
         )

--- a/tests/evaluation/test_distance_function_additional_params.py
+++ b/tests/evaluation/test_distance_function_additional_params.py
@@ -1,0 +1,15 @@
+import unittest
+
+from pyrecest.evaluation.get_distance_function import get_distance_function
+
+
+class DistanceFunctionAdditionalParamsTest(unittest.TestCase):
+    def test_euclidean_mtt_rejects_non_mapping_params(self):
+        for params in ([], ["cutoff_distance"], "cutoff_distance", 2.5):
+            with self.subTest(params=params):
+                with self.assertRaisesRegex(ValueError, "additional_params.*mapping"):
+                    get_distance_function("euclidean_mtt", params)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add explicit mapping validation for `additional_params` in the built-in `euclidean_mtt` distance factory
- preserve `None` as the default-parameter path
- add regression coverage for non-mapping `additional_params` values

## Bug fixed
`get_distance_function("euclidean_mtt", additional_params)` previously assumed truthy `additional_params` objects had a `.get(...)` method, so values such as strings or lists raised `AttributeError`. Falsey non-mappings such as `[]` were silently treated as the default config. The new helper rejects non-mapping values consistently with `ValueError`.

## Validation
- `python -m py_compile /tmp/get_distance_function.py /tmp/test_distance_function_additional_params.py`