### PR TITLE
Preserve RNG state during scenario generation

### DIFF
--- a/src/pyrecest/evaluation/generate_simulated_scenarios.py
+++ b/src/pyrecest/evaluation/generate_simulated_scenarios.py
@@ -1,7 +1,10 @@
+from contextlib import contextmanager
+
 import numpy as np
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import random
+from pyrecest.reproducibility import preserve_backend_random_state
 
 from .check_and_fix_config import check_and_fix_config
 from .generate_groundtruth import generate_groundtruth
@@ -12,6 +15,17 @@ def _seed_simulation_rngs(seed):
     """Seed all RNGs used by the simulation-generation helpers."""
     random.seed(seed)
     np.random.seed(seed)
+
+
+@contextmanager
+def _preserve_simulation_rngs():
+    """Restore backend and NumPy RNG streams after scenario generation."""
+    numpy_state = np.random.get_state()
+    with preserve_backend_random_state():
+        try:
+            yield
+        finally:
+            np.random.set_state(numpy_state)
 
 
 def generate_simulated_scenarios(
@@ -45,11 +59,12 @@ def generate_simulated_scenarios(
         dtype=object,
     )
 
-    for run, seed in enumerate(all_seeds):
-        _seed_simulation_rngs(seed)
-        groundtruths[run, :] = generate_groundtruth(simulation_params)
-        measurements[run, :] = generate_measurements(
-            groundtruths[run, :], simulation_params
-        )
+    with _preserve_simulation_rngs():
+        for run, seed in enumerate(all_seeds):
+            _seed_simulation_rngs(seed)
+            groundtruths[run, :] = generate_groundtruth(simulation_params)
+            measurements[run, :] = generate_measurements(
+                groundtruths[run, :], simulation_params
+            )
 
     return groundtruths, measurements

--- a/tests/evaluation/test_scenario_generation_rng_state.py
+++ b/tests/evaluation/test_scenario_generation_rng_state.py
@@ -1,0 +1,83 @@
+"""Regression tests for RNG isolation during scenario generation."""
+
+from __future__ import annotations
+
+import copy
+import importlib
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+import numpy.testing as npt
+
+import pyrecest.backend
+from pyrecest.backend import random
+
+scenario_generation = importlib.import_module(
+    "pyrecest.evaluation.generate_simulated_scenarios"
+)
+
+
+class TestScenarioGenerationRandomState(unittest.TestCase):
+    @staticmethod
+    def _run_stubbed_generation():
+        simulation_params = {"all_seeds": [7, 11], "n_timesteps": 1}
+        groundtruth = [np.array([0.0])]
+        measurements = [np.array([[0.0]])]
+
+        with (
+            patch.object(
+                scenario_generation,
+                "check_and_fix_config",
+                side_effect=lambda config: config,
+            ),
+            patch.object(
+                scenario_generation,
+                "generate_groundtruth",
+                return_value=groundtruth,
+            ),
+            patch.object(
+                scenario_generation,
+                "generate_measurements",
+                return_value=measurements,
+            ),
+        ):
+            scenario_generation.generate_simulated_scenarios(simulation_params)
+
+    def test_generation_preserves_caller_rng_state(self):
+        original_backend_state = copy.deepcopy(random.get_state())
+        original_numpy_state = np.random.get_state()
+        try:
+            if pyrecest.backend.__backend_name__ in ("numpy", "autograd"):
+                np.random.seed(314159)
+                expected_numpy = np.random.random(4)
+                np.random.seed(314159)
+
+                self._run_stubbed_generation()
+
+                npt.assert_allclose(np.random.random(4), expected_numpy)
+                return
+
+            random.seed(314159)
+            expected_backend = pyrecest.backend.to_numpy(
+                random.rand(size=(4,))
+            ).copy()
+            random.seed(314159)
+
+            np.random.seed(271828)
+            expected_numpy = np.random.random(4)
+            np.random.seed(271828)
+
+            self._run_stubbed_generation()
+
+            actual_backend = pyrecest.backend.to_numpy(random.rand(size=(4,)))
+            actual_numpy = np.random.random(4)
+            npt.assert_allclose(actual_backend, expected_backend)
+            npt.assert_allclose(actual_numpy, expected_numpy)
+        finally:
+            random.set_state(original_backend_state)
+            np.random.set_state(original_numpy_state)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- preserve and restore the active backend RNG state around simulated-scenario generation
- separately preserve NumPy's legacy RNG stream, which is also seeded by the simulation helpers
- add backend-aware regression coverage proving that scenario generation no longer changes the caller's subsequent random draws

## Bug fixed
`generate_simulated_scenarios()` seeded both `pyrecest.backend.random` and `numpy.random` for every configured run but left both global streams at the final simulation seed. Calling the scenario generator therefore changed unrelated random draws in the surrounding application. This also made behavior after an evaluation depend on the last configured scenario seed.

The generator still reseeds each run exactly as before, so generated scenarios remain deterministic; it now restores the caller's RNG streams on both normal completion and exceptions.

## Validation
- branch is 2 commits ahead of current `main` and 0 behind
- `python -m py_compile` passed for the modified module and regression test
- focused test stubs scenario construction so it isolates RNG state behavior across shared NumPy/Autograd streams and independent JAX/PyTorch plus NumPy streams
