### PR TITLE
Reject singular SE2 Bingham C3 matrices

### DIFF
--- a/src/pyrecest/distributions/cart_prod/se2_bingham_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/se2_bingham_distribution.py
@@ -144,8 +144,8 @@ class SE2BinghamDistribution(AbstractSE2Distribution):
                 ]
             ).T
 
-        if not _to_python_bool(all(linalg.eigvalsh(self.C3) <= 0)):
-            raise ValueError("C3 must be negative semi-definite.")
+        if not _to_python_bool(all(linalg.eigvalsh(self.C3) < 0)):
+            raise ValueError("C3 must be negative definite.")
 
         self._nc = None  # lazily computed
 

--- a/tests/distributions/test_se2_bingham_c3_definiteness.py
+++ b/tests/distributions/test_se2_bingham_c3_definiteness.py
@@ -1,0 +1,16 @@
+import numpy as np
+import pytest
+from pyrecest.distributions import SE2BinghamDistribution
+
+
+def test_rejects_singular_c3_from_parts_and_full_matrix():
+    c1 = np.array([[-3.0, 0.5], [0.5, -1.0]])
+    c2 = np.array([[0.1, 0.2], [-0.1, 0.3]])
+    singular_c3 = np.array([[-1.0, 0.0], [0.0, 0.0]])
+
+    with pytest.raises(ValueError, match="negative definite"):
+        SE2BinghamDistribution(c1, c2, singular_c3)
+
+    full_matrix = np.block([[c1, c2.T], [c2, singular_c3]])
+    with pytest.raises(ValueError, match="negative definite"):
+        SE2BinghamDistribution(full_matrix)


### PR DESCRIPTION
## Summary

- require the translational `C3` block of `SE2BinghamDistribution` to be strictly negative definite
- reject singular negative-semidefinite matrices during construction
- add regression coverage for both the three-block and full-matrix constructors

## Bug

The class documentation and mathematics require `C3` to be negative definite, but the constructor checked only that every eigenvalue was non-positive. A singular matrix such as `diag(-1, 0)` therefore constructed successfully.

All core operations then require `C3^{-1}`: normalization, mode computation, sampling, and marginalization. The accepted object consequently failed later with a linear-algebra exception and did not define a normalizable density over the translational state.

## Fix

Require every eigenvalue of `C3` to be strictly negative and update the validation error to match the documented contract. The same validation applies whether parameters are supplied as `C1`, `C2`, `C3` blocks or as one full 4×4 matrix.

## Validation

- verified the old predicate accepts eigenvalues `[-1, 0]` while matrix inversion fails
- verified the new predicate rejects that singular case and still accepts the existing negative-definite test matrix
- added constructor regressions for both supported input forms
- branch is two commits ahead of `main`, zero behind, and changes only the implementation plus one focused test file

The full backend matrix is delegated to GitHub Actions.