### PR TITLE
Handle empty matrix-function batches

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/linalg.py
+++ b/src/pyrecest/_backend/_shared_numpy/linalg.py
@@ -50,6 +50,18 @@ def _cast_scipy_linalg_result_to_input_dtype(result, input_array):
     return result
 
 
+def _empty_batched_square_matrix_result(array):
+    """Return an empty matrix-function result for a valid empty batch."""
+
+    if (
+        array.ndim > 2
+        and 0 in array.shape[:-2]
+        and array.shape[-2] == array.shape[-1]
+    ):
+        return _np.empty_like(array)
+    return None
+
+
 def _is_symmetric(x, tol=atol):
     return (_np.abs(x - _transpose(x)) < tol).all()
 
@@ -69,6 +81,9 @@ _logm_vec = _np.vectorize(_scipy.linalg.logm, signature="(n,m)->(n,m)")
 
 def logm(x):
     x = _as_scipy_linalg_array(x)
+    empty_result = _empty_batched_square_matrix_result(x)
+    if empty_result is not None:
+        return empty_result
     if _is_symmetric(x) and x.dtype not in [_np.complex64, _np.complex128]:
         eigvals, eigvecs = _np.linalg.eigh(x)
         if (eigvals > 0).all():
@@ -108,6 +123,9 @@ def solve_sylvester(a, b, q, tol=atol):
 
 def sqrtm(x):
     x = _as_scipy_linalg_array(x)
+    empty_result = _empty_batched_square_matrix_result(x)
+    if empty_result is not None:
+        return empty_result
     result = _np.vectorize(_scipy.linalg.sqrtm, signature="(n,m)->(n,m)")(x)
     return _cast_scipy_linalg_result_to_input_dtype(result, x)
 
@@ -157,6 +175,9 @@ def is_single_matrix_pd(mat):
 
 def fractional_matrix_power(A, t):
     A = _as_scipy_linalg_array(A)
+    empty_result = _empty_batched_square_matrix_result(A)
+    if empty_result is not None:
+        return empty_result
     result = _np.vectorize(
         lambda one_matrix: _scipy.linalg.fractional_matrix_power(one_matrix, t),
         signature="(n,n)->(n,n)",
@@ -178,7 +199,6 @@ def solve(a, b):
 
     Computes the "exact" solution, `x`, of the well-determined, i.e., full
     rank, linear matrix equation `ax = b`.
-
     Parameters
     ----------
     a : array-like, shape=[..., M, M]

--- a/tests/backend/test_numpy_linalg_empty_matrix_functions.py
+++ b/tests/backend/test_numpy_linalg_empty_matrix_functions.py
@@ -1,0 +1,55 @@
+import numpy as np
+import pytest
+from pyrecest._backend.numpy import linalg
+
+
+@pytest.mark.parametrize(
+    ("matrix_function", "args"),
+    [
+        pytest.param(linalg.logm, (), id="logm"),
+        pytest.param(linalg.sqrtm, (), id="sqrtm"),
+        pytest.param(
+            linalg.fractional_matrix_power,
+            (0.5,),
+            id="fractional_matrix_power",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    ("dtype", "expected_dtype"),
+    [
+        pytest.param(np.float32, np.float32, id="float32"),
+        pytest.param(np.complex64, np.complex64, id="complex64"),
+        pytest.param(np.int64, np.float64, id="integer-promoted"),
+    ],
+)
+def test_empty_matrix_function_batches_preserve_shape_and_dtype(
+    matrix_function, args, dtype, expected_dtype
+):
+    matrices = np.empty((2, 0, 3, 3), dtype=dtype)
+
+    result = matrix_function(matrices, *args)
+
+    assert result.shape == matrices.shape
+    assert result.dtype == np.dtype(expected_dtype)
+
+
+@pytest.mark.parametrize(
+    ("matrix_function", "args"),
+    [
+        pytest.param(linalg.logm, (), id="logm"),
+        pytest.param(linalg.sqrtm, (), id="sqrtm"),
+        pytest.param(
+            linalg.fractional_matrix_power,
+            (0.5,),
+            id="fractional_matrix_power",
+        ),
+    ],
+)
+def test_empty_rectangular_matrix_function_batches_remain_invalid(
+    matrix_function, args
+):
+    matrices = np.empty((0, 3, 2))
+
+    with pytest.raises(ValueError):
+        matrix_function(matrices, *args)


### PR DESCRIPTION
## Bug

The shared NumPy/autograd wrappers for `logm`, `sqrtm`, and `fractional_matrix_power` apply `numpy.vectorize` to batched inputs. A valid zero-length batch such as shape `(2, 0, 3, 3)` therefore raises:

```text
ValueError: cannot call `vectorize` on size 0 inputs unless `otypes` is set
```

This is inconsistent with the backend's other batched linear-algebra operations, which preserve zero-length batch dimensions.

## Fix

- add a shared fast path for empty batches of square matrices;
- preserve the matrix shape and the SciPy-compatible promoted dtype;
- leave nonempty execution unchanged;
- keep empty rectangular batches invalid rather than bypassing matrix-shape validation.

## Regression coverage

The focused tests cover all three affected functions with:

- `float32` inputs;
- `complex64` inputs;
- integer inputs promoted to `float64`;
- a nested zero-length batch dimension;
- rejection of empty rectangular matrices.

## Validation

- reproduced the original `numpy.vectorize` failure for all three functions;
- isolated focused suite: `12 passed`;
- focused suite plus the existing integer-promotion tests: `15 passed`;
- branch is 2 commits ahead of current `main` and 0 behind.