### PR TITLE
Preserve generic LinHypersphereCartProdDiracDistribution dimensions

### DIFF
--- a/src/pyrecest/distributions/cart_prod/lin_hypersphere_cart_prod_dirac_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/lin_hypersphere_cart_prod_dirac_distribution.py
@@ -1,14 +1,16 @@
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 from pyrecest.backend import abs, amax, asarray, linalg
 
-from ..abstract_se3_distribution import AbstractSE3Distribution
+from .abstract_lin_hypersphere_cart_prod_distribution import (
+    AbstractLinHypersphereCartProdDistribution,
+)
 from .lin_bounded_cart_prod_dirac_distribution import (
     LinBoundedCartProdDiracDistribution,
 )
 
 
 class LinHypersphereCartProdDiracDistribution(
-    LinBoundedCartProdDiracDistribution, AbstractSE3Distribution
+    LinBoundedCartProdDiracDistribution, AbstractLinHypersphereCartProdDistribution
 ):
     def __init__(self, bound_dim, d, w=None):
         d = asarray(d)
@@ -20,7 +22,11 @@ class LinHypersphereCartProdDiracDistribution(
             amax(abs(linalg.norm(d[:, : (bound_dim + 1)], None, -1) - 1), 0) < 1e-5
         ):
             raise ValueError("The hypersphere subset part of d must be normalized")
-        AbstractSE3Distribution.__init__(self)
+        AbstractLinHypersphereCartProdDistribution.__init__(
+            self,
+            bound_dim,
+            d.shape[-1] - bound_dim - 1,
+        )
         LinBoundedCartProdDiracDistribution.__init__(self, d, w)
 
     @property

--- a/tests/distributions/test_lin_hypersphere_cart_prod_dirac_distribution.py
+++ b/tests/distributions/test_lin_hypersphere_cart_prod_dirac_distribution.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+from pyrecest.distributions.cart_prod.lin_hypersphere_cart_prod_dirac_distribution import (
+    LinHypersphereCartProdDiracDistribution,
+)
+
+
+class ConcreteLinHypersphereCartProdDiracDistribution(
+    LinHypersphereCartProdDiracDistribution
+):
+    def marginalize_linear(self):
+        raise NotImplementedError
+
+
+def test_constructor_preserves_generic_hypersphere_and_linear_dimensions():
+    particles = np.array(
+        [
+            [1.0, 0.0, 2.0],
+            [0.0, 1.0, 3.0],
+        ]
+    )
+
+    dist = ConcreteLinHypersphereCartProdDiracDistribution(bound_dim=1, d=particles)
+
+    assert dist.bound_dim == 1
+    assert dist.lin_dim == 1
+    assert dist.dim == 2
+    assert dist.input_dim == particles.shape[-1]


### PR DESCRIPTION
## Summary
- Fix `LinHypersphereCartProdDiracDistribution` so it initializes via the generic `AbstractLinHypersphereCartProdDistribution` instead of hard-coding `AbstractSE3Distribution` dimensions.
- Add a regression test covering a non-SE(3) hypersphere/linear Cartesian product constructor.

## Why
The constructor accepts a generic `bound_dim`, but the previous implementation always called `AbstractSE3Distribution.__init__()`, setting `bound_dim=3`, `lin_dim=3`, `dim=6`, and `input_dim=7` even for smaller Cartesian products.

## Verification
- `python -m pytest -q /mnt/data/test_lin_hypersphere_cart_prod_dirac_distribution.py`
- `python -m ruff check --select F821,F822,F823 /opt/pyvenv/lib/python3.13/site-packages/pyrecest/distributions/cart_prod/lin_hypersphere_cart_prod_dirac_distribution.py /mnt/data/test_lin_hypersphere_cart_prod_dirac_distribution.py`