### PR TITLE
Reject boolean axes for PyTorch sum

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_reduction_axis_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_reduction_axis_contract.py
@@ -172,7 +172,7 @@ def patch_pytorch_reduction_axis_contract() -> None:
             if getattr(backend, "__backend_name__", None) == "pytorch":
                 setattr(backend, helper_name, wrapped_helper)
 
-    for helper_name in ("mean", "std"):
+    for helper_name in ("mean", "std", "sum"):
         raw_helper = getattr(raw_pytorch, helper_name, None)
         if raw_helper is not None:
             wrapped_helper = _wrap_boolean_axis_dim_reduction(raw_helper, torch)

--- a/tests/backend_support/test_pytorch_reduction_axis_bool_contract.py
+++ b/tests/backend_support/test_pytorch_reduction_axis_bool_contract.py
@@ -38,7 +38,7 @@ axis_values = [
 
 def assert_bool_axes_rejected(module):
     values = module.array([[0, 1], [2, 3]])
-    for helper_name in ("any", "all", "count_nonzero", "max", "mean", "std"):
+    for helper_name in ("any", "all", "count_nonzero", "max", "mean", "std", "sum"):
         helper = getattr(module, helper_name)
         for axis in axis_values:
             try:
@@ -47,7 +47,7 @@ def assert_bool_axes_rejected(module):
                 continue
             raise AssertionError(f"{helper_name} accepted boolean axis {axis!r}")
 
-    for helper_name in ("mean", "std"):
+    for helper_name in ("mean", "std", "sum"):
         helper = getattr(module, helper_name)
         for dim in axis_values:
             try:
@@ -59,6 +59,7 @@ def assert_bool_axes_rejected(module):
     assert module.to_numpy(module.any(values, axis=1)).tolist() == [True, True]
     assert module.to_numpy(module.max(values, axis=0)).tolist() == [2, 3]
     assert module.to_numpy(module.mean(values, axis=0)).tolist() == [1.0, 2.0]
+    assert module.to_numpy(module.sum(values, axis=1)).tolist() == [1, 5]
 '''
 
 


### PR DESCRIPTION
## Summary
- extend the PyTorch reduction-axis runtime patch to cover `sum`
- reject boolean `axis` and PyTorch-style `dim` values before PyTorch can silently interpret boolean tensors as integer axes
- extend the existing reduction-axis regression to include `sum` while preserving valid integer-axis behavior

## Bug fixed
The existing boolean-axis patch covered `any`, `all`, `count_nonzero`, `max`, `mean`, and `std`, but not `sum`. Raw PyTorch accepts boolean tensor dimensions such as `torch.tensor(True)` and `torch.tensor([True])`, silently reducing over axis 1. PyRecEst's PyTorch backend should reject those malformed axes consistently with the other reduction helpers.

## Validation
- `python -m py_compile /mnt/data/_pytorch_reduction_axis_contract.py /mnt/data/test_pytorch_reduction_axis_bool_contract.py`
- isolated PyTorch probe confirmed `torch.sum(values, dim=torch.tensor(True))` and `torch.sum(values, dim=torch.tensor([True]))` silently reduce over axis 1 before the wrapper
- GitHub compare: branch is 2 commits ahead of `main`, 0 behind, changing only the reduction-axis runtime patch and focused regression test

Full in-repository pytest was not run locally because this environment cannot clone GitHub; CI should run the in-tree backend-portable regression.