### PR TITLE
Validate UKF transition output dimensions

### DIFF
--- a/src/pyrecest/filters/_ukf.py
+++ b/src/pyrecest/filters/_ukf.py
@@ -84,12 +84,17 @@ class UnscentedKalmanFilter:
         sigmas = points.sigma_points(self.x, self.P)
         n_sigmas = sigmas.shape[0]
 
-        sigmas_f = stack(
-            [
-                reshape(asarray(fx(sigmas[i], dt, **fx_args), dtype=float64), (-1,))
-                for i in range(n_sigmas)
-            ]
-        )
+        sigma_rows = [
+            reshape(asarray(fx(sigmas[i], dt, **fx_args), dtype=float64), (-1,))
+            for i in range(n_sigmas)
+        ]
+        for sigma_f in sigma_rows:
+            if sigma_f.shape[0] != self._model.dim_x:
+                raise ValueError(
+                    "transition function must return vectors with state dimension "
+                    f"{self._model.dim_x}; got {sigma_f.shape[0]}"
+                )
+        sigmas_f = stack(sigma_rows)
 
         Wm = points.Wm
         Wc = points.Wc

--- a/tests/filters/test_unscented_kalman_filter.py
+++ b/tests/filters/test_unscented_kalman_filter.py
@@ -188,6 +188,26 @@ class UnscentedKalmanFilterTest(unittest.TestCase):
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
         reason="Not supported on this backend",
     )
+    def test_predict_rejects_wrong_transition_dimension_without_mutating_state(self):
+        kf = UnscentedKalmanFilter(
+            GaussianDistribution(array([0.5, -0.25]), diag(array([1.2, 0.8])))
+        )
+
+        def fx(_x, _dt):
+            return array([0.0])
+
+        with self.assertRaisesRegex(
+            ValueError, "transition function must return vectors with state dimension 2"
+        ):
+            kf.predict_nonlinear(fx, eye(2), dt=1.0)
+
+        npt.assert_allclose(kf.get_point_estimate(), array([0.5, -0.25]))
+        npt.assert_allclose(kf.filter_state.covariance(), diag(array([1.2, 0.8])))
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
     def test_linear_predict_update_with_process_noise_matches_kalman_filter(self):
         initial_state = GaussianDistribution(
             array([0.5, -0.25]),


### PR DESCRIPTION
## Bug

The internal unscented Kalman filter flattened transition outputs but did not verify that each propagated sigma point retained the configured state dimension.

For a two-dimensional filter, a transition returning a one-element vector produced a `1 x 1` outer product that NumPy broadcast into the `2 x 2` covariance accumulator. The prediction then overwrote `x` and `P` before failing later while regenerating sigma points, leaving the filter in an inconsistent, partially mutated state.

## Fix

- validate every propagated sigma point against the configured state dimension before computing the predicted moments;
- raise a deterministic `ValueError` describing the expected and returned dimensions;
- add a regression proving that a malformed transition is rejected without changing the state mean or covariance.

## Impact

Malformed nonlinear transition functions now fail at the transition boundary instead of relying on backend broadcasting and potentially corrupting the filter state before an exception.

## Validation

- branch is 2 commits ahead of current `main` and 0 behind;
- final diff is limited to the UKF prediction path and one focused regression;
- Python syntax parsing passed for both modified files;
- GitHub Actions should run the supported NumPy test matrix.