### PR TITLE
Copy wrapped Laplace parameters on construction

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_laplace_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_laplace_distribution.py
@@ -2,7 +2,17 @@
 from numbers import Integral
 
 import numpy as np
-from pyrecest.backend import all, asarray, exp, isfinite, mod, ndim, pi, to_numpy
+from pyrecest.backend import (
+    all,
+    asarray,
+    copy as backend_copy,
+    exp,
+    isfinite,
+    mod,
+    ndim,
+    pi,
+    to_numpy,
+)
 
 from .abstract_circular_distribution import AbstractCircularDistribution
 
@@ -54,8 +64,8 @@ class WrappedLaplaceDistribution(AbstractCircularDistribution):
 
     def __init__(self, lambda_, kappa_):
         AbstractCircularDistribution.__init__(self)
-        lambda_ = _validate_positive_scalar(lambda_, "lambda_")
-        kappa_ = _validate_positive_scalar(kappa_, "kappa_")
+        lambda_ = backend_copy(_validate_positive_scalar(lambda_, "lambda_"))
+        kappa_ = backend_copy(_validate_positive_scalar(kappa_, "kappa_"))
         self.lambda_ = lambda_
         self.kappa = kappa_
 

--- a/tests/distributions/test_wrapped_laplace_parameter_copy.py
+++ b/tests/distributions/test_wrapped_laplace_parameter_copy.py
@@ -1,0 +1,42 @@
+import unittest
+
+import numpy.testing as npt
+import pyrecest.backend
+from pyrecest.backend import array, to_numpy
+from pyrecest.distributions.circle.wrapped_laplace_distribution import (
+    WrappedLaplaceDistribution,
+)
+
+
+class WrappedLaplaceParameterCopyTest(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="JAX arrays are immutable and cannot expose caller-side aliasing.",
+    )
+    def test_constructor_owns_mutable_parameter_storage(self):
+        rate = array(2.0)
+        asymmetry = array(3.0)
+        distribution = WrappedLaplaceDistribution(rate, asymmetry)
+        evaluation_points = array([0.0, 0.5, 1.0])
+        expected_pdf = to_numpy(distribution.pdf(evaluation_points)).copy()
+        expected_moment = to_numpy(distribution.trigonometric_moment(1)).copy()
+
+        rate[...] = 4.0
+        asymmetry[...] = 0.5
+
+        npt.assert_allclose(to_numpy(rate), 4.0)
+        npt.assert_allclose(to_numpy(asymmetry), 0.5)
+        npt.assert_allclose(to_numpy(distribution.lambda_), 2.0)
+        npt.assert_allclose(to_numpy(distribution.kappa), 3.0)
+        npt.assert_allclose(
+            to_numpy(distribution.pdf(evaluation_points)),
+            expected_pdf,
+        )
+        npt.assert_allclose(
+            to_numpy(distribution.trigonometric_moment(1)),
+            expected_moment,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`WrappedLaplaceDistribution` validated `lambda_` and `kappa_` with the active backend's `asarray` conversion and stored the returned arrays directly. With mutable backends such as NumPy and PyTorch, that conversion can retain caller-owned storage. Mutating either input after construction therefore silently changed the distribution's PDF and trigonometric moments.

This violates the copy-on-construction ownership invariant already used by the adjacent wrapped-exponential distribution.

## Fix

- copy both validated parameters with the backend-aware copy primitive before storing them
- preserve backend and dtype behavior
- add a backend-aware regression that mutates both caller arrays and verifies the stored parameters, PDF, and first trigonometric moment remain unchanged
- skip only JAX, whose arrays are immutable and cannot expose the aliasing defect

## Validation

- modified module compiles successfully
- standalone NumPy ownership regression passed
- changes are limited to the distribution and its focused regression

Full repository CI is requested by this pull request.