### PR TITLE
Fix shared NumPy triangular vector helpers for rectangular inputs

### DIFF
--- a/src/pyrecest/_backend/autograd/__init__.py
+++ b/src/pyrecest/_backend/autograd/__init__.py
@@ -1,5 +1,7 @@
 """Autograd based computation backend."""
 
+from operator import index as _operator_index
+
 import autograd.numpy as _np
 from autograd.numpy import (
     all,
@@ -233,3 +235,19 @@ def outer(a, b):
         out = out.swapaxes(0, -2)
 
     return out
+
+
+def _triangular_vector_indices(x, k, index_helper):
+    x = _np.asarray(x)
+    if x.ndim < 2:
+        raise ValueError("triangular vector helpers require at least two dimensions")
+    rows, cols = index_helper(x.shape[-2], k=_operator_index(k), m=x.shape[-1])
+    return x[..., rows, cols]
+
+
+def tril_to_vec(x, k=0):
+    return _triangular_vector_indices(x, k, _np.tril_indices)
+
+
+def triu_to_vec(x, k=0):
+    return _triangular_vector_indices(x, k, _np.triu_indices)

--- a/src/pyrecest/_backend/numpy/__init__.py
+++ b/src/pyrecest/_backend/numpy/__init__.py
@@ -328,3 +328,19 @@ def vmap(pyfunc, randomness="error"):
         return _np.stack(outputs)
 
     return vmapped_fun
+
+
+def _triangular_vector_indices(x, k, index_helper):
+    x = _np.asarray(x)
+    if x.ndim < 2:
+        raise ValueError("triangular vector helpers require at least two dimensions")
+    rows, cols = index_helper(x.shape[-2], k=_operator_index(k), m=x.shape[-1])
+    return x[..., rows, cols]
+
+
+def tril_to_vec(x, k=0):
+    return _triangular_vector_indices(x, k, _np.tril_indices)
+
+
+def triu_to_vec(x, k=0):
+    return _triangular_vector_indices(x, k, _np.triu_indices)

--- a/tests/backend_support/test_shared_numpy_triangular_helpers_contract.py
+++ b/tests/backend_support/test_shared_numpy_triangular_helpers_contract.py
@@ -1,0 +1,51 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _backend_test_env(backend_name):
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = backend_name
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    return env
+
+
+@pytest.mark.backend_portable
+@pytest.mark.parametrize("backend_name", ["numpy", "autograd"])
+def test_shared_numpy_triangular_helpers_accept_rectangular_array_like_inputs(
+    backend_name,
+):
+    if backend_name == "autograd" and importlib.util.find_spec("autograd") is None:
+        pytest.skip("autograd is not installed")
+
+    code = """
+import pyrecest.backend as backend
+
+wide = [[1, 2, 3], [4, 5, 6]]
+tall = [[1, 2], [3, 4], [5, 6]]
+
+lower_wide = backend.tril_to_vec(wide)
+assert backend.to_numpy(lower_wide).tolist() == [1, 4, 5]
+
+upper_wide = backend.triu_to_vec(wide, k=1)
+assert backend.to_numpy(upper_wide).tolist() == [2, 3, 6]
+
+lower_tall = backend.tril_to_vec(tall, k=-1)
+assert backend.to_numpy(lower_tall).tolist() == [3, 5, 6]
+
+upper_tall = backend.triu_to_vec(tall)
+assert backend.to_numpy(upper_tall).tolist() == [1, 2, 4]
+"""
+    subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        env=_backend_test_env(backend_name),
+    )


### PR DESCRIPTION
## Summary

- fix NumPy and Autograd `tril_to_vec` / `triu_to_vec` to use both trailing matrix dimensions for rectangular inputs
- coerce array-like inputs before triangular indexing
- add subprocess regression coverage for NumPy and Autograd backends

## Bug fixed

The shared NumPy triangular vector helpers derived triangular indices from `x.shape[-1]` only. For rectangular matrices this either missed valid entries or produced row indices outside the number of rows, for example `tril_to_vec([[1, 2, 3], [4, 5, 6]])` attempted to index row 2 of a 2-row matrix. The backend-specific overrides now call `tril_indices` / `triu_indices` with explicit row and column dimensions.

## Validation

- Added `tests/backend_support/test_shared_numpy_triangular_helpers_contract.py`
- Verified the branch diff contains only the NumPy/Autograd helper overrides and the focused regression test via the GitHub connector
- Full test suite was not run locally because this execution environment cannot clone/install the repository from GitHub