### PR TITLE
Reject boolean PyTorch matrix_power exponents

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -66,8 +66,21 @@ def _as_linalg_tensor(value):
     return tensor
 
 
+def _is_boolean_scalar(value):
+    """Return whether ``value`` is a scalar boolean exponent candidate."""
+    if isinstance(value, (bool, _np.bool_)):
+        return True
+    if isinstance(value, _np.ndarray):
+        return value.shape == () and value.dtype == _np.bool_
+    if _torch.is_tensor(value):
+        return value.ndim == 0 and value.dtype == _torch.bool
+    return False
+
+
 def _as_integer_scalar(value, name):
-    """Return a Python integer for Torch integer-scalar arguments."""
+    """Return a non-boolean Python integer for Torch integer-scalar arguments."""
+    if _is_boolean_scalar(value):
+        raise TypeError(f"{name} must be an integer scalar, not boolean")
     try:
         return _operator_index(value)
     except TypeError as exc:

--- a/tests/backend_support/test_pytorch_matrix_power_bool_contract.py
+++ b/tests/backend_support/test_pytorch_matrix_power_bool_contract.py
@@ -1,0 +1,47 @@
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_pytorch_matrix_power_rejects_boolean_exponents():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import numpy as np
+import torch
+from pyrecest.backend import linalg
+import pyrecest._backend.pytorch.linalg as raw_linalg
+
+matrix = [[1.0, 1.0], [0.0, 1.0]]
+boolean_exponents = [
+    True,
+    False,
+    np.bool_(True),
+    np.array(True),
+    torch.tensor(True),
+]
+
+for exponent in boolean_exponents:
+    for linalg_module in (linalg, raw_linalg):
+        try:
+            linalg_module.matrix_power(matrix, exponent)
+        except TypeError as exc:
+            assert "boolean" in str(exc)
+        else:
+            raise AssertionError(
+                f"matrix_power accepted boolean exponent {exponent!r} via {linalg_module!r}"
+            )
+
+valid_result = raw_linalg.matrix_power(matrix, np.array(2))
+assert valid_result.detach().cpu().numpy().tolist() == [[1.0, 2.0], [0.0, 1.0]]
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- reject boolean scalar exponents in PyTorch `linalg.matrix_power`
- preserve valid integer scalar exponent coercion
- add a focused PyTorch backend regression for public and raw linalg calls

## Validation
- Syntax-checked the modified module and regression test locally.
- Compared the branch with `main`: 0 behind; changed files are limited to the PyTorch linalg module and the new test.

Full test suite not run locally; CI should run the focused regression.