### PR TITLE
Tolerate numerical equator residuals in vMF updates

### DIFF
--- a/src/pyrecest/filters/hyperhemispherical_grid_filter.py
+++ b/src/pyrecest/filters/hyperhemispherical_grid_filter.py
@@ -34,6 +34,9 @@ from .abstract_grid_filter import AbstractGridFilter
 from .manifold_mixins import HyperhemisphericalFilterMixin
 
 
+_VMF_EQUATOR_TOLERANCE = 1e-10
+
+
 class HyperhemisphericalGridFilter(AbstractGridFilter, HyperhemisphericalFilterMixin):
     """
     Grid-based recursive Bayesian filter on the hyperhemisphere.
@@ -193,7 +196,7 @@ class HyperhemisphericalGridFilter(AbstractGridFilter, HyperhemisphericalFilterM
 
         Supported noise: :class:`HyperhemisphericalWatsonDistribution`,
         :class:`WatsonDistribution`, :class:`VonMisesFisherDistribution`
-        (with ``mu[-1] == 0``), symmetric :class:`HypersphericalMixture`.
+        for measurements on the equator, symmetric :class:`HypersphericalMixture`.
 
         Parameters
         ----------
@@ -216,7 +219,10 @@ class HyperhemisphericalGridFilter(AbstractGridFilter, HyperhemisphericalFilterM
                     "UpdateIdentity:UnexpectedMeas: mu needs to be [0;...; 0; 1]."
                 )
             meas_noise = WatsonDistribution(z, meas_noise.kappa)
-        elif isinstance(meas_noise, VonMisesFisherDistribution) and z[-1] == 0:
+        elif (
+            isinstance(meas_noise, VonMisesFisherDistribution)
+            and linalg.norm(z[-1:]) <= _VMF_EQUATOR_TOLERANCE
+        ):
             standard_pole = array([*([0.0] * self.dim), 1.0])
             if linalg.norm(meas_noise.mu - standard_pole) > 1e-6:
                 raise ValueError(

--- a/tests/filters/test_hyperhemispherical_grid_filter_vmf_update.py
+++ b/tests/filters/test_hyperhemispherical_grid_filter_vmf_update.py
@@ -1,0 +1,51 @@
+"""Regression coverage for vMF hyperhemispherical grid updates."""
+
+import math
+import unittest
+
+import pyrecest.backend
+from pyrecest.backend import array, linalg
+from pyrecest.distributions import VonMisesFisherDistribution
+from pyrecest.filters import HyperhemisphericalGridFilter
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+    reason="Not supported on JAX backend",
+)
+class TestHyperhemisphericalGridFilterVmfUpdate(unittest.TestCase):
+    def test_accepts_numerically_equatorial_vmf_measurement(self):
+        filter_ = HyperhemisphericalGridFilter(50, 2)
+        equator_residual = 1e-12
+        measurement = array(
+            [math.sqrt(1.0 - equator_residual**2), 0.0, equator_residual]
+        )
+        standard_pole = array([0.0, 0.0, 1.0])
+        measurement_noise = VonMisesFisherDistribution(standard_pole, 3.0)
+
+        filter_.update_identity(measurement_noise, measurement)
+
+        estimate = filter_.get_point_estimate()
+        self.assertAlmostEqual(float(linalg.norm(estimate)), 1.0, places=5)
+        self.assertGreater(abs(float(estimate[0])), 0.9)
+
+    def test_rejects_vmf_measurement_outside_equator_tolerance(self):
+        filter_ = HyperhemisphericalGridFilter(50, 2)
+        off_equator = 1e-6
+        measurement = array([math.sqrt(1.0 - off_equator**2), 0.0, off_equator])
+        measurement_noise = VonMisesFisherDistribution(array([0.0, 0.0, 1.0]), 3.0)
+
+        with self.assertRaisesRegex(ValueError, "unsupported measurement noise"):
+            filter_.update_identity(measurement_noise, measurement)
+
+    def test_rejects_non_zonal_vmf_noise(self):
+        filter_ = HyperhemisphericalGridFilter(50, 2)
+        equatorial_measurement = array([1.0, 0.0, 0.0])
+        non_zonal_noise = VonMisesFisherDistribution(array([1.0, 0.0, 0.0]), 3.0)
+
+        with self.assertRaisesRegex(ValueError, "mu needs to be"):
+            filter_.update_identity(non_zonal_noise, equatorial_measurement)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- preserve the intentional equator-only restriction for von Mises–Fisher hyperhemisphere updates
- replace the exact `z[-1] == 0` comparison with a small numerical tolerance
- clarify that the restriction applies to the measurement after re-centering
- add regressions for residuals inside and outside the tolerance, plus canonical-noise validation

## Bug
`HyperhemisphericalGridFilter.update_identity` accepted a vMF likelihood only when `z[-1] == 0` exactly. The equator restriction is intentional and follows the upstream libDirectional implementation: only an equatorial vMF mode produces the required symmetric likelihood on the represented hyperhemisphere.

However, valid equatorial unit vectors produced by normalization, rotations, or coordinate transforms commonly retain residual final coordinates around machine precision. Exact equality therefore rejects mathematically valid measurements and routes them to the unsupported-noise error.

## Fix
Treat `z` as equatorial when the norm of its final coordinate is at most `1e-10`. Measurements materially outside that tolerance remain rejected, and the existing requirement that the supplied vMF noise be zonal around `[0, ..., 0, 1]` is unchanged.

## Validation
- traced the intended semantics to `libDirectional/libDirectional`'s `HyperhemisphericalGridFilter.m`
- confirmed no existing issue or PR covers this tolerance defect
- regression reproduces the old failure with a normalized measurement whose final coordinate is `1e-12`
- boundary regression confirms a `1e-6` residual is still rejected
- non-zonal vMF noise remains rejected
- final diff is limited to the filter and one focused regression file

Full repository tests are delegated to GitHub Actions because this runtime cannot obtain a network checkout of the repository.