### PR TITLE
Normalize circular grid weights without overflow

### DIFF
--- a/src/pyrecest/filters/relaxed_s3f_circular.py
+++ b/src/pyrecest/filters/relaxed_s3f_circular.py
@@ -35,6 +35,7 @@ from pyrecest.backend import (
     sin,
     stack,
 )
+from pyrecest.backend import max as backend_max
 from pyrecest.backend import sum as backend_sum
 from pyrecest.backend import (
     zeros,
@@ -230,10 +231,18 @@ def grid_probability_masses(grid_values: Any) -> Any:
         raise ValueError("grid values must be finite.")
     if not bool(all(values >= 0.0)):
         raise ValueError("grid values must be nonnegative.")
-    total = backend_sum(values)
-    if float(total) <= 0.0:
+    if values.shape[0] == 0:
         raise ValueError("grid values must have positive total mass.")
-    return values / total
+
+    scale = backend_max(values)
+    if float(scale) <= 0.0:
+        raise ValueError("grid values must have positive total mass.")
+    scaled_values = values / scale
+    total = backend_sum(scaled_values)
+    total_float = float(total)
+    if not np.isfinite(total_float) or total_float <= 0.0:
+        raise ValueError("grid values must have positive total mass.")
+    return scaled_values / total
 
 
 def circular_error(angle_a: float, angle_b: float) -> float:

--- a/tests/filters/test_relaxed_s3f_circular_weight_overflow.py
+++ b/tests/filters/test_relaxed_s3f_circular_weight_overflow.py
@@ -1,0 +1,31 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+import pyrecest.backend
+from pyrecest.backend import array, to_numpy
+from pyrecest.filters.relaxed_s3f_circular import grid_probability_masses
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ == "jax",
+    reason="This regression requires float64 values near the representable limit.",
+)
+class RelaxedS3FCircularWeightOverflowTest(unittest.TestCase):
+    def test_normalizes_finite_weights_with_overflowing_raw_sum(self):
+        relative_weights = np.array([1.0, 0.5, 0.25], dtype=np.float64)
+        huge_weights = relative_weights * np.finfo(np.float64).max
+
+        self.assertTrue(np.all(np.isfinite(huge_weights)))
+        with np.errstate(over="ignore"):
+            self.assertTrue(np.isinf(np.sum(huge_weights)))
+
+        actual = to_numpy(grid_probability_masses(array(huge_weights)))
+        expected = relative_weights / relative_weights.sum()
+
+        npt.assert_allclose(actual, expected, rtol=1.0e-12, atol=0.0)
+        npt.assert_allclose(np.sum(actual), 1.0, rtol=1.0e-12, atol=0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- normalize circular S3F grid weights after scaling by their largest entry
- preserve relative probability mass when a finite raw weight sum overflows
- add a focused regression using finite values near the `float64` limit

## Bug

`grid_probability_masses()` summed nonnegative weights at their caller-provided scale. Inputs such as `[max_float, max_float / 2, max_float / 4]` are individually finite and define valid relative probabilities, but their raw sum overflows to infinity. The previous implementation then divided every finite weight by infinity and silently returned all-zero masses. This also corrupted downstream circular weighted means.

## Fix

Reject empty or all-zero inputs, scale all weights by their largest positive entry, and normalize the scaled values. Scaling preserves all relative masses and zero support while ensuring the summation remains finite.

## Validation

- isolated reproduction confirms the old calculation returns all zeros for an overflowing finite sum
- the regression verifies the fixed result equals the safely scaled probability vector and sums to one
- branch comparison is limited to the normalization helper and one focused regression file
- branch is two commits ahead of `main` and zero behind

The full configured test and lint suite is delegated to GitHub Actions.