### PR TITLE
Reject invalid Python sequence indices in PyTorch take

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_take_index_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_take_index_contract.py
@@ -17,8 +17,13 @@ def _validate_take_indices(indices, torch_module):
             raise TypeError(_TAKE_INDEX_TYPE_MESSAGE)
         return indices
 
-    if isinstance(indices, np.ndarray) and not np.can_cast(
-        indices.dtype,
+    try:
+        indices_array = np.asarray(indices)
+    except (TypeError, ValueError):
+        return indices
+
+    if indices_array.ndim > 0 and not np.can_cast(
+        indices_array.dtype,
         np.dtype(np.intp),
         casting="same_kind",
     ):

--- a/tests/test_pytorch_take_sequence_index_contract.py
+++ b/tests/test_pytorch_take_sequence_index_contract.py
@@ -1,0 +1,48 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.backend_support._pytorch_take_index_contract import (
+    _validate_take_indices,
+)
+
+
+class _TorchStub:
+    @staticmethod
+    def is_tensor(value):
+        del value
+        return False
+
+
+class PytorchTakeSequenceIndexContractTest(unittest.TestCase):
+    def test_rejects_invalid_plain_python_index_sequences(self):
+        invalid_indices = (
+            [0.0, 1.0],
+            (0.0, 1.0),
+            [0.0 + 0.0j, 1.0 + 0.0j],
+            ["0", "1"],
+        )
+
+        for indices in invalid_indices:
+            with self.subTest(indices=indices):
+                with self.assertRaisesRegex(
+                    TypeError,
+                    "indices must be integers or boolean values",
+                ):
+                    _validate_take_indices(indices, _TorchStub)
+
+    def test_preserves_valid_plain_python_index_sequences(self):
+        valid_indices = ([0, 2], (1, 0), [True, False])
+
+        for indices in valid_indices:
+            with self.subTest(indices=indices):
+                self.assertIs(_validate_take_indices(indices, _TorchStub), indices)
+
+    def test_preserves_scalar_indices_for_existing_scalar_handling(self):
+        scalar = np.float64(1.0)
+
+        self.assertIs(_validate_take_indices(scalar, _TorchStub), scalar)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

The PyTorch `take()` compatibility contract validates tensors and NumPy arrays, but plain Python lists and tuples bypass validation. Fractional, complex, or textual index sequences can therefore reach backend coercion paths instead of being rejected consistently with NumPy array inputs.

For example, `[0.0, 1.0]` was not checked even though `np.array([0.0, 1.0])` was rejected.

## Fix

- normalize non-tensor index inputs with `np.asarray` for dtype inspection;
- apply the existing `same_kind` castability check to all non-scalar array-like inputs;
- preserve valid integer and Boolean sequences;
- preserve scalar handling in the underlying implementation.

## Regression coverage

Focused tests cover plain Python lists and tuples containing floating-point, complex, and textual indices, plus valid integer/Boolean sequences and scalar passthrough.

## Scope

The branch is based on current `main`, is 2 commits ahead and 0 behind, and changes only the take-index compatibility validator plus focused tests.

GitHub Actions provides the authoritative repository-wide validation.