### PR TITLE
Reject non-integer wrapped Laplace moment orders

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_laplace_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_laplace_distribution.py
@@ -1,4 +1,6 @@
 # pylint: disable=no-name-in-module,no-member
+from numbers import Integral
+
 from pyrecest.backend import all, asarray, exp, isfinite, mod, ndim, pi
 
 from .abstract_circular_distribution import AbstractCircularDistribution
@@ -33,6 +35,9 @@ class WrappedLaplaceDistribution(AbstractCircularDistribution):
         self.kappa = kappa_
 
     def trigonometric_moment(self, n):
+        if isinstance(n, bool) or not isinstance(n, Integral):
+            raise ValueError("n must be an integer.")
+        n = int(n)
         return (
             1
             / (1 - 1j * n / self.lambda_ / self.kappa)

--- a/tests/distributions/test_wrapped_laplace_distribution.py
+++ b/tests/distributions/test_wrapped_laplace_distribution.py
@@ -86,6 +86,18 @@ class WrappedLaplaceDistributionTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "one-dimensional"):
             self.wl.pdf(array([[0.0, 1.0]]))
 
+    def test_trigonometric_moment_rejects_non_integer_orders(self):
+        for order in (0.5, True, "1"):
+            with self.subTest(order=order):
+                with self.assertRaisesRegex(ValueError, "n must be an integer"):
+                    self.wl.trigonometric_moment(order)
+
+    def test_trigonometric_moment_accepts_negative_integer_orders(self):
+        positive_moment = self.wl.trigonometric_moment(2)
+        negative_moment = self.wl.trigonometric_moment(-2)
+
+        npt.assert_allclose(negative_moment, positive_moment.conjugate(), rtol=1e-12)
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
         reason="Not supported on this backend",


### PR DESCRIPTION
## Summary
- validate `WrappedLaplaceDistribution.trigonometric_moment()` orders before evaluating the analytic formula
- reject fractional, boolean, and textual orders consistently with the circular moment API
- preserve negative integer orders and add focused regression coverage

## Bug
`WrappedLaplaceDistribution.trigonometric_moment()` accepted any value that happened to work in arithmetic. Inputs such as `0.5`, `True`, and `"1"` were therefore either silently evaluated or failed with an incidental type error, even though circular trigonometric moments are indexed by integers.

This was inconsistent with the integer-order validation being applied to other circular and hypertoroidal distributions.

## Fix
Require `n` to be a non-boolean `numbers.Integral`, convert accepted integer-like values to a Python `int`, and then evaluate the existing closed-form expression unchanged. Negative integer orders remain supported.

## Validation
- regression rejects `0.5`, `True`, and `"1"` with a clear `ValueError`
- regression verifies the `-2` moment is the conjugate of the `+2` moment
- `python -m py_compile` passed for the modified source and test files
- focused standalone checks confirmed Python and NumPy integer handling and the conjugacy identity
- branch is 2 commits ahead of `main`, 0 behind, and changes only the wrapped Laplace implementation and its existing test module

The full repository suite is delegated to GitHub Actions because a network checkout and GitHub CLI are unavailable in this execution environment.