### PR TITLE
Reject datetime-like time offset inputs

### DIFF
--- a/src/pyrecest/calibration/time_offset.py
+++ b/src/pyrecest/calibration/time_offset.py
@@ -10,6 +10,7 @@ import numpy as np
 
 _ERROR_METRIC_NAMES = frozenset({"max", "mean", "p95", "rmse", "std"})
 _ERROR_METRIC_MESSAGE = "metric must be one of 'max', 'mean', 'p95', 'rmse', or 'std'"
+_TEMPORAL_SCALAR_TYPES = (np.datetime64, np.timedelta64)
 
 
 @dataclass(frozen=True)
@@ -59,12 +60,19 @@ def _validate_error_metric(metric: Any) -> str:
     return normalized
 
 
+def _is_datetime_like_scalar(value: Any) -> bool:
+    if isinstance(value, _TEMPORAL_SCALAR_TYPES):
+        return True
+    dtype = getattr(value, "dtype", None)
+    return getattr(dtype, "kind", None) in ("M", "m")
+
+
 def _as_finite_float(value: Any, name: str) -> float:
     arr = np.asarray(value)
-    if arr.ndim != 0 or arr.dtype == np.bool_:
+    if arr.ndim != 0 or arr.dtype == np.bool_ or arr.dtype.kind in "Mm":
         raise ValueError(f"{name} must be a finite scalar")
     scalar = arr.item()
-    if isinstance(scalar, (bool, np.bool_, str, bytes, bytearray)):
+    if isinstance(scalar, (bool, np.bool_, str, bytes, bytearray, complex, np.complexfloating)) or _is_datetime_like_scalar(scalar):
         raise ValueError(f"{name} must be a finite scalar")
     try:
         result = float(scalar)
@@ -77,10 +85,10 @@ def _as_finite_float(value: Any, name: str) -> float:
 
 def _as_nonnegative_time_delta(value: Any, name: str) -> float:
     arr = np.asarray(value)
-    if arr.ndim != 0 or arr.dtype == np.bool_:
+    if arr.ndim != 0 or arr.dtype == np.bool_ or arr.dtype.kind in "Mm":
         raise ValueError(f"{name} must be nonnegative")
     scalar = arr.item()
-    if isinstance(scalar, (bool, np.bool_, str, bytes, bytearray)):
+    if isinstance(scalar, (bool, np.bool_, str, bytes, bytearray, complex, np.complexfloating)) or _is_datetime_like_scalar(scalar):
         raise ValueError(f"{name} must be nonnegative")
     try:
         result = float(scalar)
@@ -97,7 +105,7 @@ def _as_real_numeric_array(value: Any, name: str) -> np.ndarray:
         raise ValueError(f"{name} must contain real numeric values")
     if arr.dtype.kind == "O":
         for item in arr.reshape(-1):
-            if item is None or isinstance(item, (bool, np.bool_, str, bytes, bytearray, complex, np.complexfloating)):
+            if item is None or isinstance(item, (bool, np.bool_, str, bytes, bytearray, complex, np.complexfloating)) or _is_datetime_like_scalar(item):
                 raise ValueError(f"{name} must contain real numeric values")
     try:
         return np.asarray(value, dtype=float)
@@ -110,7 +118,7 @@ def _as_summary_scalar(value: Any, name: str, *, allow_nan: bool = False) -> flo
     if arr.ndim != 0 or arr.dtype == np.bool_ or arr.dtype.kind in "USbcMm":
         raise ValueError(f"{name} must be a real scalar")
     scalar = arr.item()
-    if isinstance(scalar, (bool, np.bool_, str, bytes, bytearray)):
+    if isinstance(scalar, (bool, np.bool_, str, bytes, bytearray, complex, np.complexfloating)) or _is_datetime_like_scalar(scalar):
         raise ValueError(f"{name} must be a real scalar")
     try:
         result = float(scalar)

--- a/tests/calibration/test_time_offset_real_numeric_validation.py
+++ b/tests/calibration/test_time_offset_real_numeric_validation.py
@@ -2,7 +2,11 @@ import unittest
 
 import numpy as np
 
-from pyrecest.calibration import apply_time_offset, make_offset_grid
+from pyrecest.calibration import (
+    apply_time_offset,
+    interpolate_reference_values,
+    make_offset_grid,
+)
 
 
 class TimeOffsetRealNumericValidationTest(unittest.TestCase):
@@ -20,6 +24,42 @@ class TimeOffsetRealNumericValidationTest(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "min_s must be a finite scalar"):
             make_offset_grid(min_s, 1.0, 1.0)
+
+    def test_apply_time_offset_rejects_datetime_like_object_arrays(self):
+        for times in (
+            np.array([np.datetime64("2020-01-01")], dtype=object),
+            np.array([np.timedelta64(2, "ns")], dtype=object),
+        ):
+            with self.subTest(times=times):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "times_s must contain real numeric values",
+                ):
+                    apply_time_offset(times, 0.0)
+
+    def test_apply_time_offset_rejects_temporal_scalar_offsets(self):
+        times = np.array([0.0, 1.0])
+
+        for offset_s in (
+            np.timedelta64(1, "ns"),
+            np.array(np.timedelta64(1, "ns"), dtype=object),
+        ):
+            with self.subTest(offset_s=offset_s):
+                with self.assertRaisesRegex(ValueError, "offset_s must be a finite scalar"):
+                    apply_time_offset(times, offset_s)
+
+    def test_interpolation_rejects_temporal_max_time_delta_scalar(self):
+        reference_times = np.array([0.0, 1.0])
+        reference_values = np.array([[0.0], [1.0]])
+        query_times = np.array([0.5])
+
+        with self.assertRaisesRegex(ValueError, "max_time_delta_s must be nonnegative"):
+            interpolate_reference_values(
+                reference_times,
+                reference_values,
+                query_times,
+                max_time_delta_s=np.timedelta64(1, "ns"),
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- reject NumPy `datetime64`/`timedelta64` scalar values in time-offset scalar validators before float coercion
- reject object arrays containing datetime-like values in time-series inputs
- reject complex object scalars explicitly in scalar validators, preventing NumPy from discarding imaginary parts during `float(...)` conversion
- add focused regressions for object-array times, scalar offsets, and max-time-delta inputs

## Bug fixed
`time_offset.py` previously allowed some non-real time-like values through float coercion. In particular, nanosecond `np.timedelta64` values can expose integer-like payloads, so inputs such as `np.timedelta64(1, "ns")` could be interpreted as `1.0` seconds for `offset_s` or `max_time_delta_s`. Object arrays containing `np.datetime64`/`np.timedelta64` could also be converted to floats by `np.asarray(..., dtype=float)`. The patch rejects these datetime-like inputs before conversion.

The same scalar path now also rejects complex object scalars explicitly so NumPy cannot silently discard the imaginary part under a `ComplexWarning`.

## Validation
- `python -m py_compile /mnt/data/time_offset_patched.py`
- isolated focused unittest mirror: `PYTHONPATH=/mnt/data python -m unittest /mnt/data/test_time_offset_real_numeric_validation_patched.py -v` → 5 passed

Full in-repository pytest was not run locally because this environment cannot resolve `github.com` for a checkout; CI should run the in-tree regression.