### PR TITLE
Reject non-vector sigma-point means

### DIFF
--- a/src/pyrecest/sampling/sigma_points.py
+++ b/src/pyrecest/sampling/sigma_points.py
@@ -17,7 +17,6 @@ from pyrecest.backend import (
     full,
     isfinite,
     linalg,
-    reshape,
     stack,
     transpose,
 )
@@ -106,7 +105,7 @@ def _validate_finite_scalar(value, name: str) -> float:
 def _validate_sigma_inputs(x, P, n: int):
     if _has_complex_dtype(x):
         raise ValueError("x must contain real values")
-    x = reshape(asarray(x, dtype=float64), (-1,))
+    x = asarray(x, dtype=float64)
     if x.shape != (n,):
         raise ValueError(f"x must have shape ({n},)")
     if not _to_python_bool(all(isfinite(x))):

--- a/tests/test_sigma_points_mean_shape_validation.py
+++ b/tests/test_sigma_points_mean_shape_validation.py
@@ -1,0 +1,32 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.backend import asarray
+from pyrecest.sampling import JulierSigmaPoints, MerweScaledSigmaPoints
+
+
+class TestSigmaPointMeanShapeValidation(unittest.TestCase):
+    def test_sigma_points_reject_nonvector_means(self):
+        point_sets = (
+            JulierSigmaPoints(n=2, kappa=1.0),
+            MerweScaledSigmaPoints(n=2, alpha=0.5, beta=2.0, kappa=0.0),
+        )
+        invalid_means = (
+            np.array([[0.0, 1.0]]),
+            np.array([[0.0], [1.0]]),
+            np.array([[[0.0]], [[1.0]]]),
+        )
+        covariance = asarray(np.eye(2))
+
+        for point_set in point_sets:
+            for mean in invalid_means:
+                with self.subTest(point_set=type(point_set).__name__, shape=mean.shape):
+                    with self.assertRaisesRegex(
+                        ValueError, r"x must have shape \(2,\)"
+                    ):
+                        point_set.sigma_points(asarray(mean), covariance)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`_validate_sigma_inputs()` reshaped the state mean to one dimension before checking its shape. As a result, arrays such as `(1, n)`, `(n, 1)`, or higher-rank arrays with exactly `n` elements were silently accepted even though both sigma-point APIs document and require a state mean of shape `(n,)`.

This can hide upstream batching or orientation mistakes and makes the mean-shape contract inconsistent with the covariance validation.

## Fix

- convert the mean to the active backend without flattening it;
- validate the original backend-array shape against `(n,)`;
- remove the now-unused `reshape` backend import.

## Regression coverage

A focused test exercises both `JulierSigmaPoints` and `MerweScaledSigmaPoints` and verifies rejection of:

- row-vector means `(1, 2)`;
- column-vector means `(2, 1)`;
- higher-rank means `(2, 1, 1)`.

## Validation

- branch is based on the current `main` head and is two commits ahead, zero behind;
- compare diff is limited to the sigma-point validator and one focused regression test;
- GitHub Actions will provide the authoritative backend-matrix validation.