### PR TITLE
Fix Pareto front eligibility for nonnumeric objectives

### DIFF
--- a/src/pyrecest/evaluation/pareto.py
+++ b/src/pyrecest/evaluation/pareto.py
@@ -301,7 +301,7 @@ def _has_front_eligible_objectives(
 ) -> bool:
     if allow_missing:
         return any(
-            not _is_missing(record.get(objective, np.nan))
+            not _is_missing(_lookup_numeric(record, objective))
             for objective in objectives
         )
     return all(

--- a/tests/evaluation/test_pareto_missing_front_eligibility.py
+++ b/tests/evaluation/test_pareto_missing_front_eligibility.py
@@ -28,6 +28,29 @@ def test_pareto_front_excludes_rows_without_comparable_objectives() -> None:
     assert mask.tolist() == [True, False]
 
 
+def test_pareto_front_excludes_rows_with_only_nonnumeric_objectives() -> None:
+    table = pd.DataFrame(
+        [
+            {"name": "valid", "error": 1.0, "runtime": 1.0},
+            {"name": "nonnumeric", "error": "unavailable", "runtime": b"bad"},
+        ]
+    )
+
+    indices = pareto_front_indices(
+        table,
+        ["error", "runtime"],
+        directions={"error": "min", "runtime": "min"},
+    )
+    mask = is_pareto_front(
+        table,
+        ["error", "runtime"],
+        directions={"error": "min", "runtime": "min"},
+    )
+
+    assert table.loc[indices, "name"].tolist() == ["valid"]
+    assert mask.tolist() == [True, False]
+
+
 def test_strict_pareto_front_requires_complete_objectives() -> None:
     table = pd.DataFrame(
         [


### PR DESCRIPTION
## Summary
- Treat nonnumeric objective values as non-comparable when deciding whether a row is eligible for the Pareto front.
- Reuse the same `_lookup_numeric(...)` coercion path for front eligibility that dominance comparisons already use.
- Add a regression test covering rows whose objective values are text/bytes rather than numeric or NaN.

## Bug fixed
With `allow_missing=True`, `_has_front_eligible_objectives(...)` checked raw values with `record.get(...)` and `pd.isna(...)`. Text or bytes objective values are not missing under that raw check, so a row with no numeric comparable objectives could be marked front-eligible. Later, `record_dominates(...)` coerces those same values through `_lookup_numeric(...)` and treats them as missing/non-comparable, meaning no other row could dominate the malformed row. The result was a spurious Pareto-front entry.

The patch makes front eligibility use `_lookup_numeric(...)` as well, so rows need at least one numeric comparable objective before they can appear on the front.

## Validation
- `python -m py_compile /tmp/pareto.py /tmp/test_pareto_missing_front_eligibility.py`
- In a minimal local package harness: `PYTHONPATH=/tmp/pyrecest_testpkg python -m pytest -q /tmp/test_pareto_missing_front_eligibility.py` → 3 passed
- Confirmed the new regression fails against the previous raw-value eligibility logic: 1 failed, 2 passed
- GitHub compare: branch is 2 commits ahead of `main`, 0 behind; changed files are limited to the Pareto utility and focused regression test.