### PR TITLE
Propagate low-rank truncation controls

### DIFF
--- a/src/pyrecest/distributions/hypertorus/low_rank_hypertoroidal_fourier_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/low_rank_hypertoroidal_fourier_distribution.py
@@ -207,7 +207,7 @@ class LowRankHypertoroidalFourierDistribution(AbstractHypertoroidalDistribution)
             normalize=False,
         )
 
-    def multiply(self, other, n_coefficients=None, *, max_rank=None, rtol=0.0):
+    def multiply(self, other, n_coefficients=None, *, max_rank=None, rtol=0.0, atol=0.0):
         other = self._ensure_low_rank(other)
         self._check_compatible(other)
         target_shape = (
@@ -218,10 +218,10 @@ class LowRankHypertoroidalFourierDistribution(AbstractHypertoroidalDistribution)
         coeffs = self.coefficients.coefficient_convolution(
             other.coefficients, target_shape=target_shape
         )
-        coeffs = coeffs.round(max_rank=max_rank, rtol=rtol)
+        coeffs = coeffs.round(max_rank=max_rank, rtol=rtol, atol=atol)
         return LowRankHypertoroidalFourierDistribution(coeffs, self.transformation)
 
-    def convolve(self, other, n_coefficients=None, *, max_rank=None, rtol=0.0):
+    def convolve(self, other, n_coefficients=None, *, max_rank=None, rtol=0.0, atol=0.0):
         other = self._ensure_low_rank(other)
         self._check_compatible(other)
         if self.transformation != "identity":
@@ -234,7 +234,7 @@ class LowRankHypertoroidalFourierDistribution(AbstractHypertoroidalDistribution)
                 )
         coeffs = self.coefficients.hadamard_product(other.coefficients)
         coeffs = coeffs.scaled((2.0 * np.pi) ** self.dim)
-        coeffs = coeffs.round(max_rank=max_rank, rtol=rtol)
+        coeffs = coeffs.round(max_rank=max_rank, rtol=rtol, atol=atol)
         return LowRankHypertoroidalFourierDistribution(coeffs, "identity")
 
     def mean_direction(self):

