### PR TITLE
Handle scalar linear Dirac samples

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/linear_dirac_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/linear_dirac_distribution.py
@@ -15,6 +15,8 @@ from .abstract_linear_distribution import AbstractLinearDistribution
 class LinearDiracDistribution(AbstractDiracDistribution, AbstractLinearDistribution):
     def __init__(self, d, w=None):
         d = asarray(d)
+        if d.ndim == 0:
+            d = reshape(d, (1,))
         dim = d.shape[1] if d.ndim > 1 else 1
         AbstractLinearDistribution.__init__(self, dim)
         AbstractDiracDistribution.__init__(self, d, w)
@@ -121,9 +123,9 @@ class LinearDiracDistribution(AbstractDiracDistribution, AbstractLinearDistribut
     @staticmethod
     def weighted_samples_to_mean_and_cov(samples, weights=None):
         samples = asarray(samples)
-        sample_matrix = reshape(samples, (-1, 1)) if samples.ndim == 1 else samples
+        sample_matrix = reshape(samples, (-1, 1)) if samples.ndim <= 1 else samples
         if sample_matrix.ndim != 2:
-            raise ValueError("samples must be a 1D or 2D array")
+            raise ValueError("samples must be a scalar, 1D array, or 2D array")
         if sample_matrix.shape[0] == 0:
             raise ValueError("samples must contain at least one sample")
 

--- a/tests/distributions/test_linear_dirac_distribution.py
+++ b/tests/distributions/test_linear_dirac_distribution.py
@@ -31,6 +31,20 @@ class LinearDiracDistributionTest(TestAbstractDiracDistribution):
         npt.assert_allclose(multidimensional.d, array([[1.0, 2.0], [3.0, 4.0]]))
         npt.assert_allclose(multidimensional.w, array([0.25, 0.75]))
 
+    def test_constructor_accepts_scalar_location(self):
+        scalar_dist = LinearDiracDistribution(2.5)
+
+        self.assertEqual(scalar_dist.dim, 1)
+        npt.assert_allclose(scalar_dist.d, array([2.5]))
+        npt.assert_allclose(scalar_dist.w, array([1.0]))
+        npt.assert_allclose(scalar_dist.covariance(), array([[0.0]]))
+
+    def test_weighted_samples_to_mean_and_cov_accepts_scalar_sample(self):
+        mean, covariance = LinearDiracDistribution.weighted_samples_to_mean_and_cov(2.5)
+
+        npt.assert_allclose(mean, array([2.5]))
+        npt.assert_allclose(covariance, array([[0.0]]))
+
     def test_from_distribution(self):
         random.seed(0)
         C = wishart.rvs(3, eye(3))


### PR DESCRIPTION
## Summary
- reshape scalar `LinearDiracDistribution` locations to a one-sample 1-D Dirac array before the abstract Dirac initializer accesses `d.shape[0]`
- treat scalar inputs to `weighted_samples_to_mean_and_cov` as a single 1-D sample with zero covariance
- add regression tests for scalar construction and scalar moment/covariance conversion

## Bug fixed
`LinearDiracDistribution(2.5)` currently fails because a scalar location is converted to a 0-D backend array and `AbstractDiracDistribution.__init__` immediately reads `d.shape[0]`. Scalars are a natural single-particle representation for one-dimensional Dirac distributions, and the moment helper has an unambiguous mean/covariance for that case.

## Validation
- Inspected the modified files and branch diff via the GitHub connector.
- Not run locally; the execution environment cannot clone GitHub repositories from the network.