### PR TITLE
Normalize NumPy integer axes in PyTorch flip

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_reduction_axis_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_reduction_axis_contract.py
@@ -59,7 +59,7 @@ def normalize_flip_axes(axis):
 
     try:
         return (_operator_index(axis),)
-    except TypeError as index_error:
+    except TypeError:
         try:
             axes = tuple(axis)
         except TypeError as iterable_error:

--- a/src/pyrecest/backend_support/_pytorch_reduction_axis_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_reduction_axis_contract.py
@@ -1,4 +1,4 @@
-"""Runtime patch for PyTorch reduction-axis normalization."""
+"""Runtime patch for PyTorch axis normalization."""
 
 from __future__ import annotations
 
@@ -52,6 +52,37 @@ def _normalize_scalar_axis_value(axis, torch_module):
         return _operator_index(axis)
     except TypeError:
         return axis
+
+
+def normalize_flip_axes(axis):
+    """Convert NumPy-style flip axes to a tuple accepted by ``torch.flip``."""
+
+    try:
+        return (_operator_index(axis),)
+    except TypeError as index_error:
+        try:
+            axes = tuple(axis)
+        except TypeError as iterable_error:
+            raise TypeError(_AXIS_TYPE_MESSAGE) from iterable_error
+        try:
+            return tuple(_operator_index(one_axis) for one_axis in axes)
+        except TypeError as item_error:
+            raise TypeError(_AXIS_TYPE_MESSAGE) from item_error
+
+
+def _wrap_flip_axis_contract(helper, raw_pytorch, torch_module):
+    if getattr(helper, "_pyrecest_flip_axis_contract", False):
+        return helper
+
+    def flip(x, axis):
+        values = raw_pytorch.array(x)
+        axes = tuple(range(values.ndim)) if axis is None else normalize_flip_axes(axis)
+        return torch_module.flip(values, dims=axes)
+
+    flip.__name__ = getattr(helper, "__name__", "flip")
+    flip.__doc__ = getattr(helper, "__doc__", None)
+    flip._pyrecest_flip_axis_contract = True
+    return flip
 
 
 def normalize_reduction_axes(axis, ndim_value, torch_module):
@@ -148,7 +179,7 @@ def _wrap_boolean_axis_dim_reduction(helper, torch_module):
 
 
 def patch_pytorch_reduction_axis_contract() -> None:
-    """Make raw/public PyTorch reduction helpers reject boolean axes."""
+    """Normalize raw/public PyTorch axes to match the NumPy-style facade."""
 
     _patch_pytorch_searchsorted_sorter_contract()
     _patch_pytorch_split_index_contract()
@@ -160,6 +191,13 @@ def patch_pytorch_reduction_axis_contract() -> None:
         import torch  # pylint: disable=import-outside-toplevel
     except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
         return
+
+    raw_flip = getattr(raw_pytorch, "flip", None)
+    if raw_flip is not None:
+        wrapped_flip = _wrap_flip_axis_contract(raw_flip, raw_pytorch, torch)
+        raw_pytorch.flip = wrapped_flip
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.flip = wrapped_flip
 
     backend_normalizer = getattr(backend_loader, "_normalize_reduction_axes", None)
     if backend_normalizer is not None and not getattr(

--- a/tests/backend_support/test_pytorch_flip_numpy_axis_contract.py
+++ b/tests/backend_support/test_pytorch_flip_numpy_axis_contract.py
@@ -1,0 +1,40 @@
+"""Regression tests for NumPy-style PyTorch flip axes."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_pytorch_flip_accepts_numpy_integer_axis_values():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import numpy as np
+import torch
+
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_backend
+
+values = backend.asarray([[0, 1, 2], [3, 4, 5]])
+expected_axis_0 = [[3, 4, 5], [0, 1, 2]]
+expected_axis_1 = [[2, 1, 0], [5, 4, 3]]
+expected_both = [[5, 4, 3], [2, 1, 0]]
+
+for flip in (backend.flip, raw_backend.flip):
+    assert backend.to_numpy(flip(values, np.int64(0))).tolist() == expected_axis_0
+    assert backend.to_numpy(flip(values, np.asarray(1))).tolist() == expected_axis_1
+    assert backend.to_numpy(flip(values, np.asarray([0, 1]))).tolist() == expected_both
+    assert backend.to_numpy(flip(values, torch.tensor(0))).tolist() == expected_axis_0
+    assert backend.to_numpy(flip(values, torch.tensor([0, 1]))).tolist() == expected_both
+""",
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- normalize NumPy and Torch integer axis scalars/sequences before dispatching to `torch.flip`
- update both the raw PyTorch backend and the active public backend facade
- add portable regression coverage for NumPy scalar/array axes and Torch scalar/vector axes

## Bug fixed
The PyTorch backend's `flip(x, axis)` only wrapped native Python `int` values. Standard NumPy-style inputs such as `np.int64(0)`, `np.asarray(1)`, and `np.asarray([0, 1])` were passed directly to `torch.flip`, which rejects NumPy objects for `dims` with `TypeError`. Integer Torch tensors had the same problem. The NumPy backend accepts these integer axis forms, so backend behavior was inconsistent.

## Validation
- `python -m py_compile` on the modified runtime patch
- isolated behavioral smoke for five affected axis forms: NumPy integer scalar, NumPy 0-D array, NumPy 1-D array, Torch scalar tensor, and Torch vector tensor
- branch comparison: 3 commits ahead of current `main`, 0 behind; only the runtime compatibility patch and one regression test are changed

The full in-repository pytest suite was not run locally because this environment cannot resolve `github.com`; GitHub Actions should run the portable regression in-tree.