### PR TITLE
Reject boolean linear-update arrays

### DIFF
--- a/src/pyrecest/filters/linear_update_planning.py
+++ b/src/pyrecest/filters/linear_update_planning.py
@@ -389,7 +389,19 @@ def _symmetrized(matrix: np.ndarray) -> np.ndarray:
     return 0.5 * (matrix + matrix.T)
 
 
+def _contains_boolean_value(value: Any) -> bool:
+    if isinstance(value, (bool, np.bool_)):
+        return True
+    try:
+        values = np.asarray(value, dtype=object).reshape(-1)
+    except (TypeError, ValueError, RuntimeError):
+        return False
+    return any(isinstance(item, (bool, np.bool_)) for item in values)
+
+
 def _as_finite_array(value: Any, name: str) -> np.ndarray:
+    if _contains_boolean_value(value):
+        raise ValueError(f"{name} must contain finite numeric values")
     try:
         array = np.asarray(value, dtype=float)
     except (TypeError, ValueError, OverflowError) as exc:

--- a/tests/filters/test_linear_update_planning.py
+++ b/tests/filters/test_linear_update_planning.py
@@ -107,12 +107,43 @@ def test_plan_rejects_nonfinite_array_inputs():
             plan_linear_measurement_update(**kwargs)
 
 
+def test_plan_rejects_boolean_array_inputs():
+    base_kwargs = {
+        "mean": np.zeros(1),
+        "covariance_matrix": np.eye(1),
+        "measurement_vector": np.array([1.0]),
+        "measurement_covariance": np.eye(1),
+        "observation_matrix": np.eye(1),
+    }
+    invalid_overrides = (
+        {"measurement_vector": np.array([True])},
+        {"measurement_covariance": np.array([[True]])},
+        {"observation_matrix": np.array([[True]])},
+        {"mean": np.array([True])},
+        {"covariance_matrix": np.array([[True]])},
+    )
+
+    for overrides in invalid_overrides:
+        invalid_name = next(iter(overrides))
+        kwargs = {**base_kwargs, **overrides}
+        with pytest.raises(ValueError, match=invalid_name):
+            plan_linear_measurement_update(**kwargs)
+
+
 def test_normalized_innovation_squared_rejects_nonfinite_inputs():
     with pytest.raises(ValueError, match="residual"):
         normalized_innovation_squared(np.array([np.nan]), np.eye(1))
 
     with pytest.raises(ValueError, match="innovation_covariance"):
         normalized_innovation_squared(np.array([0.0]), np.array([[np.inf]]))
+
+
+def test_normalized_innovation_squared_rejects_boolean_inputs():
+    with pytest.raises(ValueError, match="residual"):
+        normalized_innovation_squared(np.array([True]), np.eye(1))
+
+    with pytest.raises(ValueError, match="innovation_covariance"):
+        normalized_innovation_squared(np.array([0.0]), np.array([[True]]))
 
 
 def test_robust_scale_rejects_nonfinite_parameters():


### PR DESCRIPTION
## Summary
- reject boolean-valued array inputs in `linear_update_planning` instead of silently coercing them to `0.0`/`1.0`
- add regression coverage for boolean measurement vectors, covariance matrices, observation matrices, means, and NIS inputs

## Validation
- `PYTHONPATH=/tmp/linplan/src pytest -q /tmp/linplan/tests/filters/test_linear_update_planning.py` → 13 passed

The local validation used an isolated copy of the patched planning module because this environment cannot clone the full GitHub repository directly.