### PR TITLE
Allow zero hard gate in robust linear Gaussian update

### DIFF
--- a/src/pyrecest/filters/_linear_gaussian.py
+++ b/src/pyrecest/filters/_linear_gaussian.py
@@ -213,7 +213,7 @@ def _robust_update_decision(
 
     if robust_update is None:
         if gate_threshold is not None:
-            gate_threshold = _as_positive_float(gate_threshold, "gate_threshold")
+            gate_threshold = _as_nonnegative_float(gate_threshold, "gate_threshold")
             if nis > gate_threshold:
                 return False, "rejected", 1.0
         return True, "updated", 1.0

--- a/tests/filters/test_linear_gaussian_zero_gate.py
+++ b/tests/filters/test_linear_gaussian_zero_gate.py
@@ -1,0 +1,58 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+from pyrecest.backend import __backend_name__, array, eye, to_numpy
+from pyrecest.filters._linear_gaussian import linear_gaussian_update_robust
+
+
+@unittest.skipIf(
+    __backend_name__ in ("pytorch", "jax"),
+    reason="tests compare backend arrays with NumPy helpers",
+)
+class LinearGaussianZeroGateThresholdTest(unittest.TestCase):
+    def setUp(self):
+        self.mean = array([0.0, 0.0])
+        self.covariance = eye(2)
+        self.measurement_matrix = eye(2)
+        self.meas_noise = eye(2)
+
+    def test_zero_hard_gate_threshold_rejects_nonzero_nis(self):
+        updated_mean, updated_covariance, diagnostics = linear_gaussian_update_robust(
+            self.mean,
+            self.covariance,
+            array([1.0, 0.0]),
+            self.measurement_matrix,
+            self.meas_noise,
+            robust_update="none",
+            gate_threshold=0.0,
+            return_diagnostics=True,
+        )
+
+        self.assertFalse(diagnostics["accepted"])
+        self.assertEqual(diagnostics["action"], "rejected")
+        self.assertEqual(float(diagnostics["scale"]), 1.0)
+        npt.assert_allclose(to_numpy(updated_mean), to_numpy(self.mean))
+        npt.assert_allclose(to_numpy(updated_covariance), to_numpy(self.covariance))
+
+    def test_zero_hard_gate_threshold_accepts_zero_nis(self):
+        updated_mean, updated_covariance, diagnostics = linear_gaussian_update_robust(
+            self.mean,
+            self.covariance,
+            array([0.0, 0.0]),
+            self.measurement_matrix,
+            self.meas_noise,
+            robust_update="none",
+            gate_threshold=0.0,
+            return_diagnostics=True,
+        )
+
+        self.assertTrue(diagnostics["accepted"])
+        self.assertEqual(diagnostics["action"], "updated")
+        self.assertEqual(float(diagnostics["nis"]), 0.0)
+        npt.assert_allclose(to_numpy(updated_mean), to_numpy(self.mean))
+        npt.assert_allclose(to_numpy(updated_covariance), to_numpy(self.covariance))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/filters/test_linear_gaussian_zero_gate.py
+++ b/tests/filters/test_linear_gaussian_zero_gate.py
@@ -51,7 +51,7 @@ class LinearGaussianZeroGateThresholdTest(unittest.TestCase):
         self.assertEqual(diagnostics["action"], "updated")
         self.assertEqual(float(diagnostics["nis"]), 0.0)
         npt.assert_allclose(to_numpy(updated_mean), to_numpy(self.mean))
-        npt.assert_allclose(to_numpy(updated_covariance), to_numpy(self.covariance))
+        npt.assert_allclose(to_numpy(updated_covariance), 0.5 * np.eye(2))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow `gate_threshold=0.0` for hard NIS rejection in `linear_gaussian_update_robust(..., robust_update="none")`
- keep positive-only validation for `nis-inflate`, where the threshold is used as a divisor
- add regression coverage for zero-threshold hard gates rejecting nonzero NIS and accepting zero NIS

## Bug fixed
`plan_linear_measurement_update(...)` already treats a zero NIS gate as a valid hard gate, but the backend-native robust update path called `_as_positive_float(...)` for hard-gate thresholds. As a result, `linear_gaussian_update_robust(..., robust_update="none", gate_threshold=0.0)` raised `ValueError` instead of behaving as the strict hard gate requested by the caller.

## Validation
- `python -m py_compile` on the patched `_linear_gaussian.py` and new regression test in an isolated copy
- Full pytest not run locally: this environment cannot resolve `github.com` for a full checkout, so CI should run the in-tree test suite.