### PR TITLE
Validate expected final_estimate in CLI

### DIFF
--- a/src/pyrecest/cli.py
+++ b/src/pyrecest/cli.py
@@ -65,6 +65,22 @@ def _is_finite_real_number(value: Any) -> bool:
     )
 
 
+def _coerce_finite_real_sequence(value: Any, *, field_name: str) -> list[float]:
+    if isinstance(value, (str, bytes, bytearray, dict)):
+        raise ValueError(f"{field_name} must be a sequence of finite numbers")
+    try:
+        items = list(value)
+    except TypeError as exc:
+        raise ValueError(f"{field_name} must be a sequence of finite numbers") from exc
+
+    coerced: list[float] = []
+    for item in items:
+        if not _is_finite_real_number(item):
+            raise ValueError(f"{field_name} must contain only finite numbers")
+        coerced.append(float(item))
+    return coerced
+
+
 def _comparison_value(value: Any) -> Any:
     if isinstance(value, np.ndarray):
         return _comparison_value(value.tolist())
@@ -190,17 +206,29 @@ def _cmd_run_scenario(args: argparse.Namespace) -> int:
         failures: list[str] = []
         expected_estimate = expected.get("final_estimate")
         if expected_estimate is not None:
-            if len(result.final_estimate) != len(expected_estimate):
-                failures.append(
-                    "final_estimate length mismatch: "
-                    f"expected {len(expected_estimate)}, got {len(result.final_estimate)}"
+            try:
+                actual_estimate_values = _coerce_finite_real_sequence(
+                    result.final_estimate,
+                    field_name="scenario result final_estimate",
                 )
+                expected_estimate_values = _coerce_finite_real_sequence(
+                    expected_estimate,
+                    field_name="final_estimate",
+                )
+            except ValueError as exc:
+                failures.append(str(exc))
             else:
-                max_error = _max_abs_error(result.final_estimate, expected_estimate)
-                if max_error > tolerance:
+                if len(actual_estimate_values) != len(expected_estimate_values):
                     failures.append(
-                        f"final_estimate mismatch: max_abs_error={max_error:.6g} > tolerance={tolerance:.6g}"
+                        "final_estimate length mismatch: "
+                        f"expected {len(expected_estimate_values)}, got {len(actual_estimate_values)}"
                     )
+                else:
+                    max_error = _max_abs_error(actual_estimate_values, expected_estimate_values)
+                    if max_error > tolerance:
+                        failures.append(
+                            f"final_estimate mismatch: max_abs_error={max_error:.6g} > tolerance={tolerance:.6g}"
+                        )
         if isinstance(expected.get("metrics"), dict):
             failures.extend(
                 _check_expected_mapping(

--- a/tests/test_cli_final_estimate_validation.py
+++ b/tests/test_cli_final_estimate_validation.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from pyrecest.cli import _cmd_run_scenario
+
+
+class _DummyScenarioResult:
+    final_estimate = [1.0, 2.0]
+    metrics: dict[str, float] = {}
+    diagnostics: dict[str, float] = {}
+
+    def to_json(self, *, indent: int | None = None) -> str:
+        return json.dumps({"name": "dummy"}, indent=indent)
+
+
+@pytest.mark.parametrize(
+    "invalid_final_estimate",
+    [
+        1.0,
+        {"first": 1.0, "second": 2.0},
+        ["not-a-number", 2.0],
+        [True, 2.0],
+    ],
+)
+def test_cmd_run_scenario_reports_malformed_expected_final_estimate(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    capsys: pytest.CaptureFixture[str],
+    invalid_final_estimate,
+) -> None:
+    import pyrecest.scenarios as scenarios
+
+    monkeypatch.setattr(
+        scenarios,
+        "run_scenario",
+        lambda config: _DummyScenarioResult(),
+    )
+    expected_path = tmp_path / "expected.json"
+    expected_path.write_text(
+        json.dumps({"final_estimate": invalid_final_estimate}),
+        encoding="utf-8",
+    )
+
+    result = _cmd_run_scenario(
+        SimpleNamespace(config=tmp_path / "config.toml", expected=expected_path, tolerance=None)
+    )
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert json.loads(captured.out)["name"] == "dummy"
+    assert "final_estimate" in captured.err


### PR DESCRIPTION
## Summary
- Add shared finite-real sequence validation before comparing `run-scenario --expected` final estimates.
- Convert malformed expected `final_estimate` payloads into normal CLI comparison failures instead of allowing `len(...)` or numeric conversion exceptions to escape.
- Add focused regression coverage using a stub scenario result for scalar, mapping, non-numeric, and boolean expected values.

## Bug fixed
A malformed `final_estimate` in an expected-results JSON file could crash `pyrecest run-scenario --expected ...` before the CLI returned a comparison failure. For example, scalar values, dictionaries, or lists containing non-numeric/boolean entries reached length or `float(...)` conversion paths directly.

## Validation
- `python -m py_compile /mnt/data/pyrecest_patch/pyrecest/cli.py /mnt/data/pyrecest_patch/tests/test_cli_final_estimate_validation.py`
- `PYTHONPATH=/mnt/data/pyrecest_patch pytest -q /mnt/data/pyrecest_patch/tests/test_cli_final_estimate_validation.py` (4 passed)
- Verified GitHub compare: branch is 2 commits ahead of `main`, 0 behind; changes limited to `src/pyrecest/cli.py` and `tests/test_cli_final_estimate_validation.py`.

Note: direct `git clone` from GitHub is unavailable in this sandbox, so local validation used the patched CLI code in a minimal package shim with the added focused test.