### PR TITLE
Validate mixture component input dimensions

### DIFF
--- a/src/pyrecest/distributions/abstract_mixture.py
+++ b/src/pyrecest/distributions/abstract_mixture.py
@@ -140,6 +140,8 @@ class AbstractMixture(AbstractDistributionType):
 
         if not all(dists[0].dim == dist.dim for dist in dists):
             raise ValueError("All distributions must have the same dimension")
+        if not all(dists[0].input_dim == dist.input_dim for dist in dists):
+            raise ValueError("All distributions must have the same input dimension")
 
         non_zero_indices = [i for i, weight in enumerate(weights) if bool(weight != 0)]
 

--- a/tests/distributions/test_mixture_input_dimension.py
+++ b/tests/distributions/test_mixture_input_dimension.py
@@ -1,0 +1,30 @@
+from types import SimpleNamespace
+
+import pytest
+
+from pyrecest.backend import array
+from pyrecest.distributions.abstract_mixture import AbstractMixture
+
+
+def test_mixture_rejects_components_with_different_input_dimensions():
+    distributions = [
+        SimpleNamespace(dim=2, input_dim=2),
+        SimpleNamespace(dim=2, input_dim=3),
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match="All distributions must have the same input dimension",
+    ):
+        AbstractMixture(distributions, array([0.5, 0.5]))
+
+
+def test_mixture_accepts_components_with_matching_dimensions():
+    distributions = [
+        SimpleNamespace(dim=2, input_dim=3),
+        SimpleNamespace(dim=2, input_dim=3),
+    ]
+
+    mixture = AbstractMixture(distributions, array([0.5, 0.5]))
+
+    assert mixture.input_dim == 3


### PR DESCRIPTION
## Bug

`AbstractMixture` verified that all components had the same manifold dimension (`dim`) but did not verify their sample-coordinate dimension (`input_dim`). Components can therefore pass construction while producing incompatible sample vectors. The mixture allocates its output using only the first component's `input_dim`, so a later component with a different coordinate width fails only during sampling or PDF evaluation, far from the invalid constructor input.

## Fix

- require every mixture component to have the same `input_dim`;
- raise a clear constructor-time `ValueError` before incompatible components are stored.

## Regression coverage

- reject components with equal manifold dimension but different input dimensions;
- preserve construction when both dimensions agree.

## Scope

The branch is two commits ahead of and zero commits behind `main`. The production diff is two lines plus one focused test module.