### PR TITLE
Reject surplus coordinates in stacked product PDFs

### DIFF
--- a/src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py
@@ -58,6 +58,11 @@ class CartProdStackedDistribution(AbstractCartProdDistribution):
 
     def pdf(self, xs):
         xs = asarray(xs)
+        if xs.ndim not in (1, 2) or xs.shape[-1] != self.input_dim:
+            raise ValueError(
+                "xs must be a one-dimensional point or a two-dimensional batch "
+                f"with trailing dimension {self.input_dim}, got shape {xs.shape}."
+            )
         ps = []
         next_dim = 0
         for dist in self.dists:

--- a/tests/distributions/test_cart_prod_stacked_pdf_shape_validation.py
+++ b/tests/distributions/test_cart_prod_stacked_pdf_shape_validation.py
@@ -1,0 +1,35 @@
+import pytest
+
+from pyrecest.backend import array, eye
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.distributions.cart_prod.cart_prod_stacked_distribution import (
+    CartProdStackedDistribution,
+)
+
+
+def _stacked_gaussian_distribution():
+    return CartProdStackedDistribution(
+        [
+            GaussianDistribution(array([0.0, 0.0]), eye(2)),
+            GaussianDistribution(array([0.0, 0.0, 0.0]), eye(3)),
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    "xs",
+    [
+        array([1.0, 2.0, 3.0, 4.0, 5.0, 99.0]),
+        array(
+            [
+                [1.0, 2.0, 3.0, 4.0, 5.0, 99.0],
+                [0.5, 1.5, 2.5, 3.5, 4.5, -99.0],
+            ]
+        ),
+    ],
+)
+def test_pdf_rejects_surplus_coordinates(xs):
+    distribution = _stacked_gaussian_distribution()
+
+    with pytest.raises(ValueError, match="trailing dimension 5"):
+        distribution.pdf(xs)


### PR DESCRIPTION
## Summary
- validate `CartProdStackedDistribution.pdf()` inputs before splitting them across component distributions
- require single points and batches to match the exact stacked `input_dim`
- add regression coverage for surplus coordinates in both single-point and batched inputs

## Bug
`CartProdStackedDistribution.pdf()` sliced only the coordinates needed by its component distributions and never checked whether the full input had the expected dimension.

For a stacked model with `input_dim == 5`, both a six-dimensional point and an `(n, 6)` batch were accepted. The sixth coordinate was silently discarded, so inputs with an incorrect state layout produced plausible densities instead of failing fast.

## Fix
Validate that `xs` is either:
- a one-dimensional point of length `input_dim`, or
- a two-dimensional batch whose trailing dimension is `input_dim`

Only after that validation are component slices evaluated. Existing valid single-point and batched behavior is unchanged.

## Validation
- added regression coverage for surplus coordinates in single and batched inputs
- `python -m py_compile` passed for the modified implementation and new regression file
- branch is 2 commits ahead of current `main`, 0 behind
- final diff is limited to 5 implementation lines and one focused test module

The full repository/backend test matrix is delegated to GitHub Actions because this runtime cannot obtain a network checkout and does not provide the GitHub CLI.