### PR TITLE
Validate tensor-train tolerance inputs

### DIFF
--- a/src/pyrecest/distributions/hypertorus/_tensor_train.py
+++ b/src/pyrecest/distributions/hypertorus/_tensor_train.py
@@ -22,6 +22,23 @@ def _normalize_max_rank(max_rank):
     return normalized
 
 
+def _normalize_nonnegative_tolerance(value, name):
+    """Return a finite non-negative scalar tolerance."""
+    message = f"{name} must be a non-negative finite real scalar."
+    if isinstance(value, (bool, np.bool_)):
+        raise TypeError(message)
+    try:
+        values = np.asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(message) from exc
+    if values.shape != () or values.dtype.kind not in "iuf":
+        raise TypeError(message)
+    tolerance = float(values)
+    if not np.isfinite(tolerance) or tolerance < 0.0:
+        raise ValueError(message)
+    return tolerance
+
+
 def _choose_rank(singular_values, max_rank, local_tolerance):
     max_rank = _normalize_max_rank(max_rank)
     full_rank = singular_values.size
@@ -91,18 +108,18 @@ class TensorTrain:
     @classmethod
     def from_dense(cls, tensor, *, max_rank=None, rtol=0.0, atol=0.0):
         max_rank = _normalize_max_rank(max_rank)
+        rtol = _normalize_nonnegative_tolerance(rtol, "rtol")
+        atol = _normalize_nonnegative_tolerance(atol, "atol")
         array = np.asarray(tensor, dtype=np.complex128)
         if array.ndim < 1:
             raise ValueError("A tensor with at least one axis is required.")
         if any(axis_size < 1 for axis_size in array.shape):
             raise ValueError("All tensor axes must be non-empty.")
-        if rtol < 0 or atol < 0:
-            raise ValueError("rtol and atol must be non-negative.")
         if array.ndim == 1:
             return cls((array.reshape(1, array.shape[0], 1),))
 
         norm = float(np.linalg.norm(array.ravel()))
-        global_tolerance = max(float(atol), float(rtol) * norm)
+        global_tolerance = max(atol, rtol * norm)
         local_tolerance = global_tolerance / sqrt(array.ndim - 1) if global_tolerance > 0 else 0.0
 
         cores = []
@@ -206,13 +223,13 @@ class TensorTrain:
 
         del max_dense_entries
         max_rank = _normalize_max_rank(max_rank)
-        if rtol < 0 or atol < 0:
-            raise ValueError("rtol and atol must be non-negative.")
+        rtol = _normalize_nonnegative_tolerance(rtol, "rtol")
+        atol = _normalize_nonnegative_tolerance(atol, "atol")
         if self.ndim == 1:
             return self.copy()
 
         norm = self.norm()
-        global_tolerance = max(float(atol), float(rtol) * norm)
+        global_tolerance = max(atol, rtol * norm)
         local_tolerance = global_tolerance / sqrt(self.ndim - 1) if global_tolerance > 0 else 0.0
 
         cores = [core.copy() for core in self.cores]

--- a/tests/distributions/test_hypertoroidal_tensor_train.py
+++ b/tests/distributions/test_hypertoroidal_tensor_train.py
@@ -67,6 +67,25 @@ class TestHypertoroidalTensorTrain(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     tt.round(max_rank=invalid)
 
+    def test_tolerances_require_nonnegative_finite_scalars(self):
+        tensor = np.arange(8, dtype=float).reshape(2, 2, 2)
+        tt = TensorTrain.from_dense(tensor)
+
+        for keyword in ("rtol", "atol"):
+            for invalid in (True, np.bool_(False), "0.1", [0.1], 1.0 + 0.0j):
+                with self.subTest(keyword=keyword, invalid=invalid):
+                    with self.assertRaises(TypeError):
+                        TensorTrain.from_dense(tensor, **{keyword: invalid})
+                    with self.assertRaises(TypeError):
+                        tt.round(**{keyword: invalid})
+
+            for invalid in (-1.0, np.inf, np.nan):
+                with self.subTest(keyword=keyword, invalid=invalid):
+                    with self.assertRaises(ValueError):
+                        TensorTrain.from_dense(tensor, **{keyword: invalid})
+                    with self.assertRaises(ValueError):
+                        tt.round(**{keyword: invalid})
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Add strict finite, non-negative scalar validation for TensorTrain `rtol` and `atol` arguments.
- Reject booleans, array-valued inputs, complex/text values, negative values, NaN, and infinity before rank truncation.
- Cover both `TensorTrain.from_dense(...)` and `TensorTrain.round(...)` with regression tests.

## Bug fixed
`rtol` and `atol` were previously only compared against zero, so values like `True`, `np.inf`, or `np.nan` could enter the truncation tolerance computation. That can silently change rank-selection behavior or produce non-finite truncation thresholds instead of failing early with a clear validation error.

## Validation
- Added targeted unittest coverage in `tests/distributions/test_hypertoroidal_tensor_train.py`.
- Not run locally; this environment cannot clone GitHub or install the project dependencies.