### PR TITLE
Handle empty Sylvester matrix batches

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/linalg.py
+++ b/src/pyrecest/_backend/_shared_numpy/linalg.py
@@ -75,6 +75,60 @@ def _sylvester_candidate_is_accurate(a, b, q, candidate):
     return _np.all(_np.isclose(residual_target, q, atol=atol, rtol=rtol))
 
 
+def _broadcast_shapes(*shapes):
+    """Return the NumPy-style broadcast shape without allocating arrays."""
+
+    reversed_shapes = [tuple(reversed(shape)) for shape in shapes]
+    result = []
+    for index in range(max((len(shape) for shape in reversed_shapes), default=0)):
+        dimensions = {
+            shape[index] if index < len(shape) else 1 for shape in reversed_shapes
+        }
+        dimensions.discard(1)
+        if len(dimensions) > 1:
+            raise ValueError("operands could not be broadcast together")
+        result.append(dimensions.pop() if dimensions else 1)
+    return tuple(reversed(result))
+
+
+def _empty_sylvester_batch_result(a, b, q):
+    """Return a broadcast, SciPy-compatible empty Sylvester result."""
+
+    if a.ndim < 2 or b.ndim < 2 or q.ndim < 2:
+        return None
+    if a.shape[-2] != a.shape[-1] or b.shape[-2] != b.shape[-1]:
+        return None
+    if q.shape[-2:] != (a.shape[-1], b.shape[-1]):
+        return None
+
+    try:
+        batch_shape = _broadcast_shapes(
+            a.shape[:-2],
+            b.shape[:-2],
+            q.shape[:-2],
+        )
+    except ValueError:
+        return None
+    if 0 not in batch_shape:
+        return None
+
+    promoted_dtypes = []
+    for array in (a, b, q):
+        dtype = array.dtype
+        if dtype.kind in "iu":
+            dtype = _np.dtype(_np.float64)
+        elif dtype.kind == "b" or dtype == _np.dtype(_np.float16):
+            dtype = _np.dtype(_np.float32)
+        elif dtype.kind not in "fc":
+            return None
+        promoted_dtypes.append(dtype)
+
+    return _np.empty(
+        batch_shape + q.shape[-2:],
+        dtype=_np.result_type(*promoted_dtypes),
+    )
+
+
 _diag_vec = _np.vectorize(_np.diag, signature="(n)->(n,n)")
 _logm_vec = _np.vectorize(_scipy.linalg.logm, signature="(n,m)->(n,m)")
 
@@ -104,6 +158,10 @@ def solve_sylvester(a, b, q, tol=atol):
     a = _np.asarray(a)
     b = _np.asarray(b)
     q = _np.asarray(q)
+
+    empty_result = _empty_sylvester_batch_result(a, b, q)
+    if empty_result is not None:
+        return empty_result
 
     if a.shape == b.shape:
         if _np.all(_np.isclose(a, b)) and _is_hermitian(a, tol=tol):

--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -208,7 +208,7 @@ def eigvalsh(a, UPLO="L", out=None):
 
 
 def inv(a, out=None):
-    """Invert a matrix after PyRecEst-style array-like promotion."""
+    """Invert a matrix after PyRecEst-style array-like input promotion."""
     return _torch.linalg.inv(_as_linalg_tensor(a), **_out_kwargs(out))
 
 
@@ -412,6 +412,30 @@ def _sylvester_candidate_is_accurate(a, b, q, candidate):
     )
 
 
+def _empty_sylvester_batch_result(a, b, q):
+    """Return a broadcast, shape-preserving empty Sylvester result."""
+
+    if a.ndim < 2 or b.ndim < 2 or q.ndim < 2:
+        return None
+    if a.shape[-2] != a.shape[-1] or b.shape[-2] != b.shape[-1]:
+        return None
+    if q.shape[-2:] != (a.shape[-1], b.shape[-1]):
+        return None
+
+    try:
+        batch_shape = _torch.broadcast_shapes(
+            a.shape[:-2],
+            b.shape[:-2],
+            q.shape[:-2],
+        )
+    except (RuntimeError, ValueError):
+        return None
+    if 0 not in batch_shape:
+        return None
+
+    return q.new_empty(tuple(batch_shape) + tuple(q.shape[-2:]))
+
+
 def solve_sylvester(a, b, q):
     device = _preferred_linalg_device(a, b, q)
     a = _as_linalg_tensor(a)
@@ -425,6 +449,11 @@ def solve_sylvester(a, b, q):
     a = a.to(dtype=common_dtype)
     b = b.to(dtype=common_dtype)
     q = q.to(dtype=common_dtype)
