### PR TITLE
Add PyTorch cross-product backend fallback

### DIFF
--- a/src/pyrecest/_backend/_common.py
+++ b/src/pyrecest/_backend/_common.py
@@ -203,6 +203,67 @@ def diagonal(a, offset=0, axis1=0, axis2=1):
     return _np.diagonal(a, offset=offset, axis1=axis1, axis2=axis2)
 
 
+def _normalize_cross_axis(axis, ndim_value, name):
+    """Return a normalized NumPy-style cross-product axis."""
+    if isinstance(axis, _AXIS_FLAG_TYPES):
+        raise TypeError(f"{name} must be an integer")
+    try:
+        axis_index = _operator.index(axis)
+    except TypeError as exc:
+        raise TypeError(f"{name} must be an integer") from exc
+
+    normalized_axis = axis_index + ndim_value if axis_index < 0 else axis_index
+    if normalized_axis < 0 or normalized_axis >= ndim_value:
+        raise IndexError(
+            f"{name} {axis_index} is out of bounds for array of dimension {ndim_value}"
+        )
+    return normalized_axis
+
+
+def _torch_cross(a, b, torch, *, axisa=-1, axisb=-1, axisc=-1, axis=None):
+    """Return a NumPy-compatible cross product for PyTorch tensors."""
+    if axis is not None:
+        axisa = axisb = axisc = axis
+    if a.ndim == 0 or b.ndim == 0:
+        raise ValueError("At least one array has zero dimension")
+
+    axisa = _normalize_cross_axis(axisa, a.ndim, "axisa")
+    axisb = _normalize_cross_axis(axisb, b.ndim, "axisb")
+    a = torch.movedim(a, axisa, -1)
+    b = torch.movedim(b, axisb, -1)
+
+    if a.dtype == torch.bool:
+        a = a.to(dtype=torch.int64)
+    if b.dtype == torch.bool:
+        b = b.to(dtype=torch.int64)
+
+    a_dim = a.shape[-1]
+    b_dim = b.shape[-1]
+    if a_dim not in (2, 3) or b_dim not in (2, 3):
+        raise ValueError("incompatible dimensions for cross product (dimension must be 2 or 3)")
+
+    a0 = a[..., 0]
+    a1 = a[..., 1]
+    b0 = b[..., 0]
+    b1 = b[..., 1]
+    a2 = a[..., 2] if a_dim == 3 else torch.zeros_like(a0)
+    b2 = b[..., 2] if b_dim == 3 else torch.zeros_like(b0)
+
+    if a_dim == 2 and b_dim == 2:
+        return a0 * b1 - a1 * b0
+
+    result = torch.stack(
+        (
+            a1 * b2 - a2 * b1,
+            a2 * b0 - a0 * b2,
+            a0 * b1 - a1 * b0,
+        ),
+        dim=-1,
+    )
+    axisc = _normalize_cross_axis(axisc, result.ndim, "axisc")
+    return torch.movedim(result, -1, axisc)
+
+
 def _active_backend_name():
     try:
         import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
@@ -271,6 +332,17 @@ def dot(a, b):
         return torch.tensordot(a, b, dims=([-1], [-2]))
 
     return _np.dot(_np.asarray(a), _np.asarray(b))
+
+
+def cross(a, b, axisa=-1, axisb=-1, axisc=-1, axis=None):
+    """Return NumPy-compatible cross products for NumPy and PyTorch values."""
+    torch_pair = _torch_promoted_pair(a, b)
+    if torch_pair is not None:
+        a, b = torch_pair
+        torch = _torch_module_for_values(a, b)
+        return _torch_cross(a, b, torch, axisa=axisa, axisb=axisb, axisc=axisc, axis=axis)
+
+    return _np.cross(_np.asarray(a), _np.asarray(b), axisa=axisa, axisb=axisb, axisc=axisc, axis=axis)
 
 
 def matvec(matrix, vector):

--- a/src/pyrecest/backend_support/_pytorch_dot_outer_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_dot_outer_device_contract.py
@@ -60,6 +60,21 @@ def _patch_sort_axis_none_contract(raw_pytorch, backend, torch_module) -> None:
         setattr(backend, "sort", sort)
 
 
+def _ensure_raw_pytorch_cross(raw_pytorch):
+    """Expose the shared cross-product fallback on raw PyTorch when absent."""
+    original_cross = getattr(raw_pytorch, "cross", None)
+    if original_cross is not None:
+        return original_cross
+
+    try:
+        import pyrecest._backend._common as common_backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - shared backend should be available
+        return None
+
+    raw_pytorch.cross = common_backend.cross
+    return raw_pytorch.cross
+
+
 def patch_pytorch_dot_outer_device_contract() -> None:
     """Patch raw/public PyTorch vector-product helpers to preserve non-CPU operands."""
     try:
@@ -73,7 +88,7 @@ def patch_pytorch_dot_outer_device_contract() -> None:
 
     original_dot = getattr(raw_pytorch, "dot", None)
     original_outer = getattr(raw_pytorch, "outer", None)
-    original_cross = getattr(raw_pytorch, "cross", None)
+    original_cross = _ensure_raw_pytorch_cross(raw_pytorch)
     if original_dot is None or original_outer is None:
         return
 

--- a/tests/test_pytorch_cross_contract.py
+++ b/tests/test_pytorch_cross_contract.py
@@ -20,3 +20,23 @@ def test_pytorch_cross_returns_scalar_z_component_for_2d_vectors():
     )
 
     npt.assert_allclose(backend.to_numpy(batched), np.array([-4.0, -4.0]))
+
+
+@pytest.mark.skipif(
+    backend.__backend_name__ != "pytorch",
+    reason="PyTorch-specific cross-product contract regression test",
+)
+def test_pytorch_cross_accepts_numpy_axis_keywords():
+    left = np.arange(24.0).reshape(3, 2, 4)
+    right = np.ones_like(left)
+
+    result = backend.cross(
+        backend.asarray(left),
+        backend.asarray(right),
+        axisa=0,
+        axisb=0,
+        axisc=1,
+    )
+
+    expected = np.cross(left, right, axisa=0, axisb=0, axisc=1)
+    npt.assert_allclose(backend.to_numpy(result), expected)


### PR DESCRIPTION
## Summary
- add a shared NumPy-compatible `cross` fallback that supports PyTorch tensors when the raw backend does not expose `cross`
- make the PyTorch dot/outer/cross stability hook install that fallback onto the raw PyTorch backend before applying the device-preserving wrapper
- add PyTorch regression coverage for NumPy-style `axisa`/`axisb`/`axisc` handling

## Bug fixed
`BACKEND_ATTRIBUTES` requires `cross`, and existing tests expect both public and raw PyTorch `cross` to work. The raw PyTorch backend did not expose `cross`, so selecting the PyTorch backend could fail during backend construction, and raw `pyrecest._backend.pytorch.cross` remained unavailable even after importing stability hooks. The new shared fallback keeps NumPy semantics, including 2-D vector scalar z-components and axis keywords, while preserving PyTorch tensor/device behavior.

## Validation
- Compared `pytorch-cross-regression` against `main`: 3 commits ahead, 0 behind.
- Diff is limited to the shared backend fallback, the PyTorch stability hook, and focused cross-product regression coverage.
- Full test suite was not run locally in this connector environment.