### PR TITLE
Fix PyTorch like creation array-like inputs

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_creation_shape_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_creation_shape_contract.py
@@ -160,6 +160,42 @@ def patch_pytorch_creation_shape_contract() -> None:
         creation_helper._pyrecest_boolean_shape_contract = True
         return creation_helper
 
+    def _wrap_like_creation_helper(helper_name, torch_helper, *, has_fill_value=False):
+        original_helper = getattr(raw_pytorch, helper_name, None)
+        if original_helper is None:
+            return None
+        if getattr(original_helper, "_pyrecest_arraylike_contract", False):
+            if active_pytorch_backend:
+                setattr(backend, helper_name, original_helper)
+            return original_helper
+
+        if has_fill_value:
+
+            def like_creation_helper(a, fill_value, dtype=None, *args, **kwargs):
+                return torch_helper(
+                    raw_pytorch.array(a),
+                    fill_value,
+                    *args,
+                    dtype=_normalize_dtype(dtype),
+                    **kwargs,
+                )
+
+        else:
+
+            def like_creation_helper(a, dtype=None, *args, **kwargs):
+                return torch_helper(
+                    raw_pytorch.array(a),
+                    *args,
+                    dtype=_normalize_dtype(dtype),
+                    **kwargs,
+                )
+
+        like_creation_helper.__name__ = getattr(original_helper, "__name__", helper_name)
+        like_creation_helper.__doc__ = getattr(original_helper, "__doc__", None)
+        like_creation_helper._pyrecest_numpy_contract = True
+        like_creation_helper._pyrecest_arraylike_contract = True
+        return like_creation_helper
+
     for helper_name, torch_helper, has_fill_value in (
         ("empty", torch.empty, False),
         ("zeros", torch.zeros, False),
@@ -167,6 +203,23 @@ def patch_pytorch_creation_shape_contract() -> None:
         ("full", torch.full, True),
     ):
         helper = _wrap_creation_helper(
+            helper_name,
+            torch_helper,
+            has_fill_value=has_fill_value,
+        )
+        if helper is None:
+            continue
+        setattr(raw_pytorch, helper_name, helper)
+        if active_pytorch_backend:
+            setattr(backend, helper_name, helper)
+
+    for helper_name, torch_helper, has_fill_value in (
+        ("empty_like", torch.empty_like, False),
+        ("zeros_like", torch.zeros_like, False),
+        ("ones_like", torch.ones_like, False),
+        ("full_like", torch.full_like, True),
+    ):
+        helper = _wrap_like_creation_helper(
             helper_name,
             torch_helper,
             has_fill_value=has_fill_value,

--- a/src/pyrecest/backend_support/_pytorch_creation_shape_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_creation_shape_contract.py
@@ -164,7 +164,7 @@ def patch_pytorch_creation_shape_contract() -> None:
         original_helper = getattr(raw_pytorch, helper_name, None)
         if original_helper is None:
             return None
-        if getattr(original_helper, "_pyrecest_arraylike_contract", False):
+        if getattr(original_helper, "_pyrecest_like_creation_contract", False):
             if active_pytorch_backend:
                 setattr(backend, helper_name, original_helper)
             return original_helper
@@ -194,6 +194,7 @@ def patch_pytorch_creation_shape_contract() -> None:
         like_creation_helper.__doc__ = getattr(original_helper, "__doc__", None)
         like_creation_helper._pyrecest_numpy_contract = True
         like_creation_helper._pyrecest_arraylike_contract = True
+        like_creation_helper._pyrecest_like_creation_contract = True
         return like_creation_helper
 
     for helper_name, torch_helper, has_fill_value in (

--- a/tests/backend_support/test_pytorch_like_creation_contract.py
+++ b/tests/backend_support/test_pytorch_like_creation_contract.py
@@ -1,0 +1,98 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _subprocess_env(selected_backend):
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = selected_backend
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    return env
+
+
+@pytest.mark.backend_portable
+def test_public_pytorch_like_creation_accepts_array_like_inputs():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import pyrecest.backend as backend
+
+source = [[1, 2], [3, 4]]
+
+zeros = backend.zeros_like(source)
+assert backend.to_numpy(zeros).tolist() == [[0, 0], [0, 0]]
+
+ones = backend.ones_like(source)
+assert backend.to_numpy(ones).tolist() == [[1, 1], [1, 1]]
+
+filled = backend.full_like(source, 7)
+assert backend.to_numpy(filled).tolist() == [[7, 7], [7, 7]]
+
+empty = backend.empty_like(source)
+assert tuple(empty.shape) == (2, 2)
+assert empty.dtype == zeros.dtype
+
+typed = backend.zeros_like(source, dtype="torch.float64")
+assert str(typed.dtype) == "torch.float64"
+
+print("ok")
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        env=_subprocess_env("pytorch"),
+        text=True,
+        timeout=30.0,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "ok" in completed.stdout
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_like_creation_is_patched_under_numpy_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import pyrecest  # noqa: F401  # triggers raw-backend compatibility patches
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+assert backend.__backend_name__ == "numpy"
+source = [[1, 2], [3, 4]]
+
+zeros = raw_pytorch.zeros_like(source)
+assert raw_pytorch.to_numpy(zeros).tolist() == [[0, 0], [0, 0]]
+
+ones = raw_pytorch.ones_like(source)
+assert raw_pytorch.to_numpy(ones).tolist() == [[1, 1], [1, 1]]
+
+filled = raw_pytorch.full_like(source, 5)
+assert raw_pytorch.to_numpy(filled).tolist() == [[5, 5], [5, 5]]
+
+empty = raw_pytorch.empty_like(source)
+assert tuple(empty.shape) == (2, 2)
+assert empty.dtype == zeros.dtype
+
+print("ok")
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        env=_subprocess_env("numpy"),
+        text=True,
+        timeout=30.0,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "ok" in completed.stdout

--- a/tests/backend_support/test_pytorch_like_creation_contract.py
+++ b/tests/backend_support/test_pytorch_like_creation_contract.py
@@ -84,6 +84,9 @@ empty = raw_pytorch.empty_like(source)
 assert tuple(empty.shape) == (2, 2)
 assert empty.dtype == zeros.dtype
 
+typed = raw_pytorch.zeros_like(source, dtype="torch.float64")
+assert str(typed.dtype) == "torch.float64"
+
 print("ok")
 """
     completed = subprocess.run(


### PR DESCRIPTION
## Summary
- Extend the PyTorch creation-helper compatibility hook to cover `empty_like`, `zeros_like`, `ones_like`, and `full_like`.
- Coerce array-like inputs through the PyTorch backend array constructor before calling the corresponding torch helper.
- Add subprocess regression coverage for public PyTorch backend use and raw PyTorch backend use after package import.

## Validation
- Python syntax compile check for the edited source and test content.
- Branch comparison: 2 commits ahead of main, 0 behind.