### PR TITLE
Reject non-integer wrapped exponential moment orders

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
@@ -124,6 +124,9 @@ class WrappedExponentialDistribution(AbstractCircularDistribution):
         return self.lambda_ * exp(-self.lambda_ * xs) * self._normalization_const
 
     def trigonometric_moment(self, n):
+        if isinstance(n, bool) or not isinstance(n, Integral):
+            raise ValueError("n must be an integer.")
+        n = int(n)
         return 1.0 / (1.0 - 1j * n / self.lambda_)
 
     def sample(self, n: Union[int, int32, int64]):

--- a/tests/distributions/test_wrapped_exponential_distribution.py
+++ b/tests/distributions/test_wrapped_exponential_distribution.py
@@ -91,6 +91,18 @@ class WrappedExponentialDistributionTest(unittest.TestCase):
                 rtol=5e-7,
             )
 
+    def test_trigonometric_moment_rejects_non_integer_orders(self):
+        for order in (0.5, True, "1"):
+            with self.subTest(order=order):
+                with self.assertRaisesRegex(ValueError, "n must be an integer"):
+                    self.we.trigonometric_moment(order)
+
+    def test_trigonometric_moment_accepts_negative_integer_orders(self):
+        positive_moment = self.we.trigonometric_moment(2)
+        negative_moment = self.we.trigonometric_moment(-2)
+
+        npt.assert_allclose(negative_moment, positive_moment.conjugate(), rtol=5e-7)
+
     def test_circular_mean(self):
         npt.assert_allclose(
             self.we.mean_direction(), float(arctan(1.0 / self.lambda_)), rtol=5e-7


### PR DESCRIPTION
## Summary
- validate `WrappedExponentialDistribution.trigonometric_moment()` orders before evaluating the analytic formula
- reject fractional, boolean, and textual orders consistently with the circular moment API
- preserve support for negative integer orders and NumPy integer scalars

## Bug
`WrappedExponentialDistribution.trigonometric_moment()` accepted any value that happened to work in arithmetic. Inputs such as `0.5` and `True` were silently evaluated, while textual input failed incidentally during division.

Circular trigonometric moments are Fourier coefficients indexed by integers, so accepting non-integer orders is mathematically invalid and inconsistent with the validation used by other circular distributions.

## Fix
Require `n` to be a non-boolean `numbers.Integral`, normalize accepted integer-like values to a Python `int`, and then evaluate the existing closed-form expression unchanged.

## Validation
- regression rejects `0.5`, `True`, and `"1"` with a clear `ValueError`
- regression verifies the `-2` moment is the conjugate of the `+2` moment
- standalone validation confirmed NumPy integer acceptance and the conjugacy identity
- branch is 2 commits ahead of current `main`, 0 behind, and changes only the wrapped exponential implementation and its existing test module

The full repository test matrix is delegated to GitHub Actions because this runtime cannot resolve `github.com` for a local checkout and does not provide the GitHub CLI.