### PR TITLE
Fix PyTorch sort keyword handling

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_dot_outer_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_dot_outer_device_contract.py
@@ -39,8 +39,17 @@ def _patch_sort_axis_none_contract(raw_pytorch, backend, torch_module) -> None:
             setattr(backend, "sort", original_sort)
         return
 
-    def sort(a, axis=-1):
-        return _sort_axis_none(raw_pytorch, torch_module, a, axis=axis)
+    def sort(a, axis=-1, kind=None, order=None, *, stable=None, descending=False):
+        return _sort_axis_none(
+            raw_pytorch,
+            torch_module,
+            a,
+            axis=axis,
+            kind=kind,
+            order=order,
+            stable=stable,
+            descending=descending,
+        )
 
     sort.__name__ = getattr(original_sort, "__name__", "sort")
     sort.__doc__ = getattr(original_sort, "__doc__", None)

--- a/src/pyrecest/backend_support/_pytorch_sort_numpy_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_sort_numpy_contract.py
@@ -12,11 +12,46 @@ def normalize_sort_axis(axis):
     return _operator_index(axis)
 
 
-def sort_axis_none(backend_module, torch_module, values, axis=-1):
-    """Sort values with NumPy-style ``axis=None`` support."""
+def resolve_sort_stability(kind, stable):
+    """Return PyTorch's stable flag for NumPy-style sort keyword aliases."""
+    if kind is None:
+        return stable
+    if kind in {"stable", "mergesort"}:
+        if stable is False:
+            raise TypeError("sort() got conflicting 'kind' and 'stable' arguments")
+        return True
+    if kind in {"quicksort", "heapsort"}:
+        if stable is True:
+            raise TypeError("sort() got conflicting 'kind' and 'stable' arguments")
+        return False
+    raise ValueError(
+        "sort kind must be one of 'quicksort', 'heapsort', 'stable', or 'mergesort'"
+    )
+
+
+def sort_axis_none(
+    backend_module,
+    torch_module,
+    values,
+    axis=-1,
+    kind=None,
+    order=None,
+    *,
+    stable=None,
+    descending=False,
+):
+    """Sort values with NumPy-style ``axis=None`` and PyTorch ordering support."""
+    if order is not None:
+        raise ValueError("order is not supported by this backend")
+    stable = resolve_sort_stability(kind, stable)
     values = backend_module.array(values)
     axis = normalize_sort_axis(axis)
     if axis is None:
         values = torch_module.flatten(values)
         axis = 0
-    return torch_module.sort(values, dim=axis).values
+    return torch_module.sort(
+        values,
+        dim=axis,
+        descending=descending,
+        stable=bool(stable) if stable is not None else False,
+    ).values

--- a/tests/backend_support/test_pytorch_sort_axis_none_contract.py
+++ b/tests/backend_support/test_pytorch_sort_axis_none_contract.py
@@ -33,6 +33,9 @@ assert backend.__backend_name__ == "pytorch"
 flat_result = backend.sort([[3, 1], [2, 0]], axis=None)
 assert backend.to_numpy(flat_result).tolist() == [0, 1, 2, 3]
 
+descending_flat = backend.sort([[3, 1], [2, 0]], axis=None, descending=True)
+assert backend.to_numpy(descending_flat).tolist() == [3, 2, 1, 0]
+
 axis_result = backend.sort([[3, 1], [2, 0]], axis=0)
 assert backend.to_numpy(axis_result).tolist() == [[2, 0], [3, 1]]
 """
@@ -55,6 +58,9 @@ assert public_backend.__backend_name__ == "numpy"
 
 flat_result = raw_pytorch.sort([[3, 1], [2, 0]], axis=None)
 assert raw_pytorch.to_numpy(flat_result).tolist() == [0, 1, 2, 3]
+
+descending_flat = raw_pytorch.sort([[3, 1], [2, 0]], axis=None, descending=True)
+assert raw_pytorch.to_numpy(descending_flat).tolist() == [3, 2, 1, 0]
 
 axis_result = raw_pytorch.sort([[3, 1], [2, 0]], axis=0)
 assert raw_pytorch.to_numpy(axis_result).tolist() == [[2, 0], [3, 1]]


### PR DESCRIPTION
Forward PyTorch sort keyword arguments through the existing axis=None wrapper and add descending=True regression coverage.