### PR TITLE
Stabilize Merwe sigma-point scaling

### DIFF
--- a/.github/ci-refresh/4447.txt
+++ b/.github/ci-refresh/4447.txt
@@ -1,1 +1,0 @@
-Temporary CI refresh marker.

--- a/.github/ci-refresh/4447.txt
+++ b/.github/ci-refresh/4447.txt
@@ -1,0 +1,1 @@
+Temporary CI refresh marker.

--- a/src/pyrecest/sampling/sigma_points.py
+++ b/src/pyrecest/sampling/sigma_points.py
@@ -147,12 +147,15 @@ class MerweScaledSigmaPoints:
             raise ValueError("alpha must be positive")
         if self.n + self.kappa <= 0.0:
             raise ValueError("n + kappa must be positive")
+        self._scale = self.alpha * self.alpha * (self.n + self.kappa)
+        if not math.isfinite(self._scale) or self._scale <= 0.0:
+            raise ValueError("alpha scaling factor must be finite and positive")
         self._compute_weights()
 
     def _compute_weights(self):
         n = self.n
-        lam = self.alpha**2 * (n + self.kappa) - n
-        scale = n + lam
+        scale = self._scale
+        lam = scale - n
 
         self.Wm = concatenate(
             [
@@ -181,11 +184,10 @@ class MerweScaledSigmaPoints:
             State covariance, shape ``(n, n)``.
         """
         n = self.n
-        lam = self.alpha**2 * (n + self.kappa) - n
 
         x, P = _validate_sigma_inputs(x, P, n)
 
-        U = linalg.cholesky((n + lam) * P)  # lower-triangular
+        U = linalg.cholesky(self._scale * P)  # lower-triangular
 
         positive = [x + U[:, i] for i in range(n)]
         negative = [x - U[:, i] for i in range(n)]

--- a/tests/test_sigma_points_small_alpha.py
+++ b/tests/test_sigma_points_small_alpha.py
@@ -1,0 +1,43 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+from pyrecest.backend import __backend_name__, asarray, to_numpy
+from pyrecest.sampling import MerweScaledSigmaPoints
+
+
+@unittest.skipIf(
+    __backend_name__ == "pytorch",
+    reason="Sigma-point tests use NumPy assertions and the PyTorch backend is unsupported",
+)
+class TestMerweSigmaPointScaling(unittest.TestCase):
+    def test_small_alpha_uses_direct_positive_scale(self):
+        alpha = 1.0e-10
+        points = MerweScaledSigmaPoints(n=2, alpha=alpha, beta=2.0, kappa=0.0)
+
+        sigmas = to_numpy(points.sigma_points(asarray(np.zeros(2)), asarray(np.eye(2))))
+        step = np.sqrt(alpha * alpha * 2.0)
+        expected = np.array(
+            [
+                [0.0, 0.0],
+                [step, 0.0],
+                [0.0, step],
+                [-step, 0.0],
+                [0.0, -step],
+            ]
+        )
+
+        self.assertTrue(np.all(np.isfinite(to_numpy(points.Wm))))
+        self.assertTrue(np.all(np.isfinite(to_numpy(points.Wc))))
+        npt.assert_allclose(sigmas, expected, rtol=1.0e-12, atol=0.0)
+
+    def test_rejects_underflowing_and_overflowing_scale(self):
+        for alpha in (1.0e-200, 1.0e200):
+            with self.subTest(alpha=alpha), self.assertRaisesRegex(
+                ValueError, "alpha scaling factor must be finite and positive"
+            ):
+                MerweScaledSigmaPoints(n=2, alpha=alpha, beta=2.0, kappa=0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`MerweScaledSigmaPoints` computed the positive sigma-point scale as `n + lambda` after first evaluating `lambda = alpha**2 * (n + kappa) - n`. For sufficiently small but representable positive `alpha`, subtracting `n` rounds `lambda` to exactly `-n`; adding `n` back then yields zero. Construction consequently raises `ZeroDivisionError`, and sigma-point generation would use a zero Cholesky scale.

For example, `n=2`, `kappa=0`, and `alpha=1e-10` have the valid direct scale `2e-20`, but the previous cancellation-prone reconstruction produces `0.0`.

## Fix

- compute and retain `alpha * alpha * (n + kappa)` directly
- use that retained value for both weights and covariance scaling
- reject only genuine scale underflow or overflow with a clear `ValueError`
- add focused regressions for the small-alpha cancellation case and for non-representable scales

## Validation

- reproduced the previous `ZeroDivisionError` analytically for `alpha=1e-10`
- syntax-compiled the modified implementation and regression
- ran the exact regression through an isolated NumPy-backed PyRecEst harness: `2 passed`
- branch is 2 commits ahead of `main`, 0 behind, with 10 implementation-line changes and one focused test file

Full repository CI should run on this pull request.