### PR TITLE
Validate wrapped-normal CDF starting points

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
@@ -8,6 +8,7 @@ import pyrecest.backend
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 from pyrecest.backend import (
     abs,
+    all,
     angle,
     any,
     array,
@@ -15,6 +16,7 @@ from pyrecest.backend import (
     exp,
     int32,
     int64,
+    isfinite as backend_isfinite,
     log,
     mod,
     ndim,
@@ -34,6 +36,15 @@ from ..hypertorus.hypertoroidal_wrapped_normal_distribution import (
 )
 from .abstract_circular_distribution import AbstractCircularDistribution
 from .von_mises_distribution import VonMisesDistribution
+
+
+def _validate_finite_scalar(value, name):
+    value = array(value)
+    if value.shape not in ((), (1,)):
+        raise ValueError(f"{name} must be a scalar.")
+    if not bool(all(backend_isfinite(value))):
+        raise ValueError(f"{name} must be finite.")
+    return value
 
 
 class WrappedNormalDistribution(
@@ -163,6 +174,7 @@ class WrappedNormalDistribution(
         n_wraps = _validate_series_order(n_wraps)
         mu = self.scalar_mu
         sigma = self.sigma
+        starting_point = _validate_finite_scalar(starting_point, "starting_point")
         starting_point = mod(starting_point, 2 * pi)
         xs = mod(xs, 2 * pi)
 

--- a/tests/distributions/test_wrapped_normal_cdf_starting_point_validation.py
+++ b/tests/distributions/test_wrapped_normal_cdf_starting_point_validation.py
@@ -1,0 +1,31 @@
+import pytest
+
+from pyrecest.backend import array
+from pyrecest.distributions import WrappedNormalDistribution
+
+
+@pytest.mark.parametrize("starting_point", ([0.0, 1.0], [[0.0]]))
+def test_wrapped_normal_cdf_rejects_non_scalar_starting_points(starting_point):
+    distribution = WrappedNormalDistribution(0.0, 0.5)
+
+    with pytest.raises(ValueError, match="starting_point must be a scalar"):
+        distribution.cdf(array([0.5]), starting_point=starting_point)
+
+
+@pytest.mark.parametrize(
+    "starting_point", (float("nan"), float("inf"), float("-inf"))
+)
+def test_wrapped_normal_cdf_rejects_nonfinite_starting_points(starting_point):
+    distribution = WrappedNormalDistribution(0.0, 0.5)
+
+    with pytest.raises(ValueError, match="starting_point must be finite"):
+        distribution.cdf(array([0.5]), starting_point=starting_point)
+
+
+def test_wrapped_normal_cdf_accepts_singleton_starting_point():
+    distribution = WrappedNormalDistribution(0.0, 0.5)
+
+    scalar_result = distribution.cdf(array([0.5]), starting_point=0.25)
+    singleton_result = distribution.cdf(array([0.5]), starting_point=array([0.25]))
+
+    assert float(scalar_result) == pytest.approx(float(singleton_result))


### PR DESCRIPTION
## Bug

`WrappedNormalDistribution.cdf()` documents `starting_point` as a scalar, but previously passed it directly to backend arithmetic. Vector-valued origins were silently broadcast against the evaluation points, producing elementwise CDF origins rather than one circular CDF. Non-finite origins propagated `NaN` values instead of failing at the API boundary.

## Fix

- validate `starting_point` as a finite scalar before wrapping it modulo `2π`;
- reject vector/matrix origins and `NaN`/positive or negative infinity;
- preserve existing support for ordinary scalar and singleton-array origins;
- add focused regression tests.

## Impact

Malformed CDF origins now raise a clear `ValueError` rather than returning plausible-looking but semantically invalid or non-finite results.

## Validation

- branch is 2 commits ahead of current `main` and 0 behind;
- diff is limited to 12 source additions and a focused 31-line regression file;
- repository Actions should exercise the tests across configured backends.