### PR TITLE
Reject inconsistent smoother measurement dimensions

### DIFF
--- a/src/pyrecest/smoothers/abstract_smoother.py
+++ b/src/pyrecest/smoothers/abstract_smoother.py
@@ -28,7 +28,15 @@ class AbstractSmoother(ABC):
     @staticmethod
     def _normalize_measurements(measurements) -> list:
         if isinstance(measurements, (list, tuple)):
-            return [asarray(measurement).reshape(-1) for measurement in measurements]
+            normalized = [
+                asarray(measurement).reshape(-1) for measurement in measurements
+            ]
+            if normalized and any(
+                measurement.shape != normalized[0].shape
+                for measurement in normalized[1:]
+            ):
+                raise ValueError("All measurements must have the same dimension.")
+            return normalized
 
         measurements_array = asarray(measurements)
         if ndim(measurements_array) == 0:

--- a/tests/smoothers/test_rts_measurement_dimension_validation.py
+++ b/tests/smoothers/test_rts_measurement_dimension_validation.py
@@ -1,0 +1,24 @@
+import unittest
+
+from pyrecest.backend import array, eye, zeros
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.smoothers import RauchTungStriebelSmoother
+
+
+class RauchTungStriebelMeasurementDimensionValidationTest(unittest.TestCase):
+    def test_rejects_measurement_sequence_with_changing_dimension(self):
+        smoother = RauchTungStriebelSmoother()
+
+        with self.assertRaisesRegex(ValueError, "same dimension"):
+            smoother.filter(
+                initial_state=GaussianDistribution(zeros(2), eye(2)),
+                measurements=[zeros(2), array([1.0])],
+                measurement_matrices=eye(2),
+                meas_noise_covariances=eye(2),
+                system_matrices=eye(2),
+                sys_noise_covariances=zeros((2, 2)),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- validate list/tuple measurement sequences after normalization
- require every time step to use the same measurement-vector dimension
- add an RTS regression for a two-dimensional measurement followed by a one-dimensional measurement

## Bug

`AbstractSmoother._normalize_measurements()` flattened each entry in a Python sequence but did not verify that the resulting vectors had equal shapes. In an RTS filter with a two-dimensional state, a later one-element measurement could therefore reach

```python
innovation = measurement - measurement_matrix @ predicted_mean
```

and broadcast from shape `(1,)` to `(2,)`. The scalar measurement was silently treated as though it had been repeated across both measurement components instead of being rejected as malformed input.

## Fix

Normalize the sequence first, then compare every measurement shape with the first entry. A changing measurement dimension now raises a clear `ValueError` at the input boundary. Empty sequences and consistently scalar or vector-valued sequences retain their existing behavior.

## Impact

Malformed time-varying measurement sequences can no longer silently change the effective observation model through backend broadcasting.

## Validation

- reproduced the pre-fix NumPy broadcasting from a one-element measurement to a two-element innovation
- compiled the modified helper and regression test with `python -m py_compile`
- verified the new shape guard detects the reproduced mismatch
- branch is two commits ahead of current `main`, zero behind, and changes one production helper plus one focused regression test

Full backend validation is delegated to GitHub Actions.