### PR TITLE
Fix cartesian hypertoroidal grid regeneration shape

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_grid_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_grid_distribution.py
@@ -181,6 +181,13 @@ class HypertoroidalGridDistribution(
     def get_manifold_size(self):
         return AbstractHypertoroidalDistribution.get_manifold_size(self)
 
+    @property
+    def n_grid_points(self):
+        """Return the per-axis cartesian-product resolution when available."""
+        if self.grid_type == "cartesian_prod":
+            return self.grid_values.shape
+        return super().n_grid_points
+
     # ---------------------------------------------------------- grid helpers
     @staticmethod
     def generate_cartesian_product_grid(n_grid_points):

--- a/tests/distributions/test_hypertoroidal_grid_distribution.py
+++ b/tests/distributions/test_hypertoroidal_grid_distribution.py
@@ -27,6 +27,24 @@ class HypertoroidalGridDistributionTest(unittest.TestCase):
         npt.assert_allclose(hgd.get_grid(), grid)
         npt.assert_allclose(hgd.get_grid().shape, (4, 2))
 
+    def test_get_grid_regenerates_cartesian_product_with_full_shape(self):
+        grid_values = array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]) / (
+            ((2.0 * pi) ** 2) * 3.5
+        )
+        hgd = HypertoroidalGridDistribution(
+            grid_values,
+            grid_type="cartesian_prod",
+            grid=None,
+        )
+
+        grid = hgd.get_grid()
+
+        self.assertEqual(hgd.dim, 2)
+        self.assertEqual(hgd.n_grid_points, (2, 3))
+        npt.assert_allclose(grid.shape, (6, 2))
+        npt.assert_allclose(min(grid, 0), array([0.0, 0.0]))
+        npt.assert_allclose(max(grid, 0), array([pi, 4.0 * pi / 3.0]))
+
     def test_custom_flat_grid_honors_explicit_dim(self):
         grid = array([[0.0, 0.0], [pi, 0.0], [0.0, pi], [pi, pi]])
         grid_values = array([1.0, 1.0, 1.0, 1.0]) / ((2.0 * pi) ** 2)


### PR DESCRIPTION
## Summary
- preserve full per-axis cartesian-product resolution in `HypertoroidalGridDistribution.n_grid_points`
- add a regression for cartesian-product hypertoroidal grids constructed without stored coordinates

## Bug fixed
For `grid_type="cartesian_prod"`, `get_grid()` regenerates coordinates from `self.n_grid_points` when `self.grid` is not stored. The inherited `AbstractGridDistribution.n_grid_points` returned only `grid_values.shape[0]`, so a 2-D grid with values shaped `(2, 3)` regenerated as a one-dimensional 2-point grid instead of a six-point 2-D cartesian product.

## Validation
- Compared the branch against `main`: 2 commits ahead, 0 behind; changes are limited to the hypertoroidal grid distribution and its focused regression test.
- Local pytest was not run because this environment cannot clone/install the repository; CI should run `tests/distributions/test_hypertoroidal_grid_distribution.py`.