### PR TITLE
Fix JAX matrix_power integer scalar coercion

### DIFF
--- a/src/pyrecest/_backend/jax/linalg.py
+++ b/src/pyrecest/_backend/jax/linalg.py
@@ -17,8 +17,15 @@ def _as_integer_scalar(value, name):
     """Return a Python integer for JAX static integer arguments."""
     try:
         return _operator_index(value)
-    except TypeError as exc:
-        raise TypeError(f"{name} must be an integer scalar") from exc
+    except TypeError:
+        pass
+
+    value_array = _jnp.asarray(value)
+    if value_array.shape != () or value_array.dtype == _jnp.bool_:
+        raise TypeError(f"{name} must be an integer scalar")
+    if not _jnp.issubdtype(value_array.dtype, _jnp.integer):
+        raise TypeError(f"{name} must be an integer scalar")
+    return int(value_array.item())
 
 
 def cholesky(a, *args, **kwargs):

--- a/tests/backend_support/test_jax_linalg_contract.py
+++ b/tests/backend_support/test_jax_linalg_contract.py
@@ -64,6 +64,34 @@ def test_jax_linalg_accepts_array_like_inputs_directly():
 
 
 @pytest.mark.backend_portable
+def test_jax_matrix_power_accepts_zero_dimensional_integer_scalars():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("JAX is not installed")
+
+    result = run_backend_code(
+        "jax",
+        """
+import jax.numpy as jnp
+import numpy as np
+import pyrecest.backend as backend
+
+matrix = backend.array([[1.0, 1.0], [0.0, 1.0]])
+expected = backend.array([[1.0, 2.0], [0.0, 1.0]])
+
+np_scalar_result = backend.linalg.matrix_power(matrix, np.array(2))
+jax_scalar_result = backend.linalg.matrix_power(matrix, jnp.array(2))
+
+assert bool(jnp.allclose(np_scalar_result, expected))
+assert bool(jnp.allclose(jax_scalar_result, expected))
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+@pytest.mark.backend_portable
 def test_jax_qr_accepts_numpy_economic_mode():
     if importlib.util.find_spec("jax") is None:
         pytest.skip("JAX is not installed")


### PR DESCRIPTION
## Summary
- make the JAX linalg backend accept zero-dimensional integer scalar inputs for `matrix_power`
- preserve rejection of non-scalar, boolean, and non-integer exponents
- add a JAX backend regression test covering NumPy and JAX zero-dimensional integer scalars

## Notes
This aligns the wrapper with NumPy-style scalar coercion expected by PyRecEst backend callers while still returning a Python integer for JAX's static `matrix_power` exponent argument.

## Testing
- Not run locally; this environment cannot clone/install the repository. Added subprocess backend regression coverage in `tests/backend_support/test_jax_linalg_contract.py`.