### PR TITLE
Fix Autograd vmap array-like inputs

### DIFF
--- a/src/pyrecest/_backend/autograd/__init__.py
+++ b/src/pyrecest/_backend/autograd/__init__.py
@@ -1,5 +1,7 @@
 """Autograd based computation backend."""
 
+import builtins as _builtins
+
 import autograd.numpy as _np
 from autograd.numpy import (
     all,
@@ -205,17 +207,29 @@ def vmap(pyfunc, randomness="error"):
         raise ValueError("randomness must be either 'error' or 'different'")
 
     def vmapped_fun(*args):
-        if not all([arg.shape[0] == args[0].shape[0] for arg in args]):
+        if not args:
+            raise ValueError("vmap requires at least one positional argument")
+        mapped_args = [_np.asarray(arg) for arg in args]
+        leading_sizes = [arg.shape[0] if arg.ndim > 0 else None for arg in mapped_args]
+        sized_leading = [size for size in leading_sizes if size is not None]
+        if sized_leading and not _builtins.all(
+            size == sized_leading[0] for size in sized_leading
+        ):
             raise ValueError(
                 "All arguments must have the same size in the first dimension"
             )
+        if _builtins.any(size is None for size in leading_sizes):
+            raise ValueError("vmap arguments must have at least one dimension")
 
         # Use autograd.numpy.stack instead of preallocating and assigning into
         # an output array.  The old implementation coerced integer/complex
         # results to the backend default float dtype and in-place assignment is
         # not a reliable autograd operation when pyfunc returns ArrayBox values.
         return _np.stack(
-            [pyfunc(*(arg[i, ...] for arg in args)) for i in range(args[0].shape[0])]
+            [
+                pyfunc(*(arg[index, ...] for arg in mapped_args))
+                for index in range(sized_leading[0])
+            ]
         )
 
     return vmapped_fun

--- a/src/pyrecest/_backend/autograd/__init__.py
+++ b/src/pyrecest/_backend/autograd/__init__.py
@@ -206,10 +206,15 @@ def vmap(pyfunc, randomness="error"):
     if randomness not in ("error", "different"):
         raise ValueError("randomness must be either 'error' or 'different'")
 
+    def _as_mapped_arg(arg):
+        if hasattr(arg, "shape") and hasattr(arg, "ndim"):
+            return arg
+        return _np.asarray(arg)
+
     def vmapped_fun(*args):
         if not args:
             raise ValueError("vmap requires at least one positional argument")
-        mapped_args = [_np.asarray(arg) for arg in args]
+        mapped_args = [_as_mapped_arg(arg) for arg in args]
         leading_sizes = [arg.shape[0] if arg.ndim > 0 else None for arg in mapped_args]
         sized_leading = [size for size in leading_sizes if size is not None]
         if sized_leading and not _builtins.all(

--- a/tests/test_autograd_vmap_contract.py
+++ b/tests/test_autograd_vmap_contract.py
@@ -1,1 +1,20 @@
-# Regression tests for autograd vmap.
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+def test_autograd_vmap_accepts_array_like_inputs():
+    pytest.importorskip("autograd")
+
+    code = """
+import pyrecest.backend as backend
+
+
+def add_one(row):
+    return row + 1
+
+result = backend.vmap(add_one)([[1, 2], [3, 4]])
+assert backend.to_numpy(result).tolist() == [[2, 3], [4, 5]]
+"""
+    result = run_backend_code("autograd", code)
+    assert result.returncode == 0, result.stderr

--- a/tests/test_autograd_vmap_contract.py
+++ b/tests/test_autograd_vmap_contract.py
@@ -39,3 +39,21 @@ else:
 """
     result = run_backend_code("autograd", code)
     assert result.returncode == 0, result.stderr
+
+
+def test_autograd_vmap_remains_differentiable():
+    pytest.importorskip("autograd")
+
+    code = """
+import pyrecest.backend as backend
+from autograd import grad
+
+
+def vmap_square_sum(x):
+    return backend.sum(backend.vmap(lambda row: row * row)(x))
+
+actual = grad(vmap_square_sum)(backend.array([1.0, 2.0]))
+assert backend.to_numpy(actual).tolist() == [2.0, 4.0]
+"""
+    result = run_backend_code("autograd", code)
+    assert result.returncode == 0, result.stderr

--- a/tests/test_autograd_vmap_contract.py
+++ b/tests/test_autograd_vmap_contract.py
@@ -1,0 +1,1 @@
+# Regression tests for autograd vmap.

--- a/tests/test_autograd_vmap_contract.py
+++ b/tests/test_autograd_vmap_contract.py
@@ -18,3 +18,24 @@ assert backend.to_numpy(result).tolist() == [[2, 3], [4, 5]]
 """
     result = run_backend_code("autograd", code)
     assert result.returncode == 0, result.stderr
+
+
+def test_autograd_vmap_rejects_scalar_arguments_with_value_error():
+    pytest.importorskip("autograd")
+
+    code = """
+import pyrecest.backend as backend
+
+
+def identity(value):
+    return value
+
+try:
+    backend.vmap(identity)(1.0)
+except ValueError as exc:
+    assert "at least one dimension" in str(exc)
+else:
+    raise AssertionError("scalar argument unexpectedly accepted")
+"""
+    result = run_backend_code("autograd", code)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Convert Autograd `vmap` positional arguments with `autograd.numpy.asarray`, matching the NumPy backend contract for array-like inputs.
- Validate empty, scalar, and mismatched leading-dimension arguments with clear `ValueError`s instead of low-level shape errors.
- Add subprocess regression tests for array-like list inputs and scalar rejection under the Autograd backend.

## Validation
- `python -m py_compile /tmp/autograd_backend_init.py /tmp/test_autograd_vmap_contract.py`
- Compared branch against `main`: 2 changed files, 0 behind.

Full Autograd runtime tests were not run locally because `autograd` is not installed in this container; CI should exercise the new tests when the optional dependency is available.