### PR TITLE
Fix multi-turn custom torus distances

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_grid_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_grid_distribution.py
@@ -170,11 +170,11 @@ class HypertoroidalGridDistribution(
         if self.grid is None or self.grid.size == 0:
             raise ValueError("Grid is empty; cannot find closest point.")
 
-        # Toroidal squared distance: min(Δ^2, (2π - |Δ|)^2) summed over dimensions
+        # Reduce angular differences modulo 2π before taking the shortest arc.
         delta = self.grid[None, :, :] - xs[:, None, :]  # (1, n_grid, dim)
-        abs_delta = abs(delta)
-        wrapped_delta_sq = minimum(abs_delta**2, (2 * pi - abs_delta) ** 2)
-        dists = sum(wrapped_delta_sq, axis=-1)
+        abs_delta = mod(abs(delta), 2.0 * pi)
+        wrapped_delta = minimum(abs_delta, 2.0 * pi - abs_delta)
+        dists = sum(wrapped_delta**2, axis=-1)
         min_index = int(argmin(dists[0]))
         return self.grid[min_index]
 
@@ -317,9 +317,9 @@ class HypertoroidalGridDistribution(
 
         # Broadcast differences: (n_eval, n_grid, dim)
         delta = self.grid[None, :, :] - xa[:, None, :]
-        abs_delta = abs(delta)
-        wrapped_delta_sq = minimum(abs_delta**2, (2 * pi - abs_delta) ** 2)
-        dists = sum(wrapped_delta_sq, axis=-1)
+        abs_delta = mod(abs(delta), 2.0 * pi)
+        wrapped_delta = minimum(abs_delta, 2.0 * pi - abs_delta)
+        dists = sum(wrapped_delta**2, axis=-1)
         min_inds = argmin(dists, axis=1)
         grid_values_flat = reshape(self.grid_values, (-1,))
         return grid_values_flat[min_inds]

--- a/tests/distributions/test_hypertoroidal_grid_multiturn_wrap.py
+++ b/tests/distributions/test_hypertoroidal_grid_multiturn_wrap.py
@@ -17,6 +17,15 @@ def test_custom_grid_nearest_neighbor_is_invariant_to_full_turns():
         distribution.value_of_closest(shifted_queries),
         distribution.value_of_closest(base_queries),
     )
-    npt.assert_allclose(distribution.pdf(shifted_queries), distribution.pdf(base_queries))
-    npt.assert_allclose(distribution.get_closest_point(shifted_queries[0]), grid[0])
-    npt.assert_allclose(distribution.get_closest_point(shifted_queries[1]), grid[1])
+    npt.assert_allclose(
+        distribution.pdf(shifted_queries),
+        distribution.pdf(base_queries),
+    )
+    npt.assert_allclose(
+        distribution.get_closest_point(shifted_queries[0]),
+        grid[0],
+    )
+    npt.assert_allclose(
+        distribution.get_closest_point(shifted_queries[1]),
+        grid[1],
+    )

--- a/tests/distributions/test_hypertoroidal_grid_multiturn_wrap.py
+++ b/tests/distributions/test_hypertoroidal_grid_multiturn_wrap.py
@@ -1,0 +1,22 @@
+import numpy.testing as npt
+
+from pyrecest.backend import array, pi
+from pyrecest.distributions.hypertorus.hypertoroidal_grid_distribution import (
+    HypertoroidalGridDistribution,
+)
+
+
+def test_custom_grid_nearest_neighbor_is_invariant_to_full_turns():
+    grid = array([[0.0], [pi]])
+    distribution = HypertoroidalGridDistribution(array([3.0, 1.0]), grid=grid)
+
+    base_queries = array([[0.1], [pi + 0.1]])
+    shifted_queries = base_queries + array([[4.0 * pi], [-4.0 * pi]])
+
+    npt.assert_allclose(
+        distribution.value_of_closest(shifted_queries),
+        distribution.value_of_closest(base_queries),
+    )
+    npt.assert_allclose(distribution.pdf(shifted_queries), distribution.pdf(base_queries))
+    npt.assert_allclose(distribution.get_closest_point(shifted_queries[0]), grid[0])
+    npt.assert_allclose(distribution.get_closest_point(shifted_queries[1]), grid[1])


### PR DESCRIPTION
## Summary

- reduce custom-grid angular differences modulo `2π` before computing shortest toroidal arcs
- apply the correction to both `get_closest_point` and `value_of_closest`
- add regression coverage for positive and negative multi-turn query shifts

## Bug

Custom hypertoroidal nearest-neighbor lookup used `min(|Δ|², (2π - |Δ|)²)` directly. That expression is only valid when `|Δ| <= 2π`. For queries displaced by multiple full turns, the second term squares a negative, non-periodic residual and can select the wrong grid point.

For a custom one-dimensional grid at `0` and `π`, shifting equivalent queries by `+4π` and `-4π` reverses both nearest-neighbor assignments on current `main`.

## Fix

Reduce `|Δ|` modulo `2π`, then compute the shortest arc as `min(δ, 2π - δ)` before squaring and summing.

## Validation

- isolated NumPy reproduction: old shifted assignments `[1, 0]`, corrected assignments `[0, 1]`
- regression covers `value_of_closest`, `pdf`, and `get_closest_point`
- `python -m py_compile` passed for the modified source and regression test
- branch diff is limited to the grid distribution and one focused test

Full repository tests were not run locally because this runtime cannot resolve `github.com` for a checkout and does not provide the GitHub CLI.