### PR TITLE
Reject complex-valued Bingham filter vectors

### DIFF
--- a/src/pyrecest/filters/bingham_filter.py
+++ b/src/pyrecest/filters/bingham_filter.py
@@ -30,6 +30,15 @@ def _to_python_bool(value):
     return bool(value)
 
 
+def _is_complex_array(value):
+    """Return whether a NumPy/JAX array or PyTorch tensor has complex dtype."""
+    dtype = getattr(value, "dtype", None)
+    if getattr(dtype, "kind", None) == "c":
+        return True
+    is_complex = getattr(value, "is_complex", None)
+    return bool(is_complex()) if callable(is_complex) else False
+
+
 def _validate_bingham_distribution(distribution, role):
     if not isinstance(distribution, BinghamDistribution):
         raise ValueError(f"{role} must be a BinghamDistribution.")
@@ -65,6 +74,8 @@ def _validate_bingham_measurement(z, input_dim):
     measurement = asarray(z)
     if measurement.shape != (input_dim,):
         raise ValueError(f"measurement z must have shape ({input_dim},).")
+    if _is_complex_array(measurement):
+        raise ValueError("measurement z must be real-valued.")
     if not _to_python_bool(backend_all(isfinite(measurement))):
         raise ValueError("measurement z must be finite.")
     if not _to_python_bool(isclose(linalg.norm(measurement), 1.0)):
@@ -76,6 +87,8 @@ def _validate_bingham_system_output(value, input_dim):
     propagated = asarray(value)
     if propagated.shape != (input_dim,):
         raise ValueError(f"system function output must have shape ({input_dim},).")
+    if _is_complex_array(propagated):
+        raise ValueError("system function output must be real-valued.")
     if not _to_python_bool(backend_all(isfinite(propagated))):
         raise ValueError("system function output must be finite.")
     if not _to_python_bool(isclose(linalg.norm(propagated), 1.0)):

--- a/tests/filters/test_bingham_filter_complex_vector_validation.py
+++ b/tests/filters/test_bingham_filter_complex_vector_validation.py
@@ -1,0 +1,50 @@
+import unittest
+
+# pylint: disable=no-name-in-module,no-member
+import pyrecest.backend
+from pyrecest.backend import array, complex128, cos, sin
+from pyrecest.distributions.hypersphere_subset.bingham_distribution import (
+    BinghamDistribution,
+)
+from pyrecest.filters.bingham_filter import BinghamFilter
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ == "jax",
+    reason="BinghamFilter is not supported on JAX",
+)
+class TestBinghamFilterComplexVectorValidation(unittest.TestCase):
+    def setUp(self):
+        phi = 0.4
+        self.state = BinghamDistribution(
+            array([-5.0, 0.0]),
+            array([[cos(phi), -sin(phi)], [sin(phi), cos(phi)]]),
+        )
+        self.noise = BinghamDistribution(
+            array([-3.0, 0.0]),
+            array([[0.0, 1.0], [1.0, 0.0]]),
+        )
+        self.filter = BinghamFilter()
+        self.filter.filter_state = self.state
+
+    def test_update_rejects_complex_measurement(self):
+        measurement = array([1.0 + 0.0j, 0.0 + 0.0j], dtype=complex128)
+
+        with self.assertRaisesRegex(ValueError, "measurement z must be real-valued"):
+            self.filter.update_identity(self.noise, measurement)
+
+    def test_prediction_rejects_complex_system_output(self):
+        def system_function(sample):
+            return array(
+                [sample[0] + 0.0j, sample[1] + 0.0j],
+                dtype=complex128,
+            )
+
+        with self.assertRaisesRegex(
+            ValueError, "system function output must be real-valued"
+        ):
+            self.filter.predict_nonlinear(system_function, self.noise)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`BinghamFilter` represents unit complex numbers and quaternions as **real coordinate vectors** of length 2 or 4. Its measurement and nonlinear-system validators checked shape, finiteness, and norm, but did not reject arrays with complex dtype.

A complex vector such as `[1+0j, 0+0j]` therefore passed validation. In nonlinear prediction, NumPy may then discard the imaginary component while assigning into the real sigma-point matrix, whereas PyTorch can fail through a different backend-specific conversion path. This makes invalid inputs backend-dependent and can silently alter propagated states.

## Fix

- add a small backend-neutral complex-dtype detector supporting NumPy/JAX dtype metadata and PyTorch tensor predicates;
- reject complex-valued measurements with a clear `ValueError`;
- reject complex-valued nonlinear system outputs before sigma-point assignment;
- preserve valid real unit vectors and the existing shape, finite-value, and unit-norm checks.

## Regression coverage

- reject a complex-valued identity-update measurement;
- reject a complex-valued nonlinear-system output;
- run the same tests on supported NumPy and PyTorch backends; JAX remains skipped because `BinghamFilter` itself is unsupported there.

## Validation

- branch is based on current `main`, two commits ahead and zero behind;
- diff is limited to the Bingham filter validator and focused regression tests;
- GitHub Actions provides the authoritative backend-matrix and repository-wide validation.