### PR TITLE
Reject invalid tensor-like implicit-surface dtypes

### DIFF
--- a/src/pyrecest/evaluation/implicit_surfaces.py
+++ b/src/pyrecest/evaluation/implicit_surfaces.py
@@ -21,6 +21,15 @@ _INVALID_NUMERIC_SCALAR_TYPES = (
     np.complexfloating,
     type(None),
 )
+_INVALID_TENSOR_DTYPE_TOKENS = (
+    "bool",
+    "complex",
+    "str",
+    "string",
+    "bytes",
+    "datetime",
+    "timedelta",
+)
 
 
 def _surface_method(surface: Any, name: str) -> Callable[[Any], Any]:
@@ -124,14 +133,29 @@ def _positive_float(name: str, value: float) -> float:
     return parsed
 
 
+def _has_invalid_numeric_dtype(values: Any) -> bool:
+    dtype = getattr(values, "dtype", None)
+    if dtype is None:
+        return False
+    kind = getattr(dtype, "kind", None)
+    if kind in _INVALID_NUMERIC_KINDS:
+        return True
+    dtype_name = str(dtype).casefold()
+    return any(token in dtype_name for token in _INVALID_TENSOR_DTYPE_TOKENS)
+
+
 def _as_numeric_field(values: Any, name: str) -> Any:
     if hasattr(values, "clamp"):
+        if _has_invalid_numeric_dtype(values):
+            raise ValueError(f"{name} must contain numeric values.")
         return values
     return _as_numpy_numeric_array(values, name)
 
 
 def _nonnegative_finite_numeric_field(values: Any, name: str) -> Any:
     if hasattr(values, "clamp"):
+        if _has_invalid_numeric_dtype(values):
+            raise ValueError(f"{name} must contain numeric values.")
         if hasattr(values, "isfinite"):
             finite = values.isfinite()
             if bool((~finite).any()):

--- a/tests/evaluation/test_implicit_surface_numeric_validation.py
+++ b/tests/evaluation/test_implicit_surface_numeric_validation.py
@@ -7,6 +7,14 @@ from pyrecest.evaluation import (
 )
 
 
+class _TensorLikeField:
+    def __init__(self, dtype):
+        self.dtype = dtype
+
+    def clamp(self, *, min=None, max=None):  # noqa: A002 - mirrors tensor APIs.
+        return self
+
+
 @pytest.mark.parametrize(
     "values",
     (
@@ -28,3 +36,16 @@ def test_surface_numeric_fields_reject_malformed_array_likes(values) -> None:
         surface_band_probability_from_signed_distance(values, [0.1, 0.1], 0.1)
     with pytest.raises(ValueError, match="distance_std"):
         surface_band_probability_from_signed_distance([0.0, 0.1], values, 0.1)
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    (np.dtype(bool), np.dtype(complex), "torch.bool", "torch.complex64"),
+)
+def test_surface_numeric_fields_reject_tensor_like_invalid_dtypes(dtype) -> None:
+    values = _TensorLikeField(dtype)
+
+    with pytest.raises(ValueError, match="distance"):
+        surface_band_probability_from_signed_distance(values, [0.1], 0.1)
+    with pytest.raises(ValueError, match="distance_std"):
+        surface_band_probability_from_signed_distance([0.0], values, 0.1)


### PR DESCRIPTION
## Summary
- reject tensor-like implicit-surface fields whose dtype is boolean, complex, string/bytes, datetime, or timedelta
- keep existing NumPy array validation unchanged while closing the `.clamp` tensor-like bypass
- add regression coverage with tensor-like stand-ins for `np.dtype(bool)`, `np.dtype(complex)`, `torch.bool`, and `torch.complex64`

## Bug fixed
`surface_band_probability_from_signed_distance(...)` already rejected malformed NumPy array-like inputs, but tensor-like inputs with a `.clamp(...)` method bypassed `_as_numpy_numeric_array(...)`. That meant boolean or complex tensor dtypes could proceed into signed-distance probability arithmetic instead of failing with the same validation semantics as NumPy inputs.

## Validation
- `python -m py_compile /tmp/implicit_surfaces.py /tmp/test_implicit_surface_numeric_validation.py`

Full in-repository pytest was not run locally because this environment cannot clone GitHub directly; CI should run the focused regression in-tree.