### PR TITLE
Fix CustomLinearDistribution set_mean copy semantics

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/custom_linear_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/custom_linear_distribution.py
@@ -52,11 +52,12 @@ class CustomLinearDistribution(
         return cd
 
     def set_mean(self, new_mean):
+        """Return a shifted copy whose mean equals ``new_mean``."""
         new_mean = _as_shift_vector(new_mean, self.dim, name="new_mean")
         mean_offset = new_mean - self.mean()
-        self.shift_by = self.shift_by + mean_offset
-        if self._mean_numerical is not None:
-            self._mean_numerical = new_mean
+        cd = self.shift(mean_offset)
+        cd._mean_numerical = new_mean
+        return cd
 
     def pdf(self, xs):
         xs = array(xs)

--- a/tests/distributions/test_custom_linear_distribution.py
+++ b/tests/distributions/test_custom_linear_distribution.py
@@ -27,15 +27,18 @@ class CustomLinearDistributionTest(unittest.TestCase):
         cld = CustomLinearDistribution.from_distribution(self.gm)
         self.assertAlmostEqual(cld.integrate(), 0.5, delta=1e-8)
 
-    def test_set_mean_shifts_distribution(self):
+    def test_set_mean_returns_shifted_distribution_copy(self):
         g = GaussianDistribution(array([1.0]), eye(1))
         cld = CustomLinearDistribution.from_distribution(g)
 
-        cld.set_mean(array([3.0]))
+        shifted = cld.set_mean(array([3.0]))
 
-        npt.assert_allclose(cld.mean(), array([3.0]))
-        npt.assert_allclose(cld.shift_by, array([2.0]))
-        npt.assert_allclose(cld.pdf(array([3.0])), g.pdf(array([1.0])))
+        self.assertIsNot(shifted, cld)
+        npt.assert_allclose(cld.shift_by, array([0.0]))
+        npt.assert_allclose(shifted.mean(), array([3.0]))
+        npt.assert_allclose(shifted.shift_by, array([2.0]))
+        npt.assert_allclose(shifted.pdf(array([3.0])), g.pdf(array([1.0])))
+        npt.assert_allclose(cld.pdf(array([1.0])), g.pdf(array([1.0])))
 
     def test_pdf_accepts_scalar_and_list_inputs(self):
         cld = CustomLinearDistribution(
@@ -90,7 +93,3 @@ class CustomLinearDistributionTest(unittest.TestCase):
             dist2.pdf(concatenate((x, y)).reshape(2, -1).T),
             atol=tol,
         )
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
## Summary
- make `CustomLinearDistribution.set_mean(...)` return a shifted copy instead of mutating the source distribution in place
- cache the requested mean on the returned shifted distribution
- update the custom linear distribution regression test to verify copy semantics and unchanged source `shift_by`

## Bug fixed
`CustomLinearDistribution.set_mean(...)` previously behaved differently from the surrounding linear distribution API: it mutated `self.shift_by` and returned `None`. This made chained or functional-style distribution updates fail and could unexpectedly alter a distribution reused elsewhere.

## Validation
- Inspected the modified method and focused regression test on the branch.
- Full repository test suite not run locally in this connector-only environment; CI should run on the PR.