### PR TITLE
Fix PyTorch where device contract

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_where_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_where_device_contract.py
@@ -1,0 +1,87 @@
+"""PyTorch ``where`` device compatibility hook."""
+
+from __future__ import annotations
+
+import importlib
+
+
+def _preferred_pytorch_device(torch_module, *values):
+    """Return a non-CPU tensor device when mixed-device operands are present."""
+    for value in values:
+        if torch_module.is_tensor(value) and value.device.type == "meta":
+            return value.device
+    for value in values:
+        if torch_module.is_tensor(value) and value.device.type != "cpu":
+            return value.device
+    for value in values:
+        if torch_module.is_tensor(value):
+            return value.device
+    return None
+
+
+def _tensor_on_device(torch_module, value, *, device, dtype=None):
+    """Return ``value`` as a tensor on ``device`` without losing the preferred device."""
+    if torch_module.is_tensor(value):
+        target_dtype = dtype if dtype is not None else value.dtype
+        if device is None and target_dtype == value.dtype:
+            return value
+        return value.to(
+            device=device if device is not None else value.device,
+            dtype=target_dtype,
+        )
+    return torch_module.as_tensor(value, dtype=dtype, device=device)
+
+
+def _raw_pytorch_module():
+    """Return the raw PyTorch backend module, importing it when available."""
+    try:
+        return importlib.import_module("pyrecest._backend.pytorch")
+    except ModuleNotFoundError:
+        return None
+
+
+def patch_pytorch_where_device_contract() -> None:
+    """Patch raw/public PyTorch ``where`` to preserve an existing non-CPU device."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    raw_pytorch = _raw_pytorch_module()
+    if raw_pytorch is None:  # pragma: no cover - backend import failed earlier
+        return
+
+    original_where = getattr(raw_pytorch, "where", None)
+    if original_where is None:
+        return
+    if getattr(original_where, "_pyrecest_where_device_contract", False):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.where = original_where
+        return
+
+    def where(condition, x=None, y=None):
+        device = _preferred_pytorch_device(torch, condition, x, y)
+        condition = _tensor_on_device(
+            torch,
+            condition,
+            device=device,
+            dtype=torch.bool,
+        )
+        if x is None and y is None:
+            return torch.where(condition)
+
+        x = _tensor_on_device(torch, x, device=device)
+        y = _tensor_on_device(torch, y, device=device)
+        result_dtype = torch.result_type(x, y)
+        x = x.to(dtype=result_dtype)
+        y = y.to(dtype=result_dtype)
+        return torch.where(condition, x, y)
+
+    where.__name__ = getattr(original_where, "__name__", "where")
+    where.__doc__ = getattr(original_where, "__doc__", None)
+    where._pyrecest_where_device_contract = True
+    where._pyrecest_device_contract = True
+    raw_pytorch.where = where
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.where = where

--- a/src/pyrecest/stability.py
+++ b/src/pyrecest/stability.py
@@ -25,6 +25,9 @@ from pyrecest.backend_support._pytorch_one_hot_scalar_contract import (
 from pyrecest.backend_support._pytorch_trapezoid_numpy_contract import (
     patch_pytorch_trapezoid_numpy_contract as _patch_pytorch_trapezoid_numpy_contract,
 )
+from pyrecest.backend_support._pytorch_where_device_contract import (
+    patch_pytorch_where_device_contract as _patch_pytorch_where_device_contract,
+)
 
 
 def _patch_pytorch_raw_comparison_arraylike_contract() -> None:
@@ -324,6 +327,7 @@ _patch_pytorch_matmul_device_contract()
 _patch_pytorch_minmax_device_contract()
 _patch_pytorch_one_hot_scalar_contract()
 _patch_pytorch_trapezoid_numpy_contract()
+_patch_pytorch_where_device_contract()
 _patch_jax_squeeze_numpy_contract()
 
 P = ParamSpec("P")

--- a/tests/backend_support/test_pytorch_where_device_contract.py
+++ b/tests/backend_support/test_pytorch_where_device_contract.py
@@ -1,0 +1,66 @@
+"""Regression tests for PyTorch where device preservation."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+pytestmark = pytest.mark.backend_portable
+
+
+def _where_device_contract_code(target_module: str) -> str:
+    return f"""
+import torch
+import pyrecest  # noqa: F401  # triggers backend-support compatibility patches
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+
+def _non_cpu_device():
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    return torch.device("meta")
+
+
+target = {target_module}
+device = _non_cpu_device()
+
+right = torch.ones(2, device=device)
+result = target.where([True, False], torch.tensor([1.0, 2.0]), right)
+assert result.device.type == device.type
+assert tuple(result.shape) == (2,)
+if device.type != "meta":
+    assert torch.allclose(result.cpu(), torch.tensor([1.0, 1.0]))
+
+condition = torch.tensor([True, False], device=device)
+result = target.where(condition, [1.0, 2.0], torch.tensor([3.0, 4.0]))
+assert result.device.type == device.type
+assert tuple(result.shape) == (2,)
+if device.type != "meta":
+    assert torch.allclose(result.cpu(), torch.tensor([1.0, 4.0]))
+
+print("ok")
+"""
+
+
+def test_raw_pytorch_where_prefers_existing_non_cpu_device_after_import():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code("numpy", _where_device_contract_code("raw_pytorch"))
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_public_pytorch_where_prefers_existing_non_cpu_device():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code("pytorch", _where_device_contract_code("backend"))
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- Add a backend-support patch for raw/public PyTorch `where` so it prefers an existing non-CPU operand device before coercing array-like operands.
- Keep the active public PyTorch backend facade synchronized with the patched raw helper.
- Add backend-portable regression coverage for raw PyTorch under the default NumPy public backend and for the selected public PyTorch backend.

## Bug fixed
`pyrecest._backend.pytorch.where([True, False], torch.tensor(...), non_cpu_tensor)` selected the CPU tensor's device because the raw helper scanned `(x, y, condition)` and picked the first tensor. With meta tensors this raised `NotImplementedError: Cannot copy out of meta tensor`; with CUDA-like operands it could move data off the existing non-CPU device instead of preserving the backend's device contract.

## Validation
- `python -m py_compile /mnt/data/_pytorch_where_device_contract.py /mnt/data/test_pytorch_where_device_contract.py /mnt/data/stability.py`
- Standalone PyTorch reproduction confirmed the old device-selection path raises on a meta operand and the patched non-CPU preference returns a meta tensor.
- Confirmed the branch is based on current `main` with `compare_commits` (`behind_by=0`).

Not run: full repository pytest, because this execution container cannot clone/install the repository from GitHub; CI should exercise the added backend-portable tests.