### PR TITLE
Stabilize generalized sine-skewed wrapped-Cauchy PDFs

### DIFF
--- a/src/pyrecest/distributions/circle/sine_skewed_distributions.py
+++ b/src/pyrecest/distributions/circle/sine_skewed_distributions.py
@@ -2,7 +2,7 @@ from abc import abstractmethod
 from numbers import Integral
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array, exp, isfinite, mod, ndim, pi, sin
+from pyrecest.backend import array, cos, exp, isfinite, mod, ndim, pi, sin, tanh
 from scipy.special import ive  # pylint: disable=no-name-in-module
 
 from .abstract_circular_distribution import AbstractCircularDistribution
@@ -257,16 +257,17 @@ class GeneralizedKSineSkewedWrappedCauchyDistribution(AbstractCircularDistributi
         if self.k != 1:
             raise NotImplementedError("Currently, only k=1 is supported")
 
-        # Parameterizing the wrapped Cauchy density through rho avoids the
-        # sinh/cosh overflow and inf/inf cancellation that occur for large gamma.
-        rho = exp(-self.gamma)
-        one_minus_rho = 1.0 - rho
-        numerator = one_minus_rho * (1.0 + rho)
-        denominator = (
-            one_minus_rho**2
-            + 4.0 * rho * sin((xs - self.mu) / 2.0) ** 2
-        )
-        wc_pdf_vals = numerator / (2.0 * pi * denominator)
+        # Express the wrapped-Cauchy density through tanh(gamma / 2). The
+        # algebraically equivalent rho = exp(-gamma) form subtracts rho from
+        # one; for tiny positive gamma that rounds to zero and produces 0 / 0
+        # at the mode. This half-angle form remains stable for both tiny and
+        # large gamma.
+        half_angle = (xs - self.mu) / 2.0
+        half_gamma_tanh = tanh(self.gamma / 2.0)
+        denominator = sin(half_angle) ** 2 + half_gamma_tanh**2 * cos(
+            half_angle
+        ) ** 2
+        wc_pdf_vals = half_gamma_tanh / (2.0 * pi * denominator)
 
         skew_factor = (1 + self.lambda_ * sin(self.k * (xs - self.mu))) ** self.m
         # For the wrapped Cauchy: E[cos(n*(x-mu))] = exp(-n*k*gamma)

--- a/tests/distributions/test_generalized_sine_skewed_wrapped_cauchy_stability.py
+++ b/tests/distributions/test_generalized_sine_skewed_wrapped_cauchy_stability.py
@@ -1,7 +1,7 @@
 import numpy as np
 import numpy.testing as npt
 
-from pyrecest.backend import array, pi, sin
+from pyrecest.backend import array, pi, sin, tanh
 from pyrecest.distributions.circle.sine_skewed_distributions import (
     GeneralizedKSineSkewedWrappedCauchyDistribution,
 )
@@ -24,3 +24,25 @@ def test_pdf_remains_finite_for_large_gamma():
 
     assert np.all(np.isfinite(np.asarray(pdf_values)))
     npt.assert_allclose(pdf_values, expected, rtol=1e-12, atol=0.0)
+
+
+def test_pdf_remains_finite_and_positive_for_tiny_gamma():
+    mu = 0.3
+    gamma = 1.0e-20
+    dist = GeneralizedKSineSkewedWrappedCauchyDistribution(
+        mu=mu,
+        gamma=gamma,
+        lambda_=0.4,
+        k=1,
+        m=1,
+    )
+
+    pdf_values = np.asarray(dist.pdf(array([mu, mu + 0.2, pi])), dtype=float)
+
+    assert np.all(np.isfinite(pdf_values))
+    assert np.all(pdf_values > 0.0)
+    npt.assert_allclose(
+        pdf_values[0],
+        1.0 / (2.0 * np.pi * float(tanh(gamma / 2.0))),
+        rtol=1e-6,
+    )


### PR DESCRIPTION
## Summary

- evaluate the generalized sine-skewed wrapped-Cauchy density with the cancellation-free half-angle `tanh(gamma / 2)` formulation
- preserve the existing large-`gamma` uniform limit
- extend the existing stability test with a tiny-positive-`gamma` regression

## Bug

`GeneralizedKSineSkewedWrappedCauchyDistribution.pdf()` still represented the wrapped-Cauchy factor through `rho = exp(-gamma)` and then computed `1 - rho`.

For sufficiently small positive `gamma`, floating-point arithmetic rounds `exp(-gamma)` to exactly one. At the mode, both the numerator and denominator become zero, so a valid distribution returns `NaN`; away from the mode it can return zero density.

This code path is separate from the base `WrappedCauchyDistribution` implementation and therefore remained affected after the base distribution was stabilized.

## Fix

Use the algebraically equivalent half-angle representation

```text
t = tanh(gamma / 2)
f(x) = t / (2 pi [sin^2((x-mu)/2) + t^2 cos^2((x-mu)/2)])
```

The surrounding skew factor and normalization constants are unchanged.

## Validation

- reproduced the old `NaN` at the mode for `gamma = 1e-20`
- verified the replacement returns a finite, positive modal density matching `1 / (2 pi tanh(gamma / 2))`
- verified the `gamma = 1000` uniform-limit regression remains valid
- syntax-compiled the modified implementation and regression test
- reconstructed the pre-change source and matched its Git blob SHA before publishing, confirming the diff contains only the intended changes