### PR TITLE
Reject masked update diagnostic integers

### DIFF
--- a/src/pyrecest/filters/update_diagnostics.py
+++ b/src/pyrecest/filters/update_diagnostics.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from operator import index as operator_index
 from typing import Any
 
+import numpy as np
+
 _TEXT_SEQUENCE_TYPES = (str, bytes, bytearray)
 _ACTIVE_INDICES_MESSAGE = (
     "active_measurement_indices must be a sequence of non-negative integers"
@@ -129,6 +131,8 @@ def _normalize_metadata(metadata: Mapping[str, Any] | None) -> dict[str, Any]:
 
 def _as_nonnegative_integer(value: Any, name: str) -> int:
     message = f"{name} must be a non-negative integer"
+    if np.ma.isMaskedArray(value) and bool(np.any(np.ma.getmaskarray(value))):
+        raise ValueError(message)
     if _is_boolean_scalar(value):
         raise ValueError(message)
     try:

--- a/tests/filters/test_update_diagnostics_validation.py
+++ b/tests/filters/test_update_diagnostics_validation.py
@@ -20,6 +20,18 @@ def test_active_measurement_indices_reject_non_integer_values():
             MeasurementUpdateDiagnostics(active_measurement_indices=(invalid_index,))
 
 
+def test_active_measurement_indices_reject_masked_integer_values():
+    masked_indices = (
+        np.ma.array(0, mask=True),
+        np.ma.array(7, mask=True),
+        np.ma.masked,
+    )
+
+    for masked_index in masked_indices:
+        with pytest.raises(ValueError, match="active_measurement_indices"):
+            MeasurementUpdateDiagnostics(active_measurement_indices=(masked_index,))
+
+
 def test_active_measurement_indices_reject_non_sequence_values():
     with pytest.raises(ValueError, match="active_measurement_indices"):
         MeasurementUpdateDiagnostics(active_measurement_indices=1)  # type: ignore[arg-type]
@@ -75,11 +87,22 @@ def test_measurement_count_rejects_non_integer_values():
             MeasurementUpdateDiagnostics(measurement_count=invalid_count)
 
 
+def test_measurement_count_rejects_masked_integer_values():
+    for masked_count in (np.ma.array(0, mask=True), np.ma.array(3, mask=True)):
+        with pytest.raises(ValueError, match="measurement_count"):
+            MeasurementUpdateDiagnostics(measurement_count=masked_count)
+
+
 def test_diagnostics_accept_integer_like_numpy_scalars():
     diagnostics = MeasurementUpdateDiagnostics(
-        active_measurement_indices=(0, np.int64(2), np.array(3)),
-        measurement_count=np.int64(4),
+        active_measurement_indices=(
+            0,
+            np.ma.array(1, mask=False),
+            np.int64(2),
+            np.array(3),
+        ),
+        measurement_count=np.ma.array(4, mask=False),
     )
 
-    assert diagnostics.active_measurement_indices == (0, 2, 3)
+    assert diagnostics.active_measurement_indices == (0, 1, 2, 3)
     assert diagnostics.measurement_count == 4


### PR DESCRIPTION
## Bug

`MeasurementUpdateDiagnostics` validates `active_measurement_indices` and `measurement_count` through `operator.index`. NumPy masked integer scalars expose their hidden payload to that conversion, so a genuinely missing value such as `np.ma.array(7, mask=True)` was silently accepted as the integer `7`.

This can make diagnostics report measurements as active, or accept a measurement count, based on inaccessible masked data.

## Fix

- reject NumPy masked scalars and arrays whenever any value is genuinely masked
- retain support for ordinary Python/NumPy integer-like scalars
- retain support for `MaskedArray` integer scalars whose mask is false
- add focused regressions for active indices, measurement counts, and unmasked compatibility

## Validation

- reproduced `operator.index(np.ma.array(7, mask=True)) == 7` before the fix
- syntax-compiled the patched module in isolation
- ran focused behavior checks for masked rejection and unmasked compatibility
- branch comparison: 2 commits ahead of `main`, 0 behind; only the diagnostics helper and its validation test changed

The full repository CI matrix should provide integration and backend coverage.