### PR TITLE
Reject indefinite Gaussian hypothesis covariances

### DIFF
--- a/src/pyrecest/filters/gaussian_hypothesis_mixture.py
+++ b/src/pyrecest/filters/gaussian_hypothesis_mixture.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
+from pyrecest.numerics import is_positive_semidefinite
 
 _INVALID_FLOAT_ARRAY_KINDS = {"b", "S", "U", "c", "M", "m"}
 _INVALID_FLOAT_ARRAY_SCALAR_TYPES = (
@@ -41,9 +42,12 @@ class WeightedGaussianHypothesis:
             raise ValueError("covariance must match mean dimension")
         if not np.all(np.isfinite(covariance)):
             raise ValueError("covariance must contain only finite values")
+        covariance = _symmetrized(covariance)
+        if not is_positive_semidefinite(covariance):
+            raise ValueError("covariance must be positive semidefinite")
         log_weight = _as_log_weight(self.log_weight)
         object.__setattr__(self, "mean", mean)
-        object.__setattr__(self, "covariance", _symmetrized(covariance))
+        object.__setattr__(self, "covariance", covariance)
         object.__setattr__(self, "log_weight", log_weight)
         if self.metadata is not None:
             object.__setattr__(self, "metadata", dict(self.metadata))

--- a/tests/filters/test_gaussian_hypothesis_covariance_validation.py
+++ b/tests/filters/test_gaussian_hypothesis_covariance_validation.py
@@ -1,0 +1,32 @@
+import unittest
+
+import numpy as np
+from pyrecest.filters import WeightedGaussianHypothesis
+
+
+class GaussianHypothesisCovarianceValidationTest(unittest.TestCase):
+    def test_rejects_negative_scalar_variance(self):
+        with self.assertRaisesRegex(ValueError, "positive semidefinite"):
+            WeightedGaussianHypothesis(
+                mean=np.array([0.0]),
+                covariance=np.array([[-1.0]]),
+            )
+
+    def test_rejects_indefinite_covariance_with_positive_diagonal(self):
+        with self.assertRaisesRegex(ValueError, "positive semidefinite"):
+            WeightedGaussianHypothesis(
+                mean=np.array([0.0, 0.0]),
+                covariance=np.array([[1.0, 2.0], [2.0, 1.0]]),
+            )
+
+    def test_accepts_positive_semidefinite_covariance(self):
+        hypothesis = WeightedGaussianHypothesis(
+            mean=np.array([0.0, 0.0]),
+            covariance=np.array([[1.0, 1.0], [1.0, 1.0]]),
+        )
+
+        self.assertTrue(np.allclose(hypothesis.covariance, np.ones((2, 2))))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- validate symmetrized `WeightedGaussianHypothesis` covariances with PyRecEst's existing positive-semidefinite contract
- reject negative scalar variances and indefinite matrices even when their diagonal entries are positive
- add focused regressions for invalid and rank-deficient valid covariances

## Bug
`WeightedGaussianHypothesis.__post_init__` checked covariance shape and finiteness, then symmetrized the matrix without verifying positive semidefiniteness. Inputs such as

```python
WeightedGaussianHypothesis(
    mean=np.array([0.0, 0.0]),
    covariance=np.array([[1.0, 2.0], [2.0, 1.0]]),
)
```

were accepted even though the covariance eigenvalues are `[-1, 3]`. Moment matching then propagated an invalid covariance into downstream filters.

## Fix
After the existing intentional symmetrization, call `pyrecest.numerics.is_positive_semidefinite`. This reuses the repository-wide numerical tolerance and preserves valid singular covariances while rejecting materially indefinite ones.

## Validation
- isolated eigenspectrum reproduction confirms the invalid examples have negative variance/eigenvalues
- focused tests cover a negative 1-D variance, a 2-D indefinite matrix with positive diagonal entries, and a valid rank-one PSD covariance
- branch comparison: 2 commits, 2 files, 37 additions, 1 deletion

The full repository test suite was not run locally because this runtime cannot resolve GitHub for a checkout and does not provide the GitHub CLI; CI should execute the added regressions.