### PR TITLE
Fix circular grid closest point

### DIFF
--- a/src/pyrecest/distributions/circle/circular_grid_distribution.py
+++ b/src/pyrecest/distributions/circle/circular_grid_distribution.py
@@ -6,8 +6,10 @@ from pyrecest.backend import (
     arange,
     array,
     atleast_1d,
+    cast,
     ceil,
     floor,
+    int64,
     isclose,
     linspace,
     mod,
@@ -123,7 +125,7 @@ class CircularGridDistribution(AbstractCircularDistribution, AbstractGridDistrib
     def get_closest_point(self, xs):
         xs = array(xs)
         n = self.grid_values.shape[0]
-        indices = mod(round(xs / (2.0 * pi / n)), n).astype(int)
+        indices = cast(mod(round(xs / (2.0 * pi / n)), n), dtype=int64)
         points = indices * (2.0 * pi / n)
         return points, indices
 

--- a/tests/backend_support/test_circular_grid_pytorch_closest_point.py
+++ b/tests/backend_support/test_circular_grid_pytorch_closest_point.py
@@ -1,0 +1,51 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _backend_test_env(backend_name):
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = backend_name
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    return env
+
+
+@pytest.mark.backend_portable
+def test_circular_grid_get_closest_point_uses_backend_integer_indices():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import math
+import numpy as np
+
+import pyrecest.backend as backend
+from pyrecest.distributions.circle.circular_grid_distribution import CircularGridDistribution
+
+assert getattr(backend, "__backend_name__", None) == "pytorch"
+
+dist = CircularGridDistribution(backend.ones(4))
+points, indices = dist.get_closest_point(backend.asarray([0.1, 2.9, 6.1]))
+
+indices_np = backend.to_numpy(indices)
+assert indices_np.dtype.kind in "iu"
+assert indices_np.tolist() == [0, 2, 0]
+np.testing.assert_allclose(backend.to_numpy(points), [0.0, math.pi, 0.0])
+
+scalar_point, scalar_index = dist.get_closest_point(backend.asarray(math.pi / 2 + 0.1))
+assert int(backend.to_numpy(scalar_index).item()) == 1
+np.testing.assert_allclose(float(backend.to_numpy(scalar_point)), math.pi / 2)
+"""
+    subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        env=_backend_test_env("pytorch"),
+    )


### PR DESCRIPTION
Fixes backend casting for circular grid closest-point indices and adds a PyTorch regression test.