### PR TITLE
Fix asymmetric rectangle contour corner sampling

### DIFF
--- a/src/pyrecest/experimental/dvs/active_contour.py
+++ b/src/pyrecest/experimental/dvs/active_contour.py
@@ -79,13 +79,15 @@ def rectangle_contour_samples(
 
     half_width = 0.5 * float(width)
     half_height = 0.5 * float(height)
-    xs = np.linspace(-half_width, half_width, samples_per_edge, endpoint=False)
-    ys = np.linspace(-half_height, half_height, samples_per_edge, endpoint=False)
+    xs_forward = np.linspace(-half_width, half_width, samples_per_edge, endpoint=False)
+    xs_backward = np.linspace(half_width, -half_width, samples_per_edge, endpoint=False)
+    ys_forward = np.linspace(-half_height, half_height, samples_per_edge, endpoint=False)
+    ys_backward = np.linspace(half_height, -half_height, samples_per_edge, endpoint=False)
 
-    top = np.column_stack([xs, np.full(samples_per_edge, half_height)])
-    right = np.column_stack([np.full(samples_per_edge, half_width), ys])
-    bottom = np.column_stack([xs[::-1], np.full(samples_per_edge, -half_height)])
-    left = np.column_stack([np.full(samples_per_edge, -half_width), ys[::-1]])
+    top = np.column_stack([xs_forward, np.full(samples_per_edge, half_height)])
+    right = np.column_stack([np.full(samples_per_edge, half_width), ys_backward])
+    bottom = np.column_stack([xs_backward, np.full(samples_per_edge, -half_height)])
+    left = np.column_stack([np.full(samples_per_edge, -half_width), ys_forward])
 
     points = np.vstack([top, right, bottom, left])
     normals = np.vstack(

--- a/tests/experimental/test_dvs_active_contour.py
+++ b/tests/experimental/test_dvs_active_contour.py
@@ -23,3 +23,20 @@ def test_rectangle_activity_matches_horizontal_translation():
     assert by_edge["right"] == 1.0
     assert by_edge["top"] == 0.0
     assert by_edge["bottom"] == 0.0
+
+
+def test_rectangle_contour_covers_each_corner_once():
+    contour = rectangle_contour_samples(width=2.0, height=1.0, samples_per_edge=4)
+    corners = np.array(
+        [
+            [-1.0, 0.5],
+            [1.0, 0.5],
+            [1.0, -0.5],
+            [-1.0, -0.5],
+        ]
+    )
+
+    assert np.unique(contour.points, axis=0).shape == contour.points.shape
+    for corner in corners:
+        matches = np.all(np.isclose(contour.points, corner), axis=1)
+        assert np.count_nonzero(matches) == 1


### PR DESCRIPTION
## Bug

`rectangle_contour_samples()` used one ascending coordinate grid for the right edge and reversed grids for the bottom and left edges. With `endpoint=False`, that combination duplicated the bottom-left corner and omitted the top-right corner.

For example, `samples_per_edge=4` returned 16 rows but only 15 unique contour points. This made a geometrically symmetric rectangle asymmetric and could bias downstream uses of the sampled point coordinates.

## Fix

- sample each edge in continuous clockwise order;
- include each rectangle corner exactly once;
- preserve the existing edge order, labels, outward normals, and number of samples per edge.

## Regression coverage

The focused test verifies that all generated points are unique and that each of the four corners occurs exactly once.

## Validation

- reproduced the original 15-unique-points-for-16-samples failure;
- checked the patched sampler with 1, 4, and 40 samples per edge;
- verified exact single coverage of every corner in each case;
- `python -m py_compile` succeeds for the modified production module;
- branch is 2 commits ahead of current `main` and 0 behind.