### PR TITLE
Reject overflowing PyTorch uniform ranges

### DIFF
--- a/src/pyrecest/_backend/pytorch/random/__init__.py
+++ b/src/pyrecest/_backend/pytorch/random/__init__.py
@@ -155,15 +155,15 @@ def uniform(low=0.0, high=1.0, size=None, dtype=None):
     size = _LEGACY._uniform_size(size, low, high)
     _LEGACY._validate_uniform_bounds(low, high)
 
-    sample_dtype = dtype or torch.promote_types(
+    arithmetic_dtype = dtype or torch.promote_types(
         torch.result_type(low, high), torch.get_default_dtype()
     )
-    low = low.to(dtype=sample_dtype)
-    high = high.to(dtype=sample_dtype)
+    low = low.to(dtype=arithmetic_dtype)
+    high = high.to(dtype=arithmetic_dtype)
     span = high - low
     if bool(torch.any(~torch.isfinite(span))):
         raise OverflowError(_UNIFORM_RANGE_ERROR)
-    return span * torch.rand(size, dtype=sample_dtype, device=device) + low
+    return span * torch.rand(size, dtype=dtype, device=device) + low
 
 
 def multivariate_normal(mean, cov, size=None, *args, **kwargs):

--- a/src/pyrecest/_backend/pytorch/random/__init__.py
+++ b/src/pyrecest/_backend/pytorch/random/__init__.py
@@ -19,6 +19,7 @@ _LEGACY_SPEC.loader.exec_module(_LEGACY)
 
 _BOOLEAN_SCALAR_TYPES = (bool, _np.bool_)
 _PROBABILITY_SUM_ERROR = "probabilities do not sum to a positive value"
+_UNIFORM_RANGE_ERROR = "high - low range exceeds valid bounds"
 
 
 def _probability_accumulation_dtype(probabilities):
@@ -141,6 +142,28 @@ def randint(low, high=None, size=None, *args, **kwargs):
         kwargs["device"] = bound_device
 
     return _LEGACY.randint(low, high, size, *args, **kwargs)
+
+
+def uniform(low=0.0, high=1.0, size=None, dtype=None):
+    """Draw uniform samples while rejecting non-representable finite ranges."""
+
+    torch = _LEGACY._torch
+    dtype = _LEGACY._normalize_random_dtype(dtype, default=None)
+    device = _LEGACY._tensor_device(low, high)
+    low = _LEGACY._validate_uniform_bound(low, "low", dtype=dtype, device=device)
+    high = _LEGACY._validate_uniform_bound(high, "high", dtype=dtype, device=device)
+    size = _LEGACY._uniform_size(size, low, high)
+    _LEGACY._validate_uniform_bounds(low, high)
+
+    sample_dtype = dtype or torch.promote_types(
+        torch.result_type(low, high), torch.get_default_dtype()
+    )
+    low = low.to(dtype=sample_dtype)
+    high = high.to(dtype=sample_dtype)
+    span = high - low
+    if bool(torch.any(~torch.isfinite(span))):
+        raise OverflowError(_UNIFORM_RANGE_ERROR)
+    return span * torch.rand(size, dtype=sample_dtype, device=device) + low
 
 
 def multivariate_normal(mean, cov, size=None, *args, **kwargs):

--- a/tests/backend_support/test_random_uniform_contract.py
+++ b/tests/backend_support/test_random_uniform_contract.py
@@ -63,6 +63,22 @@ print("ok")
 """
 
 
+_UNIFORM_OVERFLOWING_RANGE_REJECTION_CHECK = """
+import numpy as np
+from pyrecest.backend import random
+
+maximum = np.finfo(np.float64).max
+try:
+    random.uniform(low=-maximum, high=maximum, size=(2,))
+except OverflowError as exc:
+    assert "high - low range exceeds valid bounds" in str(exc)
+else:
+    raise AssertionError("uniform accepted a non-representable finite range")
+
+print("ok")
+"""
+
+
 @pytest.mark.backend_portable
 @pytest.mark.parametrize(
     "backend,required_module",
@@ -113,6 +129,24 @@ def test_uniform_rejects_nonfinite_bounds(backend, required_module):
         pytest.skip(f"{backend} backend dependency is not installed")
 
     result = run_backend_code(backend, _UNIFORM_NONFINITE_BOUNDS_REJECTION_CHECK)
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+@pytest.mark.backend_portable
+@pytest.mark.parametrize(
+    "backend,required_module",
+    [
+        ("numpy", "numpy"),
+        ("pytorch", "torch"),
+    ],
+)
+def test_uniform_rejects_overflowing_finite_range(backend, required_module):
+    if importlib.util.find_spec(required_module) is None:
+        pytest.skip(f"{backend} backend dependency is not installed")
+
+    result = run_backend_code(backend, _UNIFORM_OVERFLOWING_RANGE_REJECTION_CHECK)
 
     assert result.returncode == 0, result.stderr
     assert "ok" in result.stdout


### PR DESCRIPTION
## Summary

- reject finite PyTorch `random.uniform` bounds when their promoted floating-point span is not representable
- compute the span after promoting integer/low-precision bounds to a safe arithmetic dtype
- preserve the existing random-stream dtype and scalar/array broadcasting behavior
- add a NumPy/PyTorch regression for the maximum-finite symmetric range

## Bug

The PyTorch backend validated `low` and `high` independently as finite, then sampled with:

```python
(high - low) * rand + low
```

For finite endpoints such as `-np.finfo(np.float64).max` and `np.finfo(np.float64).max`, `high - low` overflows to infinity. The sampler therefore returned non-finite values even though both inputs passed validation. NumPy rejects the same request with `OverflowError`.

## Fix

Promote both validated bounds to the effective floating arithmetic dtype before subtraction, validate that the resulting span is finite, and raise `OverflowError("high - low range exceeds valid bounds")` when it is not. The random draw still uses the prior dtype path, so ordinary seeded sampling is unchanged.

## Validation

- reproduced the pre-fix PyTorch result as all-`inf` samples for the maximum-finite symmetric range
- focused smoke test verifies the patched path raises `OverflowError`
- focused smoke test verifies ordinary array-valued bounds still return finite in-range samples
- seeded smoke test verifies the existing float64-bound RNG stream is preserved exactly
- `python -m py_compile` passes for both modified files
- branch is 3 commits ahead of and 0 behind `main`

The full repository test matrix is delegated to GitHub Actions.