### PR TITLE
Reject non-integer wrapped-normal moment orders

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
@@ -104,7 +104,6 @@ class WrappedNormalDistribution(
 
             for i in range(n_inputs):
                 result[i] = squeeze(exp(x[i] * x[i] * tmp))
-
                 for k in range(1, m + 1):
                     xp = x[i] + 2 * pi * k
                     xm = x[i] - 2 * pi * k
@@ -188,6 +187,9 @@ class WrappedNormalDistribution(
         return squeeze(val)
 
     def trigonometric_moment(self, n: Union[int, int32, int64]):
+        if isinstance(n, bool) or not isinstance(n, Integral):
+            raise ValueError("n must be an integer")
+        n = int(n)
         return exp(1j * n * self.scalar_mu - n**2 * self.sigma**2 / 2)
 
     def multiply(

--- a/tests/distributions/test_wrapped_normal_moment_order.py
+++ b/tests/distributions/test_wrapped_normal_moment_order.py
@@ -1,0 +1,23 @@
+"""Regression coverage for wrapped-normal trigonometric-moment orders."""
+
+import pytest
+
+from pyrecest.backend import allclose, array, conj
+from pyrecest.distributions import WrappedNormalDistribution
+
+
+@pytest.mark.parametrize("order", [0.5, True, "1"])
+def test_wrapped_normal_rejects_non_integer_moment_orders(order):
+    distribution = WrappedNormalDistribution(array(0.3), array(0.7))
+
+    with pytest.raises(ValueError, match="n must be an integer"):
+        distribution.trigonometric_moment(order)
+
+
+def test_wrapped_normal_accepts_negative_integer_moment_orders():
+    distribution = WrappedNormalDistribution(array(0.3), array(0.7))
+
+    positive_moment = distribution.trigonometric_moment(2)
+    negative_moment = distribution.trigonometric_moment(-2)
+
+    assert bool(allclose(negative_moment, conj(positive_moment)))


### PR DESCRIPTION
## Summary
- validate `WrappedNormalDistribution.trigonometric_moment()` orders before evaluating the analytic formula
- reject fractional, boolean, and textual orders consistently with the hypertoroidal wrapped-normal implementation
- preserve support for negative integer orders and add focused regression coverage

## Bug
The circular wrapped-normal specialization overrode `trigonometric_moment()` without retaining the integer-order validation implemented by its hypertoroidal parent. Inputs such as `0.5`, `True`, or `"1"` were therefore silently accepted and evaluated by the closed-form expression, even though trigonometric moments on the circle are indexed by integers.

This also made the circular and hypertoroidal wrapped-normal APIs inconsistent.

## Fix
Require `n` to be a non-boolean `numbers.Integral`, convert accepted integer-like values to a Python `int`, and then evaluate the existing formula unchanged. Negative integer orders remain valid and produce the conjugate of the corresponding positive-order moment.

## Validation
- regression rejects `0.5`, `True`, and `"1"`
- regression confirms the `-2` moment equals the conjugate of the `+2` moment
- focused standalone execution of the validation and moment formula passed
- branch is 2 commits ahead of `main`, 0 behind, and changes only the wrapped-normal implementation plus one regression file

The full repository suite is delegated to GitHub Actions because this execution environment has no GitHub CLI and cannot resolve github.com for a local checkout.