### PR TITLE
Stabilize generalized sine-skewed wrapped Cauchy densities

### DIFF
--- a/src/pyrecest/distributions/circle/sine_skewed_distributions.py
+++ b/src/pyrecest/distributions/circle/sine_skewed_distributions.py
@@ -2,7 +2,7 @@ from abc import abstractmethod
 from numbers import Integral
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array, cos, cosh, exp, mod, ndim, pi, sin, sinh
+from pyrecest.backend import array, exp, mod, ndim, pi, sin
 from scipy.special import ive  # pylint: disable=no-name-in-module
 
 from .abstract_circular_distribution import AbstractCircularDistribution
@@ -249,10 +249,18 @@ class GeneralizedKSineSkewedWrappedCauchyDistribution(AbstractCircularDistributi
         xs = array(xs)
         if self.k != 1:
             raise NotImplementedError("Currently, only k=1 is supported")
-        # Use the WC pdf formula directly to ensure correct centering at mu
-        wc_pdf_vals = (
-            1 / (2 * pi) * sinh(self.gamma) / (cosh(self.gamma) - cos(xs - self.mu))
+
+        # Parameterizing the wrapped Cauchy density through rho avoids the
+        # sinh/cosh overflow and inf/inf cancellation that occur for large gamma.
+        rho = exp(-self.gamma)
+        one_minus_rho = 1.0 - rho
+        numerator = one_minus_rho * (1.0 + rho)
+        denominator = (
+            one_minus_rho**2
+            + 4.0 * rho * sin((xs - self.mu) / 2.0) ** 2
         )
+        wc_pdf_vals = numerator / (2.0 * pi * denominator)
+
         skew_factor = (1 + self.lambda_ * sin(self.k * (xs - self.mu))) ** self.m
         # For the wrapped Cauchy: E[cos(n*(x-mu))] = exp(-n*k*gamma)
         r2 = exp(-2 * self.k * self.gamma)

--- a/tests/distributions/test_generalized_sine_skewed_wrapped_cauchy_stability.py
+++ b/tests/distributions/test_generalized_sine_skewed_wrapped_cauchy_stability.py
@@ -1,0 +1,26 @@
+import numpy as np
+import numpy.testing as npt
+
+from pyrecest.backend import array, pi, sin
+from pyrecest.distributions.circle.sine_skewed_distributions import (
+    GeneralizedKSineSkewedWrappedCauchyDistribution,
+)
+
+
+def test_pdf_remains_finite_for_large_gamma():
+    mu = 0.3
+    skewness = 0.4
+    xs = array([0.0, 0.3, 1.0, pi, 2.0 * pi - 1e-6])
+    dist = GeneralizedKSineSkewedWrappedCauchyDistribution(
+        mu=mu,
+        gamma=1000.0,
+        lambda_=skewness,
+        k=1,
+        m=1,
+    )
+
+    pdf_values = dist.pdf(xs)
+    expected = (1.0 + skewness * sin(xs - mu)) / (2.0 * pi)
+
+    assert np.all(np.isfinite(np.asarray(pdf_values)))
+    npt.assert_allclose(pdf_values, expected, rtol=1e-12, atol=0.0)


### PR DESCRIPTION
## Summary
- rewrite the generalized sine-skewed wrapped Cauchy base density using the bounded parameter `rho = exp(-gamma)`
- remove the overflowing `sinh`/`cosh` evaluation path
- add a focused regression for a large valid concentration parameter

## Bug
`GeneralizedKSineSkewedWrappedCauchyDistribution.pdf()` still evaluated the wrapped Cauchy factor as

```python
sinh(gamma) / (2 * pi * (cosh(gamma) - cos(x - mu)))
```

For large finite `gamma`, both hyperbolic terms overflow and the density becomes `inf / inf = NaN`. This remained after the corresponding base `WrappedCauchyDistribution` implementation was stabilized because the generalized sine-skewed class carried its own copy of the old formula.

## Fix
Use the algebraically equivalent bounded representation

```python
rho = exp(-gamma)
(1 - rho) * (1 + rho) / (
    2 * pi * ((1 - rho)**2 + 4 * rho * sin((x - mu) / 2)**2)
)
```

When `rho` underflows to zero, the wrapped Cauchy factor correctly approaches `1 / (2*pi)` and the configured sine-skew factor remains finite.

## Validation
- reproduced the old all-`NaN` result at `gamma=1000`
- verified the replacement against the analytic large-`gamma` limit for a nonzero skew parameter
- branch is 2 commits ahead of `main`, 0 behind, changing only the implementation and a focused regression test

A full repository test run was not available in this connector-only environment; GitHub Actions should run the normal matrix.