### PR TITLE
Reject temporal tracking event scalars

### DIFF
--- a/src/pyrecest/tracking/event_records.py
+++ b/src/pyrecest/tracking/event_records.py
@@ -26,7 +26,10 @@ _INVALID_NUMERIC_SCALAR_TYPES = (
     bytearray,
     complex,
     np.complexfloating,
+    np.datetime64,
+    np.timedelta64,
 )
+_TEMPORAL_ARRAY_KINDS = {"M", "m"}
 
 
 def _invalid_numeric_array_message(name: str) -> str:
@@ -35,6 +38,10 @@ def _invalid_numeric_array_message(name: str) -> str:
 
 def _dtype_is_real_numeric(dtype: np.dtype) -> bool:
     return np.dtype(dtype).kind in _REAL_NUMERIC_ARRAY_KINDS
+
+
+def _dtype_is_temporal(dtype: np.dtype) -> bool:
+    return np.dtype(dtype).kind in _TEMPORAL_ARRAY_KINDS
 
 
 def _raw_item_is_invalid_numeric(value: Any) -> bool:
@@ -112,11 +119,15 @@ def _optional_bool(value: Any, *, name: str) -> bool | None:
 
 def _finite_scalar(value: Any, *, name: str, message: str) -> float:
     value_array = np.asarray(value)
-    if value_array.shape != () or value_array.dtype == np.bool_:
+    if (
+        value_array.shape != ()
+        or value_array.dtype == np.bool_
+        or _dtype_is_temporal(value_array.dtype)
+    ):
         raise ValueError(message)
 
     scalar = value_array.item()
-    if isinstance(scalar, (bool, np.bool_, str, bytes, bytearray)):
+    if isinstance(scalar, _INVALID_NUMERIC_SCALAR_TYPES):
         raise ValueError(message)
     try:
         parsed = float(scalar)

--- a/tests/test_event_records.py
+++ b/tests/test_event_records.py
@@ -4,6 +4,15 @@ import numpy as np
 from pyrecest.tracking.event_records import TrackingEvent, TrackingRecord
 
 
+def _temporal_scalars():
+    return (
+        np.datetime64("1970-01-01T00:00:00.000000001"),
+        np.timedelta64(1, "ns"),
+        np.array(np.datetime64("1970-01-01T00:00:00.000000001"), dtype=object),
+        np.array(np.timedelta64(1, "ns"), dtype=object),
+    )
+
+
 class TestTrackingEventScalarValidation(unittest.TestCase):
     def test_time_accepts_scalar_numeric_values(self):
         event = TrackingEvent(time=np.array(1.25), source="sensor")
@@ -24,6 +33,21 @@ class TestTrackingEventScalarValidation(unittest.TestCase):
             with self.subTest(time=time):
                 with self.assertRaisesRegex(ValueError, "time must be finite"):
                     TrackingEvent(time=time, source="sensor")
+
+    def test_time_rejects_temporal_scalars(self):
+        for time in _temporal_scalars():
+            with self.subTest(time=repr(time)):
+                with self.assertRaisesRegex(ValueError, "time must be finite"):
+                    TrackingEvent(time=time, source="sensor")
+
+    def test_measurement_and_covariance_reject_object_temporal_values(self):
+        temporal_measurement = np.array([np.timedelta64(1, "ns")], dtype=object)
+        temporal_covariance = np.array([[np.datetime64("1970-01-01")]], dtype=object)
+
+        with self.assertRaisesRegex(ValueError, "measurement must contain"):
+            TrackingEvent(time=0.0, source="sensor", measurement=temporal_measurement)
+        with self.assertRaisesRegex(ValueError, "covariance must contain"):
+            TrackingEvent(time=0.0, source="sensor", covariance=temporal_covariance)
 
 
 class TestTrackingRecordScalarValidation(unittest.TestCase):
@@ -60,6 +84,14 @@ class TestTrackingRecordScalarValidation(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, "time must be finite"):
                     TrackingRecord(**kwargs)
 
+    def test_time_rejects_temporal_scalars(self):
+        for time in _temporal_scalars():
+            kwargs = self._valid_record_kwargs()
+            kwargs["time"] = time
+            with self.subTest(time=repr(time)):
+                with self.assertRaisesRegex(ValueError, "time must be finite"):
+                    TrackingRecord(**kwargs)
+
     def test_nis_rejects_bool_text_non_scalar_and_negative_values(self):
         invalid_nis_values = (
             True,
@@ -79,6 +111,29 @@ class TestTrackingRecordScalarValidation(unittest.TestCase):
                     "nis must be finite and nonnegative",
                 ):
                     TrackingRecord(**self._valid_record_kwargs(), nis=nis)
+
+    def test_nis_rejects_temporal_scalars(self):
+        for nis in _temporal_scalars():
+            with self.subTest(nis=repr(nis)):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "nis must be finite and nonnegative",
+                ):
+                    TrackingRecord(**self._valid_record_kwargs(), nis=nis)
+
+    def test_state_and_covariance_reject_object_temporal_values(self):
+        temporal_vector = np.array([np.timedelta64(1, "ns")], dtype=object)
+        temporal_matrix = np.array([[np.datetime64("1970-01-01")]], dtype=object)
+
+        kwargs = self._valid_record_kwargs()
+        kwargs["prior_mean"] = temporal_vector
+        with self.assertRaisesRegex(ValueError, "prior_mean must contain"):
+            TrackingRecord(**kwargs)
+
+        kwargs = self._valid_record_kwargs()
+        kwargs["prior_cov"] = temporal_matrix
+        with self.assertRaisesRegex(ValueError, "prior_cov must contain"):
+            TrackingRecord(**kwargs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- reject native and object-wrapped NumPy `datetime64` / `timedelta64` values in tracking event scalar validation
- reject object arrays containing temporal values before numeric event/record fields are cast to floats
- add regression coverage for event time, record time, NIS, measurement, state, and covariance inputs

## Bug fixed
`np.datetime64` / `np.timedelta64` values at nanosecond precision can expose integer payloads through `.item()` / `float(...)`, and object arrays containing those temporal scalars can be cast to floats. That allowed malformed temporal values to be accepted as tracking-event times, record NIS values, measurements, states, or covariance entries.

## Validation
- `PYTHONPATH=/mnt/data/pyrecest_event_records_patch/src python -m py_compile /mnt/data/pyrecest_event_records_patch/src/pyrecest/tracking/event_records.py /mnt/data/pyrecest_event_records_patch/tests/test_event_records.py`
- `PYTHONPATH=/mnt/data/pyrecest_event_records_patch/src python -m pytest -q /mnt/data/pyrecest_event_records_patch/tests/test_event_records.py` → `10 passed, 34 subtests passed`