### PR TITLE
Fix PyTorch unsigned extrema promotion

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_minmax_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_minmax_device_contract.py
@@ -44,8 +44,12 @@ def _minmax_operands(raw_pytorch, torch_module, left, right):
         dtype = torch_module.promote_types(left.dtype, right.dtype)
     except RuntimeError as promotion_error:
         try:
-            left_numpy_dtype = torch_module.empty((), dtype=left.dtype).numpy().dtype
-            right_numpy_dtype = torch_module.empty((), dtype=right.dtype).numpy().dtype
+            left_numpy_dtype = (
+                torch_module.empty((), dtype=left.dtype, device="cpu").numpy().dtype
+            )
+            right_numpy_dtype = (
+                torch_module.empty((), dtype=right.dtype, device="cpu").numpy().dtype
+            )
             promoted_numpy_dtype = _np.result_type(
                 left_numpy_dtype,
                 right_numpy_dtype,

--- a/src/pyrecest/backend_support/_pytorch_minmax_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_minmax_device_contract.py
@@ -35,8 +35,29 @@ def _binary_operands(raw_pytorch, torch_module, left, right):
     return left.to(device=device, dtype=dtype), right.to(device=device, dtype=dtype)
 
 
-# Backwards-compatible alias for existing imports/tests that used the old helper name.
-_minmax_operands = _binary_operands
+def _minmax_operands(raw_pytorch, torch_module, left, right):
+    """Return extrema operands using NumPy-compatible dtype promotion."""
+    device = _preferred_pytorch_device(torch_module, left, right)
+    left = raw_pytorch.array(left)
+    right = raw_pytorch.array(right)
+    try:
+        dtype = torch_module.promote_types(left.dtype, right.dtype)
+    except RuntimeError as promotion_error:
+        try:
+            left_numpy_dtype = torch_module.empty((), dtype=left.dtype).numpy().dtype
+            right_numpy_dtype = torch_module.empty((), dtype=right.dtype).numpy().dtype
+            promoted_numpy_dtype = _np.result_type(
+                left_numpy_dtype,
+                right_numpy_dtype,
+            )
+            dtype = torch_module.from_numpy(
+                _np.empty((), dtype=promoted_numpy_dtype)
+            ).dtype
+        except (TypeError, RuntimeError):
+            raise promotion_error
+    if device is None:
+        return left.to(dtype=dtype), right.to(dtype=dtype)
+    return left.to(device=device, dtype=dtype), right.to(device=device, dtype=dtype)
 
 
 def _copy_to_out(result, out):
@@ -184,6 +205,7 @@ def _patch_binary_helpers(
     contract_attr,
     *,
     supports_out=False,
+    operand_normalizer=_binary_operands,
 ):
     """Patch raw/public binary helpers to share dtype and preserve device."""
     if all(
@@ -204,8 +226,19 @@ def _patch_binary_helpers(
 
         if supports_out:
 
-            def binary_helper(left, right, out=None, _torch_helper=torch_helper):
-                left, right = _binary_operands(raw_pytorch, torch_module, left, right)
+            def binary_helper(
+                left,
+                right,
+                out=None,
+                _torch_helper=torch_helper,
+                _operand_normalizer=operand_normalizer,
+            ):
+                left, right = _operand_normalizer(
+                    raw_pytorch,
+                    torch_module,
+                    left,
+                    right,
+                )
                 result = _torch_helper(left, right)
                 if out is None:
                     return result
@@ -213,8 +246,18 @@ def _patch_binary_helpers(
 
         else:
 
-            def binary_helper(left, right, _torch_helper=torch_helper):
-                left, right = _binary_operands(raw_pytorch, torch_module, left, right)
+            def binary_helper(
+                left,
+                right,
+                _torch_helper=torch_helper,
+                _operand_normalizer=operand_normalizer,
+            ):
+                left, right = _operand_normalizer(
+                    raw_pytorch,
+                    torch_module,
+                    left,
+                    right,
+                )
                 return _torch_helper(left, right)
 
         binary_helper.__name__ = getattr(original_helper, "__name__", helper_name)
@@ -247,6 +290,7 @@ def patch_pytorch_minmax_device_contract() -> None:
         },
         "_pyrecest_minmax_device_contract",
         supports_out=True,
+        operand_normalizer=_minmax_operands,
     )
     _patch_binary_helpers(
         raw_pytorch,

--- a/tests/backend_support/test_pytorch_minmax_unsigned_promotion.py
+++ b/tests/backend_support/test_pytorch_minmax_unsigned_promotion.py
@@ -1,0 +1,74 @@
+"""Regression tests for mixed unsigned PyTorch extrema promotion."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+pytestmark = pytest.mark.backend_portable
+
+
+def _unsigned_promotion_code(target_module: str) -> str:
+    return f"""
+import numpy as np
+import torch
+import pyrecest  # noqa: F401  # triggers backend-support compatibility patches
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+
+target = {target_module}
+cases = (
+    (
+        np.array([0, 65535], dtype=np.uint16),
+        np.array([-1, 32767], dtype=np.int16),
+    ),
+    (
+        np.array([1, 2**32 - 1], dtype=np.uint32),
+        np.array([-1, 2**31 - 1], dtype=np.int32),
+    ),
+    (
+        np.array([0, 2**63], dtype=np.uint64),
+        np.array([-1, 2**63 - 1], dtype=np.int64),
+    ),
+)
+
+for left_numpy, right_numpy in cases:
+    left = torch.from_numpy(left_numpy)
+    right = torch.from_numpy(right_numpy)
+
+    maximum_result = target.maximum(left, right)
+    maximum_expected = torch.from_numpy(np.maximum(left_numpy, right_numpy))
+    assert maximum_result.dtype == maximum_expected.dtype
+    assert torch.equal(maximum_result, maximum_expected)
+
+    minimum_result = target.minimum(left, right)
+    minimum_expected = torch.from_numpy(np.minimum(left_numpy, right_numpy))
+    assert minimum_result.dtype == minimum_expected.dtype
+    assert torch.equal(minimum_result, minimum_expected)
+
+print("ok")
+"""
+
+
+def test_raw_pytorch_minmax_matches_numpy_unsigned_promotion():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code("numpy", _unsigned_promotion_code("raw_pytorch"))
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_public_pytorch_minmax_matches_numpy_unsigned_promotion():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code("pytorch", _unsigned_promotion_code("backend"))
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Bug

The PyTorch backend compatibility layer normalized `maximum` and `minimum` operands with `torch.promote_types`. PyTorch raises `RuntimeError` for several valid mixed unsigned/signed integer pairs, including `uint16` with `int16`, `uint32` with `int32`, and `uint64` with `int64`.

The same calls work under the NumPy backend, so backend-portable code could fail solely because `PYRECEST_BACKEND=pytorch` was selected.

## Fix

- keep the existing PyTorch promotion path for supported dtype pairs
- use NumPy `result_type` as a narrowly scoped fallback for extrema when PyTorch cannot resolve the pair
- convert the resolved NumPy dtype back to the corresponding PyTorch dtype
- leave `equal`, `less_equal`, and `logical_and` on their existing comparison-specific path
- preserve existing device selection and NumPy-style `out=` handling

## Validation

- reproduced the pre-fix `torch.promote_types` failures locally with PyTorch 2.10
- verified the fallback against `numpy.maximum` and `numpy.minimum` for mixed `uint16/int16`, `uint32/int32`, and `uint64/int64` arrays
- added subprocess regressions for both the raw PyTorch module and the public PyTorch backend facade
- branch comparison: 2 commits ahead of `main`, 0 behind; only the compatibility hook and focused regression file changed

The full repository CI matrix should provide integration and supported-PyTorch-version coverage.