### PR TITLE
Reject non-finite custom linear shifts

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/custom_linear_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/custom_linear_distribution.py
@@ -1,7 +1,8 @@
 import copy
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array, ndim, reshape, zeros
+from pyrecest.backend import all as backend_all
+from pyrecest.backend import array, isfinite, ndim, reshape, zeros
 
 from ..abstract_custom_nonperiodic_distribution import (
     AbstractCustomNonPeriodicDistribution,
@@ -14,10 +15,12 @@ def _as_shift_vector(shift_by, dim: int, *, name: str = "shift_by"):
     if shift_by.ndim == 0:
         if dim != 1:
             raise ValueError(f"{name} must have shape ({dim},), got scalar.")
-        return reshape(shift_by, (1,))
-    if shift_by.ndim == 1 and shift_by.shape[0] == dim:
-        return shift_by
-    raise ValueError(f"{name} must have shape ({dim},), got {shift_by.shape}.")
+        shift_by = reshape(shift_by, (1,))
+    elif shift_by.ndim != 1 or shift_by.shape[0] != dim:
+        raise ValueError(f"{name} must have shape ({dim},), got {shift_by.shape}.")
+    if not bool(backend_all(isfinite(shift_by))):
+        raise ValueError(f"{name} must contain only finite values.")
+    return shift_by
 
 
 class CustomLinearDistribution(

--- a/tests/distributions/test_custom_linear_distribution.py
+++ b/tests/distributions/test_custom_linear_distribution.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
@@ -96,6 +97,23 @@ class CustomLinearDistributionTest(unittest.TestCase):
         shifted = cld.shift([0.2, -0.1])
 
         npt.assert_allclose(shifted.shift_by, array([0.2, -0.1]))
+
+    def test_shift_like_operations_reject_nonfinite_vectors(self):
+        cld = CustomLinearDistribution(lambda xs: xs[:, 0], 2)
+
+        for invalid_value in (np.nan, np.inf, -np.inf):
+            invalid_vector = array([0.0, invalid_value])
+            with self.subTest(operation="constructor", invalid_value=invalid_value):
+                with self.assertRaisesRegex(ValueError, "shift_by.*finite"):
+                    CustomLinearDistribution(
+                        lambda xs: xs[:, 0], 2, shift_by=invalid_vector
+                    )
+            with self.subTest(operation="shift", invalid_value=invalid_value):
+                with self.assertRaisesRegex(ValueError, "shift_by.*finite"):
+                    cld.shift(invalid_vector)
+            with self.subTest(operation="set_mean", invalid_value=invalid_value):
+                with self.assertRaisesRegex(ValueError, "new_mean.*finite"):
+                    cld.set_mean(invalid_vector)
 
     @staticmethod
     def verify_pdf_equal(dist1, dist2, tol):


### PR DESCRIPTION
## Summary

- require finite shift vectors in `CustomLinearDistribution`
- apply the same validation to constructor offsets, `shift()`, and `set_mean()` targets
- add regression coverage for `NaN`, positive infinity, and negative infinity

## Bug

`CustomLinearDistribution` validated only the shape of `shift_by` and `new_mean`. Non-finite values therefore entered `self.shift_by` directly or were used to construct a shifted copy.

A distribution created with a `NaN` or infinite offset then propagated invalid values through `pdf()`, numerical moments, and subsequent shifts. This also allowed `set_mean()` to cache a non-finite `_mean_numerical` value instead of rejecting an invalid Euclidean location.

## Fix

Normalize scalar/vector shapes as before, then require every element of the resulting vector to be finite using the backend-neutral `isfinite` reduction. Invalid inputs now fail before copying, numerical integration, or state mutation.

## Validation

- regression covers constructor `shift_by`, `shift()`, and `set_mean()`
- regression covers `NaN`, `+inf`, and `-inf`
- valid list-based shifts retain their existing behavior
- modified source and test modules pass Python syntax compilation
- focused isolated runtime smoke test passes
- branch comparison: two commits ahead of `main`, zero behind; only the implementation and its existing test module changed

The full multi-backend test matrix is delegated to GitHub Actions.