### PR TITLE
Add PyTorch bfloat16 dtype alias

### DIFF
--- a/src/pyrecest/_backend/pytorch/_dtype.py
+++ b/src/pyrecest/_backend/pytorch/_dtype.py
@@ -38,6 +38,7 @@ MAP_DTYPE = {
     "int16": int16,
     "int32": int32,
     "int64": int64,
+    "bfloat16": _torch.bfloat16,
     "float16": float16,
     "float32": float32,
     "float64": float64,

--- a/tests/test_pytorch_dtype_aliases.py
+++ b/tests/test_pytorch_dtype_aliases.py
@@ -32,3 +32,14 @@ def test_pytorch_as_dtype_accepts_dtype_like_aliases():
         assert backend.get_default_cdtype() == torch.complex128
     finally:
         backend.set_default_dtype(original_dtype)
+
+
+def test_pytorch_as_dtype_accepts_bfloat16_aliases():
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific dtype alias regression test")
+
+    torch = pytest.importorskip("torch")
+
+    assert backend.as_dtype(torch.bfloat16) == torch.bfloat16
+    assert backend.as_dtype("bfloat16") == torch.bfloat16
+    assert backend.as_dtype("torch.bfloat16") == torch.bfloat16


### PR DESCRIPTION
## Summary
- add the missing `bfloat16` entry to the PyTorch backend dtype alias map
- add focused PyTorch regression coverage for `torch.bfloat16`, `"bfloat16"`, and `"torch.bfloat16"`

## Bug fixed
The PyTorch dtype resolver normalizes dtype-like values through `_dtype_key(...)` and then indexes `MAP_DTYPE`. `torch.bfloat16` normalizes to `"bfloat16"`, but that key was absent, so valid calls such as `backend.as_dtype("bfloat16")` or `backend.as_dtype(torch.bfloat16)` failed with a raw lookup error.

## Validation
- Verified the branch diff is limited to the PyTorch dtype map and the focused regression test.
- Full test suite not run in this connector environment.