### PR TITLE
Fix PyTorch dtype string alias normalization

### DIFF
--- a/src/pyrecest/_backend/pytorch/_common.py
+++ b/src/pyrecest/_backend/pytorch/_common.py
@@ -30,13 +30,29 @@ _TORCH_DTYPE_BY_NAME = {
     "complex128": _torch_complex128,
 }
 
+_TORCH_DTYPE_BY_TORCH_ALIAS = {
+    "byte": _torch_uint8,
+    "char": _torch_int8,
+    "short": _torch_int16,
+    "int": _torch_int32,
+    "long": _torch_int64,
+    "half": _torch_float16,
+    "float": _torch_float32,
+    "double": _torch_float64,
+    "cfloat": _torch_complex64,
+    "cdouble": _torch_complex128,
+}
+
 
 def _normalize_dtype(dtype):
     """Return a torch dtype for dtype-like values understood by PyTorch/NumPy."""
     if dtype is None or isinstance(dtype, _torch_dtype):
         return dtype
     if isinstance(dtype, str) and dtype.startswith("torch."):
-        dtype = dtype.split(".", 1)[1]
+        torch_alias = dtype.split(".", 1)[1]
+        if torch_alias in _TORCH_DTYPE_BY_TORCH_ALIAS:
+            return _TORCH_DTYPE_BY_TORCH_ALIAS[torch_alias]
+        dtype = torch_alias
     try:
         np_dtype = _np.dtype(dtype)
     except (TypeError, ValueError):

--- a/tests/backend_support/test_pytorch_dtype_alias_contract.py
+++ b/tests/backend_support/test_pytorch_dtype_alias_contract.py
@@ -1,0 +1,50 @@
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+pytestmark = pytest.mark.backend_portable
+
+
+def test_public_pytorch_asarray_resolves_torch_dtype_alias_strings():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    code = """
+import pyrecest.backend as backend
+
+assert backend.asarray([1.0], dtype="torch.float").dtype == backend.float32
+assert backend.asarray([1.0], dtype="torch.double").dtype == backend.float64
+assert backend.asarray([1], dtype="torch.int").dtype == backend.int32
+assert backend.asarray([1], dtype="torch.long").dtype == backend.int64
+assert backend.asarray([1.0 + 0.0j], dtype="torch.cfloat").dtype == backend.complex64
+assert backend.asarray([1.0], dtype="float").dtype == backend.float64
+assert backend.asarray([1], dtype="int").dtype == backend.int64
+print("ok")
+"""
+    result = run_backend_code("pytorch", code)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_raw_pytorch_array_resolves_torch_dtype_alias_strings_after_import():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    code = """
+import pyrecest
+import pyrecest._backend.pytorch as raw_pytorch
+
+assert raw_pytorch.array([1.0], dtype="torch.float").dtype == raw_pytorch.float32
+assert raw_pytorch.array([1.0], dtype="torch.double").dtype == raw_pytorch.float64
+assert raw_pytorch.array([1], dtype="torch.int").dtype == raw_pytorch.int32
+assert raw_pytorch.array([1], dtype="torch.long").dtype == raw_pytorch.int64
+assert raw_pytorch.array([1.0 + 0.0j], dtype="torch.cfloat").dtype == raw_pytorch.complex64
+assert raw_pytorch.array([1.0], dtype="float").dtype == raw_pytorch.float64
+assert raw_pytorch.array([1], dtype="int").dtype == raw_pytorch.int64
+print("ok")
+"""
+    result = run_backend_code("numpy", code)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- Resolve explicit `torch.*` dtype alias strings before falling back to NumPy dtype names in the PyTorch backend.
- Preserve NumPy-style aliases such as `"float"` and `"int"` for unprefixed dtype strings.
- Add backend-portable regression tests for public and raw PyTorch dtype normalization.

## Motivation
The PyTorch backend strips the `torch.` prefix before using `np.dtype(...)` for string dtype normalization. That is wrong for aliases whose NumPy names differ from PyTorch aliases, e.g. `"torch.float"` should map to `torch.float32`, not NumPy's default `float64`, and `"torch.int"` should map to `torch.int32`, not platform `int64`.

## Tests
- Added `tests/backend_support/test_pytorch_dtype_alias_contract.py`.
- Not run locally in this environment.