### PR TITLE
Reject non-bivariate toroidal wrapped normals

### DIFF
--- a/src/pyrecest/distributions/hypertorus/toroidal_wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/toroidal_wrapped_normal_distribution.py
@@ -20,6 +20,13 @@ class ToroidalWrappedNormalDistribution(
     Decision and Control.
     """
 
+    def __init__(self, mu, C):
+        super().__init__(mu, C)
+        if self.dim != 2:
+            raise ValueError(
+                "ToroidalWrappedNormalDistribution requires exactly two dimensions"
+            )
+
     def mean_4D(self):
         """
         Compute the 4D mean of the distribution.

--- a/tests/distributions/test_toroidal_wrapped_normal_distribution.py
+++ b/tests/distributions/test_toroidal_wrapped_normal_distribution.py
@@ -4,7 +4,7 @@ import unittest
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import allclose, array, cos, exp, mod, pi, sin
+from pyrecest.backend import allclose, array, cos, exp, eye, mod, pi, sin
 from pyrecest.distributions.hypertorus.toroidal_wrapped_normal_distribution import (
     ToroidalWrappedNormalDistribution,
 )
@@ -20,6 +20,13 @@ class TestToroidalWrappedNormalDistribution(unittest.TestCase):
         self.assertIsInstance(self.twn, ToroidalWrappedNormalDistribution)
         self.assertTrue(allclose(self.twn.mu, self.mu))
         self.assertTrue(allclose(self.twn.C, self.C))
+
+    def test_rejects_non_bivariate_parameters(self):
+        for dim in (1, 3):
+            with self.subTest(dim=dim), self.assertRaisesRegex(
+                ValueError, "exactly two dimensions"
+            ):
+                ToroidalWrappedNormalDistribution(array([0.0] * dim), eye(dim))
 
     def test_mean_4d(self):
         expected_mean = array(


### PR DESCRIPTION
## Summary
- add an explicit dimensionality invariant to `ToroidalWrappedNormalDistribution`
- reject one-dimensional and higher-dimensional wrapped-normal parameters instead of constructing an inconsistent toroidal object
- add focused regressions for 1-D and 3-D inputs

## Bug
`ToroidalWrappedNormalDistribution` inherited the unrestricted `HypertoroidalWrappedNormalDistribution.__init__`. As a result, matching `mu`/`C` inputs of any dimension were accepted. This is inconsistent with the class's bivariate torus contract and especially dangerous because `mean_4D()` and `covariance_4D()` hard-code only the first two angular coordinates, silently ignoring additional dimensions.

## Fix
After the shared wrapped-normal validation and initialization, require `dim == 2` and raise a clear `ValueError` otherwise. Valid bivariate construction and all existing formulas remain unchanged.

## Validation
- `python -m py_compile` on the modified source and test files
- added unit coverage for rejected 1-D and 3-D construction
