### PR TITLE
Reject non-integer NumPy randint dtypes

### DIFF
--- a/src/pyrecest/_backend/numpy/random.py
+++ b/src/pyrecest/_backend/numpy/random.py
@@ -41,10 +41,21 @@ def _validate_randint_bound(bound, name):
         raise TypeError(f"{name} must contain integer values")
 
 
+def _validate_randint_dtype(dtype):
+    try:
+        dtype = _np.dtype(dtype)
+    except (TypeError, ValueError) as exc:
+        raise TypeError("dtype must be an integer dtype") from exc
+    if dtype.kind not in "iu":
+        raise TypeError("dtype must be an integer dtype")
+    return dtype
+
+
 def randint(low, high=None, size=None, dtype=int):
-    """Draw integer samples after rejecting non-integer bounds."""
+    """Draw integer samples after rejecting non-integer bounds and dtypes."""
 
     size = _normalize_size(size)
+    dtype = _validate_randint_dtype(dtype)
     if high is None:
         _validate_randint_bound(low, "high")
         return _np.random.randint(low, high=None, size=size, dtype=dtype)

--- a/tests/backend/test_numpy_randint_dtype_validation.py
+++ b/tests/backend/test_numpy_randint_dtype_validation.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pytest
+from pyrecest._backend.numpy import random
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        bool,
+        np.bool_,
+        np.dtype("bool"),
+        float,
+        np.float64,
+        np.dtype("float32"),
+        object,
+    ],
+)
+def test_randint_rejects_non_integer_dtypes(dtype):
+    with pytest.raises(TypeError, match="integer dtype"):
+        random.randint(0, 2, size=3, dtype=dtype)
+
+
+@pytest.mark.parametrize(
+    ("dtype", "expected_dtype"),
+    [
+        (int, np.dtype(int)),
+        (np.int32, np.dtype("int32")),
+        (np.dtype("uint32"), np.dtype("uint32")),
+    ],
+)
+def test_randint_accepts_integer_dtype_aliases(dtype, expected_dtype):
+    samples = random.randint(0, 2, size=3, dtype=dtype)
+
+    assert samples.shape == (3,)
+    assert samples.dtype == expected_dtype
+    assert np.all(samples >= 0)
+    assert np.all(samples < 2)


### PR DESCRIPTION
## Summary
- validate the NumPy backend `random.randint` output dtype before calling `np.random.randint`
- reject boolean, floating, and object dtypes with a consistent `integer dtype` error
- add focused regression coverage for rejected non-integer dtypes and accepted integer dtype aliases

## Motivation
The NumPy backend already validates that `randint` bounds contain integer values, but `np.random.randint(..., dtype=bool)` returns boolean samples. That leaks a non-integer output dtype through PyRecEst's integer random-sampling API and is inconsistent with the stricter dtype handling in the optional PyTorch backend.

## Validation
- Locally exercised the new dtype validator behavior in this environment for boolean, floating, object, signed-integer, and unsigned-integer dtype cases.
- Full repository pytest was not run locally because this environment cannot clone GitHub over git; CI should exercise the branch.