### PR TITLE
Fix positional-only dt dispatch in additive-noise models

### DIFF
--- a/src/pyrecest/models/additive_noise.py
+++ b/src/pyrecest/models/additive_noise.py
@@ -99,9 +99,15 @@ def _dt_call_mode(function: Callable[..., Any]) -> str | None:
         return "positional"
 
     parameters = tuple(signature.parameters.values())
-    if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters):
+    dt_parameter = signature.parameters.get("dt")
+    if dt_parameter is not None:
+        if dt_parameter.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.VAR_POSITIONAL,
+        ):
+            return "positional"
         return "keyword"
-    if "dt" in signature.parameters:
+    if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters):
         return "keyword"
     if any(param.kind == inspect.Parameter.VAR_POSITIONAL for param in parameters):
         return "positional"

--- a/tests/models/test_additive_noise_positional_only_dt.py
+++ b/tests/models/test_additive_noise_positional_only_dt.py
@@ -1,0 +1,44 @@
+from pyrecest.models.additive_noise import AdditiveNoiseTransitionModel
+
+
+def test_transition_and_jacobian_accept_positional_only_dt():
+    calls = {}
+
+    def transition(state, dt, /):
+        calls["transition"] = (state, dt)
+        return state + dt
+
+    def jacobian(state, dt, /):
+        calls["jacobian"] = (state, dt)
+        return dt
+
+    model = AdditiveNoiseTransitionModel(
+        transition,
+        jacobian=jacobian,
+        dt=0.25,
+    )
+
+    assert model.evaluate(2.0) == 2.25
+    assert model.jacobian(2.0) == 0.25
+    assert calls == {
+        "transition": (2.0, 0.25),
+        "jacobian": (2.0, 0.25),
+    }
+
+
+def test_positional_only_dt_takes_precedence_over_var_keyword_fallback():
+    def transition(state, dt, /, **kwargs):
+        return state + dt + kwargs["offset"]
+
+    def jacobian(state, dt, /, **kwargs):
+        return dt + kwargs["offset"]
+
+    model = AdditiveNoiseTransitionModel(
+        transition,
+        jacobian=jacobian,
+        dt=0.5,
+        function_args={"offset": 3.0},
+    )
+
+    assert model.evaluate(1.0) == 4.5
+    assert model.jacobian(1.0) == 3.5


### PR DESCRIPTION
## Bug

`AdditiveNoiseTransitionModel` inspects transition and Jacobian callback signatures to decide whether to pass `dt` positionally or by keyword. An explicit positional-only signature such as

```python
def transition(state, dt, /):
    ...
```

was classified as keyword-capable merely because the parameter was named `dt`. Calls then failed with `TypeError`. The same issue was more subtle for callbacks that also accepted `**kwargs`: `dt` was captured as a keyword while the required positional-only argument remained missing.

## Fix

- inspect the explicit `dt` parameter kind before generic `*args`/`**kwargs` fallbacks
- route positional-only (and variadic-positional) `dt` parameters positionally
- preserve keyword routing for positional-or-keyword and keyword-only `dt`
- add regressions for transition and Jacobian callbacks, including the `**kwargs` case

## Validation

- reproduced the old dispatch failure in an isolated Python check
- inspected the branch comparison: only `src/pyrecest/models/additive_noise.py` and the focused regression test are changed
- full repository pytest was not run locally because this runtime cannot clone GitHub; CI should run the added tests
