### PR TITLE
Reject complex SO(3) helper inputs

### DIFF
--- a/src/pyrecest/distributions/_so3_helpers.py
+++ b/src/pyrecest/distributions/_so3_helpers.py
@@ -11,6 +11,7 @@ from pyrecest.backend import (
     clip,
     concatenate,
     cos,
+    is_complex,
     isfinite,
     linalg,
     log,
@@ -24,9 +25,17 @@ from pyrecest.backend import (
 )
 
 
+def _as_real_array(values, name):
+    """Convert array-like values without discarding complex components."""
+    values = array(values)
+    if is_complex(values):
+        raise ValueError(f"{name} must contain real values.")
+    return array(values, dtype=float)
+
+
 def as_batch(values, width, name):
     """Return values with a fixed trailing width as a two-dimensional batch."""
-    values = array(values, dtype=float)
+    values = _as_real_array(values, name)
     if ndim(values) == 1:
         if values.shape[0] != width:
             raise ValueError(f"{name} must have length {width}.")
@@ -42,7 +51,7 @@ def as_batch(values, width, name):
 
 def normalize_quaternions(quaternions):
     """Return canonical scalar-last unit quaternions."""
-    quaternions = array(quaternions, dtype=float)
+    quaternions = _as_real_array(quaternions, "SO(3) quaternions")
     if ndim(quaternions) == 1:
         if quaternions.shape[0] != 4:
             raise ValueError("SO(3) quaternions must have length 4.")
@@ -111,7 +120,7 @@ def so3_exp_map_volume_log_jacobian(tangent_vectors):
     with limiting value ``1 / 8`` at the identity.  The returned value is
     ``log(dV / dv)`` and preserves all leading dimensions of ``tangent_vectors``.
     """
-    tangent_vectors = array(tangent_vectors, dtype=float)
+    tangent_vectors = _as_real_array(tangent_vectors, "SO(3) tangent vectors")
     if ndim(tangent_vectors) == 0 or tangent_vectors.shape[-1] != 3:
         raise ValueError("SO(3) tangent vectors must have length 3.")
 
@@ -124,7 +133,7 @@ def so3_exp_map_volume_log_jacobian(tangent_vectors):
 
 def exp_map_identity(tangent_vectors):
     """Map SO(3) tangent vectors at identity to scalar-last quaternions."""
-    tangent_vectors = array(tangent_vectors, dtype=float)
+    tangent_vectors = _as_real_array(tangent_vectors, "SO(3) tangent vectors")
     if ndim(tangent_vectors) == 1:
         if tangent_vectors.shape[0] != 3:
             raise ValueError("SO(3) tangent vectors must have length 3.")
@@ -170,10 +179,7 @@ def log_map_identity(rotations):
 
 def geodesic_distance(rotation_a, rotation_b):
     """Return the SO(3) geodesic distance between quaternions in radians."""
-    scalar_input = (
-        ndim(array(rotation_a, dtype=float)) == 1
-        and ndim(array(rotation_b, dtype=float)) == 1
-    )
+    scalar_input = ndim(array(rotation_a)) == 1 and ndim(array(rotation_b)) == 1
     quat_a = normalize_quaternions(rotation_a)
     quat_b = normalize_quaternions(rotation_b)
     inner = abs(sum(quat_a * quat_b, axis=-1))

--- a/tests/distributions/test_so3_helpers.py
+++ b/tests/distributions/test_so3_helpers.py
@@ -48,6 +48,26 @@ class SO3HelpersTest(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, message):
                     private_normalize_quaternions(quaternions)
 
+    def test_helpers_reject_complex_inputs_without_lossy_cast(self):
+        complex_quaternion = array([1.0 + 2.0j, 0.0, 0.0, 1.0])
+        complex_tangent = array([1.0 + 2.0j, 0.0, 0.0])
+        identity = array([0.0, 0.0, 0.0, 1.0])
+        invalid_calls = [
+            lambda: so3_helpers.normalize_quaternions(complex_quaternion),
+            lambda: private_normalize_quaternions(complex_quaternion),
+            lambda: so3_helpers.as_batch(
+                complex_tangent, 3, "SO(3) tangent vectors"
+            ),
+            lambda: so3_helpers.so3_exp_map_volume_log_jacobian(complex_tangent),
+            lambda: so3_helpers.exp_map_identity(complex_tangent),
+            lambda: so3_helpers.geodesic_distance(complex_quaternion, identity),
+        ]
+
+        for invalid_call in invalid_calls:
+            with self.subTest(call=invalid_call):
+                with self.assertRaisesRegex(ValueError, "must contain real values"):
+                    invalid_call()
+
     def test_helpers_reject_invalid_batch_widths(self):
         invalid_calls = [
             (


### PR DESCRIPTION
## Bug

The shared SO(3) helpers converted quaternions and tangent vectors with `array(..., dtype=float)` before validating their numeric domain. Complex inputs could therefore lose their imaginary components during conversion and be processed as a different real rotation or tangent vector.

For example, a quaternion containing `1 + 2j` could be silently interpreted using only its real component rather than rejected.

## Fix

- add a shared backend-aware real-array conversion helper;
- detect complex backend arrays before any floating-point cast;
- apply the validation consistently to quaternion normalization, generic SO(3) batching, exponential-map inputs, and exponential-map Jacobian inputs;
- avoid the lossy float cast in geodesic-distance input-shape detection.

## Regression coverage

A focused regression verifies rejection through:

- public and private quaternion normalization;
- generic SO(3) batch conversion;
- exponential-map volume Jacobian;
- identity exponential map;
- geodesic distance.

## Validation

- single focused commit;
- diff limited to the shared SO(3) helper module and its existing focused test module;
- PR is mergeable against the current base;
- GitHub Actions backend-matrix validation is running.