### PR TITLE
Reject scalar inputs in PyTorch nonzero

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_nonzero_scalar_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_nonzero_scalar_contract.py
@@ -1,0 +1,44 @@
+"""Runtime patch for PyTorch ``nonzero`` scalar validation."""
+
+from __future__ import annotations
+
+
+_NONZERO_SCALAR_MESSAGE = (
+    "Calling nonzero on 0d arrays is not allowed. "
+    "Use np.atleast_1d(scalar).nonzero() instead."
+)
+
+
+def patch_pytorch_nonzero_scalar_contract() -> None:
+    """Make public and raw PyTorch ``nonzero`` reject 0-D inputs."""
+
+    try:
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch may be unavailable
+        return
+
+    original_nonzero = getattr(raw_pytorch, "nonzero", None)
+    if original_nonzero is None:
+        return
+    if getattr(original_nonzero, "_pyrecest_nonzero_scalar_contract", False):
+        if getattr(backend, "__backend_name__", None) == "pytorch":
+            backend.nonzero = original_nonzero
+        return
+
+    def nonzero(x):
+        values = x if torch.is_tensor(x) else torch.as_tensor(x)
+        if values.ndim == 0:
+            raise ValueError(_NONZERO_SCALAR_MESSAGE)
+        return original_nonzero(values)
+
+    nonzero.__name__ = getattr(original_nonzero, "__name__", "nonzero")
+    nonzero.__doc__ = getattr(original_nonzero, "__doc__", None)
+    nonzero._pyrecest_nonzero_scalar_contract = True
+    raw_pytorch.nonzero = nonzero
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        backend.nonzero = nonzero
+
+
+__all__ = ["patch_pytorch_nonzero_scalar_contract"]

--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -223,6 +223,9 @@ try:
     from pyrecest.backend_support._jax_array_from_sparse_contract import (  # pylint: disable=import-outside-toplevel
         patch_jax_array_from_sparse_flat_index_contract as _patch_jax_array_from_sparse_flat_index_contract,
     )
+    from pyrecest.backend_support._pytorch_nonzero_scalar_contract import (  # pylint: disable=import-outside-toplevel
+        patch_pytorch_nonzero_scalar_contract as _patch_pytorch_nonzero_scalar_contract,
+    )
     from pyrecest.backend_support._pytorch_one_hot_scalar_contract import (  # pylint: disable=import-outside-toplevel
         patch_pytorch_one_hot_scalar_contract as _patch_pytorch_one_hot_scalar_contract,
     )
@@ -242,6 +245,7 @@ else:
     _patch_raw_pytorch_reduction_alias_contract()
     _patch_pytorch_take_axis_contract()
     _patch_pytorch_transpose_boolean_axes_contract()
+    _patch_pytorch_nonzero_scalar_contract()
     _patch_pytorch_one_hot_scalar_contract()
     _patch_pytorch_quantile_empty_batch_contract()
     _patch_pytorch_reduction_axis_contract()

--- a/tests/backend_support/test_pytorch_nonzero_scalar_contract.py
+++ b/tests/backend_support/test_pytorch_nonzero_scalar_contract.py
@@ -1,0 +1,42 @@
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_pytorch_nonzero_rejects_zero_dimensional_inputs():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import pyrecest._backend.pytorch as raw_pytorch
+import pyrecest.backend as backend
+import torch
+
+
+def assert_rejects_scalar(helper, value):
+    try:
+        helper(value)
+    except ValueError as exc:
+        assert "nonzero on 0d arrays is not allowed" in str(exc)
+    else:
+        raise AssertionError("nonzero accepted a zero-dimensional input")
+
+
+for nonzero in (backend.nonzero, raw_pytorch.nonzero):
+    for scalar in (0, 1, torch.tensor(0), torch.tensor(1)):
+        assert_rejects_scalar(nonzero, scalar)
+
+    rows, columns = nonzero([[0, 2], [3, 0]])
+    assert rows.tolist() == [0, 1]
+    assert columns.tolist() == [1, 0]
+
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary

Make the PyTorch `nonzero` backend follow NumPy's zero-dimensional input contract.

## Root cause

The raw PyTorch implementation delegates scalar inputs to `torch.nonzero(..., as_tuple=True)`. PyTorch returns an index tuple for 0-D tensors, while NumPy rejects 0-D inputs with `ValueError`. This made backend-dependent code behave differently for Python scalars and scalar tensors.

## Fix

- add an idempotent runtime contract patch for raw and public PyTorch `nonzero`
- reject Python scalars and 0-D tensors with the NumPy-compatible error
- preserve the existing tuple-of-index-arrays behavior for non-scalar inputs
- register the patch during normal package initialization

## Validation

- add a backend-portable regression test covering both public and raw PyTorch helpers
- verify valid 2-D inputs still return the expected row and column indices

The repository's pull-request checks should run against the resulting three-file diff.