### PR TITLE
Stabilize concentrated Mardia-Sutton densities

### DIFF
--- a/src/pyrecest/distributions/cart_prod/mardia_sutton_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/mardia_sutton_distribution.py
@@ -13,7 +13,7 @@ from pyrecest.backend import (
     sin,
     sqrt,
 )
-from scipy.special import iv
+from scipy.special import ive
 from scipy.stats import norm, vonmises
 
 from ..circle.von_mises_distribution import VonMisesDistribution
@@ -132,8 +132,8 @@ class MardiaSuttonDistribution(AbstractHypercylindricalDistribution):
 
         muc, sigmac = self.get_mu_sigma(circular)
 
-        vm_part = exp(self.kappa * cos(circular - self.mu0)) / (
-            2.0 * pi * iv(0, float(self.kappa))
+        vm_part = exp(self.kappa * (cos(circular - self.mu0) - 1.0)) / (
+            2.0 * pi * ive(0, self.kappa)
         )
         gaussian_part = array(norm.pdf(linear, loc=muc, scale=float(sigmac)))
 
@@ -174,9 +174,9 @@ class MardiaSuttonDistribution(AbstractHypercylindricalDistribution):
         _ = approximate_mean
 
         kappa = float(self.kappa)
-        bessel_0 = iv(0, kappa)
-        bessel_ratio_1 = iv(1, kappa) / bessel_0
-        bessel_ratio_2 = iv(2, kappa) / bessel_0
+        scaled_bessel_0 = ive(0, kappa)
+        bessel_ratio_1 = ive(1, kappa) / scaled_bessel_0
+        bessel_ratio_2 = ive(2, kappa) / scaled_bessel_0
 
         rho_squared = self.rho1**2 + self.rho2**2
         conditional_variance = self.sigma**2 * (1.0 - rho_squared)

--- a/tests/distributions/test_mardia_sutton_distribution.py
+++ b/tests/distributions/test_mardia_sutton_distribution.py
@@ -80,6 +80,45 @@ class TestMardiaSuttonDistribution(unittest.TestCase):
         p = self.dist.pdf(array([[self.mu0, self.mu]]))
         npt.assert_allclose(float(p[0]), expected, rtol=1e-6)
 
+    def test_large_kappa_pdf_and_covariance_remain_finite(self):
+        import math
+
+        from scipy.special import ive  # pylint: disable=no-name-in-module
+        from scipy.stats import norm
+
+        kappa = 1000.0
+        dist = MardiaSuttonDistribution(
+            self.mu, self.mu0, kappa, self.rho1, self.rho2, self.sigma
+        )
+
+        rho_squared = self.rho1**2 + self.rho2**2
+        sigmac = self.sigma * math.sqrt(1.0 - rho_squared)
+        expected_pdf = norm.pdf(self.mu, loc=self.mu, scale=sigmac) / (
+            2.0 * math.pi * ive(0, kappa)
+        )
+        actual_pdf = float(dist.pdf(array([[self.mu0, self.mu]]))[0])
+        self.assertTrue(math.isfinite(actual_pdf))
+        npt.assert_allclose(actual_pdf, expected_pdf, rtol=1e-12)
+
+        bessel_ratio_1 = ive(1, kappa) / ive(0, kappa)
+        bessel_ratio_2 = ive(2, kappa) / ive(0, kappa)
+        aligned_rho_cos = self.rho1 * math.cos(self.mu0) + self.rho2 * math.sin(
+            self.mu0
+        )
+        aligned_rho_sin = -self.rho1 * math.sin(self.mu0) + self.rho2 * math.cos(
+            self.mu0
+        )
+        cos_variance = 0.5 * (1.0 + bessel_ratio_2) - bessel_ratio_1**2
+        sin_variance = 0.5 * (1.0 - bessel_ratio_2)
+        expected_covariance = self.sigma**2 * (1.0 - rho_squared) + (
+            self.sigma**2
+            * kappa
+            * (aligned_rho_cos**2 * cos_variance + aligned_rho_sin**2 * sin_variance)
+        )
+        actual_covariance = float(dist.linear_covariance()[0, 0])
+        self.assertTrue(math.isfinite(actual_covariance))
+        npt.assert_allclose(actual_covariance, expected_covariance, rtol=1e-12)
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
         reason="Not supported on this backend",


### PR DESCRIPTION
## Bug

`MardiaSuttonDistribution.pdf()` evaluated its von Mises factor as

```python
exp(kappa * cos(delta)) / (2 * pi * I0(kappa))
```

For large but valid finite concentrations such as `kappa=1000`, both the numerator and `I0(kappa)` overflow. The density therefore becomes `inf / inf = NaN`, including exactly at the mode.

`linear_covariance()` had the same failure mode because it computed `I1(kappa) / I0(kappa)` and `I2(kappa) / I0(kappa)` from unscaled Bessel functions, yielding `inf / inf` and a `NaN` covariance.

## Fix

- use the exponentially scaled modified Bessel function `ive`
- shift the density exponent by `-kappa`, giving the algebraically equivalent bounded expression
- compute both moment ratios from scaled Bessel functions

This follows the stable formulation already used by `VonMisesDistribution`.

## Regression coverage

- `kappa=1000` mode density remains finite and matches a scaled-reference expression
- `kappa=1000` linear covariance remains finite and matches the scaled Bessel-ratio formula

## Validation

- reproduced the previous `NaN` density and covariance ratios with SciPy
- checked the stable formula numerically at `kappa=1000`
- `python -m py_compile` passed for the modified source and regression test
- branch diff is limited to the implementation and its focused test: 45 additions, 6 deletions

The full repository/backend test matrix is delegated to GitHub Actions because this runtime does not provide GitHub CLI and could not obtain a network checkout.