### PR TITLE
Validate NumPy choice population size

### DIFF
--- a/src/pyrecest/_backend/numpy/random.py
+++ b/src/pyrecest/_backend/numpy/random.py
@@ -1,5 +1,7 @@
 """Numpy based random backend."""
 
+from operator import index as _operator_index
+
 import numpy as _np
 from numpy.random import default_rng as _default_rng
 from numpy.random import (  # For PyRecEst
@@ -11,7 +13,7 @@ from numpy.random import (  # For PyRecEst
 from .._shared_numpy.random import (
     _normalize_probability_values,
     _normalize_size,
-    choice,
+    choice as _shared_choice,
     multivariate_normal,
     normal,
     rand,
@@ -19,6 +21,7 @@ from .._shared_numpy.random import (
 )
 
 _BOOLEAN_TYPES = (bool, _np.bool_)
+_CHOICE_POPULATION_ERROR = "a must be a positive integer or a non-empty array"
 
 
 def _contains_boolean_value(value):
@@ -64,6 +67,44 @@ def randint(low, high=None, size=None, dtype=int):
     _validate_randint_bound(low, "low")
     _validate_randint_bound(high, "high")
     return _np.random.randint(low, high=high, size=size, dtype=dtype)
+
+
+def _normalize_choice_axis(axis, ndim):
+    if isinstance(axis, _BOOLEAN_TYPES):
+        raise TypeError("axis must be an integer")
+    try:
+        axis = _operator_index(axis)
+    except TypeError as exc:
+        raise TypeError("axis must be an integer") from exc
+    if axis < -ndim or axis >= ndim:
+        raise ValueError(f"axis {axis} is out of bounds for array of dimension {ndim}")
+    return axis % ndim
+
+
+def _validate_choice_population_size(a, axis):
+    a_array = _np.asarray(a)
+    if a_array.ndim == 0:
+        scalar = a_array.item()
+        if isinstance(scalar, _BOOLEAN_TYPES):
+            raise ValueError(_CHOICE_POPULATION_ERROR)
+        try:
+            population_size = _operator_index(scalar)
+        except TypeError:
+            return
+        if population_size <= 0:
+            raise ValueError(_CHOICE_POPULATION_ERROR)
+        return
+
+    axis = _normalize_choice_axis(axis, a_array.ndim)
+    if a_array.shape[axis] <= 0:
+        raise ValueError(_CHOICE_POPULATION_ERROR)
+
+
+def choice(a, size=None, replace=True, p=None, axis=0, shuffle=True):
+    """Draw samples from a non-empty integer or array population."""
+
+    _validate_choice_population_size(a, axis)
+    return _shared_choice(a, size=size, replace=replace, p=p, axis=axis, shuffle=shuffle)
 
 
 def _validate_multinomial_sample_count(n):

--- a/tests/backend/test_numpy_random_choice_population.py
+++ b/tests/backend/test_numpy_random_choice_population.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pytest
+
+from pyrecest._backend.numpy import random
+
+
+@pytest.mark.parametrize("population", [0, -1, np.array(0), np.array(-3)])
+def test_choice_rejects_non_positive_integer_population_for_empty_sample(population):
+    with pytest.raises(ValueError, match="positive integer"):
+        random.choice(population, size=0)
+
+
+@pytest.mark.parametrize(
+    ("population", "axis"),
+    [
+        (np.empty((0,), dtype=int), 0),
+        (np.empty((2, 0), dtype=int), 1),
+    ],
+)
+def test_choice_rejects_empty_array_population_axis_for_empty_sample(population, axis):
+    with pytest.raises(ValueError, match="non-empty array"):
+        random.choice(population, size=0, axis=axis)
+
+
+def test_choice_allows_empty_non_population_dimensions():
+    random.seed(0)
+
+    samples = random.choice(np.empty((2, 0), dtype=int), size=1, axis=0)
+
+    assert samples.shape == (1, 0)

--- a/tests/test_backend_random.py
+++ b/tests/test_backend_random.py
@@ -74,10 +74,9 @@ class TestBackendRandom(unittest.TestCase):
         for sample in pyrecest.backend.to_numpy(samples).tolist():
             self.assertIn(sample, (10, 20, 30))
 
-    def test_choice_accepts_zero_sized_integer_population_sample(self):
-        samples = random.choice(0, size=(0,))
-
-        self.assertEqual(samples.shape, (0,))
+    def test_choice_rejects_zero_sized_integer_population_sample(self):
+        with self.assertRaises(ValueError):
+            random.choice(0, size=(0,))
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ != "jax",


### PR DESCRIPTION
## Summary
- add an explicit NumPy backend `random.choice` population-size validation wrapper
- reject non-positive scalar populations and empty array populations even when `size=0`
- cover scalar, array-axis, and non-population empty-dimension cases with regression tests

## Rationale
`random.choice` already reports that `a` must be a positive integer or a non-empty array for boolean scalar populations. However, NumPy permits empty draws from empty or non-positive populations when `size=0`, so PyRecEst accepted invalid populations in that edge case. This patch makes validation independent of the requested sample shape and keeps empty dimensions that are not the sampled population axis valid.

## Testing
- Not run locally; patch was prepared through the GitHub connector.