### PR TITLE
Reject noninteger PyTorch one-hot labels

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_one_hot_scalar_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_one_hot_scalar_contract.py
@@ -84,16 +84,15 @@ def _patch_pytorch_one_hot_scalar_contract(
 
     def one_hot(labels, num_classes):
         num_classes = _normalize_num_classes(num_classes, torch_module)
-        if torch_module.is_tensor(labels):
-            if (
-                labels.dtype == torch_module.bool
-                or labels.dtype.is_floating_point
-                or labels.dtype.is_complex
-            ):
-                return original_one_hot(labels, num_classes)
-            labels = labels.to(dtype=torch_module.long)
-        else:
-            labels = torch_module.as_tensor(labels, dtype=torch_module.long)
+        if not torch_module.is_tensor(labels):
+            labels = torch_module.as_tensor(labels)
+        if (
+            labels.dtype == torch_module.bool
+            or labels.dtype.is_floating_point
+            or labels.dtype.is_complex
+        ):
+            return original_one_hot(labels, num_classes)
+        labels = labels.to(dtype=torch_module.long)
         return torch_module.nn.functional.one_hot(labels, num_classes).to(
             dtype=torch_module.uint8
         )

--- a/tests/backend_support/test_pytorch_one_hot_label_dtype_contract.py
+++ b/tests/backend_support/test_pytorch_one_hot_label_dtype_contract.py
@@ -1,0 +1,67 @@
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+pytestmark = pytest.mark.backend_portable
+
+
+def _label_dtype_contract_code(target_module):
+    return f"""
+import numpy as np
+import torch
+import pyrecest  # noqa: F401  # triggers backend-support compatibility patches
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+
+target = {target_module}
+
+invalid_labels = (
+    [0.0, 1.0],
+    np.array([0.5, 1.0], dtype=np.float64),
+    True,
+    np.array([True, False], dtype=bool),
+    np.array([0.0 + 0.0j, 1.0 + 0.0j], dtype=np.complex128),
+)
+for labels in invalid_labels:
+    try:
+        target.one_hot(labels, 2)
+    except (RuntimeError, TypeError, ValueError):
+        pass
+    else:
+        raise AssertionError(f"non-integer labels were accepted: {{labels!r}}")
+
+integer_labels = np.array([0, 2], dtype=np.int32)
+result = target.one_hot(integer_labels, 3)
+assert result.dtype == torch.uint8
+assert tuple(result.shape) == (2, 3)
+assert torch.equal(
+    result,
+    torch.tensor([[1, 0, 0], [0, 0, 1]], dtype=torch.uint8),
+)
+
+print("ok")
+"""
+
+
+def test_raw_pytorch_one_hot_rejects_noninteger_array_like_labels():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code("numpy", _label_dtype_contract_code("raw_pytorch"))
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_public_pytorch_one_hot_rejects_noninteger_array_like_labels():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code("pytorch", _label_dtype_contract_code("backend"))
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary

- preserve the input dtype when converting Python and NumPy label values for the PyTorch `one_hot` compatibility wrapper
- reject floating-point, boolean, and complex array-like labels consistently with equivalent PyTorch tensor inputs
- retain support for integer arrays such as NumPy `int32` by promoting them to `torch.long`
- add focused regressions for both the raw and public PyTorch backend entry points

## Bug

The scalar-label compatibility patch converted every non-tensor label input directly with `dtype=torch.long`. As a result, inputs such as `[0.5, 1.0]`, NumPy floating arrays, and boolean values were silently truncated or coerced into integer class indices. Equivalent PyTorch tensor inputs were correctly rejected by `torch.nn.functional.one_hot`, so behavior depended on the input container rather than the label dtype.

## Fix

Convert non-tensor labels without forcing a dtype first. Floating-point, boolean, and complex labels are then routed through the original backend function, which rejects them using PyTorch's normal integer-index contract. Valid integer inputs continue to be promoted to `torch.long` before encoding.

## Validation

- reproduced the pre-fix silent coercion for Python lists, NumPy float arrays, and booleans
- verified the patched logic rejects float, boolean, and complex inputs while accepting NumPy `int32` labels
- added backend-portable subprocess tests for `raw_pytorch.one_hot` and the public PyTorch backend
- branch is two commits ahead of `main` and zero behind

The full backend and lint matrices are delegated to GitHub Actions.