### PR TITLE
Avoid overflow in hypertoroidal grid-to-Dirac conversion

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_dirac_distribution.py
@@ -89,7 +89,7 @@ class HypertoroidalDiracDistribution(
         get_grid = getattr(distribution, "get_grid", None)
         if hasattr(distribution, "grid_values") and callable(get_grid):
             weights = reshape(distribution.grid_values, (-1,))
-            weights = weights / sum(weights)
+            # The Dirac constructor performs overflow-safe normalization.
             return HypertoroidalDiracDistribution(
                 get_grid(), weights, dim=distribution.dim
             )

--- a/tests/distributions/test_hypertoroidal_dirac_grid_weight_overflow.py
+++ b/tests/distributions/test_hypertoroidal_dirac_grid_weight_overflow.py
@@ -1,0 +1,58 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+import pyrecest.backend
+
+from pyrecest.backend import array, to_numpy, zeros_like
+from pyrecest.distributions import (
+    AbstractHypertoroidalDistribution,
+    HypertoroidalDiracDistribution,
+)
+
+
+class _ExtremeGridDistribution(AbstractHypertoroidalDistribution):
+    def __init__(self):
+        super().__init__(2)
+        maximum = np.finfo(np.float64).max
+        self.grid_values = array(
+            np.array([maximum, maximum / 2.0], dtype=np.float64)
+        )
+        self._grid = array([[0.1, 0.2], [0.3, 0.4]])
+
+    def get_grid(self):
+        return self._grid
+
+    def pdf(self, xs):
+        return zeros_like(xs)
+
+    def sample(self, _n):
+        raise AssertionError("grid conversion must not sample")
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ == "jax",
+    reason="This regression requires float64 values near the representable limit.",
+)
+class HypertoroidalDiracGridWeightOverflowTest(unittest.TestCase):
+    def test_grid_conversion_preserves_extreme_finite_weight_ratios(self):
+        source = _ExtremeGridDistribution()
+        source_weights = to_numpy(source.grid_values)
+
+        self.assertTrue(np.all(np.isfinite(source_weights)))
+        with np.errstate(over="ignore"):
+            self.assertTrue(np.isinf(np.sum(source_weights)))
+
+        converted = HypertoroidalDiracDistribution.from_distribution(source)
+
+        npt.assert_allclose(
+            to_numpy(converted.w),
+            np.array([2.0 / 3.0, 1.0 / 3.0]),
+            rtol=1.0e-12,
+            atol=0.0,
+        )
+        npt.assert_allclose(to_numpy(converted.d), to_numpy(source.get_grid()))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- remove redundant raw-sum normalization from `HypertoroidalDiracDistribution.from_distribution()`
- delegate normalization to the Dirac constructor's existing overflow-safe max-scaled implementation
- add a focused regression for finite grid weights whose direct sum overflows

## Bug

Grid-backed hypertoroidal distributions were normalized with `weights / sum(weights)` before constructing the Dirac approximation. A valid finite vector such as `[max_float, max_float / 2]` has a raw sum of infinity, so the pre-normalization produced `[0, 0]`. The Dirac constructor then rejected the result as having no positive mass, even though the original weights define the valid probability vector `[2/3, 1/3]`.

## Fix

Pass the raw grid values to `HypertoroidalDiracDistribution`. `AbstractDiracDistribution` already validates and normalizes weights after scaling by their maximum, preserving relative mass without an overflowing intermediate sum.

## Impact

Deterministic conversion from grid-backed hypertoroidal distributions now works for all finite nonnegative weight scales accepted by the Dirac distribution itself. Ordinary-scale conversions are unchanged.

## Validation

- reproduced the old overflow: direct normalization returns `[0, 0]`
- verified max-scaled normalization returns `[2/3, 1/3]`
- added a regression that also verifies conversion does not fall back to sampling
- syntax-compiled the regression module
- branch is two commits ahead of `main`, zero behind, with changes limited to one implementation line and one focused test file

The full backend and lint matrices are delegated to GitHub Actions.