### PR TITLE
Reject temporal PyTorch creation inputs

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_creation_shape_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_creation_shape_contract.py
@@ -8,6 +8,21 @@ from operator import index as _operator_index
 _ARANGE_SENTINEL = object()
 
 
+def _pytorch_has_temporal_dtype(value, numpy_module) -> bool:
+    """Return whether ``value`` has a NumPy temporal dtype."""
+    dtype = getattr(value, "dtype", None)
+    if dtype is None:
+        return False
+    try:
+        return bool(
+            numpy_module.issubdtype(dtype, numpy_module.datetime64)
+            or numpy_module.issubdtype(dtype, numpy_module.timedelta64)
+        )
+    except TypeError:
+        dtype_name = str(dtype).lower()
+        return "datetime64" in dtype_name or "timedelta64" in dtype_name
+
+
 def _pytorch_creation_dimension(dimension, numpy_module) -> int:
     """Return one NumPy-style shape dimension as a non-boolean integer."""
     if isinstance(dimension, (bool, numpy_module.bool_)):
@@ -31,6 +46,8 @@ def _pytorch_creation_shape(shape, numpy_module, torch_module) -> tuple[int, ...
             raise ValueError("negative dimensions are not allowed")
         return normalized_shape
     shape_array = numpy_module.asarray(shape)
+    if _pytorch_has_temporal_dtype(shape_array, numpy_module):
+        raise TypeError("shape dimensions must be integers")
     if shape_array.shape == ():
         normalized_shape = (
             _pytorch_creation_dimension(shape_array.item(), numpy_module),
@@ -54,6 +71,8 @@ def _pytorch_creation_scalar(value, numpy_module, torch_module, *, argument_name
     value_array = numpy_module.asarray(value)
     if value_array.shape != ():
         raise TypeError(f"{argument_name} must be a scalar")
+    if _pytorch_has_temporal_dtype(value_array, numpy_module):
+        raise TypeError(f"{argument_name} must be numeric")
     return value_array.item()
 
 

--- a/tests/backend_support/test_pytorch_creation_temporal_contract.py
+++ b/tests/backend_support/test_pytorch_creation_temporal_contract.py
@@ -1,0 +1,57 @@
+import numpy as np
+import pytest
+
+from pyrecest.backend_support._pytorch_creation_shape_contract import (
+    _pytorch_creation_scalar,
+    _pytorch_creation_shape,
+)
+
+
+class _NoTensorTorch:
+    @staticmethod
+    def is_tensor(value):
+        del value
+        return False
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        np.timedelta64(3, "ns"),
+        np.datetime64("1970-01-01T00:00:00.000000003"),
+        np.asarray(np.timedelta64(3, "ns")),
+        np.asarray(np.datetime64("1970-01-01T00:00:00.000000003")),
+        np.asarray([np.timedelta64(3, "ns")]),
+        np.asarray([np.datetime64("1970-01-01T00:00:00.000000003")]),
+    ],
+)
+def test_pytorch_creation_shape_rejects_native_temporal_dtypes(shape):
+    with pytest.raises(TypeError, match="shape dimensions must be integers"):
+        _pytorch_creation_shape(shape, np, _NoTensorTorch)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        np.timedelta64(3, "ns"),
+        np.datetime64("1970-01-01T00:00:00.000000003"),
+        np.asarray(np.timedelta64(3, "ns")),
+        np.asarray(np.datetime64("1970-01-01T00:00:00.000000003")),
+    ],
+)
+def test_pytorch_creation_scalar_rejects_native_temporal_dtypes(value):
+    with pytest.raises(TypeError, match="arange start must be numeric"):
+        _pytorch_creation_scalar(value, np, _NoTensorTorch, argument_name="arange start")
+
+
+def test_pytorch_creation_shape_still_accepts_numpy_integer_scalars():
+    assert _pytorch_creation_shape(np.asarray(3), np, _NoTensorTorch) == (3,)
+
+
+def test_pytorch_creation_scalar_still_accepts_numpy_numeric_scalars():
+    assert _pytorch_creation_scalar(
+        np.asarray(3.5),
+        np,
+        _NoTensorTorch,
+        argument_name="arange start",
+    ) == 3.5


### PR DESCRIPTION
## Summary
- reject native NumPy `datetime64` / `timedelta64` dtypes before PyTorch creation shape normalization calls `.item()` / `.tolist()`
- reject temporal scalar inputs for patched PyTorch `arange(...)` and `full(..., fill_value=...)` scalar normalization
- add focused regression coverage for temporal scalar, scalar-array, and vector shape inputs while preserving ordinary NumPy numeric scalars

## Bug fixed
The PyTorch creation helper normalizes NumPy-style shapes and scalar creation arguments by converting inputs with `np.asarray(...)` and then unwrapping scalar arrays with `.item()` or vector arrays with `.tolist()`. For nanosecond-resolution NumPy temporal dtypes, those operations can expose the raw integer payload. That meant malformed inputs such as `np.timedelta64(3, "ns")` or `np.asarray([np.datetime64("1970-01-01T00:00:00.000000003")])` could silently become integer shape/scalar values.

## Validation
- isolated regression run against the patched helper: `12 passed`
- `py_compile` on the patched helper and the new regression test
- GitHub compare: branch is 2 commits ahead of `main`, 0 behind, changing only `src/pyrecest/backend_support/_pytorch_creation_shape_contract.py` and `tests/backend_support/test_pytorch_creation_temporal_contract.py`

I could not run the full repository suite locally because this container cannot resolve `github.com`; CI should run the in-tree regression.