### PR TITLE
Tighten low-rank Fourier coefficient shape validation

### DIFF
--- a/src/pyrecest/distributions/hypertorus/low_rank_hypertoroidal_fourier_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/low_rank_hypertoroidal_fourier_distribution.py
@@ -13,24 +13,27 @@ from .abstract_hypertoroidal_distribution import AbstractHypertoroidalDistributi
 from .hypertoroidal_fourier_distribution import HypertoroidalFourierDistribution
 
 
-def _as_positive_odd_length(value):
+_SHAPE_ERROR = "Fourier coefficient side lengths must be positive odd integers."
+
+
+def _as_positive_odd_coefficient_count(value):
     if isinstance(value, (bool, np.bool_)) or not isinstance(value, Integral):
-        raise ValueError("Fourier coefficient side lengths must be positive odd integers.")
+        raise ValueError(_SHAPE_ERROR)
     value = int(value)
     if value < 1 or value % 2 != 1:
-        raise ValueError("Fourier coefficient side lengths must be positive and odd.")
+        raise ValueError(_SHAPE_ERROR)
     return value
 
 
 def _as_shape(shape, *, dim=None):
     if isinstance(shape, (bool, np.bool_)):
-        raise ValueError("Fourier coefficient side lengths must be positive odd integers.")
+        raise ValueError(_SHAPE_ERROR)
     if isinstance(shape, Integral):
-        value = _as_positive_odd_length(shape)
+        value = _as_positive_odd_coefficient_count(shape)
         normalized = (value,) if dim is None else (value,) * dim
     else:
         try:
-            normalized = tuple(_as_positive_odd_length(n) for n in shape)
+            normalized = tuple(_as_positive_odd_coefficient_count(n) for n in shape)
         except TypeError as exc:
             raise TypeError("shape must be an integer or a sequence of integers.") from exc
     if not normalized:

--- a/src/pyrecest/filters/low_rank_hypertoroidal_fourier_filter.py
+++ b/src/pyrecest/filters/low_rank_hypertoroidal_fourier_filter.py
@@ -35,9 +35,6 @@ class LowRankHypertoroidalFourierFilter(AbstractFilter, HypertoroidalFilterMixin
             raise NotImplementedError(
                 "The first low-rank prototype supports only transformation='identity'."
             )
-        if isinstance(n_coefficients, int):
-            n_coefficients = (n_coefficients,)
-        n_coefficients = tuple(int(n) for n in n_coefficients)
         self.max_rank = max_rank
         self.rtol = rtol
         initial_state = LowRankHypertoroidalFourierDistribution.uniform(

--- a/tests/distributions/test_low_rank_hypertoroidal_fourier_distribution.py
+++ b/tests/distributions/test_low_rank_hypertoroidal_fourier_distribution.py
@@ -43,6 +43,28 @@ class TestLowRankHypertoroidalFourierDistribution(unittest.TestCase):
             dist.coefficient_at_zero(), 1.0 / (2.0 * np.pi) ** 3, atol=1e-12
         )
 
+    def test_accepts_numpy_integer_shape(self):
+        dist = LowRankHypertoroidalFourierDistribution.uniform(np.int64(3))
+        self.assertEqual(dist.coeff_shape, (3,))
+
+    def test_rejects_non_integral_shape_entries(self):
+        invalid_shapes = [
+            True,
+            np.bool_(True),
+            3.0,
+            np.float64(3.0),
+            "3",
+            (True,),
+            (np.bool_(True),),
+            (3.0,),
+            (np.float64(3.0),),
+            ("3",),
+        ]
+        for shape in invalid_shapes:
+            with self.subTest(shape=shape):
+                with self.assertRaises((TypeError, ValueError)):
+                    LowRankHypertoroidalFourierDistribution.uniform(shape)
+
     def test_value_and_pdf_match_dense_1d(self):
         dense = HypertoroidalFourierDistribution(_identity_coefficients_1d(), "identity")
         low_rank = LowRankHypertoroidalFourierDistribution.from_dense(dense)

--- a/tests/filters/test_low_rank_hypertoroidal_fourier_filter.py
+++ b/tests/filters/test_low_rank_hypertoroidal_fourier_filter.py
@@ -30,6 +30,24 @@ class TestLowRankHypertoroidalFourierFilter(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             LowRankHypertoroidalFourierFilter((5,), "sqrt")
 
+    def test_rejects_non_integral_coefficient_counts(self):
+        invalid_counts = [
+            True,
+            np.bool_(True),
+            5.0,
+            np.float64(5.0),
+            "5",
+            (True,),
+            (np.bool_(True),),
+            (5.0,),
+            (np.float64(5.0),),
+            ("5",),
+        ]
+        for n_coefficients in invalid_counts:
+            with self.subTest(n_coefficients=n_coefficients):
+                with self.assertRaises((TypeError, ValueError)):
+                    LowRankHypertoroidalFourierFilter(n_coefficients, "identity")
+
     def test_predict_identity_matches_dense_1d(self):
         dense_filter = HypertoroidalFourierFilter((5,), "identity")
         low_rank_filter = LowRankHypertoroidalFourierFilter((5,), "identity")


### PR DESCRIPTION
## Summary
- Make low-rank hypertoroidal Fourier coefficient-shape validation require integer scalar/sequence entries instead of silently coercing through `int(...)`.
- Reject Python/NumPy booleans, floats, and text inputs for low-rank Fourier shape/count arguments.
- Let `LowRankHypertoroidalFourierFilter` delegate coefficient-count validation to the strict distribution parser instead of pre-coercing values.

## Bug fixed
The new low-rank Fourier path normalized coefficient side lengths via plain `int(...)`, so malformed inputs such as `True`, `3.0`, `np.float64(3.0)`, or `"3"` could be accepted as valid coefficient counts. That diverged from the dense Fourier coefficient-count contract and could silently turn invalid configuration values into a valid TT coefficient shape.

## Validation
- Added regression coverage for distribution and filter constructors.
- Syntax-checked the modified modules and tests locally with `python -m py_compile`.
- Full pytest was not run locally because this connector-only environment cannot clone github.com directly.