### PR TITLE
Validate PyTorch where branch arguments

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_where_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_where_device_contract.py
@@ -61,6 +61,9 @@ def patch_pytorch_where_device_contract() -> None:
         return
 
     def where(condition, x=None, y=None):
+        if (x is None) != (y is None):
+            raise ValueError("either both or neither of x and y should be given")
+
         device = _preferred_pytorch_device(torch, condition, x, y)
         condition = _tensor_on_device(
             torch,

--- a/tests/backend_support/test_pytorch_where_device_contract.py
+++ b/tests/backend_support/test_pytorch_where_device_contract.py
@@ -19,10 +19,21 @@ import pyrecest.backend as backend
 import pyrecest._backend.pytorch as raw_pytorch
 
 
+
 def _non_cpu_device():
     if torch.cuda.is_available():
         return torch.device("cuda")
     return torch.device("meta")
+
+
+
+def _assert_one_sided_where_raises(*args, **kwargs):
+    try:
+        target.where(*args, **kwargs)
+    except ValueError as exc:
+        assert "either both or neither" in str(exc)
+    else:
+        raise AssertionError("one-sided where did not raise ValueError")
 
 
 target = {target_module}
@@ -41,6 +52,9 @@ assert result.device.type == device.type
 assert tuple(result.shape) == (2,)
 if device.type != "meta":
     assert torch.allclose(result.cpu(), torch.tensor([1.0, 4.0]))
+
+_assert_one_sided_where_raises([True, False], [1.0, 2.0])
+_assert_one_sided_where_raises([True, False], y=[1.0, 2.0])
 
 print("ok")
 """


### PR DESCRIPTION
## Summary
- Reject one-sided PyTorch `where(condition, x)` / `where(condition, y=...)` calls before tensor conversion.
- Match NumPy's contract that `x` and `y` must be supplied together or both omitted.
- Extend the existing PyTorch where backend-support regression test for both raw and public patched backends.

## Testing
- Not run locally; repository checkout is not available in this environment.