### PR TITLE
Stabilize discrete-state initial probability normalization

### DIFF
--- a/src/pyrecest/filters/discrete_state/__init__.py
+++ b/src/pyrecest/filters/discrete_state/__init__.py
@@ -114,10 +114,11 @@ def _validated_probability_vector(
     mask = _module_globals["_coerce_valid_state_mask"](valid_state_mask, n_entries)
     if mask is not None:
         values[~mask] = 0.0
-    total = float(values.sum())
-    if total <= 0.0:
+    scale = float(values.max())
+    if scale <= 0.0:
         raise ValueError(f"{name} must contain positive probability mass")
-    return values / total
+    values /= scale
+    return values / float(values.sum())
 
 
 def sparse_gaussian_transition_matrix(

--- a/tests/filters/test_discrete_state_extreme_probabilities.py
+++ b/tests/filters/test_discrete_state_extreme_probabilities.py
@@ -1,0 +1,39 @@
+import numpy as np
+
+from pyrecest.filters.discrete_state import (
+    discrete_forward_backward,
+    imm_forward_backward,
+)
+
+
+def test_forward_backward_normalizes_extreme_finite_initial_probabilities():
+    max_finite = np.finfo(float).max
+
+    result = discrete_forward_backward(
+        np.zeros((1, 2)),
+        np.eye(2),
+        initial_probabilities=np.array([max_finite, max_finite / 2.0]),
+    )
+
+    expected = np.array([2.0 / 3.0, 1.0 / 3.0])
+    np.testing.assert_allclose(result.filtered_probabilities[0], expected)
+    np.testing.assert_allclose(result.smoothed_probabilities[0], expected)
+    assert np.isfinite(result.log_marginal_likelihood)
+
+
+def test_imm_normalizes_extreme_finite_state_and_mode_probabilities():
+    max_finite = np.finfo(float).max
+
+    result = imm_forward_backward(
+        np.zeros((1, 2)),
+        [np.eye(2), np.eye(2)],
+        np.eye(2),
+        initial_state_probabilities=np.array([max_finite, max_finite / 2.0]),
+        initial_mode_probabilities=np.array([max_finite / 2.0, max_finite]),
+    )
+
+    expected_state = np.array([2.0 / 3.0, 1.0 / 3.0])
+    expected_mode = np.array([1.0 / 3.0, 2.0 / 3.0])
+    np.testing.assert_allclose(result.filtered_state_probabilities[0], expected_state)
+    np.testing.assert_allclose(result.filtered_mode_probabilities[0], expected_mode)
+    np.testing.assert_allclose(result.filtered_joint_probabilities.sum(), 1.0)


### PR DESCRIPTION
## Summary

- normalize finite-state initial probability vectors after scaling by their largest entry
- preserve relative HMM and IMM priors when their direct floating-point sum would overflow
- add regressions for both `discrete_forward_backward()` and `imm_forward_backward()`

## Root cause

The public discrete-state compatibility layer validated each prior entry as finite and non-negative, then summed the raw values directly:

```python
total = float(values.sum())
return values / total
```

Individually finite weights can still have an infinite sum. For example, `[max_float, max_float / 2]` has the well-defined ratio `2:1`, but its direct sum overflows to `inf`. Dividing by that total produces `[0, 0]`, so valid initial HMM or IMM probabilities lose all mass and the filter fails at the first emission.

## Fix

After applying the optional valid-state mask, scale the vector by its largest entry before summing. The scaled values lie in `[0, 1]`, retain the original ratios, and normalize to finite unit mass. Existing validation for shape, numeric type, finiteness, non-negativity, and positive mass is preserved.

## Validation

- reproduced the old normalization result: `[max_float, max_float / 2] -> [0, 0]`
- verified the scale-first result is `[2/3, 1/3]` with unit mass
- added end-to-end HMM and IMM regressions through the public API
- `python -m py_compile` passes for the modified source and new test
- branch is two commits ahead of current `main` and zero behind; production diff is 4 additions and 3 deletions

The full repository test and backend matrix is delegated to GitHub Actions.