### PR TITLE
Preserve deprecated generator function contracts

### DIFF
--- a/src/pyrecest/deprecation.py
+++ b/src/pyrecest/deprecation.py
@@ -49,6 +49,19 @@ def deprecated(
         if replacement:
             message += f" Use {replacement} instead."
 
+        if inspect.isasyncgenfunction(func):
+
+            @functools.wraps(func)
+            async def async_generator_wrapper(*args: P.args, **kwargs: P.kwargs):
+                warnings.warn(message, DeprecationWarning, stacklevel=2)
+                async for item in func(*args, **kwargs):  # type: ignore[attr-defined]
+                    yield item
+
+            async_generator_wrapper.__deprecated_since__ = since  # type: ignore[attr-defined]
+            async_generator_wrapper.__deprecated_remove_in__ = remove_in  # type: ignore[attr-defined]
+            async_generator_wrapper.__deprecated_replacement__ = replacement  # type: ignore[attr-defined]
+            return async_generator_wrapper  # type: ignore[return-value]
+
         if inspect.iscoroutinefunction(func):
 
             @functools.wraps(func)
@@ -60,6 +73,18 @@ def deprecated(
             async_wrapper.__deprecated_remove_in__ = remove_in  # type: ignore[attr-defined]
             async_wrapper.__deprecated_replacement__ = replacement  # type: ignore[attr-defined]
             return async_wrapper  # type: ignore[return-value]
+
+        if inspect.isgeneratorfunction(func):
+
+            @functools.wraps(func)
+            def generator_wrapper(*args: P.args, **kwargs: P.kwargs):
+                warnings.warn(message, DeprecationWarning, stacklevel=2)
+                return (yield from func(*args, **kwargs))  # type: ignore[misc]
+
+            generator_wrapper.__deprecated_since__ = since  # type: ignore[attr-defined]
+            generator_wrapper.__deprecated_remove_in__ = remove_in  # type: ignore[attr-defined]
+            generator_wrapper.__deprecated_replacement__ = replacement  # type: ignore[attr-defined]
+            return generator_wrapper  # type: ignore[return-value]
 
         @functools.wraps(func)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:

--- a/tests/test_deprecation_helper.py
+++ b/tests/test_deprecation_helper.py
@@ -35,6 +35,45 @@ def test_deprecated_decorator_preserves_async_function_contract():
     assert "new_async_function" in str(caught[0].message)
 
 
+def test_deprecated_decorator_preserves_generator_function_contract():
+    @deprecated(since="2.3.0", remove_in="3.0.0", replacement="new_generator")
+    def legacy_generator():
+        yield 1
+        return 2
+
+    assert inspect.isgeneratorfunction(legacy_generator)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        generator = legacy_generator()
+        assert next(generator) == 1
+        with pytest.raises(StopIteration) as stopped:
+            next(generator)
+
+    assert stopped.value.value == 2
+    assert len(caught) == 1
+    assert issubclass(caught[0].category, DeprecationWarning)
+    assert "new_generator" in str(caught[0].message)
+
+
+def test_deprecated_decorator_preserves_async_generator_function_contract():
+    @deprecated(since="2.3.0", remove_in="3.0.0", replacement="new_async_generator")
+    async def legacy_async_generator():
+        yield 1
+        yield 2
+
+    async def consume():
+        return [value async for value in legacy_async_generator()]
+
+    assert inspect.isasyncgenfunction(legacy_async_generator)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert asyncio.run(consume()) == [1, 2]
+
+    assert len(caught) == 1
+    assert issubclass(caught[0].category, DeprecationWarning)
+    assert "new_async_generator" in str(caught[0].message)
+
+
 def test_deprecated_decorator_rejects_blank_since():
     with pytest.raises(ValueError, match="since must be a non-empty string"):
         deprecated(since=" ", remove_in="3.0.0")


### PR DESCRIPTION
## Bug

`pyrecest.deprecation.deprecated()` only distinguished coroutine functions from ordinary callables. Decorating a synchronous generator or asynchronous generator therefore replaced it with a plain synchronous wrapper:

- `inspect.isgeneratorfunction()` returned `False` for decorated generators;
- `inspect.isasyncgenfunction()` returned `False` for decorated async generators.

Calls still returned generator objects, but introspection-based frameworks could misclassify the decorated streaming function and invoke it through the wrong execution path.

## Fix

- add an async-generator wrapper that delegates with `async for`;
- add a generator wrapper that delegates with `yield from` and preserves the generator return value;
- keep the standard warning and deprecation metadata on both wrappers.

## Regression coverage

- verify synchronous generator introspection, yielded values, and `StopIteration.value`;
- verify async-generator introspection and yielded values;
- verify each wrapper emits exactly one deprecation warning.

## Validation

- focused local test module: `8 passed`;
- branch is based on current `main`, is 2 commits ahead and 0 behind, and changes only the deprecation helper and its focused regression tests.

GitHub Actions should provide the authoritative repository-wide validation.