### PR TITLE
Fix PyTorch array_equal equal_nan contract

### DIFF
--- a/src/pyrecest/stability.py
+++ b/src/pyrecest/stability.py
@@ -91,6 +91,67 @@ def _patch_pytorch_raw_comparison_arraylike_contract() -> None:
             setattr(backend, helper_name, helper)
 
 
+def _patch_pytorch_array_equal_equal_nan_contract() -> None:
+    """Patch raw/public PyTorch ``array_equal`` to accept ``equal_nan``."""
+
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    original_array_equal = getattr(raw_pytorch, "array_equal", None)
+    if original_array_equal is None:
+        return
+    if getattr(original_array_equal, "_pyrecest_equal_nan_contract", False):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.array_equal = original_array_equal
+        return
+
+    def _preferred_pytorch_device(*values):
+        for value in values:
+            if torch.is_tensor(value) and value.device.type != "cpu":
+                return value.device
+        for value in values:
+            if torch.is_tensor(value):
+                return value.device
+        return None
+
+    def _coerce_array_equal_arg(value, *, device):
+        if not torch.is_tensor(value):
+            return torch.as_tensor(value, device=device)
+        if device is not None and value.device != device:
+            return value.to(device=device)
+        return value
+
+    def array_equal(a, b, equal_nan=False):
+        device = _preferred_pytorch_device(a, b)
+        a = _coerce_array_equal_arg(a, device=device)
+        b = _coerce_array_equal_arg(b, device=device)
+        if tuple(a.shape) != tuple(b.shape):
+            return False
+
+        dtype = torch.promote_types(a.dtype, b.dtype)
+        a = a.to(dtype=dtype)
+        b = b.to(dtype=dtype)
+        if not equal_nan:
+            return torch.equal(a, b)
+
+        comparison = torch.eq(a, b)
+        if dtype.is_floating_point or dtype.is_complex:
+            comparison = comparison | (torch.isnan(a) & torch.isnan(b))
+        return bool(torch.all(comparison))
+
+    array_equal.__name__ = getattr(original_array_equal, "__name__", "array_equal")
+    array_equal.__doc__ = getattr(original_array_equal, "__doc__", None)
+    array_equal._pyrecest_equal_nan_contract = True
+    array_equal._pyrecest_numpy_contract = True
+    raw_pytorch.array_equal = array_equal
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.array_equal = array_equal
+
+
 def _patch_pytorch_diag_numpy_contract() -> None:
     """Patch raw/public PyTorch ``diag`` to accept NumPy-style inputs."""
     try:
@@ -254,6 +315,7 @@ _patch_pytorch_diag_numpy_contract()
 _patch_pytorch_vec_to_diag_numpy_contract()
 _patch_pytorch_arctan_numpy_contract()
 _patch_pytorch_raw_comparison_arraylike_contract()
+_patch_pytorch_array_equal_equal_nan_contract()
 _patch_pytorch_dot_outer_device_contract()
 _patch_pytorch_matmul_device_contract()
 _patch_pytorch_minmax_device_contract()

--- a/tests/backend_support/test_pytorch_array_equal_equal_nan_contract.py
+++ b/tests/backend_support/test_pytorch_array_equal_equal_nan_contract.py
@@ -1,0 +1,57 @@
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+_ARRAY_EQUAL_EQUAL_NAN_SCRIPT = """
+import importlib
+
+raw_pytorch = importlib.import_module("pyrecest._backend.pytorch")
+
+assert raw_pytorch.array_equal(
+    [1.0, float("nan")],
+    raw_pytorch.asarray([1.0, float("nan")]),
+    equal_nan=True,
+)
+assert not raw_pytorch.array_equal([1.0, float("nan")], [1.0, float("nan")])
+assert not raw_pytorch.array_equal(
+    [1.0, float("nan")],
+    [1.0, 2.0],
+    equal_nan=True,
+)
+assert raw_pytorch.array_equal(
+    [complex(float("nan"), 1.0)],
+    [complex(float("nan"), 2.0)],
+    equal_nan=True,
+)
+"""
+
+
+@pytest.mark.backend_portable
+@pytest.mark.parametrize("backend_name", ["numpy", "pytorch"])
+def test_raw_pytorch_array_equal_accepts_equal_nan_keyword(backend_name):
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(backend_name, _ARRAY_EQUAL_EQUAL_NAN_SCRIPT)
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.backend_portable
+def test_public_pytorch_array_equal_accepts_equal_nan_keyword_when_active():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import pyrecest.backend as backend
+
+assert backend.array_equal([1.0, float("nan")], [1.0, float("nan")], equal_nan=True)
+assert not backend.array_equal([1.0, float("nan")], [1.0, 2.0], equal_nan=True)
+""",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Patch raw/public PyTorch `array_equal` so it accepts NumPy's `equal_nan` keyword.
- Preserve existing shape-strict `array_equal` behavior while treating paired NaNs as equal when requested.
- Add regression coverage for raw PyTorch under both NumPy/PyTorch public backends and the active public PyTorch facade.

## Bug fixed
The NumPy backend exposes `array_equal(..., equal_nan=True)`, but the PyTorch backend helper only accepted two operands. Backend-portable code that supplied `equal_nan` therefore raised `TypeError` under PyTorch instead of following NumPy-style NaN equality semantics.

## Validation
- `python -m py_compile /tmp/stability_new.py /tmp/test_pytorch_array_equal_equal_nan_contract.py`
- Isolated local PyTorch smoke check confirmed the old helper rejects `equal_nan` and the patched logic accepts matching NaNs.
- Full repository tests were not run locally because the sandbox cannot resolve `github.com`; CI should run the focused regression.