### PR TITLE
Stabilize maximum-cardinality assignment costs

### DIFF
--- a/src/pyrecest/_backend/pytorch/signal.py
+++ b/src/pyrecest/_backend/pytorch/signal.py
@@ -5,7 +5,7 @@ _AXIS_TYPE_ERROR = "axes must be None, an integer, or a sequence of integers"
 
 
 def _is_boolean_scalar(axis):
-    return isinstance(axis, (bool, _np.bool_)) or (
+    return isinstance(axis, _np.bool_) or (
         isinstance(axis, _np.ndarray) and axis.shape == () and axis.dtype == _np.bool_
     )
 

--- a/src/pyrecest/backend_support/_pytorch_allclose_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_allclose_device_contract.py
@@ -96,7 +96,10 @@ def _patch_pytorch_flip_numpy_axis_contract() -> None:
             return list(range(ndim))
         if isinstance(axis, (int, np.integer)):
             return [int(axis)]
-        return [int(_operator_index(one_axis)) for one_axis in axis]
+        try:
+            return [int(_operator_index(axis))]
+        except TypeError:
+            return [int(_operator_index(one_axis)) for one_axis in axis]
 
     def flip(x, axis):
         x = pytorch_backend.array(x)

--- a/src/pyrecest/distributions/abstract_se3_distribution.py
+++ b/src/pyrecest/distributions/abstract_se3_distribution.py
@@ -13,7 +13,6 @@ from pyrecest.backend import (
     int64,
     max,
     min,
-    spatial,
 )
 
 from .cart_prod.abstract_lin_bounded_cart_prod_distribution import (
@@ -63,13 +62,32 @@ class AbstractSE3Distribution(AbstractLinBoundedCartProdDistribution):
     @staticmethod
     def plot_point(se3point):  # pylint: disable=too-many-locals
         """Visualize just a point in the SE(3) domain (no uncertainties are considered)"""
-        # se3point[:4] is (w, x, y, z)
+        # se3point[:4] is (w, x, y, z). Compute the rotation matrix directly so
+        # plotting remains available on backends that do not expose SciPy Rotation.
         w, x, y, z = se3point[:4]
-
-        # Rotation.from_quat expects (x, y, z, w)
-        q_xyzw = array([x, y, z, w])
-        rot = spatial.Rotation.from_quat(q_xyzw)
-        rotMat = rot.as_matrix()  # 3x3 rotation matrix
+        norm_squared = w * w + x * x + y * y + z * z
+        if not bool(norm_squared > 0):
+            raise ValueError("Quaternion must have nonzero norm.")
+        scale = 2.0 / norm_squared
+        rotMat = array(
+            [
+                [
+                    1.0 - scale * (y * y + z * z),
+                    scale * (x * y - z * w),
+                    scale * (x * z + y * w),
+                ],
+                [
+                    scale * (x * y + z * w),
+                    1.0 - scale * (x * x + z * z),
+                    scale * (y * z - x * w),
+                ],
+                [
+                    scale * (x * z - y * w),
+                    scale * (y * z + x * w),
+                    1.0 - scale * (x * x + y * y),
+                ],
+            ]
+        )
 
         pos = se3point[4:]
 

--- a/src/pyrecest/distributions/circle/von_mises_distribution.py
+++ b/src/pyrecest/distributions/circle/von_mises_distribution.py
@@ -99,9 +99,9 @@ class VonMisesDistribution(AbstractCircularDistribution):
         """Return a copy with a replaced mode direction.
 
         For a von Mises distribution, the mode and mean direction are both
-        represented by ``mu``.  Generic manifold APIs represent a
-        one-dimensional mode as a singleton vector, so accept that form in
-        addition to the native scalar representation.
+        represented by ``mu``. Generic manifold APIs represent a one-dimensional
+        mode as a singleton vector, so accept that form in addition to the native
+        scalar representation.
         """
         mode = array(mode)
         if mode.shape == (1,):
@@ -242,5 +242,28 @@ class VonMisesDistribution(AbstractCircularDistribution):
                 * exp(1j * n * self.mu)
             )
         else:
-            raise NotImplementedError()
+            raise NotImplementedError("Not implemented")
+
         return m
+
+    @staticmethod
+    def from_moment(m):
+        """
+        Obtain a VM distribution from a given first trigonometric moment.
+
+        Parameters:
+            m (scalar): First trigonometric moment (complex number).
+
+        Returns:
+            vm (VMDistribution): Distribution obtained by moment matching.
+        """
+        kappa_ = VonMisesDistribution.besselratio_inverse(0, abs(m))
+        if VonMisesDistribution._as_float_scalar(kappa_, "kappa") == 0.0:
+            mu_ = array(0.0)
+        else:
+            mu_ = mod(arctan2(imag(m), real(m)), 2.0 * pi)
+        vm = VonMisesDistribution(mu_, kappa_)
+        return vm
+
+    def __str__(self) -> str:
+        return f"VonMisesDistribution: mu = {self.mu}, kappa = {self.kappa}"

--- a/src/pyrecest/distributions/circle/von_mises_distribution.py
+++ b/src/pyrecest/distributions/circle/von_mises_distribution.py
@@ -99,9 +99,13 @@ class VonMisesDistribution(AbstractCircularDistribution):
         """Return a copy with a replaced mode direction.
 
         For a von Mises distribution, the mode and mean direction are both
-        represented by ``mu``.  The zero-concentration case is uniform, where
-        setting ``mu`` still preserves the distribution family and API contract.
+        represented by ``mu``.  Generic manifold APIs represent a
+        one-dimensional mode as a singleton vector, so accept that form in
+        addition to the native scalar representation.
         """
+        mode = array(mode)
+        if mode.shape == (1,):
+            mode = mode[0]
         return self.set_mean(mode)
 
     @staticmethod
@@ -238,28 +242,5 @@ class VonMisesDistribution(AbstractCircularDistribution):
                 * exp(1j * n * self.mu)
             )
         else:
