### PR TITLE
Guard PyTorch Sylvester shortcut residual

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -380,6 +380,16 @@ def qr(a, mode="reduced"):
     raise ValueError(f"Unrecognized mode {mode!r}")
 
 
+def _sylvester_candidate_is_accurate(a, b, q, candidate):
+    """Return whether a shortcut candidate solves the original equation."""
+    return _torch.allclose(
+        a @ candidate + candidate @ b,
+        q,
+        atol=1e-6,
+        rtol=1e-6,
+    )
+
+
 def solve_sylvester(a, b, q):
     device = _preferred_linalg_device(a, b, q)
     a = _as_linalg_tensor(a)
@@ -405,7 +415,9 @@ def solve_sylvester(a, b, q):
             adjoint_eigvecs = eigvecs.transpose(-2, -1).conj()
             tilde_q = adjoint_eigvecs @ q @ eigvecs
             tilde_x = tilde_q / (eigvals[..., :, None] + eigvals[..., None, :])
-            return eigvecs @ tilde_x @ adjoint_eigvecs
+            candidate = eigvecs @ tilde_x @ adjoint_eigvecs
+            if _sylvester_candidate_is_accurate(a, b, q, candidate):
+                return candidate
 
     is_real_shared_symmetric_factor = (
         is_shared_factor
@@ -434,7 +446,9 @@ def solve_sylvester(a, b, q):
                 _torch.zeros((), dtype=tilde_x.dtype, device=tilde_x.device),
                 tilde_x,
             )
-            return eigvecs @ tilde_x @ eigvecs.transpose(-2, -1)
+            candidate = eigvecs @ tilde_x @ eigvecs.transpose(-2, -1)
+            if _sylvester_candidate_is_accurate(a, b, q, candidate):
+                return candidate
 
     solution = _np.vectorize(
         _scipy.linalg.solve_sylvester, signature="(m,m),(n,n),(m,n)->(m,n)"

--- a/tests/backend_support/test_pytorch_sylvester_close_factor_residual.py
+++ b/tests/backend_support/test_pytorch_sylvester_close_factor_residual.py
@@ -1,0 +1,33 @@
+"""Regression coverage for close-factor PyTorch Sylvester shortcuts."""
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+def test_pytorch_sylvester_falls_back_when_close_factor_shortcut_is_inaccurate():
+    pytest.importorskip("torch")
+    code = """
+import torch
+from pyrecest.backend import linalg
+
+# These positive-definite factors pass the shortcut's approximate equality
+# check, but replacing B by A changes the ill-conditioned solution materially.
+a = torch.diag(torch.tensor([1.0e-6, 1.0], dtype=torch.float64))
+b = torch.diag(torch.tensor([1.5e-6, 1.0], dtype=torch.float64))
+q = torch.eye(2, dtype=torch.float64)
+
+assert torch.allclose(a, b, atol=1e-6, rtol=1e-6)
+
+solution = linalg.solve_sylvester(a, b, q)
+residual = a @ solution + solution @ b - q
+
+assert torch.linalg.norm(residual).item() < 1e-12
+torch.testing.assert_close(
+    solution[0, 0],
+    torch.tensor(4.0e5, dtype=torch.float64),
+    rtol=1e-12,
+    atol=0.0,
+)
+"""
+    result = run_backend_code("pytorch", code)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- validate eigendecomposition shortcut candidates against the original `A X + X B = Q` equation
- fall back to the existing SciPy solver when approximately equal factors produce an inaccurate shortcut solution
- apply the same residual guard to both Hermitian and real-symmetric shortcut paths
- add a PyTorch backend regression for an ill-conditioned close-factor case

## Bug fixed
`solve_sylvester` deliberately accepts factors that are close under `atol=rtol=1e-6` as shared so it can use the faster eigendecomposition path. The shortcut then solves with `A` on both sides. For ill-conditioned factors, a perturbation that is small entrywise can change the solution substantially.

For

```python
A = diag(1e-6, 1)
B = diag(1.5e-6, 1)
Q = I
```

`torch.allclose(A, B, atol=1e-6, rtol=1e-6)` is true, but the old shortcut returned `X[0, 0] = 500000` and left residual norm `||AX + XB - Q|| = 0.25`. The correct solution has `X[0, 0] = 400000` and zero residual.

## Validation
- local deterministic reproduction of the old failure: residual norm `0.25`
- local execution of the guarded algorithm: fallback solution residual norm `0.0`, `X[0, 0] = 400000.00000000006`
- existing well-conditioned close complex-Hermitian case still satisfies the shortcut guard with residual norm `6.08e-9`
- branch comparison: 2 commits, 2 files, 49 additions, 2 deletions

The full repository test suite was not run locally because this execution environment cannot resolve GitHub for a checkout; the focused regression is included for CI.