### PR TITLE
Stabilize wrapped Cauchy CDF for tiny gamma

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py
@@ -151,18 +151,21 @@ class WrappedCauchyDistribution(AbstractCircularDistribution):
         the value at the requested starting point.
         """
 
-        def coth(x):
-            return 1 / tanh(x)
-
         starting_point = _validate_finite_scalar(starting_point, "starting_point")
         xs = _as_1d_input(xs)
+        half_gamma_tanh = tanh(self.gamma / 2.0)
 
         def primitive(angles):
             angles = array(angles)
             angles_centered = mod(angles - self.mu, 2.0 * pi)
             half_angles = angles_centered / 2.0
+            # Multiplying both atan2 arguments by tanh(gamma / 2) preserves
+            # the angle while avoiding reciprocal overflow for tiny gamma.
             return (
-                arctan2(coth(self.gamma / 2.0) * sin(half_angles), cos(half_angles))
+                arctan2(
+                    sin(half_angles),
+                    half_gamma_tanh * cos(half_angles),
+                )
                 / pi
             )
 

--- a/tests/distributions/test_wrapped_cauchy_small_gamma_stability.py
+++ b/tests/distributions/test_wrapped_cauchy_small_gamma_stability.py
@@ -1,6 +1,8 @@
+import unittest
+
 import numpy as np
 import numpy.testing as npt
-
+import pyrecest.backend
 from pyrecest.backend import array, to_numpy
 from pyrecest.distributions.circle.wrapped_cauchy_distribution import (
     WrappedCauchyDistribution,
@@ -20,3 +22,20 @@ def test_pdf_remains_finite_and_positive_for_tiny_gamma():
         1.0 / (2.0 * np.pi * np.tanh(gamma / 2.0)),
         rtol=1.0e-6,
     )
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+    reason="Wrapped Cauchy CDF is not supported on this backend",
+)
+def test_cdf_remains_finite_at_mode_when_tiny_gamma_overflows_coth():
+    gamma = 1.0e-308
+    dist = WrappedCauchyDistribution(1.0, gamma)
+
+    values = np.asarray(
+        to_numpy(dist.cdf(array([1.0]), starting_point=0.0)),
+        dtype=float,
+    )
+
+    assert np.all(np.isfinite(values))
+    npt.assert_allclose(values, [0.5], atol=1.0e-12)


### PR DESCRIPTION
## Bug

`WrappedCauchyDistribution.cdf()` evaluated its half-angle primitive with `coth(gamma / 2) = 1 / tanh(gamma / 2)`. For very small positive scales, such as `gamma = 1e-308`, that reciprocal overflows to infinity. At the distribution mode the implementation then multiplies infinity by `sin(0)`, producing `NaN` instead of a finite CDF value.

## Fix

Scale both arguments of `atan2` by the positive factor `tanh(gamma / 2)`:

- old: `atan2(coth(gamma / 2) * sin(a), cos(a))`
- new: `atan2(sin(a), tanh(gamma / 2) * cos(a))`

The angle is unchanged for positive `gamma`, while the new form avoids the reciprocal overflow and the resulting `inf * 0` indeterminacy.

## Regression coverage

A focused regression evaluates the CDF at the mode with `gamma = 1e-308` and verifies that it remains finite and equals the symmetric half-mass value `0.5`. The test follows the existing backend support boundary for the wrapped-Cauchy CDF.

## Validation

- standalone NumPy reproducer: old formula returned `NaN`; scaled `atan2` returned `0.5`;
- Python syntax compilation passed for the modified source and regression test;
- branch is two commits ahead of `main` and zero behind;
- diff is limited to the wrapped-Cauchy CDF implementation and its small-gamma stability tests.

GitHub Actions will provide the authoritative repository and backend validation.