### PR TITLE
Reject boolean PyTorch one_hot class counts

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_one_hot_scalar_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_one_hot_scalar_contract.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from operator import index as _operator_index
 
 
+_INTEGER_MESSAGE = "num_classes must be an integer"
+
+
 def _is_boolean_take_axis(axis, torch_module) -> bool:
     """Return whether ``axis`` is a boolean scalar, not an integer axis."""
     if isinstance(axis, bool) or type(axis).__name__ == "bool_":
@@ -14,6 +17,20 @@ def _is_boolean_take_axis(axis, torch_module) -> bool:
         and axis.ndim == 0
         and axis.dtype == torch_module.bool
     )
+
+
+def _normalize_num_classes(num_classes, torch_module) -> int:
+    """Return a non-boolean integer ``num_classes`` value."""
+    if isinstance(num_classes, bool) or type(num_classes).__name__ == "bool_":
+        raise TypeError(f"{_INTEGER_MESSAGE}, not boolean")
+    if torch_module.is_tensor(num_classes):
+        if num_classes.ndim != 0 or num_classes.dtype == torch_module.bool:
+            raise TypeError(_INTEGER_MESSAGE)
+        num_classes = num_classes.item()
+    try:
+        return _operator_index(num_classes)
+    except TypeError as exc:
+        raise TypeError(_INTEGER_MESSAGE) from exc
 
 
 def _patch_pytorch_take_axis_contract(pytorch_backend, torch_module) -> None:
@@ -66,7 +83,7 @@ def _patch_pytorch_one_hot_scalar_contract(
         return
 
     def one_hot(labels, num_classes):
-        num_classes = _operator_index(num_classes)
+        num_classes = _normalize_num_classes(num_classes, torch_module)
         if torch_module.is_tensor(labels):
             if (
                 labels.dtype == torch_module.bool

--- a/tests/backend_support/test_pytorch_one_hot_scalar_contract.py
+++ b/tests/backend_support/test_pytorch_one_hot_scalar_contract.py
@@ -30,6 +30,14 @@ assert torch.equal(
     torch.tensor([[1, 0, 0, 0], [0, 0, 1, 0]], dtype=torch.uint8),
 )
 
+for bad_num_classes in (True, torch.tensor(True)):
+    try:
+        target.one_hot([0], bad_num_classes)
+    except TypeError as exc:
+        assert "num_classes must be an integer" in str(exc)
+    else:
+        raise AssertionError("boolean num_classes was accepted")
+
 device = torch.device("cuda") if torch.cuda.is_available() else torch.device("meta")
 device_result = target.one_hot(torch.tensor(2, device=device), 4)
 assert device_result.device.type == device.type


### PR DESCRIPTION
## Summary
- normalize PyTorch `one_hot` `num_classes` through an explicit non-boolean integer helper
- reject Python/NumPy-style boolean values and scalar torch boolean tensors instead of treating `True` as class count `1`
- extend the existing raw/public PyTorch scalar-label contract regression test

## Testing
- Not run locally: the execution container could not resolve `github.com` for a full checkout, so I patched through the GitHub API and added the focused regression test for CI.