### PR TITLE
Reject masked HistoryRecorder boolean flags

### DIFF
--- a/src/pyrecest/utils/history_recorder.py
+++ b/src/pyrecest/utils/history_recorder.py
@@ -22,6 +22,8 @@ class _HistoryEntry:
 
 
 def _validate_bool_flag(value: Any, name: str) -> bool:
+    if np.ma.is_masked(value):
+        raise TypeError(f"{name} must be a boolean")
     if isinstance(value, bool):
         return value
     try:

--- a/tests/test_history_recorder_masked_flags.py
+++ b/tests/test_history_recorder_masked_flags.py
@@ -1,0 +1,40 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.utils import HistoryRecorder
+
+
+class HistoryRecorderMaskedFlagTest(unittest.TestCase):
+    def test_rejects_masked_boolean_flags(self):
+        for hidden_payload in (False, True):
+            masked_flag = np.ma.array(hidden_payload, mask=True)
+
+            with self.subTest(flag="register.pad_with_nan", hidden=hidden_payload):
+                recorder = HistoryRecorder()
+                with self.assertRaisesRegex(TypeError, "pad_with_nan"):
+                    recorder.register("padded", pad_with_nan=masked_flag)
+
+            with self.subTest(flag="record.pad_with_nan", hidden=hidden_payload):
+                recorder = HistoryRecorder()
+                with self.assertRaisesRegex(TypeError, "pad_with_nan"):
+                    recorder.record("padded", [1.0], pad_with_nan=masked_flag)
+
+            with self.subTest(flag="record.copy_value", hidden=hidden_payload):
+                recorder = HistoryRecorder()
+                recorder.register("events")
+                with self.assertRaisesRegex(TypeError, "copy_value"):
+                    recorder.record("events", {"value": 1}, copy_value=masked_flag)
+
+    def test_accepts_unmasked_masked_array_boolean(self):
+        flag = np.ma.array(True, mask=False)
+        recorder = HistoryRecorder()
+
+        recorder.register("padded", pad_with_nan=flag)
+        history = recorder.record("padded", [1.0], pad_with_nan=flag)
+
+        self.assertEqual(tuple(history.shape), (1, 1))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`HistoryRecorder._validate_bool_flag()` converted flag inputs with the active backend before accounting for NumPy masked-array semantics. For a genuinely masked Boolean scalar, conversion exposes the hidden payload rather than the missing value.

Consequently, values such as `np.ma.array(True, mask=True)` and `np.ma.array(False, mask=True)` were silently accepted for `pad_with_nan` and `copy_value`. A missing configuration value could therefore enable or disable padded storage or deep-copy behavior based on an inaccessible payload.

## Fix

- reject genuinely masked Boolean controls before backend conversion
- apply the validation consistently to `register(..., pad_with_nan=...)`, `record(..., pad_with_nan=...)`, and `record(..., copy_value=...)`
- preserve Python, NumPy, backend scalar, and unmasked `MaskedArray` Boolean support
- add focused regressions for both hidden Boolean payloads and all public flag paths

## Validation

- reproduced the old NumPy behavior: `np.asarray()` exposes the hidden Boolean payload
- isolated validation passed for masked rejection and ordinary/unmasked Boolean compatibility
- branch comparison against `main`: 2 files, +42/-0, 2 commits ahead, 0 behind

The full repository backend and CI matrices should provide integration validation.