### PR TITLE
Reject boolean scalar PyTorch randint bounds

### DIFF
--- a/src/pyrecest/_backend/pytorch/random/__init__.py
+++ b/src/pyrecest/_backend/pytorch/random/__init__.py
@@ -17,6 +17,8 @@ _LEGACY = _importlib_util.module_from_spec(_LEGACY_SPEC)
 _sys.modules[_LEGACY_MODULE_NAME] = _LEGACY
 _LEGACY_SPEC.loader.exec_module(_LEGACY)
 
+_BOOLEAN_SCALAR_TYPES = (bool, _np.bool_)
+
 
 def _validate_multivariate_normal_check_valid(check_valid):
     if check_valid not in {"warn", "raise", "ignore"}:
@@ -44,6 +46,20 @@ def _validate_multivariate_normal_tol(tol):
     return tol_value
 
 
+def _reject_boolean_randint_bound(value, name):
+    if isinstance(value, _BOOLEAN_SCALAR_TYPES):
+        raise TypeError(f"{name} must contain integer values")
+
+
+def randint(low, high=None, size=None, *args, **kwargs):
+    """Draw integer samples, rejecting boolean scalar bounds consistently."""
+
+    _reject_boolean_randint_bound(low, "low" if high is not None else "high")
+    if high is not None:
+        _reject_boolean_randint_bound(high, "high")
+    return _LEGACY.randint(low, high, size, *args, **kwargs)
+
+
 def multivariate_normal(mean, cov, size=None, *args, **kwargs):
     """Draw samples with NumPy-compatible validation keyword handling."""
 
@@ -60,7 +76,7 @@ __all__ = sorted(
         for name in dir(_LEGACY)
         if not (name.startswith("__") and name.endswith("__"))
     }
-    | {"multivariate_normal"}
+    | {"multivariate_normal", "randint"}
 )
 
 

--- a/tests/backend/test_pytorch_random_backend.py
+++ b/tests/backend/test_pytorch_random_backend.py
@@ -132,6 +132,26 @@ def test_randint_rejects_non_integer_array_high_only(high):
         random.randint(high)
 
 
+@pytest.mark.parametrize(
+    ("low", "high"),
+    [
+        (True, None),
+        (False, None),
+        (np.bool_(True), None),
+        (False, 3),
+        (0, True),
+        (np.bool_(False), 3),
+        (0, np.bool_(True)),
+    ],
+)
+def test_randint_rejects_boolean_scalar_bounds(low, high):
+    with pytest.raises(TypeError, match="integer"):
+        if high is None:
+            random.randint(low)
+        else:
+            random.randint(low, high)
+
+
 @pytest.mark.parametrize("bad_size", [(), (3,), (3, 1)])
 def test_normal_rejects_array_parameters_incompatible_with_explicit_size(bad_size):
     with pytest.raises(ValueError, match="broadcast"):


### PR DESCRIPTION
## Summary
- add PyTorch random shim validation for scalar boolean `randint` bounds
- keep array/tensor bound handling delegated to the legacy implementation
- add regression coverage for high-only and low/high scalar boolean cases

## Rationale
The PyTorch random backend already rejects boolean array/tensor bounds for `randint`, but Python and NumPy scalar booleans could still reach `torch.randint`, where they may be interpreted as integer values. This makes the PyTorch backend inconsistent with the NumPy backend validation contract and can silently accept invalid bounds.

## Tests
- Not run locally; changes were made through the GitHub connector.