### PR TITLE
Reject NaN costs in configured candidate pruning

### DIFF
--- a/src/pyrecest/utils/candidate_pruning.py
+++ b/src/pyrecest/utils/candidate_pruning.py
@@ -230,9 +230,9 @@ def candidate_mask_from_costs(
 ) -> np.ndarray:
     """Return a boolean candidate mask for a pairwise association matrix."""
 
-    costs = _as_cost_matrix(cost_matrix)
-    finite_costs = np.isfinite(costs)
     cfg = candidate_pruning_config_from_mapping(config)
+    costs = _as_cost_matrix(cost_matrix, allow_nan_as_infinite=cfg is None)
+    finite_costs = np.isfinite(costs)
     if cfg is None:
         return finite_costs
 
@@ -281,8 +281,8 @@ def prune_pairwise_cost_matrix(
 ) -> np.ndarray:
     """Replace pruned candidate entries by a large finite cost."""
 
-    costs = _as_cost_matrix(cost_matrix)
     cfg = candidate_pruning_config_from_mapping(config)
+    costs = _as_cost_matrix(cost_matrix, allow_nan_as_infinite=cfg is None)
     if cfg is None:
         return costs
 
@@ -358,11 +358,18 @@ def _effective_large_cost(costs: np.ndarray, penalty: float) -> float:
     return adjusted_penalty
 
 
-def _as_cost_matrix(cost_matrix: Any) -> np.ndarray:
+def _as_cost_matrix(
+    cost_matrix: Any,
+    *,
+    allow_nan_as_infinite: bool = True,
+) -> np.ndarray:
     costs = _as_numeric_matrix(cost_matrix, "cost_matrix")
     if costs.ndim != 2:
         raise ValueError("cost_matrix must be two-dimensional")
-    if np.any(np.isneginf(costs)):
+    invalid_nonfinite = np.isneginf(costs)
+    if not allow_nan_as_infinite:
+        invalid_nonfinite |= np.isnan(costs)
+    if np.any(invalid_nonfinite):
         raise ValueError(
             "cost_matrix may only contain finite values or positive infinity"
         )

--- a/tests/test_candidate_pruning_configured_nan_costs.py
+++ b/tests/test_candidate_pruning_configured_nan_costs.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pytest
+
+from pyrecest.utils import (
+    CandidatePruningConfig,
+    candidate_mask_from_costs,
+    prune_pairwise_cost_matrix,
+)
+
+
+def test_configured_candidate_pruning_rejects_nan_costs() -> None:
+    costs = np.array([[1.0, np.nan], [2.0, 3.0]])
+    config = CandidatePruningConfig(row_top_k=1)
+    message = "cost_matrix may only contain finite values or positive infinity"
+
+    with pytest.raises(ValueError, match=message):
+        candidate_mask_from_costs(costs, config=config)
+
+    with pytest.raises(ValueError, match=message):
+        prune_pairwise_cost_matrix(costs, config=config)


### PR DESCRIPTION
## Summary
- reject `NaN` cost entries when candidate pruning is configured
- keep the existing config-free behavior that treats `NaN` as a forbidden/non-finite edge
- add focused regression coverage for both `candidate_mask_from_costs(...)` and `prune_pairwise_cost_matrix(...)`

## Bug fixed
Configured candidate pruning previously normalized malformed `NaN` costs to `+inf`, hiding invalid pruning inputs as impossible/forbidden edges. That is especially risky for row/column top-k or threshold-based pruning because the configured pruning path is supposed to rank or threshold meaningful numeric costs. The configured path now rejects `NaN` while preserving the legacy config-free behavior.

## Validation
- Inspected the patched files through the GitHub connector
- Full local pytest was not run: this environment could not resolve `github.com` for a full checkout, so CI should run the in-tree regression.