### PR TITLE
Fix PyTorch linalg logm array-like inputs

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -460,4 +460,4 @@ def polar(a, side="right"):
     func = _np.vectorize(_scipy.linalg.polar, signature=signature, excluded=["side"])
     unitary, hermitian = func(_as_numpy_no_grad(a), side=side)
 
-    return _torch_as_like(unitary, a)
+    return _torch_as_like(unitary, a), _torch_as_like(hermitian, a)

--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -236,7 +236,9 @@ class _Logm(_torch.autograd.Function):
         return _Logm._logm(backward_tensor).to(tensor.dtype)[..., :n, n:]
 
 
-logm = _Logm.apply
+def logm(x):
+    """Compute the matrix logarithm after PyRecEst-style array-like promotion."""
+    return _Logm.apply(_as_linalg_tensor(x))
 
 
 def sqrtm(x):
@@ -458,4 +460,4 @@ def polar(a, side="right"):
     func = _np.vectorize(_scipy.linalg.polar, signature=signature, excluded=["side"])
     unitary, hermitian = func(_as_numpy_no_grad(a), side=side)
 
-    return _torch_as_like(unitary, a), _torch_as_like(hermitian, a)
+    return _torch_as_like(unitary, a)

--- a/tests/backend_support/test_pytorch_linalg_logm_arraylike_contract.py
+++ b/tests/backend_support/test_pytorch_linalg_logm_arraylike_contract.py
@@ -1,0 +1,24 @@
+"""Regression tests for PyTorch linalg matrix logarithm input coercion."""
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+def test_pytorch_linalg_logm_accepts_array_like_integer_matrix():
+    pytest.importorskip("torch")
+
+    code = """
+import torch
+
+from pyrecest.backend import linalg
+
+result = linalg.logm([[1, 0], [0, 1]])
+expected = torch.zeros((2, 2), dtype=result.dtype)
+
+assert torch.is_tensor(result)
+assert result.dtype.is_floating_point
+assert torch.allclose(result, expected)
+"""
+    result = run_backend_code("pytorch", code)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Wrap PyTorch `linalg.logm` with the existing `_as_linalg_tensor` normalizer before the custom autograd function is invoked.
- Preserve the existing tensor/autograd behavior.
- Add a focused PyTorch backend regression test for Python-list integer matrix input.

## Bug fixed
The PyTorch linalg backend exported `logm` directly as `_Logm.apply`, while neighboring linalg helpers first coerce PyRecEst-style array-like inputs. Under the PyTorch backend, `linalg.logm([[1, 0], [0, 1]])` could therefore fail because a Python list reached the custom autograd function instead of a tensor.

## Validation
- Syntax-compiled the modified linalg content and new test content locally.
- Compared branch with `main`: 3 commits ahead, 0 behind; only the linalg helper and new regression test changed.