### PR TITLE
Fix PyTorch logm array-like inputs

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -236,7 +236,9 @@ class _Logm(_torch.autograd.Function):
         return _Logm._logm(backward_tensor).to(tensor.dtype)[..., :n, n:]
 
 
-logm = _Logm.apply
+def logm(x):
+    """Compute a matrix logarithm after array-like input promotion."""
+    return _Logm.apply(_as_linalg_tensor(x))
 
 
 def sqrtm(x):

--- a/tests/backend_support/test_pytorch_linalg_logm_arraylike_contract.py
+++ b/tests/backend_support/test_pytorch_linalg_logm_arraylike_contract.py
@@ -1,0 +1,28 @@
+import pytest
+
+import pyrecest.backend as backend
+from pyrecest.backend import linalg as backend_linalg
+
+pytorch_backend = pytest.importorskip("pyrecest._backend.pytorch")
+pytorch_linalg = pytest.importorskip("pyrecest._backend.pytorch.linalg")
+
+
+def _as_list(value):
+    return pytorch_backend.to_numpy(value).tolist()
+
+
+def test_raw_pytorch_logm_accepts_array_like_integer_inputs():
+    result = pytorch_linalg.logm([[1, 0], [0, 1]])
+
+    assert result.dtype.is_floating_point
+    assert _as_list(result) == [[0.0, 0.0], [0.0, 0.0]]
+
+
+def test_public_pytorch_logm_accepts_array_like_integer_inputs_when_active():
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        pytest.skip("public PyTorch backend is not active")
+
+    result = backend_linalg.logm([[1, 0], [0, 1]])
+
+    assert result.dtype.is_floating_point
+    assert _as_list(result) == [[0.0, 0.0], [0.0, 0.0]]


### PR DESCRIPTION
## Summary
- wrap the PyTorch `linalg.logm` entry point so inputs pass through `_as_linalg_tensor` before reaching the custom autograd function
- add raw/public PyTorch regression coverage for Python-list integer matrix inputs

## Bug fixed
`logm = _Logm.apply` bypassed the linalg backend's normal array-like promotion path. That meant calls such as `pyrecest._backend.pytorch.linalg.logm([[1, 0], [0, 1]])` passed a Python list directly into `torch.autograd.Function.apply`, rather than accepting NumPy-style array-like inputs like the neighboring PyTorch linalg helpers.

## Validation
- Compared branch against `main`: 2 commits ahead, 0 behind; changes limited to `src/pyrecest/_backend/pytorch/linalg.py` and the new focused regression test.
- Syntax-checked the modified linalg module content locally with Python AST parsing.
- Full pytest suite not run in this connector-only environment; CI should run the new focused backend test.