### PR TITLE
Fix PyTorch take axis validation

### DIFF
--- a/src/pyrecest/_backend_runtime_patches.py
+++ b/src/pyrecest/_backend_runtime_patches.py
@@ -523,6 +523,7 @@ def patch_pytorch_take_axis_contract() -> None:
     try:
         import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
         import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
     except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
         return
 
@@ -535,8 +536,15 @@ def patch_pytorch_take_axis_contract() -> None:
             backend.take = original_take
         return
 
+    def _take_axis(axis):
+        if isinstance(axis, bool) or (
+            torch.is_tensor(axis) and axis.ndim == 0 and axis.dtype == torch.bool
+        ):
+            raise TypeError("an integer is required for the axis")
+        return _operator_index(axis)
+
     def take(a, indices, axis=None, out=None, mode=None):
-        axis = None if axis is None else _operator_index(axis)
+        axis = None if axis is None else _take_axis(axis)
         return original_take(a, indices, axis=axis, out=out, mode=mode)
 
     take.__name__ = getattr(original_take, "__name__", "take")

--- a/src/pyrecest/_backend_runtime_patches.py
+++ b/src/pyrecest/_backend_runtime_patches.py
@@ -517,6 +517,36 @@ def patch_pytorch_assignment_uint8_index_contract() -> None:
         backend.assignment = raw_pytorch.assignment
         backend.assignment_by_sum = raw_pytorch.assignment_by_sum
 
+def patch_pytorch_take_axis_contract() -> None:
+    """Make PyTorch ``take`` reject non-integer axes like NumPy."""
+
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+    original_take = getattr(raw_pytorch, "take", None)
+    if original_take is None:
+        return
+    if getattr(original_take, "_pyrecest_axis_index_contract", False):
+        if active_pytorch_backend:
+            backend.take = original_take
+        return
+
+    def take(a, indices, axis=None, out=None, mode=None):
+        axis = None if axis is None else _operator_index(axis)
+        return original_take(a, indices, axis=axis, out=out, mode=mode)
+
+    take.__name__ = getattr(original_take, "__name__", "take")
+    take.__doc__ = getattr(original_take, "__doc__", None)
+    take._pyrecest_axis_index_contract = True
+    raw_pytorch.take = take
+    if active_pytorch_backend:
+        backend.take = take
+
 
 patch_jax_take_arraylike_contract()
 patch_pytorch_assignment_uint8_index_contract()
+patch_pytorch_take_axis_contract()

--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -217,6 +217,7 @@ try:
         patch_pytorch_repeat_numpy_contract as _patch_pytorch_repeat_numpy_contract,
         patch_pytorch_searchsorted_contract as _patch_pytorch_searchsorted_contract,
         patch_raw_pytorch_reduction_alias_contract as _patch_raw_pytorch_reduction_alias_contract,
+        patch_pytorch_take_axis_contract as _patch_pytorch_take_axis_contract,
         patch_pytorch_transpose_boolean_axes_contract as _patch_pytorch_transpose_boolean_axes_contract,
     )
     from pyrecest.backend_support._pytorch_one_hot_scalar_contract import (  # pylint: disable=import-outside-toplevel
@@ -230,5 +231,6 @@ else:
     _patch_pytorch_edge_pad_contract()
     _patch_pytorch_searchsorted_contract()
     _patch_raw_pytorch_reduction_alias_contract()
+    _patch_pytorch_take_axis_contract()
     _patch_pytorch_transpose_boolean_axes_contract()
     _patch_pytorch_one_hot_scalar_contract()


### PR DESCRIPTION
## Summary
- Add a runtime PyTorch backend patch for `take` so `axis` is normalized with `operator.index` instead of implicit `int(...)` coercion.
- Explicitly reject Python and scalar PyTorch boolean axes, matching NumPy's `take` axis contract.
- Wire the patch into the existing backend runtime patch hook.

## Bug fixed
The raw PyTorch backend normalized `take(..., axis=...)` with `int(axis)`, which silently accepts invalid axes such as `0.0`, `True`, and `False`. NumPy rejects those axis values for `np.take`, so PyRecEst's PyTorch backend could silently run invalid calls instead of preserving the NumPy-compatible contract.

## Validation
- Syntax-checked the patched Python snippets locally before applying them through the GitHub connector.
- Existing focused coverage in `tests/backend_support/test_pytorch_take_axis_contract.py` checks the public and raw PyTorch helpers for boolean/float axis rejection and scalar integer tensor axis acceptance.
- Full repository pytest was not run locally because this environment cannot clone GitHub directly; changes were applied via the GitHub connector.