### PR TITLE
Validate discrete-state initial prior types

### DIFF
--- a/src/pyrecest/filters/discrete_state.py
+++ b/src/pyrecest/filters/discrete_state.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from numbers import Real
 
 import numpy as np
 from scipy.sparse import csr_matrix, issparse, spmatrix
@@ -626,6 +627,40 @@ def _coerce_valid_state_mask(
     return mask
 
 
+def _contains_only_real_probability_values(values: np.ndarray) -> bool:
+    if np.issubdtype(values.dtype, np.bool_):
+        return False
+    if np.issubdtype(values.dtype, np.complexfloating):
+        return False
+    if np.issubdtype(values.dtype, np.datetime64) or np.issubdtype(
+        values.dtype,
+        np.timedelta64,
+    ):
+        return False
+    if np.issubdtype(values.dtype, np.str_) or np.issubdtype(values.dtype, np.bytes_):
+        return False
+    if values.dtype != object:
+        return np.issubdtype(values.dtype, np.number)
+
+    return all(
+        isinstance(value, Real)
+        and not isinstance(value, (bool, np.bool_, str, bytes, np.str_, np.bytes_))
+        for value in values.ravel()
+    )
+
+
+def _as_real_probability_values(probabilities, n_entries: int, name: str) -> np.ndarray:
+    raw_values = np.asarray(probabilities)
+    if raw_values.shape != (n_entries,):
+        raise ValueError(f"{name} must have shape ({n_entries},)")
+    if not _contains_only_real_probability_values(raw_values):
+        raise ValueError(f"{name} must contain real probability values")
+    try:
+        return np.asarray(raw_values, dtype=float)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must contain real probability values") from exc
+
+
 def _normalize_probability_vector(
     probabilities: np.ndarray | None,
     n_entries: int,
@@ -635,9 +670,7 @@ def _normalize_probability_vector(
 ) -> np.ndarray:
     if probabilities is None:
         return uniform_probabilities(n_entries, valid_state_mask)
-    values = np.asarray(probabilities, dtype=float)
-    if values.shape != (n_entries,):
-        raise ValueError(f"{name} must have shape ({n_entries},)")
+    values = _as_real_probability_values(probabilities, n_entries, name)
     if np.any(~np.isfinite(values)) or np.any(values < 0.0):
         raise ValueError(f"{name} must be finite and non-negative")
     values = values.copy()

--- a/src/pyrecest/filters/discrete_state/__init__.py
+++ b/src/pyrecest/filters/discrete_state/__init__.py
@@ -80,6 +80,46 @@ def _validated_positive_scalar(
     return parsed
 
 
+def _validated_probability_vector(
+    probabilities: Any,
+    n_entries: int,
+    name: str,
+    *,
+    valid_state_mask=None,
+) -> np.ndarray:
+    if probabilities is None:
+        return _module_globals["uniform_probabilities"](n_entries, valid_state_mask)
+    try:
+        raw_values = np.asarray(probabilities)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must contain real probability values") from exc
+    if raw_values.shape != (n_entries,):
+        raise ValueError(f"{name} must have shape ({n_entries},)")
+    if raw_values.dtype.kind in _REJECTED_STATE_KINDS:
+        raise ValueError(f"{name} must contain real probability values")
+    if raw_values.dtype == object:
+        for value in raw_values.ravel():
+            if isinstance(
+                value,
+                _TEXT_TYPES + _BOOLEAN_TYPES + _COMPLEX_TYPES,
+            ):
+                raise ValueError(f"{name} must contain real probability values")
+    try:
+        values = raw_values.astype(float, copy=False)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must contain real probability values") from exc
+    if np.any(~np.isfinite(values)) or np.any(values < 0.0):
+        raise ValueError(f"{name} must be finite and non-negative")
+    values = values.copy()
+    mask = _module_globals["_coerce_valid_state_mask"](valid_state_mask, n_entries)
+    if mask is not None:
+        values[~mask] = 0.0
+    total = float(values.sum())
+    if total <= 0.0:
+        raise ValueError(f"{name} must contain positive probability mass")
+    return values / total
+
+
 def sparse_gaussian_transition_matrix(
     state_vectors,
     sigma,
@@ -103,6 +143,7 @@ def sparse_gaussian_transition_matrix(
 
 
 _module_globals["sparse_gaussian_transition_matrix"] = sparse_gaussian_transition_matrix
+_module_globals["_normalize_probability_vector"] = _validated_probability_vector
 for name in _module_globals["__all__"]:
     globals()[name] = _module_globals[name]
 __all__ = _module_globals["__all__"]

--- a/tests/filters/test_discrete_state.py
+++ b/tests/filters/test_discrete_state.py
@@ -96,6 +96,53 @@ class TestDiscreteStateUtilities(unittest.TestCase):
             result.smoothed_probabilities.sum(axis=1), np.ones(log_likelihood.shape[0])
         )
 
+    def test_forward_backward_initial_probabilities_reject_non_numeric_values(self):
+        log_likelihood = np.log(np.array([[0.5, 0.5]]))
+        transition = np.eye(2)
+        invalid_priors = (
+            [True, False],
+            np.array([True, False]),
+            ["0.6", "0.4"],
+            np.array([b"0.6", b"0.4"]),
+            [0.6 + 0.0j, 0.4 + 0.0j],
+        )
+
+        for initial_probabilities in invalid_priors:
+            with self.subTest(initial_probabilities=initial_probabilities):
+                with self.assertRaisesRegex(
+                    ValueError, "initial_probabilities.*real probability values"
+                ):
+                    discrete_forward_backward(
+                        log_likelihood,
+                        transition,
+                        initial_probabilities=initial_probabilities,
+                    )
+
+    def test_imm_initial_probability_vectors_reject_non_numeric_values(self):
+        log_likelihood = np.log(np.array([[0.5, 0.5]]))
+        state_transitions = [np.eye(2), np.eye(2)]
+        mode_transition = np.eye(2)
+
+        with self.assertRaisesRegex(
+            ValueError, "initial_state_probabilities.*real probability values"
+        ):
+            imm_forward_backward(
+                log_likelihood,
+                state_transitions,
+                mode_transition,
+                initial_state_probabilities=["0.5", "0.5"],
+            )
+
+        with self.assertRaisesRegex(
+            ValueError, "initial_mode_probabilities.*real probability values"
+        ):
+            imm_forward_backward(
+                log_likelihood,
+                state_transitions,
+                mode_transition,
+                initial_mode_probabilities=np.array([True, False]),
+            )
+
     def test_time_varying_forward_backward_matches_constant_version(self):
         log_likelihood = np.log(np.array([[0.5, 0.2], [0.1, 0.8], [0.9, 0.4]]))
         transition = csr_matrix(np.array([[0.7, 0.2], [0.3, 0.8]]))


### PR DESCRIPTION
## Summary
- Add a strict probability-vector validator for finite-state HMM/IMM initial priors.
- Reject boolean, complex, datetime/timedelta, and text/bytes probability vectors before float coercion.
- Add regressions for malformed `initial_probabilities`, `initial_state_probabilities`, and `initial_mode_probabilities`.

## Bug fixed
The discrete-state prior normalizer converted inputs directly with `np.asarray(..., dtype=float)`. That silently accepted malformed priors such as `[True, False]`, `["0.6", "0.4"]`, or `[0.6 + 0j, 0.4 + 0j]` and normalized them as if they were real probability vectors.

## Validation
- `python -m py_compile /tmp/discrete_state_init.py /tmp/test_discrete_state.py`
- Full pytest was not run locally because this connector environment does not have a repository checkout or network access for cloning; CI should run the added focused regressions.