### PR TITLE
Keep GNN gating hard beyond dummy capacity

### DIFF
--- a/src/pyrecest/filters/global_nearest_neighbor.py
+++ b/src/pyrecest/filters/global_nearest_neighbor.py
@@ -285,17 +285,20 @@ class GlobalNearestNeighbor(AbstractNearestNeighborTracker):
             association = assignment_result["assignment"]
             association = where(association < 0, n_meas, association)
         else:
-            # Pad to square and add max_new_tracks rows and columns
-            pad_to = max(n_targets, n_meas) + self.association_param["max_new_tracks"]
-            association_matrix = full(
-                (pad_to, pad_to), self.association_param["gating_distance_threshold"]
+            # Give every target a dummy option so the gate remains a hard constraint.
+            n_dummy_assignments = max(
+                n_targets, self.association_param["max_new_tracks"]
             )
-            association_matrix[: dists.shape[0], : dists.shape[1]] = dists
+            association_matrix = full(
+                (n_targets, n_meas + n_dummy_assignments),
+                self.association_param["gating_distance_threshold"],
+            )
+            association_matrix[:, :n_meas] = dists
 
-            # Use the Hungarian algorithm to find the optimal assignment
-            _, col_ind = linear_sum_assignment(association_matrix)
-
-            association = col_ind[:n_targets]
+            # Rectangular assignment leaves unused measurements unassigned naturally.
+            row_ind, col_ind = linear_sum_assignment(association_matrix)
+            association = np.full(n_targets, n_meas, dtype=int)
+            association[row_ind] = np.where(col_ind < n_meas, col_ind, n_meas)
 
         if warn_on_no_meas_for_track and any(association >= n_meas):
             warnings.warn(

--- a/tests/filters/test_global_nearest_neighbor_dummy_capacity.py
+++ b/tests/filters/test_global_nearest_neighbor_dummy_capacity.py
@@ -1,0 +1,42 @@
+import unittest
+
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+import pyrecest.backend
+from pyrecest.backend import array, eye
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.filters import GlobalNearestNeighbor, KalmanFilter
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ != "numpy",
+    reason="Only supported on numpy backend",
+)
+class GlobalNearestNeighborDummyCapacityTest(unittest.TestCase):
+    def test_all_out_of_gate_tracks_can_use_dummy_assignments(self):
+        tracker = GlobalNearestNeighbor(
+            association_param={
+                "distance_metric_pos": "Euclidean",
+                "square_dist": False,
+                "gating_distance_threshold": 1.0,
+                "max_new_tracks": 1,
+            }
+        )
+        tracker.filter_state = [
+            KalmanFilter(GaussianDistribution(array([0.0, 0.0]), eye(2)))
+            for _ in range(3)
+        ]
+
+        association = tracker.find_association(
+            array([[10.0, 20.0, 30.0], [0.0, 0.0, 0.0]]),
+            eye(2),
+            eye(2),
+            warn_on_no_meas_for_track=False,
+        )
+
+        npt.assert_array_equal(association, array([3, 3, 3]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

The default Hungarian-assignment path padded the square cost matrix with only `max_new_tracks` dummy rows and columns. When more tracks were outside the gate than that dummy capacity, the solver was forced to assign some tracks to real measurements whose costs exceeded `gating_distance_threshold`.

For example, with three tracks, three distant measurements, and `max_new_tracks=1`, two tracks received invalid real-measurement assignments instead of the no-measurement sentinel.

## Fix

- build a rectangular target-to-measurement-plus-dummy cost matrix;
- provide at least one dummy assignment option per target;
- map every selected dummy column back to the existing `n_meas` sentinel;
- leave unused measurements unassigned naturally through rectangular Hungarian assignment.

This keeps the gating threshold a hard constraint without the quadratic square padding that would otherwise be required to represent every unmatched track and measurement.

## Regression coverage

The new test creates three tracks whose measurements are all outside the gate while `max_new_tracks=1`, and verifies that all three receive dummy assignments.

## Validation

- reproduced the old forced-assignment behavior with SciPy's `linear_sum_assignment`;
- exercised the new rectangular formulation on the failing case and ordinary valid assignments;
- diff is limited to the GNN assignment construction and one focused regression test;
- GitHub Actions should provide the authoritative repository-wide validation.