### PR TITLE
Handle empty GNN measurement updates

### DIFF
--- a/src/pyrecest/filters/global_nearest_neighbor.py
+++ b/src/pyrecest/filters/global_nearest_neighbor.py
@@ -145,6 +145,21 @@ class GlobalNearestNeighbor(AbstractNearestNeighborTracker):
             raise ValueError(
                 "cov_mats_meas must be a matrix or contain one covariance per measurement."
             )
+
+        pairwise_cost_matrix = self._validate_pairwise_cost_matrix(
+            pairwise_cost_matrix, n_targets, n_meas
+        )
+        if n_targets == 0:
+            return np.empty(0, dtype=int)
+        if n_meas == 0:
+            association = np.full(n_targets, n_meas, dtype=int)
+            if warn_on_no_meas_for_track:
+                warnings.warn(
+                    "GNN: No measurement was within gating threshold for at least one target.",
+                    stacklevel=2,
+                )
+            return association
+
         all_gaussians = [filter.filter_state for filter in self.filter_bank]
         all_means_prior = stack([gaussian.mu for gaussian in all_gaussians], axis=1)
         all_cov_mats_prior = stack([gaussian.C for gaussian in all_gaussians], axis=2)
@@ -237,9 +252,6 @@ class GlobalNearestNeighbor(AbstractNearestNeighborTracker):
         if self.association_param.get("square_dist", False):
             dists = dists * dists
 
-        pairwise_cost_matrix = self._validate_pairwise_cost_matrix(
-            pairwise_cost_matrix, n_targets, n_meas
-        )
         dists = self._apply_pairwise_cost_matrix(dists, pairwise_cost_matrix)
 
         if self.association_param.get("maximize_cardinality", False):

--- a/tests/filters/test_global_nearest_neighbor_empty_measurements.py
+++ b/tests/filters/test_global_nearest_neighbor_empty_measurements.py
@@ -1,0 +1,48 @@
+"""Regression tests for empty GlobalNearestNeighbor measurement updates."""
+
+import unittest
+
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+import pyrecest.backend
+from pyrecest.backend import eye, zeros
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.filters import KalmanFilter
+from pyrecest.filters.global_nearest_neighbor import GlobalNearestNeighbor
+
+
+class TestGlobalNearestNeighborEmptyMeasurements(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Nearest-neighbor trackers are not supported on this backend",
+    )
+    def test_empty_per_measurement_covariance_tensor_is_a_missed_update(self):
+        tracker = GlobalNearestNeighbor()
+        tracker.filter_state = [KalmanFilter(GaussianDistribution(zeros(2), eye(2)))]
+        prior_mean = tracker.filter_bank[0].filter_state.mu.copy()
+        prior_covariance = tracker.filter_bank[0].filter_state.C.copy()
+
+        measurements = zeros((2, 0))
+        covariances = zeros((2, 2, 0))
+
+        with self.assertWarnsRegex(UserWarning, "No measurement"):
+            association = tracker.find_association(
+                measurements,
+                eye(2),
+                covariances,
+            )
+        npt.assert_array_equal(association, [0])
+
+        with self.assertWarnsRegex(UserWarning, "No measurement"):
+            tracker.update_linear(measurements, eye(2), covariances)
+
+        npt.assert_array_equal(tracker.filter_bank[0].filter_state.mu, prior_mean)
+        npt.assert_array_equal(
+            tracker.filter_bank[0].filter_state.C,
+            prior_covariance,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- short-circuit GNN association when there are no tracks or no measurements
- preserve pairwise-cost shape validation on empty inputs
- treat `(dim_meas, dim_meas, 0)` per-measurement covariance tensors as a valid missed-update case
- add a regression proving `find_association` and `update_linear` leave filter state unchanged

## Bug
`GlobalNearestNeighbor.find_association()` accepts one covariance matrix per measurement. For an empty measurement set, the valid tensor shape is `(dim_meas, dim_meas, 0)`. The Mahalanobis fast path still indexed `cov_mats_meas[:, :, 0]`, raising `IndexError` before association. Empty frames therefore crashed instead of marking every track unassigned and leaving the filter states unchanged.

## Validation
- `python -m py_compile` passed for the modified module and new regression test
- regression covers the empty association sentinel, warning behavior, and state preservation through `update_linear`
- branch is 2 commits ahead of current `main`, 0 behind, and changes only the GNN implementation plus the focused test