### PR TITLE
Preserve batch dimensions in stacked product PDFs

### DIFF
--- a/src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py
@@ -58,14 +58,16 @@ class CartProdStackedDistribution(AbstractCartProdDistribution):
 
     def pdf(self, xs):
         xs = asarray(xs)
+        if xs.ndim == 0 or xs.shape[-1] != self.input_dim:
+            raise ValueError(
+                f"xs must have trailing dimension {self.input_dim}, got shape {xs.shape}."
+            )
+
         ps = []
         next_dim = 0
         for dist in self.dists:
             next_input_dim = next_dim + dist.input_dim
-            if xs.ndim == 1:
-                xs_curr = xs[next_dim:next_input_dim]
-            else:
-                xs_curr = xs[:, next_dim:next_input_dim]
+            xs_curr = xs[..., next_dim:next_input_dim]
             pdf_value = asarray(dist.pdf(xs_curr))
             if xs.ndim == 1:
                 pdf_value = reshape(pdf_value, ())

--- a/tests/distributions/test_cart_prod_stacked_pdf_batch_shape.py
+++ b/tests/distributions/test_cart_prod_stacked_pdf_batch_shape.py
@@ -1,0 +1,54 @@
+import unittest
+
+from pyrecest.backend import allclose, array, eye
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.distributions.cart_prod.cart_prod_stacked_distribution import (
+    CartProdStackedDistribution,
+)
+
+
+class TestCartProdStackedPdfBatchShape(unittest.TestCase):
+    def setUp(self):
+        self.dist = CartProdStackedDistribution(
+            [
+                GaussianDistribution(array([0.0, 0.0]), eye(2)),
+                GaussianDistribution(array([0.0, 0.0, 0.0]), eye(3)),
+            ]
+        )
+
+    def test_pdf_preserves_arbitrary_leading_batch_dimensions(self):
+        xs = array(
+            [
+                [
+                    [1.0, 2.0, 3.0, 4.0, 5.0],
+                    [0.5, 1.5, 2.5, 3.5, 4.5],
+                ],
+                [
+                    [-1.0, 0.0, 1.0, 2.0, 3.0],
+                    [2.0, 1.0, 0.0, -1.0, -2.0],
+                ],
+            ]
+        )
+
+        actual = self.dist.pdf(xs)
+        expected = self.dist.dists[0].pdf(xs[..., :2]) * self.dist.dists[1].pdf(
+            xs[..., 2:]
+        )
+
+        self.assertEqual(actual.shape, (2, 2))
+        self.assertTrue(allclose(actual, expected))
+
+    def test_pdf_rejects_surplus_event_coordinates(self):
+        invalid_points = (
+            array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+            array([[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]]),
+        )
+
+        for xs in invalid_points:
+            with self.subTest(shape=xs.shape):
+                with self.assertRaisesRegex(ValueError, "trailing dimension 5"):
+                    self.dist.pdf(xs)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- slice stacked component inputs along the trailing event axis
- validate that each evaluation point has exactly the combined input dimension
- add regressions for nested batches and surplus event coordinates

## Bug
`CartProdStackedDistribution.pdf()` treated every non-vector input as a two-dimensional matrix and sliced it with `xs[:, start:end]`.

For an input with shape `(2, 2, 5)`, this slices the second axis and passes a tensor with trailing dimension `5` to the first two-dimensional component, so otherwise valid nested batches fail.

The method also never checked the total event dimension. A six-dimensional point passed to a five-dimensional stacked distribution was evaluated using only its first five coordinates, silently ignoring the surplus value.

## Fix
Require `xs.shape[-1] == self.input_dim`, then slice each component with `xs[..., start:end]`. This preserves all leading batch dimensions and prevents unused coordinates from being accepted.

Single-point behavior remains unchanged, including scalarizing component densities before stacking.

## Validation
- reproduced the old nested-batch failure: the first component received shape `(2, 2, 5)` instead of `(2, 2, 2)`
- reproduced silent coordinate loss: `[1, 2, 3, 4, 5, 999]` returned exactly the same density as `[1, 2, 3, 4, 5]`
- standalone execution of the patched slicing and dimension-validation logic passed
- branch is 2 commits ahead of current `main`, 0 behind
- final diff changes one implementation file and adds one focused regression module

The full repository/backend test matrix is delegated to GitHub Actions because this execution environment cannot resolve `github.com` for a checkout and does not provide the GitHub CLI.