### PR TITLE
Add low-rank hypertoroidal Fourier prototype

### DIFF
--- a/src/pyrecest/distributions/hypertorus/__init__.py
+++ b/src/pyrecest/distributions/hypertorus/__init__.py
@@ -1,0 +1,7 @@
+"""Hypertoroidal distribution exports."""
+
+from .low_rank_hypertoroidal_fourier_distribution import (
+    LowRankHypertoroidalFourierDistribution,
+)
+
+__all__ = ("LowRankHypertoroidalFourierDistribution",)

--- a/src/pyrecest/distributions/hypertorus/_tensor_train.py
+++ b/src/pyrecest/distributions/hypertorus/_tensor_train.py
@@ -1,5 +1,48 @@
 """Private tensor-train helper for hypertoroidal Fourier coefficients."""
 
+from __future__ import annotations
+
+from math import prod, sqrt
+
+import numpy as np
+
 
 class TensorTrain:
-    pass
+    """Minimal complex tensor-train representation."""
+
+    def __init__(self, cores):
+        checked = tuple(np.asarray(core, dtype=np.complex128).copy() for core in cores)
+        if not checked:
+            raise ValueError("At least one TT core is required.")
+        for core in checked:
+            if core.ndim != 3:
+                raise ValueError("TT cores must have shape (left_rank, mode_size, right_rank).")
+        if checked[0].shape[0] != 1 or checked[-1].shape[2] != 1:
+            raise ValueError("Boundary TT ranks must be one.")
+        for left, right in zip(checked, checked[1:]):
+            if left.shape[2] != right.shape[0]:
+                raise ValueError("Adjacent TT ranks do not match.")
+        self.cores = checked
+
+    @property
+    def ndim(self):
+        return len(self.cores)
+
+    @property
+    def shape(self):
+        return tuple(core.shape[1] for core in self.cores)
+
+    @property
+    def ranks(self):
+        return (self.cores[0].shape[0],) + tuple(core.shape[2] for core in self.cores)
+
+    @property
+    def size(self):
+        return prod(self.shape)
+
+    @property
+    def storage_size(self):
+        return int(sum(core.size for core in self.cores))
+
+    def copy(self):
+        return TensorTrain(tuple(core.copy() for core in self.cores))

--- a/src/pyrecest/distributions/hypertorus/_tensor_train.py
+++ b/src/pyrecest/distributions/hypertorus/_tensor_train.py
@@ -1,0 +1,5 @@
+"""Private tensor-train helper for hypertoroidal Fourier coefficients."""
+
+
+class TensorTrain:
+    pass

--- a/src/pyrecest/distributions/hypertorus/_tensor_train.py
+++ b/src/pyrecest/distributions/hypertorus/_tensor_train.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from math import prod, sqrt
 
 import numpy as np
+from scipy import signal
 
 
 def _choose_rank(singular_values, max_rank, local_tolerance):
@@ -110,7 +111,8 @@ class TensorTrain:
         return complex(value.reshape(()))
 
     def norm_squared(self):
-        value = np.vdot(self.to_dense().ravel(), self.to_dense().ravel())
+        dense = self.to_dense().ravel()
+        value = np.vdot(dense, dense)
         return float(np.real_if_close(value, tol=1000).real)
 
     def norm(self):
@@ -120,3 +122,37 @@ class TensorTrain:
         cores = [core.copy() for core in self.cores]
         cores[0] = cores[0] * factor
         return TensorTrain(cores)
+
+    def multiply_axis_factors(self, factors):
+        if len(factors) != self.ndim:
+            raise ValueError("factors must contain one vector per TT core.")
+        cores = []
+        for core, factor in zip(self.cores, factors):
+            vector = np.asarray(factor, dtype=np.complex128)
+            if vector.shape != (core.shape[1],):
+                raise ValueError("Each factor vector must match the corresponding mode size.")
+            cores.append(core * vector[None, :, None])
+        return TensorTrain(cores)
+
+    def hadamard_product(self, other):
+        if self.shape != other.shape:
+            raise ValueError("Hadamard products require identical tensor shapes.")
+        return TensorTrain.from_dense(self.to_dense() * other.to_dense())
+
+    def coefficient_convolution(self, other, *, target_shape=None):
+        if self.ndim != other.ndim:
+            raise ValueError("Convolution operands must have the same number of dimensions.")
+        if target_shape is None:
+            target_shape = self.shape
+        conv = signal.fftconvolve(self.to_dense(), other.to_dense(), mode="same")
+        if tuple(conv.shape) != tuple(target_shape):
+            slices = tuple(slice(0, int(n)) for n in target_shape)
+            conv = conv[slices]
+        return TensorTrain.from_dense(conv)
+
+    def round(self, *, max_rank=None, rtol=0.0, atol=0.0, max_dense_entries=1_000_000):
+        if self.size > max_dense_entries and (max_rank is not None or rtol > 0 or atol > 0):
+            raise ValueError("Dense TT-SVD fallback would exceed max_dense_entries.")
+        if self.size > max_dense_entries:
+            return self.copy()
+        return TensorTrain.from_dense(self.to_dense(), max_rank=max_rank, rtol=rtol, atol=atol)

--- a/src/pyrecest/distributions/hypertorus/_tensor_train.py
+++ b/src/pyrecest/distributions/hypertorus/_tensor_train.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from math import prod, sqrt
 
 import numpy as np
-from scipy import signal
 
 
 def _choose_rank(singular_values, max_rank, local_tolerance):
@@ -111,9 +110,14 @@ class TensorTrain:
         return complex(value.reshape(()))
 
     def norm_squared(self):
-        dense = self.to_dense().ravel()
-        value = np.vdot(dense, dense)
-        return float(np.real_if_close(value, tol=1000).real)
+        environment = np.ones((1, 1), dtype=np.complex128)
+        for core in self.cores:
+            next_environment = np.zeros((core.shape[2], core.shape[2]), dtype=np.complex128)
+            for mode_index in range(core.shape[1]):
+                core_slice = core[:, mode_index, :]
+                next_environment += core_slice.conj().T @ environment @ core_slice
+            environment = next_environment
+        return float(np.real_if_close(environment.reshape(()), tol=1000).real)
 
     def norm(self):
         return sqrt(max(self.norm_squared(), 0.0))
