### PR TITLE
Fix JAX array_from_sparse duplicate indices

### DIFF
--- a/src/pyrecest/_backend/jax/__init__.py
+++ b/src/pyrecest/_backend/jax/__init__.py
@@ -541,7 +541,17 @@ def array_from_sparse(indices, data, target_shape):
     # flattened positions would address the first axis instead of the flat
     # storage order and can therefore put values into the wrong entries or
     # raise out-of-bounds errors for multidimensional target shapes.
-    linear_indices = _jnp.ravel_multi_index(indices.T, target_shape)
+    linear_indices = _jnp.atleast_1d(_jnp.ravel_multi_index(indices.T, target_shape))
+    if linear_indices.size:
+        linear_count = linear_indices.size
+        _, reversed_first_positions = _jnp.unique(
+            linear_indices[::-1],
+            return_index=True,
+        )
+        keep_positions = _jnp.sort(linear_count - 1 - reversed_first_positions)
+        linear_indices = linear_indices[keep_positions]
+        if data.ndim > 0 and data.shape[0] == linear_count:
+            data = data[keep_positions]
     out = out.reshape(-1).at[linear_indices].set(data).reshape(target_shape)
 
     return out

--- a/tests/backend/test_jax_array_from_sparse_duplicates.py
+++ b/tests/backend/test_jax_array_from_sparse_duplicates.py
@@ -1,0 +1,15 @@
+import pytest
+
+pytest.importorskip("jax")
+import jax.numpy as jnp  # noqa: E402
+from pyrecest._backend.jax import array_from_sparse  # noqa: E402
+
+
+def test_array_from_sparse_uses_last_value_for_duplicate_indices():
+    indices = jnp.array([[0, 1], [0, 1], [1, 0], [0, 1]])
+    data = jnp.array([2, 3, 5, 7])
+
+    dense = array_from_sparse(indices, data, (2, 2))
+
+    expected = jnp.array([[0, 7], [5, 0]])
+    assert jnp.array_equal(dense, expected)


### PR DESCRIPTION
## Summary
- Make the JAX `array_from_sparse` implementation deduplicate repeated flat sparse indices before applying `.at[].set(...)`, preserving the last value for each coordinate.
- Keep scalar/broadcast data behavior unchanged when data is not a per-index vector.
- Add focused regression coverage for repeated sparse coordinates.

## Bug fixed
The shared NumPy backend uses `put` after `ravel_multi_index`, which gives deterministic last-value-wins behavior for repeated sparse coordinates. The JAX backend previously forwarded duplicate `linear_indices` directly into `.at[...].set(data)`, leaving conflicting indexed updates backend-dependent and potentially divergent from the NumPy/PyRecEst contract.

## Validation
- `python -m py_compile /mnt/data/pyrecest_jax_init.py /mnt/data/test_jax_array_from_sparse.py`
- Isolated JAX smoke check for duplicate sparse coordinates and the existing multidimensional flat-index case.
- Full repository pytest was not run locally because this session does not have a repository checkout.