### PR TITLE
Reject NumPy boolean axes in PyTorch fftconvolve

### DIFF
--- a/src/pyrecest/_backend/pytorch/signal.py
+++ b/src/pyrecest/_backend/pytorch/signal.py
@@ -4,7 +4,15 @@ import torch as _torch
 _AXIS_TYPE_ERROR = "axes must be None, an integer, or a sequence of integers"
 
 
+def _is_numpy_bool_scalar(axis):
+    return isinstance(axis, _np.bool_) or (
+        isinstance(axis, _np.ndarray) and axis.shape == () and axis.dtype == _np.bool_
+    )
+
+
 def _coerce_axis(axis):
+    if _is_numpy_bool_scalar(axis):
+        raise ValueError(_AXIS_TYPE_ERROR)
     try:
         axis_array = _np.asarray(axis)
     except (TypeError, ValueError) as exc:

--- a/tests/backend_support/test_pytorch_fftconvolve_axes_validation.py
+++ b/tests/backend_support/test_pytorch_fftconvolve_axes_validation.py
@@ -39,6 +39,20 @@ def test_pytorch_fftconvolve_rejects_non_integer_axes(axes):
         backend.signal.fftconvolve(first, second, axes=axes)
 
 
+@pytest.mark.parametrize(
+    "axes",
+    [np.bool_(True), np.array(True)],
+)
+def test_pytorch_fftconvolve_rejects_numpy_boolean_axes(axes):
+    _skip_unless_pytorch()
+
+    first = backend.asarray([1.0, 2.0])
+    second = backend.asarray([3.0, 4.0])
+
+    with pytest.raises(ValueError, match="axes must be None"):
+        backend.signal.fftconvolve(first, second, axes=axes)
+
+
 def test_pytorch_fftconvolve_rejects_incompatible_non_convolved_axes():
     _skip_unless_pytorch()
 


### PR DESCRIPTION
## Summary
- Reject NumPy boolean scalar axes in the PyTorch `signal.fftconvolve` backend.
- Add regression coverage for `np.bool_(True)` and `np.array(True)` axes.

## Validation
- Checked the modified validator locally with torch and numpy.
- Full repository test suite not run in this environment.