### PR TITLE
Preserve Torch autograd in surface band probabilities

### DIFF
--- a/src/pyrecest/evaluation/implicit_surfaces.py
+++ b/src/pyrecest/evaluation/implicit_surfaces.py
@@ -94,13 +94,20 @@ def surface_band_probability_from_signed_distance(
     """Probability that a normal signed distance lies within a surface band."""
     epsilon = _positive_float("epsilon", epsilon)
     min_std = _positive_float("min_std", min_std)
-    cdf = ndtr if normal_cdf is None else normal_cdf
+    cdf = _standard_normal_cdf if normal_cdf is None else normal_cdf
     distance = _as_numeric_field(distance, "distance")
     distance_std = _nonnegative_finite_numeric_field(distance_std, "distance_std")
     std = _maximum(distance_std, min_std)
     upper = (epsilon - distance) / std
     lower = (-epsilon - distance) / std
     return _clip_01(cdf(upper) - cdf(lower))
+
+
+def _standard_normal_cdf(values: Any) -> Any:
+    """Evaluate the standard normal CDF without detaching tensor inputs."""
+    if hasattr(values, "erf"):
+        return 0.5 * (1.0 + (values / np.sqrt(2.0)).erf())
+    return ndtr(values)
 
 
 def _boolean_flag(name: str, value: bool) -> bool:

--- a/tests/evaluation/test_implicit_surface_torch_autograd.py
+++ b/tests/evaluation/test_implicit_surface_torch_autograd.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+from pyrecest.evaluation import surface_band_probability_from_signed_distance
+
+
+torch = pytest.importorskip("torch")
+
+
+def test_surface_band_probability_preserves_torch_autograd() -> None:
+    distance = torch.tensor([0.0, 0.2], dtype=torch.float64, requires_grad=True)
+    distance_std = torch.tensor([0.05, 0.05], dtype=torch.float64)
+
+    probability = surface_band_probability_from_signed_distance(
+        distance,
+        distance_std,
+        0.1,
+    )
+
+    assert torch.is_tensor(probability)
+    assert probability.device == distance.device
+    assert probability.dtype == distance.dtype
+    assert probability.requires_grad
+    assert torch.all(torch.isfinite(probability))
+    assert torch.all((0.0 <= probability) & (probability <= 1.0))
+
+    probability.sum().backward()
+
+    assert distance.grad is not None
+    assert torch.all(torch.isfinite(distance.grad))
+    assert distance.grad[1] < 0.0


### PR DESCRIPTION
## Bug

`surface_band_probability_from_signed_distance()` preserves PyTorch tensors through its validation, flooring, and clipping helpers, but its default CDF was `scipy.special.ndtr`.

SciPy converts tensor inputs through NumPy. For a tensor with `requires_grad=True`, the public helper therefore failed with:

```text
RuntimeError: Can't call numpy() on Tensor that requires grad.
```

The same path would also be unsuitable for non-CPU tensors because it leaves the tensor device.

## Fix

- use an erf-based standard-normal CDF for tensor-like inputs;
- retain `scipy.special.ndtr` for ordinary NumPy inputs;
- preserve the existing `normal_cdf` override;
- add a focused PyTorch regression checking tensor type, device, dtype, gradient tracking, finite probabilities, and finite backward gradients.

## Impact

Surface-band probabilities can now be used inside differentiable PyTorch evaluation or loss pipelines without detaching tensors or moving them through NumPy.

## Validation

- reproduced the old failure with a float64 PyTorch tensor requiring gradients;
- exercised the patched helper in isolation: probabilities were `[0.9545, 0.0228]`, remained differentiable, and backward produced finite gradients;
- verified the NumPy result remains `[0.95449974, 0.02275013]`;
- branch is 2 commits ahead of current `main`, 0 behind, and changes only the helper plus one regression test.

GitHub Actions should provide the authoritative repository-wide validation.