### PR TITLE
Reject invalid measurement-reliability covariances

### DIFF
--- a/src/pyrecest/tracking/measurement_reliability.py
+++ b/src/pyrecest/tracking/measurement_reliability.py
@@ -16,6 +16,8 @@ from typing import Any, Literal
 
 import numpy as np
 
+from pyrecest.numerics import assert_covariance_matrix
+
 ReliabilityMode = Literal["off", "inflate", "hard"] | str
 _TEXT_OR_BOOL_SCALAR_TYPES = (
     bool,
@@ -345,6 +347,7 @@ def _covariance_matrix(value: Any, *, dim: int | None = None) -> np.ndarray:
         raise ValueError(f"covariance must have shape ({dim}, {dim})")
     if not np.isfinite(covariance).all():
         raise ValueError("covariance must contain only finite values")
+    assert_covariance_matrix(covariance, name="covariance")
     return covariance.copy()
 
 

--- a/tests/tracking/test_measurement_reliability_covariance_contract.py
+++ b/tests/tracking/test_measurement_reliability_covariance_contract.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pyrecest.tracking.measurement_reliability import (
+    ReliabilityWeightedMeasurement,
+    apply_measurement_reliability,
+    scale_covariance_by_reliability,
+)
+
+
+@pytest.mark.parametrize(
+    ("covariance", "message"),
+    [
+        (np.array([[1.0, 0.5], [0.0, 1.0]]), "symmetric"),
+        (np.diag([1.0, -0.25]), "positive semidefinite"),
+    ],
+)
+def test_reliability_helpers_reject_invalid_covariance_geometry(
+    covariance: np.ndarray, message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        scale_covariance_by_reliability(covariance, 0.5)
+
+    with pytest.raises(ValueError, match=message):
+        apply_measurement_reliability(covariance, reliability=0.5)
+
+    with pytest.raises(ValueError, match=message):
+        ReliabilityWeightedMeasurement(
+            measurement=np.array([1.0, 2.0]),
+            covariance=covariance,
+            reliability=0.5,
+        )
+
+
+def test_reliability_helpers_accept_singular_psd_covariance() -> None:
+    covariance = np.array([[1.0, 1.0], [1.0, 1.0]])
+
+    scaled, scale = scale_covariance_by_reliability(covariance, 0.5)
+
+    assert scale == 2.0
+    assert np.allclose(scaled, 2.0 * covariance)


### PR DESCRIPTION
## Bug

The measurement-reliability helpers treated every square, finite, real-valued matrix as a valid covariance. Asymmetric matrices and symmetric matrices with negative eigenvalues were therefore accepted and returned unchanged or multiplied by the reliability scale.

For example, both `[[1.0, 0.5], [0.0, 1.0]]` and `diag([1.0, -0.25])` passed `_covariance_matrix(...)`, allowing invalid measurement-noise models to propagate into downstream filters.

## Fix

- reuse the shared `assert_covariance_matrix(...)` numerical contract after the existing type, shape, dimension, and finiteness checks;
- reject covariance matrices that are asymmetric beyond tolerance or not positive semidefinite;
- preserve singular positive-semidefinite covariance support and all existing user-facing validation behavior.

## Regression coverage

The focused test verifies all three public paths:

- `scale_covariance_by_reliability(...)`;
- `apply_measurement_reliability(...)`;
- `ReliabilityWeightedMeasurement(...)`.

It covers asymmetric rejection, indefinite rejection, and acceptance/scaling of a singular PSD covariance.

## Validation

- `python -m py_compile` for the modified production module and regression test;
- isolated focused pytest run: `3 passed`;
- branch diff is limited to the covariance validator and one regression file.