### PR TITLE
Reject degenerate polygon sampling requests

### DIFF
--- a/src/pyrecest/evaluation/eot_shape_database.py
+++ b/src/pyrecest/evaluation/eot_shape_database.py
@@ -1,4 +1,5 @@
 # pylint: disable=no-name-in-module,no-member
+from math import isfinite
 from operator import index as _operator_index
 
 from pyrecest.backend import array, cos, linspace, pi, random, sin, to_numpy
@@ -42,9 +43,16 @@ class PolygonWithSampling(Polygon):  # pylint: disable=abstract-method
 
     def sample_on_boundary(self, num_points: int):
         num_points = _validate_nonnegative_sample_count(num_points)
-        points = []
-        perimeter = self.length
+        if num_points == 0:
+            return _points_to_array(())
 
+        perimeter = self.length
+        if not isfinite(perimeter) or perimeter <= 0.0:
+            raise ValueError(
+                "Cannot sample from a polygon without a positive finite perimeter."
+            )
+
+        points = []
         if isinstance(self.boundary, LineString):
             lines = [self.boundary]
         elif isinstance(self.boundary, MultiLineString):
@@ -67,6 +75,15 @@ class PolygonWithSampling(Polygon):  # pylint: disable=abstract-method
 
     def sample_within(self, num_points: int):
         num_points = _validate_nonnegative_sample_count(num_points)
+        if num_points == 0:
+            return _points_to_array(())
+
+        area = self.area
+        if self.is_empty or not isfinite(area) or area <= 0.0:
+            raise ValueError(
+                "Cannot sample from a polygon without a positive finite area."
+            )
+
         min_x, min_y, max_x, max_y = self.bounds
         points = []
 

--- a/tests/test_eot_shape_database.py
+++ b/tests/test_eot_shape_database.py
@@ -55,6 +55,20 @@ class TestStarShapedPolygon(unittest.TestCase):
         self.assertEqual(boundary_samples.shape, (0, 2))
         self.assertEqual(within_samples.shape, (0, 2))
 
+    def test_degenerate_polygon_rejects_positive_sample_requests(self):
+        degenerate_polygon = PolygonWithSampling()
+
+        with self.assertRaisesRegex(ValueError, "positive finite perimeter"):
+            degenerate_polygon.sample_on_boundary(1)
+        with self.assertRaisesRegex(ValueError, "positive finite area"):
+            degenerate_polygon.sample_within(1)
+
+    def test_degenerate_polygon_still_allows_zero_samples(self):
+        degenerate_polygon = PolygonWithSampling()
+
+        self.assertEqual(degenerate_polygon.sample_on_boundary(0).shape, (0, 2))
+        self.assertEqual(degenerate_polygon.sample_within(0).shape, (0, 2))
+
 
 class TestStar(unittest.TestCase):
     def test_compute_kernel_star_convex(self):


### PR DESCRIPTION
## Summary
- reject positive boundary-sampling requests when a polygon has no positive finite perimeter
- reject positive interior-sampling requests when a polygon is empty or has no positive finite area
- preserve the existing `(0, 2)` result for zero-sample requests, including degenerate polygons
- add regression coverage for both failure modes and the zero-sample contract

## Root cause
`PolygonWithSampling.sample_on_boundary()` attempted to sample even when the boundary length was zero. For an empty polygon this exhausted an empty boundary collection and returned fewer points than requested. `sample_within()` entered rejection sampling without first checking that the polygon had an interior; for an empty or zero-area polygon no generated point can satisfy `within()`, so the loop could run indefinitely.

## Impact
Invalid geometry now fails immediately with a clear `ValueError` instead of silently producing an undersized sample set or hanging indefinitely.

## Validation
- `python -m py_compile` on the modified source and test files
- focused local test run with NumPy-backed PyRecEst backend stubs and Shapely: 4 passed (`sample_on_boundary_with_hole`, zero-point behavior, and the two new degenerate-geometry regressions)
