### PR TITLE
Fix evaluate_for_file measurement counts

### DIFF
--- a/src/pyrecest/evaluation/evaluate_for_file.py
+++ b/src/pyrecest/evaluation/evaluate_for_file.py
@@ -41,9 +41,11 @@ def evaluate_for_file(
     else:
         scenario_config["n_timesteps"] = data["groundtruths"].shape[1]
 
-    n_meas_at_individual_time_step = np.zeros(data["measurements"].shape[1], dtype=int)
+    measurements = np.asarray(data["measurements"], dtype=object)
+    measurement_time_steps = measurements if measurements.ndim == 1 else measurements[0]
+    n_meas_at_individual_time_step = np.zeros(len(measurement_time_steps), dtype=int)
 
-    for idx, inner_array in enumerate(data["measurements"][0]):
+    for idx, inner_array in enumerate(measurement_time_steps):
         inner_array = np.asarray(inner_array)
         if inner_array.ndim == 2:
             n_meas_at_individual_time_step[idx] = inner_array.shape[0]

--- a/tests/test_evaluate_for_file_measurement_counts.py
+++ b/tests/test_evaluate_for_file_measurement_counts.py
@@ -5,16 +5,7 @@ import importlib
 import numpy as np
 
 
-def test_evaluate_for_file_counts_empty_1d_measurements_as_zero(tmp_path, monkeypatch):
-    module = importlib.import_module("pyrecest.evaluation.evaluate_for_file")
-    input_file = tmp_path / "scenario.npy"
-    measurements = np.empty((1, 3), dtype=object)
-    measurements[0, 0] = np.array([], dtype=float)
-    measurements[0, 1] = np.array([4.0, 5.0])
-    measurements[0, 2] = np.array([[1.0, 2.0], [3.0, 4.0]])
-    groundtruths = np.zeros((1, 3, 2), dtype=float)
-    np.save(input_file, {"groundtruths": groundtruths, "measurements": measurements})
-
+def _capture_evaluate_for_variables(monkeypatch, module):
     captured = {}
 
     def capture_call(
@@ -37,6 +28,40 @@ def test_evaluate_for_file_counts_empty_1d_measurements_as_zero(tmp_path, monkey
         )
 
     monkeypatch.setattr(module, "evaluate_for_variables", capture_call)
+    return captured
+
+
+def test_evaluate_for_file_counts_empty_1d_measurements_as_zero(tmp_path, monkeypatch):
+    module = importlib.import_module("pyrecest.evaluation.evaluate_for_file")
+    input_file = tmp_path / "scenario.npy"
+    measurements = np.empty((1, 3), dtype=object)
+    measurements[0, 0] = np.array([], dtype=float)
+    measurements[0, 1] = np.array([4.0, 5.0])
+    measurements[0, 2] = np.array([[1.0, 2.0], [3.0, 4.0]])
+    groundtruths = np.zeros((1, 3, 2), dtype=float)
+    np.save(input_file, {"groundtruths": groundtruths, "measurements": measurements})
+
+    captured = _capture_evaluate_for_variables(monkeypatch, module)
+
+    module.evaluate_for_file(str(input_file), [], {}, save_folder=str(tmp_path))
+
+    np.testing.assert_array_equal(
+        captured["scenario_config"]["n_meas_at_individual_time_step"],
+        np.array([0, 1, 2], dtype=int),
+    )
+
+
+def test_evaluate_for_file_counts_flat_object_measurement_timesteps(tmp_path, monkeypatch):
+    module = importlib.import_module("pyrecest.evaluation.evaluate_for_file")
+    input_file = tmp_path / "flat_scenario.npy"
+    measurements = np.empty(3, dtype=object)
+    measurements[0] = np.array([], dtype=float)
+    measurements[1] = np.array([4.0, 5.0])
+    measurements[2] = np.array([[1.0, 2.0], [3.0, 4.0]])
+    groundtruths = np.zeros((1, 3, 2), dtype=float)
+    np.save(input_file, {"groundtruths": groundtruths, "measurements": measurements})
+
+    captured = _capture_evaluate_for_variables(monkeypatch, module)
 
     module.evaluate_for_file(str(input_file), [], {}, save_folder=str(tmp_path))
 


### PR DESCRIPTION
## Summary
- Support flat per-step measurement containers when deriving measurement counts.
- Preserve the existing one-row measurement-container layout.
- Add regression coverage for both layouts.

## Validation
- Branch comparison shows 2 changed files.
- Full pytest was not run locally; CI should run the updated test.