### PR TITLE
Reject invalid piecewise sample counts

### DIFF
--- a/src/pyrecest/distributions/circle/piecewise_constant_distribution.py
+++ b/src/pyrecest/distributions/circle/piecewise_constant_distribution.py
@@ -21,14 +21,33 @@ from pyrecest.backend import (
 from .abstract_circular_distribution import AbstractCircularDistribution
 
 
+_INVALID_SAMPLE_COUNT_TYPES = (
+    bool,
+    np.bool_,
+    str,
+    bytes,
+    bytearray,
+    np.str_,
+    np.bytes_,
+    np.datetime64,
+    np.timedelta64,
+)
+_TEMPORAL_DTYPE_KINDS = {"M", "m"}
+
+
 def _validate_positive_sample_count(n) -> int:
-    count_array = np.asarray(n)
+    try:
+        count_array = np.asarray(n)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("n must be a scalar integer") from exc
     if count_array.ndim != 0:
         raise ValueError("n must be a scalar integer")
+    if count_array.dtype.kind in _TEMPORAL_DTYPE_KINDS:
+        raise ValueError("n must be an integer")
 
     count = count_array.item()
-    if isinstance(count, (bool, np.bool_)):
-        raise ValueError("n must be an integer, not a boolean")
+    if isinstance(count, _INVALID_SAMPLE_COUNT_TYPES):
+        raise ValueError("n must be an integer")
 
     try:
         count_int = int(count)

--- a/tests/distributions/test_piecewise_constant_sample_count_validation.py
+++ b/tests/distributions/test_piecewise_constant_sample_count_validation.py
@@ -1,0 +1,36 @@
+"""Regression tests for piecewise-constant sample-count validation."""
+
+import numpy as np
+import pytest
+
+from pyrecest.distributions.circle.piecewise_constant_distribution import (
+    _validate_positive_sample_count,
+)
+
+
+@pytest.mark.parametrize(
+    "count",
+    [
+        "2",
+        b"2",
+        np.str_("2"),
+        np.bytes_(b"2"),
+        np.timedelta64(2, "ns"),
+        np.datetime64("1970-01-01T00:00:00.000000002"),
+        np.asarray(np.timedelta64(2, "ns")),
+        np.asarray(np.datetime64("1970-01-01T00:00:00.000000002")),
+        np.array(np.timedelta64(2, "ns"), dtype=object),
+        np.array(
+            np.datetime64("1970-01-01T00:00:00.000000002"),
+            dtype=object,
+        ),
+    ],
+)
+def test_piecewise_sample_count_rejects_text_and_temporal_values(count):
+    with pytest.raises(ValueError, match="integer"):
+        _validate_positive_sample_count(count)
+
+
+def test_piecewise_sample_count_keeps_integer_like_numeric_values():
+    assert _validate_positive_sample_count(np.array(2.0)) == 2
+    assert _validate_positive_sample_count(np.int64(3)) == 3


### PR DESCRIPTION
## Summary

- reject text values masquerading as integer sample counts
- reject NumPy `datetime64` and `timedelta64` scalars before their nanosecond payloads can be interpreted as integers
- preserve support for genuine integer-like numeric scalars
- add focused regression coverage for scalar arrays and object-wrapped temporal values

## Root cause

`_validate_positive_sample_count` converted arbitrary scalar values with both `int()` and `float()`. Consequently, values such as `"2"` and `b"2"` were accepted, while nanosecond-resolution NumPy datetime/duration scalars exposed an integer payload through `.item()` and were also accepted as counts. Both `PiecewiseConstantDistribution.sample` and `calculate_parameters_numerically` use this validator.

## Validation

- `python -m py_compile` on the modified module and new test file
- focused pytest regression run: `11 passed`
- standalone before/after probe covering strings, bytes, temporal scalars, object-wrapped temporal scalars, and valid NumPy integer-like numerics

The full repository matrix is left to GitHub Actions.