### PR TITLE
Reject negative PyTorch one-hot class counts

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_one_hot_scalar_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_one_hot_scalar_contract.py
@@ -6,6 +6,7 @@ from operator import index as _operator_index
 
 
 _INTEGER_MESSAGE = "num_classes must be an integer"
+_NONNEGATIVE_MESSAGE = "num_classes must be non-negative"
 
 
 def _is_boolean_take_axis(axis, torch_module) -> bool:
@@ -20,7 +21,7 @@ def _is_boolean_take_axis(axis, torch_module) -> bool:
 
 
 def _normalize_num_classes(num_classes, torch_module) -> int:
-    """Return a non-boolean integer ``num_classes`` value."""
+    """Return a non-negative, non-boolean integer ``num_classes`` value."""
     if isinstance(num_classes, bool) or type(num_classes).__name__ == "bool_":
         raise TypeError(f"{_INTEGER_MESSAGE}, not boolean")
     if torch_module.is_tensor(num_classes):
@@ -28,9 +29,12 @@ def _normalize_num_classes(num_classes, torch_module) -> int:
             raise TypeError(_INTEGER_MESSAGE)
         num_classes = num_classes.item()
     try:
-        return _operator_index(num_classes)
+        normalized = _operator_index(num_classes)
     except TypeError as exc:
         raise TypeError(_INTEGER_MESSAGE) from exc
+    if normalized < 0:
+        raise ValueError(_NONNEGATIVE_MESSAGE)
+    return normalized
 
 
 def _patch_pytorch_take_axis_contract(pytorch_backend, torch_module) -> None:

--- a/tests/backend_support/test_pytorch_one_hot_scalar_contract.py
+++ b/tests/backend_support/test_pytorch_one_hot_scalar_contract.py
@@ -38,6 +38,14 @@ for bad_num_classes in (True, torch.tensor(True)):
     else:
         raise AssertionError("boolean num_classes was accepted")
 
+for bad_num_classes in (-1, torch.tensor(-1)):
+    try:
+        target.one_hot([0], bad_num_classes)
+    except ValueError as exc:
+        assert "num_classes must be non-negative" in str(exc)
+    else:
+        raise AssertionError("negative num_classes was accepted")
+
 device = torch.device("cuda") if torch.cuda.is_available() else torch.device("meta")
 device_result = target.one_hot(torch.tensor(2, device=device), 4)
 assert device_result.device.type == device.type


### PR DESCRIPTION
## Summary
- reject negative `num_classes` values in the PyTorch `one_hot` compatibility layer
- cover both Python integers and scalar PyTorch tensors
- verify the behavior through the raw PyTorch backend and the public PyTorch backend facade

## Root cause
PyTorch reserves `num_classes=-1` as a sentinel that infers the class count from the labels. PyRecEst exposes `num_classes` as an explicit dimension, and its NumPy/JAX implementations reject negative dimensions. Passing `-1` therefore silently produced a valid one-hot matrix only on the PyTorch backend instead of rejecting invalid input.

## Impact
Invalid negative class counts now fail consistently instead of changing meaning depending on the selected backend.

## Validation
- reproduced the pre-fix behavior under both NumPy-active/raw-PyTorch and public PyTorch configurations
- exercised the patched compatibility hook locally for both configurations
- preserved scalar-label, batched-label, dtype, and device behavior