### PR TITLE
Keep final registration assignment consistent

### DIFF
--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -436,9 +436,15 @@ def run_registration_loop(  # pylint: disable=too-many-locals
         moving,
         association_cost,
     )
+    final_assignment = callbacks.assignment_solver(
+        final_costs,
+        max_cost=config.max_cost,
+    )
+    if converged and not bool(array_equal(final_assignment, assignment)):
+        converged = False
     return RegistrationLoopState(
         transform=transform,
-        assignment=assignment,
+        assignment=final_assignment,
         transformed_reference_points=transformed_reference,
         costs=final_costs,
         iteration=iteration,

--- a/tests/test_registration_final_assignment_consistency.py
+++ b/tests/test_registration_final_assignment_consistency.py
@@ -1,0 +1,43 @@
+import unittest
+
+import numpy.testing as npt
+import pyrecest.backend
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array, eye, zeros
+from pyrecest.utils.point_set_registration import (
+    AffineTransform,
+    joint_registration_assignment,
+)
+
+
+class TestRegistrationFinalAssignmentConsistency(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_final_assignment_is_resolved_for_final_transform(self):
+        reference = array([[0.0], [10.0]])
+        moving = array([[4.0], [20.0]])
+
+        result = joint_registration_assignment(
+            reference,
+            moving,
+            model="translation",
+            initial_transform=AffineTransform(eye(1), zeros(1)),
+            max_cost=6.0,
+            max_iterations=1,
+        )
+
+        npt.assert_array_equal(result.assignment, array([0, 1]))
+        npt.assert_allclose(result.transform.offset, array([4.0]))
+        npt.assert_allclose(
+            result.transformed_reference_points,
+            array([[4.0], [14.0]]),
+        )
+        npt.assert_allclose(result.matched_costs, array([0.0, 6.0]))
+        self.assertFalse(result.converged)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- re-solve the gated association against the final transformed reference points
- return assignment, matched costs, and RMSE from the same final transform/cost matrix
- clear the convergence flag if that final association differs from the association used for the last refit
- add a regression test for the one-iteration boundary case

## Bug

`run_registration_loop` refits the transform from the current assignment, then recomputes the final transformed points and cost matrix under the updated transform. It previously returned the assignment computed under the pre-refit transform. When the last refit changes which pairs pass gating or minimizes the assignment objective, the returned assignment and diagnostics therefore describe different loop states.

The regression case starts with one admissible match. That match induces a translation which makes a second pair admissible. With `max_iterations=1`, the previous implementation returned the stale one-match association alongside the two-match final cost matrix.

## Validation

- Python syntax compilation passed for the modified module and regression test.
- The reproducer was checked independently: the initial assignment is `[0, -1]`, while the assignment under the fitted final translation is `[0, 1]`.
- Full repository tests are delegated to GitHub Actions because the execution environment could not resolve `github.com` for a checkout.