### PR TITLE
Treat aligned NaNs as invariant audit outputs

### DIFF
--- a/src/pyrecest/tracking/audit_guards.py
+++ b/src/pyrecest/tracking/audit_guards.py
@@ -135,10 +135,10 @@ def _comparison_is_true(comparison: Any) -> bool:
 
 
 def _results_equal(left: Any, right: Any) -> bool:
-    """Compare normalized selector outputs, including array-valued outputs."""
+    """Compare selector outputs, treating aligned NaN values as unchanged."""
 
     try:
-        comparison = left == right
+        comparison = (left == right) | ((left != left) & (right != right))
     except (TypeError, ValueError, RuntimeError):
         return False
     return _comparison_is_true(comparison)

--- a/tests/tracking/test_audit_guards_nan_outputs.py
+++ b/tests/tracking/test_audit_guards_nan_outputs.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pyrecest.tracking import assert_selector_invariant_under_forbidden_key_changes
+
+
+_ROWS = [
+    {"candidate_id": "a", "score": 2.0, "audit_delta": -100.0},
+    {"candidate_id": "b", "score": 1.0, "audit_delta": 100.0},
+]
+_FORBIDDEN = {"audit_delta"}
+
+
+def test_selector_invariance_accepts_identical_scalar_nan_outputs() -> None:
+    def selector(_candidate_rows):
+        return float("nan")
+
+    assert_selector_invariant_under_forbidden_key_changes(
+        selector,
+        _ROWS,
+        _FORBIDDEN,
+    )
+
+
+def test_selector_invariance_accepts_aligned_nan_array_outputs() -> None:
+    def selector(candidate_rows):
+        scores = [row["score"] for row in candidate_rows]
+        return np.asarray([max(scores), np.nan])
+
+    assert_selector_invariant_under_forbidden_key_changes(
+        selector,
+        _ROWS,
+        _FORBIDDEN,
+    )
+
+
+def test_selector_invariance_still_rejects_finite_differences_next_to_nan() -> None:
+    def selector(candidate_rows):
+        return np.asarray([len(candidate_rows[0]), np.nan])
+
+    with pytest.raises(AssertionError, match="selector output changed"):
+        assert_selector_invariant_under_forbidden_key_changes(
+            selector,
+            _ROWS,
+            _FORBIDDEN,
+        )


### PR DESCRIPTION
## Bug

`assert_selector_invariant_under_forbidden_key_changes()` compared selector results with ordinary equality. IEEE NaN values are unequal to themselves, so a selector that returned the same scalar `NaN` or the same array with aligned NaNs for the original, stripped, poisoned, and guarded inputs was incorrectly reported as non-invariant.

This creates false leakage alarms for diagnostics and score vectors that legitimately use NaN as a stable missing-value marker.

## Fix

- compare outputs elementwise using ordinary equality or aligned self-inequality (`x != x`) for NaN positions;
- preserve scalar and array/backend-compatible reduction through the existing comparison helper;
- continue rejecting any non-NaN element that changes.

## Regression coverage

- identical scalar NaN outputs pass;
- arrays with matching finite values and aligned NaNs pass;
- a finite-value difference next to an aligned NaN still raises `AssertionError`.

## Validation

- isolated regression exercise passed for all three cases;
- branch is 2 commits ahead of `main` and 0 behind;
- diff is limited to 4 changed production lines and one focused 48-line test file;
- full repository/backend CI is delegated to GitHub Actions because the current environment cannot clone the repository or run its complete dependency matrix.