### PR TITLE
Preserve coroutine identity in deprecated functions

### DIFF
--- a/src/pyrecest/deprecation.py
+++ b/src/pyrecest/deprecation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import functools
+import inspect
 import warnings
 from collections.abc import Callable
 from typing import ParamSpec, TypeVar
@@ -47,6 +48,18 @@ def deprecated(
         )
         if replacement:
             message += f" Use {replacement} instead."
+
+        if inspect.iscoroutinefunction(func):
+
+            @functools.wraps(func)
+            async def async_wrapper(*args: P.args, **kwargs: P.kwargs):
+                warnings.warn(message, DeprecationWarning, stacklevel=2)
+                return await func(*args, **kwargs)
+
+            async_wrapper.__deprecated_since__ = since  # type: ignore[attr-defined]
+            async_wrapper.__deprecated_remove_in__ = remove_in  # type: ignore[attr-defined]
+            async_wrapper.__deprecated_replacement__ = replacement  # type: ignore[attr-defined]
+            return async_wrapper  # type: ignore[return-value]
 
         @functools.wraps(func)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:

--- a/tests/test_deprecation_helper.py
+++ b/tests/test_deprecation_helper.py
@@ -1,3 +1,5 @@
+import asyncio
+import inspect
 import warnings
 
 import pytest
@@ -16,6 +18,21 @@ def test_deprecated_decorator_emits_standard_warning():
     assert len(caught) == 1
     assert issubclass(caught[0].category, DeprecationWarning)
     assert "new_function" in str(caught[0].message)
+
+
+def test_deprecated_decorator_preserves_async_function_contract():
+    @deprecated(since="2.3.0", remove_in="3.0.0", replacement="new_async_function")
+    async def legacy_async_function(value):
+        return value + 1
+
+    assert inspect.iscoroutinefunction(legacy_async_function)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert asyncio.run(legacy_async_function(1)) == 2
+
+    assert len(caught) == 1
+    assert issubclass(caught[0].category, DeprecationWarning)
+    assert "new_async_function" in str(caught[0].message)
 
 
 def test_deprecated_decorator_rejects_blank_since():


### PR DESCRIPTION
## Bug

`pyrecest.deprecation.deprecated()` always created a synchronous wrapper. Decorating an `async def` function therefore made `inspect.iscoroutinefunction()` return `False`, even though calling it produced a coroutine.

Async-aware frameworks and dispatch code can use that introspection result to decide whether a callable must be awaited, so a deprecated coroutine could be misclassified.

## Fix

- detect coroutine functions with `inspect.iscoroutinefunction()`;
- wrap them with an `async def` wrapper that awaits the original callable;
- preserve the existing warning message, decorator metadata, and synchronous-function path.

## Regression coverage

The focused test verifies that a decorated coroutine:

- remains identifiable as a coroutine function;
- executes and returns its value correctly;
- emits exactly one `DeprecationWarning` with the replacement name.

## Validation

- `PYTHONPATH=. python -m pytest -q tests/test_deprecation_helper.py` — 6 passed
- `python -m compileall -q pyrecest/deprecation.py`
- remote diff: 2 files, 30 additions, 0 deletions; branch is 2 commits ahead of `main` and 0 behind