### PR TITLE
Reject non-real association feature planes

### DIFF
--- a/src/pyrecest/utils/association_features.py
+++ b/src/pyrecest/utils/association_features.py
@@ -88,8 +88,9 @@ def pairwise_feature_tensor(
 ) -> Any:
     """Build a pairwise feature tensor from named component planes.
 
-    All feature planes must have the same shape. Non-finite values are converted
-    to finite sentinels: ``nan -> 0``, ``+inf -> 1e6``, and ``-inf -> -1e6``.
+    All feature planes must have the same shape and contain real numeric values.
+    Non-finite values are converted to finite sentinels: ``nan -> 0``,
+    ``+inf -> 1e6``, and ``-inf -> -1e6``.
     """
     if isinstance(feature_names, NamedPairwiseFeatureSchema):
         if transforms is not None:
@@ -386,7 +387,10 @@ def _component_feature(
 
 
 def _finite_feature_plane(values: Any, feature_name: str) -> Any:
-    values = asarray(values, dtype=float64)
+    values = _as_real_numeric_backend_array(
+        values,
+        message=f"Feature {feature_name!r} must contain real numeric values",
+    )
     if values.ndim == 0:
         raise ValueError(f"Feature {feature_name!r} must be at least one-dimensional")
     finite_values = where(isnan(values), 0.0, values)

--- a/tests/test_association_feature_real_validation.py
+++ b/tests/test_association_feature_real_validation.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+
+from pyrecest.utils import pairwise_feature_tensor
+
+
+@pytest.mark.parametrize(
+    ("components", "transforms"),
+    [
+        ({"feature": [[1.0 + 2.0j]]}, None),
+        (
+            {"source": [[1.0]]},
+            {"feature": lambda _components: [[1.0 + 2.0j]]},
+        ),
+    ],
+    ids=["component", "transform"],
+)
+def test_pairwise_feature_tensor_rejects_complex_feature_planes(
+    components, transforms
+) -> None:
+    with pytest.raises(
+        ValueError,
+        match="Feature 'feature' must contain real numeric values",
+    ):
+        pairwise_feature_tensor(
+            components,
+            ("feature",),
+            transforms=transforms,
+        )


### PR DESCRIPTION
## What changed
- validate named association feature planes with the existing real-numeric backend conversion helper before sanitization
- reject complex component values and complex transform outputs instead of silently discarding their imaginary parts during float conversion
- document the real-numeric feature-plane contract
- add public-API regression coverage for direct and transformed complex planes

## Why
`pairwise_feature_tensor` previously passed each plane directly to `asarray(..., dtype=float64)`. NumPy-compatible backends may accept a complex plane by dropping its imaginary component, so invalid association evidence can enter a model as plausible real-valued features without an exception.

## Impact
Invalid non-real feature planes now fail fast with a feature-specific `ValueError`. Existing real-valued behavior, including NaN and infinity sentinel replacement, is unchanged.

## Root cause
The module already validated model probabilities and pairwise costs through `_as_real_numeric_backend_array`, but feature-plane assembly bypassed that contract and converted directly to `float64`.

## Checks
- `python -m py_compile /tmp/association_features.py`
- `python -m py_compile /tmp/test_association_feature_real_validation.py`
- isolated NumPy-backed regression harness covering direct and transformed complex planes
- isolated regression confirming existing NaN/±infinity sanitization remains intact

Full repository tests were not available locally because this runtime has no GitHub network checkout and no `gh` executable; the draft PR is ready for the repository CI matrix.