### PR TITLE
Normalize large-sigma scalar wrapped-normal PDFs

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
@@ -91,7 +91,7 @@ class WrappedNormalDistribution(
             xs = array([xs])
         # check if sigma is large and return uniform distribution in this case
         if sigma > self.MAX_SIGMA_BEFORE_UNIFORM:
-            return 1.0 / (2.0 * pi) * ones(xs.shape[0])
+            return (1.0 / (2.0 * pi) * ones(xs.shape[0])).squeeze()
         x = mod(xs, 2.0 * pi)
         x = where(x < 0, x + 2.0 * pi, x)
         x -= mu

--- a/tests/distributions/test_wrapped_normal_large_sigma_scalar_pdf.py
+++ b/tests/distributions/test_wrapped_normal_large_sigma_scalar_pdf.py
@@ -1,0 +1,18 @@
+import unittest
+
+from pyrecest.backend import allclose, array, ndim, pi
+from pyrecest.distributions import WrappedNormalDistribution
+
+
+class WrappedNormalLargeSigmaScalarPdfTest(unittest.TestCase):
+    def test_large_sigma_scalar_pdf_returns_scalar(self):
+        dist = WrappedNormalDistribution(array(0.0), array(100.0))
+
+        value = dist.pdf(array(0.25))
+
+        self.assertEqual(ndim(value), 0)
+        self.assertTrue(allclose(value, 1.0 / (2.0 * pi), rtol=1e-12))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- make the large-variance wrapped-normal PDF fast path preserve the scalar return contract
- add a focused regression for scalar evaluation when `sigma > MAX_SIGMA_BEFORE_UNIFORM`

## Bug
`WrappedNormalDistribution.pdf()` coerces a scalar input to a length-one array. The ordinary evaluation path finishes with `result.squeeze()`, so it returns a scalar, but the large-`sigma` uniform fast path returned immediately with `ones(xs.shape[0])`.

Consequently, the same scalar PDF call changed from a scalar to an array with shape `(1,)` solely when `sigma` crossed the uniform-approximation threshold. Code consuming scalar densities could therefore fail only for broad wrapped normals.

## Fix
Apply the same squeeze normalization in the uniform fast path that the ordinary path already uses.

## Validation
- standalone reproduction confirmed the old `(1,)` output and patched zero-dimensional scalar output
- regression checks both scalar dimensionality and the expected `1 / (2π)` density
- branch is 2 commits ahead of the inspected `main` commit, 0 behind, and changes only the implementation line plus one regression file

The full repository suite is delegated to GitHub Actions because this runtime has no GitHub CLI and cannot resolve github.com for a local checkout.