### PR TITLE
Stabilize sliding-window manifold weights

### DIFF
--- a/src/pyrecest/smoothers/sliding_window_manifold_mean_smoother.py
+++ b/src/pyrecest/smoothers/sliding_window_manifold_mean_smoother.py
@@ -6,8 +6,17 @@ from collections.abc import Callable, Sequence
 from functools import partial
 from operator import index as operator_index
 
+from pyrecest.backend import all as backend_all
 from pyrecest.backend import any as backend_any
-from pyrecest.backend import asarray, concatenate, ndim, stack, sum
+from pyrecest.backend import (
+    asarray,
+    concatenate,
+    isfinite,
+    max as backend_max,
+    ndim,
+    stack,
+    sum,
+)
 from pyrecest.distributions import (
     AbstractHypercylindricalDistribution,
     AbstractHyperhemisphericalDistribution,
@@ -92,9 +101,11 @@ class SlidingWindowManifoldMeanSmoother(AbstractSmoother):
             self.window_weights = asarray(window_weights).reshape(-1)
             if self.window_weights.shape[0] != self.window_size:
                 raise ValueError("window_weights must have length window_size.")
+            if not backend_all(isfinite(self.window_weights)):
+                raise ValueError("window_weights must be finite.")
             if backend_any(self.window_weights < 0):
                 raise ValueError("window_weights must be non-negative.")
-            if sum(self.window_weights) <= 0:
+            if backend_max(self.window_weights) <= 0:
                 raise ValueError("window_weights must contain a positive weight.")
 
     @staticmethod
@@ -138,10 +149,11 @@ class SlidingWindowManifoldMeanSmoother(AbstractSmoother):
             return None
 
         weights = self.window_weights[weight_start:weight_end]
-        weights_sum = sum(weights)
-        if weights_sum <= 0:
+        weight_scale = backend_max(weights)
+        if weight_scale <= 0:
             raise ValueError("At least one active window weight must be positive.")
-        return weights / weights_sum
+        scaled_weights = weights / weight_scale
+        return scaled_weights / sum(scaled_weights)
 
     @staticmethod
     def _circular_dirac_factory(points, weights):
@@ -198,5 +210,4 @@ class SlidingWindowManifoldMeanSmoother(AbstractSmoother):
             window_weights = self._weights_for_window(weight_start, weight_end)
             window_distribution = distribution_factory(window_values, window_weights)
             smoothed_values.append(self._as_vector(window_distribution.mean()))
-
         return smoothed_values

--- a/src/pyrecest/smoothers/sliding_window_manifold_mean_smoother.py
+++ b/src/pyrecest/smoothers/sliding_window_manifold_mean_smoother.py
@@ -14,6 +14,7 @@ from pyrecest.backend import (
     isfinite,
     max as backend_max,
     ndim,
+    sqrt,
     stack,
     sum,
 )
@@ -152,7 +153,12 @@ class SlidingWindowManifoldMeanSmoother(AbstractSmoother):
         weight_scale = backend_max(weights)
         if weight_scale <= 0:
             raise ValueError("At least one active window weight must be positive.")
-        scaled_weights = weights / weight_scale
+
+        # JAX/XLA can lower division by a maximum finite float through a reciprocal
+        # that underflows to zero. Two square-root-sized divisions keep both
+        # divisors representable while retaining the original weight ratios.
+        weight_scale_root = sqrt(weight_scale)
+        scaled_weights = (weights / weight_scale_root) / weight_scale_root
         return scaled_weights / sum(scaled_weights)
 
     @staticmethod

--- a/tests/smoothers/test_sliding_window_weight_stability.py
+++ b/tests/smoothers/test_sliding_window_weight_stability.py
@@ -1,0 +1,40 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+from pyrecest.backend import array, to_numpy
+from pyrecest.smoothers import SlidingWindowManifoldMeanSmoother
+
+
+class SlidingWindowWeightStabilityTest(unittest.TestCase):
+    def test_rejects_nonfinite_window_weights(self):
+        for invalid_weight in (float("nan"), float("inf"), -float("inf")):
+            with self.subTest(invalid_weight=invalid_weight), self.assertRaisesRegex(
+                ValueError, "finite"
+            ):
+                SlidingWindowManifoldMeanSmoother(
+                    window_size=2,
+                    window_weights=array([1.0, invalid_weight]),
+                )
+
+    def test_extreme_finite_window_weights_preserve_relative_mass(self):
+        backend_dtype = to_numpy(array([1.0])).dtype
+        max_finite = np.finfo(backend_dtype).max
+        smoother = SlidingWindowManifoldMeanSmoother(
+            window_size=2,
+            window_weights=array([max_finite, max_finite / 2.0]),
+            alignment="trailing",
+        )
+
+        smoothed = smoother.smooth([array([0.0]), array([3.0])])
+
+        npt.assert_allclose(to_numpy(smoothed[0]), [0.0])
+        npt.assert_allclose(to_numpy(smoothed[1]), [1.0])
+        npt.assert_allclose(
+            to_numpy(smoother._weights_for_window(0, 2)),
+            [2.0 / 3.0, 1.0 / 3.0],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- reject non-finite `window_weights` during `SlidingWindowManifoldMeanSmoother` construction
- normalize each active window without overflowing its sum
- avoid JAX/XLA reciprocal underflow for maximum finite weights
- preserve relative weights and add end-to-end regression coverage through `smooth()`

## Root cause

The original implementation normalized weights directly with:

```python
weights / sum(weights)
```

For individually finite values such as `[max_float, max_float / 2]`, the sum overflows. The first stabilization attempt instead used:

```python
weights / max(weights)
```

That works with NumPy, PyTorch, and older JAX versions, but the CI-pinned JAX 0.10.2 lowers division by `float32.max` through reciprocal multiplication. The reciprocal underflows to zero, so both scaled weights become zero and the subsequent normalization produces NaNs. All three JAX matrix jobs failed when the downstream Dirac distribution rejected those non-finite weights; NumPy and PyTorch remained green.

## Fix

Validate that every configured weight is finite. For each active window, divide twice by the square root of its largest positive weight before normalizing:

```python
scale_root = sqrt(max(weights))
scaled = (weights / scale_root) / scale_root
normalized = scaled / sum(scaled)
```

Each divisor remains representable, avoiding JAX's extreme reciprocal underflow while retaining the original weight ratios.

## Validation

- reproduced the failure with the CI-pinned JAX 0.10.2: `[max_float, max_float / 2] / max_float` became `[0, 0]`
- verified the two-step scaling on JAX 0.10.2, NumPy, PyTorch, and JAX 0.9
- verified maximum finite 2:1 weights normalize to approximately `[2/3, 1/3]`
- verified trailing-window smoothing of `[0, 3]` returns approximately `[0, 1]`
- verified NaN and infinities are rejected

The full GitHub Actions matrix is running on the updated branch.