### PR TITLE
Stabilize sliding-window smoother weights

### DIFF
--- a/src/pyrecest/smoothers/sliding_window_manifold_mean_smoother.py
+++ b/src/pyrecest/smoothers/sliding_window_manifold_mean_smoother.py
@@ -6,8 +6,17 @@ from collections.abc import Callable, Sequence
 from functools import partial
 from operator import index as operator_index
 
+from pyrecest.backend import all as backend_all
 from pyrecest.backend import any as backend_any
-from pyrecest.backend import asarray, concatenate, ndim, stack, sum
+from pyrecest.backend import (
+    asarray,
+    concatenate,
+    isfinite,
+    max as backend_max,
+    ndim,
+    stack,
+    sum,
+)
 from pyrecest.distributions import (
     AbstractHypercylindricalDistribution,
     AbstractHyperhemisphericalDistribution,
@@ -92,10 +101,14 @@ class SlidingWindowManifoldMeanSmoother(AbstractSmoother):
             self.window_weights = asarray(window_weights).reshape(-1)
             if self.window_weights.shape[0] != self.window_size:
                 raise ValueError("window_weights must have length window_size.")
-            if backend_any(self.window_weights < 0):
+            if not bool(backend_all(isfinite(self.window_weights))):
+                raise ValueError("window_weights must be finite.")
+            if bool(backend_any(self.window_weights < 0)):
                 raise ValueError("window_weights must be non-negative.")
-            if sum(self.window_weights) <= 0:
+            weight_scale = backend_max(self.window_weights)
+            if not bool(weight_scale > 0):
                 raise ValueError("window_weights must contain a positive weight.")
+            self.window_weights = self.window_weights / weight_scale
 
     @staticmethod
     def _as_vector(value):

--- a/tests/smoothers/test_sliding_window_manifold_mean_smoother.py
+++ b/tests/smoothers/test_sliding_window_manifold_mean_smoother.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 import numpy.testing as npt
-from pyrecest.backend import array, pi
+from pyrecest.backend import array, pi, to_numpy
 from pyrecest.distributions import CircularDiracDistribution, VonMisesDistribution
 from pyrecest.smoothers import SlidingWindowManifoldMeanSmoother
 
@@ -90,6 +90,20 @@ class SlidingWindowManifoldMeanSmootherTest(unittest.TestCase):
         npt.assert_allclose(smoothed_values[0], array([2.0 / 3.0]))
         npt.assert_allclose(smoothed_values[1], array([2.0]))
         npt.assert_allclose(smoothed_values[2], array([10.0 / 3.0]))
+
+    def test_window_weights_preserve_extreme_finite_ratios(self):
+        backend_dtype = to_numpy(array([1.0])).dtype
+        largest = np.finfo(backend_dtype).max
+        smoother = SlidingWindowManifoldMeanSmoother(
+            window_size=2,
+            alignment="trailing",
+            window_weights=array([largest, largest / 2.0]),
+        )
+
+        smoothed_values = smoother.smooth([array([0.0]), array([3.0])])
+
+        npt.assert_allclose(smoothed_values[0], array([0.0]))
+        npt.assert_allclose(smoothed_values[1], array([1.0]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- validate smoothing window weights are finite before use
- scale finite nonnegative weights by their largest entry during construction
- preserve relative weights when a direct floating-point sum would overflow
- add a backend-aware regression through the public sliding-window smoother API

## Root cause

`SlidingWindowManifoldMeanSmoother` stored raw `window_weights` and summed them directly both during construction and for each active edge window. Individually finite weights can still have an infinite sum. For example, `[finfo.max, finfo.max / 2]` has the well-defined ratio `2:1`, but direct normalization produces `[0, 0]`. The subsequent Dirac distribution then rejects the zero-mass weights instead of returning the weighted manifold mean.

## Fix

After shape, finiteness, nonnegativity, and positive-mass validation, scale the complete weight vector by its largest entry. The stored values are bounded by one and preserve the original ratios, so all later truncated-window sums remain finite and can be normalized safely.

## Validation

- reproduced the pre-fix overflow: maximum finite weights sum to `inf` and direct normalization collapses to zero
- verified scale-first normalization preserves the expected `2/3, 1/3` ratio
- added a trailing-window regression where states `[0, 3]` smooth to `1` under extreme `2:1` weights
- compared the branch with `main`: two commits ahead, zero behind; only the smoother implementation and its existing test module changed

The full backend and lint matrix is delegated to GitHub Actions.