### PR TITLE
Deduplicate models in evidence margin ranking

### DIFF
--- a/src/pyrecest/evaluation/__init__.py
+++ b/src/pyrecest/evaluation/__init__.py
@@ -73,6 +73,7 @@ from .summarize_filter_results import summarize_filter_results
 
 _ORIGINAL_CLASSIFIER_ATTR = "_pyrecest_original_classify_evidence_margin"
 _ORIGINAL_DECISIONS_ATTR = "_pyrecest_original_paired_model_margin_decisions"
+_ORIGINAL_EVIDENCE_TABLE_ATTR = "_pyrecest_original_evidence_margin_table"
 
 if not hasattr(_model_comparison, _ORIGINAL_CLASSIFIER_ATTR):
     setattr(
@@ -86,12 +87,21 @@ if not hasattr(_model_comparison, _ORIGINAL_DECISIONS_ATTR):
         _ORIGINAL_DECISIONS_ATTR,
         paired_model_margin_decisions,
     )
+if not hasattr(_model_comparison, _ORIGINAL_EVIDENCE_TABLE_ATTR):
+    setattr(
+        _model_comparison,
+        _ORIGINAL_EVIDENCE_TABLE_ATTR,
+        evidence_margin_table,
+    )
 
 _original_classify_evidence_margin = getattr(
     _model_comparison, _ORIGINAL_CLASSIFIER_ATTR
 )
 _original_paired_model_margin_decisions = getattr(
     _model_comparison, _ORIGINAL_DECISIONS_ATTR
+)
+_original_evidence_margin_table = getattr(
+    _model_comparison, _ORIGINAL_EVIDENCE_TABLE_ATTR
 )
 
 
@@ -134,10 +144,38 @@ def _paired_model_margin_decisions(
     )
 
 
+def _evidence_margin_table(
+    scores,
+    *,
+    group_cols=("session", "event_index"),
+    evidence_col="log_evidence",
+    model_col="model",
+):
+    group_cols = tuple(group_cols)
+    comparable = _model_comparison._comparable_rows(scores)
+    required = [*group_cols, evidence_col, model_col]
+    if comparable.empty or any(column not in comparable.columns for column in required):
+        return _original_evidence_margin_table(
+            scores,
+            group_cols=group_cols,
+            evidence_col=evidence_col,
+            model_col=model_col,
+        )
+    distinct = comparable.drop_duplicates([*group_cols, model_col], keep="last")
+    return _original_evidence_margin_table(
+        distinct,
+        group_cols=group_cols,
+        evidence_col=evidence_col,
+        model_col=model_col,
+    )
+
+
 _model_comparison.classify_evidence_margin = _classify_evidence_margin
 classify_evidence_margin = _classify_evidence_margin
 _model_comparison.paired_model_margin_decisions = _paired_model_margin_decisions
 paired_model_margin_decisions = _paired_model_margin_decisions
+_model_comparison.evidence_margin_table = _evidence_margin_table
+evidence_margin_table = _evidence_margin_table
 
 __all__ = [
     "generate_groundtruth",

--- a/tests/test_model_comparison_duplicate_models.py
+++ b/tests/test_model_comparison_duplicate_models.py
@@ -1,0 +1,43 @@
+import pandas as pd
+
+from pyrecest.evaluation.model_comparison import evidence_margin_table
+
+
+def test_evidence_margin_uses_distinct_models_for_runner_up():
+    scores = pd.DataFrame(
+        [
+            {
+                "status": "success",
+                "session": "s1",
+                "event_index": 0,
+                "model": "a",
+                "log_evidence": 10.0,
+                "evidence_comparable": True,
+            },
+            {
+                "status": "success",
+                "session": "s1",
+                "event_index": 0,
+                "model": "b",
+                "log_evidence": 7.0,
+                "evidence_comparable": True,
+            },
+            {
+                "status": "success",
+                "session": "s1",
+                "event_index": 0,
+                "model": "a",
+                "log_evidence": 9.0,
+                "evidence_comparable": True,
+            },
+        ]
+    )
+
+    margins = evidence_margin_table(scores)
+
+    assert margins["best_model_by_evidence"].tolist() == ["a"]
+    assert margins["second_best_model_by_evidence"].tolist() == ["b"]
+    assert margins["best_log_evidence"].tolist() == [9.0]
+    assert margins["second_best_log_evidence"].tolist() == [7.0]
+    assert margins["evidence_margin_to_second_best"].tolist() == [2.0]
+    assert margins["models_compared"].tolist() == [2]


### PR DESCRIPTION
## Bug

`evidence_margin_table()` ranked every comparable score row independently. If one model appeared more than once in a group, duplicate rows for that model could occupy both the winner and runner-up positions.

That produced misleading diagnostics:

- `best_model_by_evidence` and `second_best_model_by_evidence` could name the same model
- the reported margin could compare two runs of one model instead of two distinct models
- `models_compared` counted rows rather than distinct models

The paired-model decision helper already handles repeated model rows by retaining the last comparable row per model, so the two model-comparison paths had inconsistent semantics.

## Fix

- deduplicate comparable rows by group and model before computing best-vs-runner-up margins
- retain the last row for each model, matching `paired_model_margin_decisions()`
- install the repair through the existing idempotent evaluation compatibility hook
- add a focused regression covering winner, runner-up, evidence values, margin, and distinct model count

## Validation

- reproduced the pre-fix failure: the duplicate `a` row was selected as runner-up instead of model `b`
- focused patched regression passed
- `python -m py_compile` passed for the exercised source and regression
- branch comparison: 2 commits ahead of `main`, 0 behind
- diff is limited to the evaluation compatibility hook and one focused test