### PR TITLE
Reject NaN cost-matrix adjustments

### DIFF
--- a/src/pyrecest/utils/cost_matrix_adjustments.py
+++ b/src/pyrecest/utils/cost_matrix_adjustments.py
@@ -225,9 +225,11 @@ def _as_cost_matrix(value: Any) -> np.ndarray:
         raise ValueError("cost_matrix must be two-dimensional")
     if matrix.dtype == np.bool_:
         raise ValueError("cost_matrix must be real-valued numeric")
+    if np.any(np.isnan(matrix)):
+        raise ValueError("cost_matrix may not contain NaN")
     if np.any(np.isneginf(matrix)):
         raise ValueError("cost_matrix may not contain negative infinity")
-    return np.nan_to_num(matrix, nan=np.inf, posinf=np.inf)
+    return matrix
 
 
 def _contains_invalid_values(value: Any) -> bool:

--- a/tests/test_cost_matrix_adjustment_nan_validation.py
+++ b/tests/test_cost_matrix_adjustment_nan_validation.py
@@ -1,0 +1,33 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.utils.cost_matrix_adjustments import apply_cost_matrix_adjustment
+
+
+class TestCostMatrixAdjustmentNanValidation(unittest.TestCase):
+    def test_input_nan_costs_are_rejected(self):
+        with self.assertRaisesRegex(ValueError, "NaN"):
+            apply_cost_matrix_adjustment(
+                np.array([[np.nan]]),
+                lambda matrix: matrix,
+            )
+
+    def test_adjustment_nan_output_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "NaN"):
+            apply_cost_matrix_adjustment(
+                np.array([[1.0]]),
+                lambda _matrix: np.array([[np.nan]]),
+            )
+
+    def test_positive_infinity_costs_remain_allowed(self):
+        result = apply_cost_matrix_adjustment(
+            np.array([[1.0, np.inf]]),
+            lambda matrix: matrix,
+        )
+
+        self.assertTrue(np.isposinf(result.adjusted_cost_matrix[0, 1]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Reject `NaN` values in cost matrices before or after cost-matrix adjustments.
- Preserve the existing contract that positive infinity remains allowed for forbidden/impossible assignments.
- Add focused regression tests for input-side and adjustment-output-side `NaN` handling.

## Bug fixed
`_as_cost_matrix(...)` previously returned `np.nan_to_num(matrix, nan=np.inf, posinf=np.inf)`, so malformed `NaN` costs were silently converted to `+inf`. In an association/cost-adjustment path, that can hide invalid numeric output as an impossible edge rather than surfacing the bug at the point where the malformed matrix enters the pipeline.

## Validation
- Isolated local regression smoke test: `pytest -q test_cost_matrix_adjustment_nan_validation.py` → 3 passed
- Branch comparison against `main`: 2 commits ahead, 0 behind; changed only `src/pyrecest/utils/cost_matrix_adjustments.py` and one focused test file.