### PR TITLE
Fix PyTorch comparison equality contract

### DIFF
--- a/src/pyrecest/backend_tools.py
+++ b/src/pyrecest/backend_tools.py
@@ -370,6 +370,8 @@ def _patch_raw_pytorch_comparison_numpy_contract() -> None:
     except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
         return
 
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+
     def _coerce_binary_args(x, y):
         device = _preferred_pytorch_device(_torch, x, y)
         if not _torch.is_tensor(x):
@@ -383,6 +385,12 @@ def _patch_raw_pytorch_comparison_numpy_contract() -> None:
         return x, y
 
     def _wrap_comparison(helper_name, torch_func):
+        existing = getattr(pytorch_backend, helper_name, None)
+        if getattr(existing, "_pyrecest_numpy_contract", False):
+            if active_pytorch_backend:
+                setattr(backend, helper_name, existing)
+            return existing
+
         def comparison(x, y, **kwargs):
             x, y = _coerce_binary_args(x, y)
             return torch_func(x, y, **kwargs)
@@ -393,14 +401,16 @@ def _patch_raw_pytorch_comparison_numpy_contract() -> None:
         return comparison
 
     for helper_name, torch_func in (
+        ("equal", _torch.eq),
         ("greater", _torch.greater),
         ("less", _torch.less),
+        ("less_equal", _torch.le),
         ("logical_or", _torch.logical_or),
         ("logical_and", _torch.logical_and),
     ):
         helper = _wrap_comparison(helper_name, torch_func)
         setattr(pytorch_backend, helper_name, helper)
-        if getattr(backend, "__backend_name__", None) == "pytorch":
+        if active_pytorch_backend:
             setattr(backend, helper_name, helper)
 
 


### PR DESCRIPTION
## Summary
- Extend the raw PyTorch comparison compatibility patch to cover `equal` and `less_equal`.
- Keep the active public PyTorch backend facade synchronized with the raw patched helpers.
- Preserve the existing non-CPU tensor device preference for mixed-device comparison operands.

## Bug fixed
`pyrecest.backend_tools` patched raw PyTorch comparison helpers such as `greater`, `less`, `logical_or`, and `logical_and`, but omitted `equal` and `less_equal`. That left equality helpers with inconsistent array-like and mixed-device behavior when raw PyTorch helpers were used after importing PyRecEst under another public backend.

## Validation
- Inspected `main..fix-pytorch-comparison-equality-contract`: one commit, one modified file, +11/-1.
- Full pytest was not run in this connector-only environment; CI should exercise the backend portability coverage.