### PR TITLE
Validate and copy cost adjustment result matrices

### DIFF
--- a/src/pyrecest/utils/cost_matrix_adjustments.py
+++ b/src/pyrecest/utils/cost_matrix_adjustments.py
@@ -41,6 +41,11 @@ class CostMatrixAdjustmentResult:
     def __post_init__(self) -> None:
         object.__setattr__(
             self,
+            "adjusted_cost_matrix",
+            _as_cost_matrix(self.adjusted_cost_matrix).copy(),
+        )
+        object.__setattr__(
+            self,
             "diagnostics",
             _metadata_dict(self.diagnostics, name="diagnostics"),
         )

--- a/tests/test_cost_matrix_adjustment_result_validation.py
+++ b/tests/test_cost_matrix_adjustment_result_validation.py
@@ -1,0 +1,34 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+from pyrecest.utils.cost_matrix_adjustments import CostMatrixAdjustmentResult
+
+
+class TestCostMatrixAdjustmentResultValidation(unittest.TestCase):
+    def test_result_takes_ownership_of_adjusted_matrix(self):
+        matrix = np.array([[1.0, 2.0]], dtype=float)
+
+        result = CostMatrixAdjustmentResult(matrix)
+        matrix[:] = -7.0
+
+        npt.assert_allclose(result.adjusted_cost_matrix, np.array([[1.0, 2.0]]))
+
+    def test_result_rejects_invalid_direct_construction(self):
+        invalid_matrices = (
+            np.array([1.0, 2.0]),
+            np.array([[np.nan]]),
+            np.array([[-np.inf]]),
+            np.array([[True]]),
+            np.array([[1.0 + 0.0j]]),
+        )
+
+        for matrix in invalid_matrices:
+            with self.subTest(matrix=matrix):
+                with self.assertRaises(ValueError):
+                    CostMatrixAdjustmentResult(matrix)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- validate `CostMatrixAdjustmentResult.adjusted_cost_matrix` during direct construction
- copy the validated matrix into result-owned storage
- add focused regressions for caller-side mutation and invalid direct inputs

## Root cause

`CostMatrixAdjustmentResult` is a frozen dataclass, but its `__post_init__()` only normalized diagnostics. The matrix field was stored exactly as supplied. A caller-owned NumPy array could therefore be mutated after construction and silently change an existing result. Direct construction also bypassed the cost-matrix validation used by the adjustment application helpers, allowing one-dimensional, NaN, negative-infinity, boolean, or complex matrices into the public result container.

## Fix

Normalize the matrix through the existing `_as_cost_matrix()` validation path and store an owned copy in `__post_init__()`. This aligns direct construction with matrices returned through `apply_cost_matrix_adjustment()` while preserving valid positive-infinity entries.

## Validation

- reproduced caller-side mutation of the stored matrix before the fix
- verified the result remains unchanged after mutating the original array
- verified invalid direct constructions now raise `ValueError`
- isolated focused validation passed locally
- branch is two commits ahead of `main`, zero behind, and changes only the result container plus one regression file

The full repository test matrix is delegated to GitHub Actions.