### PR TITLE
Reject complex cost-matrix adjustment inputs

### DIFF
--- a/src/pyrecest/utils/cost_matrix_adjustments.py
+++ b/src/pyrecest/utils/cost_matrix_adjustments.py
@@ -188,13 +188,15 @@ def _coerce_adjustment_output(
 
 
 def _as_cost_matrix(value: Any) -> np.ndarray:
+    if _contains_invalid_values(value):
+        raise ValueError("cost_matrix must be real-valued numeric")
     try:
         matrix = np.asarray(value, dtype=float)
     except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError("cost_matrix must be real-valued numeric") from exc
     if matrix.ndim != 2:
         raise ValueError("cost_matrix must be two-dimensional")
-    if matrix.dtype == np.bool_ or _contains_invalid_values(value):
+    if matrix.dtype == np.bool_:
         raise ValueError("cost_matrix must be real-valued numeric")
     if np.any(np.isneginf(matrix)):
         raise ValueError("cost_matrix may not contain negative infinity")
@@ -209,7 +211,7 @@ def _contains_invalid_values(value: Any) -> bool:
     for item in flat:
         if item is None or isinstance(item, (bool, np.bool_, str, bytes, bytearray)):
             return True
-        if isinstance(item, complex):
+        if isinstance(item, (complex, np.complexfloating)):
             return True
         if not isinstance(item, Real) and not np.isscalar(item):
             return True

--- a/tests/test_cost_matrix_adjustments.py
+++ b/tests/test_cost_matrix_adjustments.py
@@ -143,6 +143,7 @@ class TestCostMatrixAdjustments(unittest.TestCase):
             [["not-a-number"]],
             [1.0, 2.0],
             [[-np.inf]],
+            [[np.complex64(1.0 + 0.0j)]],
         )
         for value in invalid_inputs:
             with self.subTest(value=value):


### PR DESCRIPTION
## Summary
- Validate cost-matrix entries before casting to float so invalid scalar dtypes cannot be silently truncated.
- Reject NumPy complex scalar entries such as `np.complex64`, matching the documented real-valued cost-matrix contract.
- Add regression coverage for a complex64 input that previously could be accepted after float coercion.

## Validation
- Not run locally; change was made through the GitHub connector with a focused regression test added.