### PR TITLE
Reject invalid simulation timestep counts

### DIFF
--- a/src/pyrecest/evaluation/check_and_fix_config.py
+++ b/src/pyrecest/evaluation/check_and_fix_config.py
@@ -43,11 +43,10 @@ def check_and_fix_config(simulation_param):
     simulation_param.setdefault("n_targets", 1)
     # Check for 'timesteps'
     timesteps = simulation_param["n_timesteps"]
-    if timesteps is not None:
-        if not isinstance(timesteps, int):
-            raise TypeError("n_timesteps must be an integer")
-        if timesteps <= 0:
-            raise ValueError("n_timesteps must be positive")
+    if not _is_integer_count(timesteps):
+        raise TypeError("n_timesteps must be an integer")
+    if timesteps <= 0:
+        raise ValueError("n_timesteps must be positive")
 
     simulation_param.setdefault(
         "apply_sys_noise_times",

--- a/tests/evaluation/test_check_and_fix_config_timestep_validation.py
+++ b/tests/evaluation/test_check_and_fix_config_timestep_validation.py
@@ -1,0 +1,26 @@
+import pytest
+from pyrecest.backend import eye, zeros
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.evaluation.check_and_fix_config import check_and_fix_config
+
+
+def _base_config(n_timesteps):
+    return {
+        "n_timesteps": n_timesteps,
+        "initial_prior": GaussianDistribution(zeros(1), eye(1)),
+    }
+
+
+@pytest.mark.parametrize("invalid_timesteps", [True, False, None])
+def test_check_and_fix_config_rejects_noninteger_timestep_sentinels(
+    invalid_timesteps,
+):
+    with pytest.raises(TypeError, match="n_timesteps must be an integer"):
+        check_and_fix_config(_base_config(invalid_timesteps))
+
+
+def test_check_and_fix_config_accepts_one_timestep():
+    config = check_and_fix_config(_base_config(1))
+
+    assert config["apply_sys_noise_times"] == [False]
+    assert config["n_meas_at_individual_time_step"] == [1]


### PR DESCRIPTION
## Summary
- validate `n_timesteps` with the same strict integer-count predicate used by other simulation count fields
- reject boolean sentinels instead of silently interpreting them as zero or one time step
- reject `None` before default list construction raises an unrelated arithmetic `TypeError`
- add focused regressions for `True`, `False`, `None`, and the valid one-step boundary

## Root cause
`check_and_fix_config()` used `isinstance(timesteps, int)` only when the value was not `None`. Because `bool` subclasses `int`, boolean values passed validation. Conversely, `None` bypassed validation but was immediately used in `n_timesteps - 1`, producing an implementation-level exception instead of the documented configuration error.

## Impact
Invalid simulation configurations now fail deterministically at the validation boundary with `TypeError("n_timesteps must be an integer")`. Valid positive integer configurations are unchanged.

## Validation
- branch is 2 commits ahead of `main` and 0 behind
- diff is limited to the timestep validation and one focused regression module
- source/test changes were re-fetched from the branch and inspected

The full repository test suite is delegated to GitHub Actions because this environment cannot clone GitHub or run the project dependencies locally.