### PR TITLE
Reject infinite max time deltas

### DIFF
--- a/src/pyrecest/calibration/__init__.py
+++ b/src/pyrecest/calibration/__init__.py
@@ -50,8 +50,8 @@ def _as_nonnegative_time_delta(value: Any, name: str) -> float:
         result = float(scalar)
     except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError(f"{name} must be nonnegative") from exc
-    if result < 0.0 or np.isnan(result):
-        raise ValueError(f"{name} must be nonnegative")
+    if not np.isfinite(result) or result < 0.0:
+        raise ValueError(f"{name} must be finite and nonnegative")
     return result
 
 

--- a/tests/calibration/test_max_time_delta_validation.py
+++ b/tests/calibration/test_max_time_delta_validation.py
@@ -6,14 +6,21 @@ from pyrecest.calibration.time_offset import interpolate_reference_values
 
 
 class MaxTimeDeltaValidationTest(unittest.TestCase):
-    def test_interpolation_rejects_boolean_and_non_scalar_max_time_delta(self):
-        invalid_values = (True, np.array([1.0]), "1.0", np.array(True, dtype=object))
+    def test_interpolation_rejects_boolean_non_scalar_and_infinite_max_time_delta(self):
+        invalid_values = (
+            True,
+            np.array([1.0]),
+            "1.0",
+            np.array(True, dtype=object),
+            np.inf,
+            np.array(np.inf),
+        )
 
         for max_time_delta_s in invalid_values:
             with self.subTest(max_time_delta_s=max_time_delta_s):
                 with self.assertRaisesRegex(
                     ValueError,
-                    "max_time_delta_s must be nonnegative",
+                    "max_time_delta_s must",
                 ):
                     interpolate_reference_values(
                         np.array([0.0, 1.0]),
@@ -22,14 +29,21 @@ class MaxTimeDeltaValidationTest(unittest.TestCase):
                         max_time_delta_s=max_time_delta_s,
                     )
 
-    def test_bias_examples_reject_boolean_and_non_scalar_max_time_delta(self):
-        invalid_values = (True, np.array([1.0]), "1.0", np.array(True, dtype=object))
+    def test_bias_examples_reject_boolean_non_scalar_and_infinite_max_time_delta(self):
+        invalid_values = (
+            True,
+            np.array([1.0]),
+            "1.0",
+            np.array(True, dtype=object),
+            np.inf,
+            np.array(np.inf),
+        )
 
         for max_time_delta_s in invalid_values:
             with self.subTest(max_time_delta_s=max_time_delta_s):
                 with self.assertRaisesRegex(
                     ValueError,
-                    "max_time_delta_s must be nonnegative",
+                    "max_time_delta_s must",
                 ):
                     make_bias_training_examples(
                         np.array([0.0]),


### PR DESCRIPTION
## Summary
- reject infinite `max_time_delta_s` values in calibration validation
- keep `None` as the explicit no-limit sentinel
- add regression coverage for interpolation and bias-training helpers

## Testing
- Not run locally; patch was applied via the GitHub connector.