### PR TITLE
Reject non-real tracklet endpoint states

### DIFF
--- a/src/pyrecest/tracking/tracklet_graph.py
+++ b/src/pyrecest/tracking/tracklet_graph.py
@@ -19,6 +19,19 @@ import numpy as np
 CostFn = Callable[["Tracklet"], float]
 EdgeCostFn = Callable[["Tracklet", "Tracklet"], float | None]
 
+_REAL_STATE_ARRAY_KINDS = {"i", "u", "f"}
+_INVALID_STATE_SCALAR_TYPES = (
+    bool,
+    np.bool_,
+    str,
+    bytes,
+    bytearray,
+    complex,
+    np.complexfloating,
+    np.datetime64,
+    np.timedelta64,
+)
+
 
 @dataclass(frozen=True)
 class Tracklet:
@@ -478,8 +491,39 @@ def _path_sort_key(path: TrackletPath) -> tuple[float, int, tuple[str, ...]]:
     )
 
 
+def _raw_state_item_is_invalid(value: Any) -> bool:
+    if isinstance(value, _INVALID_STATE_SCALAR_TYPES):
+        return True
+    if isinstance(value, np.ndarray):
+        if value.dtype == object:
+            return any(
+                _raw_state_item_is_invalid(item) for item in value.reshape(-1)
+            )
+        return value.dtype.kind not in _REAL_STATE_ARRAY_KINDS
+    if isinstance(value, (list, tuple)):
+        return any(_raw_state_item_is_invalid(item) for item in value)
+    return False
+
+
 def _state_vector(value: Any, name: str) -> np.ndarray:
-    vector = np.asarray(value, dtype=float).reshape(-1)
+    message = f"{name} must contain real-valued numeric entries"
+    if _raw_state_item_is_invalid(value):
+        raise ValueError(message)
+
+    try:
+        raw = np.asarray(value)
+    except (OverflowError, TypeError, ValueError, RuntimeError) as exc:
+        raise ValueError(message) from exc
+    if raw.dtype == object:
+        if any(_raw_state_item_is_invalid(item) for item in raw.reshape(-1)):
+            raise ValueError(message)
+    elif raw.dtype.kind not in _REAL_STATE_ARRAY_KINDS:
+        raise ValueError(message)
+
+    try:
+        vector = raw.astype(float, copy=False).reshape(-1)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError(message) from exc
     if vector.size == 0:
         raise ValueError(f"{name} must contain at least one value")
     if not np.isfinite(vector).all():

--- a/tests/tracking/test_tracklet_graph_state_validation.py
+++ b/tests/tracking/test_tracklet_graph_state_validation.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from pyrecest.tracking.tracklet_graph import Tracklet
+
+
+@pytest.mark.parametrize(
+    "invalid_state",
+    [
+        np.array([1.0 + 2.0j, 3.0 + 4.0j]),
+        [True, False],
+        ["1.0", "2.0"],
+        np.array([np.datetime64("2026-01-01")]),
+    ],
+)
+def test_tracklet_rejects_non_real_numeric_state_values(invalid_state) -> None:
+    state_size = np.asarray(invalid_state).size
+
+    with pytest.raises(
+        ValueError, match="start_state must contain real-valued numeric entries"
+    ):
+        Tracklet(
+            "bad-start",
+            0.0,
+            1.0,
+            invalid_state,
+            np.zeros(state_size),
+        )
+
+    with pytest.raises(
+        ValueError, match="end_state must contain real-valued numeric entries"
+    ):
+        Tracklet(
+            "bad-end",
+            0.0,
+            1.0,
+            np.zeros(state_size),
+            invalid_state,
+        )
+
+
+def test_tracklet_rejects_nested_complex_object_state() -> None:
+    nested_complex = np.empty(1, dtype=object)
+    nested_complex[0] = np.array(1.0 + 2.0j)
+
+    with pytest.raises(
+        ValueError, match="start_state must contain real-valued numeric entries"
+    ):
+        Tracklet("nested-complex", 0.0, 1.0, nested_complex, [0.0])


### PR DESCRIPTION
## Bug

`Tracklet` normalized endpoint states with `np.asarray(..., dtype=float)`. That silently converted Boolean values and numeric strings, and discarded imaginary components from complex arrays (including complex values nested in object arrays).

The tracklet graph could therefore compute transition distances, speeds, and path costs from a different state than the caller supplied.

## Fix

- validate endpoint-state values before float conversion;
- reject Boolean, text, complex, and temporal values, including nested object-array entries;
- preserve valid real numeric sequences and the existing empty/non-finite checks.

## Regression coverage

The focused regression verifies rejection for both `start_state` and `end_state`, covering:

- native complex arrays;
- Boolean sequences;
- numeric-text sequences;
- temporal arrays;
- nested complex object-array values.

## Validation

- reproduced the prior silent complex truncation and Boolean/text coercion;
- focused regression file: `5 passed`;
- `python -m py_compile` passed;
- branch is based on the current `main` head and is two commits ahead, zero behind;
- GitHub Actions will provide the authoritative full-suite and backend validation.