### PR TITLE
Accept noise_covariance aliases in linear Gaussian models

### DIFF
--- a/src/pyrecest/models/linear_gaussian.py
+++ b/src/pyrecest/models/linear_gaussian.py
@@ -16,6 +16,7 @@ from pyrecest.backend import (
 from pyrecest.distributions import GaussianDistribution
 
 _INVALID_DIMENSION_SCALAR_TYPES = (bool, str, bytes, bytearray)
+_NOISE_COV_UNSET = object()
 
 
 def _has_boolean_dtype(value):
@@ -99,10 +100,36 @@ def _covariance(distribution):
     return distribution.C
 
 
-class LinearGaussianTransitionModel:
-    """Transition model ``x_next = F x + u + w`` with Gaussian noise."""
+def _resolve_noise_covariance(noise_cov, noise_covariance, model_name):
+    if noise_cov is _NOISE_COV_UNSET:
+        if noise_covariance is _NOISE_COV_UNSET:
+            raise TypeError(f"{model_name} missing required argument: 'noise_cov'")
+        return noise_covariance
+    if noise_covariance is not _NOISE_COV_UNSET:
+        raise TypeError(f"{model_name} got both noise_cov and noise_covariance")
+    return noise_cov
 
-    def __init__(self, matrix, noise_cov, offset=None):
+
+class LinearGaussianTransitionModel:
+    """Transition model ``x_next = F x + u + w`` with Gaussian noise.
+
+    The noise covariance can be supplied as ``noise_cov`` or, for consistency
+    with additive-noise models, as the keyword alias ``noise_covariance``.
+    """
+
+    def __init__(
+        self,
+        matrix,
+        noise_cov=_NOISE_COV_UNSET,
+        offset=None,
+        *,
+        noise_covariance=_NOISE_COV_UNSET,
+    ):
+        noise_cov = _resolve_noise_covariance(
+            noise_cov,
+            noise_covariance,
+            type(self).__name__,
+        )
         self.matrix = _as_matrix(matrix, "matrix")
         self.noise_cov = _as_square(noise_cov, "noise_cov")
         self.predicted_dim, self.state_dim = _shape(self.matrix)
@@ -166,9 +193,24 @@ class IdentityGaussianTransitionModel(LinearGaussianTransitionModel):
 
 
 class LinearGaussianMeasurementModel:
-    """Measurement model ``z = H x + v`` with Gaussian noise."""
+    """Measurement model ``z = H x + v`` with Gaussian noise.
 
-    def __init__(self, matrix, noise_cov):
+    The noise covariance can be supplied as ``noise_cov`` or, for consistency
+    with additive-noise models, as the keyword alias ``noise_covariance``.
+    """
+
+    def __init__(
+        self,
+        matrix,
+        noise_cov=_NOISE_COV_UNSET,
+        *,
+        noise_covariance=_NOISE_COV_UNSET,
+    ):
+        noise_cov = _resolve_noise_covariance(
+            noise_cov,
+            noise_covariance,
+            type(self).__name__,
+        )
         self.matrix = _as_matrix(matrix, "matrix")
         self.noise_cov = _as_square(noise_cov, "noise_cov")
         self.measurement_dim, self.state_dim = _shape(self.matrix)

--- a/src/pyrecest/models/linear_gaussian.py
+++ b/src/pyrecest/models/linear_gaussian.py
@@ -187,8 +187,20 @@ class LinearGaussianTransitionModel:
 
 
 class IdentityGaussianTransitionModel(LinearGaussianTransitionModel):
-    def __init__(self, dim, noise_cov, offset=None):
+    def __init__(
+        self,
+        dim,
+        noise_cov=_NOISE_COV_UNSET,
+        offset=None,
+        *,
+        noise_covariance=_NOISE_COV_UNSET,
+    ):
         dim = _as_positive_integer(dim, "dim")
+        noise_cov = _resolve_noise_covariance(
+            noise_cov,
+            noise_covariance,
+            type(self).__name__,
+        )
         super().__init__(eye(dim), noise_cov, offset=offset)
 
 
@@ -260,6 +272,17 @@ class LinearGaussianMeasurementModel:
 
 
 class IdentityGaussianMeasurementModel(LinearGaussianMeasurementModel):
-    def __init__(self, dim, noise_cov):
+    def __init__(
+        self,
+        dim,
+        noise_cov=_NOISE_COV_UNSET,
+        *,
+        noise_covariance=_NOISE_COV_UNSET,
+    ):
         dim = _as_positive_integer(dim, "dim")
+        noise_cov = _resolve_noise_covariance(
+            noise_cov,
+            noise_covariance,
+            type(self).__name__,
+        )
         super().__init__(eye(dim), noise_cov)

--- a/tests/models/test_linear_gaussian_models.py
+++ b/tests/models/test_linear_gaussian_models.py
@@ -39,6 +39,12 @@ class LinearGaussianModelsTest(unittest.TestCase):
         npt.assert_allclose(to_numpy(noise.mu), to_numpy(array([0.0, 0.0])), atol=1e-12)
         npt.assert_allclose(to_numpy(noise.C), to_numpy(noise_cov), atol=1e-12)
 
+    def test_transition_accepts_noise_covariance_keyword_alias(self):
+        noise_cov = diag(array([0.1, 0.2]))
+        model = LinearGaussianTransitionModel(eye(2), noise_covariance=noise_cov)
+
+        npt.assert_allclose(to_numpy(model.system_noise_cov), to_numpy(noise_cov), atol=1e-12)
+
     def test_measurement_predict_distribution(self):
         model = LinearGaussianMeasurementModel(array([[1.0, 0.0]]), array([[0.25]]))
         state = GaussianDistribution(array([2.0, 0.5]), diag(array([1.0, 2.0])))
@@ -58,6 +64,29 @@ class LinearGaussianModelsTest(unittest.TestCase):
 
         npt.assert_allclose(to_numpy(noise.mu), to_numpy(array([0.0])), atol=1e-12)
         npt.assert_allclose(to_numpy(noise.C), to_numpy(noise_cov), atol=1e-12)
+
+    def test_measurement_accepts_noise_covariance_keyword_alias(self):
+        noise_cov = array([[0.25]])
+        model = LinearGaussianMeasurementModel(
+            array([[1.0, 0.0]]), noise_covariance=noise_cov
+        )
+
+        npt.assert_allclose(to_numpy(model.measurement_noise_cov), to_numpy(noise_cov), atol=1e-12)
+
+    def test_noise_covariance_keyword_rejects_ambiguous_inputs(self):
+        with self.assertRaisesRegex(
+            TypeError, "LinearGaussianTransitionModel got both noise_cov and noise_covariance"
+        ):
+            LinearGaussianTransitionModel(
+                eye(1), array([[1.0]]), noise_covariance=array([[1.0]])
+            )
+
+        with self.assertRaisesRegex(
+            TypeError, "LinearGaussianMeasurementModel got both noise_cov and noise_covariance"
+        ):
+            LinearGaussianMeasurementModel(
+                eye(1), array([[1.0]]), noise_covariance=array([[1.0]])
+            )
 
     def test_identity_models(self):
         transition_model = IdentityGaussianTransitionModel(2, diag(array([0.1, 0.2])))

--- a/tests/models/test_linear_gaussian_models.py
+++ b/tests/models/test_linear_gaussian_models.py
@@ -91,12 +91,28 @@ class LinearGaussianModelsTest(unittest.TestCase):
     def test_identity_models(self):
         transition_model = IdentityGaussianTransitionModel(2, diag(array([0.1, 0.2])))
         measurement_model = IdentityGaussianMeasurementModel(2, diag(array([0.3, 0.4])))
+        transition_alias = IdentityGaussianTransitionModel(
+            2, noise_covariance=diag(array([0.1, 0.2]))
+        )
+        measurement_alias = IdentityGaussianMeasurementModel(
+            2, noise_covariance=diag(array([0.3, 0.4]))
+        )
 
         npt.assert_allclose(
             to_numpy(transition_model.system_matrix), to_numpy(eye(2)), atol=1e-12
         )
         npt.assert_allclose(
             to_numpy(measurement_model.measurement_matrix), to_numpy(eye(2)), atol=1e-12
+        )
+        npt.assert_allclose(
+            to_numpy(transition_alias.system_noise_cov),
+            to_numpy(diag(array([0.1, 0.2]))),
+            atol=1e-12,
+        )
+        npt.assert_allclose(
+            to_numpy(measurement_alias.measurement_noise_cov),
+            to_numpy(diag(array([0.3, 0.4]))),
+            atol=1e-12,
         )
 
     def test_identity_models_reject_invalid_dimensions(self):


### PR DESCRIPTION
## Summary
- Accept `noise_covariance=` as a keyword alias for `noise_cov` in linear Gaussian transition and measurement models.
- Extend the same alias to the identity Gaussian model wrappers.
- Reject ambiguous calls that provide both `noise_cov` and `noise_covariance`.
- Add regression coverage for the new aliases and ambiguity checks.

## Testing
- Not run locally; this environment could not create a full repository checkout, so the patch was applied through the GitHub connector.