### PR TITLE
Validate circular uniform CDF evaluation points

### DIFF
--- a/src/pyrecest/distributions/circle/circular_uniform_distribution.py
+++ b/src/pyrecest/distributions/circle/circular_uniform_distribution.py
@@ -32,6 +32,25 @@ def _as_finite_real_scalar(value, name: str) -> float:
     return scalar
 
 
+def _as_finite_real_array(value, name: str):
+    """Normalize finite real evaluation points accepted by every backend."""
+    message = f"{name} must contain only finite real values"
+    try:
+        backend_value = array(value)
+        value_array = np.asarray(to_numpy(backend_value))
+    except (TypeError, ValueError, RuntimeError, OverflowError) as exc:
+        raise ValueError(message) from exc
+
+    if (
+        np.issubdtype(value_array.dtype, np.bool_)
+        or not np.issubdtype(value_array.dtype, np.number)
+        or np.iscomplexobj(value_array)
+        or not np.all(np.isfinite(value_array))
+    ):
+        raise ValueError(message)
+    return backend_value
+
+
 class CircularUniformDistribution(
     HypertoroidalUniformDistribution, AbstractCircularDistribution
 ):
@@ -69,5 +88,5 @@ class CircularUniformDistribution(
         """
 
         starting_point = _as_finite_real_scalar(starting_point, "starting_point")
-        xa = array(xa)
+        xa = _as_finite_real_array(xa, "xa")
         return mod(xa - starting_point, 2.0 * pi) / (2.0 * pi)

--- a/tests/distributions/test_circular_uniform_cdf_wrapping.py
+++ b/tests/distributions/test_circular_uniform_cdf_wrapping.py
@@ -43,3 +43,21 @@ def test_circular_uniform_cdf_rejects_invalid_starting_points(starting_point):
 
     with pytest.raises(ValueError, match="starting_point.*finite real scalar"):
         dist.cdf(array([0.0]), starting_point=starting_point)
+
+
+@pytest.mark.parametrize(
+    "evaluation_points",
+    (
+        np.array([True]),
+        np.array([float("nan")]),
+        np.array([float("inf")]),
+        np.array([float("-inf")]),
+        np.array([1.0 + 1.0j]),
+        np.array(["0.0"]),
+    ),
+)
+def test_circular_uniform_cdf_rejects_invalid_evaluation_points(evaluation_points):
+    dist = CircularUniformDistribution()
+
+    with pytest.raises(ValueError, match="xa.*finite real"):
+        dist.cdf(evaluation_points)


### PR DESCRIPTION
## Bug

`CircularUniformDistribution.cdf()` validated `starting_point` but passed `xa` directly to the backend modulo operation.

As a result:

- boolean evaluation points were silently interpreted as angles `0` and `1`;
- `NaN` and positive/negative infinity propagated non-finite CDF values (and could emit backend warnings);
- complex or textual inputs failed later with backend-specific exceptions instead of a stable API error.

## Fix

- validate CDF evaluation points as finite, real, non-boolean numeric arrays before applying circular wrapping;
- preserve the original backend array for valid inputs;
- retain scalar, vector, multidimensional, empty-array, and shifted-origin behavior;
- add focused regressions for booleans, `NaN`, both infinities, complex values, and text.

## Impact

Malformed circular CDF queries now fail consistently with a clear `ValueError` rather than returning non-finite values or backend-dependent failures. Valid wrapped-angle results are unchanged.

## Validation

- isolated NumPy reproduction passes for the existing wrapping cases and all new invalid-input cases;
- Python syntax compilation passed for the isolated implementation;
- branch is 2 commits ahead of `main` and 0 behind;
- diff is limited to 20 source additions/1 replacement and 18 focused test lines.