### PR TITLE
Stabilize pairwise covariance log-determinant costs

### DIFF
--- a/src/pyrecest/utils/pairwise_covariance_features.py
+++ b/src/pyrecest/utils/pairwise_covariance_features.py
@@ -32,7 +32,9 @@ from pyrecest.backend import (
     log,
     maximum,
     moveaxis,
+    prod,
     reshape,
+    sign,
     sqrt,
 )
 from pyrecest.backend import sum as backend_sum
@@ -179,9 +181,11 @@ def pairwise_covariance_shape_components(
     shape_cost = sqrt(maximum(frobenius_squared, 0.0)) / sqrt(2.0)
     shape_similarity = exp(-shape_cost)
 
-    determinants_a = _positive_floor(linalg.det(moved_covariances_a), epsilon)
-    determinants_b = _positive_floor(linalg.det(moved_covariances_b), epsilon)
-    logdet_cost = abs(log(determinants_a[:, None] / determinants_b[None, :]))
+    log_determinants_a = _floored_log_determinants(moved_covariances_a, epsilon)
+    log_determinants_b = _floored_log_determinants(moved_covariances_b, epsilon)
+    logdet_cost = abs(
+        log_determinants_a[:, None] - log_determinants_b[None, :]
+    )
     return shape_cost, logdet_cost, shape_similarity
 
 
@@ -258,6 +262,29 @@ def _symmetrized_covariance_batch(covariances: Any) -> Any:
 
 def _batch_trace(matrices: Any) -> Any:
     return einsum("nii->n", matrices)
+
+
+def _floored_log_determinants(matrices: Any, epsilon: float) -> Any:
+    """Return ``log(max(det(matrix), epsilon))`` without forming determinants."""
+
+    eigenvalues = linalg.eigvalsh(matrices)
+    absolute_eigenvalues = abs(eigenvalues)
+    nonzero_eigenvalues = absolute_eigenvalues > 0.0
+    safe_absolute_eigenvalues = where(
+        nonzero_eigenvalues,
+        absolute_eigenvalues,
+        1.0,
+    )
+    determinant_signs = prod(sign(eigenvalues), axis=-1)
+    log_absolute_determinants = backend_sum(log(safe_absolute_eigenvalues), axis=-1)
+    log_epsilon = math.log(epsilon)
+    use_log_determinant = (
+        (determinant_signs > 0.0)
+        & backend_all(nonzero_eigenvalues, axis=-1)
+        & isfinite(log_absolute_determinants)
+        & (log_absolute_determinants > log_epsilon)
+    )
+    return where(use_log_determinant, log_absolute_determinants, log_epsilon)
 
 
 def _positive_floor(values: Any, epsilon: float) -> Any:

--- a/tests/test_pairwise_covariance_features.py
+++ b/tests/test_pairwise_covariance_features.py
@@ -100,6 +100,33 @@ class TestPairwiseCovarianceFeatures(unittest.TestCase):
         npt.assert_allclose(logdet_cost, array([[log(2.0), log(2.0)]]))
         npt.assert_allclose(shape_similarity, exp(-shape_cost))
 
+    def test_pairwise_covariance_shape_components_stabilize_large_determinants(self):
+        large_scale = 1.0e200
+        smaller_scale = 1.0e150
+        covariances_a = array(
+            [
+                [[large_scale], [0.0]],
+                [[0.0], [large_scale]],
+            ]
+        )
+        covariances_b = array(
+            [
+                [[large_scale, smaller_scale], [0.0, 0.0]],
+                [[0.0, 0.0], [large_scale, smaller_scale]],
+            ]
+        )
+
+        shape_cost, logdet_cost, shape_similarity = (
+            pairwise_covariance_shape_components(covariances_a, covariances_b)
+        )
+
+        expected_logdet_cost = array(
+            [[0.0, 2.0 * abs(math.log(large_scale) - math.log(smaller_scale))]]
+        )
+        npt.assert_allclose(shape_cost, array([[0.0, 0.0]]))
+        npt.assert_allclose(logdet_cost, expected_logdet_cost, rtol=1.0e-14)
+        npt.assert_allclose(shape_similarity, array([[1.0, 1.0]]))
+
     def test_pairwise_covariance_shape_components_return_zero_for_equal_shapes(self):
         covariances_a = array(
             [


### PR DESCRIPTION
## Bug

`pairwise_covariance_shape_components()` formed covariance determinants at the original numeric scale and then divided them before taking a logarithm. Valid finite covariance entries could therefore produce `inf` determinants and an `inf / inf -> NaN` scale cost. A large but unequal pair could similarly produce an infinite cost even though the exact log-determinant difference is finite.

For example, two-dimensional covariances proportional to `1e200 * I` are valid and equal, but their determinants overflow in `float64`; the previous implementation returned `NaN` instead of zero.

## Fix

- derive determinant sign and log-magnitude from the eigenvalues of the already-symmetrized covariance matrices
- apply the existing determinant floor in log space
- subtract log-determinants directly instead of forming a determinant ratio
- add a regression covering equal and unequal covariance scales whose raw determinants overflow

## Validation

- verified the new log-space calculation against the analytic two-dimensional result
- verified that ordinary-scale and singular/indefinite floor behavior remains equivalent to the previous implementation
- GitHub Actions will run the repository test matrix on this PR