### PR TITLE
Reject temporal CLI numeric inputs

### DIFF
--- a/src/pyrecest/cli.py
+++ b/src/pyrecest/cli.py
@@ -23,7 +23,10 @@ _INVALID_TOLERANCE_SCALAR_TYPES = (
     np.bool_,
     np.str_,
     np.bytes_,
+    np.datetime64,
+    np.timedelta64,
 )
+_INVALID_NUMERIC_DTYPE_KINDS = frozenset("mM")
 
 
 def _package_version(name: str) -> str | None:
@@ -41,7 +44,7 @@ def _validate_tolerance(value: Any) -> float:
     except (TypeError, ValueError, RuntimeError) as exc:
         raise ValueError(_INVALID_TOLERANCE_MESSAGE) from exc
 
-    if value_array.shape != ():
+    if value_array.shape != () or value_array.dtype.kind in _INVALID_NUMERIC_DTYPE_KINDS:
         raise ValueError(_INVALID_TOLERANCE_MESSAGE)
 
     scalar = value_array.item()
@@ -60,7 +63,7 @@ def _validate_tolerance(value: Any) -> float:
 def _is_finite_real_number(value: Any) -> bool:
     return (
         isinstance(value, Real)
-        and not isinstance(value, bool)
+        and not isinstance(value, _INVALID_TOLERANCE_SCALAR_TYPES)
         and math.isfinite(float(value))
     )
 
@@ -84,6 +87,8 @@ def _coerce_finite_real_sequence(value: Any, *, field_name: str) -> list[float]:
 def _comparison_value(value: Any) -> Any:
     if isinstance(value, np.ndarray):
         return _comparison_value(value.tolist())
+    if isinstance(value, (np.datetime64, np.timedelta64)):
+        return value
     if isinstance(value, np.generic):
         return _comparison_value(value.item())
     if isinstance(value, dict):

--- a/tests/test_cli_tolerance_validation.py
+++ b/tests/test_cli_tolerance_validation.py
@@ -4,7 +4,11 @@ import math
 
 import numpy as np
 import pytest
-from pyrecest.cli import _check_expected_mapping, _validate_tolerance
+from pyrecest.cli import (
+    _check_expected_mapping,
+    _coerce_finite_real_sequence,
+    _validate_tolerance,
+)
 
 
 def test_validate_tolerance_accepts_finite_nonnegative_numbers() -> None:
@@ -27,6 +31,18 @@ def test_validate_tolerance_rejects_invalid_values() -> None:
         np.array([0.1]),
     )
     for tolerance in invalid_tolerances:
+        with pytest.raises(ValueError, match="tolerance"):
+            _validate_tolerance(tolerance)
+
+
+def test_validate_tolerance_rejects_numpy_temporal_scalars() -> None:
+    temporal_tolerances = (
+        np.timedelta64(1, "ns"),
+        np.datetime64("1970-01-01T00:00:00.000000001", "ns"),
+        np.array(np.timedelta64(1, "ns"), dtype=object),
+        np.array(np.datetime64("1970-01-01T00:00:00.000000001", "ns"), dtype=object),
+    )
+    for tolerance in temporal_tolerances:
         with pytest.raises(ValueError, match="tolerance"):
             _validate_tolerance(tolerance)
 
@@ -66,7 +82,10 @@ def test_expected_mapping_accepts_numpy_scalar_actuals(actual_value) -> None:
     )
 
 
-@pytest.mark.parametrize("actual_value", [True, "1.0", math.nan, math.inf])
+@pytest.mark.parametrize(
+    "actual_value",
+    [True, "1.0", math.nan, math.inf, np.timedelta64(1, "ns")],
+)
 def test_expected_mapping_rejects_malformed_numeric_actuals(actual_value) -> None:
     errors = _check_expected_mapping(
         "metrics",
@@ -77,3 +96,23 @@ def test_expected_mapping_rejects_malformed_numeric_actuals(actual_value) -> Non
 
     assert errors
     assert "metrics.rmse mismatch" in errors[0]
+
+
+def test_expected_mapping_does_not_compare_temporal_expected_as_numeric() -> None:
+    errors = _check_expected_mapping(
+        "metrics",
+        {"duration": 1.0},
+        {"duration": np.timedelta64(1, "ns")},
+        tolerance=0.0,
+    )
+
+    assert errors
+    assert "metrics.duration mismatch" in errors[0]
+
+
+def test_coerce_finite_real_sequence_rejects_temporal_entries() -> None:
+    with pytest.raises(ValueError, match="final_estimate"):
+        _coerce_finite_real_sequence(
+            [np.timedelta64(1, "ns")],
+            field_name="final_estimate",
+        )


### PR DESCRIPTION
## Summary
- reject NumPy `datetime64` / `timedelta64` scalar tolerances before `.item()` can expose integer nanosecond payloads
- treat NumPy temporal scalars as nonnumeric in expected-result numeric comparisons and final-estimate sequence coercion
- add focused regression coverage for native and object-wrapped temporal CLI inputs

## Bug fixed
`np.datetime64(..., "ns")` and `np.timedelta64(..., "ns")` can unwrap to integer nanosecond payloads via `.item()`, and `float(...)` also accepts object-wrapped temporal scalars. The CLI tolerance validator therefore silently accepted malformed temporal values as numeric tolerances. Separately, `np.timedelta64` satisfies `numbers.Real`, so expected-result numeric comparison and final-estimate coercion could treat a duration as an ordinary finite number.

## Validation
- `PYTHONPATH=/tmp/pyrecest_cli_patch/src python -m pytest -q /tmp/pyrecest_cli_patch/tests/test_cli_tolerance_validation.py` → `14 passed`
- GitHub compare: branch is 2 commits ahead of `main`, 0 behind; changed only `src/pyrecest/cli.py` and `tests/test_cli_tolerance_validation.py`.