### PR TITLE
Stabilize concentrated wrapped Cauchy densities

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py
@@ -5,13 +5,11 @@ from pyrecest.backend import (
     array,
     atleast_1d,
     cos,
-    cosh,
     exp,
     isfinite,
     mod,
     pi,
     sin,
-    sinh,
     tanh,
 )
 
@@ -53,7 +51,13 @@ class WrappedCauchyDistribution(AbstractCircularDistribution):
     def pdf(self, xs):
         xs = _as_1d_input(xs)
         xs_centered = mod(xs - self.mu, 2 * pi)
-        return 1 / (2 * pi) * sinh(self.gamma) / (cosh(self.gamma) - cos(xs_centered))
+        rho = exp(-self.gamma)
+        one_minus_rho = 1.0 - rho
+        numerator = one_minus_rho * (1.0 + rho)
+        denominator = (
+            one_minus_rho**2 + 4.0 * rho * sin(xs_centered / 2.0) ** 2
+        )
+        return numerator / (2.0 * pi * denominator)
 
     def cdf(self, xs, starting_point=0.0):
         """

--- a/tests/distributions/test_wrapped_cauchy_distribution.py
+++ b/tests/distributions/test_wrapped_cauchy_distribution.py
@@ -38,6 +38,12 @@ class WrappedCauchyDistributionTest(unittest.TestCase):
             dist.pdf(xs=self.xs), custom_wrapped.pdf(xs=self.xs), atol=0.0001
         )
 
+    def test_pdf_remains_finite_for_large_gamma(self):
+        dist = WrappedCauchyDistribution(self.mu, 1000.0)
+        xs = array([0.0, 0.3, 1.0, pi, 2.0 * pi - 1e-6])
+
+        npt.assert_allclose(dist.pdf(xs), 1.0 / (2.0 * pi), rtol=1e-12)
+
     def test_pdf_mode_for_nonzero_mean(self):
         dist = WrappedCauchyDistribution(array(1.0), array(0.5))
         npt.assert_array_less(dist.pdf(array([2.0])), dist.pdf(array([1.0])))


### PR DESCRIPTION
## Summary
- rewrite the wrapped Cauchy PDF using the bounded parameter `rho = exp(-gamma)`
- avoid `sinh`/`cosh` overflow for large finite concentration parameters
- add a focused regression at `gamma=1000`

## Bug
`WrappedCauchyDistribution.pdf()` evaluated

```python
sinh(gamma) / (2 * pi * (cosh(gamma) - cos(x - mu)))
```

For large but valid finite `gamma`, both hyperbolic terms overflow to infinity and the density becomes `inf / inf = NaN`. Mathematically, the wrapped Cauchy density approaches the uniform density `1 / (2*pi)` in this limit.

## Fix
Use the algebraically equivalent representation with `rho = exp(-gamma)`:

```python
(1 - rho**2) / (
    2 * pi * ((1 - rho)**2 + 4 * rho * sin((x - mu) / 2)**2)
)
```

All intermediate quantities remain bounded for large `gamma`; when `rho` underflows to zero, the expression correctly returns `1 / (2*pi)`.

## Validation
- reproduced the old all-`NaN` result at `gamma=1000`
- compared the replacement against 80-digit reference arithmetic across small, ordinary, and large concentrations
- `python -m py_compile` passed for the modified source and test files
- isolated NumPy-backend module smoke passed for the regression and ordinary concentrations
- branch is 2 commits ahead of `main`, 0 behind, changing only the implementation and its focused test

The full backend test matrix is delegated to GitHub Actions because this runtime cannot obtain a network checkout of the repository.