### PR TITLE
Fix PyTorch triangular vector array-like inputs

### DIFF
--- a/src/pyrecest/stability.py
+++ b/src/pyrecest/stability.py
@@ -210,6 +210,49 @@ def _patch_pytorch_vec_to_diag_numpy_contract() -> None:
         backend.vec_to_diag = vec_to_diag
 
 
+def _patch_pytorch_triangular_vec_numpy_contract() -> None:
+    """Patch raw/public PyTorch triangular-vector helpers for array-like inputs."""
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+
+    def _make_triangular_to_vec(helper_name, index_helper, original_helper):
+        def triangular_to_vec(x, k=0):
+            x = raw_pytorch.array(x)
+            n = x.shape[-1]
+            rows, cols = index_helper(n, k=k)
+            rows = rows.to(device=x.device)
+            cols = cols.to(device=x.device)
+            return x[..., rows, cols]
+
+        triangular_to_vec.__name__ = getattr(original_helper, "__name__", helper_name)
+        triangular_to_vec.__doc__ = getattr(original_helper, "__doc__", None)
+        triangular_to_vec._pyrecest_numpy_contract = True
+        return triangular_to_vec
+
+    for helper_name, index_helper_name in (
+        ("tril_to_vec", "tril_indices"),
+        ("triu_to_vec", "triu_indices"),
+    ):
+        original_helper = getattr(raw_pytorch, helper_name, None)
+        index_helper = getattr(raw_pytorch, index_helper_name, None)
+        if original_helper is None or index_helper is None:
+            continue
+        if getattr(original_helper, "_pyrecest_numpy_contract", False):
+            if active_pytorch_backend:
+                setattr(backend, helper_name, original_helper)
+            continue
+
+        helper = _make_triangular_to_vec(helper_name, index_helper, original_helper)
+        setattr(raw_pytorch, helper_name, helper)
+        if active_pytorch_backend:
+            setattr(backend, helper_name, helper)
+
+
 def _patch_pytorch_arctan_numpy_contract() -> None:
     """Patch raw/public PyTorch ``arctan`` to accept NumPy-style inputs."""
     try:
@@ -316,6 +359,7 @@ def _patch_jax_squeeze_numpy_contract() -> None:
 _patch_pytorch_allclose_device_contract()
 _patch_pytorch_diag_numpy_contract()
 _patch_pytorch_vec_to_diag_numpy_contract()
+_patch_pytorch_triangular_vec_numpy_contract()
 _patch_pytorch_arctan_numpy_contract()
 _patch_pytorch_raw_comparison_arraylike_contract()
 _patch_pytorch_array_equal_equal_nan_contract()

--- a/tests/backend_support/test_pytorch_triangular_helpers_contract.py
+++ b/tests/backend_support/test_pytorch_triangular_helpers_contract.py
@@ -39,7 +39,11 @@ for module in (backend, pytorch_backend):
     upper = module.triu_to_vec(matrix, k=1)
     assert module.to_numpy(upper).tolist() == [2, 3, 6]
 """
-    subprocess.run([sys.executable, "-c", code], check=True, env=_backend_test_env("pytorch"))
+    subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        env=_backend_test_env("pytorch"),
+    )
 
 
 @pytest.mark.backend_portable
@@ -64,4 +68,8 @@ assert pytorch_backend.to_numpy(lower).tolist() == [1, 4, 5, 7, 8, 9]
 upper = pytorch_backend.triu_to_vec(matrix, k=1)
 assert pytorch_backend.to_numpy(upper).tolist() == [2, 3, 6]
 """
-    subprocess.run([sys.executable, "-c", code], check=True, env=_backend_test_env("numpy"))
+    subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        env=_backend_test_env("numpy"),
+    )

--- a/tests/backend_support/test_pytorch_triangular_helpers_contract.py
+++ b/tests/backend_support/test_pytorch_triangular_helpers_contract.py
@@ -1,0 +1,67 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _backend_test_env(backend_name):
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = backend_name
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    return env
+
+
+@pytest.mark.backend_portable
+def test_pytorch_triangular_helpers_accept_array_like_inputs():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as pytorch_backend
+
+matrix = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+
+for module in (backend, pytorch_backend):
+    diag = module.vec_to_diag([1, 2, 3])
+    assert module.to_numpy(diag).tolist() == [[1, 0, 0], [0, 2, 0], [0, 0, 3]]
+
+    lower = module.tril_to_vec(matrix)
+    assert module.to_numpy(lower).tolist() == [1, 4, 5, 7, 8, 9]
+
+    upper = module.triu_to_vec(matrix, k=1)
+    assert module.to_numpy(upper).tolist() == [2, 3, 6]
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=_backend_test_env("pytorch"))
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_triangular_helpers_with_numpy_public_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as pytorch_backend
+
+assert getattr(backend, "__backend_name__", None) == "numpy"
+
+matrix = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+
+diag = pytorch_backend.vec_to_diag([1, 2, 3])
+assert pytorch_backend.to_numpy(diag).tolist() == [[1, 0, 0], [0, 2, 0], [0, 0, 3]]
+
+lower = pytorch_backend.tril_to_vec(matrix)
+assert pytorch_backend.to_numpy(lower).tolist() == [1, 4, 5, 7, 8, 9]
+
+upper = pytorch_backend.triu_to_vec(matrix, k=1)
+assert pytorch_backend.to_numpy(upper).tolist() == [2, 3, 6]
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=_backend_test_env("numpy"))


### PR DESCRIPTION
## Summary
- Patch raw/public PyTorch `tril_to_vec` and `triu_to_vec` during stability initialization so they coerce NumPy-style array-like matrices before reading shape metadata.
- Keep the active public PyTorch backend facade synchronized with the raw helpers.
- Move generated triangular index tensors onto the input tensor device before indexing.
- Add backend-portable subprocess regression coverage for public PyTorch and raw PyTorch under the NumPy-selected public backend.

## Bug fixed
`tril_to_vec([[...]])` and `triu_to_vec([[...]])` could access `.shape` before backend array coercion in the PyTorch backend, so Python lists and other array-like matrix inputs failed instead of following the backend's NumPy-style array-like contract. The old helpers also generated CPU triangular index tensors, which could break indexing for tensors on non-CPU devices.

## Validation
- `python -m py_compile /mnt/data/stability_new.py /mnt/data/test_pytorch_triangular_helpers_contract.py`
- Local Torch smoke check for lower/upper triangular vector extraction and diagonal embedding.
- Full repository pytest was not run locally because this sandbox could not resolve `github.com` for cloning/installing the repo; the PR includes focused CI regression tests.