### PR TITLE
Reject record smoother metadata collisions

### DIFF
--- a/src/pyrecest/smoothers/record_smoother.py
+++ b/src/pyrecest/smoothers/record_smoother.py
@@ -39,7 +39,8 @@ class RecordSmootherConfig:
     filtered_state_key, filtered_covariance_key:
         Keys used to preserve the original filtered posterior in returned records.
     metadata:
-        Extra key/value pairs appended to every returned record.
+        Extra key/value pairs appended to every returned record. Metadata keys may
+        not collide with state or covariance input/output keys.
     """
 
     method: SmootherMethod = "fixed-lag"
@@ -162,11 +163,27 @@ def _smooth_records_with_config(
     fixed_lag = None
     if config.method == "fixed-lag":
         fixed_lag = _validate_fixed_lag(config.lag)
+
+    metadata = {} if config.metadata is None else dict(config.metadata)
+    protected_keys = {
+        config.state_key,
+        config.covariance_key,
+        config.output_state_key,
+        config.output_covariance_key,
+        config.filtered_state_key,
+        config.filtered_covariance_key,
+    }
+    conflicting_keys = sorted(protected_keys.intersection(metadata))
+    if conflicting_keys:
+        formatted_keys = ", ".join(repr(key) for key in conflicting_keys)
+        raise ValueError(
+            f"metadata keys must not overwrite state or covariance fields: {formatted_keys}"
+        )
+
     if not records:
         return []
 
     copied = [_copy_record(record) for record in records]
-    metadata = {} if config.metadata is None else dict(config.metadata)
     if config.method == "none":
         for item in copied:
             item.update(metadata)

--- a/tests/smoothers/test_record_smoother_metadata_collisions.py
+++ b/tests/smoothers/test_record_smoother_metadata_collisions.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from pyrecest.smoothers.record_smoother import smooth_records
+
+
+def _transition(dt: float, state_dim: int) -> np.ndarray:
+    assert state_dim == 2
+    return np.array([[1.0, dt], [0.0, 1.0]])
+
+
+def _process_noise(dt: float, state_dim: int) -> np.ndarray:
+    assert state_dim == 2
+    return 0.01 * max(dt, 0.0) * np.eye(2)
+
+
+def _records() -> list[dict[str, object]]:
+    return [
+        {
+            "time_s": 0.0,
+            "state": np.array([0.0, 1.0]),
+            "covariance": np.eye(2),
+        },
+        {
+            "time_s": 1.0,
+            "state": np.array([1.0, 1.0]),
+            "covariance": np.eye(2),
+        },
+    ]
+
+
+@pytest.mark.parametrize("method", ["none", "rts"])
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        {"state": "corrupted"},
+        {"covariance": "corrupted"},
+        {"filtered_state": "corrupted"},
+        {"filtered_covariance": "corrupted"},
+    ],
+)
+def test_metadata_must_not_overwrite_state_or_covariance_fields(
+    method: str, metadata: dict[str, object]
+) -> None:
+    with pytest.raises(ValueError, match="metadata keys must not overwrite"):
+        smooth_records(
+            _records(),
+            method=method,
+            transition_model=_transition,
+            process_noise_model=_process_noise,
+            metadata=metadata,
+        )
+
+
+def test_custom_output_keys_are_also_reserved() -> None:
+    with pytest.raises(ValueError, match="smoothed_state"):
+        smooth_records(
+            _records(),
+            method="rts",
+            transition_model=_transition,
+            process_noise_model=_process_noise,
+            output_state_key="smoothed_state",
+            metadata={"smoothed_state": "corrupted"},
+        )
+
+
+def test_nonconflicting_metadata_is_preserved() -> None:
+    out = smooth_records(
+        _records(),
+        method="rts",
+        transition_model=_transition,
+        process_noise_model=_process_noise,
+        metadata={"smoother_method": "rts"},
+    )
+
+    assert out[0]["smoother_method"] == "rts"
+    assert isinstance(out[0]["state"], np.ndarray)
+    assert isinstance(out[0]["filtered_state"], np.ndarray)


### PR DESCRIPTION
## Bug

`pyrecest.smoothers.record_smoother.smooth_records()` applied user-supplied `metadata` after writing the returned state and covariance fields.

A metadata mapping containing keys such as `state`, `covariance`, `filtered_state`, or custom output keys could therefore silently replace numerical arrays with unrelated values. The same corruption was possible in `method="none"` mode.

## Fix

- reserve all configured state and covariance input/output keys;
- reject metadata that collides with any reserved field before processing records;
- report the conflicting key names in a stable `ValueError`;
- preserve non-conflicting metadata behavior.

## Regression coverage

- collision checks for `none` and `rts` modes;
- default state, covariance, and filtered-field collisions;
- custom output-key collisions;
- successful preservation of ordinary metadata.

## Scope

The branch is 2 commits ahead of `main`, 0 behind, and changes only the record smoother plus one focused test module.