### PR TITLE
Validate sine-skewed location parameters

### DIFF
--- a/src/pyrecest/distributions/circle/sine_skewed_distributions.py
+++ b/src/pyrecest/distributions/circle/sine_skewed_distributions.py
@@ -50,7 +50,7 @@ class GeneralizedKSineSkewedVonMisesDistribution(AbstractCircularDistribution):
     # pylint: disable=too-many-positional-arguments
     def __init__(self, mu, kappa, lambda_, k, m):
         AbstractCircularDistribution.__init__(self)
-        self.mu = mod(mu, 2 * pi)
+        self.mu = mod(_validate_finite_scalar_parameter(mu, "mu"), 2 * pi)
         self.kappa = kappa
         self.lambda_ = lambda_
         self.k = k
@@ -160,7 +160,7 @@ class AbstractSineSkewedDistribution(AbstractCircularDistribution):
         and a skewness parameter lambda_.
         """
         AbstractCircularDistribution.__init__(self)
-        self.mu = mu
+        self.mu = mod(_validate_finite_scalar_parameter(mu, "mu"), 2 * pi)
         self.lambda_ = array(lambda_)
         self.validate_parameters()
 
@@ -196,7 +196,7 @@ class AbstractSineSkewedDistribution(AbstractCircularDistribution):
 class SineSkewedWrappedNormalDistribution(AbstractSineSkewedDistribution):
     def __init__(self, mu, sigma, lambda_):
         super().__init__(mu, lambda_)
-        self.wrapped_normal = WrappedNormalDistribution(mu, sigma)
+        self.wrapped_normal = WrappedNormalDistribution(self.mu, sigma)
 
     @property
     def sigma(self):
@@ -209,7 +209,7 @@ class SineSkewedWrappedNormalDistribution(AbstractSineSkewedDistribution):
 class SineSkewedWrappedCauchyDistribution(AbstractSineSkewedDistribution):
     def __init__(self, mu, gamma, lambda_):
         super().__init__(mu, lambda_)
-        self.wrapped_cauchy = WrappedCauchyDistribution(mu, gamma)
+        self.wrapped_cauchy = WrappedCauchyDistribution(self.mu, gamma)
 
     @property
     def gamma(self):
@@ -235,7 +235,7 @@ class GeneralizedKSineSkewedWrappedCauchyDistribution(AbstractCircularDistributi
     # pylint: disable=too-many-positional-arguments
     def __init__(self, mu, gamma, lambda_, k, m):
         AbstractCircularDistribution.__init__(self)
-        self.mu = mod(mu, 2 * pi)
+        self.mu = mod(_validate_finite_scalar_parameter(mu, "mu"), 2 * pi)
         self.gamma = gamma
         self.lambda_ = lambda_
         self.k = k

--- a/tests/distributions/test_sine_skewed_scalar_validation.py
+++ b/tests/distributions/test_sine_skewed_scalar_validation.py
@@ -4,7 +4,67 @@ from pyrecest.distributions.circle.sine_skewed_distributions import (
     GeneralizedKSineSkewedVonMisesDistribution,
     GeneralizedKSineSkewedWrappedCauchyDistribution,
     GSSVMDistribution,
+    SineSkewedWrappedCauchyDistribution,
+    SineSkewedWrappedNormalDistribution,
 )
+
+
+@pytest.fixture(
+    params=(
+        pytest.param(
+            lambda mu: GeneralizedKSineSkewedVonMisesDistribution(
+                mu=mu,
+                kappa=1.0,
+                lambda_=0.25,
+                k=1,
+                m=1,
+            ),
+            id="generalized-von-mises",
+        ),
+        pytest.param(
+            lambda mu: GeneralizedKSineSkewedWrappedCauchyDistribution(
+                mu=mu,
+                gamma=0.5,
+                lambda_=0.25,
+                k=1,
+                m=1,
+            ),
+            id="generalized-wrapped-cauchy",
+        ),
+        pytest.param(
+            lambda mu: SineSkewedWrappedNormalDistribution(
+                mu=mu,
+                sigma=0.5,
+                lambda_=0.25,
+            ),
+            id="wrapped-normal",
+        ),
+        pytest.param(
+            lambda mu: SineSkewedWrappedCauchyDistribution(
+                mu=mu,
+                gamma=0.5,
+                lambda_=0.25,
+            ),
+            id="wrapped-cauchy",
+        ),
+    )
+)
+def sine_skewed_constructor(request):
+    return request.param
+
+
+def test_sine_skewed_distributions_reject_vector_mu(sine_skewed_constructor):
+    with pytest.raises(ValueError, match="mu must be a scalar"):
+        sine_skewed_constructor([0.0, 0.5])
+
+
+@pytest.mark.parametrize("mu", [float("nan"), float("inf"), float("-inf")])
+def test_sine_skewed_distributions_reject_nonfinite_mu(
+    sine_skewed_constructor,
+    mu,
+):
+    with pytest.raises(ValueError, match="mu must be finite"):
+        sine_skewed_constructor(mu)
 
 
 def test_generalized_sine_skewed_von_mises_rejects_vector_lambda():


### PR DESCRIPTION
## Summary

- require finite scalar `mu` values in all sine-skewed circular distribution constructors
- normalize the validated location once and reuse it for wrapped base distributions
- add regressions for vector, `NaN`, and infinite locations across the generalized von Mises, generalized wrapped-Cauchy, wrapped-normal, and wrapped-Cauchy families

## Root cause

The generalized sine-skewed constructors normalized `mu` directly without checking its dimensionality or finiteness. In particular, `GeneralizedKSineSkewedWrappedCauchyDistribution` could accept a vector location and silently broadcast it against evaluation points, returning a malformed vector that looked like valid PDF output for a one-dimensional distribution. Non-finite locations could likewise propagate into density calculations.

## Impact

Invalid distribution instances now fail immediately with a clear `ValueError` instead of producing broadcast-dependent or non-finite density values. Valid scalar locations retain the same modulo-`2π` normalization.

## Validation

- branch is 2 commits ahead of `main` and 0 behind
- source diff is limited to five location-normalization sites
- regression coverage exercises four constructor families with vector, `NaN`, and ±infinite locations
- repository GitHub Actions will provide the full backend and lint validation