### PR TITLE
Validate GaussianMixture set_mean inputs

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/gaussian_mixture.py
+++ b/src/pyrecest/distributions/nonperiodic/gaussian_mixture.py
@@ -24,6 +24,18 @@ class GaussianMixture(LinearMixture, AbstractLinearDistribution):
         return sum(means * reshape(self.w, (-1, 1)), axis=0)
 
     def set_mean(self, new_mean):
+        new_mean = array(new_mean)
+        if new_mean.ndim == 0:
+            if self.dim != 1:
+                raise ValueError(
+                    f"new_mean must have shape ({self.dim},), got scalar."
+                )
+            new_mean = reshape(new_mean, (1,))
+        elif new_mean.shape != (self.dim,):
+            raise ValueError(
+                f"new_mean must have shape ({self.dim},), got {new_mean.shape}."
+            )
+
         new_mixture = copy.deepcopy(self)
         mean_offset = new_mean - self.mean()
         for dist in new_mixture.dists:

--- a/tests/distributions/test_gaussian_mixture_set_mean_validation.py
+++ b/tests/distributions/test_gaussian_mixture_set_mean_validation.py
@@ -1,0 +1,36 @@
+import unittest
+
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array, diag
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.distributions.nonperiodic.gaussian_mixture import GaussianMixture
+
+
+class GaussianMixtureSetMeanValidationTest(unittest.TestCase):
+    def test_set_mean_accepts_python_sequence(self):
+        gm1 = GaussianDistribution(array([0.0, 1.0]), diag(array([1.0, 2.0])))
+        gm2 = GaussianDistribution(array([2.0, 3.0]), diag(array([3.0, 4.0])))
+        gmix = GaussianMixture([gm1, gm2], array([0.25, 0.75]))
+
+        shifted = gmix.set_mean([10.0, -2.0])
+
+        npt.assert_allclose(shifted.mean(), array([10.0, -2.0]))
+        npt.assert_allclose(gmix.mean(), array([1.5, 2.5]))
+        npt.assert_allclose(shifted.w, gmix.w)
+        npt.assert_allclose(shifted.covariance(), gmix.covariance())
+
+    def test_set_mean_rejects_wrong_shape(self):
+        gm1 = GaussianDistribution(array([0.0, 1.0]), diag(array([1.0, 2.0])))
+        gm2 = GaussianDistribution(array([2.0, 3.0]), diag(array([3.0, 4.0])))
+        gmix = GaussianMixture([gm1, gm2], array([0.25, 0.75]))
+
+        for invalid_mean in (1.0, [1.0], [[1.0, 2.0]], [1.0, 2.0, 3.0]):
+            with self.subTest(invalid_mean=invalid_mean):
+                with self.assertRaisesRegex(ValueError, "new_mean"):
+                    gmix.set_mean(invalid_mean)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Coerce `GaussianMixture.set_mean` targets through the backend array helper so Python sequences work like other distribution APIs.
- Reject scalar or wrongly shaped means for multi-dimensional Gaussian mixtures instead of silently broadcasting them.
- Add focused regression coverage for array-like targets and invalid shapes.

## Bug fixed
`GaussianMixture.set_mean([x, y])` previously failed because the method subtracted a Python list from a backend array. A scalar target for a multi-dimensional mixture could also broadcast and shift all dimensions to the same value instead of rejecting the malformed mean vector.

## Validation
- `python -m py_compile src/pyrecest/distributions/nonperiodic/gaussian_mixture.py tests/distributions/test_gaussian_mixture_set_mean_validation.py`