### PR TITLE
Fix no-argument circular Dirac interpolation call

### DIFF
--- a/src/pyrecest/distributions/circle/circular_dirac_distribution.py
+++ b/src/pyrecest/distributions/circle/circular_dirac_distribution.py
@@ -63,8 +63,8 @@ class CircularDiracDistribution(
             distribution.sample(n_particles), ones(n_particles) / n_particles
         )
 
-    def plot_interpolated(self, _):
-        """
-        Raises an exception since interpolation is not available for WDDistribution.
-        """
-        raise NotImplementedError("No interpolation available for WDDistribution.")
+    def plot_interpolated(self, _=None):
+        """Raise because interpolation is unavailable for Dirac distributions."""
+        raise NotImplementedError(
+            "Interpolation is not available for CircularDiracDistribution."
+        )

--- a/tests/distributions/test_circular_dirac_plot_interpolated.py
+++ b/tests/distributions/test_circular_dirac_plot_interpolated.py
@@ -1,0 +1,15 @@
+import pytest
+
+from pyrecest.distributions.circle.circular_dirac_distribution import (
+    CircularDiracDistribution,
+)
+
+
+def test_plot_interpolated_without_arguments_raises_supported_error():
+    distribution = CircularDiracDistribution([0.0])
+
+    with pytest.raises(
+        NotImplementedError,
+        match="Interpolation is not available for CircularDiracDistribution",
+    ):
+        distribution.plot_interpolated()


### PR DESCRIPTION
## Bug

`CircularDiracDistribution.plot_interpolated()` required an otherwise unused positional argument. Calling the method through the ordinary no-argument plotting API therefore raised `TypeError` before reaching the intended `NotImplementedError`.

The exception text also referred to the unrelated `WDDistribution`, making the failure misleading.

## Fix

- make the unused argument optional so a normal no-argument call reaches the documented unsupported-operation path;
- replace the stale `WDDistribution` wording with the actual `CircularDiracDistribution` type;
- tighten the docstring.

## Regression coverage

A focused test verifies that `distribution.plot_interpolated()` raises the intended, correctly worded `NotImplementedError` rather than a missing-argument `TypeError`.

## Validation

The change is limited to one small API correction and one focused regression test. GitHub Actions should provide the authoritative repository-wide and backend-matrix validation.