### PR TITLE
Preserve Cartesian-product sample rows for scalar components

### DIFF
--- a/src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py
@@ -1,6 +1,6 @@
 # pylint: disable=no-name-in-module,no-member
 import numpy as np
-from pyrecest.backend import asarray, concatenate, hstack, prod, reshape, stack
+from pyrecest.backend import asarray, concatenate, prod, reshape, stack
 
 from .abstract_cart_prod_distribution import AbstractCartProdDistribution
 
@@ -56,7 +56,11 @@ class CartProdStackedDistribution(AbstractCartProdDistribution):
 
     def sample(self, n: int):
         n = _validate_positive_sample_count(n)
-        return hstack([dist.sample(n) for dist in self.dists])
+        component_samples = [
+            reshape(asarray(dist.sample(n)), (n, dist.input_dim))
+            for dist in self.dists
+        ]
+        return concatenate(component_samples, axis=1)
 
     def pdf(self, xs):
         xs = asarray(xs)

--- a/tests/distributions/test_cart_prod_stacked_scalar_sampling.py
+++ b/tests/distributions/test_cart_prod_stacked_scalar_sampling.py
@@ -1,0 +1,37 @@
+import unittest
+
+from pyrecest.backend import array, eye
+from pyrecest.distributions import GaussianDistribution, VonMisesDistribution
+from pyrecest.distributions.cart_prod.cart_prod_stacked_distribution import (
+    CartProdStackedDistribution,
+)
+
+
+class TestCartProdStackedScalarSampling(unittest.TestCase):
+    def test_sample_keeps_scalar_components_in_separate_columns(self):
+        dist = CartProdStackedDistribution(
+            [
+                VonMisesDistribution(0.0, 1.0),
+                VonMisesDistribution(1.0, 2.0),
+            ]
+        )
+
+        samples = dist.sample(5)
+
+        self.assertEqual(samples.shape, (5, 2))
+
+    def test_sample_combines_scalar_and_vector_components(self):
+        dist = CartProdStackedDistribution(
+            [
+                VonMisesDistribution(0.0, 1.0),
+                GaussianDistribution(array([0.0, 0.0]), eye(2)),
+            ]
+        )
+
+        samples = dist.sample(5)
+
+        self.assertEqual(samples.shape, (5, 3))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`CartProdStackedDistribution.sample()` passed raw component samples directly to `hstack`. Scalar-valued component distributions, such as `VonMisesDistribution`, return samples with shape `(n,)` rather than `(n, 1)`.

This caused two incorrect behaviors:

- two scalar components were flattened into a vector with shape `(2 * n,)` instead of an `(n, 2)` sample matrix;
- combining a scalar component with a vector-valued component raised a dimension-mismatch error instead of returning `(n, total_input_dim)`.

The resulting output violated the class's trailing-`input_dim` convention and could not reliably be passed back to `pdf()`.

## Fix

- normalize each component's samples to `(n, component.input_dim)`;
- concatenate normalized component matrices along the feature axis;
- remove the direct `hstack` path.

## Regression coverage

- verify two scalar circular components produce shape `(n, 2)`;
- verify a scalar circular component and a two-dimensional Gaussian component produce shape `(n, 3)`.

## Validation

- isolated NumPy reproduction confirms the old flattening/dimension-mismatch behavior and the corrected output shapes;
- branch is based on current `main`, is 2 commits ahead and 0 behind, and changes only the sampler plus focused regression tests.

GitHub Actions should provide the authoritative repository-wide and backend-matrix validation.