### PR TITLE
Stabilize circular grid-to-Dirac weight conversion

### DIFF
--- a/src/pyrecest/distributions/circle/circular_dirac_distribution.py
+++ b/src/pyrecest/distributions/circle/circular_dirac_distribution.py
@@ -1,4 +1,11 @@
-from pyrecest.backend import isfinite, max as backend_max, ones, reshape
+from pyrecest.backend import all as backend_all
+from pyrecest.backend import (
+    isfinite,
+    max as backend_max,
+    ones,
+    reshape,
+    sum as backend_sum,
+)
 
 from ..hypertorus.hypertoroidal_dirac_distribution import HypertoroidalDiracDistribution
 from .abstract_circular_distribution import AbstractCircularDistribution
@@ -36,10 +43,15 @@ class CircularDiracDistribution(
         get_grid = getattr(distribution, "get_grid", None)
         if hasattr(distribution, "grid_values") and callable(get_grid):
             weights = reshape(distribution.grid_values, (-1,))
-            if weights.shape[0] > 0:
+            if (
+                weights.shape[0] > 0
+                and bool(backend_all(isfinite(weights)))
+                and bool(backend_all(weights >= 0.0))
+            ):
                 weight_scale = backend_max(weights)
-                if bool(isfinite(weight_scale)) and bool(weight_scale > 0.0):
+                if bool(weight_scale > 0.0):
                     weights = weights / weight_scale
+                    weights = weights / backend_sum(weights)
             return CircularDiracDistribution(get_grid(), weights)
 
         if n_particles is None:

--- a/src/pyrecest/distributions/circle/circular_dirac_distribution.py
+++ b/src/pyrecest/distributions/circle/circular_dirac_distribution.py
@@ -1,4 +1,4 @@
-from pyrecest.backend import ones, reshape, sum
+from pyrecest.backend import isfinite, max as backend_max, ones, reshape
 
 from ..hypertorus.hypertoroidal_dirac_distribution import HypertoroidalDiracDistribution
 from .abstract_circular_distribution import AbstractCircularDistribution
@@ -36,7 +36,10 @@ class CircularDiracDistribution(
         get_grid = getattr(distribution, "get_grid", None)
         if hasattr(distribution, "grid_values") and callable(get_grid):
             weights = reshape(distribution.grid_values, (-1,))
-            weights = weights / sum(weights)
+            if weights.shape[0] > 0:
+                weight_scale = backend_max(weights)
+                if bool(isfinite(weight_scale)) and bool(weight_scale > 0.0):
+                    weights = weights / weight_scale
             return CircularDiracDistribution(get_grid(), weights)
 
         if n_particles is None:

--- a/tests/distributions/test_circular_dirac_distribution.py
+++ b/tests/distributions/test_circular_dirac_distribution.py
@@ -1,8 +1,14 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
+import pyrecest.backend
 from pyrecest.backend import array, ones, pi
-from pyrecest.distributions import CircularDiracDistribution, VonMisesDistribution
+from pyrecest.distributions import (
+    CircularDiracDistribution,
+    CircularGridDistribution,
+    VonMisesDistribution,
+)
 
 
 class TestCircularDiracDistribution(unittest.TestCase):
@@ -39,6 +45,20 @@ class TestCircularDiracDistribution(unittest.TestCase):
         self.assertEqual(wd.d.shape, (n_particles,))
         self.assertEqual(wd.w.shape, (n_particles,))
         npt.assert_allclose(wd.w, ones(n_particles) / n_particles)
+
+    @unittest.skipUnless(
+        pyrecest.backend.__backend_name__ == "numpy",
+        reason="Regression exercises NumPy float64 overflow semantics.",
+    )
+    def test_from_grid_distribution_scales_large_finite_weights(self):
+        largest = np.finfo(float).max
+        grid_distribution = CircularGridDistribution(array([largest, largest]))
+
+        with np.errstate(over="raise", invalid="raise"):
+            wd = CircularDiracDistribution.from_distribution(grid_distribution)
+
+        self.assertIsInstance(wd, CircularDiracDistribution)
+        npt.assert_allclose(wd.w, ones(2) / 2.0)
 
 
 if __name__ == "__main__":

--- a/tests/distributions/test_circular_dirac_distribution.py
+++ b/tests/distributions/test_circular_dirac_distribution.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 
 import numpy as np
 import numpy.testing as npt
@@ -53,7 +54,8 @@ class TestCircularDiracDistribution(unittest.TestCase):
         largest = np.finfo(float).max
         grid_distribution = CircularGridDistribution(array([largest, largest]))
 
-        with np.errstate(over="raise", invalid="raise"):
+        with warnings.catch_warnings(), np.errstate(over="raise", invalid="raise"):
+            warnings.simplefilter("error", RuntimeWarning)
             wd = CircularDiracDistribution.from_distribution(grid_distribution)
 
         self.assertIsInstance(wd, CircularDiracDistribution)

--- a/tests/distributions/test_circular_dirac_distribution.py
+++ b/tests/distributions/test_circular_dirac_distribution.py
@@ -4,10 +4,9 @@ import numpy as np
 import numpy.testing as npt
 import pyrecest.backend
 from pyrecest.backend import array, ones, pi
-from pyrecest.distributions import (
-    CircularDiracDistribution,
+from pyrecest.distributions import CircularDiracDistribution, VonMisesDistribution
+from pyrecest.distributions.circle.circular_grid_distribution import (
     CircularGridDistribution,
-    VonMisesDistribution,
 )
 
 


### PR DESCRIPTION
## Summary
- scale circular grid weights by their largest finite positive entry before constructing a `CircularDiracDistribution`
- preserve relative weights while avoiding overflow in direct normalization
- add a NumPy regression for two maximum finite `float64` grid weights

## Root cause
`CircularDiracDistribution.from_distribution()` normalized grid weights with `weights / sum(weights)`. For individually finite large weights, the sum can overflow to infinity. Dividing by that infinite total collapses every weight to zero, and the Dirac constructor then rejects the otherwise valid conversion because the resulting weights have no positive mass.

## Impact
Deterministic conversion from a circular grid distribution now succeeds for extreme but finite weights and preserves their relative probabilities. Invalid inputs such as non-finite, negative, empty, or zero-mass weights are still rejected by the existing Dirac-weight validation.

## Validation
- reproduced the pre-fix behavior with two `np.finfo(float).max` weights: direct normalization produces `[0, 0]`
- verified scale-before-normalize produces `[0.5, 0.5]` with unit total mass
- `python -m py_compile` passes for the patched conversion code
- branch is two commits ahead of `main` and zero behind; only the conversion and focused regression test changed

The repository's full backend and lint matrices are delegated to GitHub Actions.