### PR TITLE
Fix JAX assignment tuple advanced indices

### DIFF
--- a/src/pyrecest/backend_support/_jax_assignment_numpy_index_contract.py
+++ b/src/pyrecest/backend_support/_jax_assignment_numpy_index_contract.py
@@ -13,16 +13,50 @@ def _normalize_indices(indices, np, jnp):
     return indices
 
 
+def _is_array_like_index(index, np, jnp):
+    """Return whether one index entry is a non-scalar array-like index."""
+
+    if isinstance(index, np.ndarray):
+        return index.ndim > 0
+    if isinstance(index, jnp.ndarray):
+        return index.ndim > 0
+    return isinstance(index, (list, tuple))
+
+
+def _is_per_axis_tuple_index(indices, np, jnp):
+    """Return whether ``indices`` is a NumPy-style tuple of per-axis arrays."""
+
+    return isinstance(indices, tuple) and bool(indices) and _is_array_like_index(
+        indices[0], np, jnp
+    )
+
+
+def _as_per_axis_tuple(indices, jnp):
+    """Coerce a tuple of per-axis index arrays to JAX arrays."""
+
+    return tuple(jnp.asarray(index_axis) for index_axis in indices)
+
+
 def _wrap_helper(helper, np, jnp):
     """Normalize NumPy ndarray indices before delegating to a JAX helper."""
 
     if getattr(helper, "_pyrecest_numpy_index_contract", False):
         return helper
 
+    helper_name = getattr(helper, "__name__", "assignment")
+    is_sum_helper = helper_name == "assignment_by_sum"
+
     def wrapped(x, values, indices, axis=0):
+        if _is_per_axis_tuple_index(indices, np, jnp):
+            target = jnp.asarray(x)
+            normalized_indices = _as_per_axis_tuple(indices, jnp)
+            updater = target.at[normalized_indices]
+            if is_sum_helper:
+                return updater.add(values)
+            return updater.set(values)
         return helper(x, values, _normalize_indices(indices, np, jnp), axis=axis)
 
-    wrapped.__name__ = getattr(helper, "__name__", "assignment")
+    wrapped.__name__ = helper_name
     wrapped.__doc__ = getattr(helper, "__doc__", None)
     wrapped._pyrecest_numpy_index_contract = True
     return wrapped

--- a/tests/backend_support/test_jax_assignment_contract.py
+++ b/tests/backend_support/test_jax_assignment_contract.py
@@ -31,6 +31,28 @@ assert backend.to_numpy(summed).tolist() == [[1.0, 6.0, 1.0], [1.0, 1.0, 8.0], [
 
 
 @pytest.mark.backend_portable
+def test_jax_assignment_preserves_numpy_style_axis_tuple_indices():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("JAX is not installed")
+
+    result = run_backend_code(
+        "jax",
+        """
+import pyrecest.backend as backend
+
+x = backend.zeros((3, 4))
+assigned = backend.assignment(x, [5.0, 7.0], ([0, 1], [2, 0]))
+summed = backend.assignment_by_sum(backend.ones((3, 4)), [5.0, 7.0], ([0, 1], [2, 0]))
+
+assert backend.to_numpy(assigned).tolist() == [[0.0, 0.0, 5.0, 0.0], [7.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]
+assert backend.to_numpy(summed).tolist() == [[1.0, 1.0, 6.0, 1.0], [8.0, 1.0, 1.0, 1.0], [1.0, 1.0, 1.0, 1.0]]
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.backend_portable
 def test_jax_assignment_accepts_scalar_tuple_index():
     if importlib.util.find_spec("jax") is None:
         pytest.skip("JAX is not installed")


### PR DESCRIPTION
## Summary
- Fix the JAX assignment compatibility shim so NumPy-style tuple-of-per-axis advanced indices, e.g. `([0, 1], [2, 0])`, target the intended coordinates.
- Keep list-of-coordinate-tuples behavior through the existing helper path.
- Add focused regression coverage for `assignment` and `assignment_by_sum` with asymmetric per-axis tuple indices.

## Bug
The raw JAX assignment helper treats any iterable index whose first element is iterable as a list of coordinate tuples and transposes it with `zip(*indices)`. That is correct for `[(row, col), ...]`, but not for NumPy-style per-axis tuple indexing such as `([0, 1], [2, 0])`. As a result, asymmetric index arrays target the wrong coordinates.

## Validation
- Compared the branch with `main`: 2 commits ahead, 0 behind; only the JAX assignment shim and focused regression test changed.
- Inspected the patched shim and regression test after writing them via GitHub contents API.
