### PR TITLE
Preserve nested batch shapes in SO(3) uniform PDFs

### DIFF
--- a/src/pyrecest/distributions/so3_uniform_distribution.py
+++ b/src/pyrecest/distributions/so3_uniform_distribution.py
@@ -37,12 +37,12 @@ class SO3UniformDistribution(HyperhemisphericalUniformDistribution):
     def pdf(self, xs):
         """Evaluate the constant SO(3) density."""
         xs = self._normalize_quaternions(xs)
-        return ones(xs.shape[0]) / self.get_manifold_size()
+        return ones(xs.shape[:-1]) / self.get_manifold_size()
 
     def ln_pdf(self, xs):
         """Evaluate the natural logarithm of the constant SO(3) density."""
         xs = self._normalize_quaternions(xs)
-        return -log(self.get_manifold_size()) * ones(xs.shape[0])
+        return -log(self.get_manifold_size()) * ones(xs.shape[:-1])
 
     def sample(self, n):
         """Draw ``n`` canonical scalar-last unit quaternions."""

--- a/tests/distributions/test_so3_uniform_distribution.py
+++ b/tests/distributions/test_so3_uniform_distribution.py
@@ -45,6 +45,32 @@ class SO3UniformDistributionTest(unittest.TestCase):
         npt.assert_allclose(dist.ln_pdf(rotations), log(expected_pdf), atol=ATOL)
         self.assertAlmostEqual(dist.get_manifold_size(), math.pi**2, places=12)
 
+    def test_pdf_preserves_nested_batch_shape(self):
+        dist = SO3UniformDistribution()
+        rotations = array(
+            [
+                [
+                    [0.0, 0.0, 0.0, 1.0],
+                    [0.0, 0.0, 0.0, -2.0],
+                    [0.0, 0.0, sin(pi / 4.0), cos(pi / 4.0)],
+                ],
+                [
+                    [0.0, 0.0, sin(pi / 6.0), cos(pi / 6.0)],
+                    [0.0, sin(pi / 8.0), 0.0, cos(pi / 8.0)],
+                    [sin(pi / 10.0), 0.0, 0.0, cos(pi / 10.0)],
+                ],
+            ]
+        )
+        expected_pdf = ones((2, 3)) / (pi**2)
+
+        actual_pdf = dist.pdf(rotations)
+        actual_ln_pdf = dist.ln_pdf(rotations)
+
+        self.assertEqual(actual_pdf.shape, (2, 3))
+        self.assertEqual(actual_ln_pdf.shape, (2, 3))
+        npt.assert_allclose(actual_pdf, expected_pdf, atol=ATOL)
+        npt.assert_allclose(actual_ln_pdf, log(expected_pdf), atol=ATOL)
+
     def test_pdf_rejects_nonfinite_quaternions(self):
         dist = SO3UniformDistribution()
         invalid_rotations = [


### PR DESCRIPTION
## Summary
- preserve all leading batch dimensions in `SO3UniformDistribution.pdf()`
- apply the same shape correction to `ln_pdf()`
- add regression coverage for quaternion inputs with shape `(2, 3, 4)`

## Bug
`normalize_quaternions()` preserves arbitrary leading batch dimensions. However, the SO(3) uniform density constructed its constant output with `ones(xs.shape[0])`.

For a nested quaternion batch with shape `(2, 3, 4)`, both `pdf()` and `ln_pdf()` therefore returned shape `(2,)` instead of one value per rotation with shape `(2, 3)`. The values were constant, but four of the six evaluation positions were effectively omitted from the result layout.

## Fix
Construct the output over `xs.shape[:-1]`, treating the trailing quaternion dimension as the event dimension and retaining every leading batch axis. Existing single-quaternion and ordinary `(n, 4)` batch behavior remains unchanged.

## Validation
- regression verifies both `pdf()` and `ln_pdf()` return shape `(2, 3)` and the expected constant values
- modified source and regression syntax-compile successfully
- direct shape reproduction confirms the old output was `(2,)` and the corrected output is `(2, 3)`
- branch is based directly on current `main` and changes only the SO(3) uniform implementation and its existing test module