### PR TITLE
Validate circular grid distribution inputs before conversion

### DIFF
--- a/src/pyrecest/distributions/circle/circular_grid_distribution.py
+++ b/src/pyrecest/distributions/circle/circular_grid_distribution.py
@@ -44,13 +44,13 @@ class CircularGridDistribution(AbstractCircularDistribution, AbstractGridDistrib
     """
 
     def __init__(self, grid_values, enforce_pdf_nonnegative=True):
-        grid_values = array(grid_values)
         if isinstance(grid_values, AbstractCircularDistribution):
             raise ValueError(
                 "You gave a distribution as the first argument. "
                 "To convert distributions to a distribution in grid representation, "
                 "use from_distribution."
             )
+        grid_values = array(grid_values)
         if enforce_pdf_nonnegative and any(grid_values < 0):
             raise ValueError(
                 "grid_values must be nonnegative when "

--- a/tests/distributions/test_circular_grid_distribution.py
+++ b/tests/distributions/test_circular_grid_distribution.py
@@ -60,6 +60,12 @@ class CircularGridDistributionTest(unittest.TestCase):
         indices = array([0, 3, 7])
         npt.assert_allclose(dist.get_grid_point(indices), dist.get_grid()[indices])
 
+    def test_constructor_rejects_distribution_argument_with_conversion_guidance(self):
+        dist = VonMisesDistribution(0.4, 1.3)
+
+        with self.assertRaisesRegex(ValueError, "use from_distribution"):
+            CircularGridDistribution(dist)
+
     def test_enforced_nonnegative_interpolation_rejects_negative_grid_values(self):
         with self.assertRaisesRegex(ValueError, "nonnegative"):
             CircularGridDistribution(


### PR DESCRIPTION
## Summary
- check whether `CircularGridDistribution` received a circular distribution before converting the argument through the active array backend
- preserve the existing guidance to use `CircularGridDistribution.from_distribution(...)`
- add a focused constructor regression

## Bug fixed
`CircularGridDistribution.__init__` converted `grid_values` with the active backend before checking whether the caller had accidentally passed an `AbstractCircularDistribution` instance. That conversion changes or rejects the object, so the intended type check was effectively unreachable. Depending on the backend, callers could see an opaque conversion failure or a later scalar-shape/indexing error instead of the documented guidance.

## Fix
Run the `AbstractCircularDistribution` guard before backend array conversion. Normal array-like inputs continue through the unchanged constructor path.

## Validation
- branch is 2 commits ahead of current `main` and 0 behind
- final diff is limited to one reordered validation step and one regression test
- `python -m py_compile` passed for both modified files
- local Git blob hashes match the committed GitHub blobs exactly:
  - source: `c311cc4151ed23adac78da5f1bfc65f7099183a9`
  - test: `d3248b35b234d27609ff55323fa4df8c54574e20`

The full repository suite is delegated to GitHub Actions because this environment could not resolve `github.com` for a local checkout.