### PR TITLE
Reject temporal DVS event-likelihood scalars

### DIFF
--- a/src/pyrecest/experimental/dvs/event_likelihood.py
+++ b/src/pyrecest/experimental/dvs/event_likelihood.py
@@ -8,6 +8,20 @@ import numpy as np
 
 _TEXT_SCALAR_TYPES = (str, bytes, bytearray, np.str_, np.bytes_)
 _BOOL_SCALAR_TYPES = (bool, np.bool_)
+_TEMPORAL_SCALAR_TYPES = (np.datetime64, np.timedelta64)
+_TEMPORAL_DTYPE_KINDS = {"M", "m"}
+
+
+def _is_temporal_scalar_array(value_array: np.ndarray) -> bool:
+    if value_array.dtype.kind in _TEMPORAL_DTYPE_KINDS:
+        return True
+    if value_array.shape != ():
+        return False
+    try:
+        scalar = value_array.item()
+    except (TypeError, ValueError):
+        return False
+    return isinstance(scalar, _TEMPORAL_SCALAR_TYPES)
 
 
 def _as_finite_scalar(value: float, message: str) -> float:
@@ -15,10 +29,17 @@ def _as_finite_scalar(value: float, message: str) -> float:
         value_array = np.asarray(value)
     except (TypeError, ValueError) as exc:
         raise ValueError(message) from exc
-    if value_array.shape != () or value_array.dtype == np.bool_:
+    if (
+        value_array.shape != ()
+        or value_array.dtype == np.bool_
+        or _is_temporal_scalar_array(value_array)
+    ):
         raise ValueError(message)
     scalar = value_array.item()
-    if isinstance(scalar, (*_BOOL_SCALAR_TYPES, *_TEXT_SCALAR_TYPES)):
+    if isinstance(
+        scalar,
+        (*_BOOL_SCALAR_TYPES, *_TEXT_SCALAR_TYPES, *_TEMPORAL_SCALAR_TYPES),
+    ):
         raise ValueError(message)
     try:
         result = float(scalar)
@@ -50,10 +71,17 @@ def _as_integer_scalar(value: int, message: str) -> int:
         value_array = np.asarray(value)
     except (TypeError, ValueError) as exc:
         raise ValueError(message) from exc
-    if value_array.shape != () or value_array.dtype == np.bool_:
+    if (
+        value_array.shape != ()
+        or value_array.dtype == np.bool_
+        or _is_temporal_scalar_array(value_array)
+    ):
         raise ValueError(message)
     scalar = value_array.item()
-    if isinstance(scalar, (*_BOOL_SCALAR_TYPES, *_TEXT_SCALAR_TYPES)):
+    if isinstance(
+        scalar,
+        (*_BOOL_SCALAR_TYPES, *_TEXT_SCALAR_TYPES, *_TEMPORAL_SCALAR_TYPES),
+    ):
         raise ValueError(message)
     if isinstance(scalar, (int, np.integer)):
         return int(scalar)

--- a/tests/experimental/test_dvs_event_likelihood_temporal_validation.py
+++ b/tests/experimental/test_dvs_event_likelihood_temporal_validation.py
@@ -1,0 +1,106 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.experimental.dvs.event_likelihood import (
+    ContourSample,
+    EventLikelihoodConfig,
+    PointProcessUpdateConfig,
+    expected_event_count,
+    normal_flow_activities,
+)
+
+
+def _temporal_scalars():
+    return (
+        np.timedelta64(1, "ns"),
+        np.datetime64("1970-01-01T00:00:00.000000001"),
+        np.array(np.timedelta64(1, "ns"), dtype=object),
+        np.array(np.datetime64("1970-01-01T00:00:00.000000001"), dtype=object),
+    )
+
+
+def _contour():
+    return ContourSample(
+        points=np.array([[0.0, 0.0], [1.0, 0.0]]),
+        normals=np.array([[1.0, 0.0], [0.0, 1.0]]),
+        weights=np.array([0.5, 0.5]),
+    )
+
+
+class TestDVSEventLikelihoodTemporalValidation(unittest.TestCase):
+    def test_event_likelihood_config_rejects_temporal_numeric_scalars(self):
+        for field in (
+            "spatial_sigma_px",
+            "foreground_rate",
+            "background_rate",
+            "activity_floor",
+            "min_intensity",
+            "batch_duration",
+        ):
+            for value in _temporal_scalars():
+                with self.subTest(field=field, value=value):
+                    with self.assertRaisesRegex(ValueError, field):
+                        EventLikelihoodConfig(**{field: value})
+
+    def test_point_process_update_config_rejects_temporal_count_scalars(self):
+        cases = (
+            ("contour_samples", np.timedelta64(3, "ns")),
+            (
+                "contour_samples",
+                np.datetime64("1970-01-01T00:00:00.000000003"),
+            ),
+            ("max_map_iterations", np.timedelta64(0, "ns")),
+            (
+                "shape_update_modes",
+                np.datetime64("1970-01-01T00:00:00.000000000"),
+            ),
+        )
+        for field, value in cases:
+            with self.subTest(field=field, value=value):
+                with self.assertRaisesRegex(ValueError, field):
+                    PointProcessUpdateConfig(**{field: value})
+
+    def test_point_process_update_config_rejects_temporal_float_scalars(self):
+        cases = (
+            ("finite_difference_eps", np.timedelta64(1, "ns")),
+            (
+                "map_step_size",
+                np.datetime64("1970-01-01T00:00:00.000000000"),
+            ),
+            ("covariance_damping", np.timedelta64(1, "ns")),
+            ("max_state_update_norm", np.timedelta64(1, "ns")),
+        )
+        for field, value in cases:
+            with self.subTest(field=field, value=value):
+                with self.assertRaisesRegex(ValueError, field):
+                    PointProcessUpdateConfig(**{field: value})
+
+    def test_likelihood_helpers_reject_temporal_runtime_scalars(self):
+        contour = _contour()
+        velocity = np.array([1.0, 0.0])
+
+        with self.assertRaisesRegex(ValueError, "activity_floor"):
+            normal_flow_activities(
+                contour.normals,
+                velocity,
+                activity_floor=np.timedelta64(1, "ns"),
+            )
+
+        with self.assertRaisesRegex(ValueError, "batch_duration"):
+            expected_event_count(
+                contour,
+                velocity,
+                batch_duration=np.timedelta64(1, "ns"),
+            )
+
+        with self.assertRaisesRegex(ValueError, "image_area"):
+            expected_event_count(
+                contour,
+                velocity,
+                image_area=np.datetime64("1970-01-01T00:00:00.000000001"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reject NumPy `datetime64` / `timedelta64` scalar controls in the DVS point-process event-likelihood validators
- cover native temporal dtypes and object-wrapped temporal scalars for likelihood rates, durations, contour sample counts, MAP iteration controls, and runtime helper arguments
- preserve the existing integer-like/float-like numeric scalar behavior for ordinary numeric values

## Bug fixed
The DVS event-likelihood scalar helpers converted scalar inputs with `np.asarray(...).item()` and then `float(...)` or integer checks. For `datetime64[ns]` / `timedelta64[ns]`, NumPy can expose the nanosecond payload as an integer, so malformed temporal values could be silently accepted as event rates, durations, sample counts, iteration counts, or point-process update scales. Object-wrapped NumPy temporal scalars could also pass through the finite-float helper via `float(...)`.

The patch adds a shared temporal scalar detector and applies it before numeric coercion in both finite-float and integer scalar validators.

## Validation
- `python -m py_compile /tmp/event_likelihood.py /tmp/test_dvs_event_likelihood_temporal_validation.py`
- isolated focused pytest mirror: `PYTHONPATH=/tmp/pyrecest_local python -m pytest -q /tmp/test_dvs_event_likelihood_temporal_validation.py` → `4 passed, 32 subtests passed`
- GitHub compare: branch is 2 commits ahead of `main`, 0 behind; changed only `src/pyrecest/experimental/dvs/event_likelihood.py` and `tests/experimental/test_dvs_event_likelihood_temporal_validation.py`