### PR TITLE
Reject invalid Euclidean MTT state ranks

### DIFF
--- a/src/pyrecest/evaluation/get_distance_function.py
+++ b/src/pyrecest/evaluation/get_distance_function.py
@@ -168,6 +168,8 @@ def _as_target_matrix(
     value, name: str, *, expected_target_dim: int | None = None
 ) -> numpy.ndarray:
     value = _as_real_numeric_array(value, name)
+    if value.ndim not in (1, 2):
+        raise ValueError(f"{name} must be a one- or two-dimensional target set")
     if value.size == 0:
         if value.ndim == 2:
             return value

--- a/tests/evaluation/test_mtt_distance_input_validation.py
+++ b/tests/evaluation/test_mtt_distance_input_validation.py
@@ -36,6 +36,30 @@ class EuclideanMttDistanceInputValidationTest(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, "x2.*finite real"):
                     distance(valid_state, state)
 
+    def test_rejects_invalid_state_ranks(self):
+        distance = get_distance_function(
+            "euclidean_mtt",
+            {"cutoff_distance": 2.5},
+        )
+        valid_state = np.array([[0.0, 0.0]])
+        invalid_states = (
+            1.0,
+            np.zeros((2, 1, 1)),
+            np.empty((0, 1, 2)),
+        )
+
+        for state in invalid_states:
+            with self.subTest(state_shape=np.asarray(state).shape, argument="x1"):
+                with self.assertRaisesRegex(
+                    ValueError, "x1.*one- or two-dimensional"
+                ):
+                    distance(state, valid_state)
+            with self.subTest(state_shape=np.asarray(state).shape, argument="x2"):
+                with self.assertRaisesRegex(
+                    ValueError, "x2.*one- or two-dimensional"
+                ):
+                    distance(valid_state, state)
+
     def test_valid_empty_target_behavior_is_preserved(self):
         distance = get_distance_function(
             "euclidean_mtt",


### PR DESCRIPTION
## Summary

- reject scalar and rank-3+ state-set inputs in the Euclidean multi-target distance
- preserve valid one-dimensional single-target and two-dimensional target-set layouts
- add focused regression coverage for malformed state ranks on both arguments

## Bug

`_as_target_matrix()` validated numeric values but did not validate array rank before indexing or interpreting the target-set layout.

A scalar state therefore reached later shape indexing and failed with an accidental `IndexError`. Rank-3 arrays were accepted and could be broadcast through the pairwise delta calculation as if they represented an ordinary target matrix, producing meaningless costs or downstream shape failures.

## Fix

Require Euclidean MTT state sets to be one- or two-dimensional immediately after numeric conversion. Invalid shapes now fail at the public boundary with a parameter-specific `ValueError`. Existing behavior remains unchanged for:

- one-dimensional single-target states
- ordinary `(n_targets, state_dim)` matrices
- supported dimension-first matrices
- valid empty target sets

## Validation

- regression rejects scalar, nonempty rank-3, and empty rank-3 inputs for both `x1` and `x2`
- existing invalid-value and empty-target regressions remain covered
- focused validation tests pass
- final comparison against current `main` changes only the implementation and one existing regression module: 26 additions, no deletions