### PR TITLE
Reject temporal reproducibility seeds

### DIFF
--- a/src/pyrecest/reproducibility.py
+++ b/src/pyrecest/reproducibility.py
@@ -21,12 +21,34 @@ _UNSUPPORTED_SEED_SCALAR_TYPES = (
     np.str_,
     np.bytes_,
 )
+_TEMPORAL_SEED_SCALAR_TYPES = (np.datetime64, np.timedelta64)
+_TEMPORAL_SEED_DTYPE_KINDS = "Mm"
 
 
 def _random_backend() -> Any:
     from pyrecest.backend import random
 
     return random
+
+
+def _is_temporal_seed_scalar(seed: Any) -> bool:
+    if isinstance(seed, _TEMPORAL_SEED_SCALAR_TYPES):
+        return True
+    try:
+        seed_array = np.asarray(seed)
+    except (TypeError, ValueError, RuntimeError, OverflowError):
+        return False
+    if seed_array.shape != ():
+        return False
+    if seed_array.dtype.kind in _TEMPORAL_SEED_DTYPE_KINDS:
+        return True
+    if seed_array.dtype != object:
+        return False
+    try:
+        scalar = seed_array.item()
+    except (TypeError, ValueError, RuntimeError, OverflowError):
+        return False
+    return isinstance(scalar, _TEMPORAL_SEED_SCALAR_TYPES)
 
 
 def _normalize_seed(seed: int | None) -> int | None:
@@ -36,6 +58,9 @@ def _normalize_seed(seed: int | None) -> int | None:
         return None
 
     message = "seed must be a non-negative integer or None"
+
+    if _is_temporal_seed_scalar(seed):
+        raise ValueError(message)
 
     if hasattr(seed, "shape") and tuple(seed.shape) != ():
         raise ValueError(message)

--- a/tests/test_reproducibility_seed_validation.py
+++ b/tests/test_reproducibility_seed_validation.py
@@ -1,0 +1,42 @@
+"""Regression tests for reproducibility seed validation."""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+from pyrecest.reproducibility import _normalize_seed
+
+
+class TestReproducibilitySeedValidation(unittest.TestCase):
+    def test_temporal_seed_scalars_are_rejected_before_item_unwrap(self) -> None:
+        invalid_values = (
+            np.timedelta64(0, "ns"),
+            np.timedelta64(1, "ns"),
+            np.datetime64("1970-01-01T00:00:00.000000000"),
+            np.datetime64("1970-01-01T00:00:00.000000001"),
+            np.array(np.timedelta64(1, "ns")),
+            np.array(np.datetime64("1970-01-01T00:00:00.000000001")),
+            np.array(np.timedelta64(1, "ns"), dtype=object),
+            np.array(
+                np.datetime64("1970-01-01T00:00:00.000000001"),
+                dtype=object,
+            ),
+        )
+
+        for invalid_value in invalid_values:
+            with self.subTest(invalid_value=repr(invalid_value)):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "seed must be a non-negative integer or None",
+                ):
+                    _normalize_seed(invalid_value)
+
+    def test_numeric_scalar_arrays_are_still_valid_seeds(self) -> None:
+        self.assertEqual(_normalize_seed(np.array(0, dtype=np.int64)), 0)
+        self.assertEqual(_normalize_seed(np.array(1.0, dtype=np.float64)), 1)
+        self.assertIsNone(_normalize_seed(None))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reject native NumPy `datetime64` / `timedelta64` scalar seed values before `.item()` can expose nanosecond integer payloads
- reject scalar-array and object-wrapped temporal seed values through the same normalization path
- add focused regression coverage while preserving ordinary numeric scalar-array seeds

## Bug fixed
`pyrecest.reproducibility._normalize_seed(...)` unwrapped scalar objects with `.item()` before checking whether the value was a valid seed scalar. For nanosecond-resolution `np.datetime64` / `np.timedelta64` values, `.item()` can expose the raw integer payload, so malformed temporal values such as `np.timedelta64(1, "ns")` could be silently accepted as seed `1`, and `np.timedelta64(0, "ns")` as seed `0`.

## Validation
- `python -m py_compile /mnt/data/reproducibility.py /mnt/data/test_reproducibility_seed_validation.py`
- isolated pytest smoke with copied helper module: `2 passed, 8 subtests passed`
- GitHub compare: branch is 2 commits ahead of `main`, 0 behind; changed only `src/pyrecest/reproducibility.py` and `tests/test_reproducibility_seed_validation.py`