### PR TITLE
Reject nonfinite jittered Cholesky factors

### DIFF
--- a/.github/ci-refresh/4445.txt
+++ b/.github/ci-refresh/4445.txt
@@ -1,1 +1,0 @@
-Temporary CI refresh marker.

--- a/.github/ci-refresh/4445.txt
+++ b/.github/ci-refresh/4445.txt
@@ -1,0 +1,1 @@
+Temporary CI refresh marker.

--- a/src/pyrecest/numerics.py
+++ b/src/pyrecest/numerics.py
@@ -223,11 +223,18 @@ def jittered_cholesky(matrix, *, initial_jitter: float = 1e-12, max_attempts: in
     eye = np.eye(sym.shape[0])
     jitter = 0.0
     for attempt in range(max_attempts + 1):
+        with np.errstate(over="ignore", invalid="ignore"):
+            jittered = sym + jitter * eye
+        if not _is_finite_matrix(jittered):
+            break
         try:
-            factor = np.linalg.cholesky(sym + jitter * eye)
-            return _from_numpy_array(factor), jitter
+            factor = np.linalg.cholesky(jittered)
         except np.linalg.LinAlgError:
             jitter = initial_jitter if attempt == 0 else jitter * 10.0
+            continue
+        if not _is_finite_matrix(factor):
+            break
+        return _from_numpy_array(factor), jitter
     raise NumericalStabilityError(
         f"Cholesky factorization failed after {max_attempts} jitter attempts."
     )

--- a/tests/test_jittered_cholesky_overflow.py
+++ b/tests/test_jittered_cholesky_overflow.py
@@ -7,7 +7,7 @@ from pyrecest.numerics import jittered_cholesky
 
 def test_jittered_cholesky_rejects_factor_after_jitter_overflow():
     max_float = np.finfo(float).max
-    matrix = np.diag([max_float, -1.0])
+    matrix = np.diag([max_float / 2.0, -1.0])
 
     with pytest.raises(
         NumericalStabilityError, match="Cholesky factorization failed"

--- a/tests/test_jittered_cholesky_overflow.py
+++ b/tests/test_jittered_cholesky_overflow.py
@@ -1,0 +1,19 @@
+import numpy as np
+import pytest
+
+from pyrecest.exceptions import NumericalStabilityError
+from pyrecest.numerics import jittered_cholesky
+
+
+def test_jittered_cholesky_rejects_factor_after_jitter_overflow():
+    max_float = np.finfo(float).max
+    matrix = np.diag([max_float, -1.0])
+
+    with pytest.raises(
+        NumericalStabilityError, match="Cholesky factorization failed"
+    ):
+        jittered_cholesky(
+            matrix,
+            initial_jitter=max_float,
+            max_attempts=1,
+        )


### PR DESCRIPTION
## Bug

`jittered_cholesky()` accepted finite inputs and finite retry controls, but did not validate the matrix produced after adding diagonal jitter or the returned Cholesky factor.

For a matrix such as `diag(max_float / 2, -1)` with `initial_jitter=max_float`, the raw factorization fails as expected. Adding the first jitter then overflows one diagonal entry to `inf`. NumPy can still return a factor containing `inf`, and the helper returned that factor as a successful result.

## Fix

- form each jittered candidate under a local floating-point error state
- stop when adding jitter produces nonfinite values
- reject a nonfinite factor even if the linear algebra routine does not raise
- preserve the existing retry schedule and failure exception
- add a focused regression that reproduces the overflow path

## Validation

- reproduced the previous nonfinite factor locally with NumPy
- verified the patched logic raises `NumericalStabilityError` for the overflow case
- verified the ordinary singular-PSD jitter path still returns a finite factor
- branch is based on current `main` and changes only `src/pyrecest/numerics.py` plus one focused regression test

Full repository CI is requested by this pull request.