### PR TITLE
Reject masked transition sample counts

### DIFF
--- a/src/pyrecest/models/likelihood.py
+++ b/src/pyrecest/models/likelihood.py
@@ -42,18 +42,21 @@ def _ensure_callable(value: Any, name: str) -> None:
 def _validate_sample_count(value: Any) -> int:
     """Return ``value`` as a nonnegative integer sample count."""
 
+    message = "n must be a nonnegative integer."
+    if np.ma.is_masked(value):
+        raise ValueError(message)
     try:
         value_array = np.asarray(value)
     except (TypeError, ValueError, OverflowError) as exc:
-        raise ValueError("n must be a nonnegative integer.") from exc
+        raise ValueError(message) from exc
     if value_array.shape != () or value_array.dtype == np.bool_:
-        raise ValueError("n must be a nonnegative integer.")
+        raise ValueError(message)
     scalar = value_array.item()
     if isinstance(scalar, (bool, np.bool_)) or not isinstance(scalar, Integral):
-        raise ValueError("n must be a nonnegative integer.")
+        raise ValueError(message)
     count = int(scalar)
     if count < 0:
-        raise ValueError("n must be a nonnegative integer.")
+        raise ValueError(message)
     return count
 
 

--- a/tests/models/test_transition_sample_count_validation.py
+++ b/tests/models/test_transition_sample_count_validation.py
@@ -30,6 +30,7 @@ class TransitionSampleCountValidationTest(unittest.TestCase):
             np.array([2]),
             np.array(True, dtype=object),
             np.array("2"),
+            np.ma.array(2, mask=True),
         )
 
         for n in invalid_counts:
@@ -49,9 +50,10 @@ class TransitionSampleCountValidationTest(unittest.TestCase):
         model = SampleableTransitionModel(sample_next)
 
         sample_next_state(model, array([0.0]), n=np.array(2, dtype=np.int64))
+        sample_next_state(model, array([0.0]), n=np.ma.array(3, mask=False))
 
-        self.assertEqual(calls, [2])
-        self.assertIs(type(calls[0]), int)
+        self.assertEqual(calls, [2, 3])
+        self.assertTrue(all(type(count) is int for count in calls))
 
     def test_density_transition_model_rejects_invalid_sample_counts(self):
         calls = []
@@ -65,7 +67,7 @@ class TransitionSampleCountValidationTest(unittest.TestCase):
 
         model = DensityTransitionModel(transition_density, sample_next=sample_next)
 
-        for n in (True, -1, "2", np.array([2])):
+        for n in (True, -1, "2", np.array([2]), np.ma.array(2, mask=True)):
             with self.subTest(n=n):
                 with self.assertRaisesRegex(ValueError, "n must be"):
                     model.sample_next(array([0.0]), n=n)


### PR DESCRIPTION
## Bug

`_validate_sample_count()` converted inputs with `np.asarray()` before accounting for NumPy masked-array semantics. A genuinely masked integer scalar such as `np.ma.array(2, mask=True)` therefore exposed its hidden payload and was accepted as sample count `2`.

This could turn a missing transition-sampling configuration value into a real request and invoke sampler callbacks with an unintended count.

## Fix

- reject genuinely masked sample-count inputs before NumPy scalar conversion
- preserve support for ordinary NumPy integer scalars
- preserve support for unmasked integer-valued `MaskedArray` scalars
- add regressions for both `SampleableTransitionModel` and `DensityTransitionModel`

## Validation

- reproduced the old behavior in isolation: a masked integer scalar normalized to its hidden payload
- syntax-compiled the modified source and regression test
- ran isolated validator checks for masked rejection and ordinary/unmasked compatibility
- branch comparison: 2 commits ahead of `main`, 0 behind; only the sample-count validator and its focused tests changed

The full repository CI matrix should provide integration and backend coverage.