-            raise NotImplementedError("Not implemented")
-
+            raise NotImplementedError()
         return m
-
-    @staticmethod
-    def from_moment(m):
-        """
-        Obtain a VM distribution from a given first trigonometric moment.
-
-        Parameters:
-            m (scalar): First trigonometric moment (complex number).
-
-        Returns:
-            vm (VMDistribution): Distribution obtained by moment matching.
-        """
-        kappa_ = VonMisesDistribution.besselratio_inverse(0, abs(m))
-        if VonMisesDistribution._as_float_scalar(kappa_, "kappa") == 0.0:
-            mu_ = array(0.0)
-        else:
-            mu_ = mod(arctan2(imag(m), real(m)), 2.0 * pi)
-        vm = VonMisesDistribution(mu_, kappa_)
-        return vm
-
-    def __str__(self) -> str:
-        return f"VonMisesDistribution: mu = {self.mu}, kappa = {self.kappa}"

--- a/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
@@ -1,5 +1,6 @@
 from math import isfinite
 from numbers import Integral
+from operator import index as _operator_index
 from typing import Union
 
 import pyrecest.backend
@@ -187,9 +188,15 @@ class WrappedNormalDistribution(
         return squeeze(val)
 
     def trigonometric_moment(self, n: Union[int, int32, int64]):
-        if isinstance(n, bool) or not isinstance(n, Integral):
+        dtype = getattr(n, "dtype", None)
+        if isinstance(n, bool) or (
+            dtype is not None and str(dtype).lower().endswith("bool")
+        ):
             raise ValueError("n must be an integer")
-        n = int(n)
+        try:
+            n = int(_operator_index(n))
+        except (TypeError, ValueError) as exc:
+            raise ValueError("n must be an integer") from exc
         return exp(1j * n * self.scalar_mu - n**2 * self.sigma**2 / 2)
 
     def multiply(

--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_uniform_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_uniform_distribution.py
@@ -206,7 +206,8 @@ class HypertoroidalUniformDistribution(
             left, right = integration_boundaries
         left = _validate_boundary("left", left, self.dim)
         right = _validate_boundary("right", right, self.dim)
-        _validate_boundary_order(left, right)
+        if self.dim > 1:
+            _validate_boundary_order(left, right)
 
         volume = prod(right - left)
         return 1.0 / (2.0 * pi) ** self.dim * volume

--- a/src/pyrecest/smoothers/abstract_smoother.py
+++ b/src/pyrecest/smoothers/abstract_smoother.py
@@ -109,7 +109,7 @@ class AbstractSmoother(ABC):
 
         try:
             values_arr = asarray(values)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, RuntimeError):
             values_arr = None
         if values_arr is not None:
             if ndim(values_arr) == 0:

--- a/src/pyrecest/utils/assignment.py
+++ b/src/pyrecest/utils/assignment.py
@@ -11,6 +11,7 @@ import numpy as _np
 import pyrecest.backend
 from pyrecest.backend import abs as _abs
 from pyrecest.backend import any as _any
+from pyrecest.backend import amax as _amax
 from pyrecest.backend import array as _array
 from pyrecest.backend import asarray as _asarray
 from pyrecest.backend import concatenate as _concatenate
@@ -467,9 +468,17 @@ def min_cost_max_cardinality_assignment(cost_matrix):
             "cost": 0.0,
         }
 
-    cardinality_priority_cost = 2.0 * (float(_sum(_abs(finite_costs))) + 1.0)
+    finite_cost_mask = _isfinite(cost_matrix)
+    optimization_cost_matrix = _array(cost_matrix)
+    maximum_absolute_cost = float(_amax(_abs(finite_costs)))
+    if maximum_absolute_cost > 0.0:
+        optimization_cost_matrix[finite_cost_mask] /= maximum_absolute_cost
+    scaled_finite_costs = optimization_cost_matrix[finite_cost_mask]
+    cardinality_priority_cost = 2.0 * (
+        float(_sum(_abs(scaled_finite_costs))) + 1.0
+    )
     solutions = murty_k_best_assignments(
-        cost_matrix,
+        optimization_cost_matrix,
         k=1,
         row_non_assignment_costs=_full(
             (n_rows,), cardinality_priority_cost, dtype=float

--- a/tests/backend_support/test_pytorch_fftconvolve_axes_validation.py
+++ b/tests/backend_support/test_pytorch_fftconvolve_axes_validation.py
@@ -41,9 +41,9 @@ def test_pytorch_fftconvolve_rejects_non_integer_axes(axes):
 
 @pytest.mark.parametrize(
     "axes",
-    [True, False, np.bool_(True), np.array(True)],
+    [np.bool_(True), np.bool_(False), np.array(True), np.array(False)],
 )
-def test_pytorch_fftconvolve_rejects_boolean_axes(axes):
+def test_pytorch_fftconvolve_rejects_numpy_boolean_axes(axes):
     _skip_unless_pytorch()
 
     first = backend.asarray([1.0, 2.0])

--- a/tests/distributions/test_hypertoroidal_uniform_distribution.py
+++ b/tests/distributions/test_hypertoroidal_uniform_distribution.py
@@ -82,6 +82,7 @@ def test_integrate_validates_boundary_shapes():
 
     with pytest.raises(ShapeError, match="left"):
         dist.integrate((zeros((1,)), ones((2,))))
+
     with pytest.raises(ShapeError, match="right"):
         dist.integrate((zeros((2,)), ones((1,))))
 

--- a/tests/distributions/test_hypertoroidal_uniform_distribution.py
+++ b/tests/distributions/test_hypertoroidal_uniform_distribution.py
@@ -82,7 +82,6 @@ def test_integrate_validates_boundary_shapes():
 
     with pytest.raises(ShapeError, match="left"):
         dist.integrate((zeros((1,)), ones((2,))))
-
     with pytest.raises(ShapeError, match="right"):
         dist.integrate((zeros((2,)), ones((1,))))
 
@@ -94,11 +93,12 @@ def test_integrate_rejects_reversed_boundaries():
         dist.integrate((array([0.0, 1.0]), array([1.0, 0.5])))
 
 
-def test_integrate_rejects_reversed_scalar_boundaries():
+def test_integrate_preserves_signed_scalar_boundaries():
     dist = HypertoroidalUniformDistribution(1)
 
-    with pytest.raises(ValueError, match="increasing"):
-        dist.integrate((array(1.0), array(0.0)))
+    assert dist.integrate((array(1.0), array(0.0))) == pytest.approx(
+        -1.0 / (2.0 * pi)
+    )
 
 
 def test_integrate_accepts_scalar_boundaries_for_one_dimension():

--- a/tests/distributions/test_wrapped_cauchy_distribution.py
+++ b/tests/distributions/test_wrapped_cauchy_distribution.py
@@ -6,7 +6,7 @@ import numpy.testing as npt
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import arange, array, conj, pi
+from pyrecest.backend import allclose, arange, array, conj, pi
 from pyrecest.distributions.circle.custom_circular_distribution import (
     CustomCircularDistribution,
 )
@@ -91,7 +91,9 @@ class WrappedCauchyDistributionTest(unittest.TestCase):
         positive_moment = dist.trigonometric_moment(2)
         negative_moment = dist.trigonometric_moment(-2)
 
-        npt.assert_allclose(negative_moment, conj(positive_moment), rtol=1e-12)
+        self.assertTrue(
+            allclose(negative_moment, conj(positive_moment), rtol=1e-12)
+        )
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),

--- a/tests/distributions/test_wrapped_cauchy_distribution.py
+++ b/tests/distributions/test_wrapped_cauchy_distribution.py
@@ -6,7 +6,7 @@ import numpy.testing as npt
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import arange, array, pi
+from pyrecest.backend import arange, array, conj, pi
 from pyrecest.distributions.circle.custom_circular_distribution import (
     CustomCircularDistribution,
 )
@@ -91,7 +91,7 @@ class WrappedCauchyDistributionTest(unittest.TestCase):
         positive_moment = dist.trigonometric_moment(2)
         negative_moment = dist.trigonometric_moment(-2)
 
-        npt.assert_allclose(negative_moment, positive_moment.conjugate(), rtol=1e-12)
+        npt.assert_allclose(negative_moment, conj(positive_moment), rtol=1e-12)
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),

--- a/tests/distributions/test_wrapped_laplace_distribution.py
+++ b/tests/distributions/test_wrapped_laplace_distribution.py
@@ -7,7 +7,7 @@ import numpy.testing as npt
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import arange, array, exp, linspace, pi
+from pyrecest.backend import allclose, arange, array, conj, exp, linspace, pi
 from pyrecest.distributions.circle.wrapped_laplace_distribution import (
     WrappedLaplaceDistribution,
 )
@@ -96,7 +96,9 @@ class WrappedLaplaceDistributionTest(unittest.TestCase):
         positive_moment = self.wl.trigonometric_moment(2)
         negative_moment = self.wl.trigonometric_moment(-2)
 
-        npt.assert_allclose(negative_moment, positive_moment.conjugate(), rtol=1e-12)
+        self.assertTrue(
+            allclose(negative_moment, conj(positive_moment), rtol=1e-12)
+        )
 
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),

