### PR TITLE
Reject nonfinite linear update inputs

### DIFF
--- a/src/pyrecest/filters/linear_update_planning.py
+++ b/src/pyrecest/filters/linear_update_planning.py
@@ -93,8 +93,11 @@ def normalized_innovation_squared(
 ) -> float:
     """Return ``residual.T @ inv(innovation_covariance) @ residual`` as a float."""
 
-    residual = np.asarray(residual, dtype=float).reshape(-1)
-    innovation_covariance = np.asarray(innovation_covariance, dtype=float)
+    residual = _as_finite_array(residual, "residual").reshape(-1)
+    innovation_covariance = _as_finite_array(
+        innovation_covariance,
+        "innovation_covariance",
+    )
     if innovation_covariance.shape != (residual.size, residual.size):
         raise ValueError(
             "innovation_covariance must have shape (residual_dim, residual_dim)"
@@ -214,12 +217,12 @@ def plan_linear_measurement_update(
 
     alpha = _as_positive_scalar(inflation_alpha, "inflation_alpha")
 
-    vector = np.asarray(measurement_vector, dtype=float).reshape(-1)
+    vector = _as_finite_array(measurement_vector, "measurement_vector").reshape(-1)
     measurement_dim = vector.size
-    covariance = np.asarray(measurement_covariance, dtype=float)
-    observation = np.asarray(observation_matrix, dtype=float)
-    state_mean = np.asarray(mean, dtype=float).reshape(-1)
-    state_covariance = np.asarray(covariance_matrix, dtype=float)
+    covariance = _as_finite_array(measurement_covariance, "measurement_covariance")
+    observation = _as_finite_array(observation_matrix, "observation_matrix")
+    state_mean = _as_finite_array(mean, "mean").reshape(-1)
+    state_covariance = _as_finite_array(covariance_matrix, "covariance_matrix")
 
     if measurement_dim <= 0:
         raise ValueError("measurement_vector must contain at least one element")
@@ -341,7 +344,7 @@ def gate_threshold_for_measurement(
         return None if value is None else _as_nonnegative_scalar(value, "gate_threshold")
     if gate_probabilities_by_source and source in gate_probabilities_by_source:
         probability = gate_probabilities_by_source[source]
-        vector = np.asarray(measurement.vector).reshape(-1)
+        vector = _as_finite_array(measurement.vector, "measurement.vector").reshape(-1)
         return chi_square_gate_threshold(probability, vector.size)
     return None
 
@@ -384,6 +387,16 @@ def _resolve_threshold(
 
 def _symmetrized(matrix: np.ndarray) -> np.ndarray:
     return 0.5 * (matrix + matrix.T)
+
+
+def _as_finite_array(value: Any, name: str) -> np.ndarray:
+    try:
+        array = np.asarray(value, dtype=float)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must contain finite numeric values") from exc
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must contain only finite values")
+    return array
 
 
 def _as_finite_scalar(value: Any, name: str) -> float:

--- a/tests/filters/test_linear_update_planning.py
+++ b/tests/filters/test_linear_update_planning.py
@@ -102,8 +102,9 @@ def test_plan_rejects_nonfinite_array_inputs():
 
     for overrides in invalid_overrides:
         invalid_name = next(iter(overrides))
+        kwargs = {**base_kwargs, **overrides}
         with pytest.raises(ValueError, match=invalid_name):
-            plan_linear_measurement_update(**base_kwargs, **overrides)
+            plan_linear_measurement_update(**kwargs)
 
 
 def test_normalized_innovation_squared_rejects_nonfinite_inputs():

--- a/tests/filters/test_linear_update_planning.py
+++ b/tests/filters/test_linear_update_planning.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 from pyrecest.filters.linear_update_planning import (
     chi_square_gate_threshold,
+    normalized_innovation_squared,
     plan_linear_measurement_update,
     robust_update_covariance_scale,
     student_t_covariance_scale,
@@ -81,6 +82,36 @@ def test_plan_rejects_nonfinite_threshold_parameters():
     for overrides in invalid_overrides:
         with pytest.raises(ValueError, match=next(iter(overrides))):
             plan_linear_measurement_update(**base_kwargs, **overrides)
+
+
+def test_plan_rejects_nonfinite_array_inputs():
+    base_kwargs = {
+        "mean": np.zeros(1),
+        "covariance_matrix": np.eye(1),
+        "measurement_vector": np.array([1.0]),
+        "measurement_covariance": np.eye(1),
+        "observation_matrix": np.eye(1),
+    }
+    invalid_overrides = (
+        {"measurement_vector": np.array([np.nan])},
+        {"measurement_covariance": np.array([[np.inf]])},
+        {"observation_matrix": np.array([[np.nan]])},
+        {"mean": np.array([np.inf])},
+        {"covariance_matrix": np.array([[np.nan]])},
+    )
+
+    for overrides in invalid_overrides:
+        invalid_name = next(iter(overrides))
+        with pytest.raises(ValueError, match=invalid_name):
+            plan_linear_measurement_update(**base_kwargs, **overrides)
+
+
+def test_normalized_innovation_squared_rejects_nonfinite_inputs():
+    with pytest.raises(ValueError, match="residual"):
+        normalized_innovation_squared(np.array([np.nan]), np.eye(1))
+
+    with pytest.raises(ValueError, match="innovation_covariance"):
+        normalized_innovation_squared(np.array([0.0]), np.array([[np.inf]]))
 
 
 def test_robust_scale_rejects_nonfinite_parameters():


### PR DESCRIPTION
## Summary
- Reject NaN/Inf residual and covariance inputs before NIS computation.
- Reject NaN/Inf measurement, observation, mean, and covariance arrays before planning a linear update.
- Add regression tests for the public NIS helper and update-plan path.

## Testing
- Syntax-checked the replacement module content before pushing.
- Exercised the new validation path in an isolated Python namespace.