### PR TITLE
Stabilize bivariate von Mises models at large concentrations

### DIFF
--- a/src/pyrecest/distributions/hypertorus/abstract_toroidal_bivar_vm_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/abstract_toroidal_bivar_vm_distribution.py
@@ -45,11 +45,13 @@ def validate_scalar_parameter(value, name):
 class AbstractToroidalBivarVMDistribution(AbstractToroidalDistribution):
     """Abstract base for bivariate von Mises distributions on the torus.
 
-    Subclasses share the same ``pdf`` structure:
+    Subclasses share the same ``pdf`` structure::
 
         C * exp(kappa1*cos(x1 - mu1) + kappa2*cos(x2 - mu2) + coupling_term)
 
-    and must implement :meth:`_coupling_term`.
+    Subclasses with a stable log normalization constant may assign
+    ``self._log_norm_const``. The base density then evaluates directly in the
+    log domain, avoiding the ``0 * inf`` cancellation at high concentration.
     """
 
     def __init__(self, mu, kappa):
@@ -57,6 +59,7 @@ class AbstractToroidalBivarVMDistribution(AbstractToroidalDistribution):
         mu, kappa = validate_toroidal_vm_parameters(mu, kappa)
         self.mu = mod(mu, 2.0 * pi)
         self.kappa = kappa
+        self._log_norm_const = None
 
     def _coupling_term(self, xs):
         """Return the distribution-specific coupling term for ``pdf``."""
@@ -68,8 +71,11 @@ class AbstractToroidalBivarVMDistribution(AbstractToroidalDistribution):
             raise ValueError(
                 f"xs must have trailing dimension {self.dim}, got {xs.shape}."
             )
