### PR TITLE
Stabilize concentrated wrapped Laplace densities

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_laplace_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_laplace_distribution.py
@@ -44,15 +44,17 @@ class WrappedLaplaceDistribution(AbstractCircularDistribution):
         if ndim(xs) > 1:
             raise ValueError("xs must be a scalar or one-dimensional array.")
         xs = mod(xs, 2.0 * pi)
+        positive_rate = self.lambda_ * self.kappa
+        negative_rate = self.lambda_ / self.kappa
         p = (
             self.lambda_
             * self.kappa
             / (1 + self.kappa**2)
             * (
-                exp(-self.lambda_ * self.kappa * xs)
-                / (1 - exp(-2.0 * pi * self.lambda_ * self.kappa))
-                + exp(self.lambda_ / self.kappa * xs)
-                / (exp(2.0 * pi * self.lambda_ / self.kappa) - 1.0)
+                exp(-positive_rate * xs)
+                / (1 - exp(-2.0 * pi * positive_rate))
+                + exp(-negative_rate * (2.0 * pi - xs))
+                / (1 - exp(-2.0 * pi * negative_rate))
             )
         )
         return p

--- a/tests/distributions/test_wrapped_laplace_distribution.py
+++ b/tests/distributions/test_wrapped_laplace_distribution.py
@@ -1,3 +1,4 @@
+import math
 import unittest
 
 import numpy.testing as npt
@@ -42,6 +43,24 @@ class WrappedLaplaceDistributionTest(unittest.TestCase):
 
         for x in [0.0, 1.0, 2.0, 3.0, 4.0]:
             npt.assert_allclose(self.wl.pdf(array(x)), pdftemp(array(x)), rtol=1e-6)
+
+    def test_pdf_avoids_overflow_for_concentrated_negative_tail(self):
+        lambda_ = 500.0
+        kappa = 2.0
+        distance_from_wrap = 1.0e-3
+        negative_rate = lambda_ / kappa
+        distribution = WrappedLaplaceDistribution(array(lambda_), array(kappa))
+
+        expected = (
+            lambda_
+            * kappa
+            / (1.0 + kappa**2)
+            * math.exp(-negative_rate * distance_from_wrap)
+            / (1.0 - math.exp(-2.0 * math.pi * negative_rate))
+        )
+        actual = distribution.pdf(array(2.0 * math.pi - distance_from_wrap))
+
+        npt.assert_allclose(actual, expected, rtol=1e-6)
 
     def test_pdf_accepts_scalar_and_list_inputs(self):
         npt.assert_allclose(self.wl.pdf(1.0), self.wl.pdf(array(1.0)), rtol=1e-6)


### PR DESCRIPTION
## Summary
- rewrite the wrapped Laplace negative-tail term into an algebraically equivalent decaying-exponential form
- avoid `inf / inf` when evaluating concentrated distributions near the `2π` wrap boundary
- add a regression for a finite, nonzero high-concentration density

## Root cause
`WrappedLaplaceDistribution.pdf` evaluated the negative wrapped tail as

```python
exp(rate * x) / (exp(2 * pi * rate) - 1)
```

For large finite rates and `x` near `2π`, both exponentials overflow, so the ratio becomes `inf / inf` and the PDF returns `NaN` even though the mathematical density is finite.

## Fix
Use the equivalent expression

```python
exp(-rate * (2 * pi - x)) / (1 - exp(-2 * pi * rate))
```

Both exponentials are non-growing on the wrapped domain, eliminating the overflow without changing ordinary-parameter results.

## Validation
- reproduced the previous failure for `lambda_=500`, `kappa=2`, `x=2π-1e-3`: old result `NaN`
- verified the stabilized result is `155.76015661426797`, matching the analytic finite value
- compared old and new formulas over 1,001 points for moderate parameters (`lambda_=2`, `kappa=1.3`): equivalent to tight floating-point tolerance
- syntax-checked the modified source
- branch comparison contains only the distribution implementation and its focused test

The full repository test matrix was not run locally because this runtime cannot resolve GitHub for a checkout; repository CI is expected to execute on this PR.