### PR TITLE
Reject boolean PyTorch sort axes

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_sort_numpy_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_sort_numpy_contract.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from operator import index as _operator_index
 
+import numpy as _np
+
 
 _SORT_KIND_MESSAGE = (
     "sort kind must be one of 'quicksort', 'heapsort', 'stable', or 'mergesort'"
@@ -15,6 +17,8 @@ def normalize_sort_axis(axis):
     """Return a sort axis while preserving NumPy's flatten-all sentinel."""
     if axis is None:
         return None
+    if isinstance(axis, (bool, _np.bool_)):
+        raise TypeError("an integer is required for the axis")
     return _operator_index(axis)
 
 

--- a/tests/backend_support/test_pytorch_sort_axis_validation.py
+++ b/tests/backend_support/test_pytorch_sort_axis_validation.py
@@ -1,0 +1,9 @@
+import pytest
+
+from pyrecest.backend_support._pytorch_sort_numpy_contract import normalize_sort_axis
+
+
+@pytest.mark.parametrize("axis", [True, False])
+def test_pytorch_sort_axis_rejects_python_bool(axis):
+    with pytest.raises(TypeError, match="integer"):
+        normalize_sort_axis(axis)


### PR DESCRIPTION
## Summary
- reject Python boolean axes in the PyTorch sort axis normalizer instead of treating `True`/`False` as integer axes
- add a focused regression test for this helper contract

## Notes
- This matches the shared backend sort-axis contract, where boolean axis flags are not valid integer axes.
- Follow-up for issue #4017.

## Testing
- Not run locally; patch was applied through GitHub contents API.