### PR TITLE
Reject infeasible point-target DDP associations

### DIFF
--- a/src/pyrecest/experimental/multisensor_ddp_association.py
+++ b/src/pyrecest/experimental/multisensor_ddp_association.py
@@ -295,7 +295,10 @@ def _greedy_point_target_projection(log_scores: np.ndarray, num_targets: int) ->
             selected_column = int(column)
             break
         if selected_column is None:
-            selected_column = log_scores.shape[1] - 1
+            raise ValueError(
+                "point_target projection has no finite feasible association "
+                f"for measurement {measurement_index}"
+            )
         responsibilities[measurement_index, selected_column] = 1.0
         if selected_column < num_targets:
             used_targets.add(selected_column)

--- a/tests/experimental/test_multisensor_ddp_association.py
+++ b/tests/experimental/test_multisensor_ddp_association.py
@@ -77,6 +77,24 @@ def test_point_target_projection_allows_each_existing_target_once_per_sensor():
     assert result.posterior_for_sensor("radar").hard_assignments.count(1) == 1
 
 
+def test_point_target_projection_rejects_infeasible_finite_assignments():
+    block = SensorAssociationBlock(
+        "radar",
+        log_likelihoods=np.log([[0.90], [0.85]]),
+        clutter_log_weights=[-np.inf, -np.inf],
+        birth_log_weights=[-np.inf, -np.inf],
+        concentration=1.0,
+    )
+
+    with pytest.raises(ValueError, match="no finite feasible association"):
+        multisensor_ddp_association_update(
+            [1.0],
+            [block],
+            birth_weight=0.0,
+            point_target=True,
+        )
+
+
 def test_predict_ddp_base_weights_applies_survival_and_birth_mass():
     target_weights, birth_weight = predict_ddp_base_weights(
         [0.7, 0.3],


### PR DESCRIPTION
## Summary
- Make the experimental multisensor DDP point-target projection reject measurements with no finite feasible association after one-to-one target constraints are applied.
- Avoid returning a clutter assignment when the clutter score is `-inf`.
- Add regression coverage for the infeasible projection case.

## Testing
- `PYTHONPATH=src pytest -q tests/experimental/test_multisensor_ddp_association.py` in an isolated local layout: `6 passed`.
- Full repository suite was not run because the sandbox cannot clone github.com directly; repository writes were performed through the GitHub connector.