### PR TITLE
Handle zero-norm SE2 sigma rotations

### DIFF
--- a/src/pyrecest/filters/se2_ukf.py
+++ b/src/pyrecest/filters/se2_ukf.py
@@ -29,6 +29,7 @@ from pyrecest.backend import (
     mean,
     transpose,
     vstack,
+    where,
     zeros,
 )
 from pyrecest.distributions import GaussianDistribution
@@ -44,6 +45,25 @@ def _to_python_bool(value):
     if hasattr(value, "item"):
         return bool(value.item())
     return bool(value)
+
+
+def _normalize_rotation_columns(rotation_samples, fallback_rotation):
+    """Normalize 2-D rotation columns, replacing undefined zero directions."""
+    rotation_samples = asarray(rotation_samples)
+    fallback_rotation = asarray(fallback_rotation)
+    norms = linalg.norm(rotation_samples, axis=0)
+    zero_norms = isclose(norms, 0.0)
+    safe_norms = where(zero_norms, 1.0, norms)
+    normalized = rotation_samples / safe_norms[None, :]
+    return where(zero_norms[None, :], fallback_rotation[:, None], normalized)
+
+
+def _normalize_rotation_vector(rotation, fallback_rotation):
+    """Normalize one rotation vector with a unit fallback for zero norm."""
+    normalized = _normalize_rotation_columns(
+        asarray(rotation)[:, None], fallback_rotation
+    )
+    return normalized[:, 0]
 
 
 def _validate_se2_gaussian(distribution, role):
@@ -211,10 +231,15 @@ class SE2UKF(AbstractFilter, SE2FilterMixin):
             cols.append(mu - 2.0 * L[:, k])
         state_samples = column_stack(cols)  # 4×9
 
-        # Normalise rotation part of state sigma points.
-        norms = linalg.norm(state_samples[0:2, :], axis=0)
+        # Normalise rotation part of state sigma points.  A sigma point can land
+        # exactly at the embedding origin, where its rotational direction is
+        # undefined; retain the nominal unit rotation in that case.
         state_samples = concatenate(
-            [state_samples[0:2, :] / norms[None, :], state_samples[2:, :]], axis=0
+            [
+                _normalize_rotation_columns(state_samples[0:2, :], mu[0:2]),
+                state_samples[2:, :],
+            ],
+            axis=0,
         )
 
         # --- Noise sigma points: [mu_sys, mu_sys ± L_n[:,k]] for k=0..3 (9 pts) ---
@@ -226,10 +251,13 @@ class SE2UKF(AbstractFilter, SE2FilterMixin):
             n_cols.append(mu_sys - L_n[:, k])
         noise_samples = column_stack(n_cols)  # 4×9
 
-        # Normalise rotation part of noise sigma points.
-        norms = linalg.norm(noise_samples[0:2, :], axis=0)
+        # Normalise rotation part of noise sigma points with the same fallback.
         noise_samples = concatenate(
-            [noise_samples[0:2, :] / norms[None, :], noise_samples[2:, :]], axis=0
+            [
+                _normalize_rotation_columns(noise_samples[0:2, :], mu_sys[0:2]),
+                noise_samples[2:, :],
+            ],
+            axis=0,
         )
 
         # --- Predicted samples: all 81 = 9×9 state [⊕] noise combinations ---
@@ -246,7 +274,16 @@ class SE2UKF(AbstractFilter, SE2FilterMixin):
         # E[x x^T].  GaussianDistribution.C is used elsewhere as a covariance,
         # so it must be centered around the stored mean.
         new_mu = mean(pred_samples, axis=1)
-        new_mu = concatenate([new_mu[0:2] / linalg.norm(new_mu[0:2]), new_mu[2:]])
+        nominal_prediction = _dual_quaternion_multiply(mu, mu_sys)
+        new_mu = concatenate(
+            [
+                _normalize_rotation_vector(
+                    new_mu[0:2],
+                    nominal_prediction[0:2],
+                ),
+                new_mu[2:],
+            ]
+        )
 
         deviations = pred_samples - new_mu[:, None]
         CP = deviations @ deviations.T / pred_samples.shape[1]
@@ -299,7 +336,7 @@ class SE2UKF(AbstractFilter, SE2FilterMixin):
             axis=0,
         )  # 8×8
 
-        # --- Augmented sigma points: [x_aug, x_aug ± L_aug[:,k]] for k=0..7 (17 pts) ---
+        # --- Augmented sigma points: x_aug and x_aug ± L_aug[:, k] (17 pts) ---
         L_aug = linalg.cholesky(8.0 * C_aug)  # 8×8
         aug_cols = [x_aug]
         for k in range(8):
@@ -309,16 +346,18 @@ class SE2UKF(AbstractFilter, SE2FilterMixin):
         aug_samples = column_stack(aug_cols)  # 8×17
 
         # Normalise rotation part of state sigma points (rows 0–1).
