### PR TITLE
Reject invalid sigma-point covariance matrices

### DIFF
--- a/src/pyrecest/sampling/sigma_points.py
+++ b/src/pyrecest/sampling/sigma_points.py
@@ -8,7 +8,19 @@ from numbers import Integral
 import numpy as np
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import asarray, concatenate, float64, full, linalg, reshape, stack
+from pyrecest.backend import (
+    all,
+    allclose,
+    asarray,
+    concatenate,
+    float64,
+    full,
+    isfinite,
+    linalg,
+    reshape,
+    stack,
+    transpose,
+)
 
 _TEXT_SCALAR_TYPES = (str, bytes, np.str_, np.bytes_)
 
@@ -45,6 +57,16 @@ def _scalar_item(value, name: str):
     return scalar
 
 
+def _to_python_bool(value) -> bool:
+    """Convert a scalar backend boolean result to a Python bool."""
+
+    if isinstance(value, bool):
+        return value
+    if hasattr(value, "item"):
+        return bool(value.item())
+    return bool(value)
+
+
 def _validate_positive_integer(value, name: str) -> int:
     scalar = _scalar_item(value, name)
     if not isinstance(scalar, Integral):
@@ -79,6 +101,10 @@ def _validate_sigma_inputs(x, P, n: int):
     P = asarray(P, dtype=float64)
     if P.shape != (n, n):
         raise ValueError(f"P must have shape ({n}, {n})")
+    if not _to_python_bool(all(isfinite(P))):
+        raise ValueError("P must contain only finite values")
+    if not _to_python_bool(allclose(P, transpose(P), rtol=1e-7, atol=1e-9)):
+        raise ValueError("P must be symmetric")
     return x, P
 
 

--- a/tests/test_sigma_points_covariance_validation.py
+++ b/tests/test_sigma_points_covariance_validation.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pytest
+
+from pyrecest.sampling import JulierSigmaPoints, MerweScaledSigmaPoints
+
+
+@pytest.mark.parametrize(
+    "points",
+    [
+        JulierSigmaPoints(n=2, kappa=1.0),
+        MerweScaledSigmaPoints(n=2, alpha=0.5, beta=2.0, kappa=0.0),
+    ],
+    ids=["julier", "merwe"],
+)
+def test_sigma_points_reject_asymmetric_covariance(points):
+    covariance = np.array([[1.0, 9.0], [0.0, 1.0]])
+
+    with pytest.raises(ValueError, match="P must be symmetric"):
+        points.sigma_points(np.zeros(2), covariance)
+
+
+@pytest.mark.parametrize(
+    "points",
+    [
+        JulierSigmaPoints(n=2, kappa=1.0),
+        MerweScaledSigmaPoints(n=2, alpha=0.5, beta=2.0, kappa=0.0),
+    ],
+    ids=["julier", "merwe"],
+)
+@pytest.mark.parametrize("invalid_value", [np.nan, np.inf], ids=["nan", "infinity"])
+def test_sigma_points_reject_nonfinite_covariance(points, invalid_value):
+    covariance = np.diag([1.0, invalid_value])
+
+    with pytest.raises(ValueError, match="P must contain only finite values"):
+        points.sigma_points(np.zeros(2), covariance)


### PR DESCRIPTION
## Bug

`JulierSigmaPoints.sigma_points()` and `MerweScaledSigmaPoints.sigma_points()` passed covariance matrices directly to Cholesky after checking only dtype and shape. Cholesky implementations commonly consume one triangle without verifying symmetry, so an asymmetric matrix could be silently interpreted as a different covariance.

For example,

```python
P = np.array([[1.0, 9.0], [0.0, 1.0]])
```

was accepted by NumPy Cholesky using the lower triangle and produced sigma points whose reconstructed covariance is the identity matrix rather than `P`. Symmetric matrices containing `NaN` or infinity could also propagate non-finite sigma points instead of failing clearly.

## Fix

- require sigma-point covariance matrices to contain only finite values
- require covariance symmetry using the repository's established backend-compatible tolerance (`rtol=1e-7`, `atol=1e-9`)
- apply the shared validation path to both Julier and Merwe sigma-point schemes
- retain the existing real-valued and shape checks

## Regression coverage

- asymmetric covariance whose lower triangle is valid for Cholesky
- symmetric covariance containing `NaN`
- symmetric covariance containing infinity
- both Julier and Merwe schemes

## Validation

- focused regression suite: `6 passed`
- `python -m py_compile` passed for the modified source and regression module
- isolated valid-covariance checks preserved weighted covariance reconstruction to floating-point precision
- eager backend probes produced the intended `ValueError` under NumPy-, JAX-, and PyTorch-style backend facades
- branch comparison: 2 commits ahead of `main`, 0 behind; only the sigma-point implementation and one focused test file are changed

The full repository/backend CI matrix is delegated to GitHub Actions because this runtime has no GitHub CLI and cannot obtain a network checkout.