### PR TITLE
Fix PyTorch stack and concatenate device contract

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_stack_helpers_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_stack_helpers_device_contract.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib
 
 
-_STACK_HELPER_NAMES = ("hstack", "vstack", "column_stack", "dstack")
+_STACK_HELPER_NAMES = ("concatenate", "stack", "hstack", "vstack", "column_stack", "dstack")
 
 
 def _raw_pytorch_module():
@@ -40,11 +40,25 @@ def _tensor_sequence(raw_pytorch, torch_module, values):
         if device is not None and tensor.device != device:
             tensor = tensor.to(device=device)
         tensors.append(tensor)
-    return tensors
+    if not tensors:
+        return tensors
+    return raw_pytorch.convert_to_wider_dtype(tensors)
 
 
 def _build_stack_helpers(raw_pytorch, torch_module):
     """Build NumPy-style PyTorch stack helpers with consistent devices."""
+
+    def concatenate(seq, axis=0, out=None):
+        tensors = _tensor_sequence(raw_pytorch, torch_module, seq)
+        return torch_module.cat(tensors, dim=axis, out=out)
+
+    def stack(seq, axis=0, out=None, *, dim=None):
+        if dim is not None:
+            if axis not in (0, dim):
+                raise TypeError("stack() got both 'axis' and 'dim'")
+            axis = dim
+        tensors = _tensor_sequence(raw_pytorch, torch_module, seq)
+        return torch_module.stack(tensors, dim=axis, out=out)
 
     def hstack(tup):
         tensors = [
@@ -78,6 +92,8 @@ def _build_stack_helpers(raw_pytorch, torch_module):
         return torch_module.cat(tensors, dim=2)
 
     return {
+        "concatenate": concatenate,
+        "stack": stack,
         "hstack": hstack,
         "vstack": vstack,
         "column_stack": column_stack,

--- a/tests/backend_support/test_pytorch_stack_concat_device_contract.py
+++ b/tests/backend_support/test_pytorch_stack_concat_device_contract.py
@@ -1,0 +1,47 @@
+"""Regression tests for PyTorch stack/concatenate device normalization."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+_STACK_CONCAT_META_DEVICE_CHECK = """
+import pyrecest
+import torch
+
+meta = torch.empty((1,), device="meta")
+
+{backend_import}
+
+stacked = backend.stack(([1.0], meta), axis=0)
+concatenated = backend.concatenate(([1.0], meta), axis=0)
+
+assert stacked.device.type == "meta"
+assert tuple(stacked.shape) == (2, 1)
+assert concatenated.device.type == "meta"
+assert tuple(concatenated.shape) == (2,)
+"""
+
+
+def test_raw_pytorch_stack_and_concatenate_preserve_meta_device():
+    pytest.importorskip("torch")
+
+    code = _STACK_CONCAT_META_DEVICE_CHECK.format(
+        backend_import="import pyrecest._backend.pytorch as backend"
+    )
+    result = run_backend_code("numpy", code)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_public_pytorch_stack_and_concatenate_preserve_meta_device():
+    pytest.importorskip("torch")
+
+    code = _STACK_CONCAT_META_DEVICE_CHECK.format(
+        backend_import="import pyrecest.backend as backend"
+    )
+    result = run_backend_code("pytorch", code)
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Extend the existing PyTorch stack-helper device compatibility hook to cover `stack` and `concatenate`, not only hstack/vstack/column_stack/dstack.
- Normalize all sequence operands onto a preferred existing tensor device before dispatching to `torch.stack`/`torch.cat`.
- Preserve the previous dtype-widening behavior for normalized tensor sequences.
- Add subprocess regressions for both raw PyTorch helpers under the NumPy public backend and the active public PyTorch backend.

## Bug fixed
`pyrecest._backend.pytorch.stack` / `concatenate` and the public PyTorch backend facade still used the raw tensor sequence conversion path. Calls mixing NumPy-style array-like operands with an existing non-CPU or symbolic tensor, e.g. a `meta` tensor, could therefore call Torch with tensors on different devices and fail. The neighboring stack helpers already had device normalization; this applies the same contract to the generic sequence helpers.

## Validation
- Syntax-checked the modified hook and new regression test locally with `python -m py_compile`.
- Full pytest was not run locally because the execution environment cannot clone GitHub; CI should run the added backend-support subprocess tests.