### PR TITLE
Reject invalid ellipsoidal PDF inputs

### DIFF
--- a/src/pyrecest/distributions/ellipsoidal_ball_uniform_distribution.py
+++ b/src/pyrecest/distributions/ellipsoidal_ball_uniform_distribution.py
@@ -3,10 +3,12 @@ from typing import Union
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    all as backend_all,
     array,
     int32,
     int64,
     is_complex,
+    isfinite,
     linalg,
     random,
     reshape,
@@ -81,9 +83,18 @@ class EllipsoidalBallUniformDistribution(
         return pdf_values[0] if single else pdf_values
 
     def _coerce_points(self, xs):
-        xs = array(xs)
+        try:
+            xs = array(xs)
+        except (TypeError, ValueError, RuntimeError, OverflowError) as exc:
+            raise ValidationError("xs must be a finite real-valued array") from exc
         if is_complex(xs):
             raise ValidationError("xs must be real-valued")
+        try:
+            finite = bool(backend_all(isfinite(xs)))
+        except (TypeError, ValueError, RuntimeError) as exc:
+            raise ValidationError("xs must be a finite real-valued array") from exc
+        if not finite:
+            raise ValidationError("xs must contain only finite values")
         if xs.ndim == 0:
             if self.dim != 1:
                 raise ShapeError(

--- a/tests/distributions/test_ellipsoidal_ball_pdf_input_validation.py
+++ b/tests/distributions/test_ellipsoidal_ball_pdf_input_validation.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pytest
+
+from pyrecest.distributions import EllipsoidalBallUniformDistribution
+from pyrecest.exceptions import ValidationError
+
+
+@pytest.fixture
+def distribution():
+    return EllipsoidalBallUniformDistribution(
+        center=np.zeros(2),
+        shape_matrix=np.eye(2),
+    )
+
+
+@pytest.mark.parametrize(
+    "xs",
+    [
+        [np.nan, 0.0],
+        [np.inf, 0.0],
+        [[0.0, 0.0], [0.0, -np.inf]],
+    ],
+)
+def test_pdf_rejects_nonfinite_points(distribution, xs):
+    with pytest.raises(ValidationError, match="finite"):
+        distribution.pdf(xs)
+
+
+def test_pdf_rejects_textual_points(distribution):
+    with pytest.raises(ValidationError, match="finite real-valued"):
+        distribution.pdf(["0", "1"])


### PR DESCRIPTION
## What changed
- validate ellipsoidal-ball PDF evaluation points before arithmetic
- reject NaN, infinite, textual, and otherwise non-real/non-numeric inputs with `ValidationError`
- add regression tests for scalar batches and matrix batches containing non-finite values

## Root cause
`_coerce_points` only rejected complex arrays. Non-finite values flowed through the quadratic-form calculation and were silently classified as outside the support, returning density zero. Text arrays failed later with a backend-dependent arithmetic exception.

## Impact
Callers now receive a consistent validation error instead of a misleading zero density or an incidental type error.

## Validation
The focused regression tests are included. Local execution was unavailable because this environment has neither outbound GitHub access nor the GitHub CLI; GitHub Actions should run on the pull request.