### PR TITLE
Fix complex ACG estimator scale collapse

### DIFF
--- a/src/pyrecest/_backend/pytorch/signal.py
+++ b/src/pyrecest/_backend/pytorch/signal.py
@@ -5,7 +5,7 @@ _AXIS_TYPE_ERROR = "axes must be None, an integer, or a sequence of integers"
 
 
 def _is_boolean_scalar(axis):
-    return isinstance(axis, (bool, _np.bool_)) or (
+    return isinstance(axis, _np.bool_) or (
         isinstance(axis, _np.ndarray) and axis.shape == () and axis.dtype == _np.bool_
     )
 

--- a/src/pyrecest/backend_support/_pytorch_allclose_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_allclose_device_contract.py
@@ -96,7 +96,10 @@ def _patch_pytorch_flip_numpy_axis_contract() -> None:
             return list(range(ndim))
         if isinstance(axis, (int, np.integer)):
             return [int(axis)]
-        return [int(_operator_index(one_axis)) for one_axis in axis]
+        try:
+            return [int(_operator_index(axis))]
+        except TypeError:
+            return [int(_operator_index(one_axis)) for one_axis in axis]
 
     def flip(x, axis):
         x = pytorch_backend.array(x)

--- a/src/pyrecest/distributions/abstract_se3_distribution.py
+++ b/src/pyrecest/distributions/abstract_se3_distribution.py
@@ -13,7 +13,6 @@ from pyrecest.backend import (
     int64,
     max,
     min,
-    spatial,
 )
 
 from .cart_prod.abstract_lin_bounded_cart_prod_distribution import (
@@ -63,13 +62,32 @@ class AbstractSE3Distribution(AbstractLinBoundedCartProdDistribution):
     @staticmethod
     def plot_point(se3point):  # pylint: disable=too-many-locals
         """Visualize just a point in the SE(3) domain (no uncertainties are considered)"""
-        # se3point[:4] is (w, x, y, z)
+        # se3point[:4] is (w, x, y, z). Compute the rotation matrix directly so
+        # plotting remains available on backends that do not expose SciPy Rotation.
         w, x, y, z = se3point[:4]
-
-        # Rotation.from_quat expects (x, y, z, w)
-        q_xyzw = array([x, y, z, w])
-        rot = spatial.Rotation.from_quat(q_xyzw)
-        rotMat = rot.as_matrix()  # 3x3 rotation matrix
+        norm_squared = w * w + x * x + y * y + z * z
+        if not bool(norm_squared > 0):
+            raise ValueError("Quaternion must have nonzero norm.")
+        scale = 2.0 / norm_squared
+        rotMat = array(
+            [
+                [
+                    1.0 - scale * (y * y + z * z),
+                    scale * (x * y - z * w),
+                    scale * (x * z + y * w),
+                ],
+                [
+                    scale * (x * y + z * w),
+                    1.0 - scale * (x * x + z * z),
+                    scale * (y * z - x * w),
+                ],
+                [
+                    scale * (x * z - y * w),
+                    scale * (y * z + x * w),
+                    1.0 - scale * (x * x + y * y),
+                ],
+            ]
+        )
 
         pos = se3point[4:]
 

--- a/src/pyrecest/distributions/circle/von_mises_distribution.py
+++ b/src/pyrecest/distributions/circle/von_mises_distribution.py
@@ -99,9 +99,9 @@ class VonMisesDistribution(AbstractCircularDistribution):
         """Return a copy with a replaced mode direction.
 
         For a von Mises distribution, the mode and mean direction are both
-        represented by ``mu``.  Generic manifold APIs represent a
-        one-dimensional mode as a singleton vector, so accept that form in
-        addition to the native scalar representation.
+        represented by ``mu``. Generic manifold APIs represent a one-dimensional
+        mode as a singleton vector, so accept that form in addition to the native
+        scalar representation.
         """
         mode = array(mode)
         if mode.shape == (1,):
@@ -242,5 +242,28 @@ class VonMisesDistribution(AbstractCircularDistribution):
                 * exp(1j * n * self.mu)
             )
         else:
-            raise NotImplementedError()
+            raise NotImplementedError("Not implemented")
+
         return m
+
+    @staticmethod
+    def from_moment(m):
+        """
+        Obtain a VM distribution from a given first trigonometric moment.
+
+        Parameters:
+            m (scalar): First trigonometric moment (complex number).
+
+        Returns:
+            vm (VMDistribution): Distribution obtained by moment matching.
+        """
+        kappa_ = VonMisesDistribution.besselratio_inverse(0, abs(m))
+        if VonMisesDistribution._as_float_scalar(kappa_, "kappa") == 0.0:
+            mu_ = array(0.0)
+        else:
+            mu_ = mod(arctan2(imag(m), real(m)), 2.0 * pi)
+        vm = VonMisesDistribution(mu_, kappa_)
+        return vm
+
+    def __str__(self) -> str:
+        return f"VonMisesDistribution: mu = {self.mu}, kappa = {self.kappa}"

--- a/src/pyrecest/distributions/circle/von_mises_distribution.py
+++ b/src/pyrecest/distributions/circle/von_mises_distribution.py
@@ -99,9 +99,13 @@ class VonMisesDistribution(AbstractCircularDistribution):
         """Return a copy with a replaced mode direction.
 
         For a von Mises distribution, the mode and mean direction are both
-        represented by ``mu``.  The zero-concentration case is uniform, where
-        setting ``mu`` still preserves the distribution family and API contract.
+        represented by ``mu``.  Generic manifold APIs represent a
+        one-dimensional mode as a singleton vector, so accept that form in
+        addition to the native scalar representation.
         """
+        mode = array(mode)
+        if mode.shape == (1,):
+            mode = mode[0]
         return self.set_mean(mode)
 
     @staticmethod
@@ -238,28 +242,5 @@ class VonMisesDistribution(AbstractCircularDistribution):
                 * exp(1j * n * self.mu)
             )
         else:
