### PR TITLE
Fix shared vec_to_diag array-like inputs

### DIFF
--- a/src/pyrecest/stability.py
+++ b/src/pyrecest/stability.py
@@ -111,8 +111,43 @@ def _patch_pytorch_diag_numpy_contract() -> None:
         backend.diag = diag
 
 
+def _patch_shared_numpy_vec_to_diag_numpy_contract() -> None:
+    """Patch shared NumPy/Autograd ``vec_to_diag`` to accept array-like inputs."""
+    try:
+        import pyrecest._backend._shared_numpy as shared_numpy  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - backend import may be unavailable
+        return
+
+    backend_name = getattr(backend, "__backend_name__", None)
+    if backend_name == "numpy":
+        import pyrecest._backend.numpy as raw_backend  # pylint: disable=import-outside-toplevel
+    elif backend_name == "autograd":
+        import pyrecest._backend.autograd as raw_backend  # pylint: disable=import-outside-toplevel
+    else:
+        return
+
+    original_vec_to_diag = getattr(raw_backend, "vec_to_diag", None)
+    if original_vec_to_diag is None:
+        return
+    if getattr(original_vec_to_diag, "_pyrecest_numpy_contract", False):
+        backend.vec_to_diag = original_vec_to_diag
+        return
+
+    def vec_to_diag(vec):
+        return original_vec_to_diag(raw_backend.array(vec))
+
+    vec_to_diag.__name__ = getattr(original_vec_to_diag, "__name__", "vec_to_diag")
+    vec_to_diag.__doc__ = getattr(original_vec_to_diag, "__doc__", None)
+    vec_to_diag._pyrecest_numpy_contract = True
+    shared_numpy.vec_to_diag = vec_to_diag
+    raw_backend.vec_to_diag = vec_to_diag
+    backend.vec_to_diag = vec_to_diag
+
+
 _patch_pytorch_allclose_device_contract()
 _patch_pytorch_diag_numpy_contract()
+_patch_shared_numpy_vec_to_diag_numpy_contract()
 _patch_pytorch_raw_comparison_arraylike_contract()
 _patch_pytorch_dot_outer_device_contract()
 _patch_pytorch_matmul_device_contract()
@@ -127,8 +162,8 @@ StabilityLevel = Literal[
 STABILITY_LEVELS: Final = (
     "stable",
     "experimental",
-    "deprecated",
     "backend-specific",
+    "deprecated",
     "internal",
 )
 

--- a/src/pyrecest/stability.py
+++ b/src/pyrecest/stability.py
@@ -162,8 +162,8 @@ StabilityLevel = Literal[
 STABILITY_LEVELS: Final = (
     "stable",
     "experimental",
-    "backend-specific",
     "deprecated",
+    "backend-specific",
     "internal",
 )
 

--- a/tests/test_shared_numpy_vec_to_diag.py
+++ b/tests/test_shared_numpy_vec_to_diag.py
@@ -1,0 +1,32 @@
+import pyrecest.backend as backend
+import pytest
+
+
+def _to_python(value):
+    value = backend.to_numpy(value)
+    if hasattr(value, "tolist"):
+        return value.tolist()
+    return value
+
+
+def test_shared_numpy_vec_to_diag_accepts_array_like_inputs():
+    if backend.__backend_name__ not in {"numpy", "autograd"}:
+        pytest.skip("shared NumPy/Autograd vec_to_diag regression test")
+
+    result = backend.vec_to_diag([1, 2, 3])
+
+    assert result.shape == (3, 3)
+    assert _to_python(result) == [[1, 0, 0], [0, 2, 0], [0, 0, 3]]
+
+
+def test_shared_numpy_vec_to_diag_accepts_batched_array_like_inputs():
+    if backend.__backend_name__ not in {"numpy", "autograd"}:
+        pytest.skip("shared NumPy/Autograd vec_to_diag regression test")
+
+    result = backend.vec_to_diag([[1, 2], [3, 4]])
+
+    assert result.shape == (2, 2, 2)
+    assert _to_python(result) == [
+        [[1, 0], [0, 2]],
+        [[3, 0], [0, 4]],
+    ]


### PR DESCRIPTION
## Summary
- patch the shared NumPy/Autograd `vec_to_diag` facade so Python lists and other array-like vectors are coerced before diagonalization
- update the public and raw active shared backend references consistently
- add regression coverage for vector and batched array-like inputs

## Tests
- `python -m py_compile /mnt/data/stability_new.py`

I could not run the full repository pytest suite locally because this environment could not clone GitHub over git; CI should exercise the branch.