### PR TITLE
Reject boolean axes in PyTorch trapezoid hook

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_trapezoid_numpy_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_trapezoid_numpy_contract.py
@@ -16,6 +16,16 @@ def _preferred_pytorch_device(torch_module, *values):
     return None
 
 
+def _trapezoid_axis(axis) -> int:
+    """Return a NumPy-style integer axis while rejecting boolean axes."""
+    if isinstance(axis, bool) or type(axis).__name__ == "bool_":
+        raise TypeError("axis must be an integer")
+    try:
+        return _operator_index(axis)
+    except TypeError as exc:
+        raise TypeError("axis must be an integer") from exc
+
+
 def _as_trapezoid_tensor(value, torch_module, *, device=None, dtype=None):
     """Coerce one trapezoid argument without moving existing tensors unnecessarily."""
     if torch_module.is_tensor(value):
@@ -52,7 +62,7 @@ def patch_pytorch_trapezoid_numpy_contract() -> None:
         return
 
     def trapezoid(y, x=None, dx=1.0, axis=-1):
-        dim = _operator_index(axis)
+        dim = _trapezoid_axis(axis)
         device = _preferred_pytorch_device(torch, y, x)
         y = _as_trapezoid_tensor(y, torch, device=device)
 

--- a/tests/backend_support/test_pytorch_trapezoid_contract.py
+++ b/tests/backend_support/test_pytorch_trapezoid_contract.py
@@ -36,6 +36,32 @@ print("ok")
 
 
 @pytest.mark.backend_portable
+def test_pytorch_trapezoid_rejects_boolean_axis_like_numpy():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+for target_name, target in (("backend", backend), ("raw_pytorch", raw_pytorch)):
+    for axis in (True, False):
+        try:
+            target.trapezoid([[1.0, 2.0], [3.0, 4.0]], axis=axis)
+        except TypeError:
+            continue
+        raise AssertionError(f"{target_name}.trapezoid accepted boolean axis {axis!r}")
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+@pytest.mark.backend_portable
 def test_raw_pytorch_trapezoid_accepts_array_like_inputs_after_pyrecest_import():
     if importlib.util.find_spec("torch") is None:
         pytest.skip("PyTorch is not installed")
@@ -48,6 +74,13 @@ import pyrecest._backend.pytorch as raw_pytorch
 
 scalar = raw_pytorch.trapezoid([1.0, 2.0, 4.0])
 assert float(raw_pytorch.to_numpy(scalar)) == 4.5
+
+for axis in (True, False):
+    try:
+        raw_pytorch.trapezoid([[1.0, 2.0], [3.0, 4.0]], axis=axis)
+    except TypeError:
+        continue
+    raise AssertionError(f"raw_pytorch.trapezoid accepted boolean axis {axis!r}")
 print("ok")
 """,
     )

--- a/tests/backend_support/test_pytorch_trapezoid_contract.py
+++ b/tests/backend_support/test_pytorch_trapezoid_contract.py
@@ -74,13 +74,6 @@ import pyrecest._backend.pytorch as raw_pytorch
 
 scalar = raw_pytorch.trapezoid([1.0, 2.0, 4.0])
 assert float(raw_pytorch.to_numpy(scalar)) == 4.5
-
-for axis in (True, False):
-    try:
-        raw_pytorch.trapezoid([[1.0, 2.0], [3.0, 4.0]], axis=axis)
-    except TypeError:
-        continue
-    raise AssertionError(f"raw_pytorch.trapezoid accepted boolean axis {axis!r}")
 print("ok")
 """,
     )


### PR DESCRIPTION
## Summary
- Add explicit PyTorch `trapezoid` axis normalization that rejects boolean axes before `operator.index` can coerce `True`/`False` to `1`/`0`.
- Preserve the existing NumPy-style array-like/device handling for `trapezoid`.
- Extend backend-portable regression coverage for public and raw PyTorch helpers.

## Bug fixed
`pyrecest.backend.trapezoid(..., axis=True)` and the raw PyTorch helper could silently reduce over axis `1`, because Python booleans implement `__index__`. NumPy rejects boolean axes for `trapezoid`, so the PyTorch compatibility hook should reject them as well.

## Validation
- Syntax-compiled the changed support module and regression test locally.
- Checked the new axis helper rejects `True`/`False` and still accepts integer axes.
- Compared the branch to current `main`: 2 commits, 2 files changed, `behind_by=0`.
- Full repository pytest was not run locally because direct repository checkout/network access is unavailable in this environment.