### PR TITLE
Avoid overflow when normalizing registration weights

### DIFF
--- a/src/pyrecest/utils/point_set_registration.py
+++ b/src/pyrecest/utils/point_set_registration.py
@@ -34,6 +34,7 @@ from pyrecest.backend import (
     sum,
     zeros,
 )
+from pyrecest.backend import max as backend_max
 
 from ._point_set_registration_common import (
     RegistrationLoopCallbacks,
@@ -148,10 +149,12 @@ def _normalize_weights(weights, n_points):
         raise ValueError("weights must be finite.")
     if any(weights_array < 0.0):
         raise ValueError("weights must be non-negative.")
-    weight_sum = float(weights_array.sum())
-    if weight_sum <= 0.0:
+    weight_scale = float(backend_max(weights_array))
+    if weight_scale <= 0.0:
         raise ValueError("weights must sum to a positive value.")
-    return weights_array / weight_sum
+    scaled_weights = weights_array / weight_scale
+    scaled_weight_sum = float(scaled_weights.sum())
+    return scaled_weights / scaled_weight_sum
 
 
 def _minimum_required_matches(model: TransformModel, dim: int) -> int:

--- a/tests/test_point_set_registration_extreme_weights.py
+++ b/tests/test_point_set_registration_extreme_weights.py
@@ -1,0 +1,43 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+import pyrecest.backend
+from pyrecest.backend import array, float64
+from pyrecest.utils.point_set_registration import estimate_transform
+
+
+class TestEstimateTransformExtremeWeights(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_finite_extreme_weights_preserve_relative_mass(self):
+        source = array(
+            [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]],
+            dtype=float64,
+        )
+        true_offset = array([2.0, -3.0], dtype=float64)
+        target = source + true_offset
+        reference_weights = array([4.0, 2.0, 1.0], dtype=float64)
+        extreme_weights = reference_weights * (np.finfo(np.float64).max / 4.0)
+
+        reference = estimate_transform(
+            source,
+            target,
+            model="translation",
+            weights=reference_weights,
+        )
+        estimated = estimate_transform(
+            source,
+            target,
+            model="translation",
+            weights=extreme_weights,
+        )
+
+        npt.assert_allclose(estimated.matrix, reference.matrix, atol=1e-12)
+        npt.assert_allclose(estimated.offset, true_offset, atol=1e-12)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- scale finite registration weights by their maximum before summing
- preserve relative weight mass for values near the `float64` limit
- add an end-to-end translation-registration regression

## Bug
`_normalize_weights()` summed the raw finite weights before normalization. Inputs such as `[max_float, max_float / 2, max_float / 4]` overflowed during the reduction, so division by infinity produced all-zero normalized weights. `estimate_transform()` then rejected the input as having no positive-weight support even though every supplied weight was finite and positive.

## Fix
Normalize in two stages: divide by the largest weight, then divide by the finite sum of the scaled weights. This is invariant to a common positive scaling of all weights and avoids overflow in the reduction.

## Validation
- added `tests/test_point_set_registration_extreme_weights.py`
- verified numerically that the previous normalization yields `[0, 0, 0]` for the regression input while the new normalization preserves `[4/7, 2/7, 1/7]`
- repository CI is expected to run on this draft PR