### PR TITLE
Reject complex-valued Gaussian inputs

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/gaussian_distribution.py
@@ -42,6 +42,17 @@ def _to_python_bool(value):
     return bool(value)
 
 
+def _validate_real_values(value, name):
+    """Reject complex arrays before numerical backends can discard parts."""
+    dtype = getattr(value, "dtype", None)
+    try:
+        is_complex = bool(np.issubdtype(dtype, np.complexfloating))
+    except TypeError:
+        is_complex = "complex" in str(dtype).lower()
+    if is_complex:
+        raise ValueError(f"{name} must contain only real values.")
+
+
 def _validate_finite_values(value, name):
     """Reject arrays containing NaN or infinite values."""
     if not _to_python_bool(backend_all(isfinite(value))):
@@ -124,6 +135,8 @@ class GaussianDistribution(AbstractLinearDistribution):
     def __init__(self, mu, C, check_validity=True):
         mu = _as_backend_array(mu, "mu")
         C = _as_backend_array(C, "C")
+        _validate_real_values(mu, "mu")
+        _validate_real_values(C, "C")
         if ndim(mu) > 1:
             raise ValueError("mu must be one-dimensional or scalar.")
         if ndim(mu) == 0:
@@ -163,6 +176,7 @@ class GaussianDistribution(AbstractLinearDistribution):
             raise ValueError(
                 f"new_mean must have shape ({self.dim},), got {new_mean.shape}."
             )
+        _validate_real_values(new_mean, "new_mean")
         _validate_finite_values(new_mean, "new_mean")
         new_dist = copy.deepcopy(self)
         new_dist.mu = backend_copy(new_mean)
@@ -177,6 +191,7 @@ class GaussianDistribution(AbstractLinearDistribution):
             raise ValueError(
                 f"xs must have trailing dimension {self.dim}; got shape {xs.shape}."
             )
+        _validate_real_values(xs, "xs")
         return xs
 
     def pdf(self, xs):
@@ -257,6 +272,7 @@ class GaussianDistribution(AbstractLinearDistribution):
             raise ValueError(
                 f"shift_by must be scalar for dim=1 or have shape ({self.dim},)."
             )
+        _validate_real_values(shift_by, "shift_by")
         _validate_finite_values(shift_by, "shift_by")
 
         new_gaussian = copy.deepcopy(self)

--- a/tests/distributions/test_gaussian_complex_validation.py
+++ b/tests/distributions/test_gaussian_complex_validation.py
@@ -1,0 +1,41 @@
+import unittest
+
+from pyrecest.backend import array
+from pyrecest.distributions import GaussianDistribution
+
+
+class GaussianComplexValidationTest(unittest.TestCase):
+    def test_constructor_rejects_complex_parameters(self):
+        invalid_parameters = (
+            (array([1.0 + 2.0j]), array([[1.0]]), "mu"),
+            (array([0.0]), array([[1.0 + 2.0j]]), "C"),
+        )
+
+        for mean, covariance, name in invalid_parameters:
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(
+                    ValueError, rf"{name} must contain only real values"
+                ):
+                    GaussianDistribution(mean, covariance)
+
+    def test_pdf_rejects_complex_evaluation_points(self):
+        distribution = GaussianDistribution(array([0.0]), array([[1.0]]))
+
+        with self.assertRaisesRegex(ValueError, "xs must contain only real values"):
+            distribution.pdf(array([1.0 + 2.0j]))
+
+    def test_mean_mutators_reject_complex_values(self):
+        distribution = GaussianDistribution(array([0.0]), array([[1.0]]))
+
+        with self.assertRaisesRegex(
+            ValueError, "new_mean must contain only real values"
+        ):
+            distribution.set_mean(array([1.0 + 2.0j]))
+        with self.assertRaisesRegex(
+            ValueError, "shift_by must contain only real values"
+        ):
+            distribution.shift(array([1.0 + 2.0j]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
- enforce the real-valued Euclidean contract for `GaussianDistribution`
- reject complex means and covariances even when `check_validity=False`
- reject complex density evaluation points, replacement means, and shifts
- add focused regression tests for all affected entry points

## Why
On the NumPy backend, SciPy accepts complex Gaussian inputs by casting them to real values. It emits a `ComplexWarning`, discards the imaginary components, and returns a plausible density for a different distribution. For example, a mean of `1+2j` is evaluated as if it were `1`, which can silently corrupt downstream filtering results.

## Root cause
The existing validation checked shapes, finiteness, symmetry, and positive definiteness, but did not reject complex dtypes before passing values to backend numerical routines.

## Impact
Invalid complex inputs now fail immediately with a clear `ValueError` instead of being silently truncated. Real-valued behavior is unchanged. The dtype check is backend-portable for NumPy/JAX-style dtypes and PyTorch complex dtype names.

## Checks
- reproduced SciPy's silent imaginary-part discard locally
- `python -m py_compile` for the modified implementation and new tests
- focused NumPy-backed smoke tests for constructor, `pdf`, `set_mean`, `shift`, and unchanged real-valued behavior
- branch diff: 16 production additions, 41 test additions, no unrelated changes