### PR TITLE
Stabilize particle diagnostics weight normalization

### DIFF
--- a/src/pyrecest/diagnostics.py
+++ b/src/pyrecest/diagnostics.py
@@ -176,10 +176,12 @@ def _normalized_nonnegative_weights(values: list[float]) -> list[float]:
     if any(not isfinite(value) for value in values):
         raise ValueError("Particle weights must be finite.")
     nonnegative_values = [max(0.0, value) for value in values]
-    total = sum(nonnegative_values)
-    if total <= 0.0:
+    scale = max(nonnegative_values, default=0.0)
+    if scale <= 0.0:
         return [0.0 for _ in nonnegative_values]
-    return [value / total for value in nonnegative_values]
+    scaled_values = [value / scale for value in nonnegative_values]
+    total = sum(scaled_values)
+    return [value / total for value in scaled_values]
 
 
 class _DiagnosticsMappingMixin:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -26,6 +26,18 @@ def test_particle_diagnostics_clips_negative_weights_before_normalizing():
     assert isclose(diagnostics.weight_entropy, log(2.0))
 
 
+def test_particle_diagnostics_preserves_extreme_finite_weight_ratios():
+    maximum = np.finfo(float).max
+
+    diagnostics = ParticleDiagnostics.from_weights([maximum, maximum / 2.0])
+
+    assert isclose(diagnostics.effective_sample_size, 1.8)
+    expected_entropy = -(2.0 / 3.0) * log(2.0 / 3.0) - (1.0 / 3.0) * log(
+        1.0 / 3.0
+    )
+    assert isclose(diagnostics.weight_entropy, expected_entropy)
+
+
 def test_particle_diagnostics_rejects_nonfinite_weights():
     for weights in ([float("nan"), 1.0], [float("inf"), 1.0]):
         with pytest.raises(ValueError, match="Particle weights must be finite"):


### PR DESCRIPTION
## Summary

- normalize finite nonnegative particle weights after scaling by their largest entry
- preserve relative probability mass when the raw weight sum would overflow
- add a focused regression at the `float64` limit

## Bug

`ParticleDiagnostics.from_weights()` summed weights at their caller-provided scale. Inputs such as `[np.finfo(float).max, np.finfo(float).max / 2]` contain only finite values and define the valid probability vector `[2/3, 1/3]`, but their raw sum overflows to infinity. Direct normalization then produced `[0, 0]`, causing both effective sample size and entropy to be reported as zero.

## Fix

After the existing finiteness check and negative-weight clipping, divide all weights by the largest positive entry before summing. The scaled values lie in `[0, 1]`, so their sum remains representable while preserving all weight ratios and zero support.

## Impact

Particle diagnostics are now invariant to common positive scaling of finite weights, including values near the active floating-point limit. Zero and all-negative inputs retain the existing zero-diagnostics behavior.

## Validation

- `PYTHONPATH=/tmp/pyrecest-fix/src python -m pytest -q /tmp/pyrecest-fix/tests/test_diagnostics.py` (`6 passed`)
- `python -m py_compile` on the modified implementation and regression module
- branch comparison: two commits ahead, zero behind; 20 changed lines across two files

Closes #4415.