### PR TITLE
Fix PyTorch dot matrix product contract

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_dot_outer_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_dot_outer_device_contract.py
@@ -118,8 +118,8 @@ def patch_pytorch_dot_outer_device_contract() -> None:
         a, b = _promoted_pair(raw_pytorch, torch, a, b)
         if a.ndim == 0 or b.ndim == 0:
             return torch.multiply(a, b)
-        if a.ndim == 1 and b.ndim == 1:
-            return torch.dot(a, b)
+        if a.ndim <= 2 and b.ndim <= 2:
+            return torch.matmul(a, b)
         if b.ndim == 1:
             return torch.einsum("...i,i->...", a, b)
         if a.ndim == 1:

--- a/tests/backend_support/test_pytorch_dot_outer_device_contract.py
+++ b/tests/backend_support/test_pytorch_dot_outer_device_contract.py
@@ -25,11 +25,21 @@ target = {target_module}
 device = _non_cpu_device()
 right_vector = torch.ones(2, device=device)
 
+
 dot_result = target.dot(torch.tensor([1.0, 2.0]), right_vector)
 assert dot_result.device.type == device.type
 assert tuple(dot_result.shape) == ()
 if device.type != "meta":
     assert torch.allclose(dot_result.cpu(), torch.tensor(3.0))
+
+left_matrix = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+right_matrix = torch.tensor([[5.0, 6.0], [7.0, 8.0]], device=device)
+matrix_dot_result = target.dot(left_matrix, right_matrix)
+assert matrix_dot_result.device.type == device.type
+assert tuple(matrix_dot_result.shape) == (2, 2)
+if device.type != "meta":
+    expected_matrix_dot = torch.tensor([[19.0, 22.0], [43.0, 50.0]])
+    assert torch.allclose(matrix_dot_result.cpu(), expected_matrix_dot)
 
 outer_result = target.outer(torch.tensor([1.0, 2.0]), right_vector)
 assert outer_result.device.type == device.type


### PR DESCRIPTION
## Summary
- make the PyTorch dot/outer device compatibility hook dispatch all scalar/vector/matrix pairs through `torch.matmul` after scalar handling
- add regression coverage showing raw and public PyTorch `dot` preserve the preferred non-CPU device and return the NumPy-style matrix product shape/value for 2-D inputs

## Bug fixed
The active PyTorch compatibility hook still treated two matrix operands as a batched inner product via `einsum("...i,...i->...")`. For 2-D inputs this returned a row-wise contraction or failed on valid matrix-product shapes instead of following NumPy `dot(A, B)` semantics. The patch uses `torch.matmul` for all non-scalar operands where both inputs have at most two dimensions, preserving vector-vector, matrix-vector, vector-matrix, and matrix-matrix behavior.

## Validation
- Syntax-compiled the modified hook and regression test locally with `py_compile`.
- Compared branch against `main`: 2 commits ahead, 1 behind; changed files are limited to the PyTorch dot/outer compatibility hook and its focused backend-support test.
- Full repository tests were not run locally because this environment cannot resolve `github.com`; CI should run the focused PyTorch backend-support regression.