### PR TITLE
Fix infinite evidence margin classification

### DIFF
--- a/src/pyrecest/evaluation/__init__.py
+++ b/src/pyrecest/evaluation/__init__.py
@@ -1,3 +1,6 @@
+from math import isinf as _isinf
+
+from . import model_comparison as _model_comparison
 from .check_and_fix_config import check_and_fix_config
 from .configure_for_filter import configure_for_filter
 from .determine_all_deviations import determine_all_deviations
@@ -66,6 +69,19 @@ from .selection import (
 )
 from .simulation_database import simulation_database
 from .summarize_filter_results import summarize_filter_results
+
+_original_classify_evidence_margin = classify_evidence_margin
+
+
+def _classify_evidence_margin(delta_log_evidence: float) -> str:
+    value = float(delta_log_evidence)
+    if _isinf(value) and value > 0.0:
+        return "decisive"
+    return _original_classify_evidence_margin(delta_log_evidence)
+
+
+_model_comparison.classify_evidence_margin = _classify_evidence_margin
+classify_evidence_margin = _classify_evidence_margin
 
 __all__ = [
     "generate_groundtruth",

--- a/tests/test_model_comparison_infinite_margin.py
+++ b/tests/test_model_comparison_infinite_margin.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pandas as pd
+
+from pyrecest.evaluation.model_comparison import (
+    classify_evidence_margin,
+    evidence_margin_table,
+)
+
+
+def test_infinite_evidence_margin_is_decisive_not_missing():
+    assert classify_evidence_margin(np.inf) == "decisive"
+    assert classify_evidence_margin(-np.inf) == "missing"
+    assert classify_evidence_margin(np.nan) == "missing"
+
+    scores = pd.DataFrame(
+        [
+            {
+                "status": "success",
+                "session": "s1",
+                "event_index": 0,
+                "model": "only_model",
+                "log_evidence": 7.0,
+                "evidence_comparable": True,
+            }
+        ]
+    )
+
+    margins = evidence_margin_table(scores)
+
+    assert margins["best_model_by_evidence"].tolist() == ["only_model"]
+    assert np.isposinf(margins.loc[0, "evidence_margin_to_second_best"])
+    assert margins["evidence_margin_category"].tolist() == ["decisive"]


### PR DESCRIPTION
## Summary
- Fix evidence-margin classification so positive infinite margins are reported as `decisive` instead of `missing`.
- Keep `NaN` and negative infinite margins classified as `missing`.
- Add a regression covering both direct classification and singleton `evidence_margin_table` output.

## Bug fixed
`evidence_margin_table()` uses `np.inf` when a group has a best model but no runner-up. The qualitative classifier previously treated every non-finite value as `missing`, so singleton comparable groups were mislabeled even though the configured margin buckets include a `decisive` bucket with an infinite upper bound.

## Validation
- Added `tests/test_model_comparison_infinite_margin.py`.
- Full test suite not run in this connector-only environment.