### PR TITLE
Handle matrix sequence conversion runtime errors

### DIFF
--- a/src/pyrecest/smoothers/abstract_smoother.py
+++ b/src/pyrecest/smoothers/abstract_smoother.py
@@ -58,7 +58,7 @@ class AbstractSmoother(ABC):
 
         try:
             values_arr = asarray(values)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, RuntimeError):
             values_arr = None
         if values_arr is not None:
             if ndim(values_arr) == 0:

--- a/tests/smoothers/test_abstract_smoother_matrix_sequence_runtime_error.py
+++ b/tests/smoothers/test_abstract_smoother_matrix_sequence_runtime_error.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+import pyrecest.smoothers.abstract_smoother as abstract_smoother_module
+from pyrecest.smoothers.abstract_smoother import AbstractSmoother
+
+
+def test_matrix_sequence_falls_back_after_backend_runtime_error(monkeypatch):
+    matrices = [np.eye(2), 2.0 * np.eye(2)]
+    backend_asarray = abstract_smoother_module.asarray
+
+    def asarray_with_outer_conversion_failure(value):
+        if value is matrices:
+            raise RuntimeError("backend cannot stack the matrix sequence")
+        return backend_asarray(value)
+
+    monkeypatch.setattr(
+        abstract_smoother_module,
+        "asarray",
+        asarray_with_outer_conversion_failure,
+    )
+
+    normalized = AbstractSmoother._normalize_matrix_sequence(
+        matrices,
+        length=2,
+        name="transition_matrices",
+        matrix_dim=2,
+    )
+
+    np.testing.assert_allclose(normalized[0], matrices[0])
+    np.testing.assert_allclose(normalized[1], matrices[1])


### PR DESCRIPTION
## Summary

- treat backend `RuntimeError` during outer matrix-sequence conversion like the existing `TypeError` and `ValueError` cases
- fall back to the established per-entry matrix normalization path
- add a focused regression that simulates a backend unable to stack the outer sequence

## Root cause

`AbstractSmoother._normalize_matrix_sequence()` first tries to convert the complete input sequence with the active backend's `asarray()`. Some backends raise `RuntimeError`, rather than `TypeError` or `ValueError`, when a Python sequence cannot be converted as one dense array. The vector-sequence counterpart already handles this backend behavior, but the matrix-sequence path did not. Consequently, valid per-step matrix sequences could fail before the existing per-entry fallback was reached.

## Impact

Matrix sequence normalization now behaves consistently with vector sequence normalization and remains usable when a backend cannot stack the outer Python sequence directly. Inputs that are genuinely invalid still fail through the existing validation path.

## Validation

- branch is two commits ahead of current `main` and zero behind
- production change is limited to one additional caught exception
- regression monkeypatches the backend conversion to raise `RuntimeError` only for the outer sequence and verifies both matrices are normalized through the fallback

The full backend test matrix is delegated to GitHub Actions.