@@ -137,18 +141,30 @@ class TensorTrain:
     def hadamard_product(self, other):
         if self.shape != other.shape:
             raise ValueError("Hadamard products require identical tensor shapes.")
-        return TensorTrain.from_dense(self.to_dense() * other.to_dense())
+        cores = []
+        for left_core, right_core in zip(self.cores, other.cores):
+            ra0, mode_size, ra1 = left_core.shape
+            rb0, _, rb1 = right_core.shape
+            combined = np.zeros((ra0 * rb0, mode_size, ra1 * rb1), dtype=np.complex128)
+            for mode_index in range(mode_size):
+                combined[:, mode_index, :] = np.kron(
+                    left_core[:, mode_index, :], right_core[:, mode_index, :]
+                )
+            cores.append(combined)
+        return TensorTrain(cores)
 
     def coefficient_convolution(self, other, *, target_shape=None):
         if self.ndim != other.ndim:
             raise ValueError("Convolution operands must have the same number of dimensions.")
         if target_shape is None:
             target_shape = self.shape
-        conv = signal.fftconvolve(self.to_dense(), other.to_dense(), mode="same")
-        if tuple(conv.shape) != tuple(target_shape):
-            slices = tuple(slice(0, int(n)) for n in target_shape)
-            conv = conv[slices]
-        return TensorTrain.from_dense(conv)
+        if len(target_shape) != self.ndim:
+            raise ValueError("target_shape must contain one mode size per dimension.")
+        cores = [
+            _convolve_cores_centered(left_core, right_core, int(mode_size))
+            for left_core, right_core, mode_size in zip(self.cores, other.cores, target_shape)
+        ]
+        return TensorTrain(cores)
 
     def round(self, *, max_rank=None, rtol=0.0, atol=0.0, max_dense_entries=1_000_000):
         if self.size > max_dense_entries and (max_rank is not None or rtol > 0 or atol > 0):
@@ -156,3 +172,27 @@ class TensorTrain:
         if self.size > max_dense_entries:
             return self.copy()
         return TensorTrain.from_dense(self.to_dense(), max_rank=max_rank, rtol=rtol, atol=atol)
+
+
+def _convolve_cores_centered(left_core, right_core, target_mode_size):
+    if target_mode_size < 1:
+        raise ValueError("target mode sizes must be positive.")
+    left_center = left_core.shape[1] // 2
+    right_center = right_core.shape[1] // 2
+    target_center = target_mode_size // 2
+    ra0, _, ra1 = left_core.shape
+    rb0, _, rb1 = right_core.shape
+    result = np.zeros((ra0 * rb0, target_mode_size, ra1 * rb1), dtype=np.complex128)
+    for ell_index in range(target_mode_size):
+        ell_frequency = ell_index - target_center
+        slice_sum = np.zeros((ra0 * rb0, ra1 * rb1), dtype=np.complex128)
+        for left_index in range(left_core.shape[1]):
+            left_frequency = left_index - left_center
+            right_frequency = ell_frequency - left_frequency
+            right_index = right_frequency + right_center
+            if 0 <= right_index < right_core.shape[1]:
+                slice_sum += np.kron(
+                    left_core[:, left_index, :], right_core[:, int(right_index), :]
+                )
+        result[:, ell_index, :] = slice_sum
+    return result

--- a/src/pyrecest/distributions/hypertorus/_tensor_train.py
+++ b/src/pyrecest/distributions/hypertorus/_tensor_train.py
@@ -94,3 +94,29 @@ class TensorTrain:
 
     def copy(self):
         return TensorTrain(tuple(core.copy() for core in self.cores))
+
+    def to_dense(self):
+        result = self.cores[0][0, :, :]
+        for core in self.cores[1:]:
+            result = np.tensordot(result, core, axes=([-1], [0]))
+        return np.squeeze(result, axis=-1)
+
+    def entry(self, multi_index):
+        if len(multi_index) != self.ndim:
+            raise ValueError("multi_index must contain one index per TT core.")
+        value = self.cores[0][:, int(multi_index[0]), :]
+        for axis, index in enumerate(multi_index[1:], start=1):
+            value = value @ self.cores[axis][:, int(index), :]
+        return complex(value.reshape(()))
+
+    def norm_squared(self):
+        value = np.vdot(self.to_dense().ravel(), self.to_dense().ravel())
+        return float(np.real_if_close(value, tol=1000).real)
+
+    def norm(self):
+        return sqrt(max(self.norm_squared(), 0.0))
+
+    def scaled(self, factor):
+        cores = [core.copy() for core in self.cores]
+        cores[0] = cores[0] * factor
+        return TensorTrain(cores)

--- a/src/pyrecest/distributions/hypertorus/_tensor_train.py
+++ b/src/pyrecest/distributions/hypertorus/_tensor_train.py
@@ -7,6 +7,25 @@ from math import prod, sqrt
 import numpy as np
 
 
+def _choose_rank(singular_values, max_rank, local_tolerance):
+    full_rank = singular_values.size
+    if local_tolerance <= 0:
+        rank = full_rank
+    else:
+        squared_tail = np.cumsum(singular_values[::-1] ** 2)[::-1]
+        rank = full_rank
+        for candidate in range(1, full_rank + 1):
+            tail = 0.0 if candidate == full_rank else sqrt(float(squared_tail[candidate]))
+            if tail <= local_tolerance:
+                rank = candidate
+                break
+    if max_rank is not None:
+        if max_rank < 1:
+            raise ValueError("max_rank must be positive when provided.")
+        rank = min(rank, max_rank)
+    return max(1, rank)
+
+
 class TensorTrain:
     """Minimal complex tensor-train representation."""
 
@@ -43,6 +62,35 @@ class TensorTrain:
     @property
     def storage_size(self):
         return int(sum(core.size for core in self.cores))
