### PR TITLE
Reject complex LTI discretization inputs

### DIFF
--- a/src/pyrecest/models/_validated_motion_models.py
+++ b/src/pyrecest/models/_validated_motion_models.py
@@ -4,9 +4,49 @@ from __future__ import annotations
 
 from typing import Any
 
+import numpy as np
+
 from . import motion_models as _motion_models
 
 _nearly_coordinated_turn_model_impl = _motion_models.nearly_coordinated_turn_model
+_continuous_to_discrete_lti_impl = _motion_models.continuous_to_discrete_lti
+
+
+def _reject_complex_matrix(value: Any, name: str) -> None:
+    """Reject complex-valued matrices before NumPy can discard imaginary parts."""
+    try:
+        value_array = np.asarray(value)
+    except (TypeError, ValueError):
+        return
+
+    contains_complex_object = value_array.dtype == object and any(
+        isinstance(item, (complex, np.complexfloating)) for item in value_array.flat
+    )
+    if np.iscomplexobj(value_array) or contains_complex_object:
+        raise ValueError(f"{name} must contain real values")
+
+
+def continuous_to_discrete_lti(
+    continuous_matrix: Any,
+    noise_input_matrix: Any | None = None,
+    continuous_noise_covariance: Any | None = None,
+    dt: float = 1.0,
+) -> Any:
+    """Discretize a real LTI model without silently truncating complex inputs."""
+    _reject_complex_matrix(continuous_matrix, "continuous_matrix")
+    if noise_input_matrix is not None:
+        _reject_complex_matrix(noise_input_matrix, "noise_input_matrix")
+    if continuous_noise_covariance is not None:
+        _reject_complex_matrix(
+            continuous_noise_covariance,
+            "continuous_noise_covariance",
+        )
+    return _continuous_to_discrete_lti_impl(
+        continuous_matrix,
+        noise_input_matrix,
+        continuous_noise_covariance,
+        dt=dt,
+    )
 
 
 def nearly_coordinated_turn_model(
@@ -32,7 +72,7 @@ def nearly_coordinated_turn_model(
     )
 
 
+_motion_models.continuous_to_discrete_lti = continuous_to_discrete_lti
 _motion_models.nearly_coordinated_turn_model = nearly_coordinated_turn_model
 
-
-__all__ = ["nearly_coordinated_turn_model"]
+__all__ = ["continuous_to_discrete_lti", "nearly_coordinated_turn_model"]

--- a/tests/models/test_continuous_to_discrete_lti_complex_validation.py
+++ b/tests/models/test_continuous_to_discrete_lti_complex_validation.py
@@ -1,0 +1,41 @@
+import unittest
+
+import numpy as np
+from pyrecest.models import continuous_to_discrete_lti
+
+
+class TestContinuousToDiscreteLtiComplexValidation(unittest.TestCase):
+    def test_rejects_complex_system_and_noise_matrices(self):
+        invalid_cases = [
+            (
+                "continuous_matrix",
+                {
+                    "continuous_matrix": np.array([[1.0 + 2.0j]]),
+                },
+            ),
+            (
+                "noise_input_matrix",
+                {
+                    "continuous_matrix": np.zeros((1, 1)),
+                    "noise_input_matrix": np.array([[1.0 + 2.0j]]),
+                    "continuous_noise_covariance": np.ones((1, 1)),
+                },
+            ),
+            (
+                "continuous_noise_covariance",
+                {
+                    "continuous_matrix": np.zeros((1, 1)),
+                    "noise_input_matrix": np.ones((1, 1)),
+                    "continuous_noise_covariance": np.array([[1.0 + 2.0j]]),
+                },
+            ),
+        ]
+
+        for parameter_name, kwargs in invalid_cases:
+            with self.subTest(parameter_name=parameter_name):
+                with self.assertRaisesRegex(ValueError, parameter_name):
+                    continuous_to_discrete_lti(**kwargs)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`continuous_to_discrete_lti()` converts its system and noise matrices with `np.asarray(..., dtype=float)`. For a NumPy complex array, that conversion emits a `ComplexWarning` and discards the imaginary part. The helper then discretizes a different, real-valued model instead of rejecting an unsupported complex model.

The same silent truncation affected `continuous_matrix`, `noise_input_matrix`, and `continuous_noise_covariance`.

## Fix

- validate all supplied LTI matrices before the existing float conversion
- reject native complex arrays and object arrays containing complex scalars with a parameter-specific `ValueError`
- preserve the existing implementation and validation behavior for real inputs
- add regressions covering all three matrix parameters

## Impact

Callers can no longer receive plausible-looking transition/process-noise matrices for a model whose imaginary components were silently removed.

## Validation

- compiled the updated validation module with `py_compile`
- ran isolated validator checks for native complex arrays, object arrays containing complex values, and ordinary real matrices
- full repository tests were not run locally because this environment has no GitHub CLI or network checkout access