### PR TITLE
Fix PyTorch cross device placement

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_dot_outer_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_dot_outer_device_contract.py
@@ -1,4 +1,4 @@
-"""PyTorch ``dot``/``outer`` device compatibility hook."""
+"""PyTorch ``dot``/``outer``/``cross`` device compatibility hook."""
 
 from __future__ import annotations
 
@@ -26,7 +26,7 @@ def _promoted_pair(raw_pytorch, torch_module, left, right):
 
 
 def patch_pytorch_dot_outer_device_contract() -> None:
-    """Patch raw/public PyTorch ``dot`` and ``outer`` to preserve non-CPU operands."""
+    """Patch raw/public PyTorch vector-product helpers to preserve non-CPU operands."""
     try:
         import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
         import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
@@ -36,16 +36,30 @@ def patch_pytorch_dot_outer_device_contract() -> None:
 
     original_dot = getattr(raw_pytorch, "dot", None)
     original_outer = getattr(raw_pytorch, "outer", None)
+    original_cross = getattr(raw_pytorch, "cross", None)
     if original_dot is None or original_outer is None:
         return
-    if getattr(original_dot, "_pyrecest_dot_outer_device_contract", False) and getattr(
+
+    dot_outer_patched = getattr(
+        original_dot,
+        "_pyrecest_dot_outer_device_contract",
+        False,
+    ) and getattr(
         original_outer,
         "_pyrecest_dot_outer_device_contract",
         False,
-    ):
+    )
+    cross_patched = original_cross is None or getattr(
+        original_cross,
+        "_pyrecest_cross_device_contract",
+        False,
+    )
+    if dot_outer_patched and cross_patched:
         if getattr(backend, "__backend_name__", None) == "pytorch":
             backend.dot = original_dot
             backend.outer = original_outer
+            if original_cross is not None:
+                backend.cross = original_cross
         return
 
     def dot(a, b):
@@ -78,3 +92,35 @@ def patch_pytorch_dot_outer_device_contract() -> None:
         setattr(raw_pytorch, helper_name, helper)
         if getattr(backend, "__backend_name__", None) == "pytorch":
             setattr(backend, helper_name, helper)
+
+    if original_cross is None:
+        return
+
+    def cross(a, b, axisa=-1, axisb=-1, axisc=-1, axis=None):
+        a, b = _promoted_pair(raw_pytorch, torch, a, b)
+        return original_cross(
+            a,
+            b,
+            axisa=axisa,
+            axisb=axisb,
+            axisc=axisc,
+            axis=axis,
+        )
+
+    cross.__name__ = getattr(original_cross, "__name__", "cross")
+    cross.__doc__ = getattr(original_cross, "__doc__", None)
+    cross._pyrecest_cross_contract = getattr(
+        original_cross,
+        "_pyrecest_cross_contract",
+        True,
+    )
+    cross._pyrecest_cross_device_contract = True
+    cross._pyrecest_device_contract = True
+    cross._pyrecest_numpy_contract = getattr(
+        original_cross,
+        "_pyrecest_numpy_contract",
+        True,
+    )
+    setattr(raw_pytorch, "cross", cross)
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.cross = cross

--- a/tests/backend_support/test_pytorch_cross_device_contract.py
+++ b/tests/backend_support/test_pytorch_cross_device_contract.py
@@ -1,0 +1,33 @@
+"""Regression tests for PyTorch ``cross`` device placement."""
+
+from __future__ import annotations
+
+import pytest
+
+import pyrecest.backend as backend
+import pyrecest.stability  # noqa: F401 ensure compatibility patches are installed
+
+pytorch_backend = pytest.importorskip("pyrecest._backend.pytorch")
+torch = pytest.importorskip("torch")
+
+
+def _assert_cross_prefers_symbolic_operand_device(cross):
+    cpu_operand = torch.tensor([1.0, 0.0, 0.0])
+    symbolic_operand = torch.empty((3,), device="meta")
+
+    result = cross(cpu_operand, symbolic_operand)
+
+    assert result.device.type == "meta"
+    assert result.shape == symbolic_operand.shape
+    assert result.dtype == torch.float32
+
+
+def test_raw_pytorch_cross_prefers_meta_operand_device():
+    _assert_cross_prefers_symbolic_operand_device(pytorch_backend.cross)
+
+
+def test_public_pytorch_cross_prefers_meta_operand_device_when_active():
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        pytest.skip("public PyTorch backend is not active")
+
+    _assert_cross_prefers_symbolic_operand_device(backend.cross)

--- a/tests/backend_support/test_pytorch_cross_device_contract.py
+++ b/tests/backend_support/test_pytorch_cross_device_contract.py
@@ -19,7 +19,7 @@ def _assert_cross_prefers_symbolic_operand_device(cross):
 
     assert result.device.type == "meta"
     assert result.shape == symbolic_operand.shape
-    assert result.dtype == torch.float32
+    assert result.dtype == torch.result_type(cpu_operand, symbolic_operand)
 
 
 def test_raw_pytorch_cross_prefers_meta_operand_device():


### PR DESCRIPTION
## Summary
- Extend the PyTorch vector-product device hook to normalize `cross` operands onto a common preferred device, matching the existing `dot`/`outer` behavior.
- Preserve the existing NumPy-style `cross` wrapper contract while avoiding mixed CPU/non-CPU tensor execution.
- Add regression coverage for raw PyTorch backend `cross` and the active public PyTorch backend.

## Bug fixed
`pyrecest._backend.pytorch.cross(cpu_tensor, meta_tensor)` could evaluate with operands on different devices. In a local torch-only reproduction, the unnormalized `torch.cross(cpu, meta)` path returned a CPU tensor instead of preserving the symbolic/meta operand device. The patched wrapper now selects an existing non-CPU operand device before delegating to the existing `cross` implementation.

## Validation
- Syntax-checked the patched module and regression test with `python -m py_compile`.
- Reproduced the old CPU/meta behavior in a local torch-only simulation and verified the normalized wrapper returns a meta tensor.
- Inspected the branch diff against `main`: 2 commits, 1 modified source file, 1 new regression test, branch is 2 commits ahead and 0 behind.

I did not run the full PyRecEst pytest suite in this environment.