### PR TITLE
Reject overflowing measurement variances

### DIFF
--- a/src/pyrecest/models/weak_measurement.py
+++ b/src/pyrecest/models/weak_measurement.py
@@ -32,7 +32,11 @@ _NON_REAL_NUMERIC_SCALAR_TYPES = (
 def diagonal_measurement_covariance(stds: Sequence[float] | np.ndarray) -> np.ndarray:
     "Return a diagonal covariance matrix from measurement standard deviations."
     values = _standard_deviations_array(stds)
-    return np.diag(values**2)
+    with np.errstate(over="ignore", invalid="ignore"):
+        variances = np.square(values)
+    if not np.isfinite(variances).all():
+        raise ValueError("stds must produce a finite measurement covariance")
+    return np.diag(variances)
 
 
 def block_diag_measurement_covariance(

--- a/tests/models/test_weak_measurement_covariance_overflow.py
+++ b/tests/models/test_weak_measurement_covariance_overflow.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import numpy as np
+import pytest
+
+from pyrecest.models.weak_measurement import (
+    MaskedLinearMeasurementModel,
+    WeakDimensionMeasurementModel,
+    block_diag_measurement_covariance,
+    diagonal_measurement_covariance,
+)
+
+
+def _overflowing_finite_standard_deviation() -> float:
+    largest_safe = np.sqrt(np.finfo(float).max)
+    return float(np.nextafter(largest_safe, np.inf))
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda std: diagonal_measurement_covariance([std]),
+        lambda std: block_diag_measurement_covariance(trusted_std=[std]),
+        lambda std: MaskedLinearMeasurementModel(
+            state_dim=1, observed_dims=[0], stds=[std]
+        ),
+        lambda std: WeakDimensionMeasurementModel(np.eye(1), stds=[std]),
+    ],
+)
+def test_measurement_standard_deviation_overflow_is_rejected(
+    factory: Callable[[float], object],
+) -> None:
+    std = _overflowing_finite_standard_deviation()
+
+    assert np.isfinite(std)
+    with pytest.raises(ValueError, match="finite measurement covariance"):
+        factory(std)
+
+
+def test_largest_representable_measurement_variance_remains_supported() -> None:
+    std = np.sqrt(np.finfo(float).max)
+
+    covariance = diagonal_measurement_covariance([std])
+
+    assert np.isfinite(covariance).all()


### PR DESCRIPTION
## Bug

`diagonal_measurement_covariance()` validated that supplied standard deviations were finite and positive, but squared them without validating the result. A finite standard deviation slightly larger than `sqrt(np.finfo(float).max)` therefore produced an infinite variance and an invalid covariance matrix.

The defect propagated through block-diagonal covariance construction and both weak-measurement model constructors.

## Fix

- square validated standard deviations under a local NumPy error state
- reject nonfinite variances with a clear `ValueError`
- preserve support for the boundary value whose variance is the largest representable finite float
- add focused regression coverage for the public helper, block helper, masked model, and weak-dimension model

## Validation

- reconstructed the source from the current Git blob and verified it matched blob `b38cad4a704f105bf2b286048b9c0f5ca6aaf37f` before editing
- syntax-compiled the modified implementation and regression test
- ran the focused regression in an isolated NumPy-backed package harness: `5 passed`
- branch is 2 commits ahead of `main`, 0 behind, and changes only the weak-measurement helper plus one focused regression file

Full repository CI is delegated to GitHub Actions.