### PR TITLE
Reject fractionally rounded split section counts

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_split_index_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_split_index_contract.py
@@ -39,12 +39,14 @@ def _normalize_split_section_count(indices_or_sections, torch_module):
         raise TypeError(_SPLIT_INDEX_TYPE_MESSAGE)
 
     try:
-        scalar_float = float(scalar)
-    except (TypeError, ValueError, OverflowError) as exc:
+        section_count = int(scalar)
+    except (ValueError, OverflowError) as exc:
+        raise ValueError(_SPLIT_SECTION_COUNT_MESSAGE) from exc
+    except TypeError as exc:
         raise TypeError(_SPLIT_INDEX_TYPE_MESSAGE) from exc
-    if not np.isfinite(scalar_float) or not scalar_float.is_integer():
+    if scalar != section_count:
         raise ValueError(_SPLIT_SECTION_COUNT_MESSAGE)
-    return int(scalar_float)
+    return section_count
 
 
 def _normalize_split_cut_indices(indices_or_sections, torch_module):

--- a/tests/test_pytorch_split_index_contract.py
+++ b/tests/test_pytorch_split_index_contract.py
@@ -1,0 +1,32 @@
+import unittest
+from fractions import Fraction
+
+from pyrecest.backend_support._pytorch_split_index_contract import (
+    _normalize_split_section_count,
+)
+
+
+class _TorchStub:
+    @staticmethod
+    def is_tensor(value):
+        del value
+        return False
+
+
+class PytorchSplitIndexContractTest(unittest.TestCase):
+    def test_rejects_fractional_count_hidden_by_float_rounding(self):
+        fractional_count = Fraction(2**54 + 1, 2)
+
+        with self.assertRaisesRegex(ValueError, "number sections must be an integer"):
+            _normalize_split_section_count(fractional_count, _TorchStub)
+
+    def test_preserves_large_exact_integral_count(self):
+        exact_count = Fraction(2**54 + 2, 2)
+
+        normalized = _normalize_split_section_count(exact_count, _TorchStub)
+
+        self.assertEqual(normalized, 2**53 + 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

The PyTorch `split` compatibility validator converts non-index scalar section counts through binary `float` before checking whether they are integral. Exact numeric values beyond binary64's integer precision can therefore be misclassified or changed.

For example:

- `Fraction(2**54 + 1, 2)` is an exact half-integer, but its `float` representation is integral and was accepted;
- `Fraction(2**54 + 2, 2)` is the exact integer `2**53 + 1`, but conversion through `float` rounded it down by one.

This violates the helper's stated contract of avoiding fractional truncation and can pass an incorrect section count to the backend.

## Fix

- convert the original scalar directly with `int`;
- preserve the existing exception distinction for invalid numeric and non-numeric values;
- compare the converted integer against the original exact scalar;
- reject values that are not exactly integral without narrowing through binary64.

## Regression coverage

- reject a large exact half-integer whose fractional part disappears in binary64;
- preserve a large exact integral `Fraction` beyond binary64's consecutive-integer range.

## Validation

- isolated regression and compatibility checks passed locally;
- branch is based on current `main`, is 2 commits ahead and 0 behind, and changes only the split validator plus a focused test module.

GitHub Actions should provide the authoritative repository-wide validation.