-        norms = linalg.norm(aug_samples[0:2, :], axis=0)
         aug_samples = concatenate(
-            [aug_samples[0:2, :] / norms[None, :], aug_samples[2:, :]], axis=0
+            [
+                _normalize_rotation_columns(aug_samples[0:2, :], mu[0:2]),
+                aug_samples[2:, :],
+            ],
+            axis=0,
         )
 
         # Extract and normalise the noise-rotation part (rows 4–5).
-        noise_rot = aug_samples[4:6, :]
-        norms_n = linalg.norm(noise_rot, axis=0)
+        noise_rot = _normalize_rotation_columns(aug_samples[4:6, :], mu_meas[0:2])
         # Build the full normalised noise vectors (4-D each column).
-        norm_noise = vstack([noise_rot / norms_n[None, :], aug_samples[6:8, :]])  # 4×17
+        norm_noise = vstack([noise_rot, aug_samples[6:8, :]])  # 4×17
 
         # --- Apply measurement function: z_i = state_i [⊕] noise_i ---
         meas_cols = []
@@ -348,7 +387,12 @@ class SE2UKF(AbstractFilter, SE2FilterMixin):
         new_C = (new_C + new_C.T) / 2.0  # symmetrise
 
         # Renormalise rotation part of the mean.
-        new_mu = concatenate([new_mu[0:2] / linalg.norm(new_mu[0:2]), new_mu[2:]])
+        new_mu = concatenate(
+            [
+                _normalize_rotation_vector(new_mu[0:2], mu[0:2]),
+                new_mu[2:],
+            ]
+        )
 
         self._filter_state = GaussianDistribution(array(new_mu), array(new_C))
 

--- a/tests/filters/test_se2_ukf_zero_norm_sigma_points.py
+++ b/tests/filters/test_se2_ukf_zero_norm_sigma_points.py
@@ -1,0 +1,51 @@
+"""Regression tests for zero-norm SE(2) sigma-point rotations."""
+
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+import pyrecest.backend
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array, eye, to_numpy
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.filters.se2_ukf import SE2UKF
+
+
+_IDENTITY = array([1.0, 0.0, 0.0, 0.0])
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ == "jax",
+    reason="Not supported on JAX backend",
+)
+class TestSE2UKFZeroNormSigmaPoints(unittest.TestCase):
+    def assert_finite_normalized_state(self, filter_):
+        state = filter_.filter_state
+        mean = np.asarray(to_numpy(state.mu), dtype=float)
+        covariance = np.asarray(to_numpy(state.C), dtype=float)
+
+        self.assertTrue(np.isfinite(mean).all())
+        self.assertTrue(np.isfinite(covariance).all())
+        npt.assert_allclose(np.linalg.norm(mean[0:2]), 1.0, atol=1e-10)
+
+    def test_prediction_handles_zero_norm_state_and_noise_sigma_points(self):
+        filter_ = SE2UKF()
+        process = GaussianDistribution(_IDENTITY, eye(4) * 0.25)
+
+        filter_.predict_identity(process)
+
+        self.assert_finite_normalized_state(filter_)
+
+    def test_update_handles_zero_norm_state_and_noise_sigma_points(self):
+        filter_ = SE2UKF()
+        filter_.filter_state = GaussianDistribution(_IDENTITY, eye(4) * 0.125)
+        measurement_noise = GaussianDistribution(_IDENTITY, eye(4) * 0.125)
+
+        filter_.update_identity(measurement_noise, _IDENTITY)
+
+        self.assert_finite_normalized_state(filter_)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- normalize SE(2) state and noise rotation sigma points without dividing by zero
- use the validated nominal unit rotation when a sigma point lands at the embedding origin
- guard predicted and updated mean normalization with the same fallback
- add regressions for prediction and update at exact zero-norm boundary covariances

## Root cause

`SE2UKF` normalized every two-component rotation sigma point directly by its norm. The default state covariance has rotational variance `0.25`; with the prediction construction `mu ± 2 L[:, k]`, one state sigma point is exactly `[0, 0]`. Dividing by its norm injects non-finite values before propagation. Exact zero directions can likewise occur in process-noise and augmented measurement sigma sets.

## Impact

Calling `predict_identity()` on a newly constructed `SE2UKF` can fail or produce non-finite state values even with a valid identity process distribution. Boundary covariance values in the update path have the same failure mode.

## Validation

- reproduced the default-state zero-norm sigma point deterministically
- `python -m py_compile` passed for the modified source and regression test
- standalone numerical checks produced finite, normalized states for the exact prediction and update boundary cases
- branch is two commits ahead of current `main`, zero behind, and changes only the SE(2) UKF plus one focused regression file
- full backend and repository validation is delegated to GitHub Actions