### PR TITLE
Reject non-vector Fibonacci Gaussian means

### DIFF
--- a/src/pyrecest/sampling/euclidean_sampler.py
+++ b/src/pyrecest/sampling/euclidean_sampler.py
@@ -300,7 +300,6 @@ def _validate_gaussian_transform_args(d, covariance, mean):
         mean = np.zeros(d)
     else:
         mean = _as_real_float_array(mean, "mean")
-    mean = mean.ravel()
     if mean.shape != (d,):
         raise ValueError("mean must have shape (dim,)")
     if not np.all(np.isfinite(mean)):

--- a/tests/test_fibonacci_gaussian_parameter_validation.py
+++ b/tests/test_fibonacci_gaussian_parameter_validation.py
@@ -46,6 +46,18 @@ class TestFibonacciGaussianParameterValidation(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, "mean.*real numeric"):
                     self.sampler.get_gaussian_samples(10, 2, mean=mean)
 
+    def test_nonvector_mean_shapes_are_rejected(self):
+        invalid_means = (
+            np.zeros((1, 2)),
+            np.zeros((2, 1)),
+            np.zeros((2, 1, 1)),
+        )
+
+        for mean in invalid_means:
+            with self.subTest(shape=mean.shape):
+                with self.assertRaisesRegex(ValueError, "mean must have shape"):
+                    self.sampler.get_gaussian_samples(10, 2, mean=mean)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Bug

`FibonacciGridSampler.get_gaussian_samples()` documents `mean` as a vector with shape `(dim,)`, but `_validate_gaussian_transform_args()` flattened the input before checking its shape. As a result, row vectors, column vectors, and higher-rank arrays containing `dim` elements were silently accepted and interpreted differently from their declared shape.

## Fix

- validate the converted mean array in its original shape;
- preserve support for valid one-dimensional arrays and array-like vectors;
- reject `(1, dim)`, `(dim, 1)`, and higher-rank inputs instead of silently flattening them.

## Regression coverage

The focused test now checks that representative row, column, and rank-3 means raise `ValueError`.

## Validation

- verified the branch is exactly two commits ahead of current `main` and zero behind;
- verified the production diff is a single-line deletion with no reformatting;
- ran a targeted standalone reproduction confirming that the old path accepted all three invalid shapes while the patched validation rejects them and continues to accept a valid `(dim,)` vector.

The full repository test matrix is left to GitHub Actions because the execution environment could not access the repository through local `git`.