### PR TITLE
Reject non-integer reproducibility seeds

### DIFF
--- a/src/pyrecest/reproducibility.py
+++ b/src/pyrecest/reproducibility.py
@@ -69,22 +69,12 @@ def _normalize_seed(seed: int | None) -> int | None:
     except (TypeError, ValueError, RuntimeError, OverflowError) as exc:
         raise ValueError(message) from exc
 
-    if isinstance(scalar, _UNSUPPORTED_SEED_SCALAR_TYPES):
+    if isinstance(scalar, _UNSUPPORTED_SEED_SCALAR_TYPES) or not isinstance(
+        scalar, Integral
+    ):
         raise ValueError(message)
-    if isinstance(scalar, Integral):
-        normalized_seed = int(scalar)
-    else:
-        try:
-            normalized_seed = int(scalar)
-        except (TypeError, ValueError, OverflowError) as exc:
-            raise ValueError(message) from exc
-        try:
-            is_exact_integer = bool(scalar == normalized_seed)
-        except (TypeError, ValueError, RuntimeError, OverflowError) as exc:
-            raise ValueError(message) from exc
-        if not is_exact_integer:
-            raise ValueError(message)
 
+    normalized_seed = int(scalar)
     if normalized_seed < 0 or normalized_seed > _MAX_BACKEND_SEED:
         raise ValueError(message)
     return normalized_seed

--- a/tests/test_reproducibility_seed_type_validation.py
+++ b/tests/test_reproducibility_seed_type_validation.py
@@ -1,0 +1,28 @@
+"""Regression tests for strict reproducibility seed type validation."""
+
+from decimal import Decimal
+from fractions import Fraction
+
+import numpy as np
+import pytest
+
+from pyrecest.reproducibility import seed_all
+
+
+@pytest.mark.parametrize(
+    "seed",
+    [
+        1.0,
+        np.float64(1.0),
+        Decimal("1"),
+        Fraction(1, 1),
+    ],
+)
+def test_seed_all_rejects_noninteger_scalar_types(seed):
+    with pytest.raises(ValueError, match="non-negative integer"):
+        seed_all(seed)
+
+
+@pytest.mark.parametrize("seed", [0, 1, np.int32(2), np.int64(3)])
+def test_seed_all_accepts_integer_scalar_types(seed):
+    assert seed_all(seed) == int(seed)


### PR DESCRIPTION
## Bug

`seed_all()` and `temporary_seed()` document their seed as an integer, but `_normalize_seed()` converted any scalar that compared equal to an integer. As a result, values such as `1.0`, `Decimal("1")`, and `Fraction(1, 1)` were silently accepted.

This weakens the public type contract and can hide configuration or serialization errors where a seed was supplied with the wrong scalar type.

## Fix

- require the normalized scalar to implement `numbers.Integral`;
- continue accepting Python and NumPy integer scalars;
- preserve the existing non-negative and 32-bit backend range checks.

## Regression coverage

A focused test verifies rejection of integer-valued floats, `Decimal`, and `Fraction` seeds, while confirming that Python and NumPy integer scalar types remain accepted.

## Validation

The branch is based on the current `main` head and is two commits ahead, zero behind. The compare diff is limited to the seed validator and one focused regression test. GitHub Actions will provide the authoritative backend-matrix validation.