### PR TITLE
Fix Kernel SME kernel covariance units

### DIFF
--- a/src/pyrecest/filters/kernel_sme_filter.py
+++ b/src/pyrecest/filters/kernel_sme_filter.py
@@ -161,7 +161,7 @@ class KernelSMEFilter(AbstractMultitargetTracker):
         if gating_threshold is None:
             gating_threshold = chi2.ppf(0.99, len(measurements))
         n_meas = measurements.shape[1]
-        kernel_width = mean(diag(cov_mat_meas)) ** 2
+        kernel_width = mean(diag(cov_mat_meas))
 
         if enable_gating:
             dists = full((self.n_targets, n_meas), float("nan"))
@@ -245,7 +245,7 @@ class KernelSMEFilter(AbstractMultitargetTracker):
         # Use sigma points to generate test points
         all_sample_points_list = [
             JulierSigmaPoints(meas_dim).sigma_points(
-                measurements[:, i], sqrt(kernel_width) * eye(meas_dim)
+                measurements[:, i], kernel_width * eye(meas_dim)
             )
             for i in range(n_meas)
         ]

--- a/tests/filters/test_kernel_sme_filter_kernel_covariance.py
+++ b/tests/filters/test_kernel_sme_filter_kernel_covariance.py
@@ -1,0 +1,64 @@
+import unittest
+from unittest.mock import patch
+
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+import pyrecest.backend
+from pyrecest.backend import array, diag, eye, zeros
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.filters.kernel_sme_filter import KernelSMEFilter
+
+
+class TestKernelSMEFilterKernelCovariance(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "pytorch",
+        reason="Kernel SME test-point generation is not supported on this backend",
+    )
+    def test_test_points_treat_kernel_width_as_covariance(self):
+        test_points = KernelSMEFilter.gen_test_points(array([[10.0]]), 4.0)
+
+        npt.assert_allclose(test_points, array([[10.0, 12.0, 8.0]]))
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Kernel SME updates are not supported on this backend",
+    )
+    def test_update_uses_mean_measurement_variance_as_kernel_covariance(self):
+        tracker = KernelSMEFilter(
+            [GaussianDistribution(array([0.0]), eye(1))], log_estimates=False
+        )
+        measurements = array([[0.0]])
+        measurement_covariance = diag(array([4.0]))
+        test_points = array([[0.0]])
+
+        with (
+            patch.object(
+                KernelSMEFilter,
+                "gen_test_points",
+                return_value=test_points,
+            ) as gen_test_points,
+            patch.object(
+                KernelSMEFilter,
+                "calc_pseudo_meas",
+                return_value=zeros(1),
+            ) as calc_pseudo_meas,
+            patch.object(
+                KernelSMEFilter,
+                "calc_moments",
+                return_value=(zeros(1), eye(1), zeros((1, 1))),
+            ) as calc_moments,
+        ):
+            tracker.update_linear(
+                measurements,
+                eye(1),
+                measurement_covariance,
+            )
+
+        npt.assert_allclose(gen_test_points.call_args.args[1], 4.0)
+        npt.assert_allclose(calc_pseudo_meas.call_args.args[2], 4.0)
+        npt.assert_allclose(calc_moments.call_args.args[5], 4.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- derive the Kernel SME Gaussian bandwidth directly from the mean measurement variance instead of squaring it
- pass the kernel variance as a covariance to `JulierSigmaPoints.sigma_points`
- add regression coverage for both the update bandwidth and resulting sigma-point spread

## Bug
`cov_mat_meas` is documented and consumed as a covariance matrix. The previous code computed

```python
mean(diag(cov_mat_meas)) ** 2
```

and then passed `sqrt(kernel_width) * I` to an API whose second argument is already a covariance matrix. This mixed variance and fourth-power units. For example, a one-dimensional measurement variance of `4` produced a Gaussian kernel covariance of `16`, while its sigma-point covariance was separately reduced to `4`.

The fix uses `Gamma = mean(diag(cov_mat_meas))` consistently as the isotropic kernel covariance.

## Validation
- added a direct sigma-point regression (`Gamma=4` gives offsets of `±2`)
- added a mocked update regression confirming the same mean variance reaches test-point generation, pseudo-measurement calculation, and moment calculation
- verified the branch differs from `main` only in the two corrected expressions and the new regression file
- Python syntax compilation of the new regression file passes locally
