### PR TITLE
Reject non-real wrapped Cauchy parameters

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py
@@ -1,5 +1,5 @@
 # pylint: disable=no-name-in-module,no-member
-from numbers import Integral
+from numbers import Integral, Real
 
 from pyrecest.backend import (
     all,
@@ -22,7 +22,17 @@ def _validate_finite_scalar(value, name):
     value = array(value)
     if value.shape not in ((), (1,)):
         raise ValueError(f"{name} must be a scalar.")
-    if not bool(all(isfinite(value))):
+    try:
+        scalar = value.item()
+    except (AttributeError, RuntimeError, TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a real scalar.") from exc
+    if isinstance(scalar, bool) or not isinstance(scalar, Real):
+        raise ValueError(f"{name} must be a real scalar.")
+    try:
+        finite = bool(all(isfinite(value)))
+    except (RuntimeError, TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a real scalar.") from exc
+    if not finite:
         raise ValueError(f"{name} must be finite.")
     return value
 

--- a/tests/distributions/test_wrapped_cauchy_parameter_validation.py
+++ b/tests/distributions/test_wrapped_cauchy_parameter_validation.py
@@ -1,0 +1,22 @@
+import unittest
+
+from pyrecest.backend import array
+from pyrecest.distributions.circle.wrapped_cauchy_distribution import (
+    WrappedCauchyDistribution,
+)
+
+
+class WrappedCauchyParameterValidationTest(unittest.TestCase):
+    def test_rejects_non_real_scalar_parameters(self):
+        invalid_values = (True, array([True]), "0.5", 0.5 + 0.0j)
+        for invalid in invalid_values:
+            with self.subTest(mu=invalid), self.assertRaisesRegex(ValueError, "mu"):
+                WrappedCauchyDistribution(invalid, 0.5)
+            with self.subTest(gamma=invalid), self.assertRaisesRegex(
+                ValueError, "gamma"
+            ):
+                WrappedCauchyDistribution(0.0, invalid)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- require wrapped-Cauchy `mu` and `gamma` parameters to be real, non-boolean scalars
- normalize backend conversion and finiteness failures to parameter-specific `ValueError`s
- add focused regressions for boolean, text, and complex inputs

## Bug
`WrappedCauchyDistribution` validated only scalar shape and finiteness before accepting `mu` and `gamma`. Boolean values therefore behaved as numeric angles/rates, while text and complex inputs could either be accepted or leak backend-specific arithmetic/type errors. This violates the distribution's real-scalar parameter contract and makes failure behavior backend dependent.

## Fix
Extract the scalar value after backend conversion, require a non-boolean `numbers.Real`, and guard finiteness evaluation with a stable `ValueError`. Positive real validation for `gamma` remains unchanged after the shared real-scalar check.

## Impact
Invalid wrapped-Cauchy parameters now fail immediately with clear errors naming `mu` or `gamma`. Existing finite real Python, NumPy, and backend scalar inputs retain their behavior.

## Validation
- added `test_rejects_non_real_scalar_parameters`
- compiled the changed source and regression test with `python -m py_compile`
- ran a NumPy smoke reproduction covering rejected and accepted scalar forms
- branch is two commits ahead and zero behind audited `main`