### PR TITLE
Reject boolean fftconvolve axes in PyTorch backend

### DIFF
--- a/src/pyrecest/_backend/pytorch/signal.py
+++ b/src/pyrecest/_backend/pytorch/signal.py
@@ -5,11 +5,15 @@ _AXIS_TYPE_ERROR = "axes must be None, an integer, or a sequence of integers"
 
 
 def _coerce_axis(axis):
+    if isinstance(axis, (bool, _np.bool_)):
+        raise TypeError(_AXIS_TYPE_ERROR)
     try:
         axis_array = _np.asarray(axis)
     except (TypeError, ValueError) as exc:
         raise TypeError(_AXIS_TYPE_ERROR) from exc
     if axis_array.shape != ():
+        raise TypeError(_AXIS_TYPE_ERROR)
+    if _np.issubdtype(axis_array.dtype, _np.bool_):
         raise TypeError(_AXIS_TYPE_ERROR)
     try:
         return int(axis_array.item().__index__())

--- a/tests/backend_support/test_pytorch_fftconvolve_axes_validation.py
+++ b/tests/backend_support/test_pytorch_fftconvolve_axes_validation.py
@@ -27,7 +27,7 @@ def test_pytorch_fftconvolve_accepts_scalar_array_axis():
 
 @pytest.mark.parametrize(
     "axes",
-    ["0", np.array(0.0)],
+    ["0", np.array(0.0), True, np.bool_(True), np.array(True)],
 )
 def test_pytorch_fftconvolve_rejects_non_integer_axes(axes):
     _skip_unless_pytorch()


### PR DESCRIPTION
## Summary
- Reject boolean scalar axes in the PyTorch `signal.fftconvolve` axis normalizer instead of treating them as integer axes.
- Extend the existing PyTorch axes-validation regression to cover Python bool, NumPy bool scalar, and 0-D NumPy bool-array inputs.

## Bug fixed
`_coerce_axis()` normalized boolean axes through `__index__()`, so `axes=True`/`np.bool_(True)` could silently select an integer axis. Boolean axes are not valid integer axis specifiers under the PyRecEst backend contract, so they should stay on the same validation path as other non-integer axes.

## Validation
- `python -m py_compile /tmp/pytorch_signal_new.py /tmp/test_pytorch_fftconvolve_axes_validation_new.py`
- Local extracted smoke check for `_normalize_axes`: `np.array(0)` is still accepted, while Python/NumPy boolean axes are rejected.
- Compared branch against `main`: 2 commits ahead, 0 behind; changes are limited to `src/pyrecest/_backend/pytorch/signal.py` and `tests/backend_support/test_pytorch_fftconvolve_axes_validation.py`.