### PR TITLE
Reject nonnumeric adaptive process-noise scalars

### DIFF
--- a/src/pyrecest/filters/adaptive_process_noise.py
+++ b/src/pyrecest/filters/adaptive_process_noise.py
@@ -8,6 +8,18 @@ from numbers import Integral
 
 import numpy as np
 
+_NON_NUMERIC_SCALAR_TYPES = (
+    bool,
+    np.bool_,
+    str,
+    bytes,
+    bytearray,
+    np.str_,
+    np.bytes_,
+    np.datetime64,
+    np.timedelta64,
+)
+
 
 @dataclass(frozen=True)
 class AdaptiveProcessNoiseConfig:
@@ -64,18 +76,23 @@ class AdaptiveProcessNoiseConfig:
 
 
 def _normalize_finite_scalar(value: float, name: str) -> float:
+    message = f"{name} must be a finite scalar"
     value_array = np.asarray(value)
-    if value_array.shape != () or value_array.dtype == np.bool_:
-        raise ValueError(f"{name} must be a finite scalar")
+    if (
+        value_array.shape != ()
+        or value_array.dtype == np.bool_
+        or value_array.dtype.kind in "USbcMm"
+    ):
+        raise ValueError(message)
     value_scalar = value_array.item()
-    if isinstance(value_scalar, (bool, np.bool_)):
-        raise ValueError(f"{name} must be a finite scalar")
+    if isinstance(value_scalar, _NON_NUMERIC_SCALAR_TYPES):
+        raise ValueError(message)
     try:
         value_float = float(value_scalar)
     except (TypeError, ValueError, OverflowError) as exc:
-        raise ValueError(f"{name} must be a finite scalar") from exc
+        raise ValueError(message) from exc
     if not np.isfinite(value_float):
-        raise ValueError(f"{name} must be a finite scalar")
+        raise ValueError(message)
     return value_float
 
 
@@ -89,7 +106,7 @@ def _normalize_nonnegative_finite_scalar(value: float, name: str) -> float:
     ):
         raise ValueError(message)
     value_scalar = value_array.item()
-    if isinstance(value_scalar, (bool, np.bool_, str, bytes, bytearray)):
+    if isinstance(value_scalar, _NON_NUMERIC_SCALAR_TYPES):
         raise ValueError(message)
     try:
         value_float = float(value_scalar)

--- a/tests/filters/test_adaptive_process_noise.py
+++ b/tests/filters/test_adaptive_process_noise.py
@@ -21,7 +21,16 @@ def test_scale_increases_for_high_nis_ratio_and_decreases_for_low_ratio():
 
 @pytest.mark.parametrize(
     "ratio",
-    [np.nan, np.inf, -np.inf, -0.1, True, "1.0", np.array([1.0])],
+    [
+        np.nan,
+        np.inf,
+        -np.inf,
+        -0.1,
+        True,
+        "1.0",
+        np.array([1.0]),
+        np.array(np.timedelta64(2, "ns"), dtype=object),
+    ],
 )
 def test_scale_rejects_invalid_ratios(ratio):
     with pytest.raises(ValueError, match="ratio must be a nonnegative finite scalar"):
@@ -59,7 +68,17 @@ def test_config_normalizes_scalar_numeric_values():
 
 
 def test_config_rejects_nonfinite_or_nonscalar_values():
-    invalid_values = (np.nan, np.inf, -np.inf, True, np.array([1.0]))
+    invalid_values = (
+        np.nan,
+        np.inf,
+        -np.inf,
+        True,
+        "1.0",
+        b"1.0",
+        np.array([1.0]),
+        np.timedelta64(2, "ns"),
+        np.array(np.timedelta64(2, "ns"), dtype=object),
+    )
 
     for field_name in (
         "base_scale",


### PR DESCRIPTION
## Summary
- reject string/bytes and datetime-like scalar inputs in adaptive process-noise config validation
- reject object-wrapped `np.timedelta64` ratio values before `float(...)` coercion
- add focused regressions for config fields and `adaptive_scale_from_ratio(...)`

## Bug fixed
`AdaptiveProcessNoiseConfig(...)` used `_normalize_finite_scalar(...)`, which previously allowed values like string numerals or nanosecond `np.timedelta64` scalars to pass through `float(...)` conversion. The nonnegative ratio path also rejected temporal dtypes, but an object-wrapped `np.timedelta64` scalar could still be converted to a numeric ratio. This silently accepted nonnumeric time/string data as process-noise scales or NIS ratios.

The patch adds a shared nonnumeric scalar type guard and applies it before numeric conversion in both scalar-normalization helpers.

## Validation
- `python -m py_compile /tmp/adaptive_process_noise.py /tmp/test_adaptive_process_noise.py`
- isolated focused pytest mirror: `PYTHONPATH=/tmp/pyrecest_iso python -m pytest -q /tmp/pyrecest_iso/tests/filters/test_adaptive_process_noise.py` → `12 passed`
- GitHub compare: branch is 2 commits ahead of `main`, 0 behind; changed only `src/pyrecest/filters/adaptive_process_noise.py` and `tests/filters/test_adaptive_process_noise.py`.