### PR TITLE
Reject invalid MTT state ranks

### DIFF
--- a/src/pyrecest/evaluation/get_distance_function.py
+++ b/src/pyrecest/evaluation/get_distance_function.py
@@ -168,6 +168,8 @@ def _as_target_matrix(
     value, name: str, *, expected_target_dim: int | None = None
 ) -> numpy.ndarray:
     value = _as_real_numeric_array(value, name)
+    if value.ndim not in (1, 2):
+        raise ValueError(f"{name} must be a one- or two-dimensional target set")
     if value.size == 0:
         if value.ndim == 2:
             return value

--- a/tests/evaluation/test_mtt_distance_input_validation.py
+++ b/tests/evaluation/test_mtt_distance_input_validation.py
@@ -36,6 +36,30 @@ class EuclideanMttDistanceInputValidationTest(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, "x2.*finite real"):
                     distance(valid_state, state)
 
+    def test_rejects_invalid_state_ranks(self):
+        distance = get_distance_function(
+            "euclidean_mtt",
+            {"cutoff_distance": 2.5},
+        )
+        valid_state = np.array([[0.0, 0.0]])
+        invalid_states = (
+            1.0,
+            np.zeros((2, 1, 1)),
+            np.empty((0, 1, 2)),
+        )
+
+        for state in invalid_states:
+            with self.subTest(state_shape=np.asarray(state).shape, argument="x1"):
+                with self.assertRaisesRegex(
+                    ValueError, "x1.*one- or two-dimensional"
+                ):
+                    distance(state, valid_state)
+            with self.subTest(state_shape=np.asarray(state).shape, argument="x2"):
+                with self.assertRaisesRegex(
+                    ValueError, "x2.*one- or two-dimensional"
+                ):
+                    distance(valid_state, state)
+
     def test_valid_empty_target_behavior_is_preserved(self):
         distance = get_distance_function(
             "euclidean_mtt",


### PR DESCRIPTION
## Summary

- reject scalar and rank-3+ state sets in the Euclidean multi-target distance helper
- preserve the accepted one-dimensional single-target and two-dimensional target-set layouts
- add focused regression coverage for malformed ranks in both argument positions

## Bug

`_as_target_matrix()` converted finite numeric inputs but did not enforce the documented target-set rank. A scalar input reached `value.shape[0]` and failed with an accidental `IndexError`. Rank-3 arrays were accepted and flowed into the pairwise-cost construction, where their extra axes could be interpreted as target coordinates or produce unrelated broadcasting/assignment errors.

This made malformed MTT states fail inconsistently and, for some shapes, risked silently computing a distance over the wrong layout.

## Fix

Require every MTT state set to be one- or two-dimensional immediately after numeric validation. Valid one-dimensional inputs still represent one target, valid matrices retain the existing row-/dimension-first orientation handling, and existing empty-set behavior is unchanged.

## Validation

- regression rejects scalar, nonempty rank-3, and empty rank-3 states
- every malformed form is tested as both `x1` and `x2`
- existing finite-value and empty-target tests remain unchanged
- final comparison changes only the MTT input helper and its focused validation test module

The full backend/test matrix is delegated to GitHub Actions.