### PR TITLE
Disambiguate small dimension-first MTT sets against empty states

### DIFF
--- a/src/pyrecest/evaluation/get_distance_function.py
+++ b/src/pyrecest/evaluation/get_distance_function.py
@@ -164,7 +164,9 @@ def _symmetric_distance_function(
     return distance_function
 
 
-def _as_target_matrix(value, name: str) -> numpy.ndarray:
+def _as_target_matrix(
+    value, name: str, *, expected_target_dim: int | None = None
+) -> numpy.ndarray:
     value = _as_real_numeric_array(value, name)
     if value.size == 0:
         if value.ndim == 2:
@@ -172,6 +174,11 @@ def _as_target_matrix(value, name: str) -> numpy.ndarray:
         return value.reshape(0, 0)
     if value.ndim == 1:
         return value.reshape(1, -1)
+    if expected_target_dim is not None:
+        if value.shape[1] == expected_target_dim:
+            return value
+        if value.shape[0] == expected_target_dim:
+            return value.T
     # Common MTT layouts are either (num_targets, dim) or (dim, num_targets).
     # Prefer rows as targets when the orientation is ambiguous; only transpose
     # dim-first layouts when the trailing axis is too large to be a common
@@ -213,6 +220,14 @@ def _coerce_additional_params(additional_params: Any) -> Mapping[str, Any]:
 def _euclidean_mtt_distance(x1, x2, *, cutoff_distance: float) -> float:
     first = _as_target_matrix(x1, "x1")
     second = _as_target_matrix(x2, "x2")
+    if first.shape[0] == 0 and first.shape[1] != 0:
+        second = _as_target_matrix(
+            x2, "x2", expected_target_dim=first.shape[1]
+        )
+    elif second.shape[0] == 0 and second.shape[1] != 0:
+        first = _as_target_matrix(
+            x1, "x1", expected_target_dim=second.shape[1]
+        )
     if first.shape[0] == 0 or second.shape[0] == 0:
         if (
             first.shape[1] != 0

--- a/tests/evaluation/test_euclidean_mtt_distance_orientation.py
+++ b/tests/evaluation/test_euclidean_mtt_distance_orientation.py
@@ -27,3 +27,17 @@ def test_euclidean_mtt_distance_handles_empty_against_dim_first_targets():
 
     np.testing.assert_allclose(distance(no_targets, dim_first_targets), 35.0)
     np.testing.assert_allclose(distance(dim_first_targets, no_targets), 35.0)
+
+
+def test_empty_target_dimension_disambiguates_small_dim_first_target_set():
+    distance = get_distance_function("euclidean_mtt", {"cutoff_distance": 7.0})
+    no_targets = np.empty((0, 2))
+    dim_first_targets = np.array(
+        [
+            [0.0, 10.0, 20.0],
+            [0.0, 0.0, 0.0],
+        ]
+    )
+
+    np.testing.assert_allclose(distance(no_targets, dim_first_targets), 21.0)
+    np.testing.assert_allclose(distance(dim_first_targets, no_targets), 21.0)


### PR DESCRIPTION
## Summary
- use the target dimension carried by a typed empty MTT set to orient the non-empty state matrix
- preserve the existing row-first preference for otherwise ambiguous non-empty matrices
- add a regression for a `2 x 3` dimension-first target set in both argument orders

## Bug
The Euclidean MTT distance supports row-first `(num_targets, dim)` and dimension-first `(dim, num_targets)` layouts. Its heuristic only transposed dimension-first matrices when the number of targets exceeded four. Consequently, a small 2D dimension-first set such as shape `(2, 3)` was treated as two 3D targets.

When compared with an empty state shaped `(0, 2)`, the empty set already specifies that the target dimension is two, but the implementation ignored that information and raised `ValueError` for mismatched target dimensions instead of returning three cutoff penalties.

## Fix
Allow target-matrix normalization to accept an expected target dimension. When one state is an empty two-dimensional matrix with a known trailing dimension, re-normalize the other state against that dimension before evaluating cardinality and dimension consistency.

This leaves the existing behavior for ambiguous non-empty pairs unchanged.

## Impact
Small dimension-first MTT outputs now work correctly against typed empty ground-truth or estimate sets. For example, `(0, 2)` versus `(2, 3)` now returns `3 * cutoff_distance` symmetrically.

## Validation
- regression covers the previous `(0, 2)` versus `(2, 3)` failure in both argument orders
- existing ambiguous row-first `2 x 3` behavior remains unchanged
- existing unambiguous dimension-first `2 x 5` behavior remains unchanged
- `python -m py_compile` passed for the implementation and regression file
- focused standalone execution of all three orientation cases passed