### PR TITLE
Reject masked delayed-output step indices

### DIFF
--- a/src/pyrecest/smoothers/delayed_output.py
+++ b/src/pyrecest/smoothers/delayed_output.py
@@ -13,6 +13,8 @@ import operator
 from collections.abc import Callable
 from typing import Any, TypeAlias
 
+import numpy as np
+
 DelayedStateOutput: TypeAlias = tuple[int, Any]
 
 
@@ -31,6 +33,8 @@ def _as_step_index(value: Any, name: str) -> int:
     """Normalize a genuine integer scalar without lossy coercion."""
 
     message = f"{name} must be an integer"
+    if np.ma.isMaskedArray(value) and bool(np.any(np.ma.getmaskarray(value))):
+        raise ValueError(message)
     if _is_boolean_scalar(value):
         raise ValueError(message)
     try:

--- a/tests/smoothers/test_delayed_output.py
+++ b/tests/smoothers/test_delayed_output.py
@@ -72,6 +72,21 @@ def test_delayed_output_queue_rejects_noninteger_steps(step) -> None:
     assert smoother.last_emitted_step == -1
 
 
+def test_delayed_output_rejects_masked_step_cursors() -> None:
+    masked_step = np.ma.array(2, mask=True)
+    smoother = _DummyDelayedOutputSmoother()
+
+    with pytest.raises(ValueError, match="step must be an integer"):
+        smoother._queue_delayed_state(masked_step, "state")
+    with pytest.raises(ValueError, match="last_emitted_step must be an integer"):
+        smoother._initialize_delayed_state_outputs(last_emitted_step=masked_step)
+    with pytest.raises(ValueError, match="current_step must be an integer"):
+        smoother._finalize_delayed_state_outputs(masked_step, lambda step: step)
+
+    assert smoother.pop_ready_states() == []
+    assert smoother.last_emitted_step == -1
+
+
 def test_delayed_output_cursor_arguments_require_integer_scalars() -> None:
     smoother = _DummyDelayedOutputSmoother()
 
@@ -86,5 +101,6 @@ def test_delayed_output_accepts_numpy_integer_steps() -> None:
     smoother = _DummyDelayedOutputSmoother()
 
     assert smoother._queue_delayed_state(np.int64(2), "state")
-    assert smoother.pop_ready_states() == [(2, "state")]
-    assert smoother.last_emitted_step == 2
+    assert smoother._queue_delayed_state(np.ma.array(3, mask=False), "masked-state")
+    assert smoother.pop_ready_states() == [(2, "state"), (3, "masked-state")]
+    assert smoother.last_emitted_step == 3


### PR DESCRIPTION
## Bug

The fixed-lag smoother delayed-output helper validates step cursors with `operator.index`. NumPy masked integer scalars expose their hidden payload to that conversion, so a genuinely missing value such as `np.ma.array(2, mask=True)` was silently accepted as step `2`.

For queued or finalized outputs, this can advance the delayed-output cursor based on inaccessible data and cause valid trajectory states to be skipped as already emitted.

## Fix

- reject NumPy masked scalars or arrays whenever any step value is genuinely masked
- apply the shared validation to queued steps, initialization cursors, and finalization cursors
- preserve support for ordinary NumPy integer scalars
- preserve support for integer-valued `MaskedArray` scalars whose mask is false
- add focused regressions covering all three cursor entry points and the unmasked compatibility case

## Validation

- reproduced the pre-fix behavior: `operator.index(np.ma.array(2, mask=True))` returns the hidden value `2`
- syntax-compiled the isolated module and tests
- ran the focused delayed-output regression suite: `13 passed`
- branch comparison: 2 commits ahead of `main`, 0 behind; changes are limited to the shared delayed-output helper and its tests

The full repository CI matrix should provide integration coverage.