### PR TITLE
Bump astropy-iers-data to 0.2026.7.13.0.54.2

### DIFF
--- a/requirements-healpy.txt
+++ b/requirements-healpy.txt
@@ -1,4 +1,4 @@
-astropy-iers-data==0.2026.7.6.1.1.20 ; python_version >= "3.11" and python_version < "3.15"
+astropy-iers-data==0.2026.7.13.0.54.2 ; python_version >= "3.11" and python_version < "3.15"
 astropy==8.0.1 ; python_version >= "3.11" and python_version < "3.15"
 attrs==26.1.0 ; python_version >= "3.11" and python_version < "3.15"
 beartype==0.22.9 ; python_version >= "3.11" and python_version < "3.15"

--- a/requirements-jax.txt
+++ b/requirements-jax.txt
@@ -1,4 +1,4 @@
-astropy-iers-data==0.2026.7.6.1.1.20 ; python_version >= "3.11" and python_version < "3.15"
+astropy-iers-data==0.2026.7.13.0.54.2 ; python_version >= "3.11" and python_version < "3.15"
 astropy==8.0.1 ; python_version >= "3.11" and python_version < "3.15"
 attrs==26.1.0 ; python_version >= "3.11" and python_version < "3.15"
 autograd==1.9.1 ; python_version >= "3.11" and python_version < "3.15"

--- a/requirements-pytorch.txt
+++ b/requirements-pytorch.txt
@@ -1,4 +1,4 @@
-astropy-iers-data==0.2026.7.6.1.1.20 ; python_version >= "3.11" and python_version < "3.15"
+astropy-iers-data==0.2026.7.13.0.54.2 ; python_version >= "3.11" and python_version < "3.15"
 astropy==8.0.1 ; python_version >= "3.11" and python_version < "3.15"
 attrs==26.1.0 ; python_version >= "3.11" and python_version < "3.15"
 beartype==0.22.9 ; python_version >= "3.11" and python_version < "3.15"


### PR DESCRIPTION
Rebases the dependency update from #4270 onto current `main` without changing any unrelated generated requirements. This preserves the exact three tested requirement-file blobs from the Dependabot update while rerunning CI against the current codebase.

Supersedes #4270.