### PR TITLE
Reject temporal multisession score controls

### DIFF
--- a/src/pyrecest/utils/multisession_assignment_score.py
+++ b/src/pyrecest/utils/multisession_assignment_score.py
@@ -63,8 +63,12 @@ def _default_score_to_cost(scores: Any) -> Any:
     return -asarray(scores, dtype=float)
 
 
-def _is_text_scalar(value: Any) -> bool:
-    return isinstance(value, (str, bytes, np.str_, np.bytes_))
+def _is_rejected_scalar(value: Any) -> bool:
+    return isinstance(value, _INVALID_SCORE_SCALAR_TYPES)
+
+
+def _is_rejected_scalar_array(value_array: np.ndarray) -> bool:
+    return value_array.dtype.kind in _REJECTED_SCORE_ARRAY_KINDS
 
 
 def _raise_invalid_score_matrix() -> None:
@@ -76,7 +80,7 @@ def _validate_object_real_values(
     invalid_callback: Callable[[], None],
 ) -> None:
     for item in raw_values.reshape(-1):
-        if isinstance(item, _INVALID_SCORE_SCALAR_TYPES):
+        if _is_rejected_scalar(item):
             invalid_callback()
         try:
             float(item)
@@ -124,13 +128,11 @@ def _validate_pairwise_score_inputs(pairwise_scores: PairwiseCostsInput) -> None
 
 def _normalize_min_score(min_score: Any) -> float:
     min_score_array = np.asarray(min_score)
-    if min_score_array.shape != () or min_score_array.dtype == np.bool_:
+    if min_score_array.shape != () or _is_rejected_scalar_array(min_score_array):
         raise ValueError("min_score must be a finite scalar.")
 
     min_score_value = min_score_array.item()
-    if isinstance(min_score_value, (bool, np.bool_)) or _is_text_scalar(
-        min_score_value
-    ):
+    if _is_rejected_scalar(min_score_value):
         raise ValueError("min_score must be a finite scalar.")
 
     try:
@@ -144,11 +146,11 @@ def _normalize_min_score(min_score: Any) -> float:
 
 def _normalize_max_gap(max_gap: Any) -> int:
     max_gap_array = np.asarray(max_gap)
-    if max_gap_array.shape != () or max_gap_array.dtype == np.bool_:
+    if max_gap_array.shape != () or _is_rejected_scalar_array(max_gap_array):
         raise ValueError("max_gap must be a non-negative integer.")
 
     max_gap_value = max_gap_array.item()
-    if isinstance(max_gap_value, (bool, np.bool_)) or _is_text_scalar(max_gap_value):
+    if _is_rejected_scalar(max_gap_value):
         raise ValueError("max_gap must be a non-negative integer.")
 
     if isinstance(max_gap_value, (int, np.integer)):
@@ -171,13 +173,11 @@ def _normalize_max_gap(max_gap: Any) -> int:
 
 def _normalize_index_matrix_fill_value(fill_value: Any) -> int:
     fill_value_array = np.asarray(fill_value)
-    if fill_value_array.shape != () or fill_value_array.dtype == np.bool_:
+    if fill_value_array.shape != () or _is_rejected_scalar_array(fill_value_array):
         raise ValueError("fill_value must be a negative integer.")
 
     fill_value_value = fill_value_array.item()
-    if isinstance(fill_value_value, (bool, np.bool_)) or _is_text_scalar(
-        fill_value_value
-    ):
+    if _is_rejected_scalar(fill_value_value):
         raise ValueError("fill_value must be a negative integer.")
 
     if isinstance(fill_value_value, (int, np.integer)):

--- a/tests/test_multisession_assignment_score_validation.py
+++ b/tests/test_multisession_assignment_score_validation.py
@@ -11,6 +11,25 @@ class TestMultiSessionAssignmentScoreValidation(unittest.TestCase):
     def _text_scalars(text: str):
         return (text, text.encode(), np.str_(text), np.array(text))
 
