### PR TITLE
Copy wrapped Laplace parameters

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_laplace_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_laplace_distribution.py
@@ -2,7 +2,17 @@
 from numbers import Integral
 
 import numpy as np
-from pyrecest.backend import all, asarray, exp, isfinite, mod, ndim, pi, to_numpy
+from pyrecest.backend import (
+    all,
+    asarray,
+    copy as backend_copy,
+    exp,
+    isfinite,
+    mod,
+    ndim,
+    pi,
+    to_numpy,
+)
 
 from .abstract_circular_distribution import AbstractCircularDistribution
 
@@ -54,8 +64,8 @@ class WrappedLaplaceDistribution(AbstractCircularDistribution):
 
     def __init__(self, lambda_, kappa_):
         AbstractCircularDistribution.__init__(self)
-        lambda_ = _validate_positive_scalar(lambda_, "lambda_")
-        kappa_ = _validate_positive_scalar(kappa_, "kappa_")
+        lambda_ = backend_copy(_validate_positive_scalar(lambda_, "lambda_"))
+        kappa_ = backend_copy(_validate_positive_scalar(kappa_, "kappa_"))
         self.lambda_ = lambda_
         self.kappa = kappa_
 

--- a/tests/distributions/test_wrapped_laplace_parameter_copy.py
+++ b/tests/distributions/test_wrapped_laplace_parameter_copy.py
@@ -1,0 +1,37 @@
+import unittest
+
+import numpy.testing as npt
+import pyrecest.backend
+from pyrecest.backend import array, to_numpy
+from pyrecest.distributions.circle.wrapped_laplace_distribution import (
+    WrappedLaplaceDistribution,
+)
+
+
+class WrappedLaplaceParameterCopyTest(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="JAX arrays are immutable and cannot expose caller-side aliasing.",
+    )
+    def test_constructor_owns_mutable_parameter_storage(self):
+        rate = array(2.0)
+        asymmetry = array(1.3)
+        distribution = WrappedLaplaceDistribution(rate, asymmetry)
+        evaluation_points = array([0.0, 0.5, 1.0])
+        expected_pdf = to_numpy(distribution.pdf(evaluation_points)).copy()
+
+        rate[...] = 4.0
+        asymmetry[...] = 2.0
+
+        npt.assert_allclose(to_numpy(rate), 4.0)
+        npt.assert_allclose(to_numpy(asymmetry), 2.0)
+        npt.assert_allclose(to_numpy(distribution.lambda_), 2.0)
+        npt.assert_allclose(to_numpy(distribution.kappa), 1.3)
+        npt.assert_allclose(
+            to_numpy(distribution.pdf(evaluation_points)),
+            expected_pdf,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Copy the validated `lambda_` and `kappa_` backend arrays in `WrappedLaplaceDistribution.__init__`.
- Add a regression test that mutates both caller-owned arrays after construction and verifies that the stored parameters and PDF remain unchanged.

## Root cause

`asarray` can preserve mutable backend storage. The constructor stored those arrays directly, so caller-side mutation silently changed an already-constructed distribution.

## Impact

A `WrappedLaplaceDistribution` now owns its parameter state, matching the ownership behavior of `WrappedExponentialDistribution` and preventing action-at-a-distance bugs.

## Validation

- Inspected the two-commit diff against current `main`; only the distribution implementation and focused regression test changed.
- Syntax-compiled the modified module locally.
- GitHub Actions will run the repository's full configured checks on this PR.