### PR TITLE
Validate hypertoroidal uniform real inputs

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_uniform_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_uniform_distribution.py
@@ -8,6 +8,7 @@ from pyrecest.backend import (
     asarray,
     int32,
     int64,
+    isfinite,
     log,
     ndim,
     ones,
@@ -20,6 +21,68 @@ from pyrecest.exceptions import ShapeError
 
 from ..abstract_uniform_distribution import AbstractUniformDistribution
 from .abstract_hypertoroidal_distribution import AbstractHypertoroidalDistribution
+
+
+_INVALID_REAL_SCALAR_TYPES = (
+    bool,
+    np.bool_,
+    str,
+    bytes,
+    bytearray,
+    np.str_,
+    np.bytes_,
+    complex,
+    np.complexfloating,
+    np.datetime64,
+    np.timedelta64,
+)
+_INVALID_REAL_DTYPE_KINDS = {"b", "S", "U", "c", "M", "m"}
+
+
+def _contains_invalid_real_value(value) -> bool:
+    if np.ma.is_masked(value) or isinstance(value, _INVALID_REAL_SCALAR_TYPES):
+        return True
+
+    dtype = getattr(value, "dtype", None)
+    if dtype is not None:
+        try:
+            return np.dtype(dtype).kind in _INVALID_REAL_DTYPE_KINDS
+        except (TypeError, ValueError):
+            dtype_name = str(dtype).lower()
+            return any(
+                token in dtype_name
+                for token in (
+                    "bool",
+                    "complex",
+                    "str",
+                    "bytes",
+                    "datetime",
+                    "timedelta",
+                )
+            )
+
+    try:
+        values = np.asarray(value, dtype=object).reshape(-1)
+    except (OverflowError, TypeError, ValueError, RuntimeError):
+        return False
+    return any(isinstance(item, _INVALID_REAL_SCALAR_TYPES) for item in values)
+
+
+def _validate_finite_real_values(name: str, value):
+    message = f"{name} must contain only finite real values."
+    if _contains_invalid_real_value(value):
+        raise ValueError(message)
+    try:
+        value = asarray(value)
+    except Exception as exc:  # pragma: no cover - backend-specific conversion type
+        raise ValueError(message) from exc
+    try:
+        finite = bool(backend_all(isfinite(value)))
+    except (OverflowError, TypeError, ValueError, RuntimeError) as exc:
+        raise ValueError(message) from exc
+    if not finite:
+        raise ValueError(message)
+    return value
 
 
 def _validate_positive_sample_count(n) -> int:
@@ -75,7 +138,7 @@ def _validate_trigonometric_moment_order(n: Union[int, int32, int64]) -> int:
 
 
 def _validate_pdf_inputs(xs, dim: int):
-    xs = asarray(xs)
+    xs = _validate_finite_real_values("xs", xs)
     if xs.ndim == 0:
         if dim != 1:
             raise ShapeError(
@@ -99,14 +162,14 @@ def _validate_pdf_inputs(xs, dim: int):
 
 
 def _validate_vector(name: str, value, dim: int):
-    value = asarray(value)
+    value = _validate_finite_real_values(name, value)
     if value.shape != (dim,):
         raise ShapeError(name, value.shape, expected=f"({dim},)")
     return value
 
 
 def _validate_boundary(name: str, value, dim: int):
-    value = asarray(value)
+    value = _validate_finite_real_values(name, value)
     if ndim(value) == 0:
         if dim != 1:
             raise ShapeError(

--- a/tests/distributions/test_hypertoroidal_uniform_distribution_real_inputs.py
+++ b/tests/distributions/test_hypertoroidal_uniform_distribution_real_inputs.py
@@ -1,0 +1,66 @@
+import numpy as np
+import pytest
+from pyrecest.distributions.hypertorus.hypertoroidal_uniform_distribution import (
+    HypertoroidalUniformDistribution,
+)
+
+
+@pytest.mark.parametrize(
+    "xs",
+    [
+        True,
+        "0.1",
+        0.1 + 0.2j,
+        np.nan,
+        np.inf,
+        np.datetime64("2026-07-23"),
+        np.ma.array([0.1], mask=[True]),
+        [0.1, False],
+    ],
+)
+def test_pdf_rejects_non_real_or_non_finite_inputs(xs):
+    distribution = HypertoroidalUniformDistribution(1)
+
+    with pytest.raises(ValueError, match="xs must contain only finite real values"):
+        distribution.pdf(xs)
+
+
+@pytest.mark.parametrize(
+    "shift_by",
+    [
+        [0.1, True],
+        [0.1, "0.2"],
+        [0.1, 0.2 + 0.3j],
+        [0.1, np.nan],
+        [0.1, np.inf],
+    ],
+)
+def test_shift_rejects_non_real_or_non_finite_values(shift_by):
+    distribution = HypertoroidalUniformDistribution(2)
+
+    with pytest.raises(
+        ValueError, match="shift_by must contain only finite real values"
+    ):
+        distribution.shift(shift_by)
+
+
+@pytest.mark.parametrize(
+    ("left", "right", "invalid_name"),
+    [
+        (np.nan, 1.0, "left"),
+        (0.0, np.inf, "right"),
+        (0.0 + 1.0j, 1.0, "left"),
+        (0.0, "1.0", "right"),
+        (np.datetime64("2026-07-23"), 1.0, "left"),
+    ],
+)
+def test_integrate_rejects_non_real_or_non_finite_boundaries(
+    left, right, invalid_name
+):
+    distribution = HypertoroidalUniformDistribution(1)
+
+    with pytest.raises(
+        ValueError,
+        match=rf"{invalid_name} must contain only finite real values",
+    ):
+        distribution.integrate((left, right))


### PR DESCRIPTION
## Bug

`HypertoroidalUniformDistribution` validated only the shapes of PDF locations, shifts, and integration boundaries. Because the PDF is constant and `shift()` returns an equivalent copy, boolean, textual, complex, temporal, masked, `NaN`, and infinite values could be accepted without any numerical operation exposing the invalid input. Integration could likewise propagate non-finite boundaries into a non-finite result.

For example, `HypertoroidalUniformDistribution(1).pdf("not an angle")` returned the valid uniform density instead of rejecting the non-numeric location.

## Fix

- add a backend-aware finite-real input validator;
- reject boolean, textual, complex, temporal, masked, and non-finite values before evaluating the PDF, validating shifts, or computing bounded integrals;
- preserve valid NumPy/backend arrays, existing shape validation, periodic real inputs, and the documented signed scalar-boundary behavior for one-dimensional integration.

## Regression coverage

Focused tests cover invalid PDF locations, shift vectors, and integration boundaries across boolean, text, complex, temporal, masked, `NaN`, and infinity cases.

## Validation

- `python -m py_compile` on the exact submitted implementation and test module;
- isolated NumPy-backed smoke execution covering valid scalar/vector behavior and all affected invalid-input paths;
- branch is based on current `main` and changes only the implementation plus focused tests.

GitHub Actions should provide the authoritative repository-wide validation.