### PR TITLE
Freeze measurement score indices

### DIFF
--- a/src/pyrecest/filters/measurement_scoring.py
+++ b/src/pyrecest/filters/measurement_scoring.py
@@ -33,10 +33,11 @@ class MeasurementScore:
 
     def __post_init__(self) -> None:
         # Own caller-provided sequences so this frozen result cannot be mutated indirectly.
+        # Keep the established list-valued API used by tracker diagnostics.
         object.__setattr__(
             self,
             "active_measurement_indices",
-            tuple(self.active_measurement_indices),
+            list(self.active_measurement_indices),
         )
 
     @property

--- a/src/pyrecest/filters/measurement_scoring.py
+++ b/src/pyrecest/filters/measurement_scoring.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any
 
@@ -25,10 +26,18 @@ class MeasurementScore:
     predicted_measurements: Any | None
     innovation_covariance: Any | None
     residual: Any | None
-    active_measurement_indices: list[int]
+    active_measurement_indices: Sequence[int]
     measurement_weights: Any | None = None
     quadratic_form: float | None = None
     skipped_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        # Own caller-provided sequences so this frozen result cannot be mutated indirectly.
+        object.__setattr__(
+            self,
+            "active_measurement_indices",
+            tuple(self.active_measurement_indices),
+        )
 
     @property
     def is_active(self) -> bool:

--- a/tests/filters/test_measurement_scoring.py
+++ b/tests/filters/test_measurement_scoring.py
@@ -15,3 +15,23 @@ def _score(active_measurement_indices):
 def test_measurement_score_is_active_handles_numpy_index_arrays():
     assert _score(np.array([0, 2])).is_active
     assert not _score(np.array([], dtype=int)).is_active
+
+
+def test_measurement_score_owns_active_measurement_indices():
+    active_measurement_indices = []
+    score = _score(active_measurement_indices)
+
+    active_measurement_indices.append(0)
+
+    assert score.active_measurement_indices == ()
+    assert not score.is_active
+
+
+def test_measurement_score_copies_numpy_index_arrays():
+    active_measurement_indices = np.array([0, 2])
+    score = _score(active_measurement_indices)
+
+    active_measurement_indices[:] = 1
+
+    assert score.active_measurement_indices == (0, 2)
+    assert score.is_active

--- a/tests/filters/test_measurement_scoring.py
+++ b/tests/filters/test_measurement_scoring.py
@@ -23,7 +23,7 @@ def test_measurement_score_owns_active_measurement_indices():
 
     active_measurement_indices.append(0)
 
-    assert score.active_measurement_indices == ()
+    assert score.active_measurement_indices == []
     assert not score.is_active
 
 
@@ -33,5 +33,5 @@ def test_measurement_score_copies_numpy_index_arrays():
 
     active_measurement_indices[:] = 1
 
-    assert score.active_measurement_indices == (0, 2)
+    assert score.active_measurement_indices == [0, 2]
     assert score.is_active


### PR DESCRIPTION
## Bug

`MeasurementScore` is a frozen dataclass in a module providing non-mutating result containers, but it retained the caller-provided `active_measurement_indices` object by reference.

A caller could therefore mutate a source list or NumPy array after construction and silently change an existing score. In particular, appending to an originally empty list changed `score.is_active` from `False` to `True`, allowing a skipped measurement batch to appear active after the fact.

## Fix

- accept sequence-like index inputs;
- copy `active_measurement_indices` into an owned list in `__post_init__`;
- preserve the established list-valued diagnostics API and NumPy index-array support.

## Regression coverage

- mutate a source list after score construction and verify the score remains inactive;
- mutate a source NumPy array after construction and verify the stored indices remain unchanged;
- retain the existing NumPy-array `is_active` checks.

## Validation

The initial tuple-based implementation exposed seven existing SCGP compatibility failures (`tuple != list`) in each NumPy test job. The branch now preserves list semantics while retaining mutation isolation. GitHub Actions is rerunning the repository-wide matrix on the corrected head.

Revisits the still-applicable fix from closed, unmerged PR #4473.