### PR TITLE
Fix groundtruth system noise sample shape

### DIFF
--- a/src/pyrecest/evaluation/generate_groundtruth.py
+++ b/src/pyrecest/evaluation/generate_groundtruth.py
@@ -87,9 +87,8 @@ def generate_groundtruth(simulation_param, x0=None):
                         )
                     state_to_add_noise_to = previous_state
 
-                groundtruth[t][target_no, :] = state_to_add_noise_to + simulation_param[
-                    "sys_noise"
-                ].sample(1)
+                sys_noise_sample = squeeze(simulation_param["sys_noise"].sample(1))
+                groundtruth[t][target_no, :] = state_to_add_noise_to + sys_noise_sample
 
             else:
                 raise ValueError("Cannot generate groundtruth.")

--- a/tests/test_generate_groundtruth.py
+++ b/tests/test_generate_groundtruth.py
@@ -16,6 +16,12 @@ def _zero_noise():
     return noise
 
 
+def _zero_noise_single_sample_row():
+    noise = Mock()
+    noise.sample.return_value = zeros((1, 2))
+    return noise
+
+
 class TestGenerateGroundtruth(unittest.TestCase):
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
@@ -57,6 +63,26 @@ class TestGenerateGroundtruth(unittest.TestCase):
         npt.assert_allclose(groundtruth[0], x0)
         npt.assert_allclose(groundtruth[1], x0 + step)
         npt.assert_allclose(groundtruth[2], x0 + 2.0 * step)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
+    def test_system_noise_sample_row_is_squeezed_per_target(self):
+        x0 = array([[0.0, 1.0], [2.0, 3.0]])
+        step = array([0.5, 1.0])
+        simulation_param = {
+            "initial_prior": GaussianDistribution(zeros(2), eye(2)),
+            "n_targets": 2,
+            "n_timesteps": 2,
+            "sys_noise": _zero_noise_single_sample_row(),
+            "gen_next_state_without_noise": lambda state: state + step,
+        }
+
+        groundtruth = generate_groundtruth(simulation_param, x0)
+
+        npt.assert_allclose(groundtruth[0], x0)
+        npt.assert_allclose(groundtruth[1], x0 + step)
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),


### PR DESCRIPTION
Summary:
- Squeeze one-sample system-noise rows before adding them to target states.
- Add a regression test for row-shaped noise samples.

Testing: not run locally.