### PR TITLE
Validate HypertoroidalDiracDistribution set_mean shape

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py
@@ -7,9 +7,7 @@ import matplotlib.pyplot as plt
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import (
-    abs,
-)
+from pyrecest.backend import abs
 from pyrecest.backend import any as backend_any
 from pyrecest.backend import (
     arctan2,
@@ -120,6 +118,7 @@ class HypertoroidalDiracDistribution(
             raise ValueError("Plotting not supported for this dimension")
 
     def set_mean(self, mean):
+        mean = as_shift_vector(mean, self.dim, name="mean")
         dist = copy.deepcopy(self)
         dist.d = mod(dist.d - dist.mean_direction() + mean, 2.0 * pi)
         return dist

--- a/tests/distributions/test_hypertoroidal_dirac_set_mean_validation.py
+++ b/tests/distributions/test_hypertoroidal_dirac_set_mean_validation.py
@@ -1,14 +1,19 @@
 import numpy.testing as npt
+import pytest
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import array, zeros_like
 from pyrecest.distributions import AbstractHypertoroidalDistribution, HypertoroidalDiracDistribution
 
 
-def test_set_mean_accepts_matching_vector_and_preserves_original():
+def _three_dimensional_distribution():
     samples = array([[0.5, 2.0, 0.5], [3.0, 2.0, 0.2], [4.0, 5.0, 5.8]])
     weights = array([0.2, 0.3, 0.5])
-    dist = HypertoroidalDiracDistribution(samples, weights)
+    return HypertoroidalDiracDistribution(samples, weights), samples
+
+
+def test_set_mean_accepts_matching_vector_and_preserves_original():
+    dist, original_samples = _three_dimensional_distribution()
     target_mean = array([0.25, 1.0, 2.5])
 
     shifted = dist.set_mean(target_mean)
@@ -20,22 +25,16 @@ def test_set_mean_accepts_matching_vector_and_preserves_original():
         zeros_like(target_mean),
         atol=1e-6,
     )
-    npt.assert_allclose(dist.d, samples)
+    npt.assert_allclose(dist.d, original_samples)
 
 
 def test_set_mean_rejects_broadcasting_mean_shapes_for_multidimensional_distribution():
-    dist = HypertoroidalDiracDistribution(
-        array([[0.5, 2.0, 0.5], [3.0, 2.0, 0.2], [4.0, 5.0, 5.8]]),
-        array([0.2, 0.3, 0.5]),
-    )
+    dist, original_samples = _three_dimensional_distribution()
 
     for malformed_mean in (0.25, [0.25], [0.25, 1.0], [[0.25, 1.0, 2.5]]):
-        try:
+        with pytest.raises(ValueError, match=r"mean must have shape \(3,\)"):
             dist.set_mean(malformed_mean)
-        except ValueError as exc:
-            assert "mean must have shape (3,)" in str(exc)
-        else:  # pragma: no cover - documents the regression this test guards
-            raise AssertionError("malformed mean was accepted")
+        npt.assert_allclose(dist.d, original_samples)
 
 
 def test_set_mean_accepts_scalar_for_one_dimensional_distribution():

--- a/tests/distributions/test_hypertoroidal_dirac_set_mean_validation.py
+++ b/tests/distributions/test_hypertoroidal_dirac_set_mean_validation.py
@@ -1,0 +1,46 @@
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array, zeros_like
+from pyrecest.distributions import AbstractHypertoroidalDistribution, HypertoroidalDiracDistribution
+
+
+def test_set_mean_accepts_matching_vector_and_preserves_original():
+    samples = array([[0.5, 2.0, 0.5], [3.0, 2.0, 0.2], [4.0, 5.0, 5.8]])
+    weights = array([0.2, 0.3, 0.5])
+    dist = HypertoroidalDiracDistribution(samples, weights)
+    target_mean = array([0.25, 1.0, 2.5])
+
+    shifted = dist.set_mean(target_mean)
+
+    npt.assert_allclose(
+        AbstractHypertoroidalDistribution.angular_error(
+            shifted.mean_direction(), target_mean
+        ),
+        zeros_like(target_mean),
+        atol=1e-6,
+    )
+    npt.assert_allclose(dist.d, samples)
+
+
+def test_set_mean_rejects_broadcasting_mean_shapes_for_multidimensional_distribution():
+    dist = HypertoroidalDiracDistribution(
+        array([[0.5, 2.0, 0.5], [3.0, 2.0, 0.2], [4.0, 5.0, 5.8]]),
+        array([0.2, 0.3, 0.5]),
+    )
+
+    for malformed_mean in (0.25, [0.25], [0.25, 1.0], [[0.25, 1.0, 2.5]]):
+        try:
+            dist.set_mean(malformed_mean)
+        except ValueError as exc:
+            assert "mean must have shape (3,)" in str(exc)
+        else:  # pragma: no cover - documents the regression this test guards
+            raise AssertionError("malformed mean was accepted")
+
+
+def test_set_mean_accepts_scalar_for_one_dimensional_distribution():
+    dist = HypertoroidalDiracDistribution([0.1, 0.2, 0.3], dim=1)
+
+    shifted = dist.set_mean(0.25)
+
+    npt.assert_allclose(shifted.mean_direction(), array([0.25]), atol=1e-6)


### PR DESCRIPTION
## Summary
- validate `HypertoroidalDiracDistribution.set_mean(...)` with the existing hypertoroidal vector-shape helper
- preserve scalar `set_mean(...)` input for one-dimensional distributions
- add regression coverage for scalar, length-1, short, and non-1D target means on multi-dimensional distributions

## Bug fixed
Multi-dimensional hypertoroidal Dirac distributions previously accepted malformed target means such as scalars or length-1 vectors. NumPy/JAX/PyTorch broadcasting then applied the same value across every angular dimension, silently moving the distribution to an unintended mean instead of rejecting invalid input.

## Validation
- Not run locally; patch prepared through the GitHub connector.