### PR TITLE
Tighten update diagnostics validation

### DIFF
--- a/src/pyrecest/filters/update_diagnostics.py
+++ b/src/pyrecest/filters/update_diagnostics.py
@@ -45,8 +45,7 @@ class MeasurementUpdateDiagnostics:
                     "active_measurement_indices must be smaller than measurement_count"
                 )
             object.__setattr__(self, "measurement_count", measurement_count)
-        metadata = {} if self.metadata is None else dict(self.metadata)
-        object.__setattr__(self, "metadata", metadata)
+        object.__setattr__(self, "metadata", _normalize_metadata(self.metadata))
 
     @property
     def active_measurement_count(self) -> int:
@@ -99,6 +98,14 @@ def _normalize_active_measurement_indices(
             "active_measurement_indices must not contain duplicate indices"
         )
     return indices
+
+
+def _normalize_metadata(metadata: Mapping[str, Any] | None) -> dict[str, Any]:
+    if metadata is None:
+        return {}
+    if not isinstance(metadata, Mapping):
+        raise ValueError("metadata must be a mapping or None")
+    return dict(metadata)
 
 
 def _as_nonnegative_integer(value: Any, name: str) -> int:

--- a/tests/filters/test_update_diagnostics_metadata.py
+++ b/tests/filters/test_update_diagnostics_metadata.py
@@ -1,0 +1,8 @@
+import pytest
+
+from pyrecest.filters.update_diagnostics import MeasurementUpdateDiagnostics
+
+
+def test_metadata_rejects_non_mapping_pair_sequences():
+    with pytest.raises(ValueError, match="metadata"):
+        MeasurementUpdateDiagnostics(metadata=(("a", 1),))  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- require the diagnostics extra-info field to be a mapping or `None`
- normalize valid mappings through a small helper
- add a regression test for tuple-pair payloads that `dict(...)` would otherwise accept

## Tests
- Not run locally; change was made through the GitHub connector.