### PR TITLE
Stabilize grid integral averaging

### DIFF
--- a/src/pyrecest/distributions/abstract_grid_distribution.py
+++ b/src/pyrecest/distributions/abstract_grid_distribution.py
@@ -83,6 +83,8 @@ class AbstractGridDistribution(AbstractDistributionType):
             raise NotImplementedError(
                 "Custom integration boundaries are currently not supported."
             )
+        if prod(self.grid_values.shape) == 0:
+            return self.get_manifold_size() * mean(self.grid_values)
         value_scale = backend_max(abs(self.grid_values))
         if not bool(isfinite(value_scale)) or bool(value_scale == 0.0):
             return self.get_manifold_size() * mean(self.grid_values)

--- a/src/pyrecest/distributions/abstract_grid_distribution.py
+++ b/src/pyrecest/distributions/abstract_grid_distribution.py
@@ -7,6 +7,7 @@ from beartype import beartype
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 from pyrecest.backend import abs, allclose, any, isfinite, mean
+from pyrecest.backend import max as backend_max
 
 from .abstract_distribution_type import AbstractDistributionType
 
@@ -82,7 +83,11 @@ class AbstractGridDistribution(AbstractDistributionType):
             raise NotImplementedError(
                 "Custom integration boundaries are currently not supported."
             )
-        return self.get_manifold_size() * mean(self.grid_values)
+        value_scale = backend_max(abs(self.grid_values))
+        if not bool(isfinite(value_scale)) or bool(value_scale == 0.0):
+            return self.get_manifold_size() * mean(self.grid_values)
+        scaled_mean = mean(self.grid_values / value_scale)
+        return (self.get_manifold_size() * scaled_mean) * value_scale
 
     def normalize_in_place(self, tol=1e-4, warn_unnorm=True):
         int_val = self.integrate()

--- a/tests/distributions/test_abstract_grid_distribution.py
+++ b/tests/distributions/test_abstract_grid_distribution.py
@@ -1,6 +1,8 @@
 import unittest
 
-from pyrecest.backend import array
+import numpy as np
+
+from pyrecest.backend import array, to_numpy
 from pyrecest.distributions.abstract_grid_distribution import AbstractGridDistribution
 
 _DEFAULT_GRID = object()
@@ -60,6 +62,17 @@ class AbstractGridDistributionTest(unittest.TestCase):
 
         with self.assertRaisesRegex(NotImplementedError, "boundaries"):
             dist.integrate((0.0, 1.0))
+
+    def test_integrate_avoids_overflow_for_cancelling_finite_values(self):
+        backend_dtype = to_numpy(array([1.0])).dtype
+        max_finite = np.finfo(backend_dtype).max
+        dist = DummyGridDistribution(
+            array([max_finite, max_finite, -max_finite, -max_finite]),
+            grid=array([[0.0], [1.0], [2.0], [3.0]]),
+            enforce_pdf_nonnegative=False,
+        )
+
+        self.assertEqual(float(to_numpy(dist.integrate())), 0.0)
 
     def test_multiply_rejects_incompatible_grids(self):
         dist = DummyGridDistribution(array([1.0, 1.0]))


### PR DESCRIPTION
## Bug

`AbstractGridDistribution.integrate()` computed the grid average with the backend's raw `mean`. For finite values at extreme scale, the underlying reduction can overflow before cancellation occurs.

For example, grid values proportional to `[max_float, max_float, -max_float, -max_float]` have an exact mean and integral of zero, but NumPy's raw reduction overflows to `inf`. `normalize_in_place()` then rejects the distribution as having a nonfinite integral even though the represented integral is finite.

## Fix

- scale nonempty finite grid values by their maximum absolute magnitude before averaging
- restore the original scale after the bounded mean reduction
- retain the previous behavior for empty, zero-valued, and nonfinite grids
- add a backend-aware regression for the cancelling extreme-value case

## Impact

Grid integration and normalization no longer fail solely because an intermediate sum overflows when large positive and negative finite values cancel.

## Validation

- reproduced the old NumPy result: raw mean becomes `inf`
- verified the scaled reduction returns the exact finite result `0.0`
- branch is 3 commits ahead of `main`, 0 behind
- diff is limited to the abstract grid integration helper and its focused test module

Full repository CI is delegated to GitHub Actions.