### PR TITLE
Fix PyTorch random helper device selection

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_minmax_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_minmax_device_contract.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import importlib
 
+from pyrecest.backend_support._pytorch_random_device_contract import (
+    patch_pytorch_random_device_contract as _patch_pytorch_random_device_contract,
+)
+
 
 def _preferred_pytorch_device(torch_module, *values):
     """Return a non-CPU tensor device when mixed-device operands are present."""
@@ -136,3 +140,4 @@ def patch_pytorch_minmax_device_contract() -> None:
         },
         "_pyrecest_comparison_device_contract",
     )
+    _patch_pytorch_random_device_contract()

--- a/src/pyrecest/backend_support/_pytorch_random_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_random_device_contract.py
@@ -1,0 +1,92 @@
+"""PyTorch random-helper device compatibility hook."""
+
+from __future__ import annotations
+
+import importlib
+from functools import wraps
+
+
+def _raw_pytorch_random_module():
+    """Return the raw PyTorch random backend module when available."""
+    try:
+        return importlib.import_module("pyrecest._backend.pytorch.random")
+    except ModuleNotFoundError:
+        return None
+
+
+def _preferred_tensor_device(torch_module, *values, device=None):
+    """Return an existing non-CPU tensor device, falling back to any tensor."""
+    if device is not None:
+        return device
+    for value in values:
+        if torch_module.is_tensor(value) and value.device.type == "meta":
+            return value.device
+    for value in values:
+        if torch_module.is_tensor(value) and value.device.type != "cpu":
+            return value.device
+    for value in values:
+        if torch_module.is_tensor(value):
+            return value.device
+    return None
+
+
+def patch_pytorch_random_device_contract() -> None:
+    """Patch PyTorch random helpers to preserve existing non-CPU devices."""
+    try:
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    raw_random = _raw_pytorch_random_module()
+    if raw_random is None:  # pragma: no cover - backend import failed earlier
+        return
+    if getattr(raw_random, "_pyrecest_random_device_contract", False):
+        return
+
+    def preferred_tensor_device(*values, device=None):
+        return _preferred_tensor_device(torch, *values, device=device)
+
+    def randint_device(*values, device=None):
+        return preferred_tensor_device(*values, device=device)
+
+    original_uniform = getattr(raw_random, "uniform", None)
+
+    if original_uniform is not None:
+
+        @wraps(original_uniform)
+        def uniform(low=0.0, high=1.0, size=None, dtype=None):
+            dtype = raw_random._normalize_random_dtype(  # pylint: disable=protected-access
+                dtype,
+                default=None,
+            )
+            device = preferred_tensor_device(low, high)
+            low = raw_random._validate_uniform_bound(  # pylint: disable=protected-access
+                low,
+                "low",
+                dtype=dtype,
+                device=device,
+            )
+            high = raw_random._validate_uniform_bound(  # pylint: disable=protected-access
+                high,
+                "high",
+                dtype=dtype,
+                device=device,
+            )
+            size = raw_random._uniform_size(  # pylint: disable=protected-access
+                size,
+                low,
+                high,
+            )
+            raw_random._validate_uniform_bounds(low, high)  # pylint: disable=protected-access
+            return (high - low) * torch.rand(size, dtype=dtype, device=device) + low
+
+        uniform._pyrecest_device_contract = True
+        raw_random.uniform = uniform
+
+    preferred_tensor_device._pyrecest_device_contract = True
+    randint_device._pyrecest_device_contract = True
+    raw_random._preferred_tensor_device = preferred_tensor_device  # pylint: disable=protected-access
+    raw_random._randint_device = randint_device  # pylint: disable=protected-access
+    raw_random._normal_device = preferred_tensor_device  # pylint: disable=protected-access
+    raw_random._tensor_device = preferred_tensor_device  # pylint: disable=protected-access
+    raw_random._pyrecest_random_device_contract = True  # pylint: disable=protected-access

--- a/tests/backend_support/test_pytorch_random_device_contract.py
+++ b/tests/backend_support/test_pytorch_random_device_contract.py
@@ -1,0 +1,61 @@
+import pytest
+
+
+def test_pytorch_random_device_helpers_prefer_existing_non_cpu_tensor():
+    torch = pytest.importorskip("torch")
+
+    import pyrecest  # noqa: F401  # Triggers runtime backend compatibility hooks.
+    from pyrecest._backend.pytorch import random as torch_random
+
+    cpu_tensor = torch.empty(2)
+    meta_tensor = torch.empty(2, device="meta")
+
+    assert torch_random._preferred_tensor_device(cpu_tensor, meta_tensor).type == "meta"
+    assert torch_random._randint_device(cpu_tensor, meta_tensor).type == "meta"
+    assert torch_random._normal_device(cpu_tensor, meta_tensor).type == "meta"
+    assert torch_random._tensor_device(cpu_tensor, meta_tensor).type == "meta"
+
+
+def test_pytorch_random_device_helpers_honor_explicit_device_override():
+    torch = pytest.importorskip("torch")
+
+    import pyrecest  # noqa: F401  # Triggers runtime backend compatibility hooks.
+    from pyrecest._backend.pytorch import random as torch_random
+
+    cpu_tensor = torch.empty(2)
+    meta_tensor = torch.empty(2, device="meta")
+    explicit_device = torch.device("cpu")
+
+    assert (
+        torch_random._preferred_tensor_device(
+            cpu_tensor,
+            meta_tensor,
+            device=explicit_device,
+        )
+        == explicit_device
+    )
+    assert (
+        torch_random._randint_device(
+            cpu_tensor,
+            meta_tensor,
+            device=explicit_device,
+        )
+        == explicit_device
+    )
+
+
+def test_pytorch_random_uniform_uses_existing_cuda_bound_device_when_available():
+    torch = pytest.importorskip("torch")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is unavailable")
+
+    import pyrecest  # noqa: F401  # Triggers runtime backend compatibility hooks.
+    from pyrecest._backend.pytorch import random as torch_random
+
+    low = torch.tensor(0.0)
+    high = torch.tensor(1.0, device="cuda")
+
+    sample = torch_random.uniform(low, high, size=(2,))
+
+    assert sample.device.type == "cuda"
+    assert tuple(sample.shape) == (2,)


### PR DESCRIPTION
## Summary
- add a PyTorch random-device compatibility hook that prefers an existing non-CPU tensor device before falling back to CPU
- wire the hook into the existing runtime backend compatibility path
- add focused regression coverage for random helper device selection and a CUDA smoke path for `uniform` when available

## Bug fixed
The PyTorch random backend had several helper paths that selected the first tensor operand's device. With a CPU tensor first and a CUDA/MPS/meta tensor later, helpers such as `_normal_device`, `_tensor_device`, and `_randint_device` could choose CPU and either move data off the accelerator or fail when the later tensor cannot be materialized on CPU. The new hook mirrors the device-selection contract already used by PyTorch binary backend helpers.

## Validation
- Inspected the branch diff with the GitHub connector: 3 commits ahead of `main`, 0 behind.
- Added focused tests in `tests/backend_support/test_pytorch_random_device_contract.py`.
- Full pytest was not run in this connector-only environment; CI should run the backend matrix.