### PR TITLE
Reject Boolean PyTorch real FFT lengths

### DIFF
--- a/src/pyrecest/_backend/pytorch/fft.py
+++ b/src/pyrecest/_backend/pytorch/fft.py
@@ -7,9 +7,29 @@ import torch as _torch
 from ._common import array as _array
 
 
+_BOOLEAN_FFT_LENGTH_ERROR = "n must be an integer length, not boolean"
+
+
 def _as_fft_tensor(value):
     """Convert array-like FFT inputs to torch tensors."""
     return value if _torch.is_tensor(value) else _array(value)
+
+
+def _is_boolean_fft_length(value):
+    """Return whether a real-FFT length is Boolean-valued."""
+    if isinstance(value, bool):
+        return True
+    if _torch.is_tensor(value):
+        return value.dtype == _torch.bool
+    dtype = getattr(value, "dtype", None)
+    return dtype is not None and str(dtype) in {"bool", "bool_"}
+
+
+def _validate_real_fft_length_args(args, kwargs):
+    """Reject Boolean ``n`` values before PyTorch's FFT argument parser."""
+    length = args[0] if args else kwargs.get("n")
+    if _is_boolean_fft_length(length):
+        raise TypeError(_BOOLEAN_FFT_LENGTH_ERROR)
 
 
 def _is_empty_dim(dim):
@@ -138,6 +158,7 @@ def _wrap_arraylike_fft(
     normalize_scalar_dim=False,
     normalize_dim_sequence=False,
     normalize_shape_sequence=False,
+    validate_real_length=False,
     none_alias_means_default=True,
 ):
     @_wraps(torch_func)
@@ -149,6 +170,8 @@ def _wrap_arraylike_fft(
                 func_name,
                 none_alias_means_default=none_alias_means_default,
             )
+        if validate_real_length:
+            _validate_real_fft_length_args(args, kwargs)
         if normalize_scalar_dim and "dim" in kwargs:
             kwargs = dict(kwargs)
             kwargs["dim"] = _normalize_single_fft_dim(kwargs["dim"])
@@ -174,6 +197,7 @@ rfft = _wrap_arraylike_fft(
     func_name="rfft",
     dim_alias="axis",
     normalize_scalar_dim=True,
+    validate_real_length=True,
     none_alias_means_default=False,
 )
 irfft = _wrap_arraylike_fft(
@@ -181,6 +205,7 @@ irfft = _wrap_arraylike_fft(
     func_name="irfft",
     dim_alias="axis",
     normalize_scalar_dim=True,
+    validate_real_length=True,
     none_alias_means_default=False,
 )
 fftshift = _wrap_arraylike_fft(

--- a/tests/backend_support/test_pytorch_fft_bool_length_contract.py
+++ b/tests/backend_support/test_pytorch_fft_bool_length_contract.py
@@ -1,0 +1,40 @@
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+import pyrecest._backend.pytorch.fft as pytorch_fft  # noqa: E402
+
+
+@pytest.mark.backend_portable
+@pytest.mark.parametrize("fft_func", [pytorch_fft.rfft, pytorch_fft.irfft])
+@pytest.mark.parametrize(
+    "length",
+    [
+        True,
+        np.bool_(True),
+        np.array(True),
+        torch.tensor(True),
+        torch.tensor([True]),
+    ],
+)
+def test_raw_pytorch_real_fft_rejects_boolean_lengths(fft_func, length):
+    with pytest.raises(TypeError, match="n must be an integer length, not boolean"):
+        fft_func([1.0, 2.0, 3.0, 4.0], n=length)
+
+
+@pytest.mark.backend_portable
+@pytest.mark.parametrize("fft_func", [pytorch_fft.rfft, pytorch_fft.irfft])
+def test_raw_pytorch_real_fft_rejects_positional_boolean_tensor_length(fft_func):
+    with pytest.raises(TypeError, match="n must be an integer length, not boolean"):
+        fft_func([1.0, 2.0, 3.0, 4.0], torch.tensor(True))
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_real_fft_preserves_singleton_integer_tensor_length():
+    values = torch.tensor([1.0, 2.0, 3.0, 4.0])
+
+    actual = pytorch_fft.rfft(values, n=torch.tensor([4]))
+    expected = torch.fft.rfft(values, n=4)
+
+    torch.testing.assert_close(actual, expected)


### PR DESCRIPTION
## Bug

The PyTorch real-FFT wrappers forwarded Boolean `n` values directly to `torch.fft.rfft` and `torch.fft.irfft`.

This produced backend-dependent failures. In particular, `torch.tensor(True)` and singleton Boolean tensors could reach PyTorch's argument parser and trigger a low-level internal assertion instead of the explicit Boolean-length rejection already provided by the JAX FFT backend.

## Fix

- detect Boolean-valued real-FFT lengths before dispatch;
- cover both positional and keyword `n` arguments;
- reject Python, NumPy, scalar-tensor, and singleton-tensor Boolean values with a stable `TypeError`;
- preserve the existing compatibility behavior for singleton integer tensor lengths.

## Regression coverage

The new focused test module covers:

- `rfft` and `irfft`;
- Python and NumPy Boolean scalars;
- zero-dimensional and singleton PyTorch Boolean tensors;
- positional and keyword length arguments;
- preservation of singleton integer tensor lengths.

## Validation

- isolated regression run: `13 passed`;
- branch is 2 commits ahead of current `main` and 0 behind;
- final diff is limited to 25 source additions and a 40-line regression test.