### PR TITLE
Reject nested non-real time-offset inputs

### DIFF
--- a/src/pyrecest/filters/online_time_offset_estimator.py
+++ b/src/pyrecest/filters/online_time_offset_estimator.py
@@ -98,12 +98,17 @@ class OnlineTimeOffsetEstimator:
 
 
 def _contains_unsupported_numeric_values(value: Any) -> bool:
-    value_array = np.asarray(value)
-    if value_array.dtype.kind in _UNSUPPORTED_NUMERIC_KINDS:
+    if isinstance(value, _UNSUPPORTED_SCALAR_TYPES):
         return True
-    if value_array.dtype.kind != "O":
-        return False
-    return any(isinstance(item, _UNSUPPORTED_SCALAR_TYPES) for item in value_array.flat)
+    if isinstance(value, np.ndarray):
+        if value.dtype.kind in _UNSUPPORTED_NUMERIC_KINDS:
+            return True
+        if value.dtype.kind != "O":
+            return False
+        return any(_contains_unsupported_numeric_values(item) for item in value.flat)
+    if isinstance(value, (list, tuple)):
+        return any(_contains_unsupported_numeric_values(item) for item in value)
+    return False
 
 
 def _as_real_numeric_array(value: Any, name: str) -> np.ndarray:

--- a/tests/filters/test_online_time_offset_estimator_nested_inputs.py
+++ b/tests/filters/test_online_time_offset_estimator_nested_inputs.py
@@ -1,0 +1,70 @@
+import unittest
+
+import numpy as np
+from pyrecest.filters import OnlineTimeOffsetEstimator
+
+
+def _nested_object_array(value, *, scalar=False):
+    result = np.empty((), dtype=object) if scalar else np.empty((1,), dtype=object)
+    if scalar:
+        result[()] = np.asarray(value)
+    else:
+        result[0] = np.asarray(value)
+    return result
+
+
+class OnlineTimeOffsetEstimatorNestedInputTest(unittest.TestCase):
+    def test_update_rejects_nested_nonreal_values_without_state_change(self):
+        invalid_updates = (
+            (
+                {"residual": _nested_object_array(1.0 + 2.0j)},
+                "residual must be real-valued numeric",
+            ),
+            (
+                {"residual": _nested_object_array(True)},
+                "residual must be real-valued numeric",
+            ),
+            (
+                {"velocity": _nested_object_array("2.0")},
+                "velocity must be real-valued numeric",
+            ),
+            (
+                {"velocity": _nested_object_array(np.datetime64("2026-07-24"))},
+                "velocity must be real-valued numeric",
+            ),
+            (
+                {"measurement_variance": _nested_object_array(True, scalar=True)},
+                "measurement_variance must be a finite scalar",
+            ),
+        )
+
+        for override, message in invalid_updates:
+            estimator = OnlineTimeOffsetEstimator(offset=1.0, variance=2.0)
+            kwargs = {
+                "residual": np.array([1.0]),
+                "velocity": np.array([2.0]),
+                "measurement_variance": 1.0,
+            }
+            kwargs.update(override)
+            with self.subTest(override=override):
+                with self.assertRaisesRegex(ValueError, message):
+                    estimator.update_from_position_residual(**kwargs)
+                self.assertEqual(estimator.offset, 1.0)
+                self.assertEqual(estimator.variance, 2.0)
+
+    def test_update_preserves_nested_real_numeric_inputs(self):
+        estimator = OnlineTimeOffsetEstimator(offset=0.0, variance=1.0)
+
+        nis = estimator.update_from_position_residual(
+            residual=_nested_object_array(10.0),
+            velocity=_nested_object_array(5.0),
+            measurement_variance=_nested_object_array(1.0, scalar=True),
+        )
+
+        self.assertTrue(np.isfinite(nis))
+        self.assertGreater(estimator.offset, 0.0)
+        self.assertLess(estimator.offset, 2.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`OnlineTimeOffsetEstimator` rejected direct complex, Boolean, text, and temporal values, but its object-array validation inspected only the immediate elements.

A zero-dimensional array nested inside an object array therefore bypassed the type check. NumPy could then coerce nested Boolean values to `1.0` and discard imaginary components of nested complex arrays while constructing a real array. This allowed malformed residuals, velocities, or scalar controls to produce plausible estimator updates instead of surfacing invalid input.

## Fix

- recursively inspect NumPy object arrays, lists, and tuples for unsupported scalar and array dtypes;
- reject nested complex, Boolean, text, temporal, and missing values before float conversion;
- preserve existing support for nested real numeric arrays.

## Regression coverage

The focused tests verify rejection of nested:

- complex residuals;
- Boolean residuals;
- textual velocities;
- temporal velocities;
- Boolean scalar measurement variances.

They also verify that nested real residual, velocity, and variance inputs remain supported and that rejected updates do not mutate estimator state.

## Validation

- isolated focused test module: 2 tests passed;
- source and regression modules compile successfully;
- branch is two commits ahead of and zero commits behind current `main`;
- aggregate diff is limited to 15 source-line changes and one focused 70-line test module.