### PR TITLE
Fix PyTorch log1p array-like contract

### DIFF
--- a/src/pyrecest/_backend/pytorch/_dtype.py
+++ b/src/pyrecest/_backend/pytorch/_dtype.py
@@ -309,3 +309,26 @@ def _box_binary_scalar(target=None, box_x1=True, box_x2=True):
         return _decorator
 
     return _decorator(target)
+
+
+def _patch_parent_log1p_arraylike_contract() -> None:
+    """Make PyTorch backend ``log1p`` accept NumPy-style array-like inputs."""
+    try:
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - parent backend import failed earlier
+        return
+
+    original_log1p = getattr(pytorch_backend, "log1p", None)
+    if original_log1p is None or getattr(
+        original_log1p, "_pyrecest_arraylike_contract", False
+    ):
+        return
+
+    log1p = _box_unary_scalar(target=_torch.log1p)
+    log1p.__name__ = getattr(original_log1p, "__name__", "log1p")
+    log1p.__doc__ = getattr(original_log1p, "__doc__", None)
+    log1p._pyrecest_arraylike_contract = True
+    pytorch_backend.log1p = log1p
+
+
+_patch_parent_log1p_arraylike_contract()

--- a/tests/backend_support/test_pytorch_log1p_contract.py
+++ b/tests/backend_support/test_pytorch_log1p_contract.py
@@ -1,0 +1,65 @@
+"""Regression tests for PyTorch log1p backend contract."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_pytorch_log1p_accepts_numpy_style_array_like_inputs():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import math
+import pyrecest.backend as backend
+
+scalar = backend.log1p(1.0)
+vector = backend.log1p([0.0, 1.0, 3.0])
+out = backend.empty_like(vector)
+returned = backend.log1p([0.0, 1.0, 3.0], out=out)
+
+assert returned is out
+assert abs(backend.to_numpy(scalar).item() - math.log1p(1.0)) < 1e-6
+values = backend.to_numpy(vector).tolist()
+out_values = backend.to_numpy(out).tolist()
+for actual, expected in zip(values, [math.log1p(0.0), math.log1p(1.0), math.log1p(3.0)]):
+    assert abs(actual - expected) < 1e-6
+for actual, expected in zip(out_values, [math.log1p(0.0), math.log1p(1.0), math.log1p(3.0)]):
+    assert abs(actual - expected) < 1e-6
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_log1p_accepts_array_like_inputs_under_numpy_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "numpy",
+        """
+import math
+import pyrecest._backend.pytorch as raw_pytorch
+
+values = raw_pytorch.log1p([0.0, 1.0, 3.0])
+as_numpy = raw_pytorch.to_numpy(values).tolist()
+
+for actual, expected in zip(as_numpy, [math.log1p(0.0), math.log1p(1.0), math.log1p(3.0)]):
+    assert abs(actual - expected) < 1e-6
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- Patch the PyTorch backend `log1p` entry point so it accepts NumPy-style scalar/list/array-like inputs before dispatching to Torch.
- Keep the raw PyTorch backend behavior aligned with the public backend facade.
- Add focused subprocess regressions for public `PYRECEST_BACKEND=pytorch` usage and direct raw PyTorch backend usage.

## Bug fixed
`pyrecest._backend.pytorch.log1p` was exported directly from `torch.log1p`, unlike adjacent unary helpers such as `log`, `sqrt`, and `exp`. Torch rejects Python scalars/lists for this call path, so `backend.log1p([0.0, 1.0])` under the PyTorch backend and `raw_pytorch.log1p([...])` could fail despite PyRecEst's NumPy-style backend contract.

## Validation
- Connector diff check: branch is 2 commits ahead of `main`, touching only `src/pyrecest/_backend/pytorch/_dtype.py` and `tests/backend_support/test_pytorch_log1p_contract.py`.
- Spot-checked the committed source and regression file on the branch.

Full test execution was not run locally in this sandbox; CI should run the repository matrix on the PR.