### PR TITLE
Validate covariance symmetry in support-point helpers

### DIFF
--- a/src/pyrecest/sampling/support_points.py
+++ b/src/pyrecest/sampling/support_points.py
@@ -98,6 +98,12 @@ def _as_point_batch(
     raise ValueError(f"{name} must have shape (dim,) or (count, dim).")
 
 
+def _ensure_symmetric_covariance_batch(name: str, array: np.ndarray) -> np.ndarray:
+    if not np.allclose(array, np.swapaxes(array, -1, -2), rtol=1e-10, atol=1e-12):
+        raise ValueError(f"{name} must be symmetric.")
+    return array
+
+
 def _as_covariance_batch(
     name: str, covariance: np.ndarray | Sequence[Sequence[float]]
 ) -> tuple[np.ndarray, bool]:
@@ -105,12 +111,14 @@ def _as_covariance_batch(
     if array.ndim == 2:
         if array.shape[0] != array.shape[1] or array.shape[0] < 1:
             raise ValueError(f"{name} must be a non-empty square matrix.")
+        array = _ensure_symmetric_covariance_batch(name, array)
         return array.reshape(1, array.shape[0], array.shape[1]), True
     if array.ndim == 3:
         if array.shape[0] < 1 or array.shape[1] != array.shape[2] or array.shape[1] < 1:
             raise ValueError(
                 f"{name} must have shape (count, dim, dim) with square matrices."
             )
+        array = _ensure_symmetric_covariance_batch(name, array)
         return array, False
     raise ValueError(f"{name} must have shape (dim, dim) or (count, dim, dim).")
 
@@ -262,8 +270,7 @@ def ellipsoid_sigma_points(
     """Return support points at one or more Mahalanobis radii.
 
     The center is included at most once.  Single inputs return
-    ``(support_point_count, dim)``; batched inputs return
-    ``(count, support_point_count, dim)``.
+    ``(support_point_count, dim)``; batched inputs return ``(count, support_point_count, dim)``.
     """
 
     include_center = _as_bool_scalar("include_center", include_center)

--- a/tests/sampling/test_support_points_covariance_symmetry.py
+++ b/tests/sampling/test_support_points_covariance_symmetry.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pyrecest.sampling import (
+    ellipsoid_axis_offsets,
+    ellipsoid_sigma_points,
+    mahalanobis_support_points,
+)
+
+
+@pytest.mark.parametrize(
+    "bad_covariance",
+    [
+        np.asarray([[1.0, 0.25], [0.5, 1.0]]),
+        np.asarray(
+            [
+                [[1.0, 0.0], [0.0, 1.0]],
+                [[2.0, -0.1], [0.1, 2.0]],
+            ]
+        ),
+    ],
+)
+def test_ellipsoid_axis_offsets_reject_nonsymmetric_covariance(
+    bad_covariance: np.ndarray,
+) -> None:
+    with pytest.raises(ValueError, match="symmetric"):
+        ellipsoid_axis_offsets(bad_covariance)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda covariance: ellipsoid_sigma_points([0.0, 0.0], covariance),
+        lambda covariance: mahalanobis_support_points(
+            [0.0, 0.0], covariance, [[1.0, 0.0]]
+        ),
+    ],
+)
+def test_covariance_ellipsoid_helpers_reject_nonsymmetric_covariance(factory) -> None:
+    bad_covariance = np.asarray([[1.0, 0.25], [0.5, 1.0]])
+
+    with pytest.raises(ValueError, match="symmetric"):
+        factory(bad_covariance)


### PR DESCRIPTION
## Summary
- reject non-symmetric covariance matrices before using `np.linalg.eigh` in support-point helpers
- apply the check to both single and batched covariance inputs
- add regression coverage for `ellipsoid_axis_offsets`, `ellipsoid_sigma_points`, and `mahalanobis_support_points`

## Rationale
The support-point covariance helpers model covariance ellipsoids, but previously accepted non-symmetric square matrices. Since `np.linalg.eigh` assumes Hermitian/symmetric input and effectively interprets one triangle, asymmetric inputs could silently produce misleading support points instead of failing fast.

## Testing
- Not run locally; the execution container cannot resolve `github.com`, so I could not clone/install the repository here.
- Added focused pytest regression tests under `tests/sampling/test_support_points_covariance_symmetry.py`.