### PR TITLE
Validate explicit von Mises normalization constants

### DIFF
--- a/src/pyrecest/distributions/circle/von_mises_distribution.py
+++ b/src/pyrecest/distributions/circle/von_mises_distribution.py
@@ -47,6 +47,10 @@ class VonMisesDistribution(AbstractCircularDistribution):
         kappa_scalar = self._as_float_scalar(kappa, "kappa")
         if kappa_scalar < 0.0:
             raise ValueError("kappa must be nonnegative.")
+        if norm_const is not None:
+            norm_const = self._as_float_scalar(norm_const, "norm_const")
+            if norm_const <= 0.0:
+                raise ValueError("norm_const must be positive.")
         super().__init__()
         self.mu = mu
         self.kappa = kappa

--- a/tests/distributions/test_von_mises_norm_const_validation.py
+++ b/tests/distributions/test_von_mises_norm_const_validation.py
@@ -1,0 +1,23 @@
+import math
+import unittest
+
+from pyrecest.backend import array
+from pyrecest.distributions import VonMisesDistribution
+
+
+class VonMisesNormalizationConstantValidationTest(unittest.TestCase):
+    def test_constructor_rejects_nonpositive_or_nonfinite_norm_const(self):
+        for norm_const in (0.0, -1.0, float("nan"), float("inf"), float("-inf")):
+            with self.subTest(norm_const=norm_const):
+                with self.assertRaisesRegex(ValueError, "norm_const"):
+                    VonMisesDistribution(0.0, 1.0, norm_const=norm_const)
+
+    def test_constructor_accepts_positive_finite_norm_const(self):
+        distribution = VonMisesDistribution(0.0, 1.0, norm_const=array(2.0))
+
+        self.assertEqual(distribution.norm_const, 2.0)
+        self.assertAlmostEqual(float(distribution.pdf(array(0.0))), math.e / 2.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`VonMisesDistribution` accepted any explicitly supplied `norm_const` without validation. Values such as `0`, negative numbers, `NaN`, or infinity were stored and later used directly by `pdf()`.

This could produce division-by-zero, negative probability densities, or nonfinite probability densities from an otherwise successfully constructed distribution.

## Fix

- validate an explicit normalization constant with the existing finite-scalar helper;
- require it to be strictly positive;
- preserve the stable automatically computed normalization path when `norm_const` is omitted;
- add regressions for zero, negative, and nonfinite values, plus a positive finite explicit constant.

## Impact

Invalid explicit normalization constants now fail at construction with a clear `ValueError` instead of creating an invalid probability distribution.

## Validation

- branch is 2 commits ahead of `main` and 0 behind;
- diff is limited to 4 source additions and a focused 23-line regression file;
- repository CI should exercise the tests across the configured backends.