### PR TITLE
Stabilize toroidal von Mises sine densities at large concentration

### DIFF
--- a/src/pyrecest/distributions/hypertorus/toroidal_von_mises_sine_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/toroidal_von_mises_sine_distribution.py
@@ -2,8 +2,8 @@
 # pylint: disable=no-name-in-module,no-member
 import math
 
-from pyrecest.backend import sin
-from scipy.special import gammaln, iv
+from pyrecest.backend import array, cos, exp, sin
+from scipy.special import gammaln, ive
 
 from .abstract_toroidal_bivar_vm_distribution import (
     AbstractToroidalBivarVMDistribution,
@@ -15,14 +15,14 @@ _SERIES_MIN_TERMS = 10
 _SERIES_MAX_TERMS = 10000
 
 
-def _iv_over_power(order, concentration):
-    """Return I_order(concentration) / concentration**order robustly."""
+def _ive_over_power(order, concentration):
+    """Return exp(-concentration) * I_order(concentration) / concentration**order."""
     concentration = float(concentration)
     if order == 0:
-        return float(iv(0, concentration))
+        return float(ive(0, concentration))
     if concentration == 0.0:
         return math.exp(-order * math.log(2.0) - float(gammaln(order + 1.0)))
-    return float(iv(order, concentration)) / concentration**order
+    return float(ive(order, concentration)) / concentration**order
 
 
 def _adaptive_positive_series_sum(term):
@@ -55,10 +55,10 @@ class ToroidalVonMisesSineDistribution(AbstractToroidalBivarVMDistribution):
         AbstractToroidalBivarVMDistribution.__init__(self, mu, kappa)
         lambda_ = validate_scalar_parameter(lambda_, "lambda_")
         self.lambda_ = lambda_
-        self.C = 1.0 / self.norm_const
+        self.C = math.exp(-self.log_norm_const)
 
-    @property
-    def norm_const(self):
+    def _scaled_norm_const(self):
+        """Return the normalizer with exp(kappa[0] + kappa[1]) factored out."""
         lambda_sq_over_four = float(self.lambda_) ** 2 / 4.0
         kappa0 = float(self.kappa[0])
         kappa1 = float(self.kappa[1])
@@ -67,11 +67,39 @@ class ToroidalVonMisesSineDistribution(AbstractToroidalBivarVMDistribution):
             return (
                 math.comb(2 * order, order)
                 * lambda_sq_over_four**order
-                * _iv_over_power(order, kappa0)
-                * _iv_over_power(order, kappa1)
+                * _ive_over_power(order, kappa0)
+                * _ive_over_power(order, kappa1)
             )
 
         return 4.0 * math.pi**2 * _adaptive_positive_series_sum(s)
+
+    @property
+    def log_norm_const(self):
+        return (
+            float(self.kappa[0])
+            + float(self.kappa[1])
+            + math.log(self._scaled_norm_const())
+        )
+
+    @property
+    def norm_const(self):
+        try:
+            return math.exp(self.log_norm_const)
+        except OverflowError:
+            return math.inf
+
+    def pdf(self, xs):
+        xs = array(xs)
+        if xs.ndim == 0 or xs.shape[-1] != self.dim:
+            raise ValueError(
+                f"xs must have trailing dimension {self.dim}, got {xs.shape}."
+            )
+        return exp(
+            self.kappa[0] * (cos(xs[..., 0] - self.mu[0]) - 1.0)
+            + self.kappa[1] * (cos(xs[..., 1] - self.mu[1]) - 1.0)
+            + self._coupling_term(xs)
+            - math.log(self._scaled_norm_const())
+        )
 
     def _coupling_term(self, xs):
         return (

--- a/tests/distributions/test_toroidal_von_mises_sine_distribution.py
+++ b/tests/distributions/test_toroidal_von_mises_sine_distribution.py
@@ -13,6 +13,7 @@ from pyrecest.backend import arange, array, column_stack, cos, exp, pi, sin
 from pyrecest.distributions.hypertorus.toroidal_von_mises_sine_distribution import (
     ToroidalVonMisesSineDistribution,
 )
+from scipy.special import ive
 
 matplotlib.pyplot.close("all")
 matplotlib.use("Agg")
@@ -134,6 +135,22 @@ class ToroidalVMSineDistributionTest(ToroidalBivarVMTestMixin, unittest.TestCase
         )
         self.assertTrue(np.isfinite(tvm.norm_const))
         self.assertAlmostEqual(tvm.integrate(), 1.0, delta=1e-5)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ != "numpy",
+        reason="Regression test uses NumPy/scipy scalar semantics",
+    )
+    def test_large_kappa_independent_mode_density_is_finite(self):
+        kappa = 1000.0
+        mu = array([0.4, 1.2])
+        tvm = ToroidalVonMisesSineDistribution(mu, array([kappa, kappa]), 0.0)
+
+        mode_density = tvm.pdf(mu)
+        expected = 1.0 / (4.0 * np.pi**2 * ive(0, kappa) ** 2)
+
+        self.assertTrue(np.isfinite(mode_density))
+        self.assertGreater(float(mode_density), 0.0)
+        npt.assert_allclose(mode_density, expected, rtol=1e-12)
 
     def _unnormalized_pdf(self, xs):
         return exp(


### PR DESCRIPTION
## Summary

- evaluate the bivariate von Mises sine normalizer with exponentially scaled modified Bessel functions
- retain the common `exp(kappa[0] + kappa[1])` factor in log form
- evaluate the PDF with both concentration exponents shifted by `-kappa`
- add a focused regression for the independent `kappa = [1000, 1000]` case

## Bug

`ToroidalVonMisesSineDistribution` computed its normalization series from unscaled `scipy.special.iv` values and evaluated the density as `C * exp(raw_exponent)`.

For large but valid concentrations, `I_0(kappa)` and the density exponential overflow separately. At `kappa = [1000, 1000]` with `lambda_ = 0`, construction encounters a non-finite normalization term; equivalently, the old density formulation would combine an underflowed reciprocal normalizer with `exp(2000)` at the mode.

## Fix

Use `scipy.special.ive` in the normalization series. Every product of the two Bessel factors shares the scale `exp(kappa[0] + kappa[1])`, so the implementation factors that scale out and exposes the full normalizer through `log_norm_const`.

The PDF is evaluated as

```python
exp(
    kappa0 * (cos(delta0) - 1)
    + kappa1 * (cos(delta1) - 1)
    + coupling
    - log(scaled_norm_const)
)
```

which is algebraically identical while keeping the independent high-concentration mode finite.

`norm_const` continues to expose the ordinary-space value and returns `inf` when the mathematically valid normalizer exceeds floating-point range; PDF evaluation no longer depends on that overflowing value.

## Impact

Highly concentrated bivariate von Mises sine distributions can now be constructed and evaluated without avoidable `inf`/`NaN` intermediates. Moderate-concentration values and the zero-concentration limiting formula remain unchanged to floating-point precision.

## Validation

- exact changed module syntax-compiled successfully
- focused exact-module smoke test passed for the `kappa = [1000, 1000]`, `lambda_ = 0` regression
- mode density matched the scaled-Bessel reference: `159.1151394191558`
- moderate-parameter PDF values matched the previous expression to approximately `4.4e-16` relative error
- zero-concentration normalizer remained finite
- branch is two commits ahead of current `main`, zero behind, and changes only the implementation and its focused test