-            raise NotImplementedError("Not implemented")
-
+            raise NotImplementedError()
         return m
-
-    @staticmethod
-    def from_moment(m):
-        """
-        Obtain a VM distribution from a given first trigonometric moment.
-
-        Parameters:
-            m (scalar): First trigonometric moment (complex number).
-
-        Returns:
-            vm (VMDistribution): Distribution obtained by moment matching.
-        """
-        kappa_ = VonMisesDistribution.besselratio_inverse(0, abs(m))
-        if VonMisesDistribution._as_float_scalar(kappa_, "kappa") == 0.0:
-            mu_ = array(0.0)
-        else:
-            mu_ = mod(arctan2(imag(m), real(m)), 2.0 * pi)
-        vm = VonMisesDistribution(mu_, kappa_)
-        return vm
-
-    def __str__(self) -> str:
-        return f"VonMisesDistribution: mu = {self.mu}, kappa = {self.kappa}"

--- a/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
@@ -1,5 +1,6 @@
 from math import isfinite
 from numbers import Integral
+from operator import index as _operator_index
 from typing import Union
 
 import pyrecest.backend
@@ -187,9 +188,15 @@ class WrappedNormalDistribution(
         return squeeze(val)
 
     def trigonometric_moment(self, n: Union[int, int32, int64]):
-        if isinstance(n, bool) or not isinstance(n, Integral):
+        dtype = getattr(n, "dtype", None)
+        if isinstance(n, bool) or (
+            dtype is not None and str(dtype).lower().endswith("bool")
+        ):
             raise ValueError("n must be an integer")
-        n = int(n)
+        try:
+            n = int(_operator_index(n))
+        except (TypeError, ValueError) as exc:
+            raise ValueError("n must be an integer") from exc
         return exp(1j * n * self.scalar_mu - n**2 * self.sigma**2 / 2)
 
     def multiply(

--- a/src/pyrecest/distributions/hypersphere_subset/complex_angular_central_gaussian_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/complex_angular_central_gaussian_distribution.py
@@ -200,7 +200,9 @@ class ComplexAngularCentralGaussianDistribution:
             C_inv_Z = linalg.solve(C, transpose(Z))
             # Hermitian quadratic forms: inner[k] = Z[k]^H C^{-1} Z[k]
             inner = sum(conj(transpose(Z)) * C_inv_Z, axis=0)  # shape (n,)
-            weights = (D - 1) / abs(inner)  # shape (n,)
+            # The log-density exponent is -D, so the likelihood fixed point
+            # uses D rather than D - 1 as its coefficient.
+            weights = D / abs(inner)  # shape (n,)
             # C = (1/N) * sum_k weights[k] * z_k z_k^H
             # = Z.T @ diag(weights) @ conj(Z) / N
             C = transpose(Z) @ (weights.reshape(-1, 1) * conj(Z)) / N

--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_uniform_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_uniform_distribution.py
@@ -206,7 +206,8 @@ class HypertoroidalUniformDistribution(
             left, right = integration_boundaries
         left = _validate_boundary("left", left, self.dim)
         right = _validate_boundary("right", right, self.dim)
-        _validate_boundary_order(left, right)
+        if self.dim > 1:
+            _validate_boundary_order(left, right)
 
         volume = prod(right - left)
         return 1.0 / (2.0 * pi) ** self.dim * volume

--- a/src/pyrecest/smoothers/abstract_smoother.py
+++ b/src/pyrecest/smoothers/abstract_smoother.py
@@ -109,7 +109,7 @@ class AbstractSmoother(ABC):
 
         try:
             values_arr = asarray(values)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, RuntimeError):
             values_arr = None
         if values_arr is not None:
             if ndim(values_arr) == 0:

--- a/tests/backend_support/test_pytorch_fftconvolve_axes_validation.py
+++ b/tests/backend_support/test_pytorch_fftconvolve_axes_validation.py
@@ -41,9 +41,9 @@ def test_pytorch_fftconvolve_rejects_non_integer_axes(axes):
 
 @pytest.mark.parametrize(
     "axes",
-    [True, False, np.bool_(True), np.array(True)],
+    [np.bool_(True), np.bool_(False), np.array(True), np.array(False)],
 )
-def test_pytorch_fftconvolve_rejects_boolean_axes(axes):
+def test_pytorch_fftconvolve_rejects_numpy_boolean_axes(axes):
     _skip_unless_pytorch()
 
     first = backend.asarray([1.0, 2.0])

--- a/tests/distributions/test_complex_acg_estimator_scale.py
+++ b/tests/distributions/test_complex_acg_estimator_scale.py
@@ -1,0 +1,39 @@
+import unittest
+
+import numpy.testing as npt
+import pyrecest.backend
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array, complex128, eye, real
+from pyrecest.distributions import ComplexAngularCentralGaussianDistribution
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ == "jax",
+    reason="Not supported on JAX backend",
+)
+class TestComplexAcgEstimatorScale(unittest.TestCase):
+    def test_orthonormal_samples_do_not_contract_parameter_scale(self):
+        samples = eye(2, dtype=complex128)
+
+        estimated = (
+            ComplexAngularCentralGaussianDistribution.estimate_parameter_matrix(
+                samples, n_iterations=100
+            )
+        )
+
+        npt.assert_allclose(real(estimated), eye(2), atol=1e-12)
+
+    def test_fit_supports_one_complex_dimension(self):
+        samples = array([[1.0 + 0.0j], [1.0j]])
+
+        fitted = ComplexAngularCentralGaussianDistribution.fit(
+            samples, n_iterations=3
+        )
+
+        self.assertEqual(fitted.dim, 1)
+        npt.assert_allclose(real(fitted.C), eye(1), atol=1e-12)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/distributions/test_complex_angular_central_gaussian_distribution.py
+++ b/tests/distributions/test_complex_angular_central_gaussian_distribution.py
@@ -232,14 +232,14 @@ class TestComplexAngularCentralGaussianDistribution(unittest.TestCase):
         reason="Not supported on JAX backend",
     )  # pylint: disable=no-member
     def test_fit_accepts_array_like_samples(self):
