### PR TITLE
Normalize arbitrary-noise hyperspherical UKF samples

### DIFF
--- a/src/pyrecest/filters/hyperspherical_ukf.py
+++ b/src/pyrecest/filters/hyperspherical_ukf.py
@@ -176,12 +176,13 @@ class HypersphericalUKF(AbstractFilter, HypersphericalFilterMixin):
     ):
         """
         Predict assuming nonlinear system model with arbitrary noise:
-            x(k+1) = f(x(k), v_k)
+            x(k+1) = normalize(f(x(k), v_k))
 
         Parameters
         ----------
         f:
             Function ``f(x, v) -> x_new`` where x is a unit vector in R^d.
+            Each returned state is normalized before moment matching.
         noise_samples:
             Array of shape ``(noise_dim, n_noise)`` with noise samples (columns).
         noise_weights:
@@ -229,10 +230,10 @@ class HypersphericalUKF(AbstractFilter, HypersphericalFilterMixin):
                     ),
                     (-1,),
                 )
+                x_new = self._normalize(x_new)
                 new_samples[:, k] = x_new
                 new_weights[k] = noise_weights[j] * state_weights[i]
                 k += 1
-
         new_weights = new_weights / new_weights.sum()
 
         # Weighted mean and covariance

--- a/tests/filters/test_hyperspherical_ukf_arbitrary_noise_normalization.py
+++ b/tests/filters/test_hyperspherical_ukf_arbitrary_noise_normalization.py
@@ -1,0 +1,38 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+import pyrecest.backend
+from pyrecest.backend import array
+from pyrecest.filters.hyperspherical_ukf import HypersphericalUKF
+
+
+class HypersphericalUKFArbitraryNoiseNormalizationTest(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Arbitrary-noise prediction is not supported on this backend",
+    )
+    def test_radial_model_scale_does_not_create_spurious_covariance(self):
+        ukf = HypersphericalUKF(dim=2, alpha=1.0)
+        noise_samples = np.array([[0.0, 1.0]])
+        noise_weights = np.ones(2)
+
+        def scaled_same_direction(_x, v):
+            scale = 1.0 + float(np.asarray(v, dtype=float)[0])
+            return array([scale, 0.0])
+
+        ukf.predict_nonlinear_arbitrary_noise(
+            scaled_same_direction, noise_samples, noise_weights
+        )
+
+        npt.assert_allclose(
+            np.asarray(ukf.filter_state.mu, dtype=float),
+            np.array([1.0, 0.0]),
+            atol=1e-12,
+        )
+        npt.assert_allclose(
+            np.asarray(ukf.filter_state.C, dtype=float),
+            np.zeros((2, 2)),
+            atol=1e-12,
+        )


### PR DESCRIPTION
## Bug

`HypersphericalUKF.predict_nonlinear_arbitrary_noise()` accumulated raw model outputs when computing the predicted covariance and normalized only the final mean. Two outputs representing the same point on the hypersphere but with different radial magnitudes therefore created artificial covariance in the ambient radial direction.

This also contradicted the existing arbitrary-noise test's stated assumption that model outputs are normalized inside the filter.

## Fix

- normalize every propagated state returned by `f(x, v)` before weighted moment matching
- document the normalized transition model explicitly
- add a regression where differently scaled vectors in the same direction must yield the same unit mean and zero covariance

## Validation

- branch comparison: 2 commits ahead of `main`, 0 behind
- focused source and regression modules pass Python syntax compilation
- the regression is constructed to fail on the previous implementation: raw scales 1 and 2 produce radial variance 0.25, while normalized samples are identical and produce zero covariance

Full backend validation is delegated to GitHub Actions because the local runtime cannot clone GitHub or run the repository dependency matrix.