### PR TITLE
Stabilize particle diagnostics weight normalization

### DIFF
--- a/.github/ci-refresh/4429.txt
+++ b/.github/ci-refresh/4429.txt
@@ -1,1 +1,0 @@
-Temporary CI refresh marker.

--- a/.github/ci-refresh/4429.txt
+++ b/.github/ci-refresh/4429.txt
@@ -1,0 +1,1 @@
+Temporary CI refresh marker.

--- a/src/pyrecest/diagnostics.py
+++ b/src/pyrecest/diagnostics.py
@@ -176,10 +176,12 @@ def _normalized_nonnegative_weights(values: list[float]) -> list[float]:
     if any(not isfinite(value) for value in values):
         raise ValueError("Particle weights must be finite.")
     nonnegative_values = [max(0.0, value) for value in values]
-    total = sum(nonnegative_values)
-    if total <= 0.0:
+    scale = max(nonnegative_values, default=0.0)
+    if scale <= 0.0:
         return [0.0 for _ in nonnegative_values]
-    return [value / total for value in nonnegative_values]
+    scaled_values = [value / scale for value in nonnegative_values]
+    total = sum(scaled_values)
+    return [value / total for value in scaled_values]
 
 
 class _DiagnosticsMappingMixin:
@@ -297,7 +299,6 @@ class EvidenceSupport:
     @classmethod
     def from_mapping(cls, mapping: Mapping[str, Any]) -> "EvidenceSupport":
         """Build support metadata from a mapping, preserving unknown keys."""
-
         known = {"support_type", "comparable", "lower_bound", "diagnostics"}
         diagnostics = dict(mapping.get("diagnostics", {}))
         diagnostics.update(
@@ -376,7 +377,6 @@ class EvidenceSupport:
 
 def coerce_evidence_support(value: Any) -> EvidenceSupport:
     """Coerce a mapping, string, or :class:`EvidenceSupport` into metadata."""
-
     if isinstance(value, EvidenceSupport):
         return value
     if isinstance(value, str):

--- a/tests/test_particle_diagnostics_extreme_weights.py
+++ b/tests/test_particle_diagnostics_extreme_weights.py
@@ -1,0 +1,20 @@
+from math import isclose, isfinite, log
+
+import numpy as np
+from pyrecest.diagnostics import ParticleDiagnostics
+
+
+def test_particle_diagnostics_normalizes_extreme_finite_weights():
+    maximum = float(np.finfo(float).max)
+    weights = [maximum, maximum / 2.0]
+
+    assert all(isfinite(weight) for weight in weights)
+    assert not isfinite(sum(weights))
+
+    diagnostics = ParticleDiagnostics.from_weights(weights)
+    expected_entropy = -(2.0 / 3.0 * log(2.0 / 3.0)) - (
+        1.0 / 3.0 * log(1.0 / 3.0)
+    )
+
+    assert isclose(diagnostics.effective_sample_size, 1.8)
+    assert isclose(diagnostics.weight_entropy, expected_entropy)


### PR DESCRIPTION
## Summary

- normalize finite nonnegative particle diagnostic weights after scaling by their largest entry
- preserve relative mass when the caller-provided weight sum overflows
- add a focused regression for finite weights near the `float64` limit

## Bug

`ParticleDiagnostics.from_weights()` summed weights at their original scale. Inputs such as `[max_float, max_float / 2]` contain only finite values and define valid relative probabilities, but their raw sum is infinite. Dividing by that total produced `[0.0, 0.0]`, so effective sample size and entropy were both reported as zero.

## Fix

Clip negative values as before, scale the nonnegative vector by its largest positive entry, and then normalize the bounded scaled vector. At least one scaled value is exactly one whenever positive mass exists, so the normalization sum cannot overflow or underflow to zero.

## Validation

- branch is two commits ahead of `main` and zero behind
- implementation diff is limited to the normalization helper
- focused regression verifies that every input weight is finite while the unscaled sum is infinite
- reproduced normalized weights `[2/3, 1/3]`, ESS `1.8`, and entropy `0.6365141683`

Fixes #4415