### PR TITLE
Reject temporal PyTorch linalg tolerances

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_linalg_tolerance_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_linalg_tolerance_contract.py
@@ -1,0 +1,54 @@
+"""PyTorch linear-algebra tolerance validation contract patch."""
+
+from __future__ import annotations
+
+
+def patch_pytorch_linalg_tolerance_contract() -> None:
+    """Reject temporal NumPy tolerance values before scalar unwrapping."""
+
+    try:
+        import numpy as np  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    linalg = getattr(raw_pytorch, "linalg", None)
+    original_normalizer = getattr(linalg, "_normalize_linalg_tolerance", None)
+    if original_normalizer is None:
+        return
+    if getattr(original_normalizer, "_pyrecest_temporal_tolerance_contract", False):
+        return
+
+    temporal_types = (np.datetime64, np.timedelta64)
+    error_message = "linalg tolerances must be real numeric"
+
+    def _has_temporal_dtype(value) -> bool:
+        try:
+            return np.asarray(value).dtype.kind in {"M", "m"}
+        except (TypeError, ValueError, RuntimeError):
+            return False
+
+    def _contains_temporal_values(value) -> bool:
+        if isinstance(value, temporal_types):
+            return True
+        try:
+            values = np.asarray(value, dtype=object).reshape(-1)
+        except (TypeError, ValueError, RuntimeError):
+            return False
+        return any(isinstance(item, temporal_types) for item in values)
+
+    def _normalize_linalg_tolerance(value, reference=None):
+        if value is not None and not torch.is_tensor(value):
+            if _has_temporal_dtype(value) or _contains_temporal_values(value):
+                raise TypeError(error_message)
+        return original_normalizer(value, reference)
+
+    _normalize_linalg_tolerance.__name__ = getattr(
+        original_normalizer,
+        "__name__",
+        "_normalize_linalg_tolerance",
+    )
+    _normalize_linalg_tolerance.__doc__ = getattr(original_normalizer, "__doc__", None)
+    _normalize_linalg_tolerance._pyrecest_temporal_tolerance_contract = True
+    linalg._normalize_linalg_tolerance = _normalize_linalg_tolerance

--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -220,6 +220,9 @@ try:
         patch_pytorch_take_axis_contract as _patch_pytorch_take_axis_contract,
         patch_pytorch_transpose_boolean_axes_contract as _patch_pytorch_transpose_boolean_axes_contract,
     )
+    from pyrecest.backend_support._pytorch_linalg_tolerance_contract import (  # pylint: disable=import-outside-toplevel
+        patch_pytorch_linalg_tolerance_contract as _patch_pytorch_linalg_tolerance_contract,
+    )
     from pyrecest.backend_support._pytorch_one_hot_scalar_contract import (  # pylint: disable=import-outside-toplevel
         patch_pytorch_one_hot_scalar_contract as _patch_pytorch_one_hot_scalar_contract,
     )
@@ -230,6 +233,7 @@ except ModuleNotFoundError:  # pragma: no cover - source tree corruption only
     pass
 else:
     _patch_pytorch_close_equal_nan_device_contract()
+    _patch_pytorch_linalg_tolerance_contract()
     _patch_pytorch_repeat_numpy_contract()
     _patch_pytorch_edge_pad_contract()
     _patch_pytorch_searchsorted_contract()

--- a/tests/test_pytorch_linalg_tolerances.py
+++ b/tests/test_pytorch_linalg_tolerances.py
@@ -12,6 +12,15 @@ except ModuleNotFoundError:
 
 @unittest.skipIf(pytorch_backend is None, "PyTorch is not installed")
 class TestPytorchLinalgToleranceContract(unittest.TestCase):
+    @staticmethod
+    def _temporal_tolerances():
+        return (
+            np.timedelta64(1, "ns"),
+            np.datetime64("1970-01-01T00:00:00.000000001"),
+            np.array(np.timedelta64(1, "ns")),
+            np.array(np.datetime64("1970-01-01T00:00:00.000000001")),
+        )
+
     def test_matrix_rank_accepts_numpy_scalar_array_tolerances(self):
         value = pytorch_backend.diag(pytorch_backend.array([1.0, 1e-5]))
 
@@ -36,6 +45,17 @@ class TestPytorchLinalgToleranceContract(unittest.TestCase):
         )
 
         self.assertEqual(pytorch_backend.to_numpy(result).tolist(), [1, 2])
+
+    def test_matrix_rank_rejects_numpy_temporal_tolerances(self):
+        value = pytorch_backend.diag(
+            pytorch_backend.array([1.0, 1e-5], dtype=pytorch_backend.float64)
+        )
+
+        for keyword in ("tol", "rtol", "atol"):
+            for tolerance in self._temporal_tolerances():
+                with self.subTest(keyword=keyword, tolerance=repr(tolerance)):
+                    with self.assertRaises(TypeError):
+                        pytorch_backend.linalg.matrix_rank(value, **{keyword: tolerance})
 
     def test_pinv_accepts_numpy_scalar_array_tolerances(self):
         value = pytorch_backend.diag(
@@ -80,6 +100,17 @@ class TestPytorchLinalgToleranceContract(unittest.TestCase):
 
                 self.assertEqual(result.dtype, pytorch_backend.float64)
                 self.assertTrue(pytorch_backend.allclose(result, expected))
+
+    def test_pinv_rejects_numpy_temporal_tolerances(self):
+        value = pytorch_backend.diag(
+            pytorch_backend.array([1.0, 1e-5], dtype=pytorch_backend.float64)
+        )
+
+        for keyword in ("rcond", "rtol", "atol"):
+            for tolerance in self._temporal_tolerances():
+                with self.subTest(keyword=keyword, tolerance=repr(tolerance)):
+                    with self.assertRaises(TypeError):
+                        pytorch_backend.linalg.pinv(value, **{keyword: tolerance})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a PyTorch linalg tolerance contract patch that rejects NumPy `datetime64`/`timedelta64` tolerance inputs before scalar unwrapping can expose raw integer payloads
- wire the patch into the existing backend patch bootstrap in `pyrecest.evidence`
- add regression coverage for `matrix_rank` and `pinv` temporal tolerances while preserving existing NumPy scalar/vector numeric tolerance support

## Validation
- Not run locally: the sandbox could not clone GitHub (`Could not resolve host: github.com`), so this was applied through the GitHub connector only.