### PR TITLE
Stabilize von Mises–Fisher PDFs at high concentration

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/von_mises_fisher_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/von_mises_fisher_distribution.py
@@ -25,11 +25,10 @@ from pyrecest.backend import (
     ones,
     pi,
     sin,
-    sinh,
     stack,
     zeros,
 )
-from scipy.special import iv, ive
+from scipy.special import ive
 
 from .abstract_hyperspherical_distribution import AbstractHypersphericalDistribution
 
@@ -64,6 +63,21 @@ def _as_unit_direction(mu, *, name: str = "mu", tolerance: float = 1e-6):
     if not _as_python_bool(abs(linalg.norm(mu) - 1.0) < tolerance):
         raise ValueError(f"{name} must be normalized")
     return mu
+
+
+def _scaled_log_normalization(input_dim: int, kappa: float) -> float:
+    """Return ``log(C_d(kappa)) + kappa`` without Bessel overflow."""
+    order = input_dim / 2.0 - 1.0
+    scaled_bessel = float(ive(order, kappa))
+    if not math.isfinite(scaled_bessel) or scaled_bessel <= 0.0:
+        raise ValueError(
+            "Could not compute a finite positive scaled Bessel value for kappa."
+        )
+    return (
+        order * math.log(kappa)
+        - input_dim / 2.0 * math.log(2.0 * math.pi)
+        - math.log(scaled_bessel)
+    )
 
 
 class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
@@ -107,11 +121,13 @@ class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
 
         if kappa_scalar <= self._KAPPA_EPS:
             self.C = 1.0 / self.compute_unit_hypersphere_surface(self.dim)
-        elif self.dim == 2:
-            self.C = kappa / (4 * pi * sinh(kappa))
+            self._log_scaled_normalization = math.log(float(self.C)) + kappa_scalar
         else:
-            self.C = kappa ** ((self.dim + 1) / 2.0 - 1) / (
-                (2.0 * pi) ** ((self.dim + 1) / 2.0) * iv((self.dim + 1) / 2 - 1, kappa)
+            self._log_scaled_normalization = _scaled_log_normalization(
+                self.input_dim, kappa_scalar
+            )
+            self.C = array(
+                math.exp(self._log_scaled_normalization - kappa_scalar)
             )
 
     def pdf(self, xs):
@@ -129,7 +145,10 @@ class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
                 f"xs must have trailing dimension {self.input_dim}, got {xs.shape}."
             )
 
-        return self.C * exp(self.kappa * xs @ self.mu)
+        return exp(
+            self._log_scaled_normalization
+            + self.kappa * (xs @ self.mu - 1.0)
+        )
 
     def mean_direction(self):
         """Return the unit mean direction with shape ``(d,)``."""

--- a/tests/distributions/test_von_mises_fisher_large_kappa.py
+++ b/tests/distributions/test_von_mises_fisher_large_kappa.py
@@ -1,0 +1,41 @@
+import math
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+from scipy.special import ive
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array, to_numpy
+from pyrecest.distributions import VonMisesFisherDistribution
+
+
+class TestVonMisesFisherLargeKappa(unittest.TestCase):
+    def test_pdf_remains_finite_at_mode_for_large_kappa(self):
+        kappa = 1000.0
+
+        for input_dim in (3, 4):
+            with self.subTest(input_dim=input_dim):
+                mu_np = np.zeros(input_dim, dtype=float)
+                mu_np[0] = 1.0
+                distribution = VonMisesFisherDistribution(array(mu_np), kappa)
+
+                points = array(np.stack((mu_np, -mu_np)))
+                densities = np.asarray(to_numpy(distribution.pdf(points)), dtype=float)
+
+                order = input_dim / 2.0 - 1.0
+                expected_mode_density = kappa**order / (
+                    (2.0 * math.pi) ** (input_dim / 2.0) * ive(order, kappa)
+                )
+
+                self.assertTrue(np.all(np.isfinite(densities)))
+                self.assertGreater(densities[0], 0.0)
+                self.assertGreaterEqual(densities[1], 0.0)
+                self.assertLess(densities[1], densities[0])
+                npt.assert_allclose(
+                    densities[0], expected_mode_density, rtol=1.0e-7, atol=0.0
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- evaluate von Mises–Fisher densities through a scaled-log normalizer
- use the exponentially scaled modified Bessel function for every nonuniform dimension
- preserve the existing `C` attribute while avoiding separate underflow/overflow in `pdf`
- add a regression at `kappa = 1000` for embedding dimensions 3 and 4

## Bug
The density was evaluated as

```python
C(kappa) * exp(kappa * dot(x, mu))
```

For high concentration, the normalizing constant underflows to zero while the exponential overflows at the mode. On S², for example, `kappa = 1000` evaluates as `0 * inf`, yielding `NaN`. The general-dimensional branch has the same failure because the unscaled modified Bessel function overflows.

## Fix
Compute `log(C(kappa)) + kappa` from `scipy.special.ive`, then evaluate

```python
exp(log(C(kappa)) + kappa + kappa * (dot(x, mu) - 1))
```

This is algebraically identical but keeps both the normalizer and exponent in a representable range. Existing moderate-concentration values of `C` and the PDF are retained.

## Validation
The regression verifies for embedding dimensions 3 and 4 that, at `kappa = 1000`:
- mode and antipodal densities are finite
- the mode density is positive
- the mode density matches the scaled-Bessel reference expression
- the antipodal density is smaller than the mode density

The diff is limited to the vMF implementation and one focused regression file.