### PR TITLE
Return independent hypertoroidal uniform shifts

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_uniform_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_uniform_distribution.py
@@ -1,3 +1,4 @@
+import copy
 from typing import Union
 
 # pylint: disable=no-name-in-module,no-member
@@ -188,7 +189,7 @@ class HypertoroidalUniformDistribution(
         :returns: Shifted distribution
         """
         _validate_vector("shift_by", shift_by, self.dim)
-        return self
+        return copy.deepcopy(self)
 
     def integrate(self, integration_boundaries=None) -> float:
         """

--- a/tests/distributions/test_hypertoroidal_uniform_distribution.py
+++ b/tests/distributions/test_hypertoroidal_uniform_distribution.py
@@ -64,6 +64,19 @@ def test_shift_validates_shape():
         dist.shift(array([0.1]))
 
 
+def test_shift_returns_independent_copy():
+    dist = HypertoroidalUniformDistribution(2)
+
+    shifted = dist.shift(array([0.1, 0.2]))
+
+    assert shifted is not dist
+    assert type(shifted) is type(dist)
+    assert shifted.dim == dist.dim
+    assert float(shifted.pdf(array([0.3, 0.4]))) == pytest.approx(
+        float(dist.pdf(array([0.3, 0.4])))
+    )
+
+
 def test_integrate_validates_boundary_shapes():
     dist = HypertoroidalUniformDistribution(2)
 


### PR DESCRIPTION
## Summary

- return a deep-copied distribution from `HypertoroidalUniformDistribution.shift()`
- preserve the existing shift-vector validation and uniform density
- add regression coverage for object independence and unchanged numerical behavior

## Bug

`HypertoroidalUniformDistribution.shift()` validated the shift vector and then returned `self`. Callers therefore received an alias to the original mutable distribution rather than an independent shifted result. Mutating the returned object could unexpectedly modify the original distribution.

This was also inconsistent with the non-mutating behavior of the related circular and toroidal uniform shift implementations.

## Fix

Return `copy.deepcopy(self)` after validation. A deep copy preserves subclasses and any future instance state while retaining the mathematically unchanged uniform distribution.

## Validation

- syntax compilation passed for the modified implementation and focused regression test
- regression verifies that the result is a distinct object of the same type and dimension
- regression verifies that the shifted and original distributions retain identical PDF values
- branch comparison changes only the implementation and its test

The full backend and test matrix is delegated to GitHub Actions.