### PR TITLE
Normalize multisession fill_value conversion errors

### DIFF
--- a/src/pyrecest/utils/_multisession_assignment_labels.py
+++ b/src/pyrecest/utils/_multisession_assignment_labels.py
@@ -23,7 +23,10 @@ _TEXT_TYPES = (str, bytes, np.str_, np.bytes_)
 
 
 def _normalize_fill_value(fill_value: Any, track_count: int) -> int:
-    fill_value_array = np.asarray(fill_value)
+    try:
+        fill_value_array = np.asarray(fill_value)
+    except (TypeError, ValueError, OverflowError, RuntimeError) as exc:
+        raise ValueError("fill_value must be an integer.") from exc
     if (
         fill_value_array.shape != ()
         or fill_value_array.dtype == np.bool_

--- a/tests/test_multisession_assignment_labels.py
+++ b/tests/test_multisession_assignment_labels.py
@@ -12,6 +12,12 @@ from pyrecest.backend import (  # pylint: disable=no-name-in-module
 from pyrecest.utils import MultiSessionAssignmentResult, tracks_to_session_labels
 
 
+class _UncoercibleFillValue:
+    def __array__(self, dtype=None):
+        del dtype
+        raise RuntimeError("array conversion failed")
+
+
 class TestMultiSessionAssignmentLabels(unittest.TestCase):
     @staticmethod
     def _converters():
@@ -86,6 +92,25 @@ class TestMultiSessionAssignmentLabels(unittest.TestCase):
                         "fill_value must be an integer",
                     ):
                         converter(tracks, session_sizes=[2], fill_value=fill_value)
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_uncoercible_fill_values_are_rejected_as_value_errors(self):
+        tracks = [{0: 0}]
+
+        for name, converter in self._converters():
+            with self.subTest(converter=name):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "fill_value must be an integer",
+                ):
+                    converter(
+                        tracks,
+                        session_sizes=[1],
+                        fill_value=_UncoercibleFillValue(),
+                    )
 
     @unittest.skipIf(
         __backend_name__ == "jax",


### PR DESCRIPTION
## Summary
- Wrap `fill_value` array coercion failures in `tracks_to_session_labels` so invalid array-like fill values raise the existing public `ValueError` instead of leaking backend/NumPy conversion exceptions.
- Add regression coverage for public, module-level, and `MultiSessionAssignmentResult.to_session_labels(...)` entry points.

## Bug fixed
Objects with a failing `__array__` method could leak a raw `RuntimeError` from `np.asarray(fill_value)` before the existing `"fill_value must be an integer"` validation path ran.

## Validation
- `python -m py_compile /mnt/data/pyrecest_pkg/pyrecest/utils/_multisession_assignment_labels.py /mnt/data/test_multisession_assignment_labels_updated.py`
- `PYTHONPATH=/mnt/data/pyrecest_pkg pytest -q /mnt/data/test_multisession_assignment_labels_updated.py` (5 passed, 39 subtests passed)
- `PYTHONPATH=/mnt/data/pyrecest_pkg:/mnt/data/ruff_pkg python -m ruff check --select F821,B023 /mnt/data/pyrecest_pkg/pyrecest/utils/_multisession_assignment_labels.py /mnt/data/test_multisession_assignment_labels_updated.py` (passed)
- Verified GitHub compare: branch is 2 commits ahead of `main`, 0 behind, modifying only `src/pyrecest/utils/_multisession_assignment_labels.py` and `tests/test_multisession_assignment_labels.py`.

Note: direct `git clone` from GitHub was unavailable in this sandbox, so local validation was run against the installed package source patched with the same change and the fetched test contents.