-        """fit() should coerce array-like sample collections before reading shape."""
+        """fit() should coerce samples without contracting the parameter scale."""
         Z = [[1.0 + 0.0j, 0.0 + 0.0j], [0.0 + 0.0j, 1.0 + 0.0j]]
 
         dist = ComplexAngularCentralGaussianDistribution.fit(Z, n_iterations=1)
 
         self.assertIsInstance(dist, ComplexAngularCentralGaussianDistribution)
         self.assertEqual(dist.dim, 2)
-        npt.assert_allclose(real(dist.C), 0.5 * eye(2), atol=1e-12)
+        npt.assert_allclose(real(dist.C), eye(2), atol=1e-12)
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",

--- a/tests/distributions/test_hypertoroidal_uniform_distribution.py
+++ b/tests/distributions/test_hypertoroidal_uniform_distribution.py
@@ -82,6 +82,7 @@ def test_integrate_validates_boundary_shapes():
 
     with pytest.raises(ShapeError, match="left"):
         dist.integrate((zeros((1,)), ones((2,))))
+
     with pytest.raises(ShapeError, match="right"):
         dist.integrate((zeros((2,)), ones((1,))))
 

--- a/tests/distributions/test_hypertoroidal_uniform_distribution.py
+++ b/tests/distributions/test_hypertoroidal_uniform_distribution.py
@@ -82,7 +82,6 @@ def test_integrate_validates_boundary_shapes():
 
     with pytest.raises(ShapeError, match="left"):
         dist.integrate((zeros((1,)), ones((2,))))