+
+    empty_result = _empty_sylvester_batch_result(a, b, q)
+    if empty_result is not None:
+        return empty_result
+
     is_shared_factor = a.shape == b.shape and _torch.allclose(
         a, b, atol=1e-6, rtol=1e-6
     )

--- a/tests/backend/test_numpy_sylvester_empty_batches.py
+++ b/tests/backend/test_numpy_sylvester_empty_batches.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pytest
+
+from pyrecest._backend.numpy import linalg
+
+
+@pytest.mark.parametrize(
+    ("dtype", "expected_dtype"),
+    [
+        pytest.param(np.float32, np.float32, id="float32"),
+        pytest.param(np.complex64, np.complex64, id="complex64"),
+        pytest.param(np.int64, np.float64, id="integer-promoted"),
+    ],
+)
+def test_sylvester_preserves_broadcast_empty_batches(dtype, expected_dtype):
+    a = np.empty((2, 0, 1, 2, 2), dtype=dtype)
+    b = np.empty((1, 0, 4, 3, 3), dtype=dtype)
+    q = np.empty((2, 1, 4, 2, 3), dtype=dtype)
+
+    result = linalg.solve_sylvester(a, b, q)
+
+    assert result.shape == (2, 0, 4, 2, 3)
+    assert result.dtype == np.dtype(expected_dtype)
+
+
+def test_sylvester_rejects_empty_batches_with_invalid_core_shapes():
+    a = np.empty((0, 2, 3))
+    b = np.empty((0, 4, 4))
+    q = np.empty((0, 2, 4))
+
+    with pytest.raises(ValueError):
+        linalg.solve_sylvester(a, b, q)

--- a/tests/backend/test_pytorch_sylvester_empty_batches.py
+++ b/tests/backend/test_pytorch_sylvester_empty_batches.py
@@ -1,0 +1,33 @@
+import pytest
+
+pytest.importorskip("torch")
+
+from pyrecest._backend import pytorch as pytorch_backend
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    (
+        pytorch_backend.float32,
+        pytorch_backend.complex64,
+    ),
+)
+def test_sylvester_preserves_broadcast_empty_batches(dtype):
+    a = pytorch_backend.empty((2, 0, 1, 2, 2), dtype=dtype)
+    b = pytorch_backend.empty((1, 0, 4, 3, 3), dtype=dtype)
+    q = pytorch_backend.empty((2, 1, 4, 2, 3), dtype=dtype)
+
+    result = pytorch_backend.linalg.solve_sylvester(a, b, q)
+
+    assert tuple(result.shape) == (2, 0, 4, 2, 3)
+    assert result.dtype == dtype
+    assert result.device == q.device
+
+
+def test_sylvester_rejects_empty_batches_with_invalid_core_shapes():
+    a = pytorch_backend.empty((0, 2, 3), dtype=pytorch_backend.float32)
+    b = pytorch_backend.empty((0, 4, 4), dtype=pytorch_backend.float32)
+    q = pytorch_backend.empty((0, 2, 4), dtype=pytorch_backend.float32)
+
+    with pytest.raises(ValueError):
+        pytorch_backend.linalg.solve_sylvester(a, b, q)


### PR DESCRIPTION
## Summary
- return shape-preserving results for valid empty batched Sylvester equations in the NumPy/autograd and PyTorch backends
- preserve broadcasted batch dimensions, SciPy-compatible NumPy dtypes, and PyTorch dtype/device placement
- keep malformed core matrix shapes and incompatible batches on the existing validation/error path

## Bug
`solve_sylvester` delegates general batched inputs through `numpy.vectorize`. For valid inputs with a zero-length batch dimension, `numpy.vectorize` raises:

```text
ValueError: cannot call `vectorize` on size 0 inputs unless `otypes` is set
```

This affected rectangular Sylvester systems such as `A.shape == (2, 0, 1, 2, 2)`, `B.shape == (1, 0, 4, 3, 3)`, and `Q.shape == (2, 1, 4, 2, 3)`, whose mathematically valid broadcast result has shape `(2, 0, 4, 2, 3)`.

## Fix
- validate the Sylvester core dimensions before taking the empty-batch shortcut
- compute the broadcast batch shape without allocating dummy matrices
- construct an empty result with the output core shape `(m, n)`
- mirror SciPy's floating/complex dtype promotion for NumPy/autograd inputs
- construct PyTorch results after common dtype and device alignment

## Validation
- isolated reproduction against NumPy/SciPy and PyTorch confirms the pre-fix `numpy.vectorize` failure and the expected post-fix shapes/dtypes
- added dedicated NumPy and PyTorch regression tests; GitHub Actions validation is pending
