### PR TITLE
Fix PyTorch argsort conflict error type

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_sort_numpy_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_sort_numpy_contract.py
@@ -96,7 +96,7 @@ def patch_argsort_stability_contract() -> None:
         descending=False,
     ):
         if kind is not None and stable is not None:
-            raise TypeError(_ARGSORT_CONFLICT_MESSAGE)
+            raise ValueError(_ARGSORT_CONFLICT_MESSAGE)
         if axis is _ARGSORT_DEFAULT_AXIS:
             return original_argsort(
                 a,

--- a/tests/backend_support/test_pytorch_argsort_stability_contract.py
+++ b/tests/backend_support/test_pytorch_argsort_stability_contract.py
@@ -40,7 +40,7 @@ for kind in ("stable", "mergesort", "quicksort", "heapsort"):
     for stable in stable_values:
         try:
             backend.argsort(values, kind=kind, stable=stable)
-        except TypeError as exc:
+        except ValueError as exc:
             assert "conflicting" in str(exc)
         else:
             raise AssertionError(f"accepted kind={kind!r}, stable={stable!r}")


### PR DESCRIPTION
## Summary
- raise ValueError when PyTorch argsort receives both kind and stable
- align the wrapper with the existing backend contract test and sort helper behavior

## Validation
- python3 -m py_compile src/pyrecest/backend_support/_pytorch_sort_numpy_contract.py tests/backend_support/test_pytorch_argsort_kind_stable_contract.py
- git diff --check

This addresses the repeated unrelated PyTorch CI failure seen across multiple open PRs.