### PR TITLE
Reject lossy piecewise constant inputs

### DIFF
--- a/src/pyrecest/distributions/circle/piecewise_constant_distribution.py
+++ b/src/pyrecest/distributions/circle/piecewise_constant_distribution.py
@@ -58,6 +58,38 @@ def _validate_interval_index(m, n) -> tuple[int, int]:
     return m, n
 
 
+def _reject_complex_input(value, name: str) -> None:
+    """Reject complex-valued inputs before a backend float cast can truncate them."""
+
+    dtype = getattr(value, "dtype", None)
+    if dtype is not None:
+        try:
+            if np.dtype(dtype).kind == "c":
+                raise ValueError(f"{name} must contain real values")
+        except (TypeError, ValueError):
+            if "complex" in str(dtype).lower():
+                raise ValueError(f"{name} must contain real values")
+
+    try:
+        raw = np.asarray(value)
+    except (OverflowError, TypeError, ValueError, RuntimeError):
+        return
+    if raw.dtype.kind == "c":
+        raise ValueError(f"{name} must contain real values")
+
+
+def _validate_moment_order(n) -> int:
+    """Return an integer trigonometric-moment order without coercing other scalars."""
+
+    try:
+        order = np.asarray(n)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("n must be a scalar integer") from exc
+    if order.ndim != 0 or order.dtype.kind not in "iu":
+        raise ValueError("n must be a scalar integer")
+    return int(order.item())
+
+
 class PiecewiseConstantDistribution(AbstractCircularDistribution):
     """Piecewise constant (i.e. discrete) circular distribution, similar to a histogram.
 
@@ -80,6 +112,7 @@ class PiecewiseConstantDistribution(AbstractCircularDistribution):
             Weight for each interval (will be normalized to form a valid pdf).
         """
         AbstractCircularDistribution.__init__(self)
+        _reject_complex_input(w, "Weights")
         w = array(w, dtype=float)
         if w.ndim == 0:
             w = w.reshape((1,))
@@ -111,6 +144,7 @@ class PiecewiseConstantDistribution(AbstractCircularDistribution):
         p : ndarray, shape (n,)
             Pdf values at each point.
         """
+        _reject_complex_input(xs, "xs")
         xs = array(xs, dtype=float)
         if xs.ndim == 0:
             xs = xs.reshape((1,))
@@ -143,6 +177,7 @@ class PiecewiseConstantDistribution(AbstractCircularDistribution):
             raise NotImplementedError(
                 "trigonometric_moment is not supported on the JAX backend."
             )
+        n = _validate_moment_order(n)
         if n == 0:
             return 1.0 + 0j
         num = len(self.w)

--- a/tests/distributions/test_piecewise_constant_input_validation.py
+++ b/tests/distributions/test_piecewise_constant_input_validation.py
@@ -1,0 +1,52 @@
+"""Regression tests for piecewise-constant input validation."""
+
+import numpy as np
+import pytest
+import pyrecest.backend
+
+from pyrecest.distributions.circle.piecewise_constant_distribution import (
+    PiecewiseConstantDistribution,
+)
+
+
+def test_piecewise_constant_distribution_rejects_complex_weights():
+    with pytest.raises(ValueError, match="Weights must contain real values"):
+        PiecewiseConstantDistribution(np.asarray([1.0 + 0.0j, 2.0 + 0.0j]))
+
+
+def test_piecewise_constant_pdf_rejects_complex_angles():
+    distribution = PiecewiseConstantDistribution([1.0, 2.0])
+
+    with pytest.raises(ValueError, match="xs must contain real values"):
+        distribution.pdf(np.asarray([0.0 + 1.0j]))
+
+
+@pytest.mark.skipif(
+    pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+    reason="Not supported on JAX backend",
+)
+@pytest.mark.parametrize(
+    "order",
+    [
+        1.5,
+        True,
+        "1",
+        np.asarray([1]),
+        np.timedelta64(1, "ns"),
+        np.asarray(1.0 + 0.0j),
+    ],
+)
+def test_piecewise_constant_moment_rejects_noninteger_orders(order):
+    distribution = PiecewiseConstantDistribution([1.0, 2.0])
+
+    with pytest.raises(ValueError, match="n must be a scalar integer"):
+        distribution.trigonometric_moment(order)
+
+
+def test_piecewise_constant_moment_accepts_numpy_integer_order():
+    if pyrecest.backend.__backend_name__ == "jax":  # pylint: disable=no-member
+        pytest.skip("Not supported on JAX backend")
+
+    distribution = PiecewiseConstantDistribution([1.0, 2.0])
+
+    assert np.isfinite(distribution.trigonometric_moment(np.int64(1)))


### PR DESCRIPTION
## Summary
- reject complex-valued weights before backend float conversion can silently discard their imaginary components
- reject complex-valued PDF evaluation angles for the same reason
- require trigonometric moment orders to be genuine scalar integer dtypes
- add focused regressions for lossy complex coercion and invalid moment orders

## Root cause
`PiecewiseConstantDistribution` converted weights and evaluation points directly with `array(..., dtype=float)`. NumPy-compatible backends can accept complex arrays here while discarding the imaginary component, producing a different real-valued distribution or evaluating it at altered points instead of rejecting invalid input.

`trigonometric_moment` also used its order directly in the analytical formula. Values such as `1.5`, booleans, text, temporal scalars, and non-scalar arrays were therefore accepted even though the API defines an integer moment order.

## Impact
Invalid complex inputs now fail before any lossy conversion. Integer orders, including NumPy integer scalars and negative orders, remain supported; JAX retains its existing `NotImplementedError` behavior for trigonometric moments.

## Validation
- `python -m py_compile` on the modified module and new regression test
- focused standalone checks for complex-input rejection, invalid moment-order rejection, and accepted NumPy/negative integer orders
- full repository/backend validation delegated to GitHub Actions