### PR TITLE
Fix evaluation reload wrapper recursion

### DIFF
--- a/src/pyrecest/evaluation/__init__.py
+++ b/src/pyrecest/evaluation/__init__.py
@@ -71,8 +71,28 @@ from .selection import (
 from .simulation_database import simulation_database
 from .summarize_filter_results import summarize_filter_results
 
-_original_classify_evidence_margin = classify_evidence_margin
-_original_paired_model_margin_decisions = paired_model_margin_decisions
+_ORIGINAL_CLASSIFIER_ATTR = "_pyrecest_original_classify_evidence_margin"
+_ORIGINAL_DECISIONS_ATTR = "_pyrecest_original_paired_model_margin_decisions"
+
+if not hasattr(_model_comparison, _ORIGINAL_CLASSIFIER_ATTR):
+    setattr(
+        _model_comparison,
+        _ORIGINAL_CLASSIFIER_ATTR,
+        classify_evidence_margin,
+    )
+if not hasattr(_model_comparison, _ORIGINAL_DECISIONS_ATTR):
+    setattr(
+        _model_comparison,
+        _ORIGINAL_DECISIONS_ATTR,
+        paired_model_margin_decisions,
+    )
+
+_original_classify_evidence_margin = getattr(
+    _model_comparison, _ORIGINAL_CLASSIFIER_ATTR
+)
+_original_paired_model_margin_decisions = getattr(
+    _model_comparison, _ORIGINAL_DECISIONS_ATTR
+)
 
 
 def _classify_evidence_margin(delta_log_evidence: float) -> str:

--- a/tests/test_evaluation_reload.py
+++ b/tests/test_evaluation_reload.py
@@ -1,0 +1,22 @@
+import importlib
+
+import pandas as pd
+
+import pyrecest.evaluation as evaluation
+
+
+def test_model_comparison_hotfixes_are_reload_idempotent():
+    module = evaluation
+
+    for _ in range(2):
+        module = importlib.reload(module)
+
+        assert module.classify_evidence_margin(2.0) == "weak"
+        assert module.classify_evidence_margin(float("inf")) == "decisive"
+
+        decisions = module.paired_model_margin_decisions(
+            pd.DataFrame(),
+            positive_model="positive",
+            reference_model="reference",
+        )
+        assert decisions.empty


### PR DESCRIPTION
## Summary
- preserve the original model-comparison callables on their defining module before installing package-level compatibility wrappers
- make repeated `importlib.reload(pyrecest.evaluation)` operations idempotent
- add a regression that reloads the package twice and exercises both patched APIs after each reload

## Bug
`pyrecest.evaluation` installs compatibility wrappers for `classify_evidence_margin` and `paired_model_margin_decisions`. On reload, the import statements retrieve the wrappers already installed on `model_comparison`, then assign those wrappers as the new `_original_*` callables.

Because functions created by the previous import share the reloaded module's global dictionary, the old wrapper subsequently resolves `_original_*` to itself. Calling either patched API after one reload therefore recurses until Python raises `RecursionError`.

## Fix
Store the true original callables once on `model_comparison` under private sentinel attributes. Every initial import or reload builds the public wrappers against those stable originals instead of against a prior wrapper.

## Validation
- `python -m py_compile` passed for the modified package initializer and new regression test
- isolated reproduction confirms the previous reload pattern raises `RecursionError`
- isolated sentinel-backed reload model remains callable across repeated reloads
- branch is two commits ahead of current `main`, zero behind, and changes only the package initializer plus one focused regression

Full repository and backend-matrix validation is delegated to GitHub Actions because the execution environment has no authenticated `gh` CLI or network-capable checkout.