### PR TITLE
Fix PyTorch dot NumPy contraction contract

### DIFF
--- a/src/pyrecest/_backend_runtime_patches.py
+++ b/src/pyrecest/_backend_runtime_patches.py
@@ -108,3 +108,63 @@ def patch_pytorch_repeat_numpy_contract() -> None:
     raw_pytorch.repeat = repeat
     if active_pytorch_backend:
         backend.repeat = repeat
+
+
+def patch_pytorch_dot_numpy_contract() -> None:
+    """Make PyTorch ``dot`` follow NumPy's matrix/vector contraction contract."""
+
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+    original_dot = getattr(raw_pytorch, "dot", None)
+    if getattr(original_dot, "_pyrecest_numpy_dot_contract", False):
+        if active_pytorch_backend:
+            backend.dot = original_dot
+        return
+
+    def _preferred_device(*values):
+        for value in values:
+            if torch.is_tensor(value) and value.device.type != "cpu":
+                return value.device
+        for value in values:
+            if torch.is_tensor(value):
+                return value.device
+        return None
+
+    def _tensor_on_device(value, *, device):
+        if torch.is_tensor(value):
+            if device is not None and value.device != device:
+                return value.to(device=device)
+            return value
+        return torch.as_tensor(value, device=device)
+
+    def _promoted_pair(a, b):
+        device = _preferred_device(a, b)
+        a = _tensor_on_device(a, device=device)
+        b = _tensor_on_device(b, device=device)
+        dtype = torch.promote_types(a.dtype, b.dtype)
+        return a.to(dtype=dtype), b.to(dtype=dtype)
+
+    def dot(a, b):
+        a, b = _promoted_pair(a, b)
+        if a.ndim == 0 or b.ndim == 0:
+            return torch.multiply(a, b)
+        if a.ndim == 1 and b.ndim == 1:
+            return torch.dot(a, b)
+        if b.ndim == 1:
+            return torch.tensordot(a, b, dims=([-1], [0]))
+        if a.ndim == 1:
+            return torch.tensordot(a, b, dims=([0], [-2]))
+        return torch.tensordot(a, b, dims=([-1], [-2]))
+
+    dot.__name__ = getattr(original_dot, "__name__", "dot")
+    dot.__doc__ = getattr(original_dot, "__doc__", None)
+    dot._pyrecest_numpy_dot_contract = True
+    raw_pytorch.dot = dot
+    if active_pytorch_backend:
+        backend.dot = dot

--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -213,10 +213,12 @@ def resolve_evidence_computation_mode(
 try:
     from pyrecest._backend_runtime_patches import (  # pylint: disable=import-outside-toplevel
         patch_pytorch_close_equal_nan_device_contract as _patch_pytorch_close_equal_nan_device_contract,
+        patch_pytorch_dot_numpy_contract as _patch_pytorch_dot_numpy_contract,
         patch_pytorch_repeat_numpy_contract as _patch_pytorch_repeat_numpy_contract,
     )
 except ModuleNotFoundError:  # pragma: no cover - source tree corruption only
     pass
 else:
     _patch_pytorch_close_equal_nan_device_contract()
+    _patch_pytorch_dot_numpy_contract()
     _patch_pytorch_repeat_numpy_contract()

--- a/tests/backend_support/test_pytorch_dot_numpy_contract.py
+++ b/tests/backend_support/test_pytorch_dot_numpy_contract.py
@@ -1,0 +1,34 @@
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+def test_pytorch_dot_matches_numpy_matrix_and_vector_contracts():
+    pytest.importorskip("torch")
+
+    code = """
+import pyrecest.backend as backend
+
+assert backend.__backend_name__ == "pytorch"
+
+matrix_left = backend.array([[1.0, 2.0], [3.0, 4.0]])
+matrix_right = backend.array([[5.0, 6.0], [7.0, 8.0]])
+matrix_result = backend.dot(matrix_left, matrix_right)
+assert matrix_result.shape == (2, 2)
+assert backend.to_numpy(matrix_result).tolist() == [[19.0, 22.0], [43.0, 50.0]]
+
+vector_matrix_result = backend.dot(
+    backend.array([1.0, 2.0]),
+    backend.array([[3.0, 4.0], [5.0, 6.0]]),
+)
+assert vector_matrix_result.shape == (2,)
+assert backend.to_numpy(vector_matrix_result).tolist() == [13.0, 16.0]
+
+batched_result = backend.dot(backend.array([[[1.0, 2.0], [3.0, 4.0]]]), matrix_right)
+assert batched_result.shape == (1, 2, 2)
+assert backend.to_numpy(batched_result).tolist() == [[[19.0, 22.0], [43.0, 50.0]]]
+"""
+
+    result = run_backend_code("pytorch", code)
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Fix the PyTorch backend `dot` runtime contract so matrix/matrix, vector/matrix, matrix/vector, and batched contractions follow NumPy `dot` semantics.
- Override the previous row-wise inner-product patch with a tensor contraction over the last axis of the left operand and the second-to-last axis of the right operand.
- Add a PyTorch-backend regression test covering matrix/matrix, vector/matrix, and batched matrix cases.

## Bug
The existing PyTorch linear-helper patch used `einsum("...i,...i->...", a, b)` for higher-rank operands. For two matrices this returns row-wise inner products such as `[17, 53]` for `[[1, 2], [3, 4]] dot [[5, 6], [7, 8]]`, while NumPy returns the matrix product `[[19, 22], [43, 50]]`.

## Testing
- Added `tests/backend_support/test_pytorch_dot_numpy_contract.py`.
- I could not run the repository test suite in this environment because the repository is only accessible through the GitHub connector, not as a local checkout.