### PR TITLE
Preserve nested batch shapes in hyperspherical log-PDFs

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/hyperspherical_uniform_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/hyperspherical_uniform_distribution.py
@@ -58,10 +58,10 @@ class HypersphericalUniformDistribution(
 
     def ln_pdf(self, xs):
         xs = array(xs)
-        if xs.shape[-1] != self.input_dim:
+        if xs.ndim == 0 or xs.shape[-1] != self.input_dim:
             raise ValueError("Invalid shape of input data points.")
         log_density = -self.get_ln_manifold_size()
-        return log_density * ones(xs.shape[0]) if xs.ndim > 1 else log_density
+        return log_density * ones(xs.shape[:-1]) if xs.ndim > 1 else log_density
 
     def sample(self, n: Union[int, int32, int64]):
         n = _validate_positive_sample_count(n)

--- a/tests/distributions/test_hyperspherical_uniform_ln_pdf_batch_shape.py
+++ b/tests/distributions/test_hyperspherical_uniform_ln_pdf_batch_shape.py
@@ -1,0 +1,42 @@
+"""Regression tests for hyperspherical-uniform log-density input shapes."""
+
+import unittest
+
+import numpy.testing as npt
+from pyrecest.backend import array, ones
+from pyrecest.distributions import HypersphericalUniformDistribution
+
+
+class HypersphericalUniformLnPdfBatchShapeTest(unittest.TestCase):
+    def test_ln_pdf_preserves_all_leading_batch_dimensions(self):
+        dist = HypersphericalUniformDistribution(2)
+        points = array(
+            [
+                [
+                    [1.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0],
+                    [0.0, 0.0, 1.0],
+                ],
+                [
+                    [-1.0, 0.0, 0.0],
+                    [0.0, -1.0, 0.0],
+                    [0.0, 0.0, -1.0],
+                ],
+            ]
+        )
+
+        values = dist.ln_pdf(points)
+        expected = -dist.get_ln_manifold_size() * ones((2, 3))
+
+        self.assertEqual(values.shape, (2, 3))
+        npt.assert_allclose(values, expected)
+
+    def test_ln_pdf_rejects_scalar_input_with_value_error(self):
+        dist = HypersphericalUniformDistribution(2)
+
+        with self.assertRaisesRegex(ValueError, "shape"):
+            dist.ln_pdf(1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- preserve all leading batch dimensions in `HypersphericalUniformDistribution.ln_pdf()`
- reject scalar inputs through the intended shape-validation path
- add focused regressions for nested batches and malformed scalar input

## Bug

`ln_pdf()` accepted inputs whose trailing axis matched the hyperspherical event dimension, so arbitrary leading batch dimensions were valid. It nevertheless allocated its result with `ones(xs.shape[0])`.

For points with shape `(2, 3, 3)`, the method therefore returned shape `(2,)` instead of one log-density per point with shape `(2, 3)`. This made `ln_pdf()` inconsistent with the distribution API and could silently misalign structured batches.

A scalar input also reached `xs.shape[-1]` and raised an accidental `IndexError` rather than the method's documented `ValueError` for invalid input shape.

## Fix

Use `xs.shape[:-1]` for batched output, treating the trailing coordinate axis as the event dimension. Guard zero-dimensional inputs before indexing the shape. Existing single-point and ordinary `(n, dim + 1)` batch behavior is unchanged.

## Validation

- Python syntax compilation passed for the modified source and regression module
- direct shape regression confirms the old allocation produced `(2,)` and the corrected allocation produces `(2, 3)`
- branch is based directly on current `main`, two commits ahead and zero behind
- final diff changes one implementation method and adds one focused test module

The full repository/backend matrix is delegated to GitHub Actions.