### PR TITLE
Reject wrong-sized smoother control vectors

### DIFF
--- a/src/pyrecest/smoothers/abstract_smoother.py
+++ b/src/pyrecest/smoothers/abstract_smoother.py
@@ -107,6 +107,9 @@ class AbstractSmoother(ABC):
         if values is None:
             return [None] * length
 
+        expected_shape = (vector_dim,)
+        shape_error = f"{name} must contain vectors with shape {expected_shape}."
+
         try:
             values_arr = asarray(values)
         except (TypeError, ValueError, RuntimeError):
@@ -122,8 +125,12 @@ class AbstractSmoother(ABC):
             if ndim(values_arr) == 1:
                 if vector_dim == 1 and values_arr.shape[0] == length:
                     return [asarray([values_arr[idx]]) for idx in range(length)]
+                if values_arr.shape[0] != vector_dim:
+                    raise ValueError(shape_error)
                 return [copy(values_arr) for _ in range(length)]
             if ndim(values_arr) == 2 and values_arr.shape[0] == length:
+                if values_arr.shape[1] != vector_dim:
+                    raise ValueError(shape_error)
                 return [copy(values_arr[idx]) for idx in range(length)]
 
         if isinstance(values, (list, tuple)) and len(values) == length:
@@ -139,6 +146,8 @@ class AbstractSmoother(ABC):
                             f"Scalar entries in {name} are only supported in one-dimensional models."
                         )
                     normalized_values.append(asarray([value_arr]))
+                elif ndim(value_arr) != 1 or value_arr.shape[0] != vector_dim:
+                    raise ValueError(shape_error)
                 else:
                     normalized_values.append(value_arr)
             return normalized_values

--- a/tests/smoothers/test_rts_control_input_validation.py
+++ b/tests/smoothers/test_rts_control_input_validation.py
@@ -1,0 +1,27 @@
+import unittest
+
+from pyrecest.backend import array, eye, zeros
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.smoothers import RauchTungStriebelSmoother
+
+
+class RauchTungStriebelControlInputValidationTest(unittest.TestCase):
+    def test_rejects_broadcastable_control_vector_with_wrong_dimension(self):
+        smoother = RauchTungStriebelSmoother()
+
+        with self.assertRaisesRegex(
+            ValueError, r"sys_inputs must contain vectors with shape \(2,\)"
+        ):
+            smoother.filter(
+                initial_state=GaussianDistribution(zeros(2), eye(2)),
+                measurements=[zeros(2), zeros(2)],
+                measurement_matrices=zeros((2, 2)),
+                meas_noise_covariances=eye(2),
+                system_matrices=eye(2),
+                sys_noise_covariances=zeros((2, 2)),
+                sys_inputs=array([1.0]),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- validate shared RTS control vectors against the state dimension
- validate dense and heterogeneous per-step control-vector sequences consistently
- add an end-to-end regression for a broadcastable one-element input in a two-dimensional model

## Bug
`AbstractSmoother._normalize_vector_sequence()` accepted any one-dimensional shared vector without checking `vector_dim`. In a two-dimensional RTS model, `sys_inputs=array([1.0])` was therefore normalized as a length-one vector. During prediction, backend broadcasting silently added that value to both state components rather than reporting malformed input.

## Fix
Require shared and per-step vectors to have exactly shape `(vector_dim,)`. Existing scalar controls for one-dimensional models, valid shared vectors, dense per-step arrays, and optional `None` entries retain their current behavior.

## Impact
Malformed controls now fail at input normalization with a parameter-specific `ValueError`, preventing silent state corruption caused by broadcasting.

## Validation
- reproduced the pre-fix broadcast: `[10, 20] + [1] -> [11, 21]`
- compiled the modified source and regression test with `python -m py_compile`
- exercised the patched normalizer with NumPy stubs: wrong-sized input is rejected and a valid two-element input is preserved
- full backend test matrix delegated to GitHub Actions