### PR TITLE
Reject complex IMM probability inputs

### DIFF
--- a/src/pyrecest/filters/interacting_multiple_model_filter.py
+++ b/src/pyrecest/filters/interacting_multiple_model_filter.py
@@ -5,6 +5,7 @@ import copy
 import warnings
 from collections.abc import Sequence
 
+import numpy as np
 import pyrecest.backend
 from pyrecest.backend import (
     allclose,
@@ -32,6 +33,19 @@ from scipy.special import logsumexp
 
 from .abstract_filter import AbstractFilter
 from .manifold_mixins import EuclideanFilterMixin
+
+_COMPLEX_TYPES = (complex, np.complexfloating)
+
+
+def _reject_complex_values(values, name):
+    """Reject probability-like inputs that would lose data in a float cast."""
+    message = f"{name} must contain real values."
+    try:
+        value_array = np.asarray(pyrecest.backend.to_numpy(values), dtype=object)
+    except Exception as exc:  # pragma: no cover - backend-specific conversion failure
+        raise ValueError(message) from exc
+    if any(isinstance(value, _COMPLEX_TYPES) for value in value_array.reshape(-1)):
+        raise ValueError(message)
 
 
 class InteractingMultipleModelFilter(AbstractFilter, EuclideanFilterMixin):
@@ -383,6 +397,7 @@ class InteractingMultipleModelFilter(AbstractFilter, EuclideanFilterMixin):
             )
 
         if likelihoods is not None:
+            _reject_complex_values(likelihoods, "likelihoods")
             likelihoods = asarray(likelihoods, dtype=float).reshape(-1)
             if likelihoods.shape != (self.n_models,):
                 raise ValueError(
@@ -397,6 +412,7 @@ class InteractingMultipleModelFilter(AbstractFilter, EuclideanFilterMixin):
             log_likelihoods[positive] = log(likelihoods[positive])
             self.latest_model_likelihoods = likelihoods
         else:
+            _reject_complex_values(log_likelihoods, "log_likelihoods")
             log_likelihoods = asarray(log_likelihoods, dtype=float).reshape(-1)
             if log_likelihoods.shape != (self.n_models,):
                 raise ValueError(
@@ -446,6 +462,7 @@ class InteractingMultipleModelFilter(AbstractFilter, EuclideanFilterMixin):
 
     @staticmethod
     def _prepare_transition_matrix(transition_matrix, n_models):
+        _reject_complex_values(transition_matrix, "transition_matrix")
         transition_matrix = asarray(transition_matrix, dtype=float)
         if transition_matrix.shape != (n_models, n_models):
             raise ValueError("transition_matrix must have shape (n_models, n_models).")
@@ -472,6 +489,7 @@ class InteractingMultipleModelFilter(AbstractFilter, EuclideanFilterMixin):
         if mode_probabilities is None:
             mode_probabilities = ones(n_models) / n_models
         else:
+            _reject_complex_values(mode_probabilities, "mode_probabilities")
             mode_probabilities = asarray(mode_probabilities, dtype=float).reshape(-1)
             if mode_probabilities.shape != (n_models,):
                 raise ValueError(
@@ -548,6 +566,7 @@ class InteractingMultipleModelFilter(AbstractFilter, EuclideanFilterMixin):
 
     @staticmethod
     def _moment_match_gaussians(gaussians, weights) -> GaussianDistribution:
+        _reject_complex_values(weights, "weights")
         weights = asarray(weights, dtype=float).reshape(-1)
         if weights.shape != (len(gaussians),):
             raise ValueError("weights must have one entry per Gaussian component.")

--- a/tests/filters/test_imm_complex_input_validation.py
+++ b/tests/filters/test_imm_complex_input_validation.py
@@ -1,0 +1,89 @@
+import unittest
+
+import numpy as np
+
+# pylint: disable=no-name-in-module,no-member
+import pyrecest.backend
+from pyrecest.backend import array
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.filters.interacting_multiple_model_filter import (
+    InteractingMultipleModelFilter,
+)
+
+
+class _StateOnlyGaussianFilter:
+    def __init__(self, mean):
+        self.filter_state = GaussianDistribution(
+            array([mean]), array([[1.0]]), check_validity=False
+        )
+
+
+def _filter_bank():
+    return [_StateOnlyGaussianFilter(0.0), _StateOnlyGaussianFilter(1.0)]
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ != "numpy",
+    reason="Only supported on numpy backend",
+)
+class IMMComplexInputValidationTest(unittest.TestCase):
+    def test_rejects_complex_transition_matrix(self):
+        transition_matrix = np.array(
+            [[1.0 + 1.0j, 0.0], [0.0, 1.0]], dtype=np.complex128
+        )
+
+        with self.assertRaisesRegex(
+            ValueError, "transition_matrix must contain real values"
+        ):
+            InteractingMultipleModelFilter(_filter_bank(), transition_matrix)
+
+    def test_rejects_complex_mode_probabilities(self):
+        mode_probabilities = np.array([0.5 + 0.5j, 0.5], dtype=np.complex128)
+
+        with self.assertRaisesRegex(
+            ValueError, "mode_probabilities must contain real values"
+        ):
+            InteractingMultipleModelFilter(
+                _filter_bank(),
+                transition_matrix=array([[1.0, 0.0], [0.0, 1.0]]),
+                mode_probabilities=mode_probabilities,
+            )
+
+    def test_rejects_complex_likelihoods(self):
+        imm = InteractingMultipleModelFilter(
+            _filter_bank(),
+            transition_matrix=array([[1.0, 0.0], [0.0, 1.0]]),
+        )
+
+        with self.assertRaisesRegex(ValueError, "likelihoods must contain real values"):
+            imm.update_mode_probabilities(
+                likelihoods=np.array([1.0 + 2.0j, 1.0], dtype=np.complex128)
+            )
+
+    def test_rejects_complex_log_likelihoods(self):
+        imm = InteractingMultipleModelFilter(
+            _filter_bank(),
+            transition_matrix=array([[1.0, 0.0], [0.0, 1.0]]),
+        )
+
+        with self.assertRaisesRegex(
+            ValueError, "log_likelihoods must contain real values"
+        ):
+            imm.update_mode_probabilities(
+                log_likelihoods=np.array([0.0 + 1.0j, -1.0], dtype=np.complex128)
+            )
+
+    def test_rejects_complex_moment_match_weights(self):
+        states = [
+            GaussianDistribution(array([0.0]), array([[1.0]])),
+            GaussianDistribution(array([1.0]), array([[1.0]])),
+        ]
+
+        with self.assertRaisesRegex(ValueError, "weights must contain real values"):
+            InteractingMultipleModelFilter._moment_match_gaussians(
+                states, np.array([0.5 + 0.0j, 0.5], dtype=np.complex128)
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- reject complex transition matrices and mode probabilities before backend float conversion
- reject complex likelihoods, log-likelihoods, and Gaussian moment-matching weights
- add five NumPy-backend regression tests covering every affected entry point

## Bug

The IMM validation currently calls `asarray(..., dtype=float)` before checking probability-like inputs. NumPy therefore discards imaginary components (with only a `ComplexWarning`) and can turn invalid complex transition probabilities or likelihoods into apparently valid real values.

The new validation inspects backend values before conversion and raises a clear `ValueError` instead of silently changing the model.

## Testing

- added `tests/filters/test_imm_complex_input_validation.py`
- repository CI will provide the full-suite result
