### PR TITLE
Validate wrapped Cauchy inputs

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py
@@ -1,6 +1,7 @@
 # pylint: disable=no-name-in-module,no-member
 from numbers import Integral
 
+import numpy as np
 from pyrecest.backend import (
     all,
     arctan2,
@@ -18,11 +19,68 @@ from pyrecest.backend import (
 from .abstract_circular_distribution import AbstractCircularDistribution
 
 
+_INVALID_REAL_SCALAR_TYPES = (
+    bool,
+    np.bool_,
+    str,
+    bytes,
+    bytearray,
+    np.str_,
+    np.bytes_,
+    complex,
+    np.complexfloating,
+    np.datetime64,
+    np.timedelta64,
+)
+_INVALID_REAL_DTYPE_KINDS = {"b", "S", "U", "c", "M", "m"}
+
+
+def _contains_invalid_real_value(value) -> bool:
+    """Return whether a value is boolean, textual, complex, or temporal."""
+    if isinstance(value, _INVALID_REAL_SCALAR_TYPES):
+        return True
+
+    dtype = getattr(value, "dtype", None)
+    if dtype is not None:
+        try:
+            return np.dtype(dtype).kind in _INVALID_REAL_DTYPE_KINDS
+        except (TypeError, ValueError):
+            dtype_name = str(dtype).lower()
+            return any(
+                token in dtype_name
+                for token in (
+                    "bool",
+                    "complex",
+                    "str",
+                    "bytes",
+                    "datetime",
+                    "timedelta",
+                )
+            )
+
+    try:
+        values = np.asarray(value, dtype=object).reshape(-1)
+    except (OverflowError, TypeError, ValueError, RuntimeError):
+        return False
+    return any(isinstance(item, _INVALID_REAL_SCALAR_TYPES) for item in values)
+
+
 def _validate_finite_scalar(value, name):
-    value = array(value)
+    if _contains_invalid_real_value(value):
+        raise ValueError(f"{name} must be a finite real scalar.")
+    try:
+        value = array(value)
+    except Exception as exc:  # pragma: no cover - backend-specific conversion type
+        raise ValueError(f"{name} must be a finite real scalar.") from exc
     if value.shape not in ((), (1,)):
         raise ValueError(f"{name} must be a scalar.")
-    if not bool(all(isfinite(value))):
+    if value.shape == (1,):
+        value = value.reshape(())
+    try:
+        finite = bool(all(isfinite(value)))
+    except (OverflowError, TypeError, ValueError, RuntimeError) as exc:
+        raise ValueError(f"{name} must be a finite real scalar.") from exc
+    if not finite:
         raise ValueError(f"{name} must be finite.")
     return value
 
@@ -35,9 +93,21 @@ def _validate_positive_scalar(value, name):
 
 
 def _as_1d_input(xs):
-    xs = atleast_1d(array(xs))
+    message = "xs must contain only finite real values."
+    if _contains_invalid_real_value(xs):
+        raise ValueError(message)
+    try:
+        xs = atleast_1d(array(xs))
+    except Exception as exc:  # pragma: no cover - backend-specific conversion type
+        raise ValueError(message) from exc
     if xs.ndim != 1:
         raise ValueError("xs must be a one-dimensional array.")
+    try:
+        finite = bool(all(isfinite(xs)))
+    except (OverflowError, TypeError, ValueError, RuntimeError) as exc:
+        raise ValueError(message) from exc
+    if not finite:
+        raise ValueError(message)
     return xs
 
 

--- a/tests/distributions/test_wrapped_cauchy_input_validation.py
+++ b/tests/distributions/test_wrapped_cauchy_input_validation.py
@@ -1,0 +1,48 @@
+import numpy as np
+import pytest
+
+from pyrecest.distributions.circle.wrapped_cauchy_distribution import (
+    WrappedCauchyDistribution,
+)
+
+
+@pytest.mark.backend_portable
+@pytest.mark.parametrize("method_name", ["pdf", "cdf"])
+@pytest.mark.parametrize(
+    "xs",
+    [
+        True,
+        np.bool_(False),
+        float("nan"),
+        float("inf"),
+        -float("inf"),
+        [0.0, float("nan")],
+        1.0 + 2.0j,
+        "0.5",
+    ],
+)
+def test_wrapped_cauchy_rejects_nonfinite_or_nonreal_evaluation_points(
+    method_name, xs
+):
+    distribution = WrappedCauchyDistribution(0.0, 0.5)
+
+    with pytest.raises(ValueError, match="xs must contain only finite real values"):
+        getattr(distribution, method_name)(xs)
+
+
+@pytest.mark.backend_portable
+@pytest.mark.parametrize(
+    ("parameter_name", "value"),
+    [
+        ("mu", True),
+        ("mu", 1.0 + 2.0j),
+        ("gamma", np.bool_(True)),
+        ("gamma", "0.5"),
+    ],
+)
+def test_wrapped_cauchy_rejects_nonreal_scalar_parameters(parameter_name, value):
+    parameters = {"mu": 0.0, "gamma": 0.5}
+    parameters[parameter_name] = value
+
+    with pytest.raises(ValueError, match=parameter_name):
+        WrappedCauchyDistribution(**parameters)


### PR DESCRIPTION
## Bug

`WrappedCauchyDistribution` validated only the rank of `pdf()` and `cdf()` evaluation points before applying circular modulo and probability arithmetic.

As a result:

- Boolean values were silently interpreted as angles `0` and `1`;
- `NaN` and positive or negative infinity propagated invalid probabilities;
- complex, textual, and temporal values failed with backend-dependent exceptions;
- the scalar parameter validator likewise accepted Boolean-valued `mu` and `gamma` inputs.

## Fix

- detect Boolean, textual, complex, and temporal values before backend conversion;
- reject non-finite evaluation points before modulo arithmetic;
- normalize conversion failures to stable, field-specific `ValueError`s;
- preserve valid backend arrays and tensors rather than converting them through NumPy;
- normalize accepted singleton scalar parameters to scalar shape;
- add focused regressions for both `pdf()` and `cdf()` and for invalid constructor parameters.

## Impact

Wrapped-Cauchy probabilities are now evaluated only for finite real angles. Invalid inputs fail clearly at the public API boundary instead of returning `NaN`, treating Booleans as valid angles, or exposing backend-specific exceptions.

## Validation

- Python syntax compilation passed for the modified source and new regression module;
- branch is 2 commits ahead of current `main` and 0 behind;
- final diff is limited to the wrapped-Cauchy validator and one focused test module;
- GitHub Actions should provide the authoritative backend and repository-wide validation.