### PR TITLE
Reject masked covariance and numerics inputs

### DIFF
--- a/src/pyrecest/numerics.py
+++ b/src/pyrecest/numerics.py
@@ -42,6 +42,8 @@ def _object_item_contains_unsupported_numeric_values(item) -> bool:
 
 
 def _contains_unsupported_numeric_values(value) -> bool:
+    if np.ma.is_masked(value):
+        return True
     try:
         value_array = np.asarray(value)
     except (TypeError, ValueError, OverflowError, RuntimeError):
@@ -57,6 +59,8 @@ def _contains_unsupported_numeric_values(value) -> bool:
 
 
 def _to_numpy_array(value, *, name: str = "matrix") -> np.ndarray:
+    if np.ma.is_masked(value):
+        raise ValueError(f"{name} must contain numeric values.")
     try:
         import pyrecest.backend as backend
 
@@ -84,6 +88,8 @@ def _from_numpy_array(value: np.ndarray):
 
 
 def _validate_nonnegative_finite(name: str, value: float) -> float:
+    if np.ma.is_masked(value):
+        raise ValueError(f"{name} must be a scalar number.")
     try:
         value_array = np.asarray(value)
     except (TypeError, ValueError, OverflowError, RuntimeError) as exc:
@@ -110,6 +116,8 @@ def _validate_positive_finite(name: str, value: float) -> float:
 
 
 def _validate_nonnegative_integer(name: str, value: int) -> int:
+    if np.ma.is_masked(value):
+        raise ValueError(f"{name} must be a nonnegative integer.")
     try:
         value_array = np.asarray(value)
     except (TypeError, ValueError, OverflowError, RuntimeError) as exc:

--- a/tests/test_numerics_masked_inputs.py
+++ b/tests/test_numerics_masked_inputs.py
@@ -1,0 +1,82 @@
+import numpy as np
+import pytest
+
+from pyrecest.numerics import (
+    assert_covariance_matrix,
+    is_positive_semidefinite,
+    is_symmetric,
+    jittered_cholesky,
+    nearest_symmetric_psd,
+    symmetrize_matrix,
+)
+
+
+def test_covariance_helpers_reject_masked_matrix_entries():
+    matrix = np.ma.array(
+        [[1.0, 0.0], [0.0, 1.0]],
+        mask=[[False, True], [False, False]],
+    )
+
+    assert not is_symmetric(matrix)
+    assert not is_positive_semidefinite(matrix)
+
+    for helper in (
+        assert_covariance_matrix,
+        symmetrize_matrix,
+        nearest_symmetric_psd,
+        jittered_cholesky,
+    ):
+        with pytest.raises(ValueError, match="must contain numeric values"):
+            helper(matrix)
+
+
+def test_covariance_helpers_reject_masked_scalar_controls():
+    matrix = np.eye(2)
+
+    invalid_calls = (
+        lambda: is_symmetric(matrix, atol=np.ma.array(1e-10, mask=True)),
+        lambda: is_positive_semidefinite(
+            matrix, atol=np.ma.array(1e-10, mask=True)
+        ),
+        lambda: nearest_symmetric_psd(
+            matrix, min_eigenvalue=np.ma.array(0.0, mask=True)
+        ),
+        lambda: jittered_cholesky(
+            matrix, initial_jitter=np.ma.array(1e-12, mask=True)
+        ),
+        lambda: jittered_cholesky(
+            matrix, max_attempts=np.ma.array(2, mask=True)
+        ),
+        lambda: assert_covariance_matrix(
+            matrix, dim=np.ma.array(2, mask=True)
+        ),
+    )
+
+    for call in invalid_calls:
+        with pytest.raises(ValueError):
+            call()
+
+
+def test_covariance_helpers_accept_unmasked_masked_arrays():
+    matrix = np.ma.array(np.eye(2), mask=False)
+
+    assert is_symmetric(matrix, atol=np.ma.array(1e-10, mask=False))
+    assert is_positive_semidefinite(
+        matrix, atol=np.ma.array(1e-10, mask=False)
+    )
+    np.testing.assert_array_equal(
+        np.asarray(
+            assert_covariance_matrix(
+                matrix,
+                dim=np.ma.array(2, mask=False),
+            )
+        ),
+        np.eye(2),
+    )
+    factor, jitter = jittered_cholesky(
+        matrix,
+        initial_jitter=np.ma.array(1e-12, mask=False),
+        max_attempts=np.ma.array(2, mask=False),
+    )
+    np.testing.assert_array_equal(np.asarray(factor), np.eye(2))
+    assert jitter == 0.0


### PR DESCRIPTION
## Bug

The covariance and numerical-contract helpers converted NumPy masked arrays with `np.asarray()` before checking whether values were masked. NumPy exposes the hidden payload during that conversion.

Consequently:

- a covariance matrix with a masked entry could be accepted as symmetric and positive semidefinite
- repair and Cholesky helpers could operate on hidden masked payloads
- masked tolerances, dimensions, jitter values, and retry counts could be accepted as ordinary scalar controls

This makes missing numerical data look valid and can silently bypass covariance validation.

## Fix

- reject genuinely masked arrays before backend conversion
- include masked values in unsupported numeric-value detection
- reject masked finite-scalar and integer controls before scalar extraction
- retain support for `MaskedArray` inputs whose mask is entirely false
- add focused regressions for masked matrix entries, masked scalar controls, and unmasked masked arrays

## Validation

- reproduced the old NumPy behavior: `np.asarray()` exposes masked payloads
- syntax-compiled the modified module and regression file
- ran an isolated NumPy-backed regression harness covering all changed paths
- branch comparison: 2 commits ahead of `main`, 0 behind
- diff is limited to `src/pyrecest/numerics.py` and one focused test module

The full repository and backend matrices should run on this pull request.