### PR TITLE
Reject temporal candidate-pruning scalar controls

### DIFF
--- a/src/pyrecest/utils/candidate_pruning.py
+++ b/src/pyrecest/utils/candidate_pruning.py
@@ -106,9 +106,21 @@ def _normalize_bool(value: Any, name: str) -> bool:
     raise ValueError(f"{name} must be a boolean")
 
 
+def _has_temporal_dtype(value: Any) -> bool:
+    try:
+        return np.asarray(value).dtype.kind in {"M", "m"}
+    except (TypeError, ValueError, RuntimeError):
+        return False
+
+
 def _normalize_positive_integer(value: Any, name: str) -> int:
-    value_array = np.asarray(value)
     message = f"{name} must be a positive integer or None"
+    if _has_temporal_dtype(value) or _contains_temporal_values(value):
+        raise ValueError(message)
+    try:
+        value_array = np.asarray(value)
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise ValueError(message) from exc
     if value_array.shape != () or value_array.dtype == np.bool_:
         raise ValueError(message)
 
@@ -132,7 +144,12 @@ def _normalize_positive_integer(value: Any, name: str) -> int:
 
 
 def _normalize_finite_scalar(value: Any, *, message: str) -> float:
-    value_array = np.asarray(value)
+    if _has_temporal_dtype(value) or _contains_temporal_values(value):
+        raise ValueError(message)
+    try:
+        value_array = np.asarray(value)
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise ValueError(message) from exc
     if value_array.shape != () or value_array.dtype == np.bool_:
         raise ValueError(message)
 

--- a/tests/test_candidate_pruning_temporal_scalars.py
+++ b/tests/test_candidate_pruning_temporal_scalars.py
@@ -1,0 +1,65 @@
+import re
+import unittest
+
+import numpy as np
+
+from pyrecest.utils import CandidatePruningConfig, prune_pairwise_cost_matrix
+
+
+class TestCandidatePruningTemporalScalars(unittest.TestCase):
+    def test_scalar_cost_controls_reject_temporal_scalars(self):
+        temporal_values = (
+            np.timedelta64(1, "ns"),
+            np.datetime64("1970-01-01T00:00:00.000000001"),
+            np.asarray(np.timedelta64(1, "ns")),
+            np.asarray(np.datetime64("1970-01-01T00:00:00.000000001")),
+        )
+        cases = (
+            (
+                "probability_threshold",
+                "probability_threshold must lie in [0, 1]",
+            ),
+            ("max_cost", "max_cost must be finite or None"),
+            (
+                "max_cost_percentile",
+                "max_cost_percentile must lie in [0, 100]",
+            ),
+            ("large_cost", "large_cost must be finite and positive"),
+        )
+
+        for field_name, message in cases:
+            for value in temporal_values:
+                with self.subTest(field_name=field_name, value=value):
+                    with self.assertRaisesRegex(ValueError, re.escape(message)):
+                        CandidatePruningConfig(**{field_name: value})
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "large_cost must be finite and positive",
+        ):
+            prune_pairwise_cost_matrix(
+                np.array([[1.0, 2.0]]),
+                config=CandidatePruningConfig(row_top_k=1),
+                large_cost=np.timedelta64(2, "ns"),
+            )
+
+    def test_top_k_rejects_temporal_scalars(self):
+        temporal_top_k_values = (
+            np.timedelta64(2, "ns"),
+            np.datetime64("1970-01-01T00:00:00.000000002"),
+            np.asarray(np.timedelta64(2, "ns")),
+            np.asarray(np.datetime64("1970-01-01T00:00:00.000000002")),
+        )
+
+        for field_name in ("row_top_k", "column_top_k"):
+            for value in temporal_top_k_values:
+                with self.subTest(field_name=field_name, value=value):
+                    with self.assertRaisesRegex(
+                        ValueError,
+                        f"{field_name} must be a positive integer or None",
+                    ):
+                        CandidatePruningConfig(**{field_name: value})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reject NumPy `datetime64` / `timedelta64` scalar controls before candidate-pruning config coercion
- cover row/column top-k, probability/cost/percentile thresholds, config `large_cost`, and `prune_pairwise_cost_matrix(..., large_cost=...)`
- preserve existing numeric scalar behavior while preventing nanosecond temporal payloads from being interpreted as ordinary numbers

## Bug fixed
`CandidatePruningConfig` scalar validators called `np.asarray(...).item()` before excluding temporal dtypes. For nanosecond-resolution `np.timedelta64` and `np.datetime64`, NumPy can expose the internal payload as an integer. That allowed malformed temporal values such as `np.timedelta64(2, "ns")` to be silently accepted as `row_top_k=2`, `column_top_k=2`, `large_cost=2.0`, or other scalar pruning thresholds.

## Validation
- `PYTHONPATH=/tmp/pyrecest_candidate_patch/src python -m py_compile /tmp/pyrecest_candidate_patch/src/pyrecest/utils/candidate_pruning.py /tmp/pyrecest_candidate_patch/tests/test_candidate_pruning_temporal_scalars.py`
- `PYTHONPATH=/tmp/pyrecest_candidate_patch/src python -m pytest -q /tmp/pyrecest_candidate_patch/tests/test_candidate_pruning_temporal_scalars.py` → `2 passed, 24 subtests passed`
- GitHub compare: branch is 2 commits ahead of `main`, 0 behind; changed only `src/pyrecest/utils/candidate_pruning.py` and `tests/test_candidate_pruning_temporal_scalars.py`.