### PR TITLE
Handle overflow during numeric validation

### DIFF
--- a/src/pyrecest/numerics.py
+++ b/src/pyrecest/numerics.py
@@ -44,7 +44,7 @@ def _object_item_contains_unsupported_numeric_values(item) -> bool:
 def _contains_unsupported_numeric_values(value) -> bool:
     try:
         value_array = np.asarray(value)
-    except (TypeError, ValueError, RuntimeError):
+    except (TypeError, ValueError, OverflowError, RuntimeError):
         return True
     if value_array.dtype.kind in _UNSUPPORTED_NUMERIC_KINDS:
         return True
@@ -86,7 +86,7 @@ def _from_numpy_array(value: np.ndarray):
 def _validate_nonnegative_finite(name: str, value: float) -> float:
     try:
         value_array = np.asarray(value)
-    except (TypeError, ValueError, RuntimeError) as exc:
+    except (TypeError, ValueError, OverflowError, RuntimeError) as exc:
         raise ValueError(f"{name} must be a scalar number.") from exc
     if value_array.shape != () or np.issubdtype(value_array.dtype, np.bool_):
         raise ValueError(f"{name} must be a scalar number.")
@@ -112,7 +112,7 @@ def _validate_positive_finite(name: str, value: float) -> float:
 def _validate_nonnegative_integer(name: str, value: int) -> int:
     try:
         value_array = np.asarray(value)
-    except (TypeError, ValueError, RuntimeError) as exc:
+    except (TypeError, ValueError, OverflowError, RuntimeError) as exc:
         raise ValueError(f"{name} must be a nonnegative integer.") from exc
     if value_array.shape != () or not np.issubdtype(value_array.dtype, np.integer):
         raise ValueError(f"{name} must be a nonnegative integer.")

--- a/tests/test_numerics.py
+++ b/tests/test_numerics.py
@@ -21,6 +21,12 @@ class UncoercibleArray:
         raise RuntimeError("cannot convert")
 
 
+class OverflowingArray:
+    def __array__(self, dtype=None):
+        del dtype
+        raise OverflowError("cannot convert")
+
+
 def test_symmetrize_matrix_and_psd_projection():
     matrix = np.array([[1.0, 2.0], [0.0, -0.1]])
     symmetric = np.asarray(symmetrize_matrix(matrix))
@@ -79,8 +85,9 @@ def test_covariance_helpers_reject_bool_text_temporal_and_none_matrices(matrix):
         jittered_cholesky(matrix)
 
 
-def test_covariance_helpers_reject_uncoercible_array_like_inputs():
-    matrix = UncoercibleArray()
+@pytest.mark.parametrize("array_like_factory", [UncoercibleArray, OverflowingArray])
+def test_covariance_helpers_reject_uncoercible_array_like_inputs(array_like_factory):
+    matrix = array_like_factory()
 
     assert not is_symmetric(matrix)
     assert not is_positive_semidefinite(matrix)
@@ -95,8 +102,9 @@ def test_covariance_helpers_reject_uncoercible_array_like_inputs():
         jittered_cholesky(matrix)
 
 
-def test_covariance_helpers_reject_uncoercible_scalar_controls():
-    value = UncoercibleArray()
+@pytest.mark.parametrize("array_like_factory", [UncoercibleArray, OverflowingArray])
+def test_covariance_helpers_reject_uncoercible_scalar_controls(array_like_factory):
+    value = array_like_factory()
     matrix = np.eye(2)
 
     with pytest.raises(ValueError, match="atol"):


### PR DESCRIPTION
## Summary
- Treat `OverflowError` during NumPy coercion like other invalid array-like conversion failures.
- Keep covariance helper predicates and validators on the documented `False`/`ValueError` paths for hostile or overflowing array-like inputs.
- Add regression coverage for array-likes whose `__array__` raises `OverflowError`.

## Bug fixed
Before this change, numeric control validators such as `atol`, `min_eigenvalue`, `initial_jitter`, `max_attempts`, and `dim` could leak `OverflowError` when `np.asarray(...)` raised during coercion. Other invalid array-like failures already normalize to `ValueError`, and matrix predicates are expected to return `False` for invalid matrix-like inputs.

## Testing
- `PYTHONPATH=. pytest -q tests/test_numerics.py` in a local isolated minimal harness containing the patched numerics module and exceptions: `24 passed`.
