### PR TITLE
Accept scalar bounds for 1D linear integration

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/abstract_linear_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/abstract_linear_distribution.py
@@ -283,25 +283,40 @@ class AbstractLinearDistribution(AbstractManifoldSpecificDistribution):
         return C
 
     def integrate(self, left=None, right=None):
-        if left is None:
-            left = -float("inf") * ones(self.dim)
-        if right is None:
-            right = float("inf") * ones(self.dim)
-
-        result = self.integrate_numerically(left, right)
-        return result
+        return self.integrate_numerically(left, right)
 
     def integrate_numerically(self, left=None, right=None):
-        if left is None:
-            left = full((self.dim,), -float("inf"))
-        if right is None:
-            right = full((self.dim,), float("inf"))
+        left, right = self._normalize_integration_bounds(left, right)
         return AbstractLinearDistribution.integrate_fun_over_domain(
             self.pdf, self.dim, left, right
         )
 
+    def _normalize_integration_bounds(self, left, right):
+        left = self._normalize_integration_bound(left, -float("inf"), "left")
+        right = self._normalize_integration_bound(right, float("inf"), "right")
+        return left, right
+
+    def _normalize_integration_bound(self, bound, default, name):
+        if bound is None:
+            return full((self.dim,), default)
+
+        bound = atleast_1d(array(bound))
+        if bound.ndim != 1 or bound.shape != (self.dim,):
+            raise ValueError(
+                f"{name} integration bound must have shape ({self.dim},), "
+                f"got {bound.shape}."
+            )
+        return bound
+
     @staticmethod
     def integrate_fun_over_domain(f, dim, left, right):
+        left = AbstractLinearDistribution._normalize_static_integration_bound(
+            left, dim, "left"
+        )
+        right = AbstractLinearDistribution._normalize_static_integration_bound(
+            right, dim, "right"
+        )
+
         def f_for_nquad(*args):
             # Avoid DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future.
             return float(squeeze(f(array(args).reshape(-1, dim))))
@@ -318,6 +333,15 @@ class AbstractLinearDistribution(AbstractManifoldSpecificDistribution):
         else:
             raise ValueError("Dimension not supported.")
         return result
+
+    @staticmethod
+    def _normalize_static_integration_bound(bound, dim, name):
+        bound = atleast_1d(array(bound))
+        if bound.ndim != 1 or bound.shape != (dim,):
+            raise ValueError(
+                f"{name} integration bound must have shape ({dim},), got {bound.shape}."
+            )
+        return bound
 
     def get_suggested_integration_limits(self, scaling_factor=10):
         """

--- a/tests/distributions/test_abstract_linear_distribution.py
+++ b/tests/distributions/test_abstract_linear_distribution.py
@@ -43,6 +43,26 @@ class TestAbstractLinearDistribution(unittest.TestCase):
             integration_result, 1.0, rtol=1e-5
         ), f"Expected 1.0, but got {integration_result}"
 
+    def test_integrate_1d_accepts_scalar_bounds(self):
+        """Test that scalar bounds are accepted for one-dimensional densities."""
+        dist = GaussianDistribution(array([0.0]), array([[1.0]]))
+
+        scalar_result = dist.integrate_numerically(-float("inf"), float("inf"))
+        wrapped_result = dist.integrate_numerically([-float("inf")], [float("inf")])
+
+        assert isclose(scalar_result, 1.0, rtol=1e-5)
+        assert isclose(scalar_result, wrapped_result, rtol=1e-12)
+
+    def test_integrate_rejects_wrong_bound_shape(self):
+        """Test that ambiguous bound vectors are rejected early."""
+        dist = GaussianDistribution(array([0.0, 0.0]), diag(array([1.0, 1.0])))
+
+        with self.assertRaisesRegex(ValueError, "left integration bound"):
+            dist.integrate_numerically([0.0], [1.0, 1.0])
+
+        with self.assertRaisesRegex(ValueError, "right integration bound"):
+            dist.integrate_numerically([0.0, 0.0], [1.0])
+
     def test_integrate_fun_over_domain_1d_accepts_sequence_bounds(self):
         dist = GaussianDistribution(array([0.0]), array([[1.0]]))
 
@@ -53,6 +73,23 @@ class TestAbstractLinearDistribution(unittest.TestCase):
         assert isclose(
             integration_result, 1.0, rtol=1e-5
         ), f"Expected 1.0, but got {integration_result}"
+
+    def test_integrate_fun_over_domain_1d_accepts_scalar_bounds(self):
+        dist = GaussianDistribution(array([0.0]), array([[1.0]]))
+
+        integration_result = AbstractLinearDistribution.integrate_fun_over_domain(
+            lambda x: dist.pdf(x), 1, -float("inf"), float("inf")
+        )
+
+        assert isclose(
+            integration_result, 1.0, rtol=1e-5
+        ), f"Expected 1.0, but got {integration_result}"
+
+    def test_integrate_fun_over_domain_rejects_wrong_bound_shape(self):
+        with self.assertRaisesRegex(ValueError, "left integration bound"):
+            AbstractLinearDistribution.integrate_fun_over_domain(
+                lambda x: x[0], 2, [0.0], [1.0, 1.0]
+            )
 
     def test_integrate_fun_over_domain(self):
         dist = GaussianDistribution(array([1.0, 2.0]), diag(array([1.0, 2.0])))


### PR DESCRIPTION
## Summary
- Normalize linear numerical-integration bounds before passing them to SciPy integration routines
- Accept natural scalar bounds for one-dimensional linear distributions while preserving per-dimension vector bounds for higher dimensions
- Add regression tests for scalar 1D bounds and explicit wrong-shape validation

## Notes
I could not run the test suite locally in this environment because the repository is only accessible through the GitHub connector here, not as a local checkout.