### PR TITLE
Stabilize Complex Watson fitting for extreme weights

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/complex_watson_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/complex_watson_distribution.py
@@ -34,6 +34,7 @@ from pyrecest.backend import (
     zeros,
     zeros_like,
 )
+from pyrecest.backend import max as backend_max
 from scipy.optimize import brentq
 
 
@@ -265,11 +266,21 @@ class ComplexWatsonDistribution:
                 raise ValueError("weights must contain only finite values")
             if not _to_python_bool(all(weights >= 0.0)):
                 raise ValueError("weights must be nonnegative")
-            if not _to_python_bool(sum(weights) > 0.0):
+            if weights.shape[0] == 0:
                 raise ValueError("weights must have positive total mass")
+            weight_scale = backend_max(weights)
+            if not _to_python_bool(weight_scale > 0.0):
+                raise ValueError("weights must have positive total mass")
+            scaled_weights = weights / weight_scale
+            scaled_weight_sum = sum(scaled_weights)
             # Weighted scatter: Σ_i w_i·z_i·z_i^H, normalised so uniform
-            # weights (w_i=1) reproduce the unweighted result Z^H Z.
-            S = (Z * weights[:, None]).conj().T @ Z * (N / sum(weights))
+            # weights (w_i=1) reproduce the unweighted result Z^H Z. Scaling
+            # by max(weights) preserves the estimate while avoiding overflow.
+            S = (
+                (Z * scaled_weights[:, None]).conj().T
+                @ Z
+                * (N / scaled_weight_sum)
+            )
 
         # Force Hermitian
         S = 0.5 * (S + conj(S).T)

--- a/tests/distributions/test_complex_watson_extreme_weights.py
+++ b/tests/distributions/test_complex_watson_extreme_weights.py
@@ -1,0 +1,48 @@
+# pylint: disable=no-name-in-module,no-member
+import unittest
+
+import numpy as np
+import pyrecest.backend
+from pyrecest.backend import abs, allclose, array, complex128, conj, float64, sum
+from pyrecest.distributions import ComplexWatsonDistribution
+
+
+class TestComplexWatsonExtremeWeights(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Complex Watson parameter estimation is not tested on JAX",
+    )
+    def test_weight_rescaling_remains_finite_and_invariant(self):
+        inv_sqrt_two = 1.0 / np.sqrt(2.0)
+        samples = array(
+            [
+                [1.0 + 0.0j, 0.0 + 0.0j],
+                [0.0 + 0.0j, 1.0 + 0.0j],
+                [inv_sqrt_two + 0.0j, inv_sqrt_two + 0.0j],
+                [inv_sqrt_two + 0.0j, 1j * inv_sqrt_two],
+            ],
+            dtype=complex128,
+        )
+        reference_weights = array([8.0, 4.0, 2.0, 1.0], dtype=float64)
+        extreme_weights = reference_weights * (np.finfo(np.float64).max / 8.0)
+
+        reference_mu, reference_kappa = (
+            ComplexWatsonDistribution.estimate_parameters(
+                samples, weights=reference_weights
+            )
+        )
+        extreme_mu, extreme_kappa = ComplexWatsonDistribution.estimate_parameters(
+            samples, weights=extreme_weights
+        )
+
+        phase_invariant_overlap = abs(sum(conj(reference_mu) * extreme_mu))
+        self.assertTrue(
+            bool(allclose(phase_invariant_overlap, 1.0, rtol=1e-12, atol=1e-12))
+        )
+        self.assertTrue(
+            bool(allclose(extreme_kappa, reference_kappa, rtol=1e-12, atol=1e-12))
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- rescale finite nonnegative weights before summing them or forming the weighted Complex Watson scatter matrix
- preserve the estimator's invariance to multiplying all weights by a common positive factor
- add a regression using finite weights near the `float64` limit

## Bug

`ComplexWatsonDistribution.estimate_parameters` previously evaluated both `sum(weights)` and `Z * weights[:, None]` at the caller's raw scale. Individually finite weights could therefore overflow in the reduction or matrix product. For example, weights proportional to `[8, 4, 2, 1]` but scaled so the largest value is `float64.max` produced an infinite total and a `NaN` scatter matrix, even though common weight scaling must not change the estimate.

## Fix

Normalize weights by their largest value before computing the total and weighted scatter. The scaled weights lie in `[0, 1]`; their sum and weighted samples remain bounded, while the final normalization is algebraically identical to the original formula.

## Validation

- reproduced the pre-fix overflow with finite extreme weights
- independently verified the stabilized scatter equals the ordinary-scale reference
- added `tests/distributions/test_complex_watson_extreme_weights.py`, checking phase-invariant mean direction and concentration parameter equality
- branch is two commits ahead of `main`, zero behind; changes one production file and adds one focused regression test
