### PR TITLE
Reject complex sparse-grid weights

### DIFF
--- a/src/pyrecest/filters/sparse_second_order_grid.py
+++ b/src/pyrecest/filters/sparse_second_order_grid.py
@@ -29,6 +29,7 @@ SparsePairTransitionRowBuilder = Callable[
 SparsePairTransitionCacheKeyBuilder = Callable[[int, int, int], Hashable | None]
 _TEXT_TYPES = (str, bytes, bytearray, np.str_, np.bytes_)
 _BOOLEAN_TYPES = (bool, np.bool_)
+_COMPLEX_TYPES = (complex, np.complexfloating)
 
 
 @dataclass(frozen=True)
@@ -383,8 +384,10 @@ def _contains_values_of_type(value: Any, types: tuple[type, ...]) -> bool:
 
 def _coerce_real_weight_array(values: Any, message_prefix: str) -> np.ndarray:
     message = f"{message_prefix} must be finite and nonnegative"
-    if _contains_values_of_type(values, _TEXT_TYPES) or _contains_values_of_type(
-        values, _BOOLEAN_TYPES
+    if (
+        _contains_values_of_type(values, _TEXT_TYPES)
+        or _contains_values_of_type(values, _BOOLEAN_TYPES)
+        or _contains_values_of_type(values, _COMPLEX_TYPES)
     ):
         raise ValueError(message)
     try:

--- a/tests/test_sparse_second_order_grid_weight_validation.py
+++ b/tests/test_sparse_second_order_grid_weight_validation.py
@@ -57,3 +57,29 @@ def test_sparse_second_order_grid_rejects_text_transition_row_weights():
 
     with pytest.raises(ValueError, match="transition row weights"):
         sparse_second_order_grid_evidence(np.zeros((3, 2)), init, row)
+
+
+def test_sparse_second_order_grid_rejects_complex_initial_pair_weights():
+    def init(scaled):
+        del scaled
+        return np.array([0]), np.array([0]), np.array([1.0 + 2.0j]), [1]
+
+    def row(prev, curr, transition_index):
+        del prev, curr, transition_index
+        return np.array([0]), np.array([1.0])
+
+    with pytest.raises(ValueError, match="initial pair weights"):
+        sparse_second_order_grid_evidence(np.zeros((3, 2)), init, row)
+
+
+def test_sparse_second_order_grid_rejects_complex_transition_row_weights():
+    def init(scaled):
+        del scaled
+        return np.array([0]), np.array([0]), np.array([1.0]), [1]
+
+    def row(prev, curr, transition_index):
+        del prev, curr, transition_index
+        return np.array([0]), np.array([1.0 + 2.0j])
+
+    with pytest.raises(ValueError, match="transition row weights"):
+        sparse_second_order_grid_evidence(np.zeros((3, 2)), init, row)


### PR DESCRIPTION
## Summary
- reject complex-valued initial-pair weights before float conversion
- reject complex-valued sparse transition-row weights before normalization
- add focused regressions for both paths

## Bug
`_coerce_real_weight_array` rejected text and boolean values, but then passed complex arrays to `np.asarray(..., dtype=float)`. NumPy accepts that conversion with a warning and discards the imaginary component. Initial pair masses and transition probabilities could therefore be silently altered instead of rejected.

## Fix
Treat Python and NumPy complex scalars as invalid weight values before the float cast. This preserves the existing finite, nonnegative real-weight contract without changing valid inputs.

## Validation
- reproduced the current silent real-part conversion for both initial and transition weights
- verified the patched paths raise `ValueError`
- `python -m py_compile` passed for the modified source and regression test
- branch is two commits ahead of current `main`, zero behind, and changes only the sparse-grid implementation plus its focused weight-validation test

Full repository and backend-matrix validation is delegated to GitHub Actions.