### PR TITLE
Stabilize SO(3) quaternion normalization

### DIFF
--- a/.github/ci-refresh/4440.txt
+++ b/.github/ci-refresh/4440.txt
@@ -1,1 +1,0 @@
-Temporary CI refresh marker.

--- a/.github/ci-refresh/4440.txt
+++ b/.github/ci-refresh/4440.txt
@@ -1,0 +1,1 @@
+Temporary CI refresh marker.

--- a/src/pyrecest/distributions/_so3_helpers.py
+++ b/src/pyrecest/distributions/_so3_helpers.py
@@ -4,6 +4,7 @@
 from pyrecest.backend import (
     abs,
     all,
+    amax,
     arccos,
     arctan2,
     array,
@@ -51,15 +52,20 @@ def normalize_quaternions(quaternions):
     else:
         raise ValueError("SO(3) quaternions must have length 4.")
 
-    norms = linalg.norm(quaternions, axis=-1)
     if not bool(all(isfinite(quaternions))):
         raise ValueError("SO(3) quaternions must be finite.")
-    if not bool(all(isfinite(norms))):
-        raise ValueError("SO(3) quaternion norms must be finite.")
-    if not bool(all(norms > 0.0)):
+
+    scales = amax(abs(quaternions), axis=-1)
+    if not bool(all(scales > 0.0)):
         raise ValueError("SO(3) quaternions must be nonzero.")
 
-    normalized = quaternions / reshape(norms, tuple(norms.shape) + (1,))
+    scales_col = reshape(scales, tuple(scales.shape) + (1,))
+    scaled_quaternions = quaternions / scales_col
+    norms = linalg.norm(scaled_quaternions, axis=-1)
+    if not bool(all(isfinite(norms))):
+        raise ValueError("SO(3) quaternion norms must be finite.")
+
+    normalized = scaled_quaternions / reshape(norms, tuple(norms.shape) + (1,))
     return where(normalized[..., -1:] < 0.0, -normalized, normalized)
 
 

--- a/tests/distributions/test_so3_quaternion_extreme_scales.py
+++ b/tests/distributions/test_so3_quaternion_extreme_scales.py
@@ -1,0 +1,37 @@
+import numpy as np
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array, to_numpy
+from pyrecest.distributions import so3_helpers
+
+
+def test_normalize_quaternions_handles_extreme_finite_scales():
+    backend_dtype = to_numpy(array([1.0])).dtype
+    finfo = np.finfo(backend_dtype)
+    quaternions = array(
+        np.asarray(
+            [
+                [finfo.max, finfo.max / 2.0, 0.0, 0.0],
+                [2.0 * finfo.tiny, finfo.tiny, 0.0, 0.0],
+                [0.0, 0.0, 0.0, -finfo.max],
+            ],
+            dtype=backend_dtype,
+        )
+    )
+    expected_direction = np.asarray(
+        [2.0 / np.sqrt(5.0), 1.0 / np.sqrt(5.0), 0.0, 0.0],
+        dtype=backend_dtype,
+    )
+    expected = np.stack(
+        [
+            expected_direction,
+            expected_direction,
+            np.asarray([0.0, 0.0, 0.0, 1.0], dtype=backend_dtype),
+        ]
+    )
+
+    normalized = to_numpy(so3_helpers.normalize_quaternions(quaternions))
+
+    assert np.all(np.isfinite(normalized))
+    npt.assert_allclose(normalized, expected, rtol=1.0e-6, atol=1.0e-7)


### PR DESCRIPTION
## Bug

`normalize_quaternions()` computed the Euclidean norm at the input scale. For finite, nonzero quaternions near the active floating-point maximum, squaring components overflowed and the helper rejected the resulting infinite norm. At the opposite extreme, squaring tiny finite components underflowed to zero, so valid nonzero quaternions were rejected as zero.

Quaternion normalization is scale invariant, so both inputs should produce the same unit rotation as ordinary-scale multiples.

## Fix

- validate that quaternion entries are finite before normalization
- scale each quaternion by its largest absolute component
- compute the Euclidean norm only after scaling into `[-1, 1]`
- preserve the existing zero-input rejection and scalar-last canonical sign convention
- add a backend-aware regression covering very large, very small, and negative-scalar quaternions

## Validation

- reproduced the old NumPy failure for maximum- and minimum-scale finite inputs
- syntax-compiled the modified helper and regression
- executed the exact patched helper through a NumPy-backed PyRecEst shim
- verified unit norms, expected directions, canonical sign handling, and existing invalid-input errors
- branch comparison is limited to 10 additions/4 deletions in the helper plus one focused regression file