### PR TITLE
Copy additive cost-matrix penalty inputs

### DIFF
--- a/src/pyrecest/utils/cost_matrix_adjustments.py
+++ b/src/pyrecest/utils/cost_matrix_adjustments.py
@@ -175,7 +175,7 @@ def additive_cost_matrix_adjustment(
 ) -> CallableCostMatrixAdjustment:
     """Return an adjustment that adds a same-shaped penalty matrix."""
 
-    penalty = _as_cost_matrix(penalty_matrix)
+    penalty = _as_cost_matrix(penalty_matrix).copy()
     stored_diagnostics = _metadata_dict(diagnostics, name="diagnostics")
 
     def _add(

--- a/tests/test_additive_cost_matrix_adjustment_ownership.py
+++ b/tests/test_additive_cost_matrix_adjustment_ownership.py
@@ -1,0 +1,26 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+from pyrecest.utils.cost_matrix_adjustments import (
+    additive_cost_matrix_adjustment,
+    apply_cost_matrix_adjustment,
+)
+
+
+class TestAdditiveCostMatrixAdjustmentOwnership(unittest.TestCase):
+    def test_caller_mutation_does_not_change_stored_penalty(self):
+        penalty = np.array([[1.0, 2.0]])
+        adjustment = additive_cost_matrix_adjustment(penalty)
+
+        penalty[:] = 100.0
+
+        result = apply_cost_matrix_adjustment(
+            np.array([[10.0, 20.0]]), adjustment
+        )
+        npt.assert_allclose(result.adjusted_cost_matrix, np.array([[11.0, 22.0]]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`additive_cost_matrix_adjustment()` validated its penalty with `np.asarray(..., dtype=float)` and retained the resulting array in the adjustment closure. For an existing floating-point NumPy array, that conversion preserves caller-owned storage.

Mutating the original penalty after constructing the frozen adjustment therefore silently changed future adjusted costs. For example, changing `[[1, 2]]` to `[[100, 100]]` changed an adjustment of `[[10, 20]]` from the expected `[[11, 22]]` to `[[110, 120]]`.

## Fix

- copy the validated penalty matrix when the adjustment is created
- preserve shape validation, diagnostics, and application behavior
- add a focused regression that mutates the caller's array after construction

## Impact

Additive adjustments now have stable value semantics: their behavior no longer depends on later mutations to constructor inputs.

## Validation

- reproduced the alias with `np.shares_memory(...) == True`
- syntax-compiled the modified module and regression
- ran the focused regression through the public module import path: 1 test passed
- branch comparison against `main`: 2 files changed, +27/-1, 0 commits behind

The full repository matrix should run in GitHub Actions.