### PR TITLE
Validate scalar measurement weights before expansion

### DIFF
--- a/src/pyrecest/filters/measurement_reliability.py
+++ b/src/pyrecest/filters/measurement_reliability.py
@@ -201,6 +201,10 @@ def normalize_measurement_weights(measurement_weights, n_measurements: int):
             scalar_weight = float(weights)
         except (TypeError, ValueError, OverflowError) as exc:
             raise ValueError("measurement_weights must be real numeric") from exc
+        if not np.isfinite(scalar_weight):
+            raise ValueError("measurement_weights must be finite")
+        if scalar_weight < 0.0:
+            raise ValueError("measurement_weights must be non-negative")
         weights = ones(n_measurements) * scalar_weight
     else:
         weights = reshape(weights, (-1,))

--- a/tests/filters/test_measurement_reliability.py
+++ b/tests/filters/test_measurement_reliability.py
@@ -34,6 +34,18 @@ class TestMeasurementReliability(unittest.TestCase):
         self.assertEqual(weights.shape, (3,))
         self.assertEqual([float(value) for value in weights], [0.25, 0.25, 0.25])
 
+    def test_empty_measurement_scalar_weights_are_validated(self):
+        weights = normalize_measurement_weights(0.25, 0)
+
+        self.assertEqual(weights.shape, (0,))
+
+        with self.assertRaisesRegex(ValueError, "finite"):
+            normalize_measurement_weights(float("nan"), 0)
+        with self.assertRaisesRegex(ValueError, "finite"):
+            normalize_measurement_weights(float("inf"), 0)
+        with self.assertRaisesRegex(ValueError, "non-negative"):
+            normalize_measurement_weights(-0.1, 0)
+
     def test_weight_vector_is_validated(self):
         weights = normalize_measurement_weights(array([1.0, 0.5, 0.0]), 3)
 


### PR DESCRIPTION
## Summary
- validate scalar measurement weights before expanding them across a measurement batch
- keep empty measurement batches valid for finite, non-negative scalar weights
- add regression coverage for `NaN`, infinite, and negative scalar weights with `n_measurements=0`

## Bug fixed
`normalize_measurement_weights(...)` expanded scalar weights with `ones(n_measurements) * scalar_weight` before finite/non-negative validation. For `n_measurements == 0`, invalid scalars such as `NaN`, `inf`, or `-0.1` expanded to an empty vector, so the later `all(...)` checks passed vacuously. The patch rejects invalid scalar weights before expansion.

## Validation
- Inspected the branch diff through the GitHub connector: 2 commits ahead of `main`, 0 behind; changed only `measurement_reliability.py` and its focused test.
- Full pytest was not run in this sandbox; CI should run the focused regression.