### PR TITLE
Fix rectangular triangular vector helper contracts

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_trapezoid_numpy_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_trapezoid_numpy_contract.py
@@ -74,3 +74,92 @@ def patch_pytorch_trapezoid_numpy_contract() -> None:
     raw_pytorch.trapezoid = trapezoid
     if getattr(backend, "__backend_name__", None) == "pytorch":
         backend.trapezoid = trapezoid
+
+
+def _patch_rectangular_pytorch_triangular_vector_contract() -> None:
+    """Patch PyTorch triangular vector helpers for rectangular matrices."""
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+
+    def _make_triangular_to_vec(helper_name, torch_index_helper, original_helper):
+        def triangular_to_vec(x, k=0):
+            x = raw_pytorch.array(x)
+            if x.ndim < 2:
+                raise ValueError("triangular vector helpers require at least two dimensions")
+            rows, cols = torch_index_helper(
+                row=x.shape[-2],
+                col=x.shape[-1],
+                offset=_operator_index(k),
+                device=x.device,
+            )
+            return x[..., rows, cols]
+
+        triangular_to_vec.__name__ = getattr(original_helper, "__name__", helper_name)
+        triangular_to_vec.__doc__ = getattr(original_helper, "__doc__", None)
+        triangular_to_vec._pyrecest_numpy_contract = True
+        triangular_to_vec._pyrecest_arraylike_contract = True
+        return triangular_to_vec
+
+    for helper_name, torch_index_helper in (
+        ("tril_to_vec", torch.tril_indices),
+        ("triu_to_vec", torch.triu_indices),
+    ):
+        original_helper = getattr(raw_pytorch, helper_name, None)
+        if original_helper is None:
+            continue
+        helper = _make_triangular_to_vec(helper_name, torch_index_helper, original_helper)
+        setattr(raw_pytorch, helper_name, helper)
+        if active_pytorch_backend:
+            setattr(backend, helper_name, helper)
+
+
+def _patch_rectangular_jax_triangular_vector_contract() -> None:
+    """Patch JAX triangular vector helpers for rectangular matrices."""
+    try:
+        import jax.numpy as jnp  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.jax as raw_jax  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - JAX backend may be unavailable
+        return
+
+    active_jax_backend = getattr(backend, "__backend_name__", None) == "jax"
+
+    def _make_triangular_to_vec(helper_name, jax_index_helper, original_helper):
+        def triangular_to_vec(x, k=0):
+            x = jnp.asarray(x)
+            if x.ndim < 2:
+                raise ValueError("triangular vector helpers require at least two dimensions")
+            rows, cols = jax_index_helper(
+                n=x.shape[-2],
+                k=_operator_index(k),
+                m=x.shape[-1],
+            )
+            return x[..., rows, cols]
+
+        triangular_to_vec.__name__ = getattr(original_helper, "__name__", helper_name)
+        triangular_to_vec.__doc__ = getattr(original_helper, "__doc__", None)
+        triangular_to_vec._pyrecest_numpy_contract = True
+        triangular_to_vec._pyrecest_arraylike_contract = True
+        return triangular_to_vec
+
+    for helper_name, jax_index_helper in (
+        ("tril_to_vec", jnp.tril_indices),
+        ("triu_to_vec", jnp.triu_indices),
+    ):
+        original_helper = getattr(raw_jax, helper_name, None)
+        if original_helper is None:
+            continue
+        helper = _make_triangular_to_vec(helper_name, jax_index_helper, original_helper)
+        setattr(raw_jax, helper_name, helper)
+        if active_jax_backend:
+            setattr(backend, helper_name, helper)
+
+
+_patch_rectangular_pytorch_triangular_vector_contract()
+_patch_rectangular_jax_triangular_vector_contract()

--- a/tests/backend_support/test_pytorch_triangular_helpers_contract.py
+++ b/tests/backend_support/test_pytorch_triangular_helpers_contract.py
@@ -47,6 +47,38 @@ for module in (backend, pytorch_backend):
 
 
 @pytest.mark.backend_portable
