### PR TITLE
Reject missing grid transition densities

### DIFF
--- a/src/pyrecest/models/grid.py
+++ b/src/pyrecest/models/grid.py
@@ -25,6 +25,12 @@ def _ensure_callable(value: Any, name: str) -> None:
         raise TypeError(f"{name} must be callable")
 
 
+def _require_transition_density(value: Any, name: str) -> Any:
+    if value is None:
+        raise ValueError(f"{name} must not be None")
+    return value
+
+
 @dataclass(frozen=True)
 class GridLikelihoodMeasurementModel:
     """Measurement model that evaluates likelihoods on a filter grid.
@@ -66,6 +72,9 @@ class GridTransitionDensityModel:
 
     transition_density: Any
 
+    def __post_init__(self) -> None:
+        _require_transition_density(self.transition_density, "transition_density")
+
     def transition_density_for_filter(self, _filter: Any) -> Any:
         """Return the precomputed transition density for ``_filter``."""
         return self.transition_density
@@ -95,4 +104,8 @@ class GridTransitionDensityFactoryModel:
 
     def transition_density_for_filter(self, filter_instance: Any) -> Any:
         """Create a transition density compatible with ``filter_instance``."""
-        return self.transition_density_factory(filter_instance)
+        transition_density = self.transition_density_factory(filter_instance)
+        return _require_transition_density(
+            transition_density,
+            "transition_density_factory result",
+        )

--- a/tests/models/test_grid_model_validation.py
+++ b/tests/models/test_grid_model_validation.py
@@ -21,6 +21,19 @@ class TestGridModelValidation(unittest.TestCase):
         ):
             GridTransitionDensityFactoryModel(transition_density_factory=object())
 
+    def test_transition_density_model_rejects_none(self):
+        with self.assertRaisesRegex(ValueError, "transition_density must not be None"):
+            GridTransitionDensityModel(None)
+
+    def test_transition_density_factory_rejects_none_result(self):
+        model = GridTransitionDensityFactoryModel(lambda _filter: None)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "transition_density_factory result must not be None",
+        ):
+            model.transition_density_for_filter(object())
+
     def test_valid_grid_model_callbacks_still_evaluate(self):
         likelihood_model = GridLikelihoodMeasurementModel(
             lambda measurement, grid: (measurement, grid)


### PR DESCRIPTION
## Summary

- reject `None` when constructing a precomputed grid transition-density model
- reject factories that return `None` at evaluation time
- add focused regressions while preserving valid model behavior

## Bug

`GridTransitionDensityModel` accepted `transition_density=None`, and `GridTransitionDensityFactoryModel` accepted a factory whose result was `None`. Both objects therefore appeared to be valid transition models, but later returned `None` to a grid filter. The actual failure then occurred deeper in prediction with an unrelated attribute or type error, obscuring the invalid model configuration.

## Fix

Validate the transition-density boundary explicitly. Precomputed models now reject `None` during construction, while factory-backed models reject a `None` result immediately when the factory is evaluated. Concrete transition-density types remain intentionally unconstrained so different grid filters can continue to supply their own compatible objects.

## Validation

- `python -m py_compile` on the patched model and regression module
- isolated `unittest` execution: **5 passed**
- branch comparison against `main`: two commits ahead, zero behind; 28 changed lines across the model and focused test file

The full backend and lint matrices are delegated to GitHub Actions.