### PR TITLE
Restore SO(3) grid-to-Dirac conversion

### DIFF
--- a/src/pyrecest/distributions/so3_dirac_distribution.py
+++ b/src/pyrecest/distributions/so3_dirac_distribution.py
@@ -1,6 +1,8 @@
 """Dirac distribution on SO(3)."""
 
 # pylint: disable=no-name-in-module,no-member
+from numbers import Integral
+
 from pyrecest.backend import (
     abs,
     all,
@@ -17,6 +19,9 @@ from pyrecest.backend import (
 )
 
 from ._so3_helpers import geodesic_distance, normalize_quaternions
+from .hypersphere_subset.abstract_hypersphere_subset_grid_distribution import (
+    AbstractHypersphereSubsetGridDistribution,
+)
 from .hypersphere_subset.hyperhemispherical_dirac_distribution import (
     HyperhemisphericalDiracDistribution,
 )
@@ -97,8 +102,21 @@ class SO3DiracDistribution(HyperhemisphericalDiracDistribution):
 
     @classmethod
     def from_distribution(cls, distribution, n_particles=None):
-        """Create an SO(3) Dirac distribution from another SO(3) distribution."""
-        return super().from_distribution(distribution, n_particles)
+        """Create an SO(3) Dirac distribution from another distribution."""
+        if isinstance(distribution, AbstractHypersphereSubsetGridDistribution):
+            return cls(distribution.get_grid(), distribution.grid_values)
+        n_particles = cls._validate_particle_count(n_particles)
+        return cls(distribution.sample(n_particles))
+
+    @staticmethod
+    def _validate_particle_count(n_particles):
+        if (
+            isinstance(n_particles, bool)
+            or not isinstance(n_particles, Integral)
+            or int(n_particles) <= 0
+        ):
+            raise ValueError("n_particles must be a positive integer")
+        return int(n_particles)
 
     def angular_error_mean(self, rotation):
         """Return the weighted mean angular error to ``rotation`` in radians."""

--- a/src/pyrecest/distributions/so3_dirac_distribution.py
+++ b/src/pyrecest/distributions/so3_dirac_distribution.py
@@ -1,8 +1,6 @@
 """Dirac distribution on SO(3)."""
 
 # pylint: disable=no-name-in-module,no-member
-from numbers import Integral
-
 from pyrecest.backend import (
     abs,
     all,
@@ -99,19 +97,8 @@ class SO3DiracDistribution(HyperhemisphericalDiracDistribution):
 
     @classmethod
     def from_distribution(cls, distribution, n_particles=None):
-        """Create an SO(3) Dirac distribution by sampling another distribution."""
-        n_particles = cls._validate_particle_count(n_particles)
-        return cls(distribution.sample(n_particles))
-
-    @staticmethod
-    def _validate_particle_count(n_particles):
-        if (
-            isinstance(n_particles, bool)
-            or not isinstance(n_particles, Integral)
-            or int(n_particles) <= 0
-        ):
-            raise ValueError("n_particles must be a positive integer")
-        return int(n_particles)
+        """Create an SO(3) Dirac distribution from another SO(3) distribution."""
+        return super().from_distribution(distribution, n_particles)
 
     def angular_error_mean(self, rotation):
         """Return the weighted mean angular error to ``rotation`` in radians."""

--- a/tests/distributions/test_so3_dirac_grid_conversion.py
+++ b/tests/distributions/test_so3_dirac_grid_conversion.py
@@ -1,0 +1,23 @@
+import numpy.testing as npt
+
+from pyrecest.backend import array, to_numpy
+from pyrecest.distributions import (
+    HyperhemisphericalGridDistribution,
+    SO3DiracDistribution,
+)
+
+
+def test_so3_dirac_conversion_reuses_hyperhemispherical_grid_without_particle_count():
+    grid = array(
+        [
+            [0.0, 0.0, 0.0, 1.0],
+            [1.0, 0.0, 0.0, 0.0],
+        ]
+    )
+    grid_values = array([1.0, 3.0])
+    source = HyperhemisphericalGridDistribution(grid, grid_values)
+
+    converted = SO3DiracDistribution.from_distribution(source)
+
+    npt.assert_allclose(to_numpy(converted.d), to_numpy(grid))
+    npt.assert_allclose(to_numpy(converted.w), [0.25, 0.75])


### PR DESCRIPTION
## Bug

`SO3DiracDistribution.from_distribution()` overrode the hypersphere-subset conversion path and always validated `n_particles` before sampling. This broke deterministic conversion from `HyperhemisphericalGridDistribution`: calling `SO3DiracDistribution.from_distribution(grid_distribution)` raised a `ValueError` even though the parent implementation explicitly supports grid conversion without a particle count.

## Fix

- delegate SO(3) conversion to the inherited hypersphere-subset implementation;
- preserve deterministic grid points and grid weights for grid sources;
- retain sampling-based conversion and particle-count validation for non-grid sources through the existing base classes;
- remove the now-redundant local particle-count validator.

## Regression coverage

A focused test converts a two-point hyperhemispherical quaternion grid without `n_particles` and verifies that the Dirac locations and normalized weights are preserved.

## Scope

Two files: one small production change and one regression test.