### PR TITLE
Reject overflowed jittered Cholesky factors

### DIFF
--- a/src/pyrecest/numerics.py
+++ b/src/pyrecest/numerics.py
@@ -218,8 +218,8 @@ def jittered_cholesky(matrix, *, initial_jitter: float = 1e-12, max_attempts: in
     """Return a Cholesky factor and the jitter used to obtain it.
 
     The function tries the raw matrix first, then repeatedly adds diagonal
-    jitter. It raises :class:`NumericalStabilityError` if no factorization is
-    found within ``max_attempts``.
+    jitter. It raises :class:`NumericalStabilityError` if no finite factorization
+    is found within ``max_attempts``.
     """
     initial_jitter = _validate_positive_finite("initial_jitter", initial_jitter)
     max_attempts = _validate_nonnegative_integer("max_attempts", max_attempts)
@@ -231,11 +231,15 @@ def jittered_cholesky(matrix, *, initial_jitter: float = 1e-12, max_attempts: in
     eye = np.eye(sym.shape[0])
     jitter = 0.0
     for attempt in range(max_attempts + 1):
+        if not np.isfinite(jitter):
+            break
         try:
             factor = np.linalg.cholesky(sym + jitter * eye)
-            return _from_numpy_array(factor), jitter
+            if _is_finite_matrix(factor):
+                return _from_numpy_array(factor), jitter
         except np.linalg.LinAlgError:
-            jitter = initial_jitter if attempt == 0 else jitter * 10.0
+            pass
+        jitter = initial_jitter if attempt == 0 else jitter * 10.0
     raise NumericalStabilityError(
         f"Cholesky factorization failed after {max_attempts} jitter attempts."
     )

--- a/tests/test_jittered_cholesky_overflow.py
+++ b/tests/test_jittered_cholesky_overflow.py
@@ -1,0 +1,12 @@
+import numpy as np
+import pytest
+
+from pyrecest.exceptions import NumericalStabilityError
+from pyrecest.numerics import jittered_cholesky
+
+
+def test_jittered_cholesky_rejects_overflowed_jitter_and_factor():
+    matrix = np.array([[-1e308]])
+
+    with pytest.raises(NumericalStabilityError, match="Cholesky factorization failed"):
+        jittered_cholesky(matrix, initial_jitter=1e307, max_attempts=3)


### PR DESCRIPTION
## Bug

`jittered_cholesky()` increases diagonal jitter geometrically after failed factorizations. For sufficiently large finite matrices and retry controls, that jitter can overflow to `inf`. NumPy may then return an infinite Cholesky factor rather than raising `LinAlgError`, so the helper can report success with a numerically invalid factor and non-finite jitter.

## Fix

- stop retrying once the jitter becomes non-finite;
- accept a factorization only when every factor entry is finite;
- preserve the existing retry behavior and error type for ordinary failures.

## Regression coverage

The new test uses a finite `-1e308` scalar matrix with `initial_jitter=1e307`. It verifies that overflow during geometric retry escalation raises `NumericalStabilityError` rather than returning an infinite factor.

## Validation

- branch is 2 commits ahead of `main` and 0 behind;
- diff is limited to the numerical helper and one focused regression test;
- the failure mode was reproduced directly with NumPy (`np.linalg.cholesky([[inf]])` returns `[[inf]]`).