### PR TITLE
Copy wrapped exponential rate parameter

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
@@ -8,6 +8,7 @@ import numpy as np
 from pyrecest.backend import (
     all,
     asarray,
+    copy as backend_copy,
     exp,
     int32,
     int64,
@@ -111,7 +112,7 @@ class WrappedExponentialDistribution(AbstractCircularDistribution):
 
     def __init__(self, lambda_):
         AbstractCircularDistribution.__init__(self)
-        lambda_ = _validate_positive_scalar(lambda_, "lambda_")
+        lambda_ = backend_copy(_validate_positive_scalar(lambda_, "lambda_"))
         self.lambda_ = lambda_
         self._log_beta = 2.0 * pi * lambda_
         self._normalization_const = _normalization_const_from_log_beta(self._log_beta)

--- a/tests/distributions/test_wrapped_exponential_parameter_copy.py
+++ b/tests/distributions/test_wrapped_exponential_parameter_copy.py
@@ -1,0 +1,33 @@
+import unittest
+
+import numpy.testing as npt
+import pyrecest.backend
+from pyrecest.backend import array, to_numpy
+from pyrecest.distributions.circle.wrapped_exponential_distribution import (
+    WrappedExponentialDistribution,
+)
+
+
+class WrappedExponentialParameterCopyTest(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="JAX arrays are immutable and cannot expose caller-side aliasing.",
+    )
+    def test_constructor_owns_mutable_rate_storage(self):
+        rate = array(2.0)
+        distribution = WrappedExponentialDistribution(rate)
+        evaluation_points = array([0.0, 0.5, 1.0])
+        expected_pdf = to_numpy(distribution.pdf(evaluation_points)).copy()
+
+        rate[...] = 4.0
+
+        npt.assert_allclose(to_numpy(rate), 4.0)
+        npt.assert_allclose(to_numpy(distribution.lambda_), 2.0)
+        npt.assert_allclose(
+            to_numpy(distribution.pdf(evaluation_points)),
+            expected_pdf,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- copy the validated wrapped-exponential rate into distribution-owned backend storage
- prevent caller-side mutation from changing `lambda_` after normalization terms have been cached
- add regression coverage that mutates the original rate and verifies the distribution parameter and PDF remain unchanged

## Root cause

`_validate_positive_scalar()` uses the active backend's `asarray()`. On mutable backends, this can retain the caller's array storage. `WrappedExponentialDistribution` then stored that array directly while separately caching `_log_beta` and `_normalization_const`.

If the caller later mutated the original rate array, `self.lambda_` changed but the cached normalization terms did not. The resulting PDF combined parameters from two different rates and was no longer internally consistent.

## Impact

Constructed distributions now own their rate parameter, matching the value semantics expected from a distribution object and preventing external mutation from corrupting cached derived quantities.

## Validation

- connector diff inspection: two commits ahead of `main`, zero behind
- independent NumPy reproduction confirms the alias changes the PDF before the fix and that an owned copy preserves it
- added a backend-aware regression test for mutable backends; the full backend matrix is delegated to GitHub Actions
