### PR TITLE
Fix JAX std ddof/correction forwarding

### DIFF
--- a/src/pyrecest/__init__.py
+++ b/src/pyrecest/__init__.py
@@ -521,17 +521,28 @@ def _patch_jax_std_out_facade() -> None:
             return result
         return backend.asarray(out).at[...].set(result)
 
+    def _std_kwargs(axis, dtype, ddof, keepdims, correction):
+        kwargs = {
+            "axis": axis,
+            "dtype": dtype,
+            "out": None,
+            "keepdims": keepdims,
+        }
+        if correction is None:
+            kwargs["ddof"] = ddof
+        elif ddof == 0:
+            kwargs["correction"] = correction
+        else:
+            kwargs["ddof"] = ddof
+            kwargs["correction"] = correction
+        return kwargs
+
     def std(
-        a, axis=None, dtype=None, out=None, ddof=0, keepdims=False, *, correction=0
+        a, axis=None, dtype=None, out=None, ddof=0, keepdims=False, *, correction=None
     ):
         result = original_std(
             a,
-            axis=axis,
-            dtype=dtype,
-            out=None,
-            ddof=ddof,
-            keepdims=keepdims,
-            correction=correction,
+            **_std_kwargs(axis, dtype, ddof, keepdims, correction),
         )
         return _return_or_store_out(result, out)
 
@@ -543,18 +554,12 @@ def _patch_jax_std_out_facade() -> None:
         return
 
     def raw_std(
-        a, axis=None, dtype=None, out=None, ddof=0, keepdims=False, *, correction=0
+        a, axis=None, dtype=None, out=None, ddof=0, keepdims=False, *, correction=None
     ):
-        kwargs = {
-            "axis": axis,
-            "dtype": dtype,
-            "out": None,
-            "ddof": ddof,
-            "keepdims": keepdims,
-        }
-        if correction != 0:
-            kwargs["correction"] = correction
-        result = original_raw_std(a, **kwargs)
+        result = original_raw_std(
+            a,
+            **_std_kwargs(axis, dtype, ddof, keepdims, correction),
+        )
         return _return_or_store_out(result, out)
 
     raw_std.__name__ = getattr(original_raw_std, "__name__", "std")

--- a/tests/test_backend_std_contract.py
+++ b/tests/test_backend_std_contract.py
@@ -64,6 +64,16 @@ public_result = backend.std(
 assert tuple(public_result.shape) == (1, 3)
 assert backend.allclose(public_result, expected)
 
+correction_result = backend.std(
+    values,
+    axis=0,
+    dtype=backend.float64,
+    correction=1,
+    keepdims=True,
+)
+assert tuple(correction_result.shape) == (1, 3)
+assert backend.allclose(correction_result, expected)
+
 raw_out = backend.zeros((1, 3), dtype=backend.float64)
 raw_result = raw_jax.std(
     values,


### PR DESCRIPTION
## Summary
- Fix the JAX `std` compatibility hook so ordinary `ddof` calls do not implicitly pass `correction=0` to JAX.
- Preserve support for NumPy-style `out` handling on both public `backend.std` and raw `pyrecest._backend.jax.std`.
- Add a JAX regression covering `ddof=1`, `out=...`, and the explicit `correction=1` path.

## Bug fixed
JAX currently rejects calls that provide both `ddof` and `correction`. The public PyRecEst JAX `std` facade defaulted `correction` to `0` and forwarded it even when callers only supplied `ddof=1`, so calls like `backend.std(values, axis=0, ddof=1, out=...)` could fail with `ValueError: ddof and correction can't be provided simultaneously.`

The patch changes the facade default to `correction=None` and builds the delegated keyword arguments so that `ddof` and `correction` are only both forwarded when a caller explicitly supplies both.

## Validation
- `python -m py_compile /mnt/data/new_init.py /mnt/data/test_backend_std_contract.py`
- Local JAX smoke check showing `ddof=1` and `correction=1` both produce the expected standard deviation, while explicit `ddof=1, correction=0` still raises JAX's conflict error.
- Compared branch against `main`: 2 commits ahead, 0 behind; 2 files changed, +33/-18.

I did not run the full PyRecEst pytest suite in this connector-only environment.