### PR TITLE
Accept scalar tensor fractional matrix powers

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -491,8 +491,14 @@ def fractional_matrix_power(A, t):
     """Compute the fractional power of a matrix."""
     A = _as_linalg_tensor(A)
     A_np = _as_numpy_no_grad(A)
+    exponent = _as_numpy_no_grad(t)
+    if exponent.ndim != 0:
+        raise TypeError("t must be a scalar")
+    exponent = exponent.item()
     out = _np.vectorize(
-        lambda one_matrix: _scipy.linalg.fractional_matrix_power(one_matrix, t),
+        lambda one_matrix: _scipy.linalg.fractional_matrix_power(
+            one_matrix, exponent
+        ),
         signature="(n,n)->(n,n)",
     )(A_np)
 

--- a/tests/backend_support/test_pytorch_fractional_matrix_power_contract.py
+++ b/tests/backend_support/test_pytorch_fractional_matrix_power_contract.py
@@ -56,3 +56,29 @@ print("ok")
 
     assert result.returncode == 0, result.stderr
     assert "ok" in result.stdout
+
+
+@pytest.mark.backend_portable
+def test_pytorch_fractional_matrix_power_accepts_scalar_tensor_exponent():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import pyrecest.backend as backend
+
+values = backend.array([[4.0, 0.0], [0.0, 9.0]], dtype=backend.float64)
+exponent = backend.array(0.5, dtype=backend.float64)
+
+result = backend.linalg.fractional_matrix_power(values, exponent)
+expected = backend.array([[2.0, 0.0], [0.0, 3.0]], dtype=backend.float64)
+
+assert result.dtype == backend.float64
+assert backend.allclose(result, expected, atol=1e-10, rtol=1e-10)
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Bug

On the PyTorch backend, `backend.linalg.fractional_matrix_power(A, backend.array(0.5))` passed the scalar tensor directly into SciPy. SciPy then attempted NumPy exponentiation with a PyTorch tensor and raised `TypeError`, even though the equivalent Python-float exponent worked.

## Fix

- convert the exponent through the existing no-gradient CPU/NumPy bridge
- require the converted exponent to be scalar
- pass its Python scalar value to SciPy
- add a backend-portable regression using a PyTorch scalar tensor exponent

## Impact

PyTorch callers can use backend-native scalar exponents consistently with other scalar-like linear-algebra arguments. Non-scalar exponents now fail early with a clear error instead of reaching an opaque SciPy failure.

## Validation

- reproduced the pre-fix SciPy/PyTorch `TypeError`
- exercised the patched bridge on a `diag(4, 9)` square-root case
- verified explicit rejection of a one-dimensional exponent tensor
- compiled both changed Python files with `py_compile`
- GitHub Actions will run the repository test and backend matrix on this PR