### PR TITLE
Stabilize IMM Gaussian likelihood evaluation

### DIFF
--- a/src/pyrecest/filters/interacting_multiple_model_filter.py
+++ b/src/pyrecest/filters/interacting_multiple_model_filter.py
@@ -612,12 +612,13 @@ class InteractingMultipleModelFilter(AbstractFilter, EuclideanFilterMixin):
             @ measurement_matrix.T
             + meas_noise
         )
-        det_value = float(linalg.det(innovation_covariance))
-        if det_value <= 0.0:
+        determinant_sign, logdet = linalg.slogdet(innovation_covariance)
+        determinant_sign = float(determinant_sign)
+        logdet = float(logdet)
+        if determinant_sign <= 0.0 or not np.isfinite(logdet):
             raise ValueError(
                 "Innovation covariance must be positive definite to evaluate the IMM likelihood."
             )
-        logdet = float(log(array(det_value)))
         mahalanobis_distance = float(
             innovation.T @ linalg.solve(innovation_covariance, innovation)
         )

--- a/tests/filters/test_imm_extreme_covariance_likelihood.py
+++ b/tests/filters/test_imm_extreme_covariance_likelihood.py
@@ -1,0 +1,41 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+import pyrecest.backend
+from pyrecest.backend import array, eye
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.filters.interacting_multiple_model_filter import (
+    InteractingMultipleModelFilter,
+)
+
+
+pytestmark = pytest.mark.skipif(
+    pyrecest.backend.__backend_name__ != "numpy",
+    reason="IMM likelihood evaluation is currently supported on the NumPy backend",
+)
+
+
+@pytest.mark.parametrize("scale", [1.0e-200, 1.0e200])
+def test_linear_likelihood_stays_finite_for_extreme_covariance_scale(scale):
+    covariance = scale * eye(2)
+    predicted_state = GaussianDistribution(
+        array([0.0, 0.0]), covariance, check_validity=False
+    )
+
+    log_likelihood = (
+        InteractingMultipleModelFilter._log_linear_measurement_likelihood(
+            array([0.0, 0.0]),
+            predicted_state,
+            eye(2),
+            array([[0.0, 0.0], [0.0, 0.0]]),
+        )
+    )
+
+    determinant_sign, expected_logdet = np.linalg.slogdet(np.asarray(covariance))
+    assert determinant_sign > 0.0
+    expected = -0.5 * (2.0 * np.log(2.0 * np.pi) + expected_logdet)
+    assert np.isfinite(log_likelihood)
+    npt.assert_allclose(
+        log_likelihood, expected, rtol=1.0e-14, atol=1.0e-14
+    )


### PR DESCRIPTION
## Bug

`InteractingMultipleModelFilter._log_linear_measurement_likelihood()` computed `det(S)` before taking its logarithm. For a valid positive-definite innovation covariance at an extreme scale, the determinant can underflow to zero or overflow to infinity even though the log-determinant remains finite.

That could incorrectly reject a valid covariance or collapse a model likelihood to `-inf`.

## Fix

- evaluate the covariance normalization with `linalg.slogdet`
- preserve the existing covariance-validity guard through the determinant sign
- reject nonfinite log-determinants explicitly
- add regressions for covariance scales `1e-200` and `1e200`

## Validation

- reconstructed and verified the source against the current Git blob before editing
- parsed the patched module and regression test successfully
- executed the committed module and new regression in an isolated package harness: `2 passed`
- verified the branch is two commits ahead of `main`, not behind, with only the IMM source and regression-test files changed

Normal repository CI is triggered by this pull request; checks are currently queued in the account-wide GitHub Actions backlog.