### PR TITLE
Stabilize replay grid particle weight normalization

### DIFF
--- a/src/pyrecest/filters/replay_grid_likelihood.py
+++ b/src/pyrecest/filters/replay_grid_likelihood.py
@@ -219,10 +219,9 @@ def effective_sample_size_fraction(weights) -> float:
     weights = _coerce_particle_weights(weights)
     if weights.size == 0:
         return 0.0
-    total = float(np.sum(weights))
-    if total <= 0.0 or not np.isfinite(total):
+    normalized = _normalize_particle_weights(weights)
+    if normalized is None:
         return 0.0
-    normalized = weights / total
     ess = 1.0 / float(np.sum(normalized * normalized))
     return float(ess / weights.size)
 
@@ -281,13 +280,12 @@ def particle_position_log_posterior(
     weights = _coerce_particle_weights(weights)
     if weights.shape != (positions.shape[0],):
         raise ValueError("weights must contain one entry per position particle")
-    total = float(np.sum(weights))
-    if total <= 0.0 or not np.isfinite(total):
+    normalized = _normalize_particle_weights(weights)
+    if normalized is None:
         raise ValueError("particle weights must have positive finite total mass")
     if bin_tree is None:
         bin_tree = cKDTree(bin_centers)
 
-    normalized = weights / total
     indices = _nearest_bin_indices(positions, bin_tree)
     masses = np.zeros(bin_centers.shape[0], dtype=float)
     np.add.at(masses, indices, normalized)
@@ -307,6 +305,19 @@ def _coerce_particle_weights(weights) -> np.ndarray:
     if np.any(weights < 0.0):
         raise ValueError("particle weights must be nonnegative")
     return weights
+
+
+def _normalize_particle_weights(weights: np.ndarray) -> np.ndarray | None:
+    if weights.size == 0:
+        return weights
+    max_weight = float(np.max(weights))
+    if max_weight <= 0.0:
+        return None
+    scaled = weights / max_weight
+    total = float(np.sum(scaled))
+    if total <= 0.0 or not np.isfinite(total):
+        return None
+    return scaled / total
 
 
 def _coerce_bin_centers(bin_centers) -> np.ndarray:

--- a/tests/filters/test_replay_grid_likelihood.py
+++ b/tests/filters/test_replay_grid_likelihood.py
@@ -138,6 +138,11 @@ class TestReplayGridLikelihood(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, "particle weights"):
                     effective_sample_size_fraction(weights)
 
+    def test_effective_sample_size_scales_large_finite_weights(self):
+        weights = np.asarray([1e308, 1e308])
+
+        self.assertAlmostEqual(effective_sample_size_fraction(weights), 1.0)
+
     def test_update_position_grid_likelihood_interpolates_particle_positions(self):
         centers = np.array(
             [
@@ -186,6 +191,15 @@ class TestReplayGridLikelihood(unittest.TestCase):
     def test_particle_position_log_posterior_accumulates_weighted_grid_masses(self):
         positions = np.asarray([[0.1, 0.0], [0.2, 0.0], [1.0, 0.0]])
         weights = np.asarray([0.25, 0.25, 0.5])
+        bin_centers = np.asarray([[0.0, 0.0], [1.0, 0.0]])
+
+        log_posterior = particle_position_log_posterior(positions, weights, bin_centers)
+
+        self.assertTrue(np.allclose(np.exp(log_posterior), [0.5, 0.5]))
+
+    def test_particle_position_log_posterior_scales_large_finite_weights(self):
+        positions = np.asarray([[0.0, 0.0], [1.0, 0.0]])
+        weights = np.asarray([1e308, 1e308])
         bin_centers = np.asarray([[0.0, 0.0], [1.0, 0.0]])
 
         log_posterior = particle_position_log_posterior(positions, weights, bin_centers)


### PR DESCRIPTION
## Summary
- Normalize replay-grid particle weights after scaling by their maximum finite weight.
- Keep zero-mass ESS behavior unchanged while avoiding overflow for very large valid weights.
- Reuse the stable normalization for particle-position log posterior accumulation.

## Bug fixed
`effective_sample_size_fraction(...)` and `particle_position_log_posterior(...)` previously normalized particle weights with a direct `np.sum(weights)`. Valid finite weights such as `[1e308, 1e308]` overflowed the sum to `inf`, causing ESS to collapse to `0.0` and posterior accumulation to raise `ValueError` despite the weights being perfectly normalizable.

## Validation
- `python -m py_compile /tmp/replay_grid_likelihood.py /tmp/test_replay_grid_likelihood.py`
- `PYTHONPATH=/tmp/pyrecest_min python -m pytest -q /tmp/test_replay_grid_likelihood.py` → 14 passed, 21 subtests passed