### PR TITLE
Require scalar-array JAX FFT lengths

### DIFF
--- a/src/pyrecest/_backend/jax/fft.py
+++ b/src/pyrecest/_backend/jax/fft.py
@@ -40,14 +40,14 @@ def _normalize_real_fft_length(n):
     if isinstance(n, _np.ndarray):
         if _np.issubdtype(n.dtype, _np.bool_):
             raise TypeError(_BOOLEAN_FFT_LENGTH_ERROR)
-        if n.ndim == 0 and _np.issubdtype(n.dtype, _np.integer):
+        if n.size == 1 and _np.issubdtype(n.dtype, _np.integer):
             return int(n.item())
         return n
     if isinstance(n, _jnp.ndarray):
         n_dtype = _np.asarray(n).dtype
         if _np.issubdtype(n_dtype, _np.bool_):
             raise TypeError(_BOOLEAN_FFT_LENGTH_ERROR)
-        if n.ndim == 0 and _np.issubdtype(n_dtype, _np.integer):
+        if n.size == 1 and _np.issubdtype(n_dtype, _np.integer):
             return int(n.item())
         return n
     if isinstance(n, _np.integer):

--- a/src/pyrecest/_backend/jax/fft.py
+++ b/src/pyrecest/_backend/jax/fft.py
@@ -40,14 +40,14 @@ def _normalize_real_fft_length(n):
     if isinstance(n, _np.ndarray):
         if _np.issubdtype(n.dtype, _np.bool_):
             raise TypeError(_BOOLEAN_FFT_LENGTH_ERROR)
-        if n.size == 1 and _np.issubdtype(n.dtype, _np.integer):
+        if n.ndim == 0 and _np.issubdtype(n.dtype, _np.integer):
             return int(n.item())
         return n
     if isinstance(n, _jnp.ndarray):
         n_dtype = _np.asarray(n).dtype
         if _np.issubdtype(n_dtype, _np.bool_):
             raise TypeError(_BOOLEAN_FFT_LENGTH_ERROR)
-        if n.size == 1 and _np.issubdtype(n_dtype, _np.integer):
+        if n.ndim == 0 and _np.issubdtype(n_dtype, _np.integer):
             return int(n.item())
         return n
     if isinstance(n, _np.integer):

--- a/tests/test_jax_fft_scalar_array_axes.py
+++ b/tests/test_jax_fft_scalar_array_axes.py
@@ -28,12 +28,12 @@ def test_jax_fft_scalar_length_arrays_match_integer_length():
         assert actual.tolist() == expected.tolist()
 
 
-def test_jax_fft_rejects_non_scalar_length_arrays():
+def test_jax_fft_rejects_non_singleton_length_arrays():
     jnp = pytest.importorskip("jax.numpy")
     from pyrecest._backend.jax import fft
 
     values = jnp.arange(4.0)
 
-    for n in (np.array([3]), np.array([[3]]), jnp.array([3]), jnp.array([[3]])):
+    for n in (np.array([3, 4]), np.array([[3, 4]]), jnp.array([3, 4]), jnp.array([[3, 4]])):
         with pytest.raises(TypeError):
             fft.rfft(values, n=n)

--- a/tests/test_jax_fft_scalar_array_axes.py
+++ b/tests/test_jax_fft_scalar_array_axes.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 
@@ -12,3 +13,27 @@ def test_jax_fft_scalar_axis_smoke():
 
     assert actual.shape == expected.shape
     assert actual.tolist() == expected.tolist()
+
+
+def test_jax_fft_scalar_length_arrays_match_integer_length():
+    jnp = pytest.importorskip("jax.numpy")
+    from pyrecest._backend.jax import fft
+
+    values = jnp.arange(4.0)
+    expected = fft.rfft(values, n=3)
+
+    for n in (np.array(3), jnp.array(3)):
+        actual = fft.rfft(values, n=n)
+        assert actual.shape == expected.shape
+        assert actual.tolist() == expected.tolist()
+
+
+def test_jax_fft_rejects_non_scalar_length_arrays():
+    jnp = pytest.importorskip("jax.numpy")
+    from pyrecest._backend.jax import fft
+
+    values = jnp.arange(4.0)
+
+    for n in (np.array([3]), np.array([[3]]), jnp.array([3]), jnp.array([[3]])):
+        with pytest.raises(TypeError):
+            fft.rfft(values, n=n)


### PR DESCRIPTION
## Summary
- tighten JAX real-FFT length normalization so only 0-D integer arrays are coerced to Python `int`
- keep scalar NumPy/JAX integer arrays accepted for `n`
- add regressions rejecting one-element vector/matrix length arrays such as `jnp.array([3])`

## Bug fixed
`pyrecest._backend.jax.fft.rfft(..., n=...)` and `irfft(..., n=...)` previously coerced any size-1 integer array via `.item()`. That made non-scalar length inputs like `np.array([3])`, `np.array([[3]])`, or `jnp.array([3])` silently behave like `n=3`, even though direct NumPy/JAX FFT calls reject those values as non-scalar length arguments. The wrapper now only normalizes zero-dimensional integer arrays.

## Validation
- `python -m py_compile` on the patched JAX FFT module in an isolated copy
- `PYTHONPATH=/tmp/pyrecest_jax_fft/src pytest -q /tmp/pyrecest_jax_fft/tests/test_jax_fft_scalar_array_axes.py` → 3 passed