### PR TITLE
Reject object temporal calibration inputs

### DIFF
--- a/src/pyrecest/calibration/__init__.py
+++ b/src/pyrecest/calibration/__init__.py
@@ -16,6 +16,8 @@ _REJECTED_REAL_SCALAR_TYPES = (
     bytearray,
     complex,
     np.complexfloating,
+    np.datetime64,
+    np.timedelta64,
 )
 
 

--- a/tests/calibration/test_temporal_object_validation.py
+++ b/tests/calibration/test_temporal_object_validation.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import pyrecest.calibration as calibration
+
+
+_OBJECT_TEMPORAL_SCALARS = (
+    np.array(np.timedelta64(1, "ns"), dtype=object),
+    np.array(np.datetime64("1970-01-01T00:00:00.000000001"), dtype=object),
+)
+
+_OBJECT_TEMPORAL_ARRAYS = (
+    *_OBJECT_TEMPORAL_SCALARS,
+    np.array([np.timedelta64(1, "ns")], dtype=object),
+    np.array([np.datetime64("1970-01-01T00:00:00.000000001")], dtype=object),
+)
+
+
+@pytest.mark.parametrize("value", _OBJECT_TEMPORAL_SCALARS)
+def test_calibration_scalar_helpers_reject_object_temporal_values(value) -> None:
+    with pytest.raises(ValueError, match="offset_s must be a finite scalar"):
+        calibration._as_finite_float(value, "offset_s")
+    with pytest.raises(ValueError, match="max_time_delta_s must be nonnegative"):
+        calibration._as_nonnegative_time_delta(value, "max_time_delta_s")
+    with pytest.raises(ValueError, match="time_offset_s must be a real scalar"):
+        calibration._as_summary_scalar(value, "time_offset_s")
+
+
+@pytest.mark.parametrize("value", _OBJECT_TEMPORAL_ARRAYS)
+def test_calibration_numeric_array_helper_rejects_object_temporal_values(value) -> None:
+    with pytest.raises(
+        ValueError,
+        match="measurement_times_s must contain real numeric values",
+    ):
+        calibration._as_real_numeric_array(value, "measurement_times_s")


### PR DESCRIPTION
## Summary
- reject object-dtype `np.datetime64` and `np.timedelta64` scalars in the calibration scalar validators
- reject object arrays containing NumPy temporal scalars before they can be cast to epoch/duration floats
- add focused regression coverage for the scalar and numeric-array helper paths

## Bug fixed
The calibration helper layer already rejected native `datetime64`/`timedelta64` dtypes via `dtype.kind`, but object-dtype scalars and arrays containing NumPy temporal values bypassed `_is_rejected_real_scalar(...)`. NumPy can cast those object values to floats, so malformed timestamps/durations could be silently accepted as ordinary offsets, max deltas, summary scalars, or numeric arrays.

## Validation
- `python -m py_compile /mnt/data/pyrecest_calibration_patch/src/pyrecest/calibration/__init__.py /mnt/data/pyrecest_calibration_patch/tests/calibration/test_temporal_object_validation.py`
- Local helper smoke confirmed the previously accepted object temporal values now hit the new rejection path.
- GitHub compare: branch is 2 commits ahead of `main`, 0 behind; changed only `src/pyrecest/calibration/__init__.py` and one focused regression test.