### PR TITLE
Normalize numerics validation conversion errors

### DIFF
--- a/src/pyrecest/numerics.py
+++ b/src/pyrecest/numerics.py
@@ -42,7 +42,10 @@ def _object_item_contains_unsupported_numeric_values(item) -> bool:
 
 
 def _contains_unsupported_numeric_values(value) -> bool:
-    value_array = np.asarray(value)
+    try:
+        value_array = np.asarray(value)
+    except (TypeError, ValueError, RuntimeError):
+        return True
     if value_array.dtype.kind in _UNSUPPORTED_NUMERIC_KINDS:
         return True
     if value_array.dtype.kind != "O":
@@ -67,7 +70,7 @@ def _to_numpy_array(value, *, name: str = "matrix") -> np.ndarray:
         if _contains_unsupported_numeric_values(raw):
             raise ValueError
         return np.asarray(raw, dtype=float)
-    except (TypeError, ValueError, OverflowError) as exc:
+    except (TypeError, ValueError, OverflowError, RuntimeError) as exc:
         raise ValueError(f"{name} must contain numeric values.") from exc
 
 
@@ -83,7 +86,7 @@ def _from_numpy_array(value: np.ndarray):
 def _validate_nonnegative_finite(name: str, value: float) -> float:
     try:
         value_array = np.asarray(value)
-    except (TypeError, ValueError) as exc:
+    except (TypeError, ValueError, RuntimeError) as exc:
         raise ValueError(f"{name} must be a scalar number.") from exc
     if value_array.shape != () or np.issubdtype(value_array.dtype, np.bool_):
         raise ValueError(f"{name} must be a scalar number.")
@@ -109,7 +112,7 @@ def _validate_positive_finite(name: str, value: float) -> float:
 def _validate_nonnegative_integer(name: str, value: int) -> int:
     try:
         value_array = np.asarray(value)
-    except (TypeError, ValueError) as exc:
+    except (TypeError, ValueError, RuntimeError) as exc:
         raise ValueError(f"{name} must be a nonnegative integer.") from exc
     if value_array.shape != () or not np.issubdtype(value_array.dtype, np.integer):
         raise ValueError(f"{name} must be a nonnegative integer.")

--- a/tests/test_numerics.py
+++ b/tests/test_numerics.py
@@ -15,6 +15,12 @@ from pyrecest.numerics import (
 )
 
 
+class UncoercibleArray:
+    def __array__(self, dtype=None):
+        del dtype
+        raise RuntimeError("cannot convert")
+
+
 def test_symmetrize_matrix_and_psd_projection():
     matrix = np.array([[1.0, 2.0], [0.0, -0.1]])
     symmetric = np.asarray(symmetrize_matrix(matrix))
@@ -71,6 +77,40 @@ def test_covariance_helpers_reject_bool_text_temporal_and_none_matrices(matrix):
         nearest_symmetric_psd(matrix)
     with pytest.raises(ValueError, match="matrix must contain numeric values"):
         jittered_cholesky(matrix)
+
+
+def test_covariance_helpers_reject_uncoercible_array_like_inputs():
+    matrix = UncoercibleArray()
+
+    assert not is_symmetric(matrix)
+    assert not is_positive_semidefinite(matrix)
+
+    with pytest.raises(ValueError, match="covariance must contain numeric values"):
+        assert_covariance_matrix(matrix)
+    with pytest.raises(ValueError, match="matrix must contain numeric values"):
+        symmetrize_matrix(matrix)
+    with pytest.raises(ValueError, match="matrix must contain numeric values"):
+        nearest_symmetric_psd(matrix)
+    with pytest.raises(ValueError, match="matrix must contain numeric values"):
+        jittered_cholesky(matrix)
+
+
+def test_covariance_helpers_reject_uncoercible_scalar_controls():
+    value = UncoercibleArray()
+    matrix = np.eye(2)
+
+    with pytest.raises(ValueError, match="atol"):
+        is_symmetric(matrix, atol=value)
+    with pytest.raises(ValueError, match="atol"):
+        is_positive_semidefinite(matrix, atol=value)
+    with pytest.raises(ValueError, match="min_eigenvalue"):
+        nearest_symmetric_psd(matrix, min_eigenvalue=value)
+    with pytest.raises(ValueError, match="initial_jitter"):
+        jittered_cholesky(matrix, initial_jitter=value)
+    with pytest.raises(ValueError, match="max_attempts"):
+        jittered_cholesky(matrix, max_attempts=value)
+    with pytest.raises(ValueError, match="dim"):
+        assert_covariance_matrix(matrix, dim=value)
 
 
 def test_covariance_helpers_reject_nonfinite_matrices():


### PR DESCRIPTION
## Summary
- Wrap array-conversion failures in numerics validation helpers so public covariance predicates and repair helpers keep their documented `ValueError`/False behavior for uncoercible array-like inputs.
- Treat array-like objects that fail `np.asarray(...)` as unsupported numeric values before attempting float conversion.
- Add regression coverage for uncoercible matrix inputs and scalar control arguments.

## Bug fixed
Objects with a failing `__array__` method could leak a raw `RuntimeError` from `np.asarray(...)` through `is_symmetric`, `is_positive_semidefinite`, `assert_covariance_matrix`, `symmetrize_matrix`, `nearest_symmetric_psd`, `jittered_cholesky`, and scalar controls such as `atol`/`max_attempts`. The numerics helpers otherwise normalize invalid inputs to `False` for predicates or `ValueError` for validators.

## Validation
- `python -m py_compile /mnt/data/numerics.py /mnt/data/test_numerics.py`
- `PYTHONPATH=/mnt/data/tmp_num pytest -q /mnt/data/test_numerics.py` (22 passed in a minimal local package shim)
- Verified GitHub compare: branch is 1 commit ahead of `main`, 0 behind, modifying only `src/pyrecest/numerics.py` and `tests/test_numerics.py`.