### PR TITLE
Deduplicate zero-radius ellipsoid sigma points

### DIFF
--- a/src/pyrecest/sampling/support_points.py
+++ b/src/pyrecest/sampling/support_points.py
@@ -308,9 +308,12 @@ def ellipsoid_sigma_points(
         single = False
 
     pieces: list[np.ndarray] = []
-    if include_center:
+    zero_radius_requested = any(radius == 0.0 for radius in radii_tuple)
+    if include_center or zero_radius_requested:
         pieces.append(centers)
     for radius in radii_tuple:
+        if radius == 0.0:
+            continue
         offsets = ellipsoid_axis_offsets(
             covariances,
             radius=radius,

--- a/tests/sampling/test_support_points_zero_radius.py
+++ b/tests/sampling/test_support_points_zero_radius.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import numpy as np
+from pyrecest.sampling import ellipsoid_sigma_points
+
+
+def test_zero_radius_contributes_center_only_once() -> None:
+    support = ellipsoid_sigma_points(
+        [1.0, -2.0],
+        np.eye(2),
+        radii=(0.0, 1.0, 0.0),
+    )
+
+    center = np.asarray([1.0, -2.0])
+    assert support.shape == (5, 2)
+    assert np.count_nonzero(np.all(support == center, axis=1)) == 1
+
+
+def test_zero_radius_is_preserved_when_center_flag_is_false() -> None:
+    support = ellipsoid_sigma_points(
+        [1.0, -2.0],
+        np.eye(2),
+        radii=(0.0,),
+        include_center=False,
+    )
+
+    assert support.shape == (1, 2)
+    assert np.array_equal(support[0], [1.0, -2.0])
+
+
+def test_zero_radius_is_deduplicated_for_batched_inputs() -> None:
+    means = np.asarray([[0.0, 0.0], [2.0, 3.0]])
+    covariances = np.broadcast_to(np.eye(2), (2, 2, 2)).copy()
+
+    support = ellipsoid_sigma_points(
+        means,
+        covariances,
+        radii=(0.0, 2.0),
+        include_center=False,
+    )
+
+    assert support.shape == (2, 5, 2)
+    for batch_index, center in enumerate(means):
+        assert np.count_nonzero(np.all(support[batch_index] == center, axis=1)) == 1
+        assert np.allclose(
+            np.linalg.norm(support[batch_index, 1:] - center, axis=1),
+            2.0,
+        )


### PR DESCRIPTION
## Summary
- treat a zero Mahalanobis radius as the ellipsoid center rather than emitting one collapsed `+/-` pair per axis
- include that requested zero-radius point exactly once, even when `include_center=False`
- add regression coverage for repeated zero radii and batched inputs

## Bug
`ellipsoid_sigma_points` documents that the center is included at most once. However, each zero radius produced `2 * dim` copies of the center, in addition to the optional explicit center. For example, radii `(0.0, 1.0, 0.0)` in two dimensions returned 13 points instead of 5.

## Validation
- `PYTHONPATH=src pytest -q tests/sampling/test_support_points_zero_radius.py` — 3 passed
- `python -m py_compile src/pyrecest/sampling/support_points.py tests/sampling/test_support_points_zero_radius.py`
