### PR TITLE
Expand PyTorch dot and outer device coverage

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_dot_outer_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_dot_outer_device_contract.py
@@ -118,19 +118,11 @@ def patch_pytorch_dot_outer_device_contract() -> None:
         a, b = _promoted_pair(raw_pytorch, torch, a, b)
         if a.ndim == 0 or b.ndim == 0:
             return torch.multiply(a, b)
-        if a.ndim == 1 and b.ndim == 1:
-            return torch.dot(a, b)
-        if b.ndim == 1:
-            return torch.einsum("...i,i->...", a, b)
-        if a.ndim == 1:
-            return torch.einsum("i,...i->...", a, b)
-        return torch.einsum("...i,...i->...", a, b)
+        return torch.matmul(a, b)
 
     def outer(a, b):
         a, b = _promoted_pair(raw_pytorch, torch, a, b)
-        if a.ndim == 0 or b.ndim == 0:
-            return torch.multiply(a, b)
-        return a[..., :, None] * b[..., None, :]
+        return torch.outer(torch.flatten(a), torch.flatten(b))
 
     for helper_name, helper, original_helper in (
         ("dot", dot, original_dot),

--- a/src/pyrecest/backend_support/_pytorch_dot_outer_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_dot_outer_device_contract.py
@@ -118,11 +118,19 @@ def patch_pytorch_dot_outer_device_contract() -> None:
         a, b = _promoted_pair(raw_pytorch, torch, a, b)
         if a.ndim == 0 or b.ndim == 0:
             return torch.multiply(a, b)
-        return torch.matmul(a, b)
+        if a.ndim == 1 and b.ndim == 1:
+            return torch.dot(a, b)
+        if b.ndim == 1:
+            return torch.einsum("...i,i->...", a, b)
+        if a.ndim == 1:
+            return torch.einsum("i,...i->...", a, b)
+        return torch.einsum("...i,...i->...", a, b)
 
     def outer(a, b):
         a, b = _promoted_pair(raw_pytorch, torch, a, b)
-        return torch.outer(torch.flatten(a), torch.flatten(b))
+        if a.ndim == 0 or b.ndim == 0:
+            return torch.multiply(a, b)
+        return a[..., :, None] * b[..., None, :]
 
     for helper_name, helper, original_helper in (
         ("dot", dot, original_dot),

--- a/tests/backend_support/test_pytorch_dot_outer_device_contract.py
+++ b/tests/backend_support/test_pytorch_dot_outer_device_contract.py
@@ -24,12 +24,25 @@ def _non_cpu_device():
 target = {target_module}
 device = _non_cpu_device()
 right_vector = torch.ones(2, device=device)
+right_matrix = torch.ones((2, 1), device=device)
 
 dot_result = target.dot(torch.tensor([1.0, 2.0]), right_vector)
 assert dot_result.device.type == device.type
 assert tuple(dot_result.shape) == ()
 if device.type != "meta":
     assert torch.allclose(dot_result.cpu(), torch.tensor(3.0))
+
+dot_arraylike_result = target.dot([1.0, 2.0], right_vector)
+assert dot_arraylike_result.device.type == device.type
+assert tuple(dot_arraylike_result.shape) == ()
+if device.type != "meta":
+    assert torch.allclose(dot_arraylike_result.cpu(), torch.tensor(3.0))
+
+dot_matrix_result = target.dot(torch.tensor([[1.0, 2.0]]), right_matrix)
+assert dot_matrix_result.device.type == device.type
+assert tuple(dot_matrix_result.shape) == (1, 1)
+if device.type != "meta":
+    assert torch.allclose(dot_matrix_result.cpu(), torch.tensor([[3.0]]))
 
 outer_result = target.outer(torch.tensor([1.0, 2.0]), right_vector)
 assert outer_result.device.type == device.type
@@ -38,11 +51,18 @@ if device.type != "meta":
     expected = torch.tensor([[1.0, 1.0], [2.0, 2.0]])
     assert torch.allclose(outer_result.cpu(), expected)
 
-dot_arraylike_result = target.dot([1.0, 2.0], right_vector)
-assert dot_arraylike_result.device.type == device.type
-assert tuple(dot_arraylike_result.shape) == ()
+outer_matrix_result = target.outer(torch.tensor([[1.0, 2.0], [3.0, 4.0]]), right_vector)
+assert outer_matrix_result.device.type == device.type
+assert tuple(outer_matrix_result.shape) == (4, 2)
 if device.type != "meta":
-    assert torch.allclose(dot_arraylike_result.cpu(), torch.tensor(3.0))
+    expected = torch.tensor([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0], [4.0, 4.0]])
+    assert torch.allclose(outer_matrix_result.cpu(), expected)
+
+outer_scalar_result = target.outer(torch.tensor(2.0), right_vector)
+assert outer_scalar_result.device.type == device.type
+assert tuple(outer_scalar_result.shape) == (1, 2)
+if device.type != "meta":
+    assert torch.allclose(outer_scalar_result.cpu(), torch.tensor([[2.0, 2.0]]))
 
 print("ok")
 """

--- a/tests/backend_support/test_pytorch_dot_outer_device_contract.py
+++ b/tests/backend_support/test_pytorch_dot_outer_device_contract.py
@@ -24,7 +24,7 @@ def _non_cpu_device():
 target = {target_module}
 device = _non_cpu_device()
 right_vector = torch.ones(2, device=device)
-right_matrix = torch.ones((2, 1), device=device)
+right_matrix = torch.ones((2, 2), device=device)
 
 dot_result = target.dot(torch.tensor([1.0, 2.0]), right_vector)
 assert dot_result.device.type == device.type
@@ -38,11 +38,11 @@ assert tuple(dot_arraylike_result.shape) == ()
 if device.type != "meta":
     assert torch.allclose(dot_arraylike_result.cpu(), torch.tensor(3.0))
 
-dot_matrix_result = target.dot(torch.tensor([[1.0, 2.0]]), right_matrix)
+dot_matrix_result = target.dot(torch.tensor([[1.0, 2.0], [3.0, 4.0]]), right_matrix)
 assert dot_matrix_result.device.type == device.type
-assert tuple(dot_matrix_result.shape) == (1, 1)
+assert tuple(dot_matrix_result.shape) == (2,)
 if device.type != "meta":
-    assert torch.allclose(dot_matrix_result.cpu(), torch.tensor([[3.0]]))
+    assert torch.allclose(dot_matrix_result.cpu(), torch.tensor([3.0, 7.0]))
 
 outer_result = target.outer(torch.tensor([1.0, 2.0]), right_vector)
 assert outer_result.device.type == device.type
@@ -53,16 +53,18 @@ if device.type != "meta":
 
 outer_matrix_result = target.outer(torch.tensor([[1.0, 2.0], [3.0, 4.0]]), right_vector)
 assert outer_matrix_result.device.type == device.type
-assert tuple(outer_matrix_result.shape) == (4, 2)
+assert tuple(outer_matrix_result.shape) == (2, 2, 2)
 if device.type != "meta":
-    expected = torch.tensor([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0], [4.0, 4.0]])
+    expected = torch.tensor(
+        [[[1.0, 1.0], [2.0, 2.0]], [[3.0, 3.0], [4.0, 4.0]]]
+    )
     assert torch.allclose(outer_matrix_result.cpu(), expected)
 
 outer_scalar_result = target.outer(torch.tensor(2.0), right_vector)
 assert outer_scalar_result.device.type == device.type
-assert tuple(outer_scalar_result.shape) == (1, 2)
+assert tuple(outer_scalar_result.shape) == (2,)
 if device.type != "meta":
-    assert torch.allclose(outer_scalar_result.cpu(), torch.tensor([[2.0, 2.0]]))
+    assert torch.allclose(outer_scalar_result.cpu(), torch.tensor([2.0, 2.0]))
 
 print("ok")
 """


### PR DESCRIPTION
## Summary
- Keep PyTorch dot and outer aligned with the existing PyRecEst pairwise backend contract.
- Extend non-CPU device regression coverage for array-like dot inputs, matrix dot inputs, matrix outer inputs, and scalar outer inputs.

## Testing
- Targeted PyTorch tests skipped locally because Torch is not installed in this environment.
- python3 -m py_compile src/pyrecest/backend_support/_pytorch_dot_outer_device_contract.py tests/backend_support/test_pytorch_dot_outer_device_contract.py tests/backend_support/test_pytorch_dot_contract.py tests/backend_support/test_pytorch_outer_contract.py
- git diff --check