### PR TITLE
Reject invalid PyTorch linalg tolerances

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_linalg_tolerance_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_linalg_tolerance_contract.py
@@ -1,0 +1,128 @@
+"""Runtime patch for PyTorch linalg tolerance validation."""
+
+from __future__ import annotations
+
+from functools import wraps
+
+import numpy as np
+
+_TOLERANCE_TYPE_MESSAGE = (
+    "linalg tolerances must be real numeric, not boolean or temporal"
+)
+_BOOLEAN_TYPES = (bool, np.bool_)
+_TEMPORAL_SCALAR_TYPES = (np.datetime64, np.timedelta64)
+_TEMPORAL_DTYPE_KINDS = {"M", "m"}
+
+
+def _contains_boolean_value(value, torch_module) -> bool:
+    if isinstance(value, _BOOLEAN_TYPES):
+        return True
+    if torch_module.is_tensor(value):
+        return value.dtype == torch_module.bool
+    if isinstance(value, np.ndarray):
+        if np.issubdtype(value.dtype, np.bool_):
+            return True
+        if value.dtype == object:
+            return any(
+                _contains_boolean_value(item, torch_module)
+                for item in value.reshape(-1)
+            )
+        return False
+    if isinstance(value, (list, tuple)):
+        return any(_contains_boolean_value(item, torch_module) for item in value)
+    return False
+
+
+def _contains_temporal_value(value) -> bool:
+    if isinstance(value, _TEMPORAL_SCALAR_TYPES):
+        return True
+    if isinstance(value, np.ndarray):
+        if value.dtype.kind in _TEMPORAL_DTYPE_KINDS:
+            return True
+        if value.dtype == object:
+            return any(_contains_temporal_value(item) for item in value.reshape(-1))
+        return False
+    if isinstance(value, (list, tuple)):
+        return any(_contains_temporal_value(item) for item in value)
+    return False
+
+
+def _validate_linalg_tolerance_argument(value, torch_module) -> None:
+    if value is None:
+        return
+    if _contains_boolean_value(value, torch_module) or _contains_temporal_value(value):
+        raise TypeError(_TOLERANCE_TYPE_MESSAGE)
+
+
+def _wrap_pinv(pinv, torch_module):
+    if getattr(pinv, "_pyrecest_linalg_tolerance_contract", False):
+        return pinv
+
+    @wraps(pinv)
+    def pinv_with_tolerance_validation(
+        a, rcond=None, hermitian=False, *, atol=None, rtol=None, out=None
+    ):
+        _validate_linalg_tolerance_argument(rcond, torch_module)
+        _validate_linalg_tolerance_argument(atol, torch_module)
+        _validate_linalg_tolerance_argument(rtol, torch_module)
+        return pinv(a, rcond=rcond, hermitian=hermitian, atol=atol, rtol=rtol, out=out)
+
+    pinv_with_tolerance_validation._pyrecest_linalg_tolerance_contract = True
+    return pinv_with_tolerance_validation
+
+
+def _wrap_matrix_rank(matrix_rank, torch_module):
+    if getattr(matrix_rank, "_pyrecest_linalg_tolerance_contract", False):
+        return matrix_rank
+
+    @wraps(matrix_rank)
+    def matrix_rank_with_tolerance_validation(
+        a, tol=None, hermitian=False, *, rtol=None, atol=None, **kwargs
+    ):
+        _validate_linalg_tolerance_argument(tol, torch_module)
+        _validate_linalg_tolerance_argument(atol, torch_module)
+        _validate_linalg_tolerance_argument(rtol, torch_module)
+        return matrix_rank(
+            a,
+            tol=tol,
+            hermitian=hermitian,
+            rtol=rtol,
+            atol=atol,
+            **kwargs,
+        )
+
+    matrix_rank_with_tolerance_validation._pyrecest_linalg_tolerance_contract = True
+    return matrix_rank_with_tolerance_validation
+
+
+def _patch_linalg_module(linalg_module, torch_module) -> None:
+    pinv = getattr(linalg_module, "pinv", None)
+    if pinv is not None:
+        linalg_module.pinv = _wrap_pinv(pinv, torch_module)
+
+    matrix_rank = getattr(linalg_module, "matrix_rank", None)
+    if matrix_rank is not None:
+        linalg_module.matrix_rank = _wrap_matrix_rank(matrix_rank, torch_module)
+
+
+def patch_pytorch_linalg_tolerance_contract() -> None:
+    """Make PyTorch linalg helpers reject boolean and temporal tolerances."""
+
+    try:
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    raw_linalg = getattr(raw_pytorch, "linalg", None)
+    if raw_linalg is not None:
+        _patch_linalg_module(raw_linalg, torch)
+
+    backend_linalg = getattr(backend, "linalg", None)
+    if (
+        backend_linalg is not None
+        and getattr(backend, "__backend_name__", None) == "pytorch"
+        and backend_linalg is not raw_linalg
+    ):
+        _patch_linalg_module(backend_linalg, torch)

--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -220,6 +220,9 @@ try:
         patch_pytorch_take_axis_contract as _patch_pytorch_take_axis_contract,
         patch_pytorch_transpose_boolean_axes_contract as _patch_pytorch_transpose_boolean_axes_contract,
     )
+    from pyrecest.backend_support._pytorch_linalg_tolerance_contract import (  # pylint: disable=import-outside-toplevel
+        patch_pytorch_linalg_tolerance_contract as _patch_pytorch_linalg_tolerance_contract,
+    )
     from pyrecest.backend_support._pytorch_one_hot_scalar_contract import (  # pylint: disable=import-outside-toplevel
         patch_pytorch_one_hot_scalar_contract as _patch_pytorch_one_hot_scalar_contract,
     )
@@ -236,5 +239,6 @@ else:
     _patch_raw_pytorch_reduction_alias_contract()
     _patch_pytorch_take_axis_contract()
     _patch_pytorch_transpose_boolean_axes_contract()
+    _patch_pytorch_linalg_tolerance_contract()
     _patch_pytorch_one_hot_scalar_contract()
     _patch_pytorch_reduction_axis_contract()

--- a/tests/test_pytorch_linalg_tolerance_validation.py
+++ b/tests/test_pytorch_linalg_tolerance_validation.py
@@ -1,0 +1,67 @@
+import unittest
+from typing import Any
+
+import numpy as np
+
+pytorch_backend: Any
+try:
+    from pyrecest._backend import pytorch as pytorch_backend
+except ModuleNotFoundError:
+    pytorch_backend = None
+
+
+@unittest.skipIf(pytorch_backend is None, "PyTorch is not installed")
+class TestPytorchLinalgToleranceValidation(unittest.TestCase):
+    def _test_matrix(self):
+        return pytorch_backend.diag(
+            pytorch_backend.array([1.0, 1e-5], dtype=pytorch_backend.float64)
+        )
+
+    def _invalid_tolerances(self):
+        return [
+            True,
+            np.bool_(True),
+            np.array(True),
+            np.array([True]),
+            np.array([True], dtype=object),
+            pytorch_backend.array(True),
+            np.timedelta64(1, "ns"),
+            np.array(np.timedelta64(1, "ns")),
+            np.array([np.timedelta64(1, "ns")]),
+            np.array([np.timedelta64(1, "ns")], dtype=object),
+            np.datetime64("1970-01-01T00:00:00.000000001"),
+            np.array(np.datetime64("1970-01-01T00:00:00.000000001")),
+            np.array([np.datetime64("1970-01-01T00:00:00.000000001")]),
+            np.array(
+                [np.datetime64("1970-01-01T00:00:00.000000001")],
+                dtype=object,
+            ),
+        ]
+
+    def test_matrix_rank_rejects_boolean_and_temporal_tolerances(self):
+        value = self._test_matrix()
+
+        for keyword in ("tol", "atol", "rtol"):
+            for tolerance in self._invalid_tolerances():
+                with self.subTest(keyword=keyword, tolerance=repr(tolerance)):
+                    with self.assertRaises(TypeError):
+                        pytorch_backend.linalg.matrix_rank(
+                            value,
+                            **{keyword: tolerance},
+                        )
+
+    def test_pinv_rejects_boolean_and_temporal_tolerances(self):
+        value = self._test_matrix()
+
+        for keyword in ("rcond", "atol", "rtol"):
+            for tolerance in self._invalid_tolerances():
+                with self.subTest(keyword=keyword, tolerance=repr(tolerance)):
+                    with self.assertRaises(TypeError):
+                        pytorch_backend.linalg.pinv(
+                            value,
+                            **{keyword: tolerance},
+                        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a runtime patch around the PyTorch linalg `pinv` and `matrix_rank` tolerance arguments
- reject boolean and NumPy temporal tolerances before scalar unwrapping can turn them into numeric thresholds
- add focused regression coverage for `rcond`/`atol`/`rtol` on `pinv` and `tol`/`atol`/`rtol` on `matrix_rank`

## Bug fixed
The PyTorch linalg bridge normalizes NumPy scalar and scalar-array tolerances with `.item()`. For nanosecond-resolution `np.datetime64` / `np.timedelta64`, that can expose the raw integer payload, and boolean scalars can be accepted by PyTorch as numeric thresholds. As a result, invalid tolerances such as `np.timedelta64(1, "ns")`, `np.datetime64("1970-01-01T00:00:00.000000001")`, or `True` could silently become an effective tolerance of `1`, causing `pinv`/`matrix_rank` to zero out small singular values or rank unexpectedly instead of rejecting malformed input.

## Validation
- local `py_compile` for the new patch file, evidence wiring, and regression test
- isolated local smoke test of the wrapper rejection logic for Python/NumPy/Torch boolean tolerances and NumPy temporal tolerances
- GitHub compare: branch is 3 commits ahead of `main`, 0 behind, changing only the tolerance patch, evidence hook, and focused regression test

Full in-repository pytest was not run locally because this environment cannot clone GitHub; CI should run the new test in-repo.