### PR TITLE
Validate CartProdStackedDistribution set_mode length

### DIFF
--- a/src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py
@@ -27,6 +27,16 @@ def _validate_positive_sample_count(n) -> int:
     return count_int
 
 
+def _validate_stacked_mode_vector(new_mode, expected_input_dim: int):
+    new_mode = asarray(new_mode)
+    if new_mode.ndim != 1 or new_mode.shape[0] != expected_input_dim:
+        raise ValueError(
+            "new_mode must be a one-dimensional vector with length "
+            f"{expected_input_dim}, got shape {new_mode.shape}."
+        )
+    return new_mode
+
+
 class CartProdStackedDistribution(AbstractCartProdDistribution):
     def __init__(self, dists):
         self.dists = dists
@@ -76,6 +86,7 @@ class CartProdStackedDistribution(AbstractCartProdDistribution):
         return self.__class__(shifted_dists)
 
     def set_mode(self, new_mode):
+        new_mode = _validate_stacked_mode_vector(new_mode, self.input_dim)
         new_dists = []
         curr_ind = 0
         for dist in self.dists:

--- a/tests/distributions/test_cart_prod_stacked_distribution.py
+++ b/tests/distributions/test_cart_prod_stacked_distribution.py
@@ -149,6 +149,24 @@ class TestCartProdStackedDistribution(unittest.TestCase):
         self.assertTrue(allclose(shifted.dists[0].mu, array([2.0])))
         self.assertTrue(allclose(shifted.dists[1].mu, array([1.0, 0.0, 0.0])))
 
+    def test_set_mode_rejects_wrong_input_dimension(self):
+        dist = ConcreteCartProdStackedDistribution(
+            [
+                GaussianDistribution(array([1.0, 2.0]), eye(2)),
+                GaussianDistribution(array([3.0, 4.0, 5.0]), eye(3)),
+            ]
+        )
+
+        bad_modes = (
+            array([1.0, 2.0, 3.0, 4.0]),
+            array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+            array([[1.0, 2.0, 3.0, 4.0, 5.0]]),
+        )
+        for bad_mode in bad_modes:
+            with self.subTest(shape=bad_mode.shape):
+                with self.assertRaisesRegex(ValueError, "new_mode"):
+                    dist.set_mode(bad_mode)
+
     def test_shift_uses_cumulative_component_dimensions(self):
         dist = ConcreteCartProdStackedDistribution(
             [


### PR DESCRIPTION
## Summary
- validate that `CartProdStackedDistribution.set_mode(...)` receives a one-dimensional vector of exactly `input_dim` entries before slicing it across components
- add a regression test for too-short, too-long, and non-1D mode inputs

## Bug fixed
`CartProdStackedDistribution.set_mode(...)` previously sliced `new_mode` by each component's `input_dim` without checking the total length. As a result, extra trailing coordinates were silently ignored, and malformed higher-rank inputs were not rejected at the stacked-distribution boundary.

## Validation
- Connector diff check: branch is 2 commits ahead of `main` and only changes `src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py` plus `tests/distributions/test_cart_prod_stacked_distribution.py`.
- Not run locally: the execution container could not resolve `github.com`, so I could not clone/install the repository for a targeted pytest run. CI should run on this PR.