### PR TITLE
Validate sampleable transition vectorization flag assignments

### DIFF
--- a/src/pyrecest/models/likelihood.py
+++ b/src/pyrecest/models/likelihood.py
@@ -186,10 +186,20 @@ class SampleableTransitionModel:
         self._sample_next = sample_next
         self._sample_next_count_call_mode = _sample_count_call_mode(sample_next)
         self._transition_density = transition_density
-        self.function_is_vectorized = _validate_bool_flag(
-            function_is_vectorized, "function_is_vectorized"
-        )
+        self.function_is_vectorized = function_is_vectorized
         self.name = name
+
+    @property
+    def function_is_vectorized(self) -> bool:
+        """Whether the sampler accepts vectorized state inputs."""
+
+        return self._function_is_vectorized
+
+    @function_is_vectorized.setter
+    def function_is_vectorized(self, value: bool) -> None:
+        self._function_is_vectorized = _validate_bool_flag(
+            value, "function_is_vectorized"
+        )
 
     @property
     def has_transition_density(self) -> bool:

--- a/tests/models/test_likelihood_sampleable_models.py
+++ b/tests/models/test_likelihood_sampleable_models.py
@@ -1,5 +1,7 @@
 import unittest
 
+import numpy as np
+
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import allclose, arange, array, exp, reshape
 from pyrecest.models import (
@@ -174,6 +176,27 @@ class SampleableTransitionModelTest(unittest.TestCase):
         )
 
         self.assertFalse(model.function_is_vectorized)
+
+    def test_function_is_vectorized_flag_requires_boolean(self):
+        model = SampleableTransitionModel(
+            lambda state: state,
+            function_is_vectorized=np.bool_(True),
+        )
+
+        self.assertTrue(model.function_is_vectorized)
+        model.function_is_vectorized = False
+        self.assertFalse(model.function_is_vectorized)
+
+        invalid_flags = ("False", 1, np.array([True]))
+        for flag in invalid_flags:
+            with self.subTest(flag=flag):
+                with self.assertRaisesRegex(TypeError, "function_is_vectorized"):
+                    SampleableTransitionModel(
+                        lambda state: state,
+                        function_is_vectorized=flag,
+                    )
+                with self.assertRaisesRegex(TypeError, "function_is_vectorized"):
+                    model.function_is_vectorized = flag
 
 
 class DensityTransitionModelTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- turn `SampleableTransitionModel.function_is_vectorized` into a validated property
- keep constructor behavior while rejecting invalid post-construction assignments
- add regression coverage for NumPy boolean scalars and invalid scalar/array values

## Bug fixed
`SampleableTransitionModel` validated `function_is_vectorized` only in `__init__`. After construction, callers could assign values such as `1`, `"False"`, or non-scalar arrays, leaving invalid model metadata for particle-filter adapters.

## Testing
- Not run locally: the sandbox cannot resolve `github.com`, so I could not clone/install the repository test environment here. The focused regression test was added under `tests/models/test_likelihood_sampleable_models.py`.