### PR TITLE
Preserve signed ellipse axis magnitudes

### DIFF
--- a/src/pyrecest/tracking/ellipse_geometry.py
+++ b/src/pyrecest/tracking/ellipse_geometry.py
@@ -146,7 +146,7 @@ def wrap_ellipse_angle_to_reference(reference, theta):
 def ellipse_extent_matrix(orientation, semi_axes):
     """Return the SPD extent matrix encoded by ``orientation`` and semi-axes."""
 
-    semi_axes = maximum(asarray(semi_axes).reshape(2), 0.0)
+    semi_axes = backend_abs(asarray(semi_axes).reshape(2))
     rotation = rotation_matrix_2d(orientation)
     return symmetrize(rotation @ diag(semi_axes**2) @ rotation.T)
 

--- a/tests/tracking/test_ellipse_extent_axis_sign.py
+++ b/tests/tracking/test_ellipse_extent_axis_sign.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import numpy as np
+import numpy.testing as npt
+from pyrecest.tracking import ellipse_extent_matrix, extent_matrix_from_shape
+
+
+def test_extent_matrix_preserves_negative_axis_magnitudes() -> None:
+    orientation = 0.37
+    signed_axes = np.array([-3.0, 1.5])
+    positive_axes = np.abs(signed_axes)
+    expected_extent = ellipse_extent_matrix(orientation, positive_axes)
+
+    npt.assert_allclose(
+        ellipse_extent_matrix(orientation, signed_axes),
+        expected_extent,
+        atol=1e-12,
+    )
+    npt.assert_allclose(
+        extent_matrix_from_shape(
+            np.array([orientation, signed_axes[0], signed_axes[1]])
+        ),
+        expected_extent,
+        atol=1e-12,
+    )


### PR DESCRIPTION
## Bug

`ellipse_extent_matrix()` clamped negative semi-axis values to zero before squaring them. Negative axis signs are only a representation choice elsewhere in the ellipse-geometry helpers, so a shape such as `[-3.0, 1.5]` should encode the same extent as `[3.0, 1.5]`. Instead, the first axis was discarded and the resulting extent became degenerate.

This also affected `extent_matrix_from_shape()`, which delegates to the same conversion.

## Fix

Use the absolute semi-axis magnitudes before constructing the diagonal squared-axis matrix. This makes extent conversion consistent with the module's existing shape canonicalization behavior.

## Regression coverage

A focused test verifies sign invariance through both public entry points:

- `ellipse_extent_matrix()`;
- `extent_matrix_from_shape()`.

## Validation

- deterministic numerical reproducer confirms the old implementation yields a rank-one extent for `[-3.0, 1.5]`;
- the fixed result is full rank and exactly matches the `[3.0, 1.5]` representation within `1e-12`;
- branch is based on the current `main` head and is two commits ahead, zero behind;
- compare diff is limited to one production-line replacement and one focused regression test.