### PR TITLE
Reject invalid circular grid value shapes

### DIFF
--- a/src/pyrecest/distributions/circle/circular_grid_distribution.py
+++ b/src/pyrecest/distributions/circle/circular_grid_distribution.py
@@ -51,6 +51,10 @@ class CircularGridDistribution(AbstractCircularDistribution, AbstractGridDistrib
                 "use from_distribution."
             )
         grid_values = array(grid_values)
+        if ndim(grid_values) != 1 or grid_values.shape[0] == 0:
+            raise ValueError(
+                "grid_values must be a non-empty one-dimensional array."
+            )
         if enforce_pdf_nonnegative and any(grid_values < 0):
             raise ValueError(
                 "grid_values must be nonnegative when "

--- a/tests/distributions/test_circular_grid_value_shape_validation.py
+++ b/tests/distributions/test_circular_grid_value_shape_validation.py
@@ -1,0 +1,28 @@
+import pytest
+
+from pyrecest.distributions.circle.circular_grid_distribution import (
+    CircularGridDistribution,
+)
+
+
+@pytest.mark.parametrize(
+    "grid_values",
+    (
+        [],
+        1.0,
+        [[1.0, 2.0]],
+    ),
+)
+def test_rejects_invalid_grid_value_shapes(grid_values):
+    with pytest.raises(
+        ValueError,
+        match="grid_values must be a non-empty one-dimensional array",
+    ):
+        CircularGridDistribution(grid_values)
+
+
+def test_accepts_singleton_grid_value_vector():
+    distribution = CircularGridDistribution([1.0])
+
+    assert distribution.grid_values.shape == (1,)
+    assert distribution.grid.shape == (1,)


### PR DESCRIPTION
## Summary
- require `CircularGridDistribution.grid_values` to be a non-empty one-dimensional array
- reject empty vectors before they create a zero-point distribution
- reject scalar and matrix-shaped values with a consistent `ValueError`
- add regression coverage while preserving valid singleton vectors

## Root cause
`CircularGridDistribution.__init__()` converted `grid_values` to a backend array and immediately read `shape[0]`. Scalar inputs therefore raised an incidental `IndexError`, while empty one-dimensional inputs were accepted and produced an invalid distribution with zero grid points. Later operations such as closest-point lookup divide by the grid size.

## Impact
Callers now receive an immediate, descriptive validation error instead of an invalid object or backend-dependent exception.

## Validation
- added `tests/distributions/test_circular_grid_value_shape_validation.py`
- branch diff is limited to the constructor guard and focused tests
- GitHub Actions will run the repository's full validation matrix on this PR