### PR TITLE
Fix PyTorch one hot scalar labels

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_one_hot_scalar_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_one_hot_scalar_contract.py
@@ -1,0 +1,49 @@
+"""PyTorch ``one_hot`` scalar-label compatibility hook."""
+
+from __future__ import annotations
+
+from operator import index as _operator_index
+
+
+def patch_pytorch_one_hot_scalar_contract() -> None:
+    """Patch raw/public PyTorch ``one_hot`` to handle scalar labels correctly."""
+    try:
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import torch as torch_module  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    original_one_hot = getattr(pytorch_backend, "one_hot", None)
+    if original_one_hot is None:
+        return
+    if getattr(original_one_hot, "_pyrecest_scalar_label_contract", False):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.one_hot = original_one_hot
+        return
+
+    def one_hot(labels, num_classes):
+        num_classes = _operator_index(num_classes)
+        if torch_module.is_tensor(labels):
+            if (
+                labels.dtype == torch_module.bool
+                or labels.dtype.is_floating_point
+                or labels.dtype.is_complex
+            ):
+                return original_one_hot(labels, num_classes)
+            labels = labels.to(dtype=torch_module.long)
+        else:
+            labels = torch_module.as_tensor(labels, dtype=torch_module.long)
+        return torch_module.nn.functional.one_hot(labels, num_classes).to(
+            dtype=torch_module.uint8
+        )
+
+    one_hot.__name__ = getattr(original_one_hot, "__name__", "one_hot")
+    one_hot.__doc__ = getattr(original_one_hot, "__doc__", None)
+    one_hot._pyrecest_scalar_label_contract = True
+    pytorch_backend.one_hot = one_hot
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.one_hot = one_hot
+
+
+__all__ = ["patch_pytorch_one_hot_scalar_contract"]

--- a/src/pyrecest/stability.py
+++ b/src/pyrecest/stability.py
@@ -19,6 +19,9 @@ from pyrecest.backend_support._pytorch_matmul_device_contract import (
 from pyrecest.backend_support._pytorch_minmax_device_contract import (
     patch_pytorch_minmax_device_contract as _patch_pytorch_minmax_device_contract,
 )
+from pyrecest.backend_support._pytorch_one_hot_scalar_contract import (
+    patch_pytorch_one_hot_scalar_contract as _patch_pytorch_one_hot_scalar_contract,
+)
 from pyrecest.backend_support._pytorch_trapezoid_numpy_contract import (
     patch_pytorch_trapezoid_numpy_contract as _patch_pytorch_trapezoid_numpy_contract,
 )
@@ -319,6 +322,7 @@ _patch_pytorch_array_equal_equal_nan_contract()
 _patch_pytorch_dot_outer_device_contract()
 _patch_pytorch_matmul_device_contract()
 _patch_pytorch_minmax_device_contract()
+_patch_pytorch_one_hot_scalar_contract()
 _patch_pytorch_trapezoid_numpy_contract()
 _patch_jax_squeeze_numpy_contract()
 

--- a/tests/backend_support/test_pytorch_one_hot_scalar_contract.py
+++ b/tests/backend_support/test_pytorch_one_hot_scalar_contract.py
@@ -1,0 +1,59 @@
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+pytestmark = pytest.mark.backend_portable
+
+
+def _scalar_contract_code(target_module):
+    return f"""
+import torch
+import pyrecest  # noqa: F401  # triggers backend-support compatibility patches
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+
+target = {target_module}
+
+scalar_result = target.one_hot(2, 4)
+assert scalar_result.dtype == torch.uint8
+assert tuple(scalar_result.shape) == (4,)
+assert torch.equal(scalar_result, torch.tensor([0, 0, 1, 0], dtype=torch.uint8))
+
+batched_result = target.one_hot([0, 2], 4)
+assert batched_result.dtype == torch.uint8
+assert tuple(batched_result.shape) == (2, 4)
+assert torch.equal(
+    batched_result,
+    torch.tensor([[1, 0, 0, 0], [0, 0, 1, 0]], dtype=torch.uint8),
+)
+
+device = torch.device("cuda") if torch.cuda.is_available() else torch.device("meta")
+device_result = target.one_hot(torch.tensor(2, device=device), 4)
+assert device_result.device.type == device.type
+assert tuple(device_result.shape) == (4,)
+
+print("ok")
+"""
+
+
+def test_raw_pytorch_one_hot_accepts_scalar_label_after_import():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code("numpy", _scalar_contract_code("raw_pytorch"))
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_public_pytorch_one_hot_accepts_scalar_label():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code("pytorch", _scalar_contract_code("backend"))
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
Summary:
- Fix scalar labels for the PyTorch one_hot backend helper by converting non-tensor labels with torch.as_tensor.
- Preserve tensor-label devices and uint8 output.
- Add regression tests for raw and public PyTorch backend imports.

Testing:
- Added tests/backend_support/test_pytorch_one_hot_scalar_contract.py