### PR TITLE
Fix PyTorch arctan array-like backend contract

### DIFF
--- a/src/pyrecest/stability.py
+++ b/src/pyrecest/stability.py
@@ -143,6 +143,34 @@ def _patch_pytorch_vec_to_diag_numpy_contract() -> None:
         backend.vec_to_diag = vec_to_diag
 
 
+def _patch_pytorch_arctan_numpy_contract() -> None:
+    """Patch raw/public PyTorch ``arctan`` to accept NumPy-style inputs."""
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    original_arctan = getattr(raw_pytorch, "arctan", None)
+    if original_arctan is None:
+        return
+    if getattr(original_arctan, "_pyrecest_numpy_contract", False):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.arctan = original_arctan
+        return
+
+    def arctan(a, *args, **kwargs):
+        return torch.arctan(raw_pytorch.array(a), *args, **kwargs)
+
+    arctan.__name__ = getattr(original_arctan, "__name__", "arctan")
+    arctan.__doc__ = getattr(original_arctan, "__doc__", None)
+    arctan._pyrecest_numpy_contract = True
+    raw_pytorch.arctan = arctan
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.arctan = arctan
+
+
 def _jax_squeeze_axis(axis) -> int:
     """Return one NumPy-style integer squeeze axis."""
     if isinstance(axis, bool) or type(axis).__name__ == "bool_":
@@ -221,6 +249,7 @@ def _patch_jax_squeeze_numpy_contract() -> None:
 _patch_pytorch_allclose_device_contract()
 _patch_pytorch_diag_numpy_contract()
 _patch_pytorch_vec_to_diag_numpy_contract()
+_patch_pytorch_arctan_numpy_contract()
 _patch_pytorch_raw_comparison_arraylike_contract()
 _patch_pytorch_dot_outer_device_contract()
 _patch_pytorch_matmul_device_contract()

--- a/tests/backend_support/test_pytorch_arctan_contract.py
+++ b/tests/backend_support/test_pytorch_arctan_contract.py
@@ -1,0 +1,59 @@
+"""Regression tests for PyTorch arctan backend contract."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_pytorch_arctan_accepts_numpy_style_array_like_inputs():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import math
+import pyrecest.backend as backend
+
+scalar = backend.arctan(1.0)
+vector = backend.arctan([0.0, 1.0])
+
+assert abs(backend.to_numpy(scalar).item() - math.pi / 4.0) < 1e-6
+values = backend.to_numpy(vector).tolist()
+assert abs(values[0] - 0.0) < 1e-12
+assert abs(values[1] - math.pi / 4.0) < 1e-6
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_arctan_accepts_array_like_inputs_under_numpy_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "numpy",
+        """
+import math
+import pyrecest._backend.pytorch as raw_pytorch
+
+values = raw_pytorch.arctan([0.0, 1.0])
+as_numpy = raw_pytorch.to_numpy(values).tolist()
+
+assert abs(as_numpy[0] - 0.0) < 1e-12
+assert abs(as_numpy[1] - math.pi / 4.0) < 1e-6
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- Patch raw/public PyTorch `arctan` through the stability compatibility layer so it coerces NumPy-style array-like inputs via the raw PyTorch backend.
- Keep the active public PyTorch backend facade synchronized when `PYRECEST_BACKEND=pytorch`.
- Add backend-portable regression coverage for the public PyTorch backend and for raw PyTorch import under the NumPy backend.

## Bug fixed
The PyTorch backend imported `torch.arctan` directly while the neighboring unary math helpers use boxed wrappers. As a result, calls such as `backend.arctan(1.0)` or `raw_pytorch.arctan([0.0, 1.0])` could fail because raw `torch.arctan` expects a tensor input. The compatibility hook now normalizes inputs with `raw_pytorch.array(...)` before dispatching to `torch.arctan`.

## Testing
- Not run locally; repository access in this environment was via the GitHub connector, and direct sandbox cloning from GitHub was unavailable.