### PR TITLE
Copy padded history initial values

### DIFF
--- a/src/pyrecest/utils/history_recorder.py
+++ b/src/pyrecest/utils/history_recorder.py
@@ -12,7 +12,14 @@ import numpy as np
 from pyrecest import backend
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array, asarray, full, hstack, pad
+from pyrecest.backend import (
+    array,
+    asarray,
+    copy as backend_copy,
+    full,
+    hstack,
+    pad,
+)
 
 
 @dataclass
@@ -123,7 +130,7 @@ class HistoryRecorder:
         if initial_value is None:
             initial_value = array([[]]) if pad_with_nan else []
         elif pad_with_nan:
-            initial_value = self._ensure_2d(initial_value)
+            initial_value = backend_copy(self._ensure_2d(initial_value))
         else:
             initial_value = copy.deepcopy(initial_value)
             if not isinstance(initial_value, list):

--- a/tests/utils/test_history_recorder_padded_initial_copy.py
+++ b/tests/utils/test_history_recorder_padded_initial_copy.py
@@ -1,0 +1,25 @@
+import pytest
+
+import pyrecest.backend
+from pyrecest.backend import array
+from pyrecest.utils import HistoryRecorder
+
+
+@pytest.mark.skipif(
+    pyrecest.backend.__backend_name__ == "jax",
+    reason="JAX arrays are immutable and cannot expose mutable input aliasing.",
+)
+def test_padded_initial_value_does_not_alias_caller_array():
+    initial_value = array([1.0, 2.0])
+    recorder = HistoryRecorder()
+
+    registered_history = recorder.register(
+        "estimate",
+        initial_value=initial_value,
+        pad_with_nan=True,
+    )
+    initial_value[0] = 99.0
+
+    assert registered_history is recorder["estimate"]
+    assert float(recorder["estimate"][0, 0]) == pytest.approx(1.0)
+    assert float(recorder["estimate"][1, 0]) == pytest.approx(2.0)


### PR DESCRIPTION
## Summary

- copy padded `HistoryRecorder` initial values after backend coercion and reshaping
- prevent caller-side mutation from rewriting an already registered history
- add a focused regression for mutable backends

## Bug

`HistoryRecorder.register(..., pad_with_nan=True)` normalized an explicit initial value through `_ensure_2d()` and stored the resulting array directly. For mutable backends, `asarray()` and `reshape()` can retain the caller's storage, so later caller-side mutations could silently rewrite historical data.

This differs from generic histories, whose explicit initial values are deep-copied, and violates the recorder's snapshot/ownership semantics.

## Fix

Use the active backend's copy operation after normalization. This preserves dtype, device, shape, and backend portability while ensuring the recorder owns its initial snapshot.

## Validation

- isolated NumPy reproduction confirms the pre-fix storage alias
- isolated owning-copy check confirms caller mutations no longer affect the snapshot
- focused regression added for mutable backends; skipped for immutable JAX arrays
- regression module passes Python syntax compilation
- branch is 2 commits ahead and 0 behind `main`
- changed scope: one production module and one focused test

This is a clean replacement for the older closed, unmerged draft #4274, based directly on current `main`.