-        return self.C * exp(
+        log_unnormalized = (
             self.kappa[0] * cos(xs[..., 0] - self.mu[0])
             + self.kappa[1] * cos(xs[..., 1] - self.mu[1])
             + self._coupling_term(xs)
         )
+        if self._log_norm_const is not None:
+            return exp(log_unnormalized - self._log_norm_const)
+        return self.C * exp(log_unnormalized)

--- a/src/pyrecest/distributions/hypertorus/toroidal_von_mises_cosine_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/toroidal_von_mises_cosine_distribution.py
@@ -3,7 +3,7 @@ import math
 
 import numpy as np
 from pyrecest.backend import cos, mod, pi
-from scipy.special import iv
+from scipy.special import iv, ive
 
 from ._input_validation import as_shift_vector
 from .abstract_toroidal_bivar_vm_distribution import (
@@ -20,7 +20,11 @@ def _iv(order, concentration):
     return float(iv(order, float(concentration)))
 
 
-def _adaptive_series_sum(term, coefficient):
+def _scaled_iv(order, concentration):
+    return float(ive(order, float(concentration)))
+
+
+def _adaptive_series_sum(term, coefficient, *, scale_floor=1.0):
     """Sum a scalar series until the latest contribution is negligible."""
     total = 0.0
     terms = []
@@ -31,18 +35,26 @@ def _adaptive_series_sum(term, coefficient):
         terms.append(contribution)
         total += contribution
         if order >= _SERIES_MIN_TERMS and abs(contribution) <= _SERIES_RTOL * max(
-            1.0, abs(total)
+            scale_floor, abs(total)
         ):
             return math.fsum(terms)
     raise RuntimeError("Bivariate von Mises series did not converge")
 
 
-def _symmetric_series_sum(term):
-    return _adaptive_series_sum(term, lambda order: 1.0 if order == 0 else 2.0)
+def _symmetric_series_sum(term, *, scale_floor=1.0):
+    return _adaptive_series_sum(
+        term,
+        lambda order: 1.0 if order == 0 else 2.0,
+        scale_floor=scale_floor,
+    )
 
 
-def _half_zero_series_sum(term):
-    return _adaptive_series_sum(term, lambda order: 0.5 if order == 0 else 1.0)
+def _half_zero_series_sum(term, *, scale_floor=1.0):
+    return _adaptive_series_sum(
+        term,
+        lambda order: 0.5 if order == 0 else 1.0,
+        scale_floor=scale_floor,
+    )
 
 
 class ToroidalVonMisesCosineDistribution(AbstractToroidalBivarVMDistribution):
@@ -66,18 +78,59 @@ class ToroidalVonMisesCosineDistribution(AbstractToroidalBivarVMDistribution):
         AbstractToroidalBivarVMDistribution.__init__(self, mu, kappa)
         kappa3 = validate_scalar_parameter(kappa3, "kappa3")
         self.kappa3 = kappa3
-        self.C = 1.0 / self.norm_const
+        self._bessel_exponential_scale = (
+            float(self.kappa[0]) + float(self.kappa[1]) + abs(float(self.kappa3))
+        )
 
-    @property
-    def norm_const(self):
+        try:
+            self._norm_series_sum = self._compute_norm_series_sum(scaled=False)
+            self._norm_const = 4.0 * math.pi**2 * self._norm_series_sum
+            if not math.isfinite(self._norm_const) or self._norm_const <= 0.0:
+                raise FloatingPointError
+            self._series_uses_scaled_bessel = False
+            self._log_norm_const = math.log(self._norm_const)
+        except (FloatingPointError, OverflowError):
+            self._norm_series_sum = self._compute_norm_series_sum(scaled=True)
+            scaled_norm_const = 4.0 * math.pi**2 * self._norm_series_sum
+            if not math.isfinite(scaled_norm_const) or scaled_norm_const <= 0.0:
+                raise FloatingPointError(
+                    "Bivariate von Mises normalization constant must be positive and finite"
+                )
+            self._series_uses_scaled_bessel = True
+            self._log_norm_const = (
+                math.log(scaled_norm_const) + self._bessel_exponential_scale
+            )
+            try:
+                self._norm_const = math.exp(self._log_norm_const)
+            except OverflowError:
+                self._norm_const = float("inf")
+
+        self.C = math.exp(-self._log_norm_const)
+
+    def _compute_norm_series_sum(self, *, scaled):
         kappa0 = float(self.kappa[0])
         kappa1 = float(self.kappa[1])
         kappa3 = float(self.kappa3)
+        bessel = _scaled_iv if scaled else _iv
 
         def s(order):
-            return _iv(order, kappa0) * _iv(order, kappa1) * _iv(order, -kappa3)
+            return (
+                bessel(order, kappa0)
+                * bessel(order, kappa1)
+                * bessel(order, -kappa3)
+            )
 
-        return 4.0 * math.pi**2 * _symmetric_series_sum(s)
+        scale_floor = 0.0 if scaled else 1.0
+        return _symmetric_series_sum(s, scale_floor=scale_floor)
+
+    @property
+    def log_norm_const(self):
+        """Return the logarithm of the normalization constant."""
+        return self._log_norm_const
+
+    @property
+    def norm_const(self):
+        return self._norm_const
 
     def _coupling_term(self, xs):
         return -self.kappa3 * cos(xs[..., 0] - self.mu[0] - xs[..., 1] + self.mu[1])
@@ -87,27 +140,26 @@ class ToroidalVonMisesCosineDistribution(AbstractToroidalBivarVMDistribution):
             kappa0 = float(self.kappa[0])
             kappa1 = float(self.kappa[1])
             kappa3 = float(self.kappa3)
+            bessel = _scaled_iv if self._series_uses_scaled_bessel else _iv
+            scale_floor = 0.0 if self._series_uses_scaled_bessel else 1.0
 
             def s1(order):
                 return (
-                    (_iv(order + 1, kappa0) + _iv(order - 1, kappa0))
-                    * _iv(order, kappa1)
-                    * _iv(order, -kappa3)
+                    (bessel(order + 1, kappa0) + bessel(order - 1, kappa0))
+                    * bessel(order, kappa1)
+                    * bessel(order, -kappa3)
                 )
 
             def s2(order):
                 return (
-                    _iv(order, kappa0)
-                    * (_iv(order + 1, kappa1) + _iv(order - 1, kappa1))
-                    * _iv(order, -kappa3)
+                    bessel(order, kappa0)
+                    * (bessel(order + 1, kappa1) + bessel(order - 1, kappa1))
+                    * bessel(order, -kappa3)
                 )
 
-            def s(order):
-                return _iv(order, kappa0) * _iv(order, kappa1) * _iv(order, -kappa3)
-
-            s1_sum = _half_zero_series_sum(s1)
-            s2_sum = _half_zero_series_sum(s2)
-            s_sum = _symmetric_series_sum(s)
+            s1_sum = _half_zero_series_sum(s1, scale_floor=scale_floor)
+            s2_sum = _half_zero_series_sum(s2, scale_floor=scale_floor)
+            s_sum = self._norm_series_sum
 
             # Use numpy directly here because the result is inherently complex
             # and pyrecest.backend does not support complex-valued arrays.

--- a/src/pyrecest/distributions/hypertorus/toroidal_von_mises_cosine_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/toroidal_von_mises_cosine_distribution.py
@@ -94,7 +94,8 @@ class ToroidalVonMisesCosineDistribution(AbstractToroidalBivarVMDistribution):
             scaled_norm_const = 4.0 * math.pi**2 * self._norm_series_sum
             if not math.isfinite(scaled_norm_const) or scaled_norm_const <= 0.0:
                 raise FloatingPointError(
-                    "Bivariate von Mises normalization constant must be positive and finite"
+                    "Bivariate von Mises normalization constant must be "
+                    "positive and finite"
                 )
             self._series_uses_scaled_bessel = True
             self._log_norm_const = (

--- a/src/pyrecest/distributions/hypertorus/toroidal_von_mises_sine_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/toroidal_von_mises_sine_distribution.py
@@ -77,7 +77,8 @@ class ToroidalVonMisesSineDistribution(AbstractToroidalBivarVMDistribution):
             scaled_norm_const = self._compute_norm_const(scaled=True)
             if not math.isfinite(scaled_norm_const) or scaled_norm_const <= 0.0:
                 raise FloatingPointError(
-                    "Bivariate von Mises normalization constant must be positive and finite"
+                    "Bivariate von Mises normalization constant must be "
+                    "positive and finite"
                 )
             self._series_uses_scaled_bessel = True
             self._log_norm_const = (

--- a/src/pyrecest/distributions/hypertorus/toroidal_von_mises_sine_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/toroidal_von_mises_sine_distribution.py
@@ -3,7 +3,7 @@
 import math
 
 from pyrecest.backend import sin
-from scipy.special import gammaln, iv
+from scipy.special import gammaln, iv, ive
 
 from .abstract_toroidal_bivar_vm_distribution import (
     AbstractToroidalBivarVMDistribution,
@@ -25,7 +25,17 @@ def _iv_over_power(order, concentration):
     return float(iv(order, concentration)) / concentration**order
 
 
-def _adaptive_positive_series_sum(term):
+def _scaled_iv_over_power(order, concentration):
+    """Return exp(-concentration) * I_order(concentration) / concentration**order."""
+    concentration = float(concentration)
+    if order == 0:
+        return float(ive(0, concentration))
+    if concentration == 0.0:
+        return math.exp(-order * math.log(2.0) - float(gammaln(order + 1.0)))
+    return float(ive(order, concentration)) / concentration**order
+
+
+def _adaptive_positive_series_sum(term, *, scale_floor=1.0):
     """Sum a nonnegative series until the tail term is negligible."""
     total = 0.0
     terms = []
@@ -36,7 +46,7 @@ def _adaptive_positive_series_sum(term):
         terms.append(contribution)
         total += contribution
         if order >= _SERIES_MIN_TERMS and contribution <= _SERIES_RTOL * max(
-            1.0, abs(total)
+            scale_floor, abs(total)
         ):
             return math.fsum(terms)
     raise RuntimeError("Bivariate von Mises series did not converge")
@@ -55,23 +65,58 @@ class ToroidalVonMisesSineDistribution(AbstractToroidalBivarVMDistribution):
         AbstractToroidalBivarVMDistribution.__init__(self, mu, kappa)
         lambda_ = validate_scalar_parameter(lambda_, "lambda_")
         self.lambda_ = lambda_
-        self.C = 1.0 / self.norm_const
+        self._bessel_exponential_scale = float(self.kappa[0]) + float(self.kappa[1])
 
-    @property
-    def norm_const(self):
+        try:
+            self._norm_const = self._compute_norm_const(scaled=False)
+            if not math.isfinite(self._norm_const) or self._norm_const <= 0.0:
+                raise FloatingPointError
+            self._series_uses_scaled_bessel = False
+            self._log_norm_const = math.log(self._norm_const)
+        except (FloatingPointError, OverflowError):
+            scaled_norm_const = self._compute_norm_const(scaled=True)
+            if not math.isfinite(scaled_norm_const) or scaled_norm_const <= 0.0:
+                raise FloatingPointError(
+                    "Bivariate von Mises normalization constant must be positive and finite"
+                )
+            self._series_uses_scaled_bessel = True
+            self._log_norm_const = (
+                math.log(scaled_norm_const) + self._bessel_exponential_scale
+            )
+            try:
+                self._norm_const = math.exp(self._log_norm_const)
+            except OverflowError:
+                self._norm_const = float("inf")
+
+        self.C = math.exp(-self._log_norm_const)
+
+    def _compute_norm_const(self, *, scaled):
         lambda_sq_over_four = float(self.lambda_) ** 2 / 4.0
         kappa0 = float(self.kappa[0])
         kappa1 = float(self.kappa[1])
+        bessel_ratio = _scaled_iv_over_power if scaled else _iv_over_power
 
         def s(order):
             return (
                 math.comb(2 * order, order)
                 * lambda_sq_over_four**order
-                * _iv_over_power(order, kappa0)
-                * _iv_over_power(order, kappa1)
+                * bessel_ratio(order, kappa0)
+                * bessel_ratio(order, kappa1)
             )
 
-        return 4.0 * math.pi**2 * _adaptive_positive_series_sum(s)
+        scale_floor = 0.0 if scaled else 1.0
+        return 4.0 * math.pi**2 * _adaptive_positive_series_sum(
+            s, scale_floor=scale_floor
+        )
+
+    @property
+    def log_norm_const(self):
+        """Return the logarithm of the normalization constant."""
+        return self._log_norm_const
+
+    @property
+    def norm_const(self):
+        return self._norm_const
 
     def _coupling_term(self, xs):
         return (

--- a/tests/distributions/test_bivariate_von_mises_large_kappa.py
+++ b/tests/distributions/test_bivariate_von_mises_large_kappa.py
@@ -1,0 +1,63 @@
+import math
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+from scipy.special import ive
+
+import pyrecest.backend
+from pyrecest.backend import array, to_numpy
+from pyrecest.distributions.hypertorus.toroidal_von_mises_cosine_distribution import (
+    ToroidalVonMisesCosineDistribution,
+)
+from pyrecest.distributions.hypertorus.toroidal_von_mises_sine_distribution import (
+    ToroidalVonMisesSineDistribution,
+)
+
+
+pytestmark = pytest.mark.skipif(
+    pyrecest.backend.__backend_name__ != "numpy",
+    reason="Large-concentration SciPy reference test is NumPy-specific",
+)
+
+
+def _expected_independent_mode_density(kappa):
+    circular_mode_density = 1.0 / (2.0 * math.pi * float(ive(0, kappa)))
+    return circular_mode_density**2
+
+
+@pytest.mark.parametrize(
+    "distribution_class",
+    [ToroidalVonMisesSineDistribution, ToroidalVonMisesCosineDistribution],
+    ids=["sine", "cosine"],
+)
+def test_large_independent_concentrations_have_finite_mode_density(
+    distribution_class,
+):
+    distribution = distribution_class(
+        array([0.3, 1.2]), array([1000.0, 1000.0]), 0.0
+    )
+    density = float(np.asarray(to_numpy(distribution.pdf(distribution.mu))))
+
+    assert math.isfinite(density)
+    npt.assert_allclose(
+        density,
+        _expected_independent_mode_density(1000.0),
+        rtol=1e-12,
+        atol=0.0,
+    )
+
+
+def test_cosine_large_concentration_first_moment_remains_finite():
+    mu = array([0.3, 1.2])
+    kappa = 1000.0
+    distribution = ToroidalVonMisesCosineDistribution(
+        mu, array([kappa, kappa]), 0.0
+    )
+
+    actual = np.asarray(distribution.trigonometric_moment(1))
+    expected_magnitude = float(ive(1, kappa) / ive(0, kappa))
+    expected = expected_magnitude * np.exp(1j * np.asarray(to_numpy(mu)))
+
+    assert np.all(np.isfinite(actual))
+    npt.assert_allclose(actual, expected, rtol=1e-12, atol=0.0)


### PR DESCRIPTION
## Summary
- fall back from unscaled `iv` series to exponentially scaled `ive` series when bivariate von Mises normalization overflows
- retain the existing unscaled path for ordinary parameter values, preserving current numerical behavior and adaptive-series regressions
- evaluate shared sine/cosine PDFs using a finite log normalization constant instead of `C * exp(...)`
- use the same scaled series for the cosine model's analytical first trigonometric moment
- add regressions for `kappa = [1000, 1000]`

## Bug
Both `ToroidalVonMisesSineDistribution` and `ToroidalVonMisesCosineDistribution` accepted large finite concentrations but formed normalization terms from unscaled modified Bessel functions. At `kappa = [1000, 1000]`, `I_0(1000)` is infinite in double precision, so the first series term is non-finite and construction raises `FloatingPointError`.

Even if the normalizer were represented as infinity, evaluating the density as `C * exp(log_unnormalized)` would combine an underflowed reciprocal normalizer with an overflowing exponential at the mode.

## Fix
The constructors first use the existing unscaled series. If a term or normalization constant becomes non-finite, they recompute the series with `scipy.special.ive` and retain the common Bessel exponential scale separately. The base class then evaluates the PDF as

```python
exp(log_unnormalized - log_norm_const)
```

For the cosine model, the common scaling also cancels in the analytical moment ratio.

## Impact
Large, valid concentrations can now be constructed and evaluated. In the independent case with `kappa = [1000, 1000]`, both models return the finite mode density `159.115139419...`, and the cosine first moment remains finite.

## Validation
- Python syntax compilation passed for all modified files and the new regression module
- standalone execution of the patched formulas passed for the large-concentration sine and cosine densities and cosine first moment
- moderate-parameter PDFs match the previous `C * exp(...)` evaluation to floating-point precision
- the existing `kappa=[20, 20], kappa3=10` cosine normalization reference remains on the original unscaled path and agrees within its current tolerance
- the branch is based on current `main` and changes only the two distributions, their shared base, and one regression file