### PR TITLE
Validate product-Dirac component indices

### DIFF
--- a/src/pyrecest/distributions/cart_prod/hyperhemisphere_cart_prod_dirac_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/hyperhemisphere_cart_prod_dirac_distribution.py
@@ -1,8 +1,20 @@
 import copy
 from collections.abc import Callable
+from operator import index as operator_index
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import argmax, array, linalg, outer, reshape, stack, sum, where
+from pyrecest.backend import (
+    argmax,
+    array,
+    is_bool,
+    linalg,
+    ndim,
+    outer,
+    reshape,
+    stack,
+    sum,
+    where,
+)
 
 from ..abstract_dirac_distribution import AbstractDiracDistribution
 from ..hypersphere_subset.abstract_hypersphere_subset_distribution import (
@@ -79,8 +91,34 @@ class HyperhemisphereCartProdDiracDistribution(
         """Return locations with shape ``(n, (dim_hemisphere + 1) * n_hemispheres)``."""
         return reshape(self.as_component_array(), (self.d.shape[0], self.input_dim))
 
+    def _normalize_component_index(self, component_index):
+        """Return a non-boolean scalar component index in range."""
+        try:
+            index_array = array(component_index)
+        except (TypeError, ValueError, RuntimeError) as exc:
+            raise ValueError("component_index must be a scalar integer.") from exc
+
+        if ndim(index_array) != 0:
+            raise ValueError("component_index must be a scalar integer.")
+        if is_bool(index_array):
+            raise ValueError("component_index must be an integer, not a boolean.")
+
+        try:
+            normalized_index = operator_index(component_index)
+        except TypeError:
+            try:
+                normalized_index = operator_index(index_array.item())
+            except (AttributeError, TypeError) as exc:
+                raise ValueError("component_index must be an integer.") from exc
+
+        normalized_index = int(normalized_index)
+        if normalized_index < 0 or normalized_index >= self.n_hemispheres:
+            raise ValueError("component_index is out of range.")
+        return normalized_index
+
     def component_particles(self, component_index):
         """Return Dirac locations for one hyperhemisphere component."""
+        component_index = self._normalize_component_index(component_index)
         return self.as_component_array()[:, component_index, :]
 
     def get_manifold_size(self):

--- a/tests/distributions/test_so3_product_dirac_component_statistics_index_validation.py
+++ b/tests/distributions/test_so3_product_dirac_component_statistics_index_validation.py
@@ -1,0 +1,53 @@
+import unittest
+from math import sqrt
+
+import numpy as np
+import numpy.testing as npt
+
+from pyrecest.backend import array
+from pyrecest.distributions import SO3ProductDiracDistribution
+
+
+class SO3ProductDiracComponentStatisticsIndexValidationTest(unittest.TestCase):
+    def setUp(self):
+        identity = [0.0, 0.0, 0.0, 1.0]
+        x_ninety = [sqrt(0.5), 0.0, 0.0, sqrt(0.5)]
+        z_ninety = [0.0, 0.0, sqrt(0.5), sqrt(0.5)]
+        self.dist = SO3ProductDiracDistribution(
+            array(
+                [
+                    [identity, x_ninety],
+                    [z_ninety, identity],
+                ]
+            ),
+            array([0.25, 0.75]),
+        )
+
+    def test_component_statistics_accept_numpy_integer_scalar(self):
+        component_index = np.int64(1)
+
+        npt.assert_allclose(
+            self.dist.component_particles(component_index), self.dist.d[:, 1, :]
+        )
+        npt.assert_allclose(self.dist.moment(component_index), self.dist.moment()[1])
+        npt.assert_allclose(
+            self.dist.mean_quaternion(component_index), self.dist.mean_quaternion()[1]
+        )
+
+    def test_component_statistics_reject_invalid_indices(self):
+        invalid_indices = (True, np.bool_(True), 1.0, -1, 2, np.array([0]))
+        methods = (
+            self.dist.component_particles,
+            self.dist.moment,
+            self.dist.mean_quaternion,
+        )
+
+        for method in methods:
+            for invalid_index in invalid_indices:
+                with self.subTest(method=method.__name__, invalid_index=invalid_index):
+                    with self.assertRaisesRegex(ValueError, "component_index"):
+                        method(invalid_index)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- validate product-component indices before indexing particle arrays
- reject booleans, non-scalar/non-integral values, negative indices, and out-of-range indices
- preserve concrete scalar integer support, including NumPy integer scalars
- add regression coverage for `SO3ProductDiracDistribution.component_particles`, `moment`, and `mean_quaternion`

## Why

Raw Python/NumPy/PyTorch indexing accepts values such as `-1` and booleans. The product-Dirac statistics paths delegated directly to that indexing, so `moment(rotation_index=-1)` or `mean_quaternion(rotation_index=True)` could silently select an unintended SO(3) component even though marginalization already rejected those inputs.

## Impact

Invalid component selections now fail explicitly with `ValueError` instead of returning statistics for the wrong component. Valid integer scalar behavior is unchanged.

## Validation

Focused regression tests are included. Full validation is delegated to GitHub Actions.