### PR TITLE
Validate tensor-train convolution target sizes

### DIFF
--- a/src/pyrecest/distributions/hypertorus/_tensor_train.py
+++ b/src/pyrecest/distributions/hypertorus/_tensor_train.py
@@ -39,6 +39,19 @@ def _normalize_nonnegative_tolerance(value, name):
     return tolerance
 
 
+def _normalize_target_mode_size(value):
+    """Return a positive integer tensor-train convolution mode size."""
+    if isinstance(value, (bool, np.bool_)):
+        raise TypeError("target mode sizes must be integers.")
+    try:
+        mode_size = _operator_index(value)
+    except TypeError as exc:
+        raise TypeError("target mode sizes must be integers.") from exc
+    if mode_size < 1:
+        raise ValueError("target mode sizes must be positive.")
+    return mode_size
+
+
 def _check_dense_validation_size(size, max_entries):
     if max_entries is None:
         return
@@ -223,9 +236,14 @@ class TensorTrain:
             target_shape = self.shape
         if len(target_shape) != self.ndim:
             raise ValueError("target_shape must contain one mode size per dimension.")
+        normalized_target_shape = tuple(
+            _normalize_target_mode_size(mode_size) for mode_size in target_shape
+        )
         cores = [
-            _convolve_cores_centered(left_core, right_core, int(mode_size))
-            for left_core, right_core, mode_size in zip(self.cores, other.cores, target_shape)
+            _convolve_cores_centered(left_core, right_core, mode_size)
+            for left_core, right_core, mode_size in zip(
+                self.cores, other.cores, normalized_target_shape
+            )
         ]
         return TensorTrain(cores)
 

--- a/tests/distributions/test_tensor_train_convolution_target_shape.py
+++ b/tests/distributions/test_tensor_train_convolution_target_shape.py
@@ -1,0 +1,40 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.distributions.hypertorus._tensor_train import TensorTrain
+
+
+class TestTensorTrainConvolutionTargetShape(unittest.TestCase):
+    def setUp(self):
+        coefficients = np.array([1.0, 2.0, 3.0])
+        self.left = TensorTrain.from_dense(coefficients)
+        self.right = TensorTrain.from_dense(coefficients)
+
+    def test_rejects_non_integer_target_mode_sizes(self):
+        for invalid in (3.5, True, np.bool_(False), "3"):
+            with self.subTest(invalid=invalid):
+                with self.assertRaises(TypeError):
+                    self.left.coefficient_convolution(
+                        self.right, target_shape=(invalid,)
+                    )
+
+    def test_rejects_non_positive_target_mode_sizes(self):
+        for invalid in (0, -1):
+            with self.subTest(invalid=invalid):
+                with self.assertRaises(ValueError):
+                    self.left.coefficient_convolution(
+                        self.right, target_shape=(invalid,)
+                    )
+
+    def test_accepts_python_and_numpy_integer_target_mode_sizes(self):
+        for valid in (3, np.int64(3)):
+            with self.subTest(valid=valid):
+                result = self.left.coefficient_convolution(
+                    self.right, target_shape=(valid,)
+                )
+                self.assertEqual(result.shape, (3,))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`TensorTrain.coefficient_convolution()` converted every requested target mode size with `int(mode_size)`. This silently accepted invalid values such as `3.5`, booleans, and numeric strings, potentially changing the requested Fourier tensor shape without warning.

## Fix

- require each target mode size to implement the integer index protocol;
- reject booleans explicitly;
- preserve the existing positive-size requirement;
- continue accepting Python and NumPy integer scalars.

## Regression coverage

A focused test verifies rejection of floating-point, boolean, string, zero, and negative target sizes, while confirming acceptance of Python and NumPy integers.

## Validation

The branch is based on the current `main` head and is two commits ahead, zero behind. The compare diff is limited to the tensor-train convolution validator and one focused regression test. GitHub Actions will provide the authoritative test-matrix validation.