### PR TITLE
Reject coercive Fourier coefficient shapes

### DIFF
--- a/src/pyrecest/distributions/hypertorus/fejer.py
+++ b/src/pyrecest/distributions/hypertorus/fejer.py
@@ -21,16 +21,27 @@ def normalize_coefficient_shape(shape_like: CoefficientShape, *, dim: int | None
     ``dim`` it is broadcast to all dimensions.
     """
 
-    if isinstance(shape_like, bool):
-        raise ValueError(f"{name} must contain positive odd integers.")
+    shape_error = f"{name} must contain positive odd integers."
+    if isinstance(shape_like, (bool, np.bool_)) or isinstance(
+        shape_like, (str, bytes, bytearray)
+    ):
+        raise ValueError(shape_error)
 
     if isinstance(shape_like, Integral):
         values = (int(shape_like),) if dim is None else (int(shape_like),) * dim
     else:
         try:
-            values = tuple(int(value) for value in shape_like)
+            raw_values = tuple(shape_like)
         except TypeError as exc:
-            raise TypeError(f"{name} must be an integer or an iterable of integers.") from exc
+            raise TypeError(
+                f"{name} must be an integer or an iterable of integers."
+            ) from exc
+        if any(
+            isinstance(value, (bool, np.bool_)) or not isinstance(value, Integral)
+            for value in raw_values
+        ):
+            raise ValueError(shape_error)
+        values = tuple(int(value) for value in raw_values)
 
     if len(values) == 0:
         raise ValueError(f"{name} must contain at least one entry.")

--- a/tests/distributions/test_fejer_shape_validation.py
+++ b/tests/distributions/test_fejer_shape_validation.py
@@ -1,4 +1,5 @@
 import numpy as np
+import numpy.testing as npt
 import pytest
 
 from pyrecest.distributions.hypertorus.fejer import fejer_weights
@@ -18,3 +19,10 @@ from pyrecest.distributions.hypertorus.fejer import fejer_weights
 def test_fejer_weights_rejects_coercible_non_integer_shapes(invalid_shape):
     with pytest.raises(ValueError, match="positive odd integers"):
         fejer_weights(invalid_shape)
+
+
+def test_fejer_weights_accepts_numpy_integer_shape_entries():
+    npt.assert_allclose(
+        fejer_weights((np.int64(3),)),
+        np.array([0.5, 1.0, 0.5]),
+    )

--- a/tests/distributions/test_fejer_shape_validation.py
+++ b/tests/distributions/test_fejer_shape_validation.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pytest
+
+from pyrecest.distributions.hypertorus.fejer import fejer_weights
+
+
+@pytest.mark.parametrize(
+    "invalid_shape",
+    [
+        (3.5,),
+        ("3",),
+        (True,),
+        (np.bool_(True),),
+        "3",
+        b"3",
+    ],
+)
+def test_fejer_weights_rejects_coercible_non_integer_shapes(invalid_shape):
+    with pytest.raises(ValueError, match="positive odd integers"):
+        fejer_weights(invalid_shape)


### PR DESCRIPTION
## Summary
- require every Fourier coefficient shape entry to be an integral, non-boolean value
- reject textual and byte-string scalar shapes instead of interpreting their contents as dimensions
- add focused regressions while preserving NumPy integer shape entries

## Bug
`normalize_coefficient_shape()` converted every iterable entry with `int()`. This silently accepted malformed dimensions such as `(3.5,)`, `("3",)`, and `(True,)` as the valid shape `(3,)` or `(1,)`. A scalar byte string such as `b"3"` was even iterated as the integer byte value `51`.

These inputs could therefore allocate, crop, or pad Fourier coefficient tensors to a different size than the caller supplied, without any error.

## Fix
Validate that scalar and iterable entries are genuine integral values before normalizing them to Python integers. Explicitly reject booleans, text, bytes, and fractional values. Python and NumPy integer dimensions remain supported.

## Validation
- added parameterized regressions for fractional, textual, byte-string, and boolean shapes
- added a positive regression for `np.int64` shape entries
- verified the branch contains only the intended helper and test changes

GitHub Actions will provide the full repository/backend validation.