### PR TITLE
Reject invalid wrapped exponential PDF inputs

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
@@ -24,7 +24,7 @@ from pyrecest.backend import (
 from .abstract_circular_distribution import AbstractCircularDistribution
 
 _SMALL_RATE_SERIES_THRESHOLD = 1e-4
-_INVALID_RATE_SCALAR_TYPES = (
+_INVALID_REAL_SCALAR_TYPES = (
     bool,
     np.bool_,
     str,
@@ -37,19 +37,19 @@ _INVALID_RATE_SCALAR_TYPES = (
     np.datetime64,
     np.timedelta64,
 )
-_INVALID_RATE_DTYPE_KINDS = {"b", "S", "U", "c", "M", "m"}
+_INVALID_REAL_DTYPE_KINDS = {"b", "S", "U", "c", "M", "m"}
 
 
-def _contains_invalid_rate_scalar(value) -> bool:
-    """Return whether a rate candidate is boolean, textual, complex, or temporal."""
+def _contains_invalid_real_value(value) -> bool:
+    """Return whether a value is boolean, textual, complex, or temporal."""
 
-    if isinstance(value, _INVALID_RATE_SCALAR_TYPES):
+    if isinstance(value, _INVALID_REAL_SCALAR_TYPES):
         return True
 
     dtype = getattr(value, "dtype", None)
     if dtype is not None:
         try:
-            if np.dtype(dtype).kind in _INVALID_RATE_DTYPE_KINDS:
+            if np.dtype(dtype).kind in _INVALID_REAL_DTYPE_KINDS:
                 return True
         except (TypeError, ValueError):
             dtype_name = str(dtype).lower()
@@ -70,11 +70,11 @@ def _contains_invalid_rate_scalar(value) -> bool:
         values = np.asarray(value, dtype=object).reshape(-1)
     except (OverflowError, TypeError, ValueError, RuntimeError):
         return False
-    return any(isinstance(item, _INVALID_RATE_SCALAR_TYPES) for item in values)
+    return any(isinstance(item, _INVALID_REAL_SCALAR_TYPES) for item in values)
 
 
 def _validate_positive_scalar(value, name):
-    if _contains_invalid_rate_scalar(value):
+    if _contains_invalid_real_value(value):
         raise ValueError(f"{name} must be a positive real scalar.")
     try:
         value = asarray(value)
@@ -93,6 +93,25 @@ def _validate_positive_scalar(value, name):
         raise ValueError(f"{name} must be finite.")
     if not positive:
         raise ValueError(f"{name} must be positive.")
+    return value
+
+
+def _validate_pdf_points(value):
+    message = "xs must contain only finite real values."
+    if _contains_invalid_real_value(value):
+        raise ValueError(message)
+    try:
+        value = asarray(value)
+    except Exception as exc:  # pragma: no cover - backend-specific conversion type
+        raise ValueError(message) from exc
+    if ndim(value) > 1:
+        raise ValueError("xs must be a scalar or one-dimensional array.")
+    try:
+        finite = bool(all(isfinite(value)))
+    except (OverflowError, TypeError, ValueError, RuntimeError) as exc:
+        raise ValueError(message) from exc
+    if not finite:
+        raise ValueError(message)
     return value
 
 
@@ -126,9 +145,7 @@ class WrappedExponentialDistribution(AbstractCircularDistribution):
         self._density_scale = _density_scale_from_log_beta(self._log_beta)
 
     def pdf(self, xs):
-        xs = asarray(xs)
-        if ndim(xs) > 1:
-            raise ValueError("xs must be a scalar or one-dimensional array.")
+        xs = _validate_pdf_points(xs)
         xs = mod(xs, 2.0 * pi)
         return self._density_scale * exp(-self.lambda_ * xs)
 

--- a/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
@@ -49,11 +49,10 @@ def _contains_invalid_real_value(value) -> bool:
     dtype = getattr(value, "dtype", None)
     if dtype is not None:
         try:
-            if np.dtype(dtype).kind in _INVALID_REAL_DTYPE_KINDS:
-                return True
+            return np.dtype(dtype).kind in _INVALID_REAL_DTYPE_KINDS
         except (TypeError, ValueError):
             dtype_name = str(dtype).lower()
-            if any(
+            return any(
                 token in dtype_name
                 for token in (
                     "bool",
@@ -63,8 +62,7 @@ def _contains_invalid_real_value(value) -> bool:
                     "datetime",
                     "timedelta",
                 )
-            ):
-                return True
+            )
 
     try:
         values = np.asarray(value, dtype=object).reshape(-1)

--- a/tests/distributions/test_wrapped_exponential_pdf_input_validation.py
+++ b/tests/distributions/test_wrapped_exponential_pdf_input_validation.py
@@ -1,0 +1,26 @@
+import numpy as np
+import pytest
+
+from pyrecest.distributions.circle.wrapped_exponential_distribution import (
+    WrappedExponentialDistribution,
+)
+
+
+@pytest.mark.parametrize(
+    "xs",
+    [
+        float("nan"),
+        float("inf"),
+        -float("inf"),
+        [0.0, float("nan")],
+        True,
+        np.bool_(False),
+        1.0 + 2.0j,
+        "1.0",
+    ],
+)
+def test_wrapped_exponential_pdf_rejects_nonfinite_or_nonreal_points(xs):
+    distribution = WrappedExponentialDistribution(2.0)
+
+    with pytest.raises(ValueError, match="finite real"):
+        distribution.pdf(xs)


### PR DESCRIPTION
## Bug

`WrappedExponentialDistribution.pdf()` converted query points and immediately applied modulo arithmetic. As a result, boolean values were silently treated as angles, while `NaN` and positive or negative infinity propagated through `mod()` and produced invalid densities instead of failing at the API boundary. Complex, textual, and temporal values also failed inconsistently depending on the active backend.

## Fix

- generalize the existing non-real input detector so it can validate both rate parameters and PDF evaluation points;
- reject boolean, textual, complex, temporal, and non-finite query points before modulo arithmetic;
- avoid host conversion for typed NumPy, PyTorch, and JAX values by inspecting backend dtype metadata first;
- preserve scalar and one-dimensional real inputs and the existing matrix-rank validation;
- add focused regression coverage for `NaN`, both infinities, mixed finite/non-finite vectors, booleans, complex values, and text.

## Impact

Wrapped-exponential density evaluation now returns densities only for finite real angles. Invalid queries fail deterministically with `ValueError` rather than producing plausible-looking boolean densities or propagating `NaN` values downstream.

## Validation

- branch is 3 commits ahead of current `main` and 0 behind;
- Python syntax parsing passed for the modified source and new regression module;
- final diff is limited to the wrapped-exponential input validator and one focused test module;
- dependency review is green; the remaining GitHub Actions checks are queued or running.