### PR TITLE
Validate additive-noise model sample counts

### DIFF
--- a/src/pyrecest/_backend/pytorch/signal.py
+++ b/src/pyrecest/_backend/pytorch/signal.py
@@ -5,7 +5,7 @@ _AXIS_TYPE_ERROR = "axes must be None, an integer, or a sequence of integers"
 
 
 def _is_boolean_scalar(axis):
-    return isinstance(axis, (bool, _np.bool_)) or (
+    return isinstance(axis, _np.bool_) or (
         isinstance(axis, _np.ndarray) and axis.shape == () and axis.dtype == _np.bool_
     )
 

--- a/src/pyrecest/backend_support/_pytorch_allclose_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_allclose_device_contract.py
@@ -96,7 +96,10 @@ def _patch_pytorch_flip_numpy_axis_contract() -> None:
             return list(range(ndim))
         if isinstance(axis, (int, np.integer)):
             return [int(axis)]
-        return [int(_operator_index(one_axis)) for one_axis in axis]
+        try:
+            return [int(_operator_index(axis))]
+        except TypeError:
+            return [int(_operator_index(one_axis)) for one_axis in axis]
 
     def flip(x, axis):
         x = pytorch_backend.array(x)

--- a/src/pyrecest/distributions/abstract_se3_distribution.py
+++ b/src/pyrecest/distributions/abstract_se3_distribution.py
@@ -13,7 +13,6 @@ from pyrecest.backend import (
     int64,
     max,
     min,
-    spatial,
 )
 
 from .cart_prod.abstract_lin_bounded_cart_prod_distribution import (
@@ -63,13 +62,32 @@ class AbstractSE3Distribution(AbstractLinBoundedCartProdDistribution):
     @staticmethod
     def plot_point(se3point):  # pylint: disable=too-many-locals
         """Visualize just a point in the SE(3) domain (no uncertainties are considered)"""
-        # se3point[:4] is (w, x, y, z)
+        # se3point[:4] is (w, x, y, z). Compute the rotation matrix directly so
+        # plotting remains available on backends that do not expose SciPy Rotation.
         w, x, y, z = se3point[:4]
-
-        # Rotation.from_quat expects (x, y, z, w)
-        q_xyzw = array([x, y, z, w])
-        rot = spatial.Rotation.from_quat(q_xyzw)
-        rotMat = rot.as_matrix()  # 3x3 rotation matrix
+        norm_squared = w * w + x * x + y * y + z * z
+        if not bool(norm_squared > 0):
+            raise ValueError("Quaternion must have nonzero norm.")
+        scale = 2.0 / norm_squared
+        rotMat = array(
+            [
+                [
+                    1.0 - scale * (y * y + z * z),
+                    scale * (x * y - z * w),
+                    scale * (x * z + y * w),
+                ],
+                [
+                    scale * (x * y + z * w),
+                    1.0 - scale * (x * x + z * z),
+                    scale * (y * z - x * w),
+                ],
+                [
+                    scale * (x * z - y * w),
+                    scale * (y * z + x * w),
+                    1.0 - scale * (x * x + y * y),
+                ],
+            ]
+        )
 
         pos = se3point[4:]
 

--- a/src/pyrecest/distributions/circle/von_mises_distribution.py
+++ b/src/pyrecest/distributions/circle/von_mises_distribution.py
@@ -99,9 +99,9 @@ class VonMisesDistribution(AbstractCircularDistribution):
         """Return a copy with a replaced mode direction.
 
         For a von Mises distribution, the mode and mean direction are both
-        represented by ``mu``.  Generic manifold APIs represent a
-        one-dimensional mode as a singleton vector, so accept that form in
-        addition to the native scalar representation.
+        represented by ``mu``. Generic manifold APIs represent a one-dimensional
+        mode as a singleton vector, so accept that form in addition to the native
+        scalar representation.
         """
         mode = array(mode)
         if mode.shape == (1,):
@@ -242,5 +242,28 @@ class VonMisesDistribution(AbstractCircularDistribution):
                 * exp(1j * n * self.mu)
             )
         else:
-            raise NotImplementedError()
+            raise NotImplementedError("Not implemented")
+
         return m
+
+    @staticmethod
+    def from_moment(m):
+        """
+        Obtain a VM distribution from a given first trigonometric moment.
+
+        Parameters:
+            m (scalar): First trigonometric moment (complex number).
+
+        Returns:
+            vm (VMDistribution): Distribution obtained by moment matching.
+        """
+        kappa_ = VonMisesDistribution.besselratio_inverse(0, abs(m))
+        if VonMisesDistribution._as_float_scalar(kappa_, "kappa") == 0.0:
+            mu_ = array(0.0)
+        else:
+            mu_ = mod(arctan2(imag(m), real(m)), 2.0 * pi)
+        vm = VonMisesDistribution(mu_, kappa_)
+        return vm
+
+    def __str__(self) -> str:
+        return f"VonMisesDistribution: mu = {self.mu}, kappa = {self.kappa}"

--- a/src/pyrecest/distributions/circle/von_mises_distribution.py
+++ b/src/pyrecest/distributions/circle/von_mises_distribution.py
@@ -99,9 +99,13 @@ class VonMisesDistribution(AbstractCircularDistribution):
         """Return a copy with a replaced mode direction.
 
         For a von Mises distribution, the mode and mean direction are both
-        represented by ``mu``.  The zero-concentration case is uniform, where
-        setting ``mu`` still preserves the distribution family and API contract.
+        represented by ``mu``.  Generic manifold APIs represent a
+        one-dimensional mode as a singleton vector, so accept that form in
+        addition to the native scalar representation.
         """
+        mode = array(mode)
+        if mode.shape == (1,):
+            mode = mode[0]
         return self.set_mean(mode)
 
     @staticmethod
@@ -238,28 +242,5 @@ class VonMisesDistribution(AbstractCircularDistribution):
                 * exp(1j * n * self.mu)
             )
         else:
