### PR TITLE
Validate toroidal uniform shift dimensions

### DIFF
--- a/src/pyrecest/distributions/hypertorus/toroidal_uniform_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/toroidal_uniform_distribution.py
@@ -10,5 +10,6 @@ class ToroidalUniformDistribution(
     def get_manifold_size(self):
         return AbstractToroidalDistribution.get_manifold_size(self)
 
-    def shift(self, _):
+    def shift(self, shift_by):
+        HypertoroidalUniformDistribution.shift(self, shift_by)
         return copy.deepcopy(self)

--- a/tests/distributions/test_toroidal_uniform_shift_validation.py
+++ b/tests/distributions/test_toroidal_uniform_shift_validation.py
@@ -1,0 +1,19 @@
+import unittest
+
+from pyrecest.distributions.hypertorus.toroidal_uniform_distribution import (
+    ToroidalUniformDistribution,
+)
+
+
+class TestToroidalUniformShiftValidation(unittest.TestCase):
+    def test_shift_rejects_wrong_dimension(self):
+        dist = ToroidalUniformDistribution()
+
+        for shift_by in (1.0, [1.0], [1.0, 2.0, 3.0], [[1.0, 2.0]]):
+            with self.subTest(shift_by=shift_by):
+                with self.assertRaisesRegex(ValueError, "shift_by"):
+                    dist.shift(shift_by)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- validate toroidal-uniform shift vectors through the shared hypertoroidal implementation
- preserve the existing behavior of returning an unchanged deep copy
- add regression coverage for malformed shift dimensions

## Bug
`ToroidalUniformDistribution.shift()` ignored its argument and immediately returned a copy. Because the toroidal state is two-dimensional, scalar shifts, one-element vectors, three-element vectors, and rank-2 arrays are malformed inputs. They nevertheless succeeded silently.

The parent `HypertoroidalUniformDistribution.shift()` already enforces an exact `(dim,)` shift-vector shape. Bypassing it could hide state-layout errors while producing an apparently valid unchanged distribution.

## Fix
Call the parent shift implementation for validation before returning the deep copy. Valid two-dimensional shifts retain the existing numerical and object-copy behavior.

## Validation
- regression covers scalar, undersized, oversized, and rank-2 shift inputs
- modified source and test modules pass Python syntax compilation
- branch is based directly on current `main`, two commits ahead and zero behind
- final diff is limited to a two-line implementation change and one focused regression file

The full repository/backend test matrix is delegated to GitHub Actions because this execution environment has no local PyRecEst checkout or GitHub CLI.