### PR TITLE
Stabilize hyperspherical UKF noise-weight normalization

### DIFF
--- a/src/pyrecest/filters/hyperspherical_ukf.py
+++ b/src/pyrecest/filters/hyperspherical_ukf.py
@@ -24,6 +24,7 @@ from pyrecest.backend import (  # pylint: disable=redefined-builtin
     float64,
     isfinite,
     linalg,
+    max as backend_max,
     reshape,
     zeros,
 )
@@ -205,7 +206,9 @@ class HypersphericalUKF(AbstractFilter, HypersphericalFilterMixin):
             raise ValueError("noise_weights must be finite.")
         if not all(noise_weights > 0):
             raise ValueError("noise_weights must be strictly positive.")
-        noise_weights = noise_weights / noise_weights.sum()
+        weight_scale = backend_max(noise_weights)
+        scaled_noise_weights = noise_weights / weight_scale
+        noise_weights = scaled_noise_weights / scaled_noise_weights.sum()
 
         mu = reshape(asarray(self._filter_state.mu, dtype=float64), (-1,))
         C = asarray(self._filter_state.C, dtype=float64)

--- a/tests/filters/test_hyperspherical_ukf_arbitrary_noise_normalization.py
+++ b/tests/filters/test_hyperspherical_ukf_arbitrary_noise_normalization.py
@@ -36,3 +36,38 @@ class HypersphericalUKFArbitraryNoiseNormalizationTest(unittest.TestCase):
             np.zeros((2, 2)),
             atol=1e-12,
         )
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Arbitrary-noise prediction is not supported on this backend",
+    )
+    def test_extreme_finite_noise_weights_preserve_relative_mass(self):
+        maximum = np.finfo(np.float64).max
+        noise_samples = np.array([[0.0, 1.0]])
+
+        def direction_by_noise(_x, v):
+            return array([1.0, float(np.asarray(v, dtype=float)[0])])
+
+        reference = HypersphericalUKF(dim=2, alpha=1.0)
+        reference.predict_nonlinear_arbitrary_noise(
+            direction_by_noise,
+            noise_samples,
+            np.array([2.0, 1.0]),
+        )
+
+        extreme = HypersphericalUKF(dim=2, alpha=1.0)
+        extreme.predict_nonlinear_arbitrary_noise(
+            direction_by_noise,
+            noise_samples,
+            np.array([maximum, maximum / 2.0]),
+        )
+
+        reference_mean = np.asarray(reference.filter_state.mu, dtype=float)
+        reference_covariance = np.asarray(reference.filter_state.C, dtype=float)
+        extreme_mean = np.asarray(extreme.filter_state.mu, dtype=float)
+        extreme_covariance = np.asarray(extreme.filter_state.C, dtype=float)
+
+        self.assertTrue(np.all(np.isfinite(extreme_mean)))
+        self.assertTrue(np.all(np.isfinite(extreme_covariance)))
+        npt.assert_allclose(extreme_mean, reference_mean, atol=1e-12)
+        npt.assert_allclose(extreme_covariance, reference_covariance, atol=1e-12)


### PR DESCRIPTION
## Summary

- normalize arbitrary-noise UKF weights after scaling by their largest entry
- preserve the relative mass of finite weights near the `float64` limit
- add an end-to-end regression comparing ordinary-scale and extreme-scale predictions

## Bug

`HypersphericalUKF.predict_nonlinear_arbitrary_noise()` divided the noise weights by their raw sum. A valid vector such as `[np.finfo(float).max, np.finfo(float).max / 2]` contains only finite, strictly positive entries, but its reduction overflows to infinity. The division then produces all-zero weights, and the subsequent combined mean-weight normalization divides by zero, corrupting the predicted mean with NaNs.

## Fix

Scale the validated weights by their maximum before summing. Every scaled entry is in `(0, 1]`, the sum remains representable, and the resulting normalized probability vector is algebraically identical to direct normalization whenever the latter is finite.

## Impact

Arbitrary-noise hyperspherical UKF prediction is now invariant to a common positive scale applied to finite noise weights, including values near the active backend dtype limit.

## Validation

- reproduced the old NumPy reduction: the raw sum becomes `inf` and normalization yields `[0, 0]`
- verified maximum-scaled normalization yields `[2/3, 1/3]`
- added an end-to-end regression that checks finite state output and equality with the ordinary-scale reference prediction
- branch is two commits ahead of current `main` and zero behind

Full backend and lint validation is delegated to GitHub Actions.