### PR TITLE
Validate generalized sine-skewed von Mises concentration

### DIFF
--- a/src/pyrecest/distributions/circle/sine_skewed_distributions.py
+++ b/src/pyrecest/distributions/circle/sine_skewed_distributions.py
@@ -59,6 +59,9 @@ class GeneralizedKSineSkewedVonMisesDistribution(AbstractCircularDistribution):
         self.validate_parameters()
 
     def validate_parameters(self):
+        self.kappa = _validate_finite_scalar_parameter(self.kappa, "kappa")
+        if self.kappa < 0:
+            raise ValueError("kappa must be nonnegative")
         self.lambda_ = _validate_scalar_parameter(self.lambda_, "lambda_")
         if not (-1.0 <= self.lambda_ <= 1.0):
             raise ValueError("lambda_ must be between -1 and 1 inclusive")

--- a/tests/distributions/test_generalized_sine_skewed_kappa_validation.py
+++ b/tests/distributions/test_generalized_sine_skewed_kappa_validation.py
@@ -1,0 +1,57 @@
+import pytest
+
+from pyrecest.distributions.circle.sine_skewed_distributions import (
+    GeneralizedKSineSkewedVonMisesDistribution,
+    GSSVMDistribution,
+)
+
+
+@pytest.mark.parametrize(
+    "constructor",
+    [
+        lambda kappa: GeneralizedKSineSkewedVonMisesDistribution(
+            mu=0.0,
+            kappa=kappa,
+            lambda_=0.25,
+            k=1,
+            m=1,
+        ),
+        lambda kappa: GSSVMDistribution(
+            mu=0.0,
+            kappa=kappa,
+            lambda_=0.25,
+            n=1,
+        ),
+    ],
+)
+def test_generalized_sine_skewed_von_mises_rejects_invalid_kappa(constructor):
+    for kappa, message in (
+        (-0.1, "nonnegative"),
+        (float("nan"), "finite"),
+        (float("inf"), "finite"),
+        ([1.0, 2.0], "scalar"),
+    ):
+        with pytest.raises(ValueError, match=message):
+            constructor(kappa)
+
+
+@pytest.mark.parametrize(
+    "constructor",
+    [
+        lambda: GeneralizedKSineSkewedVonMisesDistribution(
+            mu=0.0,
+            kappa=0.0,
+            lambda_=0.25,
+            k=1,
+            m=1,
+        ),
+        lambda: GSSVMDistribution(
+            mu=0.0,
+            kappa=0.0,
+            lambda_=0.25,
+            n=1,
+        ),
+    ],
+)
+def test_generalized_sine_skewed_von_mises_accepts_zero_kappa(constructor):
+    assert float(constructor().kappa) == 0.0


### PR DESCRIPTION
## Bug

`GeneralizedKSineSkewedVonMisesDistribution` stored `kappa` without validating it. Negative, non-finite, or vector-valued concentrations therefore produced an apparently valid distribution object and failed only later when `pdf()` constructed the underlying `VonMisesDistribution`.

The defect also affected `GSSVMDistribution`, which inherits the same constructor path. This was inconsistent with the documented non-negative scalar concentration contract and with the eager validation already performed by `VonMisesDistribution` and the generalized wrapped-Cauchy counterpart.

## Fix

- validate `kappa` as a finite scalar during generalized sine-skewed von Mises construction;
- reject negative concentration immediately;
- preserve zero concentration as a valid uniform-base case;
- cover both the base generalized class and `GSSVMDistribution`.

## Regression coverage

The focused tests verify eager rejection of:

- negative `kappa`;
- `NaN` and infinite `kappa`;
- vector-valued `kappa`.

They also verify that `kappa=0` remains accepted.

## Validation

- both changed Python files pass syntax compilation;
- branch is 2 commits ahead of current `main` and 0 behind;
- production diff is limited to three validation lines plus one focused test module.

GitHub Actions provides the authoritative repository-wide and backend-matrix validation.