### PR TITLE
Validate circular uniform shift inputs

### DIFF
--- a/src/pyrecest/distributions/circle/circular_uniform_distribution.py
+++ b/src/pyrecest/distributions/circle/circular_uniform_distribution.py
@@ -1,5 +1,6 @@
 from pyrecest.backend import array, mod, pi
 
+from ..hypertorus._input_validation import as_shift_vector
 from ..hypertorus.hypertoroidal_uniform_distribution import (
     HypertoroidalUniformDistribution,
 )
@@ -20,7 +21,8 @@ class CircularUniformDistribution(
     def get_manifold_size(self):
         return AbstractCircularDistribution.get_manifold_size(self)
 
-    def shift(self, _):
+    def shift(self, shift_by):
+        as_shift_vector(shift_by, self.dim)
         return CircularUniformDistribution()
 
     def cdf(self, xa, starting_point=0):

--- a/tests/distributions/test_circular_uniform_distribution.py
+++ b/tests/distributions/test_circular_uniform_distribution.py
@@ -27,6 +27,14 @@ class CircularUniformDistributionTest(unittest.TestCase):
         x = array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
         npt.assert_allclose(cu2.pdf(x), 1.0 / (2.0 * pi) * ones(x.shape))
 
+    def test_shift_rejects_invalid_inputs(self):
+        cu = CircularUniformDistribution()
+
+        for shift_by in (True, [1.0, 2.0], [[1.0]], np.array([True])):
+            with self.subTest(shift_by=shift_by):
+                with self.assertRaises(ValueError):
+                    cu.shift(shift_by)
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
         reason="Not supported on this backend",


### PR DESCRIPTION
## Summary
- route `CircularUniformDistribution.shift()` through the shared hypertoroidal shift normalizer
- preserve valid scalar shifts for the one-dimensional circular distribution
- reject boolean and malformed vector shifts consistently with other circular distributions
- add focused regression coverage

## Bug
`CircularUniformDistribution.shift()` ignored its argument entirely and returned a new uniform distribution. Although the resulting density is correctly unchanged, bypassing validation meant calls such as `shift(True)`, `shift([1.0, 2.0])`, or `shift([[1.0]])` silently succeeded. Other circular distributions use `as_shift_vector(...)` and reject these invalid inputs.

## Fix
Validate `shift_by` with the existing backend-neutral `as_shift_vector` helper before returning the unchanged circular-uniform family. Scalar inputs remain supported because the helper explicitly accepts scalars for one-dimensional distributions.

## Validation
- both modified Python files pass `python -m py_compile`
- regression covers native booleans, boolean arrays, oversized vectors, and rank-2 inputs
- branch is based directly on current `main` and changes only the circular-uniform source and its test