### PR TITLE
Reject complex LTI discretization inputs

### DIFF
--- a/src/pyrecest/models/_validated_motion_models.py
+++ b/src/pyrecest/models/_validated_motion_models.py
@@ -4,9 +4,49 @@ from __future__ import annotations
 
 from typing import Any
 
+import numpy as np
+
 from . import motion_models as _motion_models
 
+_continuous_to_discrete_lti_impl = _motion_models.continuous_to_discrete_lti
 _nearly_coordinated_turn_model_impl = _motion_models.nearly_coordinated_turn_model
+
+
+def _reject_complex_matrix(value: Any, name: str) -> None:
+    """Reject complex matrices before NumPy can discard imaginary components."""
+    try:
+        value_array = np.asarray(value)
+    except (TypeError, ValueError):
+        return
+
+    contains_complex_object = value_array.dtype == object and any(
+        isinstance(item, (complex, np.complexfloating)) for item in value_array.flat
+    )
+    if np.iscomplexobj(value_array) or contains_complex_object:
+        raise ValueError(f"{name} must contain real values")
+
+
+def continuous_to_discrete_lti(
+    continuous_matrix: Any,
+    noise_input_matrix: Any | None = None,
+    continuous_noise_covariance: Any | None = None,
+    dt: float = 1.0,
+) -> Any:
+    """Discretize a real LTI model without silently truncating complex inputs."""
+    _reject_complex_matrix(continuous_matrix, "continuous_matrix")
+    if noise_input_matrix is not None:
+        _reject_complex_matrix(noise_input_matrix, "noise_input_matrix")
+    if continuous_noise_covariance is not None:
+        _reject_complex_matrix(
+            continuous_noise_covariance,
+            "continuous_noise_covariance",
+        )
+    return _continuous_to_discrete_lti_impl(
+        continuous_matrix,
+        noise_input_matrix,
+        continuous_noise_covariance,
+        dt=dt,
+    )
 
 
 def nearly_coordinated_turn_model(
@@ -32,7 +72,8 @@ def nearly_coordinated_turn_model(
     )
 
 
+_motion_models.continuous_to_discrete_lti = continuous_to_discrete_lti
 _motion_models.nearly_coordinated_turn_model = nearly_coordinated_turn_model
 
 
-__all__ = ["nearly_coordinated_turn_model"]
+__all__ = ["continuous_to_discrete_lti", "nearly_coordinated_turn_model"]

--- a/tests/models/test_continuous_to_discrete_lti_complex_validation.py
+++ b/tests/models/test_continuous_to_discrete_lti_complex_validation.py
@@ -1,0 +1,48 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.models import continuous_to_discrete_lti
+
+
+class TestContinuousToDiscreteLtiComplexValidation(unittest.TestCase):
+    def test_rejects_complex_system_and_noise_matrices(self):
+        complex_matrices = (
+            np.array([[1.0 + 2.0j]]),
+            np.array([[1.0 + 2.0j]], dtype=object),
+        )
+        cases = (
+            (
+                "continuous_matrix",
+                lambda matrix: {"continuous_matrix": matrix},
+            ),
+            (
+                "noise_input_matrix",
+                lambda matrix: {
+                    "continuous_matrix": np.zeros((1, 1)),
+                    "noise_input_matrix": matrix,
+                    "continuous_noise_covariance": np.ones((1, 1)),
+                },
+            ),
+            (
+                "continuous_noise_covariance",
+                lambda matrix: {
+                    "continuous_matrix": np.zeros((1, 1)),
+                    "noise_input_matrix": np.ones((1, 1)),
+                    "continuous_noise_covariance": matrix,
+                },
+            ),
+        )
+
+        for matrix in complex_matrices:
+            for parameter_name, make_kwargs in cases:
+                with self.subTest(
+                    parameter_name=parameter_name,
+                    dtype=matrix.dtype,
+                ):
+                    with self.assertRaisesRegex(ValueError, parameter_name):
+                        continuous_to_discrete_lti(**make_kwargs(matrix))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`continuous_to_discrete_lti()` converted its system and noise matrices with `np.asarray(..., dtype=float)`. NumPy accepts complex arrays on that path by discarding their imaginary components with a warning, so the function could discretize a different real-valued model instead of rejecting an unsupported complex model.

The issue affected `continuous_matrix`, `noise_input_matrix`, and `continuous_noise_covariance`, including object arrays containing complex scalars.

## Fix

- validate all three matrix inputs before the existing float conversion
- reject native complex arrays and object arrays containing complex scalars with a parameter-specific `ValueError`
- preserve the existing real-valued discretization implementation and public import path
- add focused regression coverage for every affected parameter and both complex representations

## Impact

Callers can no longer receive plausible-looking transition or process-noise matrices after imaginary components were silently removed.

## Validation

- branch is 2 commits ahead of `main` and 0 behind
- Python syntax parsing passed for the changed implementation and regression
- isolated reproduction confirmed the old NumPy conversion truncates the imaginary part
- isolated checks confirmed the new validation rejects native and object-wrapped complex matrices while accepting real matrices

GitHub Actions should provide the authoritative repository-wide validation.