### PR TITLE
Fix shared NumPy array dtype=None default handling

### DIFF
--- a/src/pyrecest/_backend/autograd/_common.py
+++ b/src/pyrecest/_backend/autograd/_common.py
@@ -12,7 +12,6 @@ from .._shared_numpy._common import (
     _box_binary_scalar,
     _box_unary_scalar,
     _cast_fout_to_input_dtype,
-    _cast_out_from_dtype,
     _cast_out_to_input_dtype,
     _get_wider_dtype,
     _is_boolean,
@@ -32,4 +31,20 @@ from .._shared_numpy._common import (
 
 zeros = _dyn_update_dtype(target=_np.zeros)
 eye = _dyn_update_dtype(target=_np.eye)
-array = _cast_out_from_dtype(target=_np.array)
+
+
+def _array_default_dtype_for(result):
+    if is_floating(result):
+        return get_default_dtype()
+    if is_complex(result):
+        return get_default_cdtype()
+    return None
+
+
+def array(object, dtype=None, *args, **kwargs):
+    result = _np.array(object, dtype=dtype, *args, **kwargs)
+    if dtype is None:
+        default_dtype = _array_default_dtype_for(result)
+        if default_dtype is not None and result.dtype != default_dtype:
+            return cast(result, default_dtype)
+    return result

--- a/src/pyrecest/_backend/numpy/_common.py
+++ b/src/pyrecest/_backend/numpy/_common.py
@@ -16,7 +16,6 @@ from .._shared_numpy._common import (
     _box_binary_scalar,
     _box_unary_scalar,
     _cast_fout_to_input_dtype,
-    _cast_out_from_dtype,
     _cast_out_to_input_dtype,
     _get_wider_dtype,
     _is_boolean,
@@ -52,7 +51,23 @@ def get_default_cdtype():
     return _normalize_numpy_dtype(_shared_get_default_cdtype(), _np.complex128)
 
 
-array = _cast_out_from_dtype(target=_np.array, dtype_pos=1)
+def _array_default_dtype_for(result):
+    if is_floating(result):
+        return get_default_dtype()
+    if is_complex(result):
+        return get_default_cdtype()
+    return None
+
+
+def array(object, dtype=None, *args, **kwargs):
+    result = _np.array(object, dtype=dtype, *args, **kwargs)
+    if dtype is None:
+        default_dtype = _array_default_dtype_for(result)
+        if default_dtype is not None and result.dtype != default_dtype:
+            return cast(result, default_dtype)
+    return result
+
+
 eye = _modify_func_default_dtype(target=_np.eye)
 
 

--- a/tests/test_shared_numpy_array_dtype_none.py
+++ b/tests/test_shared_numpy_array_dtype_none.py
@@ -9,11 +9,13 @@ backend.set_default_dtype("float32")
 try:
     omitted_real = backend.array([1.0])
     explicit_none_real = backend.array([1.0], dtype=None)
+    positional_none_real = backend.array([1.0], None)
     explicit_none_complex = backend.array([1.0 + 2.0j], dtype=None)
     explicit_none_integer = backend.array([1], dtype=None)
 
     assert str(omitted_real.dtype) == "float32", omitted_real.dtype
     assert str(explicit_none_real.dtype) == "float32", explicit_none_real.dtype
+    assert str(positional_none_real.dtype) == "float32", positional_none_real.dtype
     assert str(explicit_none_complex.dtype) == "complex64", explicit_none_complex.dtype
     assert str(explicit_none_integer.dtype).startswith("int"), explicit_none_integer.dtype
 finally:

--- a/tests/test_shared_numpy_array_dtype_none.py
+++ b/tests/test_shared_numpy_array_dtype_none.py
@@ -1,0 +1,31 @@
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+_ARRAY_DTYPE_NONE_CODE = """
+import pyrecest.backend as backend
+
+backend.set_default_dtype("float32")
+try:
+    omitted_real = backend.array([1.0])
+    explicit_none_real = backend.array([1.0], dtype=None)
+    explicit_none_complex = backend.array([1.0 + 2.0j], dtype=None)
+    explicit_none_integer = backend.array([1], dtype=None)
+
+    assert str(omitted_real.dtype) == "float32", omitted_real.dtype
+    assert str(explicit_none_real.dtype) == "float32", explicit_none_real.dtype
+    assert str(explicit_none_complex.dtype) == "complex64", explicit_none_complex.dtype
+    assert str(explicit_none_integer.dtype).startswith("int"), explicit_none_integer.dtype
+finally:
+    backend.set_default_dtype("float64")
+"""
+
+
+@pytest.mark.parametrize("backend_name", ["numpy", "autograd"])
+def test_shared_numpy_array_dtype_none_uses_default_dtype(backend_name):
+    if backend_name == "autograd":
+        pytest.importorskip("autograd")
+
+    result = run_backend_code(backend_name, _ARRAY_DTYPE_NONE_CODE)
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Treat explicit `dtype=None` in the NumPy and Autograd `array` wrappers the same as an omitted dtype for floating and complex arrays.
- Preserve inferred non-floating dtypes such as integer arrays.
- Add subprocess regression coverage for keyword and positional `dtype=None` calls on the shared NumPy-style backends.

## Bug fixed
With the default dtype set to `float32`, `backend.array([1.0])` used the backend default, but `backend.array([1.0], dtype=None)` fell through to NumPy inference and returned `float64`. This made explicit `None` inconsistent with the dynamic dtype contract used by the backend wrappers.

## Testing
- Not run locally; validation is covered by the added regression test and repository CI.