### PR TITLE
Fix PyTorch concatenate axis=None contract

### DIFF
--- a/src/pyrecest/_backend_runtime_patches.py
+++ b/src/pyrecest/_backend_runtime_patches.py
@@ -151,3 +151,43 @@ def patch_pytorch_repeat_numpy_contract() -> None:
     raw_pytorch.repeat = repeat
     if active_pytorch_backend:
         backend.repeat = repeat
+
+
+def patch_pytorch_concatenate_axis_none_contract() -> None:
+    """Make PyTorch concatenate flatten inputs for NumPy's ``axis=None`` contract."""
+
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+    original_concatenate = getattr(raw_pytorch, "concatenate", None)
+    if original_concatenate is None:
+        return
+    if getattr(original_concatenate, "_pyrecest_axis_none_contract", False):
+        if active_pytorch_backend:
+            backend.concatenate = original_concatenate
+        return
+
+    def _tensor_sequence(seq):
+        tensors = [raw_pytorch.array(item) for item in seq]
+        if not tensors:
+            return tensors
+        return raw_pytorch.convert_to_wider_dtype(tensors)
+
+    def concatenate(seq, axis=0, out=None):
+        tensors = _tensor_sequence(seq)
+        if axis is None:
+            tensors = [tensor.reshape(-1) for tensor in tensors]
+            axis = 0
+        return torch.cat(tensors, dim=axis, out=out)
+
+    concatenate.__name__ = getattr(original_concatenate, "__name__", "concatenate")
+    concatenate.__doc__ = getattr(original_concatenate, "__doc__", None)
+    concatenate._pyrecest_axis_none_contract = True
+    raw_pytorch.concatenate = concatenate
+    if active_pytorch_backend:
+        backend.concatenate = concatenate

--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -213,6 +213,7 @@ def resolve_evidence_computation_mode(
 try:
     from pyrecest._backend_runtime_patches import (  # pylint: disable=import-outside-toplevel
         patch_pytorch_close_equal_nan_device_contract as _patch_pytorch_close_equal_nan_device_contract,
+        patch_pytorch_concatenate_axis_none_contract as _patch_pytorch_concatenate_axis_none_contract,
         patch_pytorch_repeat_numpy_contract as _patch_pytorch_repeat_numpy_contract,
     )
     from pyrecest.backend_support._pytorch_one_hot_scalar_contract import (  # pylint: disable=import-outside-toplevel
@@ -222,5 +223,6 @@ except ModuleNotFoundError:  # pragma: no cover - source tree corruption only
     pass
 else:
     _patch_pytorch_close_equal_nan_device_contract()
+    _patch_pytorch_concatenate_axis_none_contract()
     _patch_pytorch_repeat_numpy_contract()
     _patch_pytorch_one_hot_scalar_contract()

--- a/tests/backend_support/test_pytorch_concatenate_contract.py
+++ b/tests/backend_support/test_pytorch_concatenate_contract.py
@@ -1,0 +1,30 @@
+import pytest
+
+import pyrecest.backend as backend
+import pyrecest.evidence  # noqa: F401 ensure runtime backend patches are installed
+
+pytorch_backend = pytest.importorskip("pyrecest._backend.pytorch")
+
+
+def _as_list(value):
+    return pytorch_backend.to_numpy(value).tolist()
+
+
+def test_raw_pytorch_concatenate_axis_none_flattens_inputs():
+    first = pytorch_backend.array([[1, 2], [3, 4]])
+    second = pytorch_backend.array([[5], [6]])
+
+    result = pytorch_backend.concatenate((first, second), axis=None)
+
+    assert result.shape == (6,)
+    assert _as_list(result) == [1, 2, 3, 4, 5, 6]
+
+
+def test_public_pytorch_concatenate_axis_none_flattens_inputs_when_active():
+    if getattr(backend, "__backend_name__", None) != "pytorch":
+        pytest.skip("public PyTorch backend is not active")
+
+    result = backend.concatenate(([[1, 2], [3, 4]], [[5], [6]]), axis=None)
+
+    assert result.shape == (6,)
+    assert backend.to_numpy(result).tolist() == [1, 2, 3, 4, 5, 6]


### PR DESCRIPTION
## Summary
- patch the PyTorch backend runtime contract so `concatenate(..., axis=None)` flattens each input before concatenation, matching NumPy/JAX semantics
- install the patch through the existing evidence/runtime backend patch path
- add raw and public PyTorch regression coverage for `axis=None`

## Tests
- Not run locally; added `tests/backend_support/test_pytorch_concatenate_contract.py` for CI coverage.