### PR TITLE
Normalize evidence bool conversion errors

### DIFF
--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -30,7 +30,7 @@ def _coerce_bool_flag(value: bool, name: str) -> bool:
 
     try:
         value_array = np.asarray(value)
-    except (TypeError, ValueError) as exc:
+    except (TypeError, ValueError, RuntimeError) as exc:
         raise ValueError(f"{name} must be a bool") from exc
     if value_array.shape == () and np.issubdtype(value_array.dtype, np.bool_):
         return bool(value_array.item())

--- a/tests/test_evidence_bool_flag_conversion.py
+++ b/tests/test_evidence_bool_flag_conversion.py
@@ -1,0 +1,23 @@
+import pytest
+
+from pyrecest.evidence import EvidenceComputationMode, resolve_evidence_computation_mode
+
+
+class FailingArrayConversion:
+    def __array__(self, dtype=None):
+        del dtype
+        raise RuntimeError("array conversion failed")
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda value: EvidenceComputationMode(return_smoothed=value),
+        lambda value: EvidenceComputationMode(terminal_posterior=value),
+        lambda value: EvidenceComputationMode.from_return_smoothed(value),
+        lambda value: resolve_evidence_computation_mode(return_smoothed=value),
+    ],
+)
+def test_evidence_bool_flags_normalize_array_conversion_errors(factory):
+    with pytest.raises(ValueError, match="must be a bool"):
+        factory(FailingArrayConversion())


### PR DESCRIPTION
## Summary
- Normalize `RuntimeError` raised during NumPy coercion of evidence bool flags into the documented `ValueError` path.
- Add a focused regression for the public `return_smoothed` and `terminal_posterior` bool-flag entry points.

## Validation
- Local `py_compile` passed for the patched module and new test.
- Targeted pytest for the new regression passed: 4 passed.

Full repository tests were not run in this connector-only environment.