### PR TITLE
Add Von Mises set_mode for circular identity updates

### DIFF
--- a/src/pyrecest/distributions/circle/von_mises_distribution.py
+++ b/src/pyrecest/distributions/circle/von_mises_distribution.py
@@ -93,6 +93,15 @@ class VonMisesDistribution(AbstractCircularDistribution):
         new_dist.mu = mu
         return new_dist
 
+    def set_mode(self, mode):
+        """Return a copy with a replaced mode direction.
+
+        For a von Mises distribution, the mode and mean direction are both
+        represented by ``mu``.  The zero-concentration case is uniform, where
+        setting ``mu`` still preserves the distribution family and API contract.
+        """
+        return self.set_mean(mode)
+
     @staticmethod
     def besselratio(nu, kappa):
         return ive(nu + 1, kappa) / ive(nu, kappa)

--- a/tests/filters/test_circular_particle_filter.py
+++ b/tests/filters/test_circular_particle_filter.py
@@ -127,6 +127,22 @@ class CircularParticleFilterTest(unittest.TestCase):
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Von Mises update regression uses the NumPy SciPy-backed pdf.",
+    )
+    def test_update_identity_accepts_von_mises_noise(self):
+        random.seed(0)
+        self.filter.filter_state = self.dist
+        measurement_noise = VonMisesDistribution(array(0.0), array(2.0))
+
+        self.filter.update_identity(measurement_noise, array(1.0))
+
+        updated = self.filter.filter_state
+        self.assertIsInstance(updated, CircularDiracDistribution)
+        self.assertEqual(updated.dim, 1)
+        npt.assert_array_almost_equal(measurement_noise.mu, array(0.0))
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
         reason="Not supported on current backend",
     )
     def test_association_likelihood(self):


### PR DESCRIPTION
## Summary
- Add `VonMisesDistribution.set_mode()` as a copy-preserving alias for updating its circular mode/mean direction.
- Add a regression to `CircularParticleFilter` covering `update_identity()` with Von Mises measurement noise.

## Bug fixed
`AbstractParticleFilter.update_identity()` recenters measurement noise via `meas_noise.set_mode(measurement)`. `VonMisesDistribution` is a natural circular measurement-noise distribution and already has `set_mean()`, but inherited the abstract `set_mode()` implementation, which raises `NotImplementedError`. This made `CircularParticleFilter.update_identity(VonMisesDistribution(...), measurement)` fail before likelihood evaluation.

## Validation
- `python -m py_compile /tmp/von_mises_distribution_new.py /tmp/test_circular_particle_filter_von_mises_update.py`
- Compared the PR branch against current `main`: 2 commits ahead, 0 behind; changed files are limited to the Von Mises distribution and circular particle filter regression test.

Full repository tests were not run locally in this environment.