### PR TITLE
Validate UKF-M measurement vector shapes

### DIFF
--- a/src/pyrecest/filters/ukf_on_manifolds.py
+++ b/src/pyrecest/filters/ukf_on_manifolds.py
@@ -40,6 +40,17 @@ class _Weights:
         self.w0 = m / (m + d) + 3.0 - alpha**2
 
 
+def _as_measurement_vector(value: Any, expected_dim: int, name: str):
+    """Validate a measurement-like value without flattening or broadcasting it."""
+
+    vector = asarray(value)
+    expected_shape = (expected_dim,)
+    actual_shape = tuple(vector.shape)
+    if actual_shape != expected_shape:
+        raise ValueError(f"{name} must have shape {expected_shape}, got {actual_shape}")
+    return vector
+
+
 class UKFOnManifolds(AbstractFilter):  # pylint: disable=too-many-instance-attributes
     """Unscented Kalman Filter on (parallelizable) Manifolds.
 
@@ -263,7 +274,7 @@ class UKFOnManifolds(AbstractFilter):  # pylint: disable=too-many-instance-attri
         """
         if pyrecest.backend.__backend_name__ == "jax":  # pylint: disable=no-member
             raise NotImplementedError("update is not supported on the JAX backend.")
-        y = asarray(y).ravel()
+        y = _as_measurement_vector(y, self.meas_dim, "measurement")
         P = self._P + self.TOL * eye(self.d)
 
         w_u = self._w_u
@@ -272,12 +283,18 @@ class UKFOnManifolds(AbstractFilter):  # pylint: disable=too-many-instance-attri
 
         # Compute predicted measurements at sigma points
         ys = zeros((2 * self.d, self.meas_dim))
-        hat_y = asarray(self.h(self._state)).ravel()
+        hat_y = _as_measurement_vector(
+            self.h(self._state), self.meas_dim, "observation function output"
+        )
         for j in range(self.d):
             s_plus = self.phi(self._state, xis[j])
             s_minus = self.phi(self._state, -xis[j])
-            ys[j] = asarray(self.h(s_plus)).ravel()
-            ys[self.d + j] = asarray(self.h(s_minus)).ravel()
+            ys[j] = _as_measurement_vector(
+                self.h(s_plus), self.meas_dim, "observation function output"
+            )
+            ys[self.d + j] = _as_measurement_vector(
+                self.h(s_minus), self.meas_dim, "observation function output"
+            )
 
         # Predicted measurement mean
         y_bar = w_u.wm * hat_y + w_u.wj * sum(ys, axis=0)

--- a/tests/filters/test_ukf_on_manifolds_measurement_shapes.py
+++ b/tests/filters/test_ukf_on_manifolds_measurement_shapes.py
@@ -1,0 +1,65 @@
+"""Regression tests for UKF-M measurement-vector shape validation."""
+
+import unittest
+
+# pylint: disable=no-name-in-module,no-member
+import pyrecest.backend
+from pyrecest.backend import array, eye, zeros
+from pyrecest.filters.ukf_on_manifolds import UKFOnManifolds
+
+
+def _make_filter(observation_function):
+    def propagation(state, omega, noise, dt):  # pylint: disable=unused-argument
+        return state + noise
+
+    return UKFOnManifolds(
+        f=propagation,
+        h=observation_function,
+        phi=lambda state, tangent: state + tangent,
+        phi_inv=lambda reference, state: state - reference,
+        Q=eye(2) * 0.1,
+        R=eye(2) * 0.5,
+        alpha=1.0e-3,
+        state0=zeros(2),
+        P0=eye(2),
+    )
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+    reason="UKFOnManifolds.update is not supported on JAX",
+)
+class TestUKFOnManifoldsMeasurementShapes(unittest.TestCase):
+    """Reject values that flatten or broadcast to the measurement dimension."""
+
+    def test_row_measurement_is_rejected(self):
+        ukf = _make_filter(lambda state: state)
+
+        with self.assertRaisesRegex(ValueError, "measurement must have shape"):
+            ukf.update(array([[1.0, -1.0]]))
+
+    def test_column_measurement_is_rejected(self):
+        ukf = _make_filter(lambda state: state)
+
+        with self.assertRaisesRegex(ValueError, "measurement must have shape"):
+            ukf.update(array([[1.0], [-1.0]]))
+
+    def test_scalar_observation_output_is_rejected(self):
+        ukf = _make_filter(lambda state: 0.0)
+
+        with self.assertRaisesRegex(
+            ValueError, "observation function output must have shape"
+        ):
+            ukf.update(array([1.0, -1.0]))
+
+    def test_row_observation_output_is_rejected(self):
+        ukf = _make_filter(lambda state: array([[state[0], state[1]]]))
+
+        with self.assertRaisesRegex(
+            ValueError, "observation function output must have shape"
+        ):
+            ukf.update(array([1.0, -1.0]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`UKFOnManifolds.update()` flattened the supplied measurement and every observation-function result with `ravel()`. This silently accepted row and column vectors despite the documented `(l,)` contract.

More seriously, assignment into the preallocated sigma-point measurement matrix allowed scalar observation outputs to broadcast across all measurement dimensions. A malformed observation model could therefore produce a plausible but mathematically incorrect update instead of failing.

## Fix

- validate measurements against the exact configured shape `(meas_dim,)` before the update;
- validate the central and sigma-point observation-function outputs before using or assigning them;
- reject scalar, row-vector, column-vector, and otherwise incompatible outputs rather than flattening or broadcasting them;
- preserve valid one-dimensional array-like measurement vectors.

## Regression coverage

Focused tests cover:

- row-vector measurements;
- column-vector measurements;
- scalar observation-function outputs that previously broadcast;
- row-vector observation-function outputs that previously flattened.

## Validation

- reviewed the branch diff against current `main`; it is 2 commits ahead and 0 behind;
- the change is limited to the UKF-M update path and focused regression coverage;
- GitHub Actions provides the authoritative repository-wide and backend-matrix validation.