### PR TITLE
Reject boolean JAX matrix_power exponents

### DIFF
--- a/src/pyrecest/_backend/jax/linalg.py
+++ b/src/pyrecest/_backend/jax/linalg.py
@@ -4,6 +4,7 @@ from operator import index as _operator_index
 
 import jax.numpy as _jnp
 import jax.scipy.linalg as _jax_scipy_linalg
+import numpy as _np
 
 from .._backend_config import jax_atol as atol
 
@@ -15,6 +16,8 @@ def _as_linalg_array(value):
 
 def _as_integer_scalar(value, name):
     """Return a Python integer for JAX static integer arguments."""
+    if isinstance(value, (bool, _np.bool_)):
+        raise TypeError(f"{name} must be an integer scalar")
     try:
         return _operator_index(value)
     except TypeError:

--- a/tests/test_jax_linalg_matrix_power.py
+++ b/tests/test_jax_linalg_matrix_power.py
@@ -21,3 +21,20 @@ for exponent in (np.array(2), jnp.array(2)):
 """
     result = run_backend_code("jax", code)
     assert result.returncode == 0, result.stderr
+
+
+def test_jax_matrix_power_rejects_boolean_exponents():
+    pytest.importorskip("jax")
+
+    code = """
+import numpy as np
+import pytest
+import jax.numpy as jnp
+from pyrecest.backend import linalg
+
+for exponent in (True, np.bool_(True), jnp.array(True)):
+    with pytest.raises(TypeError, match="n must be an integer scalar"):
+        linalg.matrix_power([[1.0, 1.0], [0.0, 1.0]], exponent)
+"""
+    result = run_backend_code("jax", code)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- reject Python and NumPy boolean values before JAX `matrix_power` exponent normalization reaches `operator.index`
- add a backend subprocess regression test covering Python `bool`, `np.bool_`, and scalar JAX boolean exponents

## Rationale
`bool` and `np.bool_` implement integer indexing semantics, so the previous validation path silently accepted `n=True` as exponent `1`. Matrix powers should require an integer scalar exponent and reject boolean inputs consistently with the scalar JAX-array boolean path.

## Tests
- Added `test_jax_matrix_power_rejects_boolean_exponents` in `tests/test_jax_linalg_matrix_power.py`.
- Not run locally here; changes were made through the GitHub connector.