### PR TITLE
Reject non-integer PyTorch split cut points

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_reduction_axis_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_reduction_axis_contract.py
@@ -6,6 +6,10 @@ from operator import index as _operator_index
 
 import numpy as np
 
+from pyrecest.backend_support._pytorch_split_index_contract import (
+    patch_pytorch_split_index_contract as _patch_pytorch_split_index_contract,
+)
+
 _AXIS_FLAG_TYPES = (bool, np.bool_)
 _AXIS_TYPE_MESSAGE = "axis must be an integer or a sequence of integers"
 
@@ -115,6 +119,8 @@ def _wrap_boolean_axis_dim_reduction(helper, torch_module):
 
 def patch_pytorch_reduction_axis_contract() -> None:
     """Make raw/public PyTorch reduction helpers reject boolean axes."""
+
+    _patch_pytorch_split_index_contract()
 
     try:
         import pyrecest._backend as backend_loader  # pylint: disable=import-outside-toplevel

--- a/src/pyrecest/backend_support/_pytorch_split_index_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_split_index_contract.py
@@ -1,0 +1,76 @@
+"""Runtime patch for PyTorch ``split`` cut-index validation."""
+
+from __future__ import annotations
+
+from operator import index as _operator_index
+
+import numpy as np
+
+_SPLIT_INDEX_TYPE_MESSAGE = (
+    "slice indices must be integers or None or have an __index__ method"
+)
+
+
+def _normalize_split_cut_indices(indices_or_sections, torch_module):
+    """Return integer cut points without silently truncating invalid values."""
+
+    if isinstance(indices_or_sections, (str, bytes)):
+        raise TypeError(_SPLIT_INDEX_TYPE_MESSAGE)
+
+    if torch_module.is_tensor(indices_or_sections):
+        if indices_or_sections.ndim == 0:
+            return indices_or_sections
+        if indices_or_sections.ndim != 1:
+            raise ValueError("indices_or_sections must be a 1-D sequence")
+        cut_points = tuple(indices_or_sections)
+    else:
+        cut_array = np.asarray(indices_or_sections)
+        if cut_array.ndim == 0:
+            return indices_or_sections
+        if cut_array.ndim != 1:
+            raise ValueError("indices_or_sections must be a 1-D sequence")
+        cut_points = (
+            tuple(indices_or_sections)
+            if isinstance(indices_or_sections, (list, tuple))
+            else tuple(cut_array)
+        )
+
+    normalized = []
+    for cut_point in cut_points:
+        if torch_module.is_tensor(cut_point) and cut_point.dtype == torch_module.bool:
+            raise TypeError(_SPLIT_INDEX_TYPE_MESSAGE)
+        try:
+            normalized.append(_operator_index(cut_point))
+        except TypeError as exc:
+            raise TypeError(_SPLIT_INDEX_TYPE_MESSAGE) from exc
+    return tuple(normalized)
+
+
+def patch_pytorch_split_index_contract() -> None:
+    """Make public and raw PyTorch ``split`` reject non-integer cut points."""
+
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch may be unavailable
+        return
+
+    original_split = getattr(raw_pytorch, "split", None)
+    if original_split is None:
+        return
+    if getattr(original_split, "_pyrecest_split_index_contract", False):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.split = original_split
+        return
+
+    def split(x, indices_or_sections, axis=0):
+        normalized = _normalize_split_cut_indices(indices_or_sections, torch)
+        return original_split(x, normalized, axis=axis)
+
+    split.__name__ = getattr(original_split, "__name__", "split")
+    split.__doc__ = getattr(original_split, "__doc__", None)
+    split._pyrecest_split_index_contract = True
+    raw_pytorch.split = split
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.split = split

--- a/tests/backend_support/.split_index_contract_marker
+++ b/tests/backend_support/.split_index_contract_marker
@@ -1,1 +1,0 @@
-This file intentionally left out of package data.

--- a/tests/backend_support/.split_index_contract_marker
+++ b/tests/backend_support/.split_index_contract_marker
@@ -1,0 +1,1 @@
+This file intentionally left out of package data.

--- a/tests/backend_support/test_pytorch_split_index_contract.py
+++ b/tests/backend_support/test_pytorch_split_index_contract.py
@@ -1,0 +1,106 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _pytorch_env(backend_name):
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = backend_name
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    return env
+
+
+@pytest.mark.backend_portable
+def test_pytorch_split_rejects_non_integer_cut_points():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import numpy as np
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+
+def assert_type_error(call, label):
+    try:
+        call()
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"{label} accepted non-integer split cut points")
+
+
+for split_func in (backend.split, raw_pytorch.split):
+    for bad_indices in (
+        [1.5],
+        np.asarray([1.5]),
+        ["2"],
+        np.asarray(["2"]),
+        np.asarray([True]),
+    ):
+        assert_type_error(
+            lambda split_func=split_func, bad_indices=bad_indices: split_func(
+                [0, 1, 2, 3], bad_indices
+            ),
+            split_func.__module__,
+        )
+
+    integer_parts = split_func([0, 1, 2, 3], np.asarray([1, 3]))
+    assert [raw_pytorch.to_numpy(part).tolist() for part in integer_parts] == [
+        [0],
+        [1, 2],
+        [3],
+    ]
+
+    bool_list_parts = split_func([0, 1, 2, 3], [True])
+    assert [raw_pytorch.to_numpy(part).tolist() for part in bool_list_parts] == [
+        [0],
+        [1, 2, 3],
+    ]
+"""
+    subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        env=_pytorch_env("pytorch"),
+    )
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_split_is_patched_under_numpy_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = """
+import pyrecest  # noqa: F401
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+assert backend.__backend_name__ == "numpy"
+
+try:
+    raw_pytorch.split([0, 1, 2, 3], [1.5])
+except TypeError:
+    pass
+else:
+    raise AssertionError("raw PyTorch split accepted fractional cut points")
+
+parts = raw_pytorch.split([0, 1, 2, 3], [1, 3])
+assert [raw_pytorch.to_numpy(part).tolist() for part in parts] == [
+    [0],
+    [1, 2],
+    [3],
+]
+"""
+    subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        env=_pytorch_env("numpy"),
+    )


### PR DESCRIPTION
## Summary
- add a runtime contract patch for the public and raw PyTorch `split` helpers
- validate one-dimensional cut-point sequences with the integer index protocol instead of `int(...)`
- add subprocess regression coverage for active PyTorch and raw PyTorch under the default NumPy backend

## Bug fixed
The PyTorch backend converted each sequence cut point with `int(index)`. Fractional and string inputs such as `[1.5]` or `["2"]` were therefore silently converted to `[1]` or `[2]`, whereas NumPy raises `TypeError`. Boolean NumPy arrays could also be accepted despite NumPy rejecting them as split cut-point arrays.

The patch preserves valid integer arrays and Python boolean lists while rejecting non-integer cut-point sequences before slicing.

## Validation
- `python -m py_compile /tmp/_pytorch_split_index_contract.py`
- isolated normalization smoke with NumPy 2.x and PyTorch 2.10: integer lists/arrays/tensors accepted; fractional, string, NumPy-bool-array, float-tensor, and bool-tensor cut points rejected
- GitHub compare: branch is based on current `main` (`23ddcb9`) and changes only the split contract patch, its wiring, and regression tests

Full in-repository pytest could not be run locally because the execution environment cannot clone GitHub; CI should run the in-tree subprocess tests.