### PR TITLE
Sync top-level copy export for PyTorch backend

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_copy_export_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_copy_export_contract.py
@@ -1,0 +1,43 @@
+"""Compatibility hook for the top-level PyTorch ``copy`` export."""
+
+from __future__ import annotations
+
+import sys
+
+
+def patch_pytorch_copy_export_contract() -> None:
+    """Keep raw, public-backend, and package-level PyTorch ``copy`` synchronized."""
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        return
+
+    original_copy = getattr(raw_pytorch, "copy", None)
+    if original_copy is None:
+        return
+
+    if getattr(original_copy, "_pyrecest_numpy_contract", False):
+        copy = original_copy
+    else:
+
+        def copy(x):
+            if raw_pytorch.is_array(x):
+                return original_copy(x)
+            return raw_pytorch.array(x)
+
+        copy.__name__ = getattr(original_copy, "__name__", "copy")
+        copy.__doc__ = getattr(original_copy, "__doc__", None)
+        copy._pyrecest_numpy_contract = True
+        raw_pytorch.copy = copy
+
+    backend.copy = copy
+    pyrecest_module = sys.modules.get("pyrecest")
+    if pyrecest_module is not None:
+        pyrecest_module.copy = copy
+
+
+__all__ = ["patch_pytorch_copy_export_contract"]

--- a/src/pyrecest/backend_support/_random_uniform_empty_contract.py
+++ b/src/pyrecest/backend_support/_random_uniform_empty_contract.py
@@ -5,6 +5,18 @@ from __future__ import annotations
 import os
 
 
+def _patch_pytorch_copy_export_contract() -> None:
+    """Keep the PyTorch package-level ``copy`` export synchronized."""
+
+    try:
+        from pyrecest.backend_support._pytorch_copy_export_contract import (  # pylint: disable=import-outside-toplevel
+            patch_pytorch_copy_export_contract,
+        )
+    except ModuleNotFoundError:  # pragma: no cover - backend support may be unavailable
+        return
+    patch_pytorch_copy_export_contract()
+
+
 def _shape_has_no_samples(shape) -> bool:
     """Return whether a sample shape requests zero samples."""
 
@@ -234,6 +246,7 @@ def _patch_jax_uniform_empty_bounds_contract() -> None:
 def patch_random_uniform_empty_bounds_contract() -> None:
     """Patch random uniform empty-bound compatibility for optional backends."""
 
+    _patch_pytorch_copy_export_contract()
     backend_name = os.environ.get("PYRECEST_BACKEND", "numpy")
     if backend_name in {"autograd", "numpy"}:
         _patch_shared_numpy_uniform_empty_bounds_contract()

--- a/tests/backend_support/test_pytorch_copy_export_contract.py
+++ b/tests/backend_support/test_pytorch_copy_export_contract.py
@@ -1,0 +1,43 @@
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+pytestmark = pytest.mark.backend_portable
+
+
+def _require_torch():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+
+def test_top_level_copy_tracks_patched_pytorch_backend_copy():
+    _require_torch()
+
+    code = """
+import torch
+
+import pyrecest
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+assert getattr(backend, "__backend_name__", None) == "pytorch"
+assert pyrecest.copy is backend.copy
+assert backend.copy is raw_pytorch.copy
+
+copied = pyrecest.copy([1.0, 2.0])
+assert torch.is_tensor(copied), type(copied)
+assert copied.dtype == backend.get_default_dtype()
+assert backend.to_numpy(copied).tolist() == [1.0, 2.0]
+
+source = torch.tensor([1.0, 2.0])
+copied_tensor = pyrecest.copy(source)
+assert torch.is_tensor(copied_tensor)
+assert copied_tensor is not source
+assert backend.to_numpy(copied_tensor).tolist() == [1.0, 2.0]
+print("ok")
+"""
+    result = run_backend_code("pytorch", code)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- synchronize the package-level `pyrecest.copy` export with the patched PyTorch backend copy helper
- add a focused backend-portable regression test

## Validation
- `python -m py_compile` on the changed helper and test files