### PR TITLE
Fix JAX one_hot out-of-range labels

### DIFF
--- a/src/pyrecest/backend_support/_jax_one_hot_bounds_contract.py
+++ b/src/pyrecest/backend_support/_jax_one_hot_bounds_contract.py
@@ -1,0 +1,60 @@
+"""JAX ``one_hot`` bounds compatibility hook."""
+
+from __future__ import annotations
+
+from operator import index as _operator_index
+
+
+def patch_jax_one_hot_bounds_contract() -> None:
+    """Patch raw/public JAX ``one_hot`` to zero labels outside the class range."""
+    try:
+        import jax.numpy as jnp  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.jax as jax_backend  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - JAX backend may be unavailable
+        return
+
+    original_one_hot = getattr(jax_backend, "one_hot", None)
+    if original_one_hot is None:
+        return
+    if getattr(original_one_hot, "_pyrecest_label_bounds_contract", False):
+        if getattr(backend, "__backend_name__", None) == "jax":
+            backend.one_hot = original_one_hot
+        return
+
+    def _uint8_one_hot(labels, num_classes):
+        num_classes = _operator_index(num_classes)
+        labels = jnp.asarray(labels)
+        if labels.dtype.kind not in "iu":
+            raise TypeError("one_hot labels must be integer-valued")
+
+        valid = (labels >= 0) & (labels < num_classes)
+        safe_labels = jnp.where(valid, labels, 0)
+        encoded = jnp.eye(num_classes, dtype=jnp.uint8)[safe_labels]
+        return jnp.where(valid[..., None], encoded, jnp.zeros_like(encoded))
+
+    def one_hot(labels=None, num_classes=None, *, indices=None, depth=None):
+        if indices is not None:
+            if labels is not None:
+                raise TypeError("one_hot() got both 'labels' and 'indices'")
+            labels = indices
+        if depth is not None:
+            if num_classes is not None and num_classes != depth:
+                raise TypeError("one_hot() got both 'num_classes' and 'depth'")
+            num_classes = depth
+        if labels is None:
+            raise TypeError("one_hot() missing required argument 'labels'")
+        if num_classes is None:
+            raise TypeError("one_hot() missing required argument 'num_classes'")
+        return _uint8_one_hot(labels, num_classes)
+
+    one_hot.__name__ = getattr(original_one_hot, "__name__", "one_hot")
+    one_hot.__doc__ = getattr(original_one_hot, "__doc__", None)
+    one_hot._pyrecest_backend_contract = True
+    one_hot._pyrecest_label_bounds_contract = True
+    jax_backend.one_hot = one_hot
+    if getattr(backend, "__backend_name__", None) == "jax":
+        backend.one_hot = one_hot
+
+
+__all__ = ["patch_jax_one_hot_bounds_contract"]

--- a/src/pyrecest/backend_support/_pytorch_one_hot_scalar_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_one_hot_scalar_contract.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from operator import index as _operator_index
 
+from pyrecest.backend_support._jax_one_hot_bounds_contract import (
+    patch_jax_one_hot_bounds_contract as _patch_jax_one_hot_bounds_contract,
+)
+
 
 def _is_boolean_take_axis(axis, torch_module) -> bool:
     """Return whether ``axis`` is a boolean scalar, not an integer axis."""
@@ -104,6 +108,7 @@ def patch_pytorch_one_hot_scalar_contract() -> None:
         torch_module,
     )
     _patch_pytorch_take_axis_contract(pytorch_backend, torch_module)
+    _patch_jax_one_hot_bounds_contract()
 
 
 __all__ = ["patch_pytorch_one_hot_scalar_contract"]

--- a/tests/backend_support/test_jax_one_hot_contract.py
+++ b/tests/backend_support/test_jax_one_hot_contract.py
@@ -41,3 +41,41 @@ print("ok")
     result = run_backend_code("numpy", code)
     assert result.returncode == 0, result.stderr
     assert "ok" in result.stdout
+
+
+def test_public_jax_one_hot_masks_out_of_range_labels():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("JAX is not installed")
+
+    code = """
+import pyrecest.backend as backend
+
+expected = [[0, 0, 0], [1, 0, 0], [0, 0, 1], [0, 0, 0]]
+result = backend.one_hot(labels=[-1, 0, 2, 3], num_classes=3)
+assert result.shape == (4, 3)
+assert str(backend.to_numpy(result).dtype) == "uint8"
+assert backend.to_numpy(result).tolist() == expected
+print("ok")
+"""
+    result = run_backend_code("jax", code)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_raw_jax_one_hot_masks_out_of_range_labels_after_import():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("JAX is not installed")
+
+    code = """
+import pyrecest  # noqa: F401  # triggers raw-backend compatibility patches
+import pyrecest._backend.jax as raw_jax
+
+expected = [[0, 0, 0], [1, 0, 0], [0, 0, 1], [0, 0, 0]]
+result = raw_jax.one_hot(labels=[-1, 0, 2, 3], num_classes=3)
+assert result.shape == (4, 3)
+assert raw_jax.to_numpy(result).tolist() == expected
+print("ok")
+"""
+    result = run_backend_code("numpy", code)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
Summary:
- add a dedicated JAX one_hot bounds compatibility hook
- wire it into the existing runtime backend patches
- add public and raw JAX regressions for labels outside [0, num_classes)

Bug fixed:
The JAX one_hot compatibility path used identity-matrix indexing directly. With JAX indexing, labels such as -1 or num_classes can select the final class instead of producing a zero row.

Validation:
- branch compare: 3 commits ahead, 0 behind main
- local syntax compilation of the edited Python content before committing

This supersedes the older non-mergeable PR #3812.