### PR TITLE
Fix hypersphere subset Dirac marginalization

### DIFF
--- a/src/pyrecest/distributions/cart_prod/lin_hypersphere_subset_dirac_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/lin_hypersphere_subset_dirac_distribution.py
@@ -1,8 +1,11 @@
 from typing import Union
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import int32, int64
+from pyrecest.backend import asarray, int32, int64
 
+from ..hypersphere_subset.hyperspherical_dirac_distribution import (
+    HypersphericalDiracDistribution,
+)
 from .abstract_lin_hyperhemisphere_cart_prod_distribution import (
     AbstractLinHypersphereSubsetCartProdDistribution,
 )
@@ -16,7 +19,14 @@ class LinHypersphereSubsetCartProdDiracDistribution(
     AbstractLinHypersphereSubsetCartProdDistribution,
 ):
     def __init__(self, bound_dim: Union[int, int32, int64], d, w=None):
+        d = asarray(d)
         AbstractLinHypersphereSubsetCartProdDistribution.__init__(
             self, bound_dim, d.shape[-1] - bound_dim - 1
         )
         LinBoundedCartProdDiracDistribution.__init__(self, d=d, w=w)
+
+    def marginalize_linear(self):
+        return HypersphericalDiracDistribution(
+            self.d[:, : self.bound_dim + 1],  # noqa: E203
+            self.w,
+        )

--- a/tests/distributions/test_lin_hypersphere_subset_dirac_distribution.py
+++ b/tests/distributions/test_lin_hypersphere_subset_dirac_distribution.py
@@ -1,0 +1,34 @@
+import numpy.testing as npt
+
+from pyrecest.backend import array
+from pyrecest.distributions.cart_prod.lin_hypersphere_subset_dirac_distribution import (
+    LinHypersphereSubsetCartProdDiracDistribution,
+)
+from pyrecest.distributions.hypersphere_subset.hyperspherical_dirac_distribution import (
+    HypersphericalDiracDistribution,
+)
+from pyrecest.distributions.nonperiodic.linear_dirac_distribution import (
+    LinearDiracDistribution,
+)
+
+
+def test_constructor_accepts_array_like_inputs_and_marginalizes():
+    d = [[1.0, 0.0, 2.0], [0.0, 1.0, 4.0]]
+    w = [0.25, 0.75]
+
+    dist = LinHypersphereSubsetCartProdDiracDistribution(1, d, w)
+    bounded = dist.marginalize_linear()
+    linear = dist.marginalize_periodic()
+
+    npt.assert_allclose(dist.d, array(d))
+    npt.assert_allclose(dist.w, array(w))
+    assert dist.bound_dim == 1
+    assert dist.lin_dim == 1
+
+    assert isinstance(bounded, HypersphericalDiracDistribution)
+    npt.assert_allclose(bounded.d, array([[1.0, 0.0], [0.0, 1.0]]))
+    npt.assert_allclose(bounded.w, array(w))
+
+    assert isinstance(linear, LinearDiracDistribution)
+    npt.assert_allclose(linear.d, array([[2.0], [4.0]]))
+    npt.assert_allclose(linear.w, array(w))


### PR DESCRIPTION
## Summary
- implement `marginalize_linear` for `LinHypersphereSubsetCartProdDiracDistribution` so the exported Cartesian-product Dirac class is instantiable and splits hypersphere/linear coordinates correctly
- coerce constructor samples with backend `asarray` before shape-based dimension bookkeeping, matching sibling Cartesian-product Dirac constructors
- add a focused regression covering array-like constructor inputs and both marginalizations

## Bug fixed
`LinHypersphereSubsetCartProdDiracDistribution` inherits the abstract `marginalize_linear` contract from `LinBoundedCartProdDiracDistribution`, but did not implement it. Instantiating the public class therefore failed as an abstract class instead of producing a hypersphere/linear product Dirac. The constructor also read `d.shape` before backend coercion, so list inputs could not satisfy the same array-like constructor contract as `HypercylindricalDiracDistribution`.

## Validation
- Syntax-checked the patched source and regression test text with Python `compile()`.
- Compared the branch against `main`: 2 commits ahead, 0 behind; changes are limited to the class implementation and focused regression test.
- Full pytest was not run in this sandbox/connector environment.