### PR TITLE
Allow zero concentration in Gauss-von-Mises distribution

### DIFF
--- a/src/pyrecest/distributions/cart_prod/gauss_von_mises_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/gauss_von_mises_distribution.py
@@ -60,22 +60,22 @@ def _validate_positive_sample_count(n) -> int:
     return count_int
 
 
-def _validate_positive_finite_scalar(value, name: str) -> float:
+def _validate_nonnegative_finite_scalar(value, name: str) -> float:
     scalar_array = np.asarray(value)
     if scalar_array.shape != ():
         raise ValueError(f"{name} must be a scalar")
 
     scalar = scalar_array.item()
     if isinstance(scalar, (bool, np.bool_)):
-        raise ValueError(f"{name} must be a positive finite scalar")
+        raise ValueError(f"{name} must be a nonnegative finite scalar")
 
     try:
         scalar_float = float(scalar)
     except (OverflowError, TypeError, ValueError) as exc:
-        raise ValueError(f"{name} must be a positive finite scalar") from exc
+        raise ValueError(f"{name} must be a nonnegative finite scalar") from exc
 
-    if not np.isfinite(scalar_float) or scalar_float <= 0.0:
-        raise ValueError(f"{name} must be a positive finite scalar")
+    if not np.isfinite(scalar_float) or scalar_float < 0.0:
+        raise ValueError(f"{name} must be a nonnegative finite scalar")
     return scalar_float
 
 
@@ -118,7 +118,7 @@ class GaussVonMisesDistribution(AbstractHypercylindricalDistribution):
             raise ValueError("Gamma and mu must have matching size")
         if not bool(allclose(Gamma, Gamma.T)):
             raise ValueError("Gamma must be symmetric")
-        kappa = _validate_positive_finite_scalar(kappa, "kappa")
+        kappa = _validate_nonnegative_finite_scalar(kappa, "kappa")
 
         AbstractHypercylindricalDistribution.__init__(self, bound_dim=1, lin_dim=n)
 
@@ -271,6 +271,10 @@ class GaussVonMisesDistribution(AbstractHypercylindricalDistribution):
             raise NotImplementedError(
                 "sample_deterministic_horwood is not supported on the JAX backend."
             )
+        if self.kappa == 0.0:
+            raise ValueError(
+                "sample_deterministic_horwood requires positive circular concentration."
+            )
         lin_dim = self.lin_dim
 
         def B(p_val, kappa_val):
@@ -336,6 +340,8 @@ class GaussVonMisesDistribution(AbstractHypercylindricalDistribution):
 
         See Horwood, Section 4.6.
         """
+        if self.kappa == 0.0:
+            raise ValueError("to_gaussian requires positive circular concentration.")
         mtmp = concatenate([array([self.alpha]), self.mu])
         top_row = hstack(
             [array([[1.0 / sqrt(array(self.kappa))]]), self.beta.reshape(1, -1)]

--- a/tests/distributions/test_gauss_von_mises_distribution.py
+++ b/tests/distributions/test_gauss_von_mises_distribution.py
@@ -91,8 +91,18 @@ class GaussVonMisesDistributionTest(unittest.TestCase):
 
         self.assertEqual(dist.kappa, 1.0)
 
+    def test_constructor_accepts_zero_kappa_uniform_limit(self):
+        dist = GaussVonMisesDistribution(2, 1.3, 3, 0, 0.001, 0.0)
+        points = array([[0.1, 1.2, 4.0], [1.5, 2.0, 3.0]])
+
+        expected_pdf = GaussianDistribution(
+            dist.mu, dist.P, check_validity=False
+        ).pdf(points[1:, :].T) / (2.0 * float(pi))
+        self.assertTrue(allclose(dist.pdf(points), expected_pdf, atol=1e-12))
+        self.assertTrue(allclose(dist.hybrid_moment(), array([0.0, 0.0, 2.0])))
+
     def test_constructor_rejects_invalid_kappa(self):
-        for kappa in (True, 0.0, -1.0, float("nan"), float("inf")):
+        for kappa in (True, -1.0, float("nan"), float("inf")):
             with self.subTest(kappa=kappa), self.assertRaisesRegex(ValueError, "kappa"):
                 GaussVonMisesDistribution(2, 1.3, 3, 0, 0.001, kappa)
 


### PR DESCRIPTION
## Summary
- Allow `GaussVonMisesDistribution` to be constructed with `kappa=0`, the uniform circular limit of the von Mises factor.
- Add a regression test that verifies the zero-concentration density factorizes as Gaussian × `1 / (2π)` and that the hybrid moment has zero circular components.
- Make Horwood sigma-point conversion and Gaussian approximation fail explicitly for `kappa=0` because those approximations divide by concentration-dependent terms.

## Testing
- Not run locally; GitHub-only change from this environment.