### PR TITLE
Reject fractional Fejer grid controls

### DIFF
--- a/src/pyrecest/distributions/hypertorus/fejer.py
+++ b/src/pyrecest/distributions/hypertorus/fejer.py
@@ -265,12 +265,27 @@ def fejer_reduce_coefficients(coefficients, target_shape: CoefficientShape | Non
     return reduce_coefficients(coefficients, target_shape, kernel="fejer")
 
 
+def _validate_integer_control(value, name: str, *, minimum: int) -> int:
+    """Return an integer control without silently truncating other scalar types."""
+
+    qualifier = "positive" if minimum == 1 else "nonnegative"
+    message = f"{name} must be a {qualifier} integer."
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Integral):
+        raise ValueError(message)
+    value = int(value)
+    if value < minimum:
+        raise ValueError(message)
+    return value
+
+
 def coefficient_grid_shape(shape: CoefficientShape, oversampling_factor: int = 1) -> tuple[int, ...]:
     """Return an odd FFT-grid shape obtained by centered zero-padding."""
 
-    if isinstance(oversampling_factor, bool) or int(oversampling_factor) < 1:
-        raise ValueError("oversampling_factor must be a positive integer.")
-    oversampling_factor = int(oversampling_factor)
+    oversampling_factor = _validate_integer_control(
+        oversampling_factor,
+        "oversampling_factor",
+        minimum=1,
+    )
     shape = normalize_coefficient_shape(shape, name="shape")
     return tuple((side_length - 1) * oversampling_factor + 1 for side_length in shape)
 
@@ -319,8 +334,11 @@ def adaptive_kernel_reduce_coefficients(
 
     if min_value_tolerance < 0.0:
         raise ValueError("min_value_tolerance must be nonnegative.")
-    if isinstance(exponent_search_steps, bool) or int(exponent_search_steps) < 0:
-        raise ValueError("exponent_search_steps must be a nonnegative integer.")
+    exponent_search_steps = _validate_integer_control(
+        exponent_search_steps,
+        "exponent_search_steps",
+        minimum=0,
+    )
 
     coeff_arr = np.asarray(coefficients)
     if target_shape is None:
@@ -339,7 +357,7 @@ def adaptive_kernel_reduce_coefficients(
     low = 0.0
     high = 1.0
     best = full
-    for _ in range(int(exponent_search_steps)):
+    for _ in range(exponent_search_steps):
         mid = 0.5 * (low + high)
         candidate = reduce_coefficients(coeff_arr, target_shape, kernel=kernel, exponent=mid)
         if minimum_on_fft_grid(candidate, diagnostic_shape) >= -min_value_tolerance:

--- a/tests/distributions/test_fejer_helpers.py
+++ b/tests/distributions/test_fejer_helpers.py
@@ -6,6 +6,7 @@ from pyrecest.distributions.hypertorus.fejer import (
     adaptive_kernel_reduce_coefficients,
     apply_fejer_weights,
     centered_coefficients,
+    coefficient_grid_shape,
     fejer_weights,
     korovkin_weights,
     minimum_on_fft_grid,
@@ -57,6 +58,16 @@ def test_reduce_coefficients_sharp_matches_centered_coefficients():
     npt.assert_array_equal(reduce_coefficients(c, (3,), kernel="sharp"), centered_coefficients(c, (3,)))
 
 
+@pytest.mark.parametrize("invalid_value", [1.5, np.float64(2.0), "2", True])
+def test_coefficient_grid_shape_rejects_noninteger_oversampling_factor(invalid_value):
+    with pytest.raises(ValueError, match="oversampling_factor must be a positive integer"):
+        coefficient_grid_shape((3,), oversampling_factor=invalid_value)
+
+
+def test_coefficient_grid_shape_accepts_numpy_integer_oversampling_factor():
+    assert coefficient_grid_shape((3,), oversampling_factor=np.int64(2)) == (5,)
+
+
 def test_adaptive_reduction_keeps_nonnegative_sharp_result_unchanged():
     coeff = np.array([0.05, 1.0 / (2.0 * np.pi), 0.05])
     reduced, exponent = adaptive_kernel_reduce_coefficients(coeff, (3,), return_exponent=True)
@@ -73,6 +84,24 @@ def test_adaptive_reduction_damps_negative_sharp_result():
     assert minimum_on_fft_grid(sharp) < 0.0
     assert exponent > 0.0
     assert minimum_on_fft_grid(reduced) >= -1e-12
+
+
+@pytest.mark.parametrize("invalid_value", [1.5, np.float64(2.0), "2", True])
+def test_adaptive_reduction_rejects_noninteger_search_steps(invalid_value):
+    with pytest.raises(ValueError, match="exponent_search_steps must be a nonnegative integer"):
+        adaptive_kernel_reduce_coefficients(
+            np.ones(3),
+            exponent_search_steps=invalid_value,
+        )
+
+
+def test_adaptive_reduction_accepts_numpy_integer_search_steps():
+    reduced = adaptive_kernel_reduce_coefficients(
+        np.ones(3),
+        exponent_search_steps=np.int64(0),
+    )
+
+    npt.assert_array_equal(reduced, np.ones(3))
 
 
 def test_even_shape_rejected():


### PR DESCRIPTION
## Bug

`coefficient_grid_shape()` and `adaptive_kernel_reduce_coefficients()` converted their integer controls with `int(...)` before validation. Fractional values were therefore silently truncated:

- `oversampling_factor=1.5` behaved as `1`
- `exponent_search_steps=2.5` behaved as `2`

String and integer-valued floating inputs were also accepted despite both parameters being documented as integers. This can silently change the diagnostic FFT grid and the number of adaptive bisection iterations.

## Fix

- add a shared strict integer-control validator
- reject booleans and non-integral scalar types instead of truncating them
- preserve support for Python and NumPy integer scalars
- use the validated search-step count directly in `range()`

## Regression coverage

- fractional, floating, string, and boolean oversampling controls are rejected
- the same invalid search-step controls are rejected
- NumPy integer controls remain accepted

## Validation

- inspected the exact two-commit diff against `main`
- branch is 2 commits ahead and 0 commits behind
- full test and backend validation is delegated to GitHub Actions