### PR TITLE
Fix PyTorch sort axis=None contract

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_dot_outer_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_dot_outer_device_contract.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from pyrecest.backend_support._pytorch_sort_numpy_contract import (
+    sort_axis_none as _sort_axis_none,
+)
+
 
 def _preferred_pytorch_device(torch_module, *values):
     """Return a non-CPU tensor device when mixed-device operands are present."""
@@ -25,6 +29,28 @@ def _promoted_pair(raw_pytorch, torch_module, left, right):
     return left.to(device=device, dtype=dtype), right.to(device=device, dtype=dtype)
 
 
+def _patch_sort_axis_none_contract(raw_pytorch, backend, torch_module) -> None:
+    """Patch raw/public PyTorch sort to flatten inputs for ``axis=None``."""
+    original_sort = getattr(raw_pytorch, "sort", None)
+    if original_sort is None:
+        return
+    if getattr(original_sort, "_pyrecest_sort_axis_none_contract", False):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            setattr(backend, "sort", original_sort)
+        return
+
+    def sort(a, axis=-1):
+        return _sort_axis_none(raw_pytorch, torch_module, a, axis=axis)
+
+    sort.__name__ = getattr(original_sort, "__name__", "sort")
+    sort.__doc__ = getattr(original_sort, "__doc__", None)
+    sort._pyrecest_sort_axis_none_contract = True
+    sort._pyrecest_numpy_contract = True
+    setattr(raw_pytorch, "sort", sort)
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        setattr(backend, "sort", sort)
+
+
 def patch_pytorch_dot_outer_device_contract() -> None:
     """Patch raw/public PyTorch vector-product helpers to preserve non-CPU operands."""
     try:
@@ -33,6 +59,8 @@ def patch_pytorch_dot_outer_device_contract() -> None:
         import torch  # pylint: disable=import-outside-toplevel
     except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
         return
+
+    _patch_sort_axis_none_contract(raw_pytorch, backend, torch)
 
     original_dot = getattr(raw_pytorch, "dot", None)
     original_outer = getattr(raw_pytorch, "outer", None)

--- a/src/pyrecest/backend_support/_pytorch_sort_numpy_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_sort_numpy_contract.py
@@ -23,3 +23,14 @@ def flatten_axis_for_sort(axis):
 def flatten_sort_values(torch_module, values):
     """Flatten values before sorting along the synthetic first axis."""
     return torch_module.flatten(values)
+
+
+def sort_axis_none(backend_module, torch_module, values, axis=-1):
+    """Sort values with NumPy-style ``axis=None`` support."""
+    values = backend_module.array(values)
+    if axis is None:
+        values = torch_module.flatten(values)
+        axis = 0
+    else:
+        axis = _operator_index(axis)
+    return torch_module.sort(values, dim=axis).values

--- a/src/pyrecest/backend_support/_pytorch_sort_numpy_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_sort_numpy_contract.py
@@ -18,3 +18,8 @@ def flatten_axis_for_sort(axis):
     if normalized_axis is None:
         return 0
     return normalized_axis
+
+
+def flatten_sort_values(torch_module, values):
+    """Flatten values before sorting along the synthetic first axis."""
+    return torch_module.flatten(values)

--- a/src/pyrecest/backend_support/_pytorch_sort_numpy_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_sort_numpy_contract.py
@@ -1,0 +1,12 @@
+"""PyTorch sort helpers for backend compatibility."""
+
+from __future__ import annotations
+
+from operator import index as _operator_index
+
+
+def normalize_sort_axis(axis):
+    """Return a sort axis while preserving NumPy's flatten-all sentinel."""
+    if axis is None:
+        return None
+    return _operator_index(axis)

--- a/src/pyrecest/backend_support/_pytorch_sort_numpy_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_sort_numpy_contract.py
@@ -10,3 +10,11 @@ def normalize_sort_axis(axis):
     if axis is None:
         return None
     return _operator_index(axis)
+
+
+def flatten_axis_for_sort(axis):
+    """Return zero for flattened sorting and a normalized axis otherwise."""
+    normalized_axis = normalize_sort_axis(axis)
+    if normalized_axis is None:
+        return 0
+    return normalized_axis

--- a/src/pyrecest/backend_support/_pytorch_sort_numpy_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_sort_numpy_contract.py
@@ -12,25 +12,11 @@ def normalize_sort_axis(axis):
     return _operator_index(axis)
 
 
-def flatten_axis_for_sort(axis):
-    """Return zero for flattened sorting and a normalized axis otherwise."""
-    normalized_axis = normalize_sort_axis(axis)
-    if normalized_axis is None:
-        return 0
-    return normalized_axis
-
-
-def flatten_sort_values(torch_module, values):
-    """Flatten values before sorting along the synthetic first axis."""
-    return torch_module.flatten(values)
-
-
 def sort_axis_none(backend_module, torch_module, values, axis=-1):
     """Sort values with NumPy-style ``axis=None`` support."""
     values = backend_module.array(values)
+    axis = normalize_sort_axis(axis)
     if axis is None:
         values = torch_module.flatten(values)
         axis = 0
-    else:
-        axis = _operator_index(axis)
     return torch_module.sort(values, dim=axis).values

--- a/tests/backend_support/test_pytorch_sort_axis_none_contract.py
+++ b/tests/backend_support/test_pytorch_sort_axis_none_contract.py
@@ -1,0 +1,62 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _backend_subprocess_env(backend_name):
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = backend_name
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    return env
+
+
+@pytest.mark.backend_portable
+def test_public_pytorch_sort_axis_none_flattens_like_numpy():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = _backend_subprocess_env("pytorch")
+
+    code = """
+import pyrecest.backend as backend
+
+assert backend.__backend_name__ == "pytorch"
+
+flat_result = backend.sort([[3, 1], [2, 0]], axis=None)
+assert backend.to_numpy(flat_result).tolist() == [0, 1, 2, 3]
+
+axis_result = backend.sort([[3, 1], [2, 0]], axis=0)
+assert backend.to_numpy(axis_result).tolist() == [[2, 0], [3, 1]]
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_sort_axis_none_is_patched_under_default_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = _backend_subprocess_env("numpy")
+
+    code = """
+import pyrecest  # noqa: F401
+import pyrecest.backend as public_backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+assert public_backend.__backend_name__ == "numpy"
+
+flat_result = raw_pytorch.sort([[3, 1], [2, 0]], axis=None)
+assert raw_pytorch.to_numpy(flat_result).tolist() == [0, 1, 2, 3]
+
+axis_result = raw_pytorch.sort([[3, 1], [2, 0]], axis=0)
+assert raw_pytorch.to_numpy(axis_result).tolist() == [[2, 0], [3, 1]]
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- Implement NumPy-style flattening for PyTorch `sort(..., axis=None)`.
- Wire the helper through backend-support initialization.
- Add subprocess regression coverage for public and raw PyTorch backend calls.

## Validation
- Syntax-checked the changed Python files locally with `py_compile`.
- Full suite was not run in this connector environment.