### PR TITLE
Validate explicit mixture weight shape

### DIFF
--- a/src/pyrecest/distributions/abstract_mixture.py
+++ b/src/pyrecest/distributions/abstract_mixture.py
@@ -53,6 +53,18 @@ def _validate_positive_sample_count(n) -> int:
     return count_int
 
 
+def _validate_explicit_weight_shape(weights, num_distributions: int):
+    """Return explicit mixture weights without silently flattening matrices."""
+    weights = asarray(weights)
+    if weights.ndim == 0:
+        if num_distributions != 1:
+            raise ValueError("Mixture weights must be one-dimensional")
+        return reshape(weights, (1,))
+    if weights.ndim != 1:
+        raise ValueError("Mixture weights must be one-dimensional")
+    return weights
+
+
 class AbstractMixture(AbstractDistributionType):
     """
     Abstract base class for mixture distributions.
@@ -72,7 +84,7 @@ class AbstractMixture(AbstractDistributionType):
         if weights is None:
             weights = ones(num_distributions) / num_distributions
         else:
-            weights = reshape(asarray(weights), (-1,))
+            weights = _validate_explicit_weight_shape(weights, num_distributions)
 
         if num_distributions != weights.shape[0]:
             raise ValueError("Sizes of distributions and weights must be equal")

--- a/tests/distributions/test_mixture_weight_shape_validation.py
+++ b/tests/distributions/test_mixture_weight_shape_validation.py
@@ -1,0 +1,14 @@
+import pytest
+
+from pyrecest.distributions.nonperiodic.gaussian_distribution import GaussianDistribution
+from pyrecest.distributions.nonperiodic.gaussian_mixture import GaussianMixture
+
+
+def test_gaussian_mixture_rejects_matrix_weights():
+    components = [
+        GaussianDistribution([0.0], [[1.0]], check_validity=False),
+        GaussianDistribution([1.0], [[1.0]], check_validity=False),
+    ]
+
+    with pytest.raises(ValueError, match="one-dimensional"):
+        GaussianMixture(components, [[0.25, 0.75]])


### PR DESCRIPTION
## Summary
- Reject multi-dimensional explicit mixture weights instead of flattening them.
- Preserve scalar weights for single-component mixtures.
- Add a regression test for matrix-shaped GaussianMixture weights.

## Validation
- Inspected changed files via GitHub connector.
- Local pytest was not run in this environment.