### PR TITLE
Fix PyTorch linalg.logm array-like inputs

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_allclose_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_allclose_device_contract.py
@@ -1,4 +1,4 @@
-"""PyTorch ``allclose`` compatibility hook."""
+"""PyTorch compatibility hooks used during stability initialization."""
 
 from __future__ import annotations
 
@@ -34,6 +34,34 @@ def _coerce_binary_args(torch_module, x, y):
     return x, y
 
 
+def _patch_pytorch_linalg_logm_arraylike_contract() -> None:
+    """Patch raw/public PyTorch ``linalg.logm`` to normalize array-like inputs."""
+
+    try:
+        import pyrecest._backend.pytorch.linalg as pytorch_linalg  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    original_logm = getattr(pytorch_linalg, "logm", None)
+    if original_logm is None:
+        return
+    if getattr(original_logm, "_pyrecest_arraylike_contract", False):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.linalg.logm = original_logm
+        return
+
+    def logm(x):
+        return original_logm(pytorch_linalg._as_linalg_tensor(x))  # pylint: disable=protected-access
+
+    logm.__name__ = getattr(original_logm, "__name__", "logm")
+    logm.__doc__ = getattr(original_logm, "__doc__", None)
+    logm._pyrecest_arraylike_contract = True
+    pytorch_linalg.logm = logm
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.linalg.logm = logm
+
+
 def patch_pytorch_allclose_device_contract() -> None:
     """Patch raw/public PyTorch ``allclose`` to preserve non-CPU operands."""
 
@@ -45,6 +73,7 @@ def patch_pytorch_allclose_device_contract() -> None:
         return
 
     _patch_pytorch_creation_shape_contract()
+    _patch_pytorch_linalg_logm_arraylike_contract()
 
     original_allclose = getattr(pytorch_backend, "allclose", None)
     if original_allclose is None:

--- a/tests/backend_support/test_pytorch_linalg_logm_contract.py
+++ b/tests/backend_support/test_pytorch_linalg_logm_contract.py
@@ -1,0 +1,26 @@
+"""Regression tests for PyTorch linalg.logm input normalization."""
+
+import pytest
+
+import pyrecest.backend as backend
+
+pytorch_backend = pytest.importorskip("pyrecest._backend.pytorch")
+pytorch_linalg = pytest.importorskip("pyrecest._backend.pytorch.linalg")
+torch = pytest.importorskip("torch")
+
+
+def test_raw_pytorch_logm_accepts_array_like_integer_inputs():
+    result = pytorch_linalg.logm([[1, 0], [0, 1]])
+
+    assert result.dtype.is_floating_point
+    assert torch.allclose(result, torch.zeros_like(result))
+
+
+def test_public_pytorch_logm_accepts_array_like_integer_inputs_when_active():
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        pytest.skip("public PyTorch backend is not active")
+
+    result = backend.linalg.logm([[1, 0], [0, 1]])
+
+    assert result.dtype.is_floating_point
+    assert torch.allclose(result, torch.zeros_like(result))


### PR DESCRIPTION
## Summary
- Patch PyTorch `linalg.logm` during stability initialization so raw/public PyTorch calls normalize array-like inputs through the existing linalg tensor coercion helper before invoking the autograd-backed logm implementation.
- Add regression coverage for Python-list integer identity matrices through both the raw PyTorch linalg module and the public PyTorch backend when active.

## Bug fixed
`pyrecest._backend.pytorch.linalg.logm([[1, 0], [0, 1]])` could pass a Python list directly into the `torch.autograd.Function.apply` path. That path expects tensors and can fail before the SciPy bridge runs, unlike neighboring PyTorch linalg helpers such as `sqrtm` and `fractional_matrix_power`, which normalize inputs first.

## Validation
- Syntax-compiled the new regression test locally.
- Reproduced the pre-fix failure mode in a minimal PyTorch custom-function check and verified that tensor coercion returns a floating zero matrix for `logm(I)`.
- Branch comparison: 2 commits ahead of `main`, 0 behind.