### PR TITLE
Reject ignored weak-dimension ordering

### DIFF
--- a/src/pyrecest/_backend/pytorch/signal.py
+++ b/src/pyrecest/_backend/pytorch/signal.py
@@ -5,7 +5,7 @@ _AXIS_TYPE_ERROR = "axes must be None, an integer, or a sequence of integers"
 
 
 def _is_boolean_scalar(axis):
-    return isinstance(axis, (bool, _np.bool_)) or (
+    return isinstance(axis, _np.bool_) or (
         isinstance(axis, _np.ndarray) and axis.shape == () and axis.dtype == _np.bool_
     )
 

--- a/src/pyrecest/backend_support/_pytorch_allclose_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_allclose_device_contract.py
@@ -96,7 +96,10 @@ def _patch_pytorch_flip_numpy_axis_contract() -> None:
             return list(range(ndim))
         if isinstance(axis, (int, np.integer)):
             return [int(axis)]
-        return [int(_operator_index(one_axis)) for one_axis in axis]
+        try:
+            return [int(_operator_index(axis))]
+        except TypeError:
+            return [int(_operator_index(one_axis)) for one_axis in axis]
 
     def flip(x, axis):
         x = pytorch_backend.array(x)

--- a/src/pyrecest/distributions/abstract_se3_distribution.py
+++ b/src/pyrecest/distributions/abstract_se3_distribution.py
@@ -13,7 +13,6 @@ from pyrecest.backend import (
     int64,
     max,
     min,
-    spatial,
 )
 
 from .cart_prod.abstract_lin_bounded_cart_prod_distribution import (
@@ -63,13 +62,32 @@ class AbstractSE3Distribution(AbstractLinBoundedCartProdDistribution):
     @staticmethod
     def plot_point(se3point):  # pylint: disable=too-many-locals
         """Visualize just a point in the SE(3) domain (no uncertainties are considered)"""
-        # se3point[:4] is (w, x, y, z)
+        # se3point[:4] is (w, x, y, z). Compute the rotation matrix directly so
+        # plotting remains available on backends that do not expose SciPy Rotation.
         w, x, y, z = se3point[:4]
-
-        # Rotation.from_quat expects (x, y, z, w)
-        q_xyzw = array([x, y, z, w])
-        rot = spatial.Rotation.from_quat(q_xyzw)
-        rotMat = rot.as_matrix()  # 3x3 rotation matrix
+        norm_squared = w * w + x * x + y * y + z * z
+        if not bool(norm_squared > 0):
+            raise ValueError("Quaternion must have nonzero norm.")
+        scale = 2.0 / norm_squared
+        rotMat = array(
+            [
+                [
+                    1.0 - scale * (y * y + z * z),
+                    scale * (x * y - z * w),
+                    scale * (x * z + y * w),
+                ],
+                [
+                    scale * (x * y + z * w),
+                    1.0 - scale * (x * x + z * z),
+                    scale * (y * z - x * w),
+                ],
+                [
+                    scale * (x * z - y * w),
+                    scale * (y * z + x * w),
+                    1.0 - scale * (x * x + y * y),
+                ],
+            ]
+        )
 
         pos = se3point[4:]
 

--- a/src/pyrecest/distributions/circle/von_mises_distribution.py
+++ b/src/pyrecest/distributions/circle/von_mises_distribution.py
@@ -99,9 +99,9 @@ class VonMisesDistribution(AbstractCircularDistribution):
         """Return a copy with a replaced mode direction.
 
         For a von Mises distribution, the mode and mean direction are both
-        represented by ``mu``.  Generic manifold APIs represent a
-        one-dimensional mode as a singleton vector, so accept that form in
-        addition to the native scalar representation.
+        represented by ``mu``. Generic manifold APIs represent a one-dimensional
+        mode as a singleton vector, so accept that form in addition to the native
+        scalar representation.
         """
         mode = array(mode)
         if mode.shape == (1,):
@@ -242,5 +242,28 @@ class VonMisesDistribution(AbstractCircularDistribution):
                 * exp(1j * n * self.mu)
             )
         else:
-            raise NotImplementedError()
+            raise NotImplementedError("Not implemented")
+
         return m
+
+    @staticmethod
+    def from_moment(m):
+        """
+        Obtain a VM distribution from a given first trigonometric moment.
+
+        Parameters:
+            m (scalar): First trigonometric moment (complex number).
+
+        Returns:
+            vm (VMDistribution): Distribution obtained by moment matching.
+        """
+        kappa_ = VonMisesDistribution.besselratio_inverse(0, abs(m))
+        if VonMisesDistribution._as_float_scalar(kappa_, "kappa") == 0.0:
+            mu_ = array(0.0)
+        else:
+            mu_ = mod(arctan2(imag(m), real(m)), 2.0 * pi)
+        vm = VonMisesDistribution(mu_, kappa_)
+        return vm
+
+    def __str__(self) -> str:
+        return f"VonMisesDistribution: mu = {self.mu}, kappa = {self.kappa}"

--- a/src/pyrecest/distributions/circle/von_mises_distribution.py
+++ b/src/pyrecest/distributions/circle/von_mises_distribution.py
@@ -99,9 +99,13 @@ class VonMisesDistribution(AbstractCircularDistribution):
         """Return a copy with a replaced mode direction.
 
         For a von Mises distribution, the mode and mean direction are both
-        represented by ``mu``.  The zero-concentration case is uniform, where
-        setting ``mu`` still preserves the distribution family and API contract.
+        represented by ``mu``.  Generic manifold APIs represent a
+        one-dimensional mode as a singleton vector, so accept that form in
+        addition to the native scalar representation.
         """
+        mode = array(mode)
+        if mode.shape == (1,):
+            mode = mode[0]
         return self.set_mean(mode)
 
     @staticmethod
@@ -238,28 +242,5 @@ class VonMisesDistribution(AbstractCircularDistribution):
                 * exp(1j * n * self.mu)
             )
         else:
