### PR TITLE
Accept scalar fill values in PyTorch full

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_creation_shape_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_creation_shape_contract.py
@@ -49,11 +49,11 @@ def _pytorch_creation_scalar(value, numpy_module, torch_module, *, argument_name
     """Normalize one NumPy-style scalar creation argument."""
     if torch_module.is_tensor(value):
         if value.ndim != 0:
-            raise TypeError(f"arange {argument_name} must be a scalar")
+            raise TypeError(f"{argument_name} must be a scalar")
         return value.item()
     value_array = numpy_module.asarray(value)
     if value_array.shape != ():
-        raise TypeError(f"arange {argument_name} must be a scalar")
+        raise TypeError(f"{argument_name} must be a scalar")
     return value_array.item()
 
 
@@ -88,7 +88,7 @@ def patch_pytorch_creation_shape_contract() -> None:
                     start,
                     np,
                     torch,
-                    argument_name="start",
+                    argument_name="arange start",
                 )
                 if end is _ARANGE_SENTINEL:
                     return torch.arange(
@@ -100,13 +100,13 @@ def patch_pytorch_creation_shape_contract() -> None:
                     end,
                     np,
                     torch,
-                    argument_name="end",
+                    argument_name="arange end",
                 )
                 step = _pytorch_creation_scalar(
                     step,
                     np,
                     torch,
-                    argument_name="step",
+                    argument_name="arange step",
                 )
                 return torch.arange(
                     start,
@@ -136,6 +136,12 @@ def patch_pytorch_creation_shape_contract() -> None:
         if has_fill_value:
 
             def creation_helper(shape, fill_value, dtype=None, *args, **kwargs):
+                fill_value = _pytorch_creation_scalar(
+                    fill_value,
+                    np,
+                    torch,
+                    argument_name="full fill_value",
+                )
                 return torch_helper(
                     _pytorch_creation_shape(shape, np, torch),
                     fill_value,

--- a/tests/backend_support/test_pytorch_creation_contract.py
+++ b/tests/backend_support/test_pytorch_creation_contract.py
@@ -47,10 +47,17 @@ for creation_backend in (backend, raw_backend):
     assert tuple(empty.shape) == (2,)
     assert empty.dtype == creation_backend.float32
 
-    full = creation_backend.full(np.array([2]), 7, dtype=np.int64)
+    full = creation_backend.full(np.array([2]), np.array(7), dtype=np.int64)
     assert tuple(full.shape) == (2,)
     assert full.dtype == creation_backend.int64
     assert creation_backend.to_numpy(full).tolist() == [7, 7]
+
+    full_from_torch_scalar = creation_backend.full(
+        np.array([2]), torch.tensor(8), dtype=np.int64
+    )
+    assert tuple(full_from_torch_scalar.shape) == (2,)
+    assert full_from_torch_scalar.dtype == creation_backend.int64
+    assert creation_backend.to_numpy(full_from_torch_scalar).tolist() == [8, 8]
 
     try:
         creation_backend.zeros(np.array([-1]))
@@ -92,10 +99,15 @@ empty = raw_backend.empty(np.array(2), dtype=np.float32)
 assert tuple(empty.shape) == (2,)
 assert empty.dtype == raw_backend.float32
 
-full = raw_backend.full(torch.tensor([2]), 5, dtype=np.int64)
+full = raw_backend.full(torch.tensor([2]), np.array(5), dtype=np.int64)
 assert tuple(full.shape) == (2,)
 assert full.dtype == raw_backend.int64
 assert raw_backend.to_numpy(full).tolist() == [5, 5]
+
+torch_scalar_full = raw_backend.full(np.array([2]), torch.tensor(6), dtype=np.int64)
+assert tuple(torch_scalar_full.shape) == (2,)
+assert torch_scalar_full.dtype == raw_backend.int64
+assert raw_backend.to_numpy(torch_scalar_full).tolist() == [6, 6]
 """
     subprocess.run(
         [sys.executable, "-c", code], check=True, env=_backend_test_env("numpy")


### PR DESCRIPTION
## Summary
- normalize `full(...)` fill values through the same scalar-array helper used by PyTorch `arange(...)`
- accept zero-dimensional NumPy arrays and scalar PyTorch tensors as fill values for raw and public PyTorch backends
- extend the existing PyTorch creation-helper regression to cover NumPy and Torch scalar fill values

## Bug fixed
The PyTorch creation compatibility hook already normalizes NumPy/Torch array-like shapes, but the `full(...)` wrapper forwarded `fill_value` directly to `torch.full(...)`. Valid NumPy-style scalar-array inputs such as `np.array(7)` or `torch.tensor(8)` were therefore rejected as non-`Number` fill values even though they are scalar values. The wrapper now unwraps those zero-dimensional values before dispatching to `torch.full(...)`, while keeping non-scalar fill values rejected.

## Validation
- Syntax-compiled the patched source and regression test in an isolated check
- Isolated helper smoke: `np.array(7)` and `torch.tensor(8)` normalize to scalar fill values and `torch.full((2,), ...)` returns the expected tensor
- Branch comparison against `main`: 2 commits ahead, 0 behind; changed only the PyTorch creation hook and its focused test