### PR TITLE
Reject boolean shapes in PyTorch creation helpers

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_allclose_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_allclose_device_contract.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from pyrecest.backend_support._pytorch_creation_shape_contract import (
+    patch_pytorch_creation_shape_contract as _patch_pytorch_creation_shape_contract,
+)
+
 
 def _preferred_pytorch_device(torch_module, *values):
     """Return a non-CPU tensor device when mixed-device operands are present."""
@@ -39,6 +43,8 @@ def patch_pytorch_allclose_device_contract() -> None:
         import torch as torch_module  # pylint: disable=import-outside-toplevel
     except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
         return
+
+    _patch_pytorch_creation_shape_contract()
 
     original_allclose = getattr(pytorch_backend, "allclose", None)
     if original_allclose is None:

--- a/src/pyrecest/backend_support/_pytorch_creation_shape_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_creation_shape_contract.py
@@ -1,0 +1,103 @@
+"""PyTorch creation-helper shape validation hook."""
+
+from __future__ import annotations
+
+from operator import index as _operator_index
+
+
+def _pytorch_creation_dimension(dimension, numpy_module) -> int:
+    """Return one NumPy-style shape dimension as a non-boolean integer."""
+    if isinstance(dimension, (bool, numpy_module.bool_)):
+        raise TypeError("shape dimensions must be integers")
+    try:
+        return _operator_index(dimension)
+    except TypeError as exc:
+        raise TypeError("shape dimensions must be integers") from exc
+
+
+def _pytorch_creation_shape(shape, numpy_module, torch_module) -> tuple[int, ...]:
+    """Normalize NumPy-style creation shapes while rejecting boolean dimensions."""
+    if torch_module.is_tensor(shape):
+        shape = shape.detach().cpu().numpy()
+    shape_array = numpy_module.asarray(shape)
+    if shape_array.shape == ():
+        normalized_shape = (
+            _pytorch_creation_dimension(shape_array.item(), numpy_module),
+        )
+    else:
+        normalized_shape = tuple(
+            _pytorch_creation_dimension(one_dimension, numpy_module)
+            for one_dimension in shape_array.tolist()
+        )
+    if any(one_dimension < 0 for one_dimension in normalized_shape):
+        raise ValueError("negative dimensions are not allowed")
+    return normalized_shape
+
+
+def patch_pytorch_creation_shape_contract() -> None:
+    """Patch raw/public PyTorch creation helpers to reject boolean shapes."""
+    try:
+        import numpy as np  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+        from pyrecest._backend.pytorch._common import (  # pylint: disable=import-outside-toplevel
+            _normalize_dtype,
+        )
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+
+    def _wrap_creation_helper(helper_name, torch_helper, *, has_fill_value=False):
+        original_helper = getattr(raw_pytorch, helper_name, None)
+        if original_helper is None:
+            return None
+        if getattr(original_helper, "_pyrecest_boolean_shape_contract", False):
+            if active_pytorch_backend:
+                setattr(backend, helper_name, original_helper)
+            return original_helper
+
+        if has_fill_value:
+
+            def creation_helper(shape, fill_value, dtype=None, *args, **kwargs):
+                return torch_helper(
+                    _pytorch_creation_shape(shape, np, torch),
+                    fill_value,
+                    *args,
+                    dtype=_normalize_dtype(dtype),
+                    **kwargs,
+                )
+
+        else:
+
+            def creation_helper(shape, dtype=None, *args, **kwargs):
+                return torch_helper(
+                    _pytorch_creation_shape(shape, np, torch),
+                    *args,
+                    dtype=_normalize_dtype(dtype),
+                    **kwargs,
+                )
+
+        creation_helper.__name__ = getattr(original_helper, "__name__", helper_name)
+        creation_helper.__doc__ = getattr(original_helper, "__doc__", None)
+        creation_helper._pyrecest_numpy_contract = True
+        creation_helper._pyrecest_boolean_shape_contract = True
+        return creation_helper
+
+    for helper_name, torch_helper, has_fill_value in (
+        ("empty", torch.empty, False),
+        ("zeros", torch.zeros, False),
+        ("ones", torch.ones, False),
+        ("full", torch.full, True),
+    ):
+        helper = _wrap_creation_helper(
+            helper_name,
+            torch_helper,
+            has_fill_value=has_fill_value,
+        )
+        if helper is None:
+            continue
+        setattr(raw_pytorch, helper_name, helper)
+        if active_pytorch_backend:
+            setattr(backend, helper_name, helper)

--- a/src/pyrecest/backend_support/_pytorch_creation_shape_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_creation_shape_contract.py
@@ -19,6 +19,14 @@ def _pytorch_creation_shape(shape, numpy_module, torch_module) -> tuple[int, ...
     """Normalize NumPy-style creation shapes while rejecting boolean dimensions."""
     if torch_module.is_tensor(shape):
         shape = shape.detach().cpu().numpy()
+    if isinstance(shape, (list, tuple)):
+        normalized_shape = tuple(
+            _pytorch_creation_dimension(one_dimension, numpy_module)
+            for one_dimension in shape
+        )
+        if any(one_dimension < 0 for one_dimension in normalized_shape):
+            raise ValueError("negative dimensions are not allowed")
+        return normalized_shape
     shape_array = numpy_module.asarray(shape)
     if shape_array.shape == ():
         normalized_shape = (

--- a/tests/backend_support/test_pytorch_creation_shape_contract.py
+++ b/tests/backend_support/test_pytorch_creation_shape_contract.py
@@ -1,0 +1,70 @@
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_public_pytorch_creation_helpers_reject_boolean_shapes():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import pyrecest.backend as backend
+
+for call in (
+    lambda: backend.empty(True),
+    lambda: backend.zeros([True, False]),
+    lambda: backend.ones(backend.asarray(True)),
+    lambda: backend.full([False], 1.0),
+):
+    try:
+        call()
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("boolean shape was accepted")
+
+assert tuple(backend.zeros([]).shape) == ()
+assert tuple(backend.ones(backend.asarray(2)).shape) == (2,)
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_creation_helpers_reject_boolean_shapes_after_import():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "numpy",
+        """
+import pyrecest
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as pytorch_backend
+
+assert backend.__backend_name__ == "numpy"
+
+for call in (
+    lambda: pytorch_backend.empty(True),
+    lambda: pytorch_backend.zeros([True, False]),
+    lambda: pytorch_backend.ones(pytorch_backend.asarray(True)),
+    lambda: pytorch_backend.full([False], 1.0),
+):
+    try:
+        call()
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("boolean shape was accepted")
+
+assert tuple(pytorch_backend.zeros([]).shape) == ()
+assert tuple(pytorch_backend.ones(pytorch_backend.asarray(2)).shape) == (2,)
+""",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- add a PyTorch creation-helper compatibility hook that rejects boolean scalar and per-axis shape dimensions
- keep `empty`, `zeros`, `ones`, and `full` aligned for raw PyTorch helpers and the selected public PyTorch backend
- add subprocess regression coverage for public PyTorch and raw PyTorch after importing PyRecEst under the NumPy backend

## Bug fixed
The existing PyTorch creation-shape normalization used `operator.index` directly on shape dimensions. Python booleans implement `__index__`, so calls such as `backend.zeros(True)` or `pyrecest._backend.pytorch.zeros([True, False])` could be accepted and converted to integer dimensions, even though NumPy and PyTorch reject boolean shapes.

## Validation
- Syntax-checked the new hook, updated activation module, and regression test with `python -m py_compile` in the sandbox.
- Full repository tests were not run locally because this environment cannot clone/install the GitHub repository; CI should run the backend-portable subprocess tests.