### PR TITLE
Validate sensor model state vectors

### DIFF
--- a/src/pyrecest/models/__init__.py
+++ b/src/pyrecest/models/__init__.py
@@ -6,6 +6,7 @@ and capability-oriented so filters can opt into the pieces they need.
 
 from ._sampleable_transition_validation import install_sampleable_transition_validation
 from ._validated_motion_models import nearly_coordinated_turn_model
+from ._validated_sensor_models import install_sensor_state_validation
 from .adapters import (
     LinearMeasurementArguments,
     LinearTransitionArguments,
@@ -39,6 +40,7 @@ from .likelihood import (
 )
 
 install_sampleable_transition_validation()
+install_sensor_state_validation()
 
 from .linear_gaussian import (
     IdentityGaussianMeasurementModel,

--- a/src/pyrecest/models/_validated_sensor_models.py
+++ b/src/pyrecest/models/_validated_sensor_models.py
@@ -1,0 +1,28 @@
+"""Validated wrappers for sensor-model state inputs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from . import sensor_models as _sensor_models
+
+_state_vector_impl = _sensor_models._state_vector  # pylint: disable=protected-access
+
+
+def _validated_state_vector(state: Any):
+    """Return a backend state vector after validating its rank."""
+    try:
+        state_vector = _state_vector_impl(state)
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise ValueError("state must be a one-dimensional array") from exc
+    if len(tuple(state_vector.shape)) != 1:
+        raise ValueError("state must be a one-dimensional array")
+    return state_vector
+
+
+def install_sensor_state_validation() -> None:
+    """Install shared rank validation for sensor-model state inputs."""
+    _sensor_models._state_vector = _validated_state_vector  # pylint: disable=protected-access
+
+
+__all__ = ["install_sensor_state_validation"]

--- a/tests/models/test_sensor_state_validation.py
+++ b/tests/models/test_sensor_state_validation.py
@@ -1,0 +1,38 @@
+"""Regression tests for sensor-model state rank validation."""
+
+import unittest
+
+import numpy as np
+from pyrecest.models import range_bearing_measurement
+from pyrecest.models.sensor_models import (
+    range_bearing_measurement as module_range_bearing_measurement,
+)
+
+
+class TestSensorStateValidation(unittest.TestCase):
+    def test_rejects_nonvector_states_with_clear_value_error(self):
+        measurement_functions = (
+            range_bearing_measurement,
+            module_range_bearing_measurement,
+        )
+        invalid_states = (
+            np.asarray(1.0),
+            np.asarray([[3.0, 4.0, 0.0, 0.0]]),
+            np.asarray([[3.0], [4.0], [0.0], [0.0]]),
+        )
+
+        for measurement_function in measurement_functions:
+            for state in invalid_states:
+                with self.subTest(
+                    function=measurement_function.__module__,
+                    shape=state.shape,
+                ):
+                    with self.assertRaisesRegex(
+                        ValueError,
+                        "state must be a one-dimensional array",
+                    ):
+                        measurement_function(state)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- validate sensor-model state inputs as one-dimensional arrays before indexing
- normalize backend conversion failures to a clear `ValueError`
- apply the validation to both package-level and direct module imports
- add regressions for scalar, row-matrix, and column-matrix states

## Root cause

The shared sensor-model `_state_vector()` helper only converted the input through the active backend. Callers immediately accessed `state.shape[0]`, so a scalar state leaked `IndexError: tuple index out of range`. Matrix-shaped states progressed further and failed with misleading errors about indices or scalar ranges, and some measurement paths could broadcast them incorrectly.

## Impact

Invalid state ranks now fail at the public sensor-model boundary with a stable, actionable `ValueError` instead of backend- and code-path-dependent failures.

## Validation

- reproduced the scalar-state `IndexError` on the previous implementation
- exercised package-level and direct-module imports with valid vectors
- verified scalar, row-matrix, and column-matrix inputs all raise the new validation error
- compiled the new validation module successfully

GitHub Actions will provide the full repository test matrix.