### PR TITLE
Reject nonfinite matrices in PyTorch PD predicate

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -466,6 +466,8 @@ def is_single_matrix_pd(mat):
     mat = _as_linalg_tensor(mat)
     if mat.ndim != 2 or mat.shape[0] != mat.shape[1]:
         return False
+    if not bool(_torch.all(_torch.isfinite(mat))):
+        return False
     if mat.dtype in [_torch.complex64, _torch.complex128]:
         is_hermitian = bool(
             _torch.all(

--- a/tests/backend_support/test_pytorch_linalg_nonfinite_pd.py
+++ b/tests/backend_support/test_pytorch_linalg_nonfinite_pd.py
@@ -1,0 +1,35 @@
+"""Regression tests for nonfinite PyTorch positive-definite inputs."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_pytorch_is_single_matrix_pd_rejects_nonfinite_entries():
+    """Nonfinite matrices must not enter the positive-definite cone."""
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import pyrecest.backend as backend
+
+matrices = [
+    backend.array([[float("nan")]]),
+    backend.array([[float("inf")]]),
+    backend.array([[float("-inf")]]),
+    backend.array([[complex(float("inf"), 0.0)]]),
+]
+for matrix in matrices:
+    assert bool(backend.linalg.is_single_matrix_pd(matrix)) is False
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Bug

The PyTorch implementation of `is_single_matrix_pd()` treated a successful Cholesky factorization as sufficient evidence of positive definiteness. PyTorch accepts a one-by-one matrix containing positive infinity and returns an infinite Cholesky factor, so `[[inf]]` was incorrectly classified as positive definite.

The NumPy-family predicate is handled separately; this fix closes the same backend contract gap specifically for PyTorch, including complex nonfinite inputs.

## Fix

- reject matrices containing any nonfinite real or complex component before symmetry, Hermitian, eigenvalue, or Cholesky checks
- preserve the existing behavior for finite positive-definite, nonsymmetric, indefinite, and wrong-shaped inputs
- add a PyTorch subprocess regression covering `NaN`, positive infinity, negative infinity, and complex infinity

## Validation

- reproduced `torch.linalg.cholesky(torch.tensor([[float("inf")]]))` returning `[[inf]]` without an exception
- verified the patched predicate rejects all four nonfinite cases while accepting an ordinary finite positive-definite matrix
- branch is two commits ahead of `main`, zero behind
- comparison is limited to two source lines plus one focused regression file

The full configured test matrix is delegated to GitHub Actions.