### PR TITLE
Add survival-aware association priors

### DIFF
--- a/src/pyrecest/filters/survival_association.py
+++ b/src/pyrecest/filters/survival_association.py
@@ -1,0 +1,439 @@
+# pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
+"""Survival-aware association priors for multitarget track management.
+
+This module provides a small CRP-inspired prior layer that can be composed with
+PyRecEst association hypotheses and :class:`TrackManager` associators.  It
+replaces raw cluster popularity with effective track mass, existence, survival,
+detection, and visibility factors.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from math import log
+from typing import Any, Literal
+
+import numpy as np
+
+from .association_hypotheses import (
+    AssociationHypothesis,
+    _coerce_measurements,
+    association_result_from_hypotheses,
+    hypothesis_cost,
+    linear_gaussian_association_hypotheses,
+)
+
+CostMode = Literal["auto", "cost", "log_likelihood"]
+
+
+@dataclass(frozen=True)
+class TrackSurvivalPriorComponents:
+    """Resolved prior factors for one track."""
+
+    track_mass: float
+    existence_probability: float
+    survival_probability: float
+    detection_probability: float
+    visibility_probability: float
+    steps_since_seen: int
+    epsilon: float = 1e-12
+
+    @property
+    def assignment_weight(self) -> float:
+        return max(
+            self.track_mass
+            * self.existence_probability
+            * self.survival_probability
+            * self.detection_probability
+            * self.visibility_probability,
+            self.epsilon,
+        )
+
+    @property
+    def log_assignment_weight(self) -> float:
+        return log(self.assignment_weight)
+
+    @property
+    def missed_detection_probability(self) -> float:
+        detection_probability = min(
+            self.existence_probability
+            * self.survival_probability
+            * self.detection_probability
+            * self.visibility_probability,
+            1.0,
+        )
+        return max(1.0 - detection_probability, self.epsilon)
+
+    @property
+    def missed_detection_cost(self) -> float:
+        return -log(self.missed_detection_probability)
+
+
+@dataclass(frozen=True)
+class SurvivalAwareAssociationConfig:
+    """Configuration for survival-aware association weighting.
+
+    Probability-valued fields may be scalars, length-matching vectors, or
+    callables. Track callables receive ``track``, ``track_index`` and
+    ``current_step``. Measurement callables receive ``measurement``,
+    ``measurement_index`` and ``current_step``.
+    """
+
+    existence_probability: Any = None
+    survival_probability: Any = 1.0
+    detection_probability: Any = None
+    visibility_probability: Any = None
+    track_mass: Any = None
+    track_mass_decay: float = 1.0
+    minimum_track_mass: float = 1.0
+    birth_probability: Any = 1.0
+    epsilon: float = 1e-12
+
+    def __post_init__(self) -> None:
+        _as_probability(self.track_mass_decay, "track_mass_decay")
+        _as_nonnegative_scalar(self.minimum_track_mass, "minimum_track_mass")
+        _as_positive_scalar(self.epsilon, "epsilon")
+
+
+def track_survival_prior_components(
+    tracks: Sequence[Any],
+    *,
+    current_step: int | None = None,
+    config: SurvivalAwareAssociationConfig | dict[str, Any] | None = None,
+) -> list[TrackSurvivalPriorComponents]:
+    """Resolve survival-aware prior factors for every track."""
+    cfg = _as_config(config)
+    return [_components_for_track(tracks, i, current_step=current_step, config=cfg) for i in range(len(tracks))]
+
+
+def survival_aware_missed_detection_costs(
+    tracks: Sequence[Any],
+    *,
+    current_step: int | None = None,
+    config: SurvivalAwareAssociationConfig | dict[str, Any] | None = None,
+) -> np.ndarray:
+    """Return per-track costs for leaving tracks unmatched."""
+    return np.asarray(
+        [component.missed_detection_cost for component in track_survival_prior_components(tracks, current_step=current_step, config=config)]
+    )
+
+
+def survival_aware_birth_costs(
+    measurements: Sequence[Any],
+    *,
+    current_step: int | None = None,
+    config: SurvivalAwareAssociationConfig | dict[str, Any] | None = None,
+    measurement_axis: str = "auto",
+    measurement_dim: int | None = None,
+) -> np.ndarray:
+    """Return per-measurement costs for leaving measurements unmatched."""
+    cfg = _as_config(config)
+    measurement_vectors = _coerce_measurements(
+        measurements,
+        measurement_axis=measurement_axis,  # type: ignore[arg-type]
+        measurement_dim=measurement_dim,
+    )
+    return np.asarray(
+        [
+            -log(
+                max(
+                    _resolve_measurement_probability(
+                        cfg.birth_probability,
+                        measurement_vectors,
+                        i,
+                        "birth_probability",
+                        current_step=current_step,
+                        default_value=1.0,
+                    ),
+                    cfg.epsilon,
+                )
+            )
+            for i in range(len(measurement_vectors))
+        ]
+    )
+
+
+def apply_survival_association_prior(
+    hypotheses: Sequence[AssociationHypothesis],
+    tracks: Sequence[Any],
+    *,
+    current_step: int | None = None,
+    config: SurvivalAwareAssociationConfig | dict[str, Any] | None = None,
+    cost_mode: CostMode = "auto",
+) -> list[AssociationHypothesis]:
+    """Fold survival-aware prior factors into pairwise hypothesis scores."""
+    _validate_cost_mode(cost_mode)
+    components = track_survival_prior_components(tracks, current_step=current_step, config=config)
+    adjusted = []
+    for hypothesis in hypotheses:
+        if hypothesis.is_missed_detection:
+            adjusted.append(hypothesis)
+            continue
+        component = components[_valid_track_index(hypothesis.track_index, len(components))]
+        log_weight = component.log_assignment_weight
+        adjusted_log_likelihood = None if hypothesis.log_likelihood is None else float(hypothesis.log_likelihood) + log_weight
+        adjusted_probability = None if hypothesis.probability is None else float(hypothesis.probability) * component.assignment_weight
+        metadata = dict(hypothesis.metadata or {})
+        metadata["survival_prior"] = {
+            "track_mass": component.track_mass,
+            "existence_probability": component.existence_probability,
+            "survival_probability": component.survival_probability,
+            "detection_probability": component.detection_probability,
+            "visibility_probability": component.visibility_probability,
+            "steps_since_seen": component.steps_since_seen,
+            "assignment_weight": component.assignment_weight,
+            "log_assignment_weight": log_weight,
+        }
+        adjusted.append(
+            replace(
+                hypothesis,
+                cost=_adjusted_cost(hypothesis, log_weight, adjusted_log_likelihood, cost_mode),
+                log_likelihood=adjusted_log_likelihood,
+                probability=adjusted_probability,
+                metadata=metadata,
+            )
+        )
+    return adjusted
+
+
+def build_survival_aware_linear_gaussian_associator(
+    measurement_matrix,
+    meas_noise,
+    *,
+    config: SurvivalAwareAssociationConfig | dict[str, Any] | None = None,
+    gates=None,
+    missing_cost: float = np.inf,
+    unassigned_track_cost: float | Sequence[float] | None = None,
+    unassigned_measurement_cost: float | Sequence[float] | None = None,
+    measurement_axis: str = "auto",
+    cost_mode: CostMode = "auto",
+):
+    """Create a TrackManager-compatible linear/Gaussian associator."""
+    default_config = _as_config(config)
+    _validate_cost_mode(cost_mode)
+
+    def associator(tracks, measurements, **kwargs):
+        cfg = _as_config(kwargs.get("survival_config", default_config))
+        eff_matrix = kwargs.get("measurement_matrix", measurement_matrix)
+        eff_axis = kwargs.get("measurement_axis", measurement_axis)
+        eff_cost_mode = kwargs.get("cost_mode", cost_mode)
+        eff_step = kwargs.get("current_step", None)
+        _validate_cost_mode(eff_cost_mode)
+        measurement_dim = int(np.asarray(eff_matrix, dtype=float).shape[0])
+        hypotheses = linear_gaussian_association_hypotheses(
+            tracks,
+            measurements,
+            eff_matrix,
+            kwargs.get("meas_noise", meas_noise),
+            gates=kwargs.get("gates", gates),
+            measurement_axis=eff_axis,
+            strict_backend=kwargs.get("strict_backend", False),
+        )
+        adjusted = apply_survival_association_prior(
+            hypotheses,
+            tracks,
+            current_step=eff_step,
+            config=cfg,
+            cost_mode=eff_cost_mode,
+        )
+        measurement_vectors = _coerce_measurements(measurements, measurement_axis=eff_axis, measurement_dim=measurement_dim)
+        track_cost = kwargs.get("unassigned_track_cost", unassigned_track_cost)
+        if track_cost is None:
+            track_cost = survival_aware_missed_detection_costs(tracks, current_step=eff_step, config=cfg)
+        measurement_cost = kwargs.get("unassigned_measurement_cost", unassigned_measurement_cost)
+        if measurement_cost is None:
+            measurement_cost = survival_aware_birth_costs(
+                measurement_vectors,
+                current_step=eff_step,
+                config=cfg,
+                measurement_axis="sequence",
+                measurement_dim=measurement_dim,
+            )
+        return association_result_from_hypotheses(
+            adjusted,
+            num_tracks=len(tracks),
+            num_measurements=len(measurement_vectors),
+            missing_cost=kwargs.get("missing_cost", missing_cost),
+            unassigned_track_cost=track_cost,
+            unassigned_measurement_cost=measurement_cost,
+        )
+
+    return associator
+
+
+def _as_config(config):
+    if config is None:
+        return SurvivalAwareAssociationConfig()
+    if isinstance(config, SurvivalAwareAssociationConfig):
+        return config
+    return SurvivalAwareAssociationConfig(**dict(config))
+
+
+def _components_for_track(tracks, track_index, *, current_step, config):
+    track = tracks[track_index]
+    miss_count = _misses(track)
+    steps_since_seen = _steps_since_seen(track, current_step=current_step)
+    base_mass = _resolve_track_nonnegative(config.track_mass, tracks, track_index, "track_mass", current_step=current_step, default_value=max(float(_hits(track)), 1.0))
+    track_mass = max(base_mass * float(config.track_mass_decay) ** miss_count, float(config.minimum_track_mass))
+    survival = _resolve_track_probability(config.survival_probability, tracks, track_index, "survival_probability", current_step=current_step, default_value=1.0) ** steps_since_seen
+    existence = _resolve_track_probability(config.existence_probability, tracks, track_index, "existence_probability", current_step=current_step, attr_name="existence_probability", metadata_key="existence_probability", default_value=1.0)
+    detection = _resolve_track_probability(config.detection_probability, tracks, track_index, "detection_probability", current_step=current_step, metadata_key="detection_probability", default_value=1.0)
+    visibility = _resolve_track_probability(config.visibility_probability, tracks, track_index, "visibility_probability", current_step=current_step, metadata_key="visibility_probability", default_value=1.0)
+    return TrackSurvivalPriorComponents(
+        track_mass=track_mass,
+        existence_probability=existence,
+        survival_probability=survival,
+        detection_probability=detection,
+        visibility_probability=visibility,
+        steps_since_seen=steps_since_seen,
+        epsilon=float(config.epsilon),
+    )
+
+
+def _adjusted_cost(hypothesis, log_weight, adjusted_log_likelihood, cost_mode):
+    if cost_mode == "log_likelihood" or (cost_mode == "auto" and adjusted_log_likelihood is not None):
+        if adjusted_log_likelihood is not None:
+            return -float(adjusted_log_likelihood)
+    return hypothesis_cost(hypothesis) - log_weight
+
+
+def _resolve_track_probability(value, tracks, index, name, *, current_step, attr_name=None, metadata_key=None, default_value):
+    return _as_probability(
+        _resolve_track_value(value, tracks, index, name, current_step=current_step, attr_name=attr_name, metadata_key=metadata_key, default_value=default_value),
+        name,
+    )
+
+
+def _resolve_track_nonnegative(value, tracks, index, name, *, current_step, default_value):
+    return _as_nonnegative_scalar(
+        _resolve_track_value(value, tracks, index, name, current_step=current_step, attr_name=None, metadata_key=None, default_value=default_value),
+        name,
+    )
+
+
+def _resolve_track_value(value, tracks, index, name, *, current_step, attr_name, metadata_key, default_value):
+    track = tracks[index]
+    if value is None:
+        metadata = _metadata(track)
+        if attr_name is not None and hasattr(track, attr_name):
+            return getattr(track, attr_name)
+        if metadata_key is not None and metadata_key in metadata:
+            return metadata[metadata_key]
+        return default_value
+    if callable(value):
+        return value(track, track_index=index, current_step=current_step)
+    values = np.asarray(value)
+    if values.shape == ():
+        return values.item()
+    if values.size != len(tracks):
+        raise ValueError(f"{name} must be scalar, callable, or have length {len(tracks)}")
+    return values.reshape(-1)[index]
+
+
+def _resolve_measurement_probability(value, measurements, index, name, *, current_step, default_value):
+    if value is None:
+        resolved = default_value
+    elif callable(value):
+        resolved = value(measurements[index], measurement_index=index, current_step=current_step)
+    else:
+        values = np.asarray(value)
+        if values.shape == ():
+            resolved = values.item()
+        else:
+            if values.size != len(measurements):
+                raise ValueError(f"{name} must be scalar, callable, or have length {len(measurements)}")
+            resolved = values.reshape(-1)[index]
+    return _as_probability(resolved, name)
+
+
+def _metadata(track):
+    metadata = getattr(track, "metadata", None)
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _hits(track):
+    return max(int(getattr(track, "hits", 1)), 1)
+
+
+def _misses(track):
+    return max(int(getattr(track, "misses", 0)), 0)
+
+
+def _steps_since_seen(track, *, current_step):
+    metadata = _metadata(track)
+    if current_step is not None and "last_seen_step" in metadata:
+        return max(int(current_step) - int(metadata["last_seen_step"]), 0)
+    if hasattr(track, "misses"):
+        return _misses(track) + 1
+    if current_step is not None and hasattr(track, "last_step"):
+        return max(int(current_step) - int(getattr(track, "last_step")), 0)
+    return 1
+
+
+def _valid_track_index(value, num_tracks):
+    values = np.asarray(value)
+    if values.shape != () or values.dtype == np.bool_:
+        raise ValueError("hypothesis.track_index must be a nonnegative integer")
+    scalar = values.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError("hypothesis.track_index must be a nonnegative integer")
+    if isinstance(scalar, (int, np.integer)):
+        index = int(scalar)
+    elif isinstance(scalar, (float, np.floating)) and np.isfinite(scalar) and float(scalar).is_integer():
+        index = int(scalar)
+    else:
+        raise ValueError("hypothesis.track_index must be a nonnegative integer")
+    if index < 0 or index >= num_tracks:
+        raise ValueError("hypothesis.track_index is out of range")
+    return index
+
+
+def _validate_cost_mode(cost_mode):
+    if cost_mode not in ("auto", "cost", "log_likelihood"):
+        raise ValueError("cost_mode must be 'auto', 'cost', or 'log_likelihood'")
+
+
+def _as_scalar_float(value, name):
+    values = np.asarray(value)
+    if values.shape != () or values.dtype == np.bool_:
+        raise ValueError(f"{name} must be a scalar number")
+    try:
+        scalar = float(values.item())
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be a scalar number") from exc
+    if not np.isfinite(scalar):
+        raise ValueError(f"{name} must be finite")
+    return scalar
+
+
+def _as_probability(value, name):
+    scalar = _as_scalar_float(value, name)
+    if not 0.0 <= scalar <= 1.0:
+        raise ValueError(f"{name} must be in [0, 1]")
+    return scalar
+
+
+def _as_nonnegative_scalar(value, name):
+    scalar = _as_scalar_float(value, name)
+    if scalar < 0.0:
+        raise ValueError(f"{name} must be nonnegative")
+    return scalar
+
+
+def _as_positive_scalar(value, name):
+    scalar = _as_scalar_float(value, name)
+    if scalar <= 0.0:
+        raise ValueError(f"{name} must be positive")
+    return scalar
+
+
+__all__ = [
+    "SurvivalAwareAssociationConfig",
+    "TrackSurvivalPriorComponents",
+    "apply_survival_association_prior",
+    "build_survival_aware_linear_gaussian_associator",
+    "survival_aware_birth_costs",
+    "survival_aware_missed_detection_costs",
+    "track_survival_prior_components",
+]

--- a/tests/filters/test_survival_association.py
+++ b/tests/filters/test_survival_association.py
@@ -1,0 +1,94 @@
+from dataclasses import dataclass, field
+import math
+import unittest
+
+import numpy as np
+from pyrecest.filters.association_hypotheses import AssociationHypothesis
+from pyrecest.filters.survival_association import (
+    SurvivalAwareAssociationConfig,
+    apply_survival_association_prior,
+    survival_aware_birth_costs,
+    survival_aware_missed_detection_costs,
+    track_survival_prior_components,
+)
+
+
+@dataclass
+class DummyTrack:
+    hits: int = 1
+    misses: int = 0
+    metadata: dict = field(default_factory=dict)
+
+
+class SurvivalAssociationTest(unittest.TestCase):
+    def test_resolves_survival_weight_from_track_lifecycle(self):
+        tracks = [DummyTrack(hits=4, misses=2, metadata={"visibility_probability": 0.25})]
+        config = SurvivalAwareAssociationConfig(
+            existence_probability=0.8,
+            survival_probability=0.5,
+            detection_probability=0.5,
+            track_mass_decay=0.5,
+            minimum_track_mass=0.0,
+        )
+
+        components = track_survival_prior_components(tracks, config=config)
+
+        self.assertEqual(components[0].steps_since_seen, 3)
+        self.assertAlmostEqual(components[0].track_mass, 1.0)
+        self.assertAlmostEqual(components[0].survival_probability, 0.125)
+        self.assertAlmostEqual(components[0].assignment_weight, 0.0125)
+        self.assertAlmostEqual(
+            components[0].missed_detection_cost,
+            -math.log(1.0 - 0.8 * 0.125 * 0.5 * 0.25),
+        )
+
+    def test_prior_can_prefer_recent_track_over_popular_stale_track(self):
+        tracks = [DummyTrack(hits=1, misses=0), DummyTrack(hits=10, misses=4)]
+        hypotheses = [
+            AssociationHypothesis(track_index=0, measurement_index=0, cost=0.0, log_likelihood=0.0),
+            AssociationHypothesis(track_index=1, measurement_index=0, cost=0.0, log_likelihood=0.0),
+        ]
+        config = SurvivalAwareAssociationConfig(
+            existence_probability=1.0,
+            survival_probability=0.5,
+            detection_probability=1.0,
+            visibility_probability=1.0,
+            minimum_track_mass=0.0,
+        )
+
+        adjusted = apply_survival_association_prior(hypotheses, tracks, config=config)
+
+        self.assertLess(adjusted[0].cost, adjusted[1].cost)
+        self.assertAlmostEqual(adjusted[0].cost, -math.log(0.5))
+        self.assertAlmostEqual(adjusted[1].cost, -math.log(10.0 * 0.5**5))
+        self.assertIn("survival_prior", adjusted[0].metadata)
+
+    def test_missed_detection_cost_decreases_for_low_visibility_track(self):
+        tracks = [
+            DummyTrack(metadata={"visibility_probability": 1.0}),
+            DummyTrack(metadata={"visibility_probability": 0.1}),
+        ]
+        config = SurvivalAwareAssociationConfig(
+            existence_probability=0.9,
+            survival_probability=1.0,
+            detection_probability=0.8,
+        )
+
+        costs = survival_aware_missed_detection_costs(tracks, config=config)
+
+        self.assertGreater(costs[0], costs[1])
+
+    def test_birth_costs_accept_per_measurement_probabilities(self):
+        config = SurvivalAwareAssociationConfig(birth_probability=[0.25, 1.0])
+
+        costs = survival_aware_birth_costs(
+            [np.array([0.0]), np.array([1.0])],
+            config=config,
+            measurement_axis="sequence",
+        )
+
+        np.testing.assert_allclose(costs, np.array([-math.log(0.25), 0.0]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a lightweight survival-aware association prior layer for multitarget track management.

Implemented pieces:

- `SurvivalAwareAssociationConfig` for existence, per-step survival, detection, visibility, effective track mass, mass decay, and birth probabilities
- `TrackSurvivalPriorComponents` for resolved per-track prior factors
- `apply_survival_association_prior(...)` to fold lifecycle-aware prior weights into existing `AssociationHypothesis` scores
- `survival_aware_missed_detection_costs(...)` so visible/high-existence tracks are expensive to miss while occluded/low-existence tracks are cheap to leave unmatched
- `survival_aware_birth_costs(...)` for per-measurement birth/unassigned-measurement costs
- `build_survival_aware_linear_gaussian_associator(...)` as a `TrackManager`-compatible linear/Gaussian associator wrapper
- focused unit tests for lifecycle weighting, stale-track downweighting, visibility-aware missed detections, and per-measurement birth costs

## Rationale

This is a first PyRecEst-native step toward non-exchangeable, tracking-specific CRP-style association priors. Instead of using raw cluster popularity, assignment scores are weighted by physically meaningful track factors:

```text
effective track mass × existence × survival × detection × visibility
```

The implementation intentionally does not claim to be a full dependent Dirichlet-process tracker. It is a composable prior layer for existing association hypotheses and `TrackManager` workflows.

## Notes

The new APIs are currently available through direct submodule imports:

```python
from pyrecest.filters.survival_association import (
    SurvivalAwareAssociationConfig,
    apply_survival_association_prior,
    build_survival_aware_linear_gaussian_associator,
)
```

A follow-up can add lazy exports in `pyrecest.filters.__init__` if this API shape is accepted.

## Validation

- Syntax-compiled the new module and tests locally.
- Ran the focused survival-association tests against a minimal local stub of the association-hypothesis dependencies.
- Full PyRecEst test suite was not run locally in this environment; CI should run the repository-level checks.