### PR TITLE
Avoid false symmetric-manifold matches

### DIFF
--- a/src/pyrecest/evaluation/get_extract_mean.py
+++ b/src/pyrecest/evaluation/get_extract_mean.py
@@ -7,6 +7,8 @@ import numpy as np
 
 MeanExtractorFactory = Callable[[str, bool], Callable[[Any], Any]]
 _EXTRACT_MEAN_FACTORIES: dict[str, MeanExtractorFactory] = {}
+_SYMMETRIC_TOKENS = {"symmetric", "symm"}
+_SYMMETRIC_MANIFOLDS = ("circle", "hypertorus", "hypersphere")
 
 
 def _normalize_registry_name(manifold_name: str) -> str:
@@ -40,21 +42,46 @@ def available_extract_mean_functions() -> tuple[str, ...]:
     return tuple(sorted(_EXTRACT_MEAN_FACTORIES))
 
 
-def _is_hypersphere_symmetric_name(normalized_name: str) -> bool:
-    tokens = tuple(
+def _manifold_name_tokens(normalized_name: str) -> tuple[str, ...]:
+    return tuple(
         token for token in normalized_name.replace("-", "_").split("_") if token
     )
+
+
+def _is_compact_symmetric_manifold_name(compact_name: str) -> bool:
+    return any(
+        compact_name
+        in {
+            f"symmetric{manifold}",
+            f"symm{manifold}",
+            f"{manifold}symmetric",
+            f"{manifold}symm",
+        }
+        for manifold in _SYMMETRIC_MANIFOLDS
+    )
+
+
+def _is_symmetric_name(normalized_name: str) -> bool:
+    tokens = _manifold_name_tokens(normalized_name)
+    if any(token in _SYMMETRIC_TOKENS for token in tokens):
+        return True
+    return _is_compact_symmetric_manifold_name("".join(tokens))
+
+
+def _is_hypersphere_symmetric_name(normalized_name: str) -> bool:
+    tokens = _manifold_name_tokens(normalized_name)
     if "hypersphere" in tokens and any(
-        token in {"symmetric", "symm"} for token in tokens
+        token in _SYMMETRIC_TOKENS for token in tokens
     ):
         return True
 
     compact = "".join(tokens)
-    return (
-        "hyperspheresymmetric" in compact
-        or "hyperspheresymm" in compact
-        or compact in {"symmetrichypersphere", "symmhypersphere"}
-    )
+    return compact in {
+        "hyperspheresymmetric",
+        "hyperspheresymm",
+        "symmetrichypersphere",
+        "symmhypersphere",
+    }
 
 
 def _is_array_state(filter_state) -> bool:
@@ -107,7 +134,7 @@ def get_extract_mean(manifold_name, mtt_scenario=False):
         _unsupported(
             "Symmetric hypersphere mean extraction needs an explicit convention via a custom extractor."
         )
-    elif "symm" in normalized_name:
+    elif _is_symmetric_name(normalized_name):
         _unsupported("Symmetric mean extraction needs an explicit convention")
     elif "circle" in normalized_name or "hypertorus" in normalized_name:
 

--- a/tests/evaluation/test_extract_mean_symmetry_name_detection.py
+++ b/tests/evaluation/test_extract_mean_symmetry_name_detection.py
@@ -1,0 +1,34 @@
+import pytest
+
+from pyrecest.evaluation.get_extract_mean import get_extract_mean
+
+
+class _DirectionalState:
+    def mean_direction(self):
+        return "direction"
+
+
+@pytest.mark.parametrize(
+    "manifold_name",
+    ("asymmetric_circle", "nonsymmetric_hypertorus"),
+)
+def test_non_symmetric_substrings_do_not_trigger_symmetry_guard(manifold_name):
+    extractor = get_extract_mean(manifold_name)
+
+    assert extractor(_DirectionalState()) == "direction"
+
+
+@pytest.mark.parametrize(
+    "manifold_name",
+    (
+        "circle_symmetric",
+        "symmetric_circle",
+        "hypertorus_symmetric",
+        "symm_hypertorus",
+        "symmetriccircle",
+        "circlesymm",
+    ),
+)
+def test_explicit_symmetric_names_still_require_a_convention(manifold_name):
+    with pytest.raises(NotImplementedError, match="explicit convention"):
+        get_extract_mean(manifold_name)


### PR DESCRIPTION
## Summary

- replace the broad `"symm" in manifold_name` guard with token-aware symmetry detection
- preserve supported symmetric circle, hypertorus, and hypersphere aliases, including compact forms
- add regressions for non-symmetric names that merely contain the substring `symm`

## Bug

`get_extract_mean()` treated every manifold name containing the character sequence `symm` as symmetric. Consequently, names such as `asymmetric_circle` and `nonsymmetric_hypertorus` raised `NotImplementedError` instead of using the ordinary directional mean extractor.

## Fix

Recognize symmetry only when `symmetric` or `symm` appears as a delimited token, or when the complete compact name matches a supported symmetric manifold alias. This avoids substring collisions while retaining the explicit symmetric-name behavior introduced for circle, hypertorus, and hypersphere manifolds.

## Validation

- added focused regressions for `asymmetric_circle` and `nonsymmetric_hypertorus`
- retained coverage for separated and compact symmetric aliases
- isolated test run: `8 passed`
- `python -m py_compile` passed for the implementation and regression test
- branch is two commits ahead of `main` and zero behind