### PR TITLE
Stabilize particle-scenario weight normalization

### DIFF
--- a/src/pyrecest/scenarios.py
+++ b/src/pyrecest/scenarios.py
@@ -180,12 +180,16 @@ def _normalized_particle_weights(raw_weights: Any, particle_count: int, backend)
     if any(weight < 0.0 for weight in weight_values):
         raise ValueError("weights must be nonnegative")
 
-    weight_total = sum(weight_values)
-    if weight_total <= 0.0:
+    weight_scale = max(weight_values, default=0.0)
+    if weight_scale <= 0.0:
         raise ValueError("weights must have positive total mass")
+    scaled_weights = [weight / weight_scale for weight in weight_values]
+    scaled_total = sum(scaled_weights)
+    if scaled_total <= 0.0 or not math.isfinite(scaled_total):
+        raise ValueError("weights must have positive finite total mass")
 
     return backend.asarray(
-        [weight / weight_total for weight in weight_values],
+        [weight / scaled_total for weight in scaled_weights],
         dtype=backend.float64,
     )
 

--- a/tests/test_scenario_particle_weight_overflow.py
+++ b/tests/test_scenario_particle_weight_overflow.py
@@ -1,0 +1,36 @@
+import math
+import sys
+from pathlib import Path
+
+from pyrecest.scenarios import run_scenario
+
+
+def test_particle_resampling_scenario_normalizes_extreme_finite_weights(
+    tmp_path: Path,
+):
+    max_float = sys.float_info.max
+    scenario = tmp_path / "extreme_particle_weights.toml"
+    scenario.write_text(
+        f"""
+[scenario]
+type = "particle_resampling"
+name = "extreme-particle-weights"
+seed = 7
+
+[data]
+particles = [[0.0], [1.0]]
+weights = [{max_float!r}, {max_float / 2.0!r}]
+num_samples = 8
+""".strip(),
+        encoding="utf-8",
+    )
+
+    result = run_scenario(scenario)
+
+    assert math.isclose(result.metrics["max_weight"], 2.0 / 3.0)
+    assert math.isclose(result.metrics["min_weight"], 1.0 / 3.0)
+    assert math.isclose(
+        result.metrics["max_weight"] + result.metrics["min_weight"],
+        1.0,
+    )
+    assert math.isfinite(result.metrics["effective_sample_size"])


### PR DESCRIPTION
## Summary

- normalize particle-resampling scenario weights after scaling by their largest finite value
- preserve relative particle probabilities while avoiding overflow in the raw Python sum
- add an end-to-end TOML scenario regression using maximum finite floating-point weights

## Bug

`_normalized_particle_weights()` summed validated finite weights directly:

```python
weight_total = sum(weight_values)
```

Individually finite nonnegative weights can still have a non-finite sum. For example, `[sys.float_info.max, sys.float_info.max / 2]` has the well-defined ratio `2:1`, but its direct sum is `inf`. Dividing by that total produces `[0.0, 0.0]`, so the particle-resampling scenario passes an invalid probability vector to the backend sampler.

## Fix

Scale all weights by their largest entry before summing. The scaled values lie in `[0, 1]`, retain the original ratios, and normalize to a finite unit-mass vector. Existing validation for length, finiteness, non-negativity, and positive mass is preserved.

## Validation

- isolated reproduction confirms the old formula returns `[0.0, 0.0]` for maximum-finite weights
- the scale-first formula returns `[2/3, 1/3]` with total mass `1.0`
- added a public `run_scenario()` regression that parses the extreme weights from TOML and checks finite normalized metrics
- branch is two commits ahead of current `main` and zero behind; the production diff is 7 additions and 3 deletions

The full backend test matrix is delegated to GitHub Actions.