### PR TITLE
Reject fractional PyTorch split section counts

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_split_index_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_split_index_contract.py
@@ -16,6 +16,35 @@ from pyrecest.backend_support._pytorch_take_index_contract import (
 _SPLIT_INDEX_TYPE_MESSAGE = (
     "slice indices must be integers or None or have an __index__ method"
 )
+_SPLIT_SECTION_COUNT_MESSAGE = "number sections must be an integer"
+
+
+def _normalize_split_section_count(indices_or_sections, torch_module):
+    """Return a scalar section count without truncating fractional values."""
+
+    if torch_module.is_tensor(indices_or_sections):
+        scalar = indices_or_sections.item()
+    else:
+        scalar = np.asarray(indices_or_sections).item()
+
+    if isinstance(scalar, (bool, np.bool_)):
+        return int(scalar)
+
+    try:
+        return _operator_index(scalar)
+    except TypeError:
+        pass
+
+    if isinstance(scalar, (str, bytes, np.str_, np.bytes_)):
+        raise TypeError(_SPLIT_INDEX_TYPE_MESSAGE)
+
+    try:
+        scalar_float = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise TypeError(_SPLIT_INDEX_TYPE_MESSAGE) from exc
+    if not np.isfinite(scalar_float) or not scalar_float.is_integer():
+        raise ValueError(_SPLIT_SECTION_COUNT_MESSAGE)
+    return int(scalar_float)
 
 
 def _normalize_split_cut_indices(indices_or_sections, torch_module):
@@ -26,14 +55,14 @@ def _normalize_split_cut_indices(indices_or_sections, torch_module):
 
     if torch_module.is_tensor(indices_or_sections):
         if indices_or_sections.ndim == 0:
-            return indices_or_sections
+            return _normalize_split_section_count(indices_or_sections, torch_module)
         if indices_or_sections.ndim != 1:
             raise ValueError("indices_or_sections must be a 1-D sequence")
         cut_points = tuple(indices_or_sections)
     else:
         cut_array = np.asarray(indices_or_sections)
         if cut_array.ndim == 0:
-            return indices_or_sections
+            return _normalize_split_section_count(indices_or_sections, torch_module)
         if cut_array.ndim != 1:
             raise ValueError("indices_or_sections must be a 1-D sequence")
         cut_points = (

--- a/tests/backend_support/test_pytorch_split_scalar_sections_contract.py
+++ b/tests/backend_support/test_pytorch_split_scalar_sections_contract.py
@@ -1,0 +1,66 @@
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+pytestmark = pytest.mark.backend_portable
+
+
+_SPLIT_SCALAR_SECTIONS_CODE = r"""
+import numpy as np
+import torch
+import pyrecest  # noqa: F401  # triggers backend-support compatibility patches
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+
+split_functions = [raw_pytorch.split]
+if backend.__backend_name__ == "pytorch":
+    split_functions.append(backend.split)
+
+for split_func in split_functions:
+    for sections in (
+        2.5,
+        np.array(2.5),
+        np.float64(2.5),
+        torch.tensor(2.5),
+    ):
+        try:
+            split_func([0, 1, 2, 3], sections)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(
+                f"{split_func.__module__} silently truncated fractional "
+                f"sections {sections!r}"
+            )
+
+    for sections in (
+        2,
+        2.0,
+        np.array(2.0),
+        np.float64(2.0),
+        torch.tensor(2),
+        torch.tensor(2.0),
+    ):
+        parts = split_func([0, 1, 2, 3], sections)
+        assert [raw_pytorch.to_numpy(part).tolist() for part in parts] == [
+            [0, 1],
+            [2, 3],
+        ]
+
+print("ok")
+"""
+
+
+@pytest.mark.parametrize("backend_name", ["numpy", "pytorch"])
+def test_pytorch_split_rejects_fractional_scalar_section_counts(backend_name):
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(backend_name, _SPLIT_SCALAR_SECTIONS_CODE)
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Bug

The PyTorch backend compatibility wrapper normalizes scalar `indices_or_sections` inputs before delegating to `split`. For zero-dimensional Python, NumPy, and PyTorch floating-point values, it previously returned the scalar unchanged. The raw backend then applied `int(...)`, so a value such as `2.5` was silently truncated to `2` and split the input into two sections instead of rejecting the invalid section count.

## Fix

- normalize scalar section counts explicitly before calling the raw PyTorch backend
- reject non-finite or fractional scalar counts rather than truncating them
- retain support for valid integer-like Python, NumPy, and PyTorch scalars such as `2`, `2.0`, `np.array(2.0)`, and `torch.tensor(2.0)`
- convert zero-dimensional tensor counts to host scalars in the compatibility layer, avoiding the raw NumPy conversion path

## Validation

- reproduced the pre-fix truncation for Python, NumPy, and PyTorch `2.5` scalars
- syntax-compiled the modified helper and regression test
- added subprocess tests under both NumPy-active and PyTorch-active backend configurations
- branch comparison: 2 commits ahead of `main`, 0 behind; changes are limited to the split compatibility helper and its regression test

The full repository CI matrix should provide integration and backend coverage.