### PR TITLE
Validate skipped update diagnostics state

### DIFF
--- a/src/pyrecest/filters/update_diagnostics.py
+++ b/src/pyrecest/filters/update_diagnostics.py
@@ -53,7 +53,12 @@ class MeasurementUpdateDiagnostics:
                     "active_measurement_indices must be smaller than measurement_count"
                 )
             object.__setattr__(self, "measurement_count", measurement_count)
-        object.__setattr__(self, "skipped_reason", _normalize_skipped_reason(self.skipped_reason))
+        skipped_reason = _normalize_skipped_reason(self.skipped_reason)
+        if skipped_reason is not None and indices:
+            raise ValueError(
+                "skipped diagnostics must not contain active_measurement_indices"
+            )
+        object.__setattr__(self, "skipped_reason", skipped_reason)
         object.__setattr__(self, "metadata", _normalize_metadata(self.metadata))
 
     @property
@@ -114,8 +119,8 @@ def _normalize_skipped_reason(skipped_reason: str | None) -> str | None:
         return None
     if not isinstance(skipped_reason, str):
         raise ValueError("skipped_reason must be a string or None")
-    if not skipped_reason:
-        raise ValueError("skipped_reason must not be empty")
+    if not skipped_reason.strip():
+        raise ValueError("skipped_reason must not be empty or whitespace-only")
     return skipped_reason
 
 

--- a/tests/filters/test_update_diagnostics_skipped_reason.py
+++ b/tests/filters/test_update_diagnostics_skipped_reason.py
@@ -3,10 +3,22 @@ import pytest
 from pyrecest.filters.update_diagnostics import MeasurementUpdateDiagnostics
 
 
-@pytest.mark.parametrize("skipped_reason", ["", 0, object()])
+@pytest.mark.parametrize("skipped_reason", ["", "   ", 0, object()])
 def test_skipped_reason_rejects_non_text_or_empty_values(skipped_reason):
     with pytest.raises(ValueError, match="skipped_reason"):
         MeasurementUpdateDiagnostics(skipped_reason=skipped_reason)
+
+
+def test_skipped_reason_rejects_active_measurements():
+    with pytest.raises(
+        ValueError,
+        match="skipped diagnostics must not contain active_measurement_indices",
+    ):
+        MeasurementUpdateDiagnostics(
+            active_measurement_indices=[0],
+            measurement_count=1,
+            skipped_reason="gated",
+        )
 
 
 def test_skipped_constructor_accepts_non_empty_reason():


### PR DESCRIPTION
## Bug

`MeasurementUpdateDiagnostics` could represent a contradictory update state: callers could provide both a non-empty `active_measurement_indices` sequence and a `skipped_reason`. The resulting object reported active measurements while `updated` returned `False`, making diagnostics and downstream logging disagree about whether the update used data.

Whitespace-only skip reasons were also accepted, so a skipped update could carry no meaningful explanation despite passing the non-empty string validation.

## Fix

- reject skipped diagnostics that also contain active measurement indices
- reject whitespace-only `skipped_reason` values
- preserve valid accepted-update and `MeasurementUpdateDiagnostics.skipped(...)` behavior

## Validation

- added focused regressions for contradictory skipped states and whitespace-only reasons
- ran a local syntax and focused behavior check for the updated diagnostics module