### PR TITLE
Handle batched hypertoroidal nearest-grid queries

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_grid_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_grid_distribution.py
@@ -154,11 +154,11 @@ class HypertoroidalGridDistribution(
 
     # ------------------------------------------------------------------ utils
     def get_closest_point(self, xs):
-        """Return the closest grid point (toroidal distance) to x.
+        """Return the closest grid point for each query using toroidal distance.
 
         Parameters
         ----------
-        x : array_like, shape (dim,) or (1, dim)
+        xs : array_like, shape (dim,) or (n_eval, dim)
         """
         xs = array(xs)
         if ndim(xs) == 1:
@@ -171,12 +171,15 @@ class HypertoroidalGridDistribution(
             raise ValueError("Grid is empty; cannot find closest point.")
 
         # Reduce angular differences modulo 2π before taking the shortest arc.
-        delta = self.grid[None, :, :] - xs[:, None, :]  # (1, n_grid, dim)
+        delta = self.grid[None, :, :] - xs[:, None, :]  # (n_eval, n_grid, dim)
         abs_delta = mod(abs(delta), 2.0 * pi)
         wrapped_delta = minimum(abs_delta, 2.0 * pi - abs_delta)
         dists = sum(wrapped_delta**2, axis=-1)
-        min_index = int(argmin(dists[0]))
-        return self.grid[min_index]
+        min_inds = argmin(dists, axis=1)
+        closest_points = self.grid[min_inds]
+        if closest_points.shape[0] == 1:
+            return closest_points[0]
+        return closest_points
 
     def get_manifold_size(self):
         return AbstractHypertoroidalDistribution.get_manifold_size(self)

--- a/tests/distributions/test_hypertoroidal_grid_batch_closest.py
+++ b/tests/distributions/test_hypertoroidal_grid_batch_closest.py
@@ -1,0 +1,30 @@
+import numpy.testing as npt
+
+from pyrecest.backend import array, pi
+from pyrecest.distributions.hypertorus.hypertoroidal_grid_distribution import (
+    HypertoroidalGridDistribution,
+)
+
+
+def test_get_closest_point_returns_one_point_per_batched_query():
+    grid = array(
+        [
+            [0.0, 0.0],
+            [0.0, pi],
+            [pi, 0.0],
+            [pi, pi],
+        ]
+    )
+    grid_values = array([1.0, 1.0, 1.0, 1.0]) / ((2.0 * pi) ** 2)
+    distribution = HypertoroidalGridDistribution(grid_values, grid=grid)
+
+    queries = array(
+        [
+            [2.0 * pi - 0.1, 0.05],
+            [pi + 0.1, pi - 0.05],
+        ]
+    )
+
+    closest = distribution.get_closest_point(queries)
+
+    npt.assert_allclose(closest, array([[0.0, 0.0], [pi, pi]]))


### PR DESCRIPTION
## Summary

- compute nearest custom-grid indices for every hypertoroidal query instead of only the first row
- return one closest grid point per batched query
- preserve the existing one-dimensional return shape for a single query
- document the accepted batched input shape and add a focused regression test

## Root cause

`HypertoroidalGridDistribution.get_closest_point()` builds a full distance matrix with shape `(n_eval, n_grid)`, but then explicitly evaluates only `dists[0]`. Any additional query rows are silently discarded, so a batched call returns the nearest grid point for only the first query.

## Impact

Callers can now pass multiple hypertoroidal query points and receive the corresponding nearest grid point for each one. Existing single-query behavior remains unchanged.

## Validation

- reproduced the old behavior with two distinct toroidal queries: only the first nearest point was returned
- verified vectorized `argmin(..., axis=1)` returns `[[0, 0], [pi, pi]]` for the regression geometry
- added `tests/distributions/test_hypertoroidal_grid_batch_closest.py`
- branch is two commits ahead of current `main`, zero behind; production diff is 8 additions and 5 deletions

The complete backend matrix is delegated to GitHub Actions.