### PR TITLE
Fix PyTorch trapezoid array-like contract

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_trapezoid_numpy_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_trapezoid_numpy_contract.py
@@ -1,0 +1,76 @@
+"""PyTorch ``trapezoid`` NumPy compatibility hook."""
+
+from __future__ import annotations
+
+from operator import index as _operator_index
+
+
+def _preferred_pytorch_device(torch_module, *values):
+    """Return an existing non-CPU tensor device, falling back to any tensor."""
+    for value in values:
+        if torch_module.is_tensor(value) and value.device.type != "cpu":
+            return value.device
+    for value in values:
+        if torch_module.is_tensor(value):
+            return value.device
+    return None
+
+
+def _as_trapezoid_tensor(value, torch_module, *, device=None, dtype=None):
+    """Coerce one trapezoid argument without moving existing tensors unnecessarily."""
+    if torch_module.is_tensor(value):
+        target_device = device if device is not None else value.device
+        target_dtype = dtype if dtype is not None else value.dtype
+        if value.device != target_device or value.dtype != target_dtype:
+            return value.to(device=target_device, dtype=target_dtype)
+        return value
+    return torch_module.as_tensor(value, device=device, dtype=dtype)
+
+
+def _promote_trapezoid_tensor(value, raw_pytorch):
+    """Promote integer and boolean inputs before PyTorch integration."""
+    if value.dtype.is_floating_point or value.dtype.is_complex:
+        return value
+    return value.to(dtype=raw_pytorch.get_default_dtype())
+
+
+def patch_pytorch_trapezoid_numpy_contract() -> None:
+    """Patch raw/public PyTorch ``trapezoid`` to accept NumPy-style inputs."""
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    original_trapezoid = getattr(raw_pytorch, "trapezoid", None)
+    if original_trapezoid is None:
+        return
+    if getattr(original_trapezoid, "_pyrecest_numpy_contract", False):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.trapezoid = original_trapezoid
+        return
+
+    def trapezoid(y, x=None, dx=1.0, axis=-1):
+        dim = _operator_index(axis)
+        device = _preferred_pytorch_device(torch, y, x)
+        y = _as_trapezoid_tensor(y, torch, device=device)
+
+        if x is None:
+            y = _promote_trapezoid_tensor(y, raw_pytorch)
+            return torch.trapezoid(y, dx=dx, dim=dim)
+
+        x = _as_trapezoid_tensor(x, torch, device=y.device)
+        result_dtype = torch.promote_types(y.dtype, x.dtype)
+        if not (result_dtype.is_floating_point or result_dtype.is_complex):
+            result_dtype = raw_pytorch.get_default_dtype()
+        y = y.to(dtype=result_dtype)
+        x = x.to(dtype=result_dtype)
+        return torch.trapezoid(y, x=x, dim=dim)
+
+    trapezoid.__name__ = getattr(original_trapezoid, "__name__", "trapezoid")
+    trapezoid.__doc__ = getattr(original_trapezoid, "__doc__", None)
+    trapezoid._pyrecest_numpy_contract = True
+    raw_pytorch.trapezoid = trapezoid
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.trapezoid = trapezoid

--- a/src/pyrecest/stability.py
+++ b/src/pyrecest/stability.py
@@ -19,6 +19,9 @@ from pyrecest.backend_support._pytorch_matmul_device_contract import (
 from pyrecest.backend_support._pytorch_minmax_device_contract import (
     patch_pytorch_minmax_device_contract as _patch_pytorch_minmax_device_contract,
 )
+from pyrecest.backend_support._pytorch_trapezoid_numpy_contract import (
+    patch_pytorch_trapezoid_numpy_contract as _patch_pytorch_trapezoid_numpy_contract,
+)
 
 
 def _patch_pytorch_raw_comparison_arraylike_contract() -> None:
@@ -254,6 +257,7 @@ _patch_pytorch_raw_comparison_arraylike_contract()
 _patch_pytorch_dot_outer_device_contract()
 _patch_pytorch_matmul_device_contract()
 _patch_pytorch_minmax_device_contract()
+_patch_pytorch_trapezoid_numpy_contract()
 _patch_jax_squeeze_numpy_contract()
 
 P = ParamSpec("P")

--- a/tests/backend_support/test_pytorch_trapezoid_contract.py
+++ b/tests/backend_support/test_pytorch_trapezoid_contract.py
@@ -1,0 +1,56 @@
+"""Regression tests for PyTorch trapezoid backend compatibility."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_pytorch_trapezoid_accepts_array_like_inputs():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import pyrecest.backend as backend
+
+scalar = backend.trapezoid([1.0, 2.0, 4.0])
+assert float(backend.to_numpy(scalar)) == 4.5
+
+weighted = backend.trapezoid(
+    [[1.0, 2.0, 4.0], [2.0, 3.0, 5.0]],
+    x=[0.0, 0.5, 2.0],
+    axis=1,
+)
+assert backend.to_numpy(weighted).tolist() == [5.25, 7.25]
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_trapezoid_accepts_array_like_inputs_after_pyrecest_import():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "numpy",
+        """
+import pyrecest  # noqa: F401
+import pyrecest._backend.pytorch as raw_pytorch
+
+scalar = raw_pytorch.trapezoid([1.0, 2.0, 4.0])
+assert float(raw_pytorch.to_numpy(scalar)) == 4.5
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- Add a PyTorch backend support hook for `trapezoid` that coerces NumPy-style array-like `y` and optional `x` inputs before calling `torch.trapezoid`.
- Preserve the existing raw/public backend patch pattern and prefer an existing non-CPU tensor device when mixed tensor/array-like operands are supplied.
- Register the hook during stability initialization and add backend-portable public/raw regression coverage.

## Bug fixed
Under the PyTorch backend, `backend.trapezoid([1.0, 2.0, 4.0])` reached `torch.trapezoid` with a Python list and raised `TypeError: argument 'y' must be Tensor`. The same issue affected `pyrecest._backend.pytorch.trapezoid([...])` after importing `pyrecest`.

## Validation
- Reproduced the failure locally against the installed PyPI package with `PYRECEST_BACKEND=pytorch`.
- Ran a local standalone smoke check of the new patch function against installed PyRecEst/PyTorch for scalar and weighted array-like inputs.
- Syntax-checked the new support module locally with `python -m py_compile`.

Full repository pytest was not run locally because this execution environment cannot clone/install the repository directly from GitHub; CI should exercise the added backend-portable regression tests.