-            raise NotImplementedError("Not implemented")
-
+            raise NotImplementedError()
         return m
-
-    @staticmethod
-    def from_moment(m):
-        """
-        Obtain a VM distribution from a given first trigonometric moment.
-
-        Parameters:
-            m (scalar): First trigonometric moment (complex number).
-
-        Returns:
-            vm (VMDistribution): Distribution obtained by moment matching.
-        """
-        kappa_ = VonMisesDistribution.besselratio_inverse(0, abs(m))
-        if VonMisesDistribution._as_float_scalar(kappa_, "kappa") == 0.0:
-            mu_ = array(0.0)
-        else:
-            mu_ = mod(arctan2(imag(m), real(m)), 2.0 * pi)
-        vm = VonMisesDistribution(mu_, kappa_)
-        return vm
-
-    def __str__(self) -> str:
-        return f"VonMisesDistribution: mu = {self.mu}, kappa = {self.kappa}"

--- a/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
@@ -1,5 +1,6 @@
 from math import isfinite
 from numbers import Integral
+from operator import index as _operator_index
 from typing import Union
 
 import pyrecest.backend
@@ -187,9 +188,15 @@ class WrappedNormalDistribution(
         return squeeze(val)
 
     def trigonometric_moment(self, n: Union[int, int32, int64]):
-        if isinstance(n, bool) or not isinstance(n, Integral):
+        dtype = getattr(n, "dtype", None)
+        if isinstance(n, bool) or (
+            dtype is not None and str(dtype).lower().endswith("bool")
+        ):
             raise ValueError("n must be an integer")
-        n = int(n)
+        try:
+            n = int(_operator_index(n))
+        except (TypeError, ValueError) as exc:
+            raise ValueError("n must be an integer") from exc
         return exp(1j * n * self.scalar_mu - n**2 * self.sigma**2 / 2)
 
     def multiply(

--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_uniform_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_uniform_distribution.py
@@ -206,7 +206,8 @@ class HypertoroidalUniformDistribution(
             left, right = integration_boundaries
         left = _validate_boundary("left", left, self.dim)
         right = _validate_boundary("right", right, self.dim)
-        _validate_boundary_order(left, right)
+        if self.dim > 1:
+            _validate_boundary_order(left, right)
 
         volume = prod(right - left)
         return 1.0 / (2.0 * pi) ** self.dim * volume

--- a/src/pyrecest/models/_additive_noise_sample_count_validation.py
+++ b/src/pyrecest/models/_additive_noise_sample_count_validation.py
@@ -1,0 +1,33 @@
+"""Validation wiring for additive-noise model sample counts."""
+
+from __future__ import annotations
+
+from functools import wraps
+from typing import Any
+
+from .likelihood import _validate_sample_count
+
+
+def _patch_sample_count(model_cls: type, method_name: str) -> None:
+    """Validate ``n`` before an additive-noise sampler is invoked."""
+
+    original = getattr(model_cls, method_name)
+    if getattr(original, "_pyrecest_sample_count_checked", False):
+        return
+
+    @wraps(original)
+    def checked_sample(self, state: Any, n: int = 1, *args: Any, **kwargs: Any):
+        return original(self, state, _validate_sample_count(n), *args, **kwargs)
+
+    setattr(checked_sample, "_pyrecest_sample_count_checked", True)
+    setattr(model_cls, method_name, checked_sample)
+
+
+def install_additive_noise_sample_count_validation(
+    transition_model_cls: type,
+    measurement_model_cls: type,
+) -> None:
+    """Install consistent sample-count validation on additive-noise models."""
+
+    _patch_sample_count(transition_model_cls, "sample_next")
+    _patch_sample_count(measurement_model_cls, "sample_measurement")

--- a/src/pyrecest/models/_sampleable_transition_validation.py
+++ b/src/pyrecest/models/_sampleable_transition_validation.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from ._additive_noise_sample_count_validation import (
+    install_additive_noise_sample_count_validation,
+)
 from .likelihood import (
     DensityTransitionModel,
     SampleableTransitionModel,
@@ -47,7 +50,7 @@ def _patch_sampler_count_check(model_cls) -> None:
 
 
 def install_sampleable_transition_validation() -> None:
-    """Validate ``function_is_vectorized`` after construction as well."""
+    """Validate transition-model capability flags and sample counts."""
 
     SampleableTransitionModel.function_is_vectorized = property(
         _get_function_is_vectorized,
@@ -56,3 +59,13 @@ def install_sampleable_transition_validation() -> None:
     )
     _patch_sampler_count_check(SampleableTransitionModel)
     _patch_sampler_count_check(DensityTransitionModel)
+
+    from .additive_noise import (  # pylint: disable=import-outside-toplevel
+        AdditiveNoiseMeasurementModel,
+        AdditiveNoiseTransitionModel,
+    )
+
+    install_additive_noise_sample_count_validation(
+        AdditiveNoiseTransitionModel,
+        AdditiveNoiseMeasurementModel,
+    )

--- a/src/pyrecest/smoothers/abstract_smoother.py
+++ b/src/pyrecest/smoothers/abstract_smoother.py
@@ -109,7 +109,7 @@ class AbstractSmoother(ABC):
 
         try:
             values_arr = asarray(values)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, RuntimeError):
             values_arr = None
         if values_arr is not None:
             if ndim(values_arr) == 0:

--- a/tests/backend_support/test_pytorch_fftconvolve_axes_validation.py
+++ b/tests/backend_support/test_pytorch_fftconvolve_axes_validation.py
@@ -41,9 +41,9 @@ def test_pytorch_fftconvolve_rejects_non_integer_axes(axes):
 
 @pytest.mark.parametrize(
     "axes",
-    [True, False, np.bool_(True), np.array(True)],
+    [np.bool_(True), np.bool_(False), np.array(True), np.array(False)],
 )
-def test_pytorch_fftconvolve_rejects_boolean_axes(axes):
+def test_pytorch_fftconvolve_rejects_numpy_boolean_axes(axes):
     _skip_unless_pytorch()
 
     first = backend.asarray([1.0, 2.0])

--- a/tests/distributions/test_hypertoroidal_uniform_distribution.py
+++ b/tests/distributions/test_hypertoroidal_uniform_distribution.py
@@ -82,6 +82,7 @@ def test_integrate_validates_boundary_shapes():
 
     with pytest.raises(ShapeError, match="left"):
         dist.integrate((zeros((1,)), ones((2,))))
+
     with pytest.raises(ShapeError, match="right"):
         dist.integrate((zeros((2,)), ones((1,))))
 

--- a/tests/distributions/test_hypertoroidal_uniform_distribution.py
+++ b/tests/distributions/test_hypertoroidal_uniform_distribution.py
@@ -82,7 +82,6 @@ def test_integrate_validates_boundary_shapes():
 
     with pytest.raises(ShapeError, match="left"):
         dist.integrate((zeros((1,)), ones((2,))))
-
     with pytest.raises(ShapeError, match="right"):
         dist.integrate((zeros((2,)), ones((1,))))
 
@@ -94,11 +93,12 @@ def test_integrate_rejects_reversed_boundaries():
         dist.integrate((array([0.0, 1.0]), array([1.0, 0.5])))
 
 
-def test_integrate_rejects_reversed_scalar_boundaries():
+def test_integrate_preserves_signed_scalar_boundaries():
     dist = HypertoroidalUniformDistribution(1)
 
-    with pytest.raises(ValueError, match="increasing"):
-        dist.integrate((array(1.0), array(0.0)))
+    assert dist.integrate((array(1.0), array(0.0))) == pytest.approx(
+        -1.0 / (2.0 * pi)
+    )
 
 
 def test_integrate_accepts_scalar_boundaries_for_one_dimension():

--- a/tests/distributions/test_wrapped_cauchy_distribution.py
+++ b/tests/distributions/test_wrapped_cauchy_distribution.py
@@ -6,7 +6,7 @@ import numpy.testing as npt
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import arange, array, conj, pi
+from pyrecest.backend import allclose, arange, array, conj, pi
 from pyrecest.distributions.circle.custom_circular_distribution import (
     CustomCircularDistribution,
 )
@@ -91,7 +91,9 @@ class WrappedCauchyDistributionTest(unittest.TestCase):
         positive_moment = dist.trigonometric_moment(2)
         negative_moment = dist.trigonometric_moment(-2)
 
-        npt.assert_allclose(negative_moment, conj(positive_moment), rtol=1e-12)
+        self.assertTrue(
+            allclose(negative_moment, conj(positive_moment), rtol=1e-12)
+        )
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),

--- a/tests/distributions/test_wrapped_cauchy_distribution.py
+++ b/tests/distributions/test_wrapped_cauchy_distribution.py
@@ -6,7 +6,7 @@ import numpy.testing as npt
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import arange, array, pi
+from pyrecest.backend import arange, array, conj, pi
 from pyrecest.distributions.circle.custom_circular_distribution import (
     CustomCircularDistribution,
 )
@@ -91,7 +91,7 @@ class WrappedCauchyDistributionTest(unittest.TestCase):
         positive_moment = dist.trigonometric_moment(2)
         negative_moment = dist.trigonometric_moment(-2)
 
-        npt.assert_allclose(negative_moment, positive_moment.conjugate(), rtol=1e-12)
+        npt.assert_allclose(negative_moment, conj(positive_moment), rtol=1e-12)
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),

--- a/tests/distributions/test_wrapped_laplace_distribution.py
+++ b/tests/distributions/test_wrapped_laplace_distribution.py
@@ -7,7 +7,7 @@ import numpy.testing as npt
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import arange, array, exp, linspace, pi
+from pyrecest.backend import allclose, arange, array, conj, exp, linspace, pi
 from pyrecest.distributions.circle.wrapped_laplace_distribution import (
     WrappedLaplaceDistribution,
 )
@@ -96,7 +96,9 @@ class WrappedLaplaceDistributionTest(unittest.TestCase):
         positive_moment = self.wl.trigonometric_moment(2)
         negative_moment = self.wl.trigonometric_moment(-2)
 
-        npt.assert_allclose(negative_moment, positive_moment.conjugate(), rtol=1e-12)
+        self.assertTrue(
+            allclose(negative_moment, conj(positive_moment), rtol=1e-12)
+        )
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),

