### PR TITLE
Fix PyTorch squeeze non-singleton axis contract

### DIFF
--- a/src/pyrecest/_backend_runtime_patches.py
+++ b/src/pyrecest/_backend_runtime_patches.py
@@ -236,6 +236,89 @@ def patch_pytorch_edge_pad_contract() -> None:
         backend.pad = pad
 
 
+def _pytorch_squeeze_axes(axis, ndim, numpy_module, torch_module):
+    """Return normalized NumPy-style squeeze axes for a PyTorch tensor."""
+
+    if torch_module.is_tensor(axis):
+        axis = axis.detach().cpu().numpy()
+
+    axis_array = numpy_module.asarray(axis)
+    if axis_array.shape == ():
+        try:
+            axes = (_operator_index(axis_array.item()),)
+        except TypeError as exc:
+            raise TypeError(
+                "only integer scalar arrays can be converted to a scalar index"
+            ) from exc
+    else:
+        if axis_array.ndim != 1:
+            raise ValueError("axis must be None, an integer, or a tuple of integers")
+        try:
+            axes = tuple(_operator_index(one_axis) for one_axis in axis_array.tolist())
+        except TypeError as exc:
+            raise TypeError("axis entries must be integers") from exc
+
+    normalized_axes = tuple(
+        one_axis + ndim if one_axis < 0 else one_axis for one_axis in axes
+    )
+    if len(set(normalized_axes)) != len(normalized_axes):
+        raise ValueError("duplicate value in 'axis'")
+    for original_axis, normalized_axis in zip(axes, normalized_axes):
+        if normalized_axis < 0 or normalized_axis >= ndim:
+            raise IndexError(
+                f"axis {original_axis} is out of bounds for array of dimension {ndim}"
+            )
+    return normalized_axes
+
+
+def patch_pytorch_squeeze_axis_contract() -> None:
+    """Make PyTorch squeeze reject non-singleton explicitly requested axes."""
+
+    try:
+        import numpy as np  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+    original_squeeze = getattr(raw_pytorch, "squeeze", None)
+    if original_squeeze is None:
+        return
+    if getattr(original_squeeze, "_pyrecest_numpy_axis_contract", False):
+        if active_pytorch_backend:
+            backend.squeeze = original_squeeze
+        return
+
+    def squeeze(x, axis=None):
+        values = raw_pytorch.array(x)
+        if axis is None:
+            return original_squeeze(values, axis=None)
+
+        axes = _pytorch_squeeze_axes(axis, values.ndim, np, torch)
+        if not axes:
+            return values
+        for one_axis in axes:
+            if values.shape[one_axis] != 1:
+                raise ValueError(
+                    "cannot select an axis to squeeze out which has "
+                    "size not equal to one"
+                )
+
+        result = values
+        for one_axis in sorted(axes, reverse=True):
+            result = torch.squeeze(result, dim=one_axis)
+        return result
+
+    squeeze.__name__ = getattr(original_squeeze, "__name__", "squeeze")
+    squeeze.__doc__ = getattr(original_squeeze, "__doc__", None)
+    squeeze._pyrecest_numpy_axis_contract = True
+    raw_pytorch.squeeze = squeeze
+    if active_pytorch_backend:
+        backend.squeeze = squeeze
+
+
 def patch_pytorch_transpose_boolean_axes_contract() -> None:
     """Make PyTorch ``transpose`` reject boolean axes sequences like NumPy."""
 

--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -215,6 +215,7 @@ try:
         patch_pytorch_close_equal_nan_device_contract as _patch_pytorch_close_equal_nan_device_contract,
         patch_pytorch_edge_pad_contract as _patch_pytorch_edge_pad_contract,
         patch_pytorch_repeat_numpy_contract as _patch_pytorch_repeat_numpy_contract,
