### PR TITLE
Freeze measurement score indices

### DIFF
--- a/src/pyrecest/filters/measurement_scoring.py
+++ b/src/pyrecest/filters/measurement_scoring.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any
 
@@ -25,10 +26,17 @@ class MeasurementScore:
     predicted_measurements: Any | None
     innovation_covariance: Any | None
     residual: Any | None
-    active_measurement_indices: list[int]
+    active_measurement_indices: Sequence[int]
     measurement_weights: Any | None = None
     quadratic_form: float | None = None
     skipped_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "active_measurement_indices",
+            tuple(self.active_measurement_indices),
+        )
 
     @property
     def is_active(self) -> bool:

--- a/src/pyrecest/filters/measurement_scoring.py
+++ b/src/pyrecest/filters/measurement_scoring.py
@@ -32,6 +32,7 @@ class MeasurementScore:
     skipped_reason: str | None = None
 
     def __post_init__(self) -> None:
+        # Own caller-provided sequences so this frozen result cannot be mutated indirectly.
         object.__setattr__(
             self,
             "active_measurement_indices",

--- a/tests/filters/test_measurement_scoring.py
+++ b/tests/filters/test_measurement_scoring.py
@@ -15,3 +15,13 @@ def _score(active_measurement_indices):
 def test_measurement_score_is_active_handles_numpy_index_arrays():
     assert _score(np.array([0, 2])).is_active
     assert not _score(np.array([], dtype=int)).is_active
+
+
+def test_measurement_score_owns_active_measurement_indices():
+    active_measurement_indices = []
+    score = _score(active_measurement_indices)
+
+    active_measurement_indices.append(0)
+
+    assert score.active_measurement_indices == ()
+    assert not score.is_active


### PR DESCRIPTION
## Bug

`MeasurementScore` is a frozen dataclass in a module explicitly providing non-mutating result containers, but it retained the caller's mutable `active_measurement_indices` list directly.

That allowed external mutation to change an already-created score. In particular, appending to an originally empty list could silently change `score.is_active` from `False` to `True`, potentially causing update logic to treat a skipped measurement batch as active.

## Fix

- accept sequence-like index inputs as before
- normalize `active_measurement_indices` to an owned tuple in `__post_init__`
- preserve NumPy index-array support and existing tracker iteration/length behavior
- add a regression that mutates the source list after construction and verifies the score remains inactive

## Validation

- syntax-compiled the modified module and test
- ran a focused runtime regression for caller-list mutation and NumPy array conversion
- branch comparison: 2 commits ahead of `main`, 0 behind
- diff is limited to the measurement-score container and its focused test

The full repository matrix should run on this pull request.