### PR TITLE
Add nonparametric cardinality priors

### DIFF
--- a/docs/advanced-tracking.md
+++ b/docs/advanced-tracking.md
@@ -15,3 +15,31 @@ Each advanced tracker example should document:
 Use small deterministic measurement sets for CI smoke tests. Assert stable
 properties such as number of tracks, selected associations, finite log-likelihoods,
 and diagnostic container shapes.
+
+## Nonparametric cardinality priors
+
+`pyrecest.tracking.nonparametric_cardinality` provides small Dirichlet-process
+and Pitman--Yor-process prior utilities for target-generated cluster counts. They
+are intentionally not complete trackers. Instead, they expose reusable prior
+terms that can be multiplied with measurement likelihoods, survival probabilities,
+and clutter alternatives inside a tracker-specific association or birth model.
+
+For current cluster sizes `n_1, ..., n_K`, `PitmanYorCardinalityPrior` returns
+Chinese-restaurant-process probabilities
+
+```text
+P(existing k) = (n_k - d) / (theta + n)
+P(new cluster) = (theta + d K) / (theta + n)
+```
+
+where `n = sum_k n_k`, `theta` is the strength parameter, and `d` is the discount
+parameter. `DirichletProcessCardinalityPrior` is the `d = 0` special case. A
+positive discount gives heavier prior mass to high cluster counts and is useful
+for prior-predictive checks in scenarios with many short-lived, bursty, or rare
+target-generated clusters.
+
+Keep the interpretation narrow: the cluster-count PMF is a prior over occupied
+exchangeable clusters after a given number of target-generated observations, not
+a full random-finite-set posterior over live targets. A multitarget tracker still
+needs explicit survival, missed-detection, clutter, and measurement-likelihood
+models.

--- a/src/pyrecest/tracking/__init__.py
+++ b/src/pyrecest/tracking/__init__.py
@@ -209,3 +209,13 @@ __all__ += [
     "symmetrize",
     "wrap_ellipse_angle_to_reference",
 ]
+
+from .nonparametric_cardinality import (
+    DirichletProcessCardinalityPrior,
+    PitmanYorCardinalityPrior,
+)
+
+__all__ += [
+    "DirichletProcessCardinalityPrior",
+    "PitmanYorCardinalityPrior",
+]

