### PR TITLE
Retain Python 3.14 scalar and Bingham ownership fixes

### DIFF
--- a/src/pyrecest/distributions/circle/von_mises_distribution.py
+++ b/src/pyrecest/distributions/circle/von_mises_distribution.py
@@ -78,7 +78,13 @@ class VonMisesDistribution(AbstractCircularDistribution):
             raise ValueError("n must be a positive integer.")
         n = int(n)
         return mod(
-            array(vonmises.rvs(kappa=float(self.kappa), loc=float(self.mu), size=n)),
+            array(
+                vonmises.rvs(
+                    kappa=self._as_float_scalar(self.kappa, "kappa"),
+                    loc=self._as_float_scalar(self.mu, "mu"),
+                    size=n,
+                )
+            ),
             2.0 * pi,
         )
 
@@ -155,8 +161,12 @@ class VonMisesDistribution(AbstractCircularDistribution):
 
     @staticmethod
     def _as_float_scalar(value, name: str) -> float:
+        value_array = array(value)
+        if value_array.shape not in ((), (1,)):
+            raise ValueError(f"{name} must be a scalar.")
+
         try:
-            scalar = float(value)
+            scalar = float(value_array.reshape(()))
         except (TypeError, ValueError) as exc:
             raise ValueError(f"{name} must be a scalar.") from exc
 

--- a/src/pyrecest/filters/bingham_filter.py
+++ b/src/pyrecest/filters/bingham_filter.py
@@ -164,7 +164,6 @@ class BinghamFilter(AbstractFilter):
         for i in range(n):
             m_conj = self._conjugate(bv.M[:, i])
             bv.M[:, i] = self._compose(z, m_conj)
-
         self.filter_state = self.filter_state.multiply(bv)
 
     def get_point_estimate(self):
@@ -178,7 +177,7 @@ class BinghamFilter(AbstractFilter):
         For q = [w, x, y, z], conjugate = [w, -x, -y, -z].
         For q = [a, b], conjugate = [a, -b].
         """
-        result = copy.copy(q)
+        result = pyrecest.backend.copy(q)
         result[1:] = -result[1:]
         return result
 

--- a/tests/distributions/test_von_mises_length_one_scalars.py
+++ b/tests/distributions/test_von_mises_length_one_scalars.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+from pyrecest.backend import array, to_numpy
+from pyrecest.distributions import VonMisesDistribution
+
+
+def test_set_mean_accepts_length_one_backend_array():
+    dist = VonMisesDistribution(array(0.0), array(2.0))
+
+    shifted = dist.set_mean(array([1.0]))
+    density_at_mode = np.asarray(to_numpy(shifted.pdf(array([1.0]))))
+
+    assert np.all(np.isfinite(density_at_mode))
+    assert np.all(density_at_mode > 0.0)
+
+
+def test_sample_accepts_length_one_parameter_arrays():
+    dist = VonMisesDistribution(array([0.3]), array([2.0]))
+
+    samples = dist.sample(3)
+
+    assert samples.shape == (3,)

--- a/tests/filters/test_bingham_filter_conjugate_independence.py
+++ b/tests/filters/test_bingham_filter_conjugate_independence.py
@@ -1,0 +1,25 @@
+import unittest
+
+import numpy.testing as npt
+
+import pyrecest.backend
+from pyrecest.backend import array, to_numpy
+from pyrecest.filters.bingham_filter import BinghamFilter
+
+
+class TestBinghamFilterConjugateIndependence(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="BinghamFilter is not supported on the JAX backend",
+    )
+    def test_conjugate_does_not_mutate_input(self):
+        quaternion = array([1.0, 2.0, 3.0, 4.0])
+
+        conjugated = BinghamFilter._conjugate(quaternion)
+
+        npt.assert_allclose(to_numpy(quaternion), [1.0, 2.0, 3.0, 4.0])
+        npt.assert_allclose(to_numpy(conjugated), [1.0, -2.0, -3.0, -4.0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This branch was manually rebased onto the now-green `main` after its original 20-commit CI-repair stack conflicted with #4293.

Already-landed or obsolete changes were dropped, including the diagnostic workflow, circular integration repair, PyTorch axis compatibility changes, wrapped-normal order handling, and the coarse-grid assertion adjustment.

The two unique fixes were retained:

- accept zero-dimensional and length-one backend arrays as scalar von Mises parameters, including the SciPy sampling path on Python 3.14
- use the active backend's owning copy in `BinghamFilter._conjugate()` so PyTorch inputs are not mutated

## Regression coverage

- length-one von Mises parameters remain accepted by `set_mean()` and `sample()`
- Bingham quaternion conjugation returns the expected value without modifying its input

## Rebase result

- based directly on current `main`
- 4 commits ahead, 0 behind
- 4 focused files changed

The full backend matrix is running on the rebased branch.