### PR TITLE
Fix raw PyTorch repeat contract after backend setup

### DIFF
--- a/src/pyrecest/_backend_runtime_patches.py
+++ b/src/pyrecest/_backend_runtime_patches.py
@@ -71,3 +71,37 @@ def patch_pytorch_close_equal_nan_device_contract() -> None:
         setattr(raw_pytorch, helper_name, helper)
         if active_pytorch_backend:
             setattr(backend, helper_name, helper)
+
+
+def patch_pytorch_repeat_numpy_contract() -> None:
+    """Preserve the raw PyTorch repeat contract for non-PyTorch public backends."""
+
+    try:
+        import numpy as np  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+        from pyrecest._backend_submodules import (  # pylint: disable=import-outside-toplevel
+            _pytorch_repeat_with_arraylike_inputs,
+        )
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+    original_repeat = getattr(raw_pytorch, "repeat", None)
+    if original_repeat is None:
+        return
+    if getattr(original_repeat, "_pyrecest_repeat_contract", False):
+        if active_pytorch_backend:
+            setattr(backend, "repeat", original_repeat)
+        return
+
+    repeat = _pytorch_repeat_with_arraylike_inputs(
+        original_repeat,
+        raw_pytorch.array,
+        np,
+        torch,
+    )
+    raw_pytorch.repeat = repeat
+    if active_pytorch_backend:
+        backend.repeat = repeat

--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -213,15 +213,10 @@ def resolve_evidence_computation_mode(
 try:
     from pyrecest._backend_runtime_patches import (  # pylint: disable=import-outside-toplevel
         patch_pytorch_close_equal_nan_device_contract as _patch_pytorch_close_equal_nan_device_contract,
+        patch_pytorch_repeat_numpy_contract as _patch_pytorch_repeat_numpy_contract,
     )
 except ModuleNotFoundError:  # pragma: no cover - source tree corruption only
     pass
 else:
     _patch_pytorch_close_equal_nan_device_contract()
-
-
-__all__ = [
-    "EvidenceComputationKind",
-    "EvidenceComputationMode",
-    "resolve_evidence_computation_mode",
-]
+    _patch_pytorch_repeat_numpy_contract()


### PR DESCRIPTION
## Summary
- add a post-setup runtime patch for `pyrecest._backend.pytorch.repeat`
- keep the raw PyTorch repeat wrapper active even when the selected public backend is NumPy
- preserve the public NumPy backend's own `repeat` while syncing the public PyTorch backend when active

## Bug fixed
`_adapt_pytorch_repeat_contract` only ran when `pyrecest.backend.__backend_name__ == "pytorch"`. As a result, under the NumPy public backend, direct raw imports such as `pyrecest._backend.pytorch.repeat([1, 2], 2)` still reached `torch.repeat_interleave` and rejected NumPy-style array-like inputs.

## Tests
- covered by existing `tests/backend_support/test_pytorch_repeat_contract.py::test_raw_pytorch_repeat_default_backend_is_patched`
- not run locally in this environment