### PR TITLE
Reject non-finite grid integrals during normalization

### DIFF
--- a/src/pyrecest/distributions/abstract_grid_distribution.py
+++ b/src/pyrecest/distributions/abstract_grid_distribution.py
@@ -6,7 +6,7 @@ from math import prod
 from beartype import beartype
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
-from pyrecest.backend import abs, allclose, any, mean
+from pyrecest.backend import abs, allclose, any, isfinite, mean
 
 from .abstract_distribution_type import AbstractDistributionType
 
@@ -86,6 +86,8 @@ class AbstractGridDistribution(AbstractDistributionType):
 
     def normalize_in_place(self, tol=1e-4, warn_unnorm=True):
         int_val = self.integrate()
+        if not bool(isfinite(int_val)):
+            raise ValueError("Integral of grid values must be finite.")
         if float(abs(int_val)) < 1e-200:
             raise ValueError(
                 "Sum of grid values is too close to zero, this usually points to a user error."

--- a/tests/distributions/test_abstract_grid_nonfinite_normalization.py
+++ b/tests/distributions/test_abstract_grid_nonfinite_normalization.py
@@ -1,0 +1,38 @@
+import pytest
+
+from pyrecest.backend import array
+from pyrecest.distributions.abstract_grid_distribution import AbstractGridDistribution
+
+
+class _DummyGridDistribution(AbstractGridDistribution):
+    def __init__(self, grid_values):
+        super().__init__(
+            grid_values,
+            grid_type="custom",
+            grid=array([[0.0], [1.0]]),
+            dim=1,
+        )
+
+    def get_closest_point(self, xs):
+        raise NotImplementedError
+
+    def get_manifold_size(self):
+        return 1.0
+
+
+@pytest.mark.parametrize(
+    "grid_values",
+    [
+        [float("nan"), 1.0],
+        [float("inf"), 1.0],
+        [-float("inf"), 1.0],
+    ],
+)
+def test_normalize_rejects_nonfinite_integral_without_mutating_values(grid_values):
+    dist = _DummyGridDistribution(array(grid_values))
+    original_values = dist.grid_values
+
+    with pytest.raises(ValueError, match="Integral of grid values must be finite"):
+        dist.normalize_in_place(warn_unnorm=False)
+
+    assert dist.grid_values is original_values


### PR DESCRIPTION
## Summary

- reject non-finite integrals in `AbstractGridDistribution.normalize_in_place()`
- fail before mutating `grid_values`
- add regression coverage for `NaN`, positive infinity, and negative infinity

## Bug

`normalize_in_place()` checked only whether the integral was close to zero. For a non-finite integral, the comparison is false, so normalization continued:

- `NaN` integrals propagated `NaN` into every grid value
- infinite integrals could collapse finite values to zero and produce `NaN` for infinite entries

The resulting object was not a valid normalized grid distribution, and the failure occurred silently after mutation.

## Fix

Use the backend-neutral `isfinite()` operation immediately after integration and raise a clear `ValueError` before any warning or division when the integral is non-finite.

## Validation

- focused runtime reproduction with a NumPy-backed stub passed for `NaN`, `+inf`, and `-inf`
- valid finite normalization behavior remained unchanged
- both modified/added Python modules passed syntax compilation
- branch is two commits ahead and zero behind current `main`