### PR TITLE
Reject boolean linear Gaussian inputs

### DIFF
--- a/src/pyrecest/filters/_linear_gaussian.py
+++ b/src/pyrecest/filters/_linear_gaussian.py
@@ -26,7 +26,7 @@ def _contains_boolean_value(x):
         values = np.asarray(x)
     except Exception:  # pragma: no cover - backend-specific conversion errors
         dtype = getattr(x, "dtype", None)
-        return dtype in (bool, np.bool_)
+        return dtype in (bool, np.bool_) or "bool" in str(dtype).lower()
     if values.dtype.kind == "b":
         return True
     if values.dtype == object:

--- a/src/pyrecest/filters/_linear_gaussian.py
+++ b/src/pyrecest/filters/_linear_gaussian.py
@@ -19,7 +19,24 @@ from pyrecest.backend import (
 from pyrecest.diagnostics import FilterDiagnostics
 
 
+def _contains_boolean_value(x):
+    if isinstance(x, (bool, np.bool_)):
+        return True
+    try:
+        values = np.asarray(x)
+    except Exception:  # pragma: no cover - backend-specific conversion errors
+        dtype = getattr(x, "dtype", None)
+        return dtype in (bool, np.bool_)
+    if values.dtype.kind == "b":
+        return True
+    if values.dtype == object:
+        return any(isinstance(item, (bool, np.bool_)) for item in values.reshape(-1))
+    return False
+
+
 def _as_vector(x, name):
+    if _contains_boolean_value(x):
+        raise ValueError(f"{name} must contain numeric values, not booleans")
     x = atleast_1d(asarray(x, dtype=float64))
     if len(x.shape) != 1:
         raise ValueError(f"{name} must be one-dimensional after coercion")
@@ -27,6 +44,8 @@ def _as_vector(x, name):
 
 
 def _as_matrix(x, name):
+    if _contains_boolean_value(x):
+        raise ValueError(f"{name} must contain numeric values, not booleans")
     x = atleast_2d(asarray(x, dtype=float64))
     if len(x.shape) != 2:
         raise ValueError(f"{name} must be two-dimensional after coercion")
@@ -71,6 +90,8 @@ def _as_nonnegative_float(x, name):
 
 
 def _as_nonnegative_nis(x, name="normalized_innovation_squared"):
+    if _contains_boolean_value(x):
+        raise ValueError(f"{name} must be finite and nonnegative")
     nis = asarray(x, dtype=float64)
     try:
         nis_values = np.asarray(to_numpy(nis), dtype=float)

--- a/tests/filters/test_linear_gaussian_robust.py
+++ b/tests/filters/test_linear_gaussian_robust.py
@@ -1,11 +1,13 @@
 # pylint: disable=no-name-in-module,no-member
 """Tests for robust linear-Gaussian helper functions."""
 
+import numpy as np
 import pytest
 from pyrecest.backend import allclose, array
 from pyrecest.filters._linear_gaussian import (
     huber_covariance_scale,
     linear_gaussian_update,
+    normalized_innovation_squared,
     student_t_covariance_scale,
 )
 
@@ -49,9 +51,27 @@ def test_huber_covariance_scale_rejects_nonfinite_nis(invalid_nis):
 
 @pytest.mark.parametrize(
     "invalid_nis",
+    [True, np.bool_(True), array([True])],
+)
+def test_huber_covariance_scale_rejects_boolean_nis(invalid_nis):
+    with pytest.raises(ValueError, match="finite and nonnegative"):
+        huber_covariance_scale(invalid_nis, huber_threshold=2.0)
+
+
+@pytest.mark.parametrize(
+    "invalid_nis",
     [-1.0, array([0.0, -1.0]), float("nan"), float("inf"), -float("inf")],
 )
 def test_student_t_covariance_scale_rejects_invalid_nis(invalid_nis):
+    with pytest.raises(ValueError, match="finite and nonnegative"):
+        student_t_covariance_scale(invalid_nis, measurement_dim=1)
+
+
+@pytest.mark.parametrize(
+    "invalid_nis",
+    [True, np.bool_(True), array([True])],
+)
+def test_student_t_covariance_scale_rejects_boolean_nis(invalid_nis):
     with pytest.raises(ValueError, match="finite and nonnegative"):
         student_t_covariance_scale(invalid_nis, measurement_dim=1)
 
@@ -83,6 +103,14 @@ def test_student_t_covariance_scale_rejects_nonfinite_min_scale(invalid_min_scal
         )
 
 
+def test_normalized_innovation_squared_rejects_boolean_inputs():
+    with pytest.raises(ValueError, match="innovation"):
+        normalized_innovation_squared(array([True]), array([[1.0]]))
+
+    with pytest.raises(ValueError, match="innovation_covariance"):
+        normalized_innovation_squared(array([0.0]), array([[True]]))
+
+
 @pytest.mark.parametrize("invalid_scale", [float("nan"), float("inf"), -float("inf")])
 def test_linear_gaussian_update_rejects_nonfinite_scale(invalid_scale):
     with pytest.raises(ValueError, match="scale must be finite and positive"):
@@ -94,3 +122,26 @@ def test_linear_gaussian_update_rejects_nonfinite_scale(invalid_scale):
             array([[1.0]]),
             scale=invalid_scale,
         )
+
+
+def test_linear_gaussian_update_rejects_boolean_array_inputs():
+    base_kwargs = {
+        "mean": array([0.0]),
+        "covariance": array([[1.0]]),
+        "measurement": array([0.0]),
+        "measurement_matrix": array([[1.0]]),
+        "meas_noise": array([[1.0]]),
+    }
+    invalid_overrides = (
+        {"mean": array([True])},
+        {"covariance": array([[True]])},
+        {"measurement": array([True])},
+        {"measurement_matrix": array([[True]])},
+        {"meas_noise": array([[True]])},
+    )
+
+    for overrides in invalid_overrides:
+        invalid_name = next(iter(overrides))
+        kwargs = {**base_kwargs, **overrides}
+        with pytest.raises(ValueError, match=invalid_name):
+            linear_gaussian_update(**kwargs)


### PR DESCRIPTION
## Summary
- reject boolean-valued vector and matrix inputs in the backend-native linear-Gaussian helper validators before float coercion
- reject boolean NIS inputs for Huber and Student-t covariance scale helpers
- add targeted regressions for boolean innovations, covariance matrices, update inputs, and robust NIS inputs

## Bug fixed
`linear_gaussian_update(...)`, `normalized_innovation_squared(...)`, `huber_covariance_scale(...)`, and `student_t_covariance_scale(...)` previously accepted boolean arrays/scalars because validation converted inputs to `float64` before checking semantic type. That silently treated boolean masks as numeric `0.0`/`1.0` values.

## Validation
- Not run locally; this environment cannot resolve `github.com` for a full checkout. The patch is limited to the linear-Gaussian helper and targeted pytest regressions.