### PR TITLE
Validate Mardia–Sutton scalar parameters

### DIFF
--- a/src/pyrecest/distributions/cart_prod/mardia_sutton_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/mardia_sutton_distribution.py
@@ -42,21 +42,28 @@ def _validate_positive_sample_count(n) -> int:
     return count_int
 
 
-def _validate_positive_finite_scalar(value, name: str) -> float:
+def _validate_finite_scalar(value, name: str) -> float:
     scalar_array = np.asarray(value)
     if scalar_array.shape != ():
-        raise ValueError(f"{name} must be a scalar")
+        raise ValueError(f"{name} must be a finite scalar")
 
     scalar = scalar_array.item()
     if isinstance(scalar, (bool, np.bool_)):
-        raise ValueError(f"{name} must be a positive finite scalar")
+        raise ValueError(f"{name} must be a finite scalar")
 
     try:
         scalar_float = float(scalar)
     except (OverflowError, TypeError, ValueError) as exc:
-        raise ValueError(f"{name} must be a positive finite scalar") from exc
+        raise ValueError(f"{name} must be a finite scalar") from exc
 
-    if not math.isfinite(scalar_float) or scalar_float <= 0.0:
+    if not math.isfinite(scalar_float):
+        raise ValueError(f"{name} must be a finite scalar")
+    return scalar_float
+
+
+def _validate_positive_finite_scalar(value, name: str) -> float:
+    scalar_float = _validate_finite_scalar(value, name)
+    if scalar_float <= 0.0:
         raise ValueError(f"{name} must be a positive finite scalar")
     return scalar_float
 
@@ -82,17 +89,21 @@ class MardiaSuttonDistribution(AbstractHypercylindricalDistribution):
             sigma (positive scalar): linear standard deviation
         """
         AbstractHypercylindricalDistribution.__init__(self, bound_dim=1, lin_dim=1)
+        mu_float = _validate_finite_scalar(mu, "mu")
+        mu0_float = _validate_finite_scalar(mu0, "mu0")
         kappa_float = _validate_positive_finite_scalar(kappa, "kappa")
+        rho1_float = _validate_finite_scalar(rho1, "rho1")
+        rho2_float = _validate_finite_scalar(rho2, "rho2")
         sigma_float = _validate_positive_finite_scalar(sigma, "sigma")
-        rho_norm = float(sqrt(rho1**2 + rho2**2))
-        if not math.isfinite(rho_norm) or rho_norm >= 1.0:
+        rho_norm = math.hypot(rho1_float, rho2_float)
+        if rho_norm >= 1.0:
             raise ValueError("sqrt(rho1^2 + rho2^2) must be strictly less than 1")
 
-        self.mu = mu
-        self.mu0 = mod(mu0, 2.0 * pi)
+        self.mu = mu_float
+        self.mu0 = mod(mu0_float, 2.0 * pi)
         self.kappa = kappa_float
-        self.rho1 = rho1
-        self.rho2 = rho2
+        self.rho1 = rho1_float
+        self.rho2 = rho2_float
         self.sigma = sigma_float
 
     def get_mu_sigma(self, xa_circular):

--- a/tests/distributions/test_mardia_sutton_parameter_validation.py
+++ b/tests/distributions/test_mardia_sutton_parameter_validation.py
@@ -1,0 +1,56 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+from pyrecest.distributions.cart_prod.mardia_sutton_distribution import (
+    MardiaSuttonDistribution,
+)
+
+
+class TestMardiaSuttonParameterValidation(unittest.TestCase):
+    @staticmethod
+    def _create(**overrides):
+        parameters = {
+            "mu": 2.0,
+            "mu0": 1.0,
+            "kappa": 0.7,
+            "rho1": 0.5,
+            "rho2": 0.3,
+            "sigma": 1.5,
+        }
+        parameters.update(overrides)
+        return MardiaSuttonDistribution(**parameters)
+
+    def test_rejects_malformed_location_parameters(self):
+        invalid_values = (True, np.nan, np.inf, -np.inf, [0.0], 1.0 + 0.0j)
+        for name in ("mu", "mu0"):
+            for value in invalid_values:
+                with self.subTest(name=name, value=value):
+                    with self.assertRaisesRegex(ValueError, name):
+                        self._create(**{name: value})
+
+    def test_rejects_malformed_correlation_parameters(self):
+        invalid_values = (True, np.nan, np.inf, -np.inf, [0.2], 0.2 + 0.0j)
+        for name in ("rho1", "rho2"):
+            for value in invalid_values:
+                with self.subTest(name=name, value=value):
+                    with self.assertRaisesRegex(ValueError, name):
+                        self._create(**{name: value})
+
+    def test_accepts_zero_dimensional_numpy_scalars(self):
+        dist = self._create(
+            mu=np.array(2.0),
+            mu0=np.array(1.0),
+            rho1=np.array(0.5),
+            rho2=np.array(0.3),
+        )
+
+        npt.assert_allclose(dist.mode(), np.array([1.0, 2.0]))
+        self.assertIsInstance(dist.mu, float)
+        self.assertIsInstance(dist.rho1, float)
+        self.assertIsInstance(dist.rho2, float)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- require finite scalar values for the Mardia–Sutton location and correlation parameters
- normalize accepted NumPy scalar parameters to Python floats
- retain the existing positivity and correlation-norm constraints
- add focused regression coverage for malformed and valid scalar inputs

## Bug

`MardiaSuttonDistribution` documented `mu`, `mu0`, `rho1`, and `rho2` as scalars, but the constructor did not validate that contract.

A vector-valued `mu`, for example, was stored directly and broadcast through the conditional Gaussian. Evaluating the PDF at one cylindrical point could therefore return multiple density values instead of one. Non-finite location parameters were also accepted and propagated `NaN` values into the mode, density, sampling, and integration paths. Correlation parameters could fail incidentally with backend or conversion exceptions rather than a clear public validation error.

## Fix

Introduce a shared finite-real-scalar validator and apply it to both location parameters and both correlation parameters. The positive-scalar validator for `kappa` and `sigma` now builds on the same validation path. Accepted zero-dimensional NumPy scalars are converted to Python floats before storage, while vectors, booleans, complex values, `NaN`, and infinities fail fast with parameter-specific `ValueError`s.

## Validation

- regression rejects malformed `mu`, `mu0`, `rho1`, and `rho2` values
- regression preserves zero-dimensional NumPy scalar support and verifies normalized parameter storage
- `python -m py_compile` passes for the modified implementation and regression module
- standalone validation checks pass for all rejected scalar categories and the valid correlation constraint
- branch is based directly on current `main`, two commits ahead and zero behind
- final diff is limited to the implementation and one new regression file

The full repository/backend test matrix is delegated to GitHub Actions because this execution environment does not contain a PyRecEst checkout and cannot clone the repository.