### PR TITLE
Stabilize GGIW Gaussian log likelihoods

### DIFF
--- a/src/pyrecest/filters/ggiw_tracker.py
+++ b/src/pyrecest/filters/ggiw_tracker.py
@@ -7,6 +7,7 @@ from pyrecest.backend import (
     array,
     concatenate,
     cos,
+    diagonal,
     eye,
     gammaln,
     linalg,
@@ -292,13 +293,15 @@ class GGIWTracker(
         )
 
     def _gaussian_log_likelihood(self, innovation, covariance):
-        determinant = linalg.det(covariance)
-        if float(determinant) <= 0.0:
+        try:
+            cholesky_factor = linalg.cholesky(covariance)
+        except (np.linalg.LinAlgError, RuntimeError, ValueError):
             return float("-inf")
+        log_determinant = 2.0 * log(diagonal(cholesky_factor)).sum()
         mahalanobis_distance = innovation.T @ linalg.solve(covariance, innovation)
         return -0.5 * (
             innovation.shape[0] * log(array(2.0 * pi))
-            + log(determinant)
+            + log_determinant
             + mahalanobis_distance
         )
 

--- a/tests/filters/test_ggiw_log_likelihood_stability.py
+++ b/tests/filters/test_ggiw_log_likelihood_stability.py
@@ -1,0 +1,55 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member,protected-access
+import pyrecest.backend
+from pyrecest.backend import array, diag, isfinite
+from pyrecest.filters import GGIWTracker
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ != "numpy",
+    reason="GGIW tracker tests currently use numpy.testing assertions",
+)
+class TestGGIWLogLikelihoodStability(unittest.TestCase):
+    def setUp(self):
+        self.tracker = GGIWTracker(
+            kinematic_state=array([0.0, 0.0]),
+            covariance=diag(array([1.0, 1.0])),
+            extent=diag(array([1.0, 1.0])),
+            extent_degrees_of_freedom=8.0,
+            gamma_shape=1.0,
+            gamma_rate=1.0,
+        )
+
+    def test_valid_covariance_with_underflowing_determinant_is_finite(self):
+        covariance = diag(array([1e-200, 1e-200]))
+        innovation = array([0.0, 0.0])
+
+        self.assertEqual(float(np.linalg.det(np.asarray(covariance))), 0.0)
+
+        log_likelihood = self.tracker._gaussian_log_likelihood(
+            innovation, covariance
+        )
+        expected = 200.0 * np.log(10.0) - np.log(2.0 * np.pi)
+
+        self.assertTrue(bool(isfinite(log_likelihood)))
+        npt.assert_allclose(float(log_likelihood), expected, rtol=1e-12)
+
+    def test_positive_determinant_does_not_accept_indefinite_covariance(self):
+        covariance = diag(array([-1.0, -1.0]))
+        innovation = array([0.0, 0.0])
+
+        self.assertEqual(float(np.linalg.det(np.asarray(covariance))), 1.0)
+
+        log_likelihood = self.tracker._gaussian_log_likelihood(
+            innovation, covariance
+        )
+
+        self.assertTrue(np.isneginf(float(log_likelihood)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`GGIWTracker._gaussian_log_likelihood()` formed `det(covariance)` before taking its logarithm and used only the determinant sign as its covariance validity check.

This caused two failures:

- a valid covariance such as `diag([1e-200, 1e-200])` has a determinant of `1e-400`, which underflows to zero in float64, so the tracker returned `-inf` for a finite Gaussian log likelihood;
- an even-dimensional indefinite covariance such as `diag([-1, -1])` has a positive determinant and was therefore accepted even though it is not a valid covariance.

## Fix

- factor the covariance with Cholesky decomposition;
- compute the log-determinant as twice the sum of the logarithms of the Cholesky diagonal;
- preserve the existing `-inf` behavior for non-positive-definite covariance inputs;
- add regressions for determinant underflow and positive-determinant indefinite matrices.

## Impact

GGIW measurement likelihoods remain finite for representable, tightly concentrated positive-definite covariances, while invalid covariance matrices are rejected reliably.

## Validation

- analytically reproduced the old determinant underflow (`det(diag([1e-200, 1e-200])) == 0.0`);
- verified the Cholesky/log-domain expression gives the finite zero-innovation value `200 * log(10) - log(2*pi)`;
- branch is 2 commits ahead of `main` and 0 behind;
- diff is limited to the GGIW likelihood implementation and focused NumPy regressions.

The repository pull-request checks should run against this draft PR.

Supersedes #4531, which GitHub automatically closed while its branch was being rebased onto a moving `main`.