### PR TITLE
Reject non-finite sigma-point means

### DIFF
--- a/src/pyrecest/sampling/sigma_points.py
+++ b/src/pyrecest/sampling/sigma_points.py
@@ -96,6 +96,8 @@ def _validate_sigma_inputs(x, P, n: int):
     x = reshape(asarray(x, dtype=float64), (-1,))
     if x.shape != (n,):
         raise ValueError(f"x must have shape ({n},)")
+    if not _to_python_bool(all(isfinite(x))):
+        raise ValueError("x must contain only finite values")
     if _has_complex_dtype(P):
         raise ValueError("P must contain real values")
     P = asarray(P, dtype=float64)

--- a/tests/test_sigma_points_covariance_validation.py
+++ b/tests/test_sigma_points_covariance_validation.py
@@ -33,3 +33,19 @@ def test_sigma_points_reject_nonfinite_covariance(points, invalid_value):
 
     with pytest.raises(ValueError, match="P must contain only finite values"):
         points.sigma_points(np.zeros(2), covariance)
+
+
+@pytest.mark.parametrize(
+    "points",
+    [
+        JulierSigmaPoints(n=2, kappa=1.0),
+        MerweScaledSigmaPoints(n=2, alpha=0.5, beta=2.0, kappa=0.0),
+    ],
+    ids=["julier", "merwe"],
+)
+@pytest.mark.parametrize("invalid_value", [np.nan, np.inf], ids=["nan", "infinity"])
+def test_sigma_points_reject_nonfinite_mean(points, invalid_value):
+    mean = np.array([0.0, invalid_value])
+
+    with pytest.raises(ValueError, match="x must contain only finite values"):
+        points.sigma_points(mean, np.eye(2))


### PR DESCRIPTION
## Summary
- validate the sigma-point state mean after backend conversion
- reject `NaN` and infinite mean entries before Cholesky-based point construction
- add regression coverage for both Julier and Merwe sigma-point schemes

## Root cause
`_validate_sigma_inputs(...)` checked the shape and real dtype of `x`, but only applied an elementwise finiteness check to the covariance `P`. A non-finite state mean therefore propagated into every generated sigma point instead of failing at the public input boundary.

## Impact
Callers now receive a clear `ValueError` (`x must contain only finite values`) rather than silently obtaining invalid sigma points that can contaminate an unscented transform or filter update.

## Validation
- inspected the branch diff after both commits
- regression test covers `NaN` and positive infinity for both sigma-point implementations
- full backend test matrix is delegated to GitHub Actions because this environment has no local repository checkout or network access to clone it