### PR TITLE
Stabilize linear box-particle weight normalization

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/linear_box_particle_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/linear_box_particle_distribution.py
@@ -19,6 +19,7 @@ from pyrecest.backend import (
     isclose,
     isfinite,
     logical_and,
+    max as backend_max,
     maximum,
     minimum,
     ones,
@@ -26,6 +27,7 @@ from pyrecest.backend import (
     prod,
     random,
     reshape,
+    sqrt,
     sum,
     where,
     zeros_like,
@@ -115,10 +117,10 @@ class LinearBoxParticleDistribution(AbstractLinearDistribution):
 
     def normalize_in_place(self):
         """Normalize weights in-place."""
-        total_weight = self._validate_weights(self.w, "Weights")
-        if not bool(isclose(total_weight, 1.0, atol=1e-10)):
+        normalized_weights = self._normalized_weights(self.w, "Weights")
+        if not bool(all(isclose(self.w, normalized_weights, atol=1e-10))):
             warnings.warn("Weights are not normalized.", RuntimeWarning)
-            self.w = self.w / total_weight
+        self.w = normalized_weights
 
     def normalize(self):
         dist = copy.deepcopy(self)
@@ -231,12 +233,10 @@ class LinearBoxParticleDistribution(AbstractLinearDistribution):
         weights_update = array(f(dist.centers()))
         if weights_update.shape != dist.w.shape:
             raise ValueError("Function returned wrong output dimensions")
-        self._validate_weights(weights_update, "Weight updates")
-        new_weights = dist.w * weights_update
-        total_weight = self._validate_weights(
-            new_weights, "Updated box particle weights"
+        normalized_update = self._normalized_weights(weights_update, "Weight updates")
+        dist.w = self._normalized_weights(
+            dist.w * normalized_update, "Updated box particle weights"
         )
-        dist.w = new_weights / total_weight
         return dist
 
     def integrate(self, left=None, right=None):
@@ -331,14 +331,21 @@ class LinearBoxParticleDistribution(AbstractLinearDistribution):
 
     @staticmethod
     def _validate_weights(weights, name):
+        if int(weights.shape[0]) == 0:
+            raise ValueError(f"{name} must have positive finite total mass")
         if not bool(all(isfinite(weights))):
             raise ValueError(f"{name} must be finite")
         if bool(any(weights < 0)):
             raise ValueError(f"{name} must be nonnegative")
-        total_weight = sum(weights)
-        if not bool(isfinite(total_weight)) or not bool(total_weight > 0):
+        if not bool(backend_max(weights) > 0):
             raise ValueError(f"{name} must have positive finite total mass")
-        return total_weight
+
+    @staticmethod
+    def _normalized_weights(weights, name):
+        LinearBoxParticleDistribution._validate_weights(weights, name)
+        weight_scale_root = sqrt(backend_max(weights))
+        scaled_weights = (weights / weight_scale_root) / weight_scale_root
+        return scaled_weights / sum(scaled_weights)
 
     @staticmethod
     def _coerce_half_width(box_half_width, dim):

--- a/tests/distributions/test_linear_box_particle_distribution.py
+++ b/tests/distributions/test_linear_box_particle_distribution.py
@@ -75,6 +75,33 @@ class LinearBoxParticleDistributionTest(unittest.TestCase):
                         array([[0.0], [1.0]]), array([[1.0], [2.0]]), weights
                     )
 
+    def test_constructor_normalizes_extreme_finite_weights(self):
+        backend_dtype = to_numpy(array([1.0])).dtype
+        max_finite = np.finfo(backend_dtype).max
+
+        with self.assertWarnsRegex(RuntimeWarning, "not normalized"):
+            dist = LinearBoxParticleDistribution(
+                array([[0.0], [1.0]]),
+                array([[1.0], [2.0]]),
+                array([max_finite, max_finite / 2.0]),
+            )
+
+        npt.assert_allclose(to_numpy(dist.w), [2.0 / 3.0, 1.0 / 3.0])
+
+    def test_reweigh_preserves_extreme_finite_relative_weights(self):
+        backend_dtype = to_numpy(array([1.0])).dtype
+        max_finite = np.finfo(backend_dtype).max
+        dist = LinearBoxParticleDistribution(
+            array([[0.0], [1.0]]), array([[1.0], [2.0]])
+        )
+
+        reweighted = dist.reweigh(
+            lambda _centers: array([max_finite, max_finite / 2.0])
+        )
+
+        npt.assert_allclose(to_numpy(reweighted.w), [2.0 / 3.0, 1.0 / 3.0])
+        npt.assert_allclose(to_numpy(dist.w), [0.5, 0.5])
+
     def test_reweigh_rejects_invalid_weight_updates(self):
         invalid_updates = (
             ("nan", lambda _centers: array([1.0, np.nan]), "finite"),


### PR DESCRIPTION
## Summary

- normalize box-particle weights after scale-safe validation instead of summing at the caller's raw magnitude
- make `reweigh()` invariant to extreme finite update scales before multiplying by the prior weights
- add focused constructor and reweight regressions near the active backend dtype limit

## Bug

`LinearBoxParticleDistribution._validate_weights()` summed finite nonnegative weights before normalization. For values such as `[max_float, max_float / 2]`, the reduction overflows to infinity even though every input is finite and the relative probability vector is valid. Construction therefore raised `ValueError` instead of producing weights `[2/3, 1/3]`.

The same raw-scale validation rejected otherwise valid extreme finite values returned by `reweigh()`.

## Fix

Validate finiteness, nonnegativity, nonempty input, and the existence of a positive entry without requiring the raw sum to be representable. Normalize through two square-root-sized scale divisions before the final bounded sum; this also avoids reciprocal underflow in JAX/XLA-style lowering. Reweight updates are normalized before multiplication, preserving the mathematical result while avoiding unnecessary overflow or underflow.

## Validation

- reproduced the old NumPy behavior: the raw sum becomes `inf` and direct normalization yields `[0, 0]`
- `python -m py_compile` passed for the modified implementation and test module
- isolated NumPy-backed execution of `tests/distributions/test_linear_box_particle_distribution.py`: **11 passed, 19 subtests passed**
- branch was refreshed onto current `main` before opening this PR

The full backend and lint matrices are delegated to GitHub Actions.