### PR TITLE
Reject overlapping weak measurement std keys

### DIFF
--- a/src/pyrecest/models/weak_measurement.py
+++ b/src/pyrecest/models/weak_measurement.py
@@ -51,6 +51,12 @@ def block_diag_measurement_covariance(
             raise TypeError("weak_std must be a mapping when trusted_std is a mapping")
         trusted_map = dict(trusted_std or {})
         weak_map = dict(weak_std or {})
+        overlapping_keys = [key for key in trusted_map if key in weak_map]
+        if overlapping_keys:
+            raise ValueError(
+                "trusted_std and weak_std must not contain overlapping dimensions: "
+                f"{overlapping_keys}"
+            )
         provided_order = [
             *trusted_map.keys(),
             *(key for key in weak_map if key not in trusted_map),

--- a/tests/models/test_weak_measurement.py
+++ b/tests/models/test_weak_measurement.py
@@ -59,6 +59,22 @@ def test_block_diag_measurement_covariance_preserves_named_order() -> None:
     assert np.allclose(covariance, np.diag([1.0, 4.0, 10000.0]))
 
 
+def test_block_diag_measurement_covariance_rejects_overlapping_named_stds() -> None:
+    with pytest.raises(ValueError, match="overlapping dimensions"):
+        block_diag_measurement_covariance(
+            trusted_std={"x": 1.0},
+            weak_std={"x": 100.0},
+        )
+
+    with pytest.raises(ValueError, match="overlapping dimensions"):
+        WeakDimensionMeasurementModel(
+            np.eye(1),
+            trusted_std={"x": 1.0},
+            weak_std={"x": 100.0},
+            dimension_order=["x"],
+        )
+
+
 def test_block_diag_measurement_covariance_rejects_duplicate_dimension_order() -> None:
     with pytest.raises(ValueError, match="dimension_order"):
         block_diag_measurement_covariance(


### PR DESCRIPTION
## Summary
- reject named dimensions that appear in both `trusted_std` and `weak_std` for weak-measurement covariance construction
- preserve the existing explicit `dimension_order` behavior for disjoint maps
- add regression coverage for both `block_diag_measurement_covariance(...)` and `WeakDimensionMeasurementModel(...)`

## Bug fixed
`block_diag_measurement_covariance(...)` previously accepted overlapping mapping keys such as `trusted_std={"x": 1.0}` and `weak_std={"x": 100.0}`. The trusted value silently won and the weak value was dropped, even though the same dimension was configured with two conflicting trust levels. This PR treats that input as ambiguous and raises a clear `ValueError`.

## Validation
- `python -m py_compile /mnt/data/weak_measurement.py /mnt/data/test_weak_measurement.py`
- focused isolated smoke check for overlapping keys through `block_diag_measurement_covariance(...)` and `WeakDimensionMeasurementModel(...)`

Full repository pytest was not run locally because this environment cannot clone github.com directly; CI should run the in-tree regression.