### PR TITLE
Validate wrapped Cauchy mean parameters

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py
@@ -18,12 +18,17 @@ from pyrecest.backend import (
 from .abstract_circular_distribution import AbstractCircularDistribution
 
 
-def _validate_positive_scalar(value, name):
+def _validate_finite_scalar(value, name):
     value = array(value)
     if value.shape not in ((), (1,)):
-        raise ValueError(f"{name} must be a positive scalar.")
+        raise ValueError(f"{name} must be a scalar.")
     if not bool(all(isfinite(value))):
         raise ValueError(f"{name} must be finite.")
+    return value
+
+
+def _validate_positive_scalar(value, name):
+    value = _validate_finite_scalar(value, name)
     if not bool(all(value > 0.0)):
         raise ValueError(f"{name} must be positive.")
     return value
@@ -47,7 +52,7 @@ class WrappedCauchyDistribution(AbstractCircularDistribution):
 
     def __init__(self, mu, gamma):
         AbstractCircularDistribution.__init__(self)
-        self.mu = mod(mu, 2 * pi)
+        self.mu = mod(_validate_finite_scalar(mu, "mu"), 2 * pi)
         self.gamma = _validate_positive_scalar(gamma, "gamma")
 
     def pdf(self, xs):

--- a/tests/distributions/test_wrapped_cauchy_mean_validation.py
+++ b/tests/distributions/test_wrapped_cauchy_mean_validation.py
@@ -1,0 +1,24 @@
+import pytest
+
+from pyrecest.backend import array
+from pyrecest.distributions.circle.wrapped_cauchy_distribution import (
+    WrappedCauchyDistribution,
+)
+
+
+@pytest.mark.parametrize(
+    "mu",
+    [
+        array([0.0, 1.0]),
+        array([[0.0]]),
+    ],
+)
+def test_wrapped_cauchy_rejects_non_scalar_mean(mu):
+    with pytest.raises(ValueError, match="mu must be a scalar"):
+        WrappedCauchyDistribution(mu, 0.5)
+
+
+@pytest.mark.parametrize("mu", [float("nan"), float("inf"), -float("inf")])
+def test_wrapped_cauchy_rejects_nonfinite_mean(mu):
+    with pytest.raises(ValueError, match="mu must be finite"):
+        WrappedCauchyDistribution(mu, 0.5)


### PR DESCRIPTION
## Bug

`WrappedCauchyDistribution` validated `gamma` as scalar but accepted arbitrary shapes for `mu`. A vector-valued mean therefore broadcast against evaluation points instead of representing one circular distribution.

For example, `mu=[0, 1]` and `xs=[0, 1]` produce two mode densities because each point is centered by a different mean. The result looks numerically plausible, so this malformed parameter can silently propagate through estimation code.

Non-finite means were also accepted and only surfaced later as `NaN` density values.

## Fix

- add a shared finite-scalar validator
- require `mu` to be scalar-like before wrapping it to `[0, 2π)`
- reject non-finite means during construction
- reuse the finite-scalar validation for `gamma` before its positivity check

The existing support for Python/backend scalars and one-element scalar-like arrays is preserved.

## Regression coverage

- vector and matrix means are rejected with a clear `ValueError`
- `NaN`, `+inf`, and `-inf` means are rejected during construction

## Validation

- `python -m py_compile` passed for the modified implementation and focused regression module
- isolated NumPy reproduction confirmed the previous vector broadcasting (`mu=[0,1]`, `xs=[0,1]`) returned two plausible mode densities instead of rejecting the parameter
- branch is two commits ahead of current `main`, zero behind, and changes only the wrapped Cauchy implementation plus one focused test file

The full backend test matrix is delegated to GitHub Actions because this runtime cannot resolve `github.com` for a local checkout.