### PR TITLE
Reject non-vector Bingham measurements

### DIFF
--- a/src/pyrecest/filters/bingham_filter.py
+++ b/src/pyrecest/filters/bingham_filter.py
@@ -62,7 +62,7 @@ def _validate_compatible_bingham(distribution, reference, role):
 
 
 def _validate_bingham_measurement(z, input_dim):
-    measurement = asarray(z).ravel()
+    measurement = asarray(z)
     if measurement.shape != (input_dim,):
         raise ValueError(f"measurement z must have shape ({input_dim},).")
     if not _to_python_bool(backend_all(isfinite(measurement))):

--- a/tests/filters/test_bingham_filter_measurement_shape.py
+++ b/tests/filters/test_bingham_filter_measurement_shape.py
@@ -1,0 +1,39 @@
+import unittest
+
+import pyrecest.backend
+from pyrecest.backend import array, eye
+from pyrecest.distributions.hypersphere_subset.bingham_distribution import (
+    BinghamDistribution,
+)
+from pyrecest.filters.bingham_filter import BinghamFilter
+
+
+class TestBinghamFilterMeasurementShape(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_update_identity_rejects_nonvector_measurements(self):
+        filter_2d = BinghamFilter()
+        filter_2d.filter_state = BinghamDistribution(array([-5.0, 0.0]), eye(2))
+        noise_2d = BinghamDistribution(array([-3.0, 0.0]), eye(2))
+
+        filter_4d = BinghamFilter()
+        noise_4d = BinghamDistribution(
+            array([-2.0, -2.0, -2.0, 0.0]),
+            eye(4),
+        )
+
+        invalid_measurements = (
+            (filter_2d, noise_2d, [[1.0, 0.0]]),
+            (filter_2d, noise_2d, [[1.0], [0.0]]),
+            (filter_4d, noise_4d, [[1.0, 0.0], [0.0, 0.0]]),
+        )
+        for filter_instance, noise, measurement in invalid_measurements:
+            with self.subTest(measurement=measurement):
+                with self.assertRaisesRegex(ValueError, "shape"):
+                    filter_instance.update_identity(noise, measurement)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- validate Bingham measurements before flattening or reshaping them
- reject row vectors, column vectors, and matrices even when their total element count matches the expected complex/quaternion dimension
- add focused regression coverage for 2D and 4D Bingham filters

## Root cause

`_validate_bingham_measurement` called `asarray(z).ravel()` before checking the shape. Consequently, any array with the right total number of elements was converted to shape `(input_dim,)` and could pass validation. For example, `[[1.0, 0.0]]` was accepted as a 2D unit-complex measurement, and `[[1.0, 0.0], [0.0, 0.0]]` was accepted as a quaternion measurement.

This contradicted the documented API contract that measurements must be unit vectors with shape `(dim + 1,)` and could hide upstream batching or orientation mistakes.

## Fix

Check the original backend-array shape first and only accept exactly `(input_dim,)`. Valid Python lists and one-dimensional backend arrays remain supported.

## Validation

- regression tests cover 2D row and column vectors
- regression tests cover a 4D matrix with the correct flattened size
- branch is based on current `main` and changes only the validator plus the focused tests

GitHub Actions should provide the authoritative repository-wide validation.