### PR TITLE
Skip unused candidate-pruning penalty escalation

### DIFF
--- a/src/pyrecest/utils/candidate_pruning.py
+++ b/src/pyrecest/utils/candidate_pruning.py
@@ -312,13 +312,16 @@ def prune_pairwise_cost_matrix(
         )
     if penalty <= 0.0:
         raise ValueError("large_cost must be finite and positive")
-    penalty = _effective_large_cost(costs, penalty)
 
     mask = candidate_mask_from_costs(
         costs,
         probability_matrix=probability_matrix,
         config=cfg,
     )
+    if np.all(mask):
+        return costs.copy()
+
+    penalty = _effective_large_cost(costs, penalty)
     return np.where(mask, costs, penalty)
 
 

--- a/tests/test_candidate_pruning_unpruned_max_cost.py
+++ b/tests/test_candidate_pruning_unpruned_max_cost.py
@@ -1,0 +1,22 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+from pyrecest.utils import CandidatePruningConfig, prune_pairwise_cost_matrix
+
+
+class TestCandidatePruningUnprunedMaxCost(unittest.TestCase):
+    def test_unpruned_max_float_does_not_require_larger_finite_penalty(self):
+        costs = np.array([[np.finfo(float).max]])
+
+        pruned = prune_pairwise_cost_matrix(
+            costs,
+            config=CandidatePruningConfig(always_keep_finite=True),
+        )
+
+        npt.assert_array_equal(pruned, costs)
+        self.assertTrue(np.all(np.isfinite(pruned)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- compute the candidate mask before escalating the replacement cost
- return a copy immediately when every matrix entry is retained
- add a regression for an unpruned matrix containing the largest finite float

## Bug

`prune_pairwise_cost_matrix()` always called `_effective_large_cost()` before checking whether the candidate mask actually pruned anything. For a retained cost equal to `np.finfo(float).max`, `_effective_large_cost()` attempted `np.nextafter(max_float, np.inf)`, obtained infinity, and raised `ValueError` even though no replacement cost was needed.

This made a valid no-op pruning configuration fail solely because the input occupied the upper end of the floating-point range.

## Fix

Build the mask first. When all entries are retained, return an owning copy of the validated costs and skip replacement-cost escalation. The existing behavior is unchanged whenever at least one entry must be replaced.

## Validation

- isolated regression reproduced the pre-fix failure and passes with the guard
- verified an actually pruned `max_float` entry still raises because no larger finite replacement exists
- `python -m py_compile` passes for the modified module and regression test
- full multi-environment validation is delegated to GitHub Actions