### PR TITLE
Fix PyTorch unique return flags

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_allclose_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_allclose_device_contract.py
@@ -66,6 +66,7 @@ def _patch_pytorch_linalg_logm_arraylike_contract() -> None:
 
 def _patch_pytorch_flip_numpy_axis_contract() -> None:
     """Patch raw/public PyTorch ``flip`` to accept NumPy integer axes."""
+
     try:
         import numpy as np  # pylint: disable=import-outside-toplevel
         import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
@@ -101,6 +102,58 @@ def _patch_pytorch_flip_numpy_axis_contract() -> None:
         backend.flip = flip
 
 
+def _patch_pytorch_unique_return_contract() -> None:
+    """Patch raw/public PyTorch ``unique`` for NumPy-style return flags."""
+
+    try:
+        import pyrecest._backend.pytorch as pytorch_backend  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import torch as torch_module  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    original_unique = getattr(pytorch_backend, "unique", None)
+    if original_unique is None:
+        return
+    if getattr(original_unique, "_pyrecest_return_contract", False):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.unique = original_unique
+        return
+
+    def unique(
+        ar,
+        return_index=False,
+        return_inverse=False,
+        return_counts=False,
+        axis=None,
+        *,
+        equal_nan=True,
+        sorted=True,
+    ):
+        if return_index:
+            raise NotImplementedError(
+                "PyTorch unique does not support return_index through this backend."
+            )
+        if not equal_nan:
+            raise NotImplementedError(
+                "PyTorch unique does not support equal_nan=False through this backend."
+            )
+        return torch_module.unique(
+            pytorch_backend.array(ar),
+            sorted=sorted,
+            return_inverse=return_inverse,
+            return_counts=return_counts,
+            dim=axis,
+        )
+
+    unique.__name__ = getattr(original_unique, "__name__", "unique")
+    unique.__doc__ = getattr(original_unique, "__doc__", None)
+    unique._pyrecest_return_contract = True
+    pytorch_backend.unique = unique
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.unique = unique
+
+
 def patch_pytorch_allclose_device_contract() -> None:
     """Patch raw/public PyTorch ``allclose`` to preserve non-CPU operands."""
 
@@ -114,6 +167,7 @@ def patch_pytorch_allclose_device_contract() -> None:
     _patch_pytorch_creation_shape_contract()
     _patch_pytorch_linalg_logm_arraylike_contract()
     _patch_pytorch_flip_numpy_axis_contract()
+    _patch_pytorch_unique_return_contract()
 
     original_allclose = getattr(pytorch_backend, "allclose", None)
     if original_allclose is None:

--- a/tests/backend_support/test_pytorch_unique_return_contract.py
+++ b/tests/backend_support/test_pytorch_unique_return_contract.py
@@ -1,0 +1,43 @@
+"""Regression tests for PyTorch unique return-value flags."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+def test_raw_pytorch_unique_accepts_return_counts_under_numpy_backend():
+    pytest.importorskip("torch")
+
+    code = """
+import pyrecest
+import pyrecest._backend.pytorch as pytorch_backend
+
+values, counts = pytorch_backend.unique([2, 1, 2, 3, 1], return_counts=True)
+
+assert values.tolist() == [1, 2, 3]
+assert counts.tolist() == [2, 2, 1]
+"""
+    result = run_backend_code("numpy", code)
+    assert result.returncode == 0, result.stderr
+
+
+def test_public_pytorch_unique_accepts_return_inverse_and_counts():
+    pytest.importorskip("torch")
+
+    code = """
+import pyrecest.backend as backend
+
+values, inverse, counts = backend.unique(
+    [2, 1, 2, 3, 1],
+    return_inverse=True,
+    return_counts=True,
+)
+
+assert values.tolist() == [1, 2, 3]
+assert inverse.tolist() == [1, 0, 1, 2, 0]
+assert counts.tolist() == [2, 2, 1]
+"""
+    result = run_backend_code("pytorch", code)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- patch raw/public PyTorch `unique` to accept NumPy-style `return_inverse` and `return_counts` flags
- keep array-like input coercion through the PyTorch backend helper
- add subprocess regression coverage for raw PyTorch under the NumPy public backend and for the selected public PyTorch backend

## Bug fixed
The PyTorch backend exposed `unique(ar, axis=None)` only, even though the underlying Torch helper supports inverse/count return values and the PyRecEst backend facade follows NumPy-style array APIs. Calls such as `backend.unique([2, 1, 2], return_counts=True)` therefore failed under `PYRECEST_BACKEND=pytorch` with an unexpected keyword argument instead of returning the requested counts.

## Validation
- Syntax-checked the modified hook and new regression test locally with Python `compile()`.
- Compared branch against `main`: 2 commits ahead, 0 behind; changes are limited to the PyTorch compatibility hook and the focused regression test.

Full pytest was not run in this connector-only environment; CI should run the added backend-support regression.