### PR TITLE
Validate mixture weights before backend comparisons

### DIFF
--- a/src/pyrecest/distributions/abstract_mixture.py
+++ b/src/pyrecest/distributions/abstract_mixture.py
@@ -13,7 +13,6 @@ from pyrecest.backend import (
     empty,
     int32,
     int64,
-    isfinite,
     ones,
     random,
     reshape,
@@ -25,6 +24,10 @@ from .abstract_distribution_type import AbstractDistributionType
 from .abstract_manifold_specific_distribution import (
     AbstractManifoldSpecificDistribution,
 )
+
+_TEXT_TYPES = (str, bytes, bytearray, np.str_, np.bytes_)
+_BOOLEAN_TYPES = (bool, np.bool_)
+_COMPLEX_TYPES = (complex, np.complexfloating)
 
 
 def _validate_positive_sample_count(n) -> int:
@@ -65,6 +68,32 @@ def _validate_explicit_weight_shape(weights, num_distributions: int):
     return weights
 
 
+def _validate_mixture_weight_values(weights) -> None:
+    """Reject invalid mixture weights before backend scalar comparisons."""
+    try:
+        weight_values = np.asarray(pyrecest.backend.to_numpy(weights), dtype=object)
+    except Exception as exc:  # pragma: no cover - backend-specific conversion type
+        raise ValueError("Mixture weights must be real-valued numeric") from exc
+
+    for weight in weight_values.reshape(-1):
+        if isinstance(weight, _BOOLEAN_TYPES):
+            raise ValueError("Mixture weights must be real-valued numeric, not boolean")
+        if isinstance(weight, _TEXT_TYPES):
+            raise ValueError("Mixture weights must be real-valued numeric")
+        if isinstance(weight, _COMPLEX_TYPES):
+            raise ValueError("Mixture weights must be real-valued numeric")
+
+        try:
+            parsed_weight = float(weight)
+        except (OverflowError, TypeError, ValueError) as exc:
+            raise ValueError("Mixture weights must be real-valued numeric") from exc
+
+        if not np.isfinite(parsed_weight):
+            raise ValueError("Mixture weights must be finite")
+        if parsed_weight < 0.0:
+            raise ValueError("Mixture weights must be nonnegative")
+
+
 class AbstractMixture(AbstractDistributionType):
     """
     Abstract base class for mixture distributions.
@@ -89,11 +118,7 @@ class AbstractMixture(AbstractDistributionType):
         if num_distributions != weights.shape[0]:
             raise ValueError("Sizes of distributions and weights must be equal")
 
-        if any(not bool(isfinite(weight)) for weight in weights):
-            raise ValueError("Mixture weights must be finite")
-
-        if any(bool(weight < 0) for weight in weights):
-            raise ValueError("Mixture weights must be nonnegative")
+        _validate_mixture_weight_values(weights)
 
         if not all(dists[0].dim == dist.dim for dist in dists):
             raise ValueError("All distributions must have the same dimension")
@@ -104,7 +129,7 @@ class AbstractMixture(AbstractDistributionType):
             raise ValueError("At least one mixture weight must be nonzero")
 
         weight_sum = sum(weights)
-        if not bool(isfinite(weight_sum)) or not bool(weight_sum > 0.0):
+        if not bool(pyrecest.backend.isfinite(weight_sum)) or not bool(weight_sum > 0.0):
             raise ValueError("Mixture weights must have positive finite total mass")
 
         if len(non_zero_indices) < len(weights):

--- a/src/pyrecest/distributions/abstract_mixture.py
+++ b/src/pyrecest/distributions/abstract_mixture.py
@@ -58,6 +58,7 @@ def _validate_positive_sample_count(n) -> int:
 
 def _validate_explicit_weight_shape(weights, num_distributions: int):
     """Return explicit mixture weights without silently flattening matrices."""
+    _validate_mixture_weight_values(weights)
     weights = asarray(weights)
     if weights.ndim == 0:
         if num_distributions != 1:

--- a/tests/distributions/test_mixture_weight_shape_validation.py
+++ b/tests/distributions/test_mixture_weight_shape_validation.py
@@ -4,11 +4,28 @@ from pyrecest.distributions.nonperiodic.gaussian_distribution import GaussianDis
 from pyrecest.distributions.nonperiodic.gaussian_mixture import GaussianMixture
 
 
-def test_gaussian_mixture_rejects_matrix_weights():
-    components = [
+def _components():
+    return [
         GaussianDistribution([0.0], [[1.0]], check_validity=False),
         GaussianDistribution([1.0], [[1.0]], check_validity=False),
     ]
 
+
+def test_gaussian_mixture_rejects_matrix_weights():
     with pytest.raises(ValueError, match="one-dimensional"):
-        GaussianMixture(components, [[0.25, 0.75]])
+        GaussianMixture(_components(), [[0.25, 0.75]])
+
+
+def test_gaussian_mixture_rejects_boolean_weights():
+    with pytest.raises(ValueError, match="not boolean"):
+        GaussianMixture(_components(), [True, False])
+
+
+def test_gaussian_mixture_rejects_complex_weights():
+    with pytest.raises(ValueError, match="real-valued numeric"):
+        GaussianMixture(_components(), [0.5 + 0.0j, 0.5])
+
+
+def test_gaussian_mixture_rejects_text_weights():
+    with pytest.raises(ValueError, match="real-valued numeric"):
+        GaussianMixture(_components(), ["0.5", 0.5])


### PR DESCRIPTION
## Summary
- reject boolean, complex, text, and non-numeric mixture weights before backend scalar comparisons
- keep explicit weight shape validation while producing deterministic `ValueError`s for invalid weight values
- add regression coverage for boolean, complex, and text weights

## Notes
I could not run the test suite locally because this environment cannot clone from github.com directly; changes were made through the GitHub connector.