### PR TITLE
Handle array-valued audit guard results

### DIFF
--- a/src/pyrecest/tracking/audit_guards.py
+++ b/src/pyrecest/tracking/audit_guards.py
@@ -119,6 +119,31 @@ def poison_forbidden_keys_in_mappings(
     )
 
 
+def _comparison_is_true(comparison: Any) -> bool:
+    """Reduce scalar or array-like equality results to one boolean."""
+
+    reduce_all = getattr(comparison, "all", None)
+    if callable(reduce_all):
+        try:
+            comparison = reduce_all()
+        except (TypeError, ValueError, RuntimeError):
+            return False
+    try:
+        return bool(comparison)
+    except (TypeError, ValueError, RuntimeError):
+        return False
+
+
+def _results_equal(left: Any, right: Any) -> bool:
+    """Compare normalized selector outputs, including array-valued outputs."""
+
+    try:
+        comparison = left == right
+    except (TypeError, ValueError, RuntimeError):
+        return False
+    return _comparison_is_true(comparison)
+
+
 def assert_selector_invariant_under_forbidden_key_changes(
     selector: Callable[[Sequence[Mapping[str, Any]]], T],
     rows: Sequence[Mapping[str, Any]],
@@ -133,7 +158,7 @@ def assert_selector_invariant_under_forbidden_key_changes(
     stripped, rows with forbidden columns poisoned, and guarded rows that raise
     if forbidden columns are accessed.  ``normalize`` may be provided when the
     selector returns a rich object and only a stable identifier should be
-    compared.
+    compared. Scalar and array-valued normalized outputs are supported.
     """
 
     forbidden = frozenset(map(str, forbidden_keys))
@@ -150,7 +175,10 @@ def assert_selector_invariant_under_forbidden_key_changes(
         )
     )
     guarded = normalize_result(selector(guarded_mappings(rows, forbidden)))
-    if not (baseline == stripped == poisoned == guarded):
+    if not all(
+        _results_equal(baseline, candidate)
+        for candidate in (stripped, poisoned, guarded)
+    ):
         raise AssertionError(
             "selector output changed when forbidden audit-only keys were removed, "
             "poisoned, or guarded"

--- a/tests/tracking/test_audit_guards.py
+++ b/tests/tracking/test_audit_guards.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import numpy as np
 import pytest
 
 from pyrecest.tracking import (
@@ -61,6 +62,19 @@ def test_selector_invariance_helper_passes_for_allowed_feature_selector() -> Non
 
     def selector(candidate_rows):
         return max(candidate_rows, key=lambda row: row["score"])["candidate_id"]
+
+    assert_selector_invariant_under_forbidden_key_changes(selector, rows, FORBIDDEN)
+
+
+def test_selector_invariance_helper_accepts_array_outputs() -> None:
+    rows = [
+        {"candidate_id": "a", "score": 2.0, "audit_delta": -100.0},
+        {"candidate_id": "b", "score": 1.0, "audit_label": "x"},
+    ]
+
+    def selector(candidate_rows):
+        scores = [row["score"] for row in candidate_rows]
+        return np.asarray([max(scores), min(scores)])
 
     assert_selector_invariant_under_forbidden_key_changes(selector, rows, FORBIDDEN)
 


### PR DESCRIPTION
## Summary
- compare normalized selector outputs through an equality reducer that accepts scalar and array-like results
- preserve existing scalar behavior while treating elementwise array equality as one invariant result
- add a NumPy regression for an allowed-feature selector that returns an array

## Bug
`assert_selector_invariant_under_forbidden_key_changes()` used chained equality directly:

```python
baseline == stripped == poisoned == guarded
```

For NumPy outputs, the first equality returns a boolean array. Python then tries to coerce that array to one truth value and raises `ValueError`, even when every selector result is identical.

## Fix
Reduce array-like equality results with their `all()` method before boolean coercion. Comparison failures are treated as non-equality so the helper continues to raise its documented `AssertionError` for changed results.

## Validation
- focused local test harness matching the current files: `PYTHONPATH=. pytest -q tests/tracking/test_audit_guards.py`
- 6 passed
