### PR TITLE
Validate wrapped normal real parameters

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_wrapped_normal_distribution.py
@@ -27,23 +27,52 @@ from ._input_validation import as_hypertoroidal_points, as_shift_vector
 from .abstract_hypertoroidal_distribution import AbstractHypertoroidalDistribution
 
 
+_FINITE_REAL_MESSAGE = "{name} must contain only finite real values"
+
+
+def _dtype_kind_and_name(value):
+    dtype = getattr(value, "dtype", None)
+    if dtype is None:
+        return None, ""
+    return getattr(dtype, "kind", None), str(dtype).lower()
+
+
+def _as_real_numeric_array(value, name: str):
+    try:
+        value = array(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(_FINITE_REAL_MESSAGE.format(name=name)) from exc
+
+    dtype_kind, dtype_name = _dtype_kind_and_name(value)
+    if (
+        dtype_kind in {"b", "c", "O", "S", "U"}
+        or "bool" in dtype_name
+        or "complex" in dtype_name
+    ):
+        raise ValueError(_FINITE_REAL_MESSAGE.format(name=name))
+    if dtype_kind is not None and dtype_kind not in "iuf":
+        raise ValueError(_FINITE_REAL_MESSAGE.format(name=name))
+
+    try:
+        finite_values = backend_all(isfinite(value))
+    except (TypeError, ValueError) as exc:
+        raise ValueError(_FINITE_REAL_MESSAGE.format(name=name)) from exc
+    if not bool(finite_values):
+        raise ValueError(_FINITE_REAL_MESSAGE.format(name=name))
+    return value
+
+
 def _as_1d_mu(mu):
-    mu = array(mu)
+    mu = _as_real_numeric_array(mu, "mu")
     if mu.ndim == 0:
         mu = mu.reshape((1,))
     if mu.ndim != 1:
         raise ValueError(f"mu must be one-dimensional, but got shape {mu.shape}")
-    try:
-        finite_mu = backend_all(isfinite(mu))
-    except (TypeError, ValueError) as exc:
-        raise ValueError("mu must contain only finite real values") from exc
-    if not bool(finite_mu):
-        raise ValueError("mu must contain only finite real values")
     return mu
 
 
 def _as_2d_covariance(C):
-    C = array(C)
+    C = _as_real_numeric_array(C, "C")
     if C.ndim == 0:
         C = C.reshape((1, 1))
     return C

--- a/tests/distributions/test_hypertoroidal_wrapped_normal_distribution.py
+++ b/tests/distributions/test_hypertoroidal_wrapped_normal_distribution.py
@@ -104,6 +104,31 @@ class TestHypertoroidalWNDistribution(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, message):
                     HypertoroidalWNDistribution(mu, C)
 
+    def test_constructor_rejects_non_real_numeric_parameters(self):
+        invalid_cases = [
+            (True, 1.0),
+            ([True], [[1.0]]),
+            (1.0 + 0.0j, [[1.0]]),
+            (["0.0"], [[1.0]]),
+            (0.0, True),
+            ([0.0], [[True]]),
+            ([0.0], [[1.0 + 0.0j]]),
+            ([0.0], [["1.0"]]),
+        ]
+
+        for mu, C in invalid_cases:
+            with self.subTest(mu=mu, C=C):
+                with self.assertRaisesRegex(ValueError, "finite real values"):
+                    HypertoroidalWNDistribution(mu, C)
+
+    def test_set_mean_and_mode_reject_boolean_angles(self):
+        dist = HypertoroidalWNDistribution(0.3, 0.7)
+
+        with self.assertRaisesRegex(ValueError, "finite real values"):
+            dist.set_mean(True)
+        with self.assertRaisesRegex(ValueError, "finite real values"):
+            dist.set_mode(True)
+
     def test_vector_pdf_accepts_single_point_sequence(self):
         dist = HypertoroidalWNDistribution(
             array([0.3, 0.4]), array([[0.7, 0.0], [0.0, 0.5]])


### PR DESCRIPTION
## Summary
- reject boolean, complex, text/object, and other non-real numeric inputs before storing hypertoroidal wrapped-normal means or covariance matrices
- share the real finite validation path between constructor, `set_mean`, and `set_mode`
- add regression coverage for malformed mean/covariance inputs and boolean mean/mode updates

## Bug fixed
`HypertoroidalWrappedNormalDistribution` converted `mu` and `C` with the backend array constructor and then checked finiteness. Boolean values such as `mu=True` or `C=True`, and complex finite values such as `C=[[1.0 + 0.0j]]`, could pass the validation path and create a valid-looking real-valued distribution state. The new helper rejects non-real numeric dtypes before shape, symmetry, and Cholesky checks.

## Validation
- `python -m py_compile /mnt/data/hypertoroidal_wrapped_normal_distribution.py /mnt/data/test_hypertoroidal_wrapped_normal_distribution.py`
- GitHub compare: branch is 2 commits ahead of `main`, 0 behind, and only changes the wrapped-normal source plus its test module.