### PR TITLE
Reject invalid adaptive process-noise covariances

### DIFF
--- a/src/pyrecest/filters/adaptive_process_noise.py
+++ b/src/pyrecest/filters/adaptive_process_noise.py
@@ -127,6 +127,29 @@ def _normalize_nonnegative_finite_scalar(value: float, name: str) -> float:
     return value_float
 
 
+def _normalize_finite_real_array(value: object, name: str) -> np.ndarray:
+    message = f"{name} must contain only finite real numeric values"
+    if _has_rejected_numeric_dtype(value):
+        raise ValueError(message)
+    try:
+        value_array = np.asarray(value)
+    except (TypeError, ValueError, OverflowError, RuntimeError) as exc:
+        raise ValueError(message) from exc
+    if _has_rejected_numeric_dtype(value_array) or np.iscomplexobj(value_array):
+        raise ValueError(message)
+    if value_array.dtype.kind == "O" and any(
+        _is_rejected_scalar_payload(item) for item in value_array.reshape(-1)
+    ):
+        raise ValueError(message)
+    try:
+        value_array = np.asarray(value_array, dtype=float)
+    except (TypeError, ValueError, OverflowError, RuntimeError) as exc:
+        raise ValueError(message) from exc
+    if not np.all(np.isfinite(value_array)):
+        raise ValueError(message)
+    return value_array
+
+
 def _normalize_bool_flag(value: bool, name: str) -> bool:
     if isinstance(value, (bool, np.bool_)):
         return bool(value)
@@ -229,9 +252,11 @@ class RollingNISProcessNoiseAdapter:
     ) -> np.ndarray:
         """Return ``process_noise_covariance`` multiplied by the adapted scale."""
 
-        return np.asarray(process_noise_covariance, dtype=float) * self.scale(
-            source_weights
+        covariance = _normalize_finite_real_array(
+            process_noise_covariance,
+            "process_noise_covariance",
         )
+        return covariance * self.scale(source_weights)
 
 
 def adaptive_scale_from_ratio(

--- a/tests/filters/test_adaptive_process_noise.py
+++ b/tests/filters/test_adaptive_process_noise.py
@@ -48,6 +48,27 @@ def test_rolling_adapter_updates_source_ratio_and_scales_covariance():
     assert np.allclose(scaled, np.eye(2) * adapter.scale({"radar": 1.0}))
 
 
+@pytest.mark.parametrize(
+    "covariance",
+    [
+        np.array([[1.0 + 2.0j]]),
+        np.array([[True]]),
+        np.array([[np.nan]]),
+        np.array([[np.inf]]),
+        np.array([[1.0 + 2.0j]], dtype=object),
+        np.array([[np.timedelta64(1, "ns")]], dtype=object),
+    ],
+)
+def test_scaled_covariance_rejects_nonreal_or_nonfinite_values(covariance):
+    adapter = RollingNISProcessNoiseAdapter()
+
+    with pytest.raises(
+        ValueError,
+        match="process_noise_covariance must contain only finite real numeric values",
+    ):
+        adapter.scaled_covariance(covariance)
+
+
 def test_config_normalizes_scalar_numeric_values():
     config = AdaptiveProcessNoiseConfig(
         base_scale=np.array(1.25),


### PR DESCRIPTION
## Bug

`RollingNISProcessNoiseAdapter.scaled_covariance()` converted its input with `np.asarray(..., dtype=float)` before scaling. NumPy therefore silently converted Boolean covariance entries to `0.0`/`1.0`, propagated non-finite values, and discarded imaginary components of complex arrays with only a warning. This could corrupt the process-noise model instead of exposing an invalid covariance input.

## Fix

- add a finite-real numeric array normalizer for process-noise covariance inputs;
- reject Boolean, complex, temporal, text, object-wrapped invalid, NaN, and infinite values with a clear `ValueError`;
- preserve the existing output and scaling behavior for valid real arrays.

## Regression coverage

The focused tests cover native and object-wrapped complex values, Boolean arrays, temporal object arrays, NaN, and infinity.

## Validation

- focused adaptive-process-noise test module: 21 tests passed in an isolated package layout;
- source and test modules compile successfully;
- branch is two commits ahead of and zero commits behind current `main`;
- diff is limited to 29 source-line changes and 21 test-line additions.