### PR TITLE
Reject nonfinite hyperrectangular PDF inputs

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/hyperrectangular_uniform_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/hyperrectangular_uniform_distribution.py
@@ -2,6 +2,7 @@ from pyrecest.backend import all as backend_all
 from pyrecest.backend import (
     array,
     is_complex,
+    isfinite,
     logical_and,
     ones,
     reshape,
@@ -40,6 +41,8 @@ class HyperrectangularUniformDistribution(
         xs = array(xs)
         if is_complex(xs):
             raise ValueError("xs must be real-valued")
+        if not bool(backend_all(isfinite(xs))):
+            raise ValueError("xs must contain only finite values")
         if xs.ndim == 0:
             if self.dim != 1:
                 raise ValueError("Scalar points are only valid for dim == 1")

--- a/tests/distributions/test_hyperrectangular_uniform_distribution.py
+++ b/tests/distributions/test_hyperrectangular_uniform_distribution.py
@@ -43,6 +43,19 @@ class TestHyperrectangularUniformDistribution(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, "real-valued"):
                     dist.pdf(points)
 
+    def test_pdf_rejects_nonfinite_points(self):
+        dist = HyperrectangularUniformDistribution(array([[0.0, 1.0], [10.0, 12.0]]))
+        invalid_points = (
+            array([0.5, float("nan")]),
+            array([float("inf"), 11.0]),
+            array([[0.5, 11.0], [-float("inf"), 11.0]]),
+        )
+
+        for points in invalid_points:
+            with self.subTest(points=points):
+                with self.assertRaisesRegex(ValueError, "finite"):
+                    dist.pdf(points)
+
     def test_pdf_rejects_wrong_point_dimension(self):
         dist = HyperrectangularUniformDistribution(array([[0.0, 1.0], [10.0, 12.0]]))
 


### PR DESCRIPTION
## What changed

- validate hyperrectangular-uniform PDF evaluation points for finiteness before support comparisons
- reject `NaN`, positive infinity, and negative infinity with a clear `ValueError`
- add regression coverage for single points and batched evaluation points

## Root cause

`HyperrectangularUniformDistribution._coerce_points()` rejected complex values but allowed nonfinite real values. Comparisons with `NaN` evaluate false, so invalid coordinates were silently classified as outside the support and returned density zero. Infinite inputs followed the same misleading path.

## Impact

Callers now get an explicit validation error instead of a plausible-looking zero density for invalid coordinates. Valid finite points and ordinary out-of-support points keep their existing behavior.

## Validation

- branch diff is limited to the distribution validation and focused tests
- Python syntax parsing passed for the changed import structure
- focused NumPy checks passed for valid finite points and `NaN`/±∞ rejection predicates
- repository CI should exercise the regression across configured backends
