### PR TITLE
Validate von Mises mean directions

### DIFF
--- a/src/pyrecest/distributions/circle/von_mises_distribution.py
+++ b/src/pyrecest/distributions/circle/von_mises_distribution.py
@@ -43,6 +43,7 @@ class VonMisesDistribution(AbstractCircularDistribution):
         kappa,
         norm_const: float | None = None,
     ):
+        self._as_float_scalar(mu, "mu")
         kappa_scalar = self._as_float_scalar(kappa, "kappa")
         if kappa_scalar < 0.0:
             raise ValueError("kappa must be nonnegative.")
@@ -89,6 +90,7 @@ class VonMisesDistribution(AbstractCircularDistribution):
         mu : scalar
             New mean direction.
         """
+        self._as_float_scalar(mu, "mu")
         new_dist = copy.deepcopy(self)
         new_dist.mu = mu
         return new_dist
@@ -249,7 +251,7 @@ class VonMisesDistribution(AbstractCircularDistribution):
             m (scalar): First trigonometric moment (complex number).
 
         Returns:
-            vm (VMDistribution): VM distribution obtained by moment matching.
+            vm (VMDistribution): Distribution obtained by moment matching.
         """
         kappa_ = VonMisesDistribution.besselratio_inverse(0, abs(m))
         if VonMisesDistribution._as_float_scalar(kappa_, "kappa") == 0.0:

--- a/tests/distributions/test_von_mises_mean_validation.py
+++ b/tests/distributions/test_von_mises_mean_validation.py
@@ -1,0 +1,35 @@
+import pytest
+
+from pyrecest.distributions import VonMisesDistribution
+
+
+@pytest.mark.parametrize(
+    "mu",
+    (
+        [0.0, 1.0],
+        [[0.0, 1.0]],
+        float("nan"),
+        float("inf"),
+        -float("inf"),
+    ),
+)
+def test_constructor_rejects_non_scalar_or_nonfinite_mean(mu):
+    with pytest.raises(ValueError):
+        VonMisesDistribution(mu, 2.0)
+
+
+@pytest.mark.parametrize(
+    "mu",
+    (
+        [0.0, 1.0],
+        [[0.0, 1.0]],
+        float("nan"),
+        float("inf"),
+        -float("inf"),
+    ),
+)
+def test_set_mean_rejects_non_scalar_or_nonfinite_mean(mu):
+    dist = VonMisesDistribution(0.3, 2.0)
+
+    with pytest.raises(ValueError):
+        dist.set_mean(mu)


### PR DESCRIPTION
## Summary
- validate `VonMisesDistribution` mean directions during construction
- apply the same validation in `set_mean()` and, transitively, `set_mode()`
- add focused regressions for vector, matrix, NaN, and infinite means

## Bug
`VonMisesDistribution.__init__()` validated `kappa` but stored `mu` without checking that it represented one finite circular mean direction. A vector-valued mean could therefore broadcast against evaluation points and return plausible-looking multiple density values instead of representing a single circular distribution. Non-finite means were likewise accepted and surfaced only later as `NaN` outputs.

`set_mean()` bypassed constructor validation entirely, so even a valid distribution could be changed into the same malformed state.

## Fix
Reuse the class's existing finite-scalar validation for `mu` before storing it. Apply that check both in the constructor and before copying in `set_mean()`. The original scalar/backend value is retained, so valid parameter behavior is unchanged.

## Impact
Malformed mean directions now fail fast with a clear `ValueError` instead of silently changing the effective dimensionality of the density or propagating non-finite values.

## Validation
- regression coverage rejects vector and matrix means through both construction and `set_mean()`
- regression coverage rejects `NaN`, positive infinity, and negative infinity through both entry points
- branch is 2 commits ahead of current `main`, 0 behind
- final diff is limited to the von Mises implementation and one focused regression module