### PR TITLE
Fix hypersphere Dirac array-like initialization

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/abstract_hypersphere_subset_dirac_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/abstract_hypersphere_subset_dirac_distribution.py
@@ -1,6 +1,6 @@
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import linalg, log, outer, reshape, sum, zeros
+from pyrecest.backend import asarray, linalg, log, outer, reshape, sum, zeros
 
 from ..abstract_dirac_distribution import AbstractDiracDistribution
 from .abstract_hypersphere_subset_distribution import (
@@ -12,6 +12,7 @@ class AbstractHypersphereSubsetDiracDistribution(
     AbstractDiracDistribution, AbstractHypersphereSubsetDistribution
 ):
     def __init__(self, d, w=None):
+        d = asarray(d)
         AbstractHypersphereSubsetDistribution.__init__(self, d.shape[-1] - 1)
         AbstractDiracDistribution.__init__(self, d, w=w)
 

--- a/tests/distributions/test_hyperspherical_dirac_distribution.py
+++ b/tests/distributions/test_hyperspherical_dirac_distribution.py
@@ -44,6 +44,16 @@ class HypersphericalDiracDistributionTest(unittest.TestCase):
     def test_instance_creation(self):
         self.assertIsInstance(self.hdd, HypersphericalDiracDistribution)
 
+    def test_constructor_accepts_array_like_locations_and_weights(self):
+        locations = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]
+        weights = [0.25, 0.75]
+
+        dist = HypersphericalDiracDistribution(locations, weights)
+
+        self.assertEqual(dist.dim, 2)
+        npt.assert_allclose(dist.d, array(locations))
+        npt.assert_allclose(dist.w, array(weights))
+
     def test_sampling(self):
         nSamples = 5
         s = self.hdd.sample(nSamples)


### PR DESCRIPTION
## Summary
- Convert hypersphere-subset Dirac locations with the backend before reading `.shape`.
- This lets hyperspherical and hyperhemispherical Dirac distributions accept ordinary array-like locations consistently with the base Dirac distribution.
- Add a regression test for Python list-of-lists locations and list weights.

## Bug fixed
`AbstractHypersphereSubsetDiracDistribution.__init__()` read `d.shape[-1]` before delegating to `AbstractDiracDistribution`, whose constructor already supports array-like inputs via `asarray`. Plain Python list inputs therefore failed with an attribute error before normalization.

## Validation
- Compared branch against `main`: 2 commits ahead, 0 behind.
- Diff is limited to the constructor and one focused regression test.
- Full local pytest was not run because repository cloning is unavailable in this environment; CI should run the added test.