### PR TITLE
Reject invalid PyTorch searchsorted sorters

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_reduction_axis_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_reduction_axis_contract.py
@@ -6,6 +6,9 @@ from operator import index as _operator_index
 
 import numpy as np
 
+from pyrecest.backend_support._pytorch_searchsorted_sorter_contract import (
+    patch_pytorch_searchsorted_sorter_contract as _patch_pytorch_searchsorted_sorter_contract,
+)
 from pyrecest.backend_support._pytorch_split_index_contract import (
     patch_pytorch_split_index_contract as _patch_pytorch_split_index_contract,
 )
@@ -120,6 +123,7 @@ def _wrap_boolean_axis_dim_reduction(helper, torch_module):
 def patch_pytorch_reduction_axis_contract() -> None:
     """Make raw/public PyTorch reduction helpers reject boolean axes."""
 
+    _patch_pytorch_searchsorted_sorter_contract()
     _patch_pytorch_split_index_contract()
 
     try:

--- a/src/pyrecest/backend_support/_pytorch_searchsorted_sorter_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_searchsorted_sorter_contract.py
@@ -1,0 +1,103 @@
+"""Runtime validation for PyTorch ``searchsorted`` sorter arrays."""
+
+from __future__ import annotations
+
+from pyrecest._backend_runtime_patches import (
+    patch_pytorch_searchsorted_contract as _patch_pytorch_searchsorted_contract,
+)
+
+_SORTER_TYPE_MESSAGE = "sorter must only contain integers"
+_SORTER_SHAPE_MESSAGE = "could not parse sorter argument"
+
+
+def _validate_sorter(sorter, numpy_module, torch_module) -> None:
+    """Reject sorter values that NumPy does not accept as integer indices."""
+
+    if sorter is None:
+        return
+
+    if torch_module.is_tensor(sorter):
+        if sorter.ndim != 1:
+            raise TypeError(_SORTER_SHAPE_MESSAGE)
+        if (
+            sorter.dtype == torch_module.bool
+            or sorter.dtype.is_floating_point
+            or sorter.dtype.is_complex
+            or str(sorter.dtype) == "torch.uint64"
+        ):
+            raise TypeError(_SORTER_TYPE_MESSAGE)
+        return
+
+    try:
+        sorter_array = numpy_module.asarray(sorter)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise TypeError(_SORTER_SHAPE_MESSAGE) from exc
+
+    if sorter_array.ndim != 1:
+        raise TypeError(_SORTER_SHAPE_MESSAGE)
+    if not numpy_module.can_cast(
+        sorter_array.dtype,
+        numpy_module.dtype(numpy_module.intp),
+        casting="safe",
+    ):
+        raise TypeError(_SORTER_TYPE_MESSAGE)
+
+
+def patch_pytorch_searchsorted_sorter_contract() -> None:
+    """Prevent lossy coercion of PyTorch ``searchsorted`` sorter arrays."""
+
+    _patch_pytorch_searchsorted_contract()
+
+    try:
+        import numpy as np  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch may be unavailable
+        return
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+    original_searchsorted = getattr(raw_pytorch, "searchsorted", None)
+    if original_searchsorted is None:
+        return
+    if getattr(
+        original_searchsorted,
+        "_pyrecest_searchsorted_sorter_contract",
+        False,
+    ):
+        if active_pytorch_backend:
+            backend.searchsorted = original_searchsorted
+        return
+
+    def searchsorted(
+        a,
+        v,
+        side="left",
+        sorter=None,
+        *,
+        out=None,
+        right=False,
+        out_int32=False,
+    ):
+        _validate_sorter(sorter, np, torch)
+        return original_searchsorted(
+            a,
+            v,
+            side=side,
+            sorter=sorter,
+            out=out,
+            right=right,
+            out_int32=out_int32,
+        )
+
+    searchsorted.__name__ = getattr(
+        original_searchsorted,
+        "__name__",
+        "searchsorted",
+    )
+    searchsorted.__doc__ = getattr(original_searchsorted, "__doc__", None)
+    searchsorted._pyrecest_searchsorted_contract = True
+    searchsorted._pyrecest_searchsorted_sorter_contract = True
+    raw_pytorch.searchsorted = searchsorted
+    if active_pytorch_backend:
+        backend.searchsorted = searchsorted

