### PR TITLE
Reject None in bias calibration numeric inputs

### DIFF
--- a/src/pyrecest/calibration/bias.py
+++ b/src/pyrecest/calibration/bias.py
@@ -17,6 +17,7 @@ _FEATURE_ROW_COUNT_ERROR = (
 )
 _REJECTED_NUMERIC_KINDS = frozenset("bUScMm")
 _REJECTED_OBJECT_VALUE_TYPES = (
+    type(None),
     bool,
     np.bool_,
     str,


### PR DESCRIPTION
## Summary
- Treat `None` as an invalid object value for bias-calibration numeric input validation.
- Prevent `np.asarray(..., dtype=float)` from silently converting `None` payloads to `nan` and letting malformed inputs pass into filtering/model code.

## Bug fixed
`_as_numeric_array()` rejects booleans, text, complex values, and datetime-like values before conversion, but it did not reject `None`. Object arrays such as `np.array([None, 1.0], dtype=object)` can become floating arrays with `nan`, which means invalid user input can be accepted and later filtered or reported as a finite-value issue rather than a numeric-type validation error.

## Validation
- Inspected the branch diff against `main`: one commit, one modified file, +1/-0.
- Attempted to add focused regression coverage in `tests/calibration/test_bias_complex_input_validation.py`, but the connector safety layer blocked the test-file write.
- Full local pytest was not run because this sandbox cannot clone GitHub repositories or install the repo from GitHub.