### PR TITLE
Stabilize ParticleDiagnostics weight normalization

### DIFF
--- a/src/pyrecest/diagnostics.py
+++ b/src/pyrecest/diagnostics.py
@@ -176,10 +176,12 @@ def _normalized_nonnegative_weights(values: list[float]) -> list[float]:
     if any(not isfinite(value) for value in values):
         raise ValueError("Particle weights must be finite.")
     nonnegative_values = [max(0.0, value) for value in values]
-    total = sum(nonnegative_values)
-    if total <= 0.0:
+    scale = max(nonnegative_values, default=0.0)
+    if scale <= 0.0:
         return [0.0 for _ in nonnegative_values]
-    return [value / total for value in nonnegative_values]
+    scaled_values = [value / scale for value in nonnegative_values]
+    total = sum(scaled_values)
+    return [value / total for value in scaled_values]
 
 
 class _DiagnosticsMappingMixin:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -26,6 +26,16 @@ def test_particle_diagnostics_clips_negative_weights_before_normalizing():
     assert isclose(diagnostics.weight_entropy, log(2.0))
 
 
+def test_particle_diagnostics_stabilizes_extreme_finite_weights():
+    maximum = np.finfo(float).max
+
+    diagnostics = ParticleDiagnostics.from_weights([maximum, maximum / 2.0])
+
+    expected_entropy = -(2.0 / 3.0 * log(2.0 / 3.0) + 1.0 / 3.0 * log(1.0 / 3.0))
+    assert isclose(diagnostics.effective_sample_size, 1.8)
+    assert isclose(diagnostics.weight_entropy, expected_entropy)
+
+
 def test_particle_diagnostics_rejects_nonfinite_weights():
     for weights in ([float("nan"), 1.0], [float("inf"), 1.0]):
         with pytest.raises(ValueError, match="Particle weights must be finite"):


### PR DESCRIPTION
## Bug

`ParticleDiagnostics.from_weights()` normalized finite nonnegative weights by summing them at their original scale. Valid inputs near the `float64` maximum can overflow the total to infinity, collapsing normalized weights, effective sample size, and entropy to zero.

For `[np.finfo(float).max, np.finfo(float).max / 2]`, the expected probabilities are `[2/3, 1/3]`, the effective sample size is `1.8`, and the entropy is approximately `0.6365141683`.

## Fix

- preserve the existing clipping of negative diagnostic weights
- scale by the largest positive weight before summing
- normalize the bounded scaled values
- preserve all-zero and nonfinite-input behavior
- add focused regression coverage

Closes #4415.

## Validation

- syntax-compiled the modified source and test
- ran an isolated source-level regression successfully
- verified the existing negative-clipping and zero-weight behavior
- branch is two commits ahead of `main`, zero behind, and changes only the diagnostics helper and its test module
