### PR TITLE
Reject wrong-shaped smoother matrices before broadcasting

### DIFF
--- a/.github/ci-refresh/4441.txt
+++ b/.github/ci-refresh/4441.txt
@@ -1,1 +1,0 @@
-Temporary CI refresh marker.

--- a/.github/ci-refresh/4441.txt
+++ b/.github/ci-refresh/4441.txt
@@ -1,0 +1,1 @@
+Temporary CI refresh marker.

--- a/src/pyrecest/smoothers/abstract_smoother.py
+++ b/src/pyrecest/smoothers/abstract_smoother.py
@@ -8,6 +8,9 @@ from pyrecest.backend import asarray, copy, ndim
 from pyrecest.distributions import GaussianDistribution
 
 
+_RECTANGULAR_MATRIX_SEQUENCE_NAMES = {"measurement_matrices"}
+
+
 class AbstractSmoother(ABC):
     """Abstract base class for all smoothers."""
 
@@ -52,6 +55,27 @@ class AbstractSmoother(ABC):
         )
 
     @staticmethod
+    def _validate_matrix_shape(matrix, name: str, matrix_dim: int):
+        """Reject matrices whose shape would otherwise broadcast silently."""
+        matrix_shape = tuple(matrix.shape)
+        if name in _RECTANGULAR_MATRIX_SEQUENCE_NAMES:
+            valid_shape = (
+                len(matrix_shape) == 2
+                and matrix_shape[0] > 0
+                and matrix_shape[1] == matrix_dim
+            )
+            expected_shape = f"(measurement_dim, {matrix_dim})"
+        else:
+            valid_shape = matrix_shape == (matrix_dim, matrix_dim)
+            expected_shape = str((matrix_dim, matrix_dim))
+
+        if not valid_shape:
+            raise ValueError(
+                f"{name} must contain matrices with shape {expected_shape}."
+            )
+        return matrix
+
+    @staticmethod
     def _normalize_matrix_sequence(  # pylint: disable=too-many-return-statements,too-many-branches
         values, length: int, name: str, matrix_dim: int, default=None
     ) -> list:
@@ -61,7 +85,9 @@ class AbstractSmoother(ABC):
         if values is None:
             if default is None:
                 raise ValueError(f"{name} must be provided.")
-            default_arr = asarray(default)
+            default_arr = AbstractSmoother._validate_matrix_shape(
+                asarray(default), name, matrix_dim
+            )
             return [copy(default_arr) for _ in range(length)]
 
         try:
@@ -74,18 +100,35 @@ class AbstractSmoother(ABC):
                     raise ValueError(
                         f"Scalar input for {name} is only supported in one-dimensional models."
                     )
-                scalar_matrix = asarray([[values_arr]])
+                scalar_matrix = AbstractSmoother._validate_matrix_shape(
+                    asarray([[values_arr]]), name, matrix_dim
+                )
                 return [copy(scalar_matrix) for _ in range(length)]
             if (
                 ndim(values_arr) == 1
                 and matrix_dim == 1
                 and values_arr.shape[0] == length
             ):
-                return [asarray([[values_arr[idx]]]) for idx in range(length)]
+                return [
+                    AbstractSmoother._validate_matrix_shape(
+                        asarray([[values_arr[idx]]]), name, matrix_dim
+                    )
+                    for idx in range(length)
+                ]
             if ndim(values_arr) == 2:
+                values_arr = AbstractSmoother._validate_matrix_shape(
+                    values_arr, name, matrix_dim
+                )
                 return [copy(values_arr) for _ in range(length)]
             if ndim(values_arr) == 3 and values_arr.shape[0] == length:
-                return [copy(values_arr[idx]) for idx in range(length)]
+                return [
+                    copy(
+                        AbstractSmoother._validate_matrix_shape(
+                            values_arr[idx], name, matrix_dim
+                        )
+                    )
+                    for idx in range(length)
+                ]
 
         if isinstance(values, (list, tuple)) and len(values) == length:
             normalized_values = []
@@ -96,9 +139,12 @@ class AbstractSmoother(ABC):
                         raise ValueError(
                             f"Scalar entries in {name} are only supported in one-dimensional models."
                         )
