### PR TITLE
Validate adaptive kernel reduction tolerance

### DIFF
--- a/src/pyrecest/distributions/hypertorus/fejer.py
+++ b/src/pyrecest/distributions/hypertorus/fejer.py
@@ -250,7 +250,7 @@ def apply_kernel_weights(coefficients, *, kernel: str = "fejer", exponent: float
 
 
 def apply_fejer_weights(coefficients):
-    """Apply separable Fejer weights to a centered Fourier coefficient tensor."""
+    """Apply separable Fejer weights to a centered coefficient tensor."""
 
     return apply_kernel_weights(coefficients, kernel="fejer")
 

--- a/src/pyrecest/distributions/hypertorus/fejer.py
+++ b/src/pyrecest/distributions/hypertorus/fejer.py
@@ -186,18 +186,18 @@ def positive_kernel_weights(shape: CoefficientShape, *, kernel: str = "fejer", d
     raise AssertionError(f"Unhandled normalized kernel {kernel!r}.")
 
 
-def _validate_kernel_exponent(exponent) -> float:
-    """Return a finite nonnegative real scalar kernel exponent."""
+def _validate_nonnegative_real_scalar(value, name: str) -> float:
+    """Return a finite nonnegative real scalar control value."""
 
-    message = "exponent must be a finite nonnegative real scalar."
+    message = f"{name} must be a finite nonnegative real scalar."
     try:
-        exponent_array = np.asarray(exponent)
+        value_array = np.asarray(value)
     except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError(message) from exc
-    if exponent_array.ndim != 0 or exponent_array.dtype.kind in "bSUcMm":
+    if value_array.ndim != 0 or value_array.dtype.kind in "bSUcMm":
         raise ValueError(message)
 
-    scalar = exponent_array.item()
+    scalar = value_array.item()
     if isinstance(
         scalar,
         (
@@ -214,12 +214,18 @@ def _validate_kernel_exponent(exponent) -> float:
     ):
         raise ValueError(message)
     try:
-        exponent_value = float(scalar)
+        parsed_value = float(scalar)
     except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError(message) from exc
-    if not np.isfinite(exponent_value) or exponent_value < 0.0:
+    if not np.isfinite(parsed_value) or parsed_value < 0.0:
         raise ValueError(message)
-    return exponent_value
+    return parsed_value
+
+
+def _validate_kernel_exponent(exponent) -> float:
+    """Return a finite nonnegative real scalar kernel exponent."""
+
+    return _validate_nonnegative_real_scalar(exponent, "exponent")
 
 
 def apply_kernel_weights(coefficients, *, kernel: str = "fejer", exponent: float = 1.0):
@@ -244,7 +250,7 @@ def apply_kernel_weights(coefficients, *, kernel: str = "fejer", exponent: float
 
 
 def apply_fejer_weights(coefficients):
-    """Apply separable Fejer weights to a centered coefficient tensor."""
+    """Apply separable Fejer weights to a centered Fourier coefficient tensor."""
 
     return apply_kernel_weights(coefficients, kernel="fejer")
 
@@ -332,8 +338,10 @@ def adaptive_kernel_reduce_coefficients(
     is certified only on the diagnostic grid.
     """
 
-    if min_value_tolerance < 0.0:
-        raise ValueError("min_value_tolerance must be nonnegative.")
+    min_value_tolerance = _validate_nonnegative_real_scalar(
+        min_value_tolerance,
+        "min_value_tolerance",
+    )
     exponent_search_steps = _validate_integer_control(
         exponent_search_steps,
         "exponent_search_steps",

--- a/tests/distributions/test_fejer_tolerance_validation.py
+++ b/tests/distributions/test_fejer_tolerance_validation.py
@@ -1,0 +1,50 @@
+import numpy as np
+import pytest
+
+from pyrecest.distributions.hypertorus.fejer import (
+    adaptive_kernel_reduce_coefficients,
+    minimum_on_fft_grid,
+)
+
+
+@pytest.mark.parametrize(
+    "invalid_tolerance",
+    [
+        np.nan,
+        np.inf,
+        -np.inf,
+        -1.0e-12,
+        True,
+        "1e-12",
+        1.0e-12 + 0.0j,
+        np.array([1.0e-12]),
+        np.datetime64("2026-01-01"),
+    ],
+)
+def test_adaptive_reduction_rejects_invalid_min_value_tolerance(
+    invalid_tolerance,
+):
+    with pytest.raises(
+        ValueError,
+        match="min_value_tolerance must be a finite nonnegative real scalar",
+    ):
+        adaptive_kernel_reduce_coefficients(
+            np.ones(3),
+            min_value_tolerance=invalid_tolerance,
+        )
+
+
+def test_adaptive_reduction_accepts_numpy_scalar_tolerance():
+    coefficients = np.array(
+        [0.0, -0.1, 1.0 / (2.0 * np.pi), -0.1, 0.0]
+    )
+
+    reduced, exponent = adaptive_kernel_reduce_coefficients(
+        coefficients,
+        (3,),
+        min_value_tolerance=np.float64(0.0),
+        return_exponent=True,
+    )
+
+    assert exponent > 0.0
+    assert minimum_on_fft_grid(reduced) >= -1.0e-12


### PR DESCRIPTION
## Bug

`adaptive_kernel_reduce_coefficients()` only checked whether `min_value_tolerance < 0`. Non-finite and non-scalar values therefore slipped through. In particular, `min_value_tolerance=np.inf` makes every negative FFT-grid value satisfy the tolerance check, so the function returns the sharp coefficients unchanged and silently disables the intended positivity repair.

Boolean, complex, textual, temporal, and one-element array values were also accepted or failed with backend-dependent comparison errors rather than a consistent validation error.

## Fix

- generalize the existing finite nonnegative real-scalar validator used for kernel exponents;
- validate `min_value_tolerance` through the same strict contract;
- preserve finite Python and NumPy scalar tolerances, including zero.

## Regression coverage

- reject NaN and positive/negative infinity;
- reject negative, Boolean, textual, complex, temporal, and non-scalar tolerances;
- verify that a valid NumPy scalar tolerance still allows adaptive damping and produces a nonnegative diagnostic grid.

## Validation

- syntax-compiled the modified implementation and regression test;
- ran focused behavioral checks for all invalid cases and the valid NumPy-scalar control;
- inspected the aggregate diff to ensure the change is limited to tolerance validation and its regression coverage.

GitHub Actions provides the authoritative repository-wide and backend-matrix validation.