### PR TITLE
Reject masked track metric controls

### DIFF
--- a/src/pyrecest/utils/track_metrics.py
+++ b/src/pyrecest/utils/track_metrics.py
@@ -324,6 +324,8 @@ def _session_times(
 ) -> np.ndarray:
     if session_times is None:
         return np.arange(n_sessions, dtype=float)
+    if np.ma.is_masked(session_times):
+        raise ValueError("session_times must contain only finite numeric values")
     try:
         native_times = np.asarray(session_times)
     except (TypeError, ValueError, RuntimeError) as exc:
@@ -354,6 +356,8 @@ def _session_times(
 
 def _validate_missed_value(value: Any) -> float:
     message = "missed_value must be a scalar numeric value"
+    if np.ma.is_masked(value):
+        raise ValueError(message)
     try:
         native_value = np.asarray(value)
     except (TypeError, ValueError, RuntimeError) as exc:
@@ -404,6 +408,8 @@ def _contains_bool_or_text(values: np.ndarray) -> bool:
 
 
 def _as_positive_int(value: Any, name: str) -> int:
+    if np.ma.is_masked(value):
+        raise ValueError(f"{name} must be a positive integer")
     array = np.asarray(value)
     if array.ndim != 0 or array.dtype == np.bool_ or array.dtype.kind in "Mm":
         raise ValueError(f"{name} must be a positive integer")

--- a/tests/test_track_metrics_masked_inputs.py
+++ b/tests/test_track_metrics_masked_inputs.py
@@ -1,0 +1,91 @@
+"""Regression tests for masked track-metric controls."""
+
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+from pyrecest.utils.track_metrics import (
+    score_false_tracks,
+    score_missed_tracks,
+    track_latencies,
+)
+
+
+class TestTrackMetricsMaskedInputs(unittest.TestCase):
+    def setUp(self):
+        self.reference = [[0, 0, None]]
+        self.predicted = [[None, 0, None]]
+
+    def test_masked_session_time_is_rejected(self):
+        session_times = np.ma.array(
+            [0.0, 100.0, 200.0], mask=[False, True, False]
+        )
+
+        with self.assertRaisesRegex(
+            ValueError, "session_times must contain only finite numeric values"
+        ):
+            track_latencies(
+                self.predicted,
+                self.reference,
+                session_times=session_times,
+            )
+
+    def test_masked_missed_value_is_rejected(self):
+        missed_value = np.ma.array(-7.0, mask=True)
+
+        with self.assertRaisesRegex(
+            ValueError, "missed_value must be a scalar numeric value"
+        ):
+            track_latencies(
+                [[None, None, None]],
+                self.reference,
+                missed_value=missed_value,
+            )
+
+    def test_masked_min_length_is_rejected(self):
+        min_length = np.ma.array(2, mask=True)
+
+        for scorer in (score_false_tracks, score_missed_tracks):
+            with self.subTest(scorer=scorer.__name__):
+                with self.assertRaisesRegex(
+                    ValueError, "min_length must be a positive integer"
+                ):
+                    scorer(
+                        [[99, 99, None]],
+                        self.reference,
+                        min_length=min_length,
+                    )
+
+    def test_unmasked_masked_arrays_remain_supported(self):
+        session_times = np.ma.array([0.0, 4.0, 9.0], mask=False)
+        missed_value = np.ma.array(-7.0, mask=False)
+        min_length = np.ma.array(1, mask=False)
+
+        npt.assert_allclose(
+            track_latencies(
+                self.predicted,
+                self.reference,
+                session_times=session_times,
+            ),
+            np.array([4.0]),
+        )
+        npt.assert_allclose(
+            track_latencies(
+                [[None, None, None]],
+                self.reference,
+                missed_value=missed_value,
+            ),
+            np.array([-7.0]),
+        )
+        self.assertEqual(
+            score_false_tracks(
+                [[99, None, None]],
+                self.reference,
+                min_length=min_length,
+            )["false_track_evaluated_tracks"],
+            1,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

The track-metrics validators converted inputs with `np.asarray()` before accounting for NumPy masked-array semantics. For genuinely masked values, `np.asarray()` exposes the hidden payload instead of the missing value.

This allowed masked controls to be silently treated as real configuration:

- a masked `session_times` entry affected the reported detection latency
- a masked `missed_value` became the returned sentinel for an undetected track
- a masked `min_length` controlled false- and missed-track selection

For example, a masked timestamp with hidden payload `100.0` produced a latency of `100.0` rather than being rejected.

## Fix

- reject genuinely masked session-time arrays before numeric conversion
- reject masked missed-track sentinel scalars
- reject masked positive-integer controls
- retain support for `MaskedArray` inputs whose mask is entirely false
- add focused regressions for all three validation paths and the unmasked compatibility path

## Validation

- reproduced the pre-fix behavior for masked `session_times`, `missed_value`, and `min_length`
- focused regression suite passed: 4 tests
- `python -m py_compile` passed for the modified module and regression test
- branch comparison: 2 commits ahead of `main`, 0 behind
- diff is limited to 6 source additions and one focused test module

The full repository CI matrix should run on this pull request.