### PR TITLE
Fix PyTorch logm array-like inputs

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -236,7 +236,9 @@ class _Logm(_torch.autograd.Function):
         return _Logm._logm(backward_tensor).to(tensor.dtype)[..., :n, n:]
 
 
-logm = _Logm.apply
+def logm(x):
+    """Compute the matrix logarithm after PyRecEst-style array-like promotion."""
+    return _Logm.apply(_as_linalg_tensor(x))
 
 
 def sqrtm(x):


### PR DESCRIPTION
## Summary
- Normalize PyTorch `linalg.logm` inputs through `_as_linalg_tensor` before invoking the existing custom autograd implementation.
- Preserve the current tensor gradient path while accepting Python-list and integer matrix inputs.

## Validation
- Syntax-checked the modified linalg module locally.
- Compared the branch against `main`: 1 commit ahead, 0 behind; only `src/pyrecest/_backend/pytorch/linalg.py` changed.

CI should run the existing focused PyTorch logm regression.