### PR TITLE
Reject non-boolean PyTorch sort flags

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_sort_numpy_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_sort_numpy_contract.py
@@ -15,6 +15,14 @@ _ARGSORT_CONFLICT_MESSAGE = "argsort() got conflicting 'kind' and 'stable' argum
 _ARGSORT_DEFAULT_AXIS = object()
 
 
+def _normalize_bool_flag(value, name, *, allow_none=False):
+    if value is None and allow_none:
+        return None
+    if isinstance(value, (bool, _np.bool_)):
+        return bool(value)
+    raise TypeError(f"{name} must be a boolean")
+
+
 def normalize_sort_axis(axis, torch_module=None):
     """Return a sort axis while preserving NumPy's flatten-all sentinel."""
     if axis is None:
@@ -36,7 +44,7 @@ def resolve_sort_stability(kind, stable):
     if kind is not None and stable is not None:
         raise ValueError(_SORT_CONFLICT_MESSAGE)
     if kind is None:
-        return stable
+        return _normalize_bool_flag(stable, "stable", allow_none=True)
     if stable is not None:
         raise TypeError(_SORT_CONFLICT_MESSAGE)
     if kind in {"stable", "mergesort"}:
@@ -60,6 +68,7 @@ def sort_axis_none(
     """Sort values with NumPy-style ``axis=None`` and keyword support."""
     if order is not None:
         raise ValueError("order is not supported by this backend")
+    descending = _normalize_bool_flag(descending, "descending")
     values = backend_module.array(values)
     axis = normalize_sort_axis(axis, torch_module)
     stable = resolve_sort_stability(kind, stable)
@@ -69,8 +78,8 @@ def sort_axis_none(
     return torch_module.sort(
         values,
         dim=axis,
-        descending=bool(descending),
-        stable=bool(stable) if stable is not None else False,
+        descending=descending,
+        stable=stable if stable is not None else False,
     ).values
 
 
@@ -102,6 +111,8 @@ def patch_argsort_stability_contract() -> None:
     ):
         if kind is not None and stable is not None:
             raise ValueError(_ARGSORT_CONFLICT_MESSAGE)
+        stable = _normalize_bool_flag(stable, "stable", allow_none=True)
+        descending = _normalize_bool_flag(descending, "descending")
         if axis is _ARGSORT_DEFAULT_AXIS:
             return original_argsort(
                 a,

--- a/tests/backend_support/test_pytorch_sort_boolean_flags.py
+++ b/tests/backend_support/test_pytorch_sort_boolean_flags.py
@@ -1,0 +1,79 @@
+import numpy as np
+import pytest
+
+from pyrecest.backend_support._pytorch_sort_numpy_contract import (
+    resolve_sort_stability,
+    sort_axis_none,
+)
+
+
+class _SortResult:
+    def __init__(self, values):
+        self.values = values
+
+
+class _FakeBackend:
+    @staticmethod
+    def array(values):
+        return np.asarray(values)
+
+
+class _FakeTorch:
+    bool = np.bool_
+    last_options = None
+
+    @staticmethod
+    def is_tensor(_value):
+        return False
+
+    @staticmethod
+    def flatten(values):
+        return np.asarray(values).reshape(-1)
+
+    @classmethod
+    def sort(cls, values, *, dim, descending, stable):
+        cls.last_options = {
+            "dim": dim,
+            "descending": descending,
+            "stable": stable,
+        }
+        ordered = np.sort(np.asarray(values), axis=dim)
+        if descending:
+            ordered = np.flip(ordered, axis=dim)
+        return _SortResult(ordered)
+
+
+@pytest.mark.parametrize("stable", ["false", "true", 0, 1, np.array(True)])
+def test_sort_stability_rejects_nonboolean_values(stable):
+    with pytest.raises(TypeError, match="stable must be a boolean"):
+        resolve_sort_stability(None, stable)
+
+
+@pytest.mark.parametrize("descending", ["false", "true", 0, 1, np.array(False)])
+def test_sort_rejects_nonboolean_descending_values(descending):
+    with pytest.raises(TypeError, match="descending must be a boolean"):
+        sort_axis_none(
+            _FakeBackend,
+            _FakeTorch,
+            [2, 1],
+            axis=None,
+            descending=descending,
+        )
+
+
+def test_sort_accepts_numpy_boolean_options_without_truthiness_coercion():
+    result = sort_axis_none(
+        _FakeBackend,
+        _FakeTorch,
+        [2, 1],
+        axis=None,
+        stable=np.bool_(False),
+        descending=np.bool_(True),
+    )
+
+    assert result.tolist() == [2, 1]
+    assert _FakeTorch.last_options == {
+        "dim": 0,
+        "descending": True,
+        "stable": False,
+    }


### PR DESCRIPTION
## Bug

The PyTorch sorting compatibility layer converted `descending` and resolved `stable` values through Python truthiness. Non-empty strings such as `"false"` therefore behaved as `True`, silently reversing a sort or enabling stable sorting instead of rejecting the invalid option. Integer and zero-dimensional array values were also accepted inconsistently.

The patched `argsort` wrapper forwarded the same invalid flags, so the behavior differed from the documented Boolean contract and could change ordering without an error.

## Fix

- add one strict Boolean-option normalizer that accepts native and NumPy Boolean scalars;
- reject strings, integers, arrays, and other non-Boolean values with a clear `TypeError`;
- apply the validation to both `sort` and the patched `argsort` wrapper;
- preserve `stable=None` and the existing `kind`/`stable` conflict behavior.

## Regression coverage

- reject truthy and falsy strings for `stable` and `descending`;
- reject integer and zero-dimensional-array substitutes;
- verify `np.bool_` options remain supported and are forwarded as actual Python booleans;
- use a lightweight fake backend so the focused tests do not require PyTorch.

## Validation

- focused regression suite: 11 tests passed;
- implementation and test files compile successfully;
- branch diff is limited to the sort compatibility helper and one focused test module.