### PR TITLE
Validate empty tail-selection controls

### DIFF
--- a/src/pyrecest/evaluation/selection.py
+++ b/src/pyrecest/evaluation/selection.py
@@ -378,8 +378,6 @@ def protected_tail_topk_mask(
             "primary_scores, tail_scores, and reliability_scores must have the same length."
         )
     count = int(primary.shape[0])
-    if count == 0:
-        return np.zeros((0,), dtype=bool)
 
     retained_total = retained_count_from_fraction(
         count,
@@ -498,8 +496,6 @@ def tail_rescue_topk_mask(
             "primary_scores, tail_scores, and reliability_scores must have the same length."
         )
     count = int(primary.shape[0])
-    if count == 0:
-        return np.zeros((0,), dtype=bool)
 
     retained_total = retained_count_from_fraction(
         count,
@@ -513,6 +509,13 @@ def tail_rescue_topk_mask(
         sanitize_nonnegative=sanitize_nonnegative,
     )
     tail_indices = np.flatnonzero(tail_mask)
+    rescue_quota = min(
+        int(tail_indices.size),
+        tail_rescue_quota_count(
+            retained_total,
+            rescue_fraction=rescue_fraction,
+        ),
+    )
     if tail_indices.size == 0:
         return top_count_mask(
             primary,
@@ -524,13 +527,6 @@ def tail_rescue_topk_mask(
         primary,
         retained_total,
         sanitize_nonnegative=sanitize_nonnegative,
-    )
-    rescue_quota = min(
-        int(tail_indices.size),
-        tail_rescue_quota_count(
-            retained_total,
-            rescue_fraction=rescue_fraction,
-        ),
     )
     current_tail = int(np.sum(mask[tail_indices]))
     missing_tail = rescue_quota - current_tail

--- a/tests/evaluation/test_selection_empty_control_validation.py
+++ b/tests/evaluation/test_selection_empty_control_validation.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from pyrecest.evaluation.selection import (
+    protected_tail_topk_mask,
+    tail_rescue_topk_mask,
+)
+
+_EMPTY_SCORES = np.empty(0, dtype=float)
+
+
+def test_protected_tail_topk_validates_controls_for_empty_inputs() -> None:
+    invalid_calls = (
+        ({"retention_fraction": -0.1, "tail_quantile": 0.5}, "retention_fraction"),
+        ({"retention_fraction": 0.5, "tail_quantile": 0.0}, "quantile"),
+        (
+            {"retention_fraction": 0.5, "tail_quantile": 0.5, "min_count": True},
+            "min_count",
+        ),
+    )
+
+    for kwargs, error_match in invalid_calls:
+        with pytest.raises(ValueError, match=error_match):
+            protected_tail_topk_mask(
+                _EMPTY_SCORES,
+                _EMPTY_SCORES,
+                _EMPTY_SCORES,
+                **kwargs,
+            )
+
+    result = protected_tail_topk_mask(
+        _EMPTY_SCORES,
+        _EMPTY_SCORES,
+        _EMPTY_SCORES,
+        0.5,
+        tail_quantile=0.5,
+    )
+    assert result.shape == (0,)
+
+
+def test_tail_rescue_topk_validates_controls_for_empty_inputs() -> None:
+    invalid_calls = (
+        (
+            {
+                "retention_fraction": -0.1,
+                "tail_quantile": 0.5,
+                "rescue_fraction": 0.5,
+            },
+            "retention_fraction",
+        ),
+        (
+            {
+                "retention_fraction": 0.5,
+                "tail_quantile": 0.0,
+                "rescue_fraction": 0.5,
+            },
+            "quantile",
+        ),
+        (
+            {
+                "retention_fraction": 0.5,
+                "tail_quantile": 0.5,
+                "rescue_fraction": 0.0,
+            },
+            "rescue_fraction",
+        ),
+        (
+            {
+                "retention_fraction": 0.5,
+                "tail_quantile": 0.5,
+                "rescue_fraction": 0.5,
+                "min_count": True,
+            },
+            "min_count",
+        ),
+    )
+
+    for kwargs, error_match in invalid_calls:
+        with pytest.raises(ValueError, match=error_match):
+            tail_rescue_topk_mask(
+                _EMPTY_SCORES,
+                _EMPTY_SCORES,
+                _EMPTY_SCORES,
+                **kwargs,
+            )
+
+    result = tail_rescue_topk_mask(
+        _EMPTY_SCORES,
+        _EMPTY_SCORES,
+        _EMPTY_SCORES,
+        0.5,
+        tail_quantile=0.5,
+        rescue_fraction=0.5,
+    )
+    assert result.shape == (0,)


### PR DESCRIPTION
## Summary
- validate retention and quantile controls before returning from empty protected-tail selections
- validate rescue fractions for empty tail-rescue selections
- preserve the existing empty boolean-mask result for valid configurations
- add focused regressions for invalid controls on empty batches

## Bug
`protected_tail_topk_mask()` and `tail_rescue_topk_mask()` returned immediately when all three score vectors were empty. That bypassed the same scalar validation performed for nonempty batches, so malformed values such as a negative `retention_fraction`, `tail_quantile=0`, boolean `min_count`, or `rescue_fraction=0` were silently accepted only when a batch happened to be empty.

## Fix
Let the existing retained-count and quantile helpers validate their controls before the empty result is produced. For the rescue selector, compute the bounded rescue quota before the empty-tail fallback so `rescue_fraction` is validated consistently as well.

## Validation
- isolated regression harness covering valid and invalid empty-input paths passed
- branch comparison: 2 commits ahead of `main`, 0 behind
- diff is limited to `selection.py` and one focused regression file

Full repository tests were not runnable locally because this runtime has neither the GitHub CLI nor direct network checkout access; GitHub Actions should provide the repository-level validation.