### PR TITLE
Reject invalid PyTorch take index arrays

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_split_index_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_split_index_contract.py
@@ -6,6 +6,10 @@ from operator import index as _operator_index
 
 import numpy as np
 
+from pyrecest.backend_support._pytorch_take_index_contract import (
+    patch_pytorch_take_index_contract as _patch_pytorch_take_index_contract,
+)
+
 _SPLIT_INDEX_TYPE_MESSAGE = (
     "slice indices must be integers or None or have an __index__ method"
 )
@@ -48,6 +52,8 @@ def _normalize_split_cut_indices(indices_or_sections, torch_module):
 
 def patch_pytorch_split_index_contract() -> None:
     """Make public and raw PyTorch ``split`` reject non-integer cut points."""
+
+    _patch_pytorch_take_index_contract()
 
     try:
         import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel

--- a/src/pyrecest/backend_support/_pytorch_take_index_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_take_index_contract.py
@@ -1,0 +1,56 @@
+"""Runtime patch for PyTorch ``take`` index-array validation."""
+
+from __future__ import annotations
+
+import numpy as np
+
+_TAKE_INDEX_TYPE_MESSAGE = (
+    "indices must be integers or boolean values when supplied as an array"
+)
+
+
+def _validate_take_indices(indices, torch_module):
+    """Reject array index dtypes that NumPy cannot cast with ``same_kind``."""
+
+    if torch_module.is_tensor(indices):
+        if indices.dtype.is_floating_point or indices.dtype.is_complex:
+            raise TypeError(_TAKE_INDEX_TYPE_MESSAGE)
+        return indices
+
+    if isinstance(indices, np.ndarray) and not np.can_cast(
+        indices.dtype,
+        np.dtype(np.intp),
+        casting="same_kind",
+    ):
+        raise TypeError(_TAKE_INDEX_TYPE_MESSAGE)
+    return indices
+
+
+def patch_pytorch_take_index_contract() -> None:
+    """Make public and raw PyTorch ``take`` reject invalid index arrays."""
+
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch may be unavailable
+        return
+
+    original_take = getattr(raw_pytorch, "take", None)
+    if original_take is None:
+        return
+    if getattr(original_take, "_pyrecest_take_index_contract", False):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.take = original_take
+        return
+
+    def take(a, indices, axis=None, out=None, mode=None):
+        indices = _validate_take_indices(indices, torch)
+        return original_take(a, indices, axis=axis, out=out, mode=mode)
+
+    take.__name__ = getattr(original_take, "__name__", "take")
+    take.__doc__ = getattr(original_take, "__doc__", None)
+    take._pyrecest_take_index_contract = True
+    raw_pytorch.take = take
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.take = take

--- a/tests/backend_support/test_pytorch_take_index_contract.py
+++ b/tests/backend_support/test_pytorch_take_index_contract.py
@@ -1,0 +1,83 @@
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+pytestmark = pytest.mark.backend_portable
+
+
+def _take_index_contract_code(target_module):
+    return f"""
+import numpy as np
+import torch
+import pyrecest  # noqa: F401  # triggers backend compatibility patches
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+values = torch.tensor([[1, 2, 3], [4, 5, 6]])
+target = {target_module}
+
+invalid_indices = (
+    np.asarray([1.5]),
+    np.asarray([1], dtype=object),
+    np.asarray(["1"]),
+    np.asarray([np.timedelta64(1, "ns")]),
+    torch.tensor([1.5]),
+    torch.tensor([1.0 + 0.0j]),
+)
+for indices in invalid_indices:
+    try:
+        target.take(values, indices, axis=1)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(
+            f"target.take accepted invalid index array with dtype {{indices.dtype}}"
+        )
+
+integer_result = target.take(values, np.asarray([1], dtype=np.int64), axis=1)
+assert target.to_numpy(integer_result).tolist() == [[2], [5]]
+
+boolean_result = target.take(values, np.asarray([True]), axis=1)
+assert target.to_numpy(boolean_result).tolist() == [[2], [5]]
+
+torch_integer_result = target.take(values, torch.tensor([1]), axis=1)
+assert target.to_numpy(torch_integer_result).tolist() == [[2], [5]]
+
+torch_boolean_result = target.take(values, torch.tensor([True]), axis=1)
+assert target.to_numpy(torch_boolean_result).tolist() == [[2], [5]]
+
+# NumPy accepts Python floating-point index lists by converting the sequence to
+# integer indices internally. Preserve that established array-like behavior.
+python_sequence_result = target.take(values, [1.5], axis=1)
+assert target.to_numpy(python_sequence_result).tolist() == [[2], [5]]
+
+print("ok")
+"""
+
+
+def test_raw_pytorch_take_rejects_invalid_index_arrays_with_numpy_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "numpy",
+        _take_index_contract_code("raw_pytorch"),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_public_pytorch_take_rejects_invalid_index_arrays():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        _take_index_contract_code("backend"),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- add a runtime contract patch for public and raw PyTorch `take`
- reject floating, complex, object, text, and temporal index arrays before PyTorch can cast them to integer indices
- preserve valid integer/Boolean arrays and the existing Python-sequence behavior
- add backend-portable regressions for both the public PyTorch backend and raw PyTorch under the NumPy backend

## Bug fixed
The PyTorch backend converted every tensor/array supplied as `indices` to `torch.long`. As a result, malformed index arrays such as `np.asarray([1.5])`, `torch.tensor([1.5])`, or `torch.tensor([1+0j])` were silently truncated to index `1`. NumPy rejects floating/complex NumPy index arrays under its `same_kind` casting rule, so the backend could select a different element instead of reporting invalid input.

The patch validates array dtypes before the existing conversion while retaining NumPy-compatible integer and Boolean arrays. Ordinary Python lists are left on the existing sequence path.

## Validation
- `python -m py_compile` passed for the new compatibility hook and regression test
- isolated validator smoke passed for invalid NumPy/PyTorch dtypes and valid integer/Boolean inputs
- isolated wrapper smoke passed for public/raw patch installation and preserved Python-list behavior
- branch is 3 commits ahead of `main`, 0 behind, changing only the compatibility hook, its existing bootstrap wiring, and focused tests

Full in-repository pytest is delegated to GitHub Actions because the local container cannot resolve `github.com`.