### PR TITLE
Reject non-finite OOSM lag windows

### DIFF
--- a/src/pyrecest/filters/out_of_sequence.py
+++ b/src/pyrecest/filters/out_of_sequence.py
@@ -35,6 +35,18 @@ def _coerce_time(time):
     return time
 
 
+def _coerce_optional_max_lag(max_lag):
+    if max_lag is None:
+        return None
+    try:
+        max_lag = float(max_lag)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError("max_lag must be finite and nonnegative or None") from exc
+    if not isfinite(max_lag) or max_lag < 0.0:
+        raise ValueError("max_lag must be finite and nonnegative or None")
+    return max_lag
+
+
 def _coerce_bool_flag(value, name):
     if isinstance(value, bool):
         return value
@@ -115,9 +127,7 @@ class FixedLagBuffer:
     """
 
     def __init__(self, max_lag=None, maxlen=None, *, copy_values=True):
-        self.max_lag = None if max_lag is None else float(max_lag)
-        if self.max_lag is not None and self.max_lag < 0.0:
-            raise ValueError("max_lag must be nonnegative or None")
+        self.max_lag = _coerce_optional_max_lag(max_lag)
         self.maxlen = None if maxlen is None else int(maxlen)
         if self.maxlen is not None and self.maxlen <= 0:
             raise ValueError("maxlen must be positive or None")
@@ -311,9 +321,7 @@ class _EventReplayMixin:
         self._filter_object = filter_object
         self._initial_time = _coerce_time(initial_time)
         self._latest_time = self._initial_time
-        self.max_lag = None if max_lag is None else float(max_lag)
-        if self.max_lag is not None and self.max_lag < 0.0:
-            raise ValueError("max_lag must be nonnegative or None")
+        self.max_lag = _coerce_optional_max_lag(max_lag)
         self._initial_state = _safe_deepcopy(self._filter_object.filter_state)
         self._events = []
         self._next_sequence = 0

--- a/tests/filters/test_out_of_sequence_max_lag_validation.py
+++ b/tests/filters/test_out_of_sequence_max_lag_validation.py
@@ -1,0 +1,37 @@
+import unittest
+
+from pyrecest.filters import (
+    FixedLagBuffer,
+    MeasurementTimeBuffer,
+    OutOfSequenceParticleUpdater,
+)
+
+
+class _DummyParticleFilter:
+    def __init__(self):
+        self.filter_state = {"updates": 0}
+
+
+class OutOfSequenceMaxLagValidationTest(unittest.TestCase):
+    def test_rejects_nonfinite_max_lag_across_public_entry_points(self):
+        constructors = {
+            "fixed_lag_buffer": lambda max_lag: FixedLagBuffer(max_lag=max_lag),
+            "measurement_time_buffer": lambda max_lag: MeasurementTimeBuffer(
+                max_lag=max_lag
+            ),
+            "particle_updater": lambda max_lag: OutOfSequenceParticleUpdater(
+                _DummyParticleFilter(), max_lag=max_lag
+            ),
+        }
+
+        for max_lag in (float("nan"), float("inf"), -float("inf")):
+            for name, constructor in constructors.items():
+                with self.subTest(max_lag=max_lag, constructor=name):
+                    with self.assertRaisesRegex(
+                        ValueError, "finite and nonnegative"
+                    ):
+                        constructor(max_lag)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- validate optional fixed-lag windows through one shared coercion helper
- reject NaN and positive/negative infinity in both buffer and replay-updater constructors
- add a regression across `FixedLagBuffer`, `MeasurementTimeBuffer`, and `OutOfSequenceParticleUpdater`

## Root cause

`FixedLagBuffer` and `_EventReplayMixin` converted `max_lag` with `float()` and only checked whether the result was negative. NaN passes that comparison. In `FixedLagBuffer._trim()`, the resulting cutoff is NaN, so every `item.time >= cutoff_time` comparison is false and an append silently empties the buffer. The replay wrapper likewise receives invalid window comparisons and trimming behavior.

## Impact

A non-finite lag configuration no longer produces silent data loss or invalid replay-window decisions. `None` remains the supported unlimited-window setting, and finite nonnegative values retain their existing behavior.

## Validation

- reproduced the old NaN cutoff behavior in isolation
- exercised the shared coercion helper against NaN, both infinities, negative values, overflow-sized integers, `None`, zero, and finite positive values
- compared the branch with `main`: two files changed, 14 production additions / 6 deletions, plus one focused 37-line regression
- full repository and backend validation is delegated to GitHub Actions
