### PR TITLE
Validate wrapped-normal CDF wrap count

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
@@ -160,6 +160,7 @@ class WrappedNormalDistribution(
         starting_point: float = 0.0,
         n_wraps: Union[int, int32, int64] = 10,
     ):
+        n_wraps = _validate_series_order(n_wraps)
         mu = self.scalar_mu
         sigma = self.sigma
         starting_point = mod(starting_point, 2 * pi)

--- a/tests/distributions/test_wrapped_normal_cdf_wrap_validation.py
+++ b/tests/distributions/test_wrapped_normal_cdf_wrap_validation.py
@@ -1,0 +1,24 @@
+"""Regression tests for wrapped-normal CDF truncation-order validation."""
+
+import numpy as np
+import pytest
+
+from pyrecest.distributions.circle.wrapped_normal_distribution import (
+    WrappedNormalDistribution,
+)
+
+
+@pytest.mark.parametrize("n_wraps", [-1, True, False, 1.5])
+def test_wrapped_normal_cdf_rejects_invalid_wrap_counts(n_wraps):
+    distribution = WrappedNormalDistribution(6.1, 0.5)
+
+    with pytest.raises(ValueError, match="non-negative integer"):
+        distribution.cdf(np.array([0.2]), n_wraps=n_wraps)
+
+
+def test_wrapped_normal_cdf_accepts_numpy_integer_wrap_count():
+    distribution = WrappedNormalDistribution(6.1, 0.5)
+
+    result = distribution.cdf(np.array([0.2]), n_wraps=np.int64(4))
+
+    assert np.isfinite(np.asarray(result)).all()


### PR DESCRIPTION
## Summary

- validate `WrappedNormalDistribution.cdf(..., n_wraps=...)` with the existing non-negative integer series-order validator
- reject negative, boolean, and non-integral wrap counts consistently with the wrapped-normal PDF
- preserve support for NumPy integer scalars
- add focused regression coverage

## Bug

The CDF used `range(1, n_wraps + 1)` without validating `n_wraps`. Negative values therefore silently skipped all wrapped terms, while Python booleans were interpreted as integer counts (`False` as zero and `True` as one). Near the circular boundary this can return a materially incomplete CDF instead of rejecting an invalid truncation order.

For example, with `mu=6.1`, `sigma=0.5`, and `x=0.2`, a negative wrap count takes only the unwrapped term and returns `0.0`, whereas the normal wrapped evaluation is approximately `0.1353`.

## Fix

Reuse `_validate_series_order`, which is already applied by the PDF implementation. This gives the CDF the same input contract and normalized integer value before entering the wrap loop.

## Validation

- verified the branch is two commits ahead of current `main` and zero behind
- verified the diff contains one source-line change plus one focused regression file
- regression covers negative counts, native booleans, a non-integral float, and a valid NumPy integer scalar
- full repository testing is delegated to GitHub Actions because this runtime has no GitHub CLI and cannot clone through DNS
