### PR TITLE
Validate circular grid values for sqrt interpolation

### DIFF
--- a/src/pyrecest/distributions/circle/circular_grid_distribution.py
+++ b/src/pyrecest/distributions/circle/circular_grid_distribution.py
@@ -2,6 +2,7 @@ from numbers import Integral
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 from pyrecest.backend import (
+    any,
     arange,
     array,
     atleast_1d,
@@ -47,6 +48,11 @@ class CircularGridDistribution(AbstractCircularDistribution, AbstractGridDistrib
                 "You gave a distribution as the first argument. "
                 "To convert distributions to a distribution in grid representation, "
                 "use from_distribution."
+            )
+        if enforce_pdf_nonnegative and any(grid_values < 0):
+            raise ValueError(
+                "grid_values must be nonnegative when "
+                "enforce_pdf_nonnegative=True."
             )
         n = grid_values.shape[0]
         grid = linspace(0.0, 2.0 * pi, n, endpoint=False)

--- a/tests/distributions/test_circular_grid_distribution.py
+++ b/tests/distributions/test_circular_grid_distribution.py
@@ -60,6 +60,17 @@ class CircularGridDistributionTest(unittest.TestCase):
         indices = array([0, 3, 7])
         npt.assert_allclose(dist.get_grid_point(indices), dist.get_grid()[indices])
 
+    def test_enforced_nonnegative_interpolation_rejects_negative_grid_values(self):
+        with self.assertRaisesRegex(ValueError, "nonnegative"):
+            CircularGridDistribution(
+                array([1.0, -0.1, 0.2]), enforce_pdf_nonnegative=True
+            )
+
+        dist = CircularGridDistribution(
+            array([1.0, -0.1, 0.2]), enforce_pdf_nonnegative=False
+        )
+        npt.assert_allclose(dist.grid_values, array([1.0, -0.1, 0.2]))
+
     def test_from_function_rejects_invalid_gridpoint_count(self):
         invalid_counts = (True, False, 0, -1, 1.5)
 


### PR DESCRIPTION
## Summary
- add constructor validation for `CircularGridDistribution` when `enforce_pdf_nonnegative=True`
- add a regression test covering rejected invalid input and the allowed identity-interpolation case

## Testing
Not run locally; changes were made through the GitHub connector.