### PR TITLE
Reject non-finite Gaussian mixture mean updates

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/gaussian_mixture.py
+++ b/src/pyrecest/distributions/nonperiodic/gaussian_mixture.py
@@ -2,7 +2,8 @@ import copy
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array, ones, reshape, stack, sum
+from pyrecest.backend import all as backend_all
+from pyrecest.backend import array, isfinite, ones, reshape, stack, sum
 
 from .abstract_linear_distribution import AbstractLinearDistribution
 from .gaussian_distribution import GaussianDistribution
@@ -35,6 +36,8 @@ class GaussianMixture(LinearMixture, AbstractLinearDistribution):
             raise ValueError(
                 f"new_mean must have shape ({self.dim},), got {new_mean.shape}."
             )
+        if not bool(backend_all(isfinite(new_mean))):
+            raise ValueError("new_mean must contain only finite values.")
 
         new_mixture = copy.deepcopy(self)
         mean_offset = new_mean - self.mean()

--- a/tests/distributions/test_gaussian_mixture_set_mean_validation.py
+++ b/tests/distributions/test_gaussian_mixture_set_mean_validation.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
@@ -30,6 +31,18 @@ class GaussianMixtureSetMeanValidationTest(unittest.TestCase):
             with self.subTest(invalid_mean=invalid_mean):
                 with self.assertRaisesRegex(ValueError, "new_mean"):
                     gmix.set_mean(invalid_mean)
+
+    def test_set_mean_rejects_nonfinite_values(self):
+        gm1 = GaussianDistribution(array([0.0, 1.0]), diag(array([1.0, 2.0])))
+        gm2 = GaussianDistribution(array([2.0, 3.0]), diag(array([3.0, 4.0])))
+        gmix = GaussianMixture([gm1, gm2], array([0.25, 0.75]))
+
+        for invalid_value in (np.nan, np.inf, -np.inf):
+            with self.subTest(invalid_value=invalid_value):
+                with self.assertRaisesRegex(
+                    ValueError, "new_mean must contain only finite values"
+                ):
+                    gmix.set_mean(array([0.0, invalid_value]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- validate `GaussianMixture.set_mean()` targets after shape normalization
- reject `NaN`, positive infinity, and negative infinity before any component is copied or mutated
- extend the dedicated set-mean regression module with non-finite inputs

## Bug

`GaussianMixture.set_mean()` checked only the target shape. A target such as `[0.0, NaN]` therefore produced a new mixture whose component means contained `NaN`; infinite targets similarly propagated infinite offsets into every Gaussian component.

This bypassed the validity guarantees expected from Gaussian distributions because the method writes the offset directly to each copied component's `mu`. Downstream calls to `mean()`, `pdf()`, `sample()`, and `to_gaussian()` could then silently propagate non-finite values.

## Fix

Apply the backend-neutral `isfinite` reduction immediately after the existing scalar/vector shape normalization. Invalid targets now fail with a clear `ValueError` before the deep copy and component update. Valid finite targets retain the existing covariance, weight, and immutability behavior.

## Validation

- regression covers `NaN`, `+inf`, and `-inf`
- both modified modules pass `python -m py_compile`
- branch is based directly on current `main`, two commits ahead and zero behind
- final diff is limited to the Gaussian-mixture implementation and its dedicated set-mean validation tests

The full multi-backend repository matrix is delegated to GitHub Actions because this execution environment cannot resolve `github.com` for a local checkout.