### PR TITLE
Fix low-rank scalar coefficient shape handling

### DIFF
--- a/src/pyrecest/distributions/hypertorus/low_rank_hypertoroidal_fourier_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/low_rank_hypertoroidal_fourier_distribution.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from math import prod, sqrt
+from numbers import Integral
 
 import numpy as np
 
@@ -12,10 +13,31 @@ from .abstract_hypertoroidal_distribution import AbstractHypertoroidalDistributi
 from .hypertoroidal_fourier_distribution import HypertoroidalFourierDistribution
 
 
-def _as_shape(shape):
-    normalized = tuple(int(n) for n in shape)
+def _as_shape(shape, *, dim=None):
+    if dim is not None:
+        dim = int(dim)
+        if dim < 1:
+            raise ValueError("dim must be positive when provided.")
+
+    if isinstance(shape, bool):
+        raise ValueError("Fourier coefficient side lengths must be positive and odd.")
+    if isinstance(shape, Integral):
+        normalized = (int(shape),) * (dim if dim is not None else 1)
+    else:
+        try:
+            values = []
+            for axis_size in shape:
+                if isinstance(axis_size, bool):
+                    raise ValueError("Fourier coefficient side lengths must be positive and odd.")
+                values.append(int(axis_size))
+            normalized = tuple(values)
+        except TypeError as exc:
+            raise TypeError("shape must be an integer or a sequence of integers.") from exc
+
     if not normalized:
         raise ValueError("shape must contain at least one dimension.")
+    if dim is not None and len(normalized) != dim:
+        raise ValueError(f"shape must contain {dim} dimensions.")
     if any(n < 1 or n % 2 != 1 for n in normalized):
         raise ValueError("Fourier coefficient side lengths must be positive and odd.")
     return normalized
@@ -63,7 +85,7 @@ class LowRankHypertoroidalFourierDistribution(AbstractHypertoroidalDistribution)
 
     @classmethod
     def uniform(cls, shape, transformation="identity"):
-        shape = _as_shape(shape if not isinstance(shape, int) else (shape,))
+        shape = _as_shape(shape)
         coefficient = (2.0 * np.pi) ** (-len(shape))
         if transformation == "sqrt":
             coefficient = sqrt(coefficient)
@@ -175,7 +197,7 @@ class LowRankHypertoroidalFourierDistribution(AbstractHypertoroidalDistribution)
     def multiply(self, other, n_coefficients=None, *, max_rank=None, rtol=0.0):
         other = self._ensure_low_rank(other)
         self._check_compatible(other)
-        target_shape = self.coeff_shape if n_coefficients is None else _as_shape(n_coefficients)
+        target_shape = self.coeff_shape if n_coefficients is None else _as_shape(n_coefficients, dim=self.dim)
         coeffs = self.coefficients.coefficient_convolution(other.coefficients, target_shape=target_shape)
         coeffs = coeffs.round(max_rank=max_rank, rtol=rtol)
         return LowRankHypertoroidalFourierDistribution(coeffs, self.transformation)
@@ -185,7 +207,7 @@ class LowRankHypertoroidalFourierDistribution(AbstractHypertoroidalDistribution)
         self._check_compatible(other)
         if self.transformation != "identity":
             raise NotImplementedError("Low-rank SqFF prediction is not implemented yet.")
-        if n_coefficients is not None and _as_shape(n_coefficients) != self.coeff_shape:
+        if n_coefficients is not None and _as_shape(n_coefficients, dim=self.dim) != self.coeff_shape:
             raise NotImplementedError("Changing coefficient shape during low-rank prediction is not implemented.")
         coeffs = self.coefficients.hadamard_product(other.coefficients)
         coeffs = coeffs.scaled((2.0 * np.pi) ** self.dim)

--- a/tests/distributions/test_low_rank_hypertoroidal_fourier_distribution.py
+++ b/tests/distributions/test_low_rank_hypertoroidal_fourier_distribution.py
@@ -66,6 +66,18 @@ class TestLowRankHypertoroidalFourierDistribution(unittest.TestCase):
         ).convolve(LowRankHypertoroidalFourierDistribution.from_dense(noise_dense))
         npt.assert_allclose(predicted_low_rank.to_dense(), predicted_dense.coeff_mat, atol=1e-10)
 
+    def test_predict_accepts_scalar_current_n_coefficients_2d(self):
+        prior_dense = HypertoroidalFourierDistribution(_identity_coefficients_2d(), "identity")
+        noise_dense = HypertoroidalFourierDistribution(_identity_coefficients_2d(), "identity")
+        predicted_dense = prior_dense.convolve(noise_dense, n_coefficients=3)
+        predicted_low_rank = LowRankHypertoroidalFourierDistribution.from_dense(
+            prior_dense
+        ).convolve(
+            LowRankHypertoroidalFourierDistribution.from_dense(noise_dense),
+            n_coefficients=3,
+        )
+        npt.assert_allclose(predicted_low_rank.to_dense(), predicted_dense.coeff_mat, atol=1e-10)
+
     def test_update_multiply_matches_dense_1d(self):
         prior_dense = HypertoroidalFourierDistribution(_identity_coefficients_1d(), "identity")
         likelihood_dense = HypertoroidalFourierDistribution(
@@ -75,6 +87,20 @@ class TestLowRankHypertoroidalFourierDistribution(unittest.TestCase):
         updated_low_rank = LowRankHypertoroidalFourierDistribution.from_dense(
             prior_dense
         ).multiply(LowRankHypertoroidalFourierDistribution.from_dense(likelihood_dense))
+        npt.assert_allclose(updated_low_rank.to_dense(), updated_dense.coeff_mat, atol=1e-10)
+
+    def test_update_accepts_scalar_n_coefficients_2d(self):
+        prior_dense = HypertoroidalFourierDistribution(_identity_coefficients_2d(), "identity")
+        likelihood_dense = HypertoroidalFourierDistribution(
+            _identity_coefficients_2d(), "identity"
+        ).shift(np.array([0.4, -0.1]))
+        updated_dense = prior_dense.multiply(likelihood_dense, n_coefficients=5)
+        updated_low_rank = LowRankHypertoroidalFourierDistribution.from_dense(
+            prior_dense
+        ).multiply(
+            LowRankHypertoroidalFourierDistribution.from_dense(likelihood_dense),
+            n_coefficients=5,
+        )
         npt.assert_allclose(updated_low_rank.to_dense(), updated_dense.coeff_mat, atol=1e-10)
 
     def test_high_dimensional_uniform_smoke(self):


### PR DESCRIPTION
## Summary
- Fix low-rank Fourier coefficient shape normalization so scalar `n_coefficients` values are accepted and broadcast across dimensions, matching the dense Fourier API.
- Validate scalar and sequence coefficient shapes consistently, including rejecting boolean side lengths.
- Add regression tests for scalar `n_coefficients` in low-rank multidimensional update and prediction paths.

## Tests
- Not run locally; the execution sandbox cannot clone/install from GitHub. Added focused regression tests under `tests/distributions/test_low_rank_hypertoroidal_fourier_distribution.py`.