### PR TITLE
Honor step in single-argument PyTorch arange

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_creation_shape_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_creation_shape_contract.py
@@ -109,9 +109,17 @@ def patch_pytorch_creation_shape_contract() -> None:
                     torch,
                     argument_name="arange start",
                 )
+                step = _pytorch_creation_scalar(
+                    step,
+                    np,
+                    torch,
+                    argument_name="arange step",
+                )
                 if end is _ARANGE_SENTINEL:
                     return torch.arange(
+                        0,
                         start,
+                        step,
                         dtype=_normalize_dtype(dtype),
                         **kwargs,
                     )
@@ -120,12 +128,6 @@ def patch_pytorch_creation_shape_contract() -> None:
                     np,
                     torch,
                     argument_name="arange end",
-                )
-                step = _pytorch_creation_scalar(
-                    step,
-                    np,
-                    torch,
-                    argument_name="arange step",
                 )
                 return torch.arange(
                     start,

--- a/tests/backend_support/test_pytorch_arange_step_contract.py
+++ b/tests/backend_support/test_pytorch_arange_step_contract.py
@@ -1,0 +1,40 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+SCRIPT = """
+import numpy as np
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch_backend
+import torch
+
+expected = torch.tensor([0, 2, 4])
+raw_result = raw_pytorch_backend.arange(np.asarray(5), step=np.asarray(2))
+public_result = backend.arange(5, step=2)
+
+assert torch.equal(raw_result, expected)
+assert torch.equal(public_result, expected)
+print("ok")
+"""
+
+
+def test_pytorch_arange_honors_step_with_single_positional_argument():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = "pytorch"
+    completed = subprocess.run(
+        [sys.executable, "-c", SCRIPT],
+        capture_output=True,
+        env=env,
+        text=True,
+        timeout=30.0,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "ok" in completed.stdout


### PR DESCRIPTION
## Bug

The PyTorch backend compatibility wrapper accepted NumPy-style calls such as

```python
backend.arange(5, step=2)
```

but returned before validating or forwarding `step` when `end` was omitted. The call therefore silently behaved like `arange(5)` and produced `[0, 1, 2, 3, 4]` instead of NumPy's `[0, 2, 4]`.

## Fix

- normalize the `step` scalar before branching on the one- or two-bound call form
- translate the one-bound NumPy form to `torch.arange(0, end, step, ...)`
- preserve the existing two-bound path and dtype/device keyword forwarding
- add a subprocess regression for both the raw PyTorch backend and the public `pyrecest.backend` facade

## Impact

PyTorch-backed code that supplies `step` with only the stop value now receives the requested grid instead of a silently denser one. NumPy scalar stop and step arguments are covered as well.

## Validation

- reproduced NumPy's expected `np.arange(5, step=2) == [0, 2, 4]`
- verified the old wrapper path ignored `step`
- syntax-compiled the modified source and regression test
- ran an isolated corrected-wrapper regression with PyTorch 2.10.0
- branch comparison: 2 commits ahead of `main`, 0 behind
- diff is limited to the creation compatibility hook and one focused test

The full repository test matrix is delegated to GitHub Actions because this runtime has no network-capable local checkout.