### PR TITLE
Reject text scalar ROI unmatched values

### DIFF
--- a/src/pyrecest/utils/__init__.py
+++ b/src/pyrecest/utils/__init__.py
@@ -41,11 +41,15 @@ if not hasattr(_assignment_module, "_solve_subproblem_without_full_assignment"):
 
 def _normalize_roi_unmatched_value(unmatched_value):
     value_array = _roi_assignment_module.asarray(unmatched_value)
-    if value_array.shape != ():
+    if (
+        value_array.shape != ()
+        or value_array.dtype == _np.bool_
+        or value_array.dtype.kind in {"S", "U"}
+    ):
         raise ValueError("unmatched_value must be an integer.")
 
     scalar = value_array.item() if hasattr(value_array, "item") else value_array
-    if isinstance(scalar, bool):
+    if isinstance(scalar, (bool, _np.bool_) + _TEXT_SCALAR_TYPES):
         raise ValueError("unmatched_value must be an integer.")
     if isinstance(scalar, int):
         return int(scalar)

--- a/tests/test_roi_assignment_unmatched_value.py
+++ b/tests/test_roi_assignment_unmatched_value.py
@@ -1,5 +1,7 @@
 import unittest
 
+import numpy as np
+
 from pyrecest import backend
 from pyrecest.backend import array
 from pyrecest.utils.roi_assignment import assign_by_similarity_matrix
@@ -28,7 +30,16 @@ class TestRoiAssignmentUnmatchedValue(unittest.TestCase):
     def test_rejects_noninteger_unmatched_value(self):
         similarity_matrix = array([[1.0]])
 
-        for unmatched_value in (True, 1.5, float("nan"), [1]):
+        for unmatched_value in (
+            True,
+            1.5,
+            float("nan"),
+            [1],
+            "2",
+            b"-1",
+            np.str_("2"),
+            np.bytes_(b"-1"),
+        ):
             with self.subTest(unmatched_value=unmatched_value):
                 with self.assertRaisesRegex(ValueError, "unmatched_value"):
                     assign_by_similarity_matrix(


### PR DESCRIPTION
## Summary
- Reject text/bytes scalar `unmatched_value` inputs in the ROI assignment validation shim instead of coercing numeric-looking strings through `float()`.
- Extend the ROI assignment regression test to cover Python and NumPy text scalar inputs that previously slipped through when they did not collide with a real column index.

## Bug fixed
`assign_by_similarity_matrix(..., unmatched_value=...)` is documented and validated as requiring an integer sentinel outside the valid column range. The validator rejected booleans, non-integral floats, NaN, and non-scalar arrays, but text scalars such as `"2"` or `b"-1"` could still be converted by `float()` and accepted. This could silently turn malformed configuration/text input into a valid sentinel.

## Validation
- Added regression coverage in `tests/test_roi_assignment_unmatched_value.py`.
- Full test suite not run in this connector-only environment.