### PR TITLE
Validate wrapped Cauchy CDF starting points

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py
@@ -84,6 +84,7 @@ class WrappedCauchyDistribution(AbstractCircularDistribution):
         def coth(x):
             return 1 / tanh(x)
 
+        starting_point = _validate_finite_scalar(starting_point, "starting_point")
         xs = _as_1d_input(xs)
 
         def primitive(angles):

--- a/tests/distributions/test_wrapped_cauchy_cdf_starting_point_validation.py
+++ b/tests/distributions/test_wrapped_cauchy_cdf_starting_point_validation.py
@@ -1,0 +1,22 @@
+import pytest
+
+from pyrecest.backend import array
+from pyrecest.distributions.circle.wrapped_cauchy_distribution import (
+    WrappedCauchyDistribution,
+)
+
+
+@pytest.mark.parametrize("starting_point", ([0.0, 1.0], [[0.0]]))
+def test_wrapped_cauchy_cdf_rejects_non_scalar_starting_points(starting_point):
+    distribution = WrappedCauchyDistribution(0.0, 0.5)
+
+    with pytest.raises(ValueError, match="starting_point must be a scalar"):
+        distribution.cdf(array([0.5]), starting_point=starting_point)
+
+
+@pytest.mark.parametrize("starting_point", (float("nan"), float("inf"), float("-inf")))
+def test_wrapped_cauchy_cdf_rejects_nonfinite_starting_points(starting_point):
+    distribution = WrappedCauchyDistribution(0.0, 0.5)
+
+    with pytest.raises(ValueError, match="starting_point must be finite"):
+        distribution.cdf(array([0.5]), starting_point=starting_point)

--- a/tests/distributions/test_wrapped_cauchy_cdf_starting_point_validation.py
+++ b/tests/distributions/test_wrapped_cauchy_cdf_starting_point_validation.py
@@ -14,7 +14,9 @@ def test_wrapped_cauchy_cdf_rejects_non_scalar_starting_points(starting_point):
         distribution.cdf(array([0.5]), starting_point=starting_point)
 
 
-@pytest.mark.parametrize("starting_point", (float("nan"), float("inf"), float("-inf")))
+@pytest.mark.parametrize(
+    "starting_point", (float("nan"), float("inf"), float("-inf"))
+)
 def test_wrapped_cauchy_cdf_rejects_nonfinite_starting_points(starting_point):
     distribution = WrappedCauchyDistribution(0.0, 0.5)
 


### PR DESCRIPTION
## Bug

`WrappedCauchyDistribution.cdf()` documents `starting_point` as a scalar, but it passed the value directly into the antiderivative. Array-valued starting points were therefore broadcast against `xs`, producing elementwise CDF origins and plausible-looking results that do not represent one circular CDF. Non-finite origins similarly propagated `NaN` values instead of failing at the API boundary.

## Fix

- validate `starting_point` with the distribution's existing finite-scalar validator before evaluating the CDF;
- reject vector/matrix origins and `NaN`/positive or negative infinity;
- preserve existing scalar and singleton-array behavior;
- add focused backend-level regression tests.

## Impact

Callers now receive a clear `ValueError` for malformed CDF origins instead of silently computing a different origin for each evaluation point.

## Validation

- Python syntax compilation passed for the modified module and regression test;
- standalone validation smoke checks passed for vector, matrix, `NaN`, and infinite inputs;
- branch is current with `main`;
- diff is limited to one validation call and focused tests;
- repository Actions are running on the pull request.