### PR TITLE
Preserve large array-like probability weights

### DIFF
--- a/src/pyrecest/_backend/pytorch/random/__init__.py
+++ b/src/pyrecest/_backend/pytorch/random/__init__.py
@@ -44,11 +44,20 @@ def _normalize_nonnegative_probabilities(probabilities):
     return scaled / total
 
 
+def _as_probability_tensor(values, device):
+    """Convert array-like probabilities without narrowing Python floats."""
+
+    torch = _LEGACY._torch
+    if torch.is_tensor(values):
+        return values.to(device=device)
+    return torch.as_tensor(_np.asarray(values), device=device)
+
+
 def _validate_choice_probabilities(p, population_size, device):
     if _LEGACY._contains_boolean_value(p):
         raise TypeError("p must be real numeric, not boolean")
     try:
-        p = _LEGACY._torch.as_tensor(p, device=device)
+        p = _as_probability_tensor(p, device)
     except (TypeError, ValueError, RuntimeError) as exc:
         raise TypeError("p must be real numeric") from exc
     if not _LEGACY._is_real_numeric_dtype(p.dtype):
@@ -62,7 +71,7 @@ def _validate_multinomial_pvals(pvals, device):
     if _LEGACY._contains_boolean_value(pvals):
         raise TypeError("pvals must be real numeric, not boolean")
     try:
-        pvals = _LEGACY._torch.as_tensor(pvals, device=device)
+        pvals = _as_probability_tensor(pvals, device)
     except (TypeError, ValueError, RuntimeError) as exc:
         raise TypeError("pvals must be real numeric") from exc
     if not _LEGACY._is_real_numeric_dtype(pvals.dtype):


### PR DESCRIPTION
## Summary
- preserve NumPy's inferred precision when converting non-tensor probability inputs to PyTorch
- keep existing tensor dtype and device semantics unchanged
- apply the same conversion path to both `random.choice` and `random.multinomial`

## Bug
`torch.as_tensor([1e300, 1e300])` uses PyTorch's default floating dtype, normally `float32`, so both finite Python values become `inf` before the scale-safe normalization runs. Consequently, valid large unnormalized probability weights are rejected by both `choice` and `multinomial`.

Converting non-tensor inputs through `numpy.asarray` first preserves Python float lists as `float64`, allowing the existing max-scaling normalization to operate without overflow. Tensor inputs remain tensors and are only moved to the requested device.

## Validation
- `PYTHONPATH=/mnt/data/pyrecest-test-stubs:src:. pytest -q tests/backend/test_pytorch_random_scalar_inputs.py tests/backend/test_pytorch_choice_probability_support.py tests/backend/test_pytorch_probability_underflow.py` — 22 passed
- `PYTHONPATH=/mnt/data/pyrecest-test-stubs:src:. pytest -q tests/backend --disable-warnings` — 480 passed, 1 skipped

The local `beartype` stub used for this source checkout is a no-op needed only because the container cannot install the declared dependency; these backend tests do not depend on runtime type enforcement.