### PR TITLE
Validate von Mises CDF starting points

### DIFF
--- a/src/pyrecest/distributions/circle/von_mises_distribution.py
+++ b/src/pyrecest/distributions/circle/von_mises_distribution.py
@@ -134,6 +134,7 @@ class VonMisesDistribution(AbstractCircularDistribution):
         xs = array(xs)
         if xs.ndim > 1:
             raise ValueError("xs must be a scalar or one-dimensional array")
+        starting_point = self._as_float_scalar(starting_point, "starting_point")
 
         r = zeros_like(xs)
 
@@ -160,8 +161,18 @@ class VonMisesDistribution(AbstractCircularDistribution):
     @staticmethod
     def _as_float_scalar(value, name: str) -> float:
         try:
+            value_array = array(value)
+        except (TypeError, ValueError, RuntimeError) as exc:
+            raise ValueError(f"{name} must be a scalar.") from exc
+
+        if value_array.ndim > 0:
+            if value_array.shape != (1,):
+                raise ValueError(f"{name} must be a scalar.")
+            value = value_array[0]
+
+        try:
             scalar = float(value)
-        except (TypeError, ValueError) as exc:
+        except (OverflowError, TypeError, ValueError) as exc:
             raise ValueError(f"{name} must be a scalar.") from exc
 
         if not math.isfinite(scalar):

--- a/tests/distributions/test_von_mises_cdf_starting_point.py
+++ b/tests/distributions/test_von_mises_cdf_starting_point.py
@@ -1,0 +1,43 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+import pyrecest.backend
+from pyrecest.backend import array
+from pyrecest.distributions import VonMisesDistribution
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+    reason="Von Mises CDF is not supported on this backend",
+)
+class TestVonMisesCdfStartingPoint(unittest.TestCase):
+    def test_rejects_non_scalar_starting_point(self):
+        dist = VonMisesDistribution(0.3, 1.2)
+
+        for starting_point in ([0.0, 1.0], array([0.0, 1.0])):
+            with self.subTest(starting_point=starting_point):
+                with self.assertRaisesRegex(ValueError, "starting_point must be a scalar"):
+                    dist.cdf(array([0.5, 1.0]), starting_point=starting_point)
+
+    def test_rejects_non_finite_starting_point(self):
+        dist = VonMisesDistribution(0.3, 1.2)
+
+        for starting_point in (float("nan"), float("inf"), float("-inf")):
+            with self.subTest(starting_point=starting_point):
+                with self.assertRaisesRegex(ValueError, "starting_point must be finite"):
+                    dist.cdf(array([0.5, 1.0]), starting_point=starting_point)
+
+    def test_accepts_singleton_and_numpy_scalar_starting_points(self):
+        dist = VonMisesDistribution(0.3, 1.2)
+        xs = array([0.5, 1.0])
+
+        expected = dist.cdf(xs, starting_point=0.25)
+        npt.assert_allclose(dist.cdf(xs, starting_point=array([0.25])), expected)
+        npt.assert_allclose(dist.cdf(xs, starting_point=np.float64(0.25)), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`VonMisesDistribution.cdf()` documents `starting_point` as a scalar, but previously passed it directly into the SciPy CDF arithmetic.

As a result, vector-valued origins were broadcast against the evaluation points, producing elementwise CDF origins rather than one circular CDF. `NaN` and positive/negative infinity similarly propagated non-finite results instead of failing at the API boundary.

## Fix

- validate `starting_point` with the existing finite-scalar helper before evaluating the CDF;
- reject vector-valued and non-finite origins with a stable `ValueError`;
- preserve ordinary scalar, NumPy scalar, and singleton-array behavior;
- add focused regression tests.

## Impact

Malformed CDF origins now fail clearly rather than returning plausible-looking but semantically invalid or non-finite values. Valid scalar-origin behavior is unchanged.

## Validation

- branch is 3 commits ahead of `main` and 0 behind;
- final diff is limited to one source validation line and a focused regression file;
- repository Actions should exercise the tests on the supported NumPy backend.