### PR TITLE
Fix JAX linalg.norm axis normalization

### DIFF
--- a/src/pyrecest/_backend/jax/linalg.py
+++ b/src/pyrecest/_backend/jax/linalg.py
@@ -8,6 +8,8 @@ import numpy as _np
 
 from .._backend_config import jax_atol as atol
 
+_AXIS_TYPE_ERROR = "axis must be None, an integer, or a tuple of integers"
+
 
 def _as_linalg_array(value):
     """Convert PyRecEst array-like inputs before calling raw JAX linalg."""
@@ -29,6 +31,38 @@ def _as_integer_scalar(value, name):
     if not _jnp.issubdtype(value_array.dtype, _jnp.integer):
         raise TypeError(f"{name} must be an integer scalar")
     return int(value_array.item())
+
+
+def _norm_axis_entry(axis) -> int:
+    """Return one non-boolean NumPy-style linalg.norm axis."""
+    if isinstance(axis, (bool, _np.bool_)):
+        raise TypeError(_AXIS_TYPE_ERROR)
+    try:
+        return _operator_index(axis)
+    except TypeError:
+        pass
+
+    axis_array = _jnp.asarray(axis)
+    if axis_array.shape != () or axis_array.dtype == _jnp.bool_:
+        raise TypeError(_AXIS_TYPE_ERROR)
+    if not _jnp.issubdtype(axis_array.dtype, _jnp.integer):
+        raise TypeError(_AXIS_TYPE_ERROR)
+    return int(axis_array.item())
+
+
+def _normalize_norm_axis(axis):
+    """Normalize JAX linalg.norm axes before they become static arguments."""
+    if axis is None:
+        return None
+    if isinstance(axis, (list, tuple)):
+        return tuple(_norm_axis_entry(one_axis) for one_axis in axis)
+
+    axis_array = _jnp.asarray(axis)
+    if axis_array.shape == ():
+        return _norm_axis_entry(axis)
+    if axis_array.ndim == 1:
+        return tuple(_norm_axis_entry(one_axis) for one_axis in axis_array.tolist())
+    raise TypeError(_AXIS_TYPE_ERROR)
 
 
 def cholesky(a, *args, **kwargs):
@@ -63,8 +97,13 @@ def matrix_rank(a, *args, **kwargs):
     return _jnp.linalg.matrix_rank(_as_linalg_array(a), *args, **kwargs)
 
 
-def norm(x, *args, **kwargs):
-    return _jnp.linalg.norm(_as_linalg_array(x), *args, **kwargs)
+def norm(x, ord=None, axis=None, keepdims=False):
+    return _jnp.linalg.norm(
+        _as_linalg_array(x),
+        ord=ord,
+        axis=_normalize_norm_axis(axis),
+        keepdims=keepdims,
+    )
 
 
 def pinv(a, *args, **kwargs):

--- a/tests/backend_support/test_jax_linalg_contract.py
+++ b/tests/backend_support/test_jax_linalg_contract.py
@@ -92,6 +92,83 @@ print("ok")
 
 
 @pytest.mark.backend_portable
+def test_jax_linalg_norm_normalizes_static_axis_inputs():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("JAX is not installed")
+
+    result = run_backend_code(
+        "jax",
+        """
+import jax.numpy as jnp
+import numpy as np
+import pyrecest.backend as backend
+
+values = backend.array([[3.0, 4.0], [5.0, 12.0]])
+expected = backend.array([5.0, 13.0])
+
+axis_cases = [
+    np.int64(1),
+    np.array(1),
+    jnp.array(1),
+    [1],
+    (1,),
+    np.array([1]),
+    jnp.array([1]),
+]
+
+for axis in axis_cases:
+    result = backend.linalg.norm(values, axis=axis)
+    assert bool(jnp.allclose(result, expected)), axis
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+@pytest.mark.backend_portable
+def test_jax_linalg_norm_rejects_boolean_axes():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("JAX is not installed")
+
+    result = run_backend_code(
+        "jax",
+        """
+import jax.numpy as jnp
+import numpy as np
+import pyrecest.backend as backend
+
+values = backend.array([[3.0, 4.0], [5.0, 12.0]])
+
+
+def assert_rejects(axis):
+    try:
+        backend.linalg.norm(values, axis=axis)
+    except TypeError:
+        return
+    raise AssertionError(f"axis {axis!r} should have raised TypeError")
+
+for axis in [
+    True,
+    np.bool_(True),
+    np.array(True),
+    jnp.array(True),
+    [True],
+    (True,),
+    np.array([True]),
+    jnp.array([True]),
+]:
+    assert_rejects(axis)
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+@pytest.mark.backend_portable
 def test_jax_qr_accepts_numpy_economic_mode():
     if importlib.util.find_spec("jax") is None:
         pytest.skip("JAX is not installed")


### PR DESCRIPTION
## Summary
- normalize JAX `linalg.norm` axes before forwarding them as JAX static arguments
- accept NumPy/JAX zero-dimensional integer axis arrays and one-dimensional integer axis arrays by converting them to Python `int`/`tuple[int, ...]`
- reject boolean scalar and boolean sequence axes instead of silently treating them as `0`/`1`

## Bug fixed
The JAX backend forwarded `axis` directly to `jax.numpy.linalg.norm`. Non-hashable static axis values such as `np.array(1)`, `jnp.array(1)`, or `np.array([1])` therefore failed before the norm was evaluated, even though other backend wrappers normalize NumPy-style scalar arguments. Boolean axes could also be interpreted as integer axes in some cases.

## Validation
- Added focused backend-portable regression tests for normalized JAX `linalg.norm` axis inputs and boolean-axis rejection.
- Smoke-checked the axis normalizer locally with NumPy scalar arrays, JAX scalar arrays, one-dimensional axis arrays, and boolean rejection cases.
- Compared the branch against current `main`: 2 commits ahead, 0 behind; changes limited to `src/pyrecest/_backend/jax/linalg.py` and `tests/backend_support/test_jax_linalg_contract.py`.

Full repository pytest was not run locally because this environment cannot clone GitHub directly; CI should run the added backend regression tests.