### PR TITLE
Handle empty QR batches

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/linalg.py
+++ b/src/pyrecest/_backend/_shared_numpy/linalg.py
@@ -117,6 +117,8 @@ def quadratic_assignment(a, b, options=None):
 
 
 def qr(a, mode="reduced"):
+    if 0 in _np.shape(a)[:-2]:
+        return _np.linalg.qr(a, mode=mode)
     if mode == "r":
         signature = "(n,m)->(k,m)"
     elif mode == "raw":

--- a/tests/backend/test_numpy_linalg_qr_modes.py
+++ b/tests/backend/test_numpy_linalg_qr_modes.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from pyrecest._backend.numpy import linalg
 
 
@@ -30,3 +31,22 @@ def test_qr_mode_raw_preserves_batched_numpy_contract():
 
     np.testing.assert_allclose(h, expected_h)
     np.testing.assert_allclose(tau, expected_tau)
+
+
+@pytest.mark.parametrize("mode", ["reduced", "complete", "r", "raw"])
+def test_qr_empty_batches_preserve_numpy_contract(mode):
+    matrices = np.empty((0, 3, 2))
+
+    result = linalg.qr(matrices, mode=mode)
+    expected = np.linalg.qr(matrices, mode=mode)
+
+    if isinstance(expected, tuple):
+        assert isinstance(result, tuple)
+        assert len(result) == len(expected)
+        for actual_factor, expected_factor in zip(result, expected):
+            assert actual_factor.shape == expected_factor.shape
+            np.testing.assert_allclose(actual_factor, expected_factor)
+    else:
+        assert isinstance(result, np.ndarray)
+        assert result.shape == expected.shape
+        np.testing.assert_allclose(result, expected)


### PR DESCRIPTION
## Bug

The shared NumPy/autograd `linalg.qr()` wrapper applies `numpy.vectorize` to batched inputs. A valid batch with a zero-length batch dimension, such as shape `(0, 3, 2)`, therefore raises:

```text
ValueError: cannot call `vectorize` on size 0 inputs unless `otypes` is set
```

Native `numpy.linalg.qr()` supports these empty batches and returns correctly shaped empty factors for every supported mode.

## Fix

- detect zero-length batch dimensions before entering the vectorized per-matrix path;
- delegate those inputs directly to the active backend's native `linalg.qr()`;
- leave the established vectorized behavior unchanged for non-empty batches.

## Regression coverage

The NumPy backend test now compares empty-batch behavior against NumPy for `reduced`, `complete`, `r`, and `raw` modes, including return type and exact factor shapes.

## Validation

- reproduced the old failure for `(0, 3, 2)` inputs in all QR modes;
- exercised the patched branch logic against NumPy for empty and non-empty rectangular batches;
- branch is 2 commits ahead of current `main` and 0 behind;
- diff is limited to 2 production lines and one focused 20-line regression test.