### PR TITLE
Fix dense point-set distances for large coordinates

### DIFF
--- a/src/pyrecest/evaluation/point_set_metrics.py
+++ b/src/pyrecest/evaluation/point_set_metrics.py
@@ -336,20 +336,22 @@ def _nearest_neighbor_distances_dense(
     query_chunk_size: int,
     return_indices: bool,
 ) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
-    ref_t = reference.T
-    ref_norm = np.sum(reference**2, axis=1)
     distances = np.empty((query.shape[0],), dtype=np.float64)
     indices = np.empty((query.shape[0],), dtype=np.int64) if return_indices else None
     for start in range(0, query.shape[0], query_chunk_size):
         chunk = query[start : start + query_chunk_size]
-        chunk_norm = np.sum(chunk**2, axis=1, keepdims=True)
-        squared = np.maximum(
-            chunk_norm + ref_norm[None, :] - 2.0 * (chunk @ ref_t), 0.0
+        pairwise_distances = np.zeros(
+            (chunk.shape[0], reference.shape[0]), dtype=np.float64
         )
-        chunk_indices = np.argmin(squared, axis=1)
-        distances[start : start + chunk.shape[0]] = np.sqrt(
-            squared[np.arange(chunk.shape[0]), chunk_indices]
-        )
+        for coordinate in range(query.shape[1]):
+            pairwise_distances = np.hypot(
+                pairwise_distances,
+                chunk[:, None, coordinate] - reference[None, :, coordinate],
+            )
+        chunk_indices = np.argmin(pairwise_distances, axis=1)
+        distances[start : start + chunk.shape[0]] = pairwise_distances[
+            np.arange(chunk.shape[0]), chunk_indices
+        ]
         if indices is not None:
             indices[start : start + chunk.shape[0]] = chunk_indices
     if indices is None:

--- a/tests/evaluation/test_point_set_metrics_large_coordinates.py
+++ b/tests/evaluation/test_point_set_metrics_large_coordinates.py
@@ -1,0 +1,45 @@
+import numpy as np
+
+import pyrecest.evaluation.point_set_metrics as point_set_metrics
+
+
+def test_dense_fallback_preserves_large_coordinate_differences(monkeypatch):
+    monkeypatch.setattr(
+        point_set_metrics,
+        "_nearest_neighbor_distances_ckdtree",
+        lambda *args, **kwargs: None,
+    )
+
+    base = 1.0e150
+    delta = 1.0e140
+    query = np.array(
+        [
+            [base, 0.0],
+            [base + 4.0 * delta, 0.0],
+        ]
+    )
+    reference = np.array(
+        [
+            [base + delta, 0.0],
+            [base + 7.0 * delta, 0.0],
+        ]
+    )
+
+    distances, indices = point_set_metrics.nearest_neighbor_distances(
+        query,
+        reference,
+        query_chunk_size=1,
+        return_indices=True,
+    )
+
+    pairwise_distances = np.linalg.norm(
+        query[:, None, :] - reference[None, :, :], axis=2
+    )
+    expected_indices = np.argmin(pairwise_distances, axis=1)
+    expected_distances = pairwise_distances[
+        np.arange(query.shape[0]), expected_indices
+    ]
+
+    np.testing.assert_allclose(distances, expected_distances)
+    np.testing.assert_array_equal(indices, expected_indices)
+    assert np.all(distances > 0.0)


### PR DESCRIPTION
## Bug

The dense fallback in `nearest_neighbor_distances` computes pairwise distances through

```python
||x||^2 + ||y||^2 - 2 x^T y
```

For distinct points with large finite coordinates and relatively small separation, this expression suffers catastrophic cancellation; at larger magnitudes the intermediate squares also overflow. The fallback can consequently report zero distances, choose the wrong nearest point, or return `NaN`, even though the true Euclidean distances are finite.

A concrete example around `1e150` produces two zero distances on `main`, although the points differ by roughly `1e140`.

## Fix

- accumulate each coordinate difference with `numpy.hypot` directly in the dense fallback
- preserve the existing query-chunking behavior and deterministic `argmin` tie handling
- add a public-API regression that forces the dense fallback and checks both distances and nearest indices

## Validation

- reconstructed the original source byte-for-byte and verified its Git blob hash before applying the focused edit
- reproduced the pre-fix zero-distance/wrong-index result locally
- compared the stable implementation against explicit pairwise Euclidean distances across randomized shapes, dimensions, and chunk sizes
- verified the large-coordinate regression and both `return_indices` modes
- syntax-compiled the modified module and regression test

The full repository CI matrix provides integration coverage.