### PR TITLE
Fix PyTorch broadcast_arrays device contract

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_allclose_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_allclose_device_contract.py
@@ -36,6 +36,15 @@ def _coerce_binary_args(torch_module, x, y):
     return x, y
 
 
+def _coerce_array_to_device(pytorch_backend, value, *, device):
+    """Return one backend tensor on the preferred existing tensor device."""
+
+    tensor = pytorch_backend.array(value)
+    if device is not None and tensor.device != device:
+        tensor = tensor.to(device=device)
+    return tensor
+
+
 def _patch_pytorch_linalg_logm_arraylike_contract() -> None:
     """Patch raw/public PyTorch ``linalg.logm`` to normalize array-like inputs."""
 
@@ -101,15 +110,8 @@ def _patch_pytorch_flip_numpy_axis_contract() -> None:
         backend.flip = flip
 
 
-def patch_pytorch_allclose_device_contract() -> None:
+def _patch_allclose(pytorch_backend, backend, torch_module) -> None:
     """Patch raw/public PyTorch ``allclose`` to preserve non-CPU operands."""
-
-    try:
-        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
-        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
-        import torch as torch_module  # pylint: disable=import-outside-toplevel
-    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
-        return
 
     _patch_pytorch_creation_shape_contract()
     _patch_pytorch_linalg_logm_arraylike_contract()
@@ -118,8 +120,9 @@ def patch_pytorch_allclose_device_contract() -> None:
     original_allclose = getattr(pytorch_backend, "allclose", None)
     if original_allclose is None:
         return
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
     if getattr(original_allclose, "_pyrecest_equal_nan_device_contract", False):
-        if getattr(backend, "__backend_name__", None) == "pytorch":
+        if active_pytorch_backend:
             backend.allclose = original_allclose
         return
 
@@ -139,5 +142,61 @@ def patch_pytorch_allclose_device_contract() -> None:
     allclose.__doc__ = getattr(original_allclose, "__doc__", None)
     allclose._pyrecest_equal_nan_device_contract = True
     pytorch_backend.allclose = allclose
-    if getattr(backend, "__backend_name__", None) == "pytorch":
+    if active_pytorch_backend:
         backend.allclose = allclose
+
+
+def _patch_broadcast_arrays(pytorch_backend, backend, torch_module) -> None:
+    """Patch raw/public PyTorch ``broadcast_arrays`` to preserve tensor devices."""
+
+    original_broadcast_arrays = getattr(pytorch_backend, "broadcast_arrays", None)
+    if original_broadcast_arrays is None:
+        return
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+    if getattr(
+        original_broadcast_arrays,
+        "_pyrecest_broadcast_arrays_device_contract",
+        False,
+    ):
+        if active_pytorch_backend:
+            backend.broadcast_arrays = original_broadcast_arrays
+        return
+
+    def broadcast_arrays(*arrays):
+        device = _preferred_pytorch_device(torch_module, *arrays)
+        tensors = tuple(
+            _coerce_array_to_device(
+                pytorch_backend,
+                value,
+                device=device,
+            )
+            for value in arrays
+        )
+        return original_broadcast_arrays(*tensors)
+
+    broadcast_arrays.__name__ = getattr(
+        original_broadcast_arrays,
+        "__name__",
+        "broadcast_arrays",
+    )
+    broadcast_arrays.__doc__ = getattr(original_broadcast_arrays, "__doc__", None)
+    broadcast_arrays._pyrecest_numpy_contract = True
+    broadcast_arrays._pyrecest_broadcast_arrays_device_contract = True
+    broadcast_arrays._pyrecest_device_contract = True
+    pytorch_backend.broadcast_arrays = broadcast_arrays
+    if active_pytorch_backend:
+        backend.broadcast_arrays = broadcast_arrays
+
+
+def patch_pytorch_allclose_device_contract() -> None:
+    """Patch raw/public PyTorch helpers to preserve existing tensor devices."""
+
+    try:
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import torch as torch_module  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    _patch_allclose(pytorch_backend, backend, torch_module)
+    _patch_broadcast_arrays(pytorch_backend, backend, torch_module)

--- a/tests/backend_support/test_pytorch_broadcast_arrays_device_contract.py
+++ b/tests/backend_support/test_pytorch_broadcast_arrays_device_contract.py
@@ -1,0 +1,51 @@
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+pytestmark = pytest.mark.backend_portable
+
+
+def _broadcast_arrays_device_contract_code(target_module):
+    return f"""
+import torch
+import pyrecest  # noqa: F401  # triggers backend-support compatibility patches
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+
+target = {target_module}
+left, right = target.broadcast_arrays([1, 2], torch.empty((2,), device="meta"))
+assert left.device.type == "meta"
+assert right.device.type == "meta"
+assert tuple(left.shape) == (2,)
+assert tuple(right.shape) == (2,)
+print("ok")
+"""
+
+
+def test_raw_pytorch_broadcast_arrays_prefers_existing_non_cpu_device_after_import():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "numpy",
+        _broadcast_arrays_device_contract_code("raw_pytorch"),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_public_pytorch_broadcast_arrays_prefers_existing_non_cpu_device():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        _broadcast_arrays_device_contract_code("backend"),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- Patch raw/public PyTorch `broadcast_arrays` so array-like operands are moved to an existing non-CPU tensor device before broadcasting.
- Keep the active public PyTorch backend synchronized with the patched raw helper.
- Add backend-portable regressions for raw PyTorch under the NumPy-selected public backend and for the selected public PyTorch backend.

## Bug fixed
`pyrecest._backend.pytorch.broadcast_arrays([1, 2], torch.empty((2,), device="meta"))` could return one CPU tensor and one non-CPU tensor because the array-like operand was materialized independently on CPU. Downstream operations could then hit mixed-device behavior even though PyRecEst's PyTorch device-contract wrappers generally prefer existing non-CPU tensor devices.

## Validation
- Syntax-checked the changed backend-support module and new regression test with `python -m py_compile` locally.
- Reproduced the underlying PyTorch behavior in the sandbox: broadcasting a CPU tensor with a meta tensor leaves devices mixed, while pre-coercing the array-like operand onto meta returns both outputs on meta.
- Confirmed the branch is based on current `main` via `compare_commits` (`behind_by=0`).
- Full repository pytest was not run locally because direct repository checkout/network access is unavailable here; the PR adds targeted CI coverage.