### PR TITLE
Avoid overflow in covariance symmetrization

### DIFF
--- a/src/pyrecest/numerics.py
+++ b/src/pyrecest/numerics.py
@@ -146,11 +146,25 @@ def _raise_if_not_square_matrix(matrix: np.ndarray, name: str = "matrix") -> Non
         raise ShapeError(f"Expected a square matrix, got shape {matrix.shape}.")
 
 
+def _symmetrized(matrix: np.ndarray) -> np.ndarray:
+    """Average a matrix with its transpose without overflowing finite entries."""
+    with np.errstate(over="ignore"):
+        symmetrized = 0.5 * (matrix + matrix.T)
+    overflowed = (
+        ~np.isfinite(symmetrized) & np.isfinite(matrix) & np.isfinite(matrix.T)
+    )
+    if np.any(overflowed):
+        symmetrized[overflowed] = (
+            0.5 * matrix[overflowed] + 0.5 * matrix.T[overflowed]
+        )
+    return symmetrized
+
+
 def symmetrize_matrix(matrix):
     """Return ``0.5 * (matrix + matrix.T)`` in the active backend representation."""
     arr = _to_numpy_array(matrix)
     _raise_if_not_square_matrix(arr)
-    return _from_numpy_array(0.5 * (arr + arr.T))
+    return _from_numpy_array(_symmetrized(arr))
 
 
 def is_symmetric(matrix, *, atol: float = 1e-10) -> bool:
@@ -199,11 +213,11 @@ def nearest_symmetric_psd(matrix, *, min_eigenvalue: float = 0.0):
     arr = _to_numpy_array(matrix)
     _raise_if_not_square_matrix(arr)
     _raise_if_nonfinite_matrix(arr, "matrix")
-    sym = 0.5 * (arr + arr.T)
+    sym = _symmetrized(arr)
     eigvals, eigvecs = np.linalg.eigh(sym)
     clipped = np.maximum(eigvals, min_eigenvalue)
     repaired = (eigvecs * clipped) @ eigvecs.T
-    return _from_numpy_array(0.5 * (repaired + repaired.T))
+    return _from_numpy_array(_symmetrized(repaired))
 
 
 def jittered_cholesky(matrix, *, initial_jitter: float = 1e-12, max_attempts: int = 8):
@@ -219,7 +233,7 @@ def jittered_cholesky(matrix, *, initial_jitter: float = 1e-12, max_attempts: in
     arr = _to_numpy_array(matrix)
     _raise_if_not_square_matrix(arr)
     _raise_if_nonfinite_matrix(arr, "matrix")
-    sym = 0.5 * (arr + arr.T)
+    sym = _symmetrized(arr)
     eye = np.eye(sym.shape[0])
     jitter = 0.0
     for attempt in range(max_attempts + 1):

--- a/tests/test_numerics_large_finite.py
+++ b/tests/test_numerics_large_finite.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+from pyrecest.numerics import (
+    jittered_cholesky,
+    nearest_symmetric_psd,
+    symmetrize_matrix,
+)
+
+
+def test_covariance_repairs_preserve_maximum_finite_diagonal():
+    maximum = np.finfo(float).max
+    matrix = np.diag([maximum, maximum])
+
+    with np.errstate(over="ignore", invalid="ignore"):
+        symmetric = np.asarray(symmetrize_matrix(matrix))
+        repaired = np.asarray(nearest_symmetric_psd(matrix))
+        factor, jitter = jittered_cholesky(matrix)
+        factor = np.asarray(factor)
+
+    assert np.all(np.isfinite(symmetric))
+    np.testing.assert_array_equal(symmetric, matrix)
+
+    assert np.all(np.isfinite(repaired))
+    np.testing.assert_allclose(repaired, matrix, rtol=2e-15, atol=0.0)
+
+    assert jitter == 0.0
+    assert np.all(np.isfinite(factor))
+    np.testing.assert_allclose(factor @ factor.T, matrix, rtol=2e-15, atol=0.0)


### PR DESCRIPTION
## Summary

- add an overflow-safe matrix symmetrization helper
- use it in `symmetrize_matrix`, `nearest_symmetric_psd`, and `jittered_cholesky`
- add regression coverage for maximum-finite diagonal covariance matrices

## Bug

The shared numerical helpers evaluated `0.5 * (A + A.T)`. For finite entries near `np.finfo(float).max`, the intermediate addition overflows before the factor of one half is applied. A valid finite covariance can therefore become infinite inside symmetrization, PSD projection, or Cholesky preparation.

For example, a diagonal covariance with maximum-finite entries is mathematically unchanged by symmetrization, but the old expression produces `inf` on its diagonal.

## Fix

Keep the ordinary averaging expression, then recompute only entries where finite operands produced a non-finite result as `0.5 * A + 0.5 * A.T`. This avoids the overflowing intermediate sum while preserving the existing behavior for ordinary values.

## Validation

- reproduced the old overflow with a maximum-finite diagonal matrix
- verified the patched helper keeps the matrix and Cholesky factor finite
- added a regression covering symmetrization, nearest-PSD projection, and jittered Cholesky
- branch is 2 commits ahead of `main` and 0 behind

Full repository tests were not runnable in this environment because local GitHub checkout access is unavailable; GitHub Actions should provide authoritative validation.