### PR TITLE
Reject zero-support PyTorch weighted choice samples

### DIFF
--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -424,6 +424,8 @@ def _choice_indices(
                 "Cannot take a larger sample than population when 'replace=False'."
             )
         p = _validate_choice_probabilities(p, population_size, device)
+        if not replace and num_samples > int(_torch.count_nonzero(p).item()):
+            raise ValueError("Fewer non-zero entries in p than size")
         if num_samples == 0:
             return _empty_choice_indices(size, p.device)
         indices = _torch.multinomial(p, num_samples=num_samples, replacement=replace)

--- a/tests/backend/test_pytorch_choice_probability_support.py
+++ b/tests/backend/test_pytorch_choice_probability_support.py
@@ -1,0 +1,37 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from pyrecest._backend.pytorch import random  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    "population",
+    [
+        4,
+        torch.tensor([10, 20, 30, 40]),
+    ],
+)
+def test_weighted_choice_without_replacement_rejects_insufficient_support(population):
+    probabilities = torch.tensor([1.0, 0.0, 0.0, 0.0])
+
+    with pytest.raises(ValueError, match="Fewer non-zero entries in p than size"):
+        random.choice(
+            population,
+            size=2,
+            replace=False,
+            p=probabilities,
+        )
+
+
+def test_weighted_choice_without_replacement_can_exhaust_positive_support():
+    values = torch.tensor([10, 20, 30])
+
+    samples = random.choice(
+        values,
+        size=2,
+        replace=False,
+        p=torch.tensor([0.25, 0.75, 0.0]),
+    )
+
+    assert set(samples.tolist()) == {10, 20}


### PR DESCRIPTION
## Summary
- reject weighted `choice(..., replace=False)` requests whose sample count exceeds the number of strictly positive probabilities
- match NumPy's `Fewer non-zero entries in p than size` behavior instead of allowing `torch.multinomial` to fill remaining slots with zero-probability entries
- add regression coverage for integer and tensor populations, plus the valid case that exactly exhausts the positive support

## Bug
PyTorch's `torch.multinomial(..., replacement=False)` can return zero-probability indices when more samples are requested than there are non-zero weights. The PyRecEst PyTorch backend delegated directly to that behavior, violating the NumPy-compatible backend contract and making impossible hypotheses selectable.

## Verification
- reproduced the pre-fix behavior with `torch.multinomial([1, 0, 0], 2, replacement=False)`
- verified the guard raises the same error as NumPy for insufficient support
- verified sampling exactly the positive support still succeeds
- GitHub CI will run the repository test matrix on this PR