### PR TITLE
Allow omitted per-step RTS control inputs

### DIFF
--- a/src/pyrecest/smoothers/abstract_smoother.py
+++ b/src/pyrecest/smoothers/abstract_smoother.py
@@ -107,24 +107,31 @@ class AbstractSmoother(ABC):
         if values is None:
             return [None] * length
 
-        values_arr = asarray(values)
-        if ndim(values_arr) == 0:
-            if vector_dim != 1:
-                raise ValueError(
-                    f"Scalar input for {name} is only supported in one-dimensional models."
-                )
-            scalar_vector = asarray([values_arr])
-            return [copy(scalar_vector) for _ in range(length)]
-        if ndim(values_arr) == 1:
-            if vector_dim == 1 and values_arr.shape[0] == length:
-                return [asarray([values_arr[idx]]) for idx in range(length)]
-            return [copy(values_arr) for _ in range(length)]
-        if ndim(values_arr) == 2 and values_arr.shape[0] == length:
-            return [copy(values_arr[idx]) for idx in range(length)]
+        try:
+            values_arr = asarray(values)
+        except (TypeError, ValueError):
+            values_arr = None
+        if values_arr is not None:
+            if ndim(values_arr) == 0:
+                if vector_dim != 1:
+                    raise ValueError(
+                        f"Scalar input for {name} is only supported in one-dimensional models."
+                    )
+                scalar_vector = asarray([values_arr])
+                return [copy(scalar_vector) for _ in range(length)]
+            if ndim(values_arr) == 1:
+                if vector_dim == 1 and values_arr.shape[0] == length:
+                    return [asarray([values_arr[idx]]) for idx in range(length)]
+                return [copy(values_arr) for _ in range(length)]
+            if ndim(values_arr) == 2 and values_arr.shape[0] == length:
+                return [copy(values_arr[idx]) for idx in range(length)]
 
         if isinstance(values, (list, tuple)) and len(values) == length:
             normalized_values = []
             for value in values:
+                if value is None:
+                    normalized_values.append(None)
+                    continue
                 value_arr = asarray(value)
                 if ndim(value_arr) == 0:
                     if vector_dim != 1:

--- a/tests/smoothers/test_rauch_tung_striebel_smoother.py
+++ b/tests/smoothers/test_rauch_tung_striebel_smoother.py
@@ -99,6 +99,24 @@ class RauchTungStriebelSmootherTest(unittest.TestCase):
             float(filtered_states[0].C[0, 0]),
         )
 
+    def test_per_step_none_control_input_defaults_to_zero(self):
+        smoother = RauchTungStriebelSmoother()
+        filtered_states, predicted_states = smoother.filter(
+            initial_state=GaussianDistribution(zeros(2), eye(2)),
+            measurements=[zeros(2), zeros(2), zeros(2)],
+            measurement_matrices=zeros((2, 2)),
+            meas_noise_covariances=eye(2),
+            system_matrices=eye(2),
+            sys_noise_covariances=zeros((2, 2)),
+            sys_inputs=[None, array([1.0, -1.0])],
+        )
+
+        self.assertEqual(len(filtered_states), 3)
+        self.assertEqual(len(predicted_states), 2)
+        npt.assert_allclose(predicted_states[0].mu, zeros(2))
+        npt.assert_allclose(predicted_states[1].mu, array([1.0, -1.0]))
+        npt.assert_allclose(filtered_states[-1].mu, array([1.0, -1.0]))
+
     def test_single_measurement_sequence_returns_single_smoothed_state(self):
         smoother = RauchTungStriebelSmoother()
         filtered_states, predicted_states, smoothed_states, smoother_gains = (


### PR DESCRIPTION
## Summary
- allow smoother control-input sequences to contain `None` for individual transitions
- interpret an omitted per-step control as the existing zero-input default
- add a two-dimensional RTS regression covering a zero first control and an explicit second control

## Bug
`AbstractSmoother._normalize_vector_sequence()` converted the complete `sys_inputs` value with `asarray()` before checking whether it was a Python sequence. A valid mixed sequence such as

```python
[None, array([1.0, -1.0])]
```

is heterogeneous, so NumPy raises during that eager conversion. The later per-entry normalization branch was therefore unreachable. This contradicted the RTS forward pass, which already treats a normalized `None` entry as a zero control for that transition.

## Fix
The vector-sequence normalizer now mirrors the matrix-sequence normalizer: it falls back to per-entry processing when whole-sequence array conversion is not possible. During per-entry processing, `None` is preserved while explicit scalar/vector inputs retain the existing normalization rules.

## Impact
Callers can now mix uncontrolled and controlled transitions in one RTS filtering sequence without manually supplying zero vectors for every omitted control. Existing scalar, shared-vector, and dense per-step array inputs are unchanged.

## Validation
- deterministic reproducer: the previous implementation raises on `[None, vector]`; the patched implementation returns `[None, vector]`
- `python -m py_compile` passed for the modified source and regression test
- regression verifies the first prediction uses zero input, the second uses `[1, -1]`, and the final filtered mean reflects the explicit control
- branch is 2 commits ahead of `main`, 0 behind, and changes only the shared smoother normalizer plus the focused RTS test

Full repository testing is delegated to GitHub Actions because a complete checkout was unavailable in the execution environment.