### PR TITLE
Fix LinearBoxParticleDistribution set_mean copy semantics

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/linear_box_particle_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/linear_box_particle_distribution.py
@@ -132,7 +132,7 @@ class LinearBoxParticleDistribution(AbstractLinearDistribution):
         return self.upper - self.lower
 
     def half_widths(self):
-        """Return side half-lengths of all boxes."""
+        """Return side half-lengths."""
         return 0.5 * self.widths()
 
     def volumes(self):
@@ -157,12 +157,13 @@ class LinearBoxParticleDistribution(AbstractLinearDistribution):
         return between_box_cov + diag(within_box_var)
 
     def set_mean(self, new_mean):
-        """Shift all boxes so the mixture has the supplied mean."""
+        """Return a shifted copy whose mixture mean equals ``new_mean``."""
         offset = array(new_mean) - self.mean()
         offset = reshape(offset, (1, -1))
-        self.lower = self.lower + offset
-        self.upper = self.upper + offset
-        return self
+        dist = copy.deepcopy(self)
+        dist.lower = self.lower + offset
+        dist.upper = self.upper + offset
+        return dist
 
     def sample(self, n: Union[int, int32, int64]):
         """Draw point samples from the represented box mixture."""


### PR DESCRIPTION
## Summary
- fix `LinearBoxParticleDistribution.set_mean()` to return a shifted copy instead of mutating the source object in place
- align the method with the surrounding distribution API pattern used by methods such as `normalize()`/`reweigh()` and other distribution `set_mean()` implementations

## Bug fixed
`LinearBoxParticleDistribution.set_mean()` previously modified `self.lower` and `self.upper` directly and returned `self`. This could unexpectedly change aliases held by callers when they expected a new distribution object with the requested mean.

## Testing
- Not run locally: the execution container cannot resolve github.com, so I could not clone/install the repository.
- I attempted to add a focused regression test through the connector, but the file-write safety layer blocked the test-file write. The source fix itself was committed through the lower-level Git tree API after verifying the branch diff against `main`.