### PR TITLE
Fix negative complex Watson normalization

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/complex_watson_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/complex_watson_distribution.py
@@ -350,7 +350,10 @@ class ComplexWatsonDistribution:
     def log_norm(D, kappa):
         """Compute the log normalization constant log(C_D(kappa)).
 
-        Uses three numerical regimes for stability (Mardia & Dryden 1999).
+        Uses separate negative, low, medium, and high concentration regimes for
+        stability. The positive-concentration formulas follow Mardia & Dryden
+        (1999); negative concentrations are evaluated from the defining
+        confluent hypergeometric function with arbitrary precision.
 
         Parameters:
             D: feature-space dimension (integer >= 1)
@@ -371,12 +374,19 @@ class ComplexWatsonDistribution:
         _validate_numpy_or_pytorch_backend("log_norm()")
         log_c = zeros_like(kappa_arr)
 
+        mask_negative = kappa_arr < 0.0
+        positive_formula_kappa = where(kappa_arr > 0.0, kappa_arr, 1.0)
+        series_kappa = where(mask_negative, 0.0, kappa_arr)
+
         # ----------------------------------------------------------
         # High-kappa asymptotic formula (Mardia1999Watson, p. 917)
         #   log(1/C) ≈ log(2) + D·log(π) + (1-D)·log(κ) + κ
         # ----------------------------------------------------------
         log_c_high = (
-            log(array(2.0)) + D * log(pi) + (1 - D) * log(kappa_arr) + kappa_arr
+            log(array(2.0))
+            + D * log(pi)
+            + (1 - D) * log(positive_formula_kappa)
+            + positive_formula_kappa
         )
 
         # ----------------------------------------------------------
@@ -386,8 +396,9 @@ class ComplexWatsonDistribution:
         # ----------------------------------------------------------
         if D > 1:
             i_arr = arange(D - 1, dtype=float)  # 0, 1, ..., D-2
-            correction = exp(-kappa_arr) * sum(
-                kappa_arr[:, None] ** i_arr / exp(gammaln(i_arr + 1.0)),
+            correction = exp(-positive_formula_kappa) * sum(
+                positive_formula_kappa[:, None] ** i_arr
+                / exp(gammaln(i_arr + 1.0)),
                 axis=1,
             )
             log_c_medium = log_c_high + log(maximum(1.0 - correction, 1e-300))
@@ -398,22 +409,49 @@ class ComplexWatsonDistribution:
         # Low-kappa Taylor series (Mardia1999Watson, Eq. 4, 10 terms)
         #   1F1(1;D;κ) ≈ 1 + Σ_{i=1}^{10} κ^i / (D·(D+1)·…·(D+i-1))
         # ----------------------------------------------------------
-        ratios = kappa_arr[:, None] / arange(D, D + 10, dtype=float)
+        ratios = series_kappa[:, None] / arange(D, D + 10, dtype=float)
         cumprods = cumprod(ratios, axis=1)
         hyp1f1_approx = 1.0 + sum(cumprods, axis=1)
         log_fact_Dm1 = gammaln(array(float(D)))  # log Γ(D) = log (D-1)!
-        log_c_low = log(array(2.0)) + D * log(pi) - log_fact_Dm1 + log(hyp1f1_approx)
+        log_c_low = (
+            log(array(2.0))
+            + D * log(pi)
+            - log_fact_Dm1
+            + log(hyp1f1_approx)
+        )
 
-        # Select the appropriate regime
-        mask_low = kappa_arr < (1.0 / D)
+        # Select the appropriate nonnegative-kappa regime.
+        mask_low = (kappa_arr >= 0.0) & (kappa_arr < (1.0 / D))
         mask_high = kappa_arr >= 100.0
-        mask_medium = ~mask_low & ~mask_high
+        mask_medium = ~(mask_negative | mask_low | mask_high)
 
         log_c[mask_low] = log_c_low[mask_low]
         log_c[mask_medium] = log_c_medium[mask_medium]
         log_c[mask_high] = log_c_high[mask_high]
 
-        # Negate: the three formulas compute log(1/C); we want log(C)
+        # The finite Taylor expansion is only a local approximation and becomes
+        # grossly inaccurate for negative concentrations. Evaluate the defining
+        # hypergeometric normalization directly for those entries instead.
+        negative_indices = np.flatnonzero(
+            np.asarray(pyrecest.backend.to_numpy(mask_negative), dtype=bool)
+        )
+        if negative_indices.size:
+            kappa_values = np.asarray(
+                pyrecest.backend.to_numpy(kappa_arr), dtype=float
+            )
+            with mpmath.workdps(50):
+                log_surface_factor = (
+                    mpmath.log(2.0)
+                    + D * mpmath.log(mpmath.pi)
+                    - mpmath.loggamma(D)
+                )
+                for index in negative_indices:
+                    log_hypergeometric = mpmath.log(
+                        mpmath.hyp1f1(1, D, mpmath.mpf(kappa_values[index]))
+                    )
+                    log_c[index] = float(log_surface_factor + log_hypergeometric)
+
+        # Negate: the formulas compute log(1/C); we want log(C)
         log_c = -log_c
 
         if scalar_input:

--- a/tests/distributions/test_complex_watson_negative_kappa.py
+++ b/tests/distributions/test_complex_watson_negative_kappa.py
@@ -1,0 +1,64 @@
+# pylint: disable=no-name-in-module,no-member
+import unittest
+
+import mpmath
+import numpy as np
+import pyrecest.backend
+from pyrecest.backend import array, complex128, to_numpy
+from pyrecest.distributions import ComplexWatsonDistribution
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+    reason="ComplexWatsonDistribution.log_norm is not supported on JAX",
+)
+class TestComplexWatsonNegativeKappa(unittest.TestCase):
+    @staticmethod
+    def _reference_log_norm(dim, kappa):
+        with mpmath.workdps(80):
+            log_reciprocal_norm = (
+                mpmath.log(2.0)
+                + dim * mpmath.log(mpmath.pi)
+                - mpmath.loggamma(dim)
+                + mpmath.log(mpmath.hyp1f1(1, dim, mpmath.mpf(kappa)))
+            )
+        return float(-log_reciprocal_norm)
+
+    def test_negative_log_norm_matches_hypergeometric_reference(self):
+        cases = (
+            (1, -100.0),
+            (2, -10.0),
+            (3, -100.0),
+            (10, -20.0),
+        )
+
+        for dim, kappa in cases:
+            with self.subTest(dim=dim, kappa=kappa):
+                actual = ComplexWatsonDistribution.log_norm(dim, kappa)
+                expected = self._reference_log_norm(dim, kappa)
+                self.assertAlmostEqual(actual, expected, places=11)
+
+    def test_negative_log_norm_array_is_finite_and_accurate(self):
+        dim = 3
+        kappas = array([-1000.0, -100.0, -20.0, -5.0, -1.0, -0.1])
+        actual = np.asarray(to_numpy(ComplexWatsonDistribution.log_norm(dim, kappas)))
+        expected = np.asarray(
+            [self._reference_log_norm(dim, float(kappa)) for kappa in to_numpy(kappas)]
+        )
+
+        self.assertTrue(np.all(np.isfinite(actual)))
+        np.testing.assert_allclose(actual, expected, rtol=1e-11, atol=1e-11)
+
+    def test_negative_concentration_pdf_remains_finite(self):
+        distribution = ComplexWatsonDistribution(
+            array([1.0 + 0.0j, 0.0 + 0.0j], dtype=complex128), -100.0
+        )
+        points = array(
+            [[1.0 + 0.0j, 0.0 + 0.0j], [0.0 + 0.0j, 1.0 + 0.0j]],
+            dtype=complex128,
+        )
+        densities = np.asarray(to_numpy(distribution.pdf(points)))
+
+        self.assertTrue(np.all(np.isfinite(densities)))
+        self.assertTrue(np.all(densities >= 0.0))
+        self.assertGreater(densities[1], densities[0])


### PR DESCRIPTION
## Bug

`ComplexWatsonDistribution.log_norm` sent every negative concentration through the 10-term near-zero Taylor series. That expansion is only local; for moderate or large negative κ it returns severely wrong log-normalization constants. For example, at `D=3`, `κ=-100`, the old result differs from the defining hypergeometric value by more than 30 nats, so the resulting PDF is incorrectly normalized.

## Fix

- retain the existing low-, medium-, and high-concentration formulas for nonnegative κ;
- avoid evaluating positive-only logarithms and powers on nonpositive inputs;
- evaluate negative κ from the defining `1F1(1; D; κ)` normalization at 50-digit precision;
- preserve scalar and array outputs and NumPy/PyTorch behavior; JAX remains explicitly unsupported by this method.

## Regression coverage

- scalar negative concentrations across `D=1,2,3,10`;
- vector-valued negative concentrations down to `κ=-1000`;
- finite, nonnegative PDF behavior for `κ=-100`.

## Validation

- reproduced the old large error against an independent high-precision `mpmath` reference;
- checked the patched algorithm against the same 80-digit reference for multiple dimensions and concentrations down to `κ=-1000`;
- reviewed the exact diff; the branch changes only the implementation and focused regression coverage;
- GitHub Actions will provide repository-wide validation.