### PR TITLE
Validate tensor-train max_rank inputs

### DIFF
--- a/src/pyrecest/distributions/hypertorus/_tensor_train.py
+++ b/src/pyrecest/distributions/hypertorus/_tensor_train.py
@@ -3,11 +3,27 @@
 from __future__ import annotations
 
 from math import prod, sqrt
+from operator import index as _operator_index
 
 import numpy as np
 
 
+def _normalize_max_rank(max_rank):
+    if max_rank is None:
+        return None
+    if isinstance(max_rank, (bool, np.bool_)):
+        raise TypeError("max_rank must be an integer when provided.")
+    try:
+        normalized = _operator_index(max_rank)
+    except TypeError as exc:
+        raise TypeError("max_rank must be an integer when provided.") from exc
+    if normalized < 1:
+        raise ValueError("max_rank must be positive when provided.")
+    return normalized
+
+
 def _choose_rank(singular_values, max_rank, local_tolerance):
+    max_rank = _normalize_max_rank(max_rank)
     full_rank = singular_values.size
     if local_tolerance <= 0:
         rank = full_rank
@@ -20,8 +36,6 @@ def _choose_rank(singular_values, max_rank, local_tolerance):
                 rank = candidate
                 break
     if max_rank is not None:
-        if max_rank < 1:
-            raise ValueError("max_rank must be positive when provided.")
         rank = min(rank, max_rank)
     return max(1, rank)
 
@@ -65,6 +79,7 @@ class TensorTrain:
 
     @classmethod
     def from_dense(cls, tensor, *, max_rank=None, rtol=0.0, atol=0.0):
+        max_rank = _normalize_max_rank(max_rank)
         array = np.asarray(tensor, dtype=np.complex128)
         if array.ndim < 1:
             raise ValueError("A tensor with at least one axis is required.")
@@ -177,6 +192,7 @@ class TensorTrain:
         """
 
         del max_dense_entries
+        max_rank = _normalize_max_rank(max_rank)
         if rtol < 0 or atol < 0:
             raise ValueError("rtol and atol must be non-negative.")
         if self.ndim == 1:

--- a/tests/distributions/test_hypertoroidal_tensor_train.py
+++ b/tests/distributions/test_hypertoroidal_tensor_train.py
@@ -51,6 +51,22 @@ class TestHypertoroidalTensorTrain(unittest.TestCase):
         self.assertEqual(rounded.shape, tt.shape)
         self.assertTrue(np.isfinite(rounded.norm_squared()))
 
+    def test_max_rank_requires_positive_integer(self):
+        tensor = np.arange(8, dtype=float).reshape(2, 2, 2)
+        tt = TensorTrain.from_dense(tensor)
+        for invalid in (True, np.bool_(False), 1.5, "1"):
+            with self.subTest(invalid=invalid):
+                with self.assertRaises(TypeError):
+                    TensorTrain.from_dense(tensor, max_rank=invalid)
+                with self.assertRaises(TypeError):
+                    tt.round(max_rank=invalid)
+        for invalid in (0, -1):
+            with self.subTest(invalid=invalid):
+                with self.assertRaises(ValueError):
+                    TensorTrain.from_dense(tensor, max_rank=invalid)
+                with self.assertRaises(ValueError):
+                    tt.round(max_rank=invalid)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/distributions/test_low_rank_hypertoroidal_fourier_distribution.py
+++ b/tests/distributions/test_low_rank_hypertoroidal_fourier_distribution.py
@@ -4,6 +4,7 @@ import numpy as np
 import numpy.testing as npt
 
 import pyrecest.backend
+from pyrecest.distributions.hypertorus._tensor_train import TensorTrain
 from pyrecest.distributions.hypertorus.hypertoroidal_fourier_distribution import (
     HypertoroidalFourierDistribution,
 )
@@ -83,6 +84,34 @@ class TestLowRankHypertoroidalFourierDistribution(unittest.TestCase):
         self.assertEqual(dist.tt_ranks, (1,) * 9)
         npt.assert_allclose(dist.integrate(), 1.0, atol=1e-12)
         self.assertTrue(np.isfinite(dist.pdf(np.zeros(8))))
+
+    def test_tensor_train_from_dense_validates_max_rank_before_one_dimensional_return(self):
+        for max_rank in (0, -1, np.array(0)):
+            with self.subTest(max_rank=repr(max_rank)):
+                with self.assertRaises(ValueError):
+                    TensorTrain.from_dense(np.ones(5), max_rank=max_rank)
+
+        for max_rank in (True, False, np.bool_(True), np.array(True), 1.5, "1"):
+            with self.subTest(max_rank=repr(max_rank)):
+                with self.assertRaises(TypeError):
+                    TensorTrain.from_dense(np.ones(5), max_rank=max_rank)
+
+    def test_tensor_train_round_validates_max_rank_before_one_dimensional_return(self):
+        tensor_train = TensorTrain.from_dense(np.ones(5))
+        for max_rank in (0, -1, np.array(0)):
+            with self.subTest(max_rank=repr(max_rank)):
+                with self.assertRaises(ValueError):
+                    tensor_train.round(max_rank=max_rank)
+
+        for max_rank in (True, False, np.bool_(True), np.array(True), 1.5, "1"):
+            with self.subTest(max_rank=repr(max_rank)):
+                with self.assertRaises(TypeError):
+                    tensor_train.round(max_rank=max_rank)
+
+    def test_tensor_train_accepts_integer_scalar_array_max_rank(self):
+        tensor_train = TensorTrain.from_dense(np.eye(3), max_rank=np.array(1))
+
+        self.assertEqual(tensor_train.ranks, (1, 1, 1))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Normalize `TensorTrain` `max_rank` with `operator.index` before rank truncation.
- Reject booleans, floats, strings, and non-positive ranks consistently.
- Validate `max_rank` before the 1-D `from_dense` / `round` fast paths so invalid inputs are no longer silently ignored.

## Bug fixed
`TensorTrain.from_dense(..., max_rank=...)` and `TensorTrain.round(..., max_rank=...)` only validated `max_rank` inside the SVD rank-selection path. For one-dimensional tensors, both methods returned before that validation, so invalid values such as `0`, `True`, `1.5`, or `"1"` could be ignored. For higher-dimensional tensors, non-integer values could also reach slicing after `min(rank, max_rank)`, producing a late low-level error instead of a clear validation error.

## Validation
- `python -m py_compile /tmp/_tensor_train.py /tmp/test_low_rank_hypertoroidal_fourier_distribution.py`
- Local isolated smoke check for invalid `max_rank` values on `from_dense` and `round`, plus valid scalar integer-array rank handling.

Full repository pytest was not run locally because this environment cannot clone GitHub directly; CI should run the added regression tests.