### PR TITLE
Normalize JAX FFTN shape and axis sequences

### DIFF
--- a/src/pyrecest/_backend/jax/fft.py
+++ b/src/pyrecest/_backend/jax/fft.py
@@ -1,5 +1,7 @@
 """JAX FFT backend wrappers."""
 
+from operator import index as _operator_index
+
 import jax.numpy as _jnp
 import numpy as _np
 from jax.numpy import fft as _fft
@@ -7,6 +9,8 @@ from jax.numpy import fft as _fft
 
 _BOOLEAN_FFT_AXIS_ERROR = "axis must be an integer, not boolean"
 _BOOLEAN_FFT_LENGTH_ERROR = "n must be an integer length, not boolean"
+_FFT_SHAPE_SEQUENCE_ERROR = "s must be None or a sequence of integer lengths"
+_FFT_AXES_SEQUENCE_ERROR = "axes must be None or a sequence of integer axes"
 
 
 def _normalize_real_fft_axis(axis):
@@ -55,6 +59,84 @@ def _normalize_real_fft_length(n):
     return n
 
 
+def _normalize_fft_sequence_item(value, boolean_error, integer_error):
+    """Return a Python ``int`` for one FFT shape or axis sequence entry."""
+    if isinstance(value, (bool, _np.bool_)):
+        raise TypeError(boolean_error)
+    if isinstance(value, _np.ndarray):
+        if _np.issubdtype(value.dtype, _np.bool_):
+            raise TypeError(boolean_error)
+        if value.size == 1 and _np.issubdtype(value.dtype, _np.integer):
+            return int(value.item())
+        raise TypeError(integer_error)
+    if isinstance(value, _jnp.ndarray):
+        value_array = _np.asarray(value)
+        if _np.issubdtype(value_array.dtype, _np.bool_):
+            raise TypeError(boolean_error)
+        if value_array.size == 1 and _np.issubdtype(value_array.dtype, _np.integer):
+            return int(value_array.item())
+        raise TypeError(integer_error)
+    try:
+        return _operator_index(value)
+    except TypeError as exc:
+        raise TypeError(integer_error) from exc
+
+
+def _normalize_fft_integer_sequence(value, sequence_error, boolean_error, integer_error):
+    """Normalize NumPy/JAX scalar-array entries inside FFT integer sequences."""
+    if value is None:
+        return None
+    if isinstance(value, (bool, _np.bool_)):
+        raise TypeError(sequence_error)
+    if isinstance(value, _np.ndarray):
+        if _np.issubdtype(value.dtype, _np.bool_):
+            raise TypeError(boolean_error)
+        if value.ndim == 0:
+            raise TypeError(sequence_error)
+        return tuple(
+            _normalize_fft_sequence_item(item, boolean_error, integer_error)
+            for item in value.tolist()
+        )
+    if isinstance(value, _jnp.ndarray):
+        value_array = _np.asarray(value)
+        if _np.issubdtype(value_array.dtype, _np.bool_):
+            raise TypeError(boolean_error)
+        if value_array.ndim == 0:
+            raise TypeError(sequence_error)
+        return tuple(
+            _normalize_fft_sequence_item(item, boolean_error, integer_error)
+            for item in value_array.tolist()
+        )
+    if isinstance(value, (str, bytes)):
+        raise TypeError(sequence_error)
+    try:
+        entries = tuple(value)
+    except TypeError as exc:
+        raise TypeError(sequence_error) from exc
+    return tuple(
+        _normalize_fft_sequence_item(item, boolean_error, integer_error)
+        for item in entries
+    )
+
+
+def _normalize_complex_fft_shape(s):
+    return _normalize_fft_integer_sequence(
+        s,
+        _FFT_SHAPE_SEQUENCE_ERROR,
+        "s entries must be integer lengths, not boolean",
+        "s entries must be integer lengths",
+    )
+
+
+def _normalize_complex_fft_axes(axes):
+    return _normalize_fft_integer_sequence(
+        axes,
+        _FFT_AXES_SEQUENCE_ERROR,
+        "axes entries must be integers, not boolean",
+        "axes entries must be integers",
+    )
+
+
 def rfft(a, n=None, axis=-1, norm=None):
     return _fft.rfft(
         _jnp.asarray(a),
@@ -74,11 +156,21 @@ def irfft(a, n=None, axis=-1, norm=None):
 
 
 def fftn(a, s=None, axes=None, norm=None):
-    return _fft.fftn(_jnp.asarray(a), s=s, axes=axes, norm=norm)
+    return _fft.fftn(
+        _jnp.asarray(a),
+        s=_normalize_complex_fft_shape(s),
+        axes=_normalize_complex_fft_axes(axes),
+        norm=norm,
+    )
 
 
 def ifftn(a, s=None, axes=None, norm=None):
-    return _fft.ifftn(_jnp.asarray(a), s=s, axes=axes, norm=norm)
+    return _fft.ifftn(
+        _jnp.asarray(a),
+        s=_normalize_complex_fft_shape(s),
+        axes=_normalize_complex_fft_axes(axes),
+        norm=norm,
+    )
 
 
 def fftshift(x, axes=None):

--- a/tests/backend_support/test_jax_fftn_sequence_contract.py
+++ b/tests/backend_support/test_jax_fftn_sequence_contract.py
@@ -1,0 +1,38 @@
+import unittest
+
+import numpy as np
+
+jax_backend = None
+try:
+    from pyrecest._backend import jax as jax_backend
+except ModuleNotFoundError:
+    pass
+
+
+@unittest.skipIf(jax_backend is None, "JAX is not installed")
+class TestJaxFftnSequenceContract(unittest.TestCase):
+    def test_fftn_accepts_scalar_array_entries_in_shape_and_axes(self):
+        values = np.arange(4.0)
+        actual = np.asarray(jax_backend.fft.fftn(values, s=(np.array(4),), axes=(np.array(0),)))
+        expected = np.fft.fftn(values, s=(4,), axes=(0,))
+        self.assertTrue(np.allclose(actual, expected))
+
+    def test_ifftn_accepts_scalar_array_entries_in_shape_and_axes(self):
+        spectrum = np.fft.fftn(np.arange(4.0))
+        actual = np.asarray(jax_backend.fft.ifftn(spectrum, s=[np.array(4)], axes=[np.array(0)]))
+        expected = np.fft.ifftn(spectrum, s=(4,), axes=(0,))
+        self.assertTrue(np.allclose(actual, expected))
+
+    def test_fftn_rejects_boolean_shape_entries(self):
+        bad_shape = [bool(1)]
+        with self.assertRaisesRegex(TypeError, "integer lengths"):
+            jax_backend.fft.fftn(np.arange(4.0), s=bad_shape, axes=(0,))
+
+    def test_fftn_rejects_boolean_axis_entries(self):
+        bad_axes = (bool(1),)
+        with self.assertRaisesRegex(TypeError, "integers"):
+            jax_backend.fft.fftn(np.arange(4.0), s=(4,), axes=bad_axes)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- normalize NumPy/JAX scalar-array entries inside JAX `fftn` / `ifftn` `s` and `axes` sequences
- reject boolean shape/axis entries before JAX silently treats booleans as integer lengths/axes
- add focused regression coverage for scalar-array sequence entries and boolean sequence rejection

## Bug fixed
The JAX FFT wrapper normalized scalar-array arguments for `rfft`/`irfft`, but forwarded `fftn`/`ifftn` `s` and `axes` directly. This left two bad edge cases:

- `axes=(np.array(0),)` failed with a backend `TypeError` even though the entry is an integer scalar-array.
- `s=[True]` could be accepted by JAX as length `1`, silently changing the requested transform size.

The wrapper now converts valid NumPy/JAX integer scalar-array sequence entries to Python `int` values and rejects boolean entries consistently with the existing real-FFT validation.

## Validation
- Reproduced the JAX edge cases locally with direct JAX calls.
- Exercised the patched normalization logic locally against NumPy FFT results.
- Connector diff check: branch changes are limited to `src/pyrecest/_backend/jax/fft.py` and `tests/backend_support/test_jax_fftn_sequence_contract.py`. The branch is currently one commit behind `main`; the touched source file is unchanged on current `main`, so the diff remains clean.