### PR TITLE
Reject masked sample counts in Gaussian and Dirac distributions

### DIFF
--- a/src/pyrecest/distributions/abstract_dirac_distribution.py
+++ b/src/pyrecest/distributions/abstract_dirac_distribution.py
@@ -36,6 +36,8 @@ from .abstract_distribution_type import AbstractDistributionType
 def _validate_positive_sample_count(n) -> int:
     """Return ``n`` as a positive Python int after scalar-count validation."""
     message = "n must be a positive integer."
+    if np.ma.isMaskedArray(n) and bool(np.ma.getmaskarray(n).any()):
+        raise ValueError(message)
     if isinstance(n, bool):
         raise ValueError(message)
 
@@ -108,7 +110,6 @@ class AbstractDiracDistribution(AbstractDistributionType):
         weight_scale = float(np.max(host_weights))
         if not math.isfinite(weight_scale) or weight_scale <= 0:
             raise ValueError("Dirac weights must have positive finite total mass.")
-
         scaled_total_weight = float(np.sum(host_weights / weight_scale))
         if not math.isfinite(scaled_total_weight) or scaled_total_weight <= 0:
             raise ValueError("Dirac weights must have positive finite total mass.")
@@ -118,7 +119,6 @@ class AbstractDiracDistribution(AbstractDistributionType):
         )
         if not math.isfinite(normalization_root) or normalization_root <= 0:
             raise ValueError("Dirac weights must have positive finite total mass.")
-
         return normalization_root, normalization_root
 
     @staticmethod

--- a/src/pyrecest/distributions/abstract_dirac_distribution.py
+++ b/src/pyrecest/distributions/abstract_dirac_distribution.py
@@ -110,6 +110,7 @@ class AbstractDiracDistribution(AbstractDistributionType):
         weight_scale = float(np.max(host_weights))
         if not math.isfinite(weight_scale) or weight_scale <= 0:
             raise ValueError("Dirac weights must have positive finite total mass.")
+
         scaled_total_weight = float(np.sum(host_weights / weight_scale))
         if not math.isfinite(scaled_total_weight) or scaled_total_weight <= 0:
             raise ValueError("Dirac weights must have positive finite total mass.")
@@ -119,6 +120,7 @@ class AbstractDiracDistribution(AbstractDistributionType):
         )
         if not math.isfinite(normalization_root) or normalization_root <= 0:
             raise ValueError("Dirac weights must have positive finite total mass.")
+
         return normalization_root, normalization_root
 
     @staticmethod

--- a/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
@@ -59,6 +59,8 @@ def _validate_same_dimension(first, second, operation):
 def _validate_positive_sample_count(n) -> int:
     """Return ``n`` as a positive Python int after scalar-count validation."""
     message = "n must be a positive integer."
+    if np.ma.isMaskedArray(n) and bool(np.ma.getmaskarray(n).any()):
+        raise ValueError(message)
     try:
         count_array = np.asarray(n)
     except (OverflowError, TypeError, ValueError) as exc:

--- a/tests/distributions/test_masked_sample_counts.py
+++ b/tests/distributions/test_masked_sample_counts.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pytest
+
+from pyrecest.backend import array
+from pyrecest.distributions import GaussianDistribution, LinearDiracDistribution
+
+
+def _sampleable_distributions():
+    return (
+        GaussianDistribution(array([0.0]), array([[1.0]])),
+        LinearDiracDistribution(array([[0.0], [1.0]]), array([0.5, 0.5])),
+    )
+
+
+@pytest.mark.parametrize(
+    "masked_count",
+    [
+        np.ma.masked,
+        np.ma.array(3, mask=True),
+    ],
+)
+def test_sampling_rejects_genuinely_masked_counts(masked_count):
+    for distribution in _sampleable_distributions():
+        with pytest.raises(ValueError, match="positive integer"):
+            distribution.sample(masked_count)
+
+
+def test_sampling_accepts_unmasked_masked_array_integer():
+    count = np.ma.array(2, mask=False)
+
+    for distribution in _sampleable_distributions():
+        assert distribution.sample(count).shape == (2, 1)


### PR DESCRIPTION
## Bug

NumPy masked scalars expose their hidden payload through ordinary scalar conversion:

```python
np.asarray(np.ma.array(3, mask=True)).item() == 3
operator.index(np.ma.array(3, mask=True)) == 3
```

As a result, both `GaussianDistribution.sample(...)` and Dirac-distribution sampling accepted a genuinely masked count and silently drew the hidden number of samples. A missing configuration value could therefore trigger real work instead of failing validation.

## Fix

- reject NumPy masked scalar counts before payload-exposing conversion
- apply the same contract to Gaussian and Dirac sample-count validators
- continue accepting integer `MaskedArray` scalars whose mask is explicitly false

## Validation

Added focused regression coverage for:

- `np.ma.masked`
- `np.ma.array(3, mask=True)`
- `np.ma.array(2, mask=False)` preserving valid behavior

The final diff is limited to two validation guards and the regression test file.