### PR TITLE
Handle PyTorch bfloat16 dtype aliases

### DIFF
--- a/src/pyrecest/_backend/pytorch/_common.py
+++ b/src/pyrecest/_backend/pytorch/_common.py
@@ -1,4 +1,5 @@
 import numpy as _np
+from torch import bfloat16 as _torch_bfloat16
 from torch import bool as _torch_bool
 from torch import complex64 as _torch_complex64
 from torch import complex128 as _torch_complex128
@@ -24,6 +25,7 @@ _TORCH_DTYPE_BY_NAME = {
     "int32": _torch_int32,
     "int64": _torch_int64,
     "float16": _torch_float16,
+    "bfloat16": _torch_bfloat16,
     "float32": _torch_float32,
     "float64": _torch_float64,
     "complex64": _torch_complex64,
@@ -37,6 +39,7 @@ _TORCH_DTYPE_BY_TORCH_ALIAS = {
     "int": _torch_int32,
     "long": _torch_int64,
     "half": _torch_float16,
+    "bfloat16": _torch_bfloat16,
     "float": _torch_float32,
     "double": _torch_float64,
     "cfloat": _torch_complex64,


### PR DESCRIPTION
## Summary

Fix PyTorch backend dtype normalization for `bfloat16` aliases.

`pyrecest._backend.pytorch._common._normalize_dtype` already accepts PyTorch-style dtype strings such as `"torch.float"`, `"torch.double"`, and `"torch.half"`. However, `"torch.bfloat16"` was not present in either dtype alias map. The function therefore stripped the `torch.` prefix, failed NumPy dtype parsing for `"bfloat16"`, and returned the raw string instead of a `torch.dtype`. That string is then passed to `torch.tensor(..., dtype=...)`, which is invalid.

This PR adds `torch.bfloat16` to both dtype lookup tables so that both `"torch.bfloat16"` and bare `"bfloat16"` normalize to the correct PyTorch dtype.

## Intended regression check

```python
result = pyrecest._backend.pytorch.array([1.0, 2.0], dtype="torch.bfloat16")
assert str(result.dtype) == "torch.bfloat16"
```

I attempted to add this as a test file and then into `tests/test_pytorch_backend.py`, but those write attempts were blocked by the tool safety layer before reaching GitHub. The source patch itself was committed successfully.
