### PR TITLE
Reject boolean diagonal axes in PyTorch backend

### DIFF
--- a/src/pyrecest/_backend/_common.py
+++ b/src/pyrecest/_backend/_common.py
@@ -45,6 +45,11 @@ def _normalize_size_axis(axis):
 
 def _normalize_diagonal_integer(value):
     """Return NumPy-style integer scalar arguments for stricter tensor APIs."""
+    if isinstance(value, _AXIS_FLAG_TYPES):
+        raise TypeError("an integer is required")
+    dtype = getattr(value, "dtype", None)
+    if dtype is not None and str(dtype).lower() in {"bool", "bool_", "torch.bool"}:
+        raise TypeError("an integer is required")
     try:
         return _operator.index(value)
     except TypeError:

--- a/tests/backend_support/test_diagonal_bool_axes.py
+++ b/tests/backend_support/test_diagonal_bool_axes.py
@@ -1,0 +1,43 @@
+"""Regression test for diagonal axis coercion."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+_CHECK = """
+import pyrecest.backend as backend
+
+matrix = backend.array([[1.0, 2.0], [3.0, 4.0]])
+
+for axis_value in (False, True):
+    try:
+        backend.diagonal(matrix, axis1=axis_value)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError('axis1 accepted boolean axis')
+
+    try:
+        backend.diagonal(matrix, axis2=axis_value)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError('axis2 accepted boolean axis')
+
+print('ok')
+"""
+
+
+@pytest.mark.backend_portable
+def test_pytorch_diagonal_rejects_bool_axes():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code("pytorch", _CHECK)
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- reject boolean scalar and boolean array values before passing `offset`, `axis1`, or `axis2` to `torch.diagonal`
- add a PyTorch backend regression test for boolean diagonal axes

## Rationale
The shared backend already rejects boolean values for size, reduction, and sort axes. `diagonal` used the same integer-normalization path but still allowed boolean axes through the PyTorch path, where they could be coerced as integer dimensions. This patch closes that contract gap.

## Testing
- Not run locally; repository access was through the GitHub connector only.