### PR TITLE
Reject temporal scalars in time-offset calibration

### DIFF
--- a/src/pyrecest/calibration/time_offset.py
+++ b/src/pyrecest/calibration/time_offset.py
@@ -10,6 +10,18 @@ import numpy as np
 
 _ERROR_METRIC_NAMES = frozenset({"max", "mean", "p95", "rmse", "std"})
 _ERROR_METRIC_MESSAGE = "metric must be one of 'max', 'mean', 'p95', 'rmse', or 'std'"
+_REJECTED_SCALAR_VALUE_TYPES = (
+    type(None),
+    bool,
+    np.bool_,
+    str,
+    bytes,
+    bytearray,
+    complex,
+    np.complexfloating,
+    np.datetime64,
+    np.timedelta64,
+)
 
 
 @dataclass(frozen=True)
@@ -59,12 +71,16 @@ def _validate_error_metric(metric: Any) -> str:
     return normalized
 
 
+def _is_temporal_dtype(arr: np.ndarray) -> bool:
+    return arr.dtype.kind in "Mm"
+
+
 def _as_finite_float(value: Any, name: str) -> float:
     arr = np.asarray(value)
-    if arr.ndim != 0 or arr.dtype == np.bool_:
+    if arr.ndim != 0 or arr.dtype == np.bool_ or _is_temporal_dtype(arr):
         raise ValueError(f"{name} must be a finite scalar")
     scalar = arr.item()
-    if isinstance(scalar, (bool, np.bool_, str, bytes, bytearray)):
+    if isinstance(scalar, _REJECTED_SCALAR_VALUE_TYPES):
         raise ValueError(f"{name} must be a finite scalar")
     try:
         result = float(scalar)
@@ -77,10 +93,10 @@ def _as_finite_float(value: Any, name: str) -> float:
 
 def _as_nonnegative_time_delta(value: Any, name: str) -> float:
     arr = np.asarray(value)
-    if arr.ndim != 0 or arr.dtype == np.bool_:
+    if arr.ndim != 0 or arr.dtype == np.bool_ or _is_temporal_dtype(arr):
         raise ValueError(f"{name} must be nonnegative")
     scalar = arr.item()
-    if isinstance(scalar, (bool, np.bool_, str, bytes, bytearray)):
+    if isinstance(scalar, _REJECTED_SCALAR_VALUE_TYPES):
         raise ValueError(f"{name} must be nonnegative")
     try:
         result = float(scalar)
@@ -97,7 +113,7 @@ def _as_real_numeric_array(value: Any, name: str) -> np.ndarray:
         raise ValueError(f"{name} must contain real numeric values")
     if arr.dtype.kind == "O":
         for item in arr.reshape(-1):
-            if item is None or isinstance(item, (bool, np.bool_, str, bytes, bytearray, complex, np.complexfloating)):
+            if isinstance(item, _REJECTED_SCALAR_VALUE_TYPES):
                 raise ValueError(f"{name} must contain real numeric values")
     try:
         return np.asarray(value, dtype=float)
@@ -110,7 +126,7 @@ def _as_summary_scalar(value: Any, name: str, *, allow_nan: bool = False) -> flo
     if arr.ndim != 0 or arr.dtype == np.bool_ or arr.dtype.kind in "USbcMm":
         raise ValueError(f"{name} must be a real scalar")
     scalar = arr.item()
-    if isinstance(scalar, (bool, np.bool_, str, bytes, bytearray)):
+    if isinstance(scalar, _REJECTED_SCALAR_VALUE_TYPES):
         raise ValueError(f"{name} must be a real scalar")
     try:
         result = float(scalar)

--- a/tests/calibration/test_time_offset_temporal_validation.py
+++ b/tests/calibration/test_time_offset_temporal_validation.py
@@ -1,0 +1,87 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.calibration.time_offset import (
+    aggregate_time_offset_sweeps,
+    apply_time_offset,
+    interpolate_reference_values,
+)
+
+
+class TimeOffsetTemporalValidationTest(unittest.TestCase):
+    def test_temporal_scalar_offsets_are_rejected(self):
+        invalid_offsets = (
+            np.datetime64("2020-01-01T00:00:00.000000001"),
+            np.array(
+                np.datetime64("2020-01-01T00:00:00.000000001"),
+                dtype=object,
+            ),
+        )
+
+        for offset_s in invalid_offsets:
+            with self.subTest(offset_s=offset_s):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "offset_s must be a finite scalar",
+                ):
+                    apply_time_offset(np.array([0.0]), offset_s)
+
+    def test_temporal_max_time_delta_is_rejected(self):
+        invalid_deltas = (
+            np.timedelta64(2, "ns"),
+            np.array(np.timedelta64(2, "ns"), dtype=object),
+        )
+
+        for max_time_delta_s in invalid_deltas:
+            with self.subTest(max_time_delta_s=max_time_delta_s):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "max_time_delta_s must be nonnegative",
+                ):
+                    interpolate_reference_values(
+                        np.array([0.0, 1.0]),
+                        np.array([[0.0], [1.0]]),
+                        np.array([0.5]),
+                        max_time_delta_s=max_time_delta_s,
+                    )
+
+    def test_temporal_object_arrays_are_rejected_as_times(self):
+        times = np.array(
+            [np.datetime64("2020-01-01T00:00:00.000000001")],
+            dtype=object,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "times_s must contain real numeric values",
+        ):
+            apply_time_offset(times, 0.0)
+
+    def test_temporal_summary_offsets_are_rejected(self):
+        sweep = [
+            [
+                {
+                    "time_offset_s": np.array(
+                        np.datetime64("2020-01-01T00:00:00.000000001"),
+                        dtype=object,
+                    ),
+                    "count": 1.0,
+                    "mean": 0.0,
+                    "std": 0.0,
+                    "rmse": 0.0,
+                    "p95": 0.0,
+                    "max": 0.0,
+                }
+            ]
+        ]
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "time_offset_s must be a real scalar",
+        ):
+            aggregate_time_offset_sweeps(sweep)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reject NumPy `datetime64`/`timedelta64` scalars before time-offset scalar coercion
- prevent object arrays containing temporal scalars from being treated as numeric times or sweep offsets
- add focused regression coverage for `offset_s`, `max_time_delta_s`, `times_s`, and aggregate sweep offsets

## Bug fixed
NumPy `datetime64`/`timedelta64` values with nanosecond units can expose integer-like scalar values and `float(...)` can turn them into epoch/duration numbers. `time_offset` validators accepted some direct scalar and object-array temporal inputs, so malformed timestamps or durations could be silently interpreted as seconds.

## Validation
- `python -m py_compile /tmp/time_offset.py`
- Focused local unittest mirror: `python -m unittest /tmp/test_time_offset_temporal.py -v` → 4 tests passed
- GitHub compare: branch is 2 commits ahead of `main`, 0 behind; changed only `src/pyrecest/calibration/time_offset.py` and `tests/calibration/test_time_offset_temporal_validation.py`

Full repository pytest was not run locally because this sandbox cannot resolve `github.com`; CI should run the in-tree regression.