### PR TITLE
Stabilize NumPy probability normalization

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/random.py
+++ b/src/pyrecest/_backend/_shared_numpy/random.py
@@ -183,6 +183,19 @@ def _validate_choice_population(a_array):
         raise ValueError("a must be a positive integer or a non-empty array")
 
 
+def _normalize_probability_values(values):
+    if _np.any(values < 0.0) or _np.any(~_np.isfinite(values)):
+        raise ValueError("probabilities do not sum to a positive value")
+    scale = float(values.max()) if values.size else 0.0
+    if scale <= 0.0:
+        raise ValueError("probabilities do not sum to a positive value")
+    scaled = values / scale
+    total = scaled.sum()
+    if not _np.isfinite(total) or total <= 0.0:
+        raise ValueError("probabilities do not sum to a positive value")
+    return scaled / total
+
+
 def _maybe_preserve_choice_order(indices, *, replace, p, shuffle, size):
     if replace or p is not None or shuffle or size is None:
         return indices
@@ -216,10 +229,7 @@ def _validate_choice_probabilities(p, population_size):
     p_array = p_array.astype(_np.float64, copy=False)
     if p_array.ndim != 1 or p_array.shape[0] != population_size:
         raise ValueError("p must be 1-dimensional with one entry per population item")
-    p_sum = p_array.sum()
-    if _np.any(p_array < 0) or not _np.isfinite(p_sum) or p_sum <= 0:
-        raise ValueError("probabilities do not sum to a positive value")
-    return p_array / p_sum
+    return _normalize_probability_values(p_array)
 
 
 def choice(a, size=None, replace=True, p=None, axis=0, shuffle=True):

--- a/src/pyrecest/_backend/numpy/random.py
+++ b/src/pyrecest/_backend/numpy/random.py
@@ -9,6 +9,7 @@ from numpy.random import (  # For PyRecEst
 )
 
 from .._shared_numpy.random import (
+    _normalize_probability_values,
     _normalize_size,
     choice,
     multivariate_normal,
@@ -96,10 +97,7 @@ def _validate_multinomial_pvals(pvals):
     if pvals_array.size == 0:
         raise ValueError("pvals must contain at least one probability")
 
-    pvals_sum = pvals_array.sum()
-    if _np.any(pvals_array < 0) or not _np.isfinite(pvals_sum) or pvals_sum <= 0:
-        raise ValueError("probabilities do not sum to a positive value")
-    return pvals_array / pvals_sum
+    return _normalize_probability_values(pvals_array)
 
 
 def _validate_multinomial_size(size):

--- a/tests/backend/test_numpy_random_backend.py
+++ b/tests/backend/test_numpy_random_backend.py
@@ -180,6 +180,15 @@ def test_multinomial_accepts_integer_like_size_argument():
     assert np.all(samples.sum(axis=1) == 2)
 
 
+def test_multinomial_accepts_large_finite_unnormalized_probabilities():
+    random.seed(0)
+
+    samples = random.multinomial(5, np.array([1e308, 1e308]), size=3)
+
+    assert samples.shape == (3, 2)
+    assert np.all(samples.sum(axis=1) == 5)
+
+
 @pytest.mark.parametrize(
     ("low", "high"),
     [
@@ -287,6 +296,15 @@ def test_choice_rejects_non_boolean_controls(control):
 
     with pytest.raises(TypeError, match=f"{control} must be a boolean"):
         random.choice(np.arange(3), size=2, **kwargs)
+
+
+def test_choice_accepts_large_finite_unnormalized_probabilities():
+    random.seed(0)
+
+    samples = random.choice(np.arange(2), size=8, p=np.array([1e308, 1e308]))
+
+    assert samples.shape == (8,)
+    assert np.all((samples == 0) | (samples == 1))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Normalize NumPy backend `choice` and `multinomial` probability weights by scaling finite weights before summing.
- Reuse one shared normalization helper so large finite unnormalized weights no longer overflow to an invalid `inf` sum.
- Add regressions for `[1e308, 1e308]` weights in both `choice` and `multinomial`.

## Bug fixed
The NumPy random backend accepted unnormalized probability weights, but normalized them with a direct floating-point sum. Very large finite weights such as `[1e308, 1e308]` can overflow during summation and were rejected even though they are valid once scale-normalized.

## Validation
- Syntax-compiled the patched source and test files locally with `python -m py_compile`.
- Full repository pytest was not run locally in this connector-only environment; CI should run the added regression tests.