### PR TITLE
Reject negative process-noise intervals in LTI discretization

### DIFF
--- a/src/pyrecest/models/motion_models.py
+++ b/src/pyrecest/models/motion_models.py
@@ -336,6 +336,7 @@ def continuous_to_discrete_lti(
         raise ValueError(
             "noise_input_matrix and continuous_noise_covariance must be supplied together"
         )
+    dt = _as_nonnegative_float(dt, "dt")
 
     noise_input_np = np.asarray(noise_input_matrix, dtype=float)
     continuous_noise_np = np.asarray(continuous_noise_covariance, dtype=float)

--- a/tests/test_dynamic_models.py
+++ b/tests/test_dynamic_models.py
@@ -140,6 +140,15 @@ class TestMotionModelCatalog(unittest.TestCase):
             covariance, np.array([[2.0 / 3.0, 1.0], [1.0, 2.0]]), atol=1e-12
         )
 
+    def test_continuous_to_discrete_lti_rejects_negative_process_noise_interval(self):
+        with self.assertRaisesRegex(ValueError, "dt"):
+            continuous_to_discrete_lti(
+                np.zeros((1, 1)),
+                np.ones((1, 1)),
+                np.ones((1, 1)),
+                dt=-1.0,
+            )
+
     def test_continuous_to_discrete_lti_rejects_nonfinite_inputs(self):
         with self.assertRaisesRegex(ValueError, "dt"):
             continuous_to_discrete_lti(np.eye(2), dt=np.nan)


### PR DESCRIPTION
## Summary

- reject negative `dt` values when `continuous_to_discrete_lti` discretizes continuous white process noise
- preserve deterministic backward propagation when no process-noise matrices are supplied
- add a regression covering the invalid stochastic interval

## Bug

For the scalar system `A = 0`, `L = 1`, `Qc = 1`, and `dt = -1`, the Van Loan path previously returned `Q = [[-1]]`. That matrix is negative semidefinite and therefore cannot be a process-noise covariance.

## Validation

- targeted reproduction now raises `ValueError` for negative stochastic intervals
- positive scalar discretization remains `F = [[1]]`, `Q = [[1]]`
- deterministic negative-time propagation remains supported
- `python -m py_compile` passes for the modified source and test files
