### PR TITLE
Normalize additive-noise bool flag conversion errors

### DIFF
--- a/src/pyrecest/models/additive_noise.py
+++ b/src/pyrecest/models/additive_noise.py
@@ -82,7 +82,10 @@ def _reject_unexpected_kwargs(kwargs: dict[str, Any]) -> None:
 
 
 def _validate_bool_flag(value: Any, name: str) -> bool:
-    value_array = np.asarray(value)
+    try:
+        value_array = np.asarray(value)
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise TypeError(f"{name} must be a boolean") from exc
     if value_array.shape != () or not np.issubdtype(value_array.dtype, np.bool_):
         raise TypeError(f"{name} must be a boolean")
     return bool(value_array.item())

--- a/tests/models/test_additive_noise_bool_validation.py
+++ b/tests/models/test_additive_noise_bool_validation.py
@@ -1,0 +1,30 @@
+import unittest
+
+from pyrecest.models import AdditiveNoiseMeasurementModel, AdditiveNoiseTransitionModel
+
+
+class UncoercibleBoolFlag:
+    def __array__(self, dtype=None):
+        del dtype
+        raise TypeError("cannot convert")
+
+
+class AdditiveNoiseBoolFlagValidationTest(unittest.TestCase):
+    def test_vectorized_flag_wraps_uncoercible_array_errors(self):
+        flag = UncoercibleBoolFlag()
+
+        with self.assertRaisesRegex(TypeError, "vectorized"):
+            AdditiveNoiseTransitionModel(lambda x: x, vectorized=flag)
+
+        transition_model = AdditiveNoiseTransitionModel(lambda x: x)
+        with self.assertRaisesRegex(TypeError, "vectorized"):
+            transition_model.vectorized = flag
+        with self.assertRaisesRegex(TypeError, "function_is_vectorized"):
+            transition_model.function_is_vectorized = flag
+
+        with self.assertRaisesRegex(TypeError, "vectorized"):
+            AdditiveNoiseMeasurementModel(lambda x: x, vectorized=flag)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Wrap NumPy coercion failures in additive-noise boolean flag validation.
- Preserve the existing `TypeError: <name> must be a boolean` contract for uncoercible `vectorized` and `function_is_vectorized` inputs.
- Add a focused regression test for transition and measurement model vectorized flags.

## Testing
- Patched module syntax-checked locally.
- Focused regression test passed locally against a minimal package stub.