### PR TITLE
Correct PyTorch sort kind/stable conflict handling

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_sort_numpy_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_sort_numpy_contract.py
@@ -8,7 +8,7 @@ from operator import index as _operator_index
 _SORT_KIND_MESSAGE = (
     "sort kind must be one of 'quicksort', 'heapsort', 'stable', or 'mergesort'"
 )
-_SORT_CONFLICT_MESSAGE = "sort() got conflicting 'kind' and 'stable' arguments"
+_SORT_CONFLICT_MESSAGE = "sort() got both 'kind' and 'stable' arguments"
 
 
 def normalize_sort_axis(axis):
@@ -20,15 +20,15 @@ def normalize_sort_axis(axis):
 
 def resolve_sort_stability(kind, stable):
     """Return the torch ``stable`` flag implied by NumPy-style options."""
+    # NumPy treats ``kind`` and ``stable`` as mutually exclusive sort-mode
+    # selectors, even when they would imply the same stable/unstable choice.
+    if kind is not None and stable is not None:
+        raise ValueError(_SORT_CONFLICT_MESSAGE)
     if kind is None:
         return stable
     if kind in {"stable", "mergesort"}:
-        if stable is False:
-            raise TypeError(_SORT_CONFLICT_MESSAGE)
         return True
     if kind in {"quicksort", "heapsort"}:
-        if stable is True:
-            raise TypeError(_SORT_CONFLICT_MESSAGE)
         return False
     raise ValueError(_SORT_KIND_MESSAGE)
 

--- a/tests/backend_support/test_pytorch_sort_axis_none_contract.py
+++ b/tests/backend_support/test_pytorch_sort_axis_none_contract.py
@@ -3,7 +3,27 @@ import os
 import subprocess
 import sys
 
+import numpy as np
 import pytest
+
+from pyrecest.backend_support._pytorch_sort_numpy_contract import (
+    resolve_sort_stability,
+)
+
+
+@pytest.mark.parametrize(
+    ("kind", "stable"),
+    [
+        ("stable", True),
+        ("stable", np.bool_(True)),
+        ("mergesort", False),
+        ("quicksort", False),
+        ("heapsort", np.bool_(False)),
+    ],
+)
+def test_sort_kind_and_stable_are_mutually_exclusive_like_numpy(kind, stable):
+    with pytest.raises(ValueError, match="kind.*stable"):
+        resolve_sort_stability(kind, stable)
 
 
 def _backend_subprocess_env(backend_name):


### PR DESCRIPTION
## Summary
- reject simultaneous NumPy-style `kind` and `stable` sort selectors for the PyTorch backend
- align the helper with NumPy's mutually-exclusive keyword contract, including `np.bool_` stable values
- add a focused regression test for conflicting `kind`/`stable` combinations

## Testing
- Not run locally; patch is small and covered by the added test in `tests/backend_support/test_pytorch_sort_axis_none_contract.py`.