### PR TITLE
Support boolean dot products in the PyTorch backend

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_dot_outer_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_dot_outer_device_contract.py
@@ -116,15 +116,21 @@ def patch_pytorch_dot_outer_device_contract() -> None:
 
     def dot(a, b):
         a, b = _promoted_pair(raw_pytorch, torch, a, b)
+        boolean_result = a.dtype == torch.bool
+        if boolean_result:
+            a = a.to(dtype=torch.int64)
+            b = b.to(dtype=torch.int64)
         if a.ndim == 0 or b.ndim == 0:
-            return torch.multiply(a, b)
-        if a.ndim == 1 and b.ndim == 1:
-            return torch.dot(a, b)
-        if b.ndim == 1:
-            return torch.einsum("...i,i->...", a, b)
-        if a.ndim == 1:
-            return torch.einsum("i,...i->...", a, b)
-        return torch.einsum("...i,...i->...", a, b)
+            result = torch.multiply(a, b)
+        elif a.ndim == 1 and b.ndim == 1:
+            result = torch.dot(a, b)
+        elif b.ndim == 1:
+            result = torch.einsum("...i,i->...", a, b)
+        elif a.ndim == 1:
+            result = torch.einsum("i,...i->...", a, b)
+        else:
+            result = torch.einsum("...i,...i->...", a, b)
+        return result != 0 if boolean_result else result
 
     def outer(a, b):
         a, b = _promoted_pair(raw_pytorch, torch, a, b)

--- a/tests/backend_support/test_pytorch_boolean_dot_contract.py
+++ b/tests/backend_support/test_pytorch_boolean_dot_contract.py
@@ -21,6 +21,8 @@ def test_pytorch_dot_supports_boolean_operands():
     )
 
     code = """
+import torch
+
 import pyrecest.backend as backend
 import pyrecest._backend.pytorch as raw_pytorch
 
@@ -38,8 +40,8 @@ for left, right, expected in cases:
     public_result = backend.dot(backend.array(left), backend.array(right))
     raw_result = raw_pytorch.dot(raw_pytorch.array(left), raw_pytorch.array(right))
 
-    assert public_result.dtype == backend.bool
-    assert raw_result.dtype == raw_pytorch.bool
+    assert public_result.dtype == torch.bool
+    assert raw_result.dtype == torch.bool
     assert public_result.tolist() == expected
     assert raw_result.tolist() == expected
 """

--- a/tests/backend_support/test_pytorch_boolean_dot_contract.py
+++ b/tests/backend_support/test_pytorch_boolean_dot_contract.py
@@ -1,0 +1,46 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_pytorch_dot_supports_boolean_operands():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+
+    code = """
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+cases = [
+    ([True, False, True], [False, True, True], True),
+    (
+        [[True, False, False], [False, False, False]],
+        [[True, True, False], [True, True, True]],
+        [True, False],
+    ),
+    (True, [False, True], [False, True]),
+]
+
+for left, right, expected in cases:
+    public_result = backend.dot(backend.array(left), backend.array(right))
+    raw_result = raw_pytorch.dot(raw_pytorch.array(left), raw_pytorch.array(right))
+
+    assert public_result.dtype == backend.bool
+    assert raw_result.dtype == raw_pytorch.bool
+    assert public_result.tolist() == expected
+    assert raw_result.tolist() == expected
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## Summary
- support boolean operands in the patched PyTorch `dot` helper
- preserve the existing scalar, vector, and paired-leading-dimension contracts
- add backend-portable regression coverage for public and raw PyTorch APIs

## Bug
The PyTorch compatibility wrapper forwarded one-dimensional boolean operands to `torch.dot` and higher-dimensional boolean operands to `torch.einsum`. PyTorch does not implement either contraction for `torch.bool`, so inputs accepted by the backend array API raised `NotImplementedError` instead of producing a boolean dot result.

## Fix
When both promoted operands are boolean, compute the contraction with `int64` accumulators and convert nonzero results back to `bool`. Mixed boolean/numeric inputs continue to follow normal PyTorch dtype promotion, and existing numeric behavior is unchanged.

## Validation
- focused local regression for scalar, vector, and paired-leading-dimension boolean inputs
- numeric dot sanity check
- new subprocess test exercises both `pyrecest.backend.dot` and `pyrecest._backend.pytorch.dot`
