### PR TITLE
Reject None values in time offset numeric arrays

### DIFF
--- a/src/pyrecest/calibration/__init__.py
+++ b/src/pyrecest/calibration/__init__.py
@@ -8,6 +8,7 @@ import numpy as np
 from . import time_offset as _time_offset_module
 
 _REJECTED_REAL_SCALAR_TYPES = (
+    type(None),
     bool,
     np.bool_,
     str,
@@ -58,7 +59,7 @@ def _as_real_numeric_array(value: Any, name: str) -> np.ndarray:
     arr = np.asarray(value)
     if arr.dtype == np.bool_ or arr.dtype.kind in "USbcMm":
         raise ValueError(f"{name} must contain real numeric values")
-    if arr.dtype == object:
+    if arr.dtype.kind == "O":
         for item in arr.reshape(-1):
             if _is_rejected_real_scalar(item):
                 raise ValueError(f"{name} must contain real numeric values")

--- a/src/pyrecest/calibration/time_offset.py
+++ b/src/pyrecest/calibration/time_offset.py
@@ -95,7 +95,7 @@ def _as_real_numeric_array(value: Any, name: str) -> np.ndarray:
     arr = np.asarray(value)
     if arr.dtype == np.bool_ or arr.dtype.kind in "USbcMm":
         raise ValueError(f"{name} must contain real numeric values")
-    if arr.dtype == object:
+    if arr.dtype.kind == "O":
         for item in arr.reshape(-1):
             if item is None or isinstance(item, (bool, np.bool_, str, bytes, bytearray, complex, np.complexfloating)):
                 raise ValueError(f"{name} must contain real numeric values")

--- a/src/pyrecest/calibration/time_offset.py
+++ b/src/pyrecest/calibration/time_offset.py
@@ -97,7 +97,7 @@ def _as_real_numeric_array(value: Any, name: str) -> np.ndarray:
         raise ValueError(f"{name} must contain real numeric values")
     if arr.dtype == object:
         for item in arr.reshape(-1):
-            if isinstance(item, (bool, np.bool_, str, bytes, bytearray)):
+            if item is None or isinstance(item, (bool, np.bool_, str, bytes, bytearray, complex, np.complexfloating)):
                 raise ValueError(f"{name} must contain real numeric values")
     try:
         return np.asarray(value, dtype=float)

--- a/tests/calibration/test_time_offset_numeric_arrays.py
+++ b/tests/calibration/test_time_offset_numeric_arrays.py
@@ -18,12 +18,13 @@ class TimeOffsetNumericArrayValidationTest(unittest.TestCase):
         ):
             func(*args)
 
-    def test_apply_time_offset_rejects_bool_and_text_time_arrays(self):
+    def test_apply_time_offset_rejects_bool_text_and_none_time_arrays(self):
         invalid_times = (
             np.array([False, True]),
             np.array(["0.0", "1.0"]),
             np.array([0.0, "1.0"], dtype=object),
             np.array([0.0, b"1.0"], dtype=object),
+            np.array([0.0, None], dtype=object),
         )
         for times_s in invalid_times:
             with self.subTest(dtype=times_s.dtype, values=times_s):
@@ -34,7 +35,7 @@ class TimeOffsetNumericArrayValidationTest(unittest.TestCase):
                     0.0,
                 )
 
-    def test_nearest_time_indices_rejects_bool_and_text_time_arrays(self):
+    def test_nearest_time_indices_rejects_bool_text_and_none_time_arrays(self):
         cases = (
             (
                 np.array([False, True]),
@@ -43,6 +44,11 @@ class TimeOffsetNumericArrayValidationTest(unittest.TestCase):
             ),
             (
                 np.array(["0.0", "1.0"]),
+                np.array([0.25]),
+                "reference_times_s",
+            ),
+            (
+                np.array([0.0, None], dtype=object),
                 np.array([0.25]),
                 "reference_times_s",
             ),
@@ -56,6 +62,11 @@ class TimeOffsetNumericArrayValidationTest(unittest.TestCase):
                 np.array(["0.25"]),
                 "query_times_s",
             ),
+            (
+                np.array([0.0, 1.0]),
+                np.array([None], dtype=object),
+                "query_times_s",
+            ),
         )
         for reference_times_s, query_times_s, expected_name in cases:
             with self.subTest(expected_name=expected_name):
@@ -66,7 +77,7 @@ class TimeOffsetNumericArrayValidationTest(unittest.TestCase):
                     query_times_s,
                 )
 
-    def test_interpolation_rejects_bool_and_text_data_arrays(self):
+    def test_interpolation_rejects_bool_text_and_none_data_arrays(self):
         numeric_times = np.array([0.0, 1.0])
         numeric_values = np.array([[0.0], [1.0]])
         numeric_query = np.array([0.25])
@@ -79,6 +90,12 @@ class TimeOffsetNumericArrayValidationTest(unittest.TestCase):
             ),
             (
                 np.array(["0.0", "1.0"]),
+                numeric_values,
+                numeric_query,
+                "reference_times_s",
+            ),
+            (
+                np.array([0.0, None], dtype=object),
                 numeric_values,
                 numeric_query,
                 "reference_times_s",
@@ -97,6 +114,12 @@ class TimeOffsetNumericArrayValidationTest(unittest.TestCase):
             ),
             (
                 numeric_times,
+                np.array([[0.0], [None]], dtype=object),
+                numeric_query,
+                "reference_values",
+            ),
+            (
+                numeric_times,
                 numeric_values,
                 np.array([False]),
                 "query_times_s",
@@ -105,6 +128,12 @@ class TimeOffsetNumericArrayValidationTest(unittest.TestCase):
                 numeric_times,
                 numeric_values,
                 np.array(["0.25"]),
+                "query_times_s",
+            ),
+            (
+                numeric_times,
+                numeric_values,
+                np.array([None], dtype=object),
                 "query_times_s",
             ),
         )
@@ -118,10 +147,14 @@ class TimeOffsetNumericArrayValidationTest(unittest.TestCase):
                     query_times_s,
                 )
 
-    def test_time_offset_summary_rejects_bool_and_text_measurement_values(self):
+    def test_time_offset_summary_rejects_bool_text_and_none_measurement_values(self):
         reference_times = np.array([0.0, 1.0])
         reference_values = np.array([[0.0], [1.0]])
-        for measurement_values in (np.array([True]), np.array(["0.0"])):
+        for measurement_values in (
+            np.array([True]),
+            np.array(["0.0"]),
+            np.array([None], dtype=object),
+        ):
             with self.subTest(dtype=measurement_values.dtype):
                 self.assert_rejects_numeric_array(
                     time_offset_error_summary,


### PR DESCRIPTION
## Summary
- Reject `None` entries in object-dtype numeric arrays used by time-offset calibration helpers.
- Preserve support for numeric object arrays.
- Add regression coverage for offset application, nearest-neighbor lookup, interpolation, and error summaries.

## Testing
- Syntax-checked the updated module and test file with `python -m py_compile`.