### PR TITLE
Reject masked evidence boolean flags

### DIFF
--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -28,6 +28,8 @@ _RESERVED_DIAGNOSTIC_METADATA_KEYS = frozenset(
 def _coerce_bool_flag(value: bool, name: str) -> bool:
     """Return a bool flag without treating arbitrary truthy objects as true."""
 
+    if np.ma.isMaskedArray(value) and bool(np.any(np.ma.getmaskarray(value))):
+        raise ValueError(f"{name} must be a bool")
     try:
         value_array = np.asarray(value)
     except (TypeError, ValueError, RuntimeError, OverflowError) as exc:

--- a/tests/test_evidence_bool_flag_conversion.py
+++ b/tests/test_evidence_bool_flag_conversion.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from pyrecest.evidence import EvidenceComputationMode, resolve_evidence_computation_mode
@@ -25,3 +26,20 @@ class FailingArrayConversion:
 def test_evidence_bool_flags_normalize_array_conversion_errors(factory, error_type):
     with pytest.raises(ValueError, match="must be a bool"):
         factory(FailingArrayConversion(error_type))
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda value: EvidenceComputationMode(return_smoothed=value),
+        lambda value: EvidenceComputationMode(terminal_posterior=value),
+        lambda value: EvidenceComputationMode.from_return_smoothed(value),
+        lambda value: resolve_evidence_computation_mode(return_smoothed=value),
+    ],
+)
+@pytest.mark.parametrize("payload", [True, False])
+def test_evidence_bool_flags_reject_masked_boolean_scalars(factory, payload):
+    masked_value = np.ma.array(payload, mask=True)
+
+    with pytest.raises(ValueError, match="must be a bool"):
+        factory(masked_value)


### PR DESCRIPTION
## Bug

Evidence-mode Boolean validation converted inputs with `np.asarray` before checking their scalar Boolean dtype. For a masked NumPy Boolean scalar, that conversion exposes the hidden payload and discards the mask, so a missing configuration value could silently become either `True` or `False`.

## Fix

- reject masked-array Boolean flags when any value is masked;
- preserve the existing acceptance of ordinary Python/NumPy Boolean scalars;
- apply the guard to all evidence-mode flag entry points through the shared coercion helper.

## Impact

Missing masked configuration values now fail explicitly instead of changing whether smoothing or terminal-posterior behavior is enabled.

## Regression coverage

The focused test exercises both hidden payloads (`True` and `False`) through:

- `EvidenceComputationMode(return_smoothed=...)`;
- `EvidenceComputationMode(terminal_posterior=...)`;
- `EvidenceComputationMode.from_return_smoothed(...)`;
- `resolve_evidence_computation_mode(return_smoothed=...)`.

## Validation

- confirmed the old conversion returns the hidden Boolean payload for fully masked scalars;
- confirmed the new guard raises the parameter-specific `ValueError` for both payloads;
- branch is 2 commits ahead and 0 behind current `main`;
- diff is limited to the shared Boolean coercion and one focused regression module.

GitHub Actions should provide the authoritative repository-wide and backend-matrix validation.