### PR TITLE
Fix JAX triangular vector helpers for rectangular matrices

### DIFF
--- a/src/pyrecest/backend_support/_jax_assignment_numpy_index_contract.py
+++ b/src/pyrecest/backend_support/_jax_assignment_numpy_index_contract.py
@@ -28,6 +28,50 @@ def _wrap_helper(helper, np, jnp):
     return wrapped
 
 
+def _rectangular_triangular_to_vec(helper_name, original_helper, index_helper, jnp):
+    """Return a triangular-vector helper that uses both trailing matrix axes."""
+
+    if getattr(original_helper, "_pyrecest_rectangular_contract", False):
+        return original_helper
+
+    def triangular_to_vec(x, k=0):
+        x = jnp.asarray(x)
+        if x.ndim < 2:
+            raise ValueError("triangular vector helpers require at least two matrix dimensions")
+        rows, cols = index_helper(x.shape[-2], k=k, m=x.shape[-1])
+        return x[..., rows, cols]
+
+    triangular_to_vec.__name__ = getattr(original_helper, "__name__", helper_name)
+    triangular_to_vec.__doc__ = getattr(original_helper, "__doc__", None)
+    triangular_to_vec._pyrecest_arraylike_contract = True
+    triangular_to_vec._pyrecest_rectangular_contract = True
+    return triangular_to_vec
+
+
+def _patch_jax_triangular_vector_helpers_rectangular_contract(jax_backend, backend, jnp) -> None:
+    """Make JAX triangular-vector helpers work for rectangular matrices."""
+
+    active_jax_backend = getattr(backend, "__backend_name__", None) == "jax"
+    for helper_name, index_helper_name in (
+        ("tril_to_vec", "tril_indices"),
+        ("triu_to_vec", "triu_indices"),
+    ):
+        original_helper = getattr(jax_backend, helper_name, None)
+        index_helper = getattr(jnp, index_helper_name, None)
+        if original_helper is None or index_helper is None:
+            continue
+
+        helper = _rectangular_triangular_to_vec(
+            helper_name,
+            original_helper,
+            index_helper,
+            jnp,
+        )
+        setattr(jax_backend, helper_name, helper)
+        if active_jax_backend:
+            setattr(backend, helper_name, helper)
+
+
 def patch_jax_assignment_numpy_index_contract() -> None:
     """Make JAX assignment helpers accept NumPy ndarray index sequences."""
 
@@ -44,3 +88,5 @@ def patch_jax_assignment_numpy_index_contract() -> None:
     if getattr(backend, "__backend_name__", None) == "jax":
         backend.assignment = jax_backend.assignment
         backend.assignment_by_sum = jax_backend.assignment_by_sum
+
+    _patch_jax_triangular_vector_helpers_rectangular_contract(jax_backend, backend, jnp)

--- a/tests/test_jax_rectangular_triangular_helpers.py
+++ b/tests/test_jax_rectangular_triangular_helpers.py
@@ -1,0 +1,29 @@
+import pytest
+
+pytest.importorskip("jax")
+
+
+def _to_list(jax_backend, value):
+    return jax_backend.to_numpy(value).tolist()
+
+
+def test_raw_jax_triangular_helpers_use_rectangular_matrix_shape_after_import():
+    import pyrecest  # noqa: F401
+    import pyrecest._backend.jax as raw_jax
+
+    values = [[1, 2, 3], [4, 5, 6]]
+
+    assert _to_list(raw_jax, raw_jax.tril_to_vec(values)) == [1, 4, 5]
+    assert _to_list(raw_jax, raw_jax.triu_to_vec(values)) == [1, 2, 3, 5, 6]
+
+
+def test_public_jax_triangular_helpers_use_rectangular_matrix_shape_when_active():
+    import pyrecest.backend as backend
+
+    if getattr(backend, "__backend_name__", None) != "jax":
+        pytest.skip("public JAX backend is not active")
+
+    values = backend.asarray([[1, 2, 3], [4, 5, 6]])
+
+    assert backend.to_numpy(backend.tril_to_vec(values)).tolist() == [1, 4, 5]
+    assert backend.to_numpy(backend.triu_to_vec(values)).tolist() == [1, 2, 3, 5, 6]


### PR DESCRIPTION
## Summary
- Use both trailing matrix dimensions when building JAX triangular-vector indices.
- Keep array-like input support for raw and active public JAX helpers.
- Add regression coverage for rectangular 2x3 inputs.

## Validation
- Syntax-compiled the modified module and new test locally with `py_compile`.
- Branch comparison: 2 commits ahead of `main`, 0 behind.
- Full pytest was not run in this connector session.