### PR TITLE
Reject boolean PyTorch matrix_power exponents

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -66,8 +66,21 @@ def _as_linalg_tensor(value):
     return tensor
 
 
+def _is_boolean_scalar(value):
+    """Return whether value is a scalar boolean accepted by Python indexing."""
+    if isinstance(value, (bool, _np.bool_)):
+        return True
+    if isinstance(value, _np.ndarray):
+        return value.shape == () and value.dtype == _np.dtype("bool")
+    if _torch.is_tensor(value):
+        return value.ndim == 0 and value.dtype is _torch.bool
+    return False
+
+
 def _as_integer_scalar(value, name):
     """Return a Python integer for Torch integer-scalar arguments."""
+    if _is_boolean_scalar(value):
+        raise TypeError(f"{name} must be an integer scalar")
     try:
         return _operator_index(value)
     except TypeError as exc:
@@ -237,7 +250,7 @@ class _Logm(_torch.autograd.Function):
 
 
 def logm(x):
-    """Compute the matrix logarithm after PyRecEst-style array-like promotion."""
+    """Compute the matrix logarithm after array-like input promotion."""
     return _Logm.apply(_as_linalg_tensor(x))
 
 

--- a/tests/backend_support/test_pytorch_linalg_matrix_power_contract.py
+++ b/tests/backend_support/test_pytorch_linalg_matrix_power_contract.py
@@ -1,0 +1,54 @@
+"""Regression tests for PyTorch linalg.matrix_power scalar exponent validation."""
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+def test_pytorch_matrix_power_rejects_boolean_exponents():
+    pytest.importorskip("torch")
+
+    code = """
+import numpy as np
+import torch
+
+from pyrecest.backend import linalg
+
+matrix = [[1.0, 1.0], [0.0, 1.0]]
+boolean_exponents = [
+    True,
+    False,
+    np.bool_(True),
+    np.array(True),
+    torch.tensor(True),
+]
+
+for exponent in boolean_exponents:
+    try:
+        linalg.matrix_power(matrix, exponent)
+    except TypeError:
+        continue
+    raise AssertionError(f"accepted boolean exponent {exponent!r}")
+"""
+    result = run_backend_code("pytorch", code)
+    assert result.returncode == 0, result.stderr
+
+
+def test_pytorch_matrix_power_still_accepts_integer_scalars():
+    pytest.importorskip("torch")
+
+    code = """
+import numpy as np
+
+import pyrecest.backend as backend
+from pyrecest.backend import linalg
+
+matrix = [[1.0, 1.0], [0.0, 1.0]]
+expected = [[1.0, 2.0], [0.0, 1.0]]
+
+for exponent in [2, np.int64(2), np.array(2)]:
+    result = linalg.matrix_power(matrix, exponent)
+    assert backend.to_numpy(result).tolist() == expected
+"""
+    result = run_backend_code("pytorch", code)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- reject Python, NumPy, and Torch boolean scalar exponents in the PyTorch `linalg.matrix_power` wrapper
- preserve integer scalar exponents including NumPy integer scalars and zero-dimensional integer arrays
- add subprocess regression coverage for the public PyTorch backend

## Bug fixed
`bool` values implement Python integer-index semantics, so the previous PyTorch wrapper accepted `n=True` as exponent `1` and `n=False` as exponent `0`. Boolean scalars are not valid matrix-power exponents under the backend contract and should be rejected instead of silently changing the requested power.

## Validation
- Compared branch against `main`: 2 commits ahead, 0 behind.
- Local tests were not run in this environment; CI should exercise the added PyTorch-backend regressions.