### PR TITLE
Normalize punctuation in axis label manifold names

### DIFF
--- a/src/pyrecest/evaluation/get_axis_label.py
+++ b/src/pyrecest/evaluation/get_axis_label.py
@@ -1,7 +1,10 @@
 def _normalize_manifold_name(manifold_name):
     if not isinstance(manifold_name, str) or not manifold_name.strip():
         raise ValueError("manifold_name must be a non-empty string")
-    return manifold_name.strip().lower()
+    compact_name = "".join(char for char in manifold_name.strip().lower() if char.isalnum())
+    if not compact_name:
+        raise ValueError("manifold_name must be a non-empty string")
+    return compact_name
 
 
 def get_axis_label(manifold_name):

--- a/tests/test_axis_labels.py
+++ b/tests/test_axis_labels.py
@@ -28,7 +28,22 @@ def test_generic_manifold_axis_labels_are_preserved(manifold_name, expected_labe
     assert get_axis_label(manifold_name) == expected_label
 
 
-@pytest.mark.parametrize("manifold_name", [None, "", "   "])
+@pytest.mark.parametrize(
+    ("manifold_name", "expected_label"),
+    [
+        ("SE(2)", "Error in meters"),
+        ("SE(2)-linear", "Error in meters"),
+        ("SE(3)-bounded", "Error in radian"),
+        ("hypersphere_symmetric", "Angular error in radian"),
+    ],
+)
+def test_axis_label_accepts_common_mathematical_notation(
+    manifold_name, expected_label
+):
+    assert get_axis_label(manifold_name) == expected_label
+
+
+@pytest.mark.parametrize("manifold_name", [None, "", "   ", "---"])
 def test_axis_label_rejects_invalid_manifold_names(manifold_name):
     with pytest.raises(ValueError, match="manifold_name must be a non-empty string"):
         get_axis_label(manifold_name)


### PR DESCRIPTION
## Summary
- Normalize manifold names for axis-label lookup by compacting punctuation/spacing after lowercasing.
- Fix common mathematical names such as `SE(2)`, `SE(2)-linear`, `SE(3)-bounded`, and `hypersphere_symmetric`.
- Add regression coverage for punctuated notation and punctuation-only invalid names.

## Rationale
`get_axis_label` previously only stripped and lowercased names. As a result, common Lie-group notation like `SE(2)` normalized to `se(2)` and missed the existing `se2`/`se2bounded` branches, raising `ValueError("Mode not recognized")` instead of returning the correct axis label.

## Tests
- Added/updated `tests/test_axis_labels.py` coverage for punctuated notation.
- Not run locally in this environment.