### PR TITLE
Preserve custom hypercylindrical covariance matrix shape

### DIFF
--- a/src/pyrecest/distributions/cart_prod/custom_hypercylindrical_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/custom_hypercylindrical_distribution.py
@@ -1,3 +1,5 @@
+from pyrecest.backend import array, reshape
+
 from .abstract_custom_lin_bounded_cart_prod_distribution import (
     AbstractCustomLinBoundedCartProdDistribution,
 )
@@ -49,6 +51,13 @@ class CustomHypercylindricalDistribution(
         return AbstractHypercylindricalDistribution.integrate(
             self, integration_boundaries
         )
+
+    def linear_covariance_numerical(self, approximate_mean=None):
+        """Return numerical linear covariance with a stable matrix shape."""
+        covariance = AbstractHypercylindricalDistribution.linear_covariance_numerical(
+            self, approximate_mean
+        )
+        return reshape(array(covariance), (self.lin_dim, self.lin_dim))
 
     def condition_on_periodic(self, input_periodic, normalize=True):
         # Call the condition_on_periodic method from the superclass

--- a/tests/distributions/test_custom_hypercylindrical_covariance_shape.py
+++ b/tests/distributions/test_custom_hypercylindrical_covariance_shape.py
@@ -1,0 +1,38 @@
+from unittest.mock import patch
+
+import numpy.testing as npt
+
+from pyrecest.backend import array, ones, pi, to_numpy
+from pyrecest.distributions.cart_prod.custom_hypercylindrical_distribution import (
+    CustomHypercylindricalDistribution,
+)
+
+
+def _constant_pdf(xs):
+    xs = array(xs)
+    return ones(1 if xs.ndim == 1 else xs.shape[0])
+
+
+def test_custom_numerical_covariance_preserves_matrix_shape_for_boundaries():
+    distribution = CustomHypercylindricalDistribution(_constant_pdf, 1, 1)
+    quadrature_path = (
+        "pyrecest.distributions.cart_prod."
+        "abstract_hypercylindrical_distribution.nquad"
+    )
+
+    with (
+        patch.object(
+            distribution, "linear_mean_numerical", return_value=array([0.0])
+        ),
+        patch.object(distribution, "mode", return_value=array([0.0, 2.0])),
+        patch(quadrature_path, return_value=(4.0, 0.0)),
+    ):
+        covariance = distribution.linear_covariance()
+        boundaries = distribution.get_reasonable_integration_boundaries(scalingFactor=3)
+
+    assert covariance.shape == (1, 1)
+    npt.assert_allclose(to_numpy(covariance), [[4.0]])
+    npt.assert_allclose(
+        to_numpy(array(boundaries)),
+        [[0.0, 2.0 * pi], [-4.0, 8.0]],
+    )


### PR DESCRIPTION
## Bug

`AbstractHypercylindricalDistribution.linear_covariance_numerical()` returns the raw scalar from SciPy quadrature for a distribution with one periodic and one linear dimension. `CustomHypercylindricalDistribution` inherited that scalar even though the covariance API and downstream boundary and plotting code require a two-dimensional `(1, 1)` matrix.

This causes scalar-indexing failures in operations such as `get_reasonable_integration_boundaries()`.

## Fix

Normalize the numerical covariance returned by `CustomHypercylindricalDistribution` to `(lin_dim, lin_dim)` using the active backend. The reshape is a no-op for already matrix-shaped multidimensional results and converts the one-dimensional scalar result to `(1, 1)`.

## Regression coverage

The focused regression test:

- constructs a one-periodic/one-linear custom distribution;
- supplies a deterministic quadrature covariance of `4.0`;
- verifies the covariance has shape `(1, 1)`; and
- verifies reasonable integration boundaries are computed as `[[0, 2π], [-4, 8]]` instead of failing on scalar indexing.

## Validation

- branch is 2 commits ahead of current `main` and 0 behind;
- diff is limited to one production module and one focused test;
- full repository and backend-matrix validation is delegated to GitHub Actions because this environment cannot clone or execute the repository test suite.