### PR TITLE
Normalize PyTorch diagonal NumPy scalar axes

### DIFF
--- a/src/pyrecest/_backend/_common.py
+++ b/src/pyrecest/_backend/_common.py
@@ -45,6 +45,16 @@ def _normalize_size_axis(axis):
 
 def _normalize_diagonal_integer(value):
     """Return NumPy-style integer scalar arguments for stricter tensor APIs."""
+    if isinstance(value, _AXIS_FLAG_TYPES):
+        raise TypeError("an integer is required")
+    if isinstance(value, _np.ndarray):
+        if value.shape != ():
+            return value
+        if value.dtype.kind == "b":
+            raise TypeError("an integer is required")
+        if value.dtype.kind in "iu":
+            return int(value.item())
+        return value
     try:
         return _operator.index(value)
     except TypeError:

--- a/tests/backend_support/test_pytorch_diagonal_numpy_scalar_axes.py
+++ b/tests/backend_support/test_pytorch_diagonal_numpy_scalar_axes.py
@@ -1,0 +1,22 @@
+from tests.support.backend_runner import run_backend_code
+
+
+def test_pytorch_diagonal_accepts_numpy_scalar_integer_arguments():
+    code = """
+import numpy as np
+import pyrecest.backend as backend
+
+values = backend.asarray([[1, 2], [3, 4]])
+
+offset_result = backend.diagonal(values, offset=np.array(0))
+axis_result = backend.diagonal(
+    values,
+    axis1=np.array(0, dtype=np.int64),
+    axis2=np.array(1, dtype=np.int64),
+)
+
+assert backend.to_numpy(offset_result).tolist() == [1, 4]
+assert backend.to_numpy(axis_result).tolist() == [1, 4]
+"""
+    result = run_backend_code("pytorch", code)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- normalize zero-dimensional NumPy integer arrays before forwarding PyTorch diagonal offset/axis arguments to `torch.diagonal`
- add a PyTorch backend regression for `np.array` scalar offset/axis arguments

## Bug fixed
The PyTorch backend uses the common `diagonal` helper. Its integer normalizer only tried `operator.index`, so NumPy zero-dimensional integer arrays such as `np.array(0)` were passed through to `torch.diagonal`, which rejects them. NumPy accepts these scalar integer arrays for `offset`, `axis1`, and `axis2`, so the backend failed a NumPy-style argument contract.

## Testing
- Added `tests/backend_support/test_pytorch_diagonal_numpy_scalar_axes.py`
- Not run locally; this environment cannot clone/install the repository from GitHub. CI should exercise the focused regression.