### PR TITLE
Recognize symmetric hypersphere axis-label aliases

### DIFF
--- a/src/pyrecest/evaluation/get_axis_label.py
+++ b/src/pyrecest/evaluation/get_axis_label.py
@@ -7,6 +7,14 @@ def _normalize_manifold_name(manifold_name):
     return compact_name
 
 
+def _is_hypersphere_symmetric_name(normalized_name):
+    return (
+        "hyperspheresymmetric" in normalized_name
+        or "hyperspheresymm" in normalized_name
+        or normalized_name in {"symmetrichypersphere", "symmhypersphere"}
+    )
+
+
 def get_axis_label(manifold_name):
     normalized_name = _normalize_manifold_name(manifold_name)
 
@@ -16,7 +24,7 @@ def get_axis_label(manifold_name):
     elif "circle" in normalized_name or "hypertorus" in normalized_name:
         error_label = "Error in radian"
 
-    elif "hyperspheresymmetric" in normalized_name:
+    elif _is_hypersphere_symmetric_name(normalized_name):
         error_label = "Angular error in radian"
 
     elif "hypersphere" in normalized_name:

--- a/tests/test_axis_labels.py
+++ b/tests/test_axis_labels.py
@@ -35,6 +35,9 @@ def test_generic_manifold_axis_labels_are_preserved(manifold_name, expected_labe
         ("SE(2)-linear", "Error in meters"),
         ("SE(3)-bounded", "Error in radian"),
         ("hypersphere_symmetric", "Angular error in radian"),
+        ("hypersphere_symm", "Angular error in radian"),
+        ("symm_hypersphere", "Angular error in radian"),
+        ("symmetric_hypersphere", "Angular error in radian"),
     ],
 )
 def test_axis_label_accepts_common_mathematical_notation(


### PR DESCRIPTION
## Bug

`get_axis_label()` only recognized the fully spelled `hypersphere_symmetric` form. Common aliases such as `hypersphere_symm`, `symm_hypersphere`, and `symmetric_hypersphere` fell through to the generic hypersphere branch and returned `Error (orthodromic distance) in radian` instead of the symmetric-space label `Angular error in radian`.

This was inconsistent with the alias handling already used by mean extraction.

## Fix

- centralize symmetric-hypersphere name recognition in a small helper;
- recognize abbreviated and reversed-order aliases;
- keep the generic hypersphere and other manifold labels unchanged.

## Regression coverage

The axis-label tests now cover:

- `hypersphere_symm`;
- `symm_hypersphere`;
- `symmetric_hypersphere`;
- the existing canonical and generic forms.

## Validation

- targeted alias regression checks passed locally;
- branch is 2 commits ahead of `main` and 0 behind;
- diff is limited to 10 production-line changes and 3 additional parametrized cases.