### PR TITLE
Validate low-rank Fourier value input shapes

### DIFF
--- a/src/pyrecest/distributions/hypertorus/low_rank_hypertoroidal_fourier_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/low_rank_hypertoroidal_fourier_distribution.py
@@ -147,12 +147,25 @@ class LowRankHypertoroidalFourierDistribution(AbstractHypertoroidalDistribution)
                 single = True
             elif points.ndim == 1:
                 points = points.reshape(-1, 1)
-            elif points.shape[-1] != 1:
-                raise ValueError("Expected one-dimensional points.")
+            elif points.ndim == 2:
+                if points.shape[-1] != 1:
+                    raise ValueError("Expected one-dimensional points.")
+            else:
+                raise ValueError(
+                    "Expected one-dimensional points as a scalar, vector, or column array."
+                )
         else:
+            if points.ndim == 0:
+                raise ValueError(
+                    f"Expected points with shape ({self.dim},) or (n, {self.dim})."
+                )
             if points.ndim == 1:
                 points = points.reshape(1, -1)
                 single = True
+            elif points.ndim != 2:
+                raise ValueError(
+                    f"Expected points with shape ({self.dim},) or (n, {self.dim})."
+                )
             if points.shape[-1] != self.dim:
                 raise ValueError(f"Expected points with {self.dim} columns.")
 

--- a/tests/distributions/test_low_rank_hypertoroidal_fourier_distribution.py
+++ b/tests/distributions/test_low_rank_hypertoroidal_fourier_distribution.py
@@ -50,6 +50,21 @@ class TestLowRankHypertoroidalFourierDistribution(unittest.TestCase):
         npt.assert_allclose(low_rank.value(xs), dense.value(xs), atol=1e-10)
         npt.assert_allclose(low_rank.pdf(xs), dense.pdf(xs), atol=1e-10)
 
+    def test_value_rejects_invalid_point_rank(self):
+        low_rank_1d = LowRankHypertoroidalFourierDistribution.from_dense(
+            HypertoroidalFourierDistribution(_identity_coefficients_1d(), "identity")
+        )
+        with self.assertRaisesRegex(ValueError, "scalar, vector, or column"):
+            low_rank_1d.value(np.zeros((2, 2, 1)))
+
+        low_rank_2d = LowRankHypertoroidalFourierDistribution.from_dense(
+            HypertoroidalFourierDistribution(_identity_coefficients_2d(), "identity")
+        )
+        for points in (0.0, np.zeros((2, 2, 2))):
+            with self.subTest(points_shape=np.shape(points)):
+                with self.assertRaisesRegex(ValueError, "shape \\(2,\\) or \\(n, 2\\)"):
+                    low_rank_2d.value(points)
+
     def test_shift_matches_dense_2d(self):
         dense = HypertoroidalFourierDistribution(_identity_coefficients_2d(), "identity")
         low_rank = LowRankHypertoroidalFourierDistribution.from_dense(dense)


### PR DESCRIPTION
## Summary
- reject unsupported high-rank point arrays in low-rank hypertoroidal Fourier `value(...)` instead of allowing later shape/broadcast failures
- reject scalar inputs for multi-dimensional low-rank Fourier distributions with a clear `ValueError`
- add regression coverage for invalid 1-D high-rank arrays, invalid 2-D scalar input, and invalid 2-D high-rank arrays

## Bug fixed
`LowRankHypertoroidalFourierDistribution.value(...)` only checked `points.shape[-1]` for some branches. For multi-dimensional distributions, scalar input could raise `IndexError` via `points.shape[-1]`, and higher-rank arrays with the right trailing dimension could proceed into the evaluation loop even though the implementation only handles a single vector or a 2-D `(n, dim)` point matrix.

## Validation
- `python -m py_compile /tmp/low_rank_hypertoroidal_fourier_distribution.py`
- `python -m py_compile /tmp/test_low_rank_hypertoroidal_fourier_distribution.py`

Full in-repository pytest was not run locally because this environment cannot resolve `github.com` for a checkout; the PR regression should run in CI.