### PR TITLE
Stabilize wrapped Laplace PDFs at small rates

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_laplace_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_laplace_distribution.py
@@ -4,6 +4,9 @@ from pyrecest.backend import all, asarray, exp, isfinite, mod, ndim, pi
 from .abstract_circular_distribution import AbstractCircularDistribution
 
 
+_SMALL_RATE_SERIES_THRESHOLD = 1e-4
+
+
 def _validate_positive_scalar(value, name):
     value = asarray(value)
     if value.shape not in ((), (1,)):
@@ -13,6 +16,22 @@ def _validate_positive_scalar(value, name):
     if not bool(all(value > 0.0)):
         raise ValueError(f"{name} must be positive.")
     return value
+
+
+def _wrapped_exponential_density(rate, distance):
+    """Evaluate a wrapped exponential component without small-rate cancellation."""
+    log_beta = 2.0 * pi * rate
+    if bool(all(log_beta < _SMALL_RATE_SERIES_THRESHOLD)):
+        # rate / (1 - exp(-2*pi*rate)) expanded around rate == 0.
+        normalization = (
+            1.0 / (2.0 * pi)
+            + rate / 2.0
+            + pi * rate**2 / 6.0
+            - pi**3 * rate**4 / 90.0
+        )
+    else:
+        normalization = rate / (1.0 - exp(-log_beta))
+    return normalization * exp(-rate * distance)
 
 
 class WrappedLaplaceDistribution(AbstractCircularDistribution):
@@ -46,15 +65,10 @@ class WrappedLaplaceDistribution(AbstractCircularDistribution):
         xs = mod(xs, 2.0 * pi)
         positive_rate = self.lambda_ * self.kappa
         negative_rate = self.lambda_ / self.kappa
+        mixture_normalization = 1.0 + self.kappa**2
         p = (
-            self.lambda_
-            * self.kappa
-            / (1 + self.kappa**2)
-            * (
-                exp(-positive_rate * xs)
-                / (1 - exp(-2.0 * pi * positive_rate))
-                + exp(-negative_rate * (2.0 * pi - xs))
-                / (1 - exp(-2.0 * pi * negative_rate))
-            )
-        )
+            _wrapped_exponential_density(positive_rate, xs)
+            + self.kappa**2
+            * _wrapped_exponential_density(negative_rate, 2.0 * pi - xs)
+        ) / mixture_normalization
         return p

--- a/tests/distributions/test_wrapped_laplace_small_rate.py
+++ b/tests/distributions/test_wrapped_laplace_small_rate.py
@@ -1,0 +1,24 @@
+"""Regression coverage for small-rate wrapped Laplace densities."""
+
+import numpy as np
+import numpy.testing as npt
+
+import pyrecest.backend
+from pyrecest.backend import array, pi
+from pyrecest.distributions.circle.wrapped_laplace_distribution import (
+    WrappedLaplaceDistribution,
+)
+
+
+def test_tiny_rate_pdf_approaches_uniform_density():
+    distribution = WrappedLaplaceDistribution(array(1.0e-18), array(3.0))
+
+    density = pyrecest.backend.to_numpy(distribution.pdf(array([0.0, pi])))
+
+    assert np.isfinite(density).all()
+    npt.assert_allclose(
+        density,
+        np.full(2, 1.0 / (2.0 * np.pi)),
+        rtol=5.0e-7,
+        atol=5.0e-7,
+    )


### PR DESCRIPTION
## Summary
- evaluate each wrapped-exponential tail of `WrappedLaplaceDistribution` with a cancellation-free scaled normalizer
- preserve the original asymmetric-Laplace mixture weights exactly
- add a regression for an asymmetric distribution with `lambda_=1e-18`

## Bug fixed
The PDF divided by terms of the form

```text
1 - exp(-2*pi*rate)
```

For sufficiently small positive rates, `exp(-2*pi*rate)` rounds to `1.0`, so the denominator becomes zero. For example, `WrappedLaplaceDistribution(1e-18, 3.0)` returned `inf` at ordinary evaluation points even though the distribution should converge to the circular uniform density.

## Fix
The two wrapped-exponential components are evaluated separately. For small rates, the implementation uses the series

```text
rate / (1 - exp(-2*pi*rate))
  = 1/(2*pi) + rate/2 + pi*rate^2/6 - pi^3*rate^4/90 + O(rate^6)
```

The components are then combined with weights `1/(1+kappa^2)` and `kappa^2/(1+kappa^2)`, which is algebraically identical to the previous formula.

## Validation
- `python -m py_compile` passed for the modified module and regression test
- at moderate and concentrated rates, the stabilized formula matched the previous expression with maximum absolute difference `3.55e-15` and maximum relative difference `3.87e-16` on representative points
- adaptive quadrature produced unit mass across tested rates and asymmetries
- the old expression returned `[inf, inf]` for `lambda_=1e-18, kappa_=3`; the patched expression returned `[0.15915494, 0.15915494]`, matching `1/(2*pi)`

The full repository suite was not run locally because this environment could not resolve GitHub for a checkout; GitHub Actions should exercise the in-repository regression.