### PR TITLE
Normalize integer-like axes in shared PyTorch reductions

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_common_reduction_axis_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_common_reduction_axis_contract.py
@@ -1,0 +1,71 @@
+"""Runtime patch for integer-like tuple axes in shared PyTorch reductions."""
+
+from __future__ import annotations
+
+from operator import index as _operator_index
+
+import numpy as np
+
+_AXIS_TYPE_MESSAGE = "axis must be an integer or a sequence of integers"
+
+
+def _is_boolean_axis(value, torch_module) -> bool:
+    if isinstance(value, (bool, np.bool_)):
+        return True
+    return torch_module.is_tensor(value) and value.dtype == torch_module.bool
+
+
+def _normalize_axis(axis, torch_module):
+    """Convert integer-like scalar axes and tuple entries to Python integers."""
+
+    if _is_boolean_axis(axis, torch_module):
+        raise TypeError(_AXIS_TYPE_MESSAGE)
+    try:
+        return _operator_index(axis)
+    except TypeError as scalar_error:
+        if getattr(axis, "shape", None) == ():
+            raise TypeError(_AXIS_TYPE_MESSAGE) from scalar_error
+        try:
+            axes = tuple(axis)
+        except TypeError as iterable_error:
+            raise TypeError(_AXIS_TYPE_MESSAGE) from iterable_error
+
+    normalized = []
+    for one_axis in axes:
+        if _is_boolean_axis(one_axis, torch_module):
+            raise TypeError(_AXIS_TYPE_MESSAGE)
+        try:
+            normalized.append(_operator_index(one_axis))
+        except TypeError as item_error:
+            raise TypeError(_AXIS_TYPE_MESSAGE) from item_error
+    return tuple(normalized)
+
+
+def patch_pytorch_common_reduction_axis_contract() -> None:
+    """Normalize integer-like axes used by ``pyrecest._backend._common``."""
+
+    try:
+        import pyrecest._backend._common as common_backend  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch may be unavailable
+        return
+
+    original_normalizer = getattr(common_backend, "_normalize_reduction_axes", None)
+    if original_normalizer is None or getattr(
+        original_normalizer,
+        "_pyrecest_common_reduction_axis_scalar_contract",
+        False,
+    ):
+        return
+
+    def _normalize_reduction_axes(axis, ndim_value):
+        return original_normalizer(_normalize_axis(axis, torch), ndim_value)
+
+    _normalize_reduction_axes.__name__ = getattr(
+        original_normalizer,
+        "__name__",
+        "_normalize_reduction_axes",
+    )
+    _normalize_reduction_axes.__doc__ = getattr(original_normalizer, "__doc__", None)
+    _normalize_reduction_axes._pyrecest_common_reduction_axis_scalar_contract = True
+    common_backend._normalize_reduction_axes = _normalize_reduction_axes

--- a/src/pyrecest/backend_support/_pytorch_split_index_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_split_index_contract.py
@@ -6,6 +6,9 @@ from operator import index as _operator_index
 
 import numpy as np
 
+from pyrecest.backend_support._pytorch_common_reduction_axis_contract import (
+    patch_pytorch_common_reduction_axis_contract as _patch_pytorch_common_reduction_axis_contract,
+)
 from pyrecest.backend_support._pytorch_take_index_contract import (
     patch_pytorch_take_index_contract as _patch_pytorch_take_index_contract,
 )
@@ -53,6 +56,10 @@ def _normalize_split_cut_indices(indices_or_sections, torch_module):
 def patch_pytorch_split_index_contract() -> None:
     """Make public and raw PyTorch ``split`` reject non-integer cut points."""
 
+    # This function is the first step in the reduction-axis bootstrap chain.
+    # Patch the shared common backend here so its reduction helpers receive the
+    # same normalized integer-like tuple axes as the public and raw backends.
+    _patch_pytorch_common_reduction_axis_contract()
     _patch_pytorch_take_index_contract()
 
     try:

--- a/tests/backend_support/test_common_pytorch_reduction_axis_scalars.py
+++ b/tests/backend_support/test_common_pytorch_reduction_axis_scalars.py
@@ -1,0 +1,49 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _backend_subprocess_env(backend_name):
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = backend_name
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    return env
+
+
+@pytest.mark.backend_portable
+def test_common_pytorch_min_accepts_integer_scalar_axis_tuples():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = r'''
+import numpy as np
+import torch
+
+import pyrecest  # noqa: F401
+from pyrecest._backend import _common
+
+values = torch.tensor([[3.0, 1.0], [2.0, 4.0]])
+for axis in ((np.asarray(0),), (torch.tensor(0),)):
+    result = _common.min(values, axis=axis)
+    assert result.tolist() == [2.0, 1.0]
+
+for axis in ((np.asarray(True),), (torch.tensor(True),)):
+    try:
+        _common.min(values, axis=axis)
+    except TypeError:
+        continue
+    raise AssertionError(f"accepted boolean axis tuple {axis!r}")
+'''
+    subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        env=_backend_subprocess_env("numpy"),
+    )


### PR DESCRIPTION
Rebuilds the intent of #4220 on current `main` without overwriting the intervening flip and backend-contract fixes.

- installs a dedicated adapter for `pyrecest._backend._common._normalize_reduction_axes`
- normalizes NumPy and Torch integer scalar tuple entries
- preserves boolean-axis rejection
- adds a backend-portable subprocess regression

Supersedes the conflicted #4220.