### PR TITLE
Fix JAX triangular vector helpers for array-like inputs

### DIFF
--- a/src/pyrecest/stability.py
+++ b/src/pyrecest/stability.py
@@ -246,6 +246,66 @@ def _patch_jax_squeeze_numpy_contract() -> None:
         backend.squeeze = squeeze
 
 
+def _patch_jax_triangular_vec_numpy_contract() -> None:
+    """Patch raw/public JAX triangular vector helpers for array-like inputs."""
+    try:
+        import jax.numpy as jnp  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.jax as raw_jax  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - JAX backend may be unavailable
+        return
+
+    helper_names = ("tril_to_vec", "triu_to_vec")
+    active_jax_backend = getattr(backend, "__backend_name__", None) == "jax"
+    if all(
+        getattr(
+            getattr(raw_jax, helper_name, None),
+            "_pyrecest_numpy_contract",
+            False,
+        )
+        for helper_name in helper_names
+    ):
+        if active_jax_backend:
+            for helper_name in helper_names:
+                setattr(backend, helper_name, getattr(raw_jax, helper_name))
+        return
+
+    def _wrap_triangular_vector_helper(helper_name, index_factory):
+        original_helper = getattr(raw_jax, helper_name, None)
+        if original_helper is None:
+            return None
+        if getattr(original_helper, "_pyrecest_numpy_contract", False):
+            return original_helper
+
+        def triangular_vector(x, k=0):
+            x = jnp.asarray(x)
+            n = x.shape[-1]
+            rows, cols = index_factory(n, k=k)
+            return x[..., rows, cols]
+
+        triangular_vector.__name__ = getattr(original_helper, "__name__", helper_name)
+        triangular_vector.__doc__ = getattr(original_helper, "__doc__", None)
+        triangular_vector._pyrecest_numpy_contract = True
+        return triangular_vector
+
+    helpers = {
+        "tril_to_vec": _wrap_triangular_vector_helper(
+            "tril_to_vec",
+            jnp.tril_indices,
+        ),
+        "triu_to_vec": _wrap_triangular_vector_helper(
+            "triu_to_vec",
+            jnp.triu_indices,
+        ),
+    }
+    for helper_name, helper in helpers.items():
+        if helper is None:
+            continue
+        setattr(raw_jax, helper_name, helper)
+        if active_jax_backend:
+            setattr(backend, helper_name, helper)
+
+
 _patch_pytorch_allclose_device_contract()
 _patch_pytorch_diag_numpy_contract()
 _patch_pytorch_vec_to_diag_numpy_contract()
@@ -255,6 +315,7 @@ _patch_pytorch_dot_outer_device_contract()
 _patch_pytorch_matmul_device_contract()
 _patch_pytorch_minmax_device_contract()
 _patch_jax_squeeze_numpy_contract()
+_patch_jax_triangular_vec_numpy_contract()
 
 P = ParamSpec("P")
 R = TypeVar("R")

--- a/tests/backend_support/test_jax_triangular_vec_contract.py
+++ b/tests/backend_support/test_jax_triangular_vec_contract.py
@@ -1,0 +1,98 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _run_python(code, *, backend_name=None):
+    env = os.environ.copy()
+    if backend_name is None:
+        env.pop("PYRECEST_BACKEND", None)
+    else:
+        env["PYRECEST_BACKEND"] = backend_name
+
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)
+
+
+@pytest.mark.backend_portable
+def test_raw_jax_triangular_vector_helpers_are_patched_under_default_backend():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("jax is not installed")
+
+    _run_python(
+        r"""
+import pyrecest  # noqa: F401
+import pyrecest.backend as public_backend
+import pyrecest._backend.jax as raw_backend
+
+assert public_backend.__backend_name__ == "numpy"
+
+matrix = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+batched_matrix = [
+    matrix,
+    [[10, 11, 12], [13, 14, 15], [16, 17, 18]],
+]
+
+
+def as_list(value):
+    converted = raw_backend.to_numpy(value)
+    return converted.tolist() if hasattr(converted, "tolist") else converted
+
+
+assert as_list(raw_backend.tril_to_vec(matrix)) == [1, 4, 5, 7, 8, 9]
+assert as_list(raw_backend.triu_to_vec(matrix)) == [1, 2, 3, 5, 6, 9]
+assert as_list(raw_backend.tril_to_vec(matrix, k=-1)) == [4, 7, 8]
+assert as_list(raw_backend.triu_to_vec(matrix, k=1)) == [2, 3, 6]
+assert as_list(raw_backend.tril_to_vec(batched_matrix)) == [
+    [1, 4, 5, 7, 8, 9],
+    [10, 13, 14, 16, 17, 18],
+]
+"""
+    )
+
+
+@pytest.mark.backend_portable
+def test_public_jax_triangular_vector_helpers_accept_arraylike_inputs():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("jax is not installed")
+
+    _run_python(
+        r"""
+import pyrecest.backend as backend
+import pyrecest._backend.jax as raw_backend
+
+assert backend.__backend_name__ == "jax"
+
+matrix = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+batched_matrix = [
+    matrix,
+    [[10, 11, 12], [13, 14, 15], [16, 17, 18]],
+]
+
+
+def as_list(module, value):
+    converted = module.to_numpy(value)
+    return converted.tolist() if hasattr(converted, "tolist") else converted
+
+
+for module in (backend, raw_backend):
+    assert as_list(module, module.tril_to_vec(matrix)) == [1, 4, 5, 7, 8, 9]
+    assert as_list(module, module.triu_to_vec(matrix)) == [1, 2, 3, 5, 6, 9]
+    assert as_list(module, module.tril_to_vec(matrix, k=-1)) == [4, 7, 8]
+    assert as_list(module, module.triu_to_vec(matrix, k=1)) == [2, 3, 6]
+    assert as_list(module, module.tril_to_vec(batched_matrix)) == [
+        [1, 4, 5, 7, 8, 9],
+        [10, 13, 14, 16, 17, 18],
+    ]
+""",
+        backend_name="jax",
+    )


### PR DESCRIPTION
## Summary
- Patch raw/public JAX `tril_to_vec` and `triu_to_vec` during stability initialization so they coerce NumPy-style array-like matrices before reading shape metadata.
- Keep the active public JAX backend facade synchronized with the patched raw helpers.
- Add regression coverage for raw JAX under the default public backend and the selected public JAX backend.

## Bug fixed
`tril_to_vec([[...]])` and `triu_to_vec([[...]])` in the JAX backend could access `.shape` before backend array coercion, so Python lists and other array-like matrix inputs failed instead of following the backend's NumPy-style array-like contract.

## Validation
- Confirmed the branch is based on current `main` with `compare_commits` (`behind_by=0`).
- Syntax-checked the modified `stability.py` and new test content locally via Python `compile()`.
- Reproduced the underlying JAX failure mode in the sandbox: the pre-fix logic raises `AttributeError` on a Python list, while coercing with `jnp.asarray` returns the expected triangular vector.
- Full repository pytest was not run locally because this environment could not clone the repository directly; the PR adds targeted tests for CI.