+
+    @classmethod
+    def from_dense(cls, tensor, *, max_rank=None, rtol=0.0, atol=0.0):
+        array = np.asarray(tensor, dtype=np.complex128)
+        if array.ndim < 1:
+            raise ValueError("A tensor with at least one axis is required.")
+        if any(axis_size < 1 for axis_size in array.shape):
+            raise ValueError("All tensor axes must be non-empty.")
+        if rtol < 0 or atol < 0:
+            raise ValueError("rtol and atol must be non-negative.")
+        if array.ndim == 1:
+            return cls((array.reshape(1, array.shape[0], 1),))
+
+        norm = float(np.linalg.norm(array.ravel()))
+        global_tolerance = max(float(atol), float(rtol) * norm)
+        local_tolerance = global_tolerance / sqrt(array.ndim - 1) if global_tolerance > 0 else 0.0
+
+        cores = []
+        unfolding = array
+        left_rank = 1
+        for mode_size in array.shape[:-1]:
+            matrix = unfolding.reshape(left_rank * mode_size, -1)
+            u, singular_values, vh = np.linalg.svd(matrix, full_matrices=False)
+            rank = _choose_rank(singular_values, max_rank, local_tolerance)
+            cores.append(u[:, :rank].reshape(left_rank, mode_size, rank))
+            unfolding = singular_values[:rank, None] * vh[:rank, :]
+            left_rank = rank
+        cores.append(unfolding.reshape(left_rank, array.shape[-1], 1))
+        return cls(cores)
 
     def copy(self):
         return TensorTrain(tuple(core.copy() for core in self.cores))

