### PR TITLE
Allow zero linear update thresholds

### DIFF
--- a/src/pyrecest/filters/linear_update_planning.py
+++ b/src/pyrecest/filters/linear_update_planning.py
@@ -248,7 +248,7 @@ def plan_linear_measurement_update(
     residual_threshold = (
         None
         if max_residual_norm is None
-        else _as_positive_scalar(max_residual_norm, "max_residual_norm")
+        else _as_nonnegative_scalar(max_residual_norm, "max_residual_norm")
     )
 
     residual = vector - observation @ state_mean
@@ -338,7 +338,7 @@ def gate_threshold_for_measurement(
     source = str(measurement.source)
     if gate_thresholds_by_source and source in gate_thresholds_by_source:
         value = gate_thresholds_by_source[source]
-        return None if value is None else _as_positive_scalar(value, "gate_threshold")
+        return None if value is None else _as_nonnegative_scalar(value, "gate_threshold")
     if gate_probabilities_by_source and source in gate_probabilities_by_source:
         probability = gate_probabilities_by_source[source]
         vector = np.asarray(measurement.vector).reshape(-1)
@@ -378,7 +378,7 @@ def _resolve_threshold(
     name: str,
 ) -> float | None:
     if threshold is not None:
-        return _as_positive_scalar(threshold, f"{name}_threshold")
+        return _as_nonnegative_scalar(threshold, f"{name}_threshold")
     return chi_square_gate_threshold(probability, measurement_dim)
 
 

--- a/tests/filters/test_linear_update_thresholds.py
+++ b/tests/filters/test_linear_update_thresholds.py
@@ -1,0 +1,66 @@
+from dataclasses import dataclass
+
+import numpy as np
+
+from pyrecest.filters.linear_update_planning import gate_threshold_for_measurement
+from pyrecest.filters.linear_update_planning import plan_linear_measurement_update
+
+
+@dataclass
+class _Measurement:
+    source: str
+    vector: np.ndarray
+
+
+def _base_plan_kwargs(measurement_value=1.0):
+    return dict(
+        mean=np.array([0.0]),
+        covariance_matrix=np.array([[1.0]]),
+        measurement_vector=np.array([measurement_value]),
+        measurement_covariance=np.array([[1.0]]),
+        observation_matrix=np.array([[1.0]]),
+    )
+
+
+def test_zero_gate_threshold_rejects_nonzero_nis():
+    kwargs = _base_plan_kwargs(measurement_value=1.0)
+    kwargs["gate_threshold"] = 0.0
+
+    plan = plan_linear_measurement_update(**kwargs)
+
+    assert plan.gate_threshold == 0.0
+    assert plan.accepted is False
+    assert plan.action == "rejected"
+
+
+def test_zero_safety_threshold_rejects_nonzero_nis():
+    kwargs = _base_plan_kwargs(measurement_value=1.0)
+    kwargs["safety_gate_threshold"] = 0.0
+
+    plan = plan_linear_measurement_update(**kwargs)
+
+    assert plan.safety_gate_threshold == 0.0
+    assert plan.accepted is False
+    assert plan.action == "safety_rejected"
+
+
+def test_zero_residual_threshold_rejects_nonzero_residual():
+    kwargs = _base_plan_kwargs(measurement_value=1.0)
+    kwargs["max_residual_norm"] = 0.0
+
+    plan = plan_linear_measurement_update(**kwargs)
+
+    assert plan.residual_threshold == 0.0
+    assert plan.accepted is False
+    assert plan.action == "residual_rejected"
+
+
+def test_zero_source_gate_threshold_is_valid_hard_gate():
+    measurement = _Measurement(source="radar", vector=np.array([1.0]))
+
+    threshold = gate_threshold_for_measurement(
+        measurement,
+        gate_thresholds_by_source={"radar": 0.0},
+    )
+
+    assert threshold == 0.0


### PR DESCRIPTION
## Summary
- allow explicit zero NIS gate thresholds in linear update planning and source-specific gate lookup
- allow zero residual-norm thresholds for hard residual gating
- add regression tests covering zero gate, safety-gate, residual, and source-specific thresholds

## Bug fixed
Explicit threshold arguments represent hard thresholds rather than probabilities. A value of `0.0` is mathematically valid: it rejects any strictly positive NIS or residual norm while still accepting exact-zero innovations. The previous validation used positive-scalar checks and rejected this valid hard-gate configuration before planning could run.

## Testing
- Added `tests/filters/test_linear_update_thresholds.py`.
- Not run locally; changes were made through the GitHub connector.