### PR TITLE
Accept scalar low-rank Fourier measurements

### DIFF
--- a/src/pyrecest/filters/low_rank_hypertoroidal_fourier_filter.py
+++ b/src/pyrecest/filters/low_rank_hypertoroidal_fourier_filter.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import warnings
 
-import numpy as np
-
 import pyrecest.backend
+from pyrecest.distributions.hypertorus._input_validation import as_shift_vector
 from pyrecest.distributions.hypertorus.abstract_hypertoroidal_distribution import (
     AbstractHypertoroidalDistribution,
 )
@@ -104,9 +103,7 @@ class LowRankHypertoroidalFourierFilter(AbstractFilter, HypertoroidalFilterMixin
         """Update for z = x + v mod 2*pi."""
 
         d_meas = self._convert_noise(d_meas)
-        z = np.asarray(z)
-        if z.shape != (self._filter_state.dim,):
-            raise ValueError(f"z must have shape ({self._filter_state.dim},), got {z.shape}")
+        z = as_shift_vector(z, self._filter_state.dim, name="z")
         likelihood = d_meas.shift(z)
         self._filter_state = self._filter_state.multiply(
             likelihood, max_rank=self.max_rank, rtol=self.rtol

--- a/tests/filters/test_low_rank_hypertoroidal_fourier_filter.py
+++ b/tests/filters/test_low_rank_hypertoroidal_fourier_filter.py
@@ -56,6 +56,23 @@ class TestLowRankHypertoroidalFourierFilter(unittest.TestCase):
             low_rank_filter.filter_state.to_dense(), dense_filter.filter_state.coeff_mat, atol=1e-10
         )
 
+    def test_update_identity_accepts_scalar_1d_measurement(self):
+        vector_filter = LowRankHypertoroidalFourierFilter((5,), "identity")
+        scalar_filter = LowRankHypertoroidalFourierFilter((5,), "identity")
+        prior = HypertoroidalFourierDistribution(_identity_coefficients_1d(), "identity")
+        noise = HypertoroidalFourierDistribution(_identity_coefficients_1d(0.5), "identity")
+        vector_filter.filter_state = prior
+        scalar_filter.filter_state = prior
+
+        vector_filter.update_identity(noise, np.array([1.5]))
+        scalar_filter.update_identity(noise, 1.5)
+
+        npt.assert_allclose(
+            scalar_filter.filter_state.to_dense(),
+            vector_filter.filter_state.to_dense(),
+            atol=1e-10,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Use `as_shift_vector` in `LowRankHypertoroidalFourierFilter.update_identity`.
- Accept scalar `z` for one-dimensional low-rank Fourier updates.
- Add regression coverage comparing scalar and vector 1-D update paths.

## Validation
- Compared branch against `main`: 2 commits ahead, 0 behind.