### PR TITLE
Preserve nested batch shapes in hypersphere uniform PDFs

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/abstract_hypersphere_subset_uniform_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/abstract_hypersphere_subset_uniform_distribution.py
@@ -33,7 +33,7 @@ class AbstractHypersphereSubsetUniformDistribution(
         if not isinstance(manifold_size, (int, float)):
             raise TypeError("Manifold size must be a numeric value.")
         p = (
-            (1 / manifold_size) * ones(xs.shape[0])
+            (1 / manifold_size) * ones(xs.shape[:-1])
             if xs.ndim > 1
             else 1 / manifold_size
         )

--- a/tests/distributions/test_hypersphere_uniform_nested_batch_pdf.py
+++ b/tests/distributions/test_hypersphere_uniform_nested_batch_pdf.py
@@ -1,0 +1,41 @@
+"""Regression tests for nested batches in hyperspherical uniform PDFs."""
+
+import unittest
+
+import numpy.testing as npt
+from pyrecest.backend import array, ones
+from pyrecest.distributions import (
+    AbstractHypersphericalDistribution,
+    HypersphericalUniformDistribution,
+)
+
+
+class HypersphericalUniformNestedBatchPdfTest(unittest.TestCase):
+    def test_pdf_preserves_all_leading_batch_dimensions(self):
+        dist = HypersphericalUniformDistribution(2)
+        points = array(
+            [
+                [
+                    [1.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0],
+                    [0.0, 0.0, 1.0],
+                ],
+                [
+                    [-1.0, 0.0, 0.0],
+                    [0.0, -1.0, 0.0],
+                    [0.0, 0.0, -1.0],
+                ],
+            ]
+        )
+
+        values = dist.pdf(points)
+
+        expected_density = 1.0 / (
+            AbstractHypersphericalDistribution.compute_unit_hypersphere_surface(2)
+        )
+        self.assertEqual(values.shape, (2, 3))
+        npt.assert_allclose(values, expected_density * ones((2, 3)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- preserve every leading batch dimension when evaluating hyperspherical and hyperhemispherical uniform PDFs
- keep scalar and ordinary two-dimensional batch behavior unchanged
- add a focused regression for input points with shape `(2, 3, 3)`

## Bug
`AbstractHypersphereSubsetUniformDistribution.pdf()` validates the event dimension through `xs.shape[-1]`, which implies that arbitrary leading batch dimensions are accepted. However, for every non-vector input it allocated the result as

```python
ones(xs.shape[0])
```

For a valid nested batch with shape `(2, 3, 3)`, the PDF therefore returned shape `(2,)` instead of one density per point with shape `(2, 3)`. The second batch dimension was silently discarded.

## Fix
Allocate batched output with `xs.shape[:-1]`, matching the trailing event-dimension convention already used by the input validation. Single-point calls still return the existing scalar density.

Because the implementation is shared, this corrects all uniform distributions derived from `AbstractHypersphereSubsetUniformDistribution`.

## Validation
- regression checks both the `(2, 3)` output shape and the expected constant density on six valid S² points
- both changed Python files pass `python -m py_compile`
- standalone reproduction confirms the old allocation produced `(2,)` while the corrected allocation produces `(2, 3)`
- branch is based directly on current `main`, is 2 commits ahead and 0 behind, and changes one implementation line plus one focused test file

The full backend matrix is delegated to GitHub Actions because GitHub CLI and a network checkout are unavailable in this execution environment.