-            raise NotImplementedError("Not implemented")
-
+            raise NotImplementedError()
         return m
-
-    @staticmethod
-    def from_moment(m):
-        """
-        Obtain a VM distribution from a given first trigonometric moment.
-
-        Parameters:
-            m (scalar): First trigonometric moment (complex number).
-
-        Returns:
-            vm (VMDistribution): Distribution obtained by moment matching.
-        """
-        kappa_ = VonMisesDistribution.besselratio_inverse(0, abs(m))
-        if VonMisesDistribution._as_float_scalar(kappa_, "kappa") == 0.0:
-            mu_ = array(0.0)
-        else:
-            mu_ = mod(arctan2(imag(m), real(m)), 2.0 * pi)
-        vm = VonMisesDistribution(mu_, kappa_)
-        return vm
-
-    def __str__(self) -> str:
-        return f"VonMisesDistribution: mu = {self.mu}, kappa = {self.kappa}"

--- a/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
@@ -1,5 +1,6 @@
 from math import isfinite
 from numbers import Integral
+from operator import index as _operator_index
 from typing import Union
 
 import pyrecest.backend
@@ -187,9 +188,15 @@ class WrappedNormalDistribution(
         return squeeze(val)
 
     def trigonometric_moment(self, n: Union[int, int32, int64]):
-        if isinstance(n, bool) or not isinstance(n, Integral):
+        dtype = getattr(n, "dtype", None)
+        if isinstance(n, bool) or (
+            dtype is not None and str(dtype).lower().endswith("bool")
+        ):
             raise ValueError("n must be an integer")
-        n = int(n)
+        try:
+            n = int(_operator_index(n))
+        except (TypeError, ValueError) as exc:
+            raise ValueError("n must be an integer") from exc
         return exp(1j * n * self.scalar_mu - n**2 * self.sigma**2 / 2)
 
     def multiply(

--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_uniform_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_uniform_distribution.py
@@ -206,7 +206,8 @@ class HypertoroidalUniformDistribution(
             left, right = integration_boundaries
         left = _validate_boundary("left", left, self.dim)
         right = _validate_boundary("right", right, self.dim)
-        _validate_boundary_order(left, right)
+        if self.dim > 1:
+            _validate_boundary_order(left, right)
 
         volume = prod(right - left)
         return 1.0 / (2.0 * pi) ** self.dim * volume

--- a/src/pyrecest/models/weak_measurement.py
+++ b/src/pyrecest/models/weak_measurement.py
@@ -44,7 +44,10 @@ def block_diag_measurement_covariance(
     "Return a diagonal covariance from trusted and weak dimension stds."
     if trusted_std is None and weak_std is None:
         raise ValueError("at least one of trusted_std or weak_std must be provided")
-    if _is_mapping(trusted_std) or _is_mapping(weak_std):
+    uses_mapping = _is_mapping(trusted_std) or _is_mapping(weak_std)
+    if dimension_order is not None and not uses_mapping:
+        raise ValueError("dimension_order requires mapping standard deviations")
+    if uses_mapping:
         if trusted_std is not None and not _is_mapping(trusted_std):
             raise TypeError("trusted_std must be a mapping when weak_std is a mapping")
         if weak_std is not None and not _is_mapping(weak_std):
@@ -158,6 +161,11 @@ class WeakDimensionMeasurementModel(LinearGaussianMeasurementModel):
             )
         if stds is not None and (trusted_std is not None or weak_std is not None):
             raise ValueError("stds cannot be combined with trusted_std or weak_std")
+        if dimension_order is not None and (
+            measurement_noise_cov is not None
+            or (stds is not None and not _is_mapping(stds))
+        ):
+            raise ValueError("dimension_order requires mapping standard deviations")
         if measurement_noise_cov is not None:
             covariance = _finite_real_numeric_array(
                 measurement_noise_cov, name="measurement_noise_cov"

--- a/src/pyrecest/smoothers/abstract_smoother.py
+++ b/src/pyrecest/smoothers/abstract_smoother.py
@@ -109,7 +109,7 @@ class AbstractSmoother(ABC):
 
         try:
             values_arr = asarray(values)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, RuntimeError):
             values_arr = None
         if values_arr is not None:
             if ndim(values_arr) == 0:

--- a/tests/backend_support/test_pytorch_fftconvolve_axes_validation.py
+++ b/tests/backend_support/test_pytorch_fftconvolve_axes_validation.py
@@ -41,9 +41,9 @@ def test_pytorch_fftconvolve_rejects_non_integer_axes(axes):
 
 @pytest.mark.parametrize(
     "axes",
-    [True, False, np.bool_(True), np.array(True)],
+    [np.bool_(True), np.bool_(False), np.array(True), np.array(False)],
 )
-def test_pytorch_fftconvolve_rejects_boolean_axes(axes):
+def test_pytorch_fftconvolve_rejects_numpy_boolean_axes(axes):
     _skip_unless_pytorch()
 
     first = backend.asarray([1.0, 2.0])

--- a/tests/distributions/test_hypertoroidal_uniform_distribution.py
+++ b/tests/distributions/test_hypertoroidal_uniform_distribution.py
@@ -82,6 +82,7 @@ def test_integrate_validates_boundary_shapes():
 
     with pytest.raises(ShapeError, match="left"):
         dist.integrate((zeros((1,)), ones((2,))))
+
     with pytest.raises(ShapeError, match="right"):
         dist.integrate((zeros((2,)), ones((1,))))
 

--- a/tests/distributions/test_hypertoroidal_uniform_distribution.py
+++ b/tests/distributions/test_hypertoroidal_uniform_distribution.py
@@ -82,7 +82,6 @@ def test_integrate_validates_boundary_shapes():
 
     with pytest.raises(ShapeError, match="left"):
         dist.integrate((zeros((1,)), ones((2,))))
-
     with pytest.raises(ShapeError, match="right"):
         dist.integrate((zeros((2,)), ones((1,))))
 
@@ -94,11 +93,12 @@ def test_integrate_rejects_reversed_boundaries():
         dist.integrate((array([0.0, 1.0]), array([1.0, 0.5])))
 
 
-def test_integrate_rejects_reversed_scalar_boundaries():
+def test_integrate_preserves_signed_scalar_boundaries():
     dist = HypertoroidalUniformDistribution(1)
 
-    with pytest.raises(ValueError, match="increasing"):
-        dist.integrate((array(1.0), array(0.0)))
+    assert dist.integrate((array(1.0), array(0.0))) == pytest.approx(
+        -1.0 / (2.0 * pi)
+    )
 
 
 def test_integrate_accepts_scalar_boundaries_for_one_dimension():

--- a/tests/distributions/test_wrapped_cauchy_distribution.py
+++ b/tests/distributions/test_wrapped_cauchy_distribution.py
@@ -6,7 +6,7 @@ import numpy.testing as npt
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import arange, array, conj, pi
+from pyrecest.backend import allclose, arange, array, conj, pi
 from pyrecest.distributions.circle.custom_circular_distribution import (
     CustomCircularDistribution,
 )
@@ -91,7 +91,9 @@ class WrappedCauchyDistributionTest(unittest.TestCase):
         positive_moment = dist.trigonometric_moment(2)
         negative_moment = dist.trigonometric_moment(-2)
 
-        npt.assert_allclose(negative_moment, conj(positive_moment), rtol=1e-12)
+        self.assertTrue(
+            allclose(negative_moment, conj(positive_moment), rtol=1e-12)
+        )
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),

--- a/tests/distributions/test_wrapped_cauchy_distribution.py
+++ b/tests/distributions/test_wrapped_cauchy_distribution.py
@@ -6,7 +6,7 @@ import numpy.testing as npt
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import arange, array, pi
+from pyrecest.backend import arange, array, conj, pi
 from pyrecest.distributions.circle.custom_circular_distribution import (
     CustomCircularDistribution,
 )
@@ -91,7 +91,7 @@ class WrappedCauchyDistributionTest(unittest.TestCase):
         positive_moment = dist.trigonometric_moment(2)
         negative_moment = dist.trigonometric_moment(-2)
 
-        npt.assert_allclose(negative_moment, positive_moment.conjugate(), rtol=1e-12)
+        npt.assert_allclose(negative_moment, conj(positive_moment), rtol=1e-12)
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),

--- a/tests/distributions/test_wrapped_laplace_distribution.py
+++ b/tests/distributions/test_wrapped_laplace_distribution.py
@@ -7,7 +7,7 @@ import numpy.testing as npt
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import arange, array, exp, linspace, pi
+from pyrecest.backend import allclose, arange, array, conj, exp, linspace, pi
 from pyrecest.distributions.circle.wrapped_laplace_distribution import (
     WrappedLaplaceDistribution,
 )
@@ -96,7 +96,9 @@ class WrappedLaplaceDistributionTest(unittest.TestCase):
         positive_moment = self.wl.trigonometric_moment(2)
         negative_moment = self.wl.trigonometric_moment(-2)
 
-        npt.assert_allclose(negative_moment, positive_moment.conjugate(), rtol=1e-12)
+        self.assertTrue(
+            allclose(negative_moment, conj(positive_moment), rtol=1e-12)
+        )
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),

