### PR TITLE
Reject boolean model validation inputs

### DIFF
--- a/src/pyrecest/models/validation.py
+++ b/src/pyrecest/models/validation.py
@@ -98,8 +98,21 @@ def _to_python_bool(value: Any) -> bool:
     return bool(value)
 
 
+def _dtype_name(value: Any) -> str:
+    dtype = getattr(value, "dtype", None)
+    return "" if dtype is None else str(dtype).lower()
+
+
+def _validate_numeric_nonboolean_entries(value: Any, name: str) -> None:
+    """Raise if a backend array is boolean-valued rather than numeric."""
+    dtype_name = _dtype_name(value)
+    if dtype_name in {"bool", "bool_", "torch.bool"}:
+        raise ValueError(f"{name} must contain numeric non-boolean values.")
+
+
 def _validate_finite_entries(value: Any, name: str) -> None:
     """Raise if a backend array contains NaN or infinite entries."""
+    _validate_numeric_nonboolean_entries(value, name)
     try:
         finite = backend.all(backend.isfinite(value))
     except Exception as exc:  # pragma: no cover - backend-specific exception type

--- a/tests/models/test_validation.py
+++ b/tests/models/test_validation.py
@@ -48,6 +48,21 @@ class TestModelValidation(unittest.TestCase):
                 with self.assertRaisesRegex(TypeError, "integer or None"):
                     call()
 
+    def test_validate_vector_and_matrix_reject_boolean_arrays(self):
+        invalid_calls = [
+            lambda: validate_state_vector(array([True, False]), state_dim=2),
+            lambda: validate_measurement_vector(array([True]), meas_dim=1),
+            lambda: validate_covariance_matrix(array([[True]])),
+            lambda: validate_noise_covariance(array([[False]])),
+            lambda: validate_transition_matrix(array([[True]])),
+            lambda: validate_measurement_matrix(array([[False]])),
+        ]
+
+        for call in invalid_calls:
+            with self.subTest(call=call):
+                with self.assertRaisesRegex(ValueError, "numeric non-boolean"):
+                    call()
+
     def test_validate_measurement_vector_accepts_expected_shape(self):
         measurement = validate_measurement_vector(array([1.0]), meas_dim=1)
 


### PR DESCRIPTION
## Summary
- reject boolean-valued arrays in reusable model validation helpers
- keep finite numeric validation behavior for real and complex arrays
- add regression coverage for state, measurement, covariance, transition, and measurement matrices

## Bug fixed
The validation helpers accepted boolean arrays because backend `isfinite` treats boolean values as finite. That allowed booleans to pass as state vectors, measurement vectors, covariance matrices, and linear model matrices despite those helpers being numeric shape validators.

## Testing
- Not run locally: this environment could not clone GitHub via git/DNS, so CI should run the focused regression tests.