### PR TITLE
Fix NumPy assignment_by_sum coordinate tuple handling

### DIFF
--- a/src/pyrecest/_backend/numpy/__init__.py
+++ b/src/pyrecest/_backend/numpy/__init__.py
@@ -217,7 +217,6 @@ def assignment_by_sum(x, values, indices, axis=0):
     if _assignment_by_sum_is_iterable(indices) and len(indices) == 0:
         return x_new
 
-    use_vectorization = hasattr(indices, "__len__") and len(indices) < ndim(x_new)
     if _assignment_by_sum_is_boolean(indices):
         x_new[indices] += values
         return x_new
@@ -225,11 +224,16 @@ def assignment_by_sum(x, values, indices, axis=0):
     zip_indices = _assignment_by_sum_is_iterable(
         indices
     ) and _assignment_by_sum_is_iterable(indices[0])
+    len_indices = len(indices) if _assignment_by_sum_is_iterable(indices) else 1
+    use_vectorization = (
+        hasattr(indices, "__len__") and len(indices) < ndim(x_new) and not zip_indices
+    )
     if zip_indices:
         indices = tuple(zip(*indices))
 
     if not use_vectorization:
-        len_indices = len(indices) if _assignment_by_sum_is_iterable(indices) else 1
+        if not zip_indices:
+            len_indices = len(indices) if _assignment_by_sum_is_iterable(indices) else 1
         len_values = len(values) if _assignment_by_sum_is_iterable(values) else 1
         if len_values > 1 and len_values != len_indices:
             raise ValueError("Either one value or as many values as indices")

--- a/tests/test_backend_contract.py
+++ b/tests/test_backend_contract.py
@@ -82,6 +82,8 @@ class BackendContractTest(unittest.TestCase):
         npt.assert_allclose(to_numpy(added), [3.0, 0.0, 4.0])
 
     def test_assignment_by_sum_uses_full_coordinate_tuples(self):
+        if backend.__backend_name__ != "numpy":
+            self.skipTest("NumPy backend coordinate tuple regression test")
         added = backend.assignment_by_sum(
             np.zeros((2, 2, 2)),
             [2.0, 3.0],

--- a/tests/test_backend_contract.py
+++ b/tests/test_backend_contract.py
@@ -123,7 +123,7 @@ class BackendContractTest(unittest.TestCase):
         )
 
     def test_meshgrid_uses_numpy_default_xy_indexing(self):
-        first, second = backend.meshgrid(array([1, 2]), array([3, 4])
+        first, second = backend.meshgrid(array([1, 2]), array([3, 4]))
 
         npt.assert_array_equal(to_numpy(first), np.array([[1, 2], [1, 2]]))
         npt.assert_array_equal(to_numpy(second), np.array([[3, 3], [4, 4]]))

--- a/tests/test_backend_contract.py
+++ b/tests/test_backend_contract.py
@@ -81,6 +81,18 @@ class BackendContractTest(unittest.TestCase):
 
         npt.assert_allclose(to_numpy(added), [3.0, 0.0, 4.0])
 
+    def test_assignment_by_sum_uses_full_coordinate_tuples(self):
+        added = backend.assignment_by_sum(
+            np.zeros((2, 2, 2)),
+            [2.0, 3.0],
+            [(0, 0, 0), (1, 1, 1)],
+        )
+        expected = np.zeros((2, 2, 2))
+        expected[0, 0, 0] = 2.0
+        expected[1, 1, 1] = 3.0
+
+        npt.assert_allclose(to_numpy(added), expected)
+
     def test_assignment_empty_indices_coerces_array_like_inputs(self):
         assigned = backend.assignment([1.0, 2.0, 3.0], 99.0, [])
         added = backend.assignment_by_sum([1.0, 2.0, 3.0], 99.0, [])
@@ -111,7 +123,7 @@ class BackendContractTest(unittest.TestCase):
         )
 
     def test_meshgrid_uses_numpy_default_xy_indexing(self):
-        first, second = backend.meshgrid(array([1, 2]), array([3, 4]))
+        first, second = backend.meshgrid(array([1, 2]), array([3, 4])
 
         npt.assert_array_equal(to_numpy(first), np.array([[1, 2], [1, 2]]))
         npt.assert_array_equal(to_numpy(second), np.array([[3, 3], [4, 4]]))


### PR DESCRIPTION
## Summary
- Fix `assignment_by_sum` in the NumPy backend so a list of full coordinate tuples is treated as advanced indexing rather than vectorized partial indexing.
- Preserve the pre-zip coordinate count when validating value lengths.
- Add a regression test for 3D coordinate tuple accumulation.

## Notes
- I could not run the test suite locally because the execution sandbox cannot clone/install the GitHub repository from the network; changes were made through the GitHub API and scoped to the affected NumPy backend helper.