### PR TITLE
Forward range-bearing Jacobian arguments

### DIFF
--- a/src/pyrecest/models/sensor_models.py
+++ b/src/pyrecest/models/sensor_models.py
@@ -372,9 +372,7 @@ def range_bearing_model(
     return AdditiveNoiseMeasurementModel(
         measurement_function=range_bearing_measurement,
         noise_covariance=noise_covariance,
-        jacobian=lambda state: range_bearing_jacobian(
-            state, sensor_position=sensor_position, position_indices=position_indices
-        ),
+        jacobian=range_bearing_jacobian,
         function_args={
             "sensor_position": sensor_position,
             "position_indices": tuple(position_indices),

--- a/tests/test_range_bearing_model_jacobian_arguments.py
+++ b/tests/test_range_bearing_model_jacobian_arguments.py
@@ -1,0 +1,46 @@
+"""Regressions for range-bearing model Jacobian argument handling."""
+
+import numpy.testing as npt
+
+from pyrecest.backend import array, diag
+from pyrecest.models import range_bearing_jacobian, range_bearing_model
+
+
+def _noise_covariance():
+    return diag(array([0.1, 0.2]))
+
+
+def test_range_bearing_model_jacobian_forwards_runtime_arguments():
+    state = array([3.0, 4.0, 13.0, 5.0])
+    sensor_position = array([10.0, 1.0])
+    position_indices = (2, 3)
+    model = range_bearing_model(_noise_covariance())
+
+    actual = model.jacobian(
+        state,
+        sensor_position=sensor_position,
+        position_indices=position_indices,
+    )
+    expected = range_bearing_jacobian(
+        state,
+        sensor_position=sensor_position,
+        position_indices=position_indices,
+    )
+
+    npt.assert_allclose(actual, expected)
+
+
+def test_range_bearing_model_snapshots_mutable_position_indices_for_jacobian():
+    position_indices = [0, 1]
+    state = array([3.0, 4.0, 13.0, 5.0])
+    model = range_bearing_model(
+        _noise_covariance(),
+        position_indices=position_indices,
+    )
+
+    position_indices[:] = [2, 3]
+
+    npt.assert_allclose(
+        model.jacobian(state),
+        range_bearing_jacobian(state, position_indices=(0, 1)),
+    )


### PR DESCRIPTION
## Summary
- pass `range_bearing_jacobian` directly to the additive-noise measurement model
- forward the same default and per-call arguments used by the measurement function
- add regressions for runtime argument overrides and mutable `position_indices`

## Bug
`range_bearing_model()` wrapped `range_bearing_jacobian()` in a `lambda state: ...`. `AdditiveNoiseMeasurementModel.jacobian()` only forwards arguments accepted by the callback, so the zero-argument lambda silently discarded per-call `sensor_position` and `position_indices` overrides.

The lambda also closed over the caller-provided `position_indices` object while the measurement function stored a tuple snapshot. Mutating a list after model construction could therefore make `evaluate()` and `jacobian()` use different state coordinates.

## Fix
Use `range_bearing_jacobian` as the callback directly. The model now routes its snapshotted defaults and runtime overrides through the same `function_args` mechanism for both measurement and Jacobian evaluation.

## Validation
- regression verifies runtime Jacobian overrides match a direct `range_bearing_jacobian()` call
- regression verifies later mutation of the caller's index list does not alter the model Jacobian
