### PR TITLE
Reject masked evidence boolean flags

### DIFF
--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -28,6 +28,8 @@ _RESERVED_DIAGNOSTIC_METADATA_KEYS = frozenset(
 def _coerce_bool_flag(value: bool, name: str) -> bool:
     """Return a bool flag without treating arbitrary truthy objects as true."""
 
+    if np.ma.is_masked(value):
+        raise ValueError(f"{name} must be a bool")
     try:
         value_array = np.asarray(value)
     except (TypeError, ValueError, RuntimeError, OverflowError) as exc:

--- a/tests/test_evidence_bool_flag_conversion.py
+++ b/tests/test_evidence_bool_flag_conversion.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from pyrecest.evidence import EvidenceComputationMode, resolve_evidence_computation_mode
@@ -25,3 +26,28 @@ class FailingArrayConversion:
 def test_evidence_bool_flags_normalize_array_conversion_errors(factory, error_type):
     with pytest.raises(ValueError, match="must be a bool"):
         factory(FailingArrayConversion(error_type))
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda value: EvidenceComputationMode(return_smoothed=value),
+        lambda value: EvidenceComputationMode(terminal_posterior=value),
+        lambda value: EvidenceComputationMode.from_return_smoothed(value),
+        lambda value: resolve_evidence_computation_mode(return_smoothed=value),
+    ],
+)
+@pytest.mark.parametrize("masked_value", [True, False])
+def test_evidence_bool_flags_reject_masked_scalars(factory, masked_value):
+    with pytest.raises(ValueError, match="must be a bool"):
+        factory(np.ma.array(masked_value, mask=True))
+
+
+def test_evidence_bool_flags_accept_unmasked_masked_scalars():
+    full = EvidenceComputationMode.from_return_smoothed(np.ma.array(True, mask=False))
+    evidence_only = EvidenceComputationMode.from_return_smoothed(
+        np.ma.array(False, mask=False)
+    )
+
+    assert full.mode == "full_smoothing"
+    assert evidence_only.mode == "evidence_only"


### PR DESCRIPTION
## Bug

`_coerce_bool_flag()` converted inputs with `np.asarray()` before accounting for NumPy masked-array semantics. For a masked Boolean scalar, `np.asarray()` exposes the hidden payload instead of the missing value.

Consequently, values such as `np.ma.array(True, mask=True)` and `np.ma.array(False, mask=True)` were silently accepted as evidence-mode controls. This could select full smoothing or evidence-only execution from a missing configuration value rather than rejecting it.

## Fix

- reject genuinely masked Boolean inputs before array conversion
- apply the validation consistently to `return_smoothed` and `terminal_posterior` construction paths
- preserve support for `MaskedArray` Boolean scalars whose mask is false
- extend the existing Boolean-conversion regression suite across all public evidence-mode factories

## Validation

- reproduced the old behavior: masked `True` and masked `False` were converted to ordinary booleans
- isolated regression passed for masked rejection and unmasked compatibility
- branch comparison: 2 commits ahead of `main`, 0 behind
- diff is limited to two source lines and focused additions to the existing evidence Boolean test module

The repository CI matrix should provide full integration validation.