### PR TITLE
Reject non-finite box particle supports

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/linear_box_particle_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/linear_box_particle_distribution.py
@@ -53,6 +53,8 @@ class LinearBoxParticleDistribution(AbstractLinearDistribution):
             raise ValueError("lower and upper must have the same shape")
         if lower.ndim != 2:
             raise ValueError("lower and upper must be arrays with shape (n_boxes, dim)")
+        if not bool(all(isfinite(lower))) or not bool(all(isfinite(upper))):
+            raise ValueError("lower and upper must contain only finite values")
         if not bool(all(upper > lower)):
             raise ValueError("Each box must satisfy upper > lower component-wise")
 

--- a/tests/distributions/test_linear_box_particle_distribution.py
+++ b/tests/distributions/test_linear_box_particle_distribution.py
@@ -50,6 +50,18 @@ class LinearBoxParticleDistributionTest(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, "upper > lower"):
                     LinearBoxParticleDistribution(lower, upper)
 
+    def test_constructor_rejects_nonfinite_box_supports(self):
+        invalid_boxes = (
+            (array([[0.0]]), array([[np.inf]])),
+            (array([[-np.inf]]), array([[0.0]])),
+            (array([[np.nan]]), array([[1.0]])),
+        )
+
+        for lower, upper in invalid_boxes:
+            with self.subTest(lower=lower, upper=upper):
+                with self.assertRaisesRegex(ValueError, "finite"):
+                    LinearBoxParticleDistribution(lower, upper)
+
     def test_constructor_rejects_nonfinite_weights(self):
         invalid_weights = (
             ("nan", array([np.nan, 1.0])),


### PR DESCRIPTION
## Summary
- reject `NaN` and infinite lower/upper box corners during `LinearBoxParticleDistribution` construction
- preserve the existing strict positive-width validation for finite supports
- add regression coverage for `+inf`, `-inf`, and `NaN` support bounds

## Bug
`LinearBoxParticleDistribution` checked only whether every upper corner was greater than its corresponding lower corner. Infinite bounds can satisfy that condition, so inputs such as `[0, +inf]` or `[-inf, 0]` constructed successfully.

Those objects do not represent finite uniform box particles: their centers, covariance, and samples can become infinite or `NaN`, while their infinite volumes drive component densities to zero. A normalized weight can therefore produce a density that no longer integrates to its nominal mass.

## Fix
Validate both corner arrays with the existing backend-neutral `isfinite` reduction before checking component-wise ordering. Malformed supports now fail at construction with a clear `ValueError`.

## Validation
- regression covers an infinite upper corner, an infinite lower corner, and a `NaN` lower corner
- final diff is limited to two implementation lines and one focused test method
- branch is based directly on current `main`, two commits ahead and zero behind

A full local test run was not possible because this environment cannot resolve `github.com` for a checkout and does not provide the GitHub CLI; GitHub Actions should run the repository matrix.