### PR TITLE
Fix array-like matrix helper backend contracts

### DIFF
--- a/src/pyrecest/stability.py
+++ b/src/pyrecest/stability.py
@@ -313,6 +313,122 @@ def _patch_jax_squeeze_numpy_contract() -> None:
         backend.squeeze = squeeze
 
 
+def _patch_shared_numpy_matrix_helpers_arraylike_contract() -> None:
+    """Patch shared NumPy/autograd matrix helpers to accept array-like inputs."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - backend import should be available
+        return
+
+    if getattr(backend, "__backend_name__", None) not in {"autograd", "numpy"}:
+        return
+
+    try:
+        import pyrecest._backend._shared_numpy as shared_numpy  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - shared backend should be available
+        return
+
+    original_helpers = {
+        "vec_to_diag": getattr(shared_numpy, "vec_to_diag", None),
+        "tril_to_vec": getattr(shared_numpy, "tril_to_vec", None),
+        "triu_to_vec": getattr(shared_numpy, "triu_to_vec", None),
+    }
+    if any(helper is None for helper in original_helpers.values()):
+        return
+    if all(
+        getattr(helper, "_pyrecest_arraylike_contract", False)
+        for helper in original_helpers.values()
+    ):
+        for helper_name in original_helpers:
+            setattr(backend, helper_name, getattr(shared_numpy, helper_name))
+        return
+
+    def vec_to_diag(vec):
+        vec = shared_numpy.array(vec)
+        d = vec.shape[-1]
+        return vec[..., :, None] * shared_numpy.eye(d, dtype=vec.dtype)
+
+    def tril_to_vec(x, k=0):
+        x = shared_numpy.array(x)
+        n = x.shape[-1]
+        rows, cols = shared_numpy._np.tril_indices(n, k=k)
+        return x[..., rows, cols]
+
+    def triu_to_vec(x, k=0):
+        x = shared_numpy.array(x)
+        n = x.shape[-1]
+        rows, cols = shared_numpy._np.triu_indices(n, k=k)
+        return x[..., rows, cols]
+
+    helpers = {
+        "vec_to_diag": vec_to_diag,
+        "tril_to_vec": tril_to_vec,
+        "triu_to_vec": triu_to_vec,
+    }
+    for helper_name, helper in helpers.items():
+        original_helper = original_helpers[helper_name]
+        helper.__name__ = getattr(original_helper, "__name__", helper_name)
+        helper.__doc__ = getattr(original_helper, "__doc__", None)
+        helper._pyrecest_arraylike_contract = True
+        setattr(shared_numpy, helper_name, helper)
+        setattr(backend, helper_name, helper)
+
+
+def _patch_jax_triangular_vector_helpers_arraylike_contract() -> None:
+    """Patch raw/public JAX triangular vector helpers for array-like matrices."""
+    try:
+        import jax.numpy as jnp  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.jax as raw_jax  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - JAX backend may be unavailable
+        return
+
+    helper_names = ("tril_to_vec", "triu_to_vec")
+    if all(
+        getattr(
+            getattr(raw_jax, helper_name, None),
+            "_pyrecest_arraylike_contract",
+            False,
+        )
+        for helper_name in helper_names
+    ):
+        if getattr(backend, "__backend_name__", None) == "jax":
+            for helper_name in helper_names:
+                setattr(backend, helper_name, getattr(raw_jax, helper_name))
+        return
+
+    original_helpers = {
+        helper_name: getattr(raw_jax, helper_name, None) for helper_name in helper_names
+    }
+    if any(helper is None for helper in original_helpers.values()):
+        return
+
+    def tril_to_vec(x, k=0):
+        x = jnp.asarray(x)
+        n = x.shape[-1]
+        rows, cols = jnp.tril_indices(n, k=k)
+        return x[..., rows, cols]
+
+    def triu_to_vec(x, k=0):
+        x = jnp.asarray(x)
+        n = x.shape[-1]
+        rows, cols = jnp.triu_indices(n, k=k)
+        return x[..., rows, cols]
+
+    helpers = {
+        "tril_to_vec": tril_to_vec,
+        "triu_to_vec": triu_to_vec,
+    }
+    for helper_name, helper in helpers.items():
+        original_helper = original_helpers[helper_name]
+        helper.__name__ = getattr(original_helper, "__name__", helper_name)
+        helper.__doc__ = getattr(original_helper, "__doc__", None)
+        helper._pyrecest_arraylike_contract = True
+        setattr(raw_jax, helper_name, helper)
+        if getattr(backend, "__backend_name__", None) == "jax":
+            setattr(backend, helper_name, helper)
+
+
 _patch_pytorch_allclose_device_contract()
 _patch_pytorch_diag_numpy_contract()
 _patch_pytorch_vec_to_diag_numpy_contract()
@@ -323,8 +439,10 @@ _patch_pytorch_dot_outer_device_contract()
 _patch_pytorch_matmul_device_contract()
 _patch_pytorch_minmax_device_contract()
 _patch_pytorch_one_hot_scalar_contract()
+_patch_shared_numpy_matrix_helpers_arraylike_contract()
 _patch_pytorch_trapezoid_numpy_contract()
 _patch_jax_squeeze_numpy_contract()
+_patch_jax_triangular_vector_helpers_arraylike_contract()
 
 P = ParamSpec("P")
 R = TypeVar("R")

--- a/tests/test_backend_arraylike_contracts.py
+++ b/tests/test_backend_arraylike_contracts.py
@@ -10,14 +10,21 @@ def _to_python(value):
     return value
 
 
-def test_pytorch_vec_to_diag_accepts_array_like_inputs():
-    if backend.__backend_name__ != "pytorch":
-        pytest.skip("PyTorch-specific vec_to_diag array-like regression test")
-
+def test_vec_to_diag_accepts_array_like_inputs():
     result = backend.vec_to_diag([1, 2, 3])
 
     assert result.shape == (3, 3)
     assert _to_python(result) == [[1, 0, 0], [0, 2, 0], [0, 0, 3]]
+
+
+def test_triangular_vector_helpers_accept_array_like_inputs():
+    if backend.__backend_name__ == "pytorch":
+        pytest.skip("PyTorch triangular array-like contract is covered separately")
+
+    matrix = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+
+    assert _to_python(backend.tril_to_vec(matrix)) == [1, 4, 5, 7, 8, 9]
+    assert _to_python(backend.triu_to_vec(matrix)) == [1, 2, 3, 5, 6, 9]
 
 
 def test_squeeze_non_singleton_axis_is_noop():


### PR DESCRIPTION
## Summary
- Patch shared NumPy/autograd `vec_to_diag`, `tril_to_vec`, and `triu_to_vec` so array-like inputs are coerced before `.shape`/dtype/indexing access.
- Patch raw/public JAX `tril_to_vec` and `triu_to_vec` to coerce array-like matrix inputs before reading shape metadata.
- Expand backend array-like regression coverage for diagonal and triangular vector helpers; skip the PyTorch triangular case because it is covered by the separate PyTorch-focused fix in #3778.

## Bug fixed
The shared NumPy/autograd helpers read `.shape` from `vec`/`x` before converting array-like inputs with the backend `array` helper. Calls such as `backend.vec_to_diag([1, 2, 3])` and `backend.tril_to_vec([[1, 2], [3, 4]])` therefore failed for plain Python lists under the default NumPy backend, despite PyRecEst's backend contract generally accepting NumPy-style array-like inputs. JAX triangular helpers had the same pre-coercion shape access issue.

## Validation
- Syntax-checked the updated file contents locally with Python `compile()`.
- Full repository pytest was not run locally because this environment cannot clone/install the repository from GitHub; CI should exercise the added regression tests.