### PR TITLE
Preserve caller RNG state during simulation generation

### DIFF
--- a/src/pyrecest/evaluation/generate_simulated_scenarios.py
+++ b/src/pyrecest/evaluation/generate_simulated_scenarios.py
@@ -18,7 +18,7 @@ def generate_simulated_scenarios(
     simulation_params,
 ):
     """
-    Generate simulated scenarios.
+    Generate simulated scenarios without perturbing caller RNG state.
 
     Returns
     -------
@@ -28,28 +28,34 @@ def generate_simulated_scenarios(
         The measurements.
 
     """
-    simulation_params = check_and_fix_config(simulation_params)
-    all_seeds = simulation_params["all_seeds"]
+    backend_random_state = random.get_state()
+    numpy_random_state = np.random.get_state()
     try:
-        all_seeds = list(all_seeds)
-    except TypeError:
-        all_seeds = [all_seeds]
-    n_runs = len(all_seeds)
+        simulation_params = check_and_fix_config(simulation_params)
+        all_seeds = simulation_params["all_seeds"]
+        try:
+            all_seeds = list(all_seeds)
+        except TypeError:
+            all_seeds = [all_seeds]
+        n_runs = len(all_seeds)
 
-    groundtruths = np.empty(
-        (n_runs, simulation_params["n_timesteps"]),
-        dtype=object,
-    )
-    measurements = np.empty(
-        (n_runs, simulation_params["n_timesteps"]),
-        dtype=object,
-    )
-
-    for run, seed in enumerate(all_seeds):
-        _seed_simulation_rngs(seed)
-        groundtruths[run, :] = generate_groundtruth(simulation_params)
-        measurements[run, :] = generate_measurements(
-            groundtruths[run, :], simulation_params
+        groundtruths = np.empty(
+            (n_runs, simulation_params["n_timesteps"]),
+            dtype=object,
+        )
+        measurements = np.empty(
+            (n_runs, simulation_params["n_timesteps"]),
+            dtype=object,
         )
 
-    return groundtruths, measurements
+        for run, seed in enumerate(all_seeds):
+            _seed_simulation_rngs(seed)
+            groundtruths[run, :] = generate_groundtruth(simulation_params)
+            measurements[run, :] = generate_measurements(
+                groundtruths[run, :], simulation_params
+            )
+
+        return groundtruths, measurements
+    finally:
+        random.set_state(backend_random_state)
+        np.random.set_state(numpy_random_state)

--- a/tests/test_generate_simulated_scenarios_rng_state.py
+++ b/tests/test_generate_simulated_scenarios_rng_state.py
@@ -1,0 +1,91 @@
+import importlib
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import random as backend_random
+
+simulation_module = importlib.import_module(
+    "pyrecest.evaluation.generate_simulated_scenarios"
+)
+
+
+def _assert_random_states_equal(actual, expected):
+    if isinstance(expected, tuple):
+        assert actual[0] == expected[0]
+        npt.assert_array_equal(actual[1], expected[1])
+        assert actual[2:] == expected[2:]
+        return
+
+    if hasattr(actual, "detach"):
+        actual = actual.detach().cpu().numpy()
+    if hasattr(expected, "detach"):
+        expected = expected.detach().cpu().numpy()
+    npt.assert_array_equal(np.asarray(actual), np.asarray(expected))
+
+
+def _patch_minimal_simulation(monkeypatch, *, fail=False):
+    monkeypatch.setattr(
+        simulation_module,
+        "check_and_fix_config",
+        lambda simulation_params: simulation_params,
+    )
+
+    def generate_groundtruth(simulation_params):
+        del simulation_params
+        np.random.random()
+        if fail:
+            raise RuntimeError("generation failed")
+        return np.array([0.0])
+
+    monkeypatch.setattr(
+        simulation_module,
+        "generate_groundtruth",
+        generate_groundtruth,
+    )
+    monkeypatch.setattr(
+        simulation_module,
+        "generate_measurements",
+        lambda groundtruth, simulation_params: np.array(
+            [float(groundtruth[0]) + simulation_params["all_seeds"][0]]
+        ),
+    )
+
+
+def _assert_generation_preserves_rng_states(monkeypatch, *, fail=False):
+    _patch_minimal_simulation(monkeypatch, fail=fail)
+    original_backend_state = backend_random.get_state()
+    original_numpy_state = np.random.get_state()
+    try:
+        backend_random.seed(101)
+        np.random.seed(202)
+        expected_backend_state = backend_random.get_state()
+        expected_numpy_state = np.random.get_state()
+
+        if fail:
+            with pytest.raises(RuntimeError, match="generation failed"):
+                simulation_module.generate_simulated_scenarios(
+                    {"all_seeds": [7], "n_timesteps": 1}
+                )
+        else:
+            simulation_module.generate_simulated_scenarios(
+                {"all_seeds": [7], "n_timesteps": 1}
+            )
+
+        _assert_random_states_equal(
+            backend_random.get_state(), expected_backend_state
+        )
+        _assert_random_states_equal(np.random.get_state(), expected_numpy_state)
+    finally:
+        backend_random.set_state(original_backend_state)
+        np.random.set_state(original_numpy_state)
+
+
+def test_generate_simulated_scenarios_preserves_rng_states(monkeypatch):
+    _assert_generation_preserves_rng_states(monkeypatch)
+
+
+def test_generate_simulated_scenarios_restores_rng_states_after_failure(monkeypatch):
+    _assert_generation_preserves_rng_states(monkeypatch, fail=True)


### PR DESCRIPTION
## Summary

- save and restore both `pyrecest.backend.random` and NumPy RNG state around `generate_simulated_scenarios`
- restore the states through a `finally` block, including when ground-truth or measurement generation raises
- add regression tests for successful and failing generation paths

## Bug

`generate_simulated_scenarios` reseeds process-wide RNGs for every requested simulation seed. Before this change, the final simulation seed and all random draws made during generation leaked into the caller, so unrelated code produced different random sequences after generating scenarios. Exceptions also left both RNGs contaminated.

## Compatibility

Simulation outputs for a given `all_seeds` configuration remain deterministic and unchanged; only the external RNG side effect is removed.