### PR TITLE
Fix GaussianMixture set_mean copy contract

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/gaussian_mixture.py
+++ b/src/pyrecest/distributions/nonperiodic/gaussian_mixture.py
@@ -1,3 +1,5 @@
+import copy
+
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import array, ones, reshape, stack, sum
@@ -22,9 +24,11 @@ class GaussianMixture(LinearMixture, AbstractLinearDistribution):
         return sum(means * reshape(self.w, (-1, 1)), axis=0)
 
     def set_mean(self, new_mean):
+        new_mixture = copy.deepcopy(self)
         mean_offset = new_mean - self.mean()
-        for dist in self.dists:
+        for dist in new_mixture.dists:
             dist.mu += mean_offset  # type: ignore
+        return new_mixture
 
     def to_gaussian(self, check_validity=True):
         gauss_array = self.dists

--- a/tests/distributions/test_linear_mixture.py
+++ b/tests/distributions/test_linear_mixture.py
@@ -141,6 +141,19 @@ class LinearMixtureTest(unittest.TestCase):
         npt.assert_allclose(gmix.pdf(xs), expected, atol=1e-20)
         npt.assert_allclose(gmix.pdf(reshape(xs, (-1, 1))), expected, atol=1e-20)
 
+    def test_gaussian_mixture_set_mean_returns_shifted_copy(self):
+        gm1 = GaussianDistribution(array([0.0, 1.0]), diag(array([1.0, 2.0])))
+        gm2 = GaussianDistribution(array([2.0, 3.0]), diag(array([3.0, 4.0])))
+        gmix = GaussianMixture([gm1, gm2], array([0.25, 0.75]))
+
+        shifted = gmix.set_mean(array([10.0, -2.0]))
+
+        self.assertIsInstance(shifted, GaussianMixture)
+        npt.assert_allclose(shifted.mean(), array([10.0, -2.0]))
+        npt.assert_allclose(gmix.mean(), array([1.5, 2.5]))
+        npt.assert_allclose(shifted.w, gmix.w)
+        npt.assert_allclose(shifted.covariance(), gmix.covariance())
+
     def test_sample_accepts_flat_one_dimensional_dirac_components(self):
         dirac = LinearDiracDistribution(array([1.0, 2.0, 3.0]), array([0.2, 0.5, 0.3]))
         lm = LinearMixture([dirac], array([1.0]))


### PR DESCRIPTION
## Summary
- make `GaussianMixture.set_mean` return a shifted copy instead of mutating the mixture in place and returning `None`
- add a regression test that the shifted mixture has the requested mean while the original mixture remains unchanged
- verify the uniform component shift preserves mixture weights and covariance

## Notes
I could not run the test suite locally from this environment because repository cloning/network access is unavailable here, so this PR relies on the focused regression test and CI.