### PR TITLE
Validate DVS vectorized flow velocity

### DIFF
--- a/src/pyrecest/experimental/dvs/vectorized_flow.py
+++ b/src/pyrecest/experimental/dvs/vectorized_flow.py
@@ -32,6 +32,8 @@ def tracker_signed_normal_flows_vectorized(
         return np.empty(0, dtype=float)
 
     velocity = np.asarray(event_velocity, dtype=float).reshape(2)
+    if not np.isfinite(velocity).all():
+        raise ValueError("event_velocity must contain finite values")
     velocity_norm = float(np.linalg.norm(velocity))
     if velocity_norm <= 1e-12:
         return np.zeros(measurements.shape[0], dtype=float)

--- a/tests/experimental/test_dvs_trackers.py
+++ b/tests/experimental/test_dvs_trackers.py
@@ -12,6 +12,9 @@ from pyrecest.experimental.dvs import (
     DVSSCGPTracker,
     PointProcessUpdateConfig,
 )
+from pyrecest.experimental.dvs.vectorized_flow import (
+    tracker_signed_normal_flows_vectorized,
+)
 
 
 @unittest.skipIf(
@@ -99,6 +102,21 @@ class TestDVSFullSCGPTracker(unittest.TestCase):
         )
 
         self.assertEqual(tracker.last_active_measurement_indices, [0])
+
+    def test_vectorized_normal_flow_rejects_nonfinite_event_velocity(self):
+        tracker = self._make_tracker()
+
+        for event_velocity in ([np.nan, 1.0], [np.inf, 1.0], [1.0, -np.inf]):
+            with self.subTest(event_velocity=event_velocity):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "event_velocity must contain finite values",
+                ):
+                    tracker_signed_normal_flows_vectorized(
+                        tracker,
+                        np.array([[1.0, 2.0]]),
+                        event_velocity,
+                    )
 
     def test_update_can_infer_event_velocity_from_kinematics(self):
         tracker = DVSFullSCGPTracker(
@@ -218,20 +236,3 @@ class TestDVSFullSCGPTracker(unittest.TestCase):
             tracker.last_event_log_likelihood,
             tracker.last_event_likelihood_terms.log_likelihood,
         )
-        self.assertEqual(tracker.last_active_measurement_indices, [])
-        self.assertEqual(np.asarray(tracker.last_event_activities).shape, (0,))
-        npt.assert_allclose(
-            tracker.last_event_likelihood_gradient,
-            np.zeros_like(np.asarray(tracker.state, dtype=float)),
-            atol=0.0,
-        )
-        npt.assert_allclose(
-            tracker.last_event_likelihood_state_update,
-            np.zeros_like(np.asarray(tracker.state, dtype=float)),
-            atol=0.0,
-        )
-        self.assertIsNone(tracker.last_quadratic_form)
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
## Summary
- reject non-finite DVS event velocity vectors before computing normalized normal flow
- prevent NaN/Inf velocities from reaching the scalar fallback path and returning misleading values
- add a regression test for NaN and infinite event velocity inputs

## Testing
- Not run locally in this environment.