### PR TITLE
Fix boolean Pareto constraint handling

### DIFF
--- a/src/pyrecest/evaluation/pareto.py
+++ b/src/pyrecest/evaluation/pareto.py
@@ -167,24 +167,33 @@ def constraint_mask(
         if column not in table.columns:
             mask &= False
             continue
-        threshold_value = _coerce_finite_threshold(threshold, column)
-        values = pd.to_numeric(table[column], errors="coerce")
-        present_values = values.notna()
-        if op == "<=":
-            comparison = values <= threshold_value + eps
-        elif op == ">=":
-            comparison = values >= threshold_value - eps
-        elif op == "<":
-            comparison = values < threshold_value - eps
-        elif op == ">":
-            comparison = values > threshold_value + eps
-        elif op == "==":
-            comparison = np.isclose(values, threshold_value, atol=eps, rtol=0.0)
-        elif op == "!=":
-            comparison = ~np.isclose(values, threshold_value, atol=eps, rtol=0.0)
-        else:  # pragma: no cover - protected by _parse_constraint_spec.
-            raise ValueError(f"Unsupported constraint operator {op!r}.")
-        comparison = pd.Series(comparison, index=table.index).fillna(False).astype(bool)
+        threshold_value = _coerce_constraint_threshold(threshold, column)
+        if isinstance(threshold_value, bool):
+            present_values, comparison = _boolean_constraint_comparison(
+                table[column],
+                op,
+                threshold_value,
+                column,
+            )
+        else:
+            values = pd.to_numeric(table[column], errors="coerce").astype(float)
+            present_values = values.notna()
+            if op == "<=":
+                comparison = values <= threshold_value + eps
+            elif op == ">=":
+                comparison = values >= threshold_value - eps
+            elif op == "<":
+                comparison = values < threshold_value - eps
+            elif op == ">":
+                comparison = values > threshold_value + eps
+            elif op == "==":
+                comparison = np.isclose(values, threshold_value, atol=eps, rtol=0.0)
+            elif op == "!=":
+                comparison = ~np.isclose(values, threshold_value, atol=eps, rtol=0.0)
+            else:  # pragma: no cover - protected by _parse_constraint_spec.
+                raise ValueError(f"Unsupported constraint operator {op!r}.")
+            comparison = pd.Series(comparison, index=table.index)
+        comparison = comparison.fillna(False).astype(bool)
         mask &= present_values & comparison
     return mask.fillna(False)
 
@@ -414,16 +423,19 @@ def _parse_constraint_spec(spec: ConstraintSpec | Mapping[str, Any]) -> Constrai
     return op, threshold
 
 
-def _coerce_finite_threshold(value: Any, column: str) -> float:
+def _coerce_constraint_threshold(value: Any, column: str) -> float | bool:
     message = f"Constraint threshold for {column!r} must be a finite scalar."
-    value_array = np.asarray(value)
+    try:
+        value_array = np.asarray(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
     if value_array.shape != ():
         raise ValueError(message)
     scalar = value_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        return bool(scalar)
     if _is_text_scalar(scalar):
         raise ValueError(message)
-    if isinstance(scalar, (bool, np.bool_)):
-        return float(scalar)
     try:
         threshold = float(scalar)
     except (TypeError, ValueError, OverflowError) as exc:
@@ -431,3 +443,32 @@ def _coerce_finite_threshold(value: Any, column: str) -> float:
     if not np.isfinite(threshold):
         raise ValueError(message)
     return threshold
+
+
+def _boolean_constraint_comparison(
+    values: pd.Series,
+    op: ConstraintOperator,
+    threshold: bool,
+    column: str,
+) -> tuple[pd.Series, pd.Series]:
+    if op not in {"==", "!="}:
+        raise ValueError(
+            f"Constraint threshold for {column!r} must be a finite scalar."
+        )
+
+    bool_values = np.zeros(len(values), dtype=bool)
+    present_values = np.zeros(len(values), dtype=bool)
+    for position, value in enumerate(values.to_numpy(dtype=object)):
+        if _is_missing(value):
+            continue
+        if isinstance(value, (bool, np.bool_)):
+            bool_values[position] = bool(value)
+            present_values[position] = True
+
+    comparison = bool_values == threshold
+    if op == "!=":
+        comparison = ~comparison
+    return (
+        pd.Series(present_values, index=values.index, dtype=bool),
+        pd.Series(comparison, index=values.index, dtype=bool),
+    )

--- a/tests/evaluation/test_pareto_boolean_constraints.py
+++ b/tests/evaluation/test_pareto_boolean_constraints.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import pandas as pd
-from pyrecest.evaluation import constraint_mask
+import pytest
+
+from pyrecest.evaluation import constraint_mask, select_under_constraints
 
 
 def test_constraint_mask_accepts_boolean_thresholds() -> None:
@@ -19,3 +21,70 @@ def test_constraint_mask_accepts_boolean_thresholds() -> None:
 
     assert table.loc[enabled, "name"].tolist() == ["enabled"]
     assert table.loc[disabled, "name"].tolist() == ["disabled"]
+
+
+def test_constraint_mask_accepts_nullable_boolean_thresholds() -> None:
+    table = pd.DataFrame(
+        {
+            "name": ["keep", "drop", "unknown"],
+            "allowed": pd.Series([True, False, pd.NA], dtype="boolean"),
+            "score": [2.0, 1.0, 0.0],
+        }
+    )
+
+    true_mask = constraint_mask(table, {"allowed": ("==", True)})
+    false_mask = constraint_mask(table, {"allowed": ("!=", True)})
+
+    assert table.loc[true_mask, "name"].tolist() == ["keep"]
+    assert table.loc[false_mask, "name"].tolist() == ["drop"]
+
+
+def test_boolean_constraints_treat_non_boolean_cells_as_infeasible() -> None:
+    table = pd.DataFrame(
+        {
+            "name": ["bool_true", "text_true", "numeric_one", "missing"],
+            "allowed": [True, "True", 1, None],
+        }
+    )
+
+    mask = constraint_mask(table, {"allowed": {"op": "==", "value": True}})
+
+    assert table.loc[mask, "name"].tolist() == ["bool_true"]
+
+
+def test_boolean_constraints_support_duplicate_index_labels() -> None:
+    table = pd.DataFrame(
+        {"allowed": [True, False, True]},
+        index=["same", "same", "other"],
+    )
+
+    mask = constraint_mask(table, {"allowed": ("==", True)})
+
+    assert mask.tolist() == [True, False, True]
+    assert mask.index.tolist() == ["same", "same", "other"]
+
+
+def test_boolean_constraints_work_through_selection() -> None:
+    table = pd.DataFrame(
+        {
+            "name": ["allowed_slow", "blocked_fast", "allowed_fast"],
+            "allowed": [True, False, True],
+            "cost": [3.0, 0.5, 1.0],
+        }
+    )
+
+    selected = select_under_constraints(
+        table,
+        constraints={"allowed": ("==", True)},
+        objective="cost",
+        direction="min",
+    )
+
+    assert selected["name"].tolist() == ["allowed_fast", "allowed_slow"]
+
+
+def test_boolean_constraints_reject_ordering_operators() -> None:
+    table = pd.DataFrame({"allowed": [True, False]})
+
+    with pytest.raises(ValueError, match="Constraint threshold"):
+        constraint_mask(table, {"allowed": ("<=", True)})

--- a/tests/evaluation/test_pareto_boolean_constraints.py
+++ b/tests/evaluation/test_pareto_boolean_constraints.py
@@ -86,5 +86,8 @@ def test_boolean_constraints_work_through_selection() -> None:
 def test_boolean_constraints_reject_ordering_operators() -> None:
     table = pd.DataFrame({"allowed": [True, False]})
 
-    with pytest.raises(ValueError, match="Constraint threshold"):
+    with pytest.raises(
+        ValueError,
+        match="Constraint threshold for 'allowed' must be a finite scalar",
+    ):
         constraint_mask(table, {"allowed": ("<=", True)})


### PR DESCRIPTION
## Summary

- allow boolean constraint thresholds in `constraint_mask`, matching the existing `ConstraintSpec` type contract
- handle boolean constraints via an explicit `==`/`!=` path instead of passing nullable-boolean pandas data through `np.isclose`
- treat missing or non-boolean cells as infeasible for boolean constraints
- add regression tests for nullable booleans, non-boolean cells, duplicate index labels, and `select_under_constraints`

## Validation

- Locally exercised the patched `constraint_mask`/`select_under_constraints` logic with pandas/numpy snippets covering the added regression cases.
- Full repository test execution was not possible in this sandbox because direct GitHub cloning/network access is unavailable here.