### PR TITLE
Expose Hermitian helpers on low-rank Fourier distributions

### DIFF
--- a/src/pyrecest/distributions/hypertorus/low_rank_hypertoroidal_fourier_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/low_rank_hypertoroidal_fourier_distribution.py
@@ -207,6 +207,44 @@ class LowRankHypertoroidalFourierDistribution(AbstractHypertoroidalDistribution)
             normalize=False,
         )
 
+    def centered_hermitian_deviation(self, *, max_entries=1_000_000):
+        """Return max ``|C[k] - conj(C[-k])|`` for identity coefficients."""
+
+        if self.transformation != "identity":
+            raise NotImplementedError("Hermitian coefficient checks apply to identity coefficients only.")
+        return self.coefficients.centered_hermitian_deviation(max_entries=max_entries)
+
+    def is_centered_hermitian(self, *, atol=1e-10, max_entries=1_000_000):
+        """Return whether identity coefficients define a real-valued Fourier series."""
+
+        if self.transformation != "identity":
+            raise NotImplementedError("Hermitian coefficient checks apply to identity coefficients only.")
+        return self.coefficients.is_centered_hermitian(atol=atol, max_entries=max_entries)
+
+    def centered_hermitianized(
+        self,
+        *,
+        max_rank=None,
+        rtol=0.0,
+        atol=0.0,
+        max_entries=1_000_000,
+    ):
+        """Return a centered-Hermitian identity-coefficient distribution."""
+
+        if self.transformation != "identity":
+            raise NotImplementedError("Hermitian coefficient repair applies to identity coefficients only.")
+        coefficients = self.coefficients.centered_hermitianized(
+            max_rank=max_rank,
+            rtol=rtol,
+            atol=atol,
+            max_entries=max_entries,
+        )
+        return LowRankHypertoroidalFourierDistribution(
+            coefficients,
+            "identity",
+            normalize=True,
+        )
+
     def multiply(self, other, n_coefficients=None, *, max_rank=None, rtol=0.0, atol=0.0):
         other = self._ensure_low_rank(other)
         self._check_compatible(other)

--- a/tests/distributions/test_low_rank_hypertoroidal_fourier_distribution.py
+++ b/tests/distributions/test_low_rank_hypertoroidal_fourier_distribution.py
@@ -122,6 +122,35 @@ class TestLowRankHypertoroidalFourierDistribution(unittest.TestCase):
         npt.assert_allclose(dist.integrate(), 1.0, atol=1e-12)
         self.assertTrue(np.isfinite(dist.pdf(np.zeros(8))))
 
+    def test_hermitian_helpers_delegate_to_coefficients(self):
+        dist = LowRankHypertoroidalFourierDistribution.from_dense(
+            HypertoroidalFourierDistribution(_identity_coefficients_2d(), "identity")
+        )
+        self.assertTrue(dist.is_centered_hermitian())
+        npt.assert_allclose(dist.centered_hermitian_deviation(), 0.0, atol=1e-12)
+
+    def test_centered_hermitianized_repairs_and_normalizes_distribution(self):
+        coeff = _identity_coefficients_1d()
+        coeff[3] += 0.1
+        dist = LowRankHypertoroidalFourierDistribution.from_dense(
+            HypertoroidalFourierDistribution(coeff, "identity")
+        )
+        self.assertFalse(dist.is_centered_hermitian(atol=1e-12))
+
+        repaired = dist.centered_hermitianized()
+
+        self.assertTrue(repaired.is_centered_hermitian())
+        npt.assert_allclose(repaired.integrate(), 1.0, atol=1e-12)
+
+    def test_hermitian_helpers_reject_sqrt_transformation(self):
+        dist = LowRankHypertoroidalFourierDistribution.uniform((3,), transformation="sqrt")
+        with self.assertRaises(NotImplementedError):
+            dist.centered_hermitian_deviation()
+        with self.assertRaises(NotImplementedError):
+            dist.is_centered_hermitian()
+        with self.assertRaises(NotImplementedError):
+            dist.centered_hermitianized()
+
     def test_tensor_train_from_dense_validates_max_rank_before_one_dimensional_return(self):
         for max_rank in (0, -1, np.array(0)):
             with self.subTest(max_rank=repr(max_rank)):


### PR DESCRIPTION
Summary:

- expose centered Hermitian coefficient diagnostics on `LowRankHypertoroidalFourierDistribution`
- add a distribution-level `centered_hermitianized(...)` repair helper that returns a normalized identity distribution
- reject Hermitian diagnostics and repair for `transformation="sqrt"`
- add focused distribution tests for delegation, repair, normalization, and sqrt rejection

Motivation:

Tensor-train Hermitian utilities are useful, but callers of the low-rank Fourier distribution should not need to access the private TT helper directly.

Validation:

- Added focused low-rank distribution tests for Hermitian checks and repair.
- Full CI will run on this PR.