### PR TITLE
Fix JPDAF log-determinant underflow

### DIFF
--- a/src/pyrecest/filters/joint_probabilistic_data_association_filter.py
+++ b/src/pyrecest/filters/joint_probabilistic_data_association_filter.py
@@ -6,6 +6,7 @@ import builtins
 import warnings
 from math import log, pi
 
+import numpy as np
 import pyrecest.backend
 from pyrecest.backend import any as backend_any
 from pyrecest.backend import (
@@ -107,10 +108,15 @@ class JointProbabilisticDataAssociationFilter(AbstractNearestNeighborTracker):
 
     @staticmethod
     def _log_gaussian_likelihood(innovation, innovation_covariance):
-        det_value = float(linalg.det(innovation_covariance))
-        if det_value <= 0.0:
-            raise ValueError("Innovation covariance must be positive definite.")
-        logdet = log(det_value)
+        try:
+            cholesky_factor = linalg.cholesky(innovation_covariance)
+        except (np.linalg.LinAlgError, RuntimeError, ValueError) as exc:
+            raise ValueError(
+                "Innovation covariance must be positive definite."
+            ) from exc
+        logdet = 2.0 * float(
+            np.log(np.diag(np.asarray(cholesky_factor))).sum()
+        )
 
         mahalanobis_distance = float(
             innovation.T @ linalg.solve(innovation_covariance, innovation)

--- a/tests/filters/test_jpdaf_logdet_underflow.py
+++ b/tests/filters/test_jpdaf_logdet_underflow.py
@@ -1,0 +1,27 @@
+import math
+import unittest
+
+import pyrecest.backend
+from pyrecest.backend import array
+from pyrecest.filters import JPDAF
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ != "numpy",
+    reason="Only supported on numpy backend",
+)
+class JointProbabilisticDataAssociationFilterLogdetTest(unittest.TestCase):
+    def test_log_gaussian_likelihood_handles_tiny_positive_definite_covariance(self):
+        log_likelihood, mahalanobis_distance = JPDAF._log_gaussian_likelihood(
+            array([0.0, 0.0]),
+            array([[1e-200, 0.0], [0.0, 1e-200]]),
+        )
+
+        expected_log_likelihood = -math.log(2.0 * math.pi) + 200.0 * math.log(10.0)
+        self.assertEqual(mahalanobis_distance, 0.0)
+        self.assertTrue(math.isfinite(log_likelihood))
+        self.assertAlmostEqual(log_likelihood, expected_log_likelihood)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- replace `log(det(S))` in JPDAF Gaussian likelihood evaluation with a Cholesky-based log-determinant
- preserve the existing positive-definite covariance validation and error message
- add a regression test for a valid covariance whose determinant underflows in float64

## Why

For `S = diag([1e-200, 1e-200])`, forming `det(S)` produces `0.0` in float64 even though `S` is positive definite. The old implementation therefore rejected a valid covariance. Summing the logarithms of the Cholesky diagonal avoids forming the tiny determinant.

## Validation

- reproduced the original determinant underflow (`det(S) == 0.0`)
- verified the branch diff is limited to the JPDAF likelihood implementation and focused regression coverage
- full repository tests could not be executed locally because this environment has no GitHub network checkout and no `gh` binary

Closes #4523