### PR TITLE
Validate numerical circular CDF inputs

### DIFF
--- a/src/pyrecest/distributions/circle/abstract_circular_distribution.py
+++ b/src/pyrecest/distributions/circle/abstract_circular_distribution.py
@@ -1,11 +1,39 @@
 import matplotlib.pyplot as plt
+import numpy as np
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array, atleast_1d, cos, linspace, log, mod, pi, sin
+from pyrecest.backend import (
+    array,
+    atleast_1d,
+    cos,
+    linspace,
+    log,
+    mod,
+    pi,
+    sin,
+    to_numpy,
+)
 
 from ..hypertorus.abstract_hypertoroidal_distribution import (
     AbstractHypertoroidalDistribution,
 )
+
+
+def _as_finite_real_numpy_array(value, message: str):
+    """Convert an input to a NumPy array and enforce finite real numeric values."""
+    try:
+        value_array = np.asarray(to_numpy(array(value)))
+    except (TypeError, ValueError, RuntimeError, OverflowError) as exc:
+        raise ValueError(message) from exc
+
+    if (
+        np.issubdtype(value_array.dtype, np.bool_)
+        or not np.issubdtype(value_array.dtype, np.number)
+        or np.iscomplexobj(value_array)
+        or not np.all(np.isfinite(value_array))
+    ):
+        raise ValueError(message)
+    return value_array
 
 
 class AbstractCircularDistribution(AbstractHypertoroidalDistribution):
@@ -23,9 +51,22 @@ class AbstractCircularDistribution(AbstractHypertoroidalDistribution):
         Returns:
             : The computed CDF as a numpy array.
         """
-        xs = atleast_1d(array(xs))
+        xs_message = "xs must contain finite real numeric values."
+        try:
+            xs = atleast_1d(array(xs))
+        except (TypeError, ValueError, RuntimeError, OverflowError) as exc:
+            raise ValueError(xs_message) from exc
         if xs.ndim != 1:
             raise ValueError("xs must be a 1D array.")
+        _as_finite_real_numpy_array(xs, xs_message)
+
+        starting_point_message = "starting_point must be a finite real scalar."
+        starting_point_array = _as_finite_real_numpy_array(
+            starting_point, starting_point_message
+        )
+        if starting_point_array.shape != ():
+            raise ValueError(starting_point_message)
+        starting_point = float(starting_point_array.item())
 
         return array([self._cdf_numerical_single(x, starting_point) for x in xs])
 

--- a/tests/distributions/test_cdf_numerical_validation.py
+++ b/tests/distributions/test_cdf_numerical_validation.py
@@ -1,0 +1,66 @@
+import unittest
+
+import pyrecest.backend
+from pyrecest.backend import allclose, array
+from pyrecest.distributions import CircularUniformDistribution
+
+
+@unittest.skipUnless(
+    pyrecest.backend.__backend_name__ == "numpy",
+    "Numerical integration is only supported on the NumPy backend.",
+)
+class CircularCdfNumericalValidationTest(unittest.TestCase):
+    def setUp(self):
+        self.distribution = CircularUniformDistribution()
+
+    def test_rejects_invalid_evaluation_points(self):
+        invalid_inputs = [
+            True,
+            [0.1, float("nan")],
+            [float("inf")],
+            [float("-inf")],
+            [1.0 + 0.5j],
+            ["0.1"],
+        ]
+
+        for xs in invalid_inputs:
+            with self.subTest(xs=xs):
+                with self.assertRaisesRegex(
+                    ValueError, "xs must contain finite real numeric values"
+                ):
+                    self.distribution.cdf_numerical(xs)
+
+    def test_rejects_invalid_starting_points(self):
+        invalid_inputs = [
+            True,
+            array([0.0]),
+            array([0.0, 1.0]),
+            float("nan"),
+            float("inf"),
+            float("-inf"),
+            1.0 + 0.5j,
+            "0.0",
+        ]
+
+        for starting_point in invalid_inputs:
+            with self.subTest(starting_point=starting_point):
+                with self.assertRaisesRegex(
+                    ValueError, "starting_point must be a finite real scalar"
+                ):
+                    self.distribution.cdf_numerical([0.5], starting_point)
+
+    def test_preserves_valid_scalar_and_vector_queries(self):
+        xs = array([0.5, 1.0])
+        starting_point = 0.25
+
+        self.assertTrue(
+            allclose(
+                self.distribution.cdf_numerical(xs, starting_point),
+                self.distribution.cdf(xs, starting_point),
+                rtol=1e-10,
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`AbstractCircularDistribution.cdf_numerical()` converted its inputs and proceeded directly to circular modulo arithmetic and numerical integration without validating the numeric domain.

This allowed malformed inputs to fail late or produce misleading behavior:

- Boolean evaluation points were interpreted as angles `0` and `1`.
- `NaN` and positive/negative infinity reached modulo and integration code.
- Complex and textual values raised backend-specific exceptions.
- Array-valued `starting_point` inputs could broadcast or fail deep inside integration instead of being rejected as non-scalars.

## Fix

- Validate numerical CDF evaluation points as one-dimensional, finite, real, non-Boolean numeric values.
- Require `starting_point` to be a finite real scalar.
- Normalize conversion failures to stable, field-specific `ValueError` messages.
- Preserve valid scalar/list/vector queries and the existing multidimensional shape error.
- Add focused regressions for Boolean, non-finite, complex, textual, and non-scalar inputs, plus a valid-result comparison against the analytic circular-uniform CDF.

## Impact

Malformed numerical CDF queries now fail at the public API boundary instead of entering modulo or SciPy integration with invalid values. Valid numerical results are unchanged.

## Validation

- Python syntax compilation passed for the modified source and new regression module.
- Local targeted run against the released PyRecEst package with the branch source overlaid: `3 passed, 14 subtests passed`.
- Branch is 2 commits ahead of `main` and 0 behind; the diff is limited to the abstract circular CDF implementation and one focused test file.

GitHub Actions should provide the authoritative repository-wide validation.