### PR TITLE
Normalize evidence bool OverflowError coercion

### DIFF
--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -30,7 +30,7 @@ def _coerce_bool_flag(value: bool, name: str) -> bool:
 
     try:
         value_array = np.asarray(value)
-    except (TypeError, ValueError, RuntimeError) as exc:
+    except (TypeError, ValueError, RuntimeError, OverflowError) as exc:
         raise ValueError(f"{name} must be a bool") from exc
     if value_array.shape == () and np.issubdtype(value_array.dtype, np.bool_):
         return bool(value_array.item())

--- a/tests/test_evidence_bool_flag_conversion.py
+++ b/tests/test_evidence_bool_flag_conversion.py
@@ -4,9 +4,12 @@ from pyrecest.evidence import EvidenceComputationMode, resolve_evidence_computat
 
 
 class FailingArrayConversion:
+    def __init__(self, error_type):
+        self.error_type = error_type
+
     def __array__(self, dtype=None):
         del dtype
-        raise RuntimeError("array conversion failed")
+        raise self.error_type("array conversion failed")
 
 
 @pytest.mark.parametrize(
@@ -18,6 +21,7 @@ class FailingArrayConversion:
         lambda value: resolve_evidence_computation_mode(return_smoothed=value),
     ],
 )
-def test_evidence_bool_flags_normalize_array_conversion_errors(factory):
+@pytest.mark.parametrize("error_type", [RuntimeError, OverflowError])
+def test_evidence_bool_flags_normalize_array_conversion_errors(factory, error_type):
     with pytest.raises(ValueError, match="must be a bool"):
-        factory(FailingArrayConversion())
+        factory(FailingArrayConversion(error_type))


### PR DESCRIPTION
## Summary
- Normalize `OverflowError` raised during NumPy coercion of evidence bool flags to the existing `ValueError` validation path.
- Extend the existing evidence bool-flag regression to cover both `RuntimeError` and `OverflowError` across the public constructors/resolver.

## Bug fixed
Objects can implement `__array__` in a way that raises `OverflowError` during `np.asarray(...)`. `EvidenceComputationMode`, `from_return_smoothed`, and `resolve_evidence_computation_mode` previously leaked that implementation exception instead of reporting the stable `ValueError: ... must be a bool` validation error used for other invalid bool-like inputs.

## Validation
- Ran a local targeted regression using the patched installed package: `python -m pytest -q /mnt/data/test_evidence_bool_flag_conversion.py` (`8 passed`).
- Verified branch diff against `main`: 2 files changed, +8/-4; branch is ahead by 2 and behind by 0.