### PR TITLE
Fix PyTorch logical_and device placement

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_minmax_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_minmax_device_contract.py
@@ -102,6 +102,7 @@ def patch_pytorch_minmax_device_contract() -> None:
         {
             "equal": torch.eq,
             "less_equal": torch.le,
+            "logical_and": torch.logical_and,
         },
         "_pyrecest_comparison_device_contract",
     )

--- a/tests/backend_support/test_pytorch_logical_and_device_contract.py
+++ b/tests/backend_support/test_pytorch_logical_and_device_contract.py
@@ -1,0 +1,33 @@
+"""Regression tests for PyTorch ``logical_and`` device placement."""
+
+from __future__ import annotations
+
+import pytest
+
+import pyrecest.backend as backend
+import pyrecest.backend_support  # noqa: F401 ensure compatibility patches are installed
+
+pytorch_backend = pytest.importorskip("pyrecest._backend.pytorch")
+torch = pytest.importorskip("torch")
+
+
+def _assert_logical_and_prefers_symbolic_operand_device(logical_and):
+    cpu_operand = torch.tensor([True, False])
+    symbolic_operand = torch.empty((2,), dtype=torch.bool, device="meta")
+
+    result = logical_and(cpu_operand, symbolic_operand)
+
+    assert result.device.type == "meta"
+    assert result.shape == symbolic_operand.shape
+    assert result.dtype == torch.bool
+
+
+def test_raw_pytorch_logical_and_prefers_meta_operand_device():
+    _assert_logical_and_prefers_symbolic_operand_device(pytorch_backend.logical_and)
+
+
+def test_public_pytorch_logical_and_prefers_meta_operand_device_when_active():
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        pytest.skip("public PyTorch backend is not active")
+
+    _assert_logical_and_prefers_symbolic_operand_device(backend.logical_and)


### PR DESCRIPTION
## Summary
- Extend the existing PyTorch binary device compatibility hook to patch `logical_and` alongside `maximum` and `minimum`.
- Prefer an existing meta/non-CPU operand device before coercing mixed-device operands.
- Add regression coverage for raw PyTorch and the active public PyTorch backend.

## Bug fixed
`pyrecest._backend.pytorch.logical_and(cpu_tensor, meta_tensor)` selected the first tensor's CPU device and then attempted to materialize the meta tensor on CPU. That raises `NotImplementedError: Cannot copy out of meta tensor; no data!`. The patched helper now chooses an existing symbolic/non-CPU operand device before coercion, matching the device-preservation behavior used by neighboring binary helpers.

## Validation
- Syntax-checked the patched module and new regression test with `python -m py_compile`.
- Reproduced the old CPU/meta failure in a local torch-only simulation and verified the patched operand normalization returns a meta boolean tensor.
- Inspected the branch diff against `main`: 2 commits, 1 modified source file, 1 new regression test, branch is 2 commits ahead and 0 behind.