### PR TITLE
Validate scalar parameters in sine-skewed distributions

### DIFF
--- a/src/pyrecest/distributions/circle/sine_skewed_distributions.py
+++ b/src/pyrecest/distributions/circle/sine_skewed_distributions.py
@@ -17,11 +17,15 @@ def _validate_sine_power(value, name):
     return int(value)
 
 
+def _validate_scalar_parameter(value, name):
+    parameter = array(value)
+    if ndim(parameter) != 0:
+        raise ValueError(f"{name} must be a scalar")
+    return parameter
+
+
 def _validate_scalar_angle(value):
-    angle = array(value)
-    if ndim(angle) != 0:
-        raise ValueError("angle must be a scalar")
-    return angle
+    return _validate_scalar_parameter(value, "angle")
 
 
 class GeneralizedKSineSkewedVonMisesDistribution(AbstractCircularDistribution):
@@ -48,6 +52,7 @@ class GeneralizedKSineSkewedVonMisesDistribution(AbstractCircularDistribution):
         self.validate_parameters()
 
     def validate_parameters(self):
+        self.lambda_ = _validate_scalar_parameter(self.lambda_, "lambda_")
         if not (-1.0 <= self.lambda_ <= 1.0):
             raise ValueError("lambda_ must be between -1 and 1 inclusive")
         self.m = _validate_sine_power(self.m, "m")
@@ -154,8 +159,7 @@ class AbstractSineSkewedDistribution(AbstractCircularDistribution):
 
     def validate_parameters(self):
         """Validate parameters common to first-order sine-skewed distributions."""
-        if ndim(self.lambda_) != 0:
-            raise ValueError("lambda_ must be a scalar")
+        self.lambda_ = _validate_scalar_parameter(self.lambda_, "lambda_")
 
         if not (-1.0 <= self.lambda_ <= 1.0):
             raise ValueError("lambda_ must be between -1 and 1 inclusive")
@@ -233,8 +237,10 @@ class GeneralizedKSineSkewedWrappedCauchyDistribution(AbstractCircularDistributi
         self.validate_parameters()
 
     def validate_parameters(self):
+        self.gamma = _validate_scalar_parameter(self.gamma, "gamma")
         if self.gamma <= 0:
             raise ValueError("gamma must be positive")
+        self.lambda_ = _validate_scalar_parameter(self.lambda_, "lambda_")
         if not (-1.0 <= self.lambda_ <= 1.0):
             raise ValueError("lambda_ must be between -1 and 1 inclusive")
         self.m = _validate_sine_power(self.m, "m")

--- a/tests/distributions/test_sine_skewed_scalar_validation.py
+++ b/tests/distributions/test_sine_skewed_scalar_validation.py
@@ -1,0 +1,43 @@
+import pytest
+
+from pyrecest.distributions.circle.sine_skewed_distributions import (
+    GeneralizedKSineSkewedVonMisesDistribution,
+    GeneralizedKSineSkewedWrappedCauchyDistribution,
+    GSSVMDistribution,
+)
+
+
+def test_generalized_sine_skewed_von_mises_rejects_vector_lambda():
+    with pytest.raises(ValueError, match="lambda_ must be a scalar"):
+        GeneralizedKSineSkewedVonMisesDistribution(
+            mu=0.0,
+            kappa=1.0,
+            lambda_=[0.25, 0.5],
+            k=1,
+            m=1,
+        )
+
+
+def test_gssvm_rejects_vector_lambda():
+    with pytest.raises(ValueError, match="lambda_ must be a scalar"):
+        GSSVMDistribution(mu=0.0, kappa=1.0, lambda_=[0.25, 0.5], n=1)
+
+
+def test_generalized_sine_skewed_wrapped_cauchy_rejects_vector_parameters():
+    with pytest.raises(ValueError, match="gamma must be a scalar"):
+        GeneralizedKSineSkewedWrappedCauchyDistribution(
+            mu=0.0,
+            gamma=[0.25, 0.5],
+            lambda_=0.25,
+            k=1,
+            m=1,
+        )
+
+    with pytest.raises(ValueError, match="lambda_ must be a scalar"):
+        GeneralizedKSineSkewedWrappedCauchyDistribution(
+            mu=0.0,
+            gamma=0.5,
+            lambda_=[0.25, 0.5],
+            k=1,
+            m=1,
+        )


### PR DESCRIPTION
## Summary
- add a shared scalar-parameter validator for sine-skewed circular distributions
- make generalized sine-skewed von Mises/GSSVM reject vector-like `lambda_` during construction
- make generalized sine-skewed wrapped Cauchy reject vector-like `gamma` and `lambda_` during construction
- add focused regression coverage for the scalar validation errors

## Bug fixed
The generalized sine-skewed classes validated skewness/concentration with direct chained comparisons. Vector-like inputs therefore reached backend truth-value evaluation and could raise ambiguous truth-value errors instead of the clear scalar-parameter `ValueError` already used by the first-order sine-skewed variants.

## Validation
- Syntax-compiled the modified distribution module locally with `py_compile`.
- Syntax-compiled the new regression test file locally with `py_compile`.
- Compared the branch against current `main`: 2 commits ahead, 0 behind, changes limited to one source file and one focused test file.

Full repository tests were not run locally because this execution environment cannot clone/install the GitHub repository directly; CI should run the added regression tests.