### PR TITLE
Reject fractionally rounded linear-Gaussian dimensions

### DIFF
--- a/src/pyrecest/models/linear_gaussian.py
+++ b/src/pyrecest/models/linear_gaussian.py
@@ -1,6 +1,5 @@
 """Reusable linear Gaussian transition and measurement models."""
 
-import math
 from numbers import Complex, Integral, Real
 
 from pyrecest.backend import (
@@ -96,12 +95,11 @@ def _as_positive_integer(value, name):
         parsed = int(scalar)
     else:
         try:
-            scalar_float = float(scalar)
+            parsed = int(scalar)
         except (TypeError, ValueError, OverflowError) as exc:
             raise ValueError(message) from exc
-        if not math.isfinite(scalar_float) or not scalar_float.is_integer():
+        if scalar != parsed:
             raise ValueError(message)
-        parsed = int(scalar_float)
     if parsed <= 0:
         raise ValueError(message)
     return parsed

--- a/tests/models/test_linear_gaussian_dimension_precision.py
+++ b/tests/models/test_linear_gaussian_dimension_precision.py
@@ -1,0 +1,22 @@
+import unittest
+from fractions import Fraction
+
+import numpy as np
+from pyrecest.models.linear_gaussian import _as_positive_integer
+
+
+class LinearGaussianDimensionPrecisionTest(unittest.TestCase):
+    def test_rejects_fractional_dimension_hidden_by_float_rounding(self):
+        fractional_dim = np.array(Fraction(2**54 + 1, 2), dtype=object)
+
+        with self.assertRaisesRegex(ValueError, "dim must be a positive integer"):
+            _as_positive_integer(fractional_dim, "dim")
+
+    def test_preserves_exact_integral_object_scalar(self):
+        exact_dim = np.array(Fraction(6, 3), dtype=object)
+
+        self.assertEqual(_as_positive_integer(exact_dim, "dim"), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/models/test_linear_gaussian_dimension_precision.py
+++ b/tests/models/test_linear_gaussian_dimension_precision.py
@@ -2,9 +2,14 @@ import unittest
 from fractions import Fraction
 
 import numpy as np
+import pyrecest.backend
 from pyrecest.models.linear_gaussian import _as_positive_integer
 
 
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ != "numpy",
+    reason="object dtype regression coverage is specific to NumPy arrays",
+)
 class LinearGaussianDimensionPrecisionTest(unittest.TestCase):
     def test_rejects_fractional_dimension_hidden_by_float_rounding(self):
         fractional_dim = np.array(Fraction(2**54 + 1, 2), dtype=object)


### PR DESCRIPTION
## Bug

The identity linear-Gaussian model dimension validator converted non-`Integral` scalar values through binary `float` before checking whether they were integers. Exact numeric values wrapped in a zero-dimensional object array could therefore lose their fractional part during binary64 conversion.

For example, `np.array(Fraction(2**54 + 1, 2), dtype=object)` is exactly `9007199254740992.5`, but the old conversion produced `9007199254740992.0`. The validator accepted that value as an integer dimension, after which the identity models could attempt to allocate an enormous identity matrix.

## Fix

- convert the original scalar directly with `int`;
- compare the converted integer against the original exact scalar;
- reject values that are not exactly integral without narrowing through binary64;
- preserve ordinary Python/NumPy integer behavior and exact integral object scalars;
- remove the now-unused `math` import.

## Regression coverage

- reject a large exact half-integer whose fractional part disappears in binary64;
- preserve an exactly integral `Fraction` wrapped in a zero-dimensional object array;
- exercise the private dimension parser directly so the regression test cannot trigger a huge allocation on the pre-fix implementation.

## Validation

- reproduced the old acceptance as dimension `9007199254740992`;
- verified the patched parser rejects the fractional input and preserves the exact integral control;
- syntax-compiled the patched production module and regression test;
- branch is based on current `main`, is 2 commits ahead and 0 behind, and changes only the dimension parser plus a focused test module.

GitHub Actions should provide the authoritative repository-wide and backend-matrix validation.