### PR TITLE
Fix SE3 linear-velocity marginal selection

### DIFF
--- a/src/pyrecest/distributions/cart_prod/se3_lin_vel_cart_prod_stacked_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/se3_lin_vel_cart_prod_stacked_distribution.py
@@ -38,10 +38,12 @@ class SE3LinVelCartProdStackedDistribution(CartProdStackedDistribution):
         return sum(dist.input_dim for dist in self.dists)
 
     def marginalize_linear(self):
-        return self.dists[1]
+        """Marginalize out linear velocity, retaining the orientation component."""
+        return self.dists[0]
 
     def marginalize_periodic(self):
-        return self.dists[0]
+        """Marginalize out orientation, retaining the linear velocity component."""
+        return self.dists[1]
 
     def pdf(self, xs):
         xs = asarray(xs)

--- a/tests/distributions/test_se3_lin_vel_cart_prod_stacked_distribution.py
+++ b/tests/distributions/test_se3_lin_vel_cart_prod_stacked_distribution.py
@@ -111,6 +111,17 @@ class TestSE3LinVelCartProdStackedDistribution(unittest.TestCase):
 
         self.assertTrue(allclose(cpd.pdf(points), cpd.pdf(array(points))))
 
+    def test_marginalization_returns_remaining_component(self):
+        orientation = HyperhemisphericalUniformDistribution(3)
+        velocity = GaussianDistribution(
+            array([1.0, 2.0, 0.0, -2.0, -1.0, 3.0]),
+            diag(array([3.0, 2.0, 3.0, 3.0, 4.0, 5.0])),
+        )
+        cpd = SE3LinVelCartProdStackedDistribution([orientation, velocity])
+
+        self.assertIs(cpd.marginalize_linear(), orientation)
+        self.assertIs(cpd.marginalize_periodic(), velocity)
+
     def test_mode(self):
         mu = array([2.0, 1.0, 3.0, 1.0])
         watson = HyperhemisphericalWatsonDistribution(mu / linalg.norm(mu), 2)


### PR DESCRIPTION
## Summary
- return the orientation distribution from `marginalize_linear()`
- return the six-dimensional linear distribution from `marginalize_periodic()`
- add a regression that locks both marginalization contracts

## Bug
`SE3LinVelCartProdStackedDistribution` stores its components as periodic orientation first and linear velocity second, but both marginalization methods returned the component that should have been integrated out.

Consequently, `marginalize_linear()` returned the linear Gaussian instead of the remaining orientation distribution, while `marginalize_periodic()` returned the orientation distribution instead of the remaining linear Gaussian. This reverses the established hypercylindrical API contract and can feed a distribution on the wrong state space into downstream code.

## Fix
Swap the two return values and document explicitly which component remains after each marginalization.

## Validation
- regression asserts that marginalizing the linear variables retains the exact orientation component
- regression asserts that marginalizing the periodic variables retains the exact velocity component
- modified implementation passes Python syntax compilation
- branch is based directly on current `main`, two commits ahead and zero behind
- final diff is limited to the SE(3)+linear-velocity distribution and its existing test module

A full repository test run was not available because this execution environment cannot resolve `github.com` for a checkout; GitHub Actions should run the in-tree regression.