### PR TITLE
Preserve live list histories when clearing

### DIFF
--- a/src/pyrecest/utils/history_recorder.py
+++ b/src/pyrecest/utils/history_recorder.py
@@ -172,7 +172,12 @@ class HistoryRecorder:
             return None
 
         entry = self._entries[name]
-        entry.values = array([[]]) if entry.pad_with_nan else []
+        if entry.pad_with_nan:
+            entry.values = array([[]])
+        elif isinstance(entry.values, list):
+            entry.values.clear()
+        else:
+            entry.values = []
         return entry.values
 
     def get(self, name: str, default=None):

--- a/tests/utils/test_history_recorder.py
+++ b/tests/utils/test_history_recorder.py
@@ -47,3 +47,19 @@ def test_padded_history_empty_initial_value_does_not_add_nan_column():
     history = recorder.record("state", [1.0, 2.0], pad_with_nan=True)
 
     npt.assert_allclose(_to_numpy(history), np.array([[1.0], [2.0]]))
+
+
+def test_clear_preserves_live_list_history_reference():
+    recorder = HistoryRecorder()
+    history = recorder.register("events")
+    recorder.record("events", {"value": 1})
+
+    cleared = recorder.clear("events")
+
+    assert cleared is history
+    assert recorder["events"] is history
+    assert history == []
+
+    recorder.record("events", {"value": 2})
+
+    assert history == [{"value": 2}]


### PR DESCRIPTION
## Summary
- clear list-backed histories in place instead of replacing their storage object
- preserve the live reference returned by `HistoryRecorder.register()`
- add a regression proving retained references observe both the clear and subsequent records

## Bug
`HistoryRecorder.register()` returns the backing storage object, and list-backed histories are updated in place by `record()`. However, `clear()` replaced that list with a new one. Callers retaining the object returned by `register()` therefore kept stale entries and stopped observing later records, despite `clear()` being documented as operating in place.

## Fix
Use `list.clear()` for valid list-backed histories. Padded numeric histories still receive a fresh empty backend array because their storage is array-backed, and the existing fallback for malformed non-list generic storage is retained.

## Validation
- added `test_clear_preserves_live_list_history_reference`
- connector diff confirms only the recorder implementation and focused regression changed
- full CI requested through this PR