### PR TITLE
Validate hypertoroidal Dirac explicit dimensions

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py
@@ -40,14 +40,42 @@ class HypertoroidalDiracDistribution(
     def __init__(self, d, w=None, dim: int | None = None):
         """Can set dim manually to tell apart number of samples vs dimension for 1-D arrays."""
         d = array(d)
-        if dim is None:
-            if d.ndim > 1:
-                dim = d.shape[-1]
-            else:
-                raise ValueError("Cannot automatically determine dimension.")
+        d, dim = self._normalize_dirac_locations_and_dim(d, dim)
 
         AbstractHypertoroidalDistribution.__init__(self, dim)
         AbstractDiracDistribution.__init__(self, atleast_1d(mod(d, 2.0 * pi)), w=w)
+
+    @staticmethod
+    def _validate_explicit_dim(dim) -> int:
+        if isinstance(dim, bool) or not isinstance(dim, Integral) or int(dim) <= 0:
+            raise ValueError("dim must be a positive integer.")
+        return int(dim)
+
+    @classmethod
+    def _normalize_dirac_locations_and_dim(cls, d, dim: int | None):
+        if dim is None:
+            if d.ndim > 1:
+                return d, int(d.shape[-1])
+            raise ValueError("Cannot automatically determine dimension.")
+
+        dim = cls._validate_explicit_dim(dim)
+        if d.ndim == 0:
+            if dim != 1:
+                raise ValueError("Scalar Dirac locations require dim=1.")
+        elif d.ndim == 1:
+            if dim > 1:
+                if d.shape[0] != dim:
+                    raise ValueError(
+                        "One-dimensional Dirac locations must have length "
+                        f"{dim} when dim={dim}."
+                    )
+                d = reshape(d, (1, dim))
+        elif d.shape[-1] != dim:
+            raise ValueError(
+                "Dirac locations have trailing dimension "
+                f"{d.shape[-1]}, but dim={dim}."
+            )
+        return d, dim
 
     @staticmethod
     def from_distribution(

--- a/tests/distributions/test_hypertoroidal_dirac_distribution.py
+++ b/tests/distributions/test_hypertoroidal_dirac_distribution.py
@@ -64,6 +64,29 @@ class TestHypertoroidalDiracDistribution(TestAbstractDiracDistribution):
         self.assertEqual(dist.dim, 1)
         npt.assert_allclose(dist.d, array([0.1, 0.2, 0.3]))
 
+    def test_init_treats_one_dimensional_locations_as_one_multivariate_sample(self):
+        dist = HypertoroidalDiracDistribution([0.1, 0.2], dim=2)
+
+        self.assertEqual(dist.dim, 2)
+        npt.assert_allclose(dist.d, array([[0.1, 0.2]]))
+        npt.assert_allclose(dist.w, array([1.0]))
+
+    def test_init_rejects_invalid_explicit_dim(self):
+        for dim in (True, 0, -1, 1.5):
+            with self.subTest(dim=dim):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
+                    HypertoroidalDiracDistribution([0.1], dim=dim)
+
+    def test_init_rejects_explicit_dim_location_mismatch(self):
+        with self.assertRaisesRegex(ValueError, "trailing dimension"):
+            HypertoroidalDiracDistribution([[0.1, 0.2]], dim=1)
+
+        with self.assertRaisesRegex(ValueError, "length 3"):
+            HypertoroidalDiracDistribution([0.1, 0.2], dim=3)
+
+        with self.assertRaisesRegex(ValueError, "Scalar"):
+            HypertoroidalDiracDistribution(0.1, dim=2)
+
     def test_from_distribution_sampling_1d(self):
         n_particles = np.int64(5)
         vm = VonMisesDistribution(array(0.2), array(1.5))


### PR DESCRIPTION
## Summary
- Validate explicit `dim` values in `HypertoroidalDiracDistribution`.
- Reject scalar, 1-D, and multi-dimensional Dirac location inputs whose coordinate shape is inconsistent with the requested dimension.
- Treat a 1-D location vector with `dim > 1` as one multivariate Dirac sample, matching the constructor's disambiguation intent.

## Bug fixed
`HypertoroidalDiracDistribution([[0.1, 0.2]], dim=1)` could create an internally inconsistent distribution with `dim == 1` but two-coordinate particles. Conversely, `[0.1, 0.2], dim=2` was still interpreted as two 1-D particles instead of one 2-D sample, despite the explicit `dim` argument being intended to disambiguate 1-D arrays.

## Validation
- `python -m py_compile /tmp/hypertoroidal_dirac_distribution.py /tmp/test_hypertoroidal_dirac_distribution.py`
- Compared branch against current `main`: 2 commits ahead, 0 behind; changed files are limited to the hypertoroidal Dirac implementation and its regression tests.

Full repository tests were not run locally because direct repository checkout/network access is unavailable in this environment.