### PR TITLE
Fix Dirac entropy with zero weights

### DIFF
--- a/src/pyrecest/distributions/abstract_dirac_distribution.py
+++ b/src/pyrecest/distributions/abstract_dirac_distribution.py
@@ -24,6 +24,7 @@ from pyrecest.backend import (
     reshape,
     stack,
     sum,
+    where,
 )
 
 from .abstract_distribution_type import AbstractDistributionType
@@ -144,7 +145,8 @@ class AbstractDiracDistribution(AbstractDistributionType):
 
     def entropy(self) -> float:
         warnings.warn("Entropy is not defined in a continuous sense")
-        return -sum(self.w * log(self.w))
+        safe_weights = where(self.w > 0, self.w, 1.0)
+        return -sum(self.w * log(safe_weights))
 
     def integrate(self, left=None, right=None):
         if left is not None or right is not None:

--- a/tests/distributions/test_dirac_entropy_zero_weights.py
+++ b/tests/distributions/test_dirac_entropy_zero_weights.py
@@ -1,0 +1,25 @@
+"""Regression coverage for zero-weight Dirac entropy terms."""
+
+import warnings
+
+import numpy as np
+import numpy.testing as npt
+
+from pyrecest.backend import array
+from pyrecest.distributions import LinearDiracDistribution
+
+
+def test_dirac_entropy_treats_zero_log_zero_as_zero():
+    distribution = LinearDiracDistribution(
+        array([[0.0], [1.0], [2.0]]),
+        array([0.25, 0.75, 0.0]),
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        entropy = distribution.entropy()
+
+    expected = -(0.25 * np.log(0.25) + 0.75 * np.log(0.75))
+    npt.assert_allclose(entropy, expected)
+    assert len(caught) == 1
+    assert "not defined in a continuous sense" in str(caught[0].message)


### PR DESCRIPTION
## Summary

- evaluate discrete Dirac entropy with the standard `0 log 0 = 0` convention
- avoid taking `log(0)` for valid zero-probability support points
- add regression coverage for the finite entropy value and warning behavior

## Bug

`AbstractDiracDistribution.entropy()` directly evaluated `-sum(w * log(w))`. Zero weights are valid in PyRecEst Dirac distributions, but array backends evaluate the zero-weight term numerically as `0 * -inf`, yielding `NaN`. On NumPy this also emits unintended divide-by-zero and invalid-value runtime warnings in addition to the method's documented continuous-entropy warning.

The fix replaces zero weights with `1` only inside the logarithm. Their contribution is therefore exactly `0 * log(1) = 0`, while every positive-weight contribution is unchanged.

## Validation

- deterministic NumPy reproducer: the old expression returns `NaN` with two runtime warnings
- corrected expression returns `0.5623351446188083`, matching `-(0.25 log 0.25 + 0.75 log 0.75)`, with no numerical runtime warnings
- branch is 2 commits ahead of `main`, 0 behind, and changes only the Dirac entropy implementation plus one focused regression test

Full repository and backend-matrix testing is delegated to GitHub Actions.