### PR TITLE
Reject complex hypertoroidal angle inputs

### DIFF
--- a/src/pyrecest/distributions/hypertorus/_input_validation.py
+++ b/src/pyrecest/distributions/hypertorus/_input_validation.py
@@ -7,6 +7,7 @@ from pyrecest.backend import array
 
 _BOOLEAN_DTYPE_NAMES = {"bool", "bool_", "torch.bool"}
 _BOOLEAN_SCALAR_TYPES = (bool, np.bool_)
+_COMPLEX_SCALAR_TYPES = (complex, np.complexfloating)
 
 
 def _reject_boolean_array(value, name: str) -> None:
@@ -22,6 +23,26 @@ def _reject_boolean_array(value, name: str) -> None:
             raise ValueError(f"{name} must contain real angles, not boolean values.")
 
 
+def _reject_complex_array(value, name: str) -> None:
+    if isinstance(value, _COMPLEX_SCALAR_TYPES):
+        raise ValueError(f"{name} must contain real angles, not complex values.")
+
+    dtype = getattr(value, "dtype", None)
+    dtype_kind = getattr(dtype, "kind", None)
+    dtype_name = "" if dtype is None else str(dtype).lower()
+    if dtype_kind == "c" or "complex" in dtype_name:
+        raise ValueError(f"{name} must contain real angles, not complex values.")
+
+    if dtype is not None and dtype_kind != "O" and dtype_name != "object":
+        return
+    try:
+        object_values = np.asarray(value, dtype=object).reshape(-1)
+    except (TypeError, ValueError, RuntimeError):
+        return
+    if any(isinstance(item, _COMPLEX_SCALAR_TYPES) for item in object_values):
+        raise ValueError(f"{name} must contain real angles, not complex values.")
+
+
 def as_shift_vector(shift_by, dim: int, *, name: str = "shift_by"):
     """Return ``shift_by`` as a one-dimensional backend vector of length ``dim``.
 
@@ -30,8 +51,10 @@ def as_shift_vector(shift_by, dim: int, *, name: str = "shift_by"):
     shape validation is performed.
     """
     _reject_boolean_array(shift_by, name)
+    _reject_complex_array(shift_by, name)
     shift_by = array(shift_by)
     _reject_boolean_array(shift_by, name)
+    _reject_complex_array(shift_by, name)
     if shift_by.ndim == 0:
         if dim != 1:
             raise ValueError(f"{name} must have shape ({dim},), got scalar.")
@@ -50,8 +73,10 @@ def as_hypertoroidal_points(xs, dim: int, *, name: str = "xs"):
     ``dim`` is treated as a single query point.
     """
     _reject_boolean_array(xs, name)
+    _reject_complex_array(xs, name)
     xs = array(xs)
     _reject_boolean_array(xs, name)
+    _reject_complex_array(xs, name)
     if xs.ndim == 0:
         if dim != 1:
             raise ValueError(f"{name} must have trailing dimension {dim}, got scalar.")

--- a/tests/distributions/test_hypertoroidal_complex_input_validation.py
+++ b/tests/distributions/test_hypertoroidal_complex_input_validation.py
@@ -1,0 +1,45 @@
+import numpy as np
+import pytest
+
+from pyrecest.distributions.hypertorus._input_validation import (
+    as_hypertoroidal_points,
+    as_shift_vector,
+)
+from pyrecest.distributions.hypertorus.hypertoroidal_wrapped_normal_distribution import (
+    HypertoroidalWrappedNormalDistribution,
+)
+
+
+@pytest.mark.parametrize(
+    ("value", "dim"),
+    [
+        (0.25 + 0.5j, 1),
+        ([0.25 + 0.5j], 1),
+        ([0.0, 0.25 + 0.5j], 2),
+        (np.array([0.0, 0.25 + 0.5j], dtype=object), 2),
+    ],
+)
+def test_shift_vector_rejects_complex_angles(value, dim):
+    with pytest.raises(ValueError, match="complex"):
+        as_shift_vector(value, dim)
+
+
+@pytest.mark.parametrize(
+    ("value", "dim"),
+    [
+        (0.25 + 0.5j, 1),
+        ([0.25 + 0.5j], 1),
+        ([0.0, 0.25 + 0.5j], 2),
+        (np.array([[0.0, 0.25 + 0.5j]], dtype=object), 2),
+    ],
+)
+def test_hypertoroidal_points_reject_complex_angles(value, dim):
+    with pytest.raises(ValueError, match="complex"):
+        as_hypertoroidal_points(value, dim)
+
+
+def test_wrapped_normal_pdf_rejects_complex_queries_before_wrapping():
+    distribution = HypertoroidalWrappedNormalDistribution([0.0], [[1.0]])
+
+    with pytest.raises(ValueError, match="complex"):
+        distribution.pdf([0.25 + 0.5j])


### PR DESCRIPTION
## Summary

- reject complex hypertoroidal shift vectors and evaluation points during shared input normalization
- cover Python complex scalars, complex sequences, backend complex dtypes, and object arrays containing complex values
- add a public wrapped-normal PDF regression that verifies validation happens before angle wrapping

## Bug

The shared hypertoroidal input helpers document real-valued angles but only rejected boolean arrays. Complex values therefore passed shape validation. In `HypertoroidalWrappedNormalDistribution.pdf()`, they subsequently reached modulo-based angle wrapping and failed with a backend-dependent arithmetic error such as NumPy's `TypeError` from the remainder ufunc.

## Fix

Detect complex scalar values, NumPy-style complex dtype kinds, backend dtype names containing `complex`, and object arrays containing complex entries before and after backend array conversion. Invalid callers now receive a stable, descriptive `ValueError` at the input boundary. Existing boolean and shape validation is unchanged.

## Validation

- reproduced the pre-fix behavior: `[0.25 + 0.5j]` passes shape normalization and later fails in modulo wrapping
- isolated focused helper suite: `9 passed`
- verified scalar/vector real inputs preserve their existing normalized shapes
- Python compilation passed for the modified helper and focused test reconstruction
- branch comparison: two commits ahead of `main`, zero behind; one production file and one regression file changed

The full backend matrix is delegated to GitHub Actions.