### PR TITLE
Fix PyTorch logm array-like inputs

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -236,7 +236,9 @@ class _Logm(_torch.autograd.Function):
         return _Logm._logm(backward_tensor).to(tensor.dtype)[..., :n, n:]
 
 
-logm = _Logm.apply
+def logm(x):
+    """Compute matrix logarithm after array-like input promotion."""
+    return _Logm.apply(_as_linalg_tensor(x))
 
 
 def sqrtm(x):

--- a/tests/backend_support/test_pytorch_linalg_logm_arraylike_contract.py
+++ b/tests/backend_support/test_pytorch_linalg_logm_arraylike_contract.py
@@ -1,0 +1,28 @@
+"""Regression tests for PyTorch linalg.logm array-like input promotion."""
+
+from __future__ import annotations
+
+import pytest
+
+import pyrecest.backend as backend
+from pyrecest.backend import linalg as public_linalg
+
+pytorch_backend = pytest.importorskip("pyrecest._backend.pytorch")
+pytorch_linalg = pytest.importorskip("pyrecest._backend.pytorch.linalg")
+
+
+def test_raw_pytorch_logm_accepts_integer_python_lists():
+    result = pytorch_linalg.logm([[1, 0], [0, 1]])
+
+    assert pytorch_backend.is_floating(result)
+    assert bool(pytorch_backend.allclose(result, pytorch_backend.zeros((2, 2))))
+
+
+def test_public_pytorch_logm_accepts_array_like_inputs_when_active():
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        pytest.skip("public PyTorch backend is not active")
+
+    result = public_linalg.logm([[1, 0], [0, 1]])
+
+    assert backend.is_floating(result)
+    assert bool(backend.allclose(result, backend.zeros((2, 2))))


### PR DESCRIPTION
## Summary
- normalize PyTorch `linalg.logm` inputs through the existing linalg tensor coercion helper before invoking the autograd-backed implementation
- preserve the existing `_Logm` autograd path for tensor inputs
- add focused raw/public PyTorch regression coverage for integer Python-list matrix inputs

## Bug fixed
`pyrecest._backend.pytorch.linalg.logm` exposed `_Logm.apply` directly, unlike neighboring linalg helpers that first call `_as_linalg_tensor`. As a result, calls such as `linalg.logm([[1, 0], [0, 1]])` could pass a Python list into `ctx.save_for_backward`, failing before the SciPy bridge and contradicting PyRecEst's NumPy-style array-like backend contract. Integer array-like inputs also skipped the standard float/complex linalg promotion.

## Validation
- `python -m py_compile /tmp/linalg_new.py /tmp/test_pytorch_linalg_logm_arraylike_contract.py`
- local minimal PyTorch/SciPy stub smoke test: `logm([[1, 0], [0, 1]])` returns a floating zero matrix and tensor-input gradients still backpropagate
- `compare_commits`: branch is 2 commits ahead of `main`, 0 behind; changed files are limited to `src/pyrecest/_backend/pytorch/linalg.py` and the new regression test

Full repository pytest was not run in this connector environment; CI should run the added focused regression.