### PR TITLE
Bound adaptive process-noise scale

### DIFF
--- a/src/pyrecest/filters/adaptive_process_noise.py
+++ b/src/pyrecest/filters/adaptive_process_noise.py
@@ -215,9 +215,11 @@ class RollingNISProcessNoiseAdapter:
     def scale(self, source_weights: Mapping[str, float] | None = None) -> float:
         """Return the adapted process-noise multiplier."""
 
+        scale = self.config.base_scale * adaptive_scale_from_ratio(
+            self.ratio(source_weights), self.config
+        )
         return float(
-            self.config.base_scale
-            * adaptive_scale_from_ratio(self.ratio(source_weights), self.config)
+            np.clip(scale, float(self.config.min_scale), float(self.config.max_scale))
         )
 
     def scaled_covariance(

--- a/tests/filters/test_adaptive_process_noise_scale_bounds.py
+++ b/tests/filters/test_adaptive_process_noise_scale_bounds.py
@@ -1,0 +1,43 @@
+import pytest
+from pyrecest.filters.adaptive_process_noise import (
+    AdaptiveProcessNoiseConfig,
+    RollingNISProcessNoiseAdapter,
+)
+
+
+@pytest.mark.parametrize(
+    ("base_scale", "nis", "expected_scale"),
+    (
+        (2.0, 10.0, 3.0),
+        (0.5, 0.0, 0.5),
+    ),
+)
+def test_rolling_adapter_clamps_final_scale_to_configured_bounds(
+    base_scale,
+    nis,
+    expected_scale,
+):
+    config = AdaptiveProcessNoiseConfig(
+        base_scale=base_scale,
+        min_scale=0.5,
+        max_scale=3.0,
+        ewma_alpha=1.0,
+        high_nis_ratio=1.5,
+        low_nis_ratio=0.5,
+        scale_gain=1.0,
+    )
+    adapter = RollingNISProcessNoiseAdapter(config)
+
+    adapter.observe(measurement_dim=1, nis=nis)
+
+    assert adapter.scale() == expected_scale
+
+
+def test_rolling_adapter_preserves_nonunit_nominal_base_scale():
+    config = AdaptiveProcessNoiseConfig(
+        base_scale=2.0,
+        min_scale=0.5,
+        max_scale=3.0,
+    )
+
+    assert RollingNISProcessNoiseAdapter(config).scale() == 2.0


### PR DESCRIPTION
## Bug

`RollingNISProcessNoiseAdapter.scale()` multiplied the configured `base_scale` by an already-clipped adaptive factor, but did not clamp the resulting process-noise multiplier. With a non-unit base scale, the final value could therefore exceed `max_scale` or fall below `min_scale`.

For example, `base_scale=2`, `max_scale=3`, and a high NIS ratio produced a scale of `6`, despite the configured upper bound of `3`.

## Fix

- clamp the final adapted multiplier after applying `base_scale`
- preserve the configured non-unit nominal scale when the NIS ratio is neutral
- add regressions for both upper- and lower-bound violations

## Validation

- branch is 2 commits ahead of `main` and 0 behind
- Python syntax compilation passed for the patched module and focused regression
- isolated focused checks passed for upper clamping, lower clamping, and nominal non-unit scaling

The repository CI matrix should run on this pull request.