### PR TITLE
Fix valid-state masking in discrete emission scaling

### DIFF
--- a/src/pyrecest/filters/discrete_state.py
+++ b/src/pyrecest/filters/discrete_state.py
@@ -500,11 +500,19 @@ mode_transition_matrix = sticky_mode_transition_matrix
 def _prepare_emissions(
     log_likelihood: np.ndarray, valid_state_mask: np.ndarray | None
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray | None]:
-    scaled, offsets = scaled_emissions(log_likelihood)
-    mask = _coerce_valid_state_mask(valid_state_mask, scaled.shape[1])
+    values = np.asarray(log_likelihood, dtype=float)
+    if values.ndim != 2:
+        raise ValueError("log_likelihood must have shape (n_time, n_states)")
+    if values.shape[0] == 0 or values.shape[1] == 0:
+        raise ValueError(
+            "log_likelihood must contain at least one time step and one state"
+        )
+
+    mask = _coerce_valid_state_mask(valid_state_mask, values.shape[1])
     if mask is not None:
-        scaled = scaled.copy()
-        scaled[:, ~mask] = 0.0
+        values = values.copy()
+        values[:, ~mask] = -np.inf
+    scaled, offsets = scaled_emissions(values)
     return scaled, offsets, mask
 
 

--- a/tests/filters/test_discrete_state_masked_emissions.py
+++ b/tests/filters/test_discrete_state_masked_emissions.py
@@ -1,0 +1,96 @@
+"""Regression tests for masked discrete-state emission scaling."""
+
+import numpy as np
+
+from pyrecest.filters.discrete_state import (
+    discrete_forward_backward,
+    discrete_forward_backward_time_varying,
+    imm_forward_backward,
+)
+
+
+def _masked_emission_case():
+    log_likelihood = np.array(
+        [
+            [1000.0, 0.0],
+            [1000.0, np.log(0.5)],
+        ]
+    )
+    valid_state_mask = np.array([False, True])
+    expected_probabilities = np.array([[0.0, 1.0], [0.0, 1.0]])
+    expected_offsets = np.array([0.0, np.log(0.5)])
+    return (
+        log_likelihood,
+        valid_state_mask,
+        expected_probabilities,
+        expected_offsets,
+    )
+
+
+def _assert_masked_result(result, expected_probabilities, expected_offsets):
+    np.testing.assert_allclose(
+        result.log_marginal_likelihood,
+        np.log(0.5),
+    )
+    np.testing.assert_allclose(result.emission_offsets, expected_offsets)
+    np.testing.assert_allclose(result.filtered_probabilities, expected_probabilities)
+    np.testing.assert_allclose(result.smoothed_probabilities, expected_probabilities)
+
+
+def test_valid_state_mask_excludes_invalid_emissions_from_hmm_scaling():
+    (
+        log_likelihood,
+        valid_state_mask,
+        expected_probabilities,
+        expected_offsets,
+    ) = _masked_emission_case()
+    transition = np.eye(2)
+
+    constant_result = discrete_forward_backward(
+        log_likelihood,
+        transition,
+        valid_state_mask=valid_state_mask,
+    )
+    time_varying_result = discrete_forward_backward_time_varying(
+        log_likelihood,
+        [transition],
+        valid_state_mask=valid_state_mask,
+    )
+
+    _assert_masked_result(
+        constant_result,
+        expected_probabilities,
+        expected_offsets,
+    )
+    _assert_masked_result(
+        time_varying_result,
+        expected_probabilities,
+        expected_offsets,
+    )
+
+
+def test_valid_state_mask_excludes_invalid_emissions_from_imm_scaling():
+    (
+        log_likelihood,
+        valid_state_mask,
+        expected_probabilities,
+        expected_offsets,
+    ) = _masked_emission_case()
+
+    result = imm_forward_backward(
+        log_likelihood,
+        [np.eye(2)],
+        np.ones((1, 1)),
+        valid_state_mask=valid_state_mask,
+    )
+
+    np.testing.assert_allclose(result.log_marginal_likelihood, np.log(0.5))
+    np.testing.assert_allclose(result.emission_offsets, expected_offsets)
+    np.testing.assert_allclose(
+        result.filtered_state_probabilities,
+        expected_probabilities,
+    )
+    np.testing.assert_allclose(
+        result.smoothed_state_probabilities,
+        expected_probabilities,
+    )


### PR DESCRIPTION
## Summary

- apply `valid_state_mask` before row-wise log-emission scaling
- prevent invalid states from determining emission offsets and corrupting log marginal likelihoods
- add regression coverage for constant-transition HMM, time-varying HMM, and IMM recursions

## Bug

`_prepare_emissions` previously called `scaled_emissions` before zeroing invalid states. A masked state with a much larger finite log likelihood could therefore determine the row offset. The valid emissions then underflowed (or were clipped), while the invalid state was zeroed only afterward. Filtered support could still look correct, but `emission_offsets` and `log_marginal_likelihood` were numerically wrong.

For the regression case with masked log likelihood `1000` and valid likelihoods `0` then `log(0.5)`, the old path reports about `511.12` instead of `log(0.5) = -0.693147...`.

## Validation

- compiled the changed module and new regression test
- executed the patched constant-transition HMM, time-varying HMM, and single-mode IMM paths against the regression case; all returned the expected evidence, offsets, filtered probabilities, and smoothed probabilities
