### PR TITLE
Fix PyTorch logm array-like inputs

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -236,7 +236,9 @@ class _Logm(_torch.autograd.Function):
         return _Logm._logm(backward_tensor).to(tensor.dtype)[..., :n, n:]
 
 
-logm = _Logm.apply
+def logm(x):
+    """Compute the matrix logarithm after array-like input promotion."""
+    return _Logm.apply(_as_linalg_tensor(x))
 
 
 def sqrtm(x):

--- a/tests/backend_support/test_pytorch_linalg_logm_contract.py
+++ b/tests/backend_support/test_pytorch_linalg_logm_contract.py
@@ -1,0 +1,31 @@
+import pytest
+
+import pyrecest.backend as backend
+from pyrecest.backend import linalg
+
+pytorch_backend = pytest.importorskip("pyrecest._backend.pytorch")
+pytorch_linalg = pytest.importorskip("pyrecest._backend.pytorch.linalg")
+
+
+def _allclose_to_zero_matrix(values):
+    expected = pytorch_backend.zeros((2, 2), dtype=values.dtype)
+    return bool(pytorch_backend.allclose(values, expected))
+
+
+def test_raw_pytorch_logm_accepts_array_like_integer_inputs():
+    result = pytorch_linalg.logm([[1, 0], [0, 1]])
+
+    assert result.shape == (2, 2)
+    assert pytorch_backend.is_floating(result)
+    assert _allclose_to_zero_matrix(result)
+
+
+def test_public_pytorch_logm_accepts_array_like_integer_inputs_when_active():
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        pytest.skip("public PyTorch backend is not active")
+
+    result = linalg.logm([[1, 0], [0, 1]])
+
+    assert result.shape == (2, 2)
+    assert backend.is_floating(result)
+    assert bool(backend.allclose(result, backend.zeros((2, 2), dtype=result.dtype)))


### PR DESCRIPTION
## Summary
- Normalize PyTorch `linalg.logm` inputs through the existing linalg tensor coercion helper.
- Keep the differentiable tensor path intact while accepting Python-list and integer array-like matrices.
- Add regression coverage for the raw PyTorch linalg module and the public PyTorch backend path.

## Validation
- Syntax-checked the modified Python content locally with `compile()`.
- Full repository tests were not run locally; CI should run the new focused regression test.