### PR TITLE
Stabilize concentrated Gauss-von-Mises evaluations

### DIFF
--- a/src/pyrecest/distributions/cart_prod/gauss_von_mises_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/gauss_von_mises_distribution.py
@@ -31,7 +31,7 @@ from pyrecest.backend import (
     zeros_like,
 )
 from scipy.integrate import nquad
-from scipy.special import iv
+from scipy.special import ive
 from scipy.stats import vonmises as _vonmises
 
 from ..nonperiodic.gaussian_distribution import GaussianDistribution
@@ -177,8 +177,8 @@ class GaussVonMisesDistribution(AbstractHypercylindricalDistribution):
         )
         p = (
             mvn_vals
-            * exp(self.kappa * cos(xa[0, :] - theta))
-            / (2.0 * float(pi) * iv(0, self.kappa))
+            * exp(self.kappa * (cos(xa[0, :] - theta) - 1.0))
+            / (2.0 * float(pi) * ive(0, self.kappa))
         )
 
         if single_point:
@@ -278,7 +278,7 @@ class GaussVonMisesDistribution(AbstractHypercylindricalDistribution):
         lin_dim = self.lin_dim
 
         def B(p_val, kappa_val):
-            return 1.0 - iv(p_val, kappa_val) / iv(0, kappa_val)
+            return 1.0 - ive(p_val, kappa_val) / ive(0, kappa_val)
 
         B1 = B(1, self.kappa)
         B2 = B(2, self.kappa)

--- a/tests/distributions/test_gauss_von_mises_large_kappa.py
+++ b/tests/distributions/test_gauss_von_mises_large_kappa.py
@@ -1,0 +1,48 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+from pyrecest import backend
+from pyrecest.distributions.cart_prod.gauss_von_mises_distribution import (
+    GaussVonMisesDistribution,
+)
+from scipy.special import ive
+from scipy.stats import multivariate_normal
+
+
+@unittest.skipIf(
+    backend.__backend_name__ == "jax",
+    reason="Gauss-von-Mises deterministic sampling is not supported on JAX",
+)
+class GaussVonMisesLargeKappaTest(unittest.TestCase):
+    @staticmethod
+    def _distribution(kappa=1000.0):
+        return GaussVonMisesDistribution(2.0, 1.3, 0.4, 0.0, 0.001, kappa)
+
+    def test_mode_density_remains_finite_for_large_kappa(self):
+        kappa = 1000.0
+        dist = self._distribution(kappa)
+
+        actual = float(dist.pdf(dist.mode()))
+        expected_gaussian = multivariate_normal.pdf(
+            np.array([2.0]), mean=np.array([2.0]), cov=np.array([[1.3]])
+        )
+        expected = expected_gaussian / (2.0 * np.pi * ive(0, kappa))
+
+        self.assertTrue(np.isfinite(actual))
+        npt.assert_allclose(actual, expected, rtol=1e-12)
+
+    def test_horwood_sigma_points_remain_finite_for_large_kappa(self):
+        dist = self._distribution()
+
+        points, weights = dist.sample_deterministic_horwood()
+        points = np.asarray(backend.to_numpy(points))
+        weights = np.asarray(backend.to_numpy(weights))
+
+        self.assertTrue(np.all(np.isfinite(points)))
+        self.assertTrue(np.all(np.isfinite(weights)))
+        npt.assert_allclose(np.sum(weights), 1.0, rtol=1e-12, atol=1e-12)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- use exponentially scaled modified Bessel functions in `GaussVonMisesDistribution`
- shift the density exponent by `-kappa` so its numerator remains bounded
- stabilize the Horwood deterministic sampler's Bessel ratios
- add focused regressions at `kappa=1000`

## Bug

`GaussVonMisesDistribution.pdf()` evaluated its circular factor as

```python
exp(kappa * cos(delta)) / (2 * pi * I0(kappa))
```

For large but valid finite concentrations such as `kappa=1000`, both the numerator and `I0(kappa)` overflow. The density therefore becomes `inf / inf = NaN`, including at the mode.

`sample_deterministic_horwood()` had the same failure mode because it computed `I_p(kappa) / I_0(kappa)` from unscaled Bessel functions. Those `inf / inf` ratios propagated `NaN` values into the sigma-point angles and weights.

## Fix

Use `scipy.special.ive`, whose common exponential scaling cancels in Bessel ratios. Rewrite the density using the algebraically equivalent bounded expression

```python
exp(kappa * (cos(delta) - 1)) / (2 * pi * ive(0, kappa))
```

and compute the Horwood ratios from `ive` as well.

## Validation

- reproduced the previous non-finite mode factor at `kappa=1000`
- verified the stable mode expression remains finite and matches the scaled-Bessel reference
- added a regression requiring finite Horwood sigma points and weights whose sum remains one
- branch is two commits ahead of `main`, zero behind, and changes only the implementation and one focused test file

The full repository/backend matrix is delegated to GitHub Actions.