### PR TITLE
Guard Sylvester shortcut against inaccurate close factors

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/linalg.py
+++ b/src/pyrecest/_backend/_shared_numpy/linalg.py
@@ -4,6 +4,7 @@ from ._dispatch import scipy as _scipy
 
 _to_ndarray = _common.to_ndarray
 atol = _common.atol
+rtol = _common.rtol
 
 
 def _transpose(array):
@@ -57,8 +58,12 @@ def _is_hermitian(x, tol=atol):
     return (_np.abs(x - _adjoint(x)) < tol).all()
 
 
-_diag_vec = _np.vectorize(_np.diag, signature="(n)->(n,n)")
+def _sylvester_candidate_is_accurate(a, b, q, candidate):
+    residual_target = a @ candidate + candidate @ b
+    return _np.all(_np.isclose(residual_target, q, atol=atol, rtol=rtol))
 
+
+_diag_vec = _np.vectorize(_np.diag, signature="(n)->(n,n)")
 _logm_vec = _np.vectorize(_scipy.linalg.logm, signature="(n,m)->(n,m)")
 
 
@@ -92,7 +97,9 @@ def solve_sylvester(a, b, q, tol=atol):
                 adjoint_eigvecs = _adjoint(eigvecs)
                 tilde_q = adjoint_eigvecs @ q @ eigvecs
                 tilde_x = tilde_q / (eigvals[..., :, None] + eigvals[..., None, :])
-                return eigvecs @ tilde_x @ adjoint_eigvecs
+                candidate = eigvecs @ tilde_x @ adjoint_eigvecs
+                if _sylvester_candidate_is_accurate(a, b, q, candidate):
+                    return candidate
 
     return _np.vectorize(
         _scipy.linalg.solve_sylvester, signature="(m,m),(n,n),(m,n)->(m,n)"
@@ -167,7 +174,6 @@ def solve(a, b):
 
     Computes the "exact" solution, `x`, of the well-determined, i.e., full
     rank, linear matrix equation `ax = b`.
-
     Parameters
     ----------
     a : array-like, shape=[..., M, M]

--- a/src/pyrecest/_backend/_shared_numpy/linalg.py
+++ b/src/pyrecest/_backend/_shared_numpy/linalg.py
@@ -174,6 +174,7 @@ def solve(a, b):
 
     Computes the "exact" solution, `x`, of the well-determined, i.e., full
     rank, linear matrix equation `ax = b`.
+
     Parameters
     ----------
     a : array-like, shape=[..., M, M]

--- a/tests/test_sylvester_shortcut_residual.py
+++ b/tests/test_sylvester_shortcut_residual.py
@@ -1,0 +1,20 @@
+import numpy as np
+import numpy.testing as npt
+
+from pyrecest._backend import numpy as numpy_backend
+
+
+def test_numpy_sylvester_falls_back_when_close_factor_shortcut_is_inaccurate():
+    a = np.diag([1e-8, 1.0])
+    b = np.diag([2e-8, 1.0])
+    q = np.eye(2)
+
+    # The shortcut's approximate shared-factor check accepts this pair, but
+    # replacing b by a changes the first solution entry by 50 percent.
+    assert np.all(np.isclose(a, b))
+
+    x = numpy_backend.linalg.solve_sylvester(a, b, q)
+
+    residual = a @ x + x @ b - q
+    npt.assert_allclose(residual, np.zeros_like(q), atol=1e-12)
+    npt.assert_allclose(x[0, 0], 1.0 / 3e-8, rtol=1e-12)


### PR DESCRIPTION
## Summary
- verify the shared NumPy Sylvester shortcut against the original equation before returning it
- fall back to SciPy when treating approximately equal factors as identical produces an inaccurate solution
- add a deterministic ill-conditioned regression

## Bug
`solve_sylvester(a, b, q)` uses an eigendecomposition shortcut when `a` and `b` are merely `isclose`. The shortcut then solves `a x + x a = q`, although the requested equation is `a x + x b = q`.

For well-conditioned factors the approximation can be harmless, but near the positivity threshold it can be large. With

```text
a = diag(1e-8, 1)
b = diag(2e-8, 1)
q = I
```

`a` and `b` pass the existing approximate equality check. The old shortcut returns `x[0,0] = 5e7` instead of `1/(3e-8)`, leaving a Sylvester residual norm of `0.5`.

## Fix
Retain the shortcut, but substitute its candidate into the original equation. Return it only when the left-hand side matches `q` at the backend tolerances; otherwise use the existing vectorized SciPy fallback.

## Validation
- standalone focused regression passed
- old shortcut reproduced a residual norm of `0.5`
- corrected path produces a zero residual and the analytical sensitive component `1/(3e-8)`
- branch is three commits ahead of current `main`, zero behind
- diff is limited to the shared NumPy linalg implementation and one focused test

Full repository/backend-matrix validation is delegated to GitHub Actions because this runtime cannot clone GitHub over DNS.