### PR TITLE
Fix PyTorch equality comparison device handling

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_minmax_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_minmax_device_contract.py
@@ -1,4 +1,4 @@
-"""PyTorch ``maximum``/``minimum`` device compatibility hook."""
+"""PyTorch binary-helper device compatibility hook."""
 
 from __future__ import annotations
 
@@ -19,7 +19,7 @@ def _preferred_pytorch_device(torch_module, *values):
     return None
 
 
-def _minmax_operands(raw_pytorch, torch_module, left, right):
+def _binary_operands(raw_pytorch, torch_module, left, right):
     """Return operands on a common dtype and an existing preferred device."""
     device = _preferred_pytorch_device(torch_module, left, right)
     left = raw_pytorch.array(left)
@@ -30,6 +30,10 @@ def _minmax_operands(raw_pytorch, torch_module, left, right):
     return left.to(device=device, dtype=dtype), right.to(device=device, dtype=dtype)
 
 
+# Backwards-compatible alias for existing imports/tests that used the old helper name.
+_minmax_operands = _binary_operands
+
+
 def _raw_pytorch_module():
     """Return the raw PyTorch backend module, importing it when available."""
     try:
@@ -38,26 +42,12 @@ def _raw_pytorch_module():
         return None
 
 
-def patch_pytorch_minmax_device_contract() -> None:
-    """Patch raw/public PyTorch ``maximum`` and ``minimum`` to preserve device."""
-    try:
-        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
-        import torch  # pylint: disable=import-outside-toplevel
-    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
-        return
-
-    raw_pytorch = _raw_pytorch_module()
-    if raw_pytorch is None:  # pragma: no cover - backend import failed earlier
-        return
-
-    helpers = {
-        "maximum": torch.maximum,
-        "minimum": torch.minimum,
-    }
+def _patch_binary_helpers(raw_pytorch, backend, torch_module, helpers, contract_attr):
+    """Patch raw/public binary helpers to share dtype and preserve device."""
     if all(
         getattr(
             getattr(raw_pytorch, helper_name, None),
-            "_pyrecest_minmax_device_contract",
+            contract_attr,
             False,
         )
         for helper_name in helpers
@@ -70,14 +60,48 @@ def patch_pytorch_minmax_device_contract() -> None:
     for helper_name, torch_helper in helpers.items():
         original_helper = getattr(raw_pytorch, helper_name)
 
-        def minmax(left, right, _torch_helper=torch_helper):
-            left, right = _minmax_operands(raw_pytorch, torch, left, right)
+        def binary_helper(left, right, _torch_helper=torch_helper):
+            left, right = _binary_operands(raw_pytorch, torch_module, left, right)
             return _torch_helper(left, right)
 
-        minmax.__name__ = getattr(original_helper, "__name__", helper_name)
-        minmax.__doc__ = getattr(original_helper, "__doc__", None)
-        minmax._pyrecest_minmax_device_contract = True
-        minmax._pyrecest_device_contract = True
-        setattr(raw_pytorch, helper_name, minmax)
+        binary_helper.__name__ = getattr(original_helper, "__name__", helper_name)
+        binary_helper.__doc__ = getattr(original_helper, "__doc__", None)
+        setattr(binary_helper, contract_attr, True)
+        binary_helper._pyrecest_device_contract = True
+        setattr(raw_pytorch, helper_name, binary_helper)
         if getattr(backend, "__backend_name__", None) == "pytorch":
-            setattr(backend, helper_name, minmax)
+            setattr(backend, helper_name, binary_helper)
+
+
+def patch_pytorch_minmax_device_contract() -> None:
+    """Patch raw/public PyTorch binary helpers to preserve device placement."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    raw_pytorch = _raw_pytorch_module()
+    if raw_pytorch is None:  # pragma: no cover - backend import failed earlier
+        return
+
+    _patch_binary_helpers(
+        raw_pytorch,
+        backend,
+        torch,
+        {
+            "maximum": torch.maximum,
+            "minimum": torch.minimum,
+        },
+        "_pyrecest_minmax_device_contract",
+    )
+    _patch_binary_helpers(
+        raw_pytorch,
+        backend,
+        torch,
+        {
+            "equal": torch.eq,
+            "less_equal": torch.le,
+        },
+        "_pyrecest_comparison_device_contract",
+    )

--- a/tests/backend_support/test_pytorch_raw_comparison_contract.py
+++ b/tests/backend_support/test_pytorch_raw_comparison_contract.py
@@ -24,11 +24,41 @@ raw_pytorch = importlib.import_module("pyrecest._backend.pytorch")
 right = raw_pytorch.asarray([0, 2, 4])
 greater_result = raw_pytorch.greater([1, 2, 3], right)
 less_result = raw_pytorch.less(right, [1, 2, 3])
+equal_result = raw_pytorch.equal([1, 2, 3], right)
+less_equal_result = raw_pytorch.less_equal([1, 2, 3], right)
 logical_result = raw_pytorch.logical_or([True, False], raw_pytorch.asarray([False, True]))
 
 assert raw_pytorch.to_numpy(greater_result).tolist() == [True, False, False]
 assert raw_pytorch.to_numpy(less_result).tolist() == [True, False, False]
+assert raw_pytorch.to_numpy(equal_result).tolist() == [False, True, False]
+assert raw_pytorch.to_numpy(less_equal_result).tolist() == [False, True, True]
 assert raw_pytorch.to_numpy(logical_result).tolist() == [True, True]
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.backend_portable
+@pytest.mark.parametrize("helper_name", ["equal", "less_equal"])
+def test_raw_pytorch_equality_comparisons_preserve_non_cpu_device(helper_name):
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "numpy",
+        f"""
+import importlib
+import torch
+
+raw_pytorch = importlib.import_module("pyrecest._backend.pytorch")
+helper = getattr(raw_pytorch, {helper_name!r})
+right = torch.empty((3,), device="meta", dtype=torch.float32)
+
+comparison = helper([1.0, 2.0, 3.0], right)
+assert tuple(comparison.shape) == (3,)
+assert comparison.dtype == torch.bool
+assert comparison.device.type == "meta"
 """,
     )
 


### PR DESCRIPTION
## Summary
- Extend the PyTorch binary-helper device hook to cover `equal` and `less_equal`.
- Preserve existing tensor device placement before coercing array-like operands.
- Add regression coverage for raw PyTorch equality comparisons with array-like and meta-device operands.

## Validation
- Added focused regression tests.
- Branch compare: ahead by 2, behind by 0 against `main`.
- Full suite not run locally; CI should run the added tests.