### PR TITLE
Preserve Dirac particle count in transformed distributions

### DIFF
--- a/src/pyrecest/distributions/abstract_dirac_distribution.py
+++ b/src/pyrecest/distributions/abstract_dirac_distribution.py
@@ -108,17 +108,14 @@ class AbstractDiracDistribution(AbstractDistributionType):
         weight_scale = float(np.max(host_weights))
         if not math.isfinite(weight_scale) or weight_scale <= 0:
             raise ValueError("Dirac weights must have positive finite total mass.")
-
         scaled_total_weight = float(np.sum(host_weights / weight_scale))
         if not math.isfinite(scaled_total_weight) or scaled_total_weight <= 0:
             raise ValueError("Dirac weights must have positive finite total mass.")
-
         normalization_root = math.sqrt(weight_scale) * math.sqrt(
             scaled_total_weight
         )
         if not math.isfinite(normalization_root) or normalization_root <= 0:
             raise ValueError("Dirac weights must have positive finite total mass.")
-
         return normalization_root, normalization_root
 
     @staticmethod
@@ -169,9 +166,15 @@ class AbstractDiracDistribution(AbstractDistributionType):
         """
         dist = copy.deepcopy(self)
         if function_is_vectorized:
-            dist.d = f(dist.d)
+            transformed_diracs = asarray(f(dist.d))
         else:
-            dist.d = stack([asarray(f(point)) for point in dist.d])
+            transformed_diracs = stack([asarray(f(point)) for point in dist.d])
+
+        if transformed_diracs.ndim == 0 or transformed_diracs.shape[0] != dist.w.shape[0]:
+            raise ValueError(
+                "Function must preserve the number of Dirac locations."
+            )
+        dist.d = transformed_diracs
         return dist
 
     def reweigh(self, f: Callable) -> "AbstractDiracDistribution":

--- a/tests/distributions/test_dirac_transform_particle_count.py
+++ b/tests/distributions/test_dirac_transform_particle_count.py
@@ -1,0 +1,38 @@
+import pytest
+
+from pyrecest.backend import array
+from pyrecest.distributions import LinearDiracDistribution
+
+
+def make_distribution():
+    return LinearDiracDistribution(
+        array([[0.0, 1.0], [2.0, 3.0]]),
+        array([0.25, 0.75]),
+    )
+
+
+def test_vectorized_transform_rejects_changed_particle_count():
+    distribution = make_distribution()
+
+    with pytest.raises(ValueError, match="preserve the number of Dirac locations"):
+        distribution.apply_function(lambda points: points[:1])
+
+
+def test_vectorized_transform_rejects_scalar_output():
+    distribution = make_distribution()
+
+    with pytest.raises(ValueError, match="preserve the number of Dirac locations"):
+        distribution.apply_function(lambda points: 1.0)
+
+
+def test_vectorized_transform_may_change_coordinate_dimension():
+    distribution = make_distribution()
+
+    transformed = distribution.apply_function(
+        lambda points: points[:, :1],
+        function_is_vectorized=True,
+    )
+
+    assert transformed.d.shape == (2, 1)
+    assert transformed.w.shape == (2,)
+    assert distribution.d.shape == (2, 2)


### PR DESCRIPTION
## Bug

`AbstractDiracDistribution.apply_function()` replaced the particle-location array without checking that the transformation preserved the number of Dirac locations. A vectorized function could return fewer particles (or even a scalar) while the copied distribution retained the original weight vector.

That leaves the object internally inconsistent: `d.shape[0] != w.shape[0]`. Subsequent sampling, mode selection, or downstream algorithms can then index incompatible particle and weight arrays or fail far from the actual source of the error.

## Fix

- convert vectorized transformation output through the active backend;
- require a non-scalar result whose leading dimension equals the weight count;
- preserve transformations that change only the coordinate dimension;
- retain the existing non-vectorized per-particle mapping behavior.

## Regression coverage

- reject a vectorized transform that drops particles;
- reject a scalar transform output;
- verify that changing the coordinate dimension while preserving particle count remains supported;
- verify that the source distribution remains unchanged.

GitHub Actions provides the authoritative repository-wide and backend-matrix validation.