### PR TITLE
Accept scalar covariance in identity Gaussian models

### DIFF
--- a/src/pyrecest/models/linear_gaussian.py
+++ b/src/pyrecest/models/linear_gaussian.py
@@ -82,6 +82,15 @@ def _as_square(value, name):
     return arr
 
 
+def _as_identity_noise_covariance(value, dim):
+    arr = asarray(value)
+    if ndim(arr) == 0:
+        if _has_boolean_dtype(arr):
+            raise ValueError("noise_cov must be a scalar variance or square covariance")
+        return arr * eye(dim)
+    return arr
+
+
 def _mean(distribution):
     mean = getattr(distribution, "mean", None)
     if callable(mean):
@@ -201,6 +210,7 @@ class IdentityGaussianTransitionModel(LinearGaussianTransitionModel):
             noise_covariance,
             type(self).__name__,
         )
+        noise_cov = _as_identity_noise_covariance(noise_cov, dim)
         super().__init__(eye(dim), noise_cov, offset=offset)
 
 
@@ -285,4 +295,5 @@ class IdentityGaussianMeasurementModel(LinearGaussianMeasurementModel):
             noise_covariance,
             type(self).__name__,
         )
+        noise_cov = _as_identity_noise_covariance(noise_cov, dim)
         super().__init__(eye(dim), noise_cov)

--- a/tests/models/test_identity_gaussian_scalar_covariance.py
+++ b/tests/models/test_identity_gaussian_scalar_covariance.py
@@ -1,0 +1,23 @@
+import numpy.testing as npt
+
+from pyrecest.backend import eye, to_numpy
+from pyrecest.models import (
+    IdentityGaussianMeasurementModel,
+    IdentityGaussianTransitionModel,
+)
+
+
+def test_identity_models_accept_scalar_noise_variance():
+    transition_model = IdentityGaussianTransitionModel(2, 0.25)
+    measurement_model = IdentityGaussianMeasurementModel(2, noise_covariance=0.5)
+
+    npt.assert_allclose(
+        to_numpy(transition_model.system_noise_cov),
+        to_numpy(0.25 * eye(2)),
+        atol=1e-12,
+    )
+    npt.assert_allclose(
+        to_numpy(measurement_model.measurement_noise_cov),
+        to_numpy(0.5 * eye(2)),
+        atol=1e-12,
+    )


### PR DESCRIPTION
## Summary
- allow `IdentityGaussianTransitionModel` and `IdentityGaussianMeasurementModel` to interpret scalar noise covariance inputs as isotropic covariance matrices
- keep the existing square-matrix covariance path unchanged for general linear Gaussian models
- add a focused regression test for positional and keyword scalar covariance inputs

## Bug fixed
The identity Gaussian model constructors know the state/measurement dimension, so scalar noise variance inputs are unambiguous. Before this change, calls such as `IdentityGaussianTransitionModel(2, 0.25)` or `IdentityGaussianMeasurementModel(2, noise_covariance=0.5)` were rejected by the shared square-matrix validator even though the identity model can safely expand them to `variance * I`.

## Validation
- Syntax-compiled the updated source/test content locally.
- Branch comparison reports 2 commits ahead of `main`, 0 behind, with changes limited to `src/pyrecest/models/linear_gaussian.py` and `tests/models/test_identity_gaussian_scalar_covariance.py`.

Full repository tests were not run locally because this environment cannot clone/install the repository from GitHub; CI should run the focused regression.