### PR TITLE
Allow boolean Pareto constraint thresholds

### DIFF
--- a/src/pyrecest/evaluation/pareto.py
+++ b/src/pyrecest/evaluation/pareto.py
@@ -417,11 +417,13 @@ def _parse_constraint_spec(spec: ConstraintSpec | Mapping[str, Any]) -> Constrai
 def _coerce_finite_threshold(value: Any, column: str) -> float:
     message = f"Constraint threshold for {column!r} must be a finite scalar."
     value_array = np.asarray(value)
-    if value_array.shape != () or value_array.dtype == np.bool_:
+    if value_array.shape != ():
         raise ValueError(message)
     scalar = value_array.item()
-    if isinstance(scalar, (bool, np.bool_)) or _is_text_scalar(scalar):
+    if _is_text_scalar(scalar):
         raise ValueError(message)
+    if isinstance(scalar, (bool, np.bool_)):
+        return float(scalar)
     try:
         threshold = float(scalar)
     except (TypeError, ValueError, OverflowError) as exc:

--- a/tests/evaluation/test_pareto_boolean_constraints.py
+++ b/tests/evaluation/test_pareto_boolean_constraints.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pandas as pd
+from pyrecest.evaluation import constraint_mask
+
+
+def test_constraint_mask_accepts_boolean_thresholds() -> None:
+    table = pd.DataFrame(
+        [
+            {"name": "enabled", "eligible": True},
+            {"name": "disabled", "eligible": False},
+            {"name": "missing", "eligible": None},
+            {"name": "text", "eligible": "unknown"},
+        ]
+    )
+
+    enabled = constraint_mask(table, {"eligible": ("==", True)})
+    disabled = constraint_mask(table, {"eligible": {"op": "!=", "value": True}})
+
+    assert table.loc[enabled, "name"].tolist() == ["enabled"]
+    assert table.loc[disabled, "name"].tolist() == ["disabled"]

--- a/tests/evaluation/test_pareto_threshold_validation.py
+++ b/tests/evaluation/test_pareto_threshold_validation.py
@@ -6,9 +6,9 @@ import pytest
 from pyrecest.evaluation import constraint_mask
 
 
-def test_constraint_threshold_rejects_bool_and_non_scalar_values() -> None:
+def test_constraint_threshold_rejects_non_scalar_values() -> None:
     table = pd.DataFrame([{"score": 1.0}])
-    invalid_thresholds = (True, np.array([1.0]))
+    invalid_thresholds = (np.array([1.0]),)
 
     for threshold in invalid_thresholds:
         with pytest.raises(


### PR DESCRIPTION
## Summary
- Allow scalar boolean thresholds in Pareto `constraint_mask`.
- Keep non-scalar and text thresholds rejected.
- Add regression coverage for boolean equality and inequality constraints.

## Validation
- `python -m py_compile /mnt/data/pareto_patch.py`
- Focused local check for boolean constraint behavior.

Full test suite was not run locally because this environment could not clone the repository.