### PR TITLE
Validate skipped update diagnostics reasons

### DIFF
--- a/src/pyrecest/filters/update_diagnostics.py
+++ b/src/pyrecest/filters/update_diagnostics.py
@@ -45,6 +45,7 @@ class MeasurementUpdateDiagnostics:
                     "active_measurement_indices must be smaller than measurement_count"
                 )
             object.__setattr__(self, "measurement_count", measurement_count)
+        object.__setattr__(self, "skipped_reason", _normalize_skipped_reason(self.skipped_reason))
         object.__setattr__(self, "metadata", _normalize_metadata(self.metadata))
 
     @property
@@ -98,6 +99,16 @@ def _normalize_active_measurement_indices(
             "active_measurement_indices must not contain duplicate indices"
         )
     return indices
+
+
+def _normalize_skipped_reason(skipped_reason: str | None) -> str | None:
+    if skipped_reason is None:
+        return None
+    if not isinstance(skipped_reason, str):
+        raise ValueError("skipped_reason must be a string or None")
+    if not skipped_reason:
+        raise ValueError("skipped_reason must not be empty")
+    return skipped_reason
 
 
 def _normalize_metadata(metadata: Mapping[str, Any] | None) -> dict[str, Any]:

--- a/tests/filters/test_update_diagnostics_skipped_reason.py
+++ b/tests/filters/test_update_diagnostics_skipped_reason.py
@@ -1,0 +1,16 @@
+import pytest
+
+from pyrecest.filters.update_diagnostics import MeasurementUpdateDiagnostics
+
+
+@pytest.mark.parametrize("skipped_reason", ["", 0, object()])
+def test_skipped_reason_rejects_non_text_or_empty_values(skipped_reason):
+    with pytest.raises(ValueError, match="skipped_reason"):
+        MeasurementUpdateDiagnostics(skipped_reason=skipped_reason)
+
+
+def test_skipped_constructor_accepts_non_empty_reason():
+    diagnostics = MeasurementUpdateDiagnostics.skipped("gated")
+
+    assert diagnostics.skipped_reason == "gated"
+    assert not diagnostics.updated


### PR DESCRIPTION
## Summary
- Validate `MeasurementUpdateDiagnostics.skipped_reason` as a non-empty string or `None`.
- Add regression coverage for invalid skipped reasons.

## Tests
Not run locally; changes were made through the GitHub connector.
