### PR TITLE
Reject subtly out-of-order smoother records

### DIFF
--- a/src/pyrecest/smoothers/record_smoother.py
+++ b/src/pyrecest/smoothers/record_smoother.py
@@ -238,7 +238,7 @@ def _record_arrays(
     times = np.asarray([float(record[time_key]) for record in records], dtype=float)
     if not np.isfinite(times).all():
         raise ValueError("record times must be finite")
-    if np.any(np.diff(times) < -1.0e-9):
+    if np.any(np.diff(times) < 0.0):
         raise ValueError("records must be sorted by nondecreasing time")
 
     states = [

--- a/tests/smoothers/test_record_smoother_time_order.py
+++ b/tests/smoothers/test_record_smoother_time_order.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from pyrecest.smoothers.record_smoother import fixed_lag_smooth_records
+
+
+def _identity_transition(_dt: float, state_dim: int) -> np.ndarray:
+    return np.eye(state_dim)
+
+
+def _zero_process_noise(_dt: float, state_dim: int) -> np.ndarray:
+    return np.zeros((state_dim, state_dim))
+
+
+def test_fixed_lag_rejects_subtly_decreasing_timestamps() -> None:
+    records = [
+        {
+            "time_s": 0.0,
+            "state": np.array([0.0, 1.0]),
+            "covariance": np.eye(2),
+        },
+        {
+            "time_s": 1.0,
+            "state": np.array([1.0, 1.0]),
+            "covariance": np.eye(2),
+        },
+        {
+            "time_s": np.nextafter(1.0, 0.0),
+            "state": np.array([1.0, 1.0]),
+            "covariance": np.eye(2),
+        },
+    ]
+
+    with pytest.raises(ValueError, match="sorted by nondecreasing time"):
+        fixed_lag_smooth_records(
+            records,
+            transition_model=_identity_transition,
+            process_noise_model=_zero_process_noise,
+            lag=0.0,
+        )


### PR DESCRIPTION
## Summary

- require record timestamps to be genuinely nondecreasing before RTS or fixed-lag smoothing
- add a regression for a one-ULP timestamp inversion

## Bug

`_record_arrays()` allowed decreases up to `1e-9` seconds. Fixed-lag smoothing subsequently calls `numpy.searchsorted(times, ...)`, which requires a sorted input array. A tiny accepted inversion could therefore select the wrong fixed-lag endpoint and smooth a record using a chronologically earlier record that happened to appear later in the sequence.

## Fix

Reject every negative adjacent timestamp difference while continuing to allow equal timestamps.

## Validation

- added `test_fixed_lag_rejects_subtly_decreasing_timestamps`
- branch diff is limited to the one-line validation change and the focused regression
