### PR TITLE
Validate hypertoroidal mixture component types

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_mixture.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_mixture.py
@@ -24,6 +24,10 @@ class HypertoroidalMixture(AbstractMixture, AbstractHypertoroidalDistribution):
         """
         if len(dists) == 0:
             raise ValueError("Mixture must contain at least one distribution")
+        if not all(
+            isinstance(dist, AbstractHypertoroidalDistribution) for dist in dists
+        ):
+            raise TypeError("All distributions must be hypertoroidal distributions")
 
         AbstractHypertoroidalDistribution.__init__(self, dim=dists[0].dim)
         AbstractMixture.__init__(self, dists, w)

--- a/tests/distributions/test_hypertoroidal_mixture.py
+++ b/tests/distributions/test_hypertoroidal_mixture.py
@@ -6,9 +6,18 @@ from pyrecest.distributions.hypertorus.custom_hypertoroidal_distribution import 
 from pyrecest.distributions.hypertorus.hypertoroidal_mixture import (
     HypertoroidalMixture,
 )
+from pyrecest.distributions.nonperiodic.custom_linear_distribution import (
+    CustomLinearDistribution,
+)
 
 
 class HypertoroidalMixtureTest(unittest.TestCase):
+    def test_constructor_rejects_nonhypertoroidal_components(self):
+        linear_dist = CustomLinearDistribution(lambda xs: xs[:, 0], 1)
+
+        with self.assertRaisesRegex(TypeError, "hypertoroidal"):
+            HypertoroidalMixture([linear_dist])
+
     def test_to_circular_mixture_rejects_multidimensional_mixture(self):
         dist = CustomHypertoroidalDistribution(lambda xs: xs[:, 0], 2)
         mixture = HypertoroidalMixture([dist])


### PR DESCRIPTION
## Summary

- require every `HypertoroidalMixture` component to inherit from `AbstractHypertoroidalDistribution`
- reject same-dimensional linear or otherwise incompatible distributions during construction
- add a focused regression using a one-dimensional `CustomLinearDistribution`

## Bug

`HypertoroidalMixture.__init__()` documented and type-annotated its components as hypertoroidal distributions, but did not enforce that contract at runtime. The generic `AbstractMixture` base only checks that component dimensions agree.

Consequently, a one-dimensional linear distribution could be placed inside a one-dimensional hypertoroidal mixture. Construction succeeded, but torus-specific operations such as trigonometric moments, circular conversion, and toroidal shifting could then fail later or operate on the wrong manifold.

## Fix

Validate all components immediately after the existing empty-mixture check. Incompatible components now raise a clear `TypeError` before any manifold state is initialized. Valid circular, toroidal, and general hypertoroidal mixtures are unchanged.

## Validation

- regression confirms a same-dimensional `CustomLinearDistribution` is rejected
- existing dimension-conversion regressions remain unchanged
- Python syntax compilation passed for both modified files
- branch comparison against current `main`: two commits ahead, zero behind; 13 additions across two files

The full backend test matrix is delegated to GitHub Actions because this environment cannot obtain a local repository checkout.