### PR TITLE
Reject complex record smoother inputs

### DIFF
--- a/src/pyrecest/smoothers/__init__.py
+++ b/src/pyrecest/smoothers/__init__.py
@@ -1,3 +1,4 @@
+from . import _record_smoother_numeric_contract  # noqa: F401
 from .abstract_smoother import AbstractSmoother
 from .delayed_output import DelayedStateOutput, DelayedStateOutputMixin
 from .fixed_lag_mem_qkf_smoother import (

--- a/src/pyrecest/smoothers/__init__.py
+++ b/src/pyrecest/smoothers/__init__.py
@@ -1,4 +1,4 @@
-from . import _record_smoother_numeric_contract  # noqa: F401
+from ._record_smoother_numeric_contract import install_record_smoother_numeric_contract
 from .abstract_smoother import AbstractSmoother
 from .delayed_output import DelayedStateOutput, DelayedStateOutputMixin
 from .fixed_lag_mem_qkf_smoother import (
@@ -68,6 +68,8 @@ from .unscented_rauch_tung_striebel_smoother import (
     UnscentedRauchTungStriebelSmoother,
     URTSSmoother,
 )
+
+install_record_smoother_numeric_contract()
 
 __all__ = [
     "AbstractSmoother",

--- a/src/pyrecest/smoothers/_record_smoother_numeric_contract.py
+++ b/src/pyrecest/smoothers/_record_smoother_numeric_contract.py
@@ -1,0 +1,102 @@
+"""Real-valued input contract for record-based Kalman smoothers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
+import numpy as np
+
+from . import record_smoother as _record_smoother
+
+# pylint: disable=protected-access
+
+# The record smoother implements a real-valued RTS recursion. NumPy's explicit
+# float conversion otherwise accepts native complex arrays by discarding their
+# imaginary parts, which silently changes the supplied state-space model.
+
+_original_record_arrays = _record_smoother._record_arrays
+
+
+def _contains_complex_values(value: Any) -> bool:
+    """Return whether an array-like value contains complex scalars."""
+
+    try:
+        value_array = np.asarray(value)
+    except (TypeError, ValueError, RuntimeError):
+        return False
+    if np.iscomplexobj(value_array):
+        return True
+    if value_array.dtype != object:
+        return False
+    return any(
+        isinstance(item, (complex, np.complexfloating)) for item in value_array.flat
+    )
+
+
+def _reject_complex_values(value: Any, message: str) -> None:
+    if _contains_complex_values(value):
+        raise ValueError(message)
+
+
+def _record_arrays(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    time_key: str,
+    state_key: str,
+    covariance_key: str,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    for record in records:
+        _reject_complex_values(
+            record[state_key],
+            "record states must contain real values",
+        )
+        _reject_complex_values(
+            record[covariance_key],
+            "record covariances must contain real values",
+        )
+    return _original_record_arrays(
+        records,
+        time_key=time_key,
+        state_key=state_key,
+        covariance_key=covariance_key,
+    )
+
+
+def _call_model(
+    model: Callable[..., np.ndarray], dt: float, state_dim: int, name: str
+) -> np.ndarray:
+    arity = _record_smoother._preferred_model_call_arity(model)
+    if arity == 2:
+        matrix = model(dt, state_dim)
+    elif arity == 1:
+        matrix = model(dt)
+    else:
+        matrix = _record_smoother._call_model_with_fallback(
+            model, dt, state_dim, name
+        )
+
+    _reject_complex_values(matrix, f"{name} must return real values")
+    array = np.asarray(matrix, dtype=float)
+    if array.shape != (state_dim, state_dim):
+        raise ValueError(f"{name} must return a ({state_dim}, {state_dim}) matrix")
+    if not np.isfinite(array).all():
+        raise ValueError(f"{name} must return finite values")
+    return array
+
+
+setattr(_record_arrays, "_pyrecest_real_numeric_contract", True)
+setattr(_call_model, "_pyrecest_real_numeric_contract", True)
+
+if not getattr(
+    _record_smoother._record_arrays,
+    "_pyrecest_real_numeric_contract",
+    False,
+):
+    _record_smoother._record_arrays = _record_arrays
+if not getattr(
+    _record_smoother._call_model,
+    "_pyrecest_real_numeric_contract",
+    False,
+):
+    _record_smoother._call_model = _call_model

--- a/src/pyrecest/smoothers/_record_smoother_numeric_contract.py
+++ b/src/pyrecest/smoothers/_record_smoother_numeric_contract.py
@@ -85,18 +85,21 @@ def _call_model(
     return array
 
 
-setattr(_record_arrays, "_pyrecest_real_numeric_contract", True)
-setattr(_call_model, "_pyrecest_real_numeric_contract", True)
+def install_record_smoother_numeric_contract() -> None:
+    """Install real-value validation on the record smoother implementation."""
 
-if not getattr(
-    _record_smoother._record_arrays,
-    "_pyrecest_real_numeric_contract",
-    False,
-):
-    _record_smoother._record_arrays = _record_arrays
-if not getattr(
-    _record_smoother._call_model,
-    "_pyrecest_real_numeric_contract",
-    False,
-):
-    _record_smoother._call_model = _call_model
+    setattr(_record_arrays, "_pyrecest_real_numeric_contract", True)
+    setattr(_call_model, "_pyrecest_real_numeric_contract", True)
+
+    if not getattr(
+        _record_smoother._record_arrays,
+        "_pyrecest_real_numeric_contract",
+        False,
+    ):
+        _record_smoother._record_arrays = _record_arrays
+    if not getattr(
+        _record_smoother._call_model,
+        "_pyrecest_real_numeric_contract",
+        False,
+    ):
+        _record_smoother._call_model = _call_model

--- a/tests/smoothers/test_record_smoother_complex_validation.py
+++ b/tests/smoothers/test_record_smoother_complex_validation.py
@@ -1,0 +1,84 @@
+"""Regression tests for real-valued record smoother inputs."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from pyrecest.smoothers.record_smoother import smooth_records
+
+
+def _records() -> list[dict[str, object]]:
+    return [
+        {
+            "time_s": 0.0,
+            "state": np.array([0.0, 1.0]),
+            "covariance": np.eye(2),
+        },
+        {
+            "time_s": 1.0,
+            "state": np.array([1.0, 1.0]),
+            "covariance": np.eye(2),
+        },
+    ]
+
+
+def _transition(dt: float, _state_dim: int) -> np.ndarray:
+    return np.array([[1.0, dt], [0.0, 1.0]])
+
+
+def _process_noise(_dt: float, state_dim: int) -> np.ndarray:
+    return np.zeros((state_dim, state_dim))
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        (
+            "state",
+            np.array([1.0 + 2.0j, 0.0]),
+            "record states must contain real values",
+        ),
+        (
+            "state",
+            np.array([1.0 + 2.0j, 0.0], dtype=object),
+            "record states must contain real values",
+        ),
+        (
+            "covariance",
+            np.array([[1.0 + 2.0j, 0.0], [0.0, 1.0]]),
+            "record covariances must contain real values",
+        ),
+        (
+            "covariance",
+            np.array([[1.0 + 2.0j, 0.0], [0.0, 1.0]], dtype=object),
+            "record covariances must contain real values",
+        ),
+    ],
+)
+def test_rejects_complex_record_values(field, value, message) -> None:
+    records = _records()
+    records[0][field] = value
+
+    with pytest.raises(ValueError, match=message):
+        smooth_records(
+            records,
+            method="rts",
+            transition_model=_transition,
+            process_noise_model=_process_noise,
+        )
+
+
+@pytest.mark.parametrize("dtype", [complex, object])
+@pytest.mark.parametrize("model_name", ["transition_model", "process_noise_model"])
+def test_rejects_complex_model_matrices(dtype, model_name) -> None:
+    def complex_matrix(_dt: float, _state_dim: int) -> np.ndarray:
+        return np.array([[1.0 + 2.0j, 0.0], [0.0, 1.0]], dtype=dtype)
+
+    models = {
+        "transition_model": _transition,
+        "process_noise_model": _process_noise,
+    }
+    models[model_name] = complex_matrix
+
+    with pytest.raises(ValueError, match=rf"{model_name} must return real values"):
+        smooth_records(_records(), method="rts", **models)


### PR DESCRIPTION
## Bug

The record-based RTS/fixed-lag smoother converts record states, covariances, and transition/process matrices with `np.asarray(..., dtype=float)`. NumPy accepts complex arrays on that path by discarding their imaginary components with a warning, so the smoother can silently process a different real-valued state-space model than the caller supplied.

The issue affects both native complex arrays and object arrays containing complex scalars.

## Fix

- install a real-valued numeric contract for the record smoother;
- reject complex record states and covariances before float conversion;
- reject complex transition and process-noise matrices before float conversion;
- preserve the existing shape, finiteness, call-arity, and real-valued behavior.

## Regression coverage

The focused tests cover native complex and object-array inputs for:

- record state vectors;
- record covariance matrices;
- transition-model outputs;
- process-noise-model outputs.

## Validation

- reproduced the prior NumPy behavior: imaginary components were discarded during the explicit float conversion;
- compiled the compatibility module successfully;
- ran an isolated import/behavior smoke test covering all affected paths plus a real-valued control;
- branch is based on current `main`, with no unrelated file changes.

GitHub Actions should provide the authoritative repository-wide validation.