### PR TITLE
Reject complex finite-state model inputs

### DIFF
--- a/src/pyrecest/filters/discrete_state/__init__.py
+++ b/src/pyrecest/filters/discrete_state/__init__.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import runpy
+from functools import wraps
 from pathlib import Path
 from typing import Any
 
 import numpy as np
+from scipy.sparse import issparse
 
 _TEXT_TYPES = (str, bytes, bytearray, np.str_, np.bytes_)
 _BOOLEAN_TYPES = (bool, np.bool_)
@@ -17,9 +19,136 @@ _module_globals = runpy.run_path(
     str(Path(__file__).resolve().parents[1] / "discrete_state.py"),
     run_name=__name__,
 )
+_original_scaled_emissions = _module_globals["scaled_emissions"]
+_original_probabilities_to_log_probabilities = _module_globals[
+    "probabilities_to_log_probabilities"
+]
+_original_discrete_forward_backward = _module_globals[
+    "discrete_forward_backward"
+]
+_original_discrete_forward_backward_time_varying = _module_globals[
+    "discrete_forward_backward_time_varying"
+]
+_original_imm_forward_backward = _module_globals["imm_forward_backward"]
 _original_sparse_gaussian_transition_matrix = _module_globals[
     "sparse_gaussian_transition_matrix"
 ]
+
+
+def _reject_complex_values(values: Any, message: str) -> None:
+    if issparse(values):
+        raw_values = values.data
+    else:
+        try:
+            raw_values = np.asarray(values)
+        except (TypeError, ValueError):
+            return
+
+    contains_complex = raw_values.dtype.kind == "c"
+    if raw_values.dtype == object:
+        contains_complex = any(
+            isinstance(value, _COMPLEX_TYPES) for value in raw_values.ravel()
+        )
+    if contains_complex:
+        raise ValueError(message)
+
+
+@wraps(_original_scaled_emissions)
+def scaled_emissions(log_likelihood):
+    _reject_complex_values(log_likelihood, "log_likelihood must contain real values")
+    return _original_scaled_emissions(log_likelihood)
+
+
+@wraps(_original_probabilities_to_log_probabilities)
+def probabilities_to_log_probabilities(
+    probabilities,
+    axis=-1,
+    *,
+    normalize=True,
+):
+    _reject_complex_values(
+        probabilities,
+        "probabilities must contain real probability values",
+    )
+    return _original_probabilities_to_log_probabilities(
+        probabilities,
+        axis=axis,
+        normalize=normalize,
+    )
+
+
+@wraps(_original_discrete_forward_backward)
+def discrete_forward_backward(
+    log_likelihood,
+    transition,
+    *,
+    initial_probabilities=None,
+    valid_state_mask=None,
+):
+    _reject_complex_values(log_likelihood, "log_likelihood must contain real values")
+    _reject_complex_values(
+        transition,
+        "transition must contain real transition probabilities",
+    )
+    return _original_discrete_forward_backward(
+        log_likelihood,
+        transition,
+        initial_probabilities=initial_probabilities,
+        valid_state_mask=valid_state_mask,
+    )
+
+
+@wraps(_original_discrete_forward_backward_time_varying)
+def discrete_forward_backward_time_varying(
+    log_likelihood,
+    transitions,
+    *,
+    initial_probabilities=None,
+    valid_state_mask=None,
+):
+    _reject_complex_values(log_likelihood, "log_likelihood must contain real values")
+    for index, transition in enumerate(transitions):
+        _reject_complex_values(
+            transition,
+            f"transitions[{index}] must contain real transition probabilities",
+        )
+    return _original_discrete_forward_backward_time_varying(
+        log_likelihood,
+        transitions,
+        initial_probabilities=initial_probabilities,
+        valid_state_mask=valid_state_mask,
+    )
+
+
+@wraps(_original_imm_forward_backward)
+def imm_forward_backward(
+    log_likelihood,
+    state_transitions,
+    mode_transition,
+    *,
+    initial_state_probabilities=None,
+    initial_mode_probabilities=None,
+    valid_state_mask=None,
+):
+    _reject_complex_values(log_likelihood, "log_likelihood must contain real values")
+    for index, transition in enumerate(state_transitions):
+        if transition is not None:
+            _reject_complex_values(
+                transition,
+                f"state_transitions[{index}] must contain real transition probabilities",
+            )
+    _reject_complex_values(
+        mode_transition,
+        "mode_transition must contain real transition probabilities",
+    )
+    return _original_imm_forward_backward(
+        log_likelihood,
+        state_transitions,
+        mode_transition,
+        initial_state_probabilities=initial_state_probabilities,
+        initial_mode_probabilities=initial_mode_probabilities,
+        valid_state_mask=valid_state_mask,
+    )
 
 
 def _validated_state_vectors(state_vectors: Any) -> np.ndarray:
@@ -142,6 +271,15 @@ def sparse_gaussian_transition_matrix(
     )
 
 
+_module_globals["scaled_emissions"] = scaled_emissions
+_module_globals["probabilities_to_log_probabilities"] = (
+    probabilities_to_log_probabilities
+)
+_module_globals["discrete_forward_backward"] = discrete_forward_backward
+_module_globals["discrete_forward_backward_time_varying"] = (
+    discrete_forward_backward_time_varying
+)
+_module_globals["imm_forward_backward"] = imm_forward_backward
 _module_globals["sparse_gaussian_transition_matrix"] = sparse_gaussian_transition_matrix
 _module_globals["_normalize_probability_vector"] = _validated_probability_vector
 for name in _module_globals["__all__"]:

