### PR TITLE
Validate hypertoroidal Dirac moment orders

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py
@@ -1,6 +1,7 @@
 import copy
 from collections.abc import Callable
 from numbers import Integral
+from operator import index as _operator_index
 from typing import Union
 
 import matplotlib.pyplot as plt
@@ -30,6 +31,27 @@ from ..abstract_dirac_distribution import AbstractDiracDistribution
 from ..nonperiodic.linear_dirac_distribution import LinearDiracDistribution
 from ._input_validation import as_shift_vector
 from .abstract_hypertoroidal_distribution import AbstractHypertoroidalDistribution
+
+
+def _validate_moment_order(n) -> int:
+    """Return a scalar integer trigonometric-moment order."""
+    message = "n must be an integer."
+    if isinstance(n, bool):
+        raise ValueError(message)
+
+    ndim = getattr(n, "ndim", None)
+    if ndim not in (None, 0):
+        raise ValueError(message)
+
+    dtype = getattr(n, "dtype", None)
+    if getattr(dtype, "kind", None) == "b" or str(dtype) == "torch.bool":
+        raise ValueError(message)
+
+    try:
+        order = _operator_index(n)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError(message) from exc
+    return int(order)
 
 
 class HypertoroidalDiracDistribution(
@@ -144,6 +166,7 @@ class HypertoroidalDiracDistribution(
         :param n: Integer moment order
         :return: Trigonometric moment
         """
+        n = _validate_moment_order(n)
         return sum(exp(1j * n * self.d.T) * tile(self.w, (self.dim, 1)), axis=1)
 
     def apply_function(self, f: Callable, function_is_vectorized: bool = True):
@@ -218,14 +241,3 @@ class HypertoroidalDiracDistribution(
         else:
             hd.d = mod(self.d + reshape(shift_by, (1, -1)), 2.0 * pi)
         return hd
-
-    def entropy(self):
-        # Implement the entropy calculation here.
-        raise NotImplementedError("Entropy calculation is not implemented")
-
-    def to_wd(self):
-        if self.dim != 1:
-            raise ValueError("The dimension must be 1")
-        from ..circle.circular_dirac_distribution import CircularDiracDistribution
-
-        return CircularDiracDistribution(self.d, self.w)

--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py
@@ -241,3 +241,14 @@ class HypertoroidalDiracDistribution(
         else:
             hd.d = mod(self.d + reshape(shift_by, (1, -1)), 2.0 * pi)
         return hd
+
+    def entropy(self):
+        # Implement the entropy calculation here.
+        raise NotImplementedError("Entropy calculation is not implemented")
+
+    def to_wd(self):
+        if self.dim != 1:
+            raise ValueError("The dimension must be 1")
+        from ..circle.circular_dirac_distribution import CircularDiracDistribution
+
+        return CircularDiracDistribution(self.d, self.w)

--- a/tests/distributions/test_hypertoroidal_dirac_moment_order_validation.py
+++ b/tests/distributions/test_hypertoroidal_dirac_moment_order_validation.py
@@ -1,0 +1,40 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+import pyrecest.backend
+from pyrecest.backend import array
+from pyrecest.distributions import HypertoroidalDiracDistribution
+
+
+def _distribution():
+    return HypertoroidalDiracDistribution(
+        array([[0.1, 0.2], [0.3, 0.4]]),
+        array([0.25, 0.75]),
+    )
+
+
+@pytest.mark.parametrize(
+    "invalid_order",
+    [True, False, 1.5, "1", np.array([1]), np.asarray(1.0)],
+)
+def test_trigonometric_moment_rejects_noninteger_orders(invalid_order):
+    with pytest.raises(ValueError, match="integer"):
+        _distribution().trigonometric_moment(invalid_order)
+
+
+def test_trigonometric_moment_accepts_integer_scalar_types():
+    dist = _distribution()
+    expected = pyrecest.backend.to_numpy(dist.trigonometric_moment(2))
+
+    for order in (np.int64(2), np.asarray(2, dtype=np.int64)):
+        actual = pyrecest.backend.to_numpy(dist.trigonometric_moment(order))
+        npt.assert_allclose(actual, expected)
+
+
+def test_trigonometric_moment_preserves_negative_orders():
+    dist = _distribution()
+    positive = pyrecest.backend.to_numpy(dist.trigonometric_moment(1))
+    negative = pyrecest.backend.to_numpy(dist.trigonometric_moment(-1))
+
+    npt.assert_allclose(negative, np.conjugate(positive))


### PR DESCRIPTION
## Bug

`HypertoroidalDiracDistribution.trigonometric_moment()` documents an integer moment order, but it previously accepted arbitrary multiplicative values. Inputs such as `True`, `1.5`, numeric text, and non-scalar arrays could therefore be evaluated as if they were valid trigonometric orders instead of failing fast. In particular, `True` silently behaved exactly like first order.

## Fix

- validate moment orders through Python's integer index protocol
- reject native and backend boolean scalars
- reject fractional, textual, and non-scalar inputs with a stable `ValueError`
- preserve Python integers, NumPy integer scalars, zero-dimensional integer arrays, zero, and negative orders

## Regression coverage

- booleans, fractional values, numeric text, one-dimensional arrays, and zero-dimensional floating arrays are rejected
- NumPy integer scalars and zero-dimensional integer arrays match the corresponding Python integer result
- negative-order conjugacy remains unchanged

## Validation

- `python -m py_compile` passed for the modified source and focused regression module
- isolated integer-index checks confirmed accepted and rejected scalar forms
- final branch comparison is three commits ahead of `main`, zero behind, and changes only the distribution implementation plus one focused test file (63 additions, 0 deletions)

The full repository/backend test matrix is delegated to GitHub Actions because this runtime could not obtain a network checkout of the repository.