### PR TITLE
Return normalized orthogonal-basis copies

### DIFF
--- a/src/pyrecest/distributions/abstract_orthogonal_basis_distribution.py
+++ b/src/pyrecest/distributions/abstract_orthogonal_basis_distribution.py
@@ -49,7 +49,8 @@ class AbstractOrthogonalBasisDistribution(AbstractDistributionType):
         :return: Normalized distribution.
         """
         result = copy.deepcopy(self)
-        return result.normalize_in_place()
+        result.normalize_in_place()
+        return result
 
     @staticmethod
     def _discard_negligible_imaginary_part(val):

--- a/tests/distributions/test_abstract_orthogonal_basis_distribution.py
+++ b/tests/distributions/test_abstract_orthogonal_basis_distribution.py
@@ -10,10 +10,11 @@ from pyrecest.distributions.abstract_orthogonal_basis_distribution import (
 class DummyOrthogonalBasisDistribution(AbstractOrthogonalBasisDistribution):
     def __init__(self, values, transformation="sqrt"):
         self._values = values
+        self.normalization_calls = 0
         super().__init__(coeff_mat=array([1.0]), transformation=transformation)
 
     def normalize_in_place(self):
-        return self
+        self.normalization_calls += 1
 
     def value(self, xs):  # pylint: disable=unused-argument
         return self._values
@@ -30,6 +31,16 @@ class AbstractOrthogonalBasisDistributionTest(unittest.TestCase):
         dist = DummyOrthogonalBasisDistribution(array([2.0 - 1j]), "sqrt")
 
         self.assertAlmostEqual(float(dist.pdf(array([0.0]))[0]), 5.0)
+
+    def test_normalize_returns_independent_copy_when_in_place_returns_none(self):
+        dist = DummyOrthogonalBasisDistribution(array([1.0]), "identity")
+
+        normalized = dist.normalize()
+
+        self.assertIsInstance(normalized, DummyOrthogonalBasisDistribution)
+        self.assertIsNot(normalized, dist)
+        self.assertEqual(dist.normalization_calls, 1)
+        self.assertEqual(normalized.normalization_calls, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- make `AbstractOrthogonalBasisDistribution.normalize()` return the normalized deep copy directly
- decouple the public return contract from the return value of `normalize_in_place()`
- add a regression for an in-place normalizer that mutates successfully and returns `None`

## Bug

`normalize()` created a deep copy and then returned `result.normalize_in_place()`.

That only works when every subclass chooses to return `self` from its in-place mutator. The abstract contract does not require such a return value, and the spherical-harmonics implementation completes normalization without returning anything. Calling `normalize()` on those valid subclasses could therefore return `None` instead of a normalized distribution.

## Fix

Normalize the copied object as a separate statement, then return the copy. This preserves non-mutating behavior and works whether a subclass's `normalize_in_place()` returns `None`, `self`, or another incidental value.

## Validation

- added a regression whose in-place normalizer mutates the copy and returns `None`
- verified the original object remains unchanged while the returned copy receives the additional normalization call
- syntax-compiled both modified Python modules
- branch is based directly on current `main`, two commits ahead and zero behind
- final diff is limited to 16 changed lines across the base implementation and its existing test module

The full repository/backend test matrix is delegated to GitHub Actions because this execution environment cannot obtain a network checkout and does not provide the GitHub CLI.