### PR TITLE
Preserve nested batch shapes in partially wrapped PDFs

### DIFF
--- a/src/pyrecest/distributions/cart_prod/partially_wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/partially_wrapped_normal_distribution.py
@@ -86,7 +86,7 @@ def _validate_nonnegative_wrap_count(m) -> int:
 
 
 def _as_2d_query_points(xs, dim: int):
-    """Normalize scalar/vector/matrix query inputs to shape ``(n_eval, dim)``."""
+    """Normalize query inputs and retain the density output shape."""
     xs = array(xs)
     if xs.ndim == 0:
         if dim != 1:
@@ -94,13 +94,13 @@ def _as_2d_query_points(xs, dim: int):
                 "Scalar query points are only valid for one-dimensional "
                 f"distributions, got dim={dim}."
             )
-        return reshape(xs, (1, 1))
+        return reshape(xs, (1, 1)), (1,)
 
     if xs.ndim == 1:
         if dim == 1:
-            return reshape(xs, (-1, 1))
+            return reshape(xs, (-1, 1)), xs.shape
         if xs.shape[0] == dim:
-            return reshape(xs, (1, dim))
+            return reshape(xs, (1, dim)), (1,)
         raise ValueError(
             "Last dimension of xs must match the distribution dimension "
             f"{dim}, got shape {xs.shape}."
@@ -111,7 +111,7 @@ def _as_2d_query_points(xs, dim: int):
             "Last dimension of xs must match the distribution dimension "
             f"{dim}, got shape {xs.shape}."
         )
-    return reshape(xs, (-1, dim))
+    return reshape(xs, (-1, dim)), xs.shape[:-1]
 
 
 def _validate_bound_dim(bound_dim, total_dim: int) -> int:
@@ -163,7 +163,7 @@ class PartiallyWrappedNormalDistribution(AbstractHypercylindricalDistribution):
 
     def pdf(self, xs, m: Union[int, int32, int64] = 3):
         m = _validate_nonnegative_wrap_count(m)
-        xs = _as_2d_query_points(xs, self.input_dim)
+        xs, output_shape = _as_2d_query_points(xs, self.input_dim)
         condition = (
             arange(xs.shape[1]) < self.bound_dim
         )  # Create a condition based on column indices
@@ -208,7 +208,7 @@ class PartiallyWrappedNormalDistribution(AbstractHypercylindricalDistribution):
         # sum evaluations for the wrapped dimensions
         summed_evals = sum(evals.reshape(-1, (2 * m + 1) ** self.bound_dim), axis=1)
 
-        return summed_evals
+        return reshape(summed_evals, output_shape)
 
     def mode(self):
         """
@@ -241,7 +241,7 @@ class PartiallyWrappedNormalDistribution(AbstractHypercylindricalDistribution):
         """
         Calculates mean of [x1, x2, .., x_lin_dim, cos(x_(linD+1), sin(x_(linD+1)), ..., cos(x_(lin_dim+boundD), sin(x_(lin_dim+bound_dim))]
         Returns:
-            mu (linD+2): expectation value of [x1, x2, .., x_lin_dim, cos(x_(lin_dim+1), sin(x_(lin_dim+1)), ..., cos(x_(lin_dim+bound_dim), sin(x_(lin_dim+bound_dim))]
+            mu (linD+2): expectation value of [x1, x2, .., x_lin_dim, cos(x_(lin_dim+1), sin(x_(lin_dim+1)), ..., cos(x_(lin_dim+boundD), sin(x_(lin_dim+bound_dim))]
         """
         mu_lin = self.mu[self.bound_dim :]  # noqa: E203
 

--- a/tests/distributions/test_partially_wrapped_normal_distribution.py
+++ b/tests/distributions/test_partially_wrapped_normal_distribution.py
@@ -31,6 +31,24 @@ class TestPartiallyWrappedNormalDistribution(unittest.TestCase):
                 rtol=1e-10,
             )
 
+    def test_pdf_preserves_nested_batch_shape(self):
+        xs = array(
+            [
+                [[0.5, 1.0], [1.5, 0.5], [2.0, 2.0]],
+                [[0.2, -0.5], [2.4, 1.2], [3.1, 0.0]],
+            ]
+        )
+
+        result = self.dist_2d.pdf(xs)
+
+        self.assertEqual(result.shape, (2, 3))
+        for batch_index in np.ndindex(result.shape):
+            npt.assert_allclose(
+                result[batch_index],
+                self.dist_2d.pdf(xs[batch_index])[0],
+                rtol=1e-10,
+            )
+
     def test_accepts_python_sequence_parameters_and_query_points(self):
         dist = PartiallyWrappedNormalDistribution(
             [0.0, 1.0], [[1.0, 0.1], [0.1, 2.0]], 0


### PR DESCRIPTION
## Summary

- retain the original leading batch dimensions when normalizing `PartiallyWrappedNormalDistribution.pdf()` inputs
- reshape the final wrapped-normal density values back to that batch shape
- add a regression for input points with shape `(2, 3, 2)`

## Bug

`_as_2d_query_points()` accepts inputs with arbitrary leading batch dimensions as long as the trailing dimension matches the distribution dimension. It then flattens those points to `(n_eval, dim)` for the wrapped-normal computation, but `pdf()` returned the resulting one-dimensional vector directly.

For a valid input with shape `(2, 3, 2)`, the method therefore returned shape `(6,)` rather than one density per point with shape `(2, 3)`. This loses the caller's batch structure and can trigger broadcasting errors or misalign densities with structured inputs.

## Fix

Carry the intended density output shape through `_as_2d_query_points()` and reshape only the final summed density vector. Existing return contracts remain unchanged for:

- scalar inputs to one-dimensional distributions: `(1,)`
- one-dimensional sequences of scalar points: `(n,)`
- one multidimensional point: `(1,)`
- ordinary point matrices: `(n,)`

## Validation

- reproduced the old behavior: `(2, 3, 2)` input produced a flat `(6,)` result
- standalone regression confirms the patched result has shape `(2, 3)`
- every nested-batch entry matches evaluation of the corresponding point in isolation
- standalone compatibility checks confirm the established scalar, vector, and matrix output shapes are preserved
- branch is based directly on current `main`, two commits ahead and zero behind
- final diff is limited to the implementation and its existing test module