### PR TITLE
Stabilize large-kappa Gauss von Mises formulas

### DIFF
--- a/src/pyrecest/distributions/cart_prod/gauss_von_mises_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/gauss_von_mises_distribution.py
@@ -31,7 +31,7 @@ from pyrecest.backend import (
     zeros_like,
 )
 from scipy.integrate import nquad
-from scipy.special import iv
+from scipy.special import ive
 from scipy.stats import vonmises as _vonmises
 
 from ..nonperiodic.gaussian_distribution import GaussianDistribution
@@ -177,8 +177,8 @@ class GaussVonMisesDistribution(AbstractHypercylindricalDistribution):
         )
         p = (
             mvn_vals
-            * exp(self.kappa * cos(xa[0, :] - theta))
-            / (2.0 * float(pi) * iv(0, self.kappa))
+            * exp(self.kappa * (cos(xa[0, :] - theta) - 1.0))
+            / (2.0 * float(pi) * ive(0, self.kappa))
         )
 
         if single_point:
@@ -278,7 +278,7 @@ class GaussVonMisesDistribution(AbstractHypercylindricalDistribution):
         lin_dim = self.lin_dim
 
         def B(p_val, kappa_val):
-            return 1.0 - iv(p_val, kappa_val) / iv(0, kappa_val)
+            return 1.0 - ive(p_val, kappa_val) / ive(0, kappa_val)
 
         B1 = B(1, self.kappa)
         B2 = B(2, self.kappa)

--- a/tests/distributions/test_gauss_von_mises_large_kappa.py
+++ b/tests/distributions/test_gauss_von_mises_large_kappa.py
@@ -1,0 +1,50 @@
+import math
+
+import numpy as np
+import pytest
+from pyrecest import backend
+from pyrecest.backend import all as backend_all
+from pyrecest.backend import allclose, array, isfinite, sum
+from pyrecest.distributions.cart_prod.gauss_von_mises_distribution import (
+    GaussVonMisesDistribution,
+)
+from scipy.special import ive
+
+
+def _large_kappa_distribution():
+    return GaussVonMisesDistribution(
+        mu=array([0.0]),
+        P=array([[1.0]]),
+        alpha=0.3,
+        beta=array([0.0]),
+        Gamma=array([[0.0]]),
+        kappa=1000.0,
+    )
+
+
+def test_large_kappa_mode_pdf_is_finite():
+    dist = _large_kappa_distribution()
+
+    value = dist.pdf(dist.mode())
+    expected = 1.0 / (
+        math.sqrt(2.0 * math.pi)
+        * 2.0
+        * math.pi
+        * ive(0, dist.kappa)
+    )
+
+    assert math.isfinite(value)
+    assert np.isclose(value, expected, rtol=1e-12, atol=0.0)
+
+
+@pytest.mark.skipif(
+    backend.__backend_name__ == "jax",
+    reason="Deterministic Horwood sampling is not supported on JAX.",
+)
+def test_large_kappa_horwood_samples_are_finite():
+    dist = _large_kappa_distribution()
+    points, weights = dist.sample_deterministic_horwood()
+
+    assert bool(backend_all(isfinite(points)))
+    assert bool(backend_all(isfinite(weights)))
+    assert bool(allclose(sum(weights), array(1.0), rtol=1e-12, atol=1e-12))


### PR DESCRIPTION
## Summary
- evaluate the Gauss–von Mises circular density with an exponent shift and the scaled modified Bessel function `ive`
- use scaled Bessel ratios in the Horwood deterministic sigma-point construction
- add regressions for `kappa=1000` covering finite mode density, finite sigma points/weights, and normalized weights

## Bug fixed
`GaussVonMisesDistribution` accepted large finite concentrations, but two formulas still used unscaled `iv` values. For `kappa=1000`, both `exp(kappa)` and `iv(0, kappa)` overflow in the density, producing `inf / inf -> NaN`. The Horwood `I_p(kappa) / I_0(kappa)` ratios had the same problem.

For nonnegative `kappa`, rewriting

`exp(kappa*cos(delta)) / I_0(kappa)`

as

`exp(kappa*(cos(delta)-1)) / ive(0, kappa)`

is algebraically equivalent while remaining finite. Ratios of `ive` values are likewise identical to ratios of `iv` values because the common exponential scaling cancels.

## Validation
- reconstructed the current source file and verified its Git blob SHA matched `70696cee334ac057644a1bebc22294682a62ab9f` before editing
- `python -m py_compile` on the modified module and new regression file
- standalone numerical comparison at moderate concentrations matched the original expression to floating-point precision
- at `kappa=1000`, the stabilized mode density is finite (`12.61408496162745` for the circular factor), and the Horwood weights are finite and sum to one

The full repository test suite was not run locally because this environment has no PyRecEst checkout; GitHub CI should exercise the in-repository regressions.