### PR TITLE
Fix lazy PyTorch minmax device patch

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_minmax_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_minmax_device_contract.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import sys
+import importlib
 
 
 def _preferred_pytorch_device(torch_module, *values):
@@ -31,8 +31,11 @@ def _minmax_operands(raw_pytorch, torch_module, left, right):
 
 
 def _raw_pytorch_module():
-    """Return the already-imported raw PyTorch backend module, if available."""
-    return sys.modules.get(".".join(("pyrecest", "_backend", "pytorch")))
+    """Return the raw PyTorch backend module, importing it when available."""
+    try:
+        return importlib.import_module("pyrecest._backend.pytorch")
+    except ModuleNotFoundError:
+        return None
 
 
 def patch_pytorch_minmax_device_contract() -> None:


### PR DESCRIPTION
## Summary
- make the PyTorch `maximum`/`minimum` device compatibility hook import the raw PyTorch backend module instead of only checking `sys.modules`
- keep the patch a no-op when PyTorch/raw backend imports are unavailable

## Bug fixed
`patch_pytorch_minmax_device_contract()` could silently return without patching anything when `pyrecest._backend.pytorch` had not already been imported. That made the hook depend on import order even though it is responsible for installing the raw/public PyTorch `maximum` and `minimum` compatibility wrappers.

## Validation
- Syntax-checked the updated helper locally with `python -m py_compile`.
- Compared `main..fix/pytorch-minmax-raw-import`: 1 file changed, +6/-3.
- Attempted to add a focused regression under `tests/backend_support`, but the GitHub connector safety layer blocked that test-file write in this session.