### PR TITLE
Reject PyTorch boolean tensor trapezoid axes

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_trapezoid_numpy_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_trapezoid_numpy_contract.py
@@ -16,9 +16,14 @@ def _preferred_pytorch_device(torch_module, *values):
     return None
 
 
-def _trapezoid_axis(axis) -> int:
+def _trapezoid_axis(axis, torch_module=None) -> int:
     """Return a NumPy-style integer axis while rejecting boolean axes."""
-    if isinstance(axis, bool) or type(axis).__name__ == "bool_":
+    if isinstance(axis, bool) or type(axis).__name__ == "bool_" or bool(
+        torch_module is not None
+        and torch_module.is_tensor(axis)
+        and axis.ndim == 0
+        and axis.dtype == torch_module.bool
+    ):
         raise TypeError("axis must be an integer")
     try:
         return _operator_index(axis)
@@ -79,7 +84,7 @@ def patch_pytorch_trapezoid_numpy_contract() -> None:
         return
 
     def trapezoid(y, x=None, dx=1.0, axis=-1):
-        dim = _trapezoid_axis(axis)
+        dim = _trapezoid_axis(axis, torch)
         device_values = (y, dx) if x is None else (y, x)
         device = _preferred_pytorch_device(torch, *device_values)
         y = _as_trapezoid_tensor(y, torch, device=device)

--- a/tests/backend_support/test_pytorch_trapezoid_contract.py
+++ b/tests/backend_support/test_pytorch_trapezoid_contract.py
@@ -43,16 +43,30 @@ def test_pytorch_trapezoid_rejects_boolean_axis_like_numpy():
     result = run_backend_code(
         "pytorch",
         """
+import numpy as np
+import torch
+
 import pyrecest.backend as backend
 import pyrecest._backend.pytorch as raw_pytorch
 
 for target_name, target in (("backend", backend), ("raw_pytorch", raw_pytorch)):
-    for axis in (True, False):
+    for axis in (
+        True,
+        False,
+        np.bool_(True),
+        np.bool_(False),
+        torch.tensor(True),
+        torch.tensor(False),
+    ):
         try:
             target.trapezoid([[1.0, 2.0], [3.0, 4.0]], axis=axis)
         except TypeError:
             continue
         raise AssertionError(f"{target_name}.trapezoid accepted boolean axis {axis!r}")
+
+    for axis in (np.int64(1), torch.tensor(1)):
+        integrated = target.trapezoid([[1.0, 2.0], [3.0, 4.0]], axis=axis)
+        assert target.to_numpy(integrated).tolist() == [1.5, 3.5]
 print("ok")
 """,
     )


### PR DESCRIPTION
## Bug

The PyTorch trapezoid compatibility wrapper rejected Python and NumPy boolean axes, but passed zero-dimensional PyTorch tensors directly to `operator.index()`.

PyTorch permits integer conversion of scalar boolean tensors, so:

```python
operator.index(torch.tensor(True)) == 1
operator.index(torch.tensor(False)) == 0
```

Consequently, `backend.trapezoid(..., axis=torch.tensor(True))` silently integrated along axis 1 instead of rejecting the invalid boolean axis. The same defect affected the raw PyTorch backend path.

## Fix

- allow the trapezoid axis normalizer to inspect PyTorch tensors
- reject zero-dimensional tensors with `dtype=torch.bool` before integer normalization
- preserve Python and NumPy integer scalars and zero-dimensional PyTorch integer axes
- expand the backend-portable regression for the public and raw PyTorch backends

## Validation

- branch comparison: 2 commits ahead of `main`, 0 behind
- diff is limited to the PyTorch trapezoid compatibility helper and its focused test
- regression covers Python booleans, NumPy booleans, PyTorch boolean scalar tensors, NumPy integer scalars, and PyTorch integer scalar tensors

The full repository backend and CI matrices should run on this pull request.