### PR TITLE
Normalize PyTorch FFT shape arrays

### DIFF
--- a/src/pyrecest/_backend/pytorch/fft.py
+++ b/src/pyrecest/_backend/pytorch/fft.py
@@ -73,6 +73,38 @@ def _normalize_fft_dim_sequence(dim):
     return tuple(normalized_entries)
 
 
+def _normalize_fft_shape_sequence(shape):
+    """Return NumPy-style FFT shape sequences in PyTorch-compatible form."""
+    if shape is None or isinstance(shape, (str, bytes)):
+        return shape
+    try:
+        shape_entries = tuple(shape)
+    except TypeError:
+        return shape
+
+    normalized_entries = []
+    for entry in shape_entries:
+        if isinstance(entry, bool):
+            normalized_entries.append(entry)
+            continue
+        try:
+            normalized_entries.append(_operator_index(entry))
+        except TypeError:
+            return shape
+    return tuple(normalized_entries)
+
+
+def _normalize_fft_shape_args(args, kwargs):
+    """Normalize the NumPy-style ``s`` FFT shape argument when present."""
+    if args:
+        return (_normalize_fft_shape_sequence(args[0]), *args[1:]), kwargs
+    if "s" not in kwargs:
+        return args, kwargs
+    kwargs = dict(kwargs)
+    kwargs["s"] = _normalize_fft_shape_sequence(kwargs["s"])
+    return args, kwargs
+
+
 def _with_dim_alias(kwargs, alias, func_name, *, none_alias_means_default=True):
     if alias not in kwargs:
         return kwargs
@@ -105,6 +137,7 @@ def _wrap_arraylike_fft(
     empty_dim_is_noop=False,
     normalize_scalar_dim=False,
     normalize_dim_sequence=False,
+    normalize_shape_sequence=False,
     none_alias_means_default=True,
 ):
     @_wraps(torch_func)
@@ -122,6 +155,8 @@ def _wrap_arraylike_fft(
         if normalize_dim_sequence and "dim" in kwargs:
             kwargs = dict(kwargs)
             kwargs["dim"] = _normalize_fft_dim_sequence(kwargs["dim"])
+        if normalize_shape_sequence:
+            args, kwargs = _normalize_fft_shape_args(args, kwargs)
         value = _as_fft_tensor(value)
         if (
             empty_dim_is_noop
@@ -168,6 +203,7 @@ fftn = _wrap_arraylike_fft(
     dim_alias="axes",
     empty_dim_is_noop=True,
     normalize_dim_sequence=True,
+    normalize_shape_sequence=True,
 )
 ifftn = _wrap_arraylike_fft(
     _torch.fft.ifftn,
@@ -175,4 +211,5 @@ ifftn = _wrap_arraylike_fft(
     dim_alias="axes",
     empty_dim_is_noop=True,
     normalize_dim_sequence=True,
+    normalize_shape_sequence=True,
 )

--- a/tests/backend_support/test_pytorch_fftn_shape_contract.py
+++ b/tests/backend_support/test_pytorch_fftn_shape_contract.py
@@ -1,0 +1,28 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+pytest.importorskip("torch")
+
+import pyrecest._backend.pytorch.fft as pytorch_fft  # noqa: E402
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_fftn_accepts_numpy_shape_array_keyword():
+    vector = np.arange(4.0)
+    shape = np.array([4], dtype=np.int64)
+
+    spectrum = pytorch_fft.fftn(vector.tolist(), s=shape)
+
+    npt.assert_allclose(spectrum.numpy(), np.fft.fftn(vector, s=shape))
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_ifftn_accepts_numpy_shape_array_positional():
+    vector = np.arange(4.0)
+    shape = np.array([4], dtype=np.int64)
+    spectrum = np.fft.fftn(vector, s=shape)
+
+    reconstructed = pytorch_fft.ifftn(spectrum.tolist(), shape)
+
+    npt.assert_allclose(reconstructed.numpy(), np.fft.ifftn(spectrum, s=shape))


### PR DESCRIPTION
## Summary
- normalize NumPy-style FFT shape sequences before dispatching PyTorch `fftn`/`ifftn`
- support `np.array([n])` for the `s` argument, both as a keyword and first positional shape argument
- add focused raw PyTorch FFT regression coverage

## Bug fixed
The raw PyTorch FFT wrapper accepted array-like signal inputs but forwarded the `s` shape argument directly to `torch.fft.fftn` / `ifftn`. Torch rejects NumPy array shape sequences such as `np.array([4])` with `TypeError: argument 's' must be tuple of ints`, while NumPy-style callers can reasonably pass those values. The wrapper now converts valid shape sequences to tuples of Python integers before calling Torch.

## Validation
- Syntax-checked the modified FFT wrapper and new test locally with `python -m py_compile`.
- Reproduced the underlying Torch failure mode locally for `torch.fft.fftn(torch.arange(4.0), s=np.array([4]))` and checked the normalized call against NumPy's result.
- Connector diff check: branch is 2 commits ahead of `main` and 0 behind; changes are limited to the PyTorch FFT wrapper and a focused regression test.