### PR TITLE
Reject complex measurement-reliability scalars

### DIFF
--- a/src/pyrecest/tracking/measurement_reliability.py
+++ b/src/pyrecest/tracking/measurement_reliability.py
@@ -26,6 +26,7 @@ _TEXT_OR_BOOL_SCALAR_TYPES = (
     np.str_,
     np.bytes_,
 )
+_COMPLEX_SCALAR_TYPES = (complex, np.complexfloating)
 _REJECTED_NUMERIC_ARRAY_KINDS = frozenset({"b", "c", "S", "U", "M", "m"})
 
 
@@ -288,10 +289,10 @@ def _scale_upper_bound(value: float, name: str) -> float:
 
 def _finite_scalar(value: Any, name: str) -> float:
     array = np.asarray(value)
-    if array.shape != () or array.dtype == np.bool_:
+    if array.shape != () or array.dtype == np.bool_ or array.dtype.kind == "c":
         raise ValueError(f"{name} must be a finite scalar")
     scalar = array.item()
-    if isinstance(scalar, _TEXT_OR_BOOL_SCALAR_TYPES):
+    if isinstance(scalar, _TEXT_OR_BOOL_SCALAR_TYPES + _COMPLEX_SCALAR_TYPES):
         raise ValueError(f"{name} must be a finite scalar")
     try:
         parsed = float(scalar)

--- a/tests/tracking/test_measurement_reliability.py
+++ b/tests/tracking/test_measurement_reliability.py
@@ -40,6 +40,21 @@ def test_scalar_reliability_inputs_reject_text_and_object_booleans() -> None:
             reliability_to_covariance_scale(value)
 
 
+def test_scalar_reliability_inputs_reject_complex_scalars() -> None:
+    invalid_values = (
+        0.5 + 0.25j,
+        np.complex128(0.5 + 0.25j),
+        np.array(0.5 + 0.25j),
+        np.array(np.complex128(0.5 + 0.25j), dtype=object),
+    )
+
+    for value in invalid_values:
+        with pytest.raises(ValueError, match="finite scalar"):
+            reliability_to_covariance_scale(value)
+        with pytest.raises(ValueError, match="finite scalar"):
+            apply_measurement_reliability(np.eye(1), reliability=value)
+
+
 def test_reliability_config_rejects_text_and_object_boolean_scalars() -> None:
     invalid_configs = (
         {"threshold": "0.5"},
@@ -50,6 +65,19 @@ def test_reliability_config_rejects_text_and_object_boolean_scalars() -> None:
 
     for kwargs in invalid_configs:
         with pytest.raises(ValueError):
+            MeasurementReliabilityConfig(**kwargs)
+
+
+def test_reliability_config_rejects_complex_scalar_parameters() -> None:
+    invalid_configs = (
+        {"threshold": np.complex128(0.5 + 0.25j)},
+        {"floor": np.array(0.1 + 0.25j)},
+        {"exponent": np.array(np.complex128(2.0 + 0.25j), dtype=object)},
+        {"max_scale": 2.0 + 0.25j},
+    )
+
+    for kwargs in invalid_configs:
+        with pytest.raises(ValueError, match="finite scalar"):
             MeasurementReliabilityConfig(**kwargs)
 
 


### PR DESCRIPTION
## Summary
- Reject complex scalar inputs in measurement-reliability scalar validation before float coercion.
- Cover direct reliability inputs and config scalar parameters with regression tests.

## Bug fixed
`_finite_scalar(...)` previously accepted NumPy complex scalar values such as `np.complex128(0.5 + 0.25j)` because `float(...)` discards the imaginary component with only a warning. That allowed `reliability`, `threshold`, `floor`, `exponent`, or `max_scale` to silently use the real part of a malformed complex value. Complex measurement/covariance arrays were already rejected; this aligns scalar validation with that behavior.

## Validation
- `python -m py_compile /tmp/pyrecest_patch/src/pyrecest/tracking/measurement_reliability.py /tmp/pyrecest_patch/tests/tracking/test_measurement_reliability.py`
- `PYTHONPATH=/tmp/pyrecest_patch/src pytest -q /tmp/pyrecest_patch/tests/tracking/test_measurement_reliability.py` → 14 passed

Full repository pytest was not run locally because this environment cannot clone github.com directly; CI should run the in-tree regression.