### PR TITLE
Stabilize complex ACG PDF evaluation

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/complex_angular_central_gaussian_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/complex_angular_central_gaussian_distribution.py
@@ -9,6 +9,7 @@ from pyrecest.backend import (
     array,
     complex128,
     conj,
+    diagonal,
     exp,
     eye,
     gammaln,
@@ -116,7 +117,10 @@ class ComplexAngularCentralGaussianDistribution:
         d = self.dim
         # gamma(d) / (2 * pi^d) in log space: gammaln(d) - log(2) - d*log(pi)
         log_normalizer = gammaln(array(float(d))) - log(2.0) - d * log(array(pi))
-        p = exp(log_normalizer) * abs(inner) ** (-d) / abs(linalg.det(self.C))
+        cholesky_factor = linalg.cholesky(self.C)
+        log_determinant = 2.0 * sum(log(real(diagonal(cholesky_factor))))
+        log_density = log_normalizer - d * log(abs(inner)) - log_determinant
+        p = exp(log_density)
 
         if single:
             return p[0]

--- a/tests/distributions/test_complex_acg_pdf_scale_invariance.py
+++ b/tests/distributions/test_complex_acg_pdf_scale_invariance.py
@@ -1,0 +1,34 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+import pyrecest.backend
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array, complex128, isfinite, real
+from pyrecest.distributions import ComplexAngularCentralGaussianDistribution
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ != "numpy",
+    reason="Numerical underflow regression is evaluated with NumPy float64 semantics",
+)
+class TestComplexACGPDFScaleInvariance(unittest.TestCase):
+    def test_pdf_is_scale_invariant_when_determinant_would_underflow(self):
+        parameter = array(
+            [[2.0 + 0.0j, 0.0 + 0.0j], [0.0 + 0.0j, 1.0 + 0.0j]],
+            dtype=complex128,
+        )
+        scaled_parameter = 1e-200 * parameter
+        inv_sqrt_two = 1.0 / np.sqrt(2.0)
+        point = array([inv_sqrt_two + 0.0j, 1j * inv_sqrt_two])
+
+        reference = ComplexAngularCentralGaussianDistribution(parameter).pdf(point)
+        scaled = ComplexAngularCentralGaussianDistribution(scaled_parameter).pdf(point)
+
+        self.assertTrue(bool(isfinite(scaled)))
+        npt.assert_allclose(float(real(scaled)), float(real(reference)), rtol=1e-12)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- evaluate the complex angular central Gaussian PDF fully in log space
- obtain `log(det(C))` from the Cholesky diagonal instead of forming the determinant directly
- add a regression for scale invariance when `det(C)` underflows in float64

## Bug

The complex angular central Gaussian distribution is invariant to positive rescaling of its parameter matrix. The previous PDF implementation evaluated

```python
abs(inner) ** (-d) / abs(det(C))
```

as separate floating-point factors. For a valid matrix such as `1e-200 * diag(2, 1)`, the determinant underflows to zero while the inverse quadratic-form power also underflows to zero, producing `0 / 0 = NaN`. The equivalent unscaled matrix returns a finite density.

## Fix

The PDF now computes the Cholesky log-determinant and combines it with the quadratic-form contribution before exponentiation. This preserves the exact scale cancellation and avoids determinant underflow.

## Validation

- reproduced the previous `NaN` with NumPy float64 semantics
- verified the log-domain expression returns the same finite density as the unscaled parameter matrix
- added a focused NumPy regression asserting finiteness and scale invariance
- branch is 2 commits ahead of `main`, 0 behind, with one source file and one focused test file changed