### PR TITLE
Reject temporal Pareto scalar inputs

### DIFF
--- a/src/pyrecest/evaluation/pareto.py
+++ b/src/pyrecest/evaluation/pareto.py
@@ -24,6 +24,10 @@ def _is_text_scalar(value: Any) -> bool:
     return isinstance(value, (str, bytes, np.str_, np.bytes_))
 
 
+def _is_temporal_scalar(value: Any) -> bool:
+    return isinstance(value, (np.datetime64, np.timedelta64))
+
+
 def pareto_front_indices(
     table: pd.DataFrame,
     objectives: Sequence[str],
@@ -393,9 +397,11 @@ def _coerce_numeric(value: Any) -> float:
     if value_array.shape != () or value_array.dtype.kind in "bSUcMm":
         return float("nan")
     scalar = value_array.item()
-    if isinstance(
-        scalar, (bool, np.bool_, complex, np.complexfloating)
-    ) or _is_text_scalar(scalar):
+    if (
+        isinstance(scalar, (bool, np.bool_, complex, np.complexfloating))
+        or _is_text_scalar(scalar)
+        or _is_temporal_scalar(scalar)
+    ):
         return float("nan")
     try:
         return float(scalar)
@@ -406,10 +412,14 @@ def _coerce_numeric(value: Any) -> float:
 def _validate_eps(eps: Any) -> float:
     message = "eps must be a finite non-negative scalar."
     value_array = np.asarray(eps)
-    if value_array.shape != () or value_array.dtype == np.bool_:
+    if value_array.shape != () or value_array.dtype.kind in "bMm":
         raise ValueError(message)
     scalar = value_array.item()
-    if isinstance(scalar, (bool, np.bool_)) or _is_text_scalar(scalar):
+    if (
+        isinstance(scalar, (bool, np.bool_))
+        or _is_text_scalar(scalar)
+        or _is_temporal_scalar(scalar)
+    ):
         raise ValueError(message)
     try:
         value = float(scalar)
@@ -452,12 +462,12 @@ def _coerce_constraint_threshold(value: Any, column: str) -> float | bool:
         value_array = np.asarray(value)
     except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError(message) from exc
-    if value_array.shape != ():
+    if value_array.shape != () or value_array.dtype.kind in "Mm":
         raise ValueError(message)
     scalar = value_array.item()
     if isinstance(scalar, (bool, np.bool_)):
         return bool(scalar)
-    if _is_text_scalar(scalar):
+    if _is_text_scalar(scalar) or _is_temporal_scalar(scalar):
         raise ValueError(message)
     try:
         threshold = float(scalar)

--- a/tests/evaluation/test_pareto_temporal_scalar_validation.py
+++ b/tests/evaluation/test_pareto_temporal_scalar_validation.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+from pyrecest.evaluation import (
+    constraint_mask,
+    equal_quality_selection,
+    is_pareto_front,
+    pareto_front_indices,
+    record_dominates,
+    select_under_constraints,
+)
+
+
+def _small_table() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {"name": "a", "error": 1.0, "runtime": 2.0},
+            {"name": "b", "error": 2.0, "runtime": 1.0},
+        ]
+    )
+
+
+_TEMPORAL_SCALARS = (
+    np.timedelta64(1, "ns"),
+    np.array(np.timedelta64(1, "ns"), dtype=object),
+)
+
+
+@pytest.mark.parametrize("eps", _TEMPORAL_SCALARS)
+def test_pareto_helpers_reject_temporal_scalar_eps(eps: object) -> None:
+    table = _small_table()
+
+    with pytest.raises(ValueError, match="eps"):
+        pareto_front_indices(
+            table,
+            ["error", "runtime"],
+            directions={"error": "min", "runtime": "min"},
+            eps=eps,
+        )
+    with pytest.raises(ValueError, match="eps"):
+        is_pareto_front(
+            table,
+            ["error", "runtime"],
+            directions={"error": "min", "runtime": "min"},
+            eps=eps,
+        )
+    with pytest.raises(ValueError, match="eps"):
+        record_dominates(
+            table.iloc[0],
+            table.iloc[1],
+            ["error", "runtime"],
+            directions={"error": "min", "runtime": "min"},
+            eps=eps,
+        )
+    with pytest.raises(ValueError, match="eps"):
+        constraint_mask(table, {"error": ("<=", 2.0)}, eps=eps)
+    with pytest.raises(ValueError, match="eps"):
+        select_under_constraints(
+            table,
+            constraints={"error": ("<=", 2.0)},
+            objective="runtime",
+            direction="min",
+            eps=eps,
+        )
+    with pytest.raises(ValueError, match="eps"):
+        equal_quality_selection(
+            table,
+            quality_constraints={"error": ("<=", 2.0)},
+            compression_objective="runtime",
+            eps=eps,
+        )
+
+
+@pytest.mark.parametrize("threshold", _TEMPORAL_SCALARS)
+def test_pareto_constraint_thresholds_reject_temporal_scalars(threshold: object) -> None:
+    table = pd.DataFrame([{"score": 1.0}])
+
+    with pytest.raises(
+        ValueError,
+        match="Constraint threshold for 'score' must be a finite scalar",
+    ):
+        constraint_mask(table, {"score": ("<=", threshold)})
+    with pytest.raises(
+        ValueError,
+        match="Constraint threshold for 'score' must be a finite scalar",
+    ):
+        select_under_constraints(
+            table,
+            constraints={"score": ("<=", threshold)},
+            objective="score",
+            direction="min",
+        )
+    with pytest.raises(
+        ValueError,
+        match="Constraint threshold for 'score' must be a finite scalar",
+    ):
+        equal_quality_selection(
+            table,
+            quality_constraints={"score": ("<=", threshold)},
+            compression_objective="score",
+        )
+
+
+def test_pareto_objective_treats_object_temporal_scalar_as_missing() -> None:
+    temporal_object = np.array(np.timedelta64(1, "ns"), dtype=object)
+
+    assert not record_dominates(
+        {"objective": temporal_object},
+        {"objective": 2.0},
+        ["objective"],
+        directions={"objective": "min"},
+    )
+    assert not record_dominates(
+        {"objective": temporal_object},
+        {"objective": 2.0},
+        ["objective"],
+        directions={"objective": "min"},
+        allow_missing=False,
+    )


### PR DESCRIPTION
## Summary
- reject NumPy `datetime64`/`timedelta64` scalar controls before Pareto `eps` and constraint-threshold coercion
- treat object-wrapped temporal objective scalars as nonnumeric/missing instead of comparable floats
- add focused regression coverage for temporal `eps`, constraint thresholds, and object temporal objectives

## Bug fixed
`np.timedelta64` values can expose integer nanosecond payloads through `.item()` / `float(...)`. That meant malformed temporal values such as `np.timedelta64(1, "ns")` could be silently accepted as Pareto tolerances or constraint thresholds, and object-wrapped temporal objective values could be compared numerically.

## Validation
- `python -m py_compile /mnt/data/pareto.py /mnt/data/test_pareto_temporal_scalar_validation.py`
- focused local smoke of the patched Pareto helper paths for temporal `eps`, temporal thresholds, object temporal objectives, and an existing min/max Pareto-front example

Full in-repository pytest was not run locally because this sandbox cannot clone from `github.com`; CI should run the added in-tree regression.