### PR TITLE
Handle empty sqrtm batches

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/linalg.py
+++ b/src/pyrecest/_backend/_shared_numpy/linalg.py
@@ -108,6 +108,8 @@ def solve_sylvester(a, b, q, tol=atol):
 
 def sqrtm(x):
     x = _as_scipy_linalg_array(x)
+    if 0 in x.shape[:-2]:
+        return _np.empty_like(x)
     result = _np.vectorize(_scipy.linalg.sqrtm, signature="(n,m)->(n,m)")(x)
     return _cast_scipy_linalg_result_to_input_dtype(result, x)
 
@@ -178,7 +180,6 @@ def solve(a, b):
 
     Computes the "exact" solution, `x`, of the well-determined, i.e., full
     rank, linear matrix equation `ax = b`.
-
     Parameters
     ----------
     a : array-like, shape=[..., M, M]

--- a/tests/backend/test_numpy_linalg_sqrtm_empty_batches.py
+++ b/tests/backend/test_numpy_linalg_sqrtm_empty_batches.py
@@ -1,0 +1,22 @@
+import numpy as np
+import pytest
+
+from pyrecest._backend.numpy import linalg
+
+
+@pytest.mark.parametrize(
+    ("dtype", "expected_dtype"),
+    [
+        (np.float32, np.float32),
+        (np.float64, np.float64),
+        (np.complex64, np.complex64),
+        (np.int64, np.float64),
+    ],
+)
+def test_sqrtm_empty_batches_preserve_shape_and_dtype(dtype, expected_dtype):
+    matrices = np.empty((0, 3, 3), dtype=dtype)
+
+    result = linalg.sqrtm(matrices)
+
+    assert result.shape == matrices.shape
+    assert result.dtype == expected_dtype


### PR DESCRIPTION
## Bug

The shared NumPy/autograd `linalg.sqrtm()` wrapper applies `numpy.vectorize` to batched inputs. A valid batch with a zero-length batch dimension, such as shape `(0, 3, 3)`, therefore raises:

```text
ValueError: cannot call `vectorize` on size 0 inputs unless `otypes` is set
```

This is inconsistent with the backend facade's shape-preserving behavior for empty batches.

## Fix

- detect zero-length batch dimensions after applying the existing SciPy-compatible dtype promotion;
- return a correctly shaped empty result without invoking `numpy.vectorize`;
- preserve float32, float64, complex64, and integer-to-float64 dtype behavior;
- leave the established SciPy path unchanged for non-empty batches.

## Regression coverage

The focused backend test verifies exact shape and dtype behavior for empty `(0, 3, 3)` batches with float32, float64, complex64, and integer inputs.

## Scope

The branch is based on current `main`, is 2 commits ahead and 0 behind, and changes only the shared NumPy linear-algebra wrapper plus one focused regression test. GitHub Actions provides the authoritative repository-wide and backend-matrix validation.