### PR TITLE
Accept scalar low-rank Fourier coefficient shapes

### DIFF
--- a/src/pyrecest/distributions/hypertorus/low_rank_hypertoroidal_fourier_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/low_rank_hypertoroidal_fourier_distribution.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from math import prod, sqrt
+from numbers import Integral
 
 import numpy as np
 
@@ -12,12 +13,30 @@ from .abstract_hypertoroidal_distribution import AbstractHypertoroidalDistributi
 from .hypertoroidal_fourier_distribution import HypertoroidalFourierDistribution
 
 
-def _as_shape(shape):
-    normalized = tuple(int(n) for n in shape)
+def _as_positive_odd_length(value):
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Integral):
+        raise ValueError("Fourier coefficient side lengths must be positive odd integers.")
+    value = int(value)
+    if value < 1 or value % 2 != 1:
+        raise ValueError("Fourier coefficient side lengths must be positive and odd.")
+    return value
+
+
+def _as_shape(shape, *, dim=None):
+    if isinstance(shape, (bool, np.bool_)):
+        raise ValueError("Fourier coefficient side lengths must be positive odd integers.")
+    if isinstance(shape, Integral):
+        value = _as_positive_odd_length(shape)
+        normalized = (value,) if dim is None else (value,) * dim
+    else:
+        try:
+            normalized = tuple(_as_positive_odd_length(n) for n in shape)
+        except TypeError as exc:
+            raise TypeError("shape must be an integer or a sequence of integers.") from exc
     if not normalized:
         raise ValueError("shape must contain at least one dimension.")
-    if any(n < 1 or n % 2 != 1 for n in normalized):
-        raise ValueError("Fourier coefficient side lengths must be positive and odd.")
+    if dim is not None and len(normalized) != dim:
+        raise ValueError(f"shape must contain {dim} dimensions.")
     return normalized
 
 
@@ -63,7 +82,7 @@ class LowRankHypertoroidalFourierDistribution(AbstractHypertoroidalDistribution)
 
     @classmethod
     def uniform(cls, shape, transformation="identity"):
-        shape = _as_shape(shape if not isinstance(shape, int) else (shape,))
+        shape = _as_shape(shape)
         coefficient = (2.0 * np.pi) ** (-len(shape))
         if transformation == "sqrt":
             coefficient = sqrt(coefficient)
@@ -175,7 +194,7 @@ class LowRankHypertoroidalFourierDistribution(AbstractHypertoroidalDistribution)
     def multiply(self, other, n_coefficients=None, *, max_rank=None, rtol=0.0):
         other = self._ensure_low_rank(other)
         self._check_compatible(other)
-        target_shape = self.coeff_shape if n_coefficients is None else _as_shape(n_coefficients)
+        target_shape = self.coeff_shape if n_coefficients is None else _as_shape(n_coefficients, dim=self.dim)
         coeffs = self.coefficients.coefficient_convolution(other.coefficients, target_shape=target_shape)
         coeffs = coeffs.round(max_rank=max_rank, rtol=rtol)
         return LowRankHypertoroidalFourierDistribution(coeffs, self.transformation)
@@ -185,7 +204,7 @@ class LowRankHypertoroidalFourierDistribution(AbstractHypertoroidalDistribution)
         self._check_compatible(other)
         if self.transformation != "identity":
             raise NotImplementedError("Low-rank SqFF prediction is not implemented yet.")
-        if n_coefficients is not None and _as_shape(n_coefficients) != self.coeff_shape:
+        if n_coefficients is not None and _as_shape(n_coefficients, dim=self.dim) != self.coeff_shape:
             raise NotImplementedError("Changing coefficient shape during low-rank prediction is not implemented.")
         coeffs = self.coefficients.hadamard_product(other.coefficients)
         coeffs = coeffs.scaled((2.0 * np.pi) ** self.dim)

--- a/tests/distributions/test_low_rank_hypertoroidal_fourier_scalar_shape.py
+++ b/tests/distributions/test_low_rank_hypertoroidal_fourier_scalar_shape.py
@@ -1,0 +1,43 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+import pyrecest.backend
+from pyrecest.distributions.hypertorus.hypertoroidal_fourier_distribution import (
+    HypertoroidalFourierDistribution,
+)
+from pyrecest.distributions.hypertorus.low_rank_hypertoroidal_fourier_distribution import (
+    LowRankHypertoroidalFourierDistribution,
+)
+
+
+def _coefficients_1d():
+    coeff = np.zeros(5, dtype=np.complex128)
+    coeff[2] = 1.0 / (2.0 * np.pi)
+    coeff[1] = 0.01 + 0.02j
+    coeff[3] = np.conjugate(coeff[1])
+    return coeff
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ != "numpy",  # pylint: disable=no-member
+    reason="Low-rank Fourier prototype is NumPy-only",
+)
+class TestLowRankHypertoroidalFourierScalarShape(unittest.TestCase):
+    def test_scalar_target_shape_matches_dense_multiply_and_convolve(self):
+        prior_dense = HypertoroidalFourierDistribution(_coefficients_1d(), "identity")
+        other_dense = HypertoroidalFourierDistribution(
+            _coefficients_1d(), "identity"
+        ).shift(np.array([0.25]))
+        prior_low_rank = LowRankHypertoroidalFourierDistribution.from_dense(prior_dense)
+        other_low_rank = LowRankHypertoroidalFourierDistribution.from_dense(other_dense)
+
+        updated_dense = prior_dense.multiply(other_dense, n_coefficients=3)
+        updated_low_rank = prior_low_rank.multiply(other_low_rank, n_coefficients=3)
+        self.assertEqual(updated_low_rank.coeff_shape, (3,))
+        npt.assert_allclose(updated_low_rank.to_dense(), updated_dense.coeff_mat, atol=1e-10)
+
+        predicted_dense = prior_dense.convolve(other_dense, n_coefficients=5)
+        predicted_low_rank = prior_low_rank.convolve(other_low_rank, n_coefficients=5)
+        npt.assert_allclose(predicted_low_rank.to_dense(), predicted_dense.coeff_mat, atol=1e-10)


### PR DESCRIPTION
## Summary
- Fix low-rank hypertoroidal Fourier shape normalization so scalar integer coefficient counts are accepted, matching the dense Fourier API.
- Broadcast scalar target shapes to the current distribution dimension in `multiply`/`convolve` validation.
- Add a regression test comparing scalar `n_coefficients` low-rank multiply/convolve against dense Fourier behavior.

## Tests
- Not run locally in this environment; regression test added for CI.