### PR TITLE
Reject nonfinite matrices in NumPy PD predicate

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/linalg.py
+++ b/src/pyrecest/_backend/_shared_numpy/linalg.py
@@ -131,20 +131,22 @@ def qr(a, mode="reduced"):
 
 
 def is_single_matrix_pd(mat):
-    """Check if 2D square matrix is positive definite."""
+    """Check if a finite 2D square matrix is positive definite."""
     mat = _np.asarray(mat)
     if mat.ndim != 2 or mat.shape[0] != mat.shape[1]:
+        return False
+    if not _np.all(_np.isfinite(mat)):
         return False
     if mat.dtype in [_np.complex64, _np.complex128]:
         if not _is_hermitian(mat):
             return False
         eigvals = _np.linalg.eigvalsh(mat)
-        return _np.min(_np.real(eigvals)) > 0
+        return _np.all(_np.isfinite(eigvals)) and _np.min(_np.real(eigvals)) > 0
     if not _is_symmetric(mat):
         return False
     try:
-        _np.linalg.cholesky(mat)
-        return True
+        factor = _np.linalg.cholesky(mat)
+        return bool(_np.all(_np.isfinite(factor)))
     except _np.linalg.LinAlgError as e:
         if e.args[0] == "Matrix is not positive definite":
             return False

--- a/tests/backend_support/test_numpy_linalg_pd_nonfinite_contract.py
+++ b/tests/backend_support/test_numpy_linalg_pd_nonfinite_contract.py
@@ -1,0 +1,24 @@
+"""Regression tests for finite positive-definite matrix validation."""
+
+from __future__ import annotations
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_numpy_is_single_matrix_pd_rejects_nonfinite_matrices():
+    result = run_backend_code(
+        "numpy",
+        """
+import pyrecest.backend as backend
+
+for value in (float("nan"), float("inf"), float("-inf")):
+    matrix = backend.array([[value]])
+    assert bool(backend.linalg.is_single_matrix_pd(matrix)) is False
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Bug

The NumPy-family `is_single_matrix_pd()` implementation treated a successful Cholesky call as sufficient evidence of positive definiteness. NumPy can return a Cholesky factor containing `nan` or `inf` for nonfinite inputs without raising `LinAlgError`, so matrices such as `[[nan]]` and `[[inf]]` were incorrectly reported as positive definite.

## Fix

- reject matrices containing nonfinite entries before symmetry or factorization checks
- require complex eigenvalues and real Cholesky factors to remain finite
- retain the existing shape, symmetry/Hermitian, and positivity checks
- add an isolated NumPy-backend regression for `NaN`, positive infinity, and negative infinity

Because the implementation is shared, the validation also applies to the Autograd backend.

## Validation

- reproduced NumPy returning nonfinite Cholesky factors without an exception
- syntax-compiled the modified module and regression test
- verified ordinary positive-definite and nonsymmetric matrices retain their expected results
- branch is 2 commits ahead of `main`, 0 behind, and changes only the shared linear-algebra helper plus one focused test

The full repository test matrix is delegated to GitHub Actions.