### PR TITLE
Reject complex hyperrectangular PDF inputs

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/hyperrectangular_uniform_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/hyperrectangular_uniform_distribution.py
@@ -1,5 +1,13 @@
 from pyrecest.backend import all as backend_all
-from pyrecest.backend import array, logical_and, ones, reshape, where, zeros
+from pyrecest.backend import (
+    array,
+    is_complex,
+    logical_and,
+    ones,
+    reshape,
+    where,
+    zeros,
+)
 
 from ..abstract_uniform_distribution import AbstractUniformDistribution
 from .abstract_hyperrectangular_distribution import AbstractHyperrectangularDistribution
@@ -30,6 +38,8 @@ class HyperrectangularUniformDistribution(
 
     def _coerce_points(self, xs):
         xs = array(xs)
+        if is_complex(xs):
+            raise ValueError("xs must be real-valued")
         if xs.ndim == 0:
             if self.dim != 1:
                 raise ValueError("Scalar points are only valid for dim == 1")

--- a/tests/distributions/test_hyperrectangular_uniform_distribution.py
+++ b/tests/distributions/test_hyperrectangular_uniform_distribution.py
@@ -31,6 +31,18 @@ class TestHyperrectangularUniformDistribution(unittest.TestCase):
 
         npt.assert_allclose(float(dist.pdf(array([0.5, 11.0]))), 0.5)
 
+    def test_pdf_rejects_complex_points(self):
+        dist = HyperrectangularUniformDistribution(array([[0.0, 1.0], [10.0, 12.0]]))
+        invalid_points = (
+            array([0.5 + 0.25j, 11.0]),
+            array([[0.5 + 0.25j, 11.0]]),
+        )
+
+        for points in invalid_points:
+            with self.subTest(points=points):
+                with self.assertRaisesRegex(ValueError, "real-valued"):
+                    dist.pdf(points)
+
     def test_pdf_rejects_wrong_point_dimension(self):
         dist = HyperrectangularUniformDistribution(array([[0.0, 1.0], [10.0, 12.0]]))
 


### PR DESCRIPTION
## Summary

- reject complex query points in `HyperrectangularUniformDistribution.pdf()` before support comparisons
- align hyperrectangular input validation with the real-valued contract already enforced by the ellipsoidal-uniform implementation
- add regression coverage for both a single complex point and a complex point batch

## Bug

`HyperrectangularUniformDistribution._coerce_points()` validated only point shape. Complex arrays therefore reached the component-wise bound comparisons.

Under NumPy, complex ordering comparisons are accepted and use an ordering rule rather than raising an error. A point such as `[0.5 + 0.25j, 11.0]` was consequently classified as inside the real rectangle `[0, 1] × [10, 12]`, and `pdf()` returned the nonzero real density `0.5` for a point outside the distribution's real-valued domain. Other backends may reject the same input incidentally, making behavior backend-dependent.

## Fix

Use the backend-neutral `is_complex()` predicate immediately after array conversion and raise a clear `ValueError` before any comparison. Valid real scalar, single-point, and batched evaluations are unchanged.

## Validation

- reproduced the pre-fix NumPy behavior: both single and batched complex points are classified as inside
- isolated regression confirms the new validation rejects both forms with `xs must be real-valued`
- syntax compilation passed for the modified implementation and test module
- branch comparison against current `main`: two commits ahead, zero behind; only the implementation and its focused test module changed

The full multi-backend test matrix is delegated to GitHub Actions.