### PR TITLE
Stabilize multisensor HDP global mass normalization

### DIFF
--- a/src/pyrecest/filters/multisensor_hdp_association.py
+++ b/src/pyrecest/filters/multisensor_hdp_association.py
@@ -257,12 +257,17 @@ def multisensor_hdp_association(
         global_birth_weight,
         "global_birth_weight",
     )
-    global_mass = float(target_weights.sum() + global_birth_weight)
-    if global_mass <= 0.0:
+    global_weights = np.concatenate(
+        [target_weights, np.asarray([global_birth_weight], dtype=float)]
+    )
+    global_scale = float(global_weights.max())
+    if global_scale <= 0.0:
         raise ValueError("global target and birth weights must contain positive total mass")
 
-    base_target_weights = target_weights / global_mass
-    base_birth_weight = global_birth_weight / global_mass
+    scaled_global_weights = global_weights / global_scale
+    base_weights = scaled_global_weights / scaled_global_weights.sum()
+    base_target_weights = base_weights[:-1]
+    base_birth_weight = float(base_weights[-1])
     labels = tuple(HDPAssociationLabel("target", index) for index in range(num_targets))
     labels += (HDPAssociationLabel("birth"), HDPAssociationLabel("clutter"))
 

--- a/tests/filters/test_multisensor_hdp_global_mass_overflow.py
+++ b/tests/filters/test_multisensor_hdp_global_mass_overflow.py
@@ -1,0 +1,29 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.filters.multisensor_hdp_association import multisensor_hdp_association
+
+
+class MultisensorHDPGlobalMassOverflowTest(unittest.TestCase):
+    def test_maximum_finite_global_masses_preserve_relative_probability(self):
+        largest = np.finfo(float).max
+
+        with np.errstate(over="raise", invalid="raise"):
+            result = multisensor_hdp_association(
+                {"radar": np.zeros((1, 2))},
+                global_target_weights=np.array([largest, largest]),
+                global_birth_weight=largest,
+                clutter_weights=0.0,
+            )["radar"]
+
+        np.testing.assert_allclose(
+            result.probabilities,
+            np.array([[1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0, 0.0]]),
+            rtol=0.0,
+            atol=1e-15,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- normalize global HDP target and birth masses after scaling by their largest entry
- avoid overflow when individually finite masses have a non-finite direct sum
- preserve relative target and birth probabilities at the maximum finite floating-point magnitude
- add a focused regression that excludes clutter and verifies equal target/target/birth posterior mass

## Root cause
`multisensor_hdp_association()` computed `target_weights.sum() + global_birth_weight` directly. With large but finite masses, the sum overflowed to infinity. Dividing by that infinite total then collapsed every target and birth base weight to zero, causing valid associations to disappear or the softmax to report that no feasible association existed.

## Validation
- compared the branch against `main`: only the HDP normalization block and one new regression test changed
- exercised the stabilized normalization numerically with `np.finfo(float).max`; the posterior is `[1/3, 1/3, 1/3, 0]` as expected
