### PR TITLE
Reject boolean axes for PyTorch mean/std

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_reduction_axis_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_reduction_axis_contract.py
@@ -92,6 +92,27 @@ def _wrap_boolean_axis_reduction(helper, torch_module):
     return reduction
 
 
+def _wrap_boolean_axis_dim_reduction(helper, torch_module):
+    if getattr(helper, "_pyrecest_reduction_axis_bool_contract", False):
+        return helper
+
+    def reduction(*args, **kwargs):
+        axis = kwargs.get("axis")
+        if "axis" not in kwargs and len(args) >= 2:
+            axis = args[1]
+        dim = kwargs.get("dim")
+        if _axis_contains_boolean_value(axis, torch_module) or _axis_contains_boolean_value(
+            dim, torch_module
+        ):
+            raise TypeError(_AXIS_TYPE_MESSAGE)
+        return helper(*args, **kwargs)
+
+    reduction.__name__ = getattr(helper, "__name__", "reduction")
+    reduction.__doc__ = getattr(helper, "__doc__", None)
+    reduction._pyrecest_reduction_axis_bool_contract = True
+    return reduction
+
+
 def patch_pytorch_reduction_axis_contract() -> None:
     """Make raw/public PyTorch reduction helpers reject boolean axes."""
 
@@ -129,25 +150,32 @@ def patch_pytorch_reduction_axis_contract() -> None:
     original_normalizer = getattr(raw_pytorch, "_normalize_reduction_axes", None)
     if original_normalizer is None:
         return
-    if getattr(original_normalizer, "_pyrecest_reduction_axis_bool_contract", False):
-        return
+    if not getattr(original_normalizer, "_pyrecest_reduction_axis_bool_contract", False):
 
-    def _normalize_reduction_axes(axis, ndim_value):
-        return normalize_reduction_axes(axis, ndim_value, torch)
+        def _normalize_reduction_axes(axis, ndim_value):
+            return normalize_reduction_axes(axis, ndim_value, torch)
 
-    _normalize_reduction_axes.__name__ = getattr(
-        original_normalizer,
-        "__name__",
-        "_normalize_reduction_axes",
-    )
-    _normalize_reduction_axes.__doc__ = getattr(original_normalizer, "__doc__", None)
-    _normalize_reduction_axes._pyrecest_reduction_axis_bool_contract = True
-    raw_pytorch._normalize_reduction_axes = _normalize_reduction_axes
+        _normalize_reduction_axes.__name__ = getattr(
+            original_normalizer,
+            "__name__",
+            "_normalize_reduction_axes",
+        )
+        _normalize_reduction_axes.__doc__ = getattr(original_normalizer, "__doc__", None)
+        _normalize_reduction_axes._pyrecest_reduction_axis_bool_contract = True
+        raw_pytorch._normalize_reduction_axes = _normalize_reduction_axes
 
     for helper_name in ("any", "all", "count_nonzero", "max"):
         raw_helper = getattr(raw_pytorch, helper_name, None)
         if raw_helper is not None:
             wrapped_helper = _wrap_boolean_axis_reduction(raw_helper, torch)
+            setattr(raw_pytorch, helper_name, wrapped_helper)
+            if getattr(backend, "__backend_name__", None) == "pytorch":
+                setattr(backend, helper_name, wrapped_helper)
+
+    for helper_name in ("mean", "std"):
+        raw_helper = getattr(raw_pytorch, helper_name, None)
+        if raw_helper is not None:
+            wrapped_helper = _wrap_boolean_axis_dim_reduction(raw_helper, torch)
             setattr(raw_pytorch, helper_name, wrapped_helper)
             if getattr(backend, "__backend_name__", None) == "pytorch":
                 setattr(backend, helper_name, wrapped_helper)

--- a/tests/backend_support/test_pytorch_reduction_axis_bool_contract.py
+++ b/tests/backend_support/test_pytorch_reduction_axis_bool_contract.py
@@ -38,7 +38,7 @@ axis_values = [
 
 def assert_bool_axes_rejected(module):
     values = module.array([[0, 1], [2, 3]])
-    for helper_name in ("any", "all", "count_nonzero", "max"):
+    for helper_name in ("any", "all", "count_nonzero", "max", "mean", "std"):
         helper = getattr(module, helper_name)
         for axis in axis_values:
             try:
@@ -47,8 +47,18 @@ def assert_bool_axes_rejected(module):
                 continue
             raise AssertionError(f"{helper_name} accepted boolean axis {axis!r}")
 
+    for helper_name in ("mean", "std"):
+        helper = getattr(module, helper_name)
+        for dim in axis_values:
+            try:
+                helper(values, dim=dim)
+            except TypeError:
+                continue
+            raise AssertionError(f"{helper_name} accepted boolean dim {dim!r}")
+
     assert module.to_numpy(module.any(values, axis=1)).tolist() == [True, True]
     assert module.to_numpy(module.max(values, axis=0)).tolist() == [2, 3]
+    assert module.to_numpy(module.mean(values, axis=0)).tolist() == [1.0, 2.0]
 '''
 
 


### PR DESCRIPTION
## Summary
- extend the existing PyTorch reduction-axis runtime patch to cover `mean` and `std`
- reject boolean `axis` and PyTorch-style `dim` values before PyTorch can silently interpret boolean tensors as integer axes
- extend the regression test to cover `mean`/`std` while preserving valid integer-axis behavior

## Bug fixed
The previous boolean-axis fix covered helpers routed through `_normalize_reduction_axes` plus `any`, `all`, `count_nonzero`, and `max`. However, `mean` and `std` bypass that normalizer and call `torch.mean(..., dim=axis)` / `torch.std(..., dim=axis)` directly. PyTorch accepts boolean tensor dimensions such as `torch.tensor(True)` and `torch.tensor([True])`, silently reducing over axis 1. NumPy rejects boolean axes, so PyRecEst's PyTorch backend should reject these too.

## Validation
- checked the changed files for syntax/structure via connector fetch
- local isolated PyTorch probe confirmed `torch.mean`/`torch.std` silently accept boolean tensor dims before the patch

Full in-repository pytest was not run locally because this environment cannot clone GitHub or install the repository dependencies; CI should run the updated backend-portable regression.