### PR TITLE
Reject temporal values in track metric controls

### DIFF
--- a/src/pyrecest/utils/track_metrics.py
+++ b/src/pyrecest/utils/track_metrics.py
@@ -324,6 +324,14 @@ def _session_times(
 ) -> np.ndarray:
     if session_times is None:
         return np.arange(n_sessions, dtype=float)
+    try:
+        native_times = np.asarray(session_times)
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise ValueError(
+            "session_times must contain only finite numeric values"
+        ) from exc
+    if native_times.dtype.kind in "Mm":
+        raise ValueError("session_times must contain only finite numeric values")
     raw_times = np.asarray(session_times, dtype=object)
     if raw_times.shape != (n_sessions,):
         raise ValueError(
@@ -345,16 +353,36 @@ def _session_times(
 
 
 def _validate_missed_value(value: Any) -> float:
+    message = "missed_value must be a scalar numeric value"
+    try:
+        native_value = np.asarray(value)
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise ValueError(message) from exc
+    if native_value.dtype.kind in "Mm":
+        raise ValueError(message)
     value_array = np.asarray(value, dtype=object)
     if value_array.shape != ():
-        raise ValueError("missed_value must be a scalar numeric value")
+        raise ValueError(message)
     scalar = value_array.item()
-    if isinstance(scalar, (bool, np.bool_, str, bytes, bytearray, np.str_, np.bytes_)):
-        raise ValueError("missed_value must be a scalar numeric value")
+    if isinstance(
+        scalar,
+        (
+            bool,
+            np.bool_,
+            str,
+            bytes,
+            bytearray,
+            np.str_,
+            np.bytes_,
+            np.datetime64,
+            np.timedelta64,
+        ),
+    ):
+        raise ValueError(message)
     try:
         parsed = float(scalar)
     except (TypeError, ValueError, OverflowError) as exc:
-        raise ValueError("missed_value must be a scalar numeric value") from exc
+        raise ValueError(message) from exc
     if np.isinf(parsed):
         raise ValueError("missed_value must be finite or NaN")
     return parsed
@@ -377,9 +405,11 @@ def _contains_bool_or_text(values: np.ndarray) -> bool:
 
 def _as_positive_int(value: Any, name: str) -> int:
     array = np.asarray(value)
-    if array.ndim != 0 or array.dtype == np.bool_:
+    if array.ndim != 0 or array.dtype == np.bool_ or array.dtype.kind in "Mm":
         raise ValueError(f"{name} must be a positive integer")
     scalar = array.item()
+    if isinstance(scalar, (np.datetime64, np.timedelta64)):
+        raise ValueError(f"{name} must be a positive integer")
     if isinstance(scalar, (int, np.integer)) and not isinstance(scalar, bool):
         result = int(scalar)
     elif (

--- a/tests/test_track_metrics_temporal_controls.py
+++ b/tests/test_track_metrics_temporal_controls.py
@@ -1,0 +1,66 @@
+"""Regression tests for temporal track-metric controls."""
+
+import unittest
+
+import numpy as np
+from pyrecest.utils.track_metrics import (
+    score_false_tracks,
+    score_missed_tracks,
+    track_latencies,
+)
+
+
+class TestTrackMetricsTemporalControls(unittest.TestCase):
+    def test_track_latency_rejects_native_temporal_session_arrays(self):
+        invalid_session_times = (
+            np.array([1, 2], dtype="datetime64[ns]"),
+            np.array([1, 2], dtype="timedelta64[ns]"),
+        )
+
+        for session_times in invalid_session_times:
+            with self.subTest(dtype=str(session_times.dtype)):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "session_times must contain only finite numeric values",
+                ):
+                    track_latencies(
+                        [[0, 0]],
+                        [[0, 0]],
+                        session_times=session_times,
+                    )
+
+    def test_track_latency_rejects_temporal_missed_values(self):
+        invalid_missed_values = (
+            np.datetime64(1, "ns"),
+            np.timedelta64(1, "ns"),
+            np.asarray(np.datetime64(1, "ns")),
+            np.asarray(np.timedelta64(1, "ns")),
+            np.array(np.datetime64(1, "ns"), dtype=object),
+            np.array(np.timedelta64(1, "ns"), dtype=object),
+        )
+
+        for missed_value in invalid_missed_values:
+            with self.subTest(missed_value=repr(missed_value)):
+                with self.assertRaisesRegex(ValueError, "missed_value"):
+                    track_latencies([[None]], [[0]], missed_value=missed_value)
+
+    def test_track_metrics_reject_temporal_min_lengths(self):
+        invalid_min_lengths = (
+            np.datetime64(1, "ns"),
+            np.timedelta64(1, "ns"),
+            np.asarray(np.datetime64(1, "ns")),
+            np.asarray(np.timedelta64(1, "ns")),
+        )
+
+        for metric in (score_false_tracks, score_missed_tracks):
+            for min_length in invalid_min_lengths:
+                with self.subTest(
+                    metric=metric.__name__,
+                    min_length=repr(min_length),
+                ):
+                    with self.assertRaisesRegex(ValueError, "min_length"):
+                        metric([[0]], [[0]], min_length=min_length)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reject native NumPy `datetime64` and `timedelta64` session-time arrays before object conversion exposes their integer payloads
- reject temporal `missed_value` sentinels, including scalar arrays and object-wrapped temporal scalars
- reject temporal `min_length` values in false-track and missed-track metrics
- add focused regression tests for all affected input forms

## Bug
For nanosecond-resolution temporal values, NumPy can return the raw integer payload from `.item()` or from conversion to `dtype=object`. The existing validators then treated timestamps/durations as ordinary numeric controls. For example, `np.array([1, 2], dtype="datetime64[ns]")` could be interpreted as session times `[1.0, 2.0]`, and `np.timedelta64(1, "ns")` could be accepted as `min_length=1`.

## Validation
- source file compiles with `py_compile`
- focused validation checks pass locally for invalid temporal inputs and valid numeric controls
- added repository regression tests for native temporal arrays, temporal sentinel variants, and temporal integer controls
