### PR TITLE
Reject masked candidate-pruning inputs

### DIFF
--- a/src/pyrecest/utils/candidate_pruning.py
+++ b/src/pyrecest/utils/candidate_pruning.py
@@ -100,6 +100,8 @@ def candidate_pruning_config_from_mapping(
 
 
 def _normalize_bool(value: Any, name: str) -> bool:
+    if _contains_missing_values(value):
+        raise ValueError(f"{name} must be a boolean")
     value_array = np.asarray(value)
     if value_array.shape == () and value_array.dtype == np.bool_:
         return bool(value_array.item())
@@ -115,7 +117,11 @@ def _has_temporal_dtype(value: Any) -> bool:
 
 def _normalize_positive_integer(value: Any, name: str) -> int:
     message = f"{name} must be a positive integer or None"
-    if _has_temporal_dtype(value) or _contains_temporal_values(value):
+    if (
+        _contains_missing_values(value)
+        or _has_temporal_dtype(value)
+        or _contains_temporal_values(value)
+    ):
         raise ValueError(message)
     try:
         value_array = np.asarray(value)
@@ -144,7 +150,11 @@ def _normalize_positive_integer(value: Any, name: str) -> int:
 
 
 def _normalize_finite_scalar(value: Any, *, message: str) -> float:
-    if _has_temporal_dtype(value) or _contains_temporal_values(value):
+    if (
+        _contains_missing_values(value)
+        or _has_temporal_dtype(value)
+        or _contains_temporal_values(value)
+    ):
         raise ValueError(message)
     try:
         value_array = np.asarray(value)
@@ -205,7 +215,9 @@ def _contains_temporal_values(value: Any) -> bool:
 
 
 def _contains_missing_values(value: Any) -> bool:
-    return _contains_values_of_type(value, _MISSING_TYPES)
+    return bool(np.ma.is_masked(value)) or _contains_values_of_type(
+        value, _MISSING_TYPES
+    )
 
 
 def _as_numeric_matrix(value: Any, name: str) -> np.ndarray:

--- a/tests/utils/test_candidate_pruning_masked_inputs.py
+++ b/tests/utils/test_candidate_pruning_masked_inputs.py
@@ -1,0 +1,56 @@
+import unittest
+
+import numpy as np
+from pyrecest.utils.candidate_pruning import (
+    CandidatePruningConfig,
+    candidate_mask_from_costs,
+)
+
+
+class TestCandidatePruningMaskedInputs(unittest.TestCase):
+    def test_masked_config_scalars_are_rejected(self):
+        invalid_configs = (
+            {"row_top_k": np.ma.array(2, mask=True)},
+            {"column_top_k": np.ma.array(2, mask=True)},
+            {"always_keep_finite": np.ma.array(True, mask=True)},
+            {"probability_threshold": np.ma.array(0.5, mask=True)},
+            {"max_cost": np.ma.array(4.0, mask=True)},
+            {"max_cost_percentile": np.ma.array(50.0, mask=True)},
+            {"large_cost": np.ma.array(100.0, mask=True)},
+        )
+
+        for kwargs in invalid_configs:
+            with self.subTest(kwargs=kwargs):
+                with self.assertRaises(ValueError):
+                    CandidatePruningConfig(**kwargs)
+
+    def test_masked_cost_and_probability_entries_are_rejected(self):
+        masked_costs = np.ma.array([[0.1, 1.0]], mask=[[True, False]])
+        with self.assertRaisesRegex(ValueError, "cost_matrix must be numeric"):
+            candidate_mask_from_costs(masked_costs)
+
+        masked_probabilities = np.ma.array(
+            [[0.9, 0.1]], mask=[[True, False]]
+        )
+        config = CandidatePruningConfig(probability_threshold=0.5)
+        with self.assertRaisesRegex(ValueError, "probability_matrix must be numeric"):
+            candidate_mask_from_costs(
+                np.array([[1.0, 2.0]]),
+                probability_matrix=masked_probabilities,
+                config=config,
+            )
+
+    def test_unmasked_masked_arrays_remain_supported(self):
+        costs = np.ma.array([[1.0, 2.0]], mask=False)
+        config = CandidatePruningConfig(
+            row_top_k=np.ma.array(1, mask=False)
+        )
+
+        np.testing.assert_array_equal(
+            candidate_mask_from_costs(costs, config=config),
+            np.array([[True, False]]),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

Candidate-pruning validation converted inputs with `np.asarray()` before accounting for NumPy masked-array semantics. For a masked scalar or matrix entry, `np.asarray()` exposes the hidden payload instead of the missing value.

This allowed masked configuration values to be accepted and could make a masked low cost win top-k pruning or a masked high probability retain a candidate.

## Fix

- treat genuinely masked NumPy scalar and array inputs as missing values
- apply the check to boolean, positive-integer, and finite-scalar configuration normalization
- reject masked cost and probability matrix entries through the shared numeric-matrix validation
- retain support for `MaskedArray` inputs whose mask is entirely false

## Validation

- reproduced the old behavior with masked `row_top_k`, cost, and probability payloads
- focused regression suite passed: 3 tests
- syntax compilation passed for the modified module and regression test
- branch comparison: 2 commits ahead of `main`, 0 behind
- diff is limited to candidate-pruning validation and one focused test module