### PR TITLE
Preserve complex precision in PyTorch logm

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -237,6 +237,10 @@ class _Logm(_torch.autograd.Function):
     @staticmethod
     def _logm(x):
         mat_log = _gsnplinalg.logm(_as_numpy_no_grad(x))
+        if mat_log.dtype.kind == "c":
+            target_complex_dtype = _COMPLEX_DTYPE_FOR_TENSOR_DTYPE.get(x.dtype)
+            if target_complex_dtype is not None:
+                mat_log = mat_log.astype(target_complex_dtype, copy=False)
         return _torch_as_like(mat_log, x)
 
     @staticmethod

--- a/tests/backend_support/test_pytorch_linalg_logm_contract.py
+++ b/tests/backend_support/test_pytorch_linalg_logm_contract.py
@@ -16,6 +16,17 @@ def test_raw_pytorch_logm_accepts_array_like_integer_inputs():
     assert torch.allclose(result, torch.zeros_like(result))
 
 
+def test_raw_pytorch_logm_preserves_float32_complex_precision():
+    matrix = torch.diag(torch.tensor([-1.0, 1.0], dtype=torch.float32))
+
+    result = pytorch_linalg.logm(matrix)
+
+    expected = torch.zeros((2, 2), dtype=torch.complex64)
+    expected[0, 0] = 1j * torch.pi
+    assert result.dtype == torch.complex64
+    assert torch.allclose(result, expected, atol=1e-5, rtol=1e-5)
+
+
 def test_public_pytorch_logm_accepts_array_like_integer_inputs_when_active():
     if getattr(backend, "__backend_name__", None) != "pytorch":
         pytest.skip("public PyTorch backend is not active")


### PR DESCRIPTION
## Summary

- preserve the input precision when PyTorch `linalg.logm` produces a complex SciPy result
- convert `float32`/`complex64` inputs back to `complex64` instead of leaking SciPy's `complex128` default
- add a focused regression using a real `float32` matrix whose principal logarithm is complex

## Bug

The PyTorch backend converted `logm` results through SciPy, but unlike `sqrtm` and `fractional_matrix_power`, it did not normalize a complex SciPy result to the complex dtype corresponding to the input precision. For example, a `torch.float32` diagonal matrix containing a negative eigenvalue returned `torch.complex128`.

This caused an unexpected precision and memory increase and made `logm` inconsistent with the shared NumPy backend and neighboring PyTorch matrix-function wrappers.

## Fix

When the SciPy result is complex, cast it to the complex NumPy dtype mapped from the input tensor dtype before moving it back to the original tensor device.

## Validation

- reproduced the old result as `torch.complex128`
- verified the patched result is `torch.complex64`
- verified the principal logarithm value against `diag(i*pi, 0)` within `1e-5`
- verified an existing `complex64` input remains `complex64`
- syntax-compiled the modified implementation and regression test
- branch is two commits ahead of `main`, zero behind, with only the implementation and focused test changed

Full repository CI should run on this pull request.