### PR TITLE
Stabilize NumPy multinomial probability normalization

### DIFF
--- a/src/pyrecest/_backend/numpy/random.py
+++ b/src/pyrecest/_backend/numpy/random.py
@@ -80,6 +80,21 @@ def _validate_multinomial_sample_count(n):
     return count
 
 
+def _normalize_probability_array(probability_array):
+    if _np.any(probability_array < 0) or _np.any(~_np.isfinite(probability_array)):
+        raise ValueError("probabilities do not sum to a positive value")
+
+    scale = float(probability_array.max())
+    if scale <= 0.0:
+        raise ValueError("probabilities do not sum to a positive value")
+
+    scaled = probability_array / scale
+    probability_sum = scaled.sum()
+    if not _np.isfinite(probability_sum) or probability_sum <= 0:
+        raise ValueError("probabilities do not sum to a positive value")
+    return scaled / probability_sum
+
+
 def _validate_multinomial_pvals(pvals):
     if _contains_boolean_value(pvals):
         raise TypeError("pvals must be real numeric, not boolean")
@@ -90,16 +105,12 @@ def _validate_multinomial_pvals(pvals):
     if pvals_array.dtype.kind not in "iuf":
         raise TypeError("pvals must be real numeric")
 
-    pvals_array = pvals_array.astype(float, copy=False)
+    pvals_array = pvals_array.astype(_np.float64, copy=False)
     if pvals_array.ndim != 1:
         raise ValueError("pvals must be 1-dimensional")
     if pvals_array.size == 0:
         raise ValueError("pvals must contain at least one probability")
-
-    pvals_sum = pvals_array.sum()
-    if _np.any(pvals_array < 0) or not _np.isfinite(pvals_sum) or pvals_sum <= 0:
-        raise ValueError("probabilities do not sum to a positive value")
-    return pvals_array / pvals_sum
+    return _normalize_probability_array(pvals_array)
 
 
 def _validate_multinomial_size(size):

--- a/tests/backend/test_numpy_random_probability_normalization.py
+++ b/tests/backend/test_numpy_random_probability_normalization.py
@@ -1,0 +1,20 @@
+import unittest
+
+import pyrecest.backend
+from pyrecest.backend import random
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ != "numpy",
+    "NumPy-specific probability normalization regression",
+)
+class TestNumpyRandomProbabilityNormalization(unittest.TestCase):
+    def test_multinomial_accepts_large_finite_unnormalized_pvals(self):
+        sample = random.multinomial(12, [1.0e308, 1.0e308, 1.0e308])
+
+        self.assertEqual(tuple(pyrecest.backend.shape(sample)), (3,))
+        self.assertEqual(int(pyrecest.backend.sum(sample)), 12)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Normalize NumPy multinomial probability weights by their maximum before summing.
- Preserve support for finite, unnormalized probability vectors whose direct float64 sum would overflow.
- Add a NumPy-specific regression test using large finite weights.

## Testing
- Not run locally; changes were made through the GitHub connector after syntax-level review of the edited snippets.