### PR TITLE
Floor indefinite covariance log determinants

### DIFF
--- a/src/pyrecest/utils/pairwise_covariance_features.py
+++ b/src/pyrecest/utils/pairwise_covariance_features.py
@@ -32,9 +32,7 @@ from pyrecest.backend import (
     log,
     maximum,
     moveaxis,
-    prod,
     reshape,
-    sign,
     sqrt,
 )
 from pyrecest.backend import sum as backend_sum
@@ -58,7 +56,6 @@ def pairwise_mahalanobis_distances(
     For a pair of items ``i`` and ``j``, the returned value is
 
     ``sqrt((mu_i - nu_j)^T (Sigma_i + Lambda_j + regularization * I)^+ (mu_i - nu_j))``,
-
     where ``^+`` denotes the Moore-Penrose pseudoinverse.  Using the summed
     covariance makes the feature symmetric in the two uncertain estimates and is
     the standard normalization for comparing two independent Gaussian position
@@ -265,26 +262,23 @@ def _batch_trace(matrices: Any) -> Any:
 
 
 def _floored_log_determinants(matrices: Any, epsilon: float) -> Any:
-    """Return ``log(max(det(matrix), epsilon))`` without forming determinants."""
+    """Return floored log determinants for positive-definite covariances."""
 
     eigenvalues = linalg.eigvalsh(matrices)
-    absolute_eigenvalues = abs(eigenvalues)
-    nonzero_eigenvalues = absolute_eigenvalues > 0.0
-    safe_absolute_eigenvalues = where(
-        nonzero_eigenvalues,
-        absolute_eigenvalues,
+    positive_eigenvalues = eigenvalues > 0.0
+    safe_eigenvalues = where(
+        positive_eigenvalues,
+        eigenvalues,
         1.0,
     )
-    determinant_signs = prod(sign(eigenvalues), axis=-1)
-    log_absolute_determinants = backend_sum(log(safe_absolute_eigenvalues), axis=-1)
+    log_determinants = backend_sum(log(safe_eigenvalues), axis=-1)
     log_epsilon = math.log(epsilon)
     use_log_determinant = (
-        (determinant_signs > 0.0)
-        & backend_all(nonzero_eigenvalues, axis=-1)
-        & isfinite(log_absolute_determinants)
-        & (log_absolute_determinants > log_epsilon)
+        backend_all(positive_eigenvalues, axis=-1)
+        & isfinite(log_determinants)
+        & (log_determinants > log_epsilon)
     )
-    return where(use_log_determinant, log_absolute_determinants, log_epsilon)
+    return where(use_log_determinant, log_determinants, log_epsilon)
 
 
 def _positive_floor(values: Any, epsilon: float) -> Any:

--- a/src/pyrecest/utils/pairwise_covariance_features.py
+++ b/src/pyrecest/utils/pairwise_covariance_features.py
@@ -56,6 +56,7 @@ def pairwise_mahalanobis_distances(
     For a pair of items ``i`` and ``j``, the returned value is
 
     ``sqrt((mu_i - nu_j)^T (Sigma_i + Lambda_j + regularization * I)^+ (mu_i - nu_j))``,
+
     where ``^+`` denotes the Moore-Penrose pseudoinverse.  Using the summed
     covariance makes the feature symmetric in the two uncertain estimates and is
     the standard normalization for comparing two independent Gaussian position

--- a/tests/test_pairwise_covariance_indefinite_logdet.py
+++ b/tests/test_pairwise_covariance_indefinite_logdet.py
@@ -1,0 +1,31 @@
+import math
+
+import numpy.testing as npt
+
+from pyrecest.backend import array
+from pyrecest.utils import pairwise_covariance_shape_components
+
+
+def test_pairwise_covariance_shape_components_floor_indefinite_logdet():
+    epsilon = 1.0e-6
+    negative_definite = array(
+        [
+            [[-2.0], [0.0]],
+            [[0.0], [-3.0]],
+        ]
+    )
+    positive_definite = array(
+        [
+            [[2.0], [0.0]],
+            [[0.0], [3.0]],
+        ]
+    )
+
+    _, logdet_cost, _ = pairwise_covariance_shape_components(
+        negative_definite,
+        positive_definite,
+        epsilon=epsilon,
+    )
+
+    expected = math.log(6.0) - math.log(epsilon)
+    npt.assert_allclose(logdet_cost, array([[expected]]))


### PR DESCRIPTION
## Bug

`_floored_log_determinants()` accepted any matrix with a positive determinant sign. For even-dimensional indefinite matrices, an even number of negative eigenvalues yields a positive determinant, so the covariance feature treated an invalid covariance as having a valid log determinant.

For example, `diag(-2, -3)` and `diag(2, 3)` both have determinant `6`. The previous implementation therefore assigned them zero log-determinant scale cost even though the first matrix is negative definite.

## Fix

- require every eigenvalue to be strictly positive before using the eigenvalue-domain log determinant;
- floor singular, indefinite, and non-finite cases to `log(epsilon)`;
- remove the determinant-sign reconstruction that allowed even-negative spectra;
- add a public regression comparing negative-definite and positive-definite covariance stacks with equal determinant magnitude.

## Impact

Pairwise covariance scale features no longer classify invalid even-dimensional covariance matrices as valid merely because their determinant is positive. Positive-definite large-scale covariance behavior remains in the stable eigenvalue/log domain.

## Validation

- isolated NumPy reproduction: the old implementation gives scale cost `0`, while the corrected criterion gives `log(6) - log(1e-6)`;
- branch is 3 commits ahead of current `main` and 0 behind;
- final diff is limited to the log-determinant helper and one focused regression test;
- GitHub Actions should provide the authoritative backend and repository-wide validation.