### PR TITLE
Reject complex LTI discretization inputs

### DIFF
--- a/src/pyrecest/models/_validated_motion_models.py
+++ b/src/pyrecest/models/_validated_motion_models.py
@@ -4,9 +4,49 @@ from __future__ import annotations
 
 from typing import Any
 
+import numpy as np
+
 from . import motion_models as _motion_models
 
 _nearly_coordinated_turn_model_impl = _motion_models.nearly_coordinated_turn_model
+_continuous_to_discrete_lti_impl = _motion_models.continuous_to_discrete_lti
+
+
+def _reject_complex_matrix(value: Any, name: str) -> None:
+    """Reject complex-valued matrices before NumPy can discard imaginary parts."""
+    try:
+        value_array = np.asarray(value)
+    except (TypeError, ValueError):
+        return
+
+    contains_complex_object = value_array.dtype == object and any(
+        isinstance(item, (complex, np.complexfloating)) for item in value_array.flat
+    )
+    if np.iscomplexobj(value_array) or contains_complex_object:
+        raise ValueError(f"{name} must contain real values")
+
+
+def continuous_to_discrete_lti(
+    continuous_matrix: Any,
+    noise_input_matrix: Any | None = None,
+    continuous_noise_covariance: Any | None = None,
+    dt: float = 1.0,
+) -> Any:
+    """Discretize a real LTI model without silently truncating complex inputs."""
+    _reject_complex_matrix(continuous_matrix, "continuous_matrix")
+    if noise_input_matrix is not None:
+        _reject_complex_matrix(noise_input_matrix, "noise_input_matrix")
+    if continuous_noise_covariance is not None:
+        _reject_complex_matrix(
+            continuous_noise_covariance,
+            "continuous_noise_covariance",
+        )
+    return _continuous_to_discrete_lti_impl(
+        continuous_matrix,
+        noise_input_matrix,
+        continuous_noise_covariance,
+        dt=dt,
+    )
 
 
 def nearly_coordinated_turn_model(
@@ -32,7 +72,8 @@ def nearly_coordinated_turn_model(
     )
 
 
+_motion_models.continuous_to_discrete_lti = continuous_to_discrete_lti
 _motion_models.nearly_coordinated_turn_model = nearly_coordinated_turn_model
 
 
-__all__ = ["nearly_coordinated_turn_model"]
+__all__ = ["continuous_to_discrete_lti", "nearly_coordinated_turn_model"]

--- a/tests/models/test_continuous_to_discrete_lti_complex_validation.py
+++ b/tests/models/test_continuous_to_discrete_lti_complex_validation.py
@@ -1,0 +1,51 @@
+"""Regression tests for complex LTI discretization inputs."""
+
+import unittest
+
+import numpy as np
+from pyrecest.models import continuous_to_discrete_lti
+
+
+class TestContinuousToDiscreteLtiComplexValidation(unittest.TestCase):
+    def test_rejects_complex_system_and_noise_matrices(self):
+        complex_variants = (
+            np.array([[1.0 + 2.0j]]),
+            np.array([[1.0 + 2.0j]], dtype=object),
+        )
+        parameter_cases = (
+            (
+                "continuous_matrix",
+                lambda matrix: {
+                    "continuous_matrix": matrix,
+                },
+            ),
+            (
+                "noise_input_matrix",
+                lambda matrix: {
+                    "continuous_matrix": np.zeros((1, 1)),
+                    "noise_input_matrix": matrix,
+                    "continuous_noise_covariance": np.ones((1, 1)),
+                },
+            ),
+            (
+                "continuous_noise_covariance",
+                lambda matrix: {
+                    "continuous_matrix": np.zeros((1, 1)),
+                    "noise_input_matrix": np.ones((1, 1)),
+                    "continuous_noise_covariance": matrix,
+                },
+            ),
+        )
+
+        for complex_matrix in complex_variants:
+            for parameter_name, build_kwargs in parameter_cases:
+                with self.subTest(
+                    parameter_name=parameter_name,
+                    dtype=complex_matrix.dtype,
+                ):
+                    with self.assertRaisesRegex(ValueError, parameter_name):
+                        continuous_to_discrete_lti(**build_kwargs(complex_matrix))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`continuous_to_discrete_lti()` converts the continuous system matrix, noise-input matrix, and continuous noise covariance with `np.asarray(..., dtype=float)`. NumPy accepts native complex arrays by discarding their imaginary parts with a warning, so the helper can silently discretize a different real-valued model than the caller supplied. Object arrays containing complex scalars expose the same failure mode.

## Fix

- validate all three LTI matrix inputs before the existing float conversion;
- reject native complex dtypes and object arrays containing complex values with parameter-specific `ValueError`s;
- keep the existing core discretization and all real-valued behavior unchanged;
- install the guard through the existing validated motion-model wrapper layer.

## Impact

Complex-valued models can no longer be silently projected onto their real parts. Callers receive an explicit error at the public API boundary instead of plausible-looking transition and process-noise matrices for the wrong system.

## Regression coverage

The focused regression covers both native complex arrays and object arrays containing complex scalars for:

- `continuous_matrix`;
- `noise_input_matrix`;
- `continuous_noise_covariance`.

## Validation

- reproduced the previous NumPy behavior: `[[1 + 2j]]` becomes `[[1.0]]` with a complex-to-real warning;
- isolated wrapper regression passed for all six invalid-input cases and an ordinary real-valued control;
- changed implementation and test pass Python syntax compilation;
- branch is 2 commits ahead of current `main` and 0 behind;
- diff is limited to the validation wrapper and one focused test module.

GitHub Actions should provide the authoritative repository-wide and backend-matrix validation.

This is a clean current-`main` replacement for the still-applicable defect previously identified in closed, unmerged PR #4450.