### PR TITLE
Fix von Mises set_mean copy semantics

### DIFF
--- a/src/pyrecest/distributions/circle/von_mises_distribution.py
+++ b/src/pyrecest/distributions/circle/von_mises_distribution.py
@@ -1,4 +1,5 @@
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
+import copy
 import math
 from numbers import Integral
 
@@ -81,14 +82,16 @@ class VonMisesDistribution(AbstractCircularDistribution):
         )
 
     def set_mean(self, mu):
-        """
-        Set the mean direction of the distribution.
+        """Return a copy with a replaced mean direction.
 
-        Parameters:
+        Parameters
+        ----------
         mu : scalar
-            New mean direction to set.
+            New mean direction.
         """
-        self.mu = mu
+        new_dist = copy.deepcopy(self)
+        new_dist.mu = mu
+        return new_dist
 
     @staticmethod
     def besselratio(nu, kappa):

--- a/tests/distributions/test_von_mises_distribution.py
+++ b/tests/distributions/test_von_mises_distribution.py
@@ -24,6 +24,17 @@ class TestVonMisesDistribution(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     VonMisesDistribution(0.0, kappa)
 
+    def test_set_mean_returns_shifted_copy(self):
+        dist = VonMisesDistribution(array(0.3), array(2.0))
+
+        shifted = dist.set_mean(array(1.1))
+
+        self.assertIsInstance(shifted, VonMisesDistribution)
+        self.assertIsNot(shifted, dist)
+        npt.assert_allclose(float(dist.mu), 0.3)
+        npt.assert_allclose(float(shifted.mu), 1.1)
+        npt.assert_allclose(float(shifted.kappa), 2.0)
+
     def test_besselratio_remains_finite_for_large_concentration(self):
         ratio = VonMisesDistribution.besselratio(0, 1000.0)
 


### PR DESCRIPTION
## Summary
- make `VonMisesDistribution.set_mean` return a copied distribution with the replaced mean direction
- preserve the original distribution and its concentration parameter
- add a regression test for the setter contract

## Testing
- Not run locally; repository access was via GitHub connector only.