### PR TITLE
Fix PyTorch linspace device selection

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_minmax_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_minmax_device_contract.py
@@ -1,8 +1,9 @@
-"""PyTorch binary-helper device compatibility hook."""
+"""PyTorch binary-helper and linspace device compatibility hooks."""
 
 from __future__ import annotations
 
 import importlib
+from operator import index as _operator_index
 
 
 def _preferred_pytorch_device(torch_module, *values):
@@ -32,6 +33,121 @@ def _binary_operands(raw_pytorch, torch_module, left, right):
 
 # Backwards-compatible alias for existing imports/tests that used the old helper name.
 _minmax_operands = _binary_operands
+
+
+def _linspace_endpoint(torch_module, value, *, dtype, device):
+    """Return a linspace endpoint tensor without copying off a preferred device."""
+    if not torch_module.is_tensor(value):
+        return torch_module.as_tensor(value, dtype=dtype, device=device)
+    if dtype is None and (device is None or value.device == device):
+        return value
+    return value.to(dtype=dtype if dtype is not None else value.dtype, device=device)
+
+
+def _linspace_result_dtype(raw_pytorch, torch_module, dtype, start, stop):
+    """Return the NumPy-compatible result dtype for PyTorch ``linspace``."""
+    result_dtype = dtype if dtype is not None else torch_module.result_type(start, stop)
+    if dtype is None and not (result_dtype.is_floating_point or result_dtype.is_complex):
+        result_dtype = raw_pytorch.get_default_dtype()
+    return result_dtype
+
+
+def _linspace_fraction_dtype(raw_pytorch, torch_module, result_dtype):
+    """Return the floating dtype used to construct normalized fractions."""
+    if result_dtype == torch_module.complex64:
+        return torch_module.float32
+    if result_dtype == torch_module.complex128:
+        return torch_module.float64
+    if not result_dtype.is_floating_point:
+        return raw_pytorch.get_default_dtype()
+    return result_dtype
+
+
+def _linspace_integer_result_dtype(torch_module, result_dtype):
+    """Return an explicit integer linspace dtype, if one was requested."""
+    integer_dtypes = {
+        torch_module.uint8,
+        torch_module.int8,
+        torch_module.int16,
+        torch_module.int32,
+        torch_module.int64,
+    }
+    return result_dtype if result_dtype in integer_dtypes else None
+
+
+def _patch_pytorch_linspace_device_contract(raw_pytorch, backend, torch_module) -> None:
+    """Patch raw/public PyTorch ``linspace`` to prefer existing non-CPU devices."""
+    original_linspace = getattr(raw_pytorch, "linspace", None)
+    if original_linspace is None:
+        return
+    if getattr(original_linspace, "_pyrecest_linspace_device_contract", False):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.linspace = original_linspace
+        return
+
+    def linspace(start, stop, num=50, endpoint=True, dtype=None):
+        num = _operator_index(num)
+        if num < 0:
+            raise ValueError("num must be non-negative")
+
+        device = _preferred_pytorch_device(torch_module, start, stop)
+        start_tensor = _linspace_endpoint(
+            torch_module,
+            start,
+            dtype=None,
+            device=device,
+        )
+        stop_tensor = _linspace_endpoint(
+            torch_module,
+            stop,
+            dtype=None,
+            device=device,
+        )
+
+        result_dtype = _linspace_result_dtype(
+            raw_pytorch,
+            torch_module,
+            dtype,
+            start_tensor,
+            stop_tensor,
+        )
+        fraction_dtype = _linspace_fraction_dtype(
+            raw_pytorch,
+            torch_module,
+            result_dtype,
+        )
+        integer_dtype = _linspace_integer_result_dtype(torch_module, result_dtype)
+        computation_dtype = fraction_dtype if integer_dtype is not None else result_dtype
+        start_tensor = start_tensor.to(dtype=computation_dtype)
+        stop_tensor = stop_tensor.to(dtype=computation_dtype)
+        start_tensor, stop_tensor = torch_module.broadcast_tensors(
+            start_tensor,
+            stop_tensor,
+        )
+        fractions = torch_module.arange(
+            num,
+            dtype=fraction_dtype,
+            device=start_tensor.device,
+        )
+        denominator = num - 1 if endpoint and num > 1 else num
+        if denominator > 0:
+            fractions = fractions / denominator
+        fractions = fractions.reshape((num,) + (1,) * start_tensor.ndim)
+
+        result = start_tensor + (stop_tensor - start_tensor) * fractions
+        if integer_dtype is not None:
+            result = torch_module.floor(result)
+        if result.dtype != result_dtype:
+            result = result.to(dtype=result_dtype)
+        return result
+
+    linspace.__name__ = getattr(original_linspace, "__name__", "linspace")
+    linspace.__doc__ = getattr(original_linspace, "__doc__", None)
+    linspace._pyrecest_linspace_device_contract = True
+    linspace._pyrecest_device_contract = True
+    raw_pytorch.linspace = linspace
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.linspace = linspace
 
 
 def _raw_pytorch_module():
@@ -105,3 +221,4 @@ def patch_pytorch_minmax_device_contract() -> None:
         },
         "_pyrecest_comparison_device_contract",
     )
+    _patch_pytorch_linspace_device_contract(raw_pytorch, backend, torch)

--- a/tests/backend_support/test_pytorch_linspace_device_contract.py
+++ b/tests/backend_support/test_pytorch_linspace_device_contract.py
@@ -1,0 +1,69 @@
+"""Regression tests for PyTorch linspace device preservation."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+pytestmark = pytest.mark.backend_portable
+
+
+def _linspace_device_contract_code(target_module: str) -> str:
+    return f"""
+import torch
+import pyrecest  # noqa: F401  # triggers backend-support compatibility patches
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+
+def _non_cpu_device():
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    return torch.device("meta")
+
+
+target = {target_module}
+device = _non_cpu_device()
+
+scalar_result = target.linspace(torch.tensor(0.0), torch.tensor(1.0, device=device), num=3)
+assert scalar_result.device.type == device.type
+assert tuple(scalar_result.shape) == (3,)
+if device.type != "meta":
+    assert torch.allclose(scalar_result.cpu(), torch.tensor([0.0, 0.5, 1.0]))
+
+batched_result = target.linspace(
+    torch.tensor([0, 10]),
+    torch.tensor([2, 14], device=device),
+    num=3,
+)
+assert batched_result.device.type == device.type
+assert tuple(batched_result.shape) == (3, 2)
+if device.type != "meta":
+    expected = torch.tensor([[0.0, 10.0], [1.0, 12.0], [2.0, 14.0]])
+    assert torch.allclose(batched_result.cpu(), expected)
+
+print("ok")
+"""
+
+
+def test_raw_pytorch_linspace_prefers_existing_non_cpu_endpoint_device_after_import():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code("numpy", _linspace_device_contract_code("raw_pytorch"))
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_public_pytorch_linspace_prefers_existing_non_cpu_endpoint_device():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code("pytorch", _linspace_device_contract_code("backend"))
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- patch PyTorch `linspace` to prefer an existing non-CPU endpoint device, including `meta`, instead of always using the first tensor endpoint's device
- preserve the previous dtype promotion, broadcasting, `endpoint`, and integer-`num` behavior
- add raw/public PyTorch regression tests that use CUDA when available and `meta` as a deterministic fallback

## Tests
- Verified the patched `linspace` logic locally with PyTorch meta tensors
- Added `tests/backend_support/test_pytorch_linspace_device_contract.py`