### PR TITLE
Fix PyTorch array_from_sparse duplicate semantics

### DIFF
--- a/src/pyrecest/_backend_runtime_patches.py
+++ b/src/pyrecest/_backend_runtime_patches.py
@@ -313,6 +313,106 @@ def patch_pytorch_edge_pad_contract() -> None:
         backend.pad = pad
 
 
+def _normalize_sparse_target_shape(target_shape, np, torch) -> tuple[int, ...]:
+    """Return a plain tuple shape for dense sparse-reconstruction output."""
+    if torch.is_tensor(target_shape):
+        target_shape = target_shape.detach().cpu().numpy()
+    shape_array = np.asarray(target_shape)
+    if shape_array.shape == ():
+        normalized_shape = (_operator_index(shape_array.item()),)
+    else:
+        normalized_shape = tuple(_operator_index(size) for size in shape_array.tolist())
+    if any(size < 0 for size in normalized_shape):
+        raise ValueError("negative dimensions are not allowed")
+    return normalized_shape
+
+
+def _torch_sparse_indices(indices, target_shape, data, torch):
+    """Return sparse coordinate indices with shape ``(n_entries, ndim)``."""
+    indices = torch.as_tensor(indices, dtype=torch.long, device=data.device)
+    if indices.numel() == 0:
+        return indices
+    if indices.ndim == 1 and len(target_shape) == 1:
+        return indices.reshape(-1, 1)
+    if indices.ndim != 2 or indices.shape[1] != len(target_shape):
+        raise ValueError("indices must have shape (n_entries, ndim)")
+    return indices
+
+
+def _ravel_sparse_indices(indices, target_shape, torch):
+    """Return C-order flat indices with NumPy ``ravel_multi_index`` checks."""
+    shape_tensor = torch.as_tensor(
+        target_shape,
+        dtype=torch.long,
+        device=indices.device,
+    )
+    if bool(torch.any(indices < 0)) or bool(torch.any(indices >= shape_tensor)):
+        raise ValueError("invalid entry in coordinates array")
+
+    strides = []
+    stride = 1
+    for size in reversed(target_shape):
+        strides.insert(0, stride)
+        stride *= size
+    stride_tensor = torch.as_tensor(strides, dtype=torch.long, device=indices.device)
+    return torch.sum(indices * stride_tensor, dim=1)
+
+
+def patch_pytorch_array_from_sparse_assignment_contract() -> None:
+    """Make PyTorch ``array_from_sparse`` match NumPy duplicate-index semantics."""
+
+    try:
+        import numpy as np  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+    original_array_from_sparse = getattr(raw_pytorch, "array_from_sparse", None)
+    if original_array_from_sparse is None:
+        return
+    if getattr(
+        original_array_from_sparse,
+        "_pyrecest_sparse_assignment_contract",
+        False,
+    ):
+        if active_pytorch_backend:
+            backend.array_from_sparse = original_array_from_sparse
+        return
+
+    def array_from_sparse(indices, data, target_shape):
+        data = raw_pytorch.array(data)
+        target_shape = _normalize_sparse_target_shape(target_shape, np, torch)
+        output = torch.zeros(
+            torch.Size(target_shape),
+            dtype=data.dtype,
+            device=data.device,
+        )
+        sparse_indices = _torch_sparse_indices(indices, target_shape, data, torch)
+
+        if sparse_indices.numel() == 0:
+            if data.numel() != 0:
+                raise ValueError("data must be empty when indices are empty")
+            return output
+
+        flat_indices = _ravel_sparse_indices(sparse_indices, target_shape, torch)
+        output.reshape(-1)[flat_indices] = data
+        return output
+
+    array_from_sparse.__name__ = getattr(
+        original_array_from_sparse,
+        "__name__",
+        "array_from_sparse",
+    )
+    array_from_sparse.__doc__ = getattr(original_array_from_sparse, "__doc__", None)
+    array_from_sparse._pyrecest_sparse_assignment_contract = True
+    raw_pytorch.array_from_sparse = array_from_sparse
+    if active_pytorch_backend:
+        backend.array_from_sparse = array_from_sparse
+
+
 def patch_raw_pytorch_reduction_alias_contract() -> None:
     """Expose PyTorch ``dim``/``keepdim`` aliases on raw reductions always."""
 
@@ -519,4 +619,5 @@ def patch_pytorch_assignment_uint8_index_contract() -> None:
 
 
 patch_jax_take_arraylike_contract()
+patch_pytorch_array_from_sparse_assignment_contract()
 patch_pytorch_assignment_uint8_index_contract()

--- a/tests/backend_support/test_pytorch_array_from_sparse_contract.py
+++ b/tests/backend_support/test_pytorch_array_from_sparse_contract.py
@@ -1,0 +1,70 @@
+"""Regression coverage for PyTorch sparse reconstruction semantics."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+pytestmark = pytest.mark.backend_portable
+
+EXPECTED_VECTOR = [5, 0, 3, 0]
+EXPECTED_MATRIX = [[0.0, 7.0], [4.0, 0.0]]
+
+
+def test_raw_pytorch_array_from_sparse_duplicate_indices_match_numpy_put():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    code = f"""
+import pyrecest  # noqa: F401  # triggers raw-backend runtime patches
+import torch
+import pyrecest._backend.pytorch as raw_pytorch_backend
+
+vector = raw_pytorch_backend.array_from_sparse(
+    [(0,), (0,), (2,)],
+    torch.tensor([1, 5, 3], dtype=torch.int64),
+    (4,),
+)
+assert vector.tolist() == {EXPECTED_VECTOR!r}
+
+matrix = raw_pytorch_backend.array_from_sparse(
+    [(0, 1), (0, 1), (1, 0)],
+    [2.0, 7.0, 4.0],
+    (2, 2),
+)
+assert matrix.tolist() == {EXPECTED_MATRIX!r}
+print("ok")
+"""
+    result = run_backend_code("numpy", code)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_public_pytorch_array_from_sparse_duplicate_indices_match_numpy_put():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    code = f"""
+import pyrecest.backend as backend
+
+vector = backend.array_from_sparse(
+    [(0,), (0,), (2,)],
+    backend.array([1, 5, 3], dtype=backend.int64),
+    (4,),
+)
+assert backend.to_numpy(vector).tolist() == {EXPECTED_VECTOR!r}
+
+matrix = backend.array_from_sparse(
+    [(0, 1), (0, 1), (1, 0)],
+    [2.0, 7.0, 4.0],
+    (2, 2),
+)
+assert backend.to_numpy(matrix).tolist() == {EXPECTED_MATRIX!r}
+print("ok")
+"""
+    result = run_backend_code("pytorch", code)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- add an idempotent PyTorch runtime patch for `array_from_sparse` that reconstructs dense outputs by flat assignment rather than sparse COO densification
- preserve NumPy/PyRecEst duplicate-coordinate semantics, where later duplicate entries overwrite earlier ones
- add focused raw and public PyTorch backend regression tests for duplicate 1D and 2D sparse coordinates

## Bug fixed
The shared NumPy backend reconstructs sparse arrays via flat `put(...)` assignment, so duplicate sparse coordinates follow last-write-wins semantics. The raw PyTorch backend used `torch.sparse_coo_tensor(...).to_dense()`, which sums duplicate coordinates. Equivalent backend-portable calls could therefore produce different dense arrays under the PyTorch backend.

## Tests
- Not run as a repository pytest suite in this connector environment; added `tests/backend_support/test_pytorch_array_from_sparse_contract.py` for CI coverage.