### PR TITLE
Reject temporal bias scalar controls

### DIFF
--- a/src/pyrecest/calibration/bias.py
+++ b/src/pyrecest/calibration/bias.py
@@ -382,7 +382,7 @@ def _as_2d(values: np.ndarray, name: str) -> np.ndarray:
 
 def _as_nonnegative_int(value: Any, name: str) -> int:
     arr = np.asarray(value)
-    if arr.ndim != 0 or arr.dtype == np.bool_:
+    if arr.ndim != 0 or _contains_invalid_numeric_values(arr):
         raise ValueError(f"{name} must be a nonnegative integer")
     scalar = arr.item()
     if isinstance(scalar, (int, np.integer)) and not isinstance(scalar, bool):
@@ -409,7 +409,7 @@ def _as_positive_int(value: Any, name: str) -> int:
 
 def _as_nonnegative_finite_float(value: Any, name: str) -> float:
     arr = np.asarray(value)
-    if arr.ndim != 0 or arr.dtype == np.bool_:
+    if arr.ndim != 0 or _contains_invalid_numeric_values(arr):
         raise ValueError(f"{name} must be a nonnegative finite scalar")
     scalar = arr.item()
     if isinstance(scalar, (bool, np.bool_)) or not isinstance(scalar, Real):

--- a/tests/calibration/test_bias_numeric_validation.py
+++ b/tests/calibration/test_bias_numeric_validation.py
@@ -73,6 +73,58 @@ def test_make_bias_training_examples_rejects_non_real_measurements():
         assert "measurement_values must contain numeric values" in str(exc_info.value)
 
 
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        (
+            "target_dim",
+            np.datetime64("1970-01-01T00:00:00.000000001"),
+            "target_dim must be a nonnegative integer",
+        ),
+        (
+            "feature_dim",
+            np.timedelta64(1, "ns"),
+            "feature_dim must be a nonnegative integer",
+        ),
+        (
+            "training_count",
+            np.timedelta64(2, "ns"),
+            "training_count must be a nonnegative integer",
+        ),
+        (
+            "ridge_alpha",
+            np.datetime64("1970-01-01T00:00:00.000000001"),
+            "ridge_alpha must be a nonnegative finite scalar",
+        ),
+    ],
+)
+def test_model_rejects_temporal_scalar_fields_before_integer_payload_coercion(
+    field, value, message
+):
+    kwargs = _unit_feature_model_kwargs()
+    kwargs[field] = value
+
+    with pytest.raises(ValueError, match=message):
+        SensorBiasCorrectionModel(**kwargs)
+
+
+def test_constant_bias_predict_rejects_temporal_n_rows_before_integer_payload():
+    model = SensorBiasCorrectionModel(
+        target_dim=1,
+        feature_dim=0,
+        intercept=np.array([2.0]),
+        coefficients=np.empty((0, 1)),
+        feature_mean=np.empty(0),
+        feature_scale=np.empty(0),
+        residual_std=np.array([0.0]),
+        training_count=3,
+        ridge_alpha=0.0,
+    )
+
+    with pytest.raises(ValueError, match="n_rows must be a nonnegative integer"):
+        model.predict(n_rows=np.timedelta64(2, "ns"))
+
+
 def test_make_bias_training_examples_accepts_real_integer_measurements():
     examples = make_bias_training_examples(
         measurement_times_s=np.array([0.0]),


### PR DESCRIPTION
## Summary
- reject NumPy `datetime64` / `timedelta64` scalar controls in the bias-correction scalar validators
- route integer and nonnegative-float scalar checks through the existing rejected numeric-kind/object-value guard before `.item()` unwrapping
- add focused regressions for temporal `target_dim`, `feature_dim`, `training_count`, `ridge_alpha`, and `predict(n_rows=...)`

## Bug fixed
`np.datetime64[ns]` and `np.timedelta64[ns]` scalar arrays can expose their nanosecond payloads through `.item()`. In `calibration/bias.py`, that meant malformed temporal values could be silently accepted as dimensions, row counts, training counts, or nonnegative scalar controls. For example, `np.timedelta64(2, "ns")` could become integer `2` and be treated as a valid `n_rows` value.

The fix rejects temporal scalar dtypes before scalar unwrapping, matching the stricter array-validation behavior already used in the same module.

## Validation
- `PYTHONPATH=/mnt/data/pyrecest_bias_patch/src python -m py_compile /mnt/data/pyrecest_bias_patch/src/pyrecest/calibration/bias.py /mnt/data/pyrecest_bias_patch/tests/calibration/test_bias_numeric_validation.py`
- `PYTHONPATH=/mnt/data/pyrecest_bias_patch/src pytest -q /mnt/data/pyrecest_bias_patch/tests/calibration/test_bias_numeric_validation.py` → `10 passed`

Full in-repository pytest was not run locally because this sandbox cannot resolve `github.com`; CI should run the in-tree regression.