### PR TITLE
Preserve caller RNG state during scenario generation

### DIFF
--- a/src/pyrecest/evaluation/generate_simulated_scenarios.py
+++ b/src/pyrecest/evaluation/generate_simulated_scenarios.py
@@ -14,6 +14,17 @@ def _seed_simulation_rngs(seed):
     np.random.seed(seed)
 
 
+def _capture_simulation_rng_states():
+    """Capture caller-owned backend and NumPy RNG states."""
+    return random.get_state(), np.random.get_state()
+
+
+def _restore_simulation_rng_states(backend_state, numpy_state):
+    """Restore caller-owned backend and NumPy RNG states."""
+    random.set_state(backend_state)
+    np.random.set_state(numpy_state)
+
+
 def generate_simulated_scenarios(
     simulation_params,
 ):
@@ -28,28 +39,32 @@ def generate_simulated_scenarios(
         The measurements.
 
     """
-    simulation_params = check_and_fix_config(simulation_params)
-    all_seeds = simulation_params["all_seeds"]
+    backend_rng_state, numpy_rng_state = _capture_simulation_rng_states()
     try:
-        all_seeds = list(all_seeds)
-    except TypeError:
-        all_seeds = [all_seeds]
-    n_runs = len(all_seeds)
+        simulation_params = check_and_fix_config(simulation_params)
+        all_seeds = simulation_params["all_seeds"]
+        try:
+            all_seeds = list(all_seeds)
+        except TypeError:
+            all_seeds = [all_seeds]
+        n_runs = len(all_seeds)
 
-    groundtruths = np.empty(
-        (n_runs, simulation_params["n_timesteps"]),
-        dtype=object,
-    )
-    measurements = np.empty(
-        (n_runs, simulation_params["n_timesteps"]),
-        dtype=object,
-    )
-
-    for run, seed in enumerate(all_seeds):
-        _seed_simulation_rngs(seed)
-        groundtruths[run, :] = generate_groundtruth(simulation_params)
-        measurements[run, :] = generate_measurements(
-            groundtruths[run, :], simulation_params
+        groundtruths = np.empty(
+            (n_runs, simulation_params["n_timesteps"]),
+            dtype=object,
+        )
+        measurements = np.empty(
+            (n_runs, simulation_params["n_timesteps"]),
+            dtype=object,
         )
 
-    return groundtruths, measurements
+        for run, seed in enumerate(all_seeds):
+            _seed_simulation_rngs(seed)
+            groundtruths[run, :] = generate_groundtruth(simulation_params)
+            measurements[run, :] = generate_measurements(
+                groundtruths[run, :], simulation_params
+            )
+
+        return groundtruths, measurements
+    finally:
+        _restore_simulation_rng_states(backend_rng_state, numpy_rng_state)

--- a/tests/test_generate_simulated_scenarios_rng_state.py
+++ b/tests/test_generate_simulated_scenarios_rng_state.py
@@ -1,0 +1,111 @@
+"""Regression tests for simulation RNG state isolation."""
+
+import importlib
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import random, to_numpy
+
+simulation_module = importlib.import_module(
+    "pyrecest.evaluation.generate_simulated_scenarios"
+)
+
+
+def _backend_random_scalar() -> float:
+    return float(np.asarray(to_numpy(random.rand())).reshape(()))
+
+
+class TestGenerateSimulatedScenariosRngState(unittest.TestCase):
+    def _assert_rng_states_preserved(self, action) -> None:
+        original_backend_state = random.get_state()
+        original_numpy_state = np.random.get_state()
+        try:
+            random.seed(314159)
+            np.random.seed(271828)
+            expected_backend_state = random.get_state()
+            expected_numpy_state = np.random.get_state()
+
+            expected_backend_value = _backend_random_scalar()
+            expected_numpy_value = float(np.random.random())
+
+            random.set_state(expected_backend_state)
+            np.random.set_state(expected_numpy_state)
+            action()
+
+            self.assertEqual(_backend_random_scalar(), expected_backend_value)
+            self.assertEqual(float(np.random.random()), expected_numpy_value)
+        finally:
+            random.set_state(original_backend_state)
+            np.random.set_state(original_numpy_state)
+
+    @staticmethod
+    def _checked_config(_simulation_params):
+        return {"all_seeds": [7, 11], "n_timesteps": 1}
+
+    @staticmethod
+    def _groundtruth(_simulation_params):
+        random.rand()
+        return [np.array([0.0])]
+
+    @staticmethod
+    def _measurements(_groundtruth, _simulation_params):
+        np.random.random()
+        return [np.array([[0.0]])]
+
+    def test_generation_preserves_backend_and_numpy_rng_states(self):
+        def generate():
+            with (
+                patch.object(
+                    simulation_module,
+                    "check_and_fix_config",
+                    side_effect=self._checked_config,
+                ),
+                patch.object(
+                    simulation_module,
+                    "generate_groundtruth",
+                    side_effect=self._groundtruth,
+                ),
+                patch.object(
+                    simulation_module,
+                    "generate_measurements",
+                    side_effect=self._measurements,
+                ),
+            ):
+                groundtruths, measurements = (
+                    simulation_module.generate_simulated_scenarios({})
+                )
+                self.assertEqual(groundtruths.shape, (2, 1))
+                self.assertEqual(measurements.shape, (2, 1))
+
+        self._assert_rng_states_preserved(generate)
+
+    def test_generation_restores_rng_states_when_generation_fails(self):
+        def failing_groundtruth(_simulation_params):
+            random.rand()
+            np.random.random()
+            raise RuntimeError("synthetic generation failure")
+
+        def generate():
+            with (
+                patch.object(
+                    simulation_module,
+                    "check_and_fix_config",
+                    side_effect=self._checked_config,
+                ),
+                patch.object(
+                    simulation_module,
+                    "generate_groundtruth",
+                    side_effect=failing_groundtruth,
+                ),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "synthetic generation failure"):
+                    simulation_module.generate_simulated_scenarios({})
+
+        self._assert_rng_states_preserved(generate)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- snapshot the selected backend RNG state and NumPy RNG state before scenario generation
- restore both states in a `finally` block so successful and failed generation cannot perturb caller-owned random streams
- add focused regressions covering normal generation and exceptions

## Bug fixed
`generate_simulated_scenarios()` seeds both `pyrecest.backend.random` and `numpy.random` for every run, but previously left those global RNGs at the state reached by the last generated scenario. Calling the helper therefore changed subsequent random values in unrelated application code. The behavior was also observable when generation raised midway through a run.

The generated scenarios remain deterministic for the configured per-run seeds; only the unintended process-wide side effect is removed.

## Validation
- branch is 2 commits ahead of current `main` and 0 behind
- Python syntax compilation passed for the modified module and new regression test
- direct NumPy-backend restoration probe passed for success and exception paths
- direct PyTorch/NumPy restoration probe passed for success and exception paths

Full repository tests are delegated to GitHub Actions because the execution environment cannot clone GitHub.