### PR TITLE
Fix MeasurementScore index ownership

### DIFF
--- a/src/pyrecest/filters/measurement_scoring.py
+++ b/src/pyrecest/filters/measurement_scoring.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any
 
@@ -25,10 +26,17 @@ class MeasurementScore:
     predicted_measurements: Any | None
     innovation_covariance: Any | None
     residual: Any | None
-    active_measurement_indices: list[int]
+    active_measurement_indices: Sequence[int]
     measurement_weights: Any | None = None
     quadratic_form: float | None = None
     skipped_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "active_measurement_indices",
+            tuple(self.active_measurement_indices),
+        )
 
     @property
     def is_active(self) -> bool:

--- a/tests/filters/test_measurement_scoring.py
+++ b/tests/filters/test_measurement_scoring.py
@@ -15,3 +15,13 @@ def _score(active_measurement_indices):
 def test_measurement_score_is_active_handles_numpy_index_arrays():
     assert _score(np.array([0, 2])).is_active
     assert not _score(np.array([], dtype=int)).is_active
+
+
+def test_measurement_score_copies_active_measurement_indices():
+    active_measurement_indices = [0, 2]
+    score = _score(active_measurement_indices)
+
+    active_measurement_indices.clear()
+
+    assert score.active_measurement_indices == (0, 2)
+    assert score.is_active


### PR DESCRIPTION
## Summary
- snapshot `active_measurement_indices` as an immutable tuple when constructing `MeasurementScore`
- preserve existing list and NumPy-array inputs
- add a regression test showing that mutating the caller-owned list no longer changes `score.is_active`

## Root cause
`MeasurementScore` is a frozen dataclass, but it retained the caller's mutable index collection by reference. Clearing or appending to that collection after score construction silently changed the stored diagnostics and could flip `is_active`.

## Validation
- reproduced the old external-mutation failure
- compiled the modified module with `python -m py_compile`
- verified list and NumPy-array inputs are converted to a stable tuple
- verified the branch differs from current `main` only in the implementation and focused regression test