### PR TITLE
Fix PyTorch matvec device contract

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_matmul_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_matmul_device_contract.py
@@ -1,4 +1,4 @@
-"""PyTorch ``matmul`` device compatibility hook."""
+"""PyTorch ``matmul``/``matvec`` device compatibility hook."""
 
 from __future__ import annotations
 
@@ -14,8 +14,19 @@ def _preferred_pytorch_device(torch_module, *values):
     return None
 
 
+def _promoted_pair(raw_pytorch, torch_module, left, right, *, device):
+    """Return operands on a common dtype and the selected device."""
+    left = raw_pytorch.array(left)
+    right = raw_pytorch.array(right)
+    dtype = torch_module.promote_types(left.dtype, right.dtype)
+
+    if device is not None:
+        return left.to(device=device, dtype=dtype), right.to(device=device, dtype=dtype)
+    return left.to(dtype=dtype), right.to(dtype=dtype)
+
+
 def patch_pytorch_matmul_device_contract() -> None:
-    """Patch raw/public PyTorch ``matmul`` to keep operands on one device."""
+    """Patch raw/public PyTorch ``matmul`` and ``matvec`` device handling."""
     try:
         import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
         import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
@@ -24,34 +35,52 @@ def patch_pytorch_matmul_device_contract() -> None:
         return
 
     original_matmul = getattr(raw_pytorch, "matmul", None)
-    if original_matmul is None:
+    original_matvec = getattr(raw_pytorch, "matvec", None)
+    if original_matmul is None or original_matvec is None:
         return
-    if getattr(original_matmul, "_pyrecest_device_contract", False):
+
+    helper_names = ("matmul", "matvec")
+    if all(
+        getattr(getattr(raw_pytorch, helper_name, None), "_pyrecest_matmul_device_contract", False)
+        for helper_name in helper_names
+    ):
         if getattr(backend, "__backend_name__", None) == "pytorch":
-            backend.matmul = original_matmul
+            for helper_name in helper_names:
+                setattr(backend, helper_name, getattr(raw_pytorch, helper_name))
         return
 
     def matmul(x, y, out=None):
         device = _preferred_pytorch_device(torch, x, y, out)
-        x = raw_pytorch.array(x)
-        y = raw_pytorch.array(y)
-        dtype = torch.promote_types(x.dtype, y.dtype)
-
-        if device is not None:
-            x = x.to(device=device, dtype=dtype)
-            y = y.to(device=device, dtype=dtype)
-        else:
-            x = x.to(dtype=dtype)
-            y = y.to(dtype=dtype)
+        x, y = _promoted_pair(raw_pytorch, torch, x, y, device=device)
 
         if out is not None:
             return torch.matmul(x, y, out=out)
         return torch.matmul(x, y)
 
-    matmul.__name__ = getattr(original_matmul, "__name__", "matmul")
-    matmul.__doc__ = getattr(original_matmul, "__doc__", None)
-    matmul._pyrecest_device_contract = True
-    matmul._pyrecest_numpy_contract = True
-    raw_pytorch.matmul = matmul
-    if getattr(backend, "__backend_name__", None) == "pytorch":
-        backend.matmul = matmul
+    def matvec(A, b):
+        device = _preferred_pytorch_device(torch, A, b)
+        A, b = _promoted_pair(raw_pytorch, torch, A, b, device=device)
+
+        if A.ndim == 2 and b.ndim == 1:
+            return torch.mv(A, b)
+
+        if b.ndim == 1:  # A.ndim > 2
+            return torch.matmul(A, b)
+
+        if A.ndim == 2:  # b.ndim > 1
+            return torch.einsum("ij,...j->...i", A, b)
+
+        return torch.einsum("...ij,...j->...i", A, b)
+
+    for helper_name, helper, original_helper in (
+        ("matmul", matmul, original_matmul),
+        ("matvec", matvec, original_matvec),
+    ):
+        helper.__name__ = getattr(original_helper, "__name__", helper_name)
+        helper.__doc__ = getattr(original_helper, "__doc__", None)
+        helper._pyrecest_matmul_device_contract = True
+        helper._pyrecest_device_contract = True
+        helper._pyrecest_numpy_contract = True
+        setattr(raw_pytorch, helper_name, helper)
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            setattr(backend, helper_name, helper)

--- a/tests/backend_support/test_pytorch_matvec_device_contract.py
+++ b/tests/backend_support/test_pytorch_matvec_device_contract.py
@@ -1,0 +1,67 @@
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+pytestmark = pytest.mark.backend_portable
+
+
+def _matvec_device_contract_code(target_module):
+    return f"""
+import torch
+import pyrecest  # noqa: F401  # triggers backend-support compatibility patches
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+
+def _non_cpu_device():
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    return torch.device("meta")
+
+
+target = {target_module}
+device = _non_cpu_device()
+
+vector = torch.ones(2, device=device)
+plain_result = target.matvec(torch.eye(2), vector)
+assert plain_result.device.type == device.type
+assert tuple(plain_result.shape) == (2,)
+if device.type != "meta":
+    assert torch.allclose(plain_result.cpu(), torch.ones(2))
+
+array_like_result = target.matvec([[1.0, 2.0]], vector)
+assert array_like_result.device.type == device.type
+assert tuple(array_like_result.shape) == (1,)
+if device.type != "meta":
+    assert torch.allclose(array_like_result.cpu(), torch.tensor([3.0]))
+
+batched_result = target.matvec(torch.eye(2).repeat(2, 1, 1), vector)
+assert batched_result.device.type == device.type
+assert tuple(batched_result.shape) == (2, 2)
+if device.type != "meta":
+    assert torch.allclose(batched_result.cpu(), torch.ones((2, 2)))
+
+print("ok")
+"""
+
+
+def test_raw_pytorch_matvec_prefers_existing_non_cpu_device_after_import():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code("numpy", _matvec_device_contract_code("raw_pytorch"))
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_public_pytorch_matvec_prefers_existing_non_cpu_device():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code("pytorch", _matvec_device_contract_code("backend"))
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- Extend the existing PyTorch matmul device compatibility hook to patch `matvec` as well.
- Move `matvec` operands to an existing non-CPU tensor device before dtype promotion and multiplication.
- Add backend-portable regressions for raw PyTorch under the NumPy-selected public backend and for the selected public PyTorch backend.

## Bug fixed
`pyrecest._backend.pytorch.matvec(torch.eye(2), torch.ones(2, device="meta"))` previously materialized the matrix on CPU while preserving the vector on `meta`, so the subsequent PyTorch matrix-vector operation hit a mixed-device runtime error. The same pattern can occur with accelerator tensors. The patched helper now follows the same preferred-device behavior as the existing `matmul` compatibility hook.

## Validation
- `python -m py_compile /mnt/data/_pytorch_matmul_device_contract.py /mnt/data/test_pytorch_matvec_device_contract.py`
- Local PyTorch smoke check reproduced the CPU/meta `torch.mv` mixed-device failure and verified the corrected device coercion returns a `meta` result with the expected shape.
- Verified branch diff against `main` (`ahead_by=2`, `behind_by=0`).

Full repository pytest was not run locally because the sandbox cannot clone GitHub directly; the PR adds focused CI regressions for the affected behavior.