### PR TITLE
Reject non-finite SO(3) chordal smoother weights

### DIFF
--- a/src/pyrecest/smoothers/so3_chordal_mean_smoother.py
+++ b/src/pyrecest/smoothers/so3_chordal_mean_smoother.py
@@ -7,7 +7,7 @@ from typing import Sequence
 
 # pylint: disable=no-member
 from pyrecest import backend
-from pyrecest.backend import asarray, diag, linalg, ndim, zeros
+from pyrecest.backend import asarray, diag, isfinite, linalg, ndim, zeros
 
 from .abstract_smoother import AbstractSmoother
 
@@ -99,6 +99,8 @@ class SO3ChordalMeanSmoother(AbstractSmoother):
         weights_array = asarray(weights).reshape(-1)
         if weights_array.shape[0] != length:
             raise ValueError(f"{name} must have length {length}.")
+        if not bool(backend.all(isfinite(weights_array))):
+            raise ValueError(f"{name} must contain only finite values.")
 
         for idx in range(length):
             if weights_array[idx] < 0.0:

--- a/tests/smoothers/test_so3_chordal_mean_nonfinite_weights.py
+++ b/tests/smoothers/test_so3_chordal_mean_nonfinite_weights.py
@@ -1,0 +1,32 @@
+"""Regression coverage for non-finite SO(3) chordal smoother weights."""
+
+import pytest
+
+from pyrecest.backend import eye
+from pyrecest.smoothers import SO3ChordalMeanSmoother
+
+
+@pytest.mark.parametrize(
+    "invalid_weight",
+    [float("nan"), float("inf"), -float("inf")],
+)
+def test_rejects_nonfinite_weights_at_all_entry_points(invalid_weight):
+    rotations = [eye(3), eye(3), eye(3)]
+
+    with pytest.raises(ValueError, match="finite"):
+        SO3ChordalMeanSmoother(
+            window_size=3,
+            kernel_weights=[1.0, invalid_weight, 1.0],
+        )
+
+    with pytest.raises(ValueError, match="finite"):
+        SO3ChordalMeanSmoother.chordal_mean(
+            rotations[:2],
+            weights=[1.0, invalid_weight],
+        )
+
+    with pytest.raises(ValueError, match="finite"):
+        SO3ChordalMeanSmoother(window_size=3).smooth(
+            rotations,
+            weights=[1.0, invalid_weight, 1.0],
+        )


### PR DESCRIPTION
## Bug

`SO3ChordalMeanSmoother._normalize_weight_vector()` checked weight length, negativity, and positive total mass, but did not reject non-finite values. Consequently, `NaN` and infinite kernel or sample weights could pass validation. Normalization then produced `NaN` weights, which could corrupt the ambient mean matrix or make the subsequent SVD fail with a lower-level numerical error.

The defect affected all three public entry points that share this helper:

- constructor `kernel_weights`
- direct `chordal_mean(..., weights=...)`
- sequence `smooth(..., weights=...)`

## Fix

Validate that every weight is finite before checking nonnegativity, total mass, or normalization. Invalid inputs now fail fast with a clear `ValueError`, while valid finite weights retain their existing behavior.

## Regression coverage

The focused regression rejects `NaN`, positive infinity, and negative infinity through each affected entry point.

## Validation

- isolated reproduction confirmed the previous normalization produced `NaN` weights for non-finite inputs
- isolated patched-validator checks passed, including unchanged normalization of valid weights
- branch comparison: 2 commits ahead of `main`, 0 behind
- diff limited to the shared smoother helper and one focused regression file: 35 additions, 1 deletion

The full repository/backend matrix is delegated to GitHub Actions because this runtime has no GitHub CLI and cannot resolve `github.com` for a local checkout.