### PR TITLE
Reject nonfinite cardinality prior scalars

### DIFF
--- a/src/pyrecest/filters/nonparametric_cardinality.py
+++ b/src/pyrecest/filters/nonparametric_cardinality.py
@@ -10,7 +10,7 @@ predictive diagnostics.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from math import exp, log
+from math import exp, isfinite, log
 from numbers import Integral, Real
 
 from scipy.special import gammaln
@@ -19,7 +19,10 @@ from scipy.special import gammaln
 def _as_float(value, name):
     if isinstance(value, bool) or not isinstance(value, Real):
         raise TypeError(f"{name} must be a real scalar.")
-    return float(value)
+    value = float(value)
+    if not isfinite(value):
+        raise ValueError(f"{name} must be finite.")
+    return value
 
 
 def _validate_nonnegative_integer(value, name):

--- a/tests/filters/test_nonparametric_cardinality.py
+++ b/tests/filters/test_nonparametric_cardinality.py
@@ -105,6 +105,22 @@ class NonparametricCardinalityPriorTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             PitmanYorBirthProbability(minimum_probability=0.9, maximum_probability=0.1)
 
+    def test_nonfinite_parameters_are_rejected(self):
+        for discount in (math.nan, math.inf, -math.inf):
+            with self.subTest(discount=discount):
+                with self.assertRaises(ValueError):
+                    PitmanYorProcessCardinalityPrior(discount=discount, strength=1.0)
+
+        for strength in (math.nan, math.inf, -math.inf):
+            with self.subTest(strength=strength):
+                with self.assertRaises(ValueError):
+                    PitmanYorProcessCardinalityPrior(discount=0.2, strength=strength)
+
+        with self.assertRaises(ValueError):
+            DirichletProcessCardinalityPrior(concentration=math.nan)
+        with self.assertRaises(ValueError):
+            PitmanYorBirthProbability(strength=math.inf)
+
     def test_boolean_parameters_are_rejected(self):
         with self.assertRaises(TypeError):
             PitmanYorProcessCardinalityPrior(discount=False, strength=1.0)


### PR DESCRIPTION
## Summary
- reject `NaN`/infinite scalar parameters before constructing Pitman--Yor and Dirichlet-process cardinality priors
- make the shared scalar coercion helper enforce finite real values before downstream probability/log computations
- add focused regression coverage for nonfinite `discount`, `strength`, DP concentration, and birth-prior strength inputs

## Bug fixed
`PitmanYorProcessCardinalityPrior.__post_init__(...)` coerced `strength` with `float(...)` but did not check finiteness. As a result, `strength=math.nan` or `strength=math.inf` could be accepted and later propagate `NaN` through predictive probabilities, EPPF values, expected cluster counts, and `PitmanYorBirthProbability(...)` outputs. The fix rejects nonfinite real scalars at validation time.

## Validation
- Isolated focused pytest mirror: `PYTHONPATH=/mnt/data/pyrecest_patch/src python -m pytest -q /mnt/data/pyrecest_patch/tests/filters/test_nonparametric_cardinality.py` → `10 passed, 6 subtests passed`
- GitHub compare: branch is 2 commits ahead of `main`, 0 behind; changed only `src/pyrecest/filters/nonparametric_cardinality.py` and `tests/filters/test_nonparametric_cardinality.py`.