### PR TITLE
Stabilize wrapped exponential density at tiny rates

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
@@ -96,11 +96,17 @@ def _validate_positive_scalar(value, name):
     return value
 
 
-def _normalization_const_from_log_beta(log_beta):
+def _density_scale_from_log_beta(log_beta):
+    """Return ``lambda / (1 - exp(-2*pi*lambda))`` without overflow."""
     if bool(all(log_beta < _SMALL_RATE_SERIES_THRESHOLD)):
-        # 1 / (1 - exp(-x)) = 1/x + 1/2 + x/12 - x**3/720 + O(x**5).
-        return 1.0 / log_beta + 0.5 + log_beta / 12.0 - log_beta**3 / 720.0
-    return 1.0 / (1.0 - exp(-log_beta))
+        # x / (1 - exp(-x)) = 1 + x/2 + x**2/12 - x**4/720 + O(x**6).
+        return (
+            1.0
+            + log_beta / 2.0
+            + log_beta**2 / 12.0
+            - log_beta**4 / 720.0
+        ) / (2.0 * pi)
+    return (log_beta / (2.0 * pi)) / (1.0 - exp(-log_beta))
 
 
 class WrappedExponentialDistribution(AbstractCircularDistribution):
@@ -117,14 +123,14 @@ class WrappedExponentialDistribution(AbstractCircularDistribution):
         lambda_ = backend_copy(_validate_positive_scalar(lambda_, "lambda_"))
         self.lambda_ = lambda_
         self._log_beta = 2.0 * pi * lambda_
-        self._normalization_const = _normalization_const_from_log_beta(self._log_beta)
+        self._density_scale = _density_scale_from_log_beta(self._log_beta)
 
     def pdf(self, xs):
         xs = asarray(xs)
         if ndim(xs) > 1:
             raise ValueError("xs must be a scalar or one-dimensional array.")
         xs = mod(xs, 2.0 * pi)
-        return self.lambda_ * exp(-self.lambda_ * xs) * self._normalization_const
+        return self._density_scale * exp(-self.lambda_ * xs)
 
     def trigonometric_moment(self, n):
         if isinstance(n, (bool, np.bool_)) or not isinstance(n, Integral):

--- a/tests/distributions/test_wrapped_exponential_tiny_rate.py
+++ b/tests/distributions/test_wrapped_exponential_tiny_rate.py
@@ -1,0 +1,31 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+import pyrecest.backend
+from pyrecest.backend import array, to_numpy
+from pyrecest.distributions.circle.wrapped_exponential_distribution import (
+    WrappedExponentialDistribution,
+)
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ != "numpy",
+    reason="Subnormal float64 regression is specific to the NumPy backend.",
+)
+class WrappedExponentialTinyRateTest(unittest.TestCase):
+    def test_pdf_stays_finite_for_subnormal_positive_rate(self):
+        distribution = WrappedExponentialDistribution(array(1.0e-310))
+        density = to_numpy(distribution.pdf(array([0.0, np.pi])))
+
+        self.assertTrue(np.isfinite(density).all())
+        npt.assert_allclose(
+            density,
+            np.full(2, 1.0 / (2.0 * np.pi)),
+            rtol=1.0e-14,
+            atol=0.0,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`WrappedExponentialDistribution` stored the reciprocal normalization constant `1 / (1 - exp(-2πλ))` separately from the leading density factor `λ`. For valid subnormal positive `float64` rates such as `λ = 1e-310`, the small-rate series began with `1 / (2πλ)`, which overflowed to infinity before the subsequent multiplication by `λ` could recover the finite limit.

The resulting PDF returned `inf` even though the wrapped exponential converges to the uniform circular density `1 / (2π)` as `λ -> 0`.

## Fix

- compute the combined density scale `λ / (1 - exp(-2πλ))` directly
- use the stable small-argument series for `x / (1 - exp(-x))`
- retain the existing ordinary- and large-rate formulas and entropy handling
- add a NumPy regression for a subnormal positive rate

## Impact

Valid extremely small rates now produce finite PDF values with the correct uniform-limit density instead of overflowing.

## Validation

- syntax-compiled the modified source and regression test
- executed the exact patched module in an isolated NumPy-backed package harness
- verified finite PDF values for `1e-310`, the smallest positive `float64`, `1e-18`, `2.0`, and `200.0`
- verified the subnormal-rate result equals `1 / (2π)` within tight floating-point tolerance
- branch is 2 commits ahead of `main`, 0 behind, and changes only the distribution implementation plus one focused test

The repository test matrix is delegated to GitHub Actions.