### PR TITLE
Reject fractionally rounded hyperspherical sample counts

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/hyperspherical_uniform_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/hyperspherical_uniform_distribution.py
@@ -36,11 +36,14 @@ def _validate_positive_sample_count(n) -> int:
 
     try:
         count_int = int(count)
-        count_float = float(count)
     except (OverflowError, TypeError, ValueError) as exc:
         raise ValueError("n must be an integer") from exc
 
-    if not np.isfinite(count_float) or not count_float.is_integer():
+    try:
+        is_exact_integer = count == count_int
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("n must be an integer") from exc
+    if not bool(is_exact_integer):
         raise ValueError("n must be a finite integer")
     if count_int <= 0:
         raise ValueError("n must be positive")

--- a/tests/distributions/test_hyperspherical_uniform_sample_count_exactness.py
+++ b/tests/distributions/test_hyperspherical_uniform_sample_count_exactness.py
@@ -1,0 +1,21 @@
+from fractions import Fraction
+
+import pytest
+
+from pyrecest.distributions.hypersphere_subset.hyperspherical_uniform_distribution import (
+    _validate_positive_sample_count,
+)
+
+
+def test_hyperspherical_uniform_sample_count_rejects_fraction_rounded_by_float():
+    count = Fraction(2**54 + 1, 2)
+
+    assert float(count).is_integer()
+    with pytest.raises(ValueError, match="finite integer"):
+        _validate_positive_sample_count(count)
+
+
+def test_hyperspherical_uniform_sample_count_preserves_large_exact_integer():
+    count = Fraction(2**54 + 2, 2)
+
+    assert _validate_positive_sample_count(count) == 2**53 + 1


### PR DESCRIPTION
## Bug

`HypersphericalUniformDistribution.sample()` validated its sample count by converting the input to `float` and checking `is_integer()`. For exact numeric types above the binary64 precision limit, a non-integral value can round to an integer-valued float.

For example, `Fraction(2**54 + 1, 2)` is mathematically fractional but converts to the integer-valued float `2**53`. The validator therefore accepted it and returned the rounded-down integer sample count.

## Fix

- parse the candidate integer as before;
- compare the original scalar directly with that integer;
- reject values that are not exactly equal, without relying on a lossy float conversion;
- preserve large exact integer values.

## Regression coverage

- reject a fractional `Fraction` that becomes integer-valued after float rounding;
- accept the adjacent exactly integral `Fraction` above `2**53`.

## Validation

- reproduced the precision failure deterministically;
- verified the exact comparison rejects the fractional case and preserves the integral control;
- branch is two commits ahead of and zero commits behind current `main`;
- the diff is limited to the validator and focused regression coverage.

GitHub Actions provides the authoritative repository-wide and backend-matrix validation.