### PR TITLE
Reject non-finite generalized wrapped-Cauchy gamma

### DIFF
--- a/src/pyrecest/distributions/circle/sine_skewed_distributions.py
+++ b/src/pyrecest/distributions/circle/sine_skewed_distributions.py
@@ -2,7 +2,7 @@ from abc import abstractmethod
 from numbers import Integral
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array, exp, mod, ndim, pi, sin
+from pyrecest.backend import array, exp, isfinite, mod, ndim, pi, sin
 from scipy.special import ive  # pylint: disable=no-name-in-module
 
 from .abstract_circular_distribution import AbstractCircularDistribution
@@ -21,6 +21,13 @@ def _validate_scalar_parameter(value, name):
     parameter = array(value)
     if ndim(parameter) != 0:
         raise ValueError(f"{name} must be a scalar")
+    return parameter
+
+
+def _validate_finite_scalar_parameter(value, name):
+    parameter = _validate_scalar_parameter(value, name)
+    if not bool(isfinite(parameter)):
+        raise ValueError(f"{name} must be finite")
     return parameter
 
 
@@ -237,7 +244,7 @@ class GeneralizedKSineSkewedWrappedCauchyDistribution(AbstractCircularDistributi
         self.validate_parameters()
 
     def validate_parameters(self):
-        self.gamma = _validate_scalar_parameter(self.gamma, "gamma")
+        self.gamma = _validate_finite_scalar_parameter(self.gamma, "gamma")
         if self.gamma <= 0:
             raise ValueError("gamma must be positive")
         self.lambda_ = _validate_scalar_parameter(self.lambda_, "lambda_")

--- a/tests/distributions/test_sine_skewed_scalar_validation.py
+++ b/tests/distributions/test_sine_skewed_scalar_validation.py
@@ -41,3 +41,15 @@ def test_generalized_sine_skewed_wrapped_cauchy_rejects_vector_parameters():
             k=1,
             m=1,
         )
+
+
+@pytest.mark.parametrize("gamma", [float("nan"), float("inf")])
+def test_generalized_sine_skewed_wrapped_cauchy_rejects_nonfinite_gamma(gamma):
+    with pytest.raises(ValueError, match="gamma must be finite"):
+        GeneralizedKSineSkewedWrappedCauchyDistribution(
+            mu=0.0,
+            gamma=gamma,
+            lambda_=0.25,
+            k=1,
+            m=1,
+        )


### PR DESCRIPTION
## Summary

- reject `NaN` and infinite `gamma` values in `GeneralizedKSineSkewedWrappedCauchyDistribution`
- keep the existing scalar and strict-positive validation behavior
- add regression coverage for both `NaN` and positive infinity

## Bug

`GeneralizedKSineSkewedWrappedCauchyDistribution.validate_parameters()` converted `gamma` to a scalar and then checked only `gamma <= 0`.

For `NaN`, that comparison is false, so construction succeeded and every downstream density value became `NaN`. Positive infinity was also accepted, despite the base `WrappedCauchyDistribution` explicitly requiring a finite positive concentration parameter. The two related APIs therefore had inconsistent parameter contracts.

## Fix

Add a backend-neutral finite-scalar validator and apply it to the generalized wrapped-Cauchy `gamma` before the existing positivity check. Valid finite positive concentration parameters retain their current behavior, including the stabilized large-`gamma` evaluation path.

## Validation

- regression rejects `gamma=float("nan")`
- regression rejects `gamma=float("inf")`
- branch is based directly on current `main`, two commits ahead and zero behind
- final diff is limited to 21 additions and 2 deletions across the implementation and its existing scalar-validation test module
- inspected the committed branch contents and final comparison against `main`

A full local pytest run was unavailable because this execution environment has no PyRecEst checkout, cannot resolve `github.com`, and does not provide the GitHub CLI; GitHub Actions should run the repository matrix.