### PR TITLE
Patch raw PyTorch round contract under NumPy backend

### DIFF
--- a/src/pyrecest/backend_tools.py
+++ b/src/pyrecest/backend_tools.py
@@ -144,25 +144,20 @@ def _patch_pytorch_broadcast_arrays_numpy_contract() -> None:
 
 
 def _patch_pytorch_round_numpy_contract() -> None:
-    """Make PyTorch round accept NumPy-style array-like inputs."""
-
-    try:
-        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
-    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
-        return
-
-    if getattr(backend, "__backend_name__", None) != "pytorch":
-        return
+    """Make raw and active public PyTorch round accept NumPy-style inputs."""
 
     try:
         import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
         import torch as _torch  # pylint: disable=import-outside-toplevel
-    except (
-        ModuleNotFoundError
-    ):  # pragma: no cover - PyTorch backend import failed earlier
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
         return
 
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+
     if getattr(pytorch_backend.round, "_pyrecest_numpy_contract", False):
+        if active_pytorch_backend:
+            backend.round = pytorch_backend.round
         return
 
     def round(a, decimals=0, out=None):  # pylint: disable=redefined-builtin
@@ -176,8 +171,9 @@ def _patch_pytorch_round_numpy_contract() -> None:
     round.__name__ = getattr(_torch.round, "__name__", "round")
     round.__doc__ = getattr(_torch.round, "__doc__", None)
     round._pyrecest_numpy_contract = True
-    backend.round = round
     pytorch_backend.round = round
+    if active_pytorch_backend:
+        backend.round = round
 
 
 def _patch_raw_pytorch_conj_numpy_contract() -> None:

--- a/tests/backend_support/test_pytorch_round_contract.py
+++ b/tests/backend_support/test_pytorch_round_contract.py
@@ -52,3 +52,48 @@ else:
     raise AssertionError("round accepted a non-integer decimals argument")
 """
     subprocess.run([sys.executable, "-c", code], check=True, env=env)
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_round_accepts_array_like_inputs_with_numpy_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "numpy"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_backend
+
+assert getattr(backend, "__backend_name__", None) == "numpy"
+
+
+def assert_close_list(actual, expected):
+    actual = [float(value) for value in actual]
+    assert len(actual) == len(expected)
+    assert all(abs(one_actual - one_expected) < 1e-6 for one_actual, one_expected in zip(actual, expected))
+
+
+result = raw_backend.round([1.24, 2.76], decimals=1)
+assert_close_list(raw_backend.to_numpy(result).tolist(), [1.2, 2.8])
+
+out = raw_backend.array([0.0, 0.0])
+returned = raw_backend.round([1.24, 2.76], decimals=1, out=out)
+assert returned is out
+assert_close_list(raw_backend.to_numpy(out).tolist(), [1.2, 2.8])
+
+try:
+    raw_backend.round([1.0], decimals=1.5)
+except TypeError:
+    pass
+else:
+    raise AssertionError("round accepted a non-integer decimals argument")
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- patch raw PyTorch `round` regardless of the selected public backend
- only reassign the public facade when the active backend is PyTorch
- add regression coverage for raw PyTorch `round` with the NumPy public backend

## Bug fixed
With `PYRECEST_BACKEND=numpy`, importing PyRecEst left the raw PyTorch backend's `round` helper as the unwrapped Torch function. Array-like inputs and `out=` therefore failed even though the compatibility layer is expected to accept NumPy-style inputs.

## Validation
- `python -m py_compile /mnt/data/backend_tools.py /mnt/data/test_pytorch_round_contract.py`
- focused smoke check of the patched raw PyTorch `round` wrapper under a NumPy-selected public backend

Not run: full repository test suite in this connector-only environment.