### PR TITLE
Fix GNN structural dummy edge costs

### DIFF
--- a/src/pyrecest/filters/track_manager.py
+++ b/src/pyrecest/filters/track_manager.py
@@ -765,9 +765,17 @@ def solve_global_nearest_neighbor(  # pylint: disable=too-many-locals
     finite_matrix = matrix.copy()
     finite_matrix[~np.isfinite(finite_matrix)] = float(invalid_cost)
 
+    assignment_size = num_tracks + num_measurements
+    structural_cost = _forbidden_assignment_cost(
+        assignment_size,
+        finite_matrix,
+        track_unassigned_costs,
+        measurement_unassigned_costs,
+        np.asarray([dummy_dummy_cost]),
+    )
     augmented_cost = np.full(
-        (num_tracks + num_measurements, num_measurements + num_tracks),
-        float(invalid_cost),
+        (assignment_size, assignment_size),
+        structural_cost,
     )
     augmented_cost[:num_tracks, :num_measurements] = finite_matrix
 
@@ -972,6 +980,22 @@ def build_kalman_measurement_initiator(
         )
 
     return initiator
+
+
+def _forbidden_assignment_cost(assignment_size: int, *cost_arrays: Any) -> float:
+    """Return a blocker cost that cannot beat a finite valid assignment."""
+
+    finite_absolute_costs = [1.0]
+    for costs in cost_arrays:
+        values = np.asarray(costs, dtype=float).reshape(-1)
+        finite_values = values[np.isfinite(values)]
+        if finite_values.size:
+            finite_absolute_costs.append(float(np.max(np.abs(finite_values))))
+
+    scale = max(finite_absolute_costs)
+    with np.errstate(over="ignore"):
+        blocker = scale * float(2 * assignment_size + 1)
+    return float(blocker) if np.isfinite(blocker) else float("inf")
 
 
 def _coerce_cost_vector(cost: Any, length: int, name: str) -> np.ndarray:

--- a/tests/filters/test_track_manager_structural_cost.py
+++ b/tests/filters/test_track_manager_structural_cost.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+from pyrecest.filters.track_manager import solve_global_nearest_neighbor
+
+
+def test_invalid_pair_replacement_is_not_used_for_structural_dummy_edges():
+    # Matching at cost 150 is cheaper than paying both missed costs (100 + 100).
+    association = solve_global_nearest_neighbor(
+        np.array([[150.0], [160.0]]),
+        unassigned_track_cost=100.0,
+        unassigned_measurement_cost=100.0,
+        invalid_cost=1.0,
+    )
+
+    assert association.matches == [(0, 0)]
+    assert association.unmatched_track_indices == [1]
+    assert association.unmatched_measurement_indices == []


### PR DESCRIPTION
## Summary
- separate structurally forbidden dummy edges from the caller-provided `invalid_cost`
- derive a blocker cost that cannot beat any finite valid complete assignment
- add a regression for low `invalid_cost` suppressing a valid match

## Bug
`solve_global_nearest_neighbor()` used `invalid_cost` both as the documented replacement for non-finite pair costs and as the fill value for impossible off-diagonal dummy assignments. When callers chose a low replacement value, the Hungarian solver could use those impossible edges and prefer leaving a track and measurement unmatched even though their real association cost was below the combined missed-assignment cost.

## Validation
- deterministic reproducer: pair costs `150/160`, track/measurement missed costs `100`, `invalid_cost=1`
- existing non-finite-pair regression preserved
- 4,000 randomized finite-cost comparisons against a reference assignment with forbidden structural edges
- source and regression test compile successfully
- repository CI retriggered on the clean one-commit branch