### PR TITLE
Reject temporal multi-session label fill values

### DIFF
--- a/src/pyrecest/utils/_multisession_assignment_labels.py
+++ b/src/pyrecest/utils/_multisession_assignment_labels.py
@@ -20,6 +20,7 @@ from .multisession_assignment import (  # pylint: disable=protected-access
 )
 
 _TEXT_TYPES = (str, bytes, np.str_, np.bytes_)
+_TEMPORAL_TYPES = (np.datetime64, np.timedelta64)
 
 
 def _normalize_fill_value(fill_value: Any, track_count: int) -> int:
@@ -30,12 +31,15 @@ def _normalize_fill_value(fill_value: Any, track_count: int) -> int:
     if (
         fill_value_array.shape != ()
         or fill_value_array.dtype == np.bool_
-        or fill_value_array.dtype.kind in "SU"
+        or fill_value_array.dtype.kind in "MmSU"
     ):
         raise ValueError("fill_value must be an integer.")
 
     fill_value_value = fill_value_array.item()
-    if isinstance(fill_value_value, (bool, np.bool_) + _TEXT_TYPES):
+    if isinstance(
+        fill_value_value,
+        (bool, np.bool_) + _TEXT_TYPES + _TEMPORAL_TYPES,
+    ):
         raise ValueError("fill_value must be an integer.")
 
     if isinstance(fill_value_value, Integral):

--- a/tests/test_multisession_assignment_labels.py
+++ b/tests/test_multisession_assignment_labels.py
@@ -72,6 +72,32 @@ class TestMultiSessionAssignmentLabels(unittest.TestCase):
         __backend_name__ == "jax",
         reason="Not supported on this backend",
     )
+    def test_temporal_fill_values_are_rejected(self):
+        tracks = [{0: 0}]
+        timestamp = np.datetime64("1969-12-31T23:59:59.999999999")
+        duration = np.timedelta64(-1, "ns")
+        invalid_fill_values = (
+            timestamp,
+            duration,
+            np.asarray(timestamp),
+            np.asarray(duration),
+            np.array(timestamp, dtype=object),
+            np.array(duration, dtype=object),
+        )
+
+        for fill_value in invalid_fill_values:
+            for name, converter in self._converters():
+                with self.subTest(converter=name, fill_value=repr(fill_value)):
+                    with self.assertRaisesRegex(
+                        ValueError,
+                        "fill_value must be an integer",
+                    ):
+                        converter(tracks, session_sizes=[2], fill_value=fill_value)
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
     def test_text_and_bytes_fill_values_are_rejected(self):
         tracks = [{0: 0}]
         invalid_fill_values = (


### PR DESCRIPTION
## Summary
- reject NumPy `datetime64` and `timedelta64` values in `tracks_to_session_labels(..., fill_value=...)`
- validate native temporal dtypes before `.item()` can expose their integer payloads
- reject object-wrapped temporal scalars as well
- add regression coverage for the public utility, module alias, and `MultiSessionAssignmentResult.to_session_labels`

## Bug fixed
For nanosecond-resolution temporal values, NumPy returns the raw integer payload from `.item()`. Consequently, values such as `np.timedelta64(-1, "ns")` and `np.datetime64("1969-12-31T23:59:59.999999999")` were silently accepted as the integer sentinel `-1` instead of being rejected as non-integer controls.

The patch checks temporal dtype kinds before scalar unwrapping and also rejects object arrays that contain NumPy temporal scalars. Existing integer-like values remain accepted.

## Validation
- reproduced the current behavior: native nanosecond datetime/timedelta scalars and scalar arrays normalize to `-1`
- focused validator probe confirms all native, scalar-array, and object-wrapped temporal cases now raise `ValueError`
- focused validator probe confirms `-2.0`, `np.int64(-3)`, and `np.array(-4)` remain valid
- branch is 2 commits ahead of `main`, 0 behind, changing only the label helper and its regression test

Full repository pytest is delegated to GitHub Actions.