### PR TITLE
Validate box-particle set_mean shape

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/linear_box_particle_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/linear_box_particle_distribution.py
@@ -158,8 +158,19 @@ class LinearBoxParticleDistribution(AbstractLinearDistribution):
 
     def set_mean(self, new_mean):
         """Return a shifted copy whose mixture mean equals ``new_mean``."""
-        offset = array(new_mean) - self.mean()
-        offset = reshape(offset, (1, -1))
+        new_mean = array(new_mean)
+        if new_mean.ndim == 0:
+            if self.dim != 1:
+                raise ValueError(
+                    f"new_mean must have shape ({self.dim},), got scalar."
+                )
+            new_mean = reshape(new_mean, (1,))
+        elif new_mean.shape != (self.dim,):
+            raise ValueError(
+                f"new_mean must have shape ({self.dim},), got {new_mean.shape}."
+            )
+
+        offset = reshape(new_mean - self.mean(), (1, -1))
         dist = copy.deepcopy(self)
         dist.lower = self.lower + offset
         dist.upper = self.upper + offset

--- a/tests/distributions/test_linear_box_particle_set_mean_validation.py
+++ b/tests/distributions/test_linear_box_particle_set_mean_validation.py
@@ -26,8 +26,8 @@ class LinearBoxParticleSetMeanValidationTest(unittest.TestCase):
             array([[2.0, 4.0], [8.0, 6.0]]),
             array([0.25, 0.75]),
         )
-        original_mean = dist.mean().copy()
-        original_widths = dist.widths().copy()
+        original_mean = dist.mean()
+        original_widths = dist.widths()
 
         shifted = dist.set_mean(array([10.0, -3.0]))
 

--- a/tests/distributions/test_linear_box_particle_set_mean_validation.py
+++ b/tests/distributions/test_linear_box_particle_set_mean_validation.py
@@ -1,0 +1,47 @@
+import unittest
+
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array
+from pyrecest.distributions.nonperiodic.linear_box_particle_distribution import (
+    LinearBoxParticleDistribution,
+)
+
+
+class LinearBoxParticleSetMeanValidationTest(unittest.TestCase):
+    def test_set_mean_rejects_broadcastable_wrong_shapes(self):
+        dist = LinearBoxParticleDistribution(
+            array([[0.0, 0.0]]), array([[2.0, 4.0]])
+        )
+
+        for new_mean in (array(10.0), array([10.0]), array([[10.0, 11.0]])):
+            with self.subTest(shape=new_mean.shape):
+                with self.assertRaisesRegex(ValueError, "new_mean must have shape"):
+                    dist.set_mean(new_mean)
+
+    def test_set_mean_reaches_target_without_changing_box_widths(self):
+        dist = LinearBoxParticleDistribution(
+            array([[0.0, 0.0], [4.0, 2.0]]),
+            array([[2.0, 4.0], [8.0, 6.0]]),
+            array([0.25, 0.75]),
+        )
+        original_mean = dist.mean().copy()
+        original_widths = dist.widths().copy()
+
+        shifted = dist.set_mean(array([10.0, -3.0]))
+
+        npt.assert_allclose(shifted.mean(), array([10.0, -3.0]))
+        npt.assert_allclose(shifted.widths(), original_widths)
+        npt.assert_allclose(dist.mean(), original_mean)
+
+    def test_set_mean_accepts_scalar_for_one_dimension(self):
+        dist = LinearBoxParticleDistribution(array([[0.0]]), array([[2.0]]))
+
+        shifted = dist.set_mean(array(4.0))
+
+        npt.assert_allclose(shifted.mean(), array([4.0]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- require `LinearBoxParticleDistribution.set_mean` to receive exactly one coordinate per distribution dimension
- preserve scalar `new_mean` support for one-dimensional box-particle distributions
- add regressions for malformed broadcastable inputs and valid mean shifts

## Bug

`set_mean` subtracted `new_mean` from the current mean before validating its shape. NumPy-style broadcasting therefore silently accepted malformed values for multidimensional distributions. For a two-dimensional box distribution, both a scalar `10.0` and a length-one vector `[10.0]` were interpreted as the target mean `[10.0, 10.0]` instead of being rejected.

## Fix

Normalize scalar input only when `dim == 1`; otherwise require `new_mean.shape == (dim,)` before computing the translation. The shifted copy still preserves every box width and leaves the original distribution unchanged.

## Validation

- reproduced the old scalar and singleton broadcasting result (`[10.0, 10.0]` for a 2-D distribution)
- isolated numerical regression passed for invalid shapes, a valid weighted 2-D shift, width preservation, source immutability, and 1-D scalar support
- `py_compile` passed for the added regression module
- branch comparison: 3 commits, 2 files, 60 additions, 2 deletions, 0 commits behind `main`

The full repository test suite was not run locally because this runtime cannot resolve `github.com` for a checkout and does not provide the GitHub CLI.