### PR TITLE
Preserve fine time-offset grid resolution

### DIFF
--- a/src/pyrecest/calibration/time_offset.py
+++ b/src/pyrecest/calibration/time_offset.py
@@ -193,7 +193,7 @@ def make_offset_grid(min_s: float, max_s: float, step_s: float) -> np.ndarray:
     offsets = min_s + np.arange(count, dtype=float) * step_s
     if offsets.size == 0 or offsets[-1] < max_s - 1.0e-12:
         offsets = np.append(offsets, max_s)
-    return np.round(offsets, decimals=9)
+    return offsets
 
 
 def _validate_time_offset(offset_s: float | None) -> float:

--- a/tests/calibration/test_time_offset_grid_resolution.py
+++ b/tests/calibration/test_time_offset_grid_resolution.py
@@ -1,0 +1,13 @@
+import numpy as np
+import numpy.testing as npt
+
+from pyrecest.calibration.time_offset import make_offset_grid
+
+
+def test_preserves_subnanosecond_offset_steps():
+    step_s = 2.5e-10
+    offsets = make_offset_grid(0.0, 1.0e-9, step_s)
+    expected = np.arange(5, dtype=float) * step_s
+
+    npt.assert_array_equal(offsets, expected)
+    assert np.unique(offsets).size == offsets.size


### PR DESCRIPTION
## Summary

- preserve the caller-requested precision in `make_offset_grid()`
- prevent distinct sub-nanosecond candidates from collapsing into duplicate offsets
- add a focused regression for a 0.25 ns grid step

## Bug

`make_offset_grid()` validates `step_s` as any positive finite scalar, constructs the requested floating-point grid, and then unconditionally rounds every value to nine decimal places.

For example, the requested grid from `0` to `1 ns` with a `0.25 ns` step should contain five distinct candidates. The final rounding instead turns it into approximately `[0, 0, 0, 1 ns, 1 ns]`. An offset sweep then silently evaluates duplicate candidates and loses most of the requested resolution.

## Fix

Return the already constructed floating-point offsets directly rather than applying a hard-coded nanosecond rounding policy. Existing validation and inclusive-endpoint behavior are unchanged.

## Validation

- added `tests/calibration/test_time_offset_grid_resolution.py`
- regression checks both the exact requested grid and uniqueness of all candidates
- the source diff is one line; GitHub Actions is expected to provide full-suite validation
