### PR TITLE
Fix PyTorch random helper device selection

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_minmax_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_minmax_device_contract.py
@@ -7,6 +7,10 @@ from operator import index as _operator_index
 
 import numpy as _np
 
+from pyrecest.backend_support._pytorch_random_device_contract import (
+    patch_pytorch_random_device_contract as _patch_pytorch_random_device_contract,
+)
+
 _AXIS_TYPE_ERROR = "axis must be None, an integer, or a tuple of integers"
 
 
@@ -223,3 +227,4 @@ def patch_pytorch_minmax_device_contract() -> None:
         "_pyrecest_comparison_device_contract",
     )
     _patch_pytorch_linalg_norm_axis_contract(raw_pytorch, backend, torch)
+    _patch_pytorch_random_device_contract()

--- a/src/pyrecest/backend_support/_pytorch_random_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_random_device_contract.py
@@ -1,0 +1,109 @@
+"""PyTorch random-helper device compatibility hook."""
+
+from __future__ import annotations
+
+import importlib
+from functools import wraps
+
+
+def _raw_pytorch_random_module():
+    """Return the raw PyTorch random backend module when available."""
+    try:
+        return importlib.import_module("pyrecest._backend.pytorch.random")
+    except ModuleNotFoundError:
+        return None
+
+
+def _active_public_random_module():
+    """Return the public PyTorch random facade when it is already active."""
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - backend import failed earlier
+        return None
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        return None
+    return getattr(backend, "random", None)
+
+
+def _preferred_tensor_device(torch_module, *values, device=None):
+    """Return an existing non-CPU tensor device, falling back to any tensor."""
+    if device is not None:
+        return device
+    for value in values:
+        if torch_module.is_tensor(value) and value.device.type == "meta":
+            return value.device
+    for value in values:
+        if torch_module.is_tensor(value) and value.device.type != "cpu":
+            return value.device
+    for value in values:
+        if torch_module.is_tensor(value):
+            return value.device
+    return None
+
+
+def patch_pytorch_random_device_contract() -> None:
+    """Patch PyTorch random helpers to preserve existing non-CPU devices."""
+    try:
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    raw_random = _raw_pytorch_random_module()
+    if raw_random is None:  # pragma: no cover - backend import failed earlier
+        return
+
+    public_random = _active_public_random_module()
+    if getattr(raw_random, "_pyrecest_random_device_contract", False):
+        if public_random is not None:
+            public_random.uniform = raw_random.uniform
+        return
+
+    def preferred_tensor_device(*values, device=None):
+        return _preferred_tensor_device(torch, *values, device=device)
+
+    def randint_device(*values, device=None):
+        return preferred_tensor_device(*values, device=device)
+
+    original_uniform = getattr(raw_random, "uniform", None)
+
+    if original_uniform is not None:
+
+        @wraps(original_uniform)
+        def uniform(low=0.0, high=1.0, size=None, dtype=None):
+            dtype = raw_random._normalize_random_dtype(  # pylint: disable=protected-access
+                dtype,
+                default=None,
+            )
+            device = preferred_tensor_device(low, high)
+            low = raw_random._validate_uniform_bound(  # pylint: disable=protected-access
+                low,
+                "low",
+                dtype=dtype,
+                device=device,
+            )
+            high = raw_random._validate_uniform_bound(  # pylint: disable=protected-access
+                high,
+                "high",
+                dtype=dtype,
+                device=device,
+            )
+            size = raw_random._uniform_size(  # pylint: disable=protected-access
+                size,
+                low,
+                high,
+            )
+            raw_random._validate_uniform_bounds(low, high)  # pylint: disable=protected-access
+            return (high - low) * torch.rand(size, dtype=dtype, device=device) + low
+
+        uniform._pyrecest_device_contract = True
+        raw_random.uniform = uniform
+        if public_random is not None:
+            public_random.uniform = uniform
+
+    preferred_tensor_device._pyrecest_device_contract = True
+    randint_device._pyrecest_device_contract = True
+    raw_random._preferred_tensor_device = preferred_tensor_device  # pylint: disable=protected-access
+    raw_random._randint_device = randint_device  # pylint: disable=protected-access
+    raw_random._normal_device = preferred_tensor_device  # pylint: disable=protected-access
+    raw_random._tensor_device = preferred_tensor_device  # pylint: disable=protected-access
+    raw_random._pyrecest_random_device_contract = True  # pylint: disable=protected-access

--- a/tests/backend_support/test_pytorch_random_device_contract.py
+++ b/tests/backend_support/test_pytorch_random_device_contract.py
@@ -1,0 +1,62 @@
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+def test_pytorch_random_device_helpers_prefer_existing_non_cpu_tensor():
+    torch = pytest.importorskip("torch")
+
+    import pyrecest  # noqa: F401  # Triggers runtime backend compatibility hooks.
+    from pyrecest._backend.pytorch import random as torch_random
+
+    cpu_tensor = torch.empty(2)
+    meta_tensor = torch.empty(2, device="meta")
+
+    assert torch_random._preferred_tensor_device(cpu_tensor, meta_tensor).type == "meta"
+    assert torch_random._randint_device(cpu_tensor, meta_tensor).type == "meta"
+    assert torch_random._normal_device(cpu_tensor, meta_tensor).type == "meta"
+    assert torch_random._tensor_device(cpu_tensor, meta_tensor).type == "meta"
+
+
+def test_pytorch_random_device_helpers_honor_explicit_device_override():
+    torch = pytest.importorskip("torch")
+
+    import pyrecest  # noqa: F401  # Triggers runtime backend compatibility hooks.
+    from pyrecest._backend.pytorch import random as torch_random
+
+    cpu_tensor = torch.empty(2)
+    meta_tensor = torch.empty(2, device="meta")
+    explicit_device = torch.device("cpu")
+
+    assert (
+        torch_random._preferred_tensor_device(
+            cpu_tensor,
+            meta_tensor,
+            device=explicit_device,
+        )
+        == explicit_device
+    )
+    assert (
+        torch_random._randint_device(
+            cpu_tensor,
+            meta_tensor,
+            device=explicit_device,
+        )
+        == explicit_device
+    )
+
+
+def test_public_pytorch_random_facade_uses_patched_uniform():
+    pytest.importorskip("torch")
+
+    code = """
+import pyrecest  # noqa: F401
+from pyrecest._backend.pytorch import random as raw_random
+from pyrecest.backend import random as public_random
+
+assert getattr(raw_random.uniform, "_pyrecest_device_contract", False)
+assert public_random.uniform is raw_random.uniform
+"""
+    result = run_backend_code("pytorch", code)
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- add a PyTorch random-device compatibility hook that prefers existing non-CPU/meta tensor devices before falling back to CPU
- activate the hook through the existing PyTorch backend-support path
- keep the active public PyTorch `backend.random.uniform` facade synchronized with the patched raw helper
- add focused regression coverage for raw helper device selection and public-facade synchronization

## Bug fixed
The PyTorch random backend selected the first tensor operand's device in helper paths such as `_normal_device`, `_tensor_device`, and `_randint_device`. With a CPU tensor first and a CUDA/MPS/meta tensor later, those helpers could choose CPU and either move data off the accelerator or fail for tensors that cannot be materialized on CPU. The new hook mirrors the non-CPU preference used by other PyTorch backend compatibility helpers.

## Validation
- Compared branch against `main`: 3 commits ahead, 0 behind; changes limited to the PyTorch backend-support hook and focused tests.
- Did not run the full pytest suite locally because this connector session cannot clone/install the repository; CI should run the added regression test.