### PR TITLE
Reject temporal Gaussian sample counts

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
@@ -59,11 +59,23 @@ def _validate_positive_sample_count(n) -> int:
 
     if count_array.ndim != 0:
         raise ValueError(message)
+    if count_array.dtype.kind in "Mm":
+        raise ValueError(message)
 
     count = count_array.item()
     if isinstance(
         count,
-        (bool, np.bool_, str, bytes, bytearray, np.str_, np.bytes_),
+        (
+            bool,
+            np.bool_,
+            str,
+            bytes,
+            bytearray,
+            np.str_,
+            np.bytes_,
+            np.datetime64,
+            np.timedelta64,
+        ),
     ):
         raise ValueError(message)
 

--- a/tests/distributions/test_gaussian_sample_count_temporal_validation.py
+++ b/tests/distributions/test_gaussian_sample_count_temporal_validation.py
@@ -1,0 +1,27 @@
+import numpy as np
+import pytest
+
+from pyrecest.backend import array, diag
+from pyrecest.distributions import GaussianDistribution
+
+
+def _standard_gaussian():
+    return GaussianDistribution(array([0.0, 0.0]), diag(array([1.0, 1.0])))
+
+
+@pytest.mark.parametrize(
+    "sample_count",
+    [
+        np.timedelta64(4, "ns"),
+        np.datetime64("1970-01-01T00:00:00.000000004", "ns"),
+        np.asarray(np.timedelta64(4, "ns")),
+        np.asarray(np.datetime64("1970-01-01T00:00:00.000000004", "ns")),
+        np.array(np.timedelta64(4, "ns"), dtype=object),
+        np.array(np.datetime64("1970-01-01T00:00:00.000000004", "ns"), dtype=object),
+    ],
+)
+def test_gaussian_sample_rejects_temporal_sample_counts(sample_count):
+    gaussian = _standard_gaussian()
+
+    with pytest.raises(ValueError, match="positive integer"):
+        gaussian.sample(sample_count)


### PR DESCRIPTION
## Summary
- reject native NumPy `datetime64` / `timedelta64` scalar values in `GaussianDistribution.sample(n)` before `.item()` can expose their nanosecond integer payload
- reject object-wrapped NumPy temporal scalars as sample counts
- add focused regression coverage for native, scalar-array, and object-array temporal sample-count inputs

## Bug fixed
`GaussianDistribution._validate_positive_sample_count(...)` converted scalar inputs with `np.asarray(...).item()` and then validated `int(...)` / `float(...)`. For nanosecond-resolution `np.datetime64` and `np.timedelta64` values, `.item()` can expose the raw integer payload. That allowed malformed temporal inputs such as `np.timedelta64(4, "ns")` to be silently interpreted as `n=4` samples.

## Validation
- GitHub compare: branch is 2 commits ahead of `main`, 0 behind
- changed only `src/pyrecest/distributions/nonperiodic/gaussian_distribution.py` and `tests/distributions/test_gaussian_sample_count_temporal_validation.py`

I could not run the full repository pytest suite locally because this container cannot resolve `github.com`; CI should run the new in-tree regression.