### PR TITLE
Reject non-real wrapped exponential rates

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
@@ -2,6 +2,8 @@
 from numbers import Integral
 from typing import Union
 
+import numpy as np
+
 # pylint: disable=redefined-builtin
 from pyrecest.backend import (
     all,
@@ -21,15 +23,72 @@ from pyrecest.backend import (
 from .abstract_circular_distribution import AbstractCircularDistribution
 
 _SMALL_RATE_SERIES_THRESHOLD = 1e-4
+_INVALID_RATE_SCALAR_TYPES = (
+    bool,
+    np.bool_,
+    str,
+    bytes,
+    bytearray,
+    np.str_,
+    np.bytes_,
+    complex,
+    np.complexfloating,
+    np.datetime64,
+    np.timedelta64,
+)
+_INVALID_RATE_DTYPE_KINDS = {"b", "S", "U", "c", "M", "m"}
+
+
+def _contains_invalid_rate_scalar(value) -> bool:
+    """Return whether a rate candidate is boolean, textual, complex, or temporal."""
+
+    if isinstance(value, _INVALID_RATE_SCALAR_TYPES):
+        return True
+
+    dtype = getattr(value, "dtype", None)
+    if dtype is not None:
+        try:
+            if np.dtype(dtype).kind in _INVALID_RATE_DTYPE_KINDS:
+                return True
+        except (TypeError, ValueError):
+            dtype_name = str(dtype).lower()
+            if any(
+                token in dtype_name
+                for token in (
+                    "bool",
+                    "complex",
+                    "str",
+                    "bytes",
+                    "datetime",
+                    "timedelta",
+                )
+            ):
+                return True
+
+    try:
+        values = np.asarray(value, dtype=object).reshape(-1)
+    except (OverflowError, TypeError, ValueError, RuntimeError):
+        return False
+    return any(isinstance(item, _INVALID_RATE_SCALAR_TYPES) for item in values)
 
 
 def _validate_positive_scalar(value, name):
-    value = asarray(value)
+    if _contains_invalid_rate_scalar(value):
+        raise ValueError(f"{name} must be a positive real scalar.")
+    try:
+        value = asarray(value)
+    except Exception as exc:  # pragma: no cover - backend-specific conversion type
+        raise ValueError(f"{name} must be a positive real scalar.") from exc
     if value.shape not in ((), (1,)):
         raise ValueError(f"{name} must be a positive scalar.")
-    if not bool(all(isfinite(value))):
+    try:
+        finite = bool(all(isfinite(value)))
+        positive = bool(all(value > 0.0))
+    except (OverflowError, TypeError, ValueError, RuntimeError) as exc:
+        raise ValueError(f"{name} must be a positive real scalar.") from exc
+    if not finite:
         raise ValueError(f"{name} must be finite.")
-    if not bool(all(value > 0.0)):
+    if not positive:
         raise ValueError(f"{name} must be positive.")
     return value
 

--- a/tests/distributions/test_wrapped_exponential_rate_validation.py
+++ b/tests/distributions/test_wrapped_exponential_rate_validation.py
@@ -1,0 +1,38 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.distributions.circle.wrapped_exponential_distribution import (
+    WrappedExponentialDistribution,
+)
+
+
+class WrappedExponentialRateValidationTest(unittest.TestCase):
+    def test_rejects_non_real_rate_scalars_before_backend_conversion(self):
+        invalid_rates = (
+            True,
+            np.bool_(True),
+            np.array(True, dtype=object),
+            "1.0",
+            np.str_("1.0"),
+            np.array("1.0", dtype=object),
+            1.0 + 0.0j,
+            np.complex128(1.0 + 0.0j),
+            np.array(1.0 + 0.0j),
+            np.datetime64("2026-01-01"),
+            np.timedelta64(1, "s"),
+        )
+
+        for rate in invalid_rates:
+            with self.subTest(rate=rate):
+                with self.assertRaisesRegex(ValueError, "positive real scalar"):
+                    WrappedExponentialDistribution(rate)
+
+    def test_accepts_real_numpy_scalar(self):
+        distribution = WrappedExponentialDistribution(np.float64(2.0))
+
+        self.assertAlmostEqual(float(distribution.lambda_), 2.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`WrappedExponentialDistribution` converted its rate parameter through the active backend before validating its numeric type. As a result, values such as `True` were silently coerced to `1` and accepted as a valid exponential rate. Text, complex, and temporal pseudo-numeric inputs could likewise leak backend-dependent behavior or lower-level exceptions.

## Fix

- reject boolean, textual, complex, and temporal scalar values before backend conversion
- inspect array/tensor dtypes as well as object-backed scalar contents
- normalize backend conversion/comparison failures to a stable `ValueError`
- preserve support for valid positive real Python and NumPy scalars

## Regression coverage

The focused tests cover:

- Python and NumPy booleans, including an object scalar array
- numeric text values
- complex values, including zero-imaginary values
- NumPy datetime and timedelta scalars
- a valid `np.float64` rate

## Validation

- focused isolated NumPy-backend regression: 2 tests passed
- `py_compile` passed for the modified implementation and regression test
- branch is 2 commits ahead of current `main`, 0 behind
- diff is limited to the wrapped-exponential implementation and one focused test file

The complete repository/backend matrix is delegated to GitHub Actions because the local environment does not provide an authenticated GitHub CLI checkout.