### PR TITLE
Sync top-level copy export for PyTorch backend

### DIFF
--- a/src/pyrecest/backend_tools.py
+++ b/src/pyrecest/backend_tools.py
@@ -3,8 +3,22 @@
 from __future__ import annotations
 
 import os
+import sys
 import warnings
 from operator import index as _operator_index
+
+
+def _sync_top_level_backend_copy_export() -> None:
+    """Refresh ``pyrecest.copy`` after import-time backend facade patches."""
+
+    pyrecest_module = sys.modules.get("pyrecest")
+    if pyrecest_module is None:
+        return
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+    setattr(pyrecest_module, "copy", backend.copy)
 
 
 def _pytorch_scalar_tensor_index(index, torch_module):
@@ -456,6 +470,7 @@ _patch_pytorch_special_numpy_contract()
 _patch_pytorch_stack_helpers_numpy_contract()
 _patch_raw_pytorch_comparison_numpy_contract()
 _patch_raw_pytorch_isclose_equal_nan_contract()
+_sync_top_level_backend_copy_export()
 
 
 def get_backend_name() -> str:

--- a/tests/backend_support/test_pytorch_copy_contract.py
+++ b/tests/backend_support/test_pytorch_copy_contract.py
@@ -1,9 +1,18 @@
+import importlib.util
+
 import numpy as np
 import pytest
 
+from tests.support.backend_runner import run_backend_code
+
+
+def _require_torch():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
 
 def test_pytorch_copy_returns_backend_tensors_for_array_like_inputs():
-    pytest.importorskip("torch")
+    _require_torch()
 
     import pyrecest  # noqa: F401
     import pyrecest._backend.pytorch as raw_pytorch
@@ -22,3 +31,26 @@ def test_pytorch_copy_returns_backend_tensors_for_array_like_inputs():
     source[0] = 99.0
     assert raw_pytorch.is_array(array_copy)
     assert array_copy.tolist() == [1.0, 2.0]
+
+
+@pytest.mark.backend_portable
+def test_top_level_copy_tracks_patched_pytorch_backend_copy():
+    _require_torch()
+
+    code = """
+import pyrecest
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+assert getattr(backend, "__backend_name__", None) == "pytorch"
+assert pyrecest.copy is backend.copy
+assert backend.copy is raw_pytorch.copy
+
+copied = pyrecest.copy([[1.0, 2.0], [3.0, 4.0]])
+assert backend.is_array(copied)
+assert backend.to_numpy(copied).tolist() == [[1.0, 2.0], [3.0, 4.0]]
+print("ok")
+"""
+    result = run_backend_code("pytorch", code)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- refresh the package-level `pyrecest.copy` export after import-time backend facade patches run
- add a PyTorch backend-portable regression asserting `pyrecest.copy`, `pyrecest.backend.copy`, and raw PyTorch `copy` stay synchronized
- preserve existing raw PyTorch array-like copy coverage

## Bug fixed
With `PYRECEST_BACKEND=pytorch`, `pyrecest.__init__` imports `copy` before backend-support hooks patch the active backend facade. The raw and active backend `copy` helpers can therefore be patched while the package-level `pyrecest.copy` name remains bound to the pre-patch function.

## Validation
- Syntax-checked the modified module and regression test locally with `python -m py_compile`.
- Compared `fix-pytorch-copy-export` against `main`: `ahead_by=2`, `behind_by=0`, changed only `src/pyrecest/backend_tools.py` and `tests/backend_support/test_pytorch_copy_contract.py`.
- Full repository tests were not run locally because this sandbox cannot clone/install the repository from GitHub.