--- a/src/pyrecest/distributions/hypertorus/low_rank_hypertoroidal_fourier_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/low_rank_hypertoroidal_fourier_distribution.py
@@ -1,0 +1,218 @@
+"""Low-rank hypertoroidal Fourier distribution."""
+
+from __future__ import annotations
+
+from math import prod, sqrt
+
+import numpy as np
+
+from ._input_validation import as_shift_vector
+from ._tensor_train import TensorTrain
+from .abstract_hypertoroidal_distribution import AbstractHypertoroidalDistribution
+from .hypertoroidal_fourier_distribution import HypertoroidalFourierDistribution
+
+
+def _as_shape(shape):
+    normalized = tuple(int(n) for n in shape)
+    if not normalized:
+        raise ValueError("shape must contain at least one dimension.")
+    if any(n < 1 or n % 2 != 1 for n in normalized):
+        raise ValueError("Fourier coefficient side lengths must be positive and odd.")
+    return normalized
+
+
+def _center(shape):
+    return tuple(n // 2 for n in shape)
+
+
+def _freqs(n):
+    return np.arange(n, dtype=float) - n // 2
+
+
+class LowRankHypertoroidalFourierDistribution(AbstractHypertoroidalDistribution):
+    """Hypertoroidal Fourier distribution with TT-compressed coefficients.
+
+    This first prototype is intended for the identity Fourier representation.
+    Square-root normalization is available as an algebraic helper, but SqFF
+    prediction is intentionally not implemented yet.
+    """
+
+    def __init__(self, coefficients, transformation="identity", *, normalize=True):
+        if not isinstance(coefficients, TensorTrain):
+            coefficients = TensorTrain(coefficients)
+        _as_shape(coefficients.shape)
+        if transformation not in ("identity", "sqrt"):
+            raise ValueError("transformation must be 'identity' or 'sqrt'.")
+        AbstractHypertoroidalDistribution.__init__(self, coefficients.ndim)
+        self.coefficients = coefficients
+        self.transformation = transformation
+        if normalize:
+            self.normalize_in_place()
+
+    @property
+    def coeff_shape(self):
+        return self.coefficients.shape
+
+    @property
+    def tt_ranks(self):
+        return self.coefficients.ranks
+
+    @property
+    def center_index(self):
+        return _center(self.coeff_shape)
+
+    @classmethod
+    def uniform(cls, shape, transformation="identity"):
+        shape = _as_shape(shape if not isinstance(shape, int) else (shape,))
+        coefficient = (2.0 * np.pi) ** (-len(shape))
+        if transformation == "sqrt":
+            coefficient = sqrt(coefficient)
+        elif transformation != "identity":
+            raise ValueError("transformation must be 'identity' or 'sqrt'.")
+        cores = []
+        for axis, axis_size in enumerate(shape):
+            core = np.zeros((1, axis_size, 1), dtype=np.complex128)
+            core[0, axis_size // 2, 0] = coefficient if axis == 0 else 1.0
+            cores.append(core)
+        return cls(TensorTrain(cores), transformation, normalize=False)
+
+    @classmethod
+    def from_dense(cls, dense, *, max_rank=None, rtol=0.0, atol=0.0):
+        if isinstance(dense, HypertoroidalFourierDistribution):
+            coeff = np.asarray(dense.coeff_mat, dtype=np.complex128)
+            transformation = dense.transformation
+        else:
+            coeff = np.asarray(dense, dtype=np.complex128)
+            transformation = "identity"
+        tt = TensorTrain.from_dense(coeff, max_rank=max_rank, rtol=rtol, atol=atol)
+        return cls(tt, transformation, normalize=True)
+
+    @classmethod
+    def from_distribution(
+        cls,
+        distribution,
+        n_coefficients,
+        desired_transformation="identity",
+        *,
+        max_rank=None,
+        rtol=0.0,
+        atol=0.0,
+    ):
+        dense = HypertoroidalFourierDistribution.from_distribution(
+            distribution, n_coefficients, desired_transformation
+        )
+        return cls.from_dense(dense, max_rank=max_rank, rtol=rtol, atol=atol)
+
+    def to_dense(self):
+        return self.coefficients.to_dense()
+
+    def coefficient_at_zero(self):
+        return self.coefficients.entry(self.center_index)
+
+    def normalize_in_place(self):
+        if self.transformation == "identity":
+            normalizer = ((2.0 * np.pi) ** self.dim) * self.coefficient_at_zero()
+        else:
+            normalizer = sqrt((2.0 * np.pi) ** self.dim) * self.coefficients.norm()
+        if abs(normalizer) == 0:
+            raise ZeroDivisionError("Cannot normalize zero coefficient tensor.")
+        self.coefficients = self.coefficients.scaled(1.0 / normalizer)
+        return self
+
+    def value(self, xs):
+        points = np.asarray(xs, dtype=float)
+        single = False
+        if self.dim == 1:
+            if points.ndim == 0:
+                points = points.reshape(1, 1)
+                single = True
+            elif points.ndim == 1:
+                points = points.reshape(-1, 1)
+            elif points.shape[-1] != 1:
+                raise ValueError("Expected one-dimensional points.")
+        else:
+            if points.ndim == 1:
+                points = points.reshape(1, -1)
+                single = True
+            if points.shape[-1] != self.dim:
+                raise ValueError(f"Expected points with {self.dim} columns.")
+
+        values = np.empty(points.shape[0], dtype=np.complex128)
+        frequencies = [_freqs(axis_size) for axis_size in self.coeff_shape]
+        for point_index, point in enumerate(points):
+            accumulated = np.ones((1, 1), dtype=np.complex128)
+            for axis, (core, ks) in enumerate(zip(self.coefficients.cores, frequencies)):
+                weights = np.exp(1j * ks * point[axis])
+                matrix = np.tensordot(weights, core, axes=([0], [1]))
+                accumulated = accumulated @ matrix
+            values[point_index] = accumulated.reshape(())
+        return values[0] if single else values
+
+    def pdf(self, xs):
+        values = self.value(xs)
+        if self.transformation == "identity":
+            return np.real_if_close(values, tol=1000).real
+        return np.real(values * np.conjugate(values))
+
+    def shift(self, shift_by):
+        shift_by = as_shift_vector(shift_by, self.dim)
+        factors = [
+            np.exp(-1j * _freqs(axis_size) * float(shift_by[axis]))
+            for axis, axis_size in enumerate(self.coeff_shape)
+        ]
+        return LowRankHypertoroidalFourierDistribution(
+            self.coefficients.multiply_axis_factors(factors),
+            self.transformation,
+            normalize=False,
+        )
+
+    def multiply(self, other, n_coefficients=None, *, max_rank=None, rtol=0.0):
+        other = self._ensure_low_rank(other)
+        self._check_compatible(other)
+        target_shape = self.coeff_shape if n_coefficients is None else _as_shape(n_coefficients)
+        coeffs = self.coefficients.coefficient_convolution(other.coefficients, target_shape=target_shape)
+        coeffs = coeffs.round(max_rank=max_rank, rtol=rtol)
+        return LowRankHypertoroidalFourierDistribution(coeffs, self.transformation)
+
+    def convolve(self, other, n_coefficients=None, *, max_rank=None, rtol=0.0):
+        other = self._ensure_low_rank(other)
+        self._check_compatible(other)
+        if self.transformation != "identity":
+            raise NotImplementedError("Low-rank SqFF prediction is not implemented yet.")
+        coeffs = self.coefficients.hadamard_product(other.coefficients)
+        coeffs = coeffs.scaled((2.0 * np.pi) ** self.dim)
+        coeffs = coeffs.round(max_rank=max_rank, rtol=rtol)
+        return LowRankHypertoroidalFourierDistribution(coeffs, "identity")
+
+    def mean_direction(self):
+        if self.transformation != "identity":
+            raise NotImplementedError("mean_direction is implemented for identity coefficients only.")
+        scale = (2.0 * np.pi) ** self.dim
+        means = np.zeros(self.dim)
+        for axis in range(self.dim):
+            index = list(self.center_index)
+            index[axis] -= 1
+            moment = scale * self.coefficients.entry(index)
+            means[axis] = np.mod(np.angle(moment), 2.0 * np.pi)
+        return means
+
+    def integrate(self):
+        if self.transformation == "identity":
+            return float(np.real_if_close(((2.0 * np.pi) ** self.dim) * self.coefficient_at_zero()).real)
+        return float(((2.0 * np.pi) ** self.dim) * self.coefficients.norm_squared())
+
+    def compression_ratio(self):
+        return prod(self.coeff_shape) / self.coefficients.storage_size
+
+    def _ensure_low_rank(self, other):
+        if isinstance(other, LowRankHypertoroidalFourierDistribution):
+            return other
+        if isinstance(other, HypertoroidalFourierDistribution):
+            return LowRankHypertoroidalFourierDistribution.from_dense(other)
+        raise TypeError("Expected a dense or low-rank hypertoroidal Fourier distribution.")
+
+    def _check_compatible(self, other):
+        if self.coeff_shape != other.coeff_shape:
+            raise ValueError("Fourier distributions must have identical coefficient shapes.")
+        if self.transformation != other.transformation:
+            raise ValueError("Fourier distributions must use the same transformation.")

--- a/src/pyrecest/distributions/hypertorus/low_rank_hypertoroidal_fourier_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/low_rank_hypertoroidal_fourier_distribution.py
@@ -151,7 +151,13 @@ class LowRankHypertoroidalFourierDistribution(AbstractHypertoroidalDistribution)
     def pdf(self, xs):
         values = self.value(xs)
         if self.transformation == "identity":
-            return np.real_if_close(values, tol=1000).real
+            imag_abs = np.abs(np.imag(values))
+            if np.any(imag_abs > 1e-10):
+                raise ValueError(
+                    "Density evaluation has a non-negligible imaginary part. "
+                    "Check that the low-rank coefficients define a real-valued density."
+                )
+            return np.real(values)
         return np.real(values * np.conjugate(values))
 
     def shift(self, shift_by):
@@ -179,6 +185,8 @@ class LowRankHypertoroidalFourierDistribution(AbstractHypertoroidalDistribution)
         self._check_compatible(other)
         if self.transformation != "identity":
             raise NotImplementedError("Low-rank SqFF prediction is not implemented yet.")
+        if n_coefficients is not None and _as_shape(n_coefficients) != self.coeff_shape:
+            raise NotImplementedError("Changing coefficient shape during low-rank prediction is not implemented.")
         coeffs = self.coefficients.hadamard_product(other.coefficients)
         coeffs = coeffs.scaled((2.0 * np.pi) ** self.dim)
         coeffs = coeffs.round(max_rank=max_rank, rtol=rtol)

--- a/src/pyrecest/filters/low_rank_hypertoroidal_fourier_filter.py
+++ b/src/pyrecest/filters/low_rank_hypertoroidal_fourier_filter.py
@@ -1,0 +1,113 @@
+"""Low-rank hypertoroidal Fourier filter."""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+
+import pyrecest.backend
+from pyrecest.distributions.hypertorus.abstract_hypertoroidal_distribution import (
+    AbstractHypertoroidalDistribution,
+)
+from pyrecest.distributions.hypertorus.hypertoroidal_fourier_distribution import (
+    HypertoroidalFourierDistribution,
+)
+from pyrecest.distributions.hypertorus.low_rank_hypertoroidal_fourier_distribution import (
+    LowRankHypertoroidalFourierDistribution,
+)
+
+from .abstract_filter import AbstractFilter
+from .manifold_mixins import HypertoroidalFilterMixin
+
+
+class LowRankHypertoroidalFourierFilter(AbstractFilter, HypertoroidalFilterMixin):
+    """Tensor-train low-rank variant of the hypertoroidal IFF.
+
+    This first prototype intentionally supports only ``transformation='identity'``.
+    The SqFF prediction step requires recovering square-root Fourier coefficients
+    after prediction and is left for later work.
+    """
+
+    def __init__(self, n_coefficients, transformation="identity", *, max_rank=None, rtol=0.0):
+        if pyrecest.backend.__backend_name__ != "numpy":  # pylint: disable=no-member
+            raise NotImplementedError("LowRankHypertoroidalFourierFilter is NumPy-only.")
+        if transformation != "identity":
+            raise NotImplementedError(
+                "The first low-rank prototype supports only transformation='identity'."
+            )
+        if isinstance(n_coefficients, int):
+            n_coefficients = (n_coefficients,)
+        n_coefficients = tuple(int(n) for n in n_coefficients)
+        self.max_rank = max_rank
+        self.rtol = rtol
+        initial_state = LowRankHypertoroidalFourierDistribution.uniform(
+            n_coefficients, transformation="identity"
+        )
+        HypertoroidalFilterMixin.__init__(self)
+        AbstractFilter.__init__(self, initial_state)
+
+    @property
+    def filter_state(self):
+        return self._filter_state
+
+    @filter_state.setter
+    def filter_state(self, new_state):
+        if not isinstance(new_state, LowRankHypertoroidalFourierDistribution):
+            if not isinstance(new_state, HypertoroidalFourierDistribution):
+                warnings.warn(
+                    "setState:nonFourier: converting state to dense Fourier first.",
+                    RuntimeWarning,
+                )
+                new_state = HypertoroidalFourierDistribution.from_distribution(
+                    new_state,
+                    self._filter_state.coeff_shape,
+                    self._filter_state.transformation,
+                )
+            new_state = LowRankHypertoroidalFourierDistribution.from_dense(
+                new_state, max_rank=self.max_rank, rtol=self.rtol
+            )
+        if new_state.transformation != "identity":
+            raise NotImplementedError("Only identity-transformed low-rank states are supported.")
+        self._filter_state = new_state
+
+    def _convert_noise(self, distribution):
+        if isinstance(distribution, LowRankHypertoroidalFourierDistribution):
+            return distribution
+        if isinstance(distribution, HypertoroidalFourierDistribution):
+            return LowRankHypertoroidalFourierDistribution.from_dense(
+                distribution, max_rank=self.max_rank, rtol=self.rtol
+            )
+        if isinstance(distribution, AbstractHypertoroidalDistribution):
+            warnings.warn(
+                "automaticConversion: transforming distribution to low-rank Fourier form.",
+                RuntimeWarning,
+            )
+            return LowRankHypertoroidalFourierDistribution.from_distribution(
+                distribution,
+                self._filter_state.coeff_shape,
+                "identity",
+                max_rank=self.max_rank,
+                rtol=self.rtol,
+            )
+        raise TypeError("distribution must be hypertoroidal.")
+
+    def predict_identity(self, d_sys):
+        """Predict for x_next = x + w mod 2*pi."""
+
+        d_sys = self._convert_noise(d_sys)
+        self._filter_state = self._filter_state.convolve(
+            d_sys, max_rank=self.max_rank, rtol=self.rtol
+        )
+
+    def update_identity(self, d_meas, z):
+        """Update for z = x + v mod 2*pi."""
+
+        d_meas = self._convert_noise(d_meas)
+        z = np.asarray(z)
+        if z.shape != (self._filter_state.dim,):
+            raise ValueError(f"z must have shape ({self._filter_state.dim},), got {z.shape}")
+        likelihood = d_meas.shift(z)
+        self._filter_state = self._filter_state.multiply(
+            likelihood, max_rank=self.max_rank, rtol=self.rtol
+        )

--- a/tests/distributions/test_hypertoroidal_tensor_train.py
+++ b/tests/distributions/test_hypertoroidal_tensor_train.py
@@ -1,0 +1,39 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+from pyrecest.distributions.hypertorus._tensor_train import TensorTrain
+
+
+class TestHypertoroidalTensorTrain(unittest.TestCase):
+    def test_dense_roundtrip_and_entry_access(self):
+        tensor = np.arange(27, dtype=float).reshape(3, 3, 3) + 1j
+        tt = TensorTrain.from_dense(tensor)
+        npt.assert_allclose(tt.to_dense(), tensor, atol=1e-12)
+        self.assertEqual(tt.shape, (3, 3, 3))
+        npt.assert_allclose(tt.entry((1, 2, 0)), tensor[1, 2, 0], atol=1e-12)
+
+    def test_frobenius_norm(self):
+        tensor = np.arange(9, dtype=float).reshape(3, 3) - 2.0
+        tt = TensorTrain.from_dense(tensor)
+        npt.assert_allclose(tt.norm_squared(), np.vdot(tensor, tensor).real, atol=1e-12)
+
+    def test_hadamard_product_matches_dense(self):
+        left = np.arange(9, dtype=float).reshape(3, 3)
+        right = np.arange(9, dtype=float).reshape(3, 3) + 1.0
+        product = TensorTrain.from_dense(left).hadamard_product(TensorTrain.from_dense(right))
+        npt.assert_allclose(product.to_dense(), left * right, atol=1e-12)
+
+    def test_centered_coefficient_convolution_matches_dense_1d(self):
+        left = np.array([1.0, 2.0, 3.0])
+        right = np.array([0.5, 1.0, -0.5])
+        result = TensorTrain.from_dense(left).coefficient_convolution(
+            TensorTrain.from_dense(right), target_shape=(3,)
+        )
+        expected = np.convolve(left, right, mode="same")
+        npt.assert_allclose(result.to_dense(), expected, atol=1e-12)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/distributions/test_low_rank_hypertoroidal_fourier_distribution.py
+++ b/tests/distributions/test_low_rank_hypertoroidal_fourier_distribution.py
@@ -4,16 +4,30 @@ import numpy as np
 import numpy.testing as npt
 
 import pyrecest.backend
-from pyrecest.distributions import WrappedNormalDistribution
 from pyrecest.distributions.hypertorus.hypertoroidal_fourier_distribution import (
     HypertoroidalFourierDistribution,
 )
 from pyrecest.distributions.hypertorus.low_rank_hypertoroidal_fourier_distribution import (
     LowRankHypertoroidalFourierDistribution,
 )
-from pyrecest.distributions.hypertorus.toroidal_wrapped_normal_distribution import (
-    ToroidalWrappedNormalDistribution,
-)
+
+
+def _identity_coefficients_1d():
+    coeff = np.zeros(5, dtype=np.complex128)
+    coeff[2] = 1.0 / (2.0 * np.pi)
+    coeff[1] = 0.01 + 0.02j
+    coeff[3] = np.conjugate(coeff[1])
+    return coeff
+
+
+def _identity_coefficients_2d():
+    coeff = np.zeros((3, 3), dtype=np.complex128)
+    coeff[1, 1] = 1.0 / (2.0 * np.pi) ** 2
+    coeff[0, 1] = 0.005 + 0.002j
+    coeff[2, 1] = np.conjugate(coeff[0, 1])
+    coeff[1, 0] = -0.004 + 0.003j
+    coeff[1, 2] = np.conjugate(coeff[1, 0])
+    return coeff
 
 
 @unittest.skipIf(
@@ -29,22 +43,14 @@ class TestLowRankHypertoroidalFourierDistribution(unittest.TestCase):
         )
 
     def test_value_and_pdf_match_dense_1d(self):
-        dense = HypertoroidalFourierDistribution.from_distribution(
-            WrappedNormalDistribution(np.array(1.0), np.array(0.6)),
-            (9,),
-            "identity",
-        )
+        dense = HypertoroidalFourierDistribution(_identity_coefficients_1d(), "identity")
         low_rank = LowRankHypertoroidalFourierDistribution.from_dense(dense)
         xs = np.linspace(0.0, 2.0 * np.pi, 17, endpoint=False)
         npt.assert_allclose(low_rank.value(xs), dense.value(xs), atol=1e-10)
         npt.assert_allclose(low_rank.pdf(xs), dense.pdf(xs), atol=1e-10)
 
     def test_shift_matches_dense_2d(self):
-        dense = HypertoroidalFourierDistribution.from_distribution(
-            ToroidalWrappedNormalDistribution(np.array([1.0, 2.0]), 0.4 * np.eye(2)),
-            (7, 7),
-            "identity",
-        )
+        dense = HypertoroidalFourierDistribution(_identity_coefficients_2d(), "identity")
         low_rank = LowRankHypertoroidalFourierDistribution.from_dense(dense)
         shift = np.array([0.2, -0.5])
         npt.assert_allclose(
@@ -52,16 +58,8 @@ class TestLowRankHypertoroidalFourierDistribution(unittest.TestCase):
         )
 
     def test_predict_additive_noise_matches_dense_2d(self):
-        prior_dense = HypertoroidalFourierDistribution.from_distribution(
-            ToroidalWrappedNormalDistribution(np.array([1.0, 2.0]), 0.4 * np.eye(2)),
-            (7, 7),
-            "identity",
-        )
-        noise_dense = HypertoroidalFourierDistribution.from_distribution(
-            ToroidalWrappedNormalDistribution(np.zeros(2), 0.2 * np.eye(2)),
-            (7, 7),
-            "identity",
-        )
+        prior_dense = HypertoroidalFourierDistribution(_identity_coefficients_2d(), "identity")
+        noise_dense = HypertoroidalFourierDistribution(_identity_coefficients_2d(), "identity")
         predicted_dense = prior_dense.convolve(noise_dense)
         predicted_low_rank = LowRankHypertoroidalFourierDistribution.from_dense(
             prior_dense
@@ -69,15 +67,9 @@ class TestLowRankHypertoroidalFourierDistribution(unittest.TestCase):
         npt.assert_allclose(predicted_low_rank.to_dense(), predicted_dense.coeff_mat, atol=1e-10)
 
     def test_update_multiply_matches_dense_1d(self):
-        prior_dense = HypertoroidalFourierDistribution.from_distribution(
-            WrappedNormalDistribution(np.array(1.0), np.array(0.5)),
-            (9,),
-            "identity",
-        )
-        likelihood_dense = HypertoroidalFourierDistribution.from_distribution(
-            WrappedNormalDistribution(np.array(0.0), np.array(1.0)),
-            (9,),
-            "identity",
+        prior_dense = HypertoroidalFourierDistribution(_identity_coefficients_1d(), "identity")
+        likelihood_dense = HypertoroidalFourierDistribution(
+            _identity_coefficients_1d(), "identity"
         ).shift(np.array([1.5]))
         updated_dense = prior_dense.multiply(likelihood_dense)
         updated_low_rank = LowRankHypertoroidalFourierDistribution.from_dense(

--- a/tests/distributions/test_low_rank_hypertoroidal_fourier_distribution.py
+++ b/tests/distributions/test_low_rank_hypertoroidal_fourier_distribution.py
@@ -51,6 +51,40 @@ class TestLowRankHypertoroidalFourierDistribution(unittest.TestCase):
             low_rank.shift(shift).to_dense(), dense.shift(shift).coeff_mat, atol=1e-10
         )
 
+    def test_predict_additive_noise_matches_dense_2d(self):
+        prior_dense = HypertoroidalFourierDistribution.from_distribution(
+            ToroidalWrappedNormalDistribution(np.array([1.0, 2.0]), 0.4 * np.eye(2)),
+            (7, 7),
+            "identity",
+        )
+        noise_dense = HypertoroidalFourierDistribution.from_distribution(
+            ToroidalWrappedNormalDistribution(np.zeros(2), 0.2 * np.eye(2)),
+            (7, 7),
+            "identity",
+        )
+        predicted_dense = prior_dense.convolve(noise_dense)
+        predicted_low_rank = LowRankHypertoroidalFourierDistribution.from_dense(
+            prior_dense
+        ).convolve(LowRankHypertoroidalFourierDistribution.from_dense(noise_dense))
+        npt.assert_allclose(predicted_low_rank.to_dense(), predicted_dense.coeff_mat, atol=1e-10)
+
+    def test_update_multiply_matches_dense_1d(self):
+        prior_dense = HypertoroidalFourierDistribution.from_distribution(
+            WrappedNormalDistribution(np.array(1.0), np.array(0.5)),
+            (9,),
+            "identity",
+        )
+        likelihood_dense = HypertoroidalFourierDistribution.from_distribution(
+            WrappedNormalDistribution(np.array(0.0), np.array(1.0)),
+            (9,),
+            "identity",
+        ).shift(np.array([1.5]))
+        updated_dense = prior_dense.multiply(likelihood_dense)
+        updated_low_rank = LowRankHypertoroidalFourierDistribution.from_dense(
+            prior_dense
+        ).multiply(LowRankHypertoroidalFourierDistribution.from_dense(likelihood_dense))
+        npt.assert_allclose(updated_low_rank.to_dense(), updated_dense.coeff_mat, atol=1e-10)
+
     def test_high_dimensional_uniform_smoke(self):
         dist = LowRankHypertoroidalFourierDistribution.uniform((3,) * 8)
         self.assertEqual(dist.coeff_shape, (3,) * 8)

--- a/tests/distributions/test_low_rank_hypertoroidal_fourier_distribution.py
+++ b/tests/distributions/test_low_rank_hypertoroidal_fourier_distribution.py
@@ -4,8 +4,15 @@ import numpy as np
 import numpy.testing as npt
 
 import pyrecest.backend
+from pyrecest.distributions import WrappedNormalDistribution
+from pyrecest.distributions.hypertorus.hypertoroidal_fourier_distribution import (
+    HypertoroidalFourierDistribution,
+)
 from pyrecest.distributions.hypertorus.low_rank_hypertoroidal_fourier_distribution import (
     LowRankHypertoroidalFourierDistribution,
+)
+from pyrecest.distributions.hypertorus.toroidal_wrapped_normal_distribution import (
+    ToroidalWrappedNormalDistribution,
 )
 
 
@@ -19,6 +26,29 @@ class TestLowRankHypertoroidalFourierDistribution(unittest.TestCase):
         npt.assert_allclose(dist.integrate(), 1.0, atol=1e-12)
         npt.assert_allclose(
             dist.coefficient_at_zero(), 1.0 / (2.0 * np.pi) ** 3, atol=1e-12
+        )
+
+    def test_value_and_pdf_match_dense_1d(self):
+        dense = HypertoroidalFourierDistribution.from_distribution(
+            WrappedNormalDistribution(np.array(1.0), np.array(0.6)),
+            (9,),
+            "identity",
+        )
+        low_rank = LowRankHypertoroidalFourierDistribution.from_dense(dense)
+        xs = np.linspace(0.0, 2.0 * np.pi, 17, endpoint=False)
+        npt.assert_allclose(low_rank.value(xs), dense.value(xs), atol=1e-10)
+        npt.assert_allclose(low_rank.pdf(xs), dense.pdf(xs), atol=1e-10)
+
+    def test_shift_matches_dense_2d(self):
+        dense = HypertoroidalFourierDistribution.from_distribution(
+            ToroidalWrappedNormalDistribution(np.array([1.0, 2.0]), 0.4 * np.eye(2)),
+            (7, 7),
+            "identity",
+        )
+        low_rank = LowRankHypertoroidalFourierDistribution.from_dense(dense)
+        shift = np.array([0.2, -0.5])
+        npt.assert_allclose(
+            low_rank.shift(shift).to_dense(), dense.shift(shift).coeff_mat, atol=1e-10
         )
 
     def test_high_dimensional_uniform_smoke(self):

--- a/tests/distributions/test_low_rank_hypertoroidal_fourier_distribution.py
+++ b/tests/distributions/test_low_rank_hypertoroidal_fourier_distribution.py
@@ -1,0 +1,33 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+import pyrecest.backend
+from pyrecest.distributions.hypertorus.low_rank_hypertoroidal_fourier_distribution import (
+    LowRankHypertoroidalFourierDistribution,
+)
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ != "numpy",  # pylint: disable=no-member
+    reason="Low-rank Fourier prototype is NumPy-only",
+)
+class TestLowRankHypertoroidalFourierDistribution(unittest.TestCase):
+    def test_uniform_identity_normalization(self):
+        dist = LowRankHypertoroidalFourierDistribution.uniform((3, 3, 3))
+        npt.assert_allclose(dist.integrate(), 1.0, atol=1e-12)
+        npt.assert_allclose(
+            dist.coefficient_at_zero(), 1.0 / (2.0 * np.pi) ** 3, atol=1e-12
+        )
+
+    def test_high_dimensional_uniform_smoke(self):
+        dist = LowRankHypertoroidalFourierDistribution.uniform((3,) * 8)
+        self.assertEqual(dist.coeff_shape, (3,) * 8)
+        self.assertEqual(dist.tt_ranks, (1,) * 9)
+        npt.assert_allclose(dist.integrate(), 1.0, atol=1e-12)
+        self.assertTrue(np.isfinite(dist.pdf(np.zeros(8))))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/filters/test_low_rank_hypertoroidal_fourier_filter.py
+++ b/tests/filters/test_low_rank_hypertoroidal_fourier_filter.py
@@ -1,0 +1,70 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+import pyrecest.backend
+from pyrecest.distributions import WrappedNormalDistribution
+from pyrecest.distributions.hypertorus.hypertoroidal_fourier_distribution import (
+    HypertoroidalFourierDistribution,
+)
+from pyrecest.filters.hypertoroidal_fourier_filter import HypertoroidalFourierFilter
+from pyrecest.filters.low_rank_hypertoroidal_fourier_filter import (
+    LowRankHypertoroidalFourierFilter,
+)
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ != "numpy",  # pylint: disable=no-member
+    reason="Low-rank Fourier prototype is NumPy-only",
+)
+class TestLowRankHypertoroidalFourierFilter(unittest.TestCase):
+    def test_rejects_sqrt_transform(self):
+        with self.assertRaises(NotImplementedError):
+            LowRankHypertoroidalFourierFilter((9,), "sqrt")
+
+    def test_predict_identity_matches_dense_1d(self):
+        dense_filter = HypertoroidalFourierFilter((9,), "identity")
+        low_rank_filter = LowRankHypertoroidalFourierFilter((9,), "identity")
+        prior = HypertoroidalFourierDistribution.from_distribution(
+            WrappedNormalDistribution(np.array(1.0), np.array(0.5)),
+            (9,),
+            "identity",
+        )
+        noise = HypertoroidalFourierDistribution.from_distribution(
+            WrappedNormalDistribution(np.array(0.0), np.array(0.3)),
+            (9,),
+            "identity",
+        )
+        dense_filter.filter_state = prior
+        low_rank_filter.filter_state = prior
+        dense_filter.predict_identity(noise)
+        low_rank_filter.predict_identity(noise)
+        npt.assert_allclose(
+            low_rank_filter.filter_state.to_dense(), dense_filter.filter_state.coeff_mat, atol=1e-10
+        )
+
+    def test_update_identity_matches_dense_1d(self):
+        dense_filter = HypertoroidalFourierFilter((9,), "identity")
+        low_rank_filter = LowRankHypertoroidalFourierFilter((9,), "identity")
+        prior = HypertoroidalFourierDistribution.from_distribution(
+            WrappedNormalDistribution(np.array(1.0), np.array(0.5)),
+            (9,),
+            "identity",
+        )
+        noise = HypertoroidalFourierDistribution.from_distribution(
+            WrappedNormalDistribution(np.array(0.0), np.array(1.0)),
+            (9,),
+            "identity",
+        )
+        dense_filter.filter_state = prior
+        low_rank_filter.filter_state = prior
+        dense_filter.update_identity(noise, np.array([1.5]))
+        low_rank_filter.update_identity(noise, np.array([1.5]))
+        npt.assert_allclose(
+            low_rank_filter.filter_state.to_dense(), dense_filter.filter_state.coeff_mat, atol=1e-10
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/filters/test_low_rank_hypertoroidal_fourier_filter.py
+++ b/tests/filters/test_low_rank_hypertoroidal_fourier_filter.py
@@ -4,7 +4,6 @@ import numpy as np
 import numpy.testing as npt
 
 import pyrecest.backend
-from pyrecest.distributions import WrappedNormalDistribution
 from pyrecest.distributions.hypertorus.hypertoroidal_fourier_distribution import (
     HypertoroidalFourierDistribution,
 )
@@ -14,6 +13,14 @@ from pyrecest.filters.low_rank_hypertoroidal_fourier_filter import (
 )
 
 
+def _identity_coefficients_1d(scale=1.0):
+    coeff = np.zeros(5, dtype=np.complex128)
+    coeff[2] = 1.0 / (2.0 * np.pi)
+    coeff[1] = scale * (0.01 + 0.02j)
+    coeff[3] = np.conjugate(coeff[1])
+    return coeff
+
+
 @unittest.skipIf(
     pyrecest.backend.__backend_name__ != "numpy",  # pylint: disable=no-member
     reason="Low-rank Fourier prototype is NumPy-only",
@@ -21,21 +28,13 @@ from pyrecest.filters.low_rank_hypertoroidal_fourier_filter import (
 class TestLowRankHypertoroidalFourierFilter(unittest.TestCase):
     def test_rejects_sqrt_transform(self):
         with self.assertRaises(NotImplementedError):
-            LowRankHypertoroidalFourierFilter((9,), "sqrt")
+            LowRankHypertoroidalFourierFilter((5,), "sqrt")
 
     def test_predict_identity_matches_dense_1d(self):
-        dense_filter = HypertoroidalFourierFilter((9,), "identity")
-        low_rank_filter = LowRankHypertoroidalFourierFilter((9,), "identity")
-        prior = HypertoroidalFourierDistribution.from_distribution(
-            WrappedNormalDistribution(np.array(1.0), np.array(0.5)),
-            (9,),
-            "identity",
-        )
-        noise = HypertoroidalFourierDistribution.from_distribution(
-            WrappedNormalDistribution(np.array(0.0), np.array(0.3)),
-            (9,),
-            "identity",
-        )
+        dense_filter = HypertoroidalFourierFilter((5,), "identity")
+        low_rank_filter = LowRankHypertoroidalFourierFilter((5,), "identity")
+        prior = HypertoroidalFourierDistribution(_identity_coefficients_1d(), "identity")
+        noise = HypertoroidalFourierDistribution(_identity_coefficients_1d(0.5), "identity")
         dense_filter.filter_state = prior
         low_rank_filter.filter_state = prior
         dense_filter.predict_identity(noise)
@@ -45,18 +44,10 @@ class TestLowRankHypertoroidalFourierFilter(unittest.TestCase):
         )
 
     def test_update_identity_matches_dense_1d(self):
-        dense_filter = HypertoroidalFourierFilter((9,), "identity")
-        low_rank_filter = LowRankHypertoroidalFourierFilter((9,), "identity")
-        prior = HypertoroidalFourierDistribution.from_distribution(
-            WrappedNormalDistribution(np.array(1.0), np.array(0.5)),
-            (9,),
-            "identity",
-        )
-        noise = HypertoroidalFourierDistribution.from_distribution(
-            WrappedNormalDistribution(np.array(0.0), np.array(1.0)),
-            (9,),
-            "identity",
-        )
+        dense_filter = HypertoroidalFourierFilter((5,), "identity")
+        low_rank_filter = LowRankHypertoroidalFourierFilter((5,), "identity")
+        prior = HypertoroidalFourierDistribution(_identity_coefficients_1d(), "identity")
+        noise = HypertoroidalFourierDistribution(_identity_coefficients_1d(0.5), "identity")
         dense_filter.filter_state = prior
         low_rank_filter.filter_state = prior
         dense_filter.update_identity(noise, np.array([1.5]))


### PR DESCRIPTION
Summary:

- add a private tensor-train helper for complex Fourier coefficient tensors
- add a low-rank hypertoroidal Fourier distribution
- add an identity-only low-rank hypertoroidal Fourier filter
- add dense-equivalence tests for evaluation, shifts, prediction, and update

Scope:

- NumPy backend only
- identity filtering only
- SqFF prediction deferred
- nonlinear transition-density prediction deferred
- TT rounding still uses a conservative dense TT-SVD fallback for small tensors

Validation:

- Release notes preview passed
- Documentation examples passed
- CodeQL passed
- Dependency review passed
- Security checks passed
- MegaLinter passed
- Test workflow passed

Refs #3976