### PR TITLE
Reject ambiguous symmetric toroidal mean extraction

### DIFF
--- a/src/pyrecest/evaluation/get_extract_mean.py
+++ b/src/pyrecest/evaluation/get_extract_mean.py
@@ -103,23 +103,21 @@ def get_extract_mean(manifold_name, mtt_scenario=False):
     if registered_factory is not None:
         return registered_factory(manifold_name, is_mtt_scenario)
 
-    if "circle" in normalized_name or "hypertorus" in normalized_name:
-
-        def extract_mean(filter_state):
-            return filter_state.mean_direction()
-
-    elif _is_hypersphere_symmetric_name(normalized_name):
+    if _is_hypersphere_symmetric_name(normalized_name):
         _unsupported(
             "Symmetric hypersphere mean extraction needs an explicit convention via a custom extractor."
         )
+    elif "symm" in normalized_name:
+        _unsupported("Symmetric mean extraction needs an explicit convention")
+    elif "circle" in normalized_name or "hypertorus" in normalized_name:
+
+        def extract_mean(filter_state):
+            return filter_state.mean_direction()
 
     elif "hypersphere" in normalized_name:
 
         def extract_mean(filter_state):
             return filter_state.mean_direction()
-
-    elif "symm" in normalized_name:
-        _unsupported("Symmetric mean extraction needs an explicit convention")
 
     elif "se2bounded" in normalized_name:
         _unsupported("Not implemented yet")

--- a/tests/evaluation/test_symmetric_hypersphere_aliases.py
+++ b/tests/evaluation/test_symmetric_hypersphere_aliases.py
@@ -36,3 +36,19 @@ def test_prefixed_symmetric_hypersphere_extract_mean_requires_convention(
         match="explicit convention|custom extractor",
     ):
         get_extract_mean(manifold_name)
+
+
+@pytest.mark.parametrize(
+    "manifold_name",
+    (
+        "circle_symmetric",
+        "symmetric_circle",
+        "hypertorus_symmetric",
+        "symm_hypertorus",
+    ),
+)
+def test_symmetric_toroidal_extract_mean_requires_convention(
+    manifold_name: str,
+) -> None:
+    with pytest.raises(NotImplementedError, match="explicit convention"):
+        get_extract_mean(manifold_name)


### PR DESCRIPTION
## Summary
- route symmetric circle and hypertorus manifold names through the existing symmetry guard
- preserve the specialized hypersphere-symmetry error and ordinary circle/hypertorus mean extraction
- add regressions for prefixed and suffixed symmetric toroidal aliases

## Bug
`get_extract_mean()` checked ordinary circle and hypertorus names before its generic symmetry guard. Names such as `circle_symmetric` and `hypertorus_symmetric` therefore returned the ordinary `mean_direction()` extractor, even though a symmetric distribution has multiple equivalent representatives and requires an explicit convention.

This branch order contradicted the existing behavior for other symmetric manifolds, which raises `NotImplementedError` until a custom extractor defines the representative convention.

## Fix
Evaluate the specialized symmetric-hypersphere case first, then reject all remaining symmetric names before dispatching ordinary circle, hypertorus, and hypersphere extractors.

## Validation
- added parameterized regressions for `circle_symmetric`, `symmetric_circle`, `hypertorus_symmetric`, and `symm_hypertorus`
- verified ordinary `circle` and `hypertorus` extraction remains unchanged
- ran Python syntax compilation and isolated behavior checks locally
- branch is 2 commits ahead of `main` and 0 behind