### PR TITLE
Fix rectangular PyTorch triangular vector helpers

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_minmax_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_minmax_device_contract.py
@@ -139,6 +139,43 @@ def _patch_pytorch_linalg_norm_axis_contract(raw_pytorch, backend, torch_module)
         backend_linalg.norm = norm
 
 
+def _patch_pytorch_rectangular_triangular_vector_contract(raw_pytorch, backend) -> None:
+    """Patch triangular-vector helpers to respect rectangular matrix shapes."""
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+
+    def _make_triangular_to_vec(helper_name, index_helper, original_helper):
+        def triangular_to_vec(x, k=0):
+            x = raw_pytorch.array(x)
+            rows, cols = index_helper(x.shape[-2], k=k, m=x.shape[-1])
+            rows = rows.to(device=x.device)
+            cols = cols.to(device=x.device)
+            return x[..., rows, cols]
+
+        triangular_to_vec.__name__ = getattr(original_helper, "__name__", helper_name)
+        triangular_to_vec.__doc__ = getattr(original_helper, "__doc__", None)
+        triangular_to_vec._pyrecest_numpy_contract = True
+        triangular_to_vec._pyrecest_rectangular_triangular_contract = True
+        return triangular_to_vec
+
+    for helper_name, index_helper_name in (
+        ("tril_to_vec", "tril_indices"),
+        ("triu_to_vec", "triu_indices"),
+    ):
+        original_helper = getattr(raw_pytorch, helper_name, None)
+        index_helper = getattr(raw_pytorch, index_helper_name, None)
+        if original_helper is None or index_helper is None:
+            continue
+        if getattr(original_helper, "_pyrecest_rectangular_triangular_contract", False):
+            if active_pytorch_backend:
+                setattr(backend, helper_name, original_helper)
+            continue
+
+        helper = _make_triangular_to_vec(helper_name, index_helper, original_helper)
+        setattr(raw_pytorch, helper_name, helper)
+        if active_pytorch_backend:
+            setattr(backend, helper_name, helper)
+
+
 def _patch_binary_helpers(
     raw_pytorch,
     backend,
@@ -223,3 +260,4 @@ def patch_pytorch_minmax_device_contract() -> None:
         "_pyrecest_comparison_device_contract",
     )
     _patch_pytorch_linalg_norm_axis_contract(raw_pytorch, backend, torch)
+    _patch_pytorch_rectangular_triangular_vector_contract(raw_pytorch, backend)


### PR DESCRIPTION
## Summary
- patch the PyTorch backend compatibility hook so `tril_to_vec` and `triu_to_vec` use both trailing matrix dimensions for rectangular inputs
- override the older square-only wrapper after the normal stability hooks run
- reuse the existing rectangular regression coverage in `tests/backend_support/test_pytorch_triangular_helpers_contract.py`

## Bug fixed
The stability patch for PyTorch triangular vector helpers still derived triangular indices from `x.shape[-1]` only. For rectangular matrices this either missed valid lower/upper-triangular entries or generated row indices outside the number of rows. The new compatibility override calls the rectangular `tril_indices` / `triu_indices` helpers with both row and column dimensions.

## Validation
- Syntax-compiled the modified module content locally with `py_compile`.
- Compared the branch against current `main`: 1 commit ahead, 0 behind, one file changed.
- Full repository tests were not run locally because the execution environment cannot resolve `github.com`; CI should run the existing rectangular PyTorch regression tests.