### PR TITLE
Fix mode-RBPF covariance axis canonicalization

### DIFF
--- a/src/pyrecest/filters/mode_rbpf_manifold_ukf_tracker.py
+++ b/src/pyrecest/filters/mode_rbpf_manifold_ukf_tracker.py
@@ -671,11 +671,11 @@ class ModeRBPFManifoldUKFTracker(AbstractExtendedObjectTracker):
         if not np.any(swap):
             return
         swapped_log_axes = self.mu[swap, 5:7][:, ::-1].copy()
-        swapped_cov_rows = self.covariances[swap, 5:7, :][:, ::-1, :].copy()
-        swapped_cov_cols = self.covariances[swap, :, 5:7][:, :, ::-1].copy()
+        state_permutation = np.array([0, 1, 2, 3, 4, 6, 5])
         self.mu[swap, 5:7] = swapped_log_axes
-        self.covariances[swap, 5:7, :] = swapped_cov_rows
-        self.covariances[swap, :, 5:7] = swapped_cov_cols
+        self.covariances[swap] = self.covariances[swap][
+            :, state_permutation
+        ][:, :, state_permutation]
         self.mu[swap, 4] = self._wrap_ellipse_angle(self.mu[swap, 4] + np.pi / 2.0)
 
     def get_point_estimate(self):

--- a/tests/filters/test_mode_rbpf_axis_canonicalization.py
+++ b/tests/filters/test_mode_rbpf_axis_canonicalization.py
@@ -1,0 +1,53 @@
+"""Regression tests for mode-RBPF extent canonicalization."""
+
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+import pyrecest.backend as pyrecest_backend
+from pyrecest.filters import ModeRBPFManifoldUKFTracker
+
+
+@unittest.skipIf(
+    pyrecest_backend.__backend_name__ != "numpy",
+    reason="ModeRBPFManifoldUKFTracker is currently NumPy-backend only",
+)
+class TestModeRBPFAxisCanonicalization(unittest.TestCase):
+    def test_axis_swap_applies_covariance_congruence_permutation(self):
+        tracker = ModeRBPFManifoldUKFTracker(
+            np.zeros(4),
+            np.eye(4),
+            np.array([0.2, 2.0, 1.0]),
+            np.eye(3),
+            n_particles=2,
+            rng=0,
+            canonicalize_extent=False,
+        )
+        tracker.canonicalize_extent = True
+        tracker.mu[:, 5:7] = np.log([[1.0, 2.0], [2.0, 1.0]])
+
+        covariance = np.diag([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
+        covariance[0, 5] = covariance[5, 0] = 0.5
+        covariance[0, 6] = covariance[6, 0] = 0.75
+        covariance[5, 6] = covariance[6, 5] = 0.25
+        tracker.covariances[0] = covariance
+        tracker.covariances[1] = 2.0 * covariance
+        untouched_covariance = tracker.covariances[1].copy()
+        untouched_angle = tracker.mu[1, 4]
+
+        permutation = np.array([0, 1, 2, 3, 4, 6, 5])
+        expected_covariance = covariance[np.ix_(permutation, permutation)]
+        expected_angle = (tracker.mu[0, 4] + np.pi / 2.0) % np.pi
+
+        tracker._canonicalize_particles()
+
+        npt.assert_allclose(np.exp(tracker.mu[0, 5:7]), [2.0, 1.0])
+        npt.assert_allclose(tracker.covariances[0], expected_covariance)
+        npt.assert_allclose(tracker.covariances[0], tracker.covariances[0].T)
+        npt.assert_allclose(tracker.mu[0, 4], expected_angle)
+        npt.assert_allclose(tracker.covariances[1], untouched_covariance)
+        npt.assert_allclose(tracker.mu[1, 4], untouched_angle)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- apply a single state permutation to both covariance dimensions when canonicalizing ellipse axes
- preserve covariance symmetry and all cross-covariances during the major/minor-axis swap
- add a focused regression covering a swapped particle and an untouched particle

## Bug

`ModeRBPFManifoldUKFTracker._canonicalize_particles()` swaps `log(a)` and `log(b)` whenever the second axis is larger. It previously prepared the covariance row swap and column swap independently from the original matrix, then assigned them sequentially. The second assignment overwrote the overlapping axis covariance block, so the result was not the required congruence transform and could become nonsymmetric.

For the regression covariance, the previous implementation changes the axis block from

```text
[[6.00, 0.25],
 [0.25, 7.00]]
```

to

```text
[[0.25, 6.00],
 [7.00, 0.25]]
```

The fix applies the permutation `[0, 1, 2, 3, 4, 6, 5]` to both covariance dimensions, producing the correct symmetric block

```text
[[7.00, 0.25],
 [0.25, 6.00]]
```

## Impact

The bug affects particles whose ellipse axes are reordered after prediction or update. Their conditional covariance can be distorted before the next UKF step, including axis variances and cross-covariances with kinematics and orientation.

## Validation

- verified the branch is two commits ahead of current `main` and changes only the tracker plus one regression file
- deterministic matrix reproducer confirms the old result is nonsymmetric and the patched result equals `P C P^T`
- regression verifies axis order, angle adjustment, full covariance permutation, symmetry, and preservation of an untouched particle

The full repository test matrix is delegated to GitHub Actions because this runtime has no GitHub CLI and cannot clone through DNS.