### PR TITLE
Reject non-real selection score payloads

### DIFF
--- a/src/pyrecest/evaluation/selection.py
+++ b/src/pyrecest/evaluation/selection.py
@@ -21,6 +21,29 @@ def _is_text_scalar(value) -> bool:
     return isinstance(value, (str, bytes, np.str_, np.bytes_))
 
 
+def _contains_invalid_score_values(values: np.ndarray) -> bool:
+    if values.dtype == np.bool_ or values.dtype.kind in "bUScMm":
+        return True
+    if values.dtype == object:
+        return any(
+            item is None
+            or isinstance(
+                item,
+                (
+                    bool,
+                    np.bool_,
+                    complex,
+                    np.complexfloating,
+                    np.datetime64,
+                    np.timedelta64,
+                ),
+            )
+            or _is_text_scalar(item)
+            for item in values.reshape(-1)
+        )
+    return False
+
+
 def _normalize_nonnegative_integer(value, name: str) -> int:
     message = f"{name} must be a non-negative integer."
     try:
@@ -121,8 +144,18 @@ def sanitized_score_vector(values, *, nonnegative: bool = True) -> np.ndarray:
     clipped to zero, matching the common interpretation of scores as confidence,
     reliability, probability, or non-negative utility.
     """
+    message = "scores must contain real numeric values."
     nonnegative = _normalize_bool_flag(nonnegative, "nonnegative")
-    clean = np.asarray(values, dtype=np.float64).reshape(-1).copy()
+    try:
+        raw = np.asarray(values)
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise ValueError(message) from exc
+    if _contains_invalid_score_values(raw):
+        raise ValueError(message)
+    try:
+        clean = raw.astype(np.float64, copy=False).reshape(-1).copy()
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
     clean[~np.isfinite(clean)] = 0.0
     if nonnegative:
         clean = np.maximum(clean, 0.0)

--- a/tests/evaluation/test_selection_score_validation.py
+++ b/tests/evaluation/test_selection_score_validation.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pytest
+
+from pyrecest.evaluation.selection import sanitized_score_vector, top_count_mask
+
+
+def test_sanitized_score_vector_rejects_boolean_scores():
+    with pytest.raises(ValueError, match="real numeric"):
+        sanitized_score_vector([True, False])
+
+
+def test_sanitized_score_vector_rejects_text_scores():
+    with pytest.raises(ValueError, match="real numeric"):
+        sanitized_score_vector(["0.1", "0.9"])
+
+
+def test_sanitized_score_vector_rejects_object_scores_with_none():
+    with pytest.raises(ValueError, match="real numeric"):
+        sanitized_score_vector([None, 0.5])
+
+
+def test_top_count_mask_rejects_boolean_scores():
+    with pytest.raises(ValueError, match="real numeric"):
+        top_count_mask([True, False], 1)
+
+
+def test_sanitized_score_vector_keeps_numeric_sanitization_contract():
+    scores = sanitized_score_vector([np.nan, -2.0, 3.5])
+
+    np.testing.assert_allclose(scores, [0.0, 0.0, 3.5])


### PR DESCRIPTION
## Summary
- validate selection score arrays before float coercion
- reject boolean, text, complex, datetime/timedelta, and `None` object score payloads instead of silently treating them as numeric scores
- add regression coverage for direct score sanitization and `top_count_mask`

## Bug fixed
`sanitized_score_vector()` converted inputs with `np.asarray(values, dtype=np.float64)` directly. That silently accepted malformed score payloads such as booleans (`True` -> `1.0`) and numeric-looking strings (`"0.9"` -> `0.9`), which can hide upstream data/configuration errors in top-k and quantile-tail selection helpers.

## Validation
- Added focused regression tests in `tests/evaluation/test_selection_score_validation.py`.
- Full test suite not run locally because this environment cannot clone/install the repository from GitHub; CI should run the full matrix on the PR.