### PR TITLE
Reject fractionally rounded exact seeds

### DIFF
--- a/src/pyrecest/reproducibility.py
+++ b/src/pyrecest/reproducibility.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import copy
-import math
 from collections.abc import Iterator
 from contextlib import contextmanager
 from numbers import Integral
@@ -76,12 +75,15 @@ def _normalize_seed(seed: int | None) -> int | None:
         normalized_seed = int(scalar)
     else:
         try:
-            scalar_float = float(scalar)
+            normalized_seed = int(scalar)
         except (TypeError, ValueError, OverflowError) as exc:
             raise ValueError(message) from exc
-        if not math.isfinite(scalar_float) or not scalar_float.is_integer():
+        try:
+            is_exact_integer = bool(scalar == normalized_seed)
+        except (TypeError, ValueError, RuntimeError, OverflowError) as exc:
+            raise ValueError(message) from exc
+        if not is_exact_integer:
             raise ValueError(message)
-        normalized_seed = int(scalar_float)
 
     if normalized_seed < 0 or normalized_seed > _MAX_BACKEND_SEED:
         raise ValueError(message)

--- a/tests/test_reproducibility_seed.py
+++ b/tests/test_reproducibility_seed.py
@@ -1,4 +1,5 @@
 import unittest
+from decimal import Decimal
 
 import numpy as np
 from pyrecest.reproducibility import seed_all
@@ -20,6 +21,7 @@ class ReproducibilitySeedValidationTest(unittest.TestCase):
             2**32,
             np.array(2**32, dtype=np.uint64),
             1.5,
+            Decimal("1.0000000000000000000000001"),
             float("nan"),
             float("inf"),
             "8",
@@ -40,6 +42,7 @@ class ReproducibilitySeedValidationTest(unittest.TestCase):
     def test_seed_all_accepts_integer_like_scalar_seed(self):
         self.assertIsNone(seed_all(None))
         self.assertEqual(seed_all(np.array(7.0)), 7)
+        self.assertEqual(seed_all(Decimal("7")), 7)
         self.assertEqual(seed_all(2**32 - 1), 2**32 - 1)
 
 


### PR DESCRIPTION
## Bug

`pyrecest.reproducibility._normalize_seed()` converted non-`Integral` scalar values through `float()` before checking whether they were integers. Exact numeric types can lose fractional information in that conversion.

For example, `Decimal("1.0000000000000000000000001")` becomes the binary64 value `1.0`, passes `is_integer()`, and is silently accepted as seed `1` even though the caller supplied a fractional value.

## Fix

- convert scalar numeric seeds directly with `int()`;
- compare the converted integer against the original scalar to require exact integrality;
- retain the existing rejection of booleans, temporal values, non-scalars, non-finite values, negative values, and values above the backend seed limit;
- remove the now-unused `math` import.

## Impact

Fractional exact numeric values can no longer be rounded into valid seeds. Exact integer-valued scalars, including `Decimal("7")`, remain accepted.

## Regression coverage

- reject a `Decimal` whose fractional part is below binary64 resolution;
- preserve acceptance of an exact integer-valued `Decimal`;
- retain the existing invalid and boundary seed cases.

## Validation

- reproduced the old conversion: the fractional `Decimal` becomes `1.0` and passes `float.is_integer()`;
- isolated validation checks passed for fractional exact values, finite integer-like values, NaN, infinity, and the maximum backend seed;
- both modified Python files pass syntax compilation;
- branch is 2 commits ahead of current `main` and 0 behind, with changes limited to the seed validator and its focused test.