### PR TITLE
Reject non-vector SE2 UKF measurements

### DIFF
--- a/src/pyrecest/filters/se2_ukf.py
+++ b/src/pyrecest/filters/se2_ukf.py
@@ -94,7 +94,7 @@ def _validate_se2_gaussian(distribution, role):
 
 
 def _validate_se2_measurement(z):
-    measurement = asarray(z).ravel()
+    measurement = asarray(z)
     if measurement.shape != (4,):
         raise ValueError("measurement z must be a 4-D vector.")
     if not _to_python_bool(backend_all(isfinite(measurement))):

--- a/tests/filters/test_se2_ukf_measurement_shape.py
+++ b/tests/filters/test_se2_ukf_measurement_shape.py
@@ -1,0 +1,34 @@
+import unittest
+
+# pylint: disable=no-name-in-module,no-member
+import pyrecest.backend
+from pyrecest.backend import array, eye
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.filters.se2_ukf import SE2UKF
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ == "jax",
+    reason="SE2UKF update is not supported on JAX",
+)
+class TestSE2UKFMeasurementShape(unittest.TestCase):
+    def test_update_identity_rejects_nonvector_measurements(self):
+        measurement_noise = GaussianDistribution(
+            array([1.0, 0.0, 0.0, 0.0]),
+            eye(4) * 0.01,
+        )
+        invalid_measurements = (
+            array([[1.0, 0.0, 0.0, 0.0]]),
+            array([[1.0], [0.0], [0.0], [0.0]]),
+            array([[1.0, 0.0], [0.0, 0.0]]),
+        )
+
+        for measurement in invalid_measurements:
+            with self.subTest(shape=tuple(measurement.shape)):
+                filter_instance = SE2UKF()
+                with self.assertRaisesRegex(ValueError, "4-D vector"):
+                    filter_instance.update_identity(measurement_noise, measurement)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`SE2UKF._validate_se2_measurement()` flattened the supplied measurement before validating its shape. Consequently, row vectors, column vectors, and matrices with four total elements—such as shapes `(1, 4)`, `(4, 1)`, and `(2, 2)`—were silently accepted as dual-quaternion measurements.

This violates the documented `(4,)` input contract and can hide upstream batching, orientation, or reshaping mistakes.

## Fix

- validate the original backend-array shape instead of flattening it;
- require measurements to have the exact shape `(4,)`;
- preserve valid Python lists and one-dimensional backend arrays.

## Regression coverage

A focused public-API test verifies that `update_identity()` rejects measurements with shapes:

- `(1, 4)`;
- `(4, 1)`;
- `(2, 2)`.

## Validation

- reproduced the old acceptance directly from the pre-validation `.ravel()` behavior;
- inspected the branch diff: one production-line change plus one focused test file;
- the branch is currently two commits behind rapidly advancing `main`, and those intervening commits concern UKF-M and Bingham-filter validation rather than `SE2UKF`;
- a local repository checkout was unavailable in this environment, so GitHub Actions provides the authoritative test and backend-matrix validation.