### PR TITLE
Accept scalar-array track completion session indices

### DIFF
--- a/src/pyrecest/utils/track_completion.py
+++ b/src/pyrecest/utils/track_completion.py
@@ -212,8 +212,8 @@ def occupied_observations_by_session(track_matrix: Any) -> dict[tuple[int, int],
 
     matrix = normalize_track_matrix(track_matrix)
     counts: dict[tuple[int, int], int] = {}
-    for _, session_index in np.ndindex(matrix.shape):
-        value = matrix[_, session_index]
+    for track_index, session_index in np.ndindex(matrix.shape):
+        value = matrix[track_index, session_index]
         if value is not None:
             key = (int(session_index), int(value))
             counts[key] = counts.get(key, 0) + 1
@@ -348,15 +348,28 @@ def _candidate_sessions(
 
 
 def _coerce_candidate_session(value: Any) -> int | None:
-    if isinstance(value, (bool, np.bool_)):
+    try:
+        value_array = np.asarray(value)
+    except (TypeError, ValueError):
         return None
-    if isinstance(value, (int, np.integer)):
-        return int(value)
-    if isinstance(value, (float, np.floating)):
-        if np.isfinite(value) and float(value).is_integer():
-            return int(value)
+    if value_array.shape != () or value_array.dtype == np.bool_:
         return None
-    return None
+
+    scalar = value_array.item()
+    if isinstance(
+        scalar, (bool, np.bool_, str, bytes, bytearray, np.str_, np.bytes_)
+    ):
+        return None
+    if isinstance(scalar, (int, np.integer)):
+        return int(scalar)
+    if isinstance(scalar, (float, np.floating)):
+        if np.isfinite(scalar) and float(scalar).is_integer():
+            return int(scalar)
+        return None
+    try:
+        return int(operator.index(scalar))
+    except TypeError:
+        return None
 
 
 def _completion_step(

--- a/tests/test_track_completion_scalar_session_arrays.py
+++ b/tests/test_track_completion_scalar_session_arrays.py
@@ -1,0 +1,34 @@
+"""Regression tests for scalar-array candidate session providers."""
+
+from __future__ import annotations
+
+import numpy as np
+from pyrecest.utils.track_completion import (
+    enumerate_fragment_completion_paths,
+    path_observations,
+    path_sessions,
+)
+
+
+def test_custom_candidate_sessions_accept_zero_dimensional_integer_arrays() -> None:
+    tracks = [[7, None, None]]
+
+    def candidate_sessions(session: int, observation: int, direction: str):
+        del session, observation, direction
+        return [np.array(2)]
+
+    def provider(session: int, observation: int, target_session: int):
+        if (session, observation, target_session) == (0, 7, 2):
+            return [9]
+        return []
+
+    paths = enumerate_fragment_completion_paths(
+        tracks,
+        direction="suffix",
+        candidate_provider=provider,
+        candidate_session_provider=candidate_sessions,
+    )
+
+    assert len(paths) == 1
+    assert path_sessions(paths[0]) == (0, 2)
+    assert path_observations(paths[0]) == (7, 9)


### PR DESCRIPTION
## Summary
- normalize custom track-completion candidate session values through NumPy scalar extraction before integer coercion
- keep non-scalar arrays, booleans, text, bytes, fractional values, and out-of-range sessions ignored as before
- add a regression for a custom `candidate_session_provider` returning `np.array(2)`

## Bug fixed
`enumerate_fragment_completion_paths(...)` previously ignored zero-dimensional NumPy integer arrays returned by a custom `candidate_session_provider`, even though equivalent scalar-like controls and candidate observations are accepted elsewhere. This meant valid skip-completion paths could be silently dropped when provider code returned NumPy scalar arrays.

## Validation
- `python -m py_compile` on the patched `track_completion.py` and new regression test in an isolated local copy
- isolated pytest smoke: `pytest -q tests/test_track_completion_scalar_session_arrays.py` → 1 passed

Full in-repository pytest was not run locally because this environment cannot resolve `github.com` for a checkout; CI should run the full matrix.