### PR TITLE
Use covariance weights in hyperspherical arbitrary-noise prediction

### DIFF
--- a/src/pyrecest/filters/hyperspherical_ukf.py
+++ b/src/pyrecest/filters/hyperspherical_ukf.py
@@ -213,13 +213,15 @@ class HypersphericalUKF(AbstractFilter, HypersphericalFilterMixin):
 
         points = self._make_sigma_points(dim_x)
         sigmas = points.sigma_points(mu, C)  # shape: (2*dim_x+1, dim_x)
-        state_weights = asarray(points.Wm, dtype=float64)
+        state_mean_weights = asarray(points.Wm, dtype=float64)
+        state_covariance_weights = asarray(points.Wc, dtype=float64)
 
         n_sigmas = sigmas.shape[0]
         n_noise = noise_samples.shape[1]
 
         new_samples = empty((dim_x, n_sigmas * n_noise))
-        new_weights = empty((n_sigmas * n_noise,))
+        new_mean_weights = empty((n_sigmas * n_noise,))
+        new_covariance_weights = empty((n_sigmas * n_noise,))
         k = 0
         for i in range(n_sigmas):
             for j in range(n_noise):
@@ -232,14 +234,20 @@ class HypersphericalUKF(AbstractFilter, HypersphericalFilterMixin):
                 )
                 x_new = self._normalize(x_new)
                 new_samples[:, k] = x_new
-                new_weights[k] = noise_weights[j] * state_weights[i]
+                new_mean_weights[k] = noise_weights[j] * state_mean_weights[i]
+                new_covariance_weights[k] = (
+                    noise_weights[j] * state_covariance_weights[i]
+                )
                 k += 1
-        new_weights = new_weights / new_weights.sum()
+        new_mean_weights = new_mean_weights / new_mean_weights.sum()
 
-        # Weighted mean and covariance
-        predicted_mean = (new_samples * expand_dims(new_weights, 0)).sum(axis=1)
+        # Wc includes Merwe's central covariance correction and therefore does
+        # not generally sum to one. Only the mean weights are normalized.
+        predicted_mean = (new_samples * expand_dims(new_mean_weights, 0)).sum(axis=1)
         diff = new_samples - expand_dims(predicted_mean, -1)
-        predicted_cov = (diff * expand_dims(new_weights, 0)) @ diff.T
+        predicted_cov = (
+            diff * expand_dims(new_covariance_weights, 0)
+        ) @ diff.T
 
         predicted_mean = self._normalize(predicted_mean)
         self._filter_state = GaussianDistribution(

--- a/tests/filters/test_hyperspherical_ukf_covariance_weights.py
+++ b/tests/filters/test_hyperspherical_ukf_covariance_weights.py
@@ -1,0 +1,67 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+import pyrecest.backend
+from pyrecest.backend import array
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.filters.hyperspherical_ukf import HypersphericalUKF
+from pyrecest.sampling.sigma_points import MerweScaledSigmaPoints
+
+
+class HypersphericalUKFCovarianceWeightsTest(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Arbitrary-noise hyperspherical prediction is not supported on this backend",
+    )
+    def test_arbitrary_noise_prediction_uses_covariance_weights(self):
+        alpha = 0.5
+        beta = 2.0
+        kappa = 0.0
+        mean = np.array([1.0, 0.0])
+        covariance = np.diag([0.04, 0.09])
+
+        filter_ = HypersphericalUKF(
+            dim=2,
+            alpha=alpha,
+            beta=beta,
+            kappa=kappa,
+        )
+        filter_.filter_state = GaussianDistribution(array(mean), array(covariance))
+        filter_.predict_nonlinear_arbitrary_noise(
+            lambda state, _noise: state,
+            array([[0.0]]),
+            array([1.0]),
+        )
+
+        points = MerweScaledSigmaPoints(
+            n=2,
+            alpha=alpha,
+            beta=beta,
+            kappa=kappa,
+        )
+        sigma_points = np.asarray(points.sigma_points(mean, covariance), dtype=float)
+        transformed = sigma_points / np.linalg.norm(
+            sigma_points,
+            axis=1,
+            keepdims=True,
+        )
+        mean_weights = np.asarray(points.Wm, dtype=float)
+        covariance_weights = np.asarray(points.Wc, dtype=float)
+        transformed_mean = mean_weights @ transformed
+        residuals = transformed - transformed_mean
+        expected_covariance = np.einsum(
+            "i,ij,ik->jk",
+            covariance_weights,
+            residuals,
+            residuals,
+        )
+
+        actual_covariance = np.asarray(filter_.filter_state.C, dtype=float)
+        npt.assert_allclose(actual_covariance, expected_covariance, atol=1e-12)
+        self.assertGreater(actual_covariance[0, 0], 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- use Merwe covariance weights (`Wc`) when computing covariance in `HypersphericalUKF.predict_nonlinear_arbitrary_noise()`
- keep the probability-normalized `Wm` product weights for the predicted mean
- add a focused regression that compares against the explicit unscented-transform covariance

## Root cause

The arbitrary-noise path constructed one Cartesian-product weight vector from `points.Wm` and reused it for both the mean and covariance. Merwe sigma points define separate mean and covariance weights; the central covariance weight includes the `1 - alpha^2 + beta` correction. Reusing `Wm` therefore ignored `beta` entirely and could produce a negative diagonal covariance entry for a valid positive-definite prior.

## Impact

Arbitrary-noise hyperspherical predictions now preserve the intended scaled-unscented-transform covariance. The reproduced two-dimensional identity case changes the first predicted variance from approximately `-9.48e-4` to the correct positive value `4.26e-3`.

## Validation

- added `tests/filters/test_hyperspherical_ukf_covariance_weights.py`
- ran the regression against a main-equivalent method: failed with the incorrect negative variance
- ran the same regression against the patched method: `1 passed`
- compiled the patched module and regression with `python -m py_compile`
- ran `ruff check --select F821,F822,F823` on both changed Python files: passed
- GitHub Actions matrix is queued for the draft PR
