### PR TITLE
Reject datetime-like track latency session times

### DIFF
--- a/src/pyrecest/utils/track_metrics.py
+++ b/src/pyrecest/utils/track_metrics.py
@@ -361,7 +361,17 @@ def _validate_missed_value(value: Any) -> float:
 
 
 def _contains_bool_or_text(values: np.ndarray) -> bool:
-    invalid_types = (bool, np.bool_, str, bytes, bytearray, np.str_, np.bytes_)
+    invalid_types = (
+        bool,
+        np.bool_,
+        str,
+        bytes,
+        bytearray,
+        np.str_,
+        np.bytes_,
+        np.datetime64,
+        np.timedelta64,
+    )
     return any(isinstance(value, invalid_types) for value in values.flat)
 
 

--- a/tests/test_track_latency_datetime_session_times.py
+++ b/tests/test_track_latency_datetime_session_times.py
@@ -1,0 +1,68 @@
+"""Regression tests for non-numeric track-latency session times."""
+
+import unittest
+
+import numpy as np
+
+from pyrecest.utils.track_metrics import score_track_latency, track_latencies
+
+
+class TrackLatencyDatetimeSessionTimesTest(unittest.TestCase):
+    def setUp(self):
+        self.predicted = [[0, 0, 0]]
+        self.reference = [[0, 0, 0]]
+
+    def test_numpy_datetime_like_session_times_are_rejected(self):
+        invalid_session_times = (
+            [
+                np.datetime64("2026-01-01"),
+                np.datetime64("2026-01-02"),
+                np.datetime64("2026-01-03"),
+            ],
+            np.array(
+                [
+                    np.datetime64("2026-01-01"),
+                    np.datetime64("2026-01-02"),
+                    np.datetime64("2026-01-03"),
+                ],
+                dtype=object,
+            ),
+            [
+                np.timedelta64(0, "s"),
+                np.timedelta64(1, "s"),
+                np.timedelta64(2, "s"),
+            ],
+            np.array(
+                [
+                    np.timedelta64(0, "s"),
+                    np.timedelta64(1, "s"),
+                    np.timedelta64(2, "s"),
+                ],
+                dtype=object,
+            ),
+        )
+
+        for session_times in invalid_session_times:
+            with self.subTest(session_times=repr(session_times)):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "session_times must contain only finite numeric values",
+                ):
+                    track_latencies(
+                        self.predicted,
+                        self.reference,
+                        session_times=session_times,
+                    )
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "session_times must contain only finite numeric values",
+                ):
+                    score_track_latency(
+                        self.predicted,
+                        self.reference,
+                        session_times=session_times,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reject NumPy `datetime64` and `timedelta64` scalars in `track_latencies(..., session_times=...)`
- prevent object arrays/lists of datetime-like scalars from being silently converted to numeric offsets
- add focused regression coverage for both `track_latencies(...)` and `score_track_latency(...)`

## Bug fixed
`_session_times(...)` converted `session_times` through `np.asarray(..., dtype=object).astype(float)` after checking only bool/text values. Lists or object arrays containing `np.datetime64` or `np.timedelta64` scalars can cast to floats, so malformed wall-clock timestamps or durations were silently accepted as numeric session times. The validator now rejects these datetime-like scalar values before float coercion.

## Validation
- Inspected the branch diff through the GitHub connector: 2 commits ahead of `main`, 0 behind; changed only `src/pyrecest/utils/track_metrics.py` and one focused regression test.
- Full local pytest was not run because this environment cannot clone `github.com`; CI should run the in-tree regression.