### PR TITLE
Reject boolean JAX FFT scalar parameters

### DIFF
--- a/src/pyrecest/_backend/jax/fft.py
+++ b/src/pyrecest/_backend/jax/fft.py
@@ -5,26 +5,28 @@ import numpy as _np
 from jax.numpy import fft as _fft
 
 
+_BOOLEAN_FFT_AXIS_ERROR = "axis must be an integer, not boolean"
+_BOOLEAN_FFT_LENGTH_ERROR = "n must be an integer length, not boolean"
+
+
 def _normalize_real_fft_axis(axis):
     """Return a Python ``int`` for integer scalar-array FFT axes."""
+    if isinstance(axis, (bool, _np.bool_)):
+        raise TypeError(_BOOLEAN_FFT_AXIS_ERROR)
     if isinstance(axis, _np.ndarray):
-        if (
-            axis.ndim == 0
-            and _np.issubdtype(axis.dtype, _np.integer)
-            and not _np.issubdtype(axis.dtype, _np.bool_)
-        ):
+        if _np.issubdtype(axis.dtype, _np.bool_):
+            raise TypeError(_BOOLEAN_FFT_AXIS_ERROR)
+        if axis.ndim == 0 and _np.issubdtype(axis.dtype, _np.integer):
             return int(axis.item())
         return axis
     if isinstance(axis, _jnp.ndarray):
         axis_dtype = _np.asarray(axis).dtype
-        if (
-            axis.ndim == 0
-            and _np.issubdtype(axis_dtype, _np.integer)
-            and not _np.issubdtype(axis_dtype, _np.bool_)
-        ):
+        if _np.issubdtype(axis_dtype, _np.bool_):
+            raise TypeError(_BOOLEAN_FFT_AXIS_ERROR)
+        if axis.ndim == 0 and _np.issubdtype(axis_dtype, _np.integer):
             return int(axis.item())
         return axis
-    if isinstance(axis, _np.integer) and not isinstance(axis, _np.bool_):
+    if isinstance(axis, _np.integer):
         return int(axis)
     return axis
 
@@ -33,24 +35,22 @@ def _normalize_real_fft_length(n):
     """Return a Python ``int`` for integer scalar-array real FFT lengths."""
     if n is None:
         return None
+    if isinstance(n, (bool, _np.bool_)):
+        raise TypeError(_BOOLEAN_FFT_LENGTH_ERROR)
     if isinstance(n, _np.ndarray):
-        if (
-            n.size == 1
-            and _np.issubdtype(n.dtype, _np.integer)
-            and not _np.issubdtype(n.dtype, _np.bool_)
-        ):
+        if _np.issubdtype(n.dtype, _np.bool_):
+            raise TypeError(_BOOLEAN_FFT_LENGTH_ERROR)
+        if n.size == 1 and _np.issubdtype(n.dtype, _np.integer):
             return int(n.item())
         return n
     if isinstance(n, _jnp.ndarray):
         n_dtype = _np.asarray(n).dtype
-        if (
-            n.size == 1
-            and _np.issubdtype(n_dtype, _np.integer)
-            and not _np.issubdtype(n_dtype, _np.bool_)
-        ):
+        if _np.issubdtype(n_dtype, _np.bool_):
+            raise TypeError(_BOOLEAN_FFT_LENGTH_ERROR)
+        if n.size == 1 and _np.issubdtype(n_dtype, _np.integer):
             return int(n.item())
         return n
-    if isinstance(n, _np.integer) and not isinstance(n, _np.bool_):
+    if isinstance(n, _np.integer):
         return int(n)
     return n
 

--- a/tests/backend_support/test_jax_fft_bool_contract.py
+++ b/tests/backend_support/test_jax_fft_bool_contract.py
@@ -1,0 +1,32 @@
+import unittest
+
+import numpy as np
+
+jax_backend = None
+try:
+    from pyrecest._backend import jax as jax_backend
+except ModuleNotFoundError:
+    pass
+
+
+@unittest.skipIf(jax_backend is None, "JAX is not installed")
+class TestJaxFftBoolContract(unittest.TestCase):
+    def test_real_fft_rejects_python_bool_axis(self):
+        with self.assertRaisesRegex(TypeError, "axis must be an integer"):
+            jax_backend.fft.rfft([1.0, 2.0], axis=True)
+
+    def test_real_fft_rejects_numpy_bool_axis(self):
+        with self.assertRaisesRegex(TypeError, "axis must be an integer"):
+            jax_backend.fft.rfft([1.0, 2.0], axis=np.array(False))
+
+    def test_real_fft_rejects_python_bool_length(self):
+        with self.assertRaisesRegex(TypeError, "n must be an integer length"):
+            jax_backend.fft.rfft([1.0, 2.0], n=True)
+
+    def test_inverse_real_fft_rejects_numpy_bool_length(self):
+        with self.assertRaisesRegex(TypeError, "n must be an integer length"):
+            jax_backend.fft.irfft([1.0, 0.0], n=np.array(True))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reject Python, NumPy, and JAX boolean scalar values for JAX real-FFT `axis` and `n` parameters
- preserve integer scalar-array normalization for valid integer `axis`/`n` inputs
- add regression tests covering boolean `axis` and `n` rejection for `rfft`/`irfft`

## Rationale
The wrapper already excluded NumPy/JAX boolean scalar arrays via integer-subdtype checks, but plain Python `bool` values could pass through as integer-like values. This can silently treat `True`/`False` as axis/length values instead of surfacing invalid input.

## Testing
- Not run locally; changes were made through the GitHub connector.