### PR TITLE
Reject zero wrapped-normal moments explicitly

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
@@ -288,6 +288,11 @@ class WrappedNormalDistribution(
             )
 
         moment_abs = min(moment_abs, 1.0)
+        if moment_abs == 0.0:
+            raise ValueError(
+                "A zero first trigonometric moment cannot be represented by a "
+                "wrapped normal with finite variance."
+            )
         if moment_abs == 1.0:
             raise ValueError(
                 "First trigonometric moment with |m| = 1 cannot be moment-matched "

--- a/tests/distributions/test_wrapped_normal_from_moment_input.py
+++ b/tests/distributions/test_wrapped_normal_from_moment_input.py
@@ -27,3 +27,11 @@ def test_from_moment_accepts_scalar_and_singleton_array_like_inputs(moment):
 def test_from_moment_rejects_vector_moments_with_clear_error():
     with pytest.raises(ValueError, match="First trigonometric moment must be a scalar"):
         WrappedNormalDistribution.from_moment([0.25 + 0.0j, 0.5 + 0.0j])
+
+
+def test_from_moment_rejects_zero_moment_with_clear_error():
+    with pytest.raises(
+        ValueError,
+        match="zero first trigonometric moment cannot be represented",
+    ):
+        WrappedNormalDistribution.from_moment(0.0)


### PR DESCRIPTION
## Bug

`WrappedNormalDistribution.from_moment(0)` evaluated `log(0)`, yielding an infinite standard deviation. The call then failed indirectly in the constructor with a backend-dependent/non-specific finite-sigma error.

A wrapped normal with finite variance has first-moment magnitude `exp(-sigma^2 / 2) > 0`, so a zero first moment is not representable by this class.

## Fix

- reject zero first moments before evaluating the logarithm
- provide a clear domain-specific `ValueError`
- add focused regression coverage

## Validation

- branch is 2 commits ahead of `main` and 0 behind
- diff is limited to the wrapped-normal moment conversion and its focused test
- repository CI should run on this pull request