### PR TITLE
Copy initial filter state on construction

### DIFF
--- a/src/pyrecest/filters/abstract_filter.py
+++ b/src/pyrecest/filters/abstract_filter.py
@@ -11,7 +11,7 @@ class AbstractFilter(ABC):
 
     @abstractmethod
     def __init__(self, initial_filter_state):
-        self._filter_state = initial_filter_state
+        self._filter_state = copy.deepcopy(initial_filter_state)
         self.history = HistoryRecorder()
 
     @property

--- a/tests/filters/test_abstract_filter_initial_state.py
+++ b/tests/filters/test_abstract_filter_initial_state.py
@@ -1,0 +1,35 @@
+import unittest
+
+from pyrecest.filters.abstract_filter import AbstractFilter
+
+
+class _MutableState:
+    def __init__(self):
+        self.values = [1.0]
+
+    def mean(self):
+        return self.values
+
+    @property
+    def dim(self):
+        return len(self.values)
+
+
+class _ConcreteFilter(AbstractFilter):
+    def __init__(self, initial_filter_state):
+        super().__init__(initial_filter_state)
+
+
+class TestAbstractFilterInitialState(unittest.TestCase):
+    def test_constructor_copies_initial_filter_state(self):
+        initial_state = _MutableState()
+
+        filter_under_test = _ConcreteFilter(initial_state)
+        initial_state.values.append(2.0)
+
+        self.assertIsNot(filter_under_test.filter_state, initial_state)
+        self.assertEqual(filter_under_test.filter_state.values, [1.0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`AbstractFilter.__init__()` stored the caller-provided `initial_filter_state` by reference, while the `filter_state` setter deep-copied later assignments.

As a result, mutating the original state object after constructing any filter could silently mutate the filter's internal state without going through the filter API. The behavior also depended on whether a state was supplied during construction or assigned afterward.

## Fix

- deep-copy the initial filter state in `AbstractFilter.__init__()`;
- add a focused regression using a mutable nested state;
- verify that the filter owns a distinct state object and remains unchanged when the caller mutates the original.

## Impact

Filter construction now has the same ownership semantics as later `filter_state` assignments. Caller-side mutations can no longer alter a filter's internal state accidentally.

## Validation

- Python syntax compilation passed for the modified source;
- the isolated regression passed;
- branch is 2 commits ahead of current `main`, 0 behind;
- final diff is one source-line replacement plus one focused test module.