### PR TITLE
Prevent out-of-range MEM-RBPF resampling indices

### DIFF
--- a/src/pyrecest/filters/mem_rbpf_tracker.py
+++ b/src/pyrecest/filters/mem_rbpf_tracker.py
@@ -557,6 +557,9 @@ class MEMRBPFTracker(AbstractExtendedObjectTracker):
             )
 
         cumulative_sum = cumsum(weights)
+        # Floating-point accumulation can leave the final CDF value just below
+        # one, while the last systematic position rounds to exactly one.
+        cumulative_sum[-1] = 1.0
         try:
             return searchsorted(cumulative_sum, positions)
         except NotImplementedError as exc:

--- a/tests/test_mem_rbpf_tracker.py
+++ b/tests/test_mem_rbpf_tracker.py
@@ -56,6 +56,28 @@ def test_mem_rbpf_predict_update_smoke():
     assert np.isclose(np.sum(np.asarray(tracker.weights)), 1.0)
 
 
+def test_mem_rbpf_systematic_resampling_closes_roundoff_gap(monkeypatch):
+    tracker = _make_tracker(
+        n_particles=3,
+        resampling_mode="systematic",
+        resampling_threshold=0,
+    )
+    tracker.weights = array(
+        [0.20381898702851367, 0.7463113329614236, 0.0498696800100626]
+    )
+    monkeypatch.setattr(
+        random,
+        "uniform",
+        lambda size=None: array(np.nextafter(1.0, 0.0)),
+    )
+
+    indices = np.asarray(tracker._resample_indices())
+
+    np.testing.assert_array_equal(indices, np.array([1, 1, 2]))
+    tracker.resample()
+    assert tracker.theta.shape == (3,)
+
+
 def test_mem_rbpf_original_parameter_constructor_alias():
     random.seed(1)
     tracker = MEMRBPFTracker.from_original_parameters(


### PR DESCRIPTION
## Summary
- close the MEM-RBPF cumulative resampling distribution explicitly at `1.0`
- prevent systematic and stratified resampling from producing the invalid index `n_particles` at the floating-point upper boundary
- add a deterministic regression for the boundary case and verify that full particle resampling remains in bounds

## Bug
`MEMRBPFTracker._resample_indices()` normalizes particle weights, computes their cumulative sum, and passes systematic/stratified positions to `searchsorted`. Floating-point accumulation can leave the final cumulative probability just below one. At the same time, the last systematic position can round to exactly one.

For the normalized three-particle weights

```text
[0.20381898702851367, 0.7463113329614236, 0.0498696800100626]
```

the cumulative sum ends at `0.9999999999999999`. With the systematic offset `nextafter(1, 0)`, the final position rounds to `1.0`, so the previous code returned indices `[1, 1, 3]`. Index `3` is out of bounds for a three-particle state and makes `resample()` fail.

The patch explicitly sets the final CDF entry to `1.0` before `searchsorted`, yielding the valid indices `[1, 1, 2]`.

## Validation
- deterministic numerical reproducer confirms the old `[1, 1, 3]` and corrected `[1, 1, 2]` results
- focused regression checks both the generated indices and a complete `resample()` call
- branch is 2 commits ahead of `main`, 0 behind
- only `mem_rbpf_tracker.py` and its existing focused test file are changed

Full repository pytest is delegated to GitHub Actions because the local execution environment could not resolve `github.com` for a checkout.