### PR TITLE
Fix JAX take array-like backend contract

### DIFF
--- a/src/pyrecest/_backend_runtime_patches.py
+++ b/src/pyrecest/_backend_runtime_patches.py
@@ -339,3 +339,6 @@ def patch_jax_take_arraylike_contract() -> None:
     raw_jax.take = take
     if getattr(backend, "__backend_name__", None) == "jax":
         backend.take = take
+
+
+patch_jax_take_arraylike_contract()

--- a/src/pyrecest/_backend_runtime_patches.py
+++ b/src/pyrecest/_backend_runtime_patches.py
@@ -288,3 +288,54 @@ def patch_pytorch_transpose_boolean_axes_contract() -> None:
     raw_pytorch.transpose = transpose
     if active_pytorch_backend:
         backend.transpose = transpose
+
+
+def patch_jax_take_arraylike_contract() -> None:
+    """Make raw/public JAX ``take`` accept NumPy-style array-like inputs."""
+
+    try:
+        import jax.numpy as jnp  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.jax as raw_jax  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - JAX backend may be unavailable
+        return
+
+    original_take = getattr(raw_jax, "take", None)
+    if original_take is None:
+        return
+    if getattr(original_take, "_pyrecest_arraylike_contract", False):
+        if getattr(backend, "__backend_name__", None) == "jax":
+            backend.take = original_take
+        return
+
+    def take(
+        a,
+        indices,
+        axis=None,
+        out=None,
+        mode=None,
+        unique_indices=False,
+        indices_are_sorted=False,
+        fill_value=None,
+    ):
+        result = original_take(
+            jnp.asarray(a),
+            jnp.asarray(indices),
+            axis=axis,
+            out=None,
+            mode=mode,
+            unique_indices=unique_indices,
+            indices_are_sorted=indices_are_sorted,
+            fill_value=fill_value,
+        )
+        if out is not None:
+            return jnp.asarray(out).at[...].set(result)
+        return result
+
+    take.__name__ = getattr(original_take, "__name__", "take")
+    take.__doc__ = getattr(original_take, "__doc__", None)
+    take._pyrecest_arraylike_contract = True
+    take._pyrecest_out_contract = True
+    raw_jax.take = take
+    if getattr(backend, "__backend_name__", None) == "jax":
+        backend.take = take

--- a/tests/backend_support/test_jax_take_arraylike_contract.py
+++ b/tests/backend_support/test_jax_take_arraylike_contract.py
@@ -1,0 +1,46 @@
+import importlib.util
+
+import pytest
+
+pytestmark = pytest.mark.backend_portable
+
+
+def _require_raw_jax_backend():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("JAX is not installed")
+    import pyrecest  # noqa: F401  # triggers runtime backend patches
+    import pyrecest._backend.jax as raw_jax  # pylint: disable=import-outside-toplevel
+
+    return raw_jax
+
+
+def test_raw_jax_take_accepts_array_like_values_after_import():
+    raw_jax = _require_raw_jax_backend()
+
+    axis_result = raw_jax.take([[10, 20], [30, 40]], [1, 0], axis=1)
+    assert raw_jax.to_numpy(axis_result).tolist() == [[20, 10], [40, 30]]
+
+    flat_result = raw_jax.take([[10, 20], [30, 40]], [3, 0], axis=None)
+    assert raw_jax.to_numpy(flat_result).tolist() == [40, 10]
+
+    out_result = raw_jax.take(
+        [[10, 20], [30, 40]],
+        [1, 0],
+        axis=1,
+        out=raw_jax.zeros((2, 2)),
+    )
+    assert raw_jax.to_numpy(out_result).tolist() == [[20, 10], [40, 30]]
+
+
+def test_public_jax_take_accepts_array_like_values_when_active():
+    _require_raw_jax_backend()
+    import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+
+    if getattr(backend, "__backend_name__", None) != "jax":
+        pytest.skip("public JAX backend is not active")
+
+    axis_result = backend.take([[10, 20], [30, 40]], [1, 0], axis=1)
+    assert backend.to_numpy(axis_result).tolist() == [[20, 10], [40, 30]]
+
+    flat_result = backend.take([[10, 20], [30, 40]], [3, 0], axis=None)
+    assert backend.to_numpy(flat_result).tolist() == [40, 10]


### PR DESCRIPTION
Summary:
- Patch the JAX backend helper for indexed selection so array-like values are converted before delegating to JAX.
- Keep raw and active public JAX backend behavior aligned, including return handling for out.
- Add focused backend-portable regression coverage.

Bug:
JAX rejects Python-list inputs for this helper unless they are converted first. PyRecEst backend-portable code generally accepts NumPy-style array-like inputs, so the raw/public JAX path could fail where the NumPy-style contract should work.

Tests:
- Added tests/backend_support/test_jax_take_arraylike_contract.py.
- Confirmed locally that the underlying JAX operation rejects list values unless coerced first.
- Full repository tests were not run locally; changes were made through the GitHub connector.