### PR TITLE
Fix PyTorch stack helper device contract

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_stack_helpers_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_stack_helpers_device_contract.py
@@ -1,0 +1,127 @@
+"""PyTorch stack-helper device compatibility hook."""
+
+from __future__ import annotations
+
+import importlib
+
+
+_STACK_HELPER_NAMES = ("hstack", "vstack", "column_stack", "dstack")
+
+
+def _raw_pytorch_module():
+    """Return the raw PyTorch backend module, importing it when available."""
+    try:
+        return importlib.import_module("pyrecest._backend.pytorch")
+    except ModuleNotFoundError:
+        return None
+
+
+def _preferred_pytorch_device(torch_module, *values):
+    """Return an existing tensor device, preferring non-copyable meta tensors."""
+    for value in values:
+        if torch_module.is_tensor(value) and value.device.type == "meta":
+            return value.device
+    for value in values:
+        if torch_module.is_tensor(value) and value.device.type != "cpu":
+            return value.device
+    for value in values:
+        if torch_module.is_tensor(value):
+            return value.device
+    return None
+
+
+def _tensor_sequence(raw_pytorch, torch_module, values):
+    """Return sequence entries normalized onto one preferred tensor device."""
+    values = tuple(values)
+    device = _preferred_pytorch_device(torch_module, *values)
+    tensors = []
+    for value in values:
+        tensor = raw_pytorch.array(value)
+        if device is not None and tensor.device != device:
+            tensor = tensor.to(device=device)
+        tensors.append(tensor)
+    return tensors
+
+
+def _build_stack_helpers(raw_pytorch, torch_module):
+    """Build NumPy-style PyTorch stack helpers with consistent devices."""
+
+    def hstack(tup):
+        tensors = [
+            torch_module.atleast_1d(tensor)
+            for tensor in _tensor_sequence(raw_pytorch, torch_module, tup)
+        ]
+        if not tensors:
+            return torch_module.cat(tensors, dim=0)
+        return torch_module.cat(tensors, dim=0 if tensors[0].ndim == 1 else 1)
+
+    def vstack(tup):
+        tensors = [
+            torch_module.atleast_2d(tensor)
+            for tensor in _tensor_sequence(raw_pytorch, torch_module, tup)
+        ]
+        return torch_module.cat(tensors, dim=0)
+
+    def column_stack(tup):
+        tensors = []
+        for tensor in _tensor_sequence(raw_pytorch, torch_module, tup):
+            if tensor.ndim < 2:
+                tensor = tensor.reshape(-1, 1)
+            tensors.append(tensor)
+        return torch_module.cat(tensors, dim=1)
+
+    def dstack(tup):
+        tensors = [
+            torch_module.atleast_3d(tensor)
+            for tensor in _tensor_sequence(raw_pytorch, torch_module, tup)
+        ]
+        return torch_module.cat(tensors, dim=2)
+
+    return {
+        "hstack": hstack,
+        "vstack": vstack,
+        "column_stack": column_stack,
+        "dstack": dstack,
+    }
+
+
+def patch_pytorch_stack_helpers_device_contract() -> None:
+    """Patch raw/public PyTorch stack helpers to preserve tensor device."""
+    try:
+        import numpy as np  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    raw_pytorch = _raw_pytorch_module()
+    if raw_pytorch is None:  # pragma: no cover - backend import failed earlier
+        return
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+    if all(
+        getattr(
+            getattr(raw_pytorch, helper_name, None),
+            "_pyrecest_stack_helpers_device_contract",
+            False,
+        )
+        for helper_name in _STACK_HELPER_NAMES
+    ):
+        if active_pytorch_backend:
+            for helper_name in _STACK_HELPER_NAMES:
+                setattr(backend, helper_name, getattr(raw_pytorch, helper_name))
+        return
+
+    helpers = _build_stack_helpers(raw_pytorch, torch)
+    for helper_name, helper in helpers.items():
+        original_helper = getattr(raw_pytorch, helper_name, None)
+        if original_helper is None:
+            continue
+        helper.__name__ = helper_name
+        helper.__doc__ = getattr(np, helper_name).__doc__
+        helper._pyrecest_numpy_contract = True
+        helper._pyrecest_device_contract = True
+        helper._pyrecest_stack_helpers_device_contract = True
+        setattr(raw_pytorch, helper_name, helper)
+        if active_pytorch_backend:
+            setattr(backend, helper_name, helper)

