### PR TITLE
Reject zero-dimensional point sets

### DIFF
--- a/src/pyrecest/evaluation/point_set_metrics.py
+++ b/src/pyrecest/evaluation/point_set_metrics.py
@@ -35,6 +35,8 @@ def as_point_set(
         raise ValueError(f"{name} must have shape (N, D).") from exc
     if array.ndim != 2:
         raise ValueError(f"{name} must have shape (N, D).")
+    if array.shape[1] == 0:
+        raise ValueError(f"{name} must contain points with at least one coordinate.")
     if expected_dim is not None and array.shape[1] != expected_dim:
         raise ValueError(f"{name} must have shape (N, {expected_dim}).")
     if array.shape[0] == 0:

--- a/tests/evaluation/test_point_set_metrics_zero_dimension.py
+++ b/tests/evaluation/test_point_set_metrics_zero_dimension.py
@@ -1,0 +1,14 @@
+import numpy as np
+import pytest
+
+from pyrecest.evaluation.point_set_metrics import as_point_set, nearest_neighbor_distances
+
+
+def test_as_point_set_rejects_zero_coordinate_dimension():
+    with pytest.raises(ValueError, match="at least one coordinate"):
+        as_point_set(np.empty((2, 0)))
+
+
+def test_nearest_neighbor_distances_rejects_zero_coordinate_dimension_cleanly():
+    with pytest.raises(ValueError, match="at least one coordinate"):
+        nearest_neighbor_distances(np.empty((2, 0)), np.empty((3, 0)))


### PR DESCRIPTION
## Summary
- reject point-set arrays with shape `(N, 0)` during `as_point_set()` validation
- prevent SciPy `cKDTree` from receiving zero-coordinate inputs that trigger an internal `IndexError`
- make behavior consistent with the deterministic dense fallback
- add regression coverage for the validator and the public nearest-neighbor API

## Root cause
`as_point_set()` required a two-dimensional, non-empty array but did not require the coordinate dimension `D` to be positive. Arrays such as `np.empty((2, 0))` therefore passed validation. With SciPy installed, `nearest_neighbor_distances()` forwarded the zero-dimensional points to `scipy.spatial.cKDTree`, which fails with an internal `IndexError`. Without SciPy, the dense fallback instead treated all such points as coincident and returned zero distances.

## Impact
Invalid zero-coordinate point sets now fail immediately with a descriptive `ValueError`, independent of whether SciPy is installed. Valid point sets are unchanged.

## Validation
- reproduced the pre-fix `cKDTree` failure with `(N, 0)` inputs
- `python -m pytest -q tests/evaluation/test_point_set_metrics_zero_dimension.py` (2 passed)
- representative smoke checks for nearest-neighbor distances, Chamfer distance, precision/recall, geometry summaries, quantiles, and deterministic subsampling
- `python -m py_compile` on the modified source and regression test