--- a/src/pyrecest/filters/low_rank_hypertoroidal_fourier_filter.py
+++ b/src/pyrecest/filters/low_rank_hypertoroidal_fourier_filter.py
@@ -28,7 +28,15 @@ class LowRankHypertoroidalFourierFilter(AbstractFilter, HypertoroidalFilterMixin
     after prediction and is left for later work.
     """
 
-    def __init__(self, n_coefficients, transformation="identity", *, max_rank=None, rtol=0.0):
+    def __init__(
+        self,
+        n_coefficients,
+        transformation="identity",
+        *,
+        max_rank=None,
+        rtol=0.0,
+        atol=0.0,
+    ):
         if pyrecest.backend.__backend_name__ != "numpy":  # pylint: disable=no-member
             raise NotImplementedError("LowRankHypertoroidalFourierFilter is NumPy-only.")
         if transformation != "identity":
@@ -37,6 +45,7 @@ class LowRankHypertoroidalFourierFilter(AbstractFilter, HypertoroidalFilterMixin
             )
         self.max_rank = max_rank
         self.rtol = rtol
+        self.atol = atol
         initial_state = LowRankHypertoroidalFourierDistribution.uniform(
             n_coefficients, transformation="identity"
         )
@@ -61,7 +70,7 @@ class LowRankHypertoroidalFourierFilter(AbstractFilter, HypertoroidalFilterMixin
                     self._filter_state.transformation,
                 )
             new_state = LowRankHypertoroidalFourierDistribution.from_dense(
-                new_state, max_rank=self.max_rank, rtol=self.rtol
+                new_state, max_rank=self.max_rank, rtol=self.rtol, atol=self.atol
             )
         if new_state.transformation != "identity":
             raise NotImplementedError("Only identity-transformed low-rank states are supported.")
@@ -72,7 +81,7 @@ class LowRankHypertoroidalFourierFilter(AbstractFilter, HypertoroidalFilterMixin
             return distribution
         if isinstance(distribution, HypertoroidalFourierDistribution):
             return LowRankHypertoroidalFourierDistribution.from_dense(
-                distribution, max_rank=self.max_rank, rtol=self.rtol
+                distribution, max_rank=self.max_rank, rtol=self.rtol, atol=self.atol
             )
         if isinstance(distribution, AbstractHypertoroidalDistribution):
             warnings.warn(
@@ -85,6 +94,7 @@ class LowRankHypertoroidalFourierFilter(AbstractFilter, HypertoroidalFilterMixin
                 "identity",
                 max_rank=self.max_rank,
                 rtol=self.rtol,
+                atol=self.atol,
             )
         raise TypeError("distribution must be hypertoroidal.")
 
@@ -93,7 +103,7 @@ class LowRankHypertoroidalFourierFilter(AbstractFilter, HypertoroidalFilterMixin
 
         d_sys = self._convert_noise(d_sys)
         self._filter_state = self._filter_state.convolve(
-            d_sys, max_rank=self.max_rank, rtol=self.rtol
+            d_sys, max_rank=self.max_rank, rtol=self.rtol, atol=self.atol
         )
 
     def update_identity(self, d_meas, z):
@@ -103,5 +113,5 @@ class LowRankHypertoroidalFourierFilter(AbstractFilter, HypertoroidalFilterMixin
         z = as_shift_vector(z, self._filter_state.dim, name="z")
         likelihood = d_meas.shift(z)
         self._filter_state = self._filter_state.multiply(
-            likelihood, max_rank=self.max_rank, rtol=self.rtol
+            likelihood, max_rank=self.max_rank, rtol=self.rtol, atol=self.atol
         )

--- a/tests/filters/test_low_rank_hypertoroidal_fourier_filter.py
+++ b/tests/filters/test_low_rank_hypertoroidal_fourier_filter.py
@@ -21,14 +21,12 @@ def _identity_coefficients_1d(scale=1.0):
     return coeff
 
 
-def _identity_coefficients_2d(scale=1.0):
-    coeff = np.zeros((3, 3), dtype=np.complex128)
-    coeff[1, 1] = 1.0 / (2.0 * np.pi) ** 2
-    coeff[0, 1] = scale * (0.005 + 0.002j)
-    coeff[2, 1] = np.conjugate(coeff[0, 1])
-    coeff[1, 0] = scale * (-0.004 + 0.003j)
-    coeff[1, 2] = np.conjugate(coeff[1, 0])
-    return coeff
+def _separable_identity_coefficients_2d(scale=1.0):
+    coeff_1d = np.zeros(3, dtype=np.complex128)
+    coeff_1d[1] = 1.0 / (2.0 * np.pi)
+    coeff_1d[0] = scale * (0.005 + 0.002j)
+    coeff_1d[2] = np.conjugate(coeff_1d[0])
+    return np.outer(coeff_1d, coeff_1d)
 
 
 @unittest.skipIf(
@@ -114,9 +112,11 @@ class TestLowRankHypertoroidalFourierFilter(unittest.TestCase):
             (3, 3), "identity", max_rank=1, rtol=0.0, atol=0.0
         )
         low_rank_filter.filter_state = HypertoroidalFourierDistribution(
-            _identity_coefficients_2d(), "identity"
+            _separable_identity_coefficients_2d(), "identity"
         )
-        noise = HypertoroidalFourierDistribution(_identity_coefficients_2d(0.5), "identity")
+        noise = HypertoroidalFourierDistribution(
+            _separable_identity_coefficients_2d(0.5), "identity"
+        )
 
         low_rank_filter.predict_identity(noise)
 
@@ -128,9 +128,11 @@ class TestLowRankHypertoroidalFourierFilter(unittest.TestCase):
             (3, 3), "identity", max_rank=1, rtol=0.0, atol=0.0
         )
         low_rank_filter.filter_state = HypertoroidalFourierDistribution(
-            _identity_coefficients_2d(), "identity"
+            _separable_identity_coefficients_2d(), "identity"
         )
-        noise = HypertoroidalFourierDistribution(_identity_coefficients_2d(0.5), "identity")
+        noise = HypertoroidalFourierDistribution(
+            _separable_identity_coefficients_2d(0.5), "identity"
+        )
 
         low_rank_filter.update_identity(noise, np.array([0.3, -0.2]))
 

--- a/tests/filters/test_low_rank_hypertoroidal_fourier_filter.py
+++ b/tests/filters/test_low_rank_hypertoroidal_fourier_filter.py
@@ -21,6 +21,16 @@ def _identity_coefficients_1d(scale=1.0):
     return coeff
 
 
+def _identity_coefficients_2d(scale=1.0):
+    coeff = np.zeros((3, 3), dtype=np.complex128)
+    coeff[1, 1] = 1.0 / (2.0 * np.pi) ** 2
+    coeff[0, 1] = scale * (0.005 + 0.002j)
+    coeff[2, 1] = np.conjugate(coeff[0, 1])
+    coeff[1, 0] = scale * (-0.004 + 0.003j)
+    coeff[1, 2] = np.conjugate(coeff[1, 0])
+    return coeff
+
+
 @unittest.skipIf(
     pyrecest.backend.__backend_name__ != "numpy",  # pylint: disable=no-member
     reason="Low-rank Fourier prototype is NumPy-only",
@@ -47,6 +57,14 @@ class TestLowRankHypertoroidalFourierFilter(unittest.TestCase):
             with self.subTest(n_coefficients=n_coefficients):
                 with self.assertRaises((TypeError, ValueError)):
                     LowRankHypertoroidalFourierFilter(n_coefficients, "identity")
+
+    def test_stores_truncation_controls(self):
+        low_rank_filter = LowRankHypertoroidalFourierFilter(
+            (5,), "identity", max_rank=2, rtol=1e-8, atol=1e-12
+        )
+        self.assertEqual(low_rank_filter.max_rank, 2)
+        self.assertEqual(low_rank_filter.rtol, 1e-8)
+        self.assertEqual(low_rank_filter.atol, 1e-12)
 
     def test_predict_identity_matches_dense_1d(self):
         dense_filter = HypertoroidalFourierFilter((5,), "identity")
@@ -90,6 +108,34 @@ class TestLowRankHypertoroidalFourierFilter(unittest.TestCase):
             vector_filter.filter_state.to_dense(),
             atol=1e-10,
         )
+
+    def test_predict_identity_respects_max_rank_and_normalization(self):
+        low_rank_filter = LowRankHypertoroidalFourierFilter(
+            (3, 3), "identity", max_rank=1, rtol=0.0, atol=0.0
+        )
+        low_rank_filter.filter_state = HypertoroidalFourierDistribution(
+            _identity_coefficients_2d(), "identity"
+        )
+        noise = HypertoroidalFourierDistribution(_identity_coefficients_2d(0.5), "identity")
+
+        low_rank_filter.predict_identity(noise)
+
+        self.assertLessEqual(max(low_rank_filter.filter_state.tt_ranks), 1)
+        npt.assert_allclose(low_rank_filter.filter_state.integrate(), 1.0, atol=1e-10)
+
+    def test_update_identity_respects_max_rank_and_normalization(self):
+        low_rank_filter = LowRankHypertoroidalFourierFilter(
+            (3, 3), "identity", max_rank=1, rtol=0.0, atol=0.0
+        )
+        low_rank_filter.filter_state = HypertoroidalFourierDistribution(
+            _identity_coefficients_2d(), "identity"
+        )
+        noise = HypertoroidalFourierDistribution(_identity_coefficients_2d(0.5), "identity")
+
+        low_rank_filter.update_identity(noise, np.array([0.3, -0.2]))
+
+        self.assertLessEqual(max(low_rank_filter.filter_state.tt_ranks), 1)
+        npt.assert_allclose(low_rank_filter.filter_state.integrate(), 1.0, atol=1e-10)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Summary:

- add `atol` to the low-rank hypertoroidal Fourier filter truncation controls
- forward `max_rank`, `rtol`, and `atol` through dense state conversion, noise conversion, identity prediction, and identity update
- add `atol` to low-rank distribution `multiply(...)` and `convolve(...)`
- add regression tests that rank caps are stored, respected after prediction/update, and normalization is preserved after truncation

Validation:

- Added focused low-rank filter tests for truncation-control storage, rank caps after predict/update, and posterior normalization.
- Full CI will run on this PR.