### PR TITLE
Copy linear Gaussian model parameters

### DIFF
--- a/src/pyrecest/models/linear_gaussian.py
+++ b/src/pyrecest/models/linear_gaussian.py
@@ -5,6 +5,7 @@ from numbers import Complex, Integral, Real
 
 from pyrecest.backend import (
     asarray,
+    copy as backend_copy,
     eye,
     matmul,
     matvec,
@@ -170,12 +171,14 @@ class LinearGaussianTransitionModel:
             noise_covariance,
             type(self).__name__,
         )
-        self.matrix = _as_matrix(matrix, "matrix")
-        self.noise_cov = _as_square(noise_cov, "noise_cov")
+        self.matrix = backend_copy(_as_matrix(matrix, "matrix"))
+        self.noise_cov = backend_copy(_as_square(noise_cov, "noise_cov"))
         self.predicted_dim, self.state_dim = _shape(self.matrix)
         if _shape(self.noise_cov) != (self.predicted_dim, self.predicted_dim):
             raise ValueError("noise_cov has incompatible shape")
-        self.offset = None if offset is None else _as_vector(offset, "offset")
+        self.offset = (
+            None if offset is None else backend_copy(_as_vector(offset, "offset"))
+        )
         if self.offset is not None and _shape(self.offset) != (self.predicted_dim,):
             raise ValueError("offset has incompatible shape")
 
@@ -264,8 +267,8 @@ class LinearGaussianMeasurementModel:
             noise_covariance,
             type(self).__name__,
         )
-        self.matrix = _as_matrix(matrix, "matrix")
-        self.noise_cov = _as_square(noise_cov, "noise_cov")
+        self.matrix = backend_copy(_as_matrix(matrix, "matrix"))
+        self.noise_cov = backend_copy(_as_square(noise_cov, "noise_cov"))
         self.measurement_dim, self.state_dim = _shape(self.matrix)
         if _shape(self.noise_cov) != (self.measurement_dim, self.measurement_dim):
             raise ValueError("noise_cov has incompatible shape")

--- a/tests/models/test_linear_gaussian_parameter_ownership.py
+++ b/tests/models/test_linear_gaussian_parameter_ownership.py
@@ -1,0 +1,50 @@
+import unittest
+
+import numpy.testing as npt
+import pyrecest.backend
+from pyrecest.backend import array, to_numpy
+from pyrecest.models import (
+    LinearGaussianMeasurementModel,
+    LinearGaussianTransitionModel,
+)
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+    reason="JAX arrays are immutable",
+)
+class LinearGaussianParameterOwnershipTest(unittest.TestCase):
+    def test_transition_model_copies_constructor_arrays(self):
+        matrix = array([[1.0, 1.0], [0.0, 1.0]])
+        noise_cov = array([[0.1, 0.0], [0.0, 0.2]])
+        offset = array([0.5, -0.25])
+        model = LinearGaussianTransitionModel(matrix, noise_cov, offset)
+
+        matrix[0, 0] = 7.0
+        noise_cov[0, 0] = 8.0
+        offset[0] = 9.0
+
+        npt.assert_allclose(
+            to_numpy(model.system_matrix),
+            [[1.0, 1.0], [0.0, 1.0]],
+        )
+        npt.assert_allclose(
+            to_numpy(model.system_noise_cov),
+            [[0.1, 0.0], [0.0, 0.2]],
+        )
+        npt.assert_allclose(to_numpy(model.sys_input), [0.5, -0.25])
+
+    def test_measurement_model_copies_constructor_arrays(self):
+        matrix = array([[1.0, 0.0]])
+        noise_cov = array([[0.25]])
+        model = LinearGaussianMeasurementModel(matrix, noise_cov)
+
+        matrix[0, 0] = 7.0
+        noise_cov[0, 0] = 8.0
+
+        npt.assert_allclose(to_numpy(model.measurement_matrix), [[1.0, 0.0]])
+        npt.assert_allclose(to_numpy(model.measurement_noise_cov), [[0.25]])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`LinearGaussianTransitionModel` and `LinearGaussianMeasurementModel` converted constructor inputs with `asarray()` but retained the resulting arrays directly. On mutable backends, callers could therefore modify the transition/measurement matrix, noise covariance, or transition offset after construction and silently change an existing model.

## Fix

- copy validated constructor arrays through the active backend
- preserve existing validation and public aliases
- avoid copying per-call prediction inputs

## Regression coverage

- transition matrix, system-noise covariance, and offset ownership
- measurement matrix and measurement-noise covariance ownership
- NumPy and PyTorch mutable backends; JAX is skipped because its arrays are immutable

## Local validation

- reconstructed source matched the current Git blob exactly before modification
- `python -m py_compile` passed for the changed source and test
- isolated NumPy ownership regressions passed

GitHub Actions remains authoritative for the complete backend matrix and repository test suite.