--- a/tests/filters/test_discrete_state_complex_inputs.py
+++ b/tests/filters/test_discrete_state_complex_inputs.py
@@ -1,0 +1,97 @@
+import unittest
+
+import numpy as np
+from pyrecest.filters.discrete_state import (
+    discrete_forward_backward,
+    discrete_forward_backward_time_varying,
+    imm_forward_backward,
+    probabilities_to_log_probabilities,
+    scaled_emissions,
+)
+from scipy.sparse import csr_matrix
+
+
+class TestDiscreteStateComplexInputs(unittest.TestCase):
+    def test_probability_utilities_reject_complex_values(self):
+        invalid_log_likelihoods = (
+            np.array([[0.0 + 0.25j, -1.0 + 0.0j]]),
+            np.array([[0.0 + 0.25j, -1.0]], dtype=object),
+        )
+        for log_likelihood in invalid_log_likelihoods:
+            with self.subTest(function="scaled_emissions", value=log_likelihood):
+                with self.assertRaisesRegex(ValueError, "real values"):
+                    scaled_emissions(log_likelihood)
+
+        invalid_probabilities = (
+            np.array([[0.5 + 0.25j, 0.5 + 0.0j]]),
+            np.array([[0.5 + 0.25j, 0.5]], dtype=object),
+        )
+        for probabilities in invalid_probabilities:
+            with self.subTest(
+                function="probabilities_to_log_probabilities", value=probabilities
+            ):
+                with self.assertRaisesRegex(ValueError, "real probability values"):
+                    probabilities_to_log_probabilities(probabilities, axis=1)
+
+    def test_forward_backward_rejects_complex_emissions(self):
+        log_likelihood = np.array([[0.0 + 0.25j, -1.0], [-0.5, -0.25]])
+
+        with self.assertRaisesRegex(ValueError, "log_likelihood.*real values"):
+            discrete_forward_backward(log_likelihood, np.eye(2))
+
+    def test_forward_backward_rejects_complex_transition_matrices(self):
+        log_likelihood = np.zeros((2, 2), dtype=float)
+        complex_transition = np.array(
+            [[0.8 + 0.25j, 0.2], [0.2, 0.8]], dtype=complex
+        )
+
+        for transition in (complex_transition, csr_matrix(complex_transition)):
+            with self.subTest(transition_type=type(transition).__name__):
+                with self.assertRaisesRegex(
+                    ValueError, "transition.*real transition probabilities"
+                ):
+                    discrete_forward_backward(log_likelihood, transition)
+
+    def test_time_varying_forward_backward_rejects_complex_transition(self):
+        log_likelihood = np.zeros((2, 2), dtype=float)
+        complex_transition = np.array(
+            [[0.8 + 0.25j, 0.2], [0.2, 0.8]], dtype=complex
+        )
+
+        with self.assertRaisesRegex(
+            ValueError, r"transitions\[0\].*real transition probabilities"
+        ):
+            discrete_forward_backward_time_varying(
+                log_likelihood, [complex_transition]
+            )
+
+    def test_imm_rejects_complex_state_and_mode_transitions(self):
+        log_likelihood = np.zeros((2, 2), dtype=float)
+        complex_transition = np.array(
+            [[0.8 + 0.25j, 0.2], [0.2, 0.8]], dtype=complex
+        )
+
+        with self.assertRaisesRegex(
+            ValueError, r"state_transitions\[0\].*real transition probabilities"
+        ):
+            imm_forward_backward(
+                log_likelihood,
+                [complex_transition, np.eye(2)],
+                np.eye(2),
+            )
+
+        complex_mode_transition = np.array(
+            [[0.9 + 0.25j, 0.1], [0.1, 0.9]], dtype=complex
+        )
+        with self.assertRaisesRegex(
+            ValueError, "mode_transition.*real transition probabilities"
+        ):
+            imm_forward_backward(
+                log_likelihood,
+                [np.eye(2), np.eye(2)],
+                complex_mode_transition,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- reject complex-valued emission log likelihoods and probability arrays before any float coercion
- reject complex dense and sparse transition matrices in constant, time-varying, and IMM forward/backward APIs
- add focused regression coverage for native complex arrays, object arrays containing complex values, dense transitions, and CSR transitions

## Root cause

The finite-state utilities convert user inputs with `np.asarray(..., dtype=float)` or sparse `.astype(float)` before validating them. NumPy/SciPy can therefore discard imaginary components with a `ComplexWarning` and continue with the real part. An invalid complex probabilistic model can consequently produce plausible but incorrect filtering and smoothing results instead of failing fast.

## Fix

The compatibility layer now detects complex dtypes and complex values inside object arrays before delegating to the existing implementations. Public function metadata is preserved with `functools.wraps`; otherwise valid real-valued behavior is unchanged.

## Validation

- `python -m pytest -q tests/filters/test_discrete_state_complex_inputs.py`
- result: 5 tests passed, including 6 subtests

The regression suite covers direct scaling/log conversion, constant and time-varying HMM transitions, dense and sparse matrices, and IMM state/mode transitions.