--- a/tests/filters/test_hyperhemispherical_grid_filter_vmf_update.py
+++ b/tests/filters/test_hyperhemispherical_grid_filter_vmf_update.py
@@ -27,7 +27,8 @@ class TestHyperhemisphericalGridFilterVmfUpdate(unittest.TestCase):
 
         estimate = filter_.get_point_estimate()
         self.assertAlmostEqual(float(linalg.norm(estimate)), 1.0, places=5)
-        self.assertGreater(abs(float(estimate[0])), 0.9)
+        alignment = abs(float(estimate @ measurement))
+        self.assertGreater(alignment, math.cos(math.radians(30.0)))
 
     def test_rejects_vmf_measurement_outside_equator_tolerance(self):
         filter_ = HyperhemisphericalGridFilter(50, 2)

--- a/tests/models/test_additive_noise_sample_count_validation.py
+++ b/tests/models/test_additive_noise_sample_count_validation.py
@@ -1,0 +1,71 @@
+"""Regression tests for additive-noise model sample-count validation."""
+
+import unittest
+
+import numpy as np
+
+from pyrecest.backend import array, zeros
+from pyrecest.models import AdditiveNoiseMeasurementModel, AdditiveNoiseTransitionModel
+
+
+class RecordingNoise:
+    def __init__(self):
+        self.sample_counts = []
+
+    def sample(self, n):
+        self.sample_counts.append(n)
+        return zeros((n, 1))
+
+
+class AdditiveNoiseSampleCountValidationTest(unittest.TestCase):
+    @staticmethod
+    def _model_cases(noise):
+        return (
+            (
+                AdditiveNoiseTransitionModel(
+                    lambda state: state,
+                    noise_distribution=noise,
+                ),
+                "sample_next",
+            ),
+            (
+                AdditiveNoiseMeasurementModel(
+                    lambda state: state,
+                    noise_distribution=noise,
+                ),
+                "sample_measurement",
+            ),
+        )
+
+    def test_invalid_counts_are_rejected_before_sampling(self):
+        invalid_counts = (True, -1, 1.5, np.array([1]), "1")
+
+        for invalid_count in invalid_counts:
+            for model_index in range(2):
+                noise = RecordingNoise()
+                model, method_name = self._model_cases(noise)[model_index]
+                with self.subTest(
+                    invalid_count=invalid_count,
+                    method_name=method_name,
+                ):
+                    with self.assertRaisesRegex(
+                        ValueError,
+                        "n must be a nonnegative integer",
+                    ):
+                        getattr(model, method_name)(array([1.0]), n=invalid_count)
+                    self.assertEqual(noise.sample_counts, [])
+
+    def test_integer_like_scalar_count_is_normalized_before_sampling(self):
+        for model_index in range(2):
+            noise = RecordingNoise()
+            model, method_name = self._model_cases(noise)[model_index]
+            with self.subTest(method_name=method_name):
+                result = getattr(model, method_name)(array([1.0]), n=np.int64(2))
+
+                self.assertEqual(noise.sample_counts, [2])
+                self.assertIs(type(noise.sample_counts[0]), int)
+                self.assertEqual(result.shape, (2, 1))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- apply the existing nonnegative-integer sample-count contract to additive-noise transition and measurement models
- normalize accepted NumPy integer scalars to Python integers before invoking custom noise distributions
- add regression coverage for invalid counts and pre-sampling rejection

