### PR TITLE
Fix tensor-train entry index validation

### DIFF
--- a/src/pyrecest/distributions/hypertorus/_tensor_train.py
+++ b/src/pyrecest/distributions/hypertorus/_tensor_train.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from math import prod, sqrt
+from operator import index as _operator_index
 
 import numpy as np
 
@@ -24,6 +25,17 @@ def _choose_rank(singular_values, max_rank, local_tolerance):
             raise ValueError("max_rank must be positive when provided.")
         rank = min(rank, max_rank)
     return max(1, rank)
+
+
+def _as_integer_index(value, axis, mode_size):
+    if isinstance(value, (bool, np.bool_)):
+        raise TypeError("TT entry indices must be integers.")
+    index = _operator_index(value)
+    if not -mode_size <= index < mode_size:
+        raise IndexError(
+            f"TT entry index {index} is out of bounds for axis {axis} with size {mode_size}."
+        )
+    return index
 
 
 class TensorTrain:
@@ -104,9 +116,11 @@ class TensorTrain:
     def entry(self, multi_index):
         if len(multi_index) != self.ndim:
             raise ValueError("multi_index must contain one index per TT core.")
-        value = self.cores[0][:, int(multi_index[0]), :]
+        first_index = _as_integer_index(multi_index[0], 0, self.cores[0].shape[1])
+        value = self.cores[0][:, first_index, :]
         for axis, index in enumerate(multi_index[1:], start=1):
-            value = value @ self.cores[axis][:, int(index), :]
+            axis_index = _as_integer_index(index, axis, self.cores[axis].shape[1])
+            value = value @ self.cores[axis][:, axis_index, :]
         return complex(value.reshape(()))
 
     def norm_squared(self):

--- a/tests/distributions/test_hypertoroidal_tensor_train_entry_validation.py
+++ b/tests/distributions/test_hypertoroidal_tensor_train_entry_validation.py
@@ -1,0 +1,36 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+from pyrecest.distributions.hypertorus._tensor_train import TensorTrain
+
+
+class TestHypertoroidalTensorTrainEntryValidation(unittest.TestCase):
+    def setUp(self):
+        self.tensor = np.arange(9, dtype=float).reshape(3, 3)
+        self.tt = TensorTrain.from_dense(self.tensor)
+
+    def test_entry_accepts_numpy_integer_and_negative_indices(self):
+        npt.assert_allclose(self.tt.entry((np.int64(1), -1)), self.tensor[1, -1], atol=1e-12)
+
+    def test_entry_rejects_non_integer_indices_without_coercion(self):
+        invalid_indices = [
+            (0.0, 1),
+            (1.5, 1),
+            ("1", 1),
+            (True, 1),
+            (np.bool_(False), 1),
+        ]
+        for multi_index in invalid_indices:
+            with self.subTest(multi_index=multi_index):
+                with self.assertRaises(TypeError):
+                    self.tt.entry(multi_index)
+
+    def test_entry_reports_out_of_bounds_axis(self):
+        with self.assertRaisesRegex(IndexError, "axis 1"):
+            self.tt.entry((0, 3))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Replace silent `int(...)` coercion in `TensorTrain.entry(...)` with true integer-index validation via `operator.index`.
- Reject boolean, float, and string indices instead of truncating or coercing them before coefficient lookup.
- Preserve NumPy-like negative integer indexing and add explicit axis-aware out-of-bounds errors.

## Bug fixed
`TensorTrain.entry(...)` accepted malformed indices such as `0.0`, `1.5`, `"1"`, and `True` because every entry index was normalized with `int(...)`. That could silently query the wrong TT coefficient, which is especially risky for low-rank Fourier coefficient access.

## Validation
- Ran an isolated local regression check for the patched TensorTrain entry semantics.
- Added focused regression coverage in `tests/distributions/test_hypertoroidal_tensor_train_entry_validation.py`.
- Full repository pytest was not run because this environment cannot clone github.com directly.