### PR TITLE
Preserve first survival-aware Pitman–Yor birth

### DIFF
--- a/src/pyrecest/filters/survival_aware_crp.py
+++ b/src/pyrecest/filters/survival_aware_crp.py
@@ -301,7 +301,8 @@ class SurvivalAwareCRPAssociationPrior:
         """Return the unnormalized new-track weight.
 
         ``base_birth_weight`` can encode a spatial birth intensity or a
-        measurement-specific birth likelihood.  The Pitman--Yor-style BNP part is
+        measurement-specific birth likelihood.  The first target-generated
+        cluster has unit Pitman--Yor weight; after that the BNP factor is
         ``concentration + discount * K``.
         """
 
@@ -313,6 +314,8 @@ class SurvivalAwareCRPAssociationPrior:
             base_birth_weight,
             "base_birth_weight",
         )
+        if num_existing_tracks == 0:
+            return base_birth_weight
         return base_birth_weight * (
             self.concentration + self.discount * num_existing_tracks
         )

--- a/tests/filters/test_survival_aware_crp_first_birth.py
+++ b/tests/filters/test_survival_aware_crp_first_birth.py
@@ -1,0 +1,38 @@
+import pytest
+
+from pyrecest.filters.survival_aware_crp import SurvivalAwareCRPAssociationPrior
+
+
+@pytest.mark.parametrize("concentration", [0.0, -0.25])
+def test_first_target_generated_cluster_uses_unit_pitman_yor_weight(concentration):
+    prior = SurvivalAwareCRPAssociationPrior(
+        concentration=concentration,
+        discount=0.5,
+    )
+
+    existing_weights, birth_weight, clutter_weight = (
+        prior.predictive_assignment_weights(
+            [],
+            base_birth_weight=0.25,
+            clutter_weight=0.75,
+        )
+    )
+    probabilities = prior.predictive_assignment_probabilities(
+        [],
+        base_birth_weight=0.25,
+        clutter_weight=0.75,
+    )
+
+    assert existing_weights == ()
+    assert birth_weight == pytest.approx(0.25)
+    assert clutter_weight == pytest.approx(0.75)
+    assert probabilities.as_tuple == pytest.approx((0.25, 0.75))
+
+
+def test_subsequent_births_still_use_concentration_and_discount():
+    prior = SurvivalAwareCRPAssociationPrior(
+        concentration=-0.25,
+        discount=0.5,
+    )
+
+    assert prior.birth_weight(1, base_birth_weight=2.0) == pytest.approx(0.5)


### PR DESCRIPTION
## Summary

- give the first target-generated cluster unit Pitman–Yor weight
- preserve concentration/discount weighting once tracks exist
- add regressions for zero and negative valid concentration values

## Bug

`SurvivalAwareCRPAssociationPrior` accepts `concentration > -discount`, so zero and negative concentration values are valid when the discount is positive. `birth_weight()` nevertheless evaluated `concentration + discount * K` at `K = 0`, producing a zero or negative birth weight.

With no existing tracks, this either made the first birth impossible or caused assignment-weight normalization to reject the result. The tracker could therefore fail to initialize for parameter values its constructor explicitly accepts.

## Fix

Follow the first-cluster Pitman–Yor rule already used by `PitmanYorCardinalityPrior`: when `K == 0`, use unit BNP mass and return `base_birth_weight`. For `K > 0`, retain `concentration + discount * K` unchanged.

## Validation

- added focused regressions for `concentration=0.0` and `concentration=-0.25` with `discount=0.5`
- verified first-birth/clutter probabilities are `(0.25, 0.75)` with no existing tracks
- verified a subsequent birth still uses concentration and discount
- `python -m py_compile /tmp/survival_aware_crp_patched.py /tmp/test_survival_aware_crp_first_birth.py`
- `pytest -q /tmp/test_survival_aware_crp_first_birth.py` (`3 passed`)
