### PR TITLE
Reject boolean PyTorch reduction axes

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_reduction_axis_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_reduction_axis_contract.py
@@ -20,6 +20,22 @@ def _is_boolean_axis_value(value, torch_module) -> bool:
     return torch_module.is_tensor(value) and value.dtype == torch_module.bool
 
 
+def _axis_contains_boolean_value(axis, torch_module) -> bool:
+    if axis is None:
+        return False
+    if _is_boolean_axis_value(axis, torch_module):
+        return True
+    try:
+        _operator_index(axis)
+    except TypeError:
+        try:
+            axes = tuple(axis)
+        except TypeError:
+            return False
+        return any(_axis_contains_boolean_value(one_axis, torch_module) for one_axis in axes)
+    return False
+
+
 def normalize_reduction_axes(axis, ndim_value, torch_module):
     """Normalize PyTorch reduction axes while rejecting boolean axes."""
 
@@ -58,11 +74,30 @@ def normalize_reduction_axes(axis, ndim_value, torch_module):
     return normalized_axes
 
 
+def _wrap_boolean_axis_reduction(helper, torch_module):
+    if getattr(helper, "_pyrecest_reduction_axis_bool_contract", False):
+        return helper
+
+    def reduction(*args, **kwargs):
+        axis = kwargs.get("axis")
+        if "axis" not in kwargs and len(args) >= 2:
+            axis = args[1]
+        if _axis_contains_boolean_value(axis, torch_module):
+            raise TypeError(_AXIS_TYPE_MESSAGE)
+        return helper(*args, **kwargs)
+
+    reduction.__name__ = getattr(helper, "__name__", "reduction")
+    reduction.__doc__ = getattr(helper, "__doc__", None)
+    reduction._pyrecest_reduction_axis_bool_contract = True
+    return reduction
+
+
 def patch_pytorch_reduction_axis_contract() -> None:
     """Make raw/public PyTorch reduction helpers reject boolean axes."""
 
     try:
         import pyrecest._backend as backend_loader  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
         import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
         import torch  # pylint: disable=import-outside-toplevel
     except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
@@ -108,3 +143,11 @@ def patch_pytorch_reduction_axis_contract() -> None:
     _normalize_reduction_axes.__doc__ = getattr(original_normalizer, "__doc__", None)
     _normalize_reduction_axes._pyrecest_reduction_axis_bool_contract = True
     raw_pytorch._normalize_reduction_axes = _normalize_reduction_axes
+
+    for helper_name in ("any", "all", "count_nonzero", "max"):
+        raw_helper = getattr(raw_pytorch, helper_name, None)
+        if raw_helper is not None:
+            wrapped_helper = _wrap_boolean_axis_reduction(raw_helper, torch)
+            setattr(raw_pytorch, helper_name, wrapped_helper)
+            if getattr(backend, "__backend_name__", None) == "pytorch":
+                setattr(backend, helper_name, wrapped_helper)

--- a/src/pyrecest/backend_support/_pytorch_reduction_axis_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_reduction_axis_contract.py
@@ -62,10 +62,34 @@ def patch_pytorch_reduction_axis_contract() -> None:
     """Make raw/public PyTorch reduction helpers reject boolean axes."""
 
     try:
+        import pyrecest._backend as backend_loader  # pylint: disable=import-outside-toplevel
         import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
         import torch  # pylint: disable=import-outside-toplevel
     except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
         return
+
+    backend_normalizer = getattr(backend_loader, "_normalize_reduction_axes", None)
+    if backend_normalizer is not None and not getattr(
+        backend_normalizer,
+        "_pyrecest_reduction_axis_bool_contract",
+        False,
+    ):
+
+        def _normalize_backend_reduction_axes(axis, ndim_value):
+            return normalize_reduction_axes(axis, ndim_value, torch)
+
+        _normalize_backend_reduction_axes.__name__ = getattr(
+            backend_normalizer,
+            "__name__",
+            "_normalize_reduction_axes",
+        )
+        _normalize_backend_reduction_axes.__doc__ = getattr(
+            backend_normalizer,
+            "__doc__",
+            None,
+        )
+        _normalize_backend_reduction_axes._pyrecest_reduction_axis_bool_contract = True
+        backend_loader._normalize_reduction_axes = _normalize_backend_reduction_axes
 
     original_normalizer = getattr(raw_pytorch, "_normalize_reduction_axes", None)
     if original_normalizer is None:

