### PR TITLE
Preserve maximum cardinality in gated registration

### DIFF
--- a/.github/ci-refresh/4444.txt
+++ b/.github/ci-refresh/4444.txt
@@ -1,1 +1,0 @@
-Temporary CI refresh marker.

--- a/.github/ci-refresh/4444.txt
+++ b/.github/ci-refresh/4444.txt
@@ -1,0 +1,1 @@
+Temporary CI refresh marker.

--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -13,7 +13,6 @@ from pyrecest.backend import (
     asarray,
     cast,
     empty,
-    full,
     int64,
     isfinite,
     mean,
@@ -21,8 +20,9 @@ from pyrecest.backend import (
     where,
     zeros,
 )
-from scipy.optimize import linear_sum_assignment
 from scipy.spatial.distance import cdist
+
+from .assignment import min_cost_max_cardinality_assignment
 
 
 @dataclass(frozen=True)
@@ -306,39 +306,8 @@ def solve_gated_assignment(cost_matrix, *, max_cost: float = float("inf")):
     if valid_costs.shape[0] == 0:
         return zeros((costs.shape[0],), dtype=int64) - 1
 
-    highest_valid_cost = float(valid_costs.max())
-    unassigned_cost = (
-        max_cost_value
-        if math.isfinite(max_cost_value)
-        else max(highest_valid_cost, 0.0) + 1.0
-    )
-    cost_scale = max(abs(highest_valid_cost), abs(unassigned_cost), 1.0)
-    invalid_cost = max(highest_valid_cost, 2.0 * unassigned_cost) + cost_scale
-
-    n_reference, n_moving = costs.shape
-    augmented_size = n_reference + n_moving
-    augmented_costs = full((augmented_size, augmented_size), invalid_cost)
-    augmented_costs[:n_reference, :n_moving] = where(
-        valid_cost_mask,
-        costs,
-        invalid_cost,
-    )
-
-    for reference_index in range(n_reference):
-        augmented_costs[reference_index, n_moving + reference_index] = unassigned_cost
-    for moving_index in range(n_moving):
-        augmented_costs[n_reference + moving_index, moving_index] = unassigned_cost
-    augmented_costs[n_reference:, n_moving:] = 0.0
-
-    row_indices, col_indices = linear_sum_assignment(augmented_costs)
-
-    assignment = zeros((n_reference,), dtype=int64) - 1
-    for row_index, col_index in zip(row_indices, col_indices):
-        if row_index >= n_reference or col_index >= n_moving:
-            continue
-        if bool(valid_cost_mask[row_index, col_index]):
-            assignment[row_index] = int(col_index)
-    return assignment
+    gated_costs = where(valid_cost_mask, costs, float("inf"))
+    return min_cost_max_cardinality_assignment(gated_costs)["assignment"]
 
 
 def default_cost(transformed_reference_points, moving_points):

--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -6,6 +6,8 @@ import math
 from dataclasses import dataclass
 from typing import Any, Callable
 
+import numpy as np
+
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import all as backend_all
 from pyrecest.backend import (
@@ -20,9 +22,8 @@ from pyrecest.backend import (
     where,
     zeros,
 )
+from scipy.optimize import linear_sum_assignment
 from scipy.spatial.distance import cdist
-
-from .assignment import min_cost_max_cardinality_assignment
 
 
 @dataclass(frozen=True)
@@ -306,8 +307,45 @@ def solve_gated_assignment(cost_matrix, *, max_cost: float = float("inf")):
     if valid_costs.shape[0] == 0:
         return zeros((costs.shape[0],), dtype=int64) - 1
 
-    gated_costs = where(valid_cost_mask, costs, float("inf"))
-    return min_cost_max_cardinality_assignment(gated_costs)["assignment"]
+    costs_numpy = np.asarray(costs, dtype=float)
+    valid_cost_mask_numpy = np.asarray(valid_cost_mask, dtype=bool)
+    valid_costs_numpy = costs_numpy[valid_cost_mask_numpy]
+    cost_scale = max(float(np.max(np.abs(valid_costs_numpy))), 1.0)
+    scaled_costs = costs_numpy / cost_scale
+    scaled_valid_costs = scaled_costs[valid_cost_mask_numpy]
+    cardinality_penalty = 2.0 * (
+        float(np.sum(np.abs(scaled_valid_costs))) + 1.0
+    )
+    invalid_cost = 2.0 * cardinality_penalty + 1.0
+
+    n_reference, n_moving = costs_numpy.shape
+    augmented_size = n_reference + n_moving
+    augmented_costs = np.full(
+        (augmented_size, augmented_size), invalid_cost, dtype=float
+    )
+    augmented_costs[:n_reference, :n_moving] = np.where(
+        valid_cost_mask_numpy,
+        scaled_costs,
+        invalid_cost,
+    )
+    for reference_index in range(n_reference):
+        augmented_costs[
+            reference_index, n_moving + reference_index
+        ] = cardinality_penalty
+    for moving_index in range(n_moving):
+        augmented_costs[n_reference + moving_index, moving_index] = 0.0
+    augmented_costs[n_reference:, n_moving:] = 0.0
+
+    row_indices, col_indices = linear_sum_assignment(augmented_costs)
+    assignment = np.full((n_reference,), -1, dtype=np.int64)
+    for row_index, col_index in zip(row_indices, col_indices):
+        if (
+            row_index < n_reference
+            and col_index < n_moving
+            and valid_cost_mask_numpy[row_index, col_index]
+        ):
+            assignment[row_index] = col_index
+    return asarray(assignment, dtype=int64)
 
 
 def default_cost(transformed_reference_points, moving_points):

--- a/tests/test_point_set_registration_gate_cardinality.py
+++ b/tests/test_point_set_registration_gate_cardinality.py
@@ -1,0 +1,20 @@
+import unittest
+
+import numpy.testing as npt
+import pyrecest.backend
+from pyrecest.backend import array
+from pyrecest.utils.point_set_registration import solve_gated_assignment
+
+
+class TestGatedAssignmentCardinality(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_gate_boundary_still_maximizes_cardinality(self):
+        assignment = solve_gated_assignment(
+            array([[float("inf"), 1.0], [1.0, 0.0]]),
+            max_cost=1.0,
+        )
+
+        npt.assert_array_equal(assignment, array([1, 0]))


### PR DESCRIPTION
## Bug

`solve_gated_assignment()` encoded row and column non-assignment with a penalty equal to the finite gate. A valid edge exactly at `max_cost` could therefore tie with leaving both endpoints unmatched. In a coupled assignment, the Hungarian solver could select a lower-cardinality solution even though a full valid matching existed.

For example, the cost matrix `[[inf, 1], [1, 0]]` with `max_cost=1` returned one match instead of the unique two-match assignment `[1, 0]`.

## Fix

- retain the existing numeric and gate validation;
- normalize valid costs before optimization to avoid extreme-value penalty overflow;
- use an augmented Hungarian formulation with a cardinality-dominating non-assignment penalty;
- convert the eager backend array only at the SciPy assignment boundary, then return the assignment in the active backend;
- add a focused boundary-cost regression.

This preserves support for the NumPy, PyTorch, and eager JAX test matrices instead of routing through the shared assignment helper, which intentionally does not support JAX.

## Validation

- reproduced the previous one-match result for the boundary case;
- Python syntax compilation passed for the original branch changes;
- full repository CI was re-triggered by the backend-compatible repair commit.