--- a/src/pyrecest/tracking/nonparametric_cardinality.py
+++ b/src/pyrecest/tracking/nonparametric_cardinality.py
@@ -1,0 +1,201 @@
+"""Bayesian nonparametric cardinality priors for tracking association.
+
+The classes in this module expose Dirichlet-process and Pitman--Yor-process
+Chinese-restaurant-process predictive probabilities in a small, deterministic
+form that can be used by multitarget trackers for birth/association proposals or
+for prior predictive diagnostics of the number of target-generated clusters.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import exp, isfinite, lgamma, log
+from numbers import Integral
+from typing import Sequence
+
+
+@dataclass(frozen=True)
+class PitmanYorCardinalityPrior:
+    """Pitman--Yor Chinese-restaurant prior over target-generated clusters.
+
+    Parameters
+    ----------
+    strength : float, optional
+        Pitman--Yor strength parameter ``theta``. It must satisfy
+        ``strength > -discount``. For the Dirichlet-process special case
+        ``discount == 0``, this means ``strength > 0``.
+    discount : float, optional
+        Pitman--Yor discount parameter ``d`` with ``0 <= d < 1``. Positive
+        values encourage heavier-tailed cluster counts than a Dirichlet process.
+
+    Notes
+    -----
+    Given current cluster sizes ``n_1, ..., n_K`` and ``n = sum_k n_k``, the
+    predictive probabilities are
+
+    ``P(existing k) = (n_k - d) / (theta + n)``
+
+    and
+
+    ``P(new cluster) = (theta + d K) / (theta + n)``.
+
+    The returned probabilities are intended as *prior* association weights; a
+    tracker should still multiply them by measurement likelihoods, survival
+    probabilities, and clutter alternatives.
+    """
+
+    strength: float = 1.0
+    discount: float = 0.0
+
+    def __post_init__(self) -> None:
+        strength = float(self.strength)
+        discount = float(self.discount)
+        if not isfinite(strength):
+            raise ValueError("strength must be finite.")
+        if not isfinite(discount):
+            raise ValueError("discount must be finite.")
+        if not 0.0 <= discount < 1.0:
+            raise ValueError("discount must satisfy 0 <= discount < 1.")
+        if strength <= -discount:
+            raise ValueError("strength must satisfy strength > -discount.")
+        object.__setattr__(self, "strength", strength)
+        object.__setattr__(self, "discount", discount)
+
+    @property
+    def is_dirichlet_process(self) -> bool:
+        """Return true if the prior is the Dirichlet-process special case."""
+
+        return self.discount == 0.0
+
+    def predictive_weights(self, cluster_sizes: Sequence[int]) -> tuple[float, ...]:
+        """Return unnormalized existing-cluster and new-cluster weights.
+
+        The final returned entry is always the weight for a new target-generated
+        cluster. The preceding entries correspond to the supplied cluster sizes
+        in order.
+        """
+
+        sizes = _validate_cluster_sizes(cluster_sizes)
+        if not sizes:
+            return (1.0,)
+        existing_weights = tuple(float(size) - self.discount for size in sizes)
+        new_weight = self.strength + self.discount * len(sizes)
+        return existing_weights + (float(new_weight),)
+
+    def predictive_probabilities(self, cluster_sizes: Sequence[int]) -> tuple[float, ...]:
+        """Return CRP predictive probabilities for existing clusters and a new cluster."""
+
+        sizes = _validate_cluster_sizes(cluster_sizes)
+        if not sizes:
+            return (1.0,)
+        denominator = self.strength + float(sum(sizes))
+        return tuple(weight / denominator for weight in self.predictive_weights(sizes))
+
+    def predictive_log_probabilities(self, cluster_sizes: Sequence[int]) -> tuple[float, ...]:
+        """Return log predictive probabilities for existing clusters and a new cluster."""
+
+        return tuple(log(probability) for probability in self.predictive_probabilities(cluster_sizes))
+
+    def log_exchangeable_partition_probability(self, cluster_sizes: Sequence[int]) -> float:
+        """Return the EPPF log probability of one partition with given block sizes.
+
+        The value is the probability of one exchangeable partition whose block
+        sizes are ``cluster_sizes``. It is not the marginal probability of the
+        unordered size histogram, because the latter also depends on the number
+        of set partitions with those sizes.
+        """
+
+        sizes = _validate_cluster_sizes(cluster_sizes)
+        if not sizes:
+            return 0.0
+
+        num_observations = sum(sizes)
+        num_clusters = len(sizes)
+        log_probability = 0.0
+
+        for cluster_index in range(1, num_clusters):
+            log_probability += log(self.strength + self.discount * cluster_index)
+        for observation_index in range(1, num_observations):
+            log_probability -= log(self.strength + observation_index)
+        for size in sizes:
+            log_probability += _log_rising_factorial(1.0 - self.discount, size - 1)
+        return float(log_probability)
+
+    def exchangeable_partition_probability(self, cluster_sizes: Sequence[int]) -> float:
+        """Return the EPPF probability of one partition with given block sizes."""
+
+        return float(exp(self.log_exchangeable_partition_probability(cluster_sizes)))
+
+    def cluster_count_pmf(self, num_observations: int) -> tuple[float, ...]:
+        """Return ``P(K_n = k)`` for ``k = 0, ..., num_observations``.
+
+        ``K_n`` is the number of occupied target-generated clusters after ``n``
+        exchangeable observations under the CRP prior. Entry zero is one only
+        when ``num_observations == 0``.
+        """
+
+        n = _validate_nonnegative_int(num_observations, "num_observations")
+        pmf = [1.0]
+        for occupied_observations in range(n):
+            next_pmf = [0.0] * (occupied_observations + 2)
+            if occupied_observations == 0:
+                next_pmf[1] = 1.0
+                pmf = next_pmf
+                continue
+            denominator = self.strength + float(occupied_observations)
+            for num_clusters, probability in enumerate(pmf):
+                if probability == 0.0 or num_clusters == 0:
+                    continue
+                stay_weight = float(occupied_observations) - self.discount * float(num_clusters)
+                new_weight = self.strength + self.discount * float(num_clusters)
+                next_pmf[num_clusters] += probability * stay_weight / denominator
+                next_pmf[num_clusters + 1] += probability * new_weight / denominator
+            pmf = next_pmf
+        return tuple(float(probability) for probability in pmf)
+
+    def expected_number_of_clusters(self, num_observations: int) -> float:
+        """Return the prior expected number of occupied clusters after ``n`` observations."""
+
+        pmf = self.cluster_count_pmf(num_observations)
+        return float(sum(num_clusters * probability for num_clusters, probability in enumerate(pmf)))
+
+    def cluster_count_tail_probability(self, num_observations: int, min_clusters: int) -> float:
+        """Return ``P(K_n >= min_clusters)`` under the prior predictive PMF."""
+
+        min_clusters = _validate_nonnegative_int(min_clusters, "min_clusters")
+        pmf = self.cluster_count_pmf(num_observations)
+        if min_clusters >= len(pmf):
+            return 0.0
+        return float(sum(pmf[min_clusters:]))
+
+
+class DirichletProcessCardinalityPrior(PitmanYorCardinalityPrior):
+    """Dirichlet-process cardinality prior with zero Pitman--Yor discount."""
+
+    def __init__(self, strength: float = 1.0) -> None:
+        super().__init__(strength=strength, discount=0.0)
+
+
+def _validate_cluster_sizes(cluster_sizes: Sequence[int]) -> tuple[int, ...]:
+    sizes = tuple(cluster_sizes)
+    for size in sizes:
+        if isinstance(size, bool) or not isinstance(size, Integral):
+            raise TypeError("cluster sizes must be positive integers.")
+        if int(size) <= 0:
+            raise ValueError("cluster sizes must be positive integers.")
+    return tuple(int(size) for size in sizes)
+
+
+def _validate_nonnegative_int(value: int, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise TypeError(f"{name} must be a nonnegative integer.")
+    value = int(value)
+    if value < 0:
+        raise ValueError(f"{name} must be a nonnegative integer.")
+    return value
+
+
+def _log_rising_factorial(start: float, length: int) -> float:
+    if length <= 0:
+        return 0.0
+    return float(lgamma(start + length) - lgamma(start))

--- a/tests/tracking/test_nonparametric_cardinality.py
+++ b/tests/tracking/test_nonparametric_cardinality.py
@@ -1,0 +1,90 @@
+import math
+
+import pytest
+
+from pyrecest.tracking.nonparametric_cardinality import (
+    DirichletProcessCardinalityPrior,
+    PitmanYorCardinalityPrior,
+)
+
+
+def test_dirichlet_process_predictive_probability_matches_crp_rule():
+    prior = DirichletProcessCardinalityPrior(strength=2.0)
+
+    probabilities = prior.predictive_probabilities((3, 1))
+
+    assert probabilities == pytest.approx((3.0 / 6.0, 1.0 / 6.0, 2.0 / 6.0))
+    assert sum(probabilities) == pytest.approx(1.0)
+
+
+def test_pitman_yor_predictive_probability_uses_discounted_counts():
+    prior = PitmanYorCardinalityPrior(strength=2.0, discount=0.25)
+
+    probabilities = prior.predictive_probabilities((3, 1))
+
+    assert probabilities == pytest.approx((2.75 / 6.0, 0.75 / 6.0, 2.5 / 6.0))
+    assert prior.predictive_weights((3, 1)) == pytest.approx((2.75, 0.75, 2.5))
+
+
+def test_first_observation_always_creates_a_cluster():
+    prior = PitmanYorCardinalityPrior(strength=0.0, discount=0.5)
+
+    assert prior.predictive_probabilities(()) == (1.0,)
+    assert prior.cluster_count_pmf(1) == (0.0, 1.0)
+
+
+def test_cluster_count_pmf_matches_small_dirichlet_process_case():
+    prior = DirichletProcessCardinalityPrior(strength=1.0)
+
+    pmf = prior.cluster_count_pmf(3)
+
+    assert pmf == pytest.approx((0.0, 1.0 / 3.0, 1.0 / 2.0, 1.0 / 6.0))
+    assert prior.expected_number_of_clusters(3) == pytest.approx(11.0 / 6.0)
+
+
+def test_zero_discount_pitman_yor_matches_dirichlet_process_cluster_count_pmf():
+    pitman_yor = PitmanYorCardinalityPrior(strength=1.7, discount=0.0)
+    dirichlet = DirichletProcessCardinalityPrior(strength=1.7)
+
+    assert pitman_yor.cluster_count_pmf(6) == pytest.approx(dirichlet.cluster_count_pmf(6))
+
+
+def test_pitman_yor_has_heavier_cluster_count_tail_than_matching_dirichlet_process():
+    num_observations = 10
+    min_clusters = 6
+    pitman_yor = PitmanYorCardinalityPrior(strength=1.0, discount=0.5)
+    dirichlet = DirichletProcessCardinalityPrior(strength=1.0)
+
+    assert pitman_yor.cluster_count_tail_probability(
+        num_observations,
+        min_clusters,
+    ) > dirichlet.cluster_count_tail_probability(num_observations, min_clusters)
+
+
+def test_eppf_probability_matches_dirichlet_process_reference_case():
+    prior = DirichletProcessCardinalityPrior(strength=1.0)
+
+    probability = prior.exchangeable_partition_probability((2, 1))
+
+    assert probability == pytest.approx(1.0 / 6.0)
+    assert prior.log_exchangeable_partition_probability((2, 1)) == pytest.approx(
+        math.log(1.0 / 6.0)
+    )
+
+
+def test_parameter_validation():
+    with pytest.raises(ValueError):
+        PitmanYorCardinalityPrior(strength=1.0, discount=1.0)
+    with pytest.raises(ValueError):
+        PitmanYorCardinalityPrior(strength=-0.5, discount=0.25)
+    with pytest.raises(ValueError):
+        DirichletProcessCardinalityPrior(strength=0.0)
+
+
+def test_cluster_size_validation():
+    prior = PitmanYorCardinalityPrior()
+
+    with pytest.raises(ValueError):
+        prior.predictive_probabilities((0, 1))
+    with pytest.raises(TypeError):
+        prior.predictive_probabilities((True, 1))


### PR DESCRIPTION
## Summary

Adds lightweight Bayesian nonparametric utilities for target-generated cardinality/cluster-count priors:

- `PitmanYorCardinalityPrior` with CRP predictive weights/probabilities, EPPF scoring, cluster-count PMFs, expected cluster count, and tail probability diagnostics.
- `DirichletProcessCardinalityPrior` as the zero-discount special case.
- Public exports from `pyrecest.tracking`.
- Advanced tracking documentation clarifying that these are reusable prior terms, not complete multitarget trackers.
- Unit tests covering CRP probabilities, DP/Pitman--Yor equivalence at zero discount, heavier Pitman--Yor cluster-count tails, EPPF reference values, and validation.

## Motivation

This gives PyRecEst a small, composable entry point for experimenting with Dirichlet-process and Pitman--Yor-style target birth/association priors without entangling them with a specific RFS, multi-Bernoulli, or MHT implementation.

## Testing

- Local isolated check of the new module/test logic: `pytest` reported 9 passing tests.
- Full repository test suite not run in a local checkout.