### PR TITLE
Stabilize measurement reliability covariance scaling

### DIFF
--- a/src/pyrecest/tracking/measurement_reliability.py
+++ b/src/pyrecest/tracking/measurement_reliability.py
@@ -153,9 +153,20 @@ def reliability_to_covariance_scale(
     if floor <= 0.0:
         raise ValueError("floor must be positive")
     exponent = _positive_scalar(exponent, "exponent")
-    scale = 1.0 / max(reliability, floor) ** exponent
-    if max_scale is not None:
-        scale = min(scale, _scale_upper_bound(max_scale, "max_scale"))
+    bounded_scale = (
+        None
+        if max_scale is None
+        else _scale_upper_bound(max_scale, "max_scale")
+    )
+    effective_reliability = max(reliability, floor)
+    log_scale = -exponent * np.log(effective_reliability)
+    if bounded_scale is not None and log_scale >= np.log(bounded_scale):
+        return float(bounded_scale)
+    if log_scale > np.log(np.finfo(float).max):
+        raise ValueError(
+            "covariance scale overflows; set max_scale to a finite upper bound"
+        )
+    scale = 1.0 / effective_reliability**exponent
     return float(max(1.0, scale))
 
 

--- a/tests/tracking/test_measurement_reliability_overflow.py
+++ b/tests/tracking/test_measurement_reliability_overflow.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from pyrecest.tracking import (
+    apply_measurement_reliability,
+    reliability_to_covariance_scale,
+)
+
+
+def test_large_exponent_respects_max_scale_before_power_underflow() -> None:
+    scale = reliability_to_covariance_scale(
+        0.5,
+        exponent=1.0e6,
+        max_scale=7.0,
+    )
+    result = apply_measurement_reliability(
+        np.eye(2),
+        reliability=0.5,
+        exponent=1.0e6,
+        max_scale=7.0,
+    )
+
+    assert scale == 7.0
+    assert result.covariance_scale == 7.0
+    assert np.allclose(result.covariance, 7.0 * np.eye(2))
+
+
+def test_large_uncapped_scale_raises_clear_overflow_error() -> None:
+    with pytest.raises(ValueError, match="covariance scale overflows"):
+        reliability_to_covariance_scale(0.5, exponent=1.0e6)


### PR DESCRIPTION
## Summary

- evaluate reliability covariance-scale overflow in log space before exponentiation
- apply a finite `max_scale` cap before the power operation can underflow to zero
- raise a clear `ValueError` when an uncapped scale cannot be represented as a finite float
- add regressions for both capped and uncapped extreme exponents

## Bug

`reliability_to_covariance_scale()` computed

```python
1.0 / max(reliability, floor) ** exponent
```

before applying `max_scale`. For large but finite exponents, the denominator can underflow to zero. The public helper then either returned `inf` or raised `ZeroDivisionError`; an explicit finite `max_scale` could not protect the computation because it was applied too late.

## Fix

Compute the logarithm of the requested scale first. If it reaches a supplied finite cap, return that cap without evaluating the unstable power. If an uncapped result exceeds the largest finite float, raise a descriptive `ValueError` rather than leaking an incidental arithmetic exception or infinity.

Normal representable inputs still use the existing power expression, preserving current results and rounding behavior.

## Validation

- reproduced the existing `ZeroDivisionError` with `reliability=0.5` and `exponent=1e6`
- verified the patched calculation returns `7.0` when `max_scale=7.0`
- verified the uncapped case raises `ValueError` containing `covariance scale overflows`
- branch is two commits ahead of and zero commits behind current `main`
- diff is limited to one production function and one focused regression file
