### PR TITLE
Copy weighted Gaussian hypothesis mean inputs

### DIFF
--- a/src/pyrecest/filters/gaussian_hypothesis_mixture.py
+++ b/src/pyrecest/filters/gaussian_hypothesis_mixture.py
@@ -34,7 +34,7 @@ class WeightedGaussianHypothesis:
     metadata: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
-        mean = _as_float_array(self.mean, "mean").reshape(-1)
+        mean = _as_float_array(self.mean, "mean").reshape(-1).copy()
         covariance = _as_float_array(self.covariance, "covariance")
         if not np.all(np.isfinite(mean)):
             raise ValueError("mean must contain only finite values")

--- a/tests/filters/test_gaussian_hypothesis_input_ownership.py
+++ b/tests/filters/test_gaussian_hypothesis_input_ownership.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+from pyrecest.filters import (
+    WeightedGaussianHypothesis,
+    moment_match_gaussian_hypotheses,
+)
+
+
+def test_weighted_gaussian_hypothesis_copies_mean_input():
+    source_mean = np.array([1.0, 2.0])
+    hypothesis = WeightedGaussianHypothesis(source_mean, np.eye(2))
+
+    source_mean[:] = np.array([10.0, 20.0])
+
+    np.testing.assert_array_equal(hypothesis.mean, np.array([1.0, 2.0]))
+    matched_mean, _, _ = moment_match_gaussian_hypotheses([hypothesis])
+    np.testing.assert_array_equal(matched_mean, np.array([1.0, 2.0]))


### PR DESCRIPTION
## Summary

- make `WeightedGaussianHypothesis` take ownership of its normalized mean array
- prevent later mutation of a caller-owned floating-point array from changing an already constructed hypothesis
- add a regression that verifies both the stored mean and moment-matched output remain stable

## Root cause

`_as_float_array(...).astype(float, copy=False).reshape(-1)` returns a view of the original input when the caller supplies a floating-point NumPy array. Although `WeightedGaussianHypothesis` is a frozen dataclass, the stored `mean` therefore still shared mutable storage with the caller. Mutating the source array after construction silently changed the hypothesis and all downstream moment matching.

## Fix

Copy the normalized one-dimensional mean before assigning it to the frozen dataclass. This preserves all existing validation and dtype conversion while severing the caller-owned alias.

## Impact

Constructed Gaussian hypotheses now behave as stable value objects with respect to their input mean arrays. Downstream mixture reduction and moment matching cannot be altered by unrelated later mutations of the original array.

## Validation

- reproduced the pre-fix alias with a floating-point NumPy input
- verified the copy-based path preserves the original mean after source mutation
- added `tests/filters/test_gaussian_hypothesis_input_ownership.py`
- branch is two commits ahead of `main`, zero behind, and changes one production line plus one focused regression test

The full repository test matrix is delegated to GitHub Actions.