### PR TITLE
Reject PyTorch boolean tensor sort axes

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_sort_numpy_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_sort_numpy_contract.py
@@ -15,11 +15,16 @@ _ARGSORT_CONFLICT_MESSAGE = "argsort() got conflicting 'kind' and 'stable' argum
 _ARGSORT_DEFAULT_AXIS = object()
 
 
-def normalize_sort_axis(axis):
+def normalize_sort_axis(axis, torch_module=None):
     """Return a sort axis while preserving NumPy's flatten-all sentinel."""
     if axis is None:
         return None
-    if isinstance(axis, (bool, _np.bool_)):
+    if isinstance(axis, (bool, _np.bool_)) or bool(
+        torch_module is not None
+        and torch_module.is_tensor(axis)
+        and axis.ndim == 0
+        and axis.dtype == torch_module.bool
+    ):
         raise TypeError("an integer is required for the axis")
     return _operator_index(axis)
 
@@ -56,7 +61,7 @@ def sort_axis_none(
     if order is not None:
         raise ValueError("order is not supported by this backend")
     values = backend_module.array(values)
-    axis = normalize_sort_axis(axis)
+    axis = normalize_sort_axis(axis, torch_module)
     stable = resolve_sort_stability(kind, stable)
     if axis is None:
         values = torch_module.flatten(values)

--- a/tests/backend_support/test_pytorch_sort_axis_none_contract.py
+++ b/tests/backend_support/test_pytorch_sort_axis_none_contract.py
@@ -48,6 +48,7 @@ def test_public_pytorch_sort_axis_none_flattens_like_numpy():
 
     code = """
 import pyrecest.backend as backend
+import torch
 
 assert backend.__backend_name__ == "pytorch"
 
@@ -62,6 +63,14 @@ assert backend.to_numpy(descending_result).tolist() == [3, 2, 1, 0]
 
 stable_result = backend.sort([[3, 1], [2, 0]], axis=None, kind="stable")
 assert backend.to_numpy(stable_result).tolist() == [0, 1, 2, 3]
+
+for invalid_axis in (torch.tensor(True), torch.tensor(False)):
+    try:
+        backend.sort([[3, 1], [2, 0]], axis=invalid_axis)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("boolean tensor axes must be rejected")
 """
     subprocess.run([sys.executable, "-c", code], check=True, env=env)
 
@@ -77,6 +86,7 @@ def test_raw_pytorch_sort_axis_none_is_patched_under_default_backend():
 import pyrecest  # noqa: F401
 import pyrecest.backend as public_backend
 import pyrecest._backend.pytorch as raw_pytorch
+import torch
 
 assert public_backend.__backend_name__ == "numpy"
 
@@ -91,6 +101,14 @@ assert raw_pytorch.to_numpy(descending_result).tolist() == [3, 2, 1, 0]
 
 stable_result = raw_pytorch.sort([[3, 1], [2, 0]], axis=None, kind="stable")
 assert raw_pytorch.to_numpy(stable_result).tolist() == [0, 1, 2, 3]
+
+for invalid_axis in (torch.tensor(True), torch.tensor(False)):
+    try:
+        raw_pytorch.sort([[3, 1], [2, 0]], axis=invalid_axis)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("boolean tensor axes must be rejected")
 """
     subprocess.run([sys.executable, "-c", code], check=True, env=env)
 


### PR DESCRIPTION
## Bug

The PyTorch sort compatibility helper rejected Python and NumPy boolean axes, but passed scalar PyTorch tensors directly to `operator.index()`.

PyTorch implements integer conversion for boolean scalar tensors, so:

```python
operator.index(torch.tensor(True)) == 1
operator.index(torch.tensor(False)) == 0
```

As a result, `backend.sort(..., axis=torch.tensor(True))` silently sorted along axis 1 instead of rejecting the invalid boolean axis. The same defect affected the raw PyTorch backend compatibility path.

## Fix

- allow `normalize_sort_axis()` to inspect PyTorch tensors when the module is available
- reject zero-dimensional tensors with `dtype=torch.bool` before integer normalization
- preserve `None`, Python/NumPy integer scalars, and PyTorch integer scalar axes
- add regression coverage for both the public PyTorch backend and the raw PyTorch backend under the default NumPy backend

## Validation

- isolated regression passed for Python booleans, NumPy booleans, PyTorch boolean scalar tensors, NumPy integer scalars, and PyTorch integer scalar tensors
- branch comparison: 2 commits ahead of `main`, 0 behind
- diff is limited to the PyTorch sort compatibility helper and its focused backend-portable test

The full repository backend and CI matrices should run on this pull request.