### PR TITLE
Fix FBFB MEM-QKF matrix noise normalization

### DIFF
--- a/src/pyrecest/smoothers/__init__.py
+++ b/src/pyrecest/smoothers/__init__.py
@@ -1,18 +1,20 @@
 from .abstract_smoother import AbstractSmoother
 from .delayed_output import DelayedStateOutput, DelayedStateOutputMixin
 from .fixed_lag_mem_qkf_smoother import (
-    FBFBMEMQKFSmoother,
     FixedIntervalMEMQKFSmoother,
     FixedIntervalMemQkfSmoother,
     FixedLagFreeMEMQKFSmoother,
     FixedLagMEMQKFSmoother,
     FixedLagMemQkfSmoother,
     FLMEMQKFSmoother,
-    ForwardBackwardForwardBackwardMEMQKFSmoother,
-    ForwardBackwardMEMQKFSmoother,
     FullIntervalMEMQKFSmoother,
     MEMQKFSmootherGain,
     MEMQKFTrackerState,
+)
+from .fbfb_mem_qkf_smoother import (
+    FBFBMEMQKFSmoother,
+    ForwardBackwardForwardBackwardMEMQKFSmoother,
+    ForwardBackwardMEMQKFSmoother,
 )
 from .fixed_lag_random_matrix_smoother import (
     FactorizedGIWRandomMatrixTrackerState,

--- a/src/pyrecest/smoothers/fbfb_mem_qkf_smoother.py
+++ b/src/pyrecest/smoothers/fbfb_mem_qkf_smoother.py
@@ -1,0 +1,53 @@
+"""Forward-backward MEM-QKF smoother public wrapper fixes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pyrecest.backend import asarray
+from pyrecest.backend import copy as backend_copy
+
+from .fixed_lag_mem_qkf_smoother import (
+    ForwardBackwardForwardBackwardMEMQKFSmoother as _BaseForwardBackwardForwardBackwardMEMQKFSmoother,
+)
+
+
+class ForwardBackwardForwardBackwardMEMQKFSmoother(
+    _BaseForwardBackwardForwardBackwardMEMQKFSmoother
+):
+    """FBFB MEM-QKF smoother with NumPy-style matrix sequence normalization."""
+
+    @staticmethod
+    def _normalize_optional_matrix_sequence(
+        values, length: int, name: str
+    ) -> list[Any | None]:
+        """Normalize optional per-scan matrices.
+
+        Plain Python nested-list matrices, such as ``[[r11, r12], [r21, r22]]``,
+        are single matrices and must be repeated for every scan.  Only fall back
+        to list/tuple sequence handling after ruling out matrix-shaped array-like
+        inputs so rows of a matrix are not misinterpreted as per-scan entries.
+        """
+        if values is None:
+            return [None] * length
+
+        try:
+            values_array = asarray(values)
+        except (TypeError, ValueError):
+            values_array = None
+        if values_array is not None:
+            if values_array.ndim == 2:
+                return [backend_copy(values_array) for _ in range(length)]
+            if values_array.ndim == 3 and values_array.shape[0] == length:
+                return [values_array[idx] for idx in range(length)]
+
+        if isinstance(values, (list, tuple)):
+            if len(values) != length:
+                raise ValueError(f"{name} must have length {length}.")
+            return [None if value is None else asarray(value) for value in values]
+
+        raise ValueError(f"{name} must be a matrix or a sequence of matrices.")
+
+
+FBFBMEMQKFSmoother = ForwardBackwardForwardBackwardMEMQKFSmoother
+ForwardBackwardMEMQKFSmoother = ForwardBackwardForwardBackwardMEMQKFSmoother

--- a/tests/smoothers/test_fbfb_mem_qkf_matrix_sequence_inputs.py
+++ b/tests/smoothers/test_fbfb_mem_qkf_matrix_sequence_inputs.py
@@ -1,0 +1,58 @@
+import numpy.testing as npt
+from pyrecest.backend import array, diag, eye
+from pyrecest.smoothers import (
+    ForwardBackwardForwardBackwardMEMQKFSmoother,
+    MEMQKFTrackerState,
+)
+
+
+def _state(kinematic_state, covariance, shape_state, shape_covariance):
+    return MEMQKFTrackerState(
+        array(kinematic_state),
+        array(covariance),
+        array(shape_state),
+        array(shape_covariance),
+    )
+
+
+def test_fbfb_accepts_python_matrix_measurement_noise_for_all_scans():
+    smoother = ForwardBackwardForwardBackwardMEMQKFSmoother(shape_smoothing="none")
+    filtered_states = [
+        _state(
+            [0.0, 0.0],
+            0.5 * eye(2),
+            [0.0, 1.0, 1.0],
+            diag(array([0.2, 0.2, 0.2])),
+        ),
+        _state(
+            [2.0, 0.0],
+            0.5 * eye(2),
+            [0.0, 1.0, 1.0],
+            diag(array([0.2, 0.2, 0.2])),
+        ),
+    ]
+    predicted_states = [
+        _state(
+            [0.0, 0.0],
+            eye(2),
+            [0.0, 1.0, 1.0],
+            diag(array([0.4, 0.4, 0.4])),
+        )
+    ]
+    measurements = [array([[2.0], [0.0]]), array([[3.0], [0.0]])]
+
+    smoothed_states, smoother_gains = smoother.smooth(
+        filtered_states,
+        predicted_states,
+        measurements=measurements,
+        system_matrices=eye(2),
+        shape_system_matrices=eye(3),
+        meas_noise_covs=[[0.05, 0.0], [0.0, 0.05]],
+        initial_shape_state=array([0.0, 1.0, 1.0]),
+        initial_shape_covariance=diag(array([0.2, 0.2, 0.2])),
+    )
+
+    assert len(smoothed_states) == 2
+    assert len(smoother_gains[0]) == 1
+    npt.assert_allclose(smoothed_states[0].kinematic_state, array([1.0, 0.0]))
+    npt.assert_allclose(smoothed_states[0].covariance, 0.375 * eye(2))


### PR DESCRIPTION
## Summary
- fix public `ForwardBackwardForwardBackwardMEMQKFSmoother` exports so optional matrix inputs first honor NumPy-style 2-D matrix semantics
- prevent Python nested-list matrices such as `[[r11, r12], [r21, r22]]` from being misinterpreted as per-scan row-vector sequences
- add a regression test covering `meas_noise_covs` supplied as a plain Python matrix across scans

## Bug
`_normalize_optional_matrix_sequence` handled any Python `list`/`tuple` as a per-scan sequence before checking whether it was a matrix-shaped array-like input. As a result, a common measurement-noise matrix written as a nested list could be rejected or converted into row vectors instead of being repeated for all scans.

## Tests
- Added `tests/smoothers/test_fbfb_mem_qkf_matrix_sequence_inputs.py`

I could not run the test suite in this environment because repository checkout from GitHub is unavailable here; the change is covered by the new focused regression test.