### PR TITLE
Preserve hypertoroidal uniform PDF batch shape

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_uniform_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_uniform_distribution.py
@@ -88,7 +88,7 @@ def _validate_pdf_inputs(xs, dim: int):
 
     if xs.shape[-1] != dim:
         raise ShapeError("xs", xs.shape, expected=f"last axis of length {dim}")
-    return xs, xs.shape[0], False
+    return xs, xs.shape[:-1], False
 
 
 def _validate_vector(name: str, value, dim: int):
@@ -129,9 +129,9 @@ class HypertoroidalUniformDistribution(
         :param xs: Values at which to evaluate the PDF
         :returns: PDF evaluated at xs
         """
-        _, n_inputs, single_input = _validate_pdf_inputs(xs, self.dim)
+        _, output_shape, single_input = _validate_pdf_inputs(xs, self.dim)
 
-        pdf_values = 1.0 / self.get_manifold_size() * ones(n_inputs)
+        pdf_values = 1.0 / self.get_manifold_size() * ones(output_shape)
         return pdf_values[0] if single_input else pdf_values
 
     def trigonometric_moment(self, n: Union[int, int32, int64]):

--- a/tests/distributions/test_hypertoroidal_uniform_distribution_batch_shape.py
+++ b/tests/distributions/test_hypertoroidal_uniform_distribution_batch_shape.py
@@ -1,0 +1,14 @@
+import pytest
+from pyrecest.backend import pi, zeros
+from pyrecest.distributions.hypertorus.hypertoroidal_uniform_distribution import (
+    HypertoroidalUniformDistribution,
+)
+
+
+def test_pdf_preserves_all_leading_batch_dimensions():
+    dist = HypertoroidalUniformDistribution(2)
+
+    values = dist.pdf(zeros((2, 3, 2)))
+
+    assert values.shape == (2, 3)
+    assert float(values[1, 2]) == pytest.approx(1.0 / (2.0 * pi) ** 2)


### PR DESCRIPTION
## Summary
- preserve every leading batch dimension in `HypertoroidalUniformDistribution.pdf()`
- retain the existing scalar, single-point, and ordinary matrix return shapes
- add a focused regression for input points with shape `(2, 3, 2)`

## Root cause
`_validate_pdf_inputs()` validates multidimensional inputs against the trailing event axis, so arbitrary leading batch dimensions are accepted. It nevertheless returned only `xs.shape[0]` as the output size. Consequently, `pdf()` collapsed nested batches: a `(2, 3, 2)` input produced a `(2,)` density array rather than `(2, 3)`.

## Impact
Callers using vectorized or nested batches received an output whose shape no longer aligned with the input batch, potentially causing broadcasting errors or silently associating densities with the wrong samples.

## Validation
- regression verifies a `(2, 3, 2)` input produces shape `(2, 3)`
- regression verifies the returned constant equals the two-dimensional torus uniform density
- local execution was unavailable because this environment cannot reach GitHub and does not provide the GitHub CLI; GitHub Actions is expected to provide the full test run