### PR TITLE
Copy manifold EMA state inputs

### DIFF
--- a/.github/ci-refresh/4434.txt
+++ b/.github/ci-refresh/4434.txt
@@ -1,1 +1,0 @@
-Temporary CI refresh marker.

--- a/.github/ci-refresh/4434.txt
+++ b/.github/ci-refresh/4434.txt
@@ -1,0 +1,1 @@
+Temporary CI refresh marker.

--- a/src/pyrecest/filters/manifold_exponential_moving_average.py
+++ b/src/pyrecest/filters/manifold_exponential_moving_average.py
@@ -1,6 +1,5 @@
 """Exponential moving average for states on manifolds."""
 
-import copy
 from typing import Any, Callable
 
 import numpy as np
@@ -49,7 +48,8 @@ class ManifoldExponentialMovingAverage(AbstractFilter):
         self.phi_inv = phi_inv
         self._alpha = self._validate_alpha(alpha)
 
-        AbstractFilter.__init__(self, copy.deepcopy(initial_state))
+        AbstractFilter.__init__(self, None)
+        self.filter_state = initial_state
 
     @staticmethod
     def _validate_alpha(alpha: float) -> float:
@@ -92,7 +92,7 @@ class ManifoldExponentialMovingAverage(AbstractFilter):
 
     @filter_state.setter
     def filter_state(self, new_state):
-        self._filter_state = copy.deepcopy(new_state)
+        AbstractFilter.filter_state.fset(self, new_state)
 
     def update(self, sample):
         """Update the moving average with a new manifold-valued sample."""

--- a/src/pyrecest/filters/manifold_exponential_moving_average.py
+++ b/src/pyrecest/filters/manifold_exponential_moving_average.py
@@ -1,5 +1,6 @@
 """Exponential moving average for states on manifolds."""
 
+import copy
 from typing import Any, Callable
 
 import numpy as np
@@ -48,7 +49,7 @@ class ManifoldExponentialMovingAverage(AbstractFilter):
         self.phi_inv = phi_inv
         self._alpha = self._validate_alpha(alpha)
 
-        AbstractFilter.__init__(self, initial_state)
+        AbstractFilter.__init__(self, copy.deepcopy(initial_state))
 
     @staticmethod
     def _validate_alpha(alpha: float) -> float:
@@ -91,12 +92,12 @@ class ManifoldExponentialMovingAverage(AbstractFilter):
 
     @filter_state.setter
     def filter_state(self, new_state):
-        self._filter_state = new_state
+        self._filter_state = copy.deepcopy(new_state)
 
     def update(self, sample):
         """Update the moving average with a new manifold-valued sample."""
         if self._filter_state is None:
-            self._filter_state = sample
+            self.filter_state = sample
             return
 
         tangent_update = self.alpha * asarray(self.phi_inv(self._filter_state, sample))

--- a/tests/filters/test_manifold_exponential_moving_average.py
+++ b/tests/filters/test_manifold_exponential_moving_average.py
@@ -53,6 +53,34 @@ class TestManifoldExponentialMovingAverage(unittest.TestCase):
 
         npt.assert_allclose(ema.get_point_estimate(), sample)
 
+    def test_mutable_input_states_are_copied(self):
+        initial_state = np.array([1.0, 2.0])
+        ema = ManifoldExponentialMovingAverage(
+            initial_state=initial_state,
+            alpha=0.5,
+            phi=_phi_euclidean,
+            phi_inv=_phi_inv_euclidean,
+        )
+
+        initial_state[0] = 99.0
+        npt.assert_allclose(ema.filter_state, np.array([1.0, 2.0]))
+
+        replacement_state = np.array([3.0, 4.0])
+        ema.filter_state = replacement_state
+        replacement_state[1] = 99.0
+        npt.assert_allclose(ema.filter_state, np.array([3.0, 4.0]))
+
+        first_sample = np.array([5.0, 6.0])
+        empty_ema = ManifoldExponentialMovingAverage(
+            initial_state=None,
+            alpha=0.5,
+            phi=_phi_euclidean,
+            phi_inv=_phi_inv_euclidean,
+        )
+        empty_ema.update(first_sample)
+        first_sample[0] = 99.0
+        npt.assert_allclose(empty_ema.filter_state, np.array([5.0, 6.0]))
+
     def test_circle_update_uses_shortest_tangent_direction(self):
         ema = ManifoldExponentialMovingAverage(
             initial_state=3.0,


### PR DESCRIPTION
## Summary

- deep-copy the initial manifold EMA state before storing it
- preserve the base filter's copy-on-assignment behavior in the overridden `filter_state` setter
- copy the first sample used to initialize an empty EMA
- add regression coverage for constructor, setter, and first-update ownership

## Bug

`ManifoldExponentialMovingAverage` stored mutable state objects directly. Mutating an input array after construction, after assigning `filter_state`, or after the first update of an empty EMA silently changed the filter's internal estimate without an EMA update.

The subclass also overrode `AbstractFilter.filter_state` and accidentally removed the base setter's deep-copy semantics.

## Fix

Deep-copy state at construction and assignment, and route first-sample initialization through the copying setter. This makes the EMA own its state while leaving ordinary manifold updates unchanged.

## Validation

- added a focused regression covering all three aliasing paths
- verified the branch changes only the EMA implementation and its existing test module
- branch is 2 commits ahead of `main` and 0 behind

GitHub Actions will run the repository's configured test and lint suite.