+def test_pytorch_triangular_helpers_accept_rectangular_matrices():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as pytorch_backend
+
+wide = [[1, 2, 3], [4, 5, 6]]
+tall = [[1, 2], [3, 4], [5, 6]]
+
+for module in (backend, pytorch_backend):
+    lower_wide = module.tril_to_vec(wide)
+    assert module.to_numpy(lower_wide).tolist() == [1, 4, 5]
+
+    upper_wide = module.triu_to_vec(wide, k=1)
+    assert module.to_numpy(upper_wide).tolist() == [2, 3, 6]
+
+    lower_tall = module.tril_to_vec(tall, k=-1)
+    assert module.to_numpy(lower_tall).tolist() == [3, 5, 6]
+
+    upper_tall = module.triu_to_vec(tall)
+    assert module.to_numpy(upper_tall).tolist() == [1, 2, 4, 6]
+"""
+    subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        env=_backend_test_env("pytorch"),
+    )
+
+
+@pytest.mark.backend_portable
 def test_raw_pytorch_triangular_helpers_with_numpy_public_backend():
     if importlib.util.find_spec("torch") is None:
         pytest.skip("torch is not installed")
@@ -59,6 +91,7 @@ assert getattr(backend, "__backend_name__", None) == "numpy"
 
 matrix = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
+assert pytorch_backend.vec_to_diag([1, 2, 3]).device.type == "cpu"
 diag = pytorch_backend.vec_to_diag([1, 2, 3])
 assert pytorch_backend.to_numpy(diag).tolist() == [[1, 0, 0], [0, 2, 0], [0, 0, 3]]
 
@@ -67,6 +100,10 @@ assert pytorch_backend.to_numpy(lower).tolist() == [1, 4, 5, 7, 8, 9]
 
 upper = pytorch_backend.triu_to_vec(matrix, k=1)
 assert pytorch_backend.to_numpy(upper).tolist() == [2, 3, 6]
+
+wide = [[1, 2, 3], [4, 5, 6]]
+assert pytorch_backend.to_numpy(pytorch_backend.tril_to_vec(wide)).tolist() == [1, 4, 5]
+assert pytorch_backend.to_numpy(pytorch_backend.triu_to_vec(wide, k=1)).tolist() == [2, 3, 6]
 """
     subprocess.run(
         [sys.executable, "-c", code],

--- a/tests/backend_support/test_pytorch_triangular_helpers_contract.py
+++ b/tests/backend_support/test_pytorch_triangular_helpers_contract.py
@@ -69,7 +69,7 @@ for module in (backend, pytorch_backend):
     assert module.to_numpy(lower_tall).tolist() == [3, 5, 6]
 
     upper_tall = module.triu_to_vec(tall)
-    assert module.to_numpy(upper_tall).tolist() == [1, 2, 4, 6]
+    assert module.to_numpy(upper_tall).tolist() == [1, 2, 4]
 """
     subprocess.run(
         [sys.executable, "-c", code],


### PR DESCRIPTION
## Summary

- fix PyTorch triangular vector helpers so `tril_to_vec` / `triu_to_vec` use both trailing matrix dimensions for rectangular inputs
- apply the same rectangular-index contract to the raw/public JAX triangular vector helpers
- add regression coverage for rectangular wide and tall matrices under the PyTorch public backend and raw PyTorch with NumPy as the public backend

## Rationale

The existing stability patch derived triangular indices from `x.shape[-1]` only. For non-square matrices this can either miss valid entries or generate row indices outside the number of rows. The updated helpers use rectangular triangular index APIs with explicit row and column dimensions.

## Validation

- Added subprocess regression tests in `tests/backend_support/test_pytorch_triangular_helpers_contract.py`
- Could not run the repository test suite locally because the execution sandbox cannot clone or install from GitHub directly in this session.