### PR TITLE
Validate conditional grid point shapes

### DIFF
--- a/src/pyrecest/distributions/conditional/abstract_conditional_distribution.py
+++ b/src/pyrecest/distributions/conditional/abstract_conditional_distribution.py
@@ -113,8 +113,11 @@ class AbstractConditionalDistribution(ABC):
         array of shape (n_points,)
         """
         d = self.grid.shape[1]
-        if point.shape[0] != d:
-            raise ValueError(f"point must have length {d} (grid dimension).")
+        expected_shape = (d,)
+        if tuple(point.shape) != expected_shape:
+            raise ValueError(
+                f"point must have shape {expected_shape} (grid dimension)."
+            )
         diffs = linalg.norm(self.grid - point[None, :], axis=1)
         locb = argmin(diffs)
         if diffs[locb] > 1e-10:

--- a/tests/distributions/test_conditional_grid_point_shape.py
+++ b/tests/distributions/test_conditional_grid_point_shape.py
@@ -1,0 +1,18 @@
+import numpy as np
+import pytest
+
+from pyrecest.backend import array
+from pyrecest.distributions.conditional.td_cond_td_grid_distribution import (
+    TdCondTdGridDistribution,
+)
+
+
+def test_fix_dim_rejects_column_point():
+    density = 1.0 / (2.0 * np.pi) ** 2
+    distribution = TdCondTdGridDistribution(
+        array([[0.0, 0.0], [1.0, 1.0]]),
+        array([[density, density], [density, density]]),
+    )
+
+    with pytest.raises(ValueError, match=r"point must have shape \(2,\)"):
+        distribution.fix_dim(1, array([[0.0], [0.0]]))


### PR DESCRIPTION
## Bug

`AbstractConditionalDistribution._get_grid_slice()` documented fixed grid points as one-dimensional vectors of shape `(d,)`, but validated only `point.shape[0] == d`.

A column matrix with shape `(d, 1)` therefore passed the check. The subsequent expression `self.grid - point[None, :]` entered unintended backend broadcasting; depending on the grid and backend, this produced incompatible shapes or an ambiguous-array error instead of a clear contract violation.

This affects the public `fix_dim()` methods of the conditional grid distribution classes that share this helper.

## Fix

- require the exact point shape `(d,)` before distance computation;
- report the expected shape in a deterministic `ValueError`;
- preserve valid one-dimensional grid points and all existing slice behavior.

## Regression coverage

A focused `T2 x T2` regression test passes a `(2, 1)` column point through the public `TdCondTdGridDistribution.fix_dim()` API and verifies that it is rejected with the documented shape requirement.

## Validation

- branch is two commits ahead of and zero commits behind current `main`;
- aggregate diff is limited to 5 additions/2 deletions in the shared validator plus one 18-line test;
- inspected the final branch contents and exact shape guard;
- GitHub Actions provides the authoritative repository-wide and backend-matrix execution because a local checkout is unavailable in this runtime.