### PR TITLE
Support multidimensional PyTorch quantiles

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_quantile_empty_batch_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_quantile_empty_batch_contract.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 
 def patch_pytorch_quantile_empty_batch_contract() -> None:
-    """Preserve empty non-reduced dimensions in PyTorch quantile reductions."""
+    """Preserve NumPy quantile shapes unsupported by native PyTorch."""
 
     try:
         import numpy as np  # pylint: disable=import-outside-toplevel
@@ -50,6 +50,7 @@ def patch_pytorch_quantile_empty_batch_contract() -> None:
 
         effective_method = method if interpolation is None else interpolation
         values = raw_pytorch.array(a)
+        q_shape = raw_pytorch._quantile_q_shape(q)
         is_integral_axis = isinstance(
             effective_axis, (int, np.integer)
         ) and not isinstance(effective_axis, (bool, np.bool_))
@@ -67,7 +68,8 @@ def patch_pytorch_quantile_empty_batch_contract() -> None:
                         values, dtype=raw_pytorch.get_default_dtype()
                     )
                 q_arg = raw_pytorch._quantile_q(q, values)
-                q_shape = raw_pytorch._quantile_q_shape(q)
+                if len(q_shape) > 1:
+                    q_arg = q_arg.reshape(-1)
                 validation_values = torch.zeros(
                     values.shape[normalized_axis],
                     dtype=values.dtype,
@@ -90,6 +92,34 @@ def patch_pytorch_quantile_empty_batch_contract() -> None:
                     out.copy_(result)
                     return out
                 return result
+
+        if len(q_shape) > 1:
+            quantile_values = values
+            if not raw_pytorch.is_floating(
+                quantile_values
+            ) and not raw_pytorch.is_complex(quantile_values):
+                quantile_values = raw_pytorch.cast(
+                    quantile_values,
+                    dtype=raw_pytorch.get_default_dtype(),
+                )
+            q_arg = raw_pytorch._quantile_q(q, quantile_values).reshape(-1)
+            result = original_quantile(
+                a,
+                q_arg,
+                axis=axis,
+                out=None,
+                overwrite_input=overwrite_input,
+                method=method,
+                keepdims=keepdims,
+                dim=dim,
+                keepdim=keepdim,
+                interpolation=interpolation,
+            )
+            result = result.reshape(q_shape + tuple(result.shape[1:]))
+            if out is not None:
+                out.copy_(result)
+                return out
+            return result
 
         return original_quantile(
             a,

--- a/tests/backend_support/test_pytorch_quantile_contract.py
+++ b/tests/backend_support/test_pytorch_quantile_contract.py
@@ -33,6 +33,46 @@ assert backend.to_numpy(list_quantile).tolist() == [[1.5, 5.0], [2.5, 7.0]]
 
 
 @pytest.mark.backend_portable
+def test_pytorch_quantile_accepts_multidimensional_q_like_numpy():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import numpy as np
+
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_backend
+
+q = np.array([[0.25, 0.75], [0.1, 0.9]])
+integer_values = [[1, 4], [3, 8]]
+cube = np.arange(24.0).reshape(2, 3, 4)
+
+for target in (backend, raw_backend):
+    column_quantiles = target.quantile(integer_values, q, axis=0)
+    tuple_axis_quantiles = target.quantile(
+        cube,
+        q,
+        axis=(0, 2),
+        keepdims=True,
+    )
+
+    np.testing.assert_allclose(
+        backend.to_numpy(column_quantiles),
+        np.quantile(integer_values, q, axis=0),
+    )
+    np.testing.assert_allclose(
+        backend.to_numpy(tuple_axis_quantiles),
+        np.quantile(cube, q, axis=(0, 2), keepdims=True),
+    )
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.backend_portable
 def test_pytorch_quantile_preserves_empty_batch_dimensions():
     if importlib.util.find_spec("torch") is None:
         pytest.skip("PyTorch is not installed")

--- a/tests/backend_support/test_pytorch_quantile_contract.py
+++ b/tests/backend_support/test_pytorch_quantile_contract.py
@@ -91,10 +91,17 @@ vector_quantile = backend.quantile(
     axis=1,
     keepdims=True,
 )
+matrix_quantile = backend.quantile(
+    values,
+    [[0.25, 0.75], [0.1, 0.9]],
+    axis=1,
+    keepdims=True,
+)
 raw_quantile = raw_backend.quantile(values, 0.5, dim=1, keepdim=True)
 
 assert tuple(scalar_quantile.shape) == (0, 2)
 assert tuple(vector_quantile.shape) == (2, 0, 1, 2)
+assert tuple(matrix_quantile.shape) == (2, 2, 0, 1, 2)
 assert tuple(raw_quantile.shape) == (0, 1, 2)
 """,
     )


### PR DESCRIPTION
## Bug

The PyTorch backend passed `q` directly to `torch.quantile`. NumPy permits quantile arrays with arbitrary shape, but PyTorch accepts only a scalar or one-dimensional `q` tensor. Consequently, valid calls such as a `2 x 2` quantile grid raised:

```text
RuntimeError: quantile() q must be a scalar or 1D tensor
```

The failure affected both the public PyTorch backend and the raw backend, including tuple-axis reductions. The existing empty-batch compatibility path also failed while validating multidimensional quantiles.

## Fix

- flatten multidimensional `q` only for the native `torch.quantile` call
- reshape the result back to NumPy's `q.shape + reduced_shape` contract
- preserve integer-input promotion before converting quantiles
- retain tuple-axis, `keepdims`, `out`, and empty-batch behavior
- apply the repair consistently to public and raw PyTorch backend entry points

## Regression coverage

- compares `2 x 2` quantile grids against `numpy.quantile`
- covers integer inputs and tuple-axis reductions with `keepdims=True`
- verifies multidimensional quantiles preserve empty non-reduced batch dimensions

## Validation

- reproduced the current failure with PyTorch 2.10.0
- syntax-compiled the modified source and regression test
- ran an exact wrapper smoke harness covering public/raw behavior, integer inputs, tuple axes, `keepdims`, and empty batch dimensions
- branch is limited to two files and is based directly on current `main`

The full repository and backend matrices should run in GitHub Actions.