### PR TITLE
Reject nonfinite DVS event coordinates

### DIFF
--- a/src/pyrecest/experimental/dvs/event_likelihood.py
+++ b/src/pyrecest/experimental/dvs/event_likelihood.py
@@ -450,6 +450,7 @@ def _as_event_xy(event_xy: np.ndarray) -> np.ndarray:
         return np.empty((0, 2), dtype=float)
     if events.ndim != 2 or events.shape[1] != 2:
         raise ValueError("event_xy must have shape (n, 2)")
+    _validate_finite_array(events, "event_xy")
     return events
 
 

--- a/tests/experimental/test_dvs_event_likelihood.py
+++ b/tests/experimental/test_dvs_event_likelihood.py
@@ -183,6 +183,24 @@ def test_normal_flow_activities_rejects_nonfinite_inputs():
         normal_flow_activities(normals, np.array([0.0, 0.0]), activity_floor=np.nan)
 
 
+@pytest.mark.parametrize(
+    "event_xy",
+    [
+        np.array([[np.nan, 0.0]]),
+        np.array([[0.0, np.inf]]),
+        np.array([[0.0, -np.inf]]),
+    ],
+)
+def test_event_likelihood_rejects_nonfinite_event_coordinates(event_xy):
+    contour = _rectangle_contour(width=1.0, height=2.0)
+    velocity = np.array([1.0, 0.0])
+
+    with pytest.raises(ValueError, match="event_xy must contain only finite values"):
+        contour_event_intensity(event_xy, contour, velocity)
+    with pytest.raises(ValueError, match="event_xy must contain only finite values"):
+        event_batch_log_likelihood(event_xy, contour, velocity)
+
+
 def test_active_edge_events_have_higher_intensity():
     contour = _rectangle_contour(width=4.0, height=2.0)
     config = EventLikelihoodConfig(


### PR DESCRIPTION
## Summary
- validate `event_xy` coordinates for finite numeric values after the existing shape coercion
- reject `NaN`, `+inf`, and `-inf` DVS event coordinates instead of letting them propagate into kernels and log likelihoods
- add focused regression coverage for both `contour_event_intensity(...)` and `event_batch_log_likelihood(...)`

## Bug fixed
`_as_event_xy(...)` converted event coordinates to `float` and checked shape, but did not check finiteness. A malformed event batch containing `NaN`/`inf` coordinates could therefore produce `NaN` kernels, intensities, and log-likelihood terms rather than failing at input validation.

## Validation
- `python -m py_compile /tmp/pyrecest/experimental/dvs/event_likelihood.py`
- `PYTHONPATH=/tmp python -m pytest -q /tmp/tests/experimental/test_dvs_event_likelihood.py` → 42 passed
- Branch comparison against `main`: 2 commits ahead, 0 behind; changed only the DVS event-likelihood source and its focused test module.