### PR TITLE
Stabilize SO(3) chordal weight normalization

### DIFF
--- a/.github/ci-refresh/4448.txt
+++ b/.github/ci-refresh/4448.txt
@@ -1,1 +1,0 @@
-Temporary CI refresh marker.

--- a/.github/ci-refresh/4448.txt
+++ b/.github/ci-refresh/4448.txt
@@ -1,0 +1,1 @@
+Temporary CI refresh marker.

--- a/src/pyrecest/smoothers/so3_chordal_mean_smoother.py
+++ b/src/pyrecest/smoothers/so3_chordal_mean_smoother.py
@@ -106,13 +106,18 @@ class SO3ChordalMeanSmoother(AbstractSmoother):
             if weights_array[idx] < 0.0:
                 raise ValueError(f"{name} must be nonnegative.")
 
-        weight_sum = backend.sum(weights_array)
-        if weight_sum <= 0.0:
+        weight_scale = backend.max(weights_array)
+        if not bool(weight_scale > 0.0):
+            raise ValueError(f"{name} must contain at least one positive entry.")
+
+        scaled_weights = weights_array / weight_scale
+        scaled_weight_sum = backend.sum(scaled_weights)
+        if not bool(isfinite(scaled_weight_sum)) or not bool(scaled_weight_sum > 0.0):
             raise ValueError(f"{name} must contain at least one positive entry.")
 
         if normalize:
-            return weights_array / weight_sum
-        return weights_array
+            return scaled_weights / scaled_weight_sum
+        return scaled_weights
 
     @staticmethod
     def project_to_so3(matrix):

--- a/tests/smoothers/test_so3_chordal_mean_extreme_weights.py
+++ b/tests/smoothers/test_so3_chordal_mean_extreme_weights.py
@@ -1,0 +1,42 @@
+import numpy as np
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array, cos, eye, sin, stack, to_numpy
+from pyrecest.smoothers import SO3ChordalMeanSmoother
+
+
+def _z_rotation(angle):
+    return array(
+        [
+            [cos(angle), -sin(angle), 0.0],
+            [sin(angle), cos(angle), 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+
+
+def test_chordal_mean_normalizes_extreme_finite_weights_stably():
+    backend_dtype = to_numpy(array([1.0])).dtype
+    maximum = np.finfo(backend_dtype).max
+    rotations = stack([eye(3), _z_rotation(0.5 * np.pi)], axis=0)
+
+    reference = SO3ChordalMeanSmoother.chordal_mean(
+        rotations,
+        weights=array([3.0, 1.0]),
+    )
+    extreme_weights = array(
+        np.asarray([maximum, maximum / 3.0], dtype=backend_dtype)
+    )
+
+    result = SO3ChordalMeanSmoother.chordal_mean(
+        rotations,
+        weights=extreme_weights,
+    )
+
+    npt.assert_allclose(
+        to_numpy(result),
+        to_numpy(reference),
+        rtol=1.0e-5,
+        atol=1.0e-6,
+    )


### PR DESCRIPTION
## Bug

`SO3ChordalMeanSmoother._normalize_weight_vector()` summed finite nonnegative weights at their original scale. For weights near the active floating-point maximum, the sum could overflow to infinity. Dividing by that total then collapsed every normalized weight to zero, so the projected chordal mean could become an unrelated rotation.

For example, weights proportional to `3:1` at the `float64` limit produced the identity rotation instead of the same weighted mean as ordinary `[3.0, 1.0]` weights.

The same risk applied when finite sample and kernel weights were multiplied during local smoothing.

## Fix

- scale every weight vector by its largest positive entry before summation
- normalize the bounded scaled weights when a probability vector is needed
- retain the bounded relative weights for kernel/sample weighting so their products cannot overflow
- preserve existing validation for length, finiteness, nonnegativity, and positive mass

## Validation

- reproduced overflow of the old raw weight sum and the resulting identity rotation
- verified scaled normalization yields `[0.75, 0.25]` for the extreme finite `3:1` case
- added a backend-aware regression comparing extreme weights with ordinary `[3.0, 1.0]` weights
- branch is 2 commits ahead of `main`, 0 behind, and changes only the smoother plus the focused regression

Full repository CI is requested by this pull request.