### PR TITLE
Stabilize wrapped-Cauchy PDFs for tiny gamma

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py
@@ -58,13 +58,17 @@ class WrappedCauchyDistribution(AbstractCircularDistribution):
     def pdf(self, xs):
         xs = _as_1d_input(xs)
         xs_centered = mod(xs - self.mu, 2 * pi)
-        rho = exp(-self.gamma)
-        one_minus_rho = 1.0 - rho
-        numerator = one_minus_rho * (1.0 + rho)
-        denominator = (
-            one_minus_rho**2 + 4.0 * rho * sin(xs_centered / 2.0) ** 2
-        )
-        return numerator / (2.0 * pi * denominator)
+
+        # The usual rho = exp(-gamma) expression subtracts rho from one.
+        # For tiny positive gamma, rho rounds to one and that form produces
+        # 0 / 0 at the mode. The equivalent half-angle representation avoids
+        # this cancellation and is also stable in the large-gamma limit.
+        half_angle = xs_centered / 2.0
+        half_gamma_tanh = tanh(self.gamma / 2.0)
+        denominator = sin(half_angle) ** 2 + half_gamma_tanh**2 * cos(
+            half_angle
+        ) ** 2
+        return half_gamma_tanh / (2.0 * pi * denominator)
 
     def cdf(self, xs, starting_point=0.0):
         """

--- a/tests/distributions/test_wrapped_cauchy_small_gamma_stability.py
+++ b/tests/distributions/test_wrapped_cauchy_small_gamma_stability.py
@@ -1,0 +1,22 @@
+import numpy as np
+import numpy.testing as npt
+
+from pyrecest.backend import array, to_numpy
+from pyrecest.distributions.circle.wrapped_cauchy_distribution import (
+    WrappedCauchyDistribution,
+)
+
+
+def test_pdf_remains_finite_and_positive_for_tiny_gamma():
+    gamma = 1.0e-20
+    dist = WrappedCauchyDistribution(0.0, gamma)
+
+    values = np.asarray(to_numpy(dist.pdf(array([0.0, 0.2, np.pi]))), dtype=float)
+
+    assert np.all(np.isfinite(values))
+    assert np.all(values > 0.0)
+    npt.assert_allclose(
+        values[0],
+        1.0 / (2.0 * np.pi * np.tanh(gamma / 2.0)),
+        rtol=1.0e-6,
+    )


### PR DESCRIPTION
Rebuilds #4243 on current `main` to preserve the recently merged validation and moment-order changes while adding the cancellation-free half-angle PDF and focused tiny-`gamma` regression.

Supersedes #4243, whose branch conflicts with current `main`.