### PR TITLE
Fix PyTorch LinearDirac plotting conversion

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/linear_dirac_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/linear_dirac_distribution.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import asarray, cov, ones, reshape, zeros
+from pyrecest.backend import asarray, cov, ones, reshape, to_numpy, zeros
 
 from ..abstract_dirac_distribution import AbstractDiracDistribution
 from .abstract_linear_distribution import AbstractLinearDistribution
@@ -49,12 +49,9 @@ class LinearDiracDistribution(AbstractDiracDistribution, AbstractLinearDistribut
         return C
 
     def plot(self, *args, **kwargs):
-        if pyrecest.backend.__backend_name__ == "numpy":
-            sample_locs = self.d
-            sample_weights = self.w
-        elif pyrecest.backend.__backend_name__ == "pytorch":
-            sample_locs = self.d.numpy()
-            sample_weights = self.w.numpy()
+        if pyrecest.backend.__backend_name__ in {"numpy", "pytorch"}:
+            sample_locs = to_numpy(self.d)
+            sample_weights = to_numpy(self.w)
         else:
             raise ValueError("Plotting not supported for this backend")
 

--- a/tests/backend_support/test_pytorch_linear_dirac_plot_contract.py
+++ b/tests/backend_support/test_pytorch_linear_dirac_plot_contract.py
@@ -1,0 +1,37 @@
+"""Regression coverage for plotting autograd-backed PyTorch Dirac particles."""
+
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_pytorch_linear_dirac_plot_detaches_tensors_for_matplotlib():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import torch
+
+from pyrecest.distributions.nonperiodic.linear_dirac_distribution import (
+    LinearDiracDistribution,
+)
+
+locations = torch.tensor([0.0, 1.0], requires_grad=True)
+weights = torch.tensor([0.25, 0.75], requires_grad=True)
+distribution = LinearDiracDistribution(locations, weights)
+
+plt.show = lambda: None
+distribution.plot()
+plt.close("all")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

- convert Dirac locations and weights through the backend `to_numpy()` helper before plotting
- preserve the existing NumPy/PyTorch plotting support and JAX rejection
- add a backend-portable regression for autograd-backed PyTorch tensors

## Bug

`LinearDiracDistribution.plot()` called `.numpy()` directly on PyTorch tensors. PyTorch rejects that conversion when a tensor requires gradients, and direct `.numpy()` also only works for CPU tensors. Consequently, valid PyTorch-backed Dirac distributions could not be plotted when their locations or weights participated in an autograd graph or lived on an accelerator.

## Fix

Use PyRecEst's existing `to_numpy()` backend helper. Its PyTorch implementation detaches tensors, resolves conjugate/negative views, moves them to CPU, and then converts them to NumPy. NumPy behavior remains unchanged.

## Validation

- `python -m py_compile` passed for the modified source and new regression test
- isolated reproduction confirmed the old direct `.numpy()` call raises for `requires_grad=True`
- isolated plotting check passed with detached NumPy arrays under Matplotlib's non-interactive backend
- branch comparison: 2 commits ahead of current `main`, 0 behind; only the plotting implementation and focused regression are changed

Full repository and backend-matrix testing is delegated to GitHub Actions because this environment cannot clone `github.com`.