### PR TITLE
Normalize NumPy scalar axes in shared PyTorch reductions

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_reduction_axis_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_reduction_axis_contract.py
@@ -147,6 +147,30 @@ def _wrap_boolean_axis_dim_reduction(helper, torch_module):
     return reduction
 
 
+def _patch_reduction_normalizer(module, torch_module) -> None:
+    """Install the strict normalizer on one backend module."""
+
+    original_normalizer = getattr(module, "_normalize_reduction_axes", None)
+    if original_normalizer is None or getattr(
+        original_normalizer,
+        "_pyrecest_reduction_axis_bool_contract",
+        False,
+    ):
+        return
+
+    def _normalize_reduction_axes(axis, ndim_value):
+        return normalize_reduction_axes(axis, ndim_value, torch_module)
+
+    _normalize_reduction_axes.__name__ = getattr(
+        original_normalizer,
+        "__name__",
+        "_normalize_reduction_axes",
+    )
+    _normalize_reduction_axes.__doc__ = getattr(original_normalizer, "__doc__", None)
+    _normalize_reduction_axes._pyrecest_reduction_axis_bool_contract = True
+    module._normalize_reduction_axes = _normalize_reduction_axes
+
+
 def patch_pytorch_reduction_axis_contract() -> None:
     """Make raw/public PyTorch reduction helpers reject boolean axes."""
 
@@ -155,51 +179,16 @@ def patch_pytorch_reduction_axis_contract() -> None:
 
     try:
         import pyrecest._backend as backend_loader  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend._common as common_backend  # pylint: disable=import-outside-toplevel
         import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
         import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
         import torch  # pylint: disable=import-outside-toplevel
     except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
         return
 
-    backend_normalizer = getattr(backend_loader, "_normalize_reduction_axes", None)
-    if backend_normalizer is not None and not getattr(
-        backend_normalizer,
-        "_pyrecest_reduction_axis_bool_contract",
-        False,
-    ):
-
-        def _normalize_backend_reduction_axes(axis, ndim_value):
-            return normalize_reduction_axes(axis, ndim_value, torch)
-
-        _normalize_backend_reduction_axes.__name__ = getattr(
-            backend_normalizer,
-            "__name__",
-            "_normalize_reduction_axes",
-        )
-        _normalize_backend_reduction_axes.__doc__ = getattr(
-            backend_normalizer,
-            "__doc__",
-            None,
-        )
-        _normalize_backend_reduction_axes._pyrecest_reduction_axis_bool_contract = True
-        backend_loader._normalize_reduction_axes = _normalize_backend_reduction_axes
-
-    original_normalizer = getattr(raw_pytorch, "_normalize_reduction_axes", None)
-    if original_normalizer is None:
-        return
-    if not getattr(original_normalizer, "_pyrecest_reduction_axis_bool_contract", False):
-
-        def _normalize_reduction_axes(axis, ndim_value):
-            return normalize_reduction_axes(axis, ndim_value, torch)
-
-        _normalize_reduction_axes.__name__ = getattr(
-            original_normalizer,
-            "__name__",
-            "_normalize_reduction_axes",
-        )
-        _normalize_reduction_axes.__doc__ = getattr(original_normalizer, "__doc__", None)
-        _normalize_reduction_axes._pyrecest_reduction_axis_bool_contract = True
-        raw_pytorch._normalize_reduction_axes = _normalize_reduction_axes
+    _patch_reduction_normalizer(backend_loader, torch)
+    _patch_reduction_normalizer(common_backend, torch)
+    _patch_reduction_normalizer(raw_pytorch, torch)
 
     for helper_name in ("any", "all", "count_nonzero", "max", "prod"):
         raw_helper = getattr(raw_pytorch, helper_name, None)

--- a/tests/backend_support/test_pytorch_reduction_axis_bool_contract.py
+++ b/tests/backend_support/test_pytorch_reduction_axis_bool_contract.py
@@ -105,3 +105,26 @@ assert_bool_axes_rejected(raw_pytorch)
         check=True,
         env=_backend_subprocess_env("numpy"),
     )
+
+
+@pytest.mark.backend_portable
+def test_common_pytorch_min_accepts_numpy_scalar_axis_tuples():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = r'''
+import numpy as np
+import torch
+
+import pyrecest  # noqa: F401
+from pyrecest._backend import _common
+
+values = torch.tensor([[3.0, 1.0], [2.0, 4.0]])
+result = _common.min(values, axis=(np.asarray(0),))
+assert result.tolist() == [2.0, 1.0]
+'''
+    subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        env=_backend_subprocess_env("numpy"),
+    )


### PR DESCRIPTION
## Summary
- patch the shared `_backend._common` reduction-axis normalizer alongside the public loader and raw PyTorch backend
- factor normalizer installation into one idempotent helper
- add subprocess regression coverage for `min(..., axis=(np.asarray(0),))` on a Torch tensor under the NumPy public backend

## Bug
The shared Torch-compatible `min` implementation resolves tuple axes through `pyrecest._backend._common._normalize_reduction_axes`. The existing runtime patch updated the loader export and raw PyTorch module, but not the shared module whose globals are used by `_common.min`.

For a valid NumPy-style tuple such as `(np.asarray(0),)`, the unpatched shared normalizer retained the zero-dimensional ndarray instead of converting it with `operator.index`. It then attempted to construct a set from the normalized axes and raised:

```text
TypeError: unhashable type: 'numpy.ndarray'
```

## Fix
Install the strict reduction-axis normalizer on all three relevant modules:
- `pyrecest._backend`
- `pyrecest._backend._common`
- `pyrecest._backend.pytorch`

The normalizer converts every integer-like tuple element to a Python integer, while preserving the existing boolean-axis rejection and duplicate/out-of-range checks.

## Validation
- reproduced the old failure with `(np.asarray(0),)`
- targeted standalone validation confirms NumPy and Torch integer scalar tuple elements normalize correctly and boolean scalar elements remain rejected
- added backend-portable subprocess regression for the shared `min` path
- branch source and test files were re-fetched from GitHub after the commits to verify the final contents

Full repository pytest was not run locally because the available environment does not contain a PyRecEst checkout; GitHub CI should exercise the in-tree regression.