--- a/src/pyrecest/backend_support/_pytorch_searchsorted_sorter_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_searchsorted_sorter_contract.py
@@ -35,7 +35,7 @@ def _validate_sorter(sorter, numpy_module, torch_module) -> None:
 
     if sorter_array.ndim != 1:
         raise TypeError(_SORTER_SHAPE_MESSAGE)
-    if not numpy_module.can_cast(
+    if numpy_module.issubdtype(sorter_array.dtype, numpy_module.bool_) or not numpy_module.can_cast(
         sorter_array.dtype,
         numpy_module.dtype(numpy_module.intp),
         casting="safe",

--- a/tests/backend_support/test_pytorch_searchsorted_sorter_contract.py
+++ b/tests/backend_support/test_pytorch_searchsorted_sorter_contract.py
@@ -1,0 +1,73 @@
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+pytestmark = pytest.mark.backend_portable
+
+
+def _searchsorted_sorter_validation_code(target_module):
+    return f"""
+import numpy as np
+import torch
+import pyrecest.evidence  # noqa: F401 ensure runtime backend patches are installed
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+target = {target_module}
+boundaries = [3.0, 1.0, 5.0]
+values = [2.0]
+
+invalid_sorters = (
+    [1.0, 0.0, 2.0],
+    [1.5, 0.0, 2.0],
+    [True, False, True],
+    np.asarray([1, 0, 2], dtype=object),
+    np.asarray([1, 0, 2], dtype=np.uint64),
+    np.asarray([[1, 0, 2]]),
+    torch.tensor([1.0, 0.0, 2.0]),
+    torch.tensor([True, False, True]),
+)
+for sorter in invalid_sorters:
+    try:
+        target.searchsorted(boundaries, values, sorter=sorter)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError(f"accepted invalid sorter {{sorter!r}}")
+
+valid = target.searchsorted(
+    boundaries,
+    values,
+    sorter=np.asarray([1, 0, 2], dtype=np.uint8),
+)
+assert target.to_numpy(valid).tolist() == [1]
+print("ok")
+"""
+
+
+def test_raw_pytorch_searchsorted_rejects_invalid_sorters_with_numpy_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "numpy",
+        _searchsorted_sorter_validation_code("raw_pytorch"),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_public_pytorch_searchsorted_rejects_invalid_sorters():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        _searchsorted_sorter_validation_code("backend"),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary
- validate PyTorch `searchsorted` sorter arrays before conversion to `torch.long`
- reject floating-point, boolean, object, unsafe unsigned, and non-1-D sorters
- preserve safe integer sorter arrays
- cover both the raw PyTorch module and the public PyTorch backend facade

## Bug
The runtime PyTorch `searchsorted` facade converted every supplied `sorter` to `torch.long`. This silently truncated floating-point values and reinterpreted booleans as integer indices, whereas NumPy rejects those sorter inputs. A malformed sorter could therefore execute with a different permutation instead of failing.

## Fix
Install an idempotent validation wrapper after the existing `searchsorted` compatibility patch. It checks dimensionality and requires a safely castable, non-boolean integer dtype before delegating to the existing device-aware implementation.

## Validation
- reproduced the old lossy float and boolean conversion against current `main`
- confirmed NumPy rejects the same sorter inputs
- standalone NumPy/PyTorch validation probe passes after the fix
- focused backend-portable regressions cover raw and public facades, plus a valid unsigned-integer sorter
- branch is four commits ahead of current `main` and zero behind

A full repository/backend matrix run is delegated to GitHub Actions because the local execution environment could not resolve `github.com` for a checkout.