### PR TITLE
Stabilize discrete-state prior normalization

### DIFF
--- a/src/pyrecest/filters/discrete_state/__init__.py
+++ b/src/pyrecest/filters/discrete_state/__init__.py
@@ -114,10 +114,11 @@ def _validated_probability_vector(
     mask = _module_globals["_coerce_valid_state_mask"](valid_state_mask, n_entries)
     if mask is not None:
         values[~mask] = 0.0
-    total = float(values.sum())
-    if total <= 0.0:
+    maximum = float(np.max(values))
+    if maximum <= 0.0:
         raise ValueError(f"{name} must contain positive probability mass")
-    return values / total
+    values /= maximum
+    return values / float(values.sum())
 
 
 def sparse_gaussian_transition_matrix(

--- a/tests/filters/test_discrete_state_prior_normalization.py
+++ b/tests/filters/test_discrete_state_prior_normalization.py
@@ -1,0 +1,40 @@
+import unittest
+
+import numpy as np
+from pyrecest.filters.discrete_state import (
+    discrete_forward_backward,
+    imm_forward_backward,
+)
+
+
+class TestDiscreteStatePriorNormalization(unittest.TestCase):
+    def test_forward_backward_normalizes_large_finite_prior_without_overflow(self):
+        maximum = np.finfo(float).max
+        result = discrete_forward_backward(
+            np.zeros((1, 2)),
+            np.eye(2),
+            initial_probabilities=np.array([maximum, maximum / 2.0]),
+        )
+
+        np.testing.assert_allclose(
+            result.filtered_probabilities[0],
+            np.array([2.0 / 3.0, 1.0 / 3.0]),
+        )
+
+    def test_imm_normalizes_large_finite_state_and_mode_priors(self):
+        maximum = np.finfo(float).max
+        result = imm_forward_backward(
+            np.zeros((1, 2)),
+            [np.eye(2), np.eye(2)],
+            np.eye(2),
+            initial_state_probabilities=np.array([maximum, maximum / 2.0]),
+            initial_mode_probabilities=np.array([maximum, maximum / 2.0]),
+        )
+
+        expected = np.array([2.0 / 3.0, 1.0 / 3.0])
+        np.testing.assert_allclose(result.filtered_state_probabilities[0], expected)
+        np.testing.assert_allclose(result.filtered_mode_probabilities[0], expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- normalize finite discrete-state priors after scaling by their largest entry
- prevent summation overflow from turning valid priors into all-zero vectors
- add public-API regressions for HMM and IMM state/mode priors near the `float64` limit

## Root cause
`_validated_probability_vector()` summed caller-provided probabilities at their original scale. A vector such as `[np.finfo(float).max, np.finfo(float).max / 2]` contains only finite, non-negative entries, but its sum overflows to infinity. Dividing by that total produces an all-zero prior, and the subsequent filtering recursion fails because no prior mass remains.

## Fix
Scale the validated and masked vector by its maximum positive entry before summing. The scaled sum is finite and at least one, while all probability ratios and zero support are preserved.

## Validation
Added focused regressions through `discrete_forward_backward()` and `imm_forward_backward()` covering state and mode priors at the maximum finite `float64` scale.