### PR TITLE
Fix SE(2) Dirac covariance centering

### DIFF
--- a/src/pyrecest/distributions/se2_dirac_distribution.py
+++ b/src/pyrecest/distributions/se2_dirac_distribution.py
@@ -47,10 +47,7 @@ class SE2DiracDistribution(HypercylindricalDiracDistribution, AbstractSE2Distrib
         return self.hybrid_moment()
 
     def covariance_4d(self):
-        """Compute the 4D second moment matrix for [cos(angle), sin(angle), x, y].
-
-        This is the weighted sum of outer products sum_i w_i * s_i * s_i^T
-        where s_i = [cos(angle_i), sin(angle_i), x_i, y_i].
+        """Compute the covariance of [cos(angle), sin(angle), x, y].
 
         Returns
         -------
@@ -62,10 +59,11 @@ class SE2DiracDistribution(HypercylindricalDiracDistribution, AbstractSE2Distrib
             sin,
         )
 
-        S = column_stack(
+        samples = column_stack(
             (cos(self.d[:, 0:1]), sin(self.d[:, 0:1]), self.d[:, 1:])
-        )  # (n, 4)
-        return (S.T * self.w) @ S  # (4, n) * (n,) -> (4, n) @ (n, 4) = (4, 4)
+        )
+        centered = samples - self.mean_4d()
+        return centered.T @ (self.w[:, None] * centered)
 
     def mean(self):
         """Return the hybrid mean for a consistent interface.

--- a/tests/distributions/test_se2_dirac_distribution.py
+++ b/tests/distributions/test_se2_dirac_distribution.py
@@ -66,6 +66,26 @@ class TestSE2DiracDistribution(unittest.TestCase):
         eigvals = np.linalg.eigvalsh(C)
         self.assertTrue(np.all(eigvals >= -1e-12))
 
+    def test_covariance_4d_matches_weighted_centered_moment(self):
+        samples = np.column_stack(
+            (
+                np.cos(np.asarray(self.d[:, 0])),
+                np.sin(np.asarray(self.d[:, 0])),
+                np.asarray(self.d[:, 1:]),
+            )
+        )
+        weights = np.asarray(self.w)
+        mean = np.sum(weights[:, None] * samples, axis=0)
+        centered = samples - mean
+        expected = centered.T @ (weights[:, None] * centered)
+
+        npt.assert_allclose(self.dist.covariance_4d(), expected, rtol=1e-10)
+
+    def test_covariance_4d_is_zero_for_single_component(self):
+        dist = SE2DiracDistribution(array([[0.5, 2.0, -3.0]]), array([1.0]))
+
+        npt.assert_allclose(dist.covariance_4d(), np.zeros((4, 4)), atol=1e-12)
+
     def test_mean_delegates_to_hybrid_mean(self):
         npt.assert_array_equal(self.dist.mean(), self.dist.hybrid_mean())
 


### PR DESCRIPTION
## Summary
- compute `SE2DiracDistribution.covariance_4d()` from centered embedded samples
- align the method with the covariance semantics used by the toroidal Dirac distribution
- add regressions for the weighted centered formula and the single-component zero-covariance case

## Root cause
`covariance_4d()` returned the raw weighted second moment `E[ss^T]` for `s = [cos(theta), sin(theta), x, y]` without subtracting `E[s]E[s]^T`. As a result, deterministic one-component distributions reported a nonzero matrix even though their covariance must be zero.

## Impact
Consumers now receive the actual embedded 4D covariance rather than an uncentered second moment. This affects uncertainty calculations for SE(2) Dirac distributions whenever the embedded mean is nonzero.

## Validation
- added an exact comparison with a NumPy weighted centered covariance
- added a deterministic one-component regression requiring a zero matrix
- syntax-checked both modified Python files locally

Full repository tests are delegated to GitHub Actions because this environment could not obtain a local repository checkout.