### PR TITLE
Reject non-finite DP birth parameters

### DIFF
--- a/src/pyrecest/filters/dirichlet_process_birth_tracker.py
+++ b/src/pyrecest/filters/dirichlet_process_birth_tracker.py
@@ -35,8 +35,8 @@ class DirichletProcessBirthAtom:
             self.mean.shape[0],
         )
         self.count = float(self.count)
-        if self.count <= 0.0:
-            raise ValueError("count must be positive")
+        if not np.isfinite(self.count) or self.count <= 0.0:
+            raise ValueError("count must be finite and positive")
 
     def copy(self):
         """Return a deep copy of the birth atom."""
@@ -279,8 +279,8 @@ class DirichletProcessBirthMultiBernoulliTracker(MultiBernoulliTracker):
         birth_covariance,
     ):
         concentration = float(self.tracker_param["dp_concentration"])
-        if concentration <= 0.0:
-            raise ValueError("dp_concentration must be positive")
+        if not np.isfinite(concentration) or concentration <= 0.0:
+            raise ValueError("dp_concentration must be finite and positive")
 
         base_likelihood = _linear_gaussian_likelihood(
             measurement,

--- a/tests/filters/test_dirichlet_process_birth_tracker.py
+++ b/tests/filters/test_dirichlet_process_birth_tracker.py
@@ -3,6 +3,7 @@ import pytest
 
 import pyrecest.backend
 from pyrecest.filters.dirichlet_process_birth_tracker import (
+    DPBirthAtom,
     DPBirthMultiBernoulliTracker,
     DirichletProcessBirthMultiBernoulliTracker,
 )
@@ -87,6 +88,26 @@ def test_nearby_unassigned_measurement_reuses_existing_birth_atom():
     assert len(tracker.birth_atoms) == 1
     assert tracker.birth_atoms[0].count > 1.0
     assert tracker.last_birth_diagnostics[-1]["action"] == "existing_atom"
+
+
+@pytest.mark.parametrize("invalid_count", [np.nan, np.inf, -np.inf])
+def test_birth_atom_rejects_nonfinite_count(invalid_count):
+    with pytest.raises(ValueError, match="count must be finite and positive"):
+        DPBirthAtom(np.zeros(2), np.eye(2), invalid_count)
+
+
+@pytest.mark.parametrize("invalid_concentration", [np.nan, np.inf, -np.inf])
+def test_tracker_rejects_nonfinite_dp_concentration(invalid_concentration):
+    tracker, measurement_matrix, measurement_covariance = _tracker(
+        dp_concentration=invalid_concentration
+    )
+
+    with pytest.raises(ValueError, match="dp_concentration must be finite and positive"):
+        tracker._create_birth_component_from_measurement(
+            np.zeros(2),
+            measurement_matrix,
+            measurement_covariance,
+        )
 
 
 def test_alias_export_matches_long_class_name():


### PR DESCRIPTION
## Summary

Reject non-finite Dirichlet-process birth atom counts and concentration values before they enter tracker calculations.

## Root cause

The existing positivity checks relied only on comparisons such as `count <= 0` and `concentration <= 0`. Comparisons with `NaN` are false, so `NaN` passed validation. Positive infinity also passed the concentration check and could make the birth probability calculation evaluate `inf / inf`, producing `NaN`.

## Fix

- require DP birth atom counts to be finite and positive
- require `dp_concentration` to be finite and positive
- add regression tests for `NaN`, positive infinity, and negative infinity

## Impact

Invalid tracker parameters now fail immediately with clear `ValueError` messages instead of silently contaminating atom scores, pruning behavior, diagnostics, and birth existence probabilities.

## Validation

Added focused NumPy-backend regression tests. The repository's GitHub Actions checks should run against the resulting two-file diff.