### PR TITLE
Normalize IMM probabilities without overflow

### DIFF
--- a/src/pyrecest/filters/interacting_multiple_model_filter.py
+++ b/src/pyrecest/filters/interacting_multiple_model_filter.py
@@ -21,6 +21,7 @@ from pyrecest.backend import (
     isfinite,
     linalg,
     log,
+    max as backend_max,
     ones,
     outer,
     pi,
@@ -471,18 +472,28 @@ class InteractingMultipleModelFilter(AbstractFilter, EuclideanFilterMixin):
         if pyrecest.backend.any(transition_matrix < 0.0):
             raise ValueError("transition_matrix must be elementwise nonnegative.")
 
-        row_sums = transition_matrix.sum(axis=1)
-        if pyrecest.backend.any(row_sums <= 0.0):
+        row_scales = backend_max(transition_matrix, axis=1)
+        if pyrecest.backend.any(row_scales <= 0.0):
             raise ValueError(
                 "Each row of transition_matrix must sum to a positive value."
             )
-        if not allclose(row_sums, 1.0):
+        scaled_transition_matrix = transition_matrix / row_scales[:, None]
+        scaled_row_sums = scaled_transition_matrix.sum(axis=1)
+        if not bool(pyrecest.backend.all(isfinite(scaled_row_sums))) or pyrecest.backend.any(
+            scaled_row_sums <= 0.0
+        ):
+            raise ValueError(
+                "Each row of transition_matrix must have positive finite total mass."
+            )
+        normalized_transition_matrix = (
+            scaled_transition_matrix / scaled_row_sums[:, None]
+        )
+        if not allclose(transition_matrix, normalized_transition_matrix):
             warnings.warn(
                 "Rows of transition_matrix do not sum to one. Renormalizing rows.",
                 UserWarning,
             )
-            transition_matrix = transition_matrix / row_sums[:, None]
-        return transition_matrix
+        return normalized_transition_matrix
 
     @staticmethod
     def _prepare_mode_probabilities(mode_probabilities, n_models):
@@ -499,17 +510,28 @@ class InteractingMultipleModelFilter(AbstractFilter, EuclideanFilterMixin):
                 raise ValueError("mode_probabilities entries must be finite.")
             if pyrecest.backend.any(mode_probabilities < 0.0):
                 raise ValueError("mode_probabilities must be elementwise nonnegative.")
-            curr_sum = mode_probabilities.sum()
-            if curr_sum <= 0.0:
+            probability_scale = backend_max(mode_probabilities)
+            if not bool(probability_scale > 0.0):
                 raise ValueError(
                     "At least one model probability must be strictly positive."
                 )
-            if not isclose(curr_sum, 1.0):
+            scaled_probabilities = mode_probabilities / probability_scale
+            scaled_probability_sum = scaled_probabilities.sum()
+            if not bool(isfinite(scaled_probability_sum)) or not bool(
+                scaled_probability_sum > 0.0
+            ):
+                raise ValueError(
+                    "Mode probabilities must have positive finite total mass."
+                )
+            normalized_probabilities = (
+                scaled_probabilities / scaled_probability_sum
+            )
+            if not allclose(mode_probabilities, normalized_probabilities):
                 warnings.warn(
                     "mode_probabilities do not sum to one. Renormalizing.",
                     UserWarning,
                 )
-                mode_probabilities = mode_probabilities / curr_sum
+            mode_probabilities = normalized_probabilities
         return array(mode_probabilities)
 
     def _broadcast_model_argument(self, value, name):

--- a/tests/filters/test_imm_probability_normalization_overflow.py
+++ b/tests/filters/test_imm_probability_normalization_overflow.py
@@ -1,0 +1,56 @@
+import unittest
+import warnings
+
+import numpy as np
+import numpy.testing as npt
+import pyrecest.backend
+from pyrecest.backend import array, to_numpy
+from pyrecest.filters.interacting_multiple_model_filter import (
+    InteractingMultipleModelFilter,
+)
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ != "numpy",
+    reason="IMM tests currently run on the numpy backend",
+)
+class IMMProbabilityNormalizationOverflowTest(unittest.TestCase):
+    def test_normalizes_extreme_finite_probabilities_without_overflow(self):
+        maximum = np.finfo(float).max
+        transition_values = np.array(
+            [[maximum, maximum / 2.0], [maximum / 2.0, maximum]]
+        )
+        mode_values = np.array([maximum, maximum / 2.0])
+
+        self.assertTrue(np.all(np.isfinite(transition_values)))
+        self.assertTrue(np.all(np.isfinite(mode_values)))
+        with np.errstate(over="ignore"):
+            self.assertTrue(np.all(np.isinf(transition_values.sum(axis=1))))
+            self.assertTrue(np.isinf(mode_values.sum()))
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            transition_matrix = (
+                InteractingMultipleModelFilter._prepare_transition_matrix(
+                    array(transition_values), 2
+                )
+            )
+            mode_probabilities = (
+                InteractingMultipleModelFilter._prepare_mode_probabilities(
+                    array(mode_values), 2
+                )
+            )
+
+        npt.assert_allclose(
+            to_numpy(transition_matrix),
+            np.array([[2.0 / 3.0, 1.0 / 3.0], [1.0 / 3.0, 2.0 / 3.0]]),
+        )
+        npt.assert_allclose(
+            to_numpy(mode_probabilities), np.array([2.0 / 3.0, 1.0 / 3.0])
+        )
+        npt.assert_allclose(to_numpy(transition_matrix).sum(axis=1), np.ones(2))
+        npt.assert_allclose(to_numpy(mode_probabilities).sum(), 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- normalize IMM transition rows after scaling each row by its largest entry
- normalize mode probabilities after scaling by their largest entry
- add a focused regression for finite values whose raw sums overflow

## Bug

`InteractingMultipleModelFilter` normalized transition rows and mode probabilities by summing values at their original scale. Valid finite inputs near the `float64` maximum can have an infinite raw sum. Dividing by that sum silently produced all-zero transition rows or all-zero model probabilities.

For example, the finite relative weights `[max_float, max_float / 2]` define probabilities `[2/3, 1/3]`, but the previous normalization returned `[0, 0]`.

## Fix

Scale each nonnegative probability vector by its largest positive entry before summing and normalizing. This preserves relative mass while keeping the intermediate sums finite. Transition matrices apply the same normalization independently to every row.

## Validation

- reproduced the old all-zero result with NumPy `float64` maximum-finite values
- verified the patched normalization returns the expected `2/3` and `1/3` probabilities with unit sums
- added regression coverage for both transition-row and mode-probability normalization
- branch is 2 commits ahead of `main` and 0 behind
- changes are limited to the IMM implementation and one focused test file

The repository's configured GitHub Actions checks provide the full-suite validation.