### PR TITLE
Copy bias model parameter arrays

### DIFF
--- a/src/pyrecest/calibration/bias.py
+++ b/src/pyrecest/calibration/bias.py
@@ -64,18 +64,28 @@ class SensorBiasCorrectionModel:
     def __post_init__(self) -> None:
         target_dim = _as_positive_int(self.target_dim, "target_dim")
         feature_dim = _as_nonnegative_int(self.feature_dim, "feature_dim")
-        intercept = _as_numeric_array(self.intercept, "intercept").reshape(target_dim)
-        coefficients = _as_numeric_array(self.coefficients, "coefficients").reshape(
-            feature_dim, target_dim
+        intercept = (
+            _as_numeric_array(self.intercept, "intercept")
+            .reshape(target_dim)
+            .copy()
         )
-        feature_mean = _as_numeric_array(self.feature_mean, "feature_mean").reshape(
-            feature_dim
+        coefficients = (
+            _as_numeric_array(self.coefficients, "coefficients")
+            .reshape(feature_dim, target_dim)
+            .copy()
+        )
+        feature_mean = (
+            _as_numeric_array(self.feature_mean, "feature_mean")
+            .reshape(feature_dim)
+            .copy()
         )
         feature_scale = _as_numeric_array(self.feature_scale, "feature_scale").reshape(
             feature_dim
         )
-        residual_std = _as_numeric_array(self.residual_std, "residual_std").reshape(
-            target_dim
+        residual_std = (
+            _as_numeric_array(self.residual_std, "residual_std")
+            .reshape(target_dim)
+            .copy()
         )
         _require_finite_array(intercept, "intercept")
         _require_finite_array(coefficients, "coefficients")

--- a/tests/calibration/test_bias_parameter_ownership.py
+++ b/tests/calibration/test_bias_parameter_ownership.py
@@ -1,0 +1,37 @@
+import numpy as np
+
+from pyrecest.calibration.bias import SensorBiasCorrectionModel
+
+
+def test_bias_model_copies_mutable_parameter_arrays():
+    intercept = np.array([1.0])
+    coefficients = np.array([[2.0]])
+    feature_mean = np.array([3.0])
+    feature_scale = np.array([4.0])
+    residual_std = np.array([5.0])
+    model = SensorBiasCorrectionModel(
+        target_dim=1,
+        feature_dim=1,
+        intercept=intercept,
+        coefficients=coefficients,
+        feature_mean=feature_mean,
+        feature_scale=feature_scale,
+        residual_std=residual_std,
+        training_count=1,
+        ridge_alpha=0.0,
+    )
+    features = np.array([[7.0]])
+    expected_prediction = model.predict(features).copy()
+
+    intercept[:] = 10.0
+    coefficients[:] = 20.0
+    feature_mean[:] = 30.0
+    feature_scale[:] = 40.0
+    residual_std[:] = 50.0
+
+    np.testing.assert_allclose(model.intercept, [1.0])
+    np.testing.assert_allclose(model.coefficients, [[2.0]])
+    np.testing.assert_allclose(model.feature_mean, [3.0])
+    np.testing.assert_allclose(model.feature_scale, [4.0])
+    np.testing.assert_allclose(model.residual_std, [5.0])
+    np.testing.assert_allclose(model.predict(features), expected_prediction)


### PR DESCRIPTION
## Summary

- copy learned bias-model parameter arrays during construction
- prevent caller-side NumPy mutations from silently changing a frozen model
- add a focused regression covering stored parameters and prediction stability

## Bug

`SensorBiasCorrectionModel` is a frozen dataclass, but `np.asarray(..., dtype=float)` can return caller-owned floating-point arrays unchanged. The constructor therefore retained aliases for `intercept`, `coefficients`, `feature_mean`, and `residual_std`. Mutating those input arrays after construction changed the model and its predictions.

## Fix

Take owned copies of the parameter arrays when normalizing their shapes. `feature_scale` already becomes an owned array through its sanitizing `np.where` operation.

## Validation

- reproduced the pre-fix prediction change (`3.0` to `-105.0`) after mutating constructor inputs
- verified the patched prediction remains `3.0`
- `PYTHONPATH=src python -m pytest -q tests/calibration/test_bias_parameter_ownership.py` (`1 passed`)
- Python compilation check passed for the modified module and regression test
- branch comparison: two commits ahead, zero behind; only the calibration model and focused regression are changed