### PR TITLE
Reject complex object sigma-point inputs

### DIFF
--- a/src/pyrecest/sampling/sigma_points.py
+++ b/src/pyrecest/sampling/sigma_points.py
@@ -23,21 +23,34 @@ from pyrecest.backend import (
 )
 
 _TEXT_SCALAR_TYPES = (str, bytes, np.str_, np.bytes_)
+_COMPLEX_SCALAR_TYPES = (complex, np.complexfloating)
 
 
 def _has_complex_dtype(value) -> bool:
-    """Return whether *value* has a complex-valued array dtype."""
+    """Return whether *value* contains complex-valued array entries."""
 
     dtype = getattr(value, "dtype", None)
     if dtype is not None:
         try:
-            return np.dtype(dtype).kind == "c"
+            dtype_kind = np.dtype(dtype).kind
         except (TypeError, ValueError):
             return "complex" in str(dtype).lower()
+        if dtype_kind == "c":
+            return True
+        if dtype_kind != "O":
+            return False
+
     try:
-        return np.asarray(value).dtype.kind == "c"
+        value_array = np.asarray(value)
     except (TypeError, ValueError):
         return False
+    if value_array.dtype.kind == "c":
+        return True
+    if value_array.dtype.kind != "O":
+        return False
+    return any(
+        isinstance(item, _COMPLEX_SCALAR_TYPES) for item in value_array.reshape(-1)
+    )
 
 
 def _scalar_item(value, name: str):

--- a/tests/test_sigma_points_object_complex_inputs.py
+++ b/tests/test_sigma_points_object_complex_inputs.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pytest
+
+from pyrecest.sampling import JulierSigmaPoints, MerweScaledSigmaPoints
+
+
+@pytest.mark.parametrize(
+    "points",
+    [
+        JulierSigmaPoints(n=2, kappa=1.0),
+        MerweScaledSigmaPoints(n=2, alpha=0.5, beta=2.0, kappa=0.0),
+    ],
+    ids=["julier", "merwe"],
+)
+def test_sigma_points_reject_object_array_with_complex_state(points):
+    mean = np.array([0.0 + 1.0j, 1.0], dtype=object)
+
+    with pytest.raises(ValueError, match="x must contain real values"):
+        points.sigma_points(mean, np.eye(2))
+
+
+@pytest.mark.parametrize(
+    "points",
+    [
+        JulierSigmaPoints(n=2, kappa=1.0),
+        MerweScaledSigmaPoints(n=2, alpha=0.5, beta=2.0, kappa=0.0),
+    ],
+    ids=["julier", "merwe"],
+)
+def test_sigma_points_reject_object_array_with_complex_covariance(points):
+    covariance = np.array(
+        [[1.0 + 0.0j, 0.0], [0.0, 1.0]],
+        dtype=object,
+    )
+
+    with pytest.raises(ValueError, match="P must contain real values"):
+        points.sigma_points(np.zeros(2), covariance)


### PR DESCRIPTION
## Summary

- detect complex entries hidden inside NumPy object-dtype arrays before backend conversion
- preserve the existing `ValueError` contract for complex sigma-point means and covariances
- retain support for real-valued object arrays
- add focused regressions for both Julier and Merwe sigma-point schemes

## Root cause

`_has_complex_dtype()` only inspected the array dtype. A normal complex array has dtype kind `c`, but an object array such as `np.array([1 + 1j, 0], dtype=object)` has dtype kind `O`. The guard therefore returned false, and the subsequent conversion to `float64` leaked a backend `TypeError` instead of the documented input-validation `ValueError`.

## Fix

For object-dtype inputs, inspect the flattened entries for Python or NumPy complex scalar types. Native complex dtypes and backend dtypes whose names contain `complex` keep their existing fast path; non-object real dtypes remain unchanged.

## Impact

Sigma-point callers now receive consistent, parameter-specific validation errors regardless of whether complex values arrive in native complex arrays or object arrays. Valid real object arrays continue to work.

## Validation

- reproduced the pre-fix `TypeError` for object-dtype complex means and covariances
- verified the patched path raises `ValueError` with `x must contain real values` or `P must contain real values`
- verified both `JulierSigmaPoints` and `MerweScaledSigmaPoints`
- verified real-valued object arrays still generate sigma points
- `python -m py_compile` passes for the modified module
- branch comparison: two commits ahead, zero behind; only the sampler and focused regression file changed

The full backend matrix is delegated to GitHub Actions.