### PR TITLE
Validate Bingham nonlinear system outputs

### DIFF
--- a/src/pyrecest/filters/bingham_filter.py
+++ b/src/pyrecest/filters/bingham_filter.py
@@ -72,6 +72,17 @@ def _validate_bingham_measurement(z, input_dim):
     return measurement
 
 
+def _validate_bingham_system_output(value, input_dim):
+    propagated = asarray(value)
+    if propagated.shape != (input_dim,):
+        raise ValueError(f"system function output must have shape ({input_dim},).")
+    if not _to_python_bool(backend_all(isfinite(propagated))):
+        raise ValueError("system function output must be finite.")
+    if not _to_python_bool(isclose(linalg.norm(propagated), 1.0)):
+        raise ValueError("system function output must be a unit vector.")
+    return propagated
+
+
 class BinghamFilter(AbstractFilter):
     """Recursive filter based on the Bingham distribution.
 
@@ -137,9 +148,11 @@ class BinghamFilter(AbstractFilter):
 
         samples, weights = self.filter_state.sample_deterministic(0.5)
 
-        # Propagate each sample through the system function
+        # Propagate each sample through the system function.
+        input_dim = self.filter_state.input_dim
         for i in range(len(weights)):
-            samples[:, i] = a(samples[:, i])
+            propagated = _validate_bingham_system_output(a(samples[:, i]), input_dim)
+            samples[:, i] = propagated
 
         # Compute scatter matrix of propagated samples
         S = samples @ diag(weights) @ samples.T

--- a/tests/filters/test_bingham_filter_system_output_validation.py
+++ b/tests/filters/test_bingham_filter_system_output_validation.py
@@ -1,0 +1,64 @@
+import unittest
+
+# pylint: disable=no-name-in-module,no-member
+import pyrecest.backend
+from pyrecest.backend import array, cos, sin
+from pyrecest.distributions.hypersphere_subset.bingham_distribution import (
+    BinghamDistribution,
+)
+from pyrecest.filters.bingham_filter import BinghamFilter
+
+
+class TestBinghamFilterSystemOutputValidation(unittest.TestCase):
+    def setUp(self):
+        phi = 0.4
+        self.state = BinghamDistribution(
+            array([-5.0, 0.0]),
+            array([[cos(phi), -sin(phi)], [sin(phi), cos(phi)]]),
+        )
+        self.noise = BinghamDistribution(
+            array([-3.0, 0.0]),
+            array([[0.0, 1.0], [1.0, 0.0]]),
+        )
+        self.filter = BinghamFilter()
+        self.filter.filter_state = self.state
+
+    def _predict_with_first_output(self, first_output):
+        calls = 0
+
+        def system_function(sample):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return first_output
+            return sample
+
+        self.filter.predict_nonlinear(system_function, self.noise)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_rejects_scalar_output_before_column_broadcast(self):
+        with self.assertRaisesRegex(ValueError, "system function output must have shape"):
+            self._predict_with_first_output(2**-0.5)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_rejects_nonfinite_output(self):
+        with self.assertRaisesRegex(ValueError, "system function output must be finite"):
+            self._predict_with_first_output(array([float("nan"), 0.0]))
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_rejects_nonunit_output(self):
+        with self.assertRaisesRegex(ValueError, "system function output must be a unit vector"):
+            self._predict_with_first_output(array([2.0, 0.0]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`BinghamFilter.predict_nonlinear()` assigned each nonlinear system-function result directly into a sigma-point column. Array backends therefore broadcast scalar outputs to the full state dimension. For example, in the 2-D complex representation a scalar `1 / sqrt(2)` could become the apparently valid unit vector `[1 / sqrt(2), 1 / sqrt(2)]` instead of being rejected.

The same path allowed non-finite and non-unit vectors to reach Bingham moment fitting, even though the approximation assumes propagated samples remain on the unit sphere.

## Fix

- validate every nonlinear system-function result before mutating the sigma-point matrix;
- require the exact state-vector shape;
- reject non-finite values;
- require unit norm;
- preserve valid array-like unit-vector outputs and the existing prediction algorithm.

## Regression coverage

Focused tests cover:

- scalar output that would otherwise be column-broadcast;
- non-finite vector output;
- non-unit vector output.

## Validation

- `python -m py_compile` on the modified implementation and new test module;
- isolated NumPy-backed execution harness covering all three rejection paths and a valid identity-system control;
- the PR changes only the Bingham filter and focused tests and is currently mergeable with `main`.

GitHub Actions provides the authoritative repository-wide and backend-matrix validation.