### PR TITLE
Fix PyTorch apply_along_axis callback arguments

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_allclose_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_allclose_device_contract.py
@@ -110,6 +110,40 @@ def _patch_pytorch_flip_numpy_axis_contract() -> None:
         backend.flip = flip
 
 
+def _patch_apply_along_axis_arguments(pytorch_backend, backend) -> None:
+    """Patch PyTorch ``apply_along_axis`` to forward callback arguments."""
+
+    original_apply_along_axis = getattr(pytorch_backend, "apply_along_axis", None)
+    if original_apply_along_axis is None:
+        return
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+    if getattr(
+        original_apply_along_axis,
+        "_pyrecest_argument_forwarding_contract",
+        False,
+    ):
+        if active_pytorch_backend:
+            backend.apply_along_axis = original_apply_along_axis
+        return
+
+    def apply_along_axis(func, axis, tensor, *args, **kwargs):
+        def wrapped_func(tensor_slice):
+            return func(tensor_slice, *args, **kwargs)
+
+        return original_apply_along_axis(wrapped_func, axis, tensor)
+
+    apply_along_axis.__name__ = getattr(
+        original_apply_along_axis,
+        "__name__",
+        "apply_along_axis",
+    )
+    apply_along_axis.__doc__ = getattr(original_apply_along_axis, "__doc__", None)
+    apply_along_axis._pyrecest_argument_forwarding_contract = True
+    pytorch_backend.apply_along_axis = apply_along_axis
+    if active_pytorch_backend:
+        backend.apply_along_axis = apply_along_axis
+
+
 def _close_operands(pytorch_backend, torch_module, a, b):
     """Return close-comparison operands on a common device and dtype."""
 
@@ -244,6 +278,7 @@ def patch_pytorch_allclose_device_contract() -> None:
     _patch_pytorch_creation_shape_contract()
     _patch_pytorch_linalg_logm_arraylike_contract()
     _patch_pytorch_flip_numpy_axis_contract()
+    _patch_apply_along_axis_arguments(pytorch_backend, backend)
     _patch_allclose(pytorch_backend, backend, torch_module)
     _patch_isclose(pytorch_backend, backend, torch_module)
     _patch_broadcast_arrays(pytorch_backend, backend, torch_module)

--- a/tests/backend_support/test_pytorch_apply_along_axis_arguments.py
+++ b/tests/backend_support/test_pytorch_apply_along_axis_arguments.py
@@ -1,0 +1,46 @@
+"""Regression tests for PyTorch apply_along_axis callback arguments."""
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+def test_public_pytorch_apply_along_axis_forwards_callback_arguments():
+    pytest.importorskip("torch")
+    code = r"""
+import torch
+import pyrecest.backend as backend
+
+
+def affine(row, scale, *, offset):
+    return row * scale + offset
+
+
+values = torch.arange(6, dtype=torch.float64).reshape(2, 3)
+result = backend.apply_along_axis(affine, 1, values, 2.0, offset=1.0)
+expected = values * 2.0 + 1.0
+assert torch.equal(result, expected)
+"""
+    result = run_backend_code("pytorch", code)
+    assert result.returncode == 0, result.stderr
+
+
+def test_raw_pytorch_apply_along_axis_forwards_callback_arguments_after_import():
+    pytest.importorskip("torch")
+    code = r"""
+import torch
+import pyrecest  # noqa: F401 - activates backend-support compatibility patches
+import pyrecest._backend.pytorch as raw_pytorch
+
+
+def affine(row, scale, *, offset):
+    return row * scale + offset
+
+
+values = torch.arange(6, dtype=torch.float64).reshape(2, 3)
+result = raw_pytorch.apply_along_axis(affine, 1, values, 2.0, offset=1.0)
+expected = values * 2.0 + 1.0
+assert torch.equal(result, expected)
+"""
+    result = run_backend_code("numpy", code)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- patch the PyTorch backend-support hook so `apply_along_axis` forwards NumPy-style `*args` and `**kwargs` to the 1-D callback
- keep the raw PyTorch helper and the active public PyTorch facade synchronized
- add focused subprocess regression coverage for public and raw PyTorch paths

## Bug fixed
The PyTorch backend implementation accepted only `(func, axis, tensor)`, unlike NumPy's `apply_along_axis(func1d, axis, arr, *args, **kwargs)` contract. Valid calls such as `backend.apply_along_axis(func, 1, values, scale, offset=...)` failed with `TypeError` before the callback could run.

This fresh branch is based on current `main` and supersedes the closed/unmerged #3380 direction.

## Validation
- Compared branch with `main`: 2 commits ahead, 0 behind.
- Diff is limited to `src/pyrecest/backend_support/_pytorch_allclose_device_contract.py` and `tests/backend_support/test_pytorch_apply_along_axis_arguments.py`.
- Full local pytest was not run in this connector environment; CI should run the new focused regression tests.