### PR TITLE
Fix SE(3) plotting axis-limit containment checks

### DIFF
--- a/src/pyrecest/distributions/abstract_se3_distribution.py
+++ b/src/pyrecest/distributions/abstract_se3_distribution.py
@@ -119,11 +119,11 @@ class AbstractSE3Distribution(AbstractLinBoundedCartProdDistribution):
         optAx = (pos // 5) * 5
 
         # Adjust axis limits if necessary
-        if xl[0] < needed_boundaries[0, 0] or xl[1] > needed_boundaries[0, 1]:
+        if xl[0] > needed_boundaries[0, 0] or xl[1] < needed_boundaries[0, 1]:
             ax.set_xlim([optAx[0] - 5, optAx[0] + 5])
-        if yl[0] < needed_boundaries[1, 0] or yl[1] > needed_boundaries[1, 1]:
+        if yl[0] > needed_boundaries[1, 0] or yl[1] < needed_boundaries[1, 1]:
             ax.set_ylim([optAx[1] - 5, optAx[1] + 5])
-        if zl[0] < needed_boundaries[2, 0] or zl[1] > needed_boundaries[2, 1]:
+        if zl[0] > needed_boundaries[2, 0] or zl[1] < needed_boundaries[2, 1]:
             ax.set_zlim([optAx[2] - 5, optAx[2] + 5])
 
         return h

--- a/tests/distributions/test_abstract_se3_plot_limits.py
+++ b/tests/distributions/test_abstract_se3_plot_limits.py
@@ -1,0 +1,86 @@
+import unittest
+from unittest.mock import patch
+
+from pyrecest.backend import array
+from pyrecest.distributions.abstract_se3_distribution import AbstractSE3Distribution
+
+
+class _RecordingAxes:
+    def __init__(self, x_limits, y_limits, z_limits):
+        self.x_limits = x_limits
+        self.y_limits = y_limits
+        self.z_limits = z_limits
+        self.set_xlim_calls = []
+        self.set_ylim_calls = []
+        self.set_zlim_calls = []
+
+    @staticmethod
+    def quiver(*_args, **_kwargs):
+        return object()
+
+    def get_xlim(self):
+        return self.x_limits
+
+    def get_ylim(self):
+        return self.y_limits
+
+    def get_zlim(self):
+        return self.z_limits
+
+    def set_xlim(self, limits):
+        self.set_xlim_calls.append(tuple(float(value) for value in limits))
+
+    def set_ylim(self, limits):
+        self.set_ylim_calls.append(tuple(float(value) for value in limits))
+
+    def set_zlim(self, limits):
+        self.set_zlim_calls.append(tuple(float(value) for value in limits))
+
+
+class _RecordingFigure:
+    def __init__(self, axes):
+        self.axes = axes
+
+    def add_subplot(self, *_args, **_kwargs):
+        return self.axes
+
+
+class TestAbstractSE3PlotLimits(unittest.TestCase):
+    @staticmethod
+    def _plot_with_axes(axes):
+        point = array([1.0, 0.0, 0.0, 0.0, 10.0, 20.0, 30.0])
+        with patch(
+            "pyrecest.distributions.abstract_se3_distribution.plt.figure",
+            return_value=_RecordingFigure(axes),
+        ):
+            AbstractSE3Distribution.plot_point(point)
+
+    def test_plot_point_preserves_limits_containing_body_axes(self):
+        axes = _RecordingAxes(
+            (-100.0, 100.0),
+            (-100.0, 100.0),
+            (-100.0, 100.0),
+        )
+
+        self._plot_with_axes(axes)
+
+        self.assertEqual(axes.set_xlim_calls, [])
+        self.assertEqual(axes.set_ylim_calls, [])
+        self.assertEqual(axes.set_zlim_calls, [])
+
+    def test_plot_point_expands_limits_inside_required_bounds(self):
+        axes = _RecordingAxes(
+            (10.25, 10.75),
+            (20.25, 20.75),
+            (30.25, 30.75),
+        )
+
+        self._plot_with_axes(axes)
+
+        self.assertEqual(axes.set_xlim_calls, [(5.0, 15.0)])
+        self.assertEqual(axes.set_ylim_calls, [(15.0, 25.0)])
+        self.assertEqual(axes.set_zlim_calls, [(25.0, 35.0)])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- correct the SE(3) plotting bounds checks so existing limits are changed only when they fail to contain a plotted body axis
- preserve broad limits that already contain the full frame
- expand limits that lie strictly inside the frame's required coordinate range
- add focused regressions for both failure modes

## Bug
`AbstractSE3Distribution.plot_point()` used the containment inequalities in the wrong direction. It reset an axis when the current lower bound was smaller than the required lower bound or the current upper bound was larger than the required upper bound. Consequently, limits that already contained the plotted frame were unnecessarily shrunk, while limits strictly inside the required frame bounds were left unchanged and could clip the body axes.

## Fix
Check whether the current lower bound is greater than the required minimum or the current upper bound is less than the required maximum before resetting that axis.

## Validation
- added deterministic mocked-axis regressions covering already-containing limits and insufficient interior limits
- inspected the branch diff against `main`; it contains only the three corrected comparisons and the new regression file

Full repository tests are delegated to GitHub Actions because the execution environment has no outbound GitHub access and no local checkout could be obtained.