### PR TITLE
Reject temporal model validation inputs

### DIFF
--- a/src/pyrecest/models/validation.py
+++ b/src/pyrecest/models/validation.py
@@ -16,8 +16,8 @@ from pyrecest import backend
 
 # pylint: disable=too-many-arguments
 
+_TEMPORAL_ARRAY_KINDS = {"M", "m"}
 _TEMPORAL_SCALAR_TYPES = (np.datetime64, np.timedelta64)
-_TEMPORAL_DTYPE_KINDS = {"M", "m"}
 
 
 def _as_backend_array(value: Any, name: str):
@@ -26,7 +26,10 @@ def _as_backend_array(value: Any, name: str):
         value_array = np.asarray(value)
     except (TypeError, ValueError, RuntimeError, OverflowError):
         value_array = None
-    if value_array is not None and _has_temporal_dtype(value_array):
+    if value_array is not None and (
+        _array_has_temporal_dtype(value_array)
+        or _contains_temporal_scalar(value_array)
+    ):
         raise ValueError(f"{name} must contain numeric non-boolean values.")
     try:
         return backend.asarray(value)
@@ -55,26 +58,33 @@ def _validate_bool_flag(value: Any, name: str) -> bool:
     raise TypeError(f"{name} must be a boolean.")
 
 
-def _has_temporal_dtype(value: Any) -> bool:
-    dtype = getattr(value, "dtype", None)
-    if dtype is None:
-        return False
-    if getattr(dtype, "kind", None) in _TEMPORAL_DTYPE_KINDS:
-        return True
-    dtype_name = str(dtype).lower()
-    return "datetime64" in dtype_name or "timedelta64" in dtype_name
-
-
-def _is_temporal_scalar_array(value_array: Any) -> bool:
-    if _has_temporal_dtype(value_array):
-        return True
-    if getattr(value_array, "shape", None) != ():
-        return False
+def _dtype_kind(dtype: Any) -> str:
     try:
-        scalar = value_array.item()
-    except (AttributeError, TypeError, ValueError):
+        return np.dtype(dtype).kind
+    except TypeError:
+        return ""
+
+
+def _dtype_is_temporal(dtype: Any) -> bool:
+    return _dtype_kind(dtype) in _TEMPORAL_ARRAY_KINDS
+
+
+def _array_has_temporal_dtype(value_array: np.ndarray) -> bool:
+    return _dtype_is_temporal(value_array.dtype)
+
+
+def _contains_temporal_scalar(value: Any) -> bool:
+    if isinstance(value, _TEMPORAL_SCALAR_TYPES):
+        return True
+    if isinstance(value, np.ndarray):
+        if _array_has_temporal_dtype(value):
+            return True
+        if value.dtype == object:
+            return any(_contains_temporal_scalar(item) for item in value.reshape(-1))
         return False
-    return isinstance(scalar, _TEMPORAL_SCALAR_TYPES)
+    if isinstance(value, (list, tuple)):
+        return any(_contains_temporal_scalar(item) for item in value)
+    return False
 
 
 def _validate_nonnegative_finite_scalar(value: Any, name: str) -> float:
@@ -82,13 +92,13 @@ def _validate_nonnegative_finite_scalar(value: Any, name: str) -> float:
     if (
         value_array.shape != ()
         or value_array.dtype == np.bool_
-        or _is_temporal_scalar_array(value_array)
+        or _array_has_temporal_dtype(value_array)
     ):
         raise ValueError(f"{name} must be a finite nonnegative scalar.")
     scalar = value_array.item()
     if isinstance(
         scalar,
-        (bool, np.bool_, str, bytes, bytearray, np.str_, np.bytes_),
+        (bool, np.bool_, str, bytes, bytearray, np.str_, np.bytes_, *_TEMPORAL_SCALAR_TYPES),
     ):
         raise ValueError(f"{name} must be a finite nonnegative scalar.")
     try:
@@ -122,11 +132,11 @@ def _validate_expected_dim_scalar(value: Any, dim_name: str) -> int:
     if (
         value_array.shape != ()
         or value_array.dtype == np.bool_
-        or _is_temporal_scalar_array(value_array)
+        or _array_has_temporal_dtype(value_array)
     ):
         raise TypeError(f"{dim_name} must be an integer or None.")
     scalar = value_array.item()
-    if isinstance(scalar, (bool, np.bool_)) or not isinstance(scalar, Integral):
+    if isinstance(scalar, (bool, np.bool_, *_TEMPORAL_SCALAR_TYPES)) or not isinstance(scalar, Integral):
         raise TypeError(f"{dim_name} must be an integer or None.")
     return int(scalar)
 
