### PR TITLE
Validate missing simulation timesteps before generation

### DIFF
--- a/src/pyrecest/evaluation/evaluate_for_simulation_config.py
+++ b/src/pyrecest/evaluation/evaluate_for_simulation_config.py
@@ -50,7 +50,7 @@ def evaluate_for_simulation_config(
         n_runs, initial_seed, consecutive_seed
     )
     if n_timesteps is None:
-        if "n_timesteps" not in simulation_config:
+        if simulation_config.get("n_timesteps") is None:
             raise ValueError(
                 "n_steps must be provided in simulation_config or as an argument."
             )

--- a/tests/evaluation/test_missing_simulation_timesteps.py
+++ b/tests/evaluation/test_missing_simulation_timesteps.py
@@ -1,0 +1,26 @@
+"""Regression tests for missing simulation horizon validation."""
+
+import pytest
+
+from pyrecest.evaluation import evaluate_for_simulation_config
+
+
+def test_custom_scenario_rejects_missing_timesteps_before_generation():
+    """The custom scenario database entry stores a present-but-None horizon."""
+    with pytest.warns(UserWarning, match="Scenario not recognized"):
+        with pytest.raises(ValueError, match="n_steps must be provided"):
+            evaluate_for_simulation_config(
+                "custom",
+                [],
+                n_runs=1,
+                scenario_customization_params={},
+            )
+
+
+def test_explicit_none_timesteps_in_mapping_is_rejected():
+    with pytest.raises(ValueError, match="n_steps must be provided"):
+        evaluate_for_simulation_config(
+            {"n_timesteps": None},
+            [],
+            n_runs=1,
+        )


### PR DESCRIPTION
## Bug

`simulation_database("custom", ...)` initializes `n_timesteps` to `None`. `evaluate_for_simulation_config` only checked whether the key was absent, so this present-but-null value bypassed the intended validation and reached scenario generation, where it failed later with an unrelated error.

## Fix

- treat a missing key and an explicit `None` horizon equivalently
- raise the existing targeted `ValueError` before scenario generation
- preserve the explicit `n_timesteps` argument override

## Regression coverage

- custom database scenario with omitted timesteps
- direct mapping with `n_timesteps=None`

## Validation

- changed source and regression module pass `py_compile`
- independent guard checks confirm missing horizons are rejected and explicit overrides remain accepted
- branch is 2 commits ahead and 0 behind current `main`

GitHub Actions remains authoritative for the full test matrix.