### PR TITLE
Reject complex Fibonacci Gaussian parameters

### DIFF
--- a/src/pyrecest/sampling/euclidean_sampler.py
+++ b/src/pyrecest/sampling/euclidean_sampler.py
@@ -259,11 +259,30 @@ def _validate_positive_finite_scalar_argument(value, name: str) -> float:
     return float_value
 
 
+def _as_real_float_array(value, name: str) -> np.ndarray:
+    """Convert an array-like argument without silently discarding complex parts."""
+    try:
+        raw_value = np.asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must contain real numeric values") from exc
+
+    contains_complex_object = raw_value.dtype == object and any(
+        isinstance(item, (complex, np.complexfloating))
+        for item in raw_value.reshape(-1)
+    )
+    if np.iscomplexobj(raw_value) or contains_complex_object:
+        raise ValueError(f"{name} must contain real numeric values")
+    try:
+        return np.asarray(value, dtype=float)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must contain real numeric values") from exc
+
+
 def _validate_gaussian_transform_args(d, covariance, mean):
     if covariance is None:
         covariance = np.eye(d)
     else:
-        covariance = np.asarray(covariance, dtype=float)
+        covariance = _as_real_float_array(covariance, "covariance")
 
     if covariance.shape != (d, d):
         raise ValueError("covariance must have shape (dim, dim)")
@@ -279,7 +298,9 @@ def _validate_gaussian_transform_args(d, covariance, mean):
 
     if mean is None:
         mean = np.zeros(d)
-    mean = np.asarray(mean, dtype=float).ravel()
+    else:
+        mean = _as_real_float_array(mean, "mean")
+    mean = mean.ravel()
     if mean.shape != (d,):
         raise ValueError("mean must have shape (dim,)")
     if not np.all(np.isfinite(mean)):

--- a/tests/test_fibonacci_gaussian_parameter_validation.py
+++ b/tests/test_fibonacci_gaussian_parameter_validation.py
@@ -1,0 +1,51 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+from pyrecest.sampling.euclidean_sampler import FibonacciGridSampler
+
+
+class TestFibonacciGaussianParameterValidation(unittest.TestCase):
+    def setUp(self):
+        self.sampler = FibonacciGridSampler()
+
+    def test_real_object_arrays_remain_supported(self):
+        covariance = np.array([[2.0, 0.5], [0.5, 1.0]], dtype=object)
+        mean = np.array([1.0, -1.0], dtype=object)
+
+        samples = self.sampler.get_gaussian_samples(
+            20, 2, covariance=covariance, mean=mean
+        )
+
+        self.assertEqual(samples.shape, (20, 2))
+        self.assertTrue(np.all(np.isfinite(samples)))
+        npt.assert_allclose(samples.mean(axis=0), np.asarray(mean, dtype=float))
+
+    def test_complex_covariance_is_rejected_without_lossy_cast(self):
+        invalid_covariances = (
+            np.array([[1.0 + 1.0j, 0.0], [0.0, 1.0]]),
+            np.array([[1.0 + 1.0j, 0.0], [0.0, 1.0]], dtype=object),
+        )
+
+        for covariance in invalid_covariances:
+            with self.subTest(dtype=covariance.dtype):
+                with self.assertRaisesRegex(ValueError, "covariance.*real numeric"):
+                    self.sampler.get_gaussian_samples(
+                        10, 2, covariance=covariance, mean=np.zeros(2)
+                    )
+
+    def test_complex_mean_is_rejected_without_lossy_cast(self):
+        invalid_means = (
+            np.array([0.0 + 1.0j, 0.0]),
+            np.array([0.0 + 1.0j, 0.0], dtype=object),
+        )
+
+        for mean in invalid_means:
+            with self.subTest(dtype=mean.dtype):
+                with self.assertRaisesRegex(ValueError, "mean.*real numeric"):
+                    self.sampler.get_gaussian_samples(10, 2, mean=mean)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`FibonacciGridSampler.get_gaussian_samples()` converted covariance and mean inputs with `np.asarray(..., dtype=float)` before validating them. For NumPy complex arrays this emits `ComplexWarning`, discards the imaginary component, and continues with a different real-valued Gaussian instead of rejecting the invalid input.

Object arrays containing complex scalars could follow the same lossy conversion path.

## Fix

- validate the raw covariance and mean arrays before float conversion;
- reject native complex dtypes and object arrays containing complex values;
- preserve support for real numeric object arrays and all existing shape, finiteness, symmetry, and positive-semidefinite checks.

## Regression coverage

The focused test module verifies that:

- real object-array covariance and mean inputs remain supported;
- native and object-array complex covariance inputs raise `ValueError`;
- native and object-array complex mean inputs raise `ValueError`.

## Validation

- production module passes Python syntax compilation;
- isolated validation exercise passes for real inputs and all four complex-input cases;
- diff is limited to the sampler validator and one focused regression test file.