### PR TITLE
Reject non-real wrapped Laplace parameters

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_laplace_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_laplace_distribution.py
@@ -1,5 +1,5 @@
 # pylint: disable=no-name-in-module,no-member
-from numbers import Integral
+from numbers import Integral, Real
 
 from pyrecest.backend import all, asarray, exp, isfinite, mod, ndim, pi
 
@@ -13,9 +13,20 @@ def _validate_positive_scalar(value, name):
     value = asarray(value)
     if value.shape not in ((), (1,)):
         raise ValueError(f"{name} must be a positive scalar.")
-    if not bool(all(isfinite(value))):
+    try:
+        scalar = value.item()
+    except (AttributeError, RuntimeError, TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a positive scalar.") from exc
+    if isinstance(scalar, bool) or not isinstance(scalar, Real):
+        raise ValueError(f"{name} must be a positive real scalar.")
+    try:
+        finite = bool(all(isfinite(value)))
+        positive = bool(all(value > 0.0))
+    except (RuntimeError, TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a positive real scalar.") from exc
+    if not finite:
         raise ValueError(f"{name} must be finite.")
-    if not bool(all(value > 0.0)):
+    if not positive:
         raise ValueError(f"{name} must be positive.")
     return value
 

--- a/tests/distributions/test_wrapped_laplace_parameter_validation.py
+++ b/tests/distributions/test_wrapped_laplace_parameter_validation.py
@@ -1,0 +1,24 @@
+import unittest
+
+from pyrecest.backend import array
+from pyrecest.distributions.circle.wrapped_laplace_distribution import (
+    WrappedLaplaceDistribution,
+)
+
+
+class WrappedLaplaceParameterValidationTest(unittest.TestCase):
+    def test_rejects_non_real_positive_scalar_parameters(self):
+        invalid_values = (True, array([True]), "2.0", 1.0 + 0.0j)
+        for invalid in invalid_values:
+            with self.subTest(lambda_=invalid), self.assertRaisesRegex(
+                ValueError, "lambda_"
+            ):
+                WrappedLaplaceDistribution(invalid, 1.0)
+            with self.subTest(kappa=invalid), self.assertRaisesRegex(
+                ValueError, "kappa_"
+            ):
+                WrappedLaplaceDistribution(1.0, invalid)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reject boolean, text, and complex values for `WrappedLaplaceDistribution` rate parameters
- preserve positive finite real scalar and length-one array inputs
- add focused regression coverage for both `lambda_` and `kappa_`

## Bug
`_validate_positive_scalar()` converted its input to a backend array and then only checked finiteness and positivity. Boolean values such as `True` therefore passed as the rate `1`, while text and complex values could either leak backend-specific exceptions or be accepted despite not being real-valued distribution parameters.

## Fix
Extract the scalar value after shape validation, require a non-boolean `numbers.Real`, and normalize backend conversion/comparison failures to a clear `ValueError` naming the invalid parameter.

## Validation
- `python -m py_compile /tmp/wrapped_laplace_distribution_patched.py /tmp/test_wrapped_laplace_parameter_validation.py`
- `python -m pytest -q /tmp/test_wrapped_laplace_parameter_validation.py` (`1 passed, 8 subtests passed`)

Full repository CI should validate the change across the configured backend matrix.