### PR TITLE
Validate circular weighted-mean inputs

### DIFF
--- a/src/pyrecest/filters/relaxed_s3f_circular.py
+++ b/src/pyrecest/filters/relaxed_s3f_circular.py
@@ -246,7 +246,13 @@ def circular_weighted_mean(angles: Any, weights: Any) -> float:
     """Return the circular mean angle for weighted grid values."""
 
     angles = asarray(angles, dtype=float).reshape(-1)
+    if not bool(all(isfinite(angles))):
+        raise ValueError("angles must be finite.")
+
     weights = grid_probability_masses(weights)
+    if angles.shape != weights.shape:
+        raise ValueError("angles and weights must contain the same number of entries.")
+
     moment = backend_sum(weights * exp(1j * angles))
     return float(mod(backend_angle(moment), 2.0 * pi))
 

--- a/tests/filters/test_relaxed_s3f_circular_weighted_mean_validation.py
+++ b/tests/filters/test_relaxed_s3f_circular_weighted_mean_validation.py
@@ -1,0 +1,37 @@
+import math
+import unittest
+
+from pyrecest.backend import array
+from pyrecest.filters.relaxed_s3f_circular import circular_weighted_mean
+
+
+class CircularWeightedMeanValidationTest(unittest.TestCase):
+    def test_rejects_mismatched_angle_and_weight_counts(self):
+        invalid_cases = [
+            (array([0.7]), array([0.2, 0.8])),
+            (array([0.0, 1.0]), array([1.0])),
+        ]
+
+        for angles, weights in invalid_cases:
+            with self.subTest(angles=angles, weights=weights):
+                with self.assertRaisesRegex(ValueError, "same number"):
+                    circular_weighted_mean(angles, weights)
+
+    def test_rejects_nonfinite_angles(self):
+        for invalid_angle in (float("nan"), float("inf"), -float("inf")):
+            with self.subTest(invalid_angle=invalid_angle):
+                with self.assertRaisesRegex(ValueError, "angles must be finite"):
+                    circular_weighted_mean(
+                        array([0.0, invalid_angle]), array([0.5, 0.5])
+                    )
+
+    def test_valid_inputs_are_unchanged(self):
+        mean_angle = circular_weighted_mean(
+            array([0.0, 0.5 * math.pi]), array([0.5, 0.5])
+        )
+
+        self.assertAlmostEqual(mean_angle, 0.25 * math.pi)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- require one weight for every angle in `circular_weighted_mean`
- reject non-finite angle values before evaluating the complex moment
- add focused regressions for singleton broadcasting, non-finite angles, and a valid reference mean

## Bug
`circular_weighted_mean` normalized weights and multiplied them by the angle phasors without checking that the two vectors had the same length. NumPy-style broadcasting therefore silently accepted malformed inputs whenever either vector had length one. For example, one angle paired with two weights returned that angle as a plausible estimate instead of reporting that the second weight had no corresponding grid point.

The function also accepted non-finite angles and returned `NaN`, despite the neighboring grid-mass helper explicitly validating its inputs.

## Fix
Validate that all angles are finite and that the flattened angle and normalized-weight arrays have identical shapes before computing the weighted trigonometric moment.

## Impact
Malformed grid summaries now fail fast instead of producing a silently broadcast circular estimate. Valid equal-length inputs retain their existing result.

## Validation
- reproduced the old singleton-broadcast result (`[0.7]` with weights `[0.2, 0.8]` returned `0.7`)
- reproduced non-finite angle propagation to `NaN`
- standalone focused regression run: `3 passed`
- `python -m py_compile` passed for the focused regression harness
- branch is two commits ahead of current `main`, zero behind, and changes only the helper plus one regression file

A full repository/backend matrix run is delegated to GitHub Actions because this execution environment cannot resolve `github.com` for a checkout and does not provide the GitHub CLI.