### PR TITLE
Reject inexact uniform integer arguments

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_uniform_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_uniform_distribution.py
@@ -35,11 +35,14 @@ def _validate_positive_sample_count(n) -> int:
 
     try:
         count_int = int(count)
-        count_float = float(count)
     except (OverflowError, TypeError, ValueError) as exc:
         raise ValueError("n must be an integer") from exc
 
-    if not np.isfinite(count_float) or not count_float.is_integer():
+    try:
+        is_exact_integer = bool(count == count_int)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("n must be an integer") from exc
+    if not is_exact_integer:
         raise ValueError("n must be a finite integer")
     if count_int <= 0:
         raise ValueError("n must be positive")
@@ -59,11 +62,14 @@ def _validate_trigonometric_moment_order(n: Union[int, int32, int64]) -> int:
 
     try:
         order_int = int(order)
-        order_float = float(order)
     except (OverflowError, TypeError, ValueError) as exc:
         raise ValueError("n must be an integer") from exc
 
-    if not np.isfinite(order_float) or not order_float.is_integer():
+    try:
+        is_exact_integer = bool(order == order_int)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("n must be an integer") from exc
+    if not is_exact_integer:
         raise ValueError("n must be a finite integer")
     return order_int
 

--- a/tests/distributions/test_uniform_order_validation.py
+++ b/tests/distributions/test_uniform_order_validation.py
@@ -1,12 +1,39 @@
+from fractions import Fraction
+
 import pytest
 
 from pyrecest.backend import array
-from pyrecest.distributions.hypertorus.hypertoroidal_uniform_distribution import HypertoroidalUniformDistribution
+from pyrecest.distributions.hypertorus.hypertoroidal_uniform_distribution import (
+    HypertoroidalUniformDistribution,
+    _validate_positive_sample_count,
+)
+
+
+_INEXACT_INTEGER_AFTER_FLOAT_ROUNDING = Fraction(2**54 + 1, 2)
 
 
 def test_uniform_moment_rejects_invalid_order():
     dist = HypertoroidalUniformDistribution(2)
 
-    for order in ("0", True, array([0]), 1.5):
+    for order in (
+        "0",
+        True,
+        array([0]),
+        1.5,
+        _INEXACT_INTEGER_AFTER_FLOAT_ROUNDING,
+    ):
         with pytest.raises(ValueError):
             dist.trigonometric_moment(order)
+
+
+def test_uniform_sample_count_rejects_fraction_rounded_to_integer_float():
+    with pytest.raises(ValueError):
+        _validate_positive_sample_count(_INEXACT_INTEGER_AFTER_FLOAT_ROUNDING)
+
+
+def test_uniform_integer_validation_accepts_exact_fraction():
+    exact_integer = Fraction(6, 3)
+
+    assert _validate_positive_sample_count(exact_integer) == 2
+    moment = HypertoroidalUniformDistribution(2).trigonometric_moment(exact_integer)
+    assert moment.shape == (2,)


### PR DESCRIPTION
## Bug

The hypertoroidal-uniform sample-count and trigonometric-moment validators converted scalar inputs to `float` before checking `is_integer()`.

Exact numeric types can lose their fractional part during binary64 conversion above the exact-integer range. For example, `Fraction(2**54 + 1, 2)` is exactly `9007199254740992.5`, but `float(...)` becomes `9007199254740992.0`. The validators therefore accepted a non-integer as a sample count or moment order and truncated it with `int()`.

## Fix

- convert the original scalar directly with `int()`;
- compare that integer back to the original scalar instead of a rounded float;
- reject values that are not exactly integral;
- preserve support for exact non-built-in numeric scalars such as `Fraction(6, 3)`.

## Impact

Non-integral exact numeric inputs can no longer be silently truncated after floating-point rounding. Ordinary Python and NumPy integer behavior is unchanged.

## Regression coverage

- reject a large half-integer `Fraction` as a trigonometric-moment order;
- reject the same value in the sample-count validator without attempting a huge allocation;
- verify an exactly integral `Fraction` remains accepted.

## Validation

- isolated reproduction confirms the old float path reports the half-integer as integral;
- isolated validation confirms the new exact comparison rejects both affected paths and accepts `Fraction(6, 3)`;
- branch is 2 commits ahead of current `main` and 0 behind;
- diff is limited to one validator module and its existing focused test module.

GitHub Actions should provide the authoritative repository-wide and backend-matrix validation.