### PR TITLE
Preserve nested batch shapes in mixture PDFs

### DIFF
--- a/src/pyrecest/distributions/abstract_mixture.py
+++ b/src/pyrecest/distributions/abstract_mixture.py
@@ -228,7 +228,7 @@ class AbstractMixture(AbstractDistributionType):
         else:
             if xs.ndim == 0 or xs.shape[-1] != self.input_dim:
                 raise ValueError("Dimension mismatch")
-            p = zeros(1) if xs.ndim == 1 else zeros(xs.shape[0])
+            p = zeros(1) if xs.ndim == 1 else zeros(xs.shape[:-1])
 
         for i, dist in enumerate(self.dists):
             p += self.w[i] * dist.pdf(xs)

--- a/tests/distributions/test_mixture_nested_batch_pdf.py
+++ b/tests/distributions/test_mixture_nested_batch_pdf.py
@@ -1,0 +1,30 @@
+import numpy as np
+import numpy.testing as npt
+
+import pyrecest.backend
+from pyrecest.backend import array, diag
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.distributions.nonperiodic.gaussian_mixture import GaussianMixture
+
+
+def test_gaussian_mixture_pdf_preserves_nested_batch_shape():
+    first = GaussianDistribution(array([0.0, 0.0]), diag(array([1.0, 2.0])))
+    second = GaussianDistribution(array([1.0, -1.0]), diag(array([2.0, 1.0])))
+    mixture = GaussianMixture([first, second], array([0.4, 0.6]))
+    points = array(
+        [
+            [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]],
+            [[-1.0, 0.5], [0.5, -0.5], [2.0, -1.0]],
+        ]
+    )
+
+    actual = mixture.pdf(points)
+    expected = 0.4 * first.pdf(points) + 0.6 * second.pdf(points)
+
+    assert actual.shape == (2, 3)
+    npt.assert_allclose(
+        np.asarray(pyrecest.backend.to_numpy(actual)),
+        np.asarray(pyrecest.backend.to_numpy(expected)),
+        rtol=1e-12,
+        atol=0.0,
+    )


### PR DESCRIPTION
## Summary
- preserve every leading batch dimension when evaluating multidimensional mixture PDFs
- keep the existing scalar and single-point return behavior unchanged
- add a regression for a Gaussian mixture evaluated on points with shape `(2, 3, 2)`

## Bug
`AbstractMixture.pdf()` validates multidimensional inputs by their trailing event dimension, matching the component-distribution API. However, for any batched input with more than one leading dimension it initialized the accumulator as

```python
zeros(xs.shape[0])
```

A component such as `GaussianDistribution` returns one density per point with shape `xs.shape[:-1]`. For an input of shape `(2, 3, 2)`, the mixture accumulator therefore had shape `(2,)` while each component density had shape `(2, 3)`, causing a broadcasting error.

## Fix
For batched multidimensional inputs, allocate the mixture accumulator with `xs.shape[:-1]`. The special case for a single point remains `zeros(1)`, so existing return behavior is preserved.

## Impact
Mixture distributions now honor the same arbitrary-leading-batch convention as their components. Nested grids and structured batches can be evaluated directly instead of being flattened manually.

## Validation
- reconstructed the current source file and verified its Git blob hash matched `7e0f794a4138c90b08f8812df40e6bac4bf2a19f` before editing
- `python -m py_compile` passed for the modified source and regression test
- local Black and isort checks passed where available
- branch is 2 commits ahead of current `main`, 0 behind
- final diff is limited to a one-line allocation fix and one focused 30-line regression test