### PR TITLE
Normalize JAX real FFT array lengths

### DIFF
--- a/src/pyrecest/_backend/jax/fft.py
+++ b/src/pyrecest/_backend/jax/fft.py
@@ -29,12 +29,48 @@ def _normalize_real_fft_axis(axis):
     return axis
 
 
+def _normalize_real_fft_length(n):
+    """Return a Python ``int`` for integer scalar-array real FFT lengths."""
+    if n is None:
+        return None
+    if isinstance(n, _np.ndarray):
+        if (
+            n.size == 1
+            and _np.issubdtype(n.dtype, _np.integer)
+            and not _np.issubdtype(n.dtype, _np.bool_)
+        ):
+            return int(n.item())
+        return n
+    if isinstance(n, _jnp.ndarray):
+        n_dtype = _np.asarray(n).dtype
+        if (
+            n.size == 1
+            and _np.issubdtype(n_dtype, _np.integer)
+            and not _np.issubdtype(n_dtype, _np.bool_)
+        ):
+            return int(n.item())
+        return n
+    if isinstance(n, _np.integer) and not isinstance(n, _np.bool_):
+        return int(n)
+    return n
+
+
 def rfft(a, n=None, axis=-1, norm=None):
-    return _fft.rfft(_jnp.asarray(a), n=n, axis=_normalize_real_fft_axis(axis), norm=norm)
+    return _fft.rfft(
+        _jnp.asarray(a),
+        n=_normalize_real_fft_length(n),
+        axis=_normalize_real_fft_axis(axis),
+        norm=norm,
+    )
 
 
 def irfft(a, n=None, axis=-1, norm=None):
-    return _fft.irfft(_jnp.asarray(a), n=n, axis=_normalize_real_fft_axis(axis), norm=norm)
+    return _fft.irfft(
+        _jnp.asarray(a),
+        n=_normalize_real_fft_length(n),
+        axis=_normalize_real_fft_axis(axis),
+        norm=norm,
+    )
 
 
 def fftn(a, s=None, axes=None, norm=None):

--- a/tests/backend_support/test_jax_fft_array_length_contract.py
+++ b/tests/backend_support/test_jax_fft_array_length_contract.py
@@ -14,10 +14,20 @@ def test_jax_real_fft_accepts_singleton_array_lengths():
     samples = np.arange(6.0).reshape(2, 3)
     backend_samples = backend.asarray(samples)
     expected_spectrum = np.fft.rfft(samples, n=samples.shape[1], axis=1)
+    lengths = (
+        np.array(samples.shape[1]),
+        np.array([samples.shape[1]]),
+        np.int64(samples.shape[1]),
+        backend.asarray(samples.shape[1]),
+    )
 
-    for length in (np.array(samples.shape[1]), np.array([samples.shape[1]]), np.int64(samples.shape[1]), backend.asarray(samples.shape[1])):
-        actual_spectrum = _as_numpy(backend.fft.rfft(backend_samples, n=length, axis=1))
+    for length in lengths:
+        actual_spectrum = _as_numpy(
+            backend.fft.rfft(backend_samples, n=length, axis=1)
+        )
         assert np.allclose(actual_spectrum, expected_spectrum)
 
-        actual_roundtrip = _as_numpy(backend.fft.irfft(actual_spectrum, n=length, axis=1))
+        actual_roundtrip = _as_numpy(
+            backend.fft.irfft(actual_spectrum, n=length, axis=1)
+        )
         assert np.allclose(actual_roundtrip, samples)

--- a/tests/backend_support/test_jax_fft_array_length_contract.py
+++ b/tests/backend_support/test_jax_fft_array_length_contract.py
@@ -1,0 +1,23 @@
+import numpy as np
+import pyrecest.backend as backend
+import pytest
+
+
+def _as_numpy(value):
+    return np.asarray(backend.to_numpy(value))
+
+
+def test_jax_real_fft_accepts_singleton_array_lengths():
+    if backend.__backend_name__ != "jax":
+        pytest.skip("JAX-specific FFT backend contract")
+
+    samples = np.arange(6.0).reshape(2, 3)
+    backend_samples = backend.asarray(samples)
+    expected_spectrum = np.fft.rfft(samples, n=samples.shape[1], axis=1)
+
+    for length in (np.array(samples.shape[1]), np.array([samples.shape[1]]), np.int64(samples.shape[1]), backend.asarray(samples.shape[1])):
+        actual_spectrum = _as_numpy(backend.fft.rfft(backend_samples, n=length, axis=1))
+        assert np.allclose(actual_spectrum, expected_spectrum)
+
+        actual_roundtrip = _as_numpy(backend.fft.irfft(actual_spectrum, n=length, axis=1))
+        assert np.allclose(actual_roundtrip, samples)

--- a/tests/backend_support/test_jax_fft_array_length_contract.py
+++ b/tests/backend_support/test_jax_fft_array_length_contract.py
@@ -19,6 +19,7 @@ def test_jax_real_fft_accepts_singleton_array_lengths():
         np.array([samples.shape[1]]),
         np.int64(samples.shape[1]),
         backend.asarray(samples.shape[1]),
+        backend.asarray([samples.shape[1]]),
     )
 
     for length in lengths:


### PR DESCRIPTION
## Summary
- Normalize integer singleton-array `n` values before calling JAX `rfft`/`irfft`.
- Add a focused JAX regression covering NumPy scalar arrays, singleton arrays, NumPy integer scalars, and backend scalar arrays.

## Bug fixed
The JAX real FFT wrappers already normalize integer scalar-array axes, but passed `n` through unchanged. JAX rejects singleton array lengths such as `jnp.asarray([3])` with `TypeError`, so `backend.fft.rfft(..., n=backend.asarray([3]))` failed even though analogous singleton array axes were accepted by the wrapper contract.

## Validation
- `python -m py_compile /mnt/data/jax_fft_new.py`
- Local standalone JAX smoke check confirmed `rfft`/`irfft` round-trip for `np.array(3)`, `np.array([3])`, `np.int64(3)`, `jnp.asarray(3)`, and `jnp.asarray([3])`.

Full repository tests were not run locally because the sandbox cannot clone/install the repository from GitHub; CI should run the focused regression.