### PR TITLE
Fix PyTorch stack helpers on empty sequences

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_stack_helpers_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_stack_helpers_device_contract.py
@@ -6,6 +6,7 @@ import importlib
 
 
 _STACK_HELPER_NAMES = ("hstack", "vstack", "column_stack", "dstack")
+_EMPTY_STACK_HELPER_ERROR = "need at least one array to concatenate"
 
 
 def _raw_pytorch_module():
@@ -43,6 +44,12 @@ def _tensor_sequence(raw_pytorch, torch_module, values):
     return tensors
 
 
+def _require_non_empty_tensors(tensors):
+    """Raise the NumPy-compatible error for empty stack-helper inputs."""
+    if not tensors:
+        raise ValueError(_EMPTY_STACK_HELPER_ERROR)
+
+
 def _build_stack_helpers(raw_pytorch, torch_module):
     """Build NumPy-style PyTorch stack helpers with consistent devices."""
 
@@ -51,8 +58,7 @@ def _build_stack_helpers(raw_pytorch, torch_module):
             torch_module.atleast_1d(tensor)
             for tensor in _tensor_sequence(raw_pytorch, torch_module, tup)
         ]
-        if not tensors:
-            return torch_module.cat(tensors, dim=0)
+        _require_non_empty_tensors(tensors)
         return torch_module.cat(tensors, dim=0 if tensors[0].ndim == 1 else 1)
 
     def vstack(tup):
@@ -60,6 +66,7 @@ def _build_stack_helpers(raw_pytorch, torch_module):
             torch_module.atleast_2d(tensor)
             for tensor in _tensor_sequence(raw_pytorch, torch_module, tup)
         ]
+        _require_non_empty_tensors(tensors)
         return torch_module.cat(tensors, dim=0)
 
     def column_stack(tup):
@@ -68,6 +75,7 @@ def _build_stack_helpers(raw_pytorch, torch_module):
             if tensor.ndim < 2:
                 tensor = tensor.reshape(-1, 1)
             tensors.append(tensor)
+        _require_non_empty_tensors(tensors)
         return torch_module.cat(tensors, dim=1)
 
     def dstack(tup):
@@ -75,6 +83,7 @@ def _build_stack_helpers(raw_pytorch, torch_module):
             torch_module.atleast_3d(tensor)
             for tensor in _tensor_sequence(raw_pytorch, torch_module, tup)
         ]
+        _require_non_empty_tensors(tensors)
         return torch_module.cat(tensors, dim=2)
 
     return {

--- a/tests/backend_support/test_pytorch_stack_helpers_empty_sequence_contract.py
+++ b/tests/backend_support/test_pytorch_stack_helpers_empty_sequence_contract.py
@@ -1,0 +1,49 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+_EMPTY_STACK_HELPER_ERROR = "need at least one array to concatenate"
+
+
+def _backend_test_env(backend_name):
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = backend_name
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    return env
+
+
+@pytest.mark.backend_portable
+@pytest.mark.parametrize("backend_name", ("pytorch", "numpy"))
+def test_pytorch_stack_helpers_empty_sequences_raise_numpy_value_error(backend_name):
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = f"""
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_backend
+
+helpers = (raw_backend,)
+if getattr(backend, "__backend_name__", None) == "pytorch":
+    helpers = (backend, raw_backend)
+
+for stack_backend in helpers:
+    for helper_name in ("hstack", "vstack", "column_stack", "dstack"):
+        try:
+            getattr(stack_backend, helper_name)([])
+        except ValueError as exc:
+            assert str(exc) == {_EMPTY_STACK_HELPER_ERROR!r}
+        else:
+            raise AssertionError(f"{{stack_backend.__name__}}.{{helper_name}}([]) did not raise")
+"""
+    subprocess.run(
+        [sys.executable, "-c", code], check=True, env=_backend_test_env(backend_name)
+    )


### PR DESCRIPTION
## Summary
- Add an explicit NumPy-compatible empty-input guard for PyTorch `hstack`, `vstack`, `column_stack`, and `dstack` compatibility helpers.
- Preserve the existing device-normalization behavior for non-empty stack-helper calls.
- Add backend-portable subprocess regression coverage for public PyTorch and raw PyTorch helpers under NumPy backend selection.

## Bug fixed
The PyTorch stack-helper compatibility hook normalized inputs and then delegated empty sequences to `torch.cat([])`. That produces a PyTorch runtime error instead of NumPy's stable `ValueError: need at least one array to concatenate` contract for `np.hstack([])`, `np.vstack([])`, `np.column_stack([])`, and `np.dstack([])`.

## Validation
- `python -m py_compile /tmp/_pytorch_stack_helpers_device_contract.py /tmp/test_pytorch_stack_helpers_empty_sequence_contract.py`
- Isolated stack-helper smoke check using a minimal raw PyTorch stub: verified all four helpers raise the intended `ValueError` for `[]` and preserve the existing non-empty examples.
- Full repository pytest was not run locally because this environment cannot clone GitHub directly; changes were applied through the GitHub connector.