### PR TITLE
Reject zero-volume linear box particles

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/linear_box_particle_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/linear_box_particle_distribution.py
@@ -53,8 +53,8 @@ class LinearBoxParticleDistribution(AbstractLinearDistribution):
             raise ValueError("lower and upper must have the same shape")
         if lower.ndim != 2:
             raise ValueError("lower and upper must be arrays with shape (n_boxes, dim)")
-        if not bool(all(upper >= lower)):
-            raise ValueError("Each box must satisfy upper >= lower component-wise")
+        if not bool(all(upper > lower)):
+            raise ValueError("Each box must satisfy upper > lower component-wise")
 
         AbstractLinearDistribution.__init__(self, int(lower.shape[1]))
         self.lower = copy.copy(lower)

--- a/tests/distributions/test_linear_box_particle_distribution.py
+++ b/tests/distributions/test_linear_box_particle_distribution.py
@@ -39,6 +39,17 @@ class LinearBoxParticleDistributionTest(unittest.TestCase):
 
         npt.assert_allclose(dist.integrate(array([1.0]), array([3.0])), 0.5)
 
+    def test_constructor_rejects_zero_volume_boxes(self):
+        invalid_boxes = (
+            (array([[0.0]]), array([[0.0]])),
+            (array([[0.0, 0.0]]), array([[1.0, 0.0]])),
+        )
+
+        for lower, upper in invalid_boxes:
+            with self.subTest(lower=lower, upper=upper):
+                with self.assertRaisesRegex(ValueError, "upper > lower"):
+                    LinearBoxParticleDistribution(lower, upper)
+
     def test_constructor_rejects_nonfinite_weights(self):
         invalid_weights = (
             ("nan", array([np.nan, 1.0])),


### PR DESCRIPTION
## Summary
- reject degenerate `LinearBoxParticleDistribution` boxes with zero side length
- add a regression test for one-dimensional and partially degenerate multidimensional boxes

## Rationale
Zero-volume boxes were accepted by the constructor, but their mass was inconsistent across APIs: `pdf()` and bounded `integrate()` treated them as zero-density boxes while `integrate(None)` still returned their positive normalized weight mass. Since the class represents mixtures of uniform densities on boxes, each box must have strictly positive volume.

## Testing
- Not run locally; repository access was through the GitHub connector only.