### PR TITLE
Reject overflowing reliability covariance products

### DIFF
--- a/src/pyrecest/tracking/measurement_reliability.py
+++ b/src/pyrecest/tracking/measurement_reliability.py
@@ -187,7 +187,13 @@ def scale_covariance_by_reliability(
         exponent=exponent,
         max_scale=max_scale,
     )
-    return covariance * scale, scale
+    with np.errstate(over="ignore", invalid="ignore"):
+        scaled_covariance = covariance * scale
+    if not np.isfinite(scaled_covariance).all():
+        raise ValueError(
+            "scaled covariance overflows; reduce covariance magnitude or max_scale"
+        )
+    return scaled_covariance, scale
 
 
 def apply_measurement_reliability(

--- a/tests/tracking/test_measurement_reliability_covariance_overflow.py
+++ b/tests/tracking/test_measurement_reliability_covariance_overflow.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from pyrecest.tracking import (
+    apply_measurement_reliability,
+    scale_covariance_by_reliability,
+)
+
+
+def test_reliability_covariance_scaling_rejects_nonfinite_product() -> None:
+    covariance = np.array([[np.finfo(float).max]])
+
+    with pytest.raises(ValueError, match="scaled covariance overflows"):
+        scale_covariance_by_reliability(covariance, 0.5)
+
+    with pytest.raises(ValueError, match="scaled covariance overflows"):
+        apply_measurement_reliability(covariance, reliability=0.5)
+
+
+def test_reliability_covariance_scaling_accepts_safe_bound() -> None:
+    covariance = np.array([[np.finfo(float).max]])
+
+    scaled, scale = scale_covariance_by_reliability(
+        covariance,
+        0.5,
+        max_scale=1.0,
+    )
+
+    assert scale == 1.0
+    np.testing.assert_array_equal(scaled, covariance)


### PR DESCRIPTION
## Bug

`scale_covariance_by_reliability()` validated the input covariance and computed a finite reliability scale, but returned `covariance * scale` without validating the product. Finite inputs could therefore produce an infinite covariance when the multiplication overflowed.

For example, scaling `[[np.finfo(float).max]]` by the valid scale `2.0` returned `[[inf]]`. The public low-level helper leaked that invalid covariance directly, while the high-level reliability path only failed later through generic result validation.

## Fix

- perform covariance scaling under a local NumPy error state
- reject any non-finite scaled covariance with a clear `ValueError`
- preserve the existing finite `max_scale` mechanism as a way to keep the product representable

## Tests

- regression for both `scale_covariance_by_reliability()` and `apply_measurement_reliability()`
- regression showing `max_scale=1.0` safely preserves a covariance at the floating-point maximum
- local `py_compile` for the modified module and new test file
- isolated targeted validation of normal scaling, overflow rejection, high-level propagation, and the safe bounded path