### PR TITLE
Normalize binary backend names in support errors

### DIFF
--- a/src/pyrecest/exceptions.py
+++ b/src/pyrecest/exceptions.py
@@ -56,14 +56,14 @@ class BackendNotSupportedError(BackendSupportError, NotImplementedError):
         reason: str | None = None,
     ) -> None:
         self.api = api
-        self.backend = backend
+        self.backend = None if backend is None else _normalize_backend_name(backend)
         self.supported_backends = _normalize_supported_backends(supported_backends)
         self.reason = reason
 
-        if backend is None:
+        if self.backend is None:
             message = api
         else:
-            message = f"{api} is unavailable for backend '{backend}'"
+            message = f"{api} is unavailable for backend '{self.backend}'"
         if self.supported_backends:
             supported = ", ".join(self.supported_backends)
             message += f"; supported backends: {supported}"

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -47,6 +47,18 @@ def test_backend_not_supported_error_accepts_single_binary_supported_backend():
     assert "n, u, m, p, y" not in str(error)
 
 
+def test_backend_not_supported_error_decodes_binary_active_backend():
+    error = BackendNotSupportedError(
+        "ExampleAPI.update",
+        bytearray(b"jax"),
+        supported_backends=("numpy", "pytorch"),
+    )
+
+    assert error.backend == "jax"
+    assert "backend 'jax'" in str(error)
+    assert "bytearray" not in str(error)
+
+
 def test_backend_not_supported_error_keeps_backendless_context():
     error = BackendNotSupportedError(
         "ExampleAPI.batch_update",


### PR DESCRIPTION
## Bug

`BackendNotSupportedError` normalized binary values in `supported_backends`, but not the active `backend` value itself. Passing a backend name from a byte-oriented configuration or serialization layer therefore produced messages such as `backend 'bytearray(b"jax")'` and retained the byte container in `error.backend`.

## Fix

- normalize a non-`None` active backend through the existing backend-name helper;
- use the normalized stored value when formatting the exception message;
- preserve the existing backendless behavior.

## Regression coverage

A focused regression verifies that a `bytearray(b"jax")` active backend is stored and rendered as `jax`, without leaking the byte-container representation.

## Validation

- branch is two commits ahead of current `main` and zero behind;
- diff is limited to `src/pyrecest/exceptions.py` and `tests/test_exceptions.py`;
- the production change is three lines, plus a focused regression test.

GitHub Actions will provide the authoritative test-matrix validation.