### PR TITLE
Fix raw JAX matmul out handling

### DIFF
--- a/src/pyrecest/_backend/jax/__init__.py
+++ b/src/pyrecest/_backend/jax/__init__.py
@@ -238,7 +238,6 @@ def cov(
 def diagonal(a, offset=0, axis1=0, axis2=1):
     return _jnp.diagonal(_jnp.asarray(a), offset=offset, axis1=axis1, axis2=axis2)
 
-
 def squeeze(a, axis=None):
     return _jnp.squeeze(_jnp.asarray(a), axis=axis)
 
@@ -603,7 +602,7 @@ def matmul(x, y, out=None):
     result = _jnp.matmul(x, y)
     if out is None:
         return result
-    return result
+    return out.at[...].set(result)
 
 
 def outer(a, b):

--- a/tests/backend_support/test_jax_matmul_out_contract.py
+++ b/tests/backend_support/test_jax_matmul_out_contract.py
@@ -7,3 +7,79 @@ import pytest
 
 
 @ pytest.mark.backend_portable
+def test_jax_matmul_honors_out_shape_contract():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("jax is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "jax"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import pyrecest.backend as backend
+import pyrecest._backend.jax as raw_jax_backend
+
+left = [[1.0, 2.0], [3.0, 4.0]]
+right = [[1.0, 0.0], [0.0, 1.0]]
+
+out = backend.zeros((2, 2))
+returned = backend.matmul(left, right, out=out)
+assert backend.to_numpy(returned).tolist() == [[1.0, 2.0], [3.0, 4.0]]
+
+bad_out = backend.zeros((1, 1))
+try:
+    backend.matmul(left, right, out=bad_out)
+except (TypeError, ValueError):
+    pass
+else:
+    raise AssertionError("JAX backend.matmul ignored incompatible out shape")
+
+raw_bad_out = raw_jax_backend.zeros((1, 1))
+try:
+    raw_jax_backend.matmul(left, right, out=raw_bad_out)
+except (TypeError, ValueError):
+    pass
+else:
+    raise AssertionError("raw JAX matmul ignored incompatible out shape")
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)
+
+
+@ pytest.mark.backend_portable
+def test_raw_jax_matmul_honors_out_shape_contract_without_jax_facade():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("jax is not installed")
+
+    env = os.environ.copy()
+    env.pop("PYRECEST_BACKEND", None)
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import pyrecest._backend.jax as raw_jax_backend
+
+left = [[1.0, 2.0], [3.0, 4.0]]
+right = [[1.0, 0.0], [0.0, 1.0]]
+
+out = raw_jax_backend.zeros((2, 2))
+returned = raw_jax_backend.matmul(left, right, out=out)
+assert raw_jax_backend.to_numpy(returned).tolist() == [[1.0, 2.0], [3.0, 4.0]]
+
+bad_out = raw_jax_backend.zeros((1, 1))
+try:
+    raw_jax_backend.matmul(left, right, out=bad_out)
+except (TypeError, ValueError):
+    pass
+else:
+    raise AssertionError("raw JAX matmul ignored incompatible out shape")
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)

--- a/tests/backend_support/test_jax_matmul_out_contract.py
+++ b/tests/backend_support/test_jax_matmul_out_contract.py
@@ -6,4 +6,4 @@ import sys
 import pytest
 
 
-@패?
+@ pytest.mark.backend_portable

--- a/tests/backend_support/test_jax_matmul_out_contract.py
+++ b/tests/backend_support/test_jax_matmul_out_contract.py
@@ -6,45 +6,4 @@ import sys
 import pytest
 
 
-@pytest.mark.backend_portable
-def test_jax_matmul_honors_out_shape_contract():
-    if importlib.util.find_spec("jax") is None:
-        pytest.skip("jax is not installed")
-
-    env = os.environ.copy()
-    env["PYRECEST_BACKEND"] = "jax"
-    src_path = os.path.abspath("src")
-    env["PYTHONPATH"] = (
-        src_path
-        if not env.get("PYTHONPATH")
-        else os.pathsep.join([src_path, env["PYTHONPATH"]])
-    )
-
-    code = """
-import pyrecest.backend as backend
-import pyrecest._backend.jax as raw_jax_backend
-
-left = [[1.0, 2.0], [3.0, 4.0]]
-right = [[1.0, 0.0], [0.0, 1.0]]
-
-out = backend.zeros((2, 2))
-returned = backend.matmul(left, right, out=out)
-assert backend.to_numpy(returned).tolist() == [[1.0, 2.0], [3.0, 4.0]]
-
-bad_out = backend.zeros((1, 1))
-try:
-    backend.matmul(left, right, out=bad_out)
-except (TypeError, ValueError):
-    pass
-else:
-    raise AssertionError("JAX backend.matmul ignored incompatible out shape")
-
-raw_bad_out = raw_jax_backend.zeros((1, 1))
-try:
-    raw_jax_backend.matmul(left, right, out=raw_bad_out)
-except (TypeError, ValueError):
-    pass
-else:
-    raise AssertionError("raw JAX matmul ignored incompatible out shape")
-"""
-    subprocess.run([sys.executable, "-c", code], check=True, env=env)
+@패?

--- a/tests/backend_support/test_jax_matmul_out_contract.py
+++ b/tests/backend_support/test_jax_matmul_out_contract.py
@@ -6,7 +6,7 @@ import sys
 import pytest
 
 
-@ pytest.mark.backend_portable
+@pytest.mark.backend_portable
 def test_jax_matmul_honors_out_shape_contract():
     if importlib.util.find_spec("jax") is None:
         pytest.skip("jax is not installed")
@@ -50,7 +50,7 @@ else:
     subprocess.run([sys.executable, "-c", code], check=True, env=env)
 
 
-@ pytest.mark.backend_portable
+@pytest.mark.backend_portable
 def test_raw_jax_matmul_honors_out_shape_contract_without_jax_facade():
     if importlib.util.find_spec("jax") is None:
         pytest.skip("jax is not installed")


### PR DESCRIPTION
## Summary
- Make the raw JAX backend's `matmul(..., out=...)` store through the provided JAX output array instead of silently ignoring `out`.
- Add a regression test that imports `pyrecest._backend.jax` without selecting the JAX facade, covering the raw backend path.

## Notes
- I could not run the repository test suite locally because this environment could not clone GitHub directly; the change is scoped to the existing JAX matmul out contract.