### PR TITLE
Validate finite bias model parameters

### DIFF
--- a/src/pyrecest/calibration/bias.py
+++ b/src/pyrecest/calibration/bias.py
@@ -75,6 +75,10 @@ class SensorBiasCorrectionModel:
         residual_std = _as_numeric_array(self.residual_std, "residual_std").reshape(
             target_dim
         )
+        _require_finite_array(intercept, "intercept")
+        _require_finite_array(coefficients, "coefficients")
+        _require_finite_array(feature_mean, "feature_mean")
+        _require_finite_array(residual_std, "residual_std")
         feature_scale = np.where(
             np.isfinite(feature_scale) & (feature_scale > 0.0), feature_scale, 1.0
         )
@@ -415,6 +419,11 @@ def _as_nonnegative_finite_float(value: Any, name: str) -> float:
     if not np.isfinite(result) or result < 0.0:
         raise ValueError(f"{name} must be a nonnegative finite scalar")
     return result
+
+
+def _require_finite_array(values: np.ndarray, name: str) -> None:
+    if not np.isfinite(values).all():
+        raise ValueError(f"{name} must contain only finite values")
 
 
 def _nanmean_or_zero(values: np.ndarray) -> np.ndarray:

--- a/tests/calibration/test_bias.py
+++ b/tests/calibration/test_bias.py
@@ -64,6 +64,23 @@ def test_model_rejects_invalid_scalar_metadata(field_name, invalid_value, match)
         SensorBiasCorrectionModel(**kwargs)
 
 
+@pytest.mark.parametrize(
+    ("field_name", "invalid_value", "match"),
+    [
+        ("intercept", np.array([np.nan]), "intercept"),
+        ("coefficients", np.array([[np.inf]]), "coefficients"),
+        ("feature_mean", np.array([np.nan]), "feature_mean"),
+        ("residual_std", np.array([np.inf]), "residual_std"),
+    ],
+)
+def test_model_rejects_nonfinite_array_parameters(field_name, invalid_value, match):
+    kwargs = _unit_feature_model_kwargs()
+    kwargs[field_name] = invalid_value
+
+    with pytest.raises(ValueError, match=match):
+        SensorBiasCorrectionModel(**kwargs)
+
+
 def test_from_dict_rejects_invalid_scalar_metadata_before_truncation():
     payload = SensorBiasCorrectionModel(**_unit_feature_model_kwargs()).to_dict()
     payload["target_dim"] = 1.5


### PR DESCRIPTION
## Summary
- reject non-finite bias model arrays for intercept, coefficients, feature mean, and residual standard deviation during model construction/deserialization
- keep existing feature-scale sanitization behavior for zero/non-finite scales
- add regression coverage for NaN/Inf model parameter arrays

## Bug fixed
`SensorBiasCorrectionModel` previously accepted NaN/Inf parameter arrays, including deserialized payloads. Those values could silently propagate into `predict`/`apply` and poison bias correction output. The constructor now fails fast for non-finite learned model arrays.

## Validation
- Not run locally: this environment could not clone the repository over git, so CI should exercise the focused pytest coverage.