### PR TITLE
Fix SO3 product marginal rotation index validation

### DIFF
--- a/src/pyrecest/distributions/so3_product_tangent_gaussian_distribution.py
+++ b/src/pyrecest/distributions/so3_product_tangent_gaussian_distribution.py
@@ -1,6 +1,8 @@
 """Tangent-space Gaussian distribution on Cartesian products of SO(3)."""
 
 # pylint: disable=no-name-in-module,no-member
+from numbers import Integral
+
 import numpy as np
 from pyrecest.backend import (
     abs,
@@ -68,6 +70,45 @@ def _to_python_bool(value) -> bool:
     if hasattr(value, "item"):
         return bool(value.item())
     return bool(value)
+
+
+def _normalize_rotation_indices(rotation_indices, num_rotations: int) -> list[int]:
+    message = "rotation_indices must contain valid zero-based integer indices."
+    if isinstance(rotation_indices, (bool, np.bool_)):
+        raise ValueError(message)
+
+    if isinstance(rotation_indices, Integral):
+        raw_indices = [rotation_indices]
+    else:
+        try:
+            indices_array = np.asarray(rotation_indices)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(message) from exc
+
+        if indices_array.ndim == 0:
+            raw_indices = [indices_array.item()]
+        elif indices_array.ndim == 1:
+            raw_indices = list(indices_array)
+        else:
+            raise ValueError(message)
+
+    if not raw_indices:
+        raise ValueError("rotation_indices must contain at least one index.")
+
+    normalized_indices = []
+    for index in raw_indices:
+        if isinstance(index, (bool, np.bool_)) or not isinstance(index, Integral):
+            raise ValueError(message)
+        parsed_index = int(index)
+        if parsed_index < 0 or parsed_index >= num_rotations:
+            raise ValueError(
+                f"rotation_indices must be in [0, {num_rotations - 1}]."
+            )
+        normalized_indices.append(parsed_index)
+
+    if len(set(normalized_indices)) != len(normalized_indices):
+        raise ValueError("rotation_indices must not contain duplicates.")
+    return normalized_indices
 
 
 class SO3ProductTangentGaussianDistribution(AbstractBoundedDomainDistribution):
@@ -429,8 +470,9 @@ class SO3ProductTangentGaussianDistribution(AbstractBoundedDomainDistribution):
 
     def marginalize_rotations(self, rotation_indices):
         """Return the marginal over selected SO(3) components."""
-        if isinstance(rotation_indices, int):
-            rotation_indices = [rotation_indices]
+        rotation_indices = _normalize_rotation_indices(
+            rotation_indices, self.num_rotations
+        )
         rotation_indices_array = array(rotation_indices)
         tangent_indices = [
             3 * rotation_index + offset

--- a/tests/distributions/test_so3_product_marginalization_validation.py
+++ b/tests/distributions/test_so3_product_marginalization_validation.py
@@ -1,0 +1,55 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array, diag
+from pyrecest.distributions import SO3ProductTangentGaussianDistribution
+from tests.distributions.so3_test_helpers import ATOL, x_quaternion, z_quaternion
+
+
+def _two_rotation_distribution():
+    covariance = diag(array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6]))
+    return SO3ProductTangentGaussianDistribution(
+        array([z_quaternion(0.0), x_quaternion(np.pi / 2.0)]),
+        covariance,
+    )
+
+
+class SO3ProductTangentGaussianMarginalizationValidationTest(unittest.TestCase):
+    def test_marginalize_rotations_accepts_numpy_scalar_integer(self):
+        dist = _two_rotation_distribution()
+
+        marginal = dist.marginalize_rotations(np.int64(1))
+
+        self.assertEqual(marginal.num_rotations, 1)
+        npt.assert_allclose(marginal.mean()[0], x_quaternion(np.pi / 2.0), atol=ATOL)
+        npt.assert_allclose(
+            marginal.covariance(),
+            diag(array([0.4, 0.5, 0.6])),
+            atol=ATOL,
+        )
+
+    def test_marginalize_rotations_rejects_invalid_indices(self):
+        dist = _two_rotation_distribution()
+
+        invalid_indices = (
+            True,
+            [True],
+            [],
+            [0, 0],
+            [-1],
+            [2],
+            [1.0],
+            [[0]],
+        )
+
+        for rotation_indices in invalid_indices:
+            with self.subTest(rotation_indices=rotation_indices):
+                with self.assertRaisesRegex(ValueError, "rotation_indices"):
+                    dist.marginalize_rotations(rotation_indices)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- normalize SO(3) product marginal rotation indices before building tangent-space indices
- accept NumPy scalar integer indices consistently with Python integers
- reject boolean, empty, duplicate, non-integer, negative, and out-of-range rotation selections
- add focused regression tests for valid NumPy scalar marginalization and invalid inputs

## Bug fixed
`SO3ProductTangentGaussianDistribution.marginalize_rotations(...)` only treated Python `int` as a scalar index. NumPy scalar integers such as `np.int64(1)` therefore failed as non-iterable inputs, while booleans, negative indices, and duplicate indices could select unintended rotations or produce malformed marginals.

## Testing
- Syntax-checked the modified source and new test with Python `ast.parse`.
- Not run locally: the execution container cannot resolve `github.com`, so I could not clone/install and run pytest here.