### PR TITLE
Copy thin-plate-spline transform parameters

### DIFF
--- a/src/pyrecest/utils/nonrigid_point_set_registration.py
+++ b/src/pyrecest/utils/nonrigid_point_set_registration.py
@@ -18,6 +18,7 @@ import pyrecest.backend
 from pyrecest.backend import (
     asarray,
     concatenate,
+    copy,
     eye,
     isfinite,
     linalg,
@@ -81,9 +82,9 @@ class ThinPlateSplineTransform:
         if affine_coefficients.shape != (3, 2):
             raise ValueError("affine_coefficients must have shape (3, 2).")
 
-        object.__setattr__(self, "control_points", control_points)
-        object.__setattr__(self, "weights", weights)
-        object.__setattr__(self, "affine_coefficients", affine_coefficients)
+        object.__setattr__(self, "control_points", copy(control_points))
+        object.__setattr__(self, "weights", copy(weights))
+        object.__setattr__(self, "affine_coefficients", copy(affine_coefficients))
 
     @staticmethod
     def identity() -> "ThinPlateSplineTransform":

--- a/tests/test_tps_transform_parameter_ownership.py
+++ b/tests/test_tps_transform_parameter_ownership.py
@@ -1,0 +1,47 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+import pyrecest.backend
+
+from pyrecest.backend import array
+from pyrecest.utils.nonrigid_point_set_registration import ThinPlateSplineTransform
+
+
+class TestThinPlateSplineTransformOwnership(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="JAX arrays are immutable and cannot expose caller-side aliasing.",
+    )
+    def test_constructor_copies_parameter_arrays(self):
+        control_points = array([[0.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
+        weights = array([[0.1, 0.0], [-0.05, 0.02], [-0.05, -0.02]])
+        affine_coefficients = array(
+            [[1.0, -1.0], [1.0, 0.0], [0.0, 1.0]]
+        )
+        query = array([[0.25, 0.5], [0.75, 0.1]])
+
+        transform = ThinPlateSplineTransform(
+            control_points=control_points,
+            weights=weights,
+            affine_coefficients=affine_coefficients,
+        )
+        expected_control_points = np.asarray(control_points).copy()
+        expected_weights = np.asarray(weights).copy()
+        expected_affine_coefficients = np.asarray(affine_coefficients).copy()
+        expected_output = np.asarray(transform.apply(query)).copy()
+
+        control_points[...] = 10.0
+        weights[...] = -20.0
+        affine_coefficients[...] = 30.0
+
+        npt.assert_allclose(transform.control_points, expected_control_points)
+        npt.assert_allclose(transform.weights, expected_weights)
+        npt.assert_allclose(
+            transform.affine_coefficients, expected_affine_coefficients
+        )
+        npt.assert_allclose(transform.apply(query), expected_output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`ThinPlateSplineTransform` is a frozen dataclass, but its constructor normalized `control_points`, `weights`, and `affine_coefficients` with the active backend's `asarray` operation and retained the resulting storage directly.

On mutable backends such as NumPy and PyTorch, `asarray` can preserve caller-owned storage. Mutating any constructor input after construction therefore silently changed the stored transform and its output, despite the frozen dataclass contract.

## Fix

- copy all three validated parameter arrays with the backend-aware `copy` primitive before storing them
- preserve backend, dtype, and shape behavior
- add a regression that mutates every caller array and verifies both the stored parameters and transformed query points remain unchanged
- skip only JAX, whose arrays are immutable and cannot expose this aliasing defect

## Validation

- reproduced the pre-fix behavior: mutating constructor arrays changed a query transform from approximately `[1.2403, -0.4961]` to `[58115.0972, 58115.0972]`
- syntax-compiled the modified source and regression test
- executed the patched transform in an isolated NumPy-backed harness; the ownership regression passed
- branch is 2 commits ahead of `main`, 0 behind, and changes only the TPS utility plus one focused regression file

The full repository test matrix is delegated to GitHub Actions.