### PR TITLE
Fix PyTorch take axis validation

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_one_hot_scalar_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_one_hot_scalar_contract.py
@@ -1,19 +1,62 @@
-"""PyTorch ``one_hot`` scalar-label compatibility hook."""
+"""PyTorch ``one_hot`` and ``take`` compatibility hooks."""
 
 from __future__ import annotations
 
 from operator import index as _operator_index
 
 
-def patch_pytorch_one_hot_scalar_contract() -> None:
-    """Patch raw/public PyTorch ``one_hot`` to handle scalar labels correctly."""
-    try:
-        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
-        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
-        import torch as torch_module  # pylint: disable=import-outside-toplevel
-    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+def _is_boolean_take_axis(axis, torch_module) -> bool:
+    """Return whether ``axis`` is a boolean scalar, not an integer axis."""
+    if isinstance(axis, bool) or type(axis).__name__ == "bool_":
+        return True
+    return bool(
+        torch_module.is_tensor(axis)
+        and axis.ndim == 0
+        and axis.dtype == torch_module.bool
+    )
+
+
+def _patch_pytorch_take_axis_contract(pytorch_backend, torch_module) -> None:
+    """Patch raw/public PyTorch ``take`` to reject non-integer axes."""
+    original_normalizer = getattr(pytorch_backend, "_normalize_take_axis", None)
+    if original_normalizer is None:
+        return
+    if getattr(original_normalizer, "_pyrecest_axis_contract", False):
         return
 
+    def _normalize_take_axis(axis, ndim_):
+        if axis is None:
+            return None
+        if _is_boolean_take_axis(axis, torch_module):
+            raise TypeError("an integer is required for the axis")
+        try:
+            axis = _operator_index(axis)
+        except TypeError as exc:
+            raise TypeError("an integer is required for the axis") from exc
+        if axis < 0:
+            axis += ndim_
+        if axis < 0 or axis >= ndim_:
+            raise IndexError(
+                f"axis {axis} is out of bounds for array of dimension {ndim_}"
+            )
+        return axis
+
+    _normalize_take_axis.__name__ = getattr(
+        original_normalizer,
+        "__name__",
+        "_normalize_take_axis",
+    )
+    _normalize_take_axis.__doc__ = getattr(original_normalizer, "__doc__", None)
+    _normalize_take_axis._pyrecest_axis_contract = True
+    pytorch_backend._normalize_take_axis = _normalize_take_axis
+
+
+def _patch_pytorch_one_hot_scalar_contract(
+    pytorch_backend,
+    backend,
+    torch_module,
+) -> None:
+    """Patch raw/public PyTorch ``one_hot`` to handle scalar labels correctly."""
     original_one_hot = getattr(pytorch_backend, "one_hot", None)
     if original_one_hot is None:
         return
@@ -44,6 +87,23 @@ def patch_pytorch_one_hot_scalar_contract() -> None:
     pytorch_backend.one_hot = one_hot
     if getattr(backend, "__backend_name__", None) == "pytorch":
         backend.one_hot = one_hot
+
+
+def patch_pytorch_one_hot_scalar_contract() -> None:
+    """Patch small PyTorch backend compatibility contracts."""
+    try:
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import torch as torch_module  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    _patch_pytorch_one_hot_scalar_contract(
+        pytorch_backend,
+        backend,
+        torch_module,
+    )
+    _patch_pytorch_take_axis_contract(pytorch_backend, torch_module)
 
 
 __all__ = ["patch_pytorch_one_hot_scalar_contract"]

--- a/tests/backend_support/test_pytorch_take_axis_contract.py
+++ b/tests/backend_support/test_pytorch_take_axis_contract.py
@@ -1,0 +1,77 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _backend_test_env(backend_name):
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = backend_name
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    return env
+
+
+@pytest.mark.backend_portable
+def test_pytorch_take_rejects_boolean_and_float_axes():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import pyrecest.backend as backend
+
+values = backend.asarray([[1, 2], [3, 4]])
+
+for axis in (True, False, 1.0):
+    try:
+        backend.take(values, [0], axis=axis)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"backend.take accepted invalid axis {axis!r}")
+
+result = backend.take(values, [0], axis=backend.asarray(1))
+assert backend.to_numpy(result).tolist() == [[1], [3]]
+"""
+    subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        env=_backend_test_env("pytorch"),
+    )
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_take_rejects_boolean_and_float_axes_with_numpy_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+assert getattr(backend, "__backend_name__", None) == "numpy"
+
+values = raw_pytorch.asarray([[1, 2], [3, 4]])
+
+for axis in (True, False, 1.0):
+    try:
+        raw_pytorch.take(values, [0], axis=axis)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"raw_pytorch.take accepted invalid axis {axis!r}")
+
+result = raw_pytorch.take(values, [0], axis=raw_pytorch.asarray(1))
+assert raw_pytorch.to_numpy(result).tolist() == [[1], [3]]
+"""
+    subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        env=_backend_test_env("numpy"),
+    )


### PR DESCRIPTION
## Summary
- Use integer-index normalization for PyTorch backend `take` axes.
- Reject boolean and floating-point axes instead of silently coercing them with `int(...)`.
- Add focused backend-portable regressions for public and raw PyTorch `take`.

## Validation
- `python -m py_compile` on the modified hook and new test file.
- Local smoke check for boolean, floating, integer, negative, NumPy scalar, and PyTorch scalar axes.

Full pytest was not run in this environment.