### PR TITLE
Validate lin-bounded dimension counts

### DIFF
--- a/src/pyrecest/distributions/cart_prod/abstract_lin_bounded_cart_prod_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/abstract_lin_bounded_cart_prod_distribution.py
@@ -1,10 +1,36 @@
 from abc import abstractmethod
+from operator import index as _operator_index
 from typing import Union
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import int32, int64
 
 from .abstract_cart_prod_distribution import AbstractCartProdDistribution
+
+
+def _validate_nonnegative_dimension_count(value, name: str) -> int:
+    """Return ``value`` as a non-negative Python integer dimension count."""
+    message = f"{name} must be a non-negative integer"
+    if isinstance(value, bool):
+        raise ValueError(message)
+
+    dtype = getattr(value, "dtype", None)
+    if getattr(dtype, "kind", None) == "b" or str(dtype) == "torch.bool":
+        raise ValueError(message)
+
+    ndim = getattr(value, "ndim", None)
+    if ndim not in (None, 0):
+        raise ValueError(message)
+    if ndim == 0 and hasattr(value, "item"):
+        value = value.item()
+
+    try:
+        count = _operator_index(value)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError(message) from exc
+    if count < 0:
+        raise ValueError(message)
+    return int(count)
 
 
 class AbstractLinBoundedCartProdDistribution(AbstractCartProdDistribution):
@@ -25,10 +51,8 @@ class AbstractLinBoundedCartProdDistribution(AbstractCartProdDistribution):
                 number of linear dimensions
 
         """
-        if not bound_dim >= 0:
-            raise ValueError("bound_dim must be a non-negative integer")
-        if not lin_dim >= 0:
-            raise ValueError("lin_dim must be a non-negative integer")
+        bound_dim = _validate_nonnegative_dimension_count(bound_dim, "bound_dim")
+        lin_dim = _validate_nonnegative_dimension_count(lin_dim, "lin_dim")
         if not bound_dim + lin_dim >= 1:
             raise ValueError("total dimension must be positive")
 

--- a/tests/distributions/test_hypercylindrical_dirac_distribution.py
+++ b/tests/distributions/test_hypercylindrical_dirac_distribution.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
@@ -66,6 +67,31 @@ class TestHypercylindricalDiracDistribution(TestAbstractDiracDistribution):
         self.assertEqual(dist.bound_dim, 1)
         self.assertEqual(dist.lin_dim, 1)
 
+    def test_constructor_accepts_scalar_integer_bound_dim(self):
+        dist = HypercylindricalDiracDistribution(
+            np.array(1, dtype=np.int64), self.d, self.w
+        )
+
+        self.assertEqual(dist.bound_dim, 1)
+        self.assertEqual(dist.lin_dim, 2)
+        self.assertIsInstance(dist.bound_dim, int)
+        self.assertIsInstance(dist.lin_dim, int)
+
+    def test_constructor_rejects_invalid_bound_dim_counts(self):
+        invalid_counts = (True, np.bool_(True), np.array(True), 1.5, np.array([1]), -1)
+        for bound_dim in invalid_counts:
+            with self.subTest(bound_dim=bound_dim):
+                with self.assertRaisesRegex(
+                    ValueError, "bound_dim must be a non-negative integer"
+                ):
+                    HypercylindricalDiracDistribution(bound_dim, self.d, self.w)
+
+    def test_constructor_rejects_negative_inferred_linear_dimension(self):
+        with self.assertRaisesRegex(
+            ValueError, "lin_dim must be a non-negative integer"
+        ):
+            HypercylindricalDiracDistribution(4, self.d, self.w)
+
     def test_apply_function_identity(self):
         same = self.pwd.apply_function(lambda x: x)
         npt.assert_array_equal(self.pwd.d, same.d)
@@ -125,9 +151,7 @@ class TestHypercylindricalDiracDistribution(TestAbstractDiracDistribution):
         self.assertTrue(all(s < 2 * pi * ones_like(s)))
 
     def test_from_distribution(self):
-        import numpy as _np
-
-        random_gen = _np.random.default_rng(0)  # Could fail randomly otherwise
+        random_gen = np.random.default_rng(0)  # Could fail randomly otherwise
         df = 4
         scale = eye(4)
         # Call array(...) to be compatibel with all backends


### PR DESCRIPTION
## Summary
- tighten `AbstractLinBoundedCartProdDistribution` dimension-count validation to require scalar non-boolean integers
- normalize accepted scalar integer counts to Python `int`
- add hypercylindrical Dirac regression coverage for NumPy scalar counts, booleans, floats, non-scalar arrays, and negative inferred linear dimensions

## Why
The previous constructor only compared `bound_dim` and `lin_dim` numerically. Because `bool` is an integer subclass and floats compare successfully, values such as `True` or `1.5` could silently create invalid Cartesian-product dimensions.

## Tests
Not run locally; changes are covered by the added focused unit tests and should be exercised by PR CI.