### PR TITLE
Handle invalid CLI expected-results JSON

### DIFF
--- a/src/pyrecest/cli.py
+++ b/src/pyrecest/cli.py
@@ -197,7 +197,14 @@ def _cmd_run_scenario(args: argparse.Namespace) -> int:
     print(result.to_json(indent=2))
 
     if args.expected is not None:
-        expected = json.loads(Path(args.expected).read_text(encoding="utf-8"))
+        try:
+            expected = json.loads(Path(args.expected).read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+            print(f"failed to read expected results: {exc}", file=sys.stderr)
+            return 2
+        if not isinstance(expected, dict):
+            print("expected results must be a JSON object", file=sys.stderr)
+            return 2
         raw_tolerance = (
             args.tolerance
             if args.tolerance is not None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,3 +50,39 @@ def test_cli_run_scenario_rejects_final_estimate_length_mismatch(tmp_path, capsy
     )
     captured = capsys.readouterr()
     assert "final_estimate length mismatch" in captured.err
+
+
+def test_cli_run_scenario_rejects_malformed_expected_json(tmp_path, capsys):
+    expected_path = tmp_path / "malformed.json"
+    expected_path.write_text("{not valid json", encoding="utf-8")
+
+    assert (
+        main(
+            [
+                "run-scenario",
+                "scenarios/linear_gaussian_cv_1d/config.toml",
+                "--expected",
+                str(expected_path),
+            ]
+        )
+        == 2
+    )
+    assert "failed to read expected results" in capsys.readouterr().err
+
+
+def test_cli_run_scenario_rejects_nonobject_expected_json(tmp_path, capsys):
+    expected_path = tmp_path / "expected_list.json"
+    expected_path.write_text("[]", encoding="utf-8")
+
+    assert (
+        main(
+            [
+                "run-scenario",
+                "scenarios/linear_gaussian_cv_1d/config.toml",
+                "--expected",
+                str(expected_path),
+            ]
+        )
+        == 2
+    )
+    assert "expected results must be a JSON object" in capsys.readouterr().err


### PR DESCRIPTION
## Bug

`pyrecest run-scenario --expected` loaded the expected-results file without handling file/JSON errors and immediately assumed the decoded value was a mapping. A malformed JSON file raised `JSONDecodeError`, while a valid JSON list or scalar raised `AttributeError` at `.get(...)`, producing an uncontrolled traceback.

## Fix

- catch expected-results file, decoding, and JSON parsing failures;
- return exit code `2` with a concise stderr diagnostic;
- require the decoded top-level value to be a JSON object before reading tolerance and expected sections.

## Regression coverage

The CLI tests now verify controlled rejection of:

- malformed expected-results JSON;
- valid JSON whose top-level value is a list.

Existing successful expected-result and mismatch behavior remains unchanged.

## Validation

- branch is based on the current `main` head and is two commits ahead, zero behind;
- compare diff is limited to `src/pyrecest/cli.py` and `tests/test_cli.py`;
- GitHub Actions will provide the authoritative full-suite validation.