### PR TITLE
Reject boolean norm axes in PyTorch backend

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -20,6 +20,9 @@ from ._dtype import (
 # functions, because raw torch.linalg rejects Python lists and integer arrays.
 
 
+_NORM_AXIS_TYPE_ERROR = "axis must be None, an integer, or a tuple of integers"
+
+
 def _as_numpy_no_grad(value):
     """Return a CPU NumPy view/copy for SciPy bridge functions."""
     if isinstance(value, _torch.Tensor):
@@ -274,34 +277,52 @@ def svd(x, full_matrices=True, compute_uv=True):
     return _torch.linalg.svdvals(x)
 
 
+def _norm_axis_entry(axis):
+    """Return one non-boolean NumPy-style linalg.norm axis."""
+    if _is_boolean_scalar(axis):
+        raise TypeError(_NORM_AXIS_TYPE_ERROR)
+    if _torch.is_tensor(axis):
+        if axis.ndim != 0:
+            raise TypeError(_NORM_AXIS_TYPE_ERROR)
+        axis = axis.item()
+    elif isinstance(axis, _np.ndarray):
+        if axis.shape != ():
+            raise TypeError(_NORM_AXIS_TYPE_ERROR)
+        axis = axis.item()
+    try:
+        return _operator_index(axis)
+    except TypeError as exc:
+        raise TypeError(_NORM_AXIS_TYPE_ERROR) from exc
+
+
 def _normalize_norm_axis(axis):
     """Return a PyTorch-compatible norm dimension from NumPy-style axis input."""
     if axis is None:
         return None
     if isinstance(axis, (bool, _np.bool_)):
-        raise TypeError("axis must be None, an integer, or a tuple of integers")
+        raise TypeError(_NORM_AXIS_TYPE_ERROR)
     if _torch.is_tensor(axis):
         if axis.dtype == _torch.bool:
-            raise TypeError("axis must be None, an integer, or a tuple of integers")
+            raise TypeError(_NORM_AXIS_TYPE_ERROR)
         if axis.ndim == 0:
-            return _operator_index(axis.item())
+            return _norm_axis_entry(axis)
         if axis.ndim != 1:
-            raise TypeError("axis must be None, an integer, or a tuple of integers")
+            raise TypeError(_NORM_AXIS_TYPE_ERROR)
         axis = axis.detach().cpu().tolist()
     elif isinstance(axis, _np.ndarray):
         if axis.dtype == _np.bool_:
-            raise TypeError("axis must be None, an integer, or a tuple of integers")
+            raise TypeError(_NORM_AXIS_TYPE_ERROR)
         if axis.ndim == 0:
-            return _operator_index(axis.item())
+            return _norm_axis_entry(axis)
         if axis.ndim != 1:
-            raise TypeError("axis must be None, an integer, or a tuple of integers")
+            raise TypeError(_NORM_AXIS_TYPE_ERROR)
         axis = axis.tolist()
     elif isinstance(axis, (int, _np.integer)):
-        return int(axis)
+        return _norm_axis_entry(axis)
 
     if isinstance(axis, (list, tuple)):
-        return tuple(_operator_index(one_axis) for one_axis in axis)
-    return _operator_index(axis)
+        return tuple(_norm_axis_entry(one_axis) for one_axis in axis)
+    return _norm_axis_entry(axis)
 
 
 def norm(x, ord=None, axis=None, keepdims=False):

--- a/tests/backend_support/test_pytorch_linalg_bool_contract.py
+++ b/tests/backend_support/test_pytorch_linalg_bool_contract.py
@@ -26,3 +26,33 @@ print("ok")
 
     assert result.returncode == 0, result.stderr
     assert "ok" in result.stdout
+
+
+@pytest.mark.backend_portable
+def test_pytorch_linalg_norm_rejects_bool_axis_entries():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import numpy as np
+import pyrecest.backend as backend
+
+matrix = backend.array([[1.0, 2.0], [3.0, 4.0]])
+
+for axis_value in (False, True, [False], (True,), [np.bool_(False)]):
+    try:
+        backend.linalg.norm(matrix, axis=axis_value)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"norm accepted boolean axis {axis_value!r}")
+
+assert backend.to_numpy(backend.linalg.norm(matrix, axis=[0, 1])).shape == ()
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- reject boolean scalar/list/tuple entries in the PyTorch `backend.linalg.norm(axis=...)` normalization path
- add a shared helper for one non-boolean norm-axis entry
- add a backend-portable regression test that covers scalar and sequence boolean axes while preserving valid integer axis sequences

## Rationale
The JAX backend already rejects boolean entries for `linalg.norm(axis=...)`, but the PyTorch backend accepted Python-list/tuple boolean entries because `bool` is indexable as an integer in Python. This made `axis=[False]` behave like `axis=(0,)` and `axis=(True,)` behave like `axis=(1,)`, which is inconsistent with the backend contract and silently masks invalid axis inputs.

## Testing
- Not run locally; repository access was through the GitHub connector.
- Added `tests/backend_support/test_pytorch_linalg_bool_contract.py::test_pytorch_linalg_norm_rejects_bool_axis_entries`.