### PR TITLE
Normalize JAX FFT array axes

### DIFF
--- a/src/pyrecest/_backend/jax/fft.py
+++ b/src/pyrecest/_backend/jax/fft.py
@@ -29,6 +29,26 @@ def _normalize_real_fft_axis(axis):
     return axis
 
 
+def _normalize_fft_axes(axes):
+    """Return Python ``int`` tuples for integer array FFT axis sequences."""
+    if axes is None:
+        return None
+    if isinstance(axes, _jnp.ndarray):
+        axes_array = _np.asarray(axes)
+    elif isinstance(axes, _np.ndarray):
+        axes_array = axes
+    else:
+        return axes
+
+    if axes_array.ndim == 0:
+        return axes
+    if axes_array.ndim == 1 and _np.issubdtype(
+        axes_array.dtype, _np.integer
+    ) and not _np.issubdtype(axes_array.dtype, _np.bool_):
+        return tuple(int(axis) for axis in axes_array.tolist())
+    return axes
+
+
 def rfft(a, n=None, axis=-1, norm=None):
     return _fft.rfft(_jnp.asarray(a), n=n, axis=_normalize_real_fft_axis(axis), norm=norm)
 
@@ -38,16 +58,16 @@ def irfft(a, n=None, axis=-1, norm=None):
 
 
 def fftn(a, s=None, axes=None, norm=None):
-    return _fft.fftn(_jnp.asarray(a), s=s, axes=axes, norm=norm)
+    return _fft.fftn(_jnp.asarray(a), s=s, axes=_normalize_fft_axes(axes), norm=norm)
 
 
 def ifftn(a, s=None, axes=None, norm=None):
-    return _fft.ifftn(_jnp.asarray(a), s=s, axes=axes, norm=norm)
+    return _fft.ifftn(_jnp.asarray(a), s=s, axes=_normalize_fft_axes(axes), norm=norm)
 
 
 def fftshift(x, axes=None):
-    return _fft.fftshift(_jnp.asarray(x), axes=axes)
+    return _fft.fftshift(_jnp.asarray(x), axes=_normalize_fft_axes(axes))
 
 
 def ifftshift(x, axes=None):
-    return _fft.ifftshift(_jnp.asarray(x), axes=axes)
+    return _fft.ifftshift(_jnp.asarray(x), axes=_normalize_fft_axes(axes))

--- a/tests/backend_support/test_jax_fft_arraylike_contract.py
+++ b/tests/backend_support/test_jax_fft_arraylike_contract.py
@@ -21,6 +21,8 @@ def test_jax_fft_helpers_accept_python_lists():
     )
 
     code = """
+import jax.numpy as jnp
+
 import pyrecest.backend as backend
 
 values = [1.0, 2.0, 3.0, 4.0]
@@ -31,5 +33,16 @@ assert bool(backend.to_numpy(backend.allclose(spectrum, expected)))
 
 shifted = backend.fft.fftshift(values)
 assert backend.to_numpy(shifted).tolist() == [3.0, 4.0, 1.0, 2.0]
+
+matrix = [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]
+axes = jnp.asarray([0, 1])
+array_axes_spectrum = backend.fft.fftn(matrix, axes=axes)
+tuple_axes_spectrum = backend.fft.fftn(matrix, axes=(0, 1))
+assert bool(
+    backend.to_numpy(backend.allclose(array_axes_spectrum, tuple_axes_spectrum))
+)
+
+roundtrip = backend.fft.ifftn(array_axes_spectrum, axes=axes)
+assert bool(backend.to_numpy(backend.allclose(roundtrip, backend.asarray(matrix))))
 """
     subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
Normalize integer array axis sequences in the JAX FFT wrapper and add a focused regression for array-valued axes.