### PR TITLE
Allow zero measurement counts in scenario configs

### DIFF
--- a/src/pyrecest/evaluation/check_and_fix_config.py
+++ b/src/pyrecest/evaluation/check_and_fix_config.py
@@ -13,8 +13,8 @@ def _expand_meas_per_step(simulation_param):
 
     if not _is_integer_count(simulation_param["meas_per_step"]):
         raise TypeError("meas_per_step must be an integer")
-    if simulation_param["meas_per_step"] <= 0:
-        raise ValueError("meas_per_step must be positive")
+    if simulation_param["meas_per_step"] < 0:
+        raise ValueError("meas_per_step must be non-negative")
 
     simulation_param["n_meas_at_individual_time_step"] = [
         simulation_param["meas_per_step"]
@@ -30,8 +30,10 @@ def _validate_measurement_counts(simulation_param):
         )
     if not all(_is_integer_count(x) for x in counts):
         raise TypeError("n_meas_at_individual_time_step must contain integer values")
-    if not all(x > 0 for x in counts):
-        raise ValueError("n_meas_at_individual_time_step must contain positive values")
+    if not all(x >= 0 for x in counts):
+        raise ValueError(
+            "n_meas_at_individual_time_step must contain non-negative values"
+        )
 
 
 def check_and_fix_config(simulation_param):

--- a/tests/evaluation/test_check_and_fix_config.py
+++ b/tests/evaluation/test_check_and_fix_config.py
@@ -26,10 +26,19 @@ def test_expand_meas_per_step_uses_one_count_per_timestep():
     assert "meas_per_step" not in simulation_param
 
 
-def test_expand_meas_per_step_rejects_nonpositive_count():
+def test_expand_meas_per_step_accepts_zero_count():
     simulation_param = {"n_timesteps": 4, "meas_per_step": 0}
 
-    with pytest.raises(ValueError, match="positive"):
+    _expand_meas_per_step(simulation_param)
+
+    assert simulation_param["n_meas_at_individual_time_step"] == [0, 0, 0, 0]
+    assert "meas_per_step" not in simulation_param
+
+
+def test_expand_meas_per_step_rejects_negative_count():
+    simulation_param = {"n_timesteps": 4, "meas_per_step": -1}
+
+    with pytest.raises(ValueError, match="non-negative"):
         _expand_meas_per_step(simulation_param)
 
 
@@ -60,14 +69,23 @@ def test_validate_measurement_counts_rejects_noninteger_entries():
         _validate_measurement_counts(simulation_param)
 
 
-def test_validate_measurement_counts_rejects_nonpositive_entries():
+def test_validate_measurement_counts_rejects_negative_entries():
     simulation_param = {
         "n_timesteps": 2,
-        "n_meas_at_individual_time_step": [1, 0],
+        "n_meas_at_individual_time_step": [1, -1],
     }
 
-    with pytest.raises(ValueError, match="positive"):
+    with pytest.raises(ValueError, match="non-negative"):
         _validate_measurement_counts(simulation_param)
+
+
+def test_validate_measurement_counts_accepts_zero_entries():
+    simulation_param = {
+        "n_timesteps": 3,
+        "n_meas_at_individual_time_step": [1, 0, 2],
+    }
+
+    _validate_measurement_counts(simulation_param)
 
 
 def test_validate_measurement_counts_accepts_matching_length():
@@ -77,6 +95,14 @@ def test_validate_measurement_counts_accepts_matching_length():
     }
 
     _validate_measurement_counts(simulation_param)
+
+
+def test_check_and_fix_config_accepts_zero_measurement_counts():
+    simulation_param = _base_config(n_meas_at_individual_time_step=[1, 0, 2])
+
+    fixed_config = check_and_fix_config(simulation_param)
+
+    assert fixed_config["n_meas_at_individual_time_step"] == [1, 0, 2]
 
 
 def test_check_and_fix_config_rejects_nonpositive_timesteps():


### PR DESCRIPTION
## Bug

`generate_measurements()` explicitly supports zero measurements at a timestep and returns an empty `(0, dim)` matrix. However, the normal `generate_simulated_scenarios()` path first calls `check_and_fix_config()`, whose count validation required every fixed measurement count to be strictly positive.

As a result, configurations containing a legitimate missed-detection timestep such as `[1, 0, 2]` failed before reaching the generator. The same inconsistency affected `meas_per_step=0`.

## Fix

- treat fixed measurement counts as non-negative rather than strictly positive;
- allow `meas_per_step=0` to expand to an all-zero count vector;
- continue rejecting negative and non-integer counts;
- update validation messages to state the actual non-negative contract.

## Regression coverage

- accept `meas_per_step=0`;
- accept zero entries in `n_meas_at_individual_time_step`;
- verify the public `check_and_fix_config()` path preserves a vector containing a zero;
- retain explicit tests rejecting negative counts.

## Validation

- branch is two commits ahead of and zero commits behind current `main`;
- diff is limited to `check_and_fix_config.py` and its focused test module;
- GitHub Actions provides the authoritative repository-wide and backend-matrix validation.