### PR TITLE
Preserve NumPy RNG state in temporary seeds

### DIFF
--- a/src/pyrecest/reproducibility.py
+++ b/src/pyrecest/reproducibility.py
@@ -124,12 +124,16 @@ def set_backend_random_state(state: Any) -> None:
 
 @contextmanager
 def preserve_backend_random_state() -> Iterator[None]:
-    """Temporarily preserve and restore the active backend random state."""
+    """Temporarily preserve backend and NumPy random state."""
     state = copy.deepcopy(get_backend_random_state())
+    numpy_state = copy.deepcopy(np.random.get_state())
     try:
         yield
     finally:
-        set_backend_random_state(state)
+        try:
+            set_backend_random_state(state)
+        finally:
+            np.random.set_state(numpy_state)
 
 
 @contextmanager

--- a/tests/test_reproducibility_numpy_state.py
+++ b/tests/test_reproducibility_numpy_state.py
@@ -1,0 +1,49 @@
+"""Regression tests for coupled backend and NumPy RNG state."""
+
+from __future__ import annotations
+
+import copy
+from unittest.mock import patch
+
+import numpy as np
+from numpy.testing import assert_array_equal
+from pyrecest.reproducibility import temporary_seed
+
+
+class _CoupledRandomBackend:
+    """Backend whose seed operation also resets NumPy's global RNG."""
+
+    def __init__(self) -> None:
+        self.state = {"seed": "original"}
+
+    def get_state(self):
+        return copy.deepcopy(self.state)
+
+    def set_state(self, state) -> None:
+        self.state = copy.deepcopy(state)
+
+    def seed(self, seed: int) -> None:
+        self.state = {"seed": seed}
+        np.random.seed(seed)
+
+
+def test_temporary_seed_restores_numpy_state_for_coupled_backend() -> None:
+    outer_numpy_state = np.random.get_state()
+    try:
+        np.random.seed(1234)
+        expected_first = np.random.random(4)
+        expected_second = np.random.random(4)
+
+        np.random.seed(1234)
+        assert_array_equal(np.random.random(4), expected_first)
+
+        backend = _CoupledRandomBackend()
+        with patch("pyrecest.reproducibility._random_backend", return_value=backend):
+            with temporary_seed(7):
+                np.random.random(20)
+                assert backend.state == {"seed": 7}
+
+        assert backend.state == {"seed": "original"}
+        assert_array_equal(np.random.random(4), expected_second)
+    finally:
+        np.random.set_state(outer_numpy_state)


### PR DESCRIPTION
## Bug

`temporary_seed()` preserved only the active backend's reported RNG state. The JAX backend's `seed()` also resets NumPy's global RNG, while its `get_state()`/`set_state()` pair covers only the JAX key. Leaving a temporary seed context could therefore silently change subsequent NumPy draws.

## Fix

- preserve NumPy's global RNG state alongside the active backend state
- restore NumPy in a nested `finally` block even if backend restoration raises
- add a backend-agnostic regression using a fake backend whose seed operation is coupled to NumPy

## Impact

Temporary seeding no longer leaks into NumPy-based code when the active backend maintains a separate RNG state.

## Validation

- focused standalone execution of the regression scenario
- verified the committed source and test on the branch
- repository CI will run on this draft PR