### PR TITLE
Reject non-vector vMF measurements

### DIFF
--- a/src/pyrecest/filters/von_mises_fisher_filter.py
+++ b/src/pyrecest/filters/von_mises_fisher_filter.py
@@ -66,7 +66,7 @@ def _validate_zonal_vmf(distribution, role):
 
 
 def _validate_vmf_measurement(z, input_dim):
-    measurement = asarray(z).ravel()
+    measurement = asarray(z)
     if measurement.shape != (input_dim,):
         raise ValueError(f"measurement z must have shape ({input_dim},).")
     if not _to_python_bool(backend_all(isfinite(measurement))):

--- a/tests/filters/test_von_mises_fisher_filter_measurement_shape.py
+++ b/tests/filters/test_von_mises_fisher_filter_measurement_shape.py
@@ -1,0 +1,21 @@
+import unittest
+
+from pyrecest.backend import array
+from pyrecest.distributions import VonMisesFisherDistribution
+from pyrecest.filters.von_mises_fisher_filter import VonMisesFisherFilter
+
+
+class TestVonMisesFisherFilterMeasurementShape(unittest.TestCase):
+    def test_update_identity_rejects_nonvector_measurements(self):
+        vmf_filter = VonMisesFisherFilter()
+        vmf_filter.filter_state = VonMisesFisherDistribution(array([1.0, 0.0]), 0.7)
+        measurement_noise = VonMisesFisherDistribution(array([0.0, 1.0]), 0.9)
+
+        for measurement in ([[1.0, 0.0]], [[1.0], [0.0]]):
+            with self.subTest(measurement=measurement):
+                with self.assertRaisesRegex(ValueError, "shape"):
+                    vmf_filter.update_identity(measurement_noise, measurement)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`VonMisesFisherFilter.update_identity()` converted a measurement with `asarray(z).ravel()` before checking its shape. Consequently, non-vector inputs such as a row matrix with shape `(1, d)` or a column matrix with shape `(d, 1)` were silently flattened and accepted, despite the API requiring an exact vector shape `(d,)`.

This can hide upstream shape errors and discard semantically meaningful batch or matrix dimensions.

## Fix

- preserve the measurement's original dimensionality during validation;
- require the exact shape `(input_dim,)` before finite-value and unit-norm checks;
- retain support for ordinary one-dimensional array-like inputs.

## Regression coverage

A focused test verifies that both row-matrix and column-matrix measurements are rejected with the documented shape error. Both cases were accepted by the previous `ravel()` path.

## Validation

- branch is 2 commits ahead of the current base and 0 behind;
- diff is limited to one production-line change and one 21-line regression test;
- GitHub Actions provides the authoritative repository-wide and backend-matrix validation.