### PR TITLE
Reject non-integer wrapped Cauchy moment orders

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py
@@ -1,4 +1,6 @@
 # pylint: disable=no-name-in-module,no-member
+from numbers import Integral
+
 from pyrecest.backend import (
     all,
     arctan2,
@@ -92,5 +94,7 @@ class WrappedCauchyDistribution(AbstractCircularDistribution):
         return mod(primitive(xs) - primitive(starting_point), 1.0)
 
     def trigonometric_moment(self, n):
-        m = exp(1j * n * self.mu - abs(n) * self.gamma)
-        return m
+        if isinstance(n, bool) or not isinstance(n, Integral):
+            raise ValueError("n must be an integer.")
+        n = int(n)
+        return exp(1j * n * self.mu - abs(n) * self.gamma)

--- a/tests/distributions/test_wrapped_cauchy_distribution.py
+++ b/tests/distributions/test_wrapped_cauchy_distribution.py
@@ -78,6 +78,21 @@ class WrappedCauchyDistributionTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "one-dimensional"):
             dist.cdf(array([[0.1, 0.2]]))
 
+    def test_trigonometric_moment_rejects_non_integer_orders(self):
+        dist = WrappedCauchyDistribution(self.mu, self.gamma)
+
+        for order in (0.5, True, "1"):
+            with self.subTest(order=order):
+                with self.assertRaisesRegex(ValueError, "n must be an integer"):
+                    dist.trigonometric_moment(order)
+
+    def test_trigonometric_moment_accepts_negative_integer_orders(self):
+        dist = WrappedCauchyDistribution(array(0.7), self.gamma)
+        positive_moment = dist.trigonometric_moment(2)
+        negative_moment = dist.trigonometric_moment(-2)
+
+        npt.assert_allclose(negative_moment, positive_moment.conjugate(), rtol=1e-12)
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
         reason="Not supported on this backend",


### PR DESCRIPTION
## Summary
- validate `WrappedCauchyDistribution.trigonometric_moment()` orders before evaluating the closed-form expression
- reject fractional, boolean, and textual orders consistently with the circular moment API
- preserve negative integer orders and add focused regression coverage

## Bug
`WrappedCauchyDistribution.trigonometric_moment()` accepted any value that happened to work in arithmetic. In particular, `0.5` and `True` were silently evaluated, while textual input failed incidentally inside multiplication. Trigonometric moments on the circle are indexed by integers, so this behavior was inconsistent with the validation now used by the other wrapped circular distributions.

## Fix
Require `n` to be a non-boolean `numbers.Integral`, normalize accepted integer-like values to a Python `int`, and then evaluate the existing analytic formula unchanged. Negative integer orders remain supported.

## Validation
- regression rejects `0.5`, `True`, and `"1"` with a clear `ValueError`
- regression verifies the `-2` moment is the conjugate of the `+2` moment for a nonzero mean
- `python -m py_compile` passed for the modified source and test files
- a focused standalone check confirmed NumPy integer acceptance and the conjugacy identity
- branch is 2 commits ahead of current `main`, 0 behind, and changes only the wrapped Cauchy implementation and its existing test module

The full repository suite is delegated to GitHub Actions because this runtime cannot resolve `github.com` for a local checkout and does not provide the GitHub CLI.