### PR TITLE
Reject nested non-real weak measurement inputs

### DIFF
--- a/src/pyrecest/models/weak_measurement.py
+++ b/src/pyrecest/models/weak_measurement.py
@@ -237,12 +237,22 @@ def _standard_deviations_array(stds: Sequence[float] | np.ndarray) -> np.ndarray
     return values
 
 
+def _value_contains_non_real_numeric_values(value: Any) -> bool:
+    if isinstance(value, _NON_REAL_NUMERIC_SCALAR_TYPES):
+        return True
+    if isinstance(value, np.ndarray):
+        return _array_contains_non_real_numeric_values(value)
+    if isinstance(value, (list, tuple)):
+        return any(_value_contains_non_real_numeric_values(item) for item in value)
+    return False
+
+
 def _array_contains_non_real_numeric_values(array: np.ndarray) -> bool:
     if array.dtype.kind in _NON_REAL_NUMERIC_KINDS:
         return True
     if array.dtype.kind != "O":
         return False
-    return any(isinstance(item, _NON_REAL_NUMERIC_SCALAR_TYPES) for item in array.flat)
+    return any(_value_contains_non_real_numeric_values(item) for item in array.flat)
 
 
 def _contains_non_real_numeric_values(value: Any) -> bool:

--- a/tests/models/test_weak_measurement_nested_nonreal_inputs.py
+++ b/tests/models/test_weak_measurement_nested_nonreal_inputs.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from pyrecest.models import (
+    MaskedLinearMeasurementModel,
+    WeakDimensionMeasurementModel,
+    diagonal_measurement_covariance,
+    selection_matrix,
+)
+
+
+def _object_array_with_nested_scalar(value, shape):
+    array = np.empty(shape, dtype=object)
+    array.flat[0] = np.asarray(value)
+    return array
+
+
+def test_nested_complex_standard_deviation_is_rejected() -> None:
+    stds = _object_array_with_nested_scalar(1.0 + 2.0j, (1,))
+
+    with pytest.raises(ValueError, match="real numeric values"):
+        diagonal_measurement_covariance(stds)
+    with pytest.raises(ValueError, match="real numeric values"):
+        MaskedLinearMeasurementModel(state_dim=1, observed_dims=[0], stds=stds)
+    with pytest.raises(ValueError, match="real numeric values"):
+        WeakDimensionMeasurementModel(np.eye(1), stds=stds)
+
+
+def test_nested_complex_measurement_covariance_is_rejected() -> None:
+    covariance = _object_array_with_nested_scalar(1.0 + 2.0j, (1, 1))
+
+    with pytest.raises(ValueError, match="measurement_noise_cov"):
+        MaskedLinearMeasurementModel(
+            state_dim=1,
+            observed_dims=[0],
+            measurement_noise_cov=covariance,
+        )
+    with pytest.raises(ValueError, match="measurement_noise_cov"):
+        WeakDimensionMeasurementModel(
+            np.eye(1),
+            measurement_noise_cov=covariance,
+        )
+
+
+def test_nested_boolean_dimensions_are_rejected() -> None:
+    state_dim = _object_array_with_nested_scalar(True, ())
+    observed_dim = _object_array_with_nested_scalar(True, ())
+
+    with pytest.raises(ValueError, match="state_dim must be a nonnegative integer"):
+        selection_matrix(state_dim, [0])
+    with pytest.raises(ValueError, match="observed_dims must be a nonnegative integer"):
+        selection_matrix(2, [observed_dim])


### PR DESCRIPTION
## Bug

The weak-measurement numeric validator only inspected direct elements of object arrays. A zero-dimensional NumPy array nested inside an object array therefore bypassed the non-real type check.

For example, an object-array standard deviation containing `np.array(1 + 2j)` reached `np.asarray(..., dtype=float)`, which discarded the imaginary component and constructed a plausible real covariance. Nested Boolean dimension values could similarly be coerced to integer dimensions.

## Fix

- recursively inspect nested NumPy arrays, lists, and tuples inside object arrays;
- reject nested complex, Boolean, text, and temporal values using the existing non-real scalar contract;
- preserve ordinary real numeric object arrays and all existing public APIs.

## Regression coverage

Focused tests verify rejection through:

- `diagonal_measurement_covariance`;
- `MaskedLinearMeasurementModel` and `WeakDimensionMeasurementModel` standard deviations;
- explicit measurement-noise covariances;
- `selection_matrix` state and observed dimensions.

## Validation

- reproduced the pre-fix complex-to-real coercion with NumPy;
- exercised the recursive validator against nested complex, Boolean, text, and temporal scalar arrays;
- compared the branch against current `main`: two commits, two files, 65 changed lines, zero commits behind;
- GitHub Actions provides the authoritative repository-wide validation.