### PR TITLE
Reject wrong-sized GGIW control inputs

### DIFF
--- a/src/pyrecest/filters/ggiw_tracker.py
+++ b/src/pyrecest/filters/ggiw_tracker.py
@@ -244,10 +244,17 @@ class GGIWTracker(
             self.kinematic_state.shape[0],
             "sys_noise",
         )
+        if inputs is not None:
+            inputs = array(inputs)
+            expected_shape = self.kinematic_state.shape
+            if inputs.shape != expected_shape:
+                raise ValueError(
+                    f"inputs must have shape {expected_shape}, got {inputs.shape}"
+                )
 
         self.kinematic_state = system_matrix @ self.kinematic_state
         if inputs is not None:
-            self.kinematic_state = self.kinematic_state + array(inputs)
+            self.kinematic_state = self.kinematic_state + inputs
         self.covariance = self._symmetrize(
             system_matrix @ self.covariance @ system_matrix.T + sys_noise
         )

--- a/tests/filters/test_ggiw_control_input_validation.py
+++ b/tests/filters/test_ggiw_control_input_validation.py
@@ -1,0 +1,59 @@
+import unittest
+
+import numpy.testing as npt
+import pyrecest.backend
+from pyrecest.backend import array, diag, eye
+from pyrecest.filters import GGIWTracker
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ != "numpy",
+    reason="GGIW tracker tests currently use numpy.testing assertions",
+)
+class GGIWControlInputValidationTest(unittest.TestCase):
+    @staticmethod
+    def _tracker():
+        return GGIWTracker(
+            kinematic_state=array([0.0, 0.0, 1.0, -1.0]),
+            covariance=diag(array([1.0, 1.0, 0.25, 0.25])),
+            extent=diag(array([4.0, 1.0])),
+            extent_degrees_of_freedom=12.0,
+            gamma_shape=4.0,
+            gamma_rate=2.0,
+            measurement_matrix=array(
+                [
+                    [1.0, 0.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0, 0.0],
+                ]
+            ),
+        )
+
+    def test_rejects_broadcastable_wrong_sized_input_without_mutating_state(self):
+        tracker = self._tracker()
+        prior_state = tracker.kinematic_state.copy()
+        prior_covariance = tracker.covariance.copy()
+        prior_extent_scale = tracker.extent_scale.copy()
+        prior_degrees_of_freedom = tracker.extent_degrees_of_freedom
+        prior_gamma_shape = tracker.gamma_shape
+        prior_gamma_rate = tracker.gamma_rate
+
+        with self.assertRaisesRegex(ValueError, r"inputs must have shape \(4,\)"):
+            tracker.predict_linear(
+                system_matrix=eye(4),
+                sys_noise=eye(4),
+                inputs=array([2.0]),
+            )
+
+        npt.assert_array_equal(tracker.kinematic_state, prior_state)
+        npt.assert_array_equal(tracker.covariance, prior_covariance)
+        npt.assert_array_equal(tracker.extent_scale, prior_extent_scale)
+        self.assertEqual(
+            tracker.extent_degrees_of_freedom,
+            prior_degrees_of_freedom,
+        )
+        self.assertEqual(tracker.gamma_shape, prior_gamma_shape)
+        self.assertEqual(tracker.gamma_rate, prior_gamma_rate)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- validate optional GGIW control inputs against the kinematic-state dimension
- reject broadcastable wrong-sized vectors before any tracker state is mutated
- add a regression that verifies all relevant tracker state remains unchanged on rejection

## Bug

`GGIWTracker.predict_linear()` added `array(inputs)` directly to the predicted kinematic state. NumPy broadcasting meant that a one-element input in a four-dimensional model was silently applied to every state component instead of being rejected.

Malformed inputs were also converted only after the system-model prediction had already mutated the tracker. An eventual shape error could therefore leave a partially predicted state.

## Fix

Normalize and validate `inputs` before prediction. Only an exact shape match with the kinematic state is accepted; the validated vector is then added after the system-model step.

## Validation

- added a focused regression for a broadcastable one-element input
- verifies kinematic state, covariance, extent scale, degrees of freedom, and Gamma parameters remain unchanged after rejection
- branch is two commits ahead of current `main` and zero behind
- full repository validation is delegated to GitHub Actions
