### PR TITLE
Fix empty PyTorch uniform device selection

### DIFF
--- a/src/pyrecest/backend_support/_random_uniform_empty_contract.py
+++ b/src/pyrecest/backend_support/_random_uniform_empty_contract.py
@@ -133,24 +133,40 @@ def _patch_pytorch_uniform_empty_bounds_contract() -> None:
         return
 
     def _empty_result(low, high, size, dtype):
-        dtype = raw_random._normalize_random_dtype(dtype, default=None)  # pylint: disable=protected-access
-        device = None
-        if torch.is_tensor(low):
-            device = low.device
-        elif torch.is_tensor(high):
-            device = high.device
-        low_tensor = raw_random._validate_uniform_bound(  # pylint: disable=protected-access
-            low,
-            "low",
-            dtype=dtype,
-            device=device,
+        dtype = raw_random._normalize_random_dtype(  # pylint: disable=protected-access
+            dtype,
+            default=None,
         )
-        high_tensor = raw_random._validate_uniform_bound(  # pylint: disable=protected-access
-            high,
-            "high",
-            dtype=dtype,
-            device=device,
+        tensor_bounds = [bound for bound in (low, high) if torch.is_tensor(bound)]
+        non_cpu_bounds = [bound for bound in tensor_bounds if bound.device.type != "cpu"]
+        device = (
+            non_cpu_bounds[0].device
+            if non_cpu_bounds
+            else tensor_bounds[0].device if tensor_bounds else None
         )
+
+        def _coerce_bound(bound, name):
+            if device is None or device.type != "meta":
+                return raw_random._validate_uniform_bound(  # pylint: disable=protected-access
+                    bound,
+                    name,
+                    dtype=dtype,
+                    device=device,
+                )
+            if raw_random._contains_boolean_value(bound):  # pylint: disable=protected-access
+                raise TypeError(f"{name} must be real numeric, not boolean")
+            try:
+                bound_tensor = torch.as_tensor(bound, dtype=dtype, device=device)
+            except (TypeError, ValueError, RuntimeError) as exc:
+                raise TypeError(f"{name} must be real numeric") from exc
+            if not raw_random._is_real_numeric_dtype(  # pylint: disable=protected-access
+                bound_tensor.dtype
+            ):
+                raise TypeError(f"{name} must be real numeric")
+            return bound_tensor
+
+        low_tensor = _coerce_bound(low, "low")
+        high_tensor = _coerce_bound(high, "high")
         sample_shape = raw_random._uniform_size(  # pylint: disable=protected-access
             size,
             low_tensor,

--- a/tests/backend_support/test_pytorch_uniform_empty_device_contract.py
+++ b/tests/backend_support/test_pytorch_uniform_empty_device_contract.py
@@ -1,9 +1,14 @@
+"""Regression tests for PyTorch empty-uniform device selection."""
+
+from __future__ import annotations
+
 import pytest
 
 
 def test_empty_uniform_prefers_existing_non_cpu_bound_device(monkeypatch):
     torch = pytest.importorskip("torch")
     import pyrecest._backend.pytorch.random as raw_random
+    import pyrecest.backend as backend
     from pyrecest.backend_support._random_uniform_empty_contract import (
         _patch_pytorch_uniform_empty_bounds_contract,
     )
@@ -12,6 +17,11 @@ def test_empty_uniform_prefers_existing_non_cpu_bound_device(monkeypatch):
         raise ValueError("Upper bound must be greater than or equal to lower bound")
 
     monkeypatch.setattr(raw_random, "uniform", reject_descending_bounds)
+    if getattr(backend, "__backend_name__", None) == "pytorch":
+        # The compatibility patch also updates the public backend alias. Register
+        # that attribute with monkeypatch so the wrapper installed below cannot
+        # leak into later tests after raw_random.uniform is restored.
+        monkeypatch.setattr(backend.random, "uniform", backend.random.uniform)
     _patch_pytorch_uniform_empty_bounds_contract()
 
     low = torch.tensor(1.0)

--- a/tests/backend_support/test_pytorch_uniform_empty_device_contract.py
+++ b/tests/backend_support/test_pytorch_uniform_empty_device_contract.py
@@ -1,0 +1,22 @@
+import pytest
+
+
+def test_empty_uniform_prefers_existing_non_cpu_bound_device(monkeypatch):
+    torch = pytest.importorskip("torch")
+    import pyrecest._backend.pytorch.random as raw_random
+    from pyrecest.backend_support._random_uniform_empty_contract import (
+        _patch_pytorch_uniform_empty_bounds_contract,
+    )
+
+    def reject_descending_bounds(*args, **kwargs):
+        raise ValueError("Upper bound must be greater than or equal to lower bound")
+
+    monkeypatch.setattr(raw_random, "uniform", reject_descending_bounds)
+    _patch_pytorch_uniform_empty_bounds_contract()
+
+    low = torch.tensor(1.0)
+    high = torch.tensor(0.0, device="meta")
+    result = raw_random.uniform(low, high, size=(0,))
+
+    assert result.shape == (0,)
+    assert result.device.type == "meta"


### PR DESCRIPTION
## What changed

- prefer an existing non-CPU tensor device when constructing the empty-result fallback for PyTorch `uniform`
- retain the first tensor device when all bounds are on CPU
- add a regression covering CPU `low` and meta-device `high` bounds

## Root cause

The empty descending-interval compatibility path selected `low.device` whenever `low` was a tensor. With a CPU `low` tensor and a non-CPU `high` tensor, it therefore attempted to coerce the non-CPU endpoint onto CPU. This was inconsistent with the backend's binary-device selection contract and could fail for non-materializable devices such as `meta`.

## Impact

Zero-sized PyTorch uniform draws now preserve an existing accelerator or meta device regardless of endpoint order.

## Validation

- branch is 2 commits ahead of `main` and 0 behind
- diff is limited to the empty-uniform compatibility helper and focused regression coverage
- full local tests were unavailable because this environment has no GitHub network checkout or `gh` binary; GitHub Actions should validate the branch