### PR TITLE
Return independent hypertoroidal Dirac shifts

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py
@@ -235,7 +235,7 @@ class HypertoroidalDiracDistribution(
 
     def shift(self, shift_by) -> "HypertoroidalDiracDistribution":
         shift_by = as_shift_vector(shift_by, self.dim)
-        hd = copy.copy(self)
+        hd = copy.deepcopy(self)
         if self.dim == 1 and self.d.ndim == 1:
             hd.d = mod(self.d + shift_by[0], 2.0 * pi)
         else:

--- a/tests/distributions/test_hypertoroidal_dirac_shift_independence.py
+++ b/tests/distributions/test_hypertoroidal_dirac_shift_independence.py
@@ -1,0 +1,22 @@
+import pytest
+
+import pyrecest.backend
+from pyrecest.backend import array
+from pyrecest.distributions import HypertoroidalDiracDistribution
+
+
+@pytest.mark.skipif(
+    pyrecest.backend.__backend_name__ == "jax",
+    reason="JAX arrays are immutable and cannot expose mutable aliasing.",
+)
+def test_shifted_weights_do_not_alias_original_distribution():
+    original = HypertoroidalDiracDistribution(
+        array([[0.1, 0.2], [0.3, 0.4]]),
+        array([0.25, 0.75]),
+    )
+
+    shifted = original.shift(array([0.2, -0.1]))
+    shifted.w[0] = 0.5
+
+    assert float(original.w[0]) == pytest.approx(0.25)
+    assert float(shifted.w[0]) == pytest.approx(0.5)


### PR DESCRIPTION
## Summary

- deep-copy `HypertoroidalDiracDistribution` before applying a shift
- prevent the shifted result from sharing its mutable particle-weight array with the source distribution
- add a regression that mutates shifted weights and verifies the original remains unchanged

## Bug

`HypertoroidalDiracDistribution.shift()` used `copy.copy(self)`. The method replaced the copied particle locations, but the shallow copy retained the same mutable `w` array as the original distribution.

As a result, downstream code that adjusted or resampled the shifted distribution's weights could silently modify the source distribution as well. This violates the method's non-mutating return contract and is inconsistent with `set_mean()`, which already returns a deep copy.

## Fix

Use `copy.deepcopy(self)` before replacing the shifted particle locations. The returned distribution now owns independent particle positions and weights.

## Validation

- deterministic shallow-copy reproduction confirms that mutating copied weights changes the original before the fix
- the equivalent deep-copy reproduction leaves the original unchanged
- focused regression covers mutable backends; JAX is skipped because its arrays are immutable and cannot expose this aliasing failure
- branch comparison is two commits ahead of `main`, zero behind, and changes one implementation line plus one focused test

The full backend test matrix is delegated to GitHub Actions.