### PR TITLE
Fix particle diagnostics normalization overflow

### DIFF
--- a/src/pyrecest/diagnostics.py
+++ b/src/pyrecest/diagnostics.py
@@ -176,10 +176,12 @@ def _normalized_nonnegative_weights(values: list[float]) -> list[float]:
     if any(not isfinite(value) for value in values):
         raise ValueError("Particle weights must be finite.")
     nonnegative_values = [max(0.0, value) for value in values]
-    total = sum(nonnegative_values)
-    if total <= 0.0:
+    scale = max(nonnegative_values, default=0.0)
+    if scale <= 0.0:
         return [0.0 for _ in nonnegative_values]
-    return [value / total for value in nonnegative_values]
+    scaled_values = [value / scale for value in nonnegative_values]
+    total = sum(scaled_values)
+    return [value / total for value in scaled_values]
 
 
 class _DiagnosticsMappingMixin:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -26,6 +26,18 @@ def test_particle_diagnostics_clips_negative_weights_before_normalizing():
     assert isclose(diagnostics.weight_entropy, log(2.0))
 
 
+def test_particle_diagnostics_stably_normalizes_extreme_finite_weights():
+    maximum = np.finfo(float).max
+    diagnostics = ParticleDiagnostics.from_weights([maximum, maximum / 2.0])
+    expected_entropy = -(
+        (2.0 / 3.0) * log(2.0 / 3.0)
+        + (1.0 / 3.0) * log(1.0 / 3.0)
+    )
+
+    assert isclose(diagnostics.effective_sample_size, 1.8)
+    assert isclose(diagnostics.weight_entropy, expected_entropy)
+
+
 def test_particle_diagnostics_rejects_nonfinite_weights():
     for weights in ([float("nan"), 1.0], [float("inf"), 1.0]):
         with pytest.raises(ValueError, match="Particle weights must be finite"):


### PR DESCRIPTION
## Summary
- normalize clipped particle weights after scaling by their maximum finite value
- preserve relative probabilities when the original finite sum would overflow
- add a regression for weights near the `float64` limit, checking ESS and entropy

## Testing
- `python -m py_compile` on the modified source and test files
- isolated `pytest -q tests/test_diagnostics.py` (`6 passed`)

Fixes #4415