### PR TITLE
Fix PyTorch array sequence device handling

### DIFF
--- a/src/pyrecest/_backend/pytorch/_common.py
+++ b/src/pyrecest/_backend/pytorch/_common.py
@@ -52,6 +52,31 @@ def _as_torch_compatible_numpy_array(x):
     return x
 
 
+def _preferred_non_cpu_tensor_device(value):
+    if _torch_is_tensor(value):
+        return value.device if value.device.type != "cpu" else None
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            device = _preferred_non_cpu_tensor_device(item)
+            if device is not None:
+                return device
+    return None
+
+
+def _preferred_sequence_device(values):
+    for value in values:
+        device = _preferred_non_cpu_tensor_device(value)
+        if device is not None:
+            return device
+    return None
+
+
+def _move_tensor_to_device(tensor, device):
+    if device is not None and tensor.device != device:
+        return tensor.to(device=device)
+    return tensor
+
+
 def from_numpy(x):
     if _torch_is_tensor(x):
         return x
@@ -76,7 +101,11 @@ def array(val, dtype=None):
         return tensor.clone()
 
     if isinstance(val, (list, tuple)) and len(val):
-        tensors = [array(tensor, dtype=dtype) for tensor in val]
+        device = _preferred_sequence_device(val)
+        tensors = [
+            _move_tensor_to_device(array(tensor, dtype=dtype), device)
+            for tensor in val
+        ]
         return _torch_stack(tensors)
 
     return _torch_tensor(val, dtype=dtype)

--- a/tests/backend_support/test_pytorch_creation_contract.py
+++ b/tests/backend_support/test_pytorch_creation_contract.py
@@ -6,6 +6,7 @@ import sys
 import pytest
 
 
+
 def _backend_test_env(backend_name):
     env = os.environ.copy()
     env["PYRECEST_BACKEND"] = backend_name
@@ -58,6 +59,37 @@ for creation_backend in (backend, raw_backend):
         pass
     else:
         raise AssertionError("zeros accepted a negative dimension")
+"""
+    subprocess.run(
+        [sys.executable, "-c", code], check=True, env=_backend_test_env("pytorch")
+    )
+
+
+@pytest.mark.backend_portable
+def test_pytorch_array_prefers_existing_non_cpu_tensor_device_in_sequences():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import torch
+
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_backend
+
+assert getattr(backend, "__backend_name__", None) == "pytorch"
+
+meta_values = torch.empty((2,), device="meta")
+
+for creation_backend in (backend, raw_backend):
+    result = creation_backend.array(([1.0, 2.0], meta_values))
+    assert tuple(result.shape) == (2, 2)
+    assert result.device.type == "meta"
+
+    nested_result = creation_backend.array(
+        (([1.0, 2.0], meta_values), (meta_values, meta_values))
+    )
+    assert tuple(nested_result.shape) == (2, 2, 2)
+    assert nested_result.device.type == "meta"
 """
     subprocess.run(
         [sys.executable, "-c", code], check=True, env=_backend_test_env("pytorch")


### PR DESCRIPTION
## Summary
- Teach the PyTorch `_common.array()` helper to scan nested sequence inputs for an existing non-CPU tensor device before recursively stacking sequence entries.
- Move array-like and CPU sequence elements to that preferred existing device so `torch.stack` receives same-device tensors.
- Add regression coverage for public and raw PyTorch backends using a `meta` tensor.

## Bug fixed
`pyrecest._backend.pytorch.array(([1.0, 2.0], torch.empty((2,), device="meta")))` materialized the list element on CPU while leaving the tensor element on `meta`, then failed in `torch.stack` with a mixed-device runtime error. The patch preserves the existing non-CPU tensor device for flat and nested sequence construction.

## Validation
- Reproduced the old mixed CPU/meta `torch.stack` failure in an isolated torch-only check.
- Syntax-checked the updated backend helper and regression test with `python -m py_compile`.
- Ran an isolated torch check of the patched helper for flat and nested sequence inputs, verifying `meta`-device outputs.
- Compared branch against `main`: 2 commits ahead, 0 behind; 2 files changed, +62/-1.

I did not run the full PyRecEst pytest suite in this connector-only environment.