### PR TITLE
Normalize wrapped Laplace singleton parameters

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_laplace_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_laplace_distribution.py
@@ -29,6 +29,8 @@ def _validate_positive_scalar(value, name):
         raise ValueError(message) from exc
     if numpy_value.shape not in ((), (1,)) or numpy_value.dtype.kind not in "iuf":
         raise ValueError(message)
+    if numpy_value.shape == (1,):
+        value = value.reshape(())
     if not bool(all(isfinite(value))):
         raise ValueError(f"{name} must be finite.")
     if not bool(all(value > 0.0)):

--- a/tests/distributions/test_wrapped_laplace_distribution.py
+++ b/tests/distributions/test_wrapped_laplace_distribution.py
@@ -24,6 +24,14 @@ class WrappedLaplaceDistributionTest(unittest.TestCase):
 
         npt.assert_allclose(wl.pdf(array(1.0)), self.wl.pdf(array(1.0)), rtol=1e-6)
 
+    def test_one_element_parameter_arrays_are_normalized_to_scalars(self):
+        wl = WrappedLaplaceDistribution(array([2.0]), array([1.3]))
+
+        self.assertEqual(wl.lambda_.shape, ())
+        self.assertEqual(wl.kappa.shape, ())
+        self.assertEqual(wl.pdf(array(1.0)).shape, ())
+        self.assertEqual(wl.trigonometric_moment(1).shape, ())
+
     def test_pdf(self):
         def laplace(x):
             return (


### PR DESCRIPTION
## Bug

`WrappedLaplaceDistribution` accepts positive one-element arrays for `lambda_` and `kappa_` as scalar parameter forms, but `_validate_positive_scalar()` returned those arrays unchanged. This left an accidental singleton batch dimension in the stored parameters.

Consequently, scalar calls such as `pdf(array(1.0))` and `trigonometric_moment(1)` returned arrays with shape `(1,)` rather than backend scalar values with shape `()`. The same numeric parameters therefore produced different output contracts depending on whether callers supplied `2.0` or `[2.0]`.

## Fix

Normalize accepted one-element parameter arrays to zero-dimensional backend scalars before the existing finiteness and positivity checks. Multi-element arrays remain rejected, and numerical values are unchanged.

## Regression coverage

The focused regression verifies that one-element `lambda_` and `kappa_` inputs yield scalar stored parameters, scalar PDF output, and a scalar trigonometric moment.

## Validation

- deterministic reproducer: old behavior produced `(1,)` for the parameter, scalar PDF, and scalar moment; the patched normalization produces `()` for all three;
- `python -m py_compile` passed for the modified source and regression test;
- GitHub reports the PR mergeable with current `main`;
- diff is limited to two production lines and eight test lines.

Full backend-matrix validation is delegated to GitHub Actions.