### PR TITLE
Reject conflicting PyTorch quantile method aliases

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_quantile_empty_batch_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_quantile_empty_batch_contract.py
@@ -3,6 +3,11 @@
 from __future__ import annotations
 
 
+_QUANTILE_METHOD_CONFLICT_MESSAGE = (
+    "quantile() cannot specify both 'method' and 'interpolation'"
+)
+
+
 def patch_pytorch_quantile_empty_batch_contract() -> None:
     """Preserve NumPy quantile shapes unsupported by native PyTorch."""
 
@@ -48,6 +53,8 @@ def patch_pytorch_quantile_empty_batch_contract() -> None:
                 raise TypeError("quantile() got both 'keepdims' and 'keepdim'")
             effective_keepdims = keepdim
 
+        if interpolation is not None and method != "linear":
+            raise TypeError(_QUANTILE_METHOD_CONFLICT_MESSAGE)
         effective_method = method if interpolation is None else interpolation
         values = raw_pytorch.array(a)
         q_shape = raw_pytorch._quantile_q_shape(q)

--- a/tests/backend_support/test_pytorch_quantile_contract.py
+++ b/tests/backend_support/test_pytorch_quantile_contract.py
@@ -33,6 +33,40 @@ assert backend.to_numpy(list_quantile).tolist() == [[1.5, 5.0], [2.5, 7.0]]
 
 
 @pytest.mark.backend_portable
+def test_pytorch_quantile_rejects_conflicting_method_aliases():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import pytest
+
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_backend
+
+for target in (backend, raw_backend):
+    with pytest.raises(TypeError, match="method.*interpolation"):
+        target.quantile(
+            [0.0, 10.0],
+            0.25,
+            method="nearest",
+            interpolation="linear",
+        )
+
+    alias_result = target.quantile(
+        [0.0, 10.0],
+        0.25,
+        interpolation="nearest",
+    )
+    assert float(alias_result) == 0.0
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.backend_portable
 def test_pytorch_quantile_accepts_multidimensional_q_like_numpy():
     if importlib.util.find_spec("torch") is None:
         pytest.skip("PyTorch is not installed")


### PR DESCRIPTION
## Bug

The PyTorch quantile compatibility wrapper accepted both a non-default `method` and the deprecated `interpolation` alias, then silently let `interpolation` override `method`. NumPy rejects this ambiguous call, so identical backend-portable code changed meaning only under PyRecEst's PyTorch backend.

For example, `quantile(..., method="nearest", interpolation="linear")` returned a linear quantile instead of raising.

## Fix

- reject simultaneous `interpolation` and non-default `method` arguments
- retain support for `interpolation` when it is used by itself
- apply the behavior to both `pyrecest.backend.quantile` and the raw PyTorch backend through the existing runtime contract patch
- add a portable regression covering the conflict and the valid deprecated-alias path

## Impact

Ambiguous quantile calls now fail consistently with NumPy instead of silently selecting one interpolation rule.

## Validation

- `python -m py_compile src/pyrecest/backend_support/_pytorch_quantile_empty_batch_contract.py tests/backend_support/test_pytorch_quantile_contract.py`
- exact runtime-patch harness with PyTorch 2.10 verifies both public/raw backends raise for conflicting selectors and still accept `interpolation` alone
- repository diff is limited to 7 implementation lines and 34 regression-test lines