--- a/src/pyrecest/backend_support/_pytorch_reduction_axis_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_reduction_axis_contract.py
@@ -1,0 +1,86 @@
+"""Runtime patch for PyTorch reduction-axis normalization."""
+
+from __future__ import annotations
+
+from operator import index as _operator_index
+
+import numpy as np
+
+_AXIS_FLAG_TYPES = (bool, np.bool_)
+_AXIS_TYPE_MESSAGE = "axis must be an integer or a sequence of integers"
+
+
+def _is_boolean_axis_value(value, torch_module) -> bool:
+    """Return whether ``value`` is a boolean axis scalar/container."""
+
+    if isinstance(value, _AXIS_FLAG_TYPES):
+        return True
+    if isinstance(value, np.ndarray):
+        return np.issubdtype(value.dtype, np.bool_)
+    return torch_module.is_tensor(value) and value.dtype == torch_module.bool
+
+
+def normalize_reduction_axes(axis, ndim_value, torch_module):
+    """Normalize PyTorch reduction axes while rejecting boolean axes."""
+
+    if _is_boolean_axis_value(axis, torch_module):
+        raise TypeError(_AXIS_TYPE_MESSAGE)
+    try:
+        axis_index = _operator_index(axis)
+    except TypeError as index_error:
+        if getattr(axis, "shape", None) == ():
+            raise TypeError(_AXIS_TYPE_MESSAGE) from index_error
+        try:
+            axes = tuple(axis)
+        except TypeError as iterable_error:
+            raise TypeError(_AXIS_TYPE_MESSAGE) from iterable_error
+        if any(_is_boolean_axis_value(one_axis, torch_module) for one_axis in axes):
+            raise TypeError(_AXIS_TYPE_MESSAGE)
+        try:
+            axes = tuple(_operator_index(one_axis) for one_axis in axes)
+        except TypeError as item_error:
+            raise TypeError(_AXIS_TYPE_MESSAGE) from item_error
+    else:
+        axes = (axis_index,)
+
+    normalized_axes = tuple(
+        one_axis + ndim_value if one_axis < 0 else one_axis for one_axis in axes
+    )
+    if len(set(normalized_axes)) != len(normalized_axes):
+        raise ValueError("duplicate value in 'axis'")
+
+    for original_axis, normalized_axis in zip(axes, normalized_axes):
+        if normalized_axis < 0 or normalized_axis >= ndim_value:
+            raise IndexError(
+                f"axis {original_axis} is out of bounds for array of dimension {ndim_value}"
+            )
+
+    return normalized_axes
+
+
+def patch_pytorch_reduction_axis_contract() -> None:
+    """Make raw/public PyTorch reduction helpers reject boolean axes."""
+
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    original_normalizer = getattr(raw_pytorch, "_normalize_reduction_axes", None)
+    if original_normalizer is None:
+        return
+    if getattr(original_normalizer, "_pyrecest_reduction_axis_bool_contract", False):
+        return
+
+    def _normalize_reduction_axes(axis, ndim_value):
+        return normalize_reduction_axes(axis, ndim_value, torch)
+
+    _normalize_reduction_axes.__name__ = getattr(
+        original_normalizer,
+        "__name__",
+        "_normalize_reduction_axes",
+    )
+    _normalize_reduction_axes.__doc__ = getattr(original_normalizer, "__doc__", None)
+    _normalize_reduction_axes._pyrecest_reduction_axis_bool_contract = True
+    raw_pytorch._normalize_reduction_axes = _normalize_reduction_axes

--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -221,6 +221,9 @@ try:
     from pyrecest.backend_support._pytorch_one_hot_scalar_contract import (  # pylint: disable=import-outside-toplevel
         patch_pytorch_one_hot_scalar_contract as _patch_pytorch_one_hot_scalar_contract,
     )
+    from pyrecest.backend_support._pytorch_reduction_axis_contract import (  # pylint: disable=import-outside-toplevel
+        patch_pytorch_reduction_axis_contract as _patch_pytorch_reduction_axis_contract,
+    )
 except ModuleNotFoundError:  # pragma: no cover - source tree corruption only
     pass
 else:
