### PR TITLE
Normalize JAX FFT shift scalar axes

### DIFF
--- a/src/pyrecest/_backend/jax/fft.py
+++ b/src/pyrecest/_backend/jax/fft.py
@@ -11,6 +11,11 @@ _BOOLEAN_FFT_AXIS_ERROR = "axis must be an integer, not boolean"
 _BOOLEAN_FFT_LENGTH_ERROR = "n must be an integer length, not boolean"
 _FFT_SHAPE_SEQUENCE_ERROR = "s must be None or a sequence of integer lengths"
 _FFT_AXES_SEQUENCE_ERROR = "axes must be None or a sequence of integer axes"
+_FFT_SHIFT_AXES_ERROR = (
+    "axes must be None, an integer axis, or a sequence of integer axes"
+)
+_FFT_SHIFT_BOOLEAN_ERROR = "axes entries must be integers, not boolean"
+_FFT_SHIFT_INTEGER_ERROR = "axes entries must be integers"
 
 
 def _normalize_real_fft_axis(axis):
@@ -137,6 +142,38 @@ def _normalize_complex_fft_axes(axes):
     )
 
 
+def _normalize_shift_axes(axes):
+    """Normalize scalar and sequence axes for FFT shift helpers."""
+    if axes is None:
+        return None
+    if isinstance(axes, (bool, _np.bool_)):
+        raise TypeError(_FFT_SHIFT_BOOLEAN_ERROR)
+    if isinstance(axes, _np.ndarray):
+        if _np.issubdtype(axes.dtype, _np.bool_):
+            raise TypeError(_FFT_SHIFT_BOOLEAN_ERROR)
+        if axes.ndim == 0:
+            if _np.issubdtype(axes.dtype, _np.integer):
+                return int(axes.item())
+            raise TypeError(_FFT_SHIFT_AXES_ERROR)
+    if isinstance(axes, _jnp.ndarray):
+        axes_array = _np.asarray(axes)
+        if _np.issubdtype(axes_array.dtype, _np.bool_):
+            raise TypeError(_FFT_SHIFT_BOOLEAN_ERROR)
+        if axes_array.ndim == 0:
+            if _np.issubdtype(axes_array.dtype, _np.integer):
+                return int(axes_array.item())
+            raise TypeError(_FFT_SHIFT_AXES_ERROR)
+    try:
+        return _operator_index(axes)
+    except TypeError:
+        return _normalize_fft_integer_sequence(
+            axes,
+            _FFT_SHIFT_AXES_ERROR,
+            _FFT_SHIFT_BOOLEAN_ERROR,
+            _FFT_SHIFT_INTEGER_ERROR,
+        )
+
+
 def rfft(a, n=None, axis=-1, norm=None):
     return _fft.rfft(
         _jnp.asarray(a),
@@ -174,8 +211,8 @@ def ifftn(a, s=None, axes=None, norm=None):
 
 
 def fftshift(x, axes=None):
-    return _fft.fftshift(_jnp.asarray(x), axes=axes)
+    return _fft.fftshift(_jnp.asarray(x), axes=_normalize_shift_axes(axes))
 
 
 def ifftshift(x, axes=None):
-    return _fft.ifftshift(_jnp.asarray(x), axes=axes)
+    return _fft.ifftshift(_jnp.asarray(x), axes=_normalize_shift_axes(axes))

--- a/tests/test_jax_fft_shift_scalar_array_axes.py
+++ b/tests/test_jax_fft_shift_scalar_array_axes.py
@@ -1,0 +1,29 @@
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize("function_name", ["fftshift", "ifftshift"])
+def test_jax_fft_shift_accepts_integer_scalar_array_axes(function_name):
+    jnp = pytest.importorskip("jax.numpy")
+    from pyrecest._backend.jax import fft
+
+    values = jnp.arange(12.0).reshape(3, 4)
+    shift = getattr(fft, function_name)
+    expected = shift(values, axes=1)
+
+    for axes in (np.int64(1), np.array(1), jnp.array(1)):
+        actual = shift(values, axes=axes)
+        np.testing.assert_array_equal(np.asarray(actual), np.asarray(expected))
+
+
+@pytest.mark.parametrize("function_name", ["fftshift", "ifftshift"])
+def test_jax_fft_shift_rejects_boolean_axes(function_name):
+    jnp = pytest.importorskip("jax.numpy")
+    from pyrecest._backend.jax import fft
+
+    values = jnp.arange(4.0)
+    shift = getattr(fft, function_name)
+
+    for axes in (True, np.bool_(True), np.array(True), jnp.array(True)):
+        with pytest.raises(TypeError, match="not boolean"):
+            shift(values, axes=axes)


### PR DESCRIPTION
## Bug

The JAX `fftshift` and `ifftshift` wrappers forwarded `axes` directly to `jax.numpy.fft`. Python integer axes worked, but equivalent NumPy/JAX integer scalars and zero-dimensional integer arrays did not. For example, `axes=np.int64(1)`, `axes=np.array(1)`, and `axes=jnp.array(1)` were treated as iterables by JAX and raised `TypeError` instead of selecting axis 1.

Boolean axes also reached JAX and produced backend-dependent low-level errors rather than the explicit integer-axis validation used by the neighboring FFT wrappers.

## Fix

- add a shift-specific axis normalizer that accepts Python, NumPy, and JAX integer scalars
- convert zero-dimensional integer arrays to Python `int`
- preserve and normalize valid axis sequences
- reject boolean scalar/array axes with a stable `TypeError`
- route both `fftshift` and `ifftshift` through the normalizer

## Regression coverage

Added parameterized tests for both shift directions covering:

- `np.int64(1)`
- `np.array(1)`
- `jnp.array(1)`
- Python, NumPy, and JAX boolean axes

## Validation

- `python -m py_compile` on the modified wrapper and regression test
- isolated JAX smoke checks comparing scalar-array axes with the equivalent Python integer for both `fftshift` and `ifftshift`

The full repository suite was not run locally because this environment cannot clone the repository; GitHub Actions should run the repository matrix.