### PR TITLE
Validate benchmark regression CLI limits

### DIFF
--- a/scripts/check_benchmark_regression.py
+++ b/scripts/check_benchmark_regression.py
@@ -81,6 +81,25 @@ def _nonnegative_integer(value: Any, *, path: str) -> tuple[int | None, str | No
     return value, None
 
 
+def _validate_cli_limits(
+    *, max_slowdown: float, abs_tol: float, rel_tol: float
+) -> list[str]:
+    """Return validation errors for command-line regression thresholds."""
+
+    failures: list[str] = []
+    if not math.isfinite(max_slowdown):
+        failures.append("max-slowdown must be finite")
+    elif max_slowdown <= 0.0:
+        failures.append("max-slowdown must be positive")
+
+    for name, value in (("abs-tol", abs_tol), ("rel-tol", rel_tol)):
+        if not math.isfinite(value):
+            failures.append(f"{name} must be finite")
+        elif value < 0.0:
+            failures.append(f"{name} must be nonnegative")
+    return failures
+
+
 def _check_numeric_sequence(
     actual: Any,
     expected: Any,
@@ -244,6 +263,16 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: Iterable[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    limit_errors = _validate_cli_limits(
+        max_slowdown=args.max_slowdown,
+        abs_tol=args.abs_tol,
+        rel_tol=args.rel_tol,
+    )
+    if limit_errors:
+        for error in limit_errors:
+            print(f"::error::{error}")
+        return 1
+
     try:
         failures = check_benchmarks(
             _load_json(args.actual),

--- a/tests/test_benchmark_regression_limits.py
+++ b/tests/test_benchmark_regression_limits.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import importlib.util
+import math
+from pathlib import Path
+
+
+def _load_checker_module():
+    module_path = Path(__file__).resolve().parents[1] / "scripts" / "check_benchmark_regression.py"
+    spec = importlib.util.spec_from_file_location("check_benchmark_regression", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_rejects_unbounded_cli_limits():
+    checker = _load_checker_module()
+
+    assert checker._validate_cli_limits(  # pylint: disable=protected-access
+        max_slowdown=math.inf,
+        abs_tol=0.0,
+        rel_tol=0.0,
+    ) == ["max-slowdown must be finite"]
+
+
+def test_accepts_default_cli_limits():
+    checker = _load_checker_module()
+
+    assert checker._validate_cli_limits(  # pylint: disable=protected-access
+        max_slowdown=1.5,
+        abs_tol=1e-8,
+        rel_tol=1e-8,
+    ) == []


### PR DESCRIPTION
## Summary
- reject non-finite `--max-slowdown`, `--abs-tol`, and `--rel-tol` values before comparing benchmark outputs
- reject non-positive slowdown factors and negative tolerances
- add regression coverage for unbounded benchmark-check limits and the default valid settings

## Bug fixed
Passing `nan`/`inf` threshold values could make the benchmark regression checker silently stop enforcing elapsed-time or numeric-output limits. For example, `math.isclose(..., rel_tol=float("inf"))` can accept arbitrary deviations, and a non-finite slowdown factor can disable elapsed-time checks. The checker now fails fast on invalid threshold values.

## Testing
- Not run locally in this environment; CI should exercise the added tests.