### PR TITLE
Reject fractionally rounded Mardia-Sutton sample counts

### DIFF
--- a/src/pyrecest/distributions/cart_prod/mardia_sutton_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/mardia_sutton_distribution.py
@@ -31,11 +31,14 @@ def _validate_positive_sample_count(n) -> int:
 
     try:
         count_int = int(count)
-        count_float = float(count)
     except (OverflowError, TypeError, ValueError) as exc:
         raise ValueError("n must be an integer") from exc
 
-    if not np.isfinite(count_float) or not count_float.is_integer():
+    try:
+        is_exact_integer = count == count_int
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("n must be a finite integer") from exc
+    if not bool(is_exact_integer):
         raise ValueError("n must be a finite integer")
     if count_int <= 0:
         raise ValueError("n must be positive")

--- a/tests/distributions/test_mardia_sutton_sample_count_exactness.py
+++ b/tests/distributions/test_mardia_sutton_sample_count_exactness.py
@@ -1,0 +1,19 @@
+from fractions import Fraction
+
+import pytest
+
+from pyrecest.distributions.cart_prod.mardia_sutton_distribution import (
+    _validate_positive_sample_count,
+)
+
+
+def test_mardia_sutton_sample_count_rejects_fraction_rounded_by_float():
+    count = Fraction(2**54 + 1, 2)
+
+    assert float(count).is_integer()
+    with pytest.raises(ValueError, match="finite integer"):
+        _validate_positive_sample_count(count)
+
+
+def test_mardia_sutton_sample_count_accepts_exact_integral_fraction():
+    assert _validate_positive_sample_count(Fraction(6, 3)) == 2


### PR DESCRIPTION
## Bug

`MardiaSuttonDistribution.sample()` validates non-Boolean scalar counts by converting them to both `int` and `float`, then checking `float.is_integer()`. Exact numeric types can lose a fractional part during binary64 conversion.

For example, `Fraction(2**54 + 1, 2)` is exactly `9007199254740992.5`, but its `float` representation is `9007199254740992.0`. The old validator therefore accepted the fractional value as the truncated integer `9007199254740992` and passed that huge count to SciPy's random sampler.

## Fix

- convert the original scalar directly to `int`;
- compare that integer against the original exact scalar;
- reject values that are not exactly integral;
- preserve support for ordinary integer-like scalar arrays and exact integral numeric types.

## Regression coverage

- reject a large half-integer `Fraction` whose fractional part disappears in binary64;
- accept an exactly integral `Fraction`.

## Validation

- reproduced the old silent acceptance in isolation;
- verified the patched validator rejects the rounded half-integer;
- verified exact integral `Fraction`, NumPy scalar arrays, and ordinary integer counts remain accepted;
- branch is based on current `main`, is 2 commits ahead and 0 behind, and changes only the validator plus one focused regression module.

GitHub Actions should provide the authoritative repository-wide and backend-matrix validation.