### PR TITLE
Reject temporal Metropolis-Hastings count parameters

### DIFF
--- a/src/pyrecest/distributions/abstract_manifold_specific_distribution.py
+++ b/src/pyrecest/distributions/abstract_manifold_specific_distribution.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from numbers import Integral, Number
 from typing import Union
 
+import numpy as np
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member,redefined-builtin
@@ -13,6 +14,8 @@ from pyrecest.backend import empty, int32, int64, log, random, squeeze
 _SCALAR_VALUE_ERROR = (
     "Metropolis-Hastings scalar evaluations must return scalar values."
 )
+_TEMPORAL_SCALAR_TYPES = (np.datetime64, np.timedelta64)
+_TEMPORAL_DTYPE_KINDS = {"M", "m"}
 
 
 def _shape_size(value) -> int | None:
@@ -70,6 +73,10 @@ def _validate_integer_sample_parameter(value, name: str, minimum: int) -> int:
         if shape_tuple != ():
             raise ValueError(f"{name} must be a scalar integer")
 
+    dtype = getattr(value, "dtype", None)
+    if getattr(dtype, "kind", None) in _TEMPORAL_DTYPE_KINDS:
+        raise ValueError(f"{name} must be an integer")
+
     try:
         scalar = value.item()
     except AttributeError:
@@ -77,6 +84,8 @@ def _validate_integer_sample_parameter(value, name: str, minimum: int) -> int:
     except (TypeError, ValueError, RuntimeError) as exc:
         raise ValueError(f"{name} must be a scalar integer") from exc
 
+    if isinstance(scalar, _TEMPORAL_SCALAR_TYPES):
+        raise ValueError(f"{name} must be an integer")
     if isinstance(scalar, bool):
         raise ValueError(f"{name} must be an integer, not a boolean")
 

--- a/tests/distributions/test_abstract_manifold_specific_distribution.py
+++ b/tests/distributions/test_abstract_manifold_specific_distribution.py
@@ -125,13 +125,18 @@ class AbstractManifoldSpecificDistributionTest(unittest.TestCase):
             {"n": np.array([1])},
             {"n": array([1])},
             {"n": "1"},
+            {"n": np.timedelta64(1, "ns")},
+            {"n": np.datetime64("1970-01-01T00:00:00.000000001")},
+            {"n": np.array(np.timedelta64(1, "ns"), dtype=object)},
             {"burn_in": -1},
             {"burn_in": False},
             {"burn_in": np.array([0])},
+            {"burn_in": np.timedelta64(0, "ns")},
             {"skipping": 0},
             {"skipping": 1.5},
             {"skipping": True},
             {"skipping": "1"},
+            {"skipping": np.timedelta64(1, "ns")},
         )
 
         for overrides in invalid_parameters:


### PR DESCRIPTION
## Summary
- reject NumPy `datetime64` and `timedelta64` values used as Metropolis–Hastings `n`, `burn_in`, or `skipping`
- validate temporal dtypes before `.item()` can expose nanosecond integer payloads
- reject object-wrapped temporal scalars as well
- extend the existing public sampler regression coverage

## Bug
The shared Metropolis–Hastings count validator unwraps scalar values with `.item()` before checking their numeric type. For nanosecond-resolution NumPy temporal scalars, `.item()` returns the raw integer payload. Values such as `np.timedelta64(1, "ns")` and `np.datetime64("1970-01-01T00:00:00.000000001")` were therefore accepted as the count `1` rather than rejected as non-integer controls. Object-wrapped `np.timedelta64` values could also pass through `numbers.Integral`.

## Fix
Reject native temporal dtype kinds before scalar unwrapping, then reject temporal scalar objects after unwrapping to cover object arrays. Genuine integer and integer-valued numeric scalar inputs retain their existing behavior.

## Validation
- branch is two commits ahead of current `main` and zero behind
- diff is limited to nine source lines and five focused regression cases
- isolated checks confirm temporal scalar forms are rejected while Python integers, NumPy integers, and scalar integer-valued arrays remain accepted
- full repository testing is delegated to GitHub Actions because the execution environment could not resolve `github.com` for a local checkout