### PR TITLE
Validate weighted registration support

### DIFF
--- a/src/pyrecest/utils/point_set_registration.py
+++ b/src/pyrecest/utils/point_set_registration.py
@@ -164,6 +164,21 @@ def _minimum_required_matches(model: TransformModel, dim: int) -> int:
     raise ValueError(f"Unsupported transform model: {model}")
 
 
+def _validate_effective_weight_support(
+    weights,
+    *,
+    min_matches: int,
+    model: TransformModel,
+    dim: int,
+) -> None:
+    positive_weight_count = int(sum(weights > 0.0))
+    if positive_weight_count < min_matches:
+        raise ValueError(
+            f"The '{model}' model requires at least {min_matches} "
+            f"positive-weight matched points in {dim}D."
+        )
+
+
 def _validate_positive_integer(value, name: str, *, minimum: int = 1) -> int:
     value_array = asarray(value)
     if value_array.shape != ():
@@ -225,6 +240,12 @@ def estimate_transform(  # pylint: disable=too-many-locals
         )
 
     normalized_weights = _normalize_weights(weights, n_points)
+    _validate_effective_weight_support(
+        normalized_weights,
+        min_matches=min_matches,
+        model=model,
+        dim=dim,
+    )
     source_centroid = sum(normalized_weights[:, None] * source, axis=0)
     target_centroid = sum(normalized_weights[:, None] * target, axis=0)
 

--- a/tests/test_point_set_registration_weight_validation.py
+++ b/tests/test_point_set_registration_weight_validation.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy.testing as npt
 import pyrecest.backend
 from pyrecest.backend import array
 from pyrecest.utils.point_set_registration import estimate_transform
@@ -23,6 +24,54 @@ class TestEstimateTransformWeightValidation(unittest.TestCase):
                         model="translation",
                         weights=array([1.0, bad_weight]),
                     )
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_estimate_transform_rejects_insufficient_positive_weight_support(self):
+        affine_source = array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+        affine_target = affine_source + array([1.0, -1.0])
+
+        with self.assertRaisesRegex(ValueError, "positive-weight matched points"):
+            estimate_transform(
+                affine_source,
+                affine_target,
+                model="affine",
+                weights=array([1.0, 0.0, 0.0]),
+            )
+
+        rigid_source = array([[0.0, 0.0], [1.0, 0.0]])
+        rigid_target = rigid_source + array([0.5, -0.5])
+        with self.assertRaisesRegex(ValueError, "positive-weight matched points"):
+            estimate_transform(
+                rigid_source,
+                rigid_target,
+                model="rigid",
+                weights=array([1.0, 0.0]),
+            )
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_estimate_transform_accepts_zero_weights_when_support_is_identifiable(self):
+        source = array(
+            [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [5.0, -3.0]],
+        )
+        true_matrix = array([[1.2, -0.3], [0.4, 0.9]])
+        true_offset = array([2.0, -1.5])
+        target = (true_matrix @ source.T).T + true_offset
+
+        estimated = estimate_transform(
+            source,
+            target,
+            model="affine",
+            weights=array([1.0, 1.0, 1.0, 0.0]),
+        )
+
+        npt.assert_allclose(estimated.matrix, true_matrix, atol=1e-10)
+        npt.assert_allclose(estimated.offset, true_offset, atol=1e-10)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- validate that weighted rigid/affine registration has enough positive-weight matched points before fitting
- reject zero-weight-degenerate weighted registrations instead of letting `pinv` produce an underconstrained transform
- add regression tests for rejected rigid/affine zero-weight support and accepted identifiable zero-weight affine fitting

## Bug fixed
`estimate_transform(...)` checked only the raw number of matched rows before fitting. With explicit weights, rows with zero weight do not constrain the weighted Kabsch or weighted affine least-squares problem. A call such as a 2D affine fit with three rows but only one positive weight could silently return a transform from an underdetermined `pinv` solve. The patch now checks the effective positive-weight support against the model identifiability threshold.

## Validation
- Syntax-checked the modified source and regression test with `ast.parse` in the local sandbox.
- Full test execution was not possible in the sandbox because the repository could not be cloned from github.com here; CI should run on the PR.