### PR TITLE
Reject nested complex LTI discretization inputs

### DIFF
--- a/src/pyrecest/models/_validated_motion_models.py
+++ b/src/pyrecest/models/_validated_motion_models.py
@@ -12,17 +12,46 @@ _nearly_coordinated_turn_model_impl = _motion_models.nearly_coordinated_turn_mod
 _continuous_to_discrete_lti_impl = _motion_models.continuous_to_discrete_lti
 
 
-def _reject_complex_matrix(value: Any, name: str) -> None:
-    """Reject complex-valued matrices before NumPy can discard imaginary parts."""
+def _contains_complex_values(value: Any, seen: set[int] | None = None) -> bool:
+    """Return whether a possibly nested array-like value contains complex data."""
+    if isinstance(value, (complex, np.complexfloating)):
+        return True
+
+    dtype = getattr(value, "dtype", None)
+    if dtype is not None:
+        try:
+            if np.dtype(dtype).kind == "c":
+                return True
+        except TypeError:
+            if "complex" in str(dtype).lower():
+                return True
+
+    if seen is None:
+        seen = set()
+    value_id = id(value)
+    if value_id in seen:
+        return False
+    seen.add(value_id)
+
+    if isinstance(value, (list, tuple)):
+        return any(_contains_complex_values(item, seen) for item in value)
+
     try:
         value_array = np.asarray(value)
     except (TypeError, ValueError):
-        return
-
-    contains_complex_object = value_array.dtype == object and any(
-        isinstance(item, (complex, np.complexfloating)) for item in value_array.flat
+        return False
+    if np.iscomplexobj(value_array):
+        return True
+    if value_array.dtype != object:
+        return False
+    return any(
+        _contains_complex_values(item, seen) for item in value_array.flat
     )
-    if np.iscomplexobj(value_array) or contains_complex_object:
+
+
+def _reject_complex_matrix(value: Any, name: str) -> None:
+    """Reject complex-valued matrices before NumPy can discard imaginary parts."""
+    if _contains_complex_values(value):
         raise ValueError(f"{name} must contain real values")
 
 

--- a/tests/models/test_continuous_to_discrete_lti_complex_validation.py
+++ b/tests/models/test_continuous_to_discrete_lti_complex_validation.py
@@ -8,9 +8,12 @@ from pyrecest.models import continuous_to_discrete_lti
 
 class TestContinuousToDiscreteLtiComplexValidation(unittest.TestCase):
     def test_rejects_complex_system_and_noise_matrices(self):
+        nested_complex = np.empty((1, 1), dtype=object)
+        nested_complex[0, 0] = np.array(1.0 + 2.0j)
         complex_variants = (
             np.array([[1.0 + 2.0j]]),
             np.array([[1.0 + 2.0j]], dtype=object),
+            nested_complex,
         )
         parameter_cases = (
             (


### PR DESCRIPTION
## Bug

The validated `continuous_to_discrete_lti()` wrapper detected native complex arrays and object arrays containing direct complex scalars, but it did not inspect nested values inside object matrices.

A matrix entry such as `np.array(1.0 + 2.0j)` therefore bypassed validation. The implementation's later `np.asarray(..., dtype=float)` conversion emitted only a `ComplexWarning` and silently changed the value to `1.0`, so the discretized system could differ from the caller's input.

## Fix

- recursively inspect nested object-array, list, and tuple values for complex data;
- recognize complex backend dtypes before NumPy conversion;
- track visited objects to avoid recursion loops for cyclic object arrays;
- preserve the existing validation error for each LTI matrix parameter.

## Regression coverage

The existing complex-input regression now includes an object matrix whose entry is a nested zero-dimensional complex NumPy array. The case is checked for:

- `continuous_matrix`;
- `noise_input_matrix`;
- `continuous_noise_covariance`.

## Validation

- reproduced the prior silent `1+2j` to `1.0` truncation with `ComplexWarning`;
- verified the recursive detector rejects the reproducer, accepts real matrices, and terminates safely on a cyclic object array;
- Python syntax compilation passed for both changed files;
- GitHub reports the PR mergeable against current `main`;
- diff is limited to the validation wrapper and its focused test.

GitHub Actions will provide the authoritative full-suite validation.