### PR TITLE
Fix SO(3) logarithm near pi rotations

### DIFF
--- a/src/pyrecest/smoothers/so3_tangent_savitzky_golay_smoother.py
+++ b/src/pyrecest/smoothers/so3_tangent_savitzky_golay_smoother.py
@@ -152,7 +152,8 @@ class SO3TangentSavitzkyGolaySmoother(AbstractSmoother):
         axis_index = max(range(3), key=lambda idx: diagonal[idx])
         axis = [0.0, 0.0, 0.0]
         axis[axis_index] = math.sqrt(max(0.5 * (diagonal[axis_index] + 1.0), 0.0))
-        denominator = max(2.0 * axis[axis_index], 1e-8)
+        # For a pi rotation, R_ij + R_ji = 4 * axis_i * axis_j.
+        denominator = max(4.0 * axis[axis_index], 1e-8)
         if axis_index == 0:
             axis[1] = float(rotation[0, 1] + rotation[1, 0]) / denominator
             axis[2] = float(rotation[0, 2] + rotation[2, 0]) / denominator

--- a/tests/smoothers/test_so3_tangent_savitzky_golay_smoother.py
+++ b/tests/smoothers/test_so3_tangent_savitzky_golay_smoother.py
@@ -27,6 +27,16 @@ def geodesic_distance(rotation_a, rotation_b):
 
 
 class SO3TangentSavitzkyGolaySmootherTest(unittest.TestCase):
+    def test_log_map_round_trips_pi_rotation_about_general_axis(self):
+        smoother = SO3TangentSavitzkyGolaySmoother()
+        axis = array([1.0, 2.0, 3.0])
+        axis = axis / np.linalg.norm(np.asarray(axis))
+        rotation = smoother._exp_map(math.pi * axis)
+
+        reconstructed = smoother._exp_map(smoother._log_map(rotation))
+
+        self.assertLess(geodesic_distance(reconstructed, rotation), ATOL)
+
     def test_bridges_single_frame_occlusion_on_linear_z_sequence(self):
         rotations = [z_rotation(0.1 * idx) for idx in range(5)]
         mask = [True, True, False, True, True]


### PR DESCRIPTION
## Bug

`SO3TangentSavitzkyGolaySmoother._log_map()` reconstructs the rotation axis from the symmetric off-diagonal terms when the angle is near π. For a π rotation,

```text
R_ij + R_ji = 4 * axis_i * axis_j
```

but the implementation divided those terms by `2 * axis_i`. For non-axis-aligned rotations this doubled the reconstructed secondary components before normalization and changed the axis direction.

For a π rotation about `(1, 2, 3) / sqrt(14)`, the old log-exp round trip has a geodesic error of approximately `0.679 rad` (`38.9°`). This can corrupt tangent vectors and therefore smoothing results whenever relative rotations approach 180 degrees.

## Fix

- use the required factor of four in the near-π axis reconstruction
- document the identity used by the implementation
- add a regression that checks `exp(log(R)) == R` for a general-axis π rotation

## Validation

- standalone numerical reproduction confirms the old formula fails and the corrected formula round-trips to numerical precision
- branch comparison against `main`: 2 files, `+12/-1`, 0 commits behind
- full backend and repository validation is delegated to GitHub Actions