### PR TITLE
Honor additive noise means in UKF model adapters

### DIFF
--- a/src/pyrecest/filters/unscented_kalman_filter.py
+++ b/src/pyrecest/filters/unscented_kalman_filter.py
@@ -112,12 +112,14 @@ class UnscentedKalmanFilter(AbstractFilter, EuclideanFilterMixin):
 
         This is an adapter around :meth:`predict_nonlinear`; it does not change
         the UKF algorithm or deprecate the existing function/covariance API.
+        The model's additive noise mean is folded into the propagated sigma
+        points, while its covariance is supplied as the UKF process covariance.
 
         Parameters
         ----------
         model:
             Reusable transition model containing the deterministic transition
-            function and additive process-noise covariance.
+            function and additive process-noise statistics.
         dt:
             Optional time step overriding ``model.dt``.
         fx_args:
@@ -125,7 +127,7 @@ class UnscentedKalmanFilter(AbstractFilter, EuclideanFilterMixin):
             model's default ``function_args`` for this prediction.
         """
         return self.predict_nonlinear(
-            model.evaluate,
+            model.mean,
             model.noise_covariance,
             dt=model.dt if dt is None else dt,
             **fx_args,
@@ -141,10 +143,13 @@ class UnscentedKalmanFilter(AbstractFilter, EuclideanFilterMixin):
 
         This is an adapter around :meth:`update_nonlinear`; it preserves the
         existing direct nonlinear update API while allowing model-object reuse.
+        The model's additive noise mean is included in the predicted
+        measurement, while its covariance is supplied as the UKF measurement
+        covariance.
         """
         return self.update_nonlinear(
             measurement,
-            model.evaluate,
+            model.predict_measurement,
             model.noise_covariance,
             **hx_args,
         )

--- a/tests/filters/test_unscented_kalman_filter_noise_means.py
+++ b/tests/filters/test_unscented_kalman_filter_noise_means.py
@@ -1,0 +1,88 @@
+import copy
+import unittest
+
+import numpy.testing as npt
+import pyrecest.backend
+from pyrecest.backend import array
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.filters.unscented_kalman_filter import UnscentedKalmanFilter
+from pyrecest.models import AdditiveNoiseMeasurementModel, AdditiveNoiseTransitionModel
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+    reason="UnscentedKalmanFilter is not supported on this backend.",
+)
+class UnscentedKalmanFilterNoiseMeanTest(unittest.TestCase):
+    def test_predict_model_applies_process_noise_mean(self):
+        initial_state = GaussianDistribution(array([1.0]), array([[1.5]]))
+        direct = UnscentedKalmanFilter(initial_state)
+        via_model = copy.deepcopy(direct)
+        noise_mean = array([2.0])
+        noise_covariance = array([[0.5]])
+
+        direct.predict_nonlinear(
+            lambda state, _dt: state + noise_mean,
+            noise_covariance,
+        )
+        via_model.predict_model(
+            AdditiveNoiseTransitionModel(
+                lambda state: state,
+                noise_mean=noise_mean,
+                noise_covariance=noise_covariance,
+            )
+        )
+
+        npt.assert_allclose(via_model.get_point_estimate(), array([3.0]), atol=1e-8)
+        npt.assert_allclose(
+            via_model.get_point_estimate(),
+            direct.get_point_estimate(),
+            rtol=1e-10,
+            atol=1e-10,
+        )
+        npt.assert_allclose(
+            via_model.filter_state.covariance(),
+            direct.filter_state.covariance(),
+            rtol=1e-10,
+            atol=1e-10,
+        )
+
+    def test_update_model_applies_measurement_noise_mean(self):
+        initial_state = GaussianDistribution(array([0.0]), array([[1.0]]))
+        direct = UnscentedKalmanFilter(initial_state)
+        via_model = copy.deepcopy(direct)
+        noise_mean = array([2.0])
+        noise_covariance = array([[1.0]])
+        measurement = array([3.0])
+
+        direct.update_nonlinear(
+            measurement,
+            lambda state: state + noise_mean,
+            noise_covariance,
+        )
+        via_model.update_model(
+            AdditiveNoiseMeasurementModel(
+                lambda state: state,
+                noise_mean=noise_mean,
+                noise_covariance=noise_covariance,
+            ),
+            measurement,
+        )
+
+        npt.assert_allclose(via_model.get_point_estimate(), array([0.5]), atol=1e-8)
+        npt.assert_allclose(
+            via_model.get_point_estimate(),
+            direct.get_point_estimate(),
+            rtol=1e-10,
+            atol=1e-10,
+        )
+        npt.assert_allclose(
+            via_model.filter_state.covariance(),
+            direct.filter_state.covariance(),
+            rtol=1e-10,
+            atol=1e-10,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- propagate `AdditiveNoiseTransitionModel.noise_mean` through `UnscentedKalmanFilter.predict_model()`
- include `AdditiveNoiseMeasurementModel.noise_mean` in `UnscentedKalmanFilter.update_model()` measurement predictions
- add focused one-dimensional regressions for both paths

## Bug

The UKF model adapters used `model.evaluate` together with the model's noise covariance. For additive-noise models with a nonzero noise mean, this silently discarded the mean:

- prediction implemented `x_next = f(x) + w` as though `E[w] = 0`
- update implemented `z = h(x) + v` as though `E[v] = 0`

The model classes explicitly expose `mean()` / `predict_measurement()` to include those offsets, so model-based filtering disagreed with the model's own statistics and with the equivalent direct UKF call.

## Fix

Use `model.mean` as the transition callback and `model.predict_measurement` as the measurement callback. The existing covariance handling remains unchanged, and zero-mean models preserve their current behavior.

## Validation

- added regressions comparing model-adapter prediction/update against equivalent direct nonlinear UKF calls
- asserted the analytic one-dimensional posterior/predicted means (`3.0` for prediction and `0.5` for update)
- `python -m py_compile` passed for the modified implementation and new test module
- branch comparison: two commits ahead, zero behind; 11 implementation-line changes plus one focused regression file

Full repository CI should run on this pull request.