### PR TITLE
Reject boolean hypertoroidal angle inputs

### DIFF
--- a/src/pyrecest/distributions/hypertorus/_input_validation.py
+++ b/src/pyrecest/distributions/hypertorus/_input_validation.py
@@ -3,6 +3,14 @@
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import array
 
+_BOOLEAN_DTYPE_NAMES = {"bool", "bool_", "torch.bool"}
+
+
+def _reject_boolean_array(value, name: str) -> None:
+    dtype = getattr(value, "dtype", None)
+    if dtype is not None and str(dtype) in _BOOLEAN_DTYPE_NAMES:
+        raise ValueError(f"{name} must contain real angles, not boolean values.")
+
 
 def as_shift_vector(shift_by, dim: int, *, name: str = "shift_by"):
     """Return ``shift_by`` as a one-dimensional backend vector of length ``dim``.
@@ -12,6 +20,7 @@ def as_shift_vector(shift_by, dim: int, *, name: str = "shift_by"):
     shape validation is performed.
     """
     shift_by = array(shift_by)
+    _reject_boolean_array(shift_by, name)
     if shift_by.ndim == 0:
         if dim != 1:
             raise ValueError(f"{name} must have shape ({dim},), got scalar.")
@@ -30,6 +39,7 @@ def as_hypertoroidal_points(xs, dim: int, *, name: str = "xs"):
     ``dim`` is treated as a single query point.
     """
     xs = array(xs)
+    _reject_boolean_array(xs, name)
     if xs.ndim == 0:
         if dim != 1:
             raise ValueError(f"{name} must have trailing dimension {dim}, got scalar.")

--- a/tests/distributions/test_abstract_hypertoroidal_distribution.py
+++ b/tests/distributions/test_abstract_hypertoroidal_distribution.py
@@ -11,6 +11,10 @@ from pyrecest.distributions import AbstractHypertoroidalDistribution
 from pyrecest.distributions.circle.wrapped_normal_distribution import (
     WrappedNormalDistribution,
 )
+from pyrecest.distributions.hypertorus._input_validation import (
+    as_hypertoroidal_points,
+    as_shift_vector,
+)
 from pyrecest.distributions.hypertorus.toroidal_wrapped_normal_distribution import (
     ToroidalWrappedNormalDistribution,
 )
@@ -100,6 +104,27 @@ class TestAbstractHypertoroidalDistribution(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "undefined"):
             dist.mean_direction()
+
+    def test_input_validation_rejects_boolean_shift_angles(self):
+        yes = bool(1)
+        no = bool(0)
+        for value, dim in ((yes, 1), ([yes], 1), ([yes, no], 2)):
+            with self.subTest(value=value, dim=dim):
+                with self.assertRaisesRegex(ValueError, "boolean"):
+                    as_shift_vector(value, dim)
+
+    def test_input_validation_rejects_boolean_evaluation_points(self):
+        yes = bool(1)
+        no = bool(0)
+        for value, dim in (
+            (yes, 1),
+            ([yes], 1),
+            ([yes, no], 2),
+            ([[yes, no]], 2),
+        ):
+            with self.subTest(value=value, dim=dim):
+                with self.assertRaisesRegex(ValueError, "boolean"):
+                    as_hypertoroidal_points(value, dim)
 
     def test_setup_axis_circular_does_not_capture_axes_at_import(self):
         signature = inspect.signature(


### PR DESCRIPTION
## Summary
- Reject boolean hypertoroidal shift-vector inputs before shape normalization.
- Reject boolean hypertoroidal evaluation-point inputs before shape normalization.
- Add regression coverage in the existing hypertoroidal distribution test module.

## Validation
- Branch comparison: 2 commits ahead of main, 0 behind.
- Full pytest was not run locally because this environment cannot clone github.com directly; CI should run the added regression tests.