### PR TITLE
Preserve nested batch shapes in custom linear PDFs

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/custom_linear_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/custom_linear_distribution.py
@@ -76,6 +76,8 @@ class CustomLinearDistribution(
         )
         if ndim(p) > 1:
             raise ValueError("The custom pdf function must return at most 1-D values.")
+        if xs.ndim > 2:
+            p = reshape(p, xs.shape[:-1])
         return p
 
     @staticmethod

--- a/tests/distributions/test_custom_linear_distribution.py
+++ b/tests/distributions/test_custom_linear_distribution.py
@@ -60,6 +60,20 @@ class CustomLinearDistributionTest(unittest.TestCase):
 
         npt.assert_allclose(list_pdf, array_pdf)
 
+    def test_pdf_preserves_nested_batch_shape(self):
+        cld = CustomLinearDistribution(lambda xs: xs[:, 0], 2)
+        xs = array(
+            [
+                [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]],
+                [[7.0, 8.0], [9.0, 10.0], [11.0, 12.0]],
+            ]
+        )
+
+        pdf_values = cld.pdf(xs)
+
+        self.assertEqual(pdf_values.shape, (2, 3))
+        npt.assert_allclose(pdf_values, xs[..., 0])
+
     def test_pdf_rejects_wrong_input_shape(self):
         cld = CustomLinearDistribution(lambda xs: xs[:, 0], 2)
 


### PR DESCRIPTION
## Summary
- restore the leading batch dimensions after evaluating flattened custom linear PDF inputs
- preserve existing scalar, single-point, and ordinary matrix return shapes
- add a focused regression for a `(2, 3, 2)` batch

## Bug
`CustomLinearDistribution.pdf()` validates multidimensional inputs using their trailing event dimension, so an input with shape `(2, 3, 2)` is accepted for a two-dimensional distribution.

The implementation then flattens the points to `(6, 2)` before invoking the custom PDF, but returns the resulting `(6,)` density vector directly. The original `(2, 3)` batch structure is therefore lost even though the input contract permits arbitrary leading batch dimensions.

This is especially surprising for distributions created with `CustomLinearDistribution.from_distribution(...)`, because wrapping a component that preserves nested batch shapes changes its public PDF output shape.

## Fix
After the custom PDF has been evaluated and validated as at most one-dimensional, reshape density values back to `xs.shape[:-1]` for inputs with more than one leading batch dimension. Existing behavior for scalars, single points, and `(n, dim)` batches is unchanged.

## Validation
- reproduced the current behavior: `(2, 3, 2)` input produced a flat `(6,)` result
- standalone regression confirms the patch produces shape `(2, 3)` with values equal to `xs[..., 0]`
- standalone checks confirm existing point and `(n, dim)` matrix output shapes are unchanged
- branch is based directly on current `main` and changes only the implementation plus its existing test module