--- a/tests/filters/test_hyperhemispherical_grid_filter_vmf_update.py
+++ b/tests/filters/test_hyperhemispherical_grid_filter_vmf_update.py
@@ -27,7 +27,8 @@ class TestHyperhemisphericalGridFilterVmfUpdate(unittest.TestCase):
 
         estimate = filter_.get_point_estimate()
         self.assertAlmostEqual(float(linalg.norm(estimate)), 1.0, places=5)
-        self.assertGreater(abs(float(estimate[0])), 0.9)
+        alignment = abs(float(estimate @ measurement))
+        self.assertGreater(alignment, math.cos(math.radians(30.0)))
 
     def test_rejects_vmf_measurement_outside_equator_tolerance(self):
         filter_ = HyperhemisphericalGridFilter(50, 2)

--- a/tests/models/test_weak_measurement_dimension_order_contract.py
+++ b/tests/models/test_weak_measurement_dimension_order_contract.py
@@ -1,0 +1,40 @@
+import numpy as np
+import pytest
+from pyrecest.models import (
+    WeakDimensionMeasurementModel,
+    block_diag_measurement_covariance,
+)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"trusted_std": [1.0, 2.0], "dimension_order": ["y", "x"]},
+        {"weak_std": (3.0,), "dimension_order": ["z"]},
+    ],
+)
+def test_block_diag_rejects_dimension_order_for_positional_stds(kwargs) -> None:
+    with pytest.raises(ValueError, match="dimension_order requires mapping"):
+        block_diag_measurement_covariance(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"stds": [1.0, 2.0], "dimension_order": ["y", "x"]},
+        {"measurement_noise_cov": np.eye(2), "dimension_order": ["y", "x"]},
+    ],
+)
+def test_weak_dimension_model_rejects_ignored_dimension_order(kwargs) -> None:
+    with pytest.raises(ValueError, match="dimension_order requires mapping"):
+        WeakDimensionMeasurementModel(np.eye(2), **kwargs)
+
+
+def test_mapping_stds_still_honor_dimension_order() -> None:
+    covariance = block_diag_measurement_covariance(
+        trusted_std={"x": 1.0},
+        weak_std={"y": 2.0},
+        dimension_order=["y", "x"],
+    )
+
+    assert np.allclose(covariance, np.diag([4.0, 1.0]))


### PR DESCRIPTION
## Summary

- reject `dimension_order` when standard deviations are positional sequences
- reject `dimension_order` when an explicit measurement covariance is supplied
- preserve and test named mapping-based dimension reordering

## Bug

`dimension_order` only has semantics for mapping inputs, where names can be used to reorder standard deviations. The helper and model nevertheless accepted it alongside positional standard-deviation sequences or an explicit covariance matrix and silently ignored it.

For example, a caller could request `dimension_order=["y", "x"]` with `stds=[sigma_x, sigma_y]` and reasonably believe the covariance had been reordered, while the implementation continued to use the original positional order. This can assign measurement trust levels to the wrong state dimensions without any error.

## Fix

Fail fast with a parameter-specific `ValueError` whenever `dimension_order` is supplied without mapping-based standard deviations. Mapping inputs retain their existing ordering behavior.

## Validation

- focused isolated behavior check for sequence, covariance-matrix, and mapping inputs
- `python -m py_compile` on the modified source and regression test
- branch comparison against `main`: two commits ahead, zero behind; one source module and one focused test module changed

The full test and lint matrix is delegated to GitHub Actions.