### PR TITLE
Reject non-integer wrapped exponential moment orders

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
@@ -124,6 +124,9 @@ class WrappedExponentialDistribution(AbstractCircularDistribution):
         return self.lambda_ * exp(-self.lambda_ * xs) * self._normalization_const
 
     def trigonometric_moment(self, n):
+        if isinstance(n, (bool, np.bool_)) or not isinstance(n, Integral):
+            raise ValueError("n must be an integer.")
+        n = int(n)
         return 1.0 / (1.0 - 1j * n / self.lambda_)
 
     def sample(self, n: Union[int, int32, int64]):

--- a/tests/distributions/test_wrapped_exponential_distribution.py
+++ b/tests/distributions/test_wrapped_exponential_distribution.py
@@ -91,6 +91,19 @@ class WrappedExponentialDistributionTest(unittest.TestCase):
                 rtol=5e-7,
             )
 
+    def test_trigonometric_moment_validates_order(self):
+        for order in (0.5, True, np.bool_(True), "1"):
+            with self.subTest(order=order), self.assertRaisesRegex(
+                ValueError, "integer"
+            ):
+                self.we.trigonometric_moment(order)
+
+        moment_two = self.we.trigonometric_moment(np.int64(2))
+        npt.assert_allclose(moment_two, self.we.trigonometric_moment(2), rtol=5e-7)
+        npt.assert_allclose(
+            self.we.trigonometric_moment(-2), np.conj(moment_two), rtol=5e-7
+        )
+
     def test_circular_mean(self):
         npt.assert_allclose(
             self.we.mean_direction(), float(arctan(1.0 / self.lambda_)), rtol=5e-7


### PR DESCRIPTION
## Summary
- validate `WrappedExponentialDistribution.trigonometric_moment()` orders before evaluating the closed-form expression
- reject fractional, boolean, and textual orders with a clear `ValueError`
- preserve Python and NumPy integer orders, including negative-order conjugacy

## Bug
`WrappedExponentialDistribution.trigonometric_moment()` accepted any value that happened to work in arithmetic. In particular, `0.5` and `True` were silently evaluated even though circular trigonometric moments are indexed by integers.

This made the wrapped-exponential API inconsistent with the integer-order validation used by the neighboring circular distributions.

## Fix
Require `n` to be a non-boolean `numbers.Integral`, normalize accepted integer-like values to a Python `int`, and then evaluate the existing analytical formula unchanged.

## Validation
- regression rejects `0.5`, Python/NumPy booleans, and `"1"`
- regression confirms `np.int64(2)` matches the Python integer result
- regression confirms the `-2` moment is the conjugate of the `+2` moment
- `python -m py_compile` passed for the modified source and test files
- focused standalone checks passed for rejection and conjugacy
- local Git blob hashes match the committed GitHub blobs exactly
- branch is 2 commits ahead of current `main`, 0 behind, with a 16-line two-file diff

The full repository/backend suite is delegated to GitHub Actions because this runtime does not provide GitHub CLI access and cannot obtain a network checkout.