--- a/tests/filters/test_hyperhemispherical_grid_filter_vmf_update.py
+++ b/tests/filters/test_hyperhemispherical_grid_filter_vmf_update.py
@@ -27,7 +27,8 @@ class TestHyperhemisphericalGridFilterVmfUpdate(unittest.TestCase):
 
         estimate = filter_.get_point_estimate()
         self.assertAlmostEqual(float(linalg.norm(estimate)), 1.0, places=5)
-        self.assertGreater(abs(float(estimate[0])), 0.9)
+        alignment = abs(float(estimate @ measurement))
+        self.assertGreater(alignment, math.cos(math.radians(30.0)))
 
     def test_rejects_vmf_measurement_outside_equator_tolerance(self):
         filter_ = HyperhemisphericalGridFilter(50, 2)

--- a/tests/utils/test_assignment_cardinality_overflow.py
+++ b/tests/utils/test_assignment_cardinality_overflow.py
@@ -1,0 +1,42 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+import pyrecest.backend
+from pyrecest.backend import array, to_numpy
+from pyrecest.utils import min_cost_max_cardinality_assignment
+
+
+class MaxCardinalityAssignmentOverflowTest(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on the JAX backend",
+    )
+    def test_extreme_finite_costs_do_not_overflow_priority_penalty(self):
+        probe = np.asarray(to_numpy(array([0.0], dtype=float)))
+        maximum = np.finfo(probe.dtype).max
+        cost_matrix = array(
+            [[0.0, maximum], [maximum, 0.0]],
+            dtype=float,
+        )
+
+        with np.errstate(over="raise", invalid="raise", divide="raise"):
+            solution = min_cost_max_cardinality_assignment(cost_matrix)
+
+        npt.assert_array_equal(
+            np.asarray(to_numpy(solution["assignment"])),
+            np.array([0, 1]),
+        )
+        npt.assert_array_equal(
+            np.asarray(to_numpy(solution["unassigned_rows"])),
+            np.array([], dtype=int),
+        )
+        npt.assert_array_equal(
+            np.asarray(to_numpy(solution["unassigned_cols"])),
+            np.array([], dtype=int),
+        )
+        self.assertEqual(solution["cost"], 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- scale finite assignment costs by their maximum absolute magnitude before constructing the maximum-cardinality priority penalty
- preserve the ordering of equal-cardinality matchings while keeping the optimization problem in a bounded numerical range
- compute the reported solution cost from the original, unscaled matrix
- add backend-aware regression coverage using the active floating-point dtype's maximum finite value

## Bug

`min_cost_max_cardinality_assignment()` constructed its unmatched-row penalty from the direct sum of all absolute finite edge costs:

```python
2.0 * (sum(abs(finite_costs)) + 1.0)
```

Individually finite edge costs can have a non-finite sum. For example, a 2-by-2 matrix with zero diagonal and maximum-finite off-diagonal entries has the unambiguous full assignment `[0, 1]` with total cost zero, but the direct sum overflows. The resulting infinite priority penalty is then rejected by the partial-assignment validator, so a valid solvable problem fails.

## Fix

Use a positive affine scaling that divides all finite optimization costs by their largest absolute value. Finite entries therefore lie in `[-1, 1]`, so the cardinality-priority penalty remains finite. Positive scaling preserves the cost ordering among matchings, and the original matrix is still used to report the final cost.

## Validation

- reproduced the pre-fix failure as `FloatingPointError: overflow encountered in reduce` under strict NumPy floating-point handling
- verified the patched implementation returns assignment `[0, 1]`, no unassigned rows or columns, and cost `0.0` for maximum-finite off-diagonal costs
- verified the existing ordinary maximum-cardinality example still returns `[1, 0]` with cost `3.1`
- verified a standard Murty partial-assignment case still returns the expected diagonal assignment
- `python -m py_compile` passes for the modified implementation and regression module
- branch is two commits ahead of `main` and zero behind

The full multi-backend repository test matrix is delegated to GitHub Actions.