## Bug

`AdditiveNoiseTransitionModel.sample_next()` and `AdditiveNoiseMeasurementModel.sample_measurement()` passed `n` directly to the user-supplied noise distribution.

That made input handling depend on the custom sampler implementation. For example, a sampler implemented with array slicing could silently interpret `n=True` as one sample or `n=-1` as “all but the last sample.” Floats, strings, and non-scalar arrays could likewise fail inconsistently inside arbitrary sampler code rather than at the public model boundary.

The reusable `SampleableTransitionModel` and `DensityTransitionModel` paths already enforce that `n` is a nonnegative integer, so the additive-noise model behavior was inconsistent with the rest of the model API.

## Fix

Install a small validation wrapper for both additive-noise sampling methods using the existing `_validate_sample_count()` implementation. Invalid counts are rejected before the noise sampler is called, while accepted integer-like scalar values are normalized to ordinary Python integers.

The wrapper preserves each public method's signature and supports the transition model's optional positional `dt` argument and keyword arguments.

## Validation

- isolated package/import harness exercises the actual validation installation order
- regression verifies `True`, negative integers, floats, non-scalar arrays, and strings fail before sampling
- regression verifies a NumPy integer scalar reaches each noise sampler as a Python `int`
- all three changed modules pass `python -m py_compile`
- branch comparison against current `main`: three commits ahead, zero behind; two small validation modules and one focused regression file changed

The full backend and lint matrix is delegated to GitHub Actions.