### PR TITLE
Stabilize NumPy probability normalization

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/random.py
+++ b/src/pyrecest/_backend/_shared_numpy/random.py
@@ -202,6 +202,19 @@ def _integer_choice_population_size(a_array):
     return None
 
 
+def _normalize_probability_values(values):
+    if _np.any(values < 0.0) or _np.any(~_np.isfinite(values)):
+        raise ValueError("probabilities do not sum to a positive value")
+    scale = float(values.max()) if values.size else 0.0
+    if scale <= 0.0:
+        raise ValueError("probabilities do not sum to a positive value")
+    scaled = values / scale
+    total = float(scaled.sum())
+    if not _np.isfinite(total) or total <= 0.0:
+        raise ValueError("probabilities do not sum to a positive value")
+    return scaled / total
+
+
 def _validate_choice_probabilities(p, population_size):
     if p is None:
         return None
@@ -216,10 +229,7 @@ def _validate_choice_probabilities(p, population_size):
     p_array = p_array.astype(_np.float64, copy=False)
     if p_array.ndim != 1 or p_array.shape[0] != population_size:
         raise ValueError("p must be 1-dimensional with one entry per population item")
-    p_sum = p_array.sum()
-    if _np.any(p_array < 0) or not _np.isfinite(p_sum) or p_sum <= 0:
-        raise ValueError("probabilities do not sum to a positive value")
-    return p_array / p_sum
+    return _normalize_probability_values(p_array)
 
 
 def choice(a, size=None, replace=True, p=None, axis=0, shuffle=True):

--- a/src/pyrecest/_backend/numpy/random.py
+++ b/src/pyrecest/_backend/numpy/random.py
@@ -9,6 +9,7 @@ from numpy.random import (  # For PyRecEst
 )
 
 from .._shared_numpy.random import (
+    _normalize_probability_values,
     _normalize_size,
     choice,
     multivariate_normal,
@@ -90,16 +91,13 @@ def _validate_multinomial_pvals(pvals):
     if pvals_array.dtype.kind not in "iuf":
         raise TypeError("pvals must be real numeric")
 
-    pvals_array = pvals_array.astype(float, copy=False)
+    pvals_array = pvals_array.astype(_np.float64, copy=False)
     if pvals_array.ndim != 1:
         raise ValueError("pvals must be 1-dimensional")
     if pvals_array.size == 0:
         raise ValueError("pvals must contain at least one probability")
 
-    pvals_sum = pvals_array.sum()
-    if _np.any(pvals_array < 0) or not _np.isfinite(pvals_sum) or pvals_sum <= 0:
-        raise ValueError("probabilities do not sum to a positive value")
-    return pvals_array / pvals_sum
+    return _normalize_probability_values(pvals_array)
 
 
 def _validate_multinomial_size(size):

--- a/tests/backend/test_numpy_probability_normalization.py
+++ b/tests/backend/test_numpy_probability_normalization.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+from pyrecest._backend.numpy import random
+
+
+def test_choice_normalizes_large_finite_unnormalized_probabilities():
+    weights = np.array([1e308, 1e308])
+
+    random.seed(123)
+    samples = random.choice(np.arange(2), size=16, p=weights)
+
+    assert samples.shape == (16,)
+    assert np.all((samples == 0) | (samples == 1))
+
+
+def test_multinomial_normalizes_large_finite_unnormalized_probabilities():
+    weights = np.array([1e308, 1e308])
+
+    random.seed(123)
+    samples = random.multinomial(5, weights, size=4)
+
+    assert samples.shape == (4, 2)
+    np.testing.assert_array_equal(samples.sum(axis=-1), np.full(4, 5))


### PR DESCRIPTION
## Summary
- Normalize NumPy `choice` and `multinomial` probability weights using max-scaling before summing.
- Share the stable probability-normalization helper between shared NumPy `choice` and NumPy `multinomial`.
- Add regression coverage for large finite unnormalized weights that used to overflow during validation.

## Bug fixed
The NumPy backend converted probability weights to float and summed them directly. Large but finite unnormalized weights such as `[1e308, 1e308]` therefore overflowed to `inf` and were rejected as invalid, even though they can be safely normalized by scaling first. This mirrors the stable normalization pattern already used in the JAX backend.

## Validation
- `python -m py_compile` on the patched source files and new regression test.
- Branch comparison shows 3 changed files.