### PR TITLE
Reject non-finite Gaussian mean updates

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
@@ -41,6 +41,12 @@ def _to_python_bool(value):
     return bool(value)
 
 
+def _validate_finite_values(value, name):
+    """Reject arrays containing NaN or infinite values."""
+    if not _to_python_bool(backend_all(isfinite(value))):
+        raise ValueError(f"{name} must contain only finite values.")
+
+
 def _validate_same_dimension(first, second, operation):
     if first.dim != second.dim:
         raise ValueError(
@@ -133,8 +139,7 @@ class GaussianDistribution(AbstractLinearDistribution):
         self.mu = mu
 
         if check_validity:
-            if not _to_python_bool(backend_all(isfinite(mu))):
-                raise ValueError("mu must contain only finite values.")
+            _validate_finite_values(mu, "mu")
             if not _to_python_bool(backend_all(isfinite(C))):
                 raise ValueError("C must contain only finite values.")
             if not _to_python_bool(allclose(C, transpose(C))):
@@ -157,6 +162,7 @@ class GaussianDistribution(AbstractLinearDistribution):
             raise ValueError(
                 f"new_mean must have shape ({self.dim},), got {new_mean.shape}."
             )
+        _validate_finite_values(new_mean, "new_mean")
         new_dist = copy.deepcopy(self)
         new_dist.mu = new_mean
         return new_dist
@@ -250,6 +256,7 @@ class GaussianDistribution(AbstractLinearDistribution):
             raise ValueError(
                 f"shift_by must be scalar for dim=1 or have shape ({self.dim},)."
             )
+        _validate_finite_values(shift_by, "shift_by")
 
         new_gaussian = copy.deepcopy(self)
         new_gaussian.mu = self.mu + shift_by

--- a/tests/distributions/test_gaussian_distribution.py
+++ b/tests/distributions/test_gaussian_distribution.py
@@ -194,6 +194,7 @@ class GaussianDistributionTest(unittest.TestCase):
         dist = StandardNormalLinearDistribution()
 
         covariance = dist.covariance_numerical()
+
         self.assertEqual(covariance.shape, (1, 1))
         npt.assert_allclose(to_numpy(covariance), [[1.0]], atol=1e-7)
 

--- a/tests/distributions/test_gaussian_distribution.py
+++ b/tests/distributions/test_gaussian_distribution.py
@@ -125,6 +125,26 @@ class GaussianDistributionTest(unittest.TestCase):
 
         self.assertTrue(allclose(g_shifted.mode(), mu + shift_by, atol=1e-6))
 
+    def test_set_mean_rejects_nonfinite_values(self):
+        g = GaussianDistribution(array([0.0, 1.0]), diag(array([1.0, 2.0])))
+
+        for value in (float("nan"), float("inf"), -float("inf")):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(
+                    ValueError, "new_mean must contain only finite values"
+                ):
+                    g.set_mean(array([0.0, value]))
+
+    def test_shift_rejects_nonfinite_values(self):
+        g = GaussianDistribution(array([0.0, 1.0]), diag(array([1.0, 2.0])))
+
+        for value in (float("nan"), float("inf"), -float("inf")):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(
+                    ValueError, "shift_by must contain only finite values"
+                ):
+                    g.shift(array([0.0, value]))
+
     def test_pdf_accepts_array_like_inputs(self):
         g = GaussianDistribution(array([0.0]), array([[1.0]]))
 
@@ -174,7 +194,6 @@ class GaussianDistributionTest(unittest.TestCase):
         dist = StandardNormalLinearDistribution()
 
         covariance = dist.covariance_numerical()
-
         self.assertEqual(covariance.shape, (1, 1))
         npt.assert_allclose(to_numpy(covariance), [[1.0]], atol=1e-7)
 


### PR DESCRIPTION
## Summary
- centralize Gaussian finite-value validation in a small backend-neutral helper
- reject non-finite values passed to `GaussianDistribution.set_mean()`
- reject non-finite offsets passed to `GaussianDistribution.shift()`
- add focused regressions for `NaN`, positive infinity, and negative infinity

## Bug
`GaussianDistribution.__init__()` rejects non-finite means when validity checking is enabled, but the value-returning `set_mean()` and `shift()` APIs only validated shape. A valid Gaussian could therefore be transformed into an invalid distribution with a `NaN` or infinite mean, causing downstream density, mode, sampling, and filtering operations to propagate non-finite values.

## Fix
Reuse one backend-neutral finite-value check in the constructor and apply it after shape validation in both mean-update paths. Valid finite means and shifts retain the existing behavior, including scalar shifts for one-dimensional Gaussians. `set_mode()` is covered transitively because it delegates to `set_mean()`.

## Validation
- syntax compilation passed for the modified implementation and regression module
- regressions cover `NaN`, `+inf`, and `-inf` for both `set_mean()` and `shift()`
- branch is based on current `main` and changes only the Gaussian implementation and its existing test file

The full repository/backend matrix is delegated to GitHub Actions because this execution environment cannot obtain a network checkout and does not provide the GitHub CLI.