### PR TITLE
Add centered Hermitian symmetry utilities for tensor trains

### DIFF
--- a/src/pyrecest/distributions/hypertorus/_tensor_train.py
+++ b/src/pyrecest/distributions/hypertorus/_tensor_train.py
@@ -39,6 +39,19 @@ def _normalize_nonnegative_tolerance(value, name):
     return tolerance
 
 
+def _check_dense_validation_size(size, max_entries):
+    if max_entries is None:
+        return
+    max_entries = _operator_index(max_entries)
+    if max_entries < 1:
+        raise ValueError("max_entries must be positive when provided.")
+    if size > max_entries:
+        raise ValueError(
+            "Centered Hermitian validation would require visiting more than "
+            f"{max_entries} tensor entries. Increase max_entries explicitly."
+        )
+
+
 def _choose_rank(singular_values, max_rank, local_tolerance):
     max_rank = _normalize_max_rank(max_rank)
     full_rank = singular_values.size
@@ -66,6 +79,11 @@ def _as_integer_index(value, axis, mode_size):
             f"TT entry index {index} is out of bounds for axis {axis} with size {mode_size}."
         )
     return index
+
+
+def _conjugate_flipped_centered(dense):
+    axes = tuple(range(dense.ndim))
+    return np.conjugate(np.flip(dense, axis=axes))
 
 
 class TensorTrain:
@@ -210,6 +228,36 @@ class TensorTrain:
             for left_core, right_core, mode_size in zip(self.cores, other.cores, target_shape)
         ]
         return TensorTrain(cores)
+
+    def centered_hermitian_deviation(self, *, max_entries=1_000_000):
+        """Return max ``|C[k] - conj(C[-k])|`` for center-indexed coefficients."""
+
+        _check_dense_validation_size(self.size, max_entries)
+        dense = self.to_dense()
+        return float(np.max(np.abs(dense - _conjugate_flipped_centered(dense))))
+
+    def is_centered_hermitian(self, *, atol=1e-10, max_entries=1_000_000):
+        """Return whether center-indexed coefficients satisfy Hermitian symmetry."""
+
+        atol = _normalize_nonnegative_tolerance(atol, "atol")
+        return self.centered_hermitian_deviation(max_entries=max_entries) <= atol
+
+    def centered_hermitianized(
+        self,
+        *,
+        max_rank=None,
+        rtol=0.0,
+        atol=0.0,
+        max_entries=1_000_000,
+    ):
+        """Return the nearest dense-average centered-Hermitian TT representation."""
+
+        _check_dense_validation_size(self.size, max_entries)
+        dense = self.to_dense()
+        hermitian_dense = 0.5 * (dense + _conjugate_flipped_centered(dense))
+        return TensorTrain.from_dense(
+            hermitian_dense, max_rank=max_rank, rtol=rtol, atol=atol
+        )
 
     def round(self, *, max_rank=None, rtol=0.0, atol=0.0, max_dense_entries=None):
         """Return a rank-rounded TT without materializing the full tensor.

--- a/tests/distributions/test_hypertoroidal_tensor_train.py
+++ b/tests/distributions/test_hypertoroidal_tensor_train.py
@@ -51,6 +51,41 @@ class TestHypertoroidalTensorTrain(unittest.TestCase):
         self.assertEqual(rounded.shape, tt.shape)
         self.assertTrue(np.isfinite(rounded.norm_squared()))
 
+    def test_centered_hermitian_symmetry_detection(self):
+        coeff = np.zeros((3, 3), dtype=np.complex128)
+        coeff[1, 1] = 1.0
+        coeff[0, 1] = 0.2 + 0.1j
+        coeff[2, 1] = np.conjugate(coeff[0, 1])
+        coeff[1, 0] = -0.3 + 0.05j
+        coeff[1, 2] = np.conjugate(coeff[1, 0])
+        tt = TensorTrain.from_dense(coeff)
+        self.assertTrue(tt.is_centered_hermitian())
+        npt.assert_allclose(tt.centered_hermitian_deviation(), 0.0, atol=1e-12)
+
+        broken = coeff.copy()
+        broken[2, 1] += 0.1
+        broken_tt = TensorTrain.from_dense(broken)
+        self.assertFalse(broken_tt.is_centered_hermitian(atol=1e-12))
+        self.assertGreater(broken_tt.centered_hermitian_deviation(), 0.0)
+
+    def test_centered_hermitianized_repairs_dense_average(self):
+        coeff = np.zeros(5, dtype=np.complex128)
+        coeff[2] = 1.0
+        coeff[1] = 0.2 + 0.1j
+        coeff[3] = 0.3 - 0.2j
+        repaired = TensorTrain.from_dense(coeff).centered_hermitianized()
+        self.assertTrue(repaired.is_centered_hermitian())
+        dense = repaired.to_dense()
+        npt.assert_allclose(dense[1], np.conjugate(dense[3]), atol=1e-12)
+        npt.assert_allclose(dense[2].imag, 0.0, atol=1e-12)
+
+    def test_centered_hermitian_validation_obeys_max_entries_guard(self):
+        tt = TensorTrain.from_dense(np.zeros((3, 3), dtype=np.complex128))
+        with self.assertRaises(ValueError):
+            tt.centered_hermitian_deviation(max_entries=1)
+        with self.assertRaises(ValueError):
+            tt.centered_hermitianized(max_entries=1)
+
     def test_max_rank_requires_positive_integer(self):
         tensor = np.arange(8, dtype=float).reshape(2, 2, 2)
         tt = TensorTrain.from_dense(tensor)


### PR DESCRIPTION
Summary:

- add centered Hermitian symmetry diagnostics for TT-compressed Fourier coefficients
- add a guarded dense-average `centered_hermitianized(...)` repair helper
- add regression tests for valid symmetry, broken symmetry detection, repair, and the max-entry validation guard

Motivation:

Identity Fourier densities should satisfy `C[k] = conj(C[-k])`. This catches invalid real-density coefficient tensors earlier than PDF evaluation.

Validation:

- Added focused tensor-train tests for Hermitian deviation, symmetry checks, repair, and dense-validation guard behavior.
- Full CI will run on this PR.