### PR TITLE
Preserve integer precision for PyTorch randint scalar bounds

### DIFF
--- a/src/pyrecest/_backend/pytorch/random/__init__.py
+++ b/src/pyrecest/_backend/pytorch/random/__init__.py
@@ -106,12 +106,40 @@ def _reject_boolean_randint_bound(value, name):
         raise TypeError(f"{name} must contain integer values")
 
 
+def _normalize_scalar_integer_randint_bound(value):
+    """Convert integer-like scalar arrays/tensors to exact Python integers."""
+    scalar = _LEGACY._scalar_integer_dimension(value)
+    return value if scalar is None else scalar
+
+
+def _first_randint_bound_device(*values):
+    """Return the first tensor-bound device so scalar normalization preserves it."""
+    return next(
+        (
+            value.device
+            for value in values
+            if _LEGACY._torch.is_tensor(value)
+        ),
+        None,
+    )
+
+
 def randint(low, high=None, size=None, *args, **kwargs):
-    """Draw integer samples, rejecting boolean scalar bounds consistently."""
+    """Draw integer samples with exact scalar-bound handling."""
 
     _reject_boolean_randint_bound(low, "low" if high is not None else "high")
     if high is not None:
         _reject_boolean_randint_bound(high, "high")
+
+    bound_device = _first_randint_bound_device(low, high)
+    low = _normalize_scalar_integer_randint_bound(low)
+    if high is not None:
+        high = _normalize_scalar_integer_randint_bound(high)
+
+    if bound_device is not None and "device" not in kwargs:
+        kwargs = dict(kwargs)
+        kwargs["device"] = bound_device
+
     return _LEGACY.randint(low, high, size, *args, **kwargs)
 
 

--- a/tests/backend/test_pytorch_randint_scalar_precision.py
+++ b/tests/backend/test_pytorch_randint_scalar_precision.py
@@ -1,0 +1,44 @@
+import numpy as np
+import pytest
+
+
+torch = pytest.importorskip("torch")
+
+from pyrecest._backend.pytorch import random  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    ("low", "high"),
+    [
+        (np.int64(0), np.int64(2**62)),
+        (np.array(0, dtype=np.int64), np.array(2**62, dtype=np.int64)),
+        (
+            torch.tensor(0, dtype=torch.int64),
+            torch.tensor(2**62, dtype=torch.int64),
+        ),
+    ],
+)
+def test_randint_integer_like_scalar_bounds_retain_full_precision(low, high):
+    random.seed(0)
+
+    samples = random.randint(low, high, size=64)
+
+    assert samples.dtype == torch.int64
+    assert torch.any(torch.remainder(samples, 256) != 0)
+
+
+@pytest.mark.parametrize(
+    "high",
+    [
+        np.int64(2**62),
+        np.array(2**62, dtype=np.int64),
+        torch.tensor(2**62, dtype=torch.int64),
+    ],
+)
+def test_randint_integer_like_scalar_high_retains_full_precision(high):
+    random.seed(0)
+
+    samples = random.randint(high, size=64)
+
+    assert samples.dtype == torch.int64
+    assert torch.any(torch.remainder(samples, 256) != 0)


### PR DESCRIPTION
## Summary

- normalize NumPy integer scalars, zero-dimensional NumPy integer arrays, and zero-dimensional Torch integer tensors to exact Python integer bounds before delegating to `torch.randint`
- preserve the first tensor-bound device when scalar normalization removes the tensor wrapper
- add regression coverage for both two-bound and high-only `randint` calls over large integer ranges

## Bug

The PyTorch random backend treated all NumPy scalar objects and zero-dimensional tensors as array-valued `randint` bounds. Those inputs were routed through the array-bounds fallback, which generated a floating-point uniform sample and then applied `floor(sample * span)`.

For large integer ranges, floating-point precision collapses the output onto a coarse lattice. For example, with an upper bound of `2**62`, every generated value from the fallback is divisible by 256 (and usually by a much larger power of two), so many valid integer residues can never be sampled.

## Fix

Convert integer-like scalar bounds to Python integers before calling the legacy backend. This selects Torch's native integer sampling path while retaining the original device choice for tensor bounds. Genuine array-valued bounds continue to use the broadcast-capable fallback.

## Validation

- deterministic reproduction confirms the previous floating-point path produces only values divisible by 256 for a `2**62` range
- the native integer path produces non-zero residues modulo 256 for the same seed and range
- regression tests cover `np.int64`, zero-dimensional NumPy integer arrays, and zero-dimensional Torch integer tensors
- branch comparison changes only the PyTorch random compatibility shim and the focused regression test

The full backend test matrix is delegated to GitHub Actions.