### PR TITLE
Copy wrapped Laplace parameters

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_laplace_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_laplace_distribution.py
@@ -2,7 +2,17 @@
 from numbers import Integral
 
 import numpy as np
-from pyrecest.backend import all, asarray, exp, isfinite, mod, ndim, pi, to_numpy
+from pyrecest.backend import (
+    all,
+    asarray,
+    copy as backend_copy,
+    exp,
+    isfinite,
+    mod,
+    ndim,
+    pi,
+    to_numpy,
+)
 
 from .abstract_circular_distribution import AbstractCircularDistribution
 
@@ -54,8 +64,8 @@ class WrappedLaplaceDistribution(AbstractCircularDistribution):
 
     def __init__(self, lambda_, kappa_):
         AbstractCircularDistribution.__init__(self)
-        lambda_ = _validate_positive_scalar(lambda_, "lambda_")
-        kappa_ = _validate_positive_scalar(kappa_, "kappa_")
+        lambda_ = backend_copy(_validate_positive_scalar(lambda_, "lambda_"))
+        kappa_ = backend_copy(_validate_positive_scalar(kappa_, "kappa_"))
         self.lambda_ = lambda_
         self.kappa = kappa_
 

--- a/tests/distributions/test_wrapped_laplace_parameter_copy.py
+++ b/tests/distributions/test_wrapped_laplace_parameter_copy.py
@@ -1,0 +1,37 @@
+import unittest
+
+import numpy.testing as npt
+import pyrecest.backend
+from pyrecest.backend import array, to_numpy
+from pyrecest.distributions.circle.wrapped_laplace_distribution import (
+    WrappedLaplaceDistribution,
+)
+
+
+class WrappedLaplaceParameterCopyTest(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="JAX arrays are immutable and cannot expose caller-side aliasing.",
+    )
+    def test_constructor_owns_mutable_parameter_storage(self):
+        lambda_ = array(2.0)
+        kappa = array(1.3)
+        distribution = WrappedLaplaceDistribution(lambda_, kappa)
+        evaluation_points = array([0.0, 0.5, 1.0])
+        expected_pdf = to_numpy(distribution.pdf(evaluation_points)).copy()
+
+        lambda_[...] = 4.0
+        kappa[...] = 0.75
+
+        npt.assert_allclose(to_numpy(lambda_), 4.0)
+        npt.assert_allclose(to_numpy(kappa), 0.75)
+        npt.assert_allclose(to_numpy(distribution.lambda_), 2.0)
+        npt.assert_allclose(to_numpy(distribution.kappa), 1.3)
+        npt.assert_allclose(
+            to_numpy(distribution.pdf(evaluation_points)),
+            expected_pdf,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`WrappedLaplaceDistribution.__init__()` validated `lambda_` and `kappa_` with `asarray()` and then stored the resulting mutable arrays/tensors directly. On mutable backends such as NumPy and PyTorch, caller-side mutation after construction therefore changed the distribution's density and moments without going through its API.

This was inconsistent with the ownership behavior already established for `WrappedExponentialDistribution`.

## Fix

- copy both validated wrapped-Laplace parameters before storing them;
- preserve backend tensors and their dtype/device through the backend `copy` facade;
- add a regression that mutates both caller-owned parameters and verifies the stored parameters and PDF remain unchanged;
- skip only the aliasing reproduction on JAX, whose arrays are immutable.

## Impact

Constructed wrapped-Laplace distributions now own their parameter storage. Mutating input arrays or tensors after construction no longer silently changes the distribution.

## Validation

- branch is 2 commits ahead of `main` and 0 behind;
- diff is limited to the constructor ownership fix and focused regression coverage;
- both changed Python files pass syntax parsing;
- full repository tests were not runnable in this environment because the checkout could not reach GitHub; GitHub Actions should provide the full backend matrix.