### PR TITLE
Reject invalid positive-kernel exponents

### DIFF
--- a/src/pyrecest/distributions/hypertorus/fejer.py
+++ b/src/pyrecest/distributions/hypertorus/fejer.py
@@ -186,6 +186,42 @@ def positive_kernel_weights(shape: CoefficientShape, *, kernel: str = "fejer", d
     raise AssertionError(f"Unhandled normalized kernel {kernel!r}.")
 
 
+def _validate_kernel_exponent(exponent) -> float:
+    """Return a finite nonnegative real scalar kernel exponent."""
+
+    message = "exponent must be a finite nonnegative real scalar."
+    try:
+        exponent_array = np.asarray(exponent)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if exponent_array.ndim != 0 or exponent_array.dtype.kind in "bSUcMm":
+        raise ValueError(message)
+
+    scalar = exponent_array.item()
+    if isinstance(
+        scalar,
+        (
+            bool,
+            np.bool_,
+            str,
+            bytes,
+            bytearray,
+            complex,
+            np.complexfloating,
+            np.datetime64,
+            np.timedelta64,
+        ),
+    ):
+        raise ValueError(message)
+    try:
+        exponent_value = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if not np.isfinite(exponent_value) or exponent_value < 0.0:
+        raise ValueError(message)
+    return exponent_value
+
+
 def apply_kernel_weights(coefficients, *, kernel: str = "fejer", exponent: float = 1.0):
     """Apply separable positive-kernel weights to a centered coefficient tensor.
 
@@ -195,8 +231,7 @@ def apply_kernel_weights(coefficients, *, kernel: str = "fejer", exponent: float
     be interpreted as an analytic nonnegativity certificate.
     """
 
-    if exponent < 0.0:
-        raise ValueError("exponent must be nonnegative.")
+    exponent = _validate_kernel_exponent(exponent)
     coeff_arr = np.asarray(coefficients)
     normalize_coefficient_shape(coeff_arr.shape, dim=coeff_arr.ndim, name="coefficients.shape")
     kernel = normalize_kernel_name(kernel)

--- a/tests/distributions/test_fejer_exponent_validation.py
+++ b/tests/distributions/test_fejer_exponent_validation.py
@@ -1,0 +1,28 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from pyrecest.distributions.hypertorus.fejer import apply_kernel_weights, fejer_weights
+
+
+@pytest.mark.parametrize(
+    "exponent",
+    (
+        np.nan,
+        np.inf,
+        -np.inf,
+        True,
+        1.0 + 0.0j,
+        "1.0",
+        np.array([1.0]),
+    ),
+)
+def test_apply_kernel_weights_rejects_invalid_exponents(exponent):
+    with pytest.raises(ValueError, match="exponent"):
+        apply_kernel_weights(np.ones(3), exponent=exponent)
+
+
+def test_apply_kernel_weights_accepts_zero_dimensional_real_exponent():
+    result = apply_kernel_weights(np.ones(3), exponent=np.array(0.5))
+
+    npt.assert_allclose(result, np.sqrt(fejer_weights(3)))


### PR DESCRIPTION
## Summary
- validate kernel damping exponents as finite, nonnegative real scalars
- reject NaN, infinities, booleans, complex/text inputs, and non-scalar arrays before kernel arithmetic
- preserve valid NumPy zero-dimensional real scalar inputs
- add focused regression coverage

## Bug
`apply_kernel_weights()` only checked whether `exponent < 0`. Non-finite values therefore passed validation. In particular, `exponent=np.nan` produced partially NaN coefficient tensors, while `exponent=np.inf` silently collapsed non-central coefficients to zero. Boolean and non-scalar values could also be accepted through Python/NumPy comparison semantics.

## Fix
Normalize and validate the exponent at the public function boundary. The new validator requires a scalar, real, finite value greater than or equal to zero, then returns a Python float for consistent downstream comparisons and `np.power()` behavior.

## Impact
Invalid adaptive-damping parameters now fail deterministically with a descriptive `ValueError` instead of silently corrupting Fourier coefficients. Existing valid integer, floating-point, and zero-dimensional NumPy scalar exponents retain their behavior.

## Validation
- `python -m py_compile` on the patched module
- direct regression checks for NaN, infinities, booleans, complex/text values, non-scalar arrays, and a valid zero-dimensional exponent
