### PR TITLE
Normalize scalar PyTorch reduction axes

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_reduction_axis_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_reduction_axis_contract.py
@@ -40,6 +40,17 @@ def _axis_contains_boolean_value(axis, torch_module) -> bool:
     return False
 
 
+def _normalize_scalar_axis_value(axis, torch_module):
+    """Convert integer-like scalar axes to Python integers before dispatch."""
+
+    if axis is None or _is_boolean_axis_value(axis, torch_module):
+        return axis
+    try:
+        return _operator_index(axis)
+    except TypeError:
+        return axis
+
+
 def normalize_reduction_axes(axis, ndim_value, torch_module):
     """Normalize PyTorch reduction axes while rejecting boolean axes."""
 
@@ -88,6 +99,13 @@ def _wrap_boolean_axis_reduction(helper, torch_module):
             axis = args[1]
         if _axis_contains_boolean_value(axis, torch_module):
             raise TypeError(_AXIS_TYPE_MESSAGE)
+
+        args = list(args)
+        kwargs = dict(kwargs)
+        if "axis" in kwargs:
+            kwargs["axis"] = _normalize_scalar_axis_value(kwargs["axis"], torch_module)
+        elif len(args) >= 2:
+            args[1] = _normalize_scalar_axis_value(args[1], torch_module)
         return helper(*args, **kwargs)
 
     reduction.__name__ = getattr(helper, "__name__", "reduction")
@@ -109,6 +127,15 @@ def _wrap_boolean_axis_dim_reduction(helper, torch_module):
             dim, torch_module
         ):
             raise TypeError(_AXIS_TYPE_MESSAGE)
+
+        args = list(args)
+        kwargs = dict(kwargs)
+        if "axis" in kwargs:
+            kwargs["axis"] = _normalize_scalar_axis_value(kwargs["axis"], torch_module)
+        elif len(args) >= 2:
+            args[1] = _normalize_scalar_axis_value(args[1], torch_module)
+        if "dim" in kwargs:
+            kwargs["dim"] = _normalize_scalar_axis_value(kwargs["dim"], torch_module)
         return helper(*args, **kwargs)
 
     reduction.__name__ = getattr(helper, "__name__", "reduction")
@@ -170,7 +197,7 @@ def patch_pytorch_reduction_axis_contract() -> None:
         _normalize_reduction_axes._pyrecest_reduction_axis_bool_contract = True
         raw_pytorch._normalize_reduction_axes = _normalize_reduction_axes
 
-    for helper_name in ("any", "all", "count_nonzero", "max"):
+    for helper_name in ("any", "all", "count_nonzero", "max", "prod"):
         raw_helper = getattr(raw_pytorch, helper_name, None)
         if raw_helper is not None:
             wrapped_helper = _wrap_boolean_axis_reduction(raw_helper, torch)
@@ -178,7 +205,7 @@ def patch_pytorch_reduction_axis_contract() -> None:
             if getattr(backend, "__backend_name__", None) == "pytorch":
                 setattr(backend, helper_name, wrapped_helper)
 
-    for helper_name in ("mean", "std"):
+    for helper_name in ("mean", "std", "sum"):
         raw_helper = getattr(raw_pytorch, helper_name, None)
         if raw_helper is not None:
             wrapped_helper = _wrap_boolean_axis_dim_reduction(raw_helper, torch)

--- a/tests/backend_support/test_pytorch_reduction_axis_scalar_contract.py
+++ b/tests/backend_support/test_pytorch_reduction_axis_scalar_contract.py
@@ -1,0 +1,96 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _backend_subprocess_env(backend_name):
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = backend_name
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    return env
+
+
+_REDUCTION_SCALAR_AXIS_CODE = r'''
+import numpy as np
+import torch
+
+
+SCALAR_AXES = (
+    np.asarray(0),
+    np.asarray(-2),
+    torch.tensor(0),
+    torch.tensor(-2),
+)
+
+
+def assert_integer_scalar_axes_supported(module):
+    values = module.array([[1.0, 2.0], [3.0, 4.0]])
+    expected = {
+        "sum": [4.0, 6.0],
+        "prod": [3.0, 8.0],
+        "mean": [2.0, 3.0],
+        "std": [1.0, 1.0],
+    }
+
+    for axis in SCALAR_AXES:
+        for helper_name, expected_values in expected.items():
+            result = getattr(module, helper_name)(values, axis=axis)
+            assert module.to_numpy(result).tolist() == expected_values
+
+    for dim in SCALAR_AXES:
+        for helper_name in ("sum", "mean", "std"):
+            result = getattr(module, helper_name)(values, dim=dim)
+            assert module.to_numpy(result).tolist() == expected[helper_name]
+'''
+
+
+@pytest.mark.backend_portable
+def test_public_pytorch_reductions_accept_integer_scalar_axes():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = (
+        _REDUCTION_SCALAR_AXIS_CODE
+        + """
+import pyrecest.backend as backend
+
+assert backend.__backend_name__ == "pytorch"
+assert_integer_scalar_axes_supported(backend)
+"""
+    )
+    subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        env=_backend_subprocess_env("pytorch"),
+    )
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_reductions_are_patched_under_numpy_backend():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = (
+        _REDUCTION_SCALAR_AXIS_CODE
+        + """
+import pyrecest  # noqa: F401
+import pyrecest.backend as public_backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+assert public_backend.__backend_name__ == "numpy"
+assert_integer_scalar_axes_supported(raw_pytorch)
+"""
+    )
+    subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        env=_backend_subprocess_env("numpy"),
+    )


### PR DESCRIPTION
## Summary
- normalize zero-dimensional integer-like reduction axes before dispatching to PyTorch
- cover `sum`, `prod`, `mean`, and `std`, including the PyTorch-style `dim` alias where supported
- add backend-portable subprocess regressions for both the public PyTorch backend and the raw PyTorch backend loaded under the NumPy backend

## Bug fixed
The raw PyTorch reduction helpers call `_is_empty_reduction_axis(...)` before dispatch. For valid integer-like scalar axes such as `np.asarray(0)` and `torch.tensor(0)`, that helper attempted `tuple(axis)` and raised `TypeError` because zero-dimensional arrays/tensors are not iterable. Passing a zero-dimensional NumPy integer directly to PyTorch can also trigger PyTorch's argument parser instead of behaving like a scalar dimension.

The existing reduction-axis contract hook now converts non-boolean objects accepted by `operator.index(...)` to ordinary Python integers before invoking the raw helper. Boolean axes remain rejected.

## Validation
- `python -m py_compile` passed for the modified compatibility hook and the new regression test
- isolated wrapper smoke passed for positive/negative NumPy and Torch scalar integer axes and preserved boolean-axis rejection
- branch is 2 commits ahead of `main`, 0 behind, changing only the existing reduction-axis hook and one focused test file

Full in-repository pytest is delegated to GitHub Actions because the local container cannot resolve `github.com`.