### PR TITLE
Fix SE(3) frame plotting orientation

### DIFF
--- a/src/pyrecest/distributions/abstract_se3_distribution.py
+++ b/src/pyrecest/distributions/abstract_se3_distribution.py
@@ -76,17 +76,18 @@ class AbstractSE3Distribution(AbstractLinBoundedCartProdDistribution):
         fig = plt.figure()
         ax = fig.add_subplot(111, projection="3d")
         h1 = ax.quiver(
-            pos[0], pos[1], pos[2], rotMat[0, 0], rotMat[0, 1], rotMat[0, 2], color="r"
+            pos[0], pos[1], pos[2], rotMat[0, 0], rotMat[1, 0], rotMat[2, 0], color="r"
         )
         h2 = ax.quiver(
-            pos[0], pos[1], pos[2], rotMat[1, 0], rotMat[1, 1], rotMat[1, 2], color="g"
+            pos[0], pos[1], pos[2], rotMat[0, 1], rotMat[1, 1], rotMat[2, 1], color="g"
         )
         h3 = ax.quiver(
-            pos[0], pos[1], pos[2], rotMat[2, 0], rotMat[2, 1], rotMat[2, 2], color="b"
+            pos[0], pos[1], pos[2], rotMat[0, 2], rotMat[1, 2], rotMat[2, 2], color="b"
         )
         h = [h1, h2, h3]
 
-        relevant_coords = concatenate((pos.reshape(-1, 1), pos + rotMat), axis=1)
+        pos_column = pos.reshape(-1, 1)
+        relevant_coords = concatenate((pos_column, pos_column + rotMat), axis=1)
         needed_boundaries = column_stack(
             (min(relevant_coords, axis=1), max(relevant_coords, axis=1))
         )

--- a/tests/distributions/test_se3_dirac_distribution.py
+++ b/tests/distributions/test_se3_dirac_distribution.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 import numpy as np
 import numpy.testing as npt
@@ -24,6 +25,63 @@ class SE3DiracDistributionTest(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "same number of samples"):
             AbstractSE3Distribution.plot_trajectory(periodic_states, lin_states)
+
+    def test_plot_point_draws_rotated_body_axes(self):
+        class RecordingAxes:
+            def __init__(self):
+                self.quiver_calls = []
+
+            def quiver(self, *args, **_kwargs):
+                self.quiver_calls.append(args)
+                return object()
+
+            @staticmethod
+            def get_xlim():
+                return (-100.0, 100.0)
+
+            @staticmethod
+            def get_ylim():
+                return (-100.0, 100.0)
+
+            @staticmethod
+            def get_zlim():
+                return (-100.0, 100.0)
+
+            @staticmethod
+            def set_xlim(_limits):
+                return None
+
+            @staticmethod
+            def set_ylim(_limits):
+                return None
+
+            @staticmethod
+            def set_zlim(_limits):
+                return None
+
+        class RecordingFigure:
+            def __init__(self, axes):
+                self.axes = axes
+
+            def add_subplot(self, *_args, **_kwargs):
+                return self.axes
+
+        axes = RecordingAxes()
+        quarter_turn = np.sqrt(0.5)
+        point = array([quarter_turn, 0.0, 0.0, quarter_turn, 10.0, 20.0, 30.0])
+
+        with patch(
+            "pyrecest.distributions.abstract_se3_distribution.plt.figure",
+            return_value=RecordingFigure(axes),
+        ):
+            AbstractSE3Distribution.plot_point(point)
+
+        directions = np.asarray([call[3:6] for call in axes.quiver_calls], dtype=float)
+        npt.assert_allclose(
+            directions,
+            np.array([[0.0, 1.0, 0.0], [-1.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
+            atol=1e-12,
+        )
 
     def test_constructor(self):
         dSph = array(


### PR DESCRIPTION
## Summary
- draw SE(3) body-frame axes from the columns of the active rotation matrix
- compute plotted frame endpoints by adding the translation as a column vector
- add a regression test for a 90-degree yaw quaternion

## Bug fixed
`AbstractSE3Distribution.plot_point(...)` passed rows of `Rotation.as_matrix()` to Matplotlib's quiver calls. SciPy's active rotation matrix maps each canonical basis vector to the corresponding matrix column, so the old implementation displayed the inverse/transposed frame for nontrivial rotations. The coordinate-bound calculation also added the position along the last dimension, mixing x/y/z translations between endpoints.

## Validation
- standalone numerical check against `Rotation.apply` for the three canonical basis vectors
- regression test asserts the plotted axes for a 90-degree yaw are `(+y, -x, +z)`
- branch is 2 commits ahead of `main`, 0 behind, changing only the SE(3) plotting implementation and its test

The full repository test matrix is left to GitHub Actions because this environment cannot clone GitHub or install the repository checkout.