### PR TITLE
Copy linear Gaussian model constructor inputs

### DIFF
--- a/src/pyrecest/models/linear_gaussian.py
+++ b/src/pyrecest/models/linear_gaussian.py
@@ -5,6 +5,7 @@ from numbers import Complex, Integral, Real
 
 from pyrecest.backend import (
     asarray,
+    copy,
     eye,
     matmul,
     matvec,
@@ -170,12 +171,14 @@ class LinearGaussianTransitionModel:
             noise_covariance,
             type(self).__name__,
         )
-        self.matrix = _as_matrix(matrix, "matrix")
-        self.noise_cov = _as_square(noise_cov, "noise_cov")
+        self.matrix = copy(_as_matrix(matrix, "matrix"))
+        self.noise_cov = copy(_as_square(noise_cov, "noise_cov"))
         self.predicted_dim, self.state_dim = _shape(self.matrix)
         if _shape(self.noise_cov) != (self.predicted_dim, self.predicted_dim):
             raise ValueError("noise_cov has incompatible shape")
-        self.offset = None if offset is None else _as_vector(offset, "offset")
+        self.offset = (
+            None if offset is None else copy(_as_vector(offset, "offset"))
+        )
         if self.offset is not None and _shape(self.offset) != (self.predicted_dim,):
             raise ValueError("offset has incompatible shape")
 
@@ -264,8 +267,8 @@ class LinearGaussianMeasurementModel:
             noise_covariance,
             type(self).__name__,
         )
-        self.matrix = _as_matrix(matrix, "matrix")
-        self.noise_cov = _as_square(noise_cov, "noise_cov")
+        self.matrix = copy(_as_matrix(matrix, "matrix"))
+        self.noise_cov = copy(_as_square(noise_cov, "noise_cov"))
         self.measurement_dim, self.state_dim = _shape(self.matrix)
         if _shape(self.noise_cov) != (self.measurement_dim, self.measurement_dim):
             raise ValueError("noise_cov has incompatible shape")

--- a/tests/models/test_linear_gaussian_input_ownership.py
+++ b/tests/models/test_linear_gaussian_input_ownership.py
@@ -1,0 +1,48 @@
+import numpy as np
+
+from pyrecest.models import (
+    LinearGaussianMeasurementModel,
+    LinearGaussianTransitionModel,
+)
+
+
+def test_transition_model_copies_mutable_constructor_arrays():
+    matrix = np.array([[1.0, 2.0], [0.0, 1.0]])
+    noise_cov = np.diag([0.1, 0.2])
+    offset = np.array([0.5, -0.5])
+    expected_matrix = matrix.copy()
+    expected_noise_cov = noise_cov.copy()
+    expected_offset = offset.copy()
+
+    model = LinearGaussianTransitionModel(matrix, noise_cov, offset)
+
+    matrix[:] = -10.0
+    noise_cov[:] = 99.0
+    offset[:] = 42.0
+
+    np.testing.assert_allclose(model.matrix, expected_matrix)
+    np.testing.assert_allclose(model.noise_cov, expected_noise_cov)
+    np.testing.assert_allclose(model.offset, expected_offset)
+    np.testing.assert_allclose(
+        model.predict_mean(np.array([1.0, 2.0])),
+        expected_matrix @ np.array([1.0, 2.0]) + expected_offset,
+    )
+
+
+def test_measurement_model_copies_mutable_constructor_arrays():
+    matrix = np.array([[1.0, 0.0], [0.5, 2.0]])
+    noise_cov = np.diag([0.3, 0.4])
+    expected_matrix = matrix.copy()
+    expected_noise_cov = noise_cov.copy()
+
+    model = LinearGaussianMeasurementModel(matrix, noise_cov)
+
+    matrix[:] = -10.0
+    noise_cov[:] = 99.0
+
+    np.testing.assert_allclose(model.matrix, expected_matrix)
+    np.testing.assert_allclose(model.noise_cov, expected_noise_cov)
+    np.testing.assert_allclose(
+        model.predict_mean(np.array([2.0, 3.0])),
+        expected_matrix @ np.array([2.0, 3.0]),
+    )


### PR DESCRIPTION
## Summary
- copy transition matrices, measurement matrices, noise covariances, and transition offsets when constructing linear-Gaussian models
- prevent later caller-side mutation from silently changing model parameters and predictions
- add focused ownership regressions for both transition and measurement models

## Bug
The linear-Gaussian constructors normalized inputs with the backend `asarray` helper and then retained the returned arrays directly. With the NumPy backend, `asarray` may return the caller's original mutable array. Mutating that array after model construction therefore changed the model's stored matrix, covariance, or offset and altered subsequent predictions.

## Fix
Take backend-native copies after validation, preserving dtype and backend behavior while establishing model ownership of constructor parameters.

## Validation
- added regressions that mutate every caller-owned constructor array and verify stored parameters and predictions remain unchanged
- reviewed the branch diff against `main`: 13 implementation-line changes and one focused 48-line test file
- parsed the updated module and tests and ran a focused NumPy-backed behavior harness for transition and measurement predictions

Full repository CI should run on this pull request.