### PR TITLE
Fix multidimensional toroidal conditional factories

### DIFF
--- a/src/pyrecest/distributions/conditional/td_cond_td_grid_distribution.py
+++ b/src/pyrecest/distributions/conditional/td_cond_td_grid_distribution.py
@@ -159,7 +159,7 @@ class TdCondTdGridDistribution(AbstractConditionalDistribution):
                 with both full grids of shape ``(n_points, d)`` and must
                 return an array of shape ``(n_points, n_points)``.
         no_of_grid_points : int
-            Number of grid points for each torus.
+            Number of grid points along each torus dimension.
         fun_does_cartesian_product : bool
             See ``fun`` description above.
         grid_type : str
@@ -191,12 +191,13 @@ class TdCondTdGridDistribution(AbstractConditionalDistribution):
             )
 
         dim_half = dim // 2
-        n = no_of_grid_points
+        n_per_dimension = no_of_grid_points
         grid = HypertoroidalGridDistribution.generate_cartesian_product_grid(
-            [n] * dim_half
+            [n_per_dimension] * dim_half
         )
+        n_grid_points = grid.shape[0]
 
         grid_values = TdCondTdGridDistribution._evaluate_on_grid(
-            fun, grid, n, fun_does_cartesian_product
+            fun, grid, n_grid_points, fun_does_cartesian_product
         )
         return TdCondTdGridDistribution(grid, grid_values)

--- a/tests/distributions/test_td_cond_td_grid_distribution_multidimensional.py
+++ b/tests/distributions/test_td_cond_td_grid_distribution_multidimensional.py
@@ -1,0 +1,46 @@
+import unittest
+
+import numpy.testing as npt
+from pyrecest.backend import asarray, ones, pi
+from pyrecest.distributions.conditional.td_cond_td_grid_distribution import (
+    TdCondTdGridDistribution,
+)
+
+
+class TdCondTdGridDistributionMultidimensionalTest(unittest.TestCase):
+    def test_from_function_uses_total_cartesian_grid_size(self):
+        """T2 x T2 factories must build one matrix row/column per grid point."""
+        n_per_dimension = 2
+        n_grid_points = n_per_dimension**2
+        density = 1.0 / (2.0 * pi) ** 2
+
+        def pairwise_conditional(a, _b):
+            return ones(a.shape[0]) * density
+
+        def cartesian_conditional(a, b):
+            return ones((a.shape[0], b.shape[0])) * density
+
+        cases = (
+            (pairwise_conditional, False),
+            (cartesian_conditional, True),
+        )
+        for conditional, does_cartesian_product in cases:
+            with self.subTest(does_cartesian_product=does_cartesian_product):
+                distribution = TdCondTdGridDistribution.from_function(
+                    conditional,
+                    n_per_dimension,
+                    fun_does_cartesian_product=does_cartesian_product,
+                    dim=4,
+                )
+
+                self.assertEqual(distribution.dim, 4)
+                self.assertEqual(asarray(distribution.grid).shape, (n_grid_points, 2))
+                self.assertEqual(
+                    asarray(distribution.grid_values).shape,
+                    (n_grid_points, n_grid_points),
+                )
+                npt.assert_allclose(distribution.grid_values, density)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`TdCondTdGridDistribution.from_function()` treated `no_of_grid_points` as both the per-dimension resolution and the total number of Cartesian grid points.

That is only correct for `T1 x T1`. For `T2 x T2` with resolution `n`, the generated grid has `n**2` points. The pairwise callable path therefore produced an `n x n` matrix that failed constructor validation, while the Cartesian-product callable path tried to reshape an `n**2 x n**2` result to `n x n` and failed immediately.

## Fix

- retain `no_of_grid_points` as the per-dimension resolution used to generate the grid;
- derive the actual total cardinality from `grid.shape[0]`;
- use that cardinality when enumerating and reshaping conditional grid values;
- clarify the parameter documentation.

## Regression coverage

A focused `T2 x T2` test exercises both supported callable contracts:

- pairwise/vectorized evaluation (`fun_does_cartesian_product=False`);
- full Cartesian-product evaluation (`fun_does_cartesian_product=True`).

It verifies the generated grid has four 2-D points for resolution two and that both modes produce the required `4 x 4` conditional-density matrix.

## Validation

- reproduced the old pairwise shape mismatch and Cartesian reshape failure with a standalone NumPy check;
- verified both fixed paths produce correctly shaped, normalized matrices;
- branch is two commits ahead of and zero commits behind current `main`;
- the diff is limited to the cardinality calculation, documentation, and focused regression coverage.

GitHub Actions provides the authoritative repository-wide and backend-matrix validation.