### PR TITLE
Fix PyTorch scatter_add array-like contract

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_creation_shape_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_creation_shape_contract.py
@@ -52,10 +52,14 @@ def patch_pytorch_creation_shape_contract() -> None:
         from pyrecest._backend.pytorch._common import (  # pylint: disable=import-outside-toplevel
             _normalize_dtype,
         )
+        from pyrecest.backend_support._pytorch_scatter_add_contract import (  # pylint: disable=import-outside-toplevel
+            patch_pytorch_scatter_add_contract,
+        )
     except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
         return
 
     active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+    patch_pytorch_scatter_add_contract()
 
     def _wrap_creation_helper(helper_name, torch_helper, *, has_fill_value=False):
         original_helper = getattr(raw_pytorch, helper_name, None)

--- a/src/pyrecest/backend_support/_pytorch_scatter_add_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_scatter_add_contract.py
@@ -1,0 +1,61 @@
+"""Compatibility hook for PyTorch ``scatter_add`` backend semantics."""
+
+from __future__ import annotations
+
+from operator import index as _operator_index
+
+
+def _normalize_pytorch_scatter_dim(dim, torch_module) -> int:
+    """Return one PyTorch scatter dimension while rejecting booleans."""
+    if isinstance(dim, bool):
+        raise TypeError("dim must be an integer")
+    if torch_module.is_tensor(dim):
+        if dim.ndim != 0 or dim.dtype == torch_module.bool:
+            raise TypeError("dim must be an integer")
+        dim = dim.item()
+    try:
+        return _operator_index(dim)
+    except TypeError as exc:
+        raise TypeError("dim must be an integer") from exc
+
+
+def patch_pytorch_scatter_add_contract() -> None:
+    """Make raw/public PyTorch ``scatter_add`` accept array-like operands."""
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    original_scatter_add = getattr(raw_pytorch, "scatter_add", None)
+    if original_scatter_add is None:
+        return
+    if getattr(original_scatter_add, "_pyrecest_numpy_contract", False):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.scatter_add = original_scatter_add
+        return
+
+    def scatter_add(input, dim, index, src):  # pylint: disable=redefined-builtin
+        values = raw_pytorch.array(input)
+        dim_value = _normalize_pytorch_scatter_dim(dim, torch)
+        if not torch.is_tensor(index):
+            index = torch.as_tensor(index, dtype=torch.long, device=values.device)
+        else:
+            index = index.to(device=values.device, dtype=torch.long)
+        if not torch.is_tensor(src):
+            src = torch.as_tensor(src, dtype=values.dtype, device=values.device)
+        else:
+            src = src.to(device=values.device, dtype=values.dtype)
+        return torch.scatter_add(values, dim_value, index, src)
+
+    scatter_add.__name__ = getattr(original_scatter_add, "__name__", "scatter_add")
+    scatter_add.__doc__ = getattr(original_scatter_add, "__doc__", None)
+    scatter_add._pyrecest_arraylike_contract = True
+    scatter_add._pyrecest_numpy_contract = True
+    raw_pytorch.scatter_add = scatter_add
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.scatter_add = scatter_add
+
+
+__all__ = ["patch_pytorch_scatter_add_contract"]

--- a/tests/backend_support/test_pytorch_scatter_add_contract.py
+++ b/tests/backend_support/test_pytorch_scatter_add_contract.py
@@ -1,0 +1,27 @@
+import pytest
+
+import pyrecest.backend as backend
+
+
+def _to_python(value):
+    converted = backend.to_numpy(value)
+    return converted.tolist() if hasattr(converted, "tolist") else converted
+
+
+@pytest.mark.backend_portable
+def test_pytorch_scatter_add_accepts_array_like_inputs():
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific backend contract")
+
+    result = backend.scatter_add([10, 20, 30], 0, [0, 2], [1, 2])
+
+    assert _to_python(result) == [11, 20, 32]
+
+
+@pytest.mark.backend_portable
+def test_pytorch_scatter_add_rejects_boolean_dim():
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific backend contract")
+
+    with pytest.raises(TypeError):
+        backend.scatter_add([1, 2], True, [0], [1])


### PR DESCRIPTION
## Summary

- add a PyTorch backend compatibility hook for `scatter_add`
- normalize array-like `input`, `index`, and `src` operands before delegating to Torch
- reject boolean scatter dimensions instead of accepting `bool` as `int`
- add focused PyTorch backend regression coverage

## Bug fixed

The PyTorch backend exposed `torch.scatter_add` directly, so calls that are valid under the PyRecEst/NumPy-style backend facade failed for plain Python array-like operands, e.g.

```python
backend.scatter_add([10, 20, 30], 0, [0, 2], [1, 2])
```

The new hook keeps raw and active public PyTorch backends aligned while preserving the existing NumPy backend behavior.

## Validation

- `python -m py_compile` on the new hook and regression test content locally
- local Torch smoke check of the underlying tensor operation: `torch.scatter_add(torch.tensor([10,20,30]), 0, torch.tensor([0,2]), torch.tensor([1,2])) -> [11, 20, 32]`

Full repository tests were not run locally in this connector session; CI should run the focused regression.