### PR TITLE
Fix PyTorch linspace device contract

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_minmax_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_minmax_device_contract.py
@@ -1,4 +1,4 @@
-"""PyTorch ``maximum``/``minimum`` device compatibility hook."""
+"""PyTorch device compatibility hooks."""
 
 from __future__ import annotations
 
@@ -30,6 +30,15 @@ def _minmax_operands(raw_pytorch, torch_module, left, right):
     return left.to(device=device, dtype=dtype), right.to(device=device, dtype=dtype)
 
 
+def _linspace_endpoint_on_device(torch_module, value, *, device):
+    """Return one linspace endpoint on the preferred existing tensor device."""
+    if torch_module.is_tensor(value):
+        if device is not None and value.device != device:
+            return value.to(device=device)
+        return value
+    return torch_module.as_tensor(value, device=device)
+
+
 def _raw_pytorch_module():
     """Return the raw PyTorch backend module, importing it when available."""
     try:
@@ -39,7 +48,7 @@ def _raw_pytorch_module():
 
 
 def patch_pytorch_minmax_device_contract() -> None:
-    """Patch raw/public PyTorch ``maximum`` and ``minimum`` to preserve device."""
+    """Patch raw/public PyTorch helpers to preserve existing tensor devices."""
     try:
         import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
         import torch  # pylint: disable=import-outside-toplevel
@@ -50,6 +59,7 @@ def patch_pytorch_minmax_device_contract() -> None:
     if raw_pytorch is None:  # pragma: no cover - backend import failed earlier
         return
 
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
     helpers = {
         "maximum": torch.maximum,
         "minimum": torch.minimum,
@@ -62,22 +72,49 @@ def patch_pytorch_minmax_device_contract() -> None:
         )
         for helper_name in helpers
     ):
-        if getattr(backend, "__backend_name__", None) == "pytorch":
+        if active_pytorch_backend:
             for helper_name in helpers:
                 setattr(backend, helper_name, getattr(raw_pytorch, helper_name))
+    else:
+        for helper_name, torch_helper in helpers.items():
+            original_helper = getattr(raw_pytorch, helper_name)
+
+            def minmax(left, right, _torch_helper=torch_helper):
+                left, right = _minmax_operands(raw_pytorch, torch, left, right)
+                return _torch_helper(left, right)
+
+            minmax.__name__ = getattr(original_helper, "__name__", helper_name)
+            minmax.__doc__ = getattr(original_helper, "__doc__", None)
+            minmax._pyrecest_minmax_device_contract = True
+            minmax._pyrecest_device_contract = True
+            setattr(raw_pytorch, helper_name, minmax)
+            if active_pytorch_backend:
+                setattr(backend, helper_name, minmax)
+
+    original_linspace = getattr(raw_pytorch, "linspace", None)
+    if original_linspace is None:
+        return
+    if getattr(original_linspace, "_pyrecest_linspace_device_contract", False):
+        if active_pytorch_backend:
+            backend.linspace = original_linspace
         return
 
-    for helper_name, torch_helper in helpers.items():
-        original_helper = getattr(raw_pytorch, helper_name)
+    def linspace(start, stop, num=50, endpoint=True, dtype=None):
+        device = _preferred_pytorch_device(torch, start, stop)
+        start = _linspace_endpoint_on_device(torch, start, device=device)
+        stop = _linspace_endpoint_on_device(torch, stop, device=device)
+        return original_linspace(
+            start,
+            stop,
+            num=num,
+            endpoint=endpoint,
+            dtype=dtype,
+        )
 
-        def minmax(left, right, _torch_helper=torch_helper):
-            left, right = _minmax_operands(raw_pytorch, torch, left, right)
-            return _torch_helper(left, right)
-
-        minmax.__name__ = getattr(original_helper, "__name__", helper_name)
-        minmax.__doc__ = getattr(original_helper, "__doc__", None)
-        minmax._pyrecest_minmax_device_contract = True
-        minmax._pyrecest_device_contract = True
-        setattr(raw_pytorch, helper_name, minmax)
-        if getattr(backend, "__backend_name__", None) == "pytorch":
-            setattr(backend, helper_name, minmax)
+    linspace.__name__ = getattr(original_linspace, "__name__", "linspace")
+    linspace.__doc__ = getattr(original_linspace, "__doc__", None)
+    linspace._pyrecest_linspace_device_contract = True
+    linspace._pyrecest_device_contract = True
+    raw_pytorch.linspace = linspace
+    if active_pytorch_backend:
+        backend.linspace = linspace

--- a/tests/backend_support/test_pytorch_linspace_device_contract.py
+++ b/tests/backend_support/test_pytorch_linspace_device_contract.py
@@ -1,0 +1,44 @@
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+pytestmark = pytest.mark.backend_portable
+
+
+def _linspace_device_contract_code(target_module):
+    return f"""
+import torch
+import pyrecest  # noqa: F401  # triggers backend-support compatibility patches
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+
+target = {target_module}
+right_endpoint = torch.empty((), device="meta")
+result = target.linspace(torch.tensor(0.0), right_endpoint, num=3)
+assert result.device.type == "meta"
+assert tuple(result.shape) == (3,)
+print("ok")
+"""
+
+
+def test_raw_pytorch_linspace_prefers_existing_non_cpu_stop_device_after_import():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code("numpy", _linspace_device_contract_code("raw_pytorch"))
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_public_pytorch_linspace_prefers_existing_non_cpu_stop_device():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code("pytorch", _linspace_device_contract_code("backend"))
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- Extend the existing PyTorch device compatibility hook to patch `linspace`.
- Prefer an existing non-CPU endpoint device before calling the raw PyTorch helper.
- Add regression coverage for raw PyTorch after importing `pyrecest` and for the public PyTorch backend.

## Validation
- Syntax-checked the patched module and test file locally.
- Ran targeted raw/public PyTorch smoke checks with a meta endpoint in a temporary source tree.
- Confirmed the branch is current with `main` (`behind_by=0`).

Full repository pytest was not run locally; CI should run the new backend-portable tests.