### PR TITLE
Reject bool inputs in PyTorch one_hot

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_one_hot_scalar_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_one_hot_scalar_contract.py
@@ -5,6 +5,24 @@ from __future__ import annotations
 from operator import index as _operator_index
 
 
+def _is_numpy_bool_scalar(value) -> bool:
+    return type(value).__module__ == "numpy" and type(value).__name__ == "bool_"
+
+
+def _contains_boolean_label(value, torch_module) -> bool:
+    """Return whether labels contain booleans before coercing to ``long``."""
+    if isinstance(value, bool) or _is_numpy_bool_scalar(value):
+        return True
+    if torch_module.is_tensor(value):
+        return value.dtype == torch_module.bool
+    dtype = getattr(value, "dtype", None)
+    if dtype is not None and str(dtype).lower() in {"bool", "bool_"}:
+        return True
+    if isinstance(value, (list, tuple)):
+        return any(_contains_boolean_label(item, torch_module) for item in value)
+    return False
+
+
 def patch_pytorch_one_hot_scalar_contract() -> None:
     """Patch raw/public PyTorch ``one_hot`` to handle scalar labels correctly."""
     try:
@@ -24,12 +42,10 @@ def patch_pytorch_one_hot_scalar_contract() -> None:
 
     def one_hot(labels, num_classes):
         num_classes = _operator_index(num_classes)
+        if _contains_boolean_label(labels, torch_module):
+            raise TypeError("one_hot labels must be integers, not booleans")
         if torch_module.is_tensor(labels):
-            if (
-                labels.dtype == torch_module.bool
-                or labels.dtype.is_floating_point
-                or labels.dtype.is_complex
-            ):
+            if labels.dtype.is_floating_point or labels.dtype.is_complex:
                 return original_one_hot(labels, num_classes)
             labels = labels.to(dtype=torch_module.long)
         else:


### PR DESCRIPTION
## Summary
- add a small guard before the PyTorch one_hot scalar shim coerces inputs to torch.long
- keep integer scalar, sequence, and tensor inputs on the existing uint8 one_hot path
- keep raw PyTorch and active public PyTorch facades synchronized

## Bug fixed
The scalar shim already avoided converting bool tensors, but Python and NumPy bool inputs still reached torch.as_tensor(..., dtype=torch.long), so True/False could be treated as class indices. This change rejects those inputs consistently before conversion.

## Validation
- python -m py_compile /tmp/_pytorch_one_hot_scalar_contract.py /tmp/test_pytorch_one_hot_scalar_contract.py
- local smoke check of the new bool-input detector with Python, NumPy, and torch values

Note: I attempted to add focused regression coverage under tests/backend_support, but the connector safety layer rejected writes to that test path in this session. The implementation change is intentionally limited to the compatibility shim.