### PR TITLE
Fix SO3 tangent Gaussian validity covariance checks

### DIFF
--- a/src/pyrecest/distributions/so3_tangent_gaussian_distribution.py
+++ b/src/pyrecest/distributions/so3_tangent_gaussian_distribution.py
@@ -209,11 +209,17 @@ class SO3TangentGaussianDistribution(AbstractBoundedDomainDistribution):
 
     def is_valid(self, tolerance=1e-6):
         """Return whether the mean and covariance have valid SO(3) dimensions."""
+        mean_is_finite = all(isfinite(self.mu))
+        covariance_is_finite = all(isfinite(self.C))
         covariance_is_symmetric = amax(abs(self.C - transpose(self.C))) <= tolerance
+        covariance_is_positive_definite = all(linalg.eigvalsh(self.C) > 0.0)
         return bool(
-            abs(linalg.norm(self.mu) - 1.0) <= tolerance
-            and self.mu[-1] >= -tolerance
-            and covariance_is_symmetric
+            _to_python_bool(mean_is_finite)
+            and _to_python_bool(abs(linalg.norm(self.mu) - 1.0) <= tolerance)
+            and _to_python_bool(self.mu[-1] >= -tolerance)
+            and _to_python_bool(covariance_is_finite)
+            and _to_python_bool(covariance_is_symmetric)
+            and _to_python_bool(covariance_is_positive_definite)
         )
 
     @staticmethod

--- a/src/pyrecest/distributions/so3_tangent_gaussian_distribution.py
+++ b/src/pyrecest/distributions/so3_tangent_gaussian_distribution.py
@@ -209,18 +209,19 @@ class SO3TangentGaussianDistribution(AbstractBoundedDomainDistribution):
 
     def is_valid(self, tolerance=1e-6):
         """Return whether the mean and covariance have valid SO(3) dimensions."""
-        mean_is_finite = all(isfinite(self.mu))
-        covariance_is_finite = all(isfinite(self.C))
-        covariance_is_symmetric = amax(abs(self.C - transpose(self.C))) <= tolerance
-        covariance_is_positive_definite = all(linalg.eigvalsh(self.C) > 0.0)
-        return bool(
-            _to_python_bool(mean_is_finite)
+        covariance_is_symmetric = _to_python_bool(
+            amax(abs(self.C - transpose(self.C))) <= tolerance
+        )
+        if not (
+            _to_python_bool(all(isfinite(self.mu)))
             and _to_python_bool(abs(linalg.norm(self.mu) - 1.0) <= tolerance)
             and _to_python_bool(self.mu[-1] >= -tolerance)
-            and _to_python_bool(covariance_is_finite)
-            and _to_python_bool(covariance_is_symmetric)
-            and _to_python_bool(covariance_is_positive_definite)
-        )
+            and _to_python_bool(all(isfinite(self.C)))
+            and covariance_is_symmetric
+        ):
+            return False
+
+        return _to_python_bool(all(linalg.eigvalsh(self.C) > 0.0))
 
     @staticmethod
     def from_covariance_diagonal(mu, covariance_diagonal):

--- a/tests/distributions/test_conversion.py
+++ b/tests/distributions/test_conversion.py
@@ -197,7 +197,9 @@ class ConversionTest(unittest.TestCase):
         )
         particles = SO3DiracDistribution(rotations, array([0.25, 0.25, 0.25, 0.25]))
 
-        gaussian = particles.approximate_as("so3_tangent_gaussian")
+        gaussian = particles.approximate_as(
+            "so3_tangent_gaussian", covariance_regularization=1e-9
+        )
 
         self.assertIsInstance(gaussian, SO3TangentGaussianDistribution)
         self.assertEqual(gaussian.mean().shape, (4,))

--- a/tests/distributions/test_so3_tangent_gaussian_distribution.py
+++ b/tests/distributions/test_so3_tangent_gaussian_distribution.py
@@ -56,6 +56,24 @@ class SO3TangentGaussianDistributionTest(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, message):
                     SO3TangentGaussianDistribution(mean, covariance)
 
+    def test_is_valid_rejects_covariances_that_constructor_would_reject(self):
+        mean = array([0.0, 0.0, 0.0, 1.0])
+        invalid_covariances = [
+            array([[0.1, 0.0, 0.0], [0.0, float("nan"), 0.0], [0.0, 0.0, 0.3]]),
+            diag(array([0.1, 0.0, 0.3])),
+            diag(array([0.1, -0.2, 0.3])),
+        ]
+
+        for covariance in invalid_covariances:
+            with self.subTest(covariance=np.asarray(covariance)):
+                dist = SO3TangentGaussianDistribution(
+                    mean,
+                    covariance,
+                    check_validity=False,
+                )
+
+                self.assertFalse(dist.is_valid())
+
     def test_exp_log_roundtrip_with_base_rotation(self):
         base = z_quaternion(pi / 3.0)
         tangent_vectors = array([[0.1, -0.2, 0.05], [0.0, 0.0, 0.0]])


### PR DESCRIPTION
## Summary
- make `SO3TangentGaussianDistribution.is_valid()` reject non-finite covariance entries
- require the tangent covariance to be positive definite, matching constructor validation
- add regression coverage for invalid covariances when constructor validation is intentionally bypassed

## Bug fixed
`SO3TangentGaussianDistribution.__init__(..., check_validity=True)` rejects non-finite and non-positive-definite tangent covariance matrices, but `is_valid()` only checked quaternion normalization/canonicalization and covariance symmetry. Objects created with `check_validity=False` could therefore report `True` for invalid covariance matrices, e.g. singular, indefinite, or NaN-containing covariances. This patch makes the validity predicate consistent with the constructor's covariance contract.

## Tests
- Not run locally; repository access is via GitHub connector only in this environment.