### PR TITLE
Fix raw PyTorch set_diag array-like inputs

### DIFF
--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -107,7 +107,7 @@ def _patch_shared_numpy_squeeze_facade() -> None:
 
 
 def _patch_set_diag_arraylike_facade() -> None:
-    """Make public set_diag accept array-like matrix inputs."""
+    """Make public and raw PyTorch set_diag accept array-like matrix inputs."""
 
     import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
 
@@ -121,6 +121,36 @@ def _patch_set_diag_arraylike_facade() -> None:
     set_diag.__name__ = getattr(original_set_diag, "__name__", "set_diag")
     set_diag.__doc__ = getattr(original_set_diag, "__doc__", None)
     backend.set_diag = set_diag
+
+    try:
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+        import torch as _torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch may be unavailable
+        return
+
+    raw_set_diag = getattr(pytorch_backend, "set_diag", None)
+    if raw_set_diag is None:
+        return
+    if getattr(raw_set_diag, "_pyrecest_arraylike_contract", False):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.set_diag = raw_set_diag
+        return
+
+    def raw_pytorch_set_diag(x, new_diag):
+        x = pytorch_backend.array(x)
+        diag_len = min(x.shape[-2], x.shape[-1])
+        result = x.clone()
+        diag_indices = _torch.arange(diag_len, device=x.device)
+        values = _torch.as_tensor(new_diag, dtype=x.dtype, device=x.device)
+        result[..., diag_indices, diag_indices] = values
+        return result
+
+    raw_pytorch_set_diag.__name__ = getattr(raw_set_diag, "__name__", "set_diag")
+    raw_pytorch_set_diag.__doc__ = getattr(raw_set_diag, "__doc__", None)
+    raw_pytorch_set_diag._pyrecest_arraylike_contract = True
+    pytorch_backend.set_diag = raw_pytorch_set_diag
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.set_diag = raw_pytorch_set_diag
 
 
 def _patch_pytorch_one_hot_integer_label_facade() -> None:

--- a/tests/test_backend_set_diag_contract.py
+++ b/tests/test_backend_set_diag_contract.py
@@ -1,3 +1,5 @@
+import pytest
+
 import pyrecest.backend as backend
 
 
@@ -12,3 +14,13 @@ def test_set_diag_accepts_array_like_matrix_inputs():
     result = backend.set_diag([[1, 2], [3, 4]], [9, 8])
 
     assert _to_python(result) == [[9, 2], [3, 8]]
+
+
+def test_raw_pytorch_set_diag_accepts_array_like_matrix_inputs():
+    pytest.importorskip("torch")
+
+    import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+
+    result = raw_pytorch.set_diag([[1, 2], [3, 4]], [9, 8])
+
+    assert raw_pytorch.to_numpy(result).tolist() == [[9, 2], [3, 8]]


### PR DESCRIPTION
## Summary
- Extend the existing `set_diag` array-like compatibility patch to the raw PyTorch backend.
- Keep the public PyTorch facade synchronized with the patched raw helper.
- Add regression coverage for `pyrecest._backend.pytorch.set_diag(...)` with Python-list matrix inputs.

## Bug fixed
The public backend already coerced array-like `set_diag` inputs, but the raw PyTorch backend still read `x.shape` and called `x.clone()` before converting `x` to a tensor. Direct raw-backend calls such as `pyrecest._backend.pytorch.set_diag([[1, 2], [3, 4]], [9, 8])` could therefore raise `AttributeError` on list input instead of following the backend array-like contract.

## Validation
- `python -m py_compile /mnt/data/pyrecest_init_new.py /mnt/data/test_backend_set_diag_contract_new.py`
- Local Torch check for the patched diagonal assignment logic.
- Verified branch comparison: 2 commits ahead of `main`, 0 behind; changes limited to `src/pyrecest/__init__.py` and `tests/test_backend_set_diag_contract.py`.

Full repository pytest was not run because this environment cannot clone GitHub directly; CI should exercise the focused regression test.