--- a/src/pyrecest/stability.py
+++ b/src/pyrecest/stability.py
@@ -22,6 +22,9 @@ from pyrecest.backend_support._pytorch_minmax_device_contract import (
 from pyrecest.backend_support._pytorch_one_hot_scalar_contract import (
     patch_pytorch_one_hot_scalar_contract as _patch_pytorch_one_hot_scalar_contract,
 )
+from pyrecest.backend_support._pytorch_stack_helpers_device_contract import (
+    patch_pytorch_stack_helpers_device_contract as _patch_pytorch_stack_helpers_device_contract,
+)
 from pyrecest.backend_support._pytorch_trapezoid_numpy_contract import (
     patch_pytorch_trapezoid_numpy_contract as _patch_pytorch_trapezoid_numpy_contract,
 )
@@ -538,6 +541,7 @@ _patch_pytorch_matmul_device_contract()
 _patch_pytorch_minmax_device_contract()
 _patch_pytorch_one_hot_scalar_contract()
 _patch_shared_numpy_matrix_helpers_arraylike_contract()
+_patch_pytorch_stack_helpers_device_contract()
 _patch_pytorch_trapezoid_numpy_contract()
 _patch_pytorch_where_device_contract()
 _patch_jax_squeeze_numpy_contract()

--- a/tests/backend_support/test_pytorch_stack_helpers_contract.py
+++ b/tests/backend_support/test_pytorch_stack_helpers_contract.py
@@ -18,6 +18,18 @@ def _backend_test_env(backend_name):
     return env
 
 
+def _skip_if_no_torch_meta_device():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    import torch  # pylint: disable=import-outside-toplevel
+
+    try:
+        torch.empty((1,), device="meta")
+    except (RuntimeError, NotImplementedError, TypeError) as exc:
+        pytest.skip(f"torch meta device is not available: {exc}")
+
+
 @pytest.mark.backend_portable
 def test_pytorch_stack_helpers_accept_array_like_sequences():
     if importlib.util.find_spec("torch") is None:
@@ -78,4 +90,43 @@ assert raw_backend.to_numpy(raw_right).tolist() == [3.0, 3.0]
 """
     subprocess.run(
         [sys.executable, "-c", code], check=True, env=_backend_test_env("numpy")
+    )
+
+
+@pytest.mark.backend_portable
+@pytest.mark.parametrize("backend_name", ("pytorch", "numpy"))
+def test_pytorch_stack_helpers_preserve_non_cpu_tensor_device(backend_name):
+    _skip_if_no_torch_meta_device()
+
+    code = """
+import torch
+
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_backend
+
+helpers = (raw_backend,)
+if getattr(backend, "__backend_name__", None) == "pytorch":
+    helpers = (backend, raw_backend)
+
+for stack_backend in helpers:
+    one_d_meta = torch.empty((2,), device="meta")
+
+    hstack_result = stack_backend.hstack(([1, 2], one_d_meta))
+    assert hstack_result.device.type == "meta"
+    assert tuple(hstack_result.shape) == (4,)
+
+    vstack_result = stack_backend.vstack(([1, 2], one_d_meta))
+    assert vstack_result.device.type == "meta"
+    assert tuple(vstack_result.shape) == (2, 2)
+
+    column_stack_result = stack_backend.column_stack(([1, 2], one_d_meta))
+    assert column_stack_result.device.type == "meta"
+    assert tuple(column_stack_result.shape) == (2, 2)
+
+    dstack_result = stack_backend.dstack(([1, 2], one_d_meta))
+    assert dstack_result.device.type == "meta"
+    assert tuple(dstack_result.shape) == (1, 2, 2)
+"""
+    subprocess.run(
+        [sys.executable, "-c", code], check=True, env=_backend_test_env(backend_name)
     )


### PR DESCRIPTION
## Summary
- Add a backend-support hook for raw/public PyTorch `hstack`, `vstack`, `column_stack`, and `dstack` that normalizes sequence entries onto a preferred existing tensor device before concatenation.
- Prefer `meta`/non-CPU tensor devices over newly materialized CPU tensors while preserving the existing NumPy-style array-like stack-helper contract.
- Add backend-portable regressions for the selected PyTorch backend and raw PyTorch helpers under the NumPy backend.

## Bug fixed
The PyTorch stack helpers first converted array-like sequence entries independently. A call such as `hstack(([1, 2], torch.empty((2,), device="meta")))` materialized the list entry on CPU while leaving the existing tensor on `meta`, so the subsequent `torch.cat` hit a mixed-device runtime error. The same pattern can occur with accelerator tensors. The new hook moves array-like entries onto the existing preferred device before shape promotion and concatenation.

## Validation
- Confirmed the branch is based on current `main` via `compare_commits` (`behind_by=0`).
- Reproduced the underlying PyTorch mixed CPU/meta concatenation failure locally and confirmed pre-coercing the array-like operand onto `meta` yields a `meta` result.
- Full repository pytest was not run locally because direct repository checkout/install from GitHub is unavailable in this execution environment; CI should exercise the added targeted tests.