### PR TITLE
Normalize model validation flag errors

### DIFF
--- a/src/pyrecest/models/validation.py
+++ b/src/pyrecest/models/validation.py
@@ -37,7 +37,10 @@ def _format_shape(shape: tuple[int, ...]) -> str:
 def _validate_bool_flag(value: Any, name: str) -> bool:
     if isinstance(value, (bool, np.bool_)):
         return bool(value)
-    value_array = np.asarray(value)
+    try:
+        value_array = np.asarray(value)
+    except (TypeError, ValueError, RuntimeError, OverflowError) as exc:
+        raise TypeError(f"{name} must be a boolean.") from exc
     if value_array.shape == () and value_array.dtype == np.bool_:
         return bool(value_array.item())
     raise TypeError(f"{name} must be a boolean.")

--- a/tests/models/test_validation_bool_flags.py
+++ b/tests/models/test_validation_bool_flags.py
@@ -12,12 +12,22 @@ from pyrecest.models.validation import (
 )
 
 
+class _ArrayCoercionFailure:
+    def __array__(self, *args, **kwargs):
+        raise RuntimeError("cannot coerce to array")
+
+
 def test_validate_state_vector_rejects_nonboolean_allow_scalar() -> None:
     invalid_flags = ("False", 1, np.array([True]))
 
     for flag in invalid_flags:
         with pytest.raises(TypeError, match="allow_scalar"):
             validate_state_vector(1.0, allow_scalar=flag)
+
+
+def test_validate_state_vector_normalizes_bool_flag_array_coercion_errors() -> None:
+    with pytest.raises(TypeError, match="allow_scalar must be a boolean"):
+        validate_state_vector(1.0, allow_scalar=_ArrayCoercionFailure())
 
 
 @pytest.mark.parametrize("flag", [True, np.bool_(True), np.array(True)])


### PR DESCRIPTION
## Summary
- Wrap NumPy conversion failures in the shared model-validation flag parser.
- Preserve the existing `TypeError: <name> must be a boolean.` contract for invalid `allow_scalar`, `check_symmetric`, and `allow_methods` inputs.
- Add a focused regression covering a conversion-time exception.

## Validation
- Inspected the branch diff against `main`: 2 commits, 2 modified files, +14/-1.
- Full local pytest was not run in this connector-only environment; CI should run the focused regression.