@@ -230,3 +233,4 @@ else:
     _patch_pytorch_searchsorted_contract()
     _patch_pytorch_transpose_boolean_axes_contract()
     _patch_pytorch_one_hot_scalar_contract()
+    _patch_pytorch_reduction_axis_contract()

--- a/tests/backend_support/test_pytorch_reduction_axis_bool_contract.py
+++ b/tests/backend_support/test_pytorch_reduction_axis_bool_contract.py
@@ -1,0 +1,96 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _backend_subprocess_env(backend_name):
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = backend_name
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    return env
+
+
+_REDUCTION_BOOL_AXIS_CODE = r'''
+import numpy as np
+import torch
+
+axis_values = [
+    True,
+    False,
+    np.bool_(True),
+    np.asarray(True),
+    np.asarray([True]),
+    (True,),
+    [False],
+    torch.tensor(True),
+    torch.tensor([True]),
+    (torch.tensor(False),),
+]
+
+
+def assert_bool_axes_rejected(module):
+    values = module.array([[0, 1], [2, 3]])
+    for helper_name in ("any", "all", "count_nonzero", "max"):
+        helper = getattr(module, helper_name)
+        for axis in axis_values:
+            try:
+                helper(values, axis=axis)
+            except TypeError:
+                continue
+            raise AssertionError(f"{helper_name} accepted boolean axis {axis!r}")
+
+    assert module.to_numpy(module.any(values, axis=1)).tolist() == [True, True]
+    assert module.to_numpy(module.max(values, axis=0)).tolist() == [2, 3]
+'''
+
+
+@pytest.mark.backend_portable
+def test_public_pytorch_reduction_helpers_reject_boolean_axes():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = (
+        _REDUCTION_BOOL_AXIS_CODE
+        + """
+import pyrecest.backend as backend
+
+assert backend.__backend_name__ == "pytorch"
+assert_bool_axes_rejected(backend)
+"""
+    )
+    subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        env=_backend_subprocess_env("pytorch"),
+    )
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_reduction_helpers_are_patched_under_numpy_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = (
+        _REDUCTION_BOOL_AXIS_CODE
+        + """
+import pyrecest  # noqa: F401
+import pyrecest.backend as public_backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+assert public_backend.__backend_name__ == "numpy"
+assert_bool_axes_rejected(raw_pytorch)
+"""
+    )
+    subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        env=_backend_subprocess_env("numpy"),
+    )


### PR DESCRIPTION
## Summary
- add a runtime patch for PyTorch reduction-axis normalization that rejects Python, NumPy, and Torch boolean axis values
- wire the patch through the existing evidence/runtime patch setup
- add subprocess regression coverage for the public PyTorch backend and for the raw PyTorch backend when NumPy is the selected public backend

## Bug fixed
The raw PyTorch backend's `_normalize_reduction_axes(...)` accepted boolean axis values because Python `bool` is an `int` subclass and boolean containers were converted with `tuple(axis)`. Helpers routed through `_reduce_over_axes(...)` such as `any`, `all`, `count_nonzero`, and `max` could therefore silently reduce over axis 0/1 for inputs like `axis=True`, `(True,)`, `np.asarray([True])`, or `torch.tensor([True])`. NumPy rejects boolean axis arguments; PyRecEst's PyTorch backend should preserve that contract instead of silently changing the reduction dimension.

## Validation
- `python3 -m py_compile /tmp/_pytorch_reduction_axis_contract.py /tmp/test_pytorch_reduction_axis_bool_contract.py`
- isolated helper smoke: boolean Python/NumPy/Torch scalar and container axes now raise `TypeError`; ordinary integer, NumPy scalar integer, tuple axes, and Torch scalar integer axes still normalize correctly
- GitHub compare: branch is 3 commits ahead of current `main`, 0 behind, changing only `src/pyrecest/backend_support/_pytorch_reduction_axis_contract.py`, `src/pyrecest/evidence.py`, and `tests/backend_support/test_pytorch_reduction_axis_bool_contract.py`

Full in-repository pytest was not run locally because this environment does not have a PyRecEst checkout/dependency setup; CI should run the new in-tree regression.