### PR TITLE
Validate SO3 product Dirac marginal indices

### DIFF
--- a/src/pyrecest/distributions/so3_product_dirac_distribution.py
+++ b/src/pyrecest/distributions/so3_product_dirac_distribution.py
@@ -4,6 +4,8 @@
 from math import prod
 from numbers import Integral
 
+import numpy as np
+
 from pyrecest.backend import (
     abs,
     all,
@@ -56,6 +58,59 @@ class SO3ProductDiracDistribution(HyperhemisphereCartProdDiracDistribution):
 
     def get_manifold_size(self):
         return pi ** (2 * self.num_rotations)
+
+    @staticmethod
+    def _normalize_rotation_index_value(rotation_index, num_rotations: int) -> int:
+        """Return a validated scalar rotation index.
+
+        NumPy and PyTorch both coerce boolean values as integer indices, which can
+        silently select the wrong SO(3) component. Keep the product marginal API
+        explicit by accepting only scalar integral indices in range.
+        """
+        index_array = np.asarray(rotation_index)
+        if index_array.ndim != 0:
+            raise ValueError("rotation_index must be a scalar integer.")
+
+        index_value = index_array.item()
+        if isinstance(index_value, (bool, np.bool_)) or not isinstance(
+            index_value, Integral
+        ):
+            raise ValueError("rotation_index must be an integer, not a boolean.")
+
+        normalized_index = int(index_value)
+        if normalized_index < 0 or normalized_index >= num_rotations:
+            raise ValueError("rotation_index is out of range.")
+        return normalized_index
+
+    def _normalize_rotation_index(self, rotation_index) -> int:
+        return self._normalize_rotation_index_value(rotation_index, self.num_rotations)
+
+    def _normalize_rotation_indices(self, rotation_indices):
+        if isinstance(rotation_indices, slice):
+            normalized_indices = list(range(self.num_rotations))[rotation_indices]
+        else:
+            indices_array = np.asarray(rotation_indices)
+            if indices_array.ndim == 0:
+                normalized_indices = [
+                    self._normalize_rotation_index_value(
+                        indices_array, self.num_rotations
+                    )
+                ]
+            elif indices_array.ndim == 1:
+                normalized_indices = [
+                    self._normalize_rotation_index_value(index, self.num_rotations)
+                    for index in indices_array.tolist()
+                ]
+            else:
+                raise ValueError(
+                    "rotation_indices must be a one-dimensional sequence of integers."
+                )
+
+        if not normalized_indices:
+            raise ValueError("rotation_indices must contain at least one index.")
+        if len(set(normalized_indices)) != len(normalized_indices):
+            raise ValueError("rotation_indices must not contain duplicate entries.")
+        return normalized_indices
 
     @staticmethod
     def _as_particle_array(d, num_rotations=None):
@@ -174,12 +229,14 @@ class SO3ProductDiracDistribution(HyperhemisphereCartProdDiracDistribution):
 
     def marginalize_rotation(self, rotation_index):
         """Return the single SO(3) marginal at ``rotation_index``."""
+        rotation_index = self._normalize_rotation_index(rotation_index)
         return HyperhemisphericalDiracDistribution(
             self.component_particles(rotation_index), self.w
         )
 
     def marginalize_rotations(self, rotation_indices):
         """Return the SO(3)^L marginal selected by ``rotation_indices``."""
+        rotation_indices = self._normalize_rotation_indices(rotation_indices)
         return SO3ProductDiracDistribution(self.d[:, rotation_indices, :], self.w)
 
     def moment(self, rotation_index=None):

--- a/tests/distributions/test_so3_product_dirac_marginal_index_validation.py
+++ b/tests/distributions/test_so3_product_dirac_marginal_index_validation.py
@@ -1,0 +1,73 @@
+import unittest
+from math import sqrt
+
+import numpy as np
+import numpy.testing as npt
+
+from pyrecest.backend import array
+from pyrecest.distributions import SO3ProductDiracDistribution
+
+
+class SO3ProductDiracMarginalIndexValidationTest(unittest.TestCase):
+    def setUp(self):
+        self.identity = array([0.0, 0.0, 0.0, 1.0])
+        self.z_ninety = array([0.0, 0.0, sqrt(0.5), sqrt(0.5)])
+        self.x_ninety = array([sqrt(0.5), 0.0, 0.0, sqrt(0.5)])
+
+    def _make_distribution(self):
+        return SO3ProductDiracDistribution(
+            array(
+                [
+                    [self.identity, self.z_ninety, self.x_ninety],
+                    [self.z_ninety, self.x_ninety, self.identity],
+                ]
+            ),
+            array([0.25, 0.75]),
+        )
+
+    def test_marginalize_rotation_accepts_numpy_integer_scalar(self):
+        dist = self._make_distribution()
+
+        marginal = dist.marginalize_rotation(np.int64(2))
+
+        npt.assert_allclose(marginal.d, dist.d[:, 2, :])
+        npt.assert_allclose(marginal.w, dist.w)
+
+    def test_marginalize_rotations_preserves_valid_order(self):
+        dist = self._make_distribution()
+
+        marginal = dist.marginalize_rotations(np.array([2, 0]))
+
+        self.assertEqual(marginal.d.shape, (2, 2, 4))
+        npt.assert_allclose(marginal.d[:, 0, :], dist.d[:, 2, :])
+        npt.assert_allclose(marginal.d[:, 1, :], dist.d[:, 0, :])
+        npt.assert_allclose(marginal.w, dist.w)
+
+    def test_marginalize_rotations_accepts_scalar_selection(self):
+        dist = self._make_distribution()
+
+        marginal = dist.marginalize_rotations(np.array(1))
+
+        self.assertEqual(marginal.d.shape, (2, 1, 4))
+        npt.assert_allclose(marginal.d[:, 0, :], dist.d[:, 1, :])
+
+    def test_marginalize_rotation_rejects_invalid_scalar_index(self):
+        dist = self._make_distribution()
+
+        for invalid in (True, 1.0, -1, 3, np.array([0])):
+            with self.subTest(invalid=invalid):
+                with self.assertRaisesRegex(ValueError, "rotation_index"):
+                    dist.marginalize_rotation(invalid)
+
+    def test_marginalize_rotations_rejects_invalid_index_sequences(self):
+        dist = self._make_distribution()
+
+        invalid_cases = ([], [True], [1.0], [-1], [3], [0, 0], [[0]], ["1"])
+        for invalid in invalid_cases:
+            with self.subTest(invalid=invalid):
+                with self.assertRaisesRegex(ValueError, "rotation_"):
+                    dist.marginalize_rotations(invalid)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- validate `SO3ProductDiracDistribution.marginalize_rotation(...)` and `marginalize_rotations(...)` before indexing quaternion components
- reject boolean, non-integer, negative, out-of-range, duplicate, empty, and non-1D rotation selections
- keep NumPy integer scalar and scalar-array selections accepted, and preserve valid selection order
- add focused regression coverage for valid and invalid marginal selections

## Bug fixed
`SO3ProductDiracDistribution.marginalize_rotations(...)` forwarded user-provided indices directly into `self.d[:, rotation_indices, :]`. That allowed several invalid selections to be silently interpreted by NumPy/PyTorch-style indexing, for example booleans as `0/1`, negative indices as reverse indexing, duplicate rotations as repeated components, and empty selections as a malformed zero-rotation product. The new normalization step makes the product marginal API explicit and prevents accidental component selection.

## Validation
- Syntax-compiled the modified source and the new regression test with `python -m py_compile` in the local execution environment.
- Compared branch against `main`: 2 commits ahead, 0 behind; changes are limited to the SO(3) product Dirac distribution and its focused regression test.
- Full repository pytest not run locally because this environment cannot clone/resolve GitHub hosts; CI should run the targeted test module.