### PR TITLE
Preserve global RNG state during simulation seed generation

### DIFF
--- a/src/pyrecest/evaluation/evaluate_for_simulation_config.py
+++ b/src/pyrecest/evaluation/evaluate_for_simulation_config.py
@@ -85,8 +85,10 @@ def get_all_seeds(n_runs: int, seed_input=None, consecutive_seed: bool = True):
         if consecutive_seed:
             all_seeds = list(range(seed_value, seed_value + n_runs))
         else:
-            random.seed(seed_value)
-            all_seeds = [random.randint(1, 0xFFFFFFFF) for _ in range(n_runs)]  # nosec
+            seed_generator = random.Random(seed_value)
+            all_seeds = [
+                seed_generator.randint(1, 0xFFFFFFFF) for _ in range(n_runs)  # nosec
+            ]
     else:
         raise ValueError(
             "The number of seeds provided must be either 1 or equal to the number of runs."

--- a/tests/test_evaluation_seed_generation.py
+++ b/tests/test_evaluation_seed_generation.py
@@ -1,0 +1,36 @@
+"""Regression tests for simulation seed generation."""
+
+from __future__ import annotations
+
+import random
+import unittest
+
+from pyrecest.evaluation.evaluate_for_simulation_config import get_all_seeds
+
+
+class TestEvaluationSeedGeneration(unittest.TestCase):
+    def test_nonconsecutive_generation_preserves_python_random_state(self) -> None:
+        original_state = random.getstate()
+        try:
+            random.seed(314159)
+            expected_next_value = random.random()
+
+            random.seed(314159)
+            generated_seeds = get_all_seeds(
+                n_runs=4,
+                seed_input=7,
+                consecutive_seed=False,
+            )
+            actual_next_value = random.random()
+        finally:
+            random.setstate(original_state)
+
+        self.assertEqual(
+            generated_seeds,
+            [1390851129, 4071050725, 647892280, 1695753999],
+        )
+        self.assertEqual(actual_next_value, expected_next_value)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- generate nonconsecutive simulation seeds with a dedicated `random.Random` instance
- preserve the caller's process-wide Python RNG state
- add a regression test that also locks the existing deterministic seed sequence

## Bug fixed
`get_all_seeds(..., consecutive_seed=False)` called `random.seed(seed_value)` before drawing per-run seeds. That reset Python's global RNG, so merely preparing a PyRecEst simulation changed subsequent random values in unrelated application code. The fix uses a local RNG seeded with the same value, preserving both the generated seed sequence and caller state.

## Validation
- reproduced the global RNG mutation with the current implementation
- verified the local RNG produces the identical seed sequence `[1390851129, 4071050725, 647892280, 1695753999]` for seed `7`
- `python -m py_compile` passed for the modified module and regression test
- isolated regression probe passed
- GitHub compare: 2 commits ahead of `main`, 0 behind; only the seed helper and focused test are changed

Full in-repository pytest was not run locally because this environment cannot resolve `github.com`; CI should run the added test in the repository environment.