### PR TITLE
Stabilize wrapped-Cauchy PDFs for tiny gamma

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py
@@ -56,13 +56,18 @@ class WrappedCauchyDistribution(AbstractCircularDistribution):
     def pdf(self, xs):
         xs = _as_1d_input(xs)
         xs_centered = mod(xs - self.mu, 2 * pi)
-        rho = exp(-self.gamma)
-        one_minus_rho = 1.0 - rho
-        numerator = one_minus_rho * (1.0 + rho)
-        denominator = (
-            one_minus_rho**2 + 4.0 * rho * sin(xs_centered / 2.0) ** 2
-        )
-        return numerator / (2.0 * pi * denominator)
+
+        # Express the wrapped-Cauchy density through tanh(gamma / 2).  The
+        # algebraically equivalent rho = exp(-gamma) form subtracts rho from
+        # one; for tiny positive gamma that rounds to zero and produces 0 / 0
+        # at the mode.  This half-angle form remains stable both as gamma tends
+        # to zero and as gamma becomes large.
+        half_angle = xs_centered / 2.0
+        half_gamma_tanh = tanh(self.gamma / 2.0)
+        denominator = sin(half_angle) ** 2 + half_gamma_tanh**2 * cos(
+            half_angle
+        ) ** 2
+        return half_gamma_tanh / (2.0 * pi * denominator)
 
     def cdf(self, xs, starting_point=0.0):
         """

--- a/tests/distributions/test_wrapped_cauchy_small_gamma_stability.py
+++ b/tests/distributions/test_wrapped_cauchy_small_gamma_stability.py
@@ -1,0 +1,22 @@
+import numpy as np
+import numpy.testing as npt
+
+from pyrecest.backend import array, to_numpy
+from pyrecest.distributions.circle.wrapped_cauchy_distribution import (
+    WrappedCauchyDistribution,
+)
+
+
+def test_pdf_remains_finite_and_positive_for_tiny_gamma():
+    gamma = 1.0e-20
+    dist = WrappedCauchyDistribution(0.0, gamma)
+
+    values = np.asarray(to_numpy(dist.pdf(array([0.0, 0.2, np.pi]))), dtype=float)
+
+    assert np.all(np.isfinite(values))
+    assert np.all(values > 0.0)
+    npt.assert_allclose(
+        values[0],
+        1.0 / (2.0 * np.pi * np.tanh(gamma / 2.0)),
+        rtol=1.0e-6,
+    )


### PR DESCRIPTION
## Summary

- evaluate the wrapped-Cauchy density with an algebraically equivalent half-angle `tanh(gamma / 2)` formulation
- avoid cancellation in `1 - exp(-gamma)` for tiny positive scale parameters
- add a regression at `gamma = 1e-20`

## Bug

`WrappedCauchyDistribution.pdf()` represented the concentration through `rho = exp(-gamma)` and then computed `1 - rho`.

For sufficiently small positive `gamma`, floating-point arithmetic rounds `exp(-gamma)` to exactly one. The numerator then becomes zero and the denominator is also zero at the mode, so a valid distribution returns `NaN`; away from the mode it returns zero density. For example, `gamma = 1e-20` produced `NaN` at `x = mu` and zero at ordinary off-mode evaluation points.

## Fix

Use the equivalent identity

```text
t = tanh(gamma / 2)
f(x) = t / (2 pi [sin^2((x-mu)/2) + t^2 cos^2((x-mu)/2)])
```

This form avoids subtracting nearly equal values. It remains stable in both limiting regimes: the sharply concentrated small-`gamma` case and the large-`gamma` uniform limit.

## Validation

- regression verifies finite, strictly positive densities for `gamma = 1e-20`
- regression checks the analytical modal density `1 / (2 pi tanh(gamma / 2))`
- syntax compilation passed for the modified implementation and new test
- standalone numerical checks passed for the tiny-`gamma` case and retained the `gamma = 1000` uniform limit
- branch is two commits ahead of current `main`, zero behind, and changes only the distribution implementation plus one focused regression file