### PR TITLE
Reject backend boolean measurement indices

### DIFF
--- a/src/pyrecest/filters/update_diagnostics.py
+++ b/src/pyrecest/filters/update_diagnostics.py
@@ -13,6 +13,14 @@ _ACTIVE_INDICES_MESSAGE = (
 )
 
 
+def _is_boolean_scalar(value: Any) -> bool:
+    """Return whether ``value`` is a scalar boolean from a supported backend."""
+    if isinstance(value, bool):
+        return True
+    dtype_name = str(getattr(value, "dtype", "")).lower()
+    return dtype_name in {"bool", "bool_", "torch.bool"}
+
+
 @dataclass(frozen=True)
 class MeasurementUpdateDiagnostics:
     """Diagnostics captured from one measurement update.
@@ -121,7 +129,7 @@ def _normalize_metadata(metadata: Mapping[str, Any] | None) -> dict[str, Any]:
 
 def _as_nonnegative_integer(value: Any, name: str) -> int:
     message = f"{name} must be a non-negative integer"
-    if isinstance(value, bool):
+    if _is_boolean_scalar(value):
         raise ValueError(message)
     try:
         parsed = operator_index(value)

--- a/tests/filters/test_update_diagnostics_backend_boolean.py
+++ b/tests/filters/test_update_diagnostics_backend_boolean.py
@@ -1,0 +1,28 @@
+import unittest
+
+from pyrecest.filters.update_diagnostics import MeasurementUpdateDiagnostics
+
+
+class _BackendBooleanScalar:
+    dtype = "torch.bool"
+
+    def __index__(self):
+        return 1
+
+
+class MeasurementUpdateDiagnosticsBackendBooleanTest(unittest.TestCase):
+    def test_rejects_backend_boolean_measurement_count(self):
+        with self.assertRaisesRegex(ValueError, "measurement_count"):
+            MeasurementUpdateDiagnostics(
+                measurement_count=_BackendBooleanScalar(),
+            )
+
+    def test_rejects_backend_boolean_active_index(self):
+        with self.assertRaisesRegex(ValueError, "active_measurement_indices"):
+            MeasurementUpdateDiagnostics(
+                active_measurement_indices=[_BackendBooleanScalar()],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reject backend boolean scalar dtypes before integer coercion in `MeasurementUpdateDiagnostics`
- prevent zero-dimensional values such as `torch.tensor(True)` from being interpreted as measurement index/count `1`
- add focused regressions for both `measurement_count` and `active_measurement_indices`

## Bug
`operator.index(...)` is intentionally used to accept backend integer scalars. Some backend boolean scalars also implement `__index__`; for example, a scalar with dtype `torch.bool` can therefore be silently accepted as integer `1`. This violates the diagnostics contract that measurement counts and indices must be non-boolean integers.

## Validation
- `python -m py_compile update_diagnostics.py test_update.py`
- `python -m unittest -v test_update.py` (`2 passed`)
- branch diff is limited to 10 changed source lines plus the regression test
