### PR TITLE
Reject unrepresentable measurement variances

### DIFF
--- a/src/pyrecest/models/weak_measurement.py
+++ b/src/pyrecest/models/weak_measurement.py
@@ -32,7 +32,11 @@ _NON_REAL_NUMERIC_SCALAR_TYPES = (
 def diagonal_measurement_covariance(stds: Sequence[float] | np.ndarray) -> np.ndarray:
     "Return a diagonal covariance matrix from measurement standard deviations."
     values = _standard_deviations_array(stds)
-    return np.diag(values**2)
+    with np.errstate(over="ignore", under="ignore", invalid="ignore"):
+        variances = np.square(values)
+    if not np.all(np.isfinite(variances)) or np.any(variances <= 0.0):
+        raise ValueError("stds must produce finite positive variances")
+    return np.diag(variances)
 
 
 def block_diag_measurement_covariance(

--- a/tests/models/test_weak_measurement_variance_range.py
+++ b/tests/models/test_weak_measurement_variance_range.py
@@ -12,7 +12,7 @@ from pyrecest.models import (
 
 @pytest.mark.parametrize(
     "std",
-    [np.finfo(float).max, np.nextafter(0.0, 1.0)],
+    [np.finfo(float).max, np.finfo(float).smallest_subnormal],
     ids=["overflow", "underflow"],
 )
 def test_measurement_covariance_rejects_unrepresentable_variances(std: float) -> None:

--- a/tests/models/test_weak_measurement_variance_range.py
+++ b/tests/models/test_weak_measurement_variance_range.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from pyrecest.models import (
+    MaskedLinearMeasurementModel,
+    WeakDimensionMeasurementModel,
+    block_diag_measurement_covariance,
+    diagonal_measurement_covariance,
+)
+
+
+@pytest.mark.parametrize(
+    "std",
+    [np.finfo(float).max, np.nextafter(0.0, 1.0)],
+    ids=["overflow", "underflow"],
+)
+def test_measurement_covariance_rejects_unrepresentable_variances(std: float) -> None:
+    with pytest.raises(ValueError, match="finite positive variances"):
+        diagonal_measurement_covariance([std])
+    with pytest.raises(ValueError, match="finite positive variances"):
+        block_diag_measurement_covariance(trusted_std=[std])
+
+
+def test_measurement_models_reject_unrepresentable_variances() -> None:
+    std = np.finfo(float).max
+
+    with pytest.raises(ValueError, match="finite positive variances"):
+        MaskedLinearMeasurementModel(state_dim=1, observed_dims=[0], stds=[std])
+    with pytest.raises(ValueError, match="finite positive variances"):
+        WeakDimensionMeasurementModel(np.eye(1), stds=[std])


### PR DESCRIPTION
## Bug

`diagonal_measurement_covariance()` validated that every supplied standard deviation was finite and positive, but then squared the values without checking the result. Finite inputs near the `float64` limits could therefore produce an invalid covariance:

- very large standard deviations overflowed to `inf`
- very small positive standard deviations underflowed to `0.0`

The low-level helper returned those matrices directly, and the same behavior propagated through block-diagonal, masked, and weak-dimension measurement-model constructors.

## Fix

- square standard deviations under a local NumPy error state
- reject variances that are non-finite or non-positive
- preserve ordinary-scale covariance behavior

## Validation

- added regressions for overflow and underflow inputs
- added coverage proving both measurement-model constructors inherit the validation
- manually verified ordinary `[2.0, 3.0]` inputs still produce `diag([4.0, 9.0])`
