### PR TITLE
Reject fractionally rounded mixture sample counts

### DIFF
--- a/src/pyrecest/distributions/abstract_mixture.py
+++ b/src/pyrecest/distributions/abstract_mixture.py
@@ -59,11 +59,14 @@ def _validate_positive_sample_count(n) -> int:
 
     try:
         count_int = int(count)
-        count_float = float(count)
     except (OverflowError, TypeError, ValueError) as exc:
         raise ValueError(message) from exc
 
-    if not np.isfinite(count_float) or not count_float.is_integer():
+    try:
+        is_exact_integer = count == count_int
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError(message) from exc
+    if not bool(is_exact_integer):
         raise ValueError(message)
     if count_int <= 0:
         raise ValueError(message)

--- a/tests/distributions/test_mixture_sample_count_exactness.py
+++ b/tests/distributions/test_mixture_sample_count_exactness.py
@@ -1,0 +1,19 @@
+from fractions import Fraction
+
+import pytest
+
+from pyrecest.distributions.abstract_mixture import _validate_positive_sample_count
+
+
+def test_mixture_sample_count_rejects_fraction_rounded_by_float():
+    count = Fraction(2**54 + 1, 2)
+
+    assert float(count).is_integer()
+    with pytest.raises(ValueError, match="positive integer"):
+        _validate_positive_sample_count(count)
+
+
+def test_mixture_sample_count_preserves_large_exact_integer():
+    count = Fraction(2**54 + 2, 2)
+
+    assert _validate_positive_sample_count(count) == 2**53 + 1


### PR DESCRIPTION
## Bug

`AbstractMixture.sample()` validates its requested sample count through `_validate_positive_sample_count()`. The validator converted exact scalar values through binary `float` before checking whether they were integers. A sufficiently large exact half-integer can therefore lose its fractional part during binary64 conversion and be accepted.

For example, `Fraction(2**54 + 1, 2)` is exactly `9007199254740992.5`, but `float(...)` rounds it to `9007199254740992.0`. The old validator accepted that count, after which mixture sampling could attempt an enormous allocation.

## Fix

- convert the original scalar directly with `int`;
- compare the converted integer against the original exact value;
- reject non-integral values without narrowing through binary64;
- preserve exact large integral scalar values and the existing validation of booleans, text, temporal values, non-scalars, and non-positive counts.

## Regression coverage

- reject a large exact half-integer whose fractional part disappears in binary64;
- preserve the neighboring exact large integer;
- exercise the private validator directly so the regression test cannot trigger an enormous allocation on the pre-fix implementation.

## Validation

- reproduced the old acceptance in an isolated Python check;
- verified the patched exact-comparison logic rejects the fractional value and preserves the exact integer;
- compared the branch against its base: two files changed, seven production-line edits, and focused regression coverage;
- GitHub Actions will provide repository-wide and backend-matrix validation.