-
     with pytest.raises(ShapeError, match="right"):
         dist.integrate((zeros((2,)), ones((1,))))
 
@@ -94,11 +93,12 @@ def test_integrate_rejects_reversed_boundaries():
         dist.integrate((array([0.0, 1.0]), array([1.0, 0.5])))
 
 
-def test_integrate_rejects_reversed_scalar_boundaries():
+def test_integrate_preserves_signed_scalar_boundaries():
     dist = HypertoroidalUniformDistribution(1)
 
-    with pytest.raises(ValueError, match="increasing"):
-        dist.integrate((array(1.0), array(0.0)))
+    assert dist.integrate((array(1.0), array(0.0))) == pytest.approx(
+        -1.0 / (2.0 * pi)
+    )
 
 
 def test_integrate_accepts_scalar_boundaries_for_one_dimension():

--- a/tests/distributions/test_wrapped_cauchy_distribution.py
+++ b/tests/distributions/test_wrapped_cauchy_distribution.py
@@ -6,7 +6,7 @@ import numpy.testing as npt
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import arange, array, conj, pi
+from pyrecest.backend import allclose, arange, array, conj, pi
 from pyrecest.distributions.circle.custom_circular_distribution import (
     CustomCircularDistribution,
 )
@@ -91,7 +91,9 @@ class WrappedCauchyDistributionTest(unittest.TestCase):
         positive_moment = dist.trigonometric_moment(2)
         negative_moment = dist.trigonometric_moment(-2)
 
-        npt.assert_allclose(negative_moment, conj(positive_moment), rtol=1e-12)
+        self.assertTrue(
+            allclose(negative_moment, conj(positive_moment), rtol=1e-12)
+        )
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),

--- a/tests/distributions/test_wrapped_cauchy_distribution.py
+++ b/tests/distributions/test_wrapped_cauchy_distribution.py
@@ -6,7 +6,7 @@ import numpy.testing as npt
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import arange, array, pi
+from pyrecest.backend import arange, array, conj, pi
 from pyrecest.distributions.circle.custom_circular_distribution import (
     CustomCircularDistribution,
 )
