### PR TITLE
Accept NumPy scalar bool tracking decisions

### DIFF
--- a/src/pyrecest/tracking/event_records.py
+++ b/src/pyrecest/tracking/event_records.py
@@ -104,6 +104,9 @@ def _optional_bool(value: Any, *, name: str) -> bool | None:
         return None
     if isinstance(value, (bool, np.bool_)):
         return bool(value)
+    array = np.asarray(value)
+    if array.shape == () and array.dtype == np.bool_:
+        return bool(array.item())
     raise ValueError(f"{name} must be a boolean or None")
 
 

--- a/tests/tracking/test_event_records.py
+++ b/tests/tracking/test_event_records.py
@@ -46,8 +46,28 @@ def test_accepted_flags_must_be_boolean_or_none() -> None:
     event = event_from_measurement(time=0.0, source="rf", accepted=np.bool_(False))
     assert event.accepted is False
 
+    scalar_array_event = event_from_measurement(
+        time=0.0,
+        source="rf",
+        accepted=np.array(True),
+    )
+    assert scalar_array_event.accepted is True
+
+    scalar_array_record = record_from_update(
+        event=event,
+        prior_mean=[0.0, 0.0],
+        prior_cov=np.eye(2),
+        posterior_mean=[0.0, 0.0],
+        posterior_cov=np.eye(2),
+        accepted=np.array(False),
+    )
+    assert scalar_array_record.accepted is False
+
     with pytest.raises(ValueError, match="accepted must be a boolean or None"):
         TrackingEvent(time=0.0, source="rf", accepted="False")
+
+    with pytest.raises(ValueError, match="accepted must be a boolean or None"):
+        TrackingEvent(time=0.0, source="rf", accepted=np.array([True]))
 
     with pytest.raises(ValueError, match="accepted must be a boolean or None"):
         record_from_update(


### PR DESCRIPTION
## Summary
- accept zero-dimensional NumPy boolean arrays for `TrackingEvent.accepted` and `TrackingRecord.accepted`
- keep non-scalar boolean arrays rejected with the existing `accepted must be a boolean or None` error
- extend the existing tracking event regression test to cover scalar NumPy bool arrays for events and records

## Validation
- `PYTHONPATH=/tmp/pyrecest-event-test pytest -q /mnt/data/test_event_records_existing.py` → 6 passed

## Note
I initially found a broader discrete-state prior-validation issue, but the platform rejected the large whole-file update payload. This PR focuses on the smaller tracking-record bug fix that I could safely push and test.