### PR TITLE
Reject temporal numerics scalar controls

### DIFF
--- a/src/pyrecest/numerics.py
+++ b/src/pyrecest/numerics.py
@@ -88,6 +88,8 @@ def _validate_nonnegative_finite(name: str, value: float) -> float:
         value_array = np.asarray(value)
     except (TypeError, ValueError, OverflowError, RuntimeError) as exc:
         raise ValueError(f"{name} must be a scalar number.") from exc
+    if _contains_unsupported_numeric_values(value_array):
+        raise ValueError(f"{name} must be a scalar number.")
     if value_array.shape != () or np.issubdtype(value_array.dtype, np.bool_):
         raise ValueError(f"{name} must be a scalar number.")
     scalar = value_array.item()

--- a/tests/test_numerics_temporal_scalars.py
+++ b/tests/test_numerics_temporal_scalars.py
@@ -1,0 +1,33 @@
+import numpy as np
+import pytest
+from pyrecest.numerics import (
+    assert_covariance_matrix,
+    is_positive_semidefinite,
+    is_symmetric,
+    jittered_cholesky,
+    nearest_symmetric_psd,
+)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        np.timedelta64(1, "ns"),
+        np.array(np.timedelta64(1, "ns"), dtype=object),
+        np.datetime64("2020-01-01"),
+        np.array(np.datetime64("2020-01-01"), dtype=object),
+    ],
+)
+def test_numerical_scalar_controls_reject_temporal_values(value):
+    matrix = np.eye(2)
+
+    with pytest.raises(ValueError, match="atol"):
+        is_symmetric(matrix, atol=value)
+    with pytest.raises(ValueError, match="atol"):
+        is_positive_semidefinite(matrix, atol=value)
+    with pytest.raises(ValueError, match="atol"):
+        assert_covariance_matrix(matrix, atol=value)
+    with pytest.raises(ValueError, match="min_eigenvalue"):
+        nearest_symmetric_psd(matrix, min_eigenvalue=value)
+    with pytest.raises(ValueError, match="initial_jitter"):
+        jittered_cholesky(matrix, initial_jitter=value)


### PR DESCRIPTION
## Summary
- reject NumPy `datetime64`/`timedelta64` scalar controls before numerical tolerance/jitter validation unwraps them with `.item()`
- cover direct and object-wrapped temporal scalar values for covariance helper tolerances, PSD repair floor, and Cholesky jitter

## Bug fixed
`_validate_nonnegative_finite(...)` converted scalar NumPy values via `.item()` before checking whether the scalar was a real number. For `np.timedelta64(1, "ns")`, `.item()` returns the integer payload `1`, so temporal durations could be silently accepted as numeric tolerances or jitter values. Object-wrapped NumPy temporal scalars could reach the same path. The fix applies the existing unsupported-numeric detector to scalar controls before unwrapping.

## Validation
- `PYTHONPATH=/tmp/pyrecest_numerics_patch/src python -m py_compile /tmp/pyrecest_numerics_patch/src/pyrecest/numerics.py /tmp/pyrecest_numerics_patch/tests/test_numerics_temporal_scalars.py`
- `PYTHONPATH=/tmp/pyrecest_numerics_patch/src python -m pytest -q /tmp/pyrecest_numerics_patch/tests/test_numerics_temporal_scalars.py` → `4 passed`
- Local smoke confirmed valid identity covariance operations still work and text/bool/vector/temporal scalar controls are rejected.
- GitHub compare: branch is 2 commits ahead of `main`, 0 behind; changed only `src/pyrecest/numerics.py` and the focused regression test.