### PR TITLE
Validate PyTorch scatter_add index inputs

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_scatter_add_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_scatter_add_contract.py
@@ -19,9 +19,38 @@ def _normalize_pytorch_scatter_dim(dim, torch_module) -> int:
         raise TypeError("dim must be an integer") from exc
 
 
+def _is_integer_scatter_index_dtype(dtype, numpy_module) -> bool:
+    """Return whether ``dtype`` can safely represent scatter indices."""
+
+    return not numpy_module.issubdtype(
+        dtype,
+        numpy_module.bool_,
+    ) and numpy_module.issubdtype(dtype, numpy_module.integer)
+
+
+def _pytorch_scatter_index(index, numpy_module, torch_module, *, device):
+    """Return scatter indices as a long tensor without truncating bad inputs."""
+
+    if torch_module.is_tensor(index):
+        if (
+            index.dtype == torch_module.bool
+            or index.dtype.is_floating_point
+            or index.dtype.is_complex
+        ):
+            raise TypeError("scatter_add indices must be integers")
+        return index.to(device=device, dtype=torch_module.long)
+
+    index_array = numpy_module.asarray(index)
+    if isinstance(index, numpy_module.ndarray) or index_array.size:
+        if not _is_integer_scatter_index_dtype(index_array.dtype, numpy_module):
+            raise TypeError("scatter_add indices must be integers")
+    return torch_module.as_tensor(index_array, dtype=torch_module.long, device=device)
+
+
 def patch_pytorch_scatter_add_contract() -> None:
     """Make raw/public PyTorch ``scatter_add`` accept array-like operands."""
     try:
+        import numpy as np  # pylint: disable=import-outside-toplevel
         import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
         import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
         import torch  # pylint: disable=import-outside-toplevel
@@ -39,10 +68,7 @@ def patch_pytorch_scatter_add_contract() -> None:
     def scatter_add(input, dim, index, src):  # pylint: disable=redefined-builtin
         values = raw_pytorch.array(input)
         dim_value = _normalize_pytorch_scatter_dim(dim, torch)
-        if not torch.is_tensor(index):
-            index = torch.as_tensor(index, dtype=torch.long, device=values.device)
-        else:
-            index = index.to(device=values.device, dtype=torch.long)
+        index = _pytorch_scatter_index(index, np, torch, device=values.device)
         if not torch.is_tensor(src):
             src = torch.as_tensor(src, dtype=values.dtype, device=values.device)
         else:

--- a/tests/backend_support/test_pytorch_scatter_add_contract.py
+++ b/tests/backend_support/test_pytorch_scatter_add_contract.py
@@ -1,6 +1,9 @@
+import importlib.util
+
 import pytest
 
 import pyrecest.backend as backend
+from tests.support.backend_runner import run_backend_code
 
 
 def _to_python(value):
@@ -25,3 +28,47 @@ def test_pytorch_scatter_add_rejects_boolean_dim():
 
     with pytest.raises(TypeError):
         backend.scatter_add([1, 2], True, [0], [1])
+
+
+@pytest.mark.backend_portable
+def test_pytorch_scatter_add_rejects_non_integer_indices():
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific backend contract")
+
+    np = pytest.importorskip("numpy")
+    for bad_index in ([0.0], [True], np.array([0.0])):
+        with pytest.raises(TypeError):
+            backend.scatter_add([1, 2], 0, bad_index, [1])
+
+    empty_result = backend.scatter_add([1, 2], 0, [], [])
+    assert _to_python(empty_result) == [1, 2]
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_scatter_add_rejects_non_integer_indices_with_numpy_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "numpy",
+        """
+import numpy as np
+import pyrecest  # noqa: F401  # triggers raw-backend compatibility patches
+import pyrecest._backend.pytorch as raw_pytorch
+
+for bad_index in ([0.0], [True], np.array([0.0])):
+    try:
+        raw_pytorch.scatter_add([1, 2], 0, bad_index, [1])
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("scatter_add accepted non-integer indices")
+
+empty_result = raw_pytorch.scatter_add([1, 2], 0, [], [])
+assert raw_pytorch.to_numpy(empty_result).tolist() == [1, 2]
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- Reject boolean, floating, and complex `scatter_add` indices before converting them to `torch.long`.
- Preserve integer array-like/tensor indices and empty-index no-op behavior.
- Add regression coverage for the public PyTorch backend and the raw PyTorch backend when NumPy is the active backend.

## Testing
- `python -m py_compile /tmp/_pytorch_scatter_add_contract.py /tmp/test_pytorch_scatter_add_contract.py`

Full repository tests were not run in this connector session.