### PR TITLE
Make affine homogeneous matrices JAX-safe

### DIFF
--- a/src/pyrecest/utils/point_set_registration.py
+++ b/src/pyrecest/utils/point_set_registration.py
@@ -124,10 +124,9 @@ class AffineTransform:
 
     def homogeneous_matrix(self) -> Any:
         """Return the homogeneous representation of the affine transform."""
-        transform = eye(self.dim + 1)
-        transform[: self.dim, : self.dim] = self.matrix
-        transform[: self.dim, -1] = self.offset
-        return transform
+        upper = concatenate([self.matrix, self.offset.reshape(-1, 1)], axis=1)
+        lower = concatenate([zeros((1, self.dim)), asarray([[1.0]])], axis=1)
+        return concatenate([upper, lower], axis=0)
 
 
 @dataclass(frozen=True)

--- a/tests/test_affine_transform_homogeneous_matrix_jax.py
+++ b/tests/test_affine_transform_homogeneous_matrix_jax.py
@@ -1,0 +1,40 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_affine_transform_homogeneous_matrix_works_on_jax_backend():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("jax is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "jax"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import numpy.testing as npt
+
+from pyrecest.backend import array, to_numpy
+from pyrecest.utils.point_set_registration import AffineTransform
+
+transform = AffineTransform(
+    array([[1.0, 2.0], [3.0, 4.0]]),
+    array([5.0, 6.0]),
+)
+homogeneous = transform.homogeneous_matrix()
+
+npt.assert_allclose(
+    to_numpy(homogeneous),
+    [[1.0, 2.0, 5.0], [3.0, 4.0, 6.0], [0.0, 0.0, 1.0]],
+)
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- Replace in-place writes in `AffineTransform.homogeneous_matrix()` with backend `concatenate` calls.
- Add a JAX subprocess regression covering homogeneous matrix construction.

## Bug fixed
`homogeneous_matrix()` built the augmented matrix by assigning into slices of a backend array. That works for mutable NumPy/PyTorch arrays, but JAX arrays are immutable and raise `TypeError` on item assignment. The new implementation constructs the same matrix without mutation.

## Validation
- `python -m py_compile /mnt/data/point_set_registration_new.py /mnt/data/test_affine_transform_homogeneous_matrix_jax.py`
- Local standalone JAX smoke check confirmed the old slice assignment raises and the concatenation construction returns the expected homogeneous matrix.
- Full repository test suite was not run locally because the sandbox cannot clone/install the repository from GitHub; CI should run the focused regression.