### PR TITLE
Reject non-string evidence metadata keys

### DIFF
--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -40,13 +40,16 @@ def _coerce_bool_flag(value: bool, name: str) -> bool:
 
 
 def _coerce_metadata(metadata: Any) -> dict[str, Any]:
-    """Return a plain metadata dictionary without sequence-to-dict surprises."""
+    """Return a plain metadata dictionary with stable string keys."""
 
     if metadata is None:
         return {}
     if not isinstance(metadata, Mapping):
         raise ValueError("metadata must be a mapping or None")
-    return dict(metadata)
+    result = dict(metadata)
+    if any(not isinstance(key, str) for key in result):
+        raise ValueError("metadata keys must be strings")
+    return result
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_evidence_metadata.py
+++ b/tests/test_evidence_metadata.py
@@ -1,0 +1,23 @@
+import pytest
+
+from pyrecest.evidence import EvidenceComputationMode
+
+
+def test_evidence_metadata_rejects_nonstring_keys():
+    with pytest.raises(ValueError, match="metadata keys must be strings"):
+        EvidenceComputationMode.full_smoothing(metadata={1: "integer key"})
+
+
+def test_evidence_metadata_prevents_stringification_collisions():
+    with pytest.raises(ValueError, match="metadata keys must be strings"):
+        EvidenceComputationMode.evidence_only(
+            metadata={1: "first", "1": "second"}
+        )
+
+
+def test_evidence_metadata_keeps_string_keys_in_diagnostics():
+    mode = EvidenceComputationMode.evidence_only(metadata={"source": "forward"})
+
+    diagnostics = mode.to_diagnostics()
+
+    assert diagnostics["evidence_source"] == "forward"


### PR DESCRIPTION
## Bug

`EvidenceComputationMode` documents metadata as `dict[str, Any]`, but `_coerce_metadata()` accepted arbitrary mapping keys. `to_diagnostics()` later interpolates every key into a string.

Distinct keys can therefore collapse silently. For example, metadata containing both `1` and `"1"` produces the same diagnostics key, `evidence_1`, and one value overwrites the other.

## Fix

- copy the supplied mapping as before;
- reject non-string metadata keys at construction time;
- keep ordinary string-key metadata behavior unchanged.

## Regression coverage

- reject a non-string metadata key;
- reject the concrete integer/string collision case;
- verify valid string-key metadata is still emitted in diagnostics.

## Validation

The branch is based on current `main`, is 2 commits ahead and 0 behind, and changes only `src/pyrecest/evidence.py` plus a focused regression test module. GitHub Actions will provide repository-wide validation.