### PR TITLE
Fix JAX array_from_sparse flat 1D indices

### DIFF
--- a/src/pyrecest/backend_support/_jax_array_from_sparse_contract.py
+++ b/src/pyrecest/backend_support/_jax_array_from_sparse_contract.py
@@ -1,0 +1,82 @@
+"""Runtime patch for JAX sparse reconstruction indexing."""
+
+from __future__ import annotations
+
+
+def _normalize_sparse_target_shape(target_shape) -> tuple[int, ...]:
+    try:
+        normalized = tuple(int(size) for size in target_shape)
+    except TypeError:
+        normalized = (int(target_shape),)
+    if any(size < 0 for size in normalized):
+        raise ValueError("negative dimensions are not allowed")
+    return normalized
+
+
+def patch_jax_array_from_sparse_flat_index_contract() -> None:
+    """Make JAX ``array_from_sparse`` accept flat indices for 1-D targets."""
+
+    try:
+        import jax.numpy as jnp  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.jax as raw_jax  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - JAX backend may be unavailable
+        return
+
+    active_jax_backend = getattr(backend, "__backend_name__", None) == "jax"
+    original_array_from_sparse = getattr(raw_jax, "array_from_sparse", None)
+    if original_array_from_sparse is None:
+        return
+    if getattr(
+        original_array_from_sparse,
+        "_pyrecest_sparse_flat_index_contract",
+        False,
+    ):
+        if active_jax_backend:
+            backend.array_from_sparse = original_array_from_sparse
+        return
+
+    def _jax_sparse_indices(indices, target_shape):
+        indices = jnp.array(indices)
+        if indices.size == 0:
+            return indices
+        if indices.ndim == 1 and len(target_shape) == 1:
+            return indices.reshape(-1, 1)
+        if indices.ndim != 2 or indices.shape[1] != len(target_shape):
+            raise ValueError("indices must have shape (n_entries, ndim)")
+        return indices
+
+    def array_from_sparse(indices, data, target_shape):
+        target_shape = _normalize_sparse_target_shape(target_shape)
+        indices = _jax_sparse_indices(indices, target_shape)
+        data = jnp.array(data)
+        out = jnp.zeros(target_shape, dtype=data.dtype)
+        if indices.size == 0:
+            if data.size != 0:
+                raise ValueError("data must be empty when indices are empty")
+            return out
+
+        linear_indices = jnp.atleast_1d(jnp.ravel_multi_index(indices.T, target_shape))
+        if linear_indices.size:
+            linear_count = linear_indices.size
+            _, reversed_first_positions = jnp.unique(
+                linear_indices[::-1],
+                return_index=True,
+            )
+            keep_positions = jnp.sort(linear_count - 1 - reversed_first_positions)
+            linear_indices = linear_indices[keep_positions]
+            if data.ndim > 0 and data.shape[0] == linear_count:
+                data = data[keep_positions]
+        out = out.reshape(-1).at[linear_indices].set(data).reshape(target_shape)
+        return out
+
+    array_from_sparse.__name__ = getattr(
+        original_array_from_sparse,
+        "__name__",
+        "array_from_sparse",
+    )
+    array_from_sparse.__doc__ = getattr(original_array_from_sparse, "__doc__", None)
+    array_from_sparse._pyrecest_sparse_flat_index_contract = True
+    raw_jax.array_from_sparse = array_from_sparse
+    if active_jax_backend:
+        backend.array_from_sparse = array_from_sparse

--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -220,6 +220,9 @@ try:
         patch_pytorch_take_axis_contract as _patch_pytorch_take_axis_contract,
         patch_pytorch_transpose_boolean_axes_contract as _patch_pytorch_transpose_boolean_axes_contract,
     )
+    from pyrecest.backend_support._jax_array_from_sparse_contract import (  # pylint: disable=import-outside-toplevel
+        patch_jax_array_from_sparse_flat_index_contract as _patch_jax_array_from_sparse_flat_index_contract,
+    )
     from pyrecest.backend_support._pytorch_one_hot_scalar_contract import (  # pylint: disable=import-outside-toplevel
         patch_pytorch_one_hot_scalar_contract as _patch_pytorch_one_hot_scalar_contract,
     )
@@ -238,3 +241,4 @@ else:
     _patch_pytorch_transpose_boolean_axes_contract()
     _patch_pytorch_one_hot_scalar_contract()
     _patch_pytorch_reduction_axis_contract()
+    _patch_jax_array_from_sparse_flat_index_contract()

--- a/tests/backend_support/test_jax_array_from_sparse_contract.py
+++ b/tests/backend_support/test_jax_array_from_sparse_contract.py
@@ -1,0 +1,56 @@
+"""Regression coverage for JAX sparse reconstruction semantics."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+pytestmark = pytest.mark.backend_portable
+
+EXPECTED_VECTOR = [5, 0, 7, 0]
+
+
+def test_public_jax_array_from_sparse_accepts_flat_1d_indices():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("JAX is not installed")
+
+    code = f"""
+import pyrecest.backend as backend
+
+vector = backend.array_from_sparse(
+    [0, 2],
+    backend.array([5, 7], dtype=backend.int32),
+    (4,),
+)
+assert backend.to_numpy(vector).tolist() == {EXPECTED_VECTOR!r}
+print("ok")
+"""
+    result = run_backend_code("jax", code)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_raw_jax_array_from_sparse_accepts_flat_1d_indices():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("JAX is not installed")
+
+    code = f"""
+import importlib
+
+from pyrecest.backend import to_numpy
+
+raw_jax = importlib.import_module("pyrecest._backend.jax")
+vector = raw_jax.array_from_sparse(
+    [0, 2],
+    raw_jax.array([5, 7], dtype=raw_jax.int32),
+    (4,),
+)
+assert to_numpy(vector).tolist() == {EXPECTED_VECTOR!r}
+print("ok")
+"""
+    result = run_backend_code("jax", code)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- add an import-time JAX backend patch for `array_from_sparse`
- accept flat sparse indices such as `[0, 2]` for one-dimensional target shapes like `(4,)`
- preserve the existing coordinate-row, empty-index, and duplicate-index last-wins semantics
- add public and raw JAX backend regression coverage

## Bug fixed
The JAX backend implementation passed `indices.T` directly into `jnp.ravel_multi_index`. For a one-dimensional target shape, coordinate-row inputs like `[(0,), (2,)]` work, but flat one-dimensional sparse indices such as `[0, 2]` are interpreted as two coordinate arrays for a single dimension and fail with a malformed-index assertion. This is inconsistent with the PyTorch sparse reconstruction contract, which already accepts flat indices for 1-D targets.

## Validation
- local isolated JAX probe reproduced the current failure for `array_from_sparse([0, 2], [5, 7], (4,))`
- the patched normalizer maps flat 1-D indices to coordinate rows and preserves the existing coordinate-row and duplicate-index behavior
- GitHub compare: branch is 3 commits ahead of `main`, 0 behind, changing only the JAX sparse-index patch, `evidence.py` hook, and a focused regression test

Full in-repository pytest was not run locally because this environment cannot clone GitHub; CI should run the new backend-portable JAX regression.