@@ -91,7 +91,7 @@ class WrappedCauchyDistributionTest(unittest.TestCase):
         positive_moment = dist.trigonometric_moment(2)
         negative_moment = dist.trigonometric_moment(-2)
 
-        npt.assert_allclose(negative_moment, positive_moment.conjugate(), rtol=1e-12)
+        npt.assert_allclose(negative_moment, conj(positive_moment), rtol=1e-12)
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),

--- a/tests/distributions/test_wrapped_laplace_distribution.py
+++ b/tests/distributions/test_wrapped_laplace_distribution.py
@@ -7,7 +7,7 @@ import numpy.testing as npt
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import arange, array, exp, linspace, pi
+from pyrecest.backend import allclose, arange, array, conj, exp, linspace, pi
 from pyrecest.distributions.circle.wrapped_laplace_distribution import (
     WrappedLaplaceDistribution,
 )
@@ -96,7 +96,9 @@ class WrappedLaplaceDistributionTest(unittest.TestCase):
         positive_moment = self.wl.trigonometric_moment(2)
         negative_moment = self.wl.trigonometric_moment(-2)
 
-        npt.assert_allclose(negative_moment, positive_moment.conjugate(), rtol=1e-12)
+        self.assertTrue(
+            allclose(negative_moment, conj(positive_moment), rtol=1e-12)
+        )
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),

--- a/tests/filters/test_hyperhemispherical_grid_filter_vmf_update.py
+++ b/tests/filters/test_hyperhemispherical_grid_filter_vmf_update.py
@@ -27,7 +27,8 @@ class TestHyperhemisphericalGridFilterVmfUpdate(unittest.TestCase):
 
         estimate = filter_.get_point_estimate()
         self.assertAlmostEqual(float(linalg.norm(estimate)), 1.0, places=5)
-        self.assertGreater(abs(float(estimate[0])), 0.9)
+        alignment = abs(float(estimate @ measurement))
+        self.assertGreater(alignment, math.cos(math.radians(30.0)))
 
     def test_rejects_vmf_measurement_outside_equator_tolerance(self):
         filter_ = HyperhemisphericalGridFilter(50, 2)


### PR DESCRIPTION
## Summary

- use the complex dimension `D` in the complex angular central Gaussian fixed-point estimator
- prevent deterministic parameter-scale contraction and the singular one-dimensional fit
- add regressions for 100-iteration orthonormal fitting and one-complex-dimensional fitting
- update the existing one-iteration identity expectation to the corrected canonical scale

## Bug

`ComplexAngularCentralGaussianDistribution.pdf()` uses the density factor

```text
det(C)^-1 * (z^H C^-1 z)^-D
```

but `estimate_parameter_matrix()` used `(D - 1) / (z^H C^-1 z)` in its fixed-point update. Differentiating the implemented log likelihood gives coefficient `D`, not `D - 1`.

The mismatch changes more than an arbitrary one-time normalization. For orthonormal samples with `C_0 = I`, the current update contracts the matrix as

```text
C_k = ((D - 1) / D)^k I.
```

For `D = 2`, the default 100 iterations reduce the scale to approximately `7.9e-31`. For `D = 1`, the first update produces the zero matrix, so `fit()` fails because the fitted parameter is singular.

## Fix

Replace the estimator coefficient `D - 1` with `D`, matching the exponent in the implemented density and preserving the initial canonical scale of the scale-invariant parameterization.

## Validation

- isolated NumPy reproduction: the old update contracts dimensions 1–3, while the corrected update keeps orthonormal identity data at `I`
- regression verifies identity scale remains stable through 100 iterations
- regression verifies fitting works in one complex dimension
- existing array-like fitting regression now expects `I` after one iteration instead of the erroneous `0.5 I`
- modified source and tests pass `python -m py_compile`
- final branch comparison: one commit ahead of `main`, zero behind; three files changed

The full multi-backend test matrix is delegated to GitHub Actions.