### PR TITLE
Validate EOT shape sample counts

### DIFF
--- a/src/pyrecest/evaluation/eot_shape_database.py
+++ b/src/pyrecest/evaluation/eot_shape_database.py
@@ -1,4 +1,6 @@
 # pylint: disable=no-name-in-module,no-member
+from operator import index as _operator_index
+
 from pyrecest.backend import array, cos, linspace, pi, random, sin, to_numpy
 from shapely.geometry import LineString, MultiLineString, Point, Polygon
 from shapely.ops import unary_union
@@ -14,6 +16,21 @@ def _points_to_array(points):
     return array([(point.x, point.y) for point in points])
 
 
+def _validate_nonnegative_sample_count(num_points) -> int:
+    message = "num_points must be a nonnegative integer."
+    if isinstance(num_points, bool):
+        raise ValueError(message)
+
+    try:
+        count = _operator_index(num_points)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError(message) from exc
+
+    if count < 0:
+        raise ValueError(message)
+    return int(count)
+
+
 class PolygonWithSampling(Polygon):  # pylint: disable=abstract-method
     __slots__ = Polygon.__slots__
 
@@ -24,6 +41,7 @@ class PolygonWithSampling(Polygon):  # pylint: disable=abstract-method
         return polygon
 
     def sample_on_boundary(self, num_points: int):
+        num_points = _validate_nonnegative_sample_count(num_points)
         points = []
         perimeter = self.length
 
@@ -48,6 +66,7 @@ class PolygonWithSampling(Polygon):  # pylint: disable=abstract-method
         return _points_to_array(points)
 
     def sample_within(self, num_points: int):
+        num_points = _validate_nonnegative_sample_count(num_points)
         min_x, min_y, max_x, max_y = self.bounds
         points = []
 

--- a/tests/test_eot_shape_sample_counts.py
+++ b/tests/test_eot_shape_sample_counts.py
@@ -1,0 +1,14 @@
+import pytest
+
+from pyrecest.evaluation.eot_shape_database import StarShapedPolygon
+
+
+def test_eot_shape_sampling_rejects_negative_counts():
+    polygon = StarShapedPolygon(
+        [(-0.5, -0.5), (-0.5, 0.5), (0.5, 0.5), (0.5, -0.5)]
+    )
+
+    with pytest.raises(ValueError, match="nonnegative integer"):
+        polygon.sample_on_boundary(-1)
+    with pytest.raises(ValueError, match="nonnegative integer"):
+        polygon.sample_within(-1)


### PR DESCRIPTION
## Summary
- Reject negative, boolean, and non-integer sample counts in EOT shape sampling helpers
- Preserve existing zero-sample behavior returning an empty `(0, 2)` coordinate array
- Add a regression test for negative sample counts

## Rationale
`sample_on_boundary(-1)` and `sample_within(-1)` previously returned empty arrays because `range(-1)` performs no iterations. This silently accepts invalid input and can hide caller-side bugs.

## Tests
- Added `tests/test_eot_shape_sample_counts.py`

I could not run the repository test suite locally because the execution container has no direct network access to clone/install the repository dependencies from GitHub; changes were made through the GitHub connector.