+    @staticmethod
+    def _temporal_scalars():
+        return (
+            np.datetime64("1970-01-01T00:00:00.000000001"),
+            np.timedelta64(1, "ns"),
+            np.array(np.datetime64("1970-01-01T00:00:00.000000001")),
+            np.array(np.timedelta64(1, "ns")),
+            np.array(np.datetime64("1970-01-01T00:00:00.000000001"), dtype=object),
+            np.array(np.timedelta64(1, "ns"), dtype=object),
+        )
+
+    @staticmethod
+    def _negative_temporal_scalars():
+        return (
+            np.timedelta64(-1, "ns"),
+            np.array(np.timedelta64(-1, "ns")),
+            np.array(np.timedelta64(-1, "ns"), dtype=object),
+        )
+
     @unittest.skipIf(
         __backend_name__ == "jax",
         reason="Not supported on this backend",
@@ -34,10 +53,48 @@ class TestMultiSessionAssignmentScoreValidation(unittest.TestCase):
         __backend_name__ == "jax",
         reason="Not supported on this backend",
     )
+    def test_similarity_wrapper_rejects_temporal_scalar_min_score(self):
+        pairwise_scores = {(0, 1): array([[0.9]], dtype=float)}
+
+        for min_score in self._temporal_scalars():
+            with self.subTest(min_score=min_score):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "min_score must be a finite scalar",
+                ):
+                    solve_multisession_assignment_from_similarity(
+                        pairwise_scores,
+                        session_sizes=[1, 1],
+                        min_score=min_score,
+                    )
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
     def test_similarity_wrapper_rejects_text_scalar_max_gap(self):
         pairwise_scores = {(0, 2): array([[0.9]], dtype=float)}
 
         for max_gap in self._text_scalars("1"):
+            with self.subTest(max_gap=max_gap):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "max_gap must be a non-negative integer",
+                ):
+                    solve_multisession_assignment_from_similarity(
+                        pairwise_scores,
+                        session_sizes=[1, 0, 1],
+                        max_gap=max_gap,
+                    )
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_similarity_wrapper_rejects_temporal_scalar_max_gap(self):
+        pairwise_scores = {(0, 2): array([[0.9]], dtype=float)}
+
+        for max_gap in self._temporal_scalars():
             with self.subTest(max_gap=max_gap):
                 with self.assertRaisesRegex(
                     ValueError,
@@ -102,6 +159,23 @@ class TestMultiSessionAssignmentScoreValidation(unittest.TestCase):
     )
     def test_tracks_to_index_matrix_rejects_text_scalar_fill_value(self):
         for fill_value in self._text_scalars("-1"):
+            with self.subTest(fill_value=fill_value):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "fill_value must be a negative integer",
+                ):
+                    score_module.tracks_to_index_matrix(
+                        [{0: 0}],
+                        session_sizes=[1],
+                        fill_value=fill_value,
+                    )
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_tracks_to_index_matrix_rejects_temporal_scalar_fill_value(self):
+        for fill_value in self._negative_temporal_scalars():
             with self.subTest(fill_value=fill_value):
                 with self.assertRaisesRegex(
                     ValueError,


### PR DESCRIPTION
## Summary
- reject NumPy `datetime64` and `timedelta64` scalar arrays before score-wrapper control coercion
- reuse the existing rejected scalar-type set for `min_score`, `max_gap`, and `tracks_to_index_matrix(..., fill_value=...)`
- add focused regressions covering native and object-wrapped temporal controls

## Bug fixed
The score-native multi-session assignment helpers validated text and boolean controls, but scalar NumPy temporal values could still pass through `np.asarray(...).item()` or `float(...)`. For nanosecond temporal scalars, NumPy exposes the integer payload, so malformed timestamps/durations could be silently accepted as ordinary `min_score`, `max_gap`, or negative `fill_value` controls.

## Validation
- `python -m py_compile /mnt/data/multisession_assignment_score_updated.py`
- `python -m py_compile /mnt/data/test_multisession_assignment_score_validation_updated.py`
- GitHub compare: branch is 2 commits ahead of `main`, 0 behind; changed only `src/pyrecest/utils/multisession_assignment_score.py` and `tests/test_multisession_assignment_score_validation.py`.

Full in-repository pytest was not run locally because this environment cannot clone `github.com`; CI should run the in-tree regression.