### PR TITLE
Reject masked MTT scenario flags

### DIFF
--- a/src/pyrecest/evaluation/get_extract_mean.py
+++ b/src/pyrecest/evaluation/get_extract_mean.py
@@ -16,6 +16,8 @@ def _normalize_registry_name(manifold_name: str) -> str:
 
 
 def _coerce_mtt_scenario_flag(value: Any) -> bool:
+    if np.ma.isMaskedArray(value) and bool(np.any(np.ma.getmaskarray(value))):
+        raise ValueError("mtt_scenario must be a bool")
     try:
         value_array = np.asarray(value)
     except (TypeError, ValueError) as exc:

--- a/tests/evaluation/test_get_extract_mean_mtt_flag.py
+++ b/tests/evaluation/test_get_extract_mean_mtt_flag.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from pyrecest.evaluation.get_extract_mean import get_extract_mean
@@ -7,3 +8,24 @@ from pyrecest.evaluation.get_extract_mean import get_extract_mean
 def test_get_extract_mean_rejects_non_boolean_mtt_scenario(mtt_scenario):
     with pytest.raises(ValueError, match="mtt_scenario must be a bool"):
         get_extract_mean("euclidean", mtt_scenario=mtt_scenario)
+
+
+@pytest.mark.parametrize(
+    "mtt_scenario",
+    [
+        np.ma.masked,
+        np.ma.array(True, mask=True),
+        np.ma.array(False, mask=True),
+    ],
+)
+def test_get_extract_mean_rejects_masked_boolean_mtt_scenario(mtt_scenario):
+    with pytest.raises(ValueError, match="mtt_scenario must be a bool"):
+        get_extract_mean("euclidean", mtt_scenario=mtt_scenario)
+
+
+def test_get_extract_mean_accepts_unmasked_boolean_mtt_scenario():
+    extract_mean = get_extract_mean(
+        "euclidean", mtt_scenario=np.ma.array(True, mask=False)
+    )
+
+    assert extract_mean([1, 2]) == [1, 2]


### PR DESCRIPTION
## Bug

`get_extract_mean` validates `mtt_scenario` through `np.asarray`. For a genuinely missing masked Boolean scalar such as `np.ma.array(True, mask=True)`, NumPy exposes the hidden payload as an ordinary scalar Boolean. The flag was therefore silently accepted and could select the multi-target extraction path based on inaccessible data.

## Fix

- reject NumPy masked scalars and arrays whenever any value is genuinely masked
- retain support for Python and NumPy Boolean scalars
- retain support for `MaskedArray` Boolean scalars whose mask is false
- add focused regressions for masked rejection and unmasked compatibility

## Validation

- reproduced the pre-fix behavior where masked `True` and `False` values were converted to their hidden payloads
- ran focused behavior checks covering masked rejection and ordinary/unmasked Boolean acceptance
- branch comparison: 2 commits ahead of `main`, 0 behind; only the flag validator and its focused test changed

The full repository CI matrix should provide integration and backend coverage.