+        patch_pytorch_squeeze_axis_contract as _patch_pytorch_squeeze_axis_contract,
         patch_pytorch_transpose_boolean_axes_contract as _patch_pytorch_transpose_boolean_axes_contract,
     )
     from pyrecest.backend_support._pytorch_one_hot_scalar_contract import (  # pylint: disable=import-outside-toplevel
@@ -226,5 +227,6 @@ else:
     _patch_pytorch_close_equal_nan_device_contract()
     _patch_pytorch_repeat_numpy_contract()
     _patch_pytorch_edge_pad_contract()
+    _patch_pytorch_squeeze_axis_contract()
     _patch_pytorch_transpose_boolean_axes_contract()
     _patch_pytorch_one_hot_scalar_contract()

--- a/tests/backend_support/test_pytorch_squeeze_axis_contract.py
+++ b/tests/backend_support/test_pytorch_squeeze_axis_contract.py
@@ -1,0 +1,53 @@
+from tests.support.backend_runner import run_backend_code
+
+
+def test_pytorch_backend_squeeze_rejects_non_singleton_axis():
+    code = """
+import pyrecest  # noqa: F401
+import pyrecest.backend as backend
+
+values = backend.array([[1], [2]])
+for axis in (0, (0, 1)):
+    try:
+        backend.squeeze(values, axis=axis)
+    except ValueError as exc:
+        assert "size not equal to one" in str(exc), str(exc)
+    else:
+        raise AssertionError("expected non-singleton squeeze axis to raise")
+
+result = backend.squeeze(values, axis=1)
+assert tuple(result.shape) == (2,)
+assert backend.to_numpy(result).tolist() == [1, 2]
+print("ok")
+"""
+
+    result = run_backend_code("pytorch", code)
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_raw_pytorch_squeeze_rejects_non_singleton_axis_after_package_import():
+    code = """
+import pyrecest  # noqa: F401
+import pyrecest._backend.pytorch as raw_pytorch
+
+values = raw_pytorch.array([[1], [2]])
+for axis in (0, (0, 1)):
+    try:
+        raw_pytorch.squeeze(values, axis=axis)
+    except ValueError as exc:
+        assert "size not equal to one" in str(exc), str(exc)
+    else:
+        raise AssertionError("expected non-singleton squeeze axis to raise")
+
+result = raw_pytorch.squeeze(values, axis=1)
+assert tuple(result.shape) == (2,)
+assert raw_pytorch.to_numpy(result).tolist() == [1, 2]
+print("ok")
+"""
+
+    result = run_backend_code("pytorch", code)
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout

--- a/tests/backend_support/test_pytorch_squeeze_axis_contract.py
+++ b/tests/backend_support/test_pytorch_squeeze_axis_contract.py
@@ -1,7 +1,14 @@
+import importlib.util
+
+import pytest
+
 from tests.support.backend_runner import run_backend_code
 
 
 def test_pytorch_backend_squeeze_rejects_non_singleton_axis():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
     code = """
 import pyrecest  # noqa: F401
 import pyrecest.backend as backend
@@ -28,6 +35,9 @@ print("ok")
 
 
 def test_raw_pytorch_squeeze_rejects_non_singleton_axis_after_package_import():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
     code = """
 import pyrecest  # noqa: F401
 import pyrecest._backend.pytorch as raw_pytorch


### PR DESCRIPTION
## Summary
- Add a PyTorch backend runtime patch so `squeeze(..., axis=...)` rejects explicitly requested non-singleton axes instead of silently returning the input.
- Wire the patch into the existing late backend-runtime patch hook used from `evidence.py`.
- Add public-backend and raw-PyTorch regression coverage for non-singleton axis handling.

## Bug
The raw PyTorch backend currently delegates `backend.squeeze(x, axis=...)` to `torch.squeeze(x, dim=...)`. PyTorch silently leaves tensors unchanged when the requested dimension has size other than one, but NumPy-compatible `squeeze(axis=...)` raises `ValueError` for an explicitly requested non-singleton axis. This made the PyTorch backend diverge from the backend contract.

## Tests
- Not run locally in this environment because the repository cannot be cloned from GitHub here; added focused pytest coverage in `tests/backend_support/test_pytorch_squeeze_axis_contract.py`.
