### PR TITLE
Fix PyTorch binary helpers for array-like operands

### DIFF
--- a/src/pyrecest/_backend/pytorch/_dtype.py
+++ b/src/pyrecest/_backend/pytorch/_dtype.py
@@ -167,6 +167,20 @@ def _is_random_array_parameter(value):
     )
 
 
+def _is_binary_array_operand(value):
+    return (
+        isinstance(value, (list, tuple))
+        or (not isinstance(value, (str, bytes)) and hasattr(value, "__array__"))
+    )
+
+
+def _binary_tensor_operand(value, reference):
+    kwargs = {}
+    if _torch.is_tensor(reference):
+        kwargs["device"] = reference.device
+    return _torch.tensor(value, **kwargs)
+
+
 def _is_real_numeric_dtype(dtype):
     return dtype.is_floating_point or dtype in {
         _torch.uint8,
@@ -225,7 +239,6 @@ def _preserve_input_dtype(target=None):
     -------------
     Only acts on input. Assumes dtype is kwarg and function accepts dtype.
     Passes dtype as input dtype.
-
     Use together with `_add_default_dtype_by_casting`.
     """
 
@@ -284,7 +297,9 @@ def _box_binary_scalar(target=None, box_x1=True, box_x2=True):
             if box_x1 and not _torch.is_tensor(x1):
                 x1 = _torch.tensor(x1)
             if box_x2 and not _torch.is_tensor(x2):
-                x2 = _torch.tensor(x2)
+                x2 = _binary_tensor_operand(x2, x1)
+            elif not box_x2 and not _torch.is_tensor(x2) and _is_binary_array_operand(x2):
+                x2 = _binary_tensor_operand(x2, x1)
 
             return func(x1, x2, *args, **kwargs)
 

--- a/tests/backend_support/test_pytorch_binary_arraylike_contract.py
+++ b/tests/backend_support/test_pytorch_binary_arraylike_contract.py
@@ -1,0 +1,55 @@
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+pytestmark = pytest.mark.backend_portable
+
+
+def _require_torch():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+
+def test_public_pytorch_mod_and_power_accept_arraylike_second_operands():
+    _require_torch()
+
+    code = """
+import pyrecest.backend as backend
+
+assert getattr(backend, "__backend_name__", None) == "pytorch"
+
+mod_result = backend.mod([5, 7, 9], [2, 3, 4])
+power_result = backend.power([2, 3, 4], [3, 2, 1])
+scalar_result = backend.mod([5, 7, 9], 2)
+
+assert backend.to_numpy(mod_result).tolist() == [1, 1, 1]
+assert backend.to_numpy(power_result).tolist() == [8, 9, 4]
+assert backend.to_numpy(scalar_result).tolist() == [1, 1, 1]
+print("ok")
+"""
+    result = run_backend_code("pytorch", code)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_raw_pytorch_mod_and_power_accept_arraylike_second_operands_after_import():
+    _require_torch()
+
+    code = """
+import pyrecest  # noqa: F401  # triggers backend compatibility patches
+import pyrecest._backend.pytorch as raw_pytorch
+
+mod_result = raw_pytorch.mod([5, 7, 9], [2, 3, 4])
+power_result = raw_pytorch.power([2, 3, 4], [3, 2, 1])
+scalar_result = raw_pytorch.power([2, 3, 4], 2)
+
+assert raw_pytorch.to_numpy(mod_result).tolist() == [1, 1, 1]
+assert raw_pytorch.to_numpy(power_result).tolist() == [8, 9, 4]
+assert raw_pytorch.to_numpy(scalar_result).tolist() == [4, 9, 16]
+print("ok")
+"""
+    result = run_backend_code("numpy", code)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- Normalize array-like second operands in the PyTorch binary scalar helper even when scalar second operands are intentionally left unboxed.
- Preserve scalar second-operand behavior for `mod`/`power` while allowing lists, tuples, and NumPy-style array operands.
- Add focused backend-portable regression tests for public and raw PyTorch `mod`/`power` calls.

## Validation
- Verified the diff is based on the current `main` branch via `compare_commits` (`behind_by=0`).
- Could not run the full repository test suite locally because this environment cannot clone the repository from GitHub, but the new tests are designed to run under the existing PyTorch CI matrix.