### PR TITLE
Fix PyTorch stack array-like inputs

### DIFF
--- a/src/pyrecest/backend_tools.py
+++ b/src/pyrecest/backend_tools.py
@@ -311,14 +311,29 @@ def _patch_pytorch_stack_helpers_numpy_contract() -> None:
     ):  # pragma: no cover - PyTorch backend import failed earlier
         return
 
-    if getattr(pytorch_backend.hstack, "_pyrecest_numpy_contract", False):
+    helper_names = ("stack", "hstack", "vstack", "column_stack", "dstack")
+    if all(
+        getattr(getattr(pytorch_backend, helper_name), "_pyrecest_numpy_contract", False)
+        for helper_name in helper_names
+    ):
         if active_pytorch_backend:
-            for helper_name in ("hstack", "vstack", "column_stack", "dstack"):
+            for helper_name in helper_names:
                 setattr(backend, helper_name, getattr(pytorch_backend, helper_name))
         return
 
     def _tensor_sequence(tup):
         return [pytorch_backend.array(item) for item in tup]
+
+    def stack(arrays, axis=0, out=None, *, dim=None):
+        if dim is not None:
+            if axis != 0 and axis != dim:
+                raise TypeError("stack() got both 'axis' and 'dim'")
+            axis = dim
+        tensors = _tensor_sequence(arrays)
+        if not tensors:
+            raise ValueError("need at least one array to stack")
+        tensors = pytorch_backend.convert_to_wider_dtype(tensors)
+        return _torch.stack(tensors, dim=_operator_index(axis), out=out)
 
     def hstack(tup):
         tensors = [_torch.atleast_1d(tensor) for tensor in _tensor_sequence(tup)]
@@ -343,6 +358,7 @@ def _patch_pytorch_stack_helpers_numpy_contract() -> None:
         return _torch.cat(tensors, dim=2)
 
     for helper_name, helper in {
+        "stack": stack,
         "hstack": hstack,
         "vstack": vstack,
         "column_stack": column_stack,

--- a/tests/backend_support/test_pytorch_stack_helpers_contract.py
+++ b/tests/backend_support/test_pytorch_stack_helpers_contract.py
@@ -30,6 +30,11 @@ import pyrecest._backend.pytorch as raw_backend
 for stack_backend in (backend, raw_backend):
     to_numpy = stack_backend.to_numpy
 
+    assert to_numpy(stack_backend.stack(([1, 2], [3, 4]))).tolist() == [[1, 2], [3, 4]]
+    assert to_numpy(stack_backend.stack(([1, 2], [3, 4]), axis=1)).tolist() == [[1, 3], [2, 4]]
+    mixed = stack_backend.stack((stack_backend.array([1, 2], dtype=stack_backend.int64), [3.5, 4.5]))
+    assert to_numpy(mixed).tolist() == [[1.0, 2.0], [3.5, 4.5]]
+
     assert to_numpy(stack_backend.hstack(([1, 2], [3, 4]))).tolist() == [1, 2, 3, 4]
     assert to_numpy(stack_backend.vstack(([1, 2], [3, 4]))).tolist() == [[1, 2], [3, 4]]
     assert to_numpy(stack_backend.column_stack(([1, 2], [3, 4]))).tolist() == [[1, 3], [2, 4]]
@@ -62,6 +67,11 @@ import pyrecest.backend as backend
 import pyrecest._backend.pytorch as raw_backend
 
 assert getattr(backend, "__backend_name__", None) == "numpy"
+
+assert raw_backend.to_numpy(raw_backend.stack(([1, 2], [3, 4]))).tolist() == [[1, 2], [3, 4]]
+assert raw_backend.to_numpy(raw_backend.stack(([1, 2], [3, 4]), axis=1)).tolist() == [[1, 3], [2, 4]]
+mixed = raw_backend.stack((raw_backend.array([1, 2], dtype=raw_backend.int64), [3.5, 4.5]))
+assert raw_backend.to_numpy(mixed).tolist() == [[1.0, 2.0], [3.5, 4.5]]
 
 assert raw_backend.to_numpy(raw_backend.hstack(([1, 2], [3, 4]))).tolist() == [1, 2, 3, 4]
 assert raw_backend.to_numpy(raw_backend.vstack(([1, 2], [3, 4]))).tolist() == [[1, 2], [3, 4]]


### PR DESCRIPTION
## Summary
- Patch the raw/public PyTorch `stack` helper alongside the existing stack-family compatibility hooks.
- Coerce NumPy-style list/array inputs before stacking, promote mixed dtypes, and support the NumPy-style `axis` keyword.
- Add backend-portable regression coverage for both the active public PyTorch backend and the raw PyTorch backend when NumPy is selected publicly.

## Bug fixed
`pyrecest._backend.pytorch.stack` was still the raw `torch.stack` import, so calls such as `stack(([1, 2], [3, 4]))` failed even though NumPy accepts them and neighboring helpers (`hstack`, `vstack`, `column_stack`, `dstack`) already normalize array-like inputs.

## Testing
- Not run locally; repository checkout/network access is unavailable in this execution environment. Regression tests were added in `tests/backend_support/test_pytorch_stack_helpers_contract.py` for CI to exercise.