### PR TITLE
Validate GNN association input dimensions

### DIFF
--- a/src/pyrecest/filters/global_nearest_neighbor.py
+++ b/src/pyrecest/filters/global_nearest_neighbor.py
@@ -134,16 +134,37 @@ class GlobalNearestNeighbor(AbstractNearestNeighborTracker):
         measurement_matrix = asarray(measurement_matrix, dtype=float)
         cov_mats_meas = asarray(cov_mats_meas, dtype=float)
 
+        if measurements.ndim != 2:
+            raise ValueError("measurements must have shape (dim_meas, n_meas).")
+        if measurement_matrix.ndim != 2:
+            raise ValueError("measurement_matrix must be a 2D matrix.")
+
         n_targets = len(self.filter_bank)
         n_meas = measurements.shape[1]
+        dim_meas = measurements.shape[0]
 
-        valid_shared_covariance = cov_mats_meas.ndim == 2
-        valid_per_measurement_covariances = (
-            cov_mats_meas.ndim == 3 and cov_mats_meas.shape[2] == n_meas
+        if measurement_matrix.shape[0] != dim_meas:
+            raise ValueError(
+                "Dimensions of measurement matrix must match measurement dimensions."
+            )
+        if n_targets > 0:
+            self._validate_measurement_update_inputs(
+                measurements,
+                measurement_matrix,
+                self.filter_bank[0].get_point_estimate().shape[0],
+            )
+
+        valid_shared_covariance = cov_mats_meas.shape == (dim_meas, dim_meas)
+        valid_per_measurement_covariances = cov_mats_meas.shape == (
+            dim_meas,
+            dim_meas,
+            n_meas,
         )
         if not (valid_shared_covariance or valid_per_measurement_covariances):
             raise ValueError(
-                "cov_mats_meas must be a matrix or contain one covariance per measurement."
+                "cov_mats_meas must have shape "
+                f"({dim_meas}, {dim_meas}) or "
+                f"({dim_meas}, {dim_meas}, {n_meas}), got {cov_mats_meas.shape}."
             )
 
         pairwise_cost_matrix = self._validate_pairwise_cost_matrix(

--- a/tests/filters/test_global_nearest_neighbor_input_dimensions.py
+++ b/tests/filters/test_global_nearest_neighbor_input_dimensions.py
@@ -1,0 +1,63 @@
+import unittest
+
+import numpy as np
+
+import pyrecest.backend
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.filters import KalmanFilter
+from pyrecest.filters.global_nearest_neighbor import GlobalNearestNeighbor
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+    reason="Global nearest-neighbor association is not supported on this backend",
+)
+class GlobalNearestNeighborInputDimensionTest(unittest.TestCase):
+    @staticmethod
+    def _tracker():
+        tracker = GlobalNearestNeighbor(
+            association_param={"distance_metric_pos": "Euclidean"}
+        )
+        tracker.filter_state = [
+            KalmanFilter(GaussianDistribution(np.zeros(2), np.eye(2)))
+        ]
+        return tracker
+
+    def test_rejects_one_dimensional_measurements(self):
+        tracker = self._tracker()
+
+        with self.assertRaisesRegex(
+            ValueError, r"measurements must have shape \(dim_meas, n_meas\)"
+        ):
+            tracker.find_association(np.zeros(2), np.eye(2), np.eye(2))
+
+    def test_rejects_measurement_matrix_row_mismatch(self):
+        tracker = self._tracker()
+
+        with self.assertRaisesRegex(ValueError, "measurement matrix"):
+            tracker.find_association(
+                np.zeros((2, 1)),
+                np.zeros((1, 2)),
+                np.eye(2),
+            )
+
+    def test_rejects_covariances_with_wrong_measurement_dimension(self):
+        tracker = self._tracker()
+        measurements = np.zeros((2, 1))
+
+        invalid_covariances = (
+            np.eye(3),
+            np.zeros((3, 3, 1)),
+        )
+        for cov_mats_meas in invalid_covariances:
+            with self.subTest(shape=cov_mats_meas.shape):
+                with self.assertRaisesRegex(ValueError, "cov_mats_meas must have shape"):
+                    tracker.find_association(
+                        measurements,
+                        np.eye(2),
+                        cov_mats_meas,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/filters/test_global_nearest_neighbor_input_dimensions.py
+++ b/tests/filters/test_global_nearest_neighbor_input_dimensions.py
@@ -51,7 +51,9 @@ class GlobalNearestNeighborInputDimensionTest(unittest.TestCase):
         )
         for cov_mats_meas in invalid_covariances:
             with self.subTest(shape=cov_mats_meas.shape):
-                with self.assertRaisesRegex(ValueError, "cov_mats_meas must have shape"):
+                with self.assertRaisesRegex(
+                    ValueError, "cov_mats_meas must have shape"
+                ):
                     tracker.find_association(
                         measurements,
                         np.eye(2),


### PR DESCRIPTION
## Summary

- validate direct `GlobalNearestNeighbor.find_association()` inputs before indexing or distance computation
- require measurement matrices to match the measurement-vector dimension
- require shared and per-measurement covariance matrices to have exact compatible shapes
- add focused regressions for malformed measurements, measurement matrices, and covariance tensors

## Bug

`find_association()` converted its inputs and immediately read `measurements.shape[1]`. A one-dimensional measurement vector therefore raised an `IndexError` instead of the API's normal `ValueError`. The covariance validation only checked rank (and, for tensors, the number of measurements), not the covariance's measurement dimensions. Consequently, incompatible covariance matrices could leak NumPy broadcasting errors in Mahalanobis mode and were silently accepted in Euclidean mode because that path does not consume the covariance values.

## Fix

Validate the measurement and measurement-matrix ranks up front, reuse the common nearest-neighbor dimension validator when targets are present, and accept covariance shapes only when they are exactly `(dim_meas, dim_meas)` or `(dim_meas, dim_meas, n_meas)`.

## Validation

- added regressions that fail on current `main` for a one-dimensional measurement input and wrong-dimensional shared/per-measurement covariances
- source and regression modules were syntax-checked while constructing the patch
- full repository validation is delegated to GitHub Actions
