### PR TITLE
Fix normalization for tuple-valued integration results

### DIFF
--- a/src/pyrecest/distributions/abstract_custom_distribution.py
+++ b/src/pyrecest/distributions/abstract_custom_distribution.py
@@ -68,6 +68,8 @@ class AbstractCustomDistribution(AbstractDistributionType):
         cd = copy.deepcopy(self)
 
         integral = self.integrate()
+        if isinstance(integral, tuple):
+            integral = integral[0]
         cd.scale_by = cd.scale_by / integral
 
         if verify:

--- a/tests/distributions/test_custom_distribution_tuple_integral.py
+++ b/tests/distributions/test_custom_distribution_tuple_integral.py
@@ -1,0 +1,30 @@
+"""Regression tests for tuple-valued custom-distribution integrals."""
+
+import pytest
+
+import pyrecest.backend
+from pyrecest.distributions.circle.custom_circular_distribution import (
+    CustomCircularDistribution,
+)
+
+
+class _TupleIntegralCircularDistribution(CustomCircularDistribution):
+    """Circular test distribution emulating ``scipy.integrate.quad`` output."""
+
+    def integrate(self, integration_boundaries=None):
+        del integration_boundaries
+        return 2.0 * self.scale_by, 1.0e-12
+
+
+@pytest.mark.skipif(
+    pyrecest.backend.__backend_name__ != "numpy",
+    reason="Custom-distribution normalization is NumPy-only",
+)
+def test_normalize_accepts_value_error_integral_tuple():
+    distribution = _TupleIntegralCircularDistribution(lambda xs: xs * 0.0 + 1.0)
+
+    normalized = distribution.normalize(verify=True)
+
+    assert normalized.scale_by == pytest.approx(0.5)
+    assert normalized.integrate()[0] == pytest.approx(1.0)
+    assert distribution.scale_by == pytest.approx(1.0)


### PR DESCRIPTION
## Bug

`AbstractCustomDistribution.normalize()` divided `scale_by` by the raw result of `integrate()`. Numerical integration APIs commonly return `(integral, error_estimate)` tuples, and the same method already recognized that tuple form during optional verification. As a result, normalization failed with a `TypeError` before reaching the existing tuple-aware verification path.

## Fix

- unwrap tuple-valued integration results before computing the normalization factor;
- preserve scalar integration results and the existing NumPy-only behavior;
- leave the original distribution unchanged.

## Regression coverage

A focused test uses a custom circular distribution whose `integrate()` method emulates `scipy.integrate.quad` by returning `(value, error)`. It verifies that normalization succeeds, produces unit integral, and does not mutate the source distribution.

GitHub Actions provides the authoritative repository-wide and backend-matrix validation.