### PR TITLE
Deduplicate residual MHT candidate IDs

### DIFF
--- a/src/pyrecest/tracking/residual_hypothesis_mht.py
+++ b/src/pyrecest/tracking/residual_hypothesis_mht.py
@@ -14,6 +14,9 @@ ResidualMHTPreset = Literal["conservative", "frontier", "multi_family"]
 class ResidualEditCandidate:
     """One discrete residual edit candidate.
 
+    ``candidate_id`` uniquely identifies the edit. If the input frontier contains
+    duplicate IDs, only the highest-scoring candidate is retained.
+
     ``family`` is an optional generic grouping label, such as ``"split"``,
     ``"merge"``, or ``"terminal_veto"``.  It has no intrinsic meaning to
     PyRecEst, but :class:`ResidualMHTConfig` can cap the number of edits selected
@@ -225,9 +228,17 @@ def _candidate_frontier(
     filtered.sort(
         key=lambda candidate: (-float(candidate.score), str(candidate.candidate_id))
     )
+    unique_candidates = []
+    seen_candidate_ids: set[str] = set()
+    for candidate in filtered:
+        candidate_id = str(candidate.candidate_id)
+        if candidate_id in seen_candidate_ids:
+            continue
+        seen_candidate_ids.add(candidate_id)
+        unique_candidates.append(candidate)
     if config.candidate_top_k is not None:
-        return tuple(filtered[: max(0, int(config.candidate_top_k))])
-    return tuple(filtered)
+        return tuple(unique_candidates[: max(0, int(config.candidate_top_k))])
+    return tuple(unique_candidates)
 
 
 def _compatible(

--- a/tests/tracking/test_residual_hypothesis_mht_duplicate_ids.py
+++ b/tests/tracking/test_residual_hypothesis_mht_duplicate_ids.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pyrecest.tracking import (
+    ResidualEditCandidate,
+    ResidualMHTConfig,
+    enumerate_residual_hypotheses,
+)
+
+
+def test_duplicate_candidate_ids_are_deduplicated_before_frontier_limits():
+    hypotheses = enumerate_residual_hypotheses(
+        [
+            ResidualEditCandidate("a", 5.0),
+            ResidualEditCandidate("a", 4.0),
+            ResidualEditCandidate("b", 3.0),
+        ],
+        config=ResidualMHTConfig(
+            max_edits=2,
+            max_hypotheses=8,
+            edit_penalty=0.0,
+            candidate_top_k=2,
+            include_empty=False,
+        ),
+    )
+
+    assert hypotheses[0].candidate_ids == ("a", "b")
+    assert hypotheses[0].score == 8.0
+    assert all(
+        len(hypothesis.candidate_ids) == len(set(hypothesis.candidate_ids))
+        for hypothesis in hypotheses
+    )
+    assert {hypothesis.candidate_ids for hypothesis in hypotheses} == {
+        ("a", "b"),
+        ("a",),
+        ("b",),
+    }


### PR DESCRIPTION
## Summary

- deduplicate residual edit candidates by `candidate_id` before applying frontier-size limits
- retain the highest-scoring candidate for each ID using the existing deterministic sort order
- add a regression proving duplicate IDs cannot be selected twice or crowd out a unique edit

## Bug

`_candidate_frontier()` previously applied `candidate_top_k` to the raw sorted candidate sequence. When two candidates described the same logical edit with the same `candidate_id`, both could enter the bounded frontier and the combination enumerator could construct a hypothesis such as `("a", "a")`.

That double-counted one edit's score and could exclude another unique candidate from the top-k frontier. In the focused reproduction, scores `a=5`, duplicate `a=4`, and `b=3` produced `("a", "a")` with score 9 instead of the valid `("a", "b")` hypothesis with score 8.

## Fix

After sorting candidates by descending score and stable candidate ID, keep only the first candidate for each string-normalized `candidate_id`. Apply `candidate_top_k` to that unique frontier. This preserves the highest-scoring representation of each edit and guarantees that one logical edit cannot occur twice in a hypothesis.

## Validation

- focused residual-MHT test suite with the regression: `11 passed`
- the new regression fails on the previous implementation with actual candidate IDs `("a", "a")`
- patched module and test pass `py_compile`
- repository GitHub Actions will exercise the normal test matrix
