### PR TITLE
Handle explicit axes for scalar PyTorch fftconvolve

### DIFF
--- a/src/pyrecest/_backend/pytorch/signal.py
+++ b/src/pyrecest/_backend/pytorch/signal.py
@@ -132,6 +132,8 @@ def fftconvolve(in1, in2, mode="full", axes=None):
     x, y = _as_tensor_pair(in1, in2)
     if x.ndim != y.ndim:
         raise ValueError("in1 and in2 should have the same dimensionality")
+    if x.ndim == 0:
+        return x * y
 
     axes = _normalize_axes(axes, x.ndim)
     x_shape = tuple(x.shape)

--- a/tests/backend_support/test_pytorch_fftconvolve_scalar_axes.py
+++ b/tests/backend_support/test_pytorch_fftconvolve_scalar_axes.py
@@ -1,0 +1,24 @@
+import numpy as np
+import pyrecest.backend as backend
+import pytest
+from scipy.signal import fftconvolve as scipy_fftconvolve
+
+
+@pytest.mark.parametrize("mode", ["full", "same", "valid"])
+@pytest.mark.parametrize("axes", [0, -1, [0], np.array(0)])
+def test_pytorch_fftconvolve_scalar_axes_match_scipy(mode, axes):
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific signal backend contract")
+
+    first = backend.asarray(2.0)
+    second = backend.asarray(3.0)
+
+    actual = backend.to_numpy(
+        backend.signal.fftconvolve(first, second, mode=mode, axes=axes)
+    )
+    expected = scipy_fftconvolve(
+        backend.to_numpy(first), backend.to_numpy(second), mode=mode, axes=axes
+    )
+
+    assert actual.shape == expected.shape == ()
+    assert np.allclose(actual, expected)


### PR DESCRIPTION
## Summary

- return the promoted scalar product before axis normalization when both PyTorch `fftconvolve` inputs are zero-dimensional
- preserve existing validation and FFT behavior for positive-dimensional inputs
- add backend contract coverage for scalar convolution across all valid modes and representative explicit axis forms

## Bug

The PyTorch backend documents SciPy-compatible `fftconvolve` shape semantics, but it normalized `axes` before handling zero-dimensional inputs. For scalar inputs, any explicit integer axis was therefore checked against `ndim == 0` and rejected:

```text
ValueError: axis 0 is out of bounds for array of dimension 0
```

SciPy treats convolution of two scalars as scalar multiplication. It returns the product for explicit scalar, negative, sequence, and zero-dimensional integer axis specifications. The mismatch affected callers that forward a uniform `axes` argument across scalar and array cases.

## Fix

After tensor conversion, dtype promotion, and dimensionality validation, return `x * y` when both inputs are scalar. There are no dimensions to transform, so axis normalization and FFT execution are unnecessary. Positive-dimensional behavior is unchanged.

## Validation

- reproduced the pre-fix failure for `axes=0`, `axes=-1`, `axes=[0]`, and `axes=np.array(0)`
- verified 12 scalar combinations (three modes × four axis forms) match SciPy exactly
- verified ordinary two-dimensional `full`, `same`, and `valid` convolution still matches SciPy
- `python -m py_compile` passes for the patched backend module
- branch is two commits ahead of `main` and zero behind; the diff is two production lines plus one focused regression file

The full backend matrix is delegated to GitHub Actions.