### PR TITLE
Fix PyTorch edge pad contract

### DIFF
--- a/src/pyrecest/_backend_runtime_patches.py
+++ b/src/pyrecest/_backend_runtime_patches.py
@@ -151,3 +151,84 @@ def patch_pytorch_repeat_numpy_contract() -> None:
     raw_pytorch.repeat = repeat
     if active_pytorch_backend:
         backend.repeat = repeat
+
+
+def patch_pytorch_edge_pad_contract() -> None:
+    """Implement NumPy-style ``pad(..., mode='edge')`` for the PyTorch backend."""
+
+    try:
+        import numpy as np  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    original_pad = getattr(raw_pytorch, "pad", None)
+    if original_pad is None:
+        return
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+    if getattr(original_pad, "_pyrecest_edge_mode_contract", False):
+        if active_pytorch_backend:
+            backend.pad = original_pad
+        return
+
+    def _normalize_pad_pairs(pad_width, ndim):
+        pad_width_array = np.asarray(pad_width)
+        if not np.issubdtype(pad_width_array.dtype, np.signedinteger):
+            raise TypeError("pad_width must be of integral type")
+        try:
+            pad_pairs = np.broadcast_to(pad_width_array, (ndim, 2))
+        except ValueError as exc:
+            raise ValueError(f"pad_width must be broadcastable to shape ({ndim}, 2)") from exc
+        if np.any(pad_pairs < 0):
+            raise ValueError("index can't contain negative values")
+        return tuple((int(before), int(after)) for before, after in pad_pairs.tolist())
+
+    def _edge_block(values, axis, width, edge_index):
+        edge = torch.narrow(values, axis, edge_index, 1)
+        shape = list(values.shape)
+        shape[axis] = width
+        return torch.broadcast_to(edge, tuple(shape))
+
+    def _edge_pad(values, pad_width):
+        result = values
+        for axis, (before, after) in enumerate(
+            _normalize_pad_pairs(pad_width, values.ndim)
+        ):
+            if (before or after) and result.shape[axis] == 0:
+                raise ValueError(
+                    f"can't extend empty axis {axis} using modes other than 'constant' or 'empty'"
+                )
+            if before:
+                result = torch.cat(
+                    (_edge_block(result, axis, before, 0), result),
+                    dim=axis,
+                )
+            if after:
+                result = torch.cat(
+                    (
+                        result,
+                        _edge_block(result, axis, after, result.shape[axis] - 1),
+                    ),
+                    dim=axis,
+                )
+        return result
+
+    def pad(a, pad_width, mode="constant", constant_values=0.0):
+        if mode != "edge":
+            return original_pad(
+                a,
+                pad_width,
+                mode=mode,
+                constant_values=constant_values,
+            )
+        values = raw_pytorch.array(a)
+        return _edge_pad(values, pad_width)
+
+    pad.__name__ = getattr(original_pad, "__name__", "pad")
+    pad.__doc__ = getattr(original_pad, "__doc__", None)
+    pad._pyrecest_edge_mode_contract = True
+    raw_pytorch.pad = pad
+    if active_pytorch_backend:
+        backend.pad = pad

--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -213,6 +213,7 @@ def resolve_evidence_computation_mode(
 try:
     from pyrecest._backend_runtime_patches import (  # pylint: disable=import-outside-toplevel
         patch_pytorch_close_equal_nan_device_contract as _patch_pytorch_close_equal_nan_device_contract,
+        patch_pytorch_edge_pad_contract as _patch_pytorch_edge_pad_contract,
         patch_pytorch_repeat_numpy_contract as _patch_pytorch_repeat_numpy_contract,
     )
     from pyrecest.backend_support._pytorch_one_hot_scalar_contract import (  # pylint: disable=import-outside-toplevel
@@ -223,4 +224,5 @@ except ModuleNotFoundError:  # pragma: no cover - source tree corruption only
 else:
     _patch_pytorch_close_equal_nan_device_contract()
     _patch_pytorch_repeat_numpy_contract()
+    _patch_pytorch_edge_pad_contract()
     _patch_pytorch_one_hot_scalar_contract()

--- a/tests/backend_support/test_pytorch_pad_edge_contract.py
+++ b/tests/backend_support/test_pytorch_pad_edge_contract.py
@@ -1,0 +1,61 @@
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+pytestmark = pytest.mark.backend_portable
+
+EXPECTED_EDGE_PADDED = [
+    [1, 1, 2, 2],
+    [1, 1, 2, 2],
+    [3, 3, 4, 4],
+    [3, 3, 4, 4],
+    [3, 3, 4, 4],
+]
+
+
+def test_raw_pytorch_pad_accepts_numpy_style_edge_mode_after_import():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    code = f"""
+import pyrecest  # noqa: F401  # triggers raw-backend compatibility patches
+import torch
+import pyrecest._backend.pytorch as raw_pytorch_backend
+
+values = torch.tensor([[1, 2], [3, 4]], dtype=torch.int64)
+result = raw_pytorch_backend.pad(values, ((1, 2), (1, 1)), mode="edge")
+assert result.tolist() == {EXPECTED_EDGE_PADDED!r}
+
+one_dimensional = raw_pytorch_backend.pad(
+    torch.tensor([1, 2], dtype=torch.int64),
+    (1, 2),
+    mode="edge",
+)
+assert one_dimensional.tolist() == [1, 1, 2, 2, 2]
+print("ok")
+"""
+    result = run_backend_code("numpy", code)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_public_pytorch_pad_accepts_numpy_style_edge_mode():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    code = f"""
+import pyrecest.backend as backend
+
+result = backend.pad(
+    backend.array([[1, 2], [3, 4]], dtype=backend.int64),
+    ((1, 2), (1, 1)),
+    mode="edge",
+)
+assert backend.to_numpy(result).tolist() == {EXPECTED_EDGE_PADDED!r}
+print("ok")
+"""
+    result = run_backend_code("pytorch", code)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- add a runtime PyTorch backend patch for NumPy-style `pad(..., mode="edge")`
- implement edge padding by replicating first/last slices along each padded axis
- add backend-portable regression tests for raw and public PyTorch pad entry points

## Notes
The existing PyTorch pad compatibility layer already normalizes NumPy-style constant padding. This extends the same backend contract to `mode="edge"`, which NumPy supports but `torch.nn.functional.pad` does not accept under that name.

## Testing
- Added `tests/backend_support/test_pytorch_pad_edge_contract.py`
- Not run locally in this connector-only environment; CI should execute the backend-portable tests.