### PR TITLE
Fix PyTorch logm array-like inputs

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -236,7 +236,9 @@ class _Logm(_torch.autograd.Function):
         return _Logm._logm(backward_tensor).to(tensor.dtype)[..., :n, n:]
 
 
-logm = _Logm.apply
+def logm(x):
+    """Compute a matrix logarithm after PyRecEst-style array-like promotion."""
+    return _Logm.apply(_as_linalg_tensor(x))
 
 
 def sqrtm(x):

--- a/tests/backend_support/test_pytorch_logm_arraylike_contract.py
+++ b/tests/backend_support/test_pytorch_logm_arraylike_contract.py
@@ -1,0 +1,50 @@
+"""Regression tests for PyTorch linalg.logm array-like promotion."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+pytestmark = pytest.mark.backend_portable
+
+
+_LOGM_ARRAYLIKE_CONTRACT = """
+import torch
+import pyrecest  # noqa: F401  # registers backend compatibility hooks
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch.linalg as raw_linalg
+from pyrecest.backend import linalg
+
+
+raw_result = raw_linalg.logm([[1, 0], [0, 1]])
+assert raw_result.shape == (2, 2)
+assert raw_result.dtype.is_floating_point
+assert torch.allclose(raw_result, torch.zeros((2, 2), dtype=raw_result.dtype))
+
+public_result = linalg.logm([[1, 0], [0, 1]])
+assert public_result.shape == (2, 2)
+assert public_result.dtype.is_floating_point
+assert bool(backend.allclose(public_result, backend.zeros((2, 2), dtype=public_result.dtype)))
+
+values = torch.eye(2, dtype=torch.float64, requires_grad=True)
+grad_result = linalg.logm(values)
+grad_result.sum().backward()
+assert values.grad is not None
+assert values.grad.shape == values.shape
+assert bool(torch.isfinite(values.grad).all())
+
+print("ok")
+"""
+
+
+def test_pytorch_logm_accepts_array_like_inputs():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code("pytorch", _LOGM_ARRAYLIKE_CONTRACT)
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- wrap the PyTorch `linalg.logm` autograd function in the existing `_as_linalg_tensor` normalizer
- preserve the existing differentiable `_Logm` implementation for tensor inputs
- add a backend-portable PyTorch regression test for raw and public `logm` calls with Python-list matrix inputs

## Bug fixed
`pyrecest._backend.pytorch.linalg.logm` was exposed directly as `_Logm.apply`, so array-like or integer matrix inputs bypassed the PyTorch linalg input normalizer. Calls such as `logm([[1, 0], [0, 1]])` could fail before reaching the SciPy bridge even though neighboring PyTorch linalg helpers accept NumPy-style array-like inputs.

## Validation
- `python -m py_compile /tmp/linalg_new.py /tmp/test_pytorch_logm_arraylike_contract.py`
- Verified branch comparison against `main`: 2 commits ahead, 0 behind; changes limited to `src/pyrecest/_backend/pytorch/linalg.py` and `tests/backend_support/test_pytorch_logm_arraylike_contract.py`.

Full repository tests were not run locally because direct GitHub cloning is unavailable in this environment; CI should run the focused regression.