### PR TITLE
Reject text ROI unmatched values

### DIFF
--- a/src/pyrecest/utils/__init__.py
+++ b/src/pyrecest/utils/__init__.py
@@ -40,12 +40,15 @@ if not hasattr(_assignment_module, "_solve_subproblem_without_full_assignment"):
 
 
 def _normalize_roi_unmatched_value(unmatched_value):
+    if isinstance(unmatched_value, _TEXT_SCALAR_TYPES):
+        raise ValueError("unmatched_value must be an integer.")
+
     value_array = _roi_assignment_module.asarray(unmatched_value)
     if value_array.shape != ():
         raise ValueError("unmatched_value must be an integer.")
 
     scalar = value_array.item() if hasattr(value_array, "item") else value_array
-    if isinstance(scalar, bool):
+    if isinstance(scalar, (bool, _np.bool_) + _TEXT_SCALAR_TYPES):
         raise ValueError("unmatched_value must be an integer.")
     if isinstance(scalar, int):
         return int(scalar)

--- a/tests/test_roi_assignment_unmatched_value.py
+++ b/tests/test_roi_assignment_unmatched_value.py
@@ -28,7 +28,7 @@ class TestRoiAssignmentUnmatchedValue(unittest.TestCase):
     def test_rejects_noninteger_unmatched_value(self):
         similarity_matrix = array([[1.0]])
 
-        for unmatched_value in (True, 1.5, float("nan"), [1]):
+        for unmatched_value in (True, 1.5, float("nan"), [1], "2", b"2"):
             with self.subTest(unmatched_value=unmatched_value):
                 with self.assertRaisesRegex(ValueError, "unmatched_value"):
                     assign_by_similarity_matrix(


### PR DESCRIPTION
## Summary
- reject text/bytes `unmatched_value` inputs before backend array coercion in ROI assignment
- keep existing integer-like numeric sentinel handling intact
- extend the ROI unmatched-value regression test to cover text and bytes sentinels

## Bug fixed
`assign_by_similarity_matrix(..., unmatched_value=...)` previously normalized the sentinel through `float(...)` after scalar extraction. That meant malformed text inputs such as `"2"` were accepted as integer sentinels instead of being rejected by the integer validator.

## Validation
- Branch comparison against `main`: 2 commits ahead, 0 behind; only `src/pyrecest/utils/__init__.py` and `tests/test_roi_assignment_unmatched_value.py` changed.
- Full local pytest was not run because this environment cannot clone the repository; CI should run the focused regression.