### PR TITLE
Stabilize Gaussian hypothesis covariance symmetrization

### DIFF
--- a/src/pyrecest/filters/gaussian_hypothesis_mixture.py
+++ b/src/pyrecest/filters/gaussian_hypothesis_mixture.py
@@ -131,4 +131,11 @@ def _as_log_weight(value: Any) -> float:
 
 def _symmetrized(matrix: np.ndarray) -> np.ndarray:
     array = _as_float_array(matrix, "matrix")
-    return 0.5 * (array + array.T)
+    with np.errstate(over="ignore"):
+        symmetrized = 0.5 * (array + array.T)
+    overflowed = ~np.isfinite(symmetrized) & np.isfinite(array) & np.isfinite(array.T)
+    if np.any(overflowed):
+        symmetrized[overflowed] = (
+            0.5 * array[overflowed] + 0.5 * array.T[overflowed]
+        )
+    return symmetrized

--- a/tests/filters/test_gaussian_hypothesis_extreme_covariance.py
+++ b/tests/filters/test_gaussian_hypothesis_extreme_covariance.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+from pyrecest.filters import (
+    WeightedGaussianHypothesis,
+    moment_match_gaussian_hypotheses,
+)
+
+
+def test_maximum_finite_covariance_survives_symmetrization_and_moment_matching():
+    maximum = np.finfo(float).max
+    hypothesis = WeightedGaussianHypothesis(
+        mean=np.array([0.0]),
+        covariance=np.array([[maximum]]),
+    )
+
+    mean, covariance, weights = moment_match_gaussian_hypotheses([hypothesis])
+
+    np.testing.assert_array_equal(hypothesis.covariance, np.array([[maximum]]))
+    np.testing.assert_array_equal(mean, np.array([0.0]))
+    np.testing.assert_array_equal(covariance, np.array([[maximum]]))
+    np.testing.assert_array_equal(weights, np.array([1.0]))


### PR DESCRIPTION
## Summary
- keep finite Gaussian-hypothesis covariances finite when symmetrization would overflow
- retry only overflowed entries using half-scaled operands
- add a regression through both `WeightedGaussianHypothesis` construction and one-component moment matching

## Bug
`_symmetrized()` evaluated `0.5 * (A + A.T)`. For a valid covariance containing `np.finfo(float).max`, the intermediate addition overflowed to infinity before multiplication by one half. `WeightedGaussianHypothesis` then rejected the covariance as non-PSD, and the same overflow affected the final covariance returned by moment matching.

## Fix
Keep the existing averaging path for normal values. When a finite input pair produces a non-finite average, recompute only that entry as `0.5 * A + 0.5 * A.T`, which avoids the overflowing intermediate sum while preserving ordinary and subnormal behavior elsewhere.

## Validation
- deterministic local regression confirms the old expression overflows for a maximum-finite 1D covariance
- the patched expression preserves the exact finite covariance through construction and moment matching
- branch diff is limited to the helper and one focused test