### PR TITLE
Fix PyTorch transpose axes validation

### DIFF
--- a/src/pyrecest/_backend_runtime_patches.py
+++ b/src/pyrecest/_backend_runtime_patches.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from operator import index as _operator_index
+
 
 def patch_pytorch_close_equal_nan_device_contract() -> None:
     """Preserve ``equal_nan`` while keeping PyTorch close operands on one device."""
@@ -232,3 +234,57 @@ def patch_pytorch_edge_pad_contract() -> None:
     raw_pytorch.pad = pad
     if active_pytorch_backend:
         backend.pad = pad
+
+
+def patch_pytorch_transpose_boolean_axes_contract() -> None:
+    """Make PyTorch ``transpose`` reject boolean axes sequences like NumPy."""
+
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+    original_transpose = getattr(raw_pytorch, "transpose", None)
+    if original_transpose is None:
+        return
+    if getattr(original_transpose, "_pyrecest_transpose_boolean_axes_contract", False):
+        if active_pytorch_backend:
+            setattr(backend, "transpose", original_transpose)
+        return
+
+    def _normalized_axes(axes):
+        if axes is None:
+            return None
+        if torch.is_tensor(axes):
+            if axes.ndim == 0:
+                axes = axes.item()
+            else:
+                axes = axes.detach().cpu().tolist()
+        if isinstance(axes, (str, bytes)):
+            raise TypeError("transpose axes must be a sequence of integers")
+        try:
+            iterator = iter(axes)
+        except TypeError as exc:
+            raise TypeError("transpose axes must be a sequence of integers") from exc
+
+        normalized = []
+        for axis in iterator:
+            if isinstance(axis, bool) or (
+                torch.is_tensor(axis) and axis.ndim == 0 and axis.dtype == torch.bool
+            ):
+                raise TypeError("an integer is required")
+            normalized.append(_operator_index(axis))
+        return tuple(normalized)
+
+    def transpose(x, axes=None):
+        return original_transpose(x, axes=_normalized_axes(axes))
+
+    transpose.__name__ = getattr(original_transpose, "__name__", "transpose")
+    transpose.__doc__ = getattr(original_transpose, "__doc__", None)
+    transpose._pyrecest_transpose_boolean_axes_contract = True
+    raw_pytorch.transpose = transpose
+    if active_pytorch_backend:
+        backend.transpose = transpose

--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -215,6 +215,7 @@ try:
         patch_pytorch_close_equal_nan_device_contract as _patch_pytorch_close_equal_nan_device_contract,
         patch_pytorch_edge_pad_contract as _patch_pytorch_edge_pad_contract,
         patch_pytorch_repeat_numpy_contract as _patch_pytorch_repeat_numpy_contract,
+        patch_pytorch_transpose_boolean_axes_contract as _patch_pytorch_transpose_boolean_axes_contract,
     )
     from pyrecest.backend_support._pytorch_one_hot_scalar_contract import (  # pylint: disable=import-outside-toplevel
         patch_pytorch_one_hot_scalar_contract as _patch_pytorch_one_hot_scalar_contract,
@@ -225,4 +226,5 @@ else:
     _patch_pytorch_close_equal_nan_device_contract()
     _patch_pytorch_repeat_numpy_contract()
     _patch_pytorch_edge_pad_contract()
+    _patch_pytorch_transpose_boolean_axes_contract()
     _patch_pytorch_one_hot_scalar_contract()

--- a/tests/backend_support/test_pytorch_transpose_axes_contract.py
+++ b/tests/backend_support/test_pytorch_transpose_axes_contract.py
@@ -1,0 +1,77 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _backend_test_env(backend_name):
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = backend_name
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    return env
+
+
+@pytest.mark.backend_portable
+def test_pytorch_transpose_rejects_boolean_axes_sequences():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import pyrecest.backend as backend
+
+values = backend.asarray([[1, 2], [3, 4]])
+
+for axes in ([True, False], backend.asarray([True, False])):
+    try:
+        backend.transpose(values, axes=axes)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"backend.transpose accepted invalid axes {axes!r}")
+
+result = backend.transpose(values, axes=[1, 0])
+assert backend.to_numpy(result).tolist() == [[1, 3], [2, 4]]
+"""
+    subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        env=_backend_test_env("pytorch"),
+    )
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_transpose_rejects_boolean_axes_sequences_with_numpy_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+assert getattr(backend, "__backend_name__", None) == "numpy"
+
+values = raw_pytorch.asarray([[1, 2], [3, 4]])
+
+for axes in ([True, False], raw_pytorch.asarray([True, False])):
+    try:
+        raw_pytorch.transpose(values, axes=axes)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"raw_pytorch.transpose accepted invalid axes {axes!r}")
+
+result = raw_pytorch.transpose(values, axes=[1, 0])
+assert raw_pytorch.to_numpy(result).tolist() == [[1, 3], [2, 4]]
+"""
+    subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        env=_backend_test_env("numpy"),
+    )


### PR DESCRIPTION
## Summary
- Patch the PyTorch backend transpose helper to normalize axes before dispatch.
- Reject boolean entries in axes sequences so the PyTorch backend matches NumPy-style axis validation.
- Add focused public and raw PyTorch regression tests.

## Validation
- Syntax-compiled the changed source and test files locally.
- Branch comparison: 3 commits ahead of main, 0 behind.
- Full pytest was not run locally because this environment cannot clone GitHub directly.