### PR TITLE
Stabilize subdivision Gaussian likelihood log determinants

### DIFF
--- a/src/pyrecest/filters/state_space_subdivision_filter.py
+++ b/src/pyrecest/filters/state_space_subdivision_filter.py
@@ -354,9 +354,10 @@ class StateSpaceSubdivisionFilter(AbstractFilter, HypercylindricalFilterMixin):
 
         combined_covariances = covariances + likelihood_cov
         deltas = means - likelihood_mu
-        combined_determinants = linalg.det(combined_covariances)
-        if bool(backend_any(less_equal(combined_determinants, 0.0))):
+        combined_eigenvalues = linalg.eigvalsh(combined_covariances)
+        if bool(backend_any(less_equal(combined_eigenvalues, 0.0))):
             raise ValueError("Combined covariance matrices must be positive definite.")
+        combined_log_determinants = backend_sum(log(combined_eigenvalues), axis=1)
 
         combined_precisions = linalg.inv(combined_covariances)
         solved_deltas = einsum("nij,nj->ni", combined_precisions, deltas)
@@ -366,7 +367,7 @@ class StateSpaceSubdivisionFilter(AbstractFilter, HypercylindricalFilterMixin):
             -0.5
             * (
                 dimension * log(2.0 * 3.141592653589793)
-                + log(combined_determinants)
+                + combined_log_determinants
                 + exponents
             )
         )

--- a/tests/filters/test_state_space_subdivision_logdet_stability.py
+++ b/tests/filters/test_state_space_subdivision_logdet_stability.py
@@ -1,0 +1,56 @@
+import unittest
+
+import numpy.testing as npt
+import pyrecest.backend
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array
+from pyrecest.distributions.cart_prod.state_space_subdivision_gaussian_distribution import (
+    StateSpaceSubdivisionGaussianDistribution,
+)
+from pyrecest.distributions.circle.circular_uniform_distribution import (
+    CircularUniformDistribution,
+)
+from pyrecest.distributions.hypertorus.hypertoroidal_grid_distribution import (
+    HypertoroidalGridDistribution,
+)
+from pyrecest.distributions.nonperiodic.gaussian_distribution import (
+    GaussianDistribution,
+)
+from pyrecest.filters.state_space_subdivision_filter import StateSpaceSubdivisionFilter
+
+
+@unittest.skipUnless(
+    pyrecest.backend.__backend_name__ == "numpy",  # pylint: disable=no-member
+    "The regression uses float64 covariances below float32 range.",
+)
+class TestStateSpaceSubdivisionLogdetStability(unittest.TestCase):
+    def test_single_likelihood_accepts_tiny_positive_definite_covariances(self):
+        covariance = array([[1.0e-200, 0.0], [0.0, 1.0e-200]])
+        mean = array([0.0, 0.0])
+        grid = HypertoroidalGridDistribution.from_distribution(
+            CircularUniformDistribution(), (4,)
+        )
+        linear_distributions = [
+            GaussianDistribution(mean, covariance) for _ in range(4)
+        ]
+        filter_ = StateSpaceSubdivisionFilter(
+            StateSpaceSubdivisionGaussianDistribution(grid, linear_distributions)
+        )
+        likelihood = GaussianDistribution(mean, covariance)
+
+        filter_.update(likelihoods_linear=[likelihood])
+
+        expected_covariance = 0.5 * covariance
+        for distribution in filter_.filter_state.linear_distributions:
+            npt.assert_allclose(distribution.mu, mean, rtol=0.0, atol=0.0)
+            npt.assert_allclose(
+                distribution.C,
+                expected_covariance,
+                rtol=1.0e-12,
+                atol=0.0,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`StateSpaceSubdivisionFilter._update_single_linear_likelihood()` computed `det(C)` and then `log(det(C))` for the combined Gaussian covariance. For valid positive-definite matrices with very small eigenvalues, the determinant can underflow to `0.0` in float64 even though every eigenvalue is strictly positive. The fast path then raised `ValueError`, while the generic per-cell likelihood path could still evaluate the same update.

## Fix

- validate positive definiteness from the combined covariance eigenvalues;
- compute the log-determinant directly as the sum of logarithms of those eigenvalues;
- avoid forming an unrepresentably small determinant;
- retain the existing public error for non-positive-definite covariances.

## Regression

Added a NumPy regression using two-dimensional covariances `diag(1e-200, 1e-200)`. Their combined determinant underflows to zero, but the covariance is positive definite and the update has the finite posterior covariance `0.5 * C`.

## Validation

- isolated NumPy reproduction confirms the old determinant is `0.0` while the eigenvalue-based log-determinant is finite;
- branch is limited to the 7-line numerical change and one focused regression module;
- GitHub Actions should run the repository test matrix on this draft PR.