-                    normalized_values.append(asarray([[value_arr]]))
-                else:
-                    normalized_values.append(value_arr)
+                    value_arr = asarray([[value_arr]])
+                normalized_values.append(
+                    AbstractSmoother._validate_matrix_shape(
+                        value_arr, name, matrix_dim
+                    )
+                )
             return normalized_values
 
         raise ValueError(

--- a/tests/smoothers/test_smoother_matrix_shape_validation.py
+++ b/tests/smoothers/test_smoother_matrix_shape_validation.py
@@ -1,0 +1,56 @@
+import unittest
+
+from pyrecest.backend import array, eye, zeros
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.smoothers import RauchTungStriebelSmoother
+
+
+class SmootherMatrixShapeValidationTest(unittest.TestCase):
+    def test_rejects_broadcastable_measurement_noise_covariance(self):
+        smoother = RauchTungStriebelSmoother()
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"meas_noise_covariances.*\(2, 2\)",
+        ):
+            smoother.filter(
+                initial_state=GaussianDistribution(zeros(2), eye(2)),
+                measurements=[zeros(2)],
+                measurement_matrices=eye(2),
+                meas_noise_covariances=array([[1.0]]),
+            )
+
+    def test_rejects_broadcastable_process_noise_covariance(self):
+        smoother = RauchTungStriebelSmoother()
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"sys_noise_covariances.*\(2, 2\)",
+        ):
+            smoother.filter(
+                initial_state=GaussianDistribution(zeros(2), eye(2)),
+                measurements=[zeros(2), zeros(2)],
+                measurement_matrices=eye(2),
+                meas_noise_covariances=eye(2),
+                system_matrices=eye(2),
+                sys_noise_covariances=array([[1.0]]),
+            )
+
+    def test_rectangular_measurement_matrix_remains_supported(self):
+        smoother = RauchTungStriebelSmoother()
+
+        filtered_states, predicted_states = smoother.filter(
+            initial_state=GaussianDistribution(zeros(2), eye(2)),
+            measurements=array([1.0]),
+            measurement_matrices=array([[1.0, 0.0]]),
+            meas_noise_covariances=array([[1.0]]),
+        )
+
+        self.assertEqual(len(filtered_states), 1)
+        self.assertEqual(len(predicted_states), 0)
+        self.assertEqual(filtered_states[0].mu.shape, (2,))
+        self.assertEqual(filtered_states[0].C.shape, (2, 2))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- validate smoother matrix shapes during sequence normalization
- require square state-transition, system-noise, measurement-noise, and shape-transition matrices
- preserve rectangular linear measurement matrices when their column count matches the state dimension
- add regressions for broadcastable `(1, 1)` covariance inputs and rectangular measurement matrices

## Bug

`AbstractSmoother._normalize_matrix_sequence()` accepted any two-dimensional matrix without checking its dimensions. In multi-dimensional models, NumPy therefore silently broadcast wrong-sized covariance inputs instead of rejecting them. For example, adding a `(1, 1)` noise covariance to a `2 x 2` covariance produces a `2 x 2` result with the scalar added to every entry, including artificial off-diagonal covariance.

The same unchecked path was shared by linear and unscented RTS smoothers and the fixed-lag smoother implementations.

## Fix

Validate every normalized matrix before returning it:

- covariance and system/transition matrices must have shape `(matrix_dim, matrix_dim)`
- linear measurement matrices remain rectangular, but must be non-empty and have `state_dim` columns
- validation covers defaults, scalar one-dimensional inputs, single reusable matrices, stacked sequences, and Python-list fallback sequences

## Validation

- reproduced the old NumPy broadcasting behavior for a `(1, 1)` covariance and a `2 x 2` covariance
- syntax-compiled the modified module and regression test
- ran an isolated NumPy-backed harness verifying rejection of wrong covariance/system shapes and acceptance of a `(1, 2)` measurement matrix
- branch comparison: 2 files changed, 109 additions, 7 deletions; 2 commits ahead of `main`, 0 behind

Full repository CI is delegated to GitHub Actions because this environment cannot clone the repository.