### PR TITLE
Reject datetime Gaussian hypothesis inputs

### DIFF
--- a/src/pyrecest/filters/gaussian_hypothesis_mixture.py
+++ b/src/pyrecest/filters/gaussian_hypothesis_mixture.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import numpy as np
 
-_INVALID_FLOAT_ARRAY_KINDS = {"b", "S", "U", "c"}
+_INVALID_FLOAT_ARRAY_KINDS = {"b", "S", "U", "c", "M", "m"}
 _INVALID_FLOAT_ARRAY_SCALAR_TYPES = (
     bool,
     np.bool_,
@@ -18,6 +18,8 @@ _INVALID_FLOAT_ARRAY_SCALAR_TYPES = (
     np.bytes_,
     complex,
     np.complexfloating,
+    np.datetime64,
+    np.timedelta64,
 )
 
 

--- a/tests/filters/test_gaussian_hypothesis_mixture.py
+++ b/tests/filters/test_gaussian_hypothesis_mixture.py
@@ -69,6 +69,35 @@ class GaussianHypothesisMixtureTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "log_weights"):
             normalize_log_weights([0.0, 1.0 + 2.0j])
 
+    def test_datetime_like_numeric_inputs_are_rejected_without_epoch_coercion(self):
+        with self.assertRaisesRegex(ValueError, "mean"):
+            WeightedGaussianHypothesis(
+                np.array([np.datetime64("2026-01-01")]), np.array([[1.0]])
+            )
+
+        with self.assertRaisesRegex(ValueError, "covariance"):
+            WeightedGaussianHypothesis(
+                np.array([0.0]), np.array([[np.timedelta64(1, "s")]])
+            )
+
+        with self.assertRaisesRegex(ValueError, "log_weight"):
+            WeightedGaussianHypothesis(
+                np.array([0.0]),
+                np.array([[1.0]]),
+                log_weight=np.datetime64("2026-01-01"),
+            )
+
+        invalid_log_weights = (
+            np.array([np.datetime64("2026-01-01")]),
+            np.array([np.timedelta64(1, "s")]),
+            np.array([np.datetime64("2026-01-01")], dtype=object),
+            np.array([np.timedelta64(1, "s")], dtype=object),
+        )
+        for log_weights in invalid_log_weights:
+            with self.subTest(log_weights=log_weights):
+                with self.assertRaisesRegex(ValueError, "log_weights"):
+                    normalize_log_weights(log_weights)
+
     def test_hypotheses_reject_nonfinite_mean_and_covariance(self):
         with self.assertRaisesRegex(ValueError, "mean"):
             WeightedGaussianHypothesis(np.array([np.nan]), np.array([[1.0]]))


### PR DESCRIPTION
## Summary
- reject NumPy `datetime64` and `timedelta64` arrays/scalars in Gaussian hypothesis mixture numeric validation
- cover native datetime/timedelta dtypes and object arrays containing datetime/timedelta scalar values
- keep existing real-valued Gaussian hypothesis and log-weight behavior unchanged

## Bug fixed
`WeightedGaussianHypothesis(...)` and `normalize_log_weights(...)` previously rejected bool, text, and complex numeric inputs, but NumPy datetime-like inputs still slipped through because `astype(float)` can convert `datetime64` to epoch-like floats and `timedelta64` to duration-like floats. That could silently turn malformed timestamp/duration data into Gaussian means, covariances, or log weights. The validator now treats dtype kinds `M`/`m` and object arrays containing `np.datetime64`/`np.timedelta64` as non-real numeric inputs.

## Validation
- `python -m py_compile /tmp/gaussian_hypothesis_mixture.py`
- Isolated focused unittest mirror: `python -m unittest tests.filters.test_gaussian_hypothesis_mixture -v` → 13 passed

Full in-repository pytest was not run locally because this environment cannot clone github.com directly; CI should run the in-tree regression.