### PR TITLE
Reject boolean nonparametric cardinality counts

### DIFF
--- a/src/pyrecest/filters/nonparametric_cardinality.py
+++ b/src/pyrecest/filters/nonparametric_cardinality.py
@@ -17,17 +17,26 @@ from scipy.special import gammaln
 
 
 def _as_float(value, name):
-    if not isinstance(value, Real):
+    if isinstance(value, bool) or not isinstance(value, Real):
         raise TypeError(f"{name} must be a real scalar.")
     return float(value)
 
 
 def _validate_nonnegative_integer(value, name):
-    if not isinstance(value, Integral):
+    if isinstance(value, bool) or not isinstance(value, Integral):
         raise TypeError(f"{name} must be an integer.")
     value = int(value)
     if value < 0:
         raise ValueError(f"{name} must be nonnegative.")
+    return value
+
+
+def _validate_positive_integer(value, name):
+    if isinstance(value, bool) or not isinstance(value, Integral):
+        raise TypeError(f"{name} must be an integer.")
+    value = int(value)
+    if value <= 0:
+        raise ValueError(f"{name} must be positive.")
     return value
 
 
@@ -101,13 +110,13 @@ class PitmanYorProcessCardinalityPrior:
     @staticmethod
     def _coerce_cluster_sizes(cluster_sizes):
         try:
-            sizes = tuple(int(size) for size in cluster_sizes)
+            raw_sizes = tuple(cluster_sizes)
         except TypeError as exc:
             raise TypeError("cluster_sizes must be an iterable of positive integers.") from exc
 
-        for size in sizes:
-            if size <= 0:
-                raise ValueError("cluster_sizes must contain positive integers only.")
+        sizes = tuple(
+            _validate_positive_integer(size, "cluster_sizes") for size in raw_sizes
+        )
         return sizes
 
     @staticmethod

--- a/tests/filters/test_nonparametric_cardinality.py
+++ b/tests/filters/test_nonparametric_cardinality.py
@@ -105,11 +105,31 @@ class NonparametricCardinalityPriorTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             PitmanYorBirthProbability(minimum_probability=0.9, maximum_probability=0.1)
 
+    def test_boolean_parameters_are_rejected(self):
+        with self.assertRaises(TypeError):
+            PitmanYorProcessCardinalityPrior(discount=False, strength=1.0)
+        with self.assertRaises(TypeError):
+            DirichletProcessCardinalityPrior(concentration=True)
+        with self.assertRaises(TypeError):
+            PitmanYorBirthProbability(base_birth_existence_probability=True)
+        with self.assertRaises(TypeError):
+            PitmanYorBirthProbability(prior_observation_count=True)
+
+        birth_probability = PitmanYorBirthProbability()
+        with self.assertRaises(TypeError):
+            birth_probability(num_existing_components=True)
+
     def test_invalid_cluster_sizes_are_rejected(self):
         prior = PitmanYorProcessCardinalityPrior(discount=0.2, strength=1.0)
 
         with self.assertRaises(ValueError):
             prior.predictive_assignment_probabilities([2, 0])
+        with self.assertRaises(TypeError):
+            prior.predictive_assignment_probabilities([2, True])
+        with self.assertRaises(TypeError):
+            prior.predictive_assignment_probabilities([2, 1.5])
+        with self.assertRaises(TypeError):
+            prior.predictive_assignment_probabilities([2, "1"])
         with self.assertRaises(ValueError):
             prior.predictive_new_cluster_probability_from_counts(2, 3)
 


### PR DESCRIPTION
## Summary
- Reject booleans in Pitman--Yor hyperparameter, probability, and count validation.
- Reject malformed cluster sizes instead of converting them with int().
- Add regression coverage for boolean parameters and invalid cluster sizes.

## Validation
- Syntax-compiled the modified source and test files locally.
- Ran a small local smoke check for valid predictive probabilities and the new rejection cases.

Full repository pytest was not run locally.