### PR TITLE
Use tolerant grid checks for hypertoroidal products

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_grid_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_grid_distribution.py
@@ -8,7 +8,6 @@ from beartype import beartype
 # pylint: disable=redefined-builtin
 from pyrecest.backend import (
     abs,
-    all,
     argmin,
     array,
     cast,
@@ -202,13 +201,6 @@ class HypertoroidalGridDistribution(
         mesh = meshgrid(*axes, indexing="ij")
         grid = stack([m.ravel() for m in mesh], axis=-1)  # (n_samples, dim)
         return grid
-
-    # ---------------------------------------------------------------- combine
-    def multiply(self, other):
-        assert all(
-            self.grid == other.grid
-        ), "Multiply:IncompatibleGrid: Can only multiply for equal grids."
-        return super().multiply(other)
 
     # pylint: disable=too-many-locals
     def pdf(self, xs):

--- a/tests/distributions/test_hypertoroidal_grid_multiply_tolerance.py
+++ b/tests/distributions/test_hypertoroidal_grid_multiply_tolerance.py
@@ -1,0 +1,29 @@
+import unittest
+
+import numpy.testing as npt
+
+from pyrecest.backend import array, mean, pi
+from pyrecest.distributions.hypertorus.hypertoroidal_grid_distribution import (
+    HypertoroidalGridDistribution,
+)
+
+
+class HypertoroidalGridMultiplyToleranceTest(unittest.TestCase):
+    def test_multiply_accepts_numerically_equivalent_custom_grids(self):
+        grid = array([[0.0], [pi]])
+        perturbed_grid = array([[0.0], [pi + 1.0e-12]])
+        left = HypertoroidalGridDistribution(array([1.0, 2.0]), grid=grid)
+        right = HypertoroidalGridDistribution(
+            array([3.0, 4.0]), grid=perturbed_grid
+        )
+
+        product = left.multiply(right)
+
+        unnormalized = left.grid_values * right.grid_values
+        expected = unnormalized / (2.0 * pi * mean(unnormalized))
+        npt.assert_allclose(product.grid_values, expected)
+        npt.assert_allclose(product.get_grid(), grid)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- remove the exact-grid `assert` from `HypertoroidalGridDistribution.multiply()`
- delegate compatibility validation to `AbstractGridDistribution.multiply()`, which uses backend-neutral `allclose`
- add a regression for numerically equivalent custom grids

## Bug
`HypertoroidalGridDistribution.multiply()` compared grid coordinates with exact elementwise equality before calling the shared multiplication code. Small floating-point perturbations that are within the base class tolerance therefore raised `AssertionError`, even though the grids are compatible. The assertion also bypassed the library's normal validation errors.

## Fix
Use the shared grid-distribution compatibility checks as the single source of truth. This preserves rejection of genuinely incompatible grids while accepting numerically equivalent coordinates.

## Validation
- focused NumPy-backed runtime regression passed
- modified source and new test passed Python syntax compilation
- branch diff is limited to the redundant override/import and the focused regression test

The full repository suite was not run locally because this environment cannot clone GitHub and does not have the project's `beartype` dependency installed; GitHub Actions is the authoritative full-suite check.