### PR TITLE
Avoid overflow in box center and half-width calculations

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/linear_box_particle_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/linear_box_particle_distribution.py
@@ -130,7 +130,7 @@ class LinearBoxParticleDistribution(AbstractLinearDistribution):
 
     def centers(self):
         """Return all box centers with shape ``(n_boxes, dim)``."""
-        return 0.5 * (self.lower + self.upper)
+        return 0.5 * self.lower + 0.5 * self.upper
 
     def widths(self):
         """Return side lengths of all boxes."""
@@ -138,7 +138,7 @@ class LinearBoxParticleDistribution(AbstractLinearDistribution):
 
     def half_widths(self):
         """Return side half-lengths."""
-        return 0.5 * self.widths()
+        return 0.5 * self.upper - 0.5 * self.lower
 
     def volumes(self):
         """Return the hypervolume of every box particle."""

--- a/tests/distributions/test_linear_box_particle_distribution_extreme_bounds.py
+++ b/tests/distributions/test_linear_box_particle_distribution_extreme_bounds.py
@@ -1,0 +1,50 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array, to_numpy
+from pyrecest.distributions.nonperiodic.linear_box_particle_distribution import (
+    LinearBoxParticleDistribution,
+)
+
+
+class LinearBoxParticleDistributionExtremeBoundsTest(unittest.TestCase):
+    @staticmethod
+    def _backend_dtype_and_maximum():
+        backend_dtype = to_numpy(array([1.0])).dtype
+        return backend_dtype, np.finfo(backend_dtype).max
+
+    def test_centers_remain_finite_for_large_same_sign_bounds(self):
+        backend_dtype, maximum = self._backend_dtype_and_maximum()
+        dist = LinearBoxParticleDistribution(
+            array([[maximum / 2.0]]),
+            array([[maximum]]),
+        )
+        expected = np.asarray([[maximum / 2.0 + maximum / 4.0]], dtype=backend_dtype)
+
+        centers = to_numpy(dist.centers())
+
+        self.assertTrue(np.all(np.isfinite(centers)))
+        npt.assert_allclose(centers, expected)
+        npt.assert_allclose(to_numpy(dist.d), expected)
+        npt.assert_allclose(to_numpy(dist.mean()), expected[0])
+        npt.assert_allclose(to_numpy(dist.mode()), expected[0])
+
+    def test_half_widths_remain_finite_for_opposite_extreme_bounds(self):
+        backend_dtype, maximum = self._backend_dtype_and_maximum()
+        dist = LinearBoxParticleDistribution(
+            array([[-maximum]]),
+            array([[maximum]]),
+        )
+        expected = np.asarray([[maximum]], dtype=backend_dtype)
+
+        half_widths = to_numpy(dist.half_widths())
+
+        self.assertTrue(np.all(np.isfinite(half_widths)))
+        npt.assert_allclose(half_widths, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- compute box centers by scaling each endpoint before addition
- compute half-widths by scaling each endpoint before subtraction
- add backend-aware regressions for finite bounds near the active floating-point limit

## Bug

`LinearBoxParticleDistribution.centers()` evaluated `0.5 * (lower + upper)`. For same-sign finite bounds near the dtype maximum, the intermediate endpoint sum overflows even when the mathematical midpoint is finite. For example, `[max / 2, max]` produced an infinite center, which also contaminated `d`, `mean()`, and `mode()`.

`half_widths()` had the analogous issue for opposite extreme bounds: `0.5 * (upper - lower)` overflowed for `[-max, max]`, although the half-width itself is exactly `max` and representable.

## Fix

Scale each finite endpoint before combining it:

- center: `0.5 * lower + 0.5 * upper`
- half-width: `0.5 * upper - 0.5 * lower`

This avoids the overflowing intermediate sum or difference while preserving the existing result for ordinary inputs.

## Validation

- reproduced both failures with NumPy `float32` and `float64`
- verified the revised expressions remain finite and return the expected values
- added regressions that derive the limit from the active PyRecEst backend dtype
- branch is 2 commits ahead of `main` and 0 behind

The repository's configured GitHub Actions checks provide the full-suite validation.