### PR TITLE
Reject temporal Pareto scalar inputs

### DIFF
--- a/src/pyrecest/evaluation/pareto.py
+++ b/src/pyrecest/evaluation/pareto.py
@@ -24,6 +24,10 @@ def _is_text_scalar(value: Any) -> bool:
     return isinstance(value, (str, bytes, np.str_, np.bytes_))
 
 
+def _is_temporal_scalar(value: Any) -> bool:
+    return isinstance(value, (np.datetime64, np.timedelta64))
+
+
 def pareto_front_indices(
     table: pd.DataFrame,
     objectives: Sequence[str],
@@ -176,7 +180,7 @@ def constraint_mask(
                 column,
             )
         else:
-            values = pd.to_numeric(table[column], errors="coerce").astype(float)
+            values = _coerce_constraint_values(table[column])
             present_values = values.notna()
             if op == "<=":
                 comparison = values <= threshold_value + eps
@@ -393,9 +397,11 @@ def _coerce_numeric(value: Any) -> float:
     if value_array.shape != () or value_array.dtype.kind in "bSUcMm":
         return float("nan")
     scalar = value_array.item()
-    if isinstance(
-        scalar, (bool, np.bool_, complex, np.complexfloating)
-    ) or _is_text_scalar(scalar):
+    if (
+        isinstance(scalar, (bool, np.bool_, complex, np.complexfloating))
+        or _is_text_scalar(scalar)
+        or _is_temporal_scalar(scalar)
+    ):
         return float("nan")
     try:
         return float(scalar)
@@ -403,13 +409,24 @@ def _coerce_numeric(value: Any) -> float:
         return float("nan")
 
 
+def _coerce_constraint_values(values: pd.Series) -> pd.Series:
+    value_array = values.to_numpy()
+    if value_array.dtype.kind in "Mm":
+        return pd.Series(np.nan, index=values.index, dtype=float)
+    return pd.to_numeric(values, errors="coerce").astype(float)
+
+
 def _validate_eps(eps: Any) -> float:
     message = "eps must be a finite non-negative scalar."
     value_array = np.asarray(eps)
-    if value_array.shape != () or value_array.dtype == np.bool_:
+    if value_array.shape != () or value_array.dtype.kind in "bMm":
         raise ValueError(message)
     scalar = value_array.item()
-    if isinstance(scalar, (bool, np.bool_)) or _is_text_scalar(scalar):
+    if (
+        isinstance(scalar, (bool, np.bool_))
+        or _is_text_scalar(scalar)
+        or _is_temporal_scalar(scalar)
+    ):
         raise ValueError(message)
     try:
         value = float(scalar)
@@ -452,12 +469,12 @@ def _coerce_constraint_threshold(value: Any, column: str) -> float | bool:
         value_array = np.asarray(value)
     except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError(message) from exc
-    if value_array.shape != ():
+    if value_array.shape != () or value_array.dtype.kind in "Mm":
         raise ValueError(message)
     scalar = value_array.item()
     if isinstance(scalar, (bool, np.bool_)):
         return bool(scalar)
-    if _is_text_scalar(scalar):
+    if _is_text_scalar(scalar) or _is_temporal_scalar(scalar):
         raise ValueError(message)
     try:
         threshold = float(scalar)

--- a/tests/evaluation/test_pareto_temporal_validation.py
+++ b/tests/evaluation/test_pareto_temporal_validation.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from pyrecest.evaluation import (
+    constraint_mask,
+    equal_quality_selection,
+    is_pareto_front,
+    pareto_front_indices,
+    record_dominates,
+    select_under_constraints,
+)
+
+
+def _small_table() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {"name": "a", "error": 1.0, "runtime": 2.0},
+            {"name": "b", "error": 2.0, "runtime": 1.0},
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    "eps",
+    [
+        np.timedelta64(1, "ns"),
+        np.array(np.timedelta64(1, "ns"), dtype=object),
+        np.datetime64("2026-01-01"),
+    ],
+)
+def test_pareto_helpers_reject_temporal_scalar_eps(eps: object) -> None:
+    table = _small_table()
+
+    with pytest.raises(ValueError, match="eps"):
+        pareto_front_indices(
+            table,
+            ["error", "runtime"],
+            directions={"error": "min", "runtime": "min"},
+            eps=eps,
+        )
+    with pytest.raises(ValueError, match="eps"):
+        is_pareto_front(
+            table,
+            ["error", "runtime"],
+            directions={"error": "min", "runtime": "min"},
+            eps=eps,
+        )
+    with pytest.raises(ValueError, match="eps"):
+        record_dominates(
+            table.iloc[0],
+            table.iloc[1],
+            ["error", "runtime"],
+            directions={"error": "min", "runtime": "min"},
+            eps=eps,
+        )
+    with pytest.raises(ValueError, match="eps"):
+        constraint_mask(table, {"error": ("<=", 2.0)}, eps=eps)
+    with pytest.raises(ValueError, match="eps"):
+        select_under_constraints(
+            table,
+            constraints={"error": ("<=", 2.0)},
+            objective="runtime",
+            direction="min",
+            eps=eps,
+        )
+    with pytest.raises(ValueError, match="eps"):
+        equal_quality_selection(
+            table,
+            quality_constraints={"error": ("<=", 2.0)},
+            compression_objective="runtime",
+            eps=eps,
+        )
+
+
+@pytest.mark.parametrize(
+    "threshold",
+    [
+        np.timedelta64(2, "ns"),
+        np.array(np.timedelta64(2, "ns"), dtype=object),
+        np.datetime64("2026-01-01"),
+    ],
+)
+def test_pareto_constraint_thresholds_reject_temporal_scalars(
+    threshold: object,
+) -> None:
+    table = pd.DataFrame([{"score": 1.0}])
+
+    with pytest.raises(
+        ValueError,
+        match="Constraint threshold for 'score' must be a finite scalar",
+    ):
+        constraint_mask(table, {"score": ("<=", threshold)})
+    with pytest.raises(
+        ValueError,
+        match="Constraint threshold for 'score' must be a finite scalar",
+    ):
+        select_under_constraints(
+            table,
+            constraints={"score": ("<=", threshold)},
+            objective="score",
+            direction="min",
+        )
+    with pytest.raises(
+        ValueError,
+        match="Constraint threshold for 'score' must be a finite scalar",
+    ):
+        equal_quality_selection(
+            table,
+            quality_constraints={"score": ("<=", threshold)},
+            compression_objective="score",
+        )
+
+
+def test_pareto_constraints_treat_temporal_columns_as_missing() -> None:
+    table = pd.DataFrame(
+        {
+            "score": [np.timedelta64(1, "ns"), np.timedelta64(10, "ns")],
+        }
+    )
+
+    mask = constraint_mask(table, {"score": ("<=", 5.0)})
+    selected = select_under_constraints(
+        table,
+        constraints={"score": ("<=", 5.0)},
+        objective="score",
+        direction="min",
+    )
+
+    assert mask.tolist() == [False, False]
+    assert selected.empty
+
+
+def test_temporal_object_objectives_are_not_treated_as_numeric() -> None:
+    left = {"runtime": np.array(np.timedelta64(1, "ns"), dtype=object)}
+    right = {"runtime": 2.0}
+
+    assert not record_dominates(
+        left,
+        right,
+        ["runtime"],
+        directions={"runtime": "min"},
+    )
+    assert not record_dominates(
+        left,
+        right,
+        ["runtime"],
+        directions={"runtime": "min"},
+        allow_missing=False,
+    )


### PR DESCRIPTION
## Summary
- reject NumPy temporal scalars before Pareto `eps` and constraint-threshold coercion
- prevent temporal-dtyped constraint columns from being interpreted as numeric epoch/duration payloads
- treat object-wrapped temporal objective scalars as missing instead of numeric values

## Bug fixed
`np.timedelta64(..., "ns")` can expose an integer payload through NumPy scalar unwrapping, so Pareto helpers could silently interpret nanosecond durations as ordinary numeric tolerances or constraint thresholds. Pandas can also coerce `datetime64[ns]` / `timedelta64[ns]` columns to integer epoch/duration values in `pd.to_numeric`, allowing malformed temporal objective tables to satisfy numeric constraints.

## Validation
- `PYTHONPATH=/mnt/data/pyrecest_pareto_patch/src python3 -m py_compile /mnt/data/pyrecest_pareto_patch/src/pyrecest/evaluation/pareto.py /mnt/data/pyrecest_pareto_patch/tests/evaluation/test_pareto_temporal_validation.py`
- `PYTHONPATH=/mnt/data/pyrecest_pareto_patch/src python3 -m pytest -q /mnt/data/pyrecest_pareto_patch/tests/evaluation/test_pareto_temporal_validation.py` → `8 passed`