### PR TITLE
Preserve exact multisession fill labels

### DIFF
--- a/src/pyrecest/utils/_multisession_assignment_labels.py
+++ b/src/pyrecest/utils/_multisession_assignment_labels.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import math
 from collections.abc import Sequence
 from numbers import Integral
 from typing import Any
@@ -46,12 +45,15 @@ def _normalize_fill_value(fill_value: Any, track_count: int) -> int:
         integer_fill_value = int(fill_value_value)
     else:
         try:
-            fill_value_float = float(fill_value_value)
+            integer_fill_value = int(fill_value_value)
         except (TypeError, ValueError, OverflowError) as exc:
             raise ValueError("fill_value must be an integer.") from exc
-        if not math.isfinite(fill_value_float) or not fill_value_float.is_integer():
+        try:
+            is_exact_integer = fill_value_value == integer_fill_value
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError("fill_value must be an integer.") from exc
+        if not bool(is_exact_integer):
             raise ValueError("fill_value must be an integer.")
-        integer_fill_value = int(fill_value_float)
 
     if 0 <= integer_fill_value < int(track_count):
         raise ValueError("fill_value must not collide with track labels.")

--- a/tests/test_multisession_assignment_fill_value_precision.py
+++ b/tests/test_multisession_assignment_fill_value_precision.py
@@ -1,0 +1,28 @@
+"""Regression test for exact multi-session label fill values."""
+
+import unittest
+from decimal import Decimal
+
+from pyrecest.backend import __backend_name__
+from pyrecest.utils import tracks_to_session_labels
+
+
+class TestMultiSessionAssignmentFillValuePrecision(unittest.TestCase):
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_exact_decimal_fill_value_is_not_rounded_through_float(self):
+        fill_value = Decimal(-(2**53 + 1))
+
+        labels = tracks_to_session_labels(
+            [{0: 0}],
+            session_sizes=[2],
+            fill_value=fill_value,
+        )
+
+        self.assertEqual(int(labels[0][1]), int(fill_value))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`tracks_to_session_labels()` accepted exact integer-like scalar values, but non-`Integral` inputs were normalized through `float()` before conversion to `int`. Exact numeric types such as `Decimal` therefore lost precision above the binary64 integer range.

For example, `Decimal(-(2**53 + 1))` was silently stored as `-2**53`, changing the caller's requested sentinel label.

## Fix

- convert integer-like scalar values directly with `int()` instead of routing them through `float()`;
- compare the converted integer with the original scalar to preserve the existing rejection of fractional values;
- retain the existing handling of booleans, text, temporal values, non-finite values, and label collisions.

## Regression coverage

- verify that `Decimal(-(2**53 + 1))` is preserved exactly in the generated label array.

## Validation

- reproduced the old precision loss in isolation;
- verified exact conversion for large `Decimal` values and existing integer-like float/NumPy scalar cases;
- verified fractional, boolean, text, NaN, and infinite values remain rejected;
- both changed files pass Python syntax parsing.

GitHub Actions remains authoritative for the full backend test matrix.