### PR TITLE
Reject non-real wrapped Laplace rate parameters

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_laplace_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_laplace_distribution.py
@@ -1,7 +1,8 @@
 # pylint: disable=no-name-in-module,no-member
 from numbers import Integral
 
-from pyrecest.backend import all, asarray, exp, isfinite, mod, ndim, pi
+import numpy as np
+from pyrecest.backend import all, asarray, exp, isfinite, mod, ndim, pi, to_numpy
 
 from .abstract_circular_distribution import AbstractCircularDistribution
 
@@ -10,9 +11,14 @@ _SMALL_RATE_SERIES_THRESHOLD = 1e-4
 
 
 def _validate_positive_scalar(value, name):
-    value = asarray(value)
-    if value.shape not in ((), (1,)):
-        raise ValueError(f"{name} must be a positive scalar.")
+    message = f"{name} must be a positive real scalar."
+    try:
+        value = asarray(value)
+        numpy_value = np.asarray(to_numpy(value))
+    except (TypeError, ValueError, RuntimeError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if numpy_value.shape not in ((), (1,)) or numpy_value.dtype.kind not in "iuf":
+        raise ValueError(message)
     if not bool(all(isfinite(value))):
         raise ValueError(f"{name} must be finite.")
     if not bool(all(value > 0.0)):

--- a/tests/distributions/test_wrapped_laplace_real_parameters.py
+++ b/tests/distributions/test_wrapped_laplace_real_parameters.py
@@ -1,0 +1,17 @@
+import pytest
+
+from pyrecest.distributions.circle.wrapped_laplace_distribution import (
+    WrappedLaplaceDistribution,
+)
+
+
+@pytest.mark.parametrize("parameter_name", ["lambda_", "kappa_"])
+@pytest.mark.parametrize("invalid_value", [True, 1.0 + 1.0j])
+def test_wrapped_laplace_rejects_non_real_rate_parameters(
+    parameter_name, invalid_value
+):
+    parameters = {"lambda_": 2.0, "kappa_": 1.3}
+    parameters[parameter_name] = invalid_value
+
+    with pytest.raises(ValueError, match=parameter_name):
+        WrappedLaplaceDistribution(**parameters)


### PR DESCRIPTION
## Summary

- reject boolean and complex `lambda_` / `kappa_` inputs in `WrappedLaplaceDistribution`
- normalize conversion failures to a parameter-specific `ValueError`
- preserve accepted Python and backend real scalar forms, including one-element arrays
- add focused regression coverage for both constructor parameters

## Root cause

`_validate_positive_scalar()` converted inputs with the active backend and then checked only shape, finiteness, and `value > 0`. NumPy considers some complex values greater than zero (for example, `np.asarray(1 + 1j) > 0` is true), and booleans also satisfy the positive-value check. The constructor could therefore accept non-real rate parameters and produce a complex-valued distribution even though `lambda_` and `kappa_` are documented as positive rates.

## Fix

Inspect the backend value through `to_numpy()` before the arithmetic checks and require a real integer, unsigned-integer, or floating dtype. Complex, boolean, textual, temporal, and other non-real values now fail with a descriptive `ValueError`. Existing finite and positivity validation remains unchanged.

## Validation

- reproduced the pre-fix acceptance of `True`, `1 + 1j`, and one-element complex arrays
- verified the patched dtype guard rejects those inputs while retaining real Python scalars and one-element real arrays
- `python -m py_compile` passes for the modified module and new regression test
- branch comparison: two commits ahead, zero behind; only the wrapped-Laplace validator and focused regression are changed

The full backend matrix is delegated to GitHub Actions.