### PR TITLE
Reject complex-valued sigma-point inputs

### DIFF
--- a/src/pyrecest/sampling/sigma_points.py
+++ b/src/pyrecest/sampling/sigma_points.py
@@ -13,6 +13,21 @@ from pyrecest.backend import asarray, concatenate, float64, full, linalg, reshap
 _TEXT_SCALAR_TYPES = (str, bytes, np.str_, np.bytes_)
 
 
+def _has_complex_dtype(value) -> bool:
+    """Return whether *value* has a complex-valued array dtype."""
+
+    dtype = getattr(value, "dtype", None)
+    if dtype is not None:
+        try:
+            return np.dtype(dtype).kind == "c"
+        except (TypeError, ValueError):
+            return "complex" in str(dtype).lower()
+    try:
+        return np.asarray(value).dtype.kind == "c"
+    except (TypeError, ValueError):
+        return False
+
+
 def _scalar_item(value, name: str):
     """Return a scalar value while rejecting arrays and booleans."""
 
@@ -54,9 +69,13 @@ def _validate_finite_scalar(value, name: str) -> float:
 
 
 def _validate_sigma_inputs(x, P, n: int):
+    if _has_complex_dtype(x):
+        raise ValueError("x must contain real values")
     x = reshape(asarray(x, dtype=float64), (-1,))
     if x.shape != (n,):
         raise ValueError(f"x must have shape ({n},)")
+    if _has_complex_dtype(P):
+        raise ValueError("P must contain real values")
     P = asarray(P, dtype=float64)
     if P.shape != (n, n):
         raise ValueError(f"P must have shape ({n}, {n})")

--- a/tests/test_sigma_points_complex_inputs.py
+++ b/tests/test_sigma_points_complex_inputs.py
@@ -1,0 +1,36 @@
+import numpy as np
+import pytest
+
+from pyrecest.sampling import JulierSigmaPoints, MerweScaledSigmaPoints
+
+
+@pytest.mark.parametrize(
+    "points",
+    [
+        JulierSigmaPoints(n=2, kappa=1.0),
+        MerweScaledSigmaPoints(n=2, alpha=0.5, beta=2.0, kappa=0.0),
+    ],
+    ids=["julier", "merwe"],
+)
+def test_sigma_points_reject_complex_state_mean(points):
+    with pytest.raises(ValueError, match="x must contain real values"):
+        points.sigma_points(
+            np.array([0.0 + 1.0j, 1.0]),
+            np.eye(2),
+        )
+
+
+@pytest.mark.parametrize(
+    "points",
+    [
+        JulierSigmaPoints(n=2, kappa=1.0),
+        MerweScaledSigmaPoints(n=2, alpha=0.5, beta=2.0, kappa=0.0),
+    ],
+    ids=["julier", "merwe"],
+)
+def test_sigma_points_reject_complex_covariance(points):
+    with pytest.raises(ValueError, match="P must contain real values"):
+        points.sigma_points(
+            np.array([0.0, 1.0]),
+            np.eye(2, dtype=complex),
+        )


### PR DESCRIPTION
## Summary
- reject complex-valued state means before converting sigma-point inputs to `float64`
- reject complex-valued covariance matrices before their imaginary components can be discarded
- add backend-portable regressions for both Julier and Merwe sigma-point implementations

## Bug fixed
`_validate_sigma_inputs` converted `x` and `P` directly to the backend's `float64` dtype. With NumPy complex arrays, this conversion emits a warning but keeps only the real component. A complex mean or covariance could therefore produce apparently valid real sigma points from altered inputs instead of failing validation.

The new dtype guard handles NumPy, JAX, and PyTorch dtype representations without converting device-backed arrays through NumPy.

## Validation
- branch is 2 commits ahead of `main` and 0 behind
- focused regressions cover complex state means and complex covariance matrices for both sigma-point schemes
- full test execution is delegated to GitHub Actions because the execution environment cannot resolve `github.com` for a checkout