### PR TITLE
Handle empty polar batches

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/linalg.py
+++ b/src/pyrecest/_backend/_shared_numpy/linalg.py
@@ -166,6 +166,15 @@ def fractional_matrix_power(A, t):
 
 def polar(a, side="right"):
     """Polar decomposition of a square or rectangular matrix."""
+    if side not in {"left", "right"}:
+        raise ValueError("`side` must be either 'right' or 'left'")
+
+    a = _as_scipy_linalg_array(a)
+    if 0 in a.shape[:-2]:
+        positive_dim = a.shape[-2] if side == "left" else a.shape[-1]
+        positive_shape = a.shape[:-2] + (positive_dim, positive_dim)
+        return _np.empty_like(a), _np.empty(positive_shape, dtype=a.dtype)
+
     signature = "(m,n)->(m,n),(m,m)" if side == "left" else "(m,n)->(m,n),(n,n)"
     return _np.vectorize(_scipy.linalg.polar, signature=signature, excluded=["side"])(
         a, side=side

--- a/tests/test_polar_backend.py
+++ b/tests/test_polar_backend.py
@@ -30,6 +30,21 @@ def test_numpy_polar_handles_rectangular_left_factor():
     npt.assert_allclose(positive @ unitary, value, atol=1e-12)
 
 
+@pytest.mark.parametrize(
+    ("side", "positive_shape"),
+    [("right", (0, 2, 2)), ("left", (0, 3, 3))],
+)
+def test_numpy_polar_handles_empty_batches(side, positive_shape):
+    value = np.empty((0, 3, 2), dtype=np.float32)
+
+    unitary, positive = numpy_backend.linalg.polar(value, side=side)
+
+    assert unitary.shape == value.shape
+    assert positive.shape == positive_shape
+    assert unitary.dtype == value.dtype
+    assert positive.dtype == value.dtype
+
+
 @pytest.mark.skipif(pytorch_backend is None, reason="PyTorch is not installed")
 def test_pytorch_polar_handles_rectangular_right_factor():
     value = pytorch_backend.array(


### PR DESCRIPTION
## Bug

The shared NumPy/autograd `linalg.polar()` wrapper applies `numpy.vectorize` to batched inputs. A valid batch with a zero-length batch dimension, such as shape `(0, 3, 2)`, therefore raises:

```text
ValueError: cannot call `vectorize` on size 0 inputs unless `otypes` is set
```

This differs from the rest of the backend facade, where empty batches preserve their batch and matrix dimensions.

## Fix

- validate `side` before the empty-input fast path so invalid values still match SciPy's error behavior;
- promote inputs to the same SciPy-compatible dtype used by the non-empty path;
- return correctly shaped empty unitary and positive-semidefinite factors for both right and left polar decompositions;
- leave the established vectorized SciPy path unchanged for non-empty batches.

## Regression coverage

The focused tests cover empty `(0, 3, 2)` batches for both `side="right"` and `side="left"`, including exact output shapes and float32 dtype preservation.

## Validation

- reproduced the original `numpy.vectorize` failure;
- exercised the patched logic for right/left factors and float32, float64, complex64, and integer-promoted inputs;
- verified ordinary non-empty rectangular decompositions still reconstruct the input;
- branch is 2 commits ahead of current `main` and 0 behind;
- diff is limited to 9 production lines and 15 focused test lines.