### PR TITLE
Handle empty PyTorch matrix batches

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -68,6 +68,20 @@ def _as_linalg_tensor(value):
     return tensor
 
 
+def _has_empty_matrix_batch(matrix):
+    """Return whether a matrix batch has a zero-length leading dimension."""
+    return matrix.ndim > 2 and 0 in matrix.shape[:-2]
+
+
+def _empty_square_matrix_batch_result(matrix, function_name):
+    """Return a shape-preserving empty result for a square matrix batch."""
+    if not _has_empty_matrix_batch(matrix):
+        return None
+    if matrix.shape[-2] != matrix.shape[-1]:
+        raise ValueError(f"{function_name} requires square matrices")
+    return matrix.new_empty(matrix.shape)
+
+
 def _is_boolean_scalar(value):
     """Return whether ``value`` is a scalar boolean exponent candidate."""
     if isinstance(value, (bool, _np.bool_)):
@@ -272,6 +286,10 @@ def logm(x):
 
 def sqrtm(x):
     x = _as_linalg_tensor(x)
+    empty_result = _empty_square_matrix_batch_result(x, "sqrtm")
+    if empty_result is not None:
+        return empty_result
+
     x_np = _as_numpy_no_grad(x)
     np_sqrtm = _np.vectorize(_scipy.linalg.sqrtm, signature="(n,m)->(n,m)")(x_np)
     if np_sqrtm.dtype.kind == "c":
@@ -495,6 +513,11 @@ def fractional_matrix_power(A, t):
     if exponent.ndim != 0:
         raise TypeError("t must be a scalar")
     exponent = exponent.item()
+
+    empty_result = _empty_square_matrix_batch_result(A, "fractional_matrix_power")
+    if empty_result is not None:
+        return empty_result
+
     out = _np.vectorize(
         lambda one_matrix: _scipy.linalg.fractional_matrix_power(
             one_matrix, exponent
@@ -512,7 +535,15 @@ def fractional_matrix_power(A, t):
 
 def polar(a, side="right"):
     """Polar decomposition of a square or rectangular matrix."""
+    if side not in {"right", "left"}:
+        raise ValueError("`side` must be either 'right' or 'left'")
+
     a = _as_linalg_tensor(a)
+    if _has_empty_matrix_batch(a):
+        factor_dim = a.shape[-2] if side == "left" else a.shape[-1]
+        factor_shape = a.shape[:-2] + (factor_dim, factor_dim)
+        return a.new_empty(a.shape), a.new_empty(factor_shape)
+
     signature = "(m,n)->(m,n),(m,m)" if side == "left" else "(m,n)->(m,n),(n,n)"
     func = _np.vectorize(_scipy.linalg.polar, signature=signature, excluded=["side"])
     unitary, hermitian = func(_as_numpy_no_grad(a), side=side)

--- a/tests/test_pytorch_empty_matrix_function_batches.py
+++ b/tests/test_pytorch_empty_matrix_function_batches.py
@@ -1,0 +1,66 @@
+import pytest
+
+pytest.importorskip("torch")
+
+from pyrecest._backend import pytorch as pytorch_backend
+
+
+@pytest.mark.parametrize(
+    ("function_name", "args"),
+    (("sqrtm", ()), ("fractional_matrix_power", (0.5,))),
+)
+@pytest.mark.parametrize(
+    "dtype",
+    (
+        pytorch_backend.float32,
+        pytorch_backend.float64,
+        pytorch_backend.complex64,
+    ),
+)
+def test_square_matrix_functions_preserve_empty_batches(function_name, args, dtype):
+    values = pytorch_backend.empty((2, 0, 3, 3), dtype=dtype)
+
+    result = getattr(pytorch_backend.linalg, function_name)(values, *args)
+
+    assert tuple(result.shape) == (2, 0, 3, 3)
+    assert result.dtype == dtype
+    assert result.device == values.device
+
+
+@pytest.mark.parametrize(
+    ("function_name", "args"),
+    (("sqrtm", ()), ("fractional_matrix_power", (0.5,))),
+)
+def test_square_matrix_functions_reject_empty_rectangular_batches(
+    function_name, args
+):
+    values = pytorch_backend.empty((0, 3, 2), dtype=pytorch_backend.float32)
+
+    with pytest.raises(ValueError, match="square matrices"):
+        getattr(pytorch_backend.linalg, function_name)(values, *args)
+
+
+@pytest.mark.parametrize(
+    ("side", "factor_shape"),
+    (("right", (2, 0, 2, 2)), ("left", (2, 0, 3, 3))),
+)
+def test_polar_preserves_empty_rectangular_batches(side, factor_shape):
+    values = pytorch_backend.empty(
+        (2, 0, 3, 2), dtype=pytorch_backend.complex64
+    )
+
+    unitary, factor = pytorch_backend.linalg.polar(values, side=side)
+
+    assert tuple(unitary.shape) == (2, 0, 3, 2)
+    assert tuple(factor.shape) == factor_shape
+    assert unitary.dtype == pytorch_backend.complex64
+    assert factor.dtype == pytorch_backend.complex64
+    assert unitary.device == values.device
+    assert factor.device == values.device
+
+
+def test_polar_validates_side_before_empty_batch_fast_path():
+    values = pytorch_backend.empty((0, 3, 2), dtype=pytorch_backend.float32)
+
+    with pytest.raises(ValueError, match="either 'right' or 'left'"):
+        pytorch_backend.linalg.polar(values, side="invalid")


### PR DESCRIPTION
## Bug

The PyTorch `sqrtm`, `fractional_matrix_power`, and `polar` wrappers delegate batched matrices through `numpy.vectorize`. Valid tensors with a zero-length batch dimension, such as `(2, 0, 3, 3)`, therefore raised:

```text
ValueError: cannot call `vectorize` on size 0 inputs unless `otypes` is set
```

This made the PyTorch backend inconsistent with shape-preserving batched linear-algebra behavior elsewhere in the backend facade.

## Fix

- detect zero-length leading batch dimensions before entering the NumPy/SciPy bridge;
- return correctly shaped empty tensors while preserving dtype and device;
- preserve the distinct left/right positive-factor shapes for empty rectangular polar decompositions;
- keep empty rectangular inputs invalid for the square-only matrix functions;
- validate `polar(side=...)` before the empty-batch fast path.

Non-empty SciPy-backed execution is unchanged.

## Regression coverage

The new focused tests cover:

- `sqrtm` and `fractional_matrix_power` with nested empty batches;
- `float32`, `float64`, and `complex64` dtype preservation;
- rejection of empty rectangular batches for square-only functions;
- left and right empty rectangular polar decompositions;
- invalid polar-side validation.

## Validation

- `python -m py_compile` passed for the modified production module and new test file;
- an isolated harness against the exact patched module passed all empty-batch cases;
- the same harness confirmed ordinary non-empty `sqrtm`, fractional-power, and polar reconstruction behavior remains unchanged;
- non-scalar fractional exponents are still rejected before the empty-batch shortcut.

GitHub Actions should provide the authoritative repository-wide PyTorch validation.