### PR TITLE
Reject boolean PyTorch linalg.norm sequence axes

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -20,7 +20,7 @@ from ._dtype import (
 # functions, because raw torch.linalg rejects Python lists and integer arrays.
 
 
-def _as_numpy_no_grad(value):
+ def _as_numpy_no_grad(value):
     """Return a CPU NumPy view/copy for SciPy bridge functions."""
     if isinstance(value, _torch.Tensor):
         return value.detach().resolve_conj().resolve_neg().cpu().numpy()
@@ -45,6 +45,8 @@ _COMPLEX_DTYPE_FOR_TENSOR_DTYPE = {
     _torch.complex64: _np.complex64,
     _torch.complex128: _np.complex128,
 }
+
+_AXIS_TYPE_ERROR = "axis must be None, an integer, or a tuple of integers"
 
 
 def _default_linalg_dtype():
@@ -85,6 +87,16 @@ def _as_integer_scalar(value, name):
         return _operator_index(value)
     except TypeError as exc:
         raise TypeError(f"{name} must be an integer scalar") from exc
+
+
+def _as_norm_axis_entry(axis) -> int:
+    """Return one non-boolean PyTorch linalg.norm axis entry."""
+    if _is_boolean_scalar(axis):
+        raise TypeError(_AXIS_TYPE_ERROR)
+    try:
+        return _operator_index(axis)
+    except TypeError as exc:
+        raise TypeError(_AXIS_TYPE_ERROR) from exc
 
 
 def _common_linalg_dtype(*tensors):
@@ -278,30 +290,30 @@ def _normalize_norm_axis(axis):
     """Return a PyTorch-compatible norm dimension from NumPy-style axis input."""
     if axis is None:
         return None
-    if isinstance(axis, (bool, _np.bool_)):
-        raise TypeError("axis must be None, an integer, or a tuple of integers")
+    if _is_boolean_scalar(axis):
+        raise TypeError(_AXIS_TYPE_ERROR)
     if _torch.is_tensor(axis):
         if axis.dtype == _torch.bool:
-            raise TypeError("axis must be None, an integer, or a tuple of integers")
+            raise TypeError(_AXIS_TYPE_ERROR)
         if axis.ndim == 0:
-            return _operator_index(axis.item())
+            return _as_norm_axis_entry(axis.item())
         if axis.ndim != 1:
-            raise TypeError("axis must be None, an integer, or a tuple of integers")
+            raise TypeError(_AXIS_TYPE_ERROR)
         axis = axis.detach().cpu().tolist()
     elif isinstance(axis, _np.ndarray):
         if axis.dtype == _np.bool_:
-            raise TypeError("axis must be None, an integer, or a tuple of integers")
+            raise TypeError(_AXIS_TYPE_ERROR)
         if axis.ndim == 0:
-            return _operator_index(axis.item())
+            return _as_norm_axis_entry(axis.item())
         if axis.ndim != 1:
-            raise TypeError("axis must be None, an integer, or a tuple of integers")
+            raise TypeError(_AXIS_TYPE_ERROR)
         axis = axis.tolist()
     elif isinstance(axis, (int, _np.integer)):
-        return int(axis)
+        return _as_norm_axis_entry(axis)
 
     if isinstance(axis, (list, tuple)):
-        return tuple(_operator_index(one_axis) for one_axis in axis)
-    return _operator_index(axis)
+        return tuple(_as_norm_axis_entry(one_axis) for one_axis in axis)
+    return _as_norm_axis_entry(axis)
 
 
 def norm(x, ord=None, axis=None, keepdims=False):

--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -20,7 +20,7 @@ from ._dtype import (
 # functions, because raw torch.linalg rejects Python lists and integer arrays.
 
 
- def _as_numpy_no_grad(value):
+def _as_numpy_no_grad(value):
     """Return a CPU NumPy view/copy for SciPy bridge functions."""
     if isinstance(value, _torch.Tensor):
         return value.detach().resolve_conj().resolve_neg().cpu().numpy()

--- a/tests/backend_support/test_pytorch_linalg_bool_contract.py
+++ b/tests/backend_support/test_pytorch_linalg_bool_contract.py
@@ -26,3 +26,57 @@ print("ok")
 
     assert result.returncode == 0, result.stderr
     assert "ok" in result.stdout
+
+
+@pytest.mark.backend_portable
+def test_pytorch_linalg_norm_rejects_boolean_sequence_axes():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import numpy as np
+import pyrecest.backend as backend
+
+values = backend.array([[3.0, 4.0], [5.0, 12.0]])
+expected = backend.array([5.0, 13.0])
+
+for axis in [
+    True,
+    False,
+    np.bool_(True),
+    np.array(True),
+    backend.asarray(True),
+    [True],
+    (True,),
+    [np.bool_(False)],
+    (np.array(True),),
+    [backend.asarray(True)],
+]:
+    try:
+        backend.linalg.norm(values, axis=axis)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"accepted boolean norm axis {axis!r}")
+
+for axis in [
+    1,
+    np.int64(1),
+    np.array(1),
+    backend.asarray(1),
+    [1],
+    (1,),
+    np.array([1]),
+    backend.asarray([1]),
+]:
+    result = backend.linalg.norm(values, axis=axis)
+    assert backend.allclose(result, expected), axis
+
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- reject boolean scalar and sequence entries before normalizing PyTorch `linalg.norm` axes
- keep NumPy/PyTorch integer scalar and one-dimensional integer-array axes accepted
- add regression coverage for boolean sequence axes and valid integer-axis normalization

## Rationale
`operator.index(True)` returns `1`, so list/tuple axes such as `(True,)` were normalized as integer axes and silently computed along the wrong dimension. This aligns the PyTorch linalg norm axis contract with the rest of the backend validation path.

## Validation
- Not run locally in this environment.