### PR TITLE
Fix PyTorch stack helpers on empty inputs

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_stack_helpers_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_stack_helpers_device_contract.py
@@ -6,6 +6,7 @@ import importlib
 
 
 _STACK_HELPER_NAMES = ("hstack", "vstack", "column_stack", "dstack")
+_EMPTY_STACK_HELPER_MESSAGE = "need at least one array to concatenate"
 
 
 def _raw_pytorch_module():
@@ -43,6 +44,12 @@ def _tensor_sequence(raw_pytorch, torch_module, values):
     return tensors
 
 
+def _require_nonempty_stack_sequence(tensors):
+    """Raise the NumPy stack-helper error for empty input sequences."""
+    if not tensors:
+        raise ValueError(_EMPTY_STACK_HELPER_MESSAGE)
+
+
 def _build_stack_helpers(raw_pytorch, torch_module):
     """Build NumPy-style PyTorch stack helpers with consistent devices."""
 
@@ -51,8 +58,7 @@ def _build_stack_helpers(raw_pytorch, torch_module):
             torch_module.atleast_1d(tensor)
             for tensor in _tensor_sequence(raw_pytorch, torch_module, tup)
         ]
-        if not tensors:
-            return torch_module.cat(tensors, dim=0)
+        _require_nonempty_stack_sequence(tensors)
         return torch_module.cat(tensors, dim=0 if tensors[0].ndim == 1 else 1)
 
     def vstack(tup):
@@ -60,6 +66,7 @@ def _build_stack_helpers(raw_pytorch, torch_module):
             torch_module.atleast_2d(tensor)
             for tensor in _tensor_sequence(raw_pytorch, torch_module, tup)
         ]
+        _require_nonempty_stack_sequence(tensors)
         return torch_module.cat(tensors, dim=0)
 
     def column_stack(tup):
@@ -68,6 +75,7 @@ def _build_stack_helpers(raw_pytorch, torch_module):
             if tensor.ndim < 2:
                 tensor = tensor.reshape(-1, 1)
             tensors.append(tensor)
+        _require_nonempty_stack_sequence(tensors)
         return torch_module.cat(tensors, dim=1)
 
     def dstack(tup):
@@ -75,6 +83,7 @@ def _build_stack_helpers(raw_pytorch, torch_module):
             torch_module.atleast_3d(tensor)
             for tensor in _tensor_sequence(raw_pytorch, torch_module, tup)
         ]
+        _require_nonempty_stack_sequence(tensors)
         return torch_module.cat(tensors, dim=2)
 
     return {

--- a/tests/backend_support/test_pytorch_stack_helpers_contract.py
+++ b/tests/backend_support/test_pytorch_stack_helpers_contract.py
@@ -105,6 +105,36 @@ assert raw_backend.to_numpy(raw_right).tolist() == [3.0, 3.0]
 
 @pytest.mark.backend_portable
 @pytest.mark.parametrize("backend_name", ("pytorch", "numpy"))
+def test_pytorch_stack_helpers_reject_empty_sequences_like_numpy(backend_name):
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_backend
+
+helpers = (raw_backend,)
+if getattr(backend, "__backend_name__", None) == "pytorch":
+    helpers = (backend, raw_backend)
+
+for stack_backend in helpers:
+    for helper_name in ("hstack", "vstack", "column_stack", "dstack"):
+        helper = getattr(stack_backend, helper_name)
+        for empty_input in ((), []):
+            try:
+                helper(empty_input)
+            except ValueError as exc:
+                assert "need at least one array to concatenate" in str(exc), str(exc)
+            else:
+                raise AssertionError(f"{helper_name} accepted an empty sequence")
+"""
+    subprocess.run(
+        [sys.executable, "-c", code], check=True, env=_backend_test_env(backend_name)
+    )
+
+
+@pytest.mark.backend_portable
+@pytest.mark.parametrize("backend_name", ("pytorch", "numpy"))
 def test_pytorch_stack_helpers_preserve_non_cpu_tensor_device(backend_name):
     _skip_if_no_torch_meta_device()
 


### PR DESCRIPTION
## Summary
- Make PyTorch-backed `hstack`, `vstack`, `column_stack`, and `dstack` raise NumPy-compatible `ValueError("need at least one array to concatenate")` for empty input sequences.
- Keep the existing device-normalization behavior for non-empty sequences unchanged.
- Add regression coverage for both the public PyTorch backend and the raw PyTorch helpers under the NumPy public backend.

## Bug fixed
The final PyTorch stack-helper compatibility hook normalized inputs and then delegated empty sequences to `torch.cat([])`. That produced a PyTorch runtime error instead of PyRecEst's NumPy-style backend contract. NumPy raises `ValueError` with `need at least one array to concatenate` for all four helpers.

## Validation
- `python -m py_compile /tmp/_pytorch_stack_helpers_device_contract.py`
- Full repository pytest was not run in this connector session because the environment cannot resolve `github.com` for a fresh checkout.