### PR TITLE
Validate multivariate-normal check modes before membership lookup

### DIFF
--- a/src/pyrecest/_backend/jax/random/__init__.py
+++ b/src/pyrecest/_backend/jax/random/__init__.py
@@ -19,7 +19,11 @@ _LEGACY_SPEC.loader.exec_module(_LEGACY)
 
 
 def _validate_multivariate_normal_check_valid(check_valid):
-    if check_valid not in {"warn", "raise", "ignore"}:
+    if not isinstance(check_valid, str) or check_valid not in {
+        "warn",
+        "raise",
+        "ignore",
+    }:
         raise ValueError("check_valid must be one of 'warn', 'raise', or 'ignore'")
     return check_valid
 

--- a/src/pyrecest/_backend/pytorch/random/__init__.py
+++ b/src/pyrecest/_backend/pytorch/random/__init__.py
@@ -86,7 +86,11 @@ _LEGACY._validate_multinomial_pvals = _validate_multinomial_pvals
 
 
 def _validate_multivariate_normal_check_valid(check_valid):
-    if check_valid not in {"warn", "raise", "ignore"}:
+    if not isinstance(check_valid, str) or check_valid not in {
+        "warn",
+        "raise",
+        "ignore",
+    }:
         raise ValueError("check_valid must be one of 'warn', 'raise', or 'ignore'")
     return check_valid
 

--- a/tests/backend/test_jax_random_multivariate_normal_keywords.py
+++ b/tests/backend/test_jax_random_multivariate_normal_keywords.py
@@ -19,7 +19,10 @@ def test_multivariate_normal_accepts_numpy_validation_keywords():
     assert sample.shape == (3, 2)
 
 
-@pytest.mark.parametrize("bad_check_valid", ["error", None, 1])
+@pytest.mark.parametrize(
+    "bad_check_valid",
+    ["error", None, 1, [], {}, bytearray(b"warn")],
+)
 def test_multivariate_normal_rejects_invalid_check_valid_keyword(bad_check_valid):
     with pytest.raises(ValueError, match="check_valid"):
         random.multivariate_normal(

--- a/tests/backend/test_pytorch_random_multivariate_normal_keywords.py
+++ b/tests/backend/test_pytorch_random_multivariate_normal_keywords.py
@@ -19,7 +19,10 @@ def test_multivariate_normal_accepts_numpy_validation_keywords():
     assert sample.shape == (3, 2)
 
 
-@pytest.mark.parametrize("bad_check_valid", ["error", None, 1])
+@pytest.mark.parametrize(
+    "bad_check_valid",
+    ["error", None, 1, [], {}, bytearray(b"warn")],
+)
 def test_multivariate_normal_rejects_invalid_check_valid_keyword(bad_check_valid):
     with pytest.raises(ValueError, match="check_valid"):
         random.multivariate_normal(


### PR DESCRIPTION
## Bug

The JAX and PyTorch `multivariate_normal()` compatibility shims validated `check_valid` with direct set membership. Unhashable invalid inputs such as lists, dictionaries, and bytearrays therefore leaked a raw `TypeError` instead of raising the documented validation `ValueError`.

## Fix

- require `check_valid` to be a string before checking the allowed modes;
- preserve the supported `warn`, `raise`, and `ignore` values;
- apply the same behavior to both optional backends.

## Regression coverage

The backend-specific tests now cover unhashable list, dictionary, and bytearray values in addition to the existing invalid scalar cases.

## Validation

- focused validator reproduction passed for all valid and invalid modes;
- Python syntax compilation passed for the changed validation logic;
- branch is based on the current `main` head and is four commits ahead, zero behind;
- diff is limited to the two backend shims and their focused tests.

GitHub Actions will provide the authoritative backend test-matrix validation.