### PR TITLE
Copy explicit additive-noise statistics

### DIFF
--- a/.github/ci-refresh/4446.txt
+++ b/.github/ci-refresh/4446.txt
@@ -1,1 +1,0 @@
-Temporary CI refresh marker.

--- a/.github/ci-refresh/4446.txt
+++ b/.github/ci-refresh/4446.txt
@@ -1,0 +1,1 @@
+Temporary CI refresh marker.

--- a/src/pyrecest/models/additive_noise.py
+++ b/src/pyrecest/models/additive_noise.py
@@ -7,12 +7,12 @@ from typing import Any
 import numpy as np
 
 # pylint: disable=no-name-in-module,no-member,too-many-instance-attributes,too-many-positional-arguments
-from pyrecest.backend import asarray, is_array
+from pyrecest.backend import asarray, copy as copy_array, is_array
 
 
 def _as_optional_array(value):
-    """Convert ``value`` through the active backend unless it is ``None``."""
-    return None if value is None else asarray(value)
+    """Convert and copy ``value`` through the active backend unless it is ``None``."""
+    return None if value is None else copy_array(asarray(value))
 
 
 def _array_difference(left, right):

--- a/tests/models/test_additive_noise_constructor_ownership.py
+++ b/tests/models/test_additive_noise_constructor_ownership.py
@@ -1,0 +1,54 @@
+import unittest
+
+import numpy as np
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import allclose, array
+from pyrecest.models import (
+    AdditiveNoiseMeasurementModel,
+    AdditiveNoiseTransitionModel,
+)
+
+
+def assert_backend_allclose(test_case, actual, expected):
+    test_case.assertTrue(bool(allclose(actual, expected)))
+
+
+class AdditiveNoiseConstructorOwnershipTest(unittest.TestCase):
+    def test_transition_model_copies_explicit_noise_statistics(self):
+        noise_mean = np.array([1.0, -1.0])
+        noise_covariance = np.array([[2.0, 0.5], [0.5, 3.0]])
+        model = AdditiveNoiseTransitionModel(
+            lambda state: state,
+            noise_mean=noise_mean,
+            noise_covariance=noise_covariance,
+        )
+
+        noise_mean[:] = 99.0
+        noise_covariance[:] = -99.0
+
+        assert_backend_allclose(self, model.noise_mean, array([1.0, -1.0]))
+        assert_backend_allclose(
+            self,
+            model.noise_covariance,
+            array([[2.0, 0.5], [0.5, 3.0]]),
+        )
+
+    def test_measurement_model_copies_explicit_noise_statistics(self):
+        noise_mean = np.array([0.25])
+        noise_covariance = np.array([[4.0]])
+        model = AdditiveNoiseMeasurementModel(
+            lambda state: state,
+            noise_mean=noise_mean,
+            noise_covariance=noise_covariance,
+        )
+
+        noise_mean[:] = 99.0
+        noise_covariance[:] = -99.0
+
+        assert_backend_allclose(self, model.noise_mean, array([0.25]))
+        assert_backend_allclose(self, model.noise_covariance, array([[4.0]]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`AdditiveNoiseTransitionModel` and `AdditiveNoiseMeasurementModel` converted explicit `noise_mean` and `noise_covariance` inputs with the active backend's `asarray` function and retained the resulting storage directly.

With the NumPy backend, `asarray` may return the caller's original array. Mutating that array after model construction therefore silently changed the model's noise statistics and subsequent predictions.

## Fix

- copy explicit noise statistics after backend conversion
- apply the ownership rule consistently to transition and measurement models
- add focused regressions that mutate both constructor inputs after construction

## Validation

- reproduced the previous aliasing behavior in an isolated harness
- verified the fix preserves the original mean and covariance after caller-side mutation
- Python syntax compilation passed for the implementation and regression test
- branch is 2 commits ahead of `main` and 0 behind

Repository CI will run the complete configured test suite on this pull request.