### PR TITLE
Stabilize ellipsoidal ball volume calculation

### DIFF
--- a/src/pyrecest/distributions/abstract_ellipsoidal_ball_distribution.py
+++ b/src/pyrecest/distributions/abstract_ellipsoidal_ball_distribution.py
@@ -3,11 +3,11 @@ from pyrecest.backend import all as backend_all
 from pyrecest.backend import (
     allclose,
     array,
+    diagonal,
     is_complex,
     isfinite,
     linalg,
     pi,
-    sqrt,
     transpose,
 )
 from pyrecest.exceptions import ShapeError, ValidationError
@@ -86,4 +86,5 @@ class AbstractEllipsoidalBallDistribution(AbstractBoundedNonPeriodicDistribution
         else:
             c = (pi ** (self.dim / 2)) / gamma((self.dim / 2) + 1)
 
-        return c * sqrt(linalg.det(self.shape_matrix))
+        cholesky_factor = linalg.cholesky(self.shape_matrix)
+        return c * diagonal(cholesky_factor).prod()

--- a/tests/distributions/test_ellipsoidal_ball_volume_stability.py
+++ b/tests/distributions/test_ellipsoidal_ball_volume_stability.py
@@ -1,0 +1,34 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array, diag
+from pyrecest.distributions import EllipsoidalBallUniformDistribution
+
+
+class TestEllipsoidalBallVolumeStability(unittest.TestCase):
+    def test_small_positive_definite_shape_has_nonzero_representable_volume(self):
+        axis_variance = 1e-200
+        dist = EllipsoidalBallUniformDistribution(
+            array([0.0, 0.0]),
+            diag(array([axis_variance, axis_variance])),
+        )
+
+        expected_volume = np.pi * axis_variance
+        npt.assert_allclose(
+            dist.get_manifold_size(),
+            expected_volume,
+            rtol=1e-14,
+            atol=0.0,
+        )
+        npt.assert_allclose(
+            dist.pdf(array([0.0, 0.0])),
+            1.0 / expected_volume,
+            rtol=1e-14,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/distributions/test_ellipsoidal_ball_volume_stability.py
+++ b/tests/distributions/test_ellipsoidal_ball_volume_stability.py
@@ -3,11 +3,17 @@ import unittest
 import numpy as np
 import numpy.testing as npt
 
+import pyrecest.backend
+
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import array, diag
 from pyrecest.distributions import EllipsoidalBallUniformDistribution
 
 
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ != "numpy",
+    reason="The underflow regression requires float64 values below float32 range",
+)
 class TestEllipsoidalBallVolumeStability(unittest.TestCase):
     def test_small_positive_definite_shape_has_nonzero_representable_volume(self):
         axis_variance = 1e-200


### PR DESCRIPTION
## Summary

- compute `sqrt(det(shape_matrix))` as the product of the Cholesky diagonal
- avoid determinant underflow for valid, very small positive-definite ellipsoids
- add a float64 regression covering both manifold size and the uniform PDF

## Root cause

`AbstractEllipsoidalBallDistribution.get_manifold_size()` evaluated the volume scale as `sqrt(det(S))`. For a valid 2D shape matrix such as `diag(1e-200, 1e-200)`, the determinant is `1e-400` and underflows to zero in float64 before the square root is taken. The true scale `1e-200` and area `pi * 1e-200` are both representable.

This made the manifold size zero and the uniform density infinite even though both quantities have finite representable values.

## Fix

For positive-definite `S = L L^T`, use

```text
sqrt(det(S)) = product(diag(L))
```

The implementation already validates positive definiteness, so the Cholesky factor is the natural stable representation and avoids squaring tiny axis scales.

## Validation

- verified the old determinant-first calculation underflows to zero for `diag(1e-200, 1e-200)`
- verified the Cholesky-diagonal calculation returns `pi * 1e-200`
- added a public `EllipsoidalBallUniformDistribution` regression checking finite, accurate volume and PDF
- branch is based on current `main` and changes only the shared volume calculation plus one focused test