### PR TITLE
Activate PyTorch minmax device patch on import

### DIFF
--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -14,6 +14,12 @@ from typing import Any, Literal
 
 import numpy as np
 
+from pyrecest.backend_support._pytorch_minmax_device_contract import (
+    patch_pytorch_minmax_device_contract as _patch_pytorch_minmax_device_contract,
+)
+
+_patch_pytorch_minmax_device_contract()
+
 EvidenceComputationKind = Literal["full_smoothing", "evidence_only"]
 _RESERVED_DIAGNOSTIC_METADATA_KEYS = frozenset(
     {


### PR DESCRIPTION
## Summary
- activate the existing PyTorch `maximum`/`minimum` device compatibility patch during the normal `import pyrecest` path
- keeps array-like operands on an existing non-CPU tensor device, matching the existing regression coverage for raw and public PyTorch backends

## Testing
- Not run locally; change is covered by the existing `tests/backend_support/test_pytorch_minmax_device_contract.py` regression test.