### PR TITLE
Reject invalid Gauss-von-Mises alpha values

### DIFF
--- a/src/pyrecest/distributions/cart_prod/gauss_von_mises_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/gauss_von_mises_distribution.py
@@ -60,6 +60,25 @@ def _validate_positive_sample_count(n) -> int:
     return count_int
 
 
+def _validate_finite_scalar(value, name: str) -> float:
+    scalar_array = np.asarray(value)
+    if scalar_array.shape != ():
+        raise ValueError(f"{name} must be a scalar")
+
+    scalar = scalar_array.item()
+    if isinstance(scalar, (bool, np.bool_)):
+        raise ValueError(f"{name} must be a finite scalar")
+
+    try:
+        scalar_float = float(scalar)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a finite scalar") from exc
+
+    if not np.isfinite(scalar_float):
+        raise ValueError(f"{name} must be a finite scalar")
+    return scalar_float
+
+
 def _validate_nonnegative_finite_scalar(value, name: str) -> float:
     scalar_array = np.asarray(value)
     if scalar_array.shape != ():
@@ -118,13 +137,14 @@ class GaussVonMisesDistribution(AbstractHypercylindricalDistribution):
             raise ValueError("Gamma and mu must have matching size")
         if not bool(allclose(Gamma, Gamma.T)):
             raise ValueError("Gamma must be symmetric")
+        alpha = _validate_finite_scalar(alpha, "alpha")
         kappa = _validate_nonnegative_finite_scalar(kappa, "kappa")
 
         AbstractHypercylindricalDistribution.__init__(self, bound_dim=1, lin_dim=n)
 
         self.mu = array(mu)
         self.P = array(P)
-        self.alpha = float(mod(array(float(alpha)), 2.0 * pi))
+        self.alpha = float(mod(array(alpha), 2.0 * pi))
         self.beta = array(beta)
         self.Gamma = array(Gamma)
         self.kappa = float(kappa)

--- a/tests/distributions/test_gauss_von_mises_alpha_validation.py
+++ b/tests/distributions/test_gauss_von_mises_alpha_validation.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pytest
+
+from pyrecest.distributions.cart_prod.gauss_von_mises_distribution import (
+    GaussVonMisesDistribution,
+)
+
+
+def _make_distribution(alpha):
+    return GaussVonMisesDistribution(
+        mu=2.0,
+        P=1.3,
+        alpha=alpha,
+        beta=0.0,
+        Gamma=0.001,
+        kappa=0.7,
+    )
+
+
+@pytest.mark.parametrize(
+    "alpha",
+    [True, np.bool_(False), float("nan"), float("inf"), -float("inf")],
+)
+def test_constructor_rejects_invalid_alpha(alpha):
+    with pytest.raises(ValueError, match="alpha"):
+        _make_distribution(alpha)
+
+
+def test_constructor_accepts_and_wraps_numpy_scalar_alpha():
+    distribution = _make_distribution(np.float64(-0.5))
+
+    assert np.isclose(distribution.alpha, 2.0 * np.pi - 0.5)


### PR DESCRIPTION
## Bug

`GaussVonMisesDistribution` converted `alpha` with `float(alpha)` and immediately wrapped it modulo `2π`, without validating that the result represented a finite scalar angle.

This allowed invalid parameters to enter the distribution:

- `NaN` and positive/negative infinity produced a non-finite stored angle and propagated `NaN` through density and moment calculations;
- booleans were silently accepted as angular locations `0` or `1`.

## Fix

- validate `alpha` as a non-boolean finite scalar before wrapping it;
- retain support for ordinary Python and NumPy scalar angles, including negative angles;
- add focused regressions for booleans, `NaN`, both infinities, and NumPy scalar wrapping.

## Impact

Invalid angular-location parameters now fail at construction with a clear `ValueError` instead of creating a distribution that later returns non-finite results. Valid finite angles keep their existing modulo-`2π` behavior.

## Validation

- branch is 2 commits ahead of `main` and 0 behind;
- diff is limited to the Gauss-von-Mises constructor validation and a focused regression file;
- inspected the exact commit patches and verified the valid negative NumPy scalar case wraps to `2π - 0.5`;
- repository CI should execute the new regressions across configured backends.