### PR TITLE
Fix PyTorch arange NumPy scalar contract

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_creation_shape_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_creation_shape_contract.py
@@ -1,8 +1,11 @@
-"""PyTorch creation-helper shape validation hook."""
+"""PyTorch creation-helper scalar and shape validation hook."""
 
 from __future__ import annotations
 
 from operator import index as _operator_index
+
+
+_ARANGE_SENTINEL = object()
 
 
 def _pytorch_creation_dimension(dimension, numpy_module) -> int:
@@ -42,8 +45,20 @@ def _pytorch_creation_shape(shape, numpy_module, torch_module) -> tuple[int, ...
     return normalized_shape
 
 
+def _pytorch_creation_scalar(value, numpy_module, torch_module, *, argument_name: str):
+    """Normalize one NumPy-style scalar creation argument."""
+    if torch_module.is_tensor(value):
+        if value.ndim != 0:
+            raise TypeError(f"arange {argument_name} must be a scalar")
+        return value.item()
+    value_array = numpy_module.asarray(value)
+    if value_array.shape != ():
+        raise TypeError(f"arange {argument_name} must be a scalar")
+    return value_array.item()
+
+
 def patch_pytorch_creation_shape_contract() -> None:
-    """Patch raw/public PyTorch creation helpers to reject boolean shapes."""
+    """Patch raw/public PyTorch creation helpers for NumPy-style inputs."""
     try:
         import numpy as np  # pylint: disable=import-outside-toplevel
         import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
@@ -60,6 +75,54 @@ def patch_pytorch_creation_shape_contract() -> None:
 
     active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
     patch_pytorch_scatter_add_contract()
+
+    original_arange = getattr(raw_pytorch, "arange", None)
+    if original_arange is not None:
+        if getattr(original_arange, "_pyrecest_numpy_scalar_contract", False):
+            if active_pytorch_backend:
+                setattr(backend, "arange", original_arange)
+        else:
+
+            def arange(start, end=_ARANGE_SENTINEL, step=1, *, dtype=None, **kwargs):
+                start = _pytorch_creation_scalar(
+                    start,
+                    np,
+                    torch,
+                    argument_name="start",
+                )
+                if end is _ARANGE_SENTINEL:
+                    return torch.arange(
+                        start,
+                        dtype=_normalize_dtype(dtype),
+                        **kwargs,
+                    )
+                end = _pytorch_creation_scalar(
+                    end,
+                    np,
+                    torch,
+                    argument_name="end",
+                )
+                step = _pytorch_creation_scalar(
+                    step,
+                    np,
+                    torch,
+                    argument_name="step",
+                )
+                return torch.arange(
+                    start,
+                    end,
+                    step,
+                    dtype=_normalize_dtype(dtype),
+                    **kwargs,
+                )
+
+            arange.__name__ = getattr(original_arange, "__name__", "arange")
+            arange.__doc__ = getattr(original_arange, "__doc__", None)
+            arange._pyrecest_numpy_contract = True
+            arange._pyrecest_numpy_scalar_contract = True
+            setattr(raw_pytorch, "arange", arange)
+            if active_pytorch_backend:
+                setattr(backend, "arange", arange)
 
     def _wrap_creation_helper(helper_name, torch_helper, *, has_fill_value=False):
         original_helper = getattr(raw_pytorch, helper_name, None)

--- a/tests/backend_support/test_pytorch_arange_numpy_contract.py
+++ b/tests/backend_support/test_pytorch_arange_numpy_contract.py
@@ -1,0 +1,76 @@
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_public_pytorch_arange_accepts_numpy_scalar_arguments():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import numpy as np
+import torch
+
+import pyrecest.backend as backend
+
+assert backend.__backend_name__ == "pytorch"
+
+values = backend.arange(np.array(3), dtype=np.float64)
+assert tuple(values.shape) == (3,)
+assert values.dtype == backend.float64
+assert backend.to_numpy(values).tolist() == [0.0, 1.0, 2.0]
+
+stepped = backend.arange(np.array(1), torch.tensor(6), np.array(2))
+assert backend.to_numpy(stepped).tolist() == [1, 3, 5]
+
+try:
+    backend.arange(np.array([1, 2]))
+except TypeError:
+    pass
+else:
+    raise AssertionError("vector-valued arange stop was accepted")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_arange_is_patched_under_numpy_public_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "numpy",
+        """
+import numpy as np
+import torch
+
+import pyrecest  # noqa: F401
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as pytorch_backend
+
+assert backend.__backend_name__ == "numpy"
+
+values = pytorch_backend.arange(np.array(4), dtype=np.dtype("int64"))
+assert tuple(values.shape) == (4,)
+assert values.dtype == pytorch_backend.int64
+assert pytorch_backend.to_numpy(values).tolist() == [0, 1, 2, 3]
+
+stepped = pytorch_backend.arange(torch.tensor(2), np.array(7), torch.tensor(2))
+assert pytorch_backend.to_numpy(stepped).tolist() == [2, 4, 6]
+
+try:
+    pytorch_backend.arange(torch.tensor([1, 2]))
+except TypeError:
+    pass
+else:
+    raise AssertionError("vector-valued arange stop was accepted")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Extend the existing PyTorch creation-helper compatibility hook to cover `arange` scalar arguments.
- Normalize Python, NumPy scalar/0-D array, and scalar torch tensor `start`/`end`/`step` arguments before dispatching to `torch.arange`.
- Preserve dtype normalization and patch both the active public PyTorch backend and the raw PyTorch backend used under other public backends.
- Add focused subprocess regression coverage for public PyTorch and raw PyTorch under the NumPy public backend.

## Bug
The raw PyTorch helper was exposed directly as `torch.arange`, which rejects NumPy 0-D array arguments such as `np.array(3)` even though PyRecEst backend APIs generally accept NumPy-style array-like scalar inputs. The same issue affected `start`, `end`, and `step` when provided as NumPy 0-D arrays or scalar tensors through the backend facade.

## Validation
- Reproduced the underlying `torch.arange(np.array(3))` failure locally outside the repository.
- Syntax-checked the modified compatibility helper and the new regression test with `python -m py_compile`.
- Could not run the full repository test suite here because this container cannot resolve `github.com` for a fresh clone; the branch is 2 commits ahead of `main` and 0 behind by connector diff check.