### PR TITLE
Reject lossy delayed-output step indices

### DIFF
--- a/src/pyrecest/smoothers/delayed_output.py
+++ b/src/pyrecest/smoothers/delayed_output.py
@@ -61,10 +61,9 @@ class DelayedStateOutputMixin:
     ) -> None:
         """Reset the delayed-output queue and emitted-step cursor."""
 
+        normalized_step = _as_step_index(last_emitted_step, "last_emitted_step")
         self._ready_queue: list[DelayedStateOutput] = []
-        self._last_emitted_step = _as_step_index(
-            last_emitted_step, "last_emitted_step"
-        )
+        self._last_emitted_step = normalized_step
 
     def _ensure_delayed_state_outputs_initialized(self) -> None:
         if not hasattr(self, "_ready_queue"):

--- a/src/pyrecest/smoothers/delayed_output.py
+++ b/src/pyrecest/smoothers/delayed_output.py
@@ -9,10 +9,34 @@ algorithm or state representation.
 
 from __future__ import annotations
 
+import operator
 from collections.abc import Callable
 from typing import Any, TypeAlias
 
 DelayedStateOutput: TypeAlias = tuple[int, Any]
+
+
+def _is_boolean_scalar(value: Any) -> bool:
+    """Return whether ``value`` is a native or backend boolean scalar."""
+
+    if isinstance(value, bool):
+        return True
+    dtype = getattr(value, "dtype", None)
+    if getattr(dtype, "kind", None) == "b":
+        return True
+    return str(dtype).lower() in {"bool", "bool_", "torch.bool"}
+
+
+def _as_step_index(value: Any, name: str) -> int:
+    """Normalize a genuine integer scalar without lossy coercion."""
+
+    message = f"{name} must be an integer"
+    if _is_boolean_scalar(value):
+        raise ValueError(message)
+    try:
+        return int(operator.index(value))
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
 
 
 class DelayedStateOutputMixin:
@@ -38,7 +62,9 @@ class DelayedStateOutputMixin:
         """Reset the delayed-output queue and emitted-step cursor."""
 
         self._ready_queue: list[DelayedStateOutput] = []
-        self._last_emitted_step = int(last_emitted_step)
+        self._last_emitted_step = _as_step_index(
+            last_emitted_step, "last_emitted_step"
+        )
 
     def _ensure_delayed_state_outputs_initialized(self) -> None:
         if not hasattr(self, "_ready_queue"):
@@ -61,7 +87,7 @@ class DelayedStateOutputMixin:
         """
 
         self._ensure_delayed_state_outputs_initialized()
-        step = int(step)
+        step = _as_step_index(step, "step")
         if step < 0 or step <= int(self._last_emitted_step):
             return False
         self._ready_queue.append((step, state))
@@ -89,7 +115,7 @@ class DelayedStateOutputMixin:
         """
 
         self._ensure_delayed_state_outputs_initialized()
-        current_step = int(current_step)
+        current_step = _as_step_index(current_step, "current_step")
         if current_step < 0:
             return self.pop_ready_states()
 

--- a/tests/smoothers/test_delayed_output.py
+++ b/tests/smoothers/test_delayed_output.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import numpy as np
+import pytest
+
 from pyrecest.smoothers import DelayedStateOutputMixin
 
 
@@ -53,3 +56,35 @@ def test_delayed_output_mixin_initializes_lazily() -> None:
     assert smoother._queue_delayed_state(0, "state")
     assert smoother.pop_ready_states() == [(0, "state")]
     assert smoother.last_emitted_step == 0
+
+
+@pytest.mark.parametrize(
+    "step",
+    [True, False, 1.5, "2", np.bool_(True), np.array(2.0)],
+)
+def test_delayed_output_queue_rejects_noninteger_steps(step) -> None:
+    smoother = _DummyDelayedOutputSmoother()
+
+    with pytest.raises(ValueError, match="step must be an integer"):
+        smoother._queue_delayed_state(step, "state")
+
+    assert smoother.pop_ready_states() == []
+    assert smoother.last_emitted_step == -1
+
+
+def test_delayed_output_cursor_arguments_require_integer_scalars() -> None:
+    smoother = _DummyDelayedOutputSmoother()
+
+    with pytest.raises(ValueError, match="last_emitted_step must be an integer"):
+        smoother._initialize_delayed_state_outputs(last_emitted_step=True)
+
+    with pytest.raises(ValueError, match="current_step must be an integer"):
+        smoother._finalize_delayed_state_outputs(1.5, lambda step: step)
+
+
+def test_delayed_output_accepts_numpy_integer_steps() -> None:
+    smoother = _DummyDelayedOutputSmoother()
+
+    assert smoother._queue_delayed_state(np.int64(2), "state")
+    assert smoother.pop_ready_states() == [(2, "state")]
+    assert smoother.last_emitted_step == 2


### PR DESCRIPTION
## Summary

- validate delayed-output step and cursor arguments with the integer index protocol instead of `int(...)`
- reject booleans, text, floating-point values, and backend boolean scalars before they can be reinterpreted as step indices
- preserve support for genuine integer scalars, including NumPy integer values
- validate initialization arguments before clearing an existing delayed-output queue
- add focused regression coverage

## Bug

`DelayedStateOutputMixin` normalized `last_emitted_step`, queued `step`, and finalization `current_step` with `int(...)`. That conversion is lossy and accepts values outside the documented integer contract. For example:

- `True` becomes step `1`
- `"2"` becomes step `2`
- `1.5` becomes step `1`

A malformed caller value could therefore queue a state under the wrong index, advance the emitted-step cursor, and suppress a later legitimate output as a duplicate or stale state.

## Fix

Use `operator.index(...)` for genuine integer scalars and explicitly reject native/backend boolean scalar dtypes. The same validator is applied consistently to initialization, queueing, and finalization. Initialization validates first so a rejected cursor does not clear existing queued outputs.

## Validation

- `python -m py_compile` on the modified module and regression test
- isolated delayed-output test run: `12 passed`
- connector comparison confirms the branch is three commits ahead of current `main`, zero behind, and changes only the mixin plus its focused test file

Full repository and backend-matrix validation is delegated to GitHub Actions because this runtime cannot resolve GitHub for a local checkout and does not provide the GitHub CLI.