### PR TITLE
Reject complex low-rank Fourier center coefficients

### DIFF
--- a/src/pyrecest/distributions/hypertorus/low_rank_hypertoroidal_fourier_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/low_rank_hypertoroidal_fourier_distribution.py
@@ -133,7 +133,10 @@ class LowRankHypertoroidalFourierDistribution(AbstractHypertoroidalDistribution)
 
     def normalize_in_place(self):
         if self.transformation == "identity":
-            normalizer = ((2.0 * np.pi) ** self.dim) * self.coefficient_at_zero()
+            center_coefficient = self.coefficient_at_zero()
+            if abs(center_coefficient.imag) > 0.001:
+                raise ValueError("Center coefficient must be real-valued.")
+            normalizer = ((2.0 * np.pi) ** self.dim) * center_coefficient.real
         else:
             normalizer = sqrt((2.0 * np.pi) ** self.dim) * self.coefficients.norm()
         if abs(normalizer) == 0:

--- a/tests/distributions/test_low_rank_fourier_complex_center.py
+++ b/tests/distributions/test_low_rank_fourier_complex_center.py
@@ -1,0 +1,27 @@
+"""Regression coverage for low-rank identity Fourier normalization."""
+
+import unittest
+
+import numpy as np
+
+import pyrecest.backend
+from pyrecest.distributions.hypertorus.low_rank_hypertoroidal_fourier_distribution import (
+    LowRankHypertoroidalFourierDistribution,
+)
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ != "numpy",  # pylint: disable=no-member
+    reason="Low-rank Fourier prototype is NumPy-only",
+)
+class TestLowRankFourierComplexCenter(unittest.TestCase):
+    def test_identity_normalization_rejects_complex_center_coefficient(self):
+        coefficients = np.zeros(3, dtype=np.complex128)
+        coefficients[1] = 1.0 + 1.0j
+
+        with self.assertRaisesRegex(ValueError, "Center coefficient must be real-valued"):
+            LowRankHypertoroidalFourierDistribution.from_dense(coefficients)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- reject non-real zero-frequency coefficients during low-rank identity Fourier normalization
- use the real center coefficient for the normalization factor, matching the dense Fourier implementation
- add a regression test for the previously accepted complex-center case

## Bug

`LowRankHypertoroidalFourierDistribution.normalize_in_place()` previously divided identity coefficients by a potentially complex integral. For a complex zero-frequency coefficient, this silently phase-rotated the complete Fourier series and accepted an invalid density instead of reporting the malformed coefficient. The dense Fourier implementation already rejects this condition.

## Test

Added `test_identity_normalization_rejects_complex_center_coefficient`, which constructs a low-rank identity representation with `C[0] = 1 + i` and verifies that normalization raises `ValueError`.