@@ -145,10 +155,22 @@ def _dtype_name(value: Any) -> str:
     return "" if dtype is None else str(dtype).lower()
 
 
-def _validate_numeric_nonboolean_entries(value: Any, name: str) -> None:
-    """Raise if a backend array is boolean-valued rather than numeric."""
+def _backend_value_has_temporal_dtype(value: Any) -> bool:
+    dtype = getattr(value, "dtype", None)
+    if dtype is None:
+        return False
+    if _dtype_is_temporal(dtype):
+        return True
     dtype_name = _dtype_name(value)
-    if dtype_name in {"bool", "bool_", "torch.bool"} or _has_temporal_dtype(value):
+    return "datetime64" in dtype_name or "timedelta64" in dtype_name
+
+
+def _validate_numeric_nonboolean_entries(value: Any, name: str) -> None:
+    """Raise if a backend array is boolean- or temporal-valued rather than numeric."""
+    dtype_name = _dtype_name(value)
+    if dtype_name in {"bool", "bool_", "torch.bool"}:
+        raise ValueError(f"{name} must contain numeric non-boolean values.")
+    if _backend_value_has_temporal_dtype(value) or _contains_temporal_scalar(value):
         raise ValueError(f"{name} must contain numeric non-boolean values.")
 
 
@@ -375,7 +397,7 @@ def _maybe_call(value: Any, *, allow_methods: bool) -> Any:
 
 
 def _positive_int_or_none(value: Any) -> int | None:
-    if isinstance(value, (bool, np.bool_)):
+    if isinstance(value, (bool, np.bool_, *_TEMPORAL_SCALAR_TYPES)):
         return None
     try:
         value_array = np.asarray(value)
@@ -384,11 +406,11 @@ def _positive_int_or_none(value: Any) -> int | None:
     if (
         value_array.shape != ()
         or value_array.dtype == np.bool_
-        or _is_temporal_scalar_array(value_array)
+        or _array_has_temporal_dtype(value_array)
     ):
         return None
     scalar = value_array.item()
-    if isinstance(scalar, (bool, np.bool_)):
+    if isinstance(scalar, (bool, np.bool_, *_TEMPORAL_SCALAR_TYPES)):
         return None
     if isinstance(scalar, Integral) and int(scalar) > 0:
         return int(scalar)

--- a/tests/models/test_validation.py
+++ b/tests/models/test_validation.py
@@ -1,5 +1,7 @@
 import unittest
 
+import numpy as np
+
 from pyrecest.backend import array, eye, zeros
 from pyrecest.models.validation import (
     infer_state_dim_from_distribution,
@@ -48,6 +50,32 @@ class TestModelValidation(unittest.TestCase):
                 with self.assertRaisesRegex(TypeError, "integer or None"):
                     call()
 
+    def test_validate_expected_dimensions_reject_temporal_values(self):
+        temporal_values = [
+            np.timedelta64(2, "ns"),
+            np.datetime64("1970-01-01T00:00:00.000000002"),
+            np.array(np.timedelta64(2, "ns")),
+            np.array(np.datetime64("1970-01-01T00:00:00.000000002")),
+            np.array(np.timedelta64(2, "ns"), dtype=object),
+            np.array(np.datetime64("1970-01-01T00:00:00.000000002"), dtype=object),
+        ]
+
+        for value in temporal_values:
+            invalid_calls = [
+                lambda value=value: validate_state_vector(array([1.0, 2.0]), state_dim=value),
+                lambda value=value: validate_measurement_vector(array([1.0, 2.0]), meas_dim=value),
+                lambda value=value: validate_covariance_matrix(eye(2), dim=value),
+                lambda value=value: validate_noise_covariance(eye(2), dim=value),
+                lambda value=value: validate_transition_matrix(zeros((2, 2)), state_dim=value),
+                lambda value=value: validate_transition_matrix(zeros((2, 2)), pred_dim=value),
+                lambda value=value: validate_measurement_matrix(zeros((2, 2)), state_dim=value),
+                lambda value=value: validate_measurement_matrix(zeros((2, 2)), meas_dim=value),
+            ]
+            for call in invalid_calls:
+                with self.subTest(value=value, call=call):
+                    with self.assertRaisesRegex(TypeError, "integer or None"):
+                        call()
+
     def test_validate_vector_and_matrix_reject_boolean_arrays(self):
         invalid_calls = [
             lambda: validate_state_vector(array([True, False]), state_dim=2),
@@ -62,6 +90,43 @@ class TestModelValidation(unittest.TestCase):
             with self.subTest(call=call):
                 with self.assertRaisesRegex(ValueError, "numeric non-boolean"):
                     call()
+
+    def test_validate_vector_and_matrix_reject_temporal_arrays(self):
+        datetime_vector = np.array(
+            ["1970-01-01T00:00:00.000000001", "1970-01-01T00:00:00.000000002"],
+            dtype="datetime64[ns]",
+        )
+        timedelta_vector = np.array([1, 2], dtype="timedelta64[ns]")
+        datetime_matrix = datetime_vector.reshape(1, 2)
+        timedelta_matrix = np.array([[1, 0], [0, 1]], dtype="timedelta64[ns]")
+        object_temporal_matrix = np.array(
+            [[np.datetime64("1970-01-01T00:00:00.000000001")]],
+            dtype=object,
+        )
+
+        invalid_calls = [
+            lambda: validate_state_vector(datetime_vector, state_dim=2),
+            lambda: validate_measurement_vector(timedelta_vector, meas_dim=2),
+            lambda: validate_covariance_matrix(timedelta_matrix, dim=2),
+            lambda: validate_noise_covariance(object_temporal_matrix, dim=1),
+            lambda: validate_transition_matrix(datetime_matrix, state_dim=2, pred_dim=1),
+            lambda: validate_measurement_matrix(timedelta_matrix, state_dim=2, meas_dim=2),
+        ]
+
+        for call in invalid_calls:
+            with self.subTest(call=call):
+                with self.assertRaisesRegex(ValueError, "numeric non-boolean"):
+                    call()
+
+    def test_validate_covariance_matrix_rejects_temporal_symmetry_tolerances(self):
+        for keyword in ("symmetric_rtol", "symmetric_atol"):
+            with self.subTest(keyword=keyword):
+                with self.assertRaisesRegex(ValueError, "finite nonnegative scalar"):
+                    validate_covariance_matrix(
+                        eye(1),
+                        check_symmetric=True,
+                        **{keyword: np.timedelta64(1, "ns")},
+                    )
 
     def test_validate_measurement_vector_accepts_expected_shape(self):
         measurement = validate_measurement_vector(array([1.0]), meas_dim=1)
@@ -151,6 +216,13 @@ class TestModelValidation(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "Could not infer"):
             infer_state_dim_from_distribution(DistributionWithBooleanDim())
+
+    def test_infer_state_dim_rejects_temporal_dim_attribute(self):
+        class DistributionWithTemporalDim:
+            dim = np.timedelta64(4, "ns")
+
+        with self.assertRaisesRegex(ValueError, "Could not infer"):
+            infer_state_dim_from_distribution(DistributionWithTemporalDim())
 
     def test_infer_state_dim_skips_disabled_callable_dim_attribute(self):
         class DistributionWithCallableDimAndMean:


### PR DESCRIPTION
## Summary
- reject NumPy `datetime64` / `timedelta64` values in model vector/matrix validators before `np.isfinite(...)` treats them as valid finite entries
- reject temporal nanosecond scalar payloads for expected dimensions and covariance symmetry tolerances
- keep existing complex Hermitian covariance support and ordinary numeric dimension/tolerance behavior

## Bug fixed
NumPy temporal values are problematic in two model-validation paths:

1. `np.isfinite(...)` returns true for native `datetime64` / `timedelta64` arrays, so `validate_state_vector(...)`, `validate_measurement_vector(...)`, and matrix/covariance validators could accept timestamps or durations as valid model coordinates/covariances.
2. Nanosecond-resolution temporal scalars can expose raw integer payloads through `np.asarray(...).item()`. That meant malformed `dim`, `rows`, `cols`, `symmetric_rtol`, `symmetric_atol`, or distribution `dim` attributes such as `np.timedelta64(2, "ns")` could be silently interpreted as ordinary numeric controls.

The patch adds shared temporal dtype/scalar guards to model validation and extends regression coverage for native and object-wrapped temporal scalar/array inputs.

## Validation
- `python -m py_compile /mnt/data/validation.py /mnt/data/test_validation.py`
- NumPy-backend isolated smoke with local backend stub: `30 passed, 73 subtests passed`
- GitHub compare: branch is 2 commits ahead of `main`, 0 behind; changed only `src/pyrecest/models/validation.py` and `tests/models/test_validation.py`.