### PR TITLE
Fix fixed-lag Viterbi prefix commitment

### DIFF
--- a/src/pyrecest/filters/tracklet_viterbi.py
+++ b/src/pyrecest/filters/tracklet_viterbi.py
@@ -209,9 +209,39 @@ def solve_tracklet_viterbi(
 ) -> TrackletViterbiResult:
     """Select a minimum-cost single-target path through candidate frames."""
 
+    return _solve_tracklet_viterbi(
+        frames,
+        config=config,
+        transition_cost=transition_cost,
+        include_missed_detection=include_missed_detection,
+        include_initial_missed_detection=include_missed_detection,
+        return_tables=return_tables,
+    )
+
+
+def _solve_tracklet_viterbi(
+    frames: Sequence[Sequence[TrackletAssociationCandidate]],
+    *,
+    config: TrackletViterbiConfig | None,
+    transition_cost: TransitionCost | None,
+    include_missed_detection: bool,
+    include_initial_missed_detection: bool,
+    return_tables: bool,
+) -> TrackletViterbiResult:
+    """Solve Viterbi with independent control of the initial miss branch."""
+
     config = TrackletViterbiConfig() if config is None else config
     nodes_by_frame = [
-        _nodes_for_frame(frame, config, include_missed_detection) for frame in frames
+        _nodes_for_frame(
+            frame,
+            config,
+            (
+                include_initial_missed_detection
+                if frame_index == 0
+                else include_missed_detection
+            ),
+        )
+        for frame_index, frame in enumerate(frames)
     ]
     if not nodes_by_frame:
         return TrackletViterbiResult([], 0.0)
@@ -336,11 +366,15 @@ def solve_fixed_lag_tracklet_viterbi(
                 committed_miss_streak,
                 config,
             )
-        local = solve_tracklet_viterbi(
+        local = _solve_tracklet_viterbi(
             window_frames,
             config=config,
             transition_cost=local_transition_cost,
             include_missed_detection=include_missed_detection,
+            include_initial_missed_detection=(
+                include_missed_detection and not prefix_added
+            ),
+            return_tables=False,
         )
         selected = local.path[1 if prefix_added else 0]
         path.append(selected)

--- a/tests/filters/test_tracklet_viterbi_forced_prefix.py
+++ b/tests/filters/test_tracklet_viterbi_forced_prefix.py
@@ -1,0 +1,35 @@
+"""Regression coverage for fixed-lag Viterbi prefix commitment."""
+
+from pyrecest.filters.tracklet_viterbi import (
+    TrackletAssociationCandidate,
+    TrackletViterbiConfig,
+    solve_fixed_lag_tracklet_viterbi,
+)
+
+
+def test_fixed_lag_prefix_cannot_be_replaced_by_missed_detection():
+    committed = TrackletAssociationCandidate(
+        "a0",
+        unary_cost=0.0,
+        track_id="A",
+        time_s=0.0,
+    )
+    switch = TrackletAssociationCandidate(
+        "b1",
+        unary_cost=0.0,
+        track_id="B",
+        time_s=10.0,
+    )
+
+    result = solve_fixed_lag_tracklet_viterbi(
+        [[committed], [switch]],
+        lag_s=1.0,
+        config=TrackletViterbiConfig(
+            missed_detection_cost=5.0,
+            consecutive_miss_cost=0.0,
+            switch_cost=100.0,
+        ),
+    )
+
+    assert result.path == [committed, None]
+    assert result.total_cost == 5.0


### PR DESCRIPTION
## Summary
- force fixed-lag look-ahead windows to retain their committed prefix state
- keep missed-detection branches available for actual uncommitted frames
- add a regression covering a high switch-cost case where the old solver discarded committed history

## Bug
`solve_fixed_lag_tracklet_viterbi(...)` prepended a synthetic prefix representing the already committed path, then called the generic Viterbi solver with missed detections enabled for every frame. That added a missed-detection alternative to the synthetic prefix frame itself. The local optimizer could therefore discard committed history, select a path through the artificial miss, and return a decision whose recomputed committed cost did not match the path optimized by the local window.

## Fix
The public solver now delegates to a private implementation that can control the initial missed-detection branch independently. Fixed-lag windows disable that branch only when an already committed prefix has been prepended.

## Validation
- focused regression: `1 passed`
- modified source and regression both pass `py_compile`
- committed Git blob hashes match the locally tested files
- repository CI is running on the final two-file diff