### PR TITLE
Reject cyclic covariance helper inputs

### DIFF
--- a/src/pyrecest/numerics.py
+++ b/src/pyrecest/numerics.py
@@ -28,34 +28,56 @@ _UNSUPPORTED_SCALAR_TYPES = (
 )
 
 
-def _object_item_contains_unsupported_numeric_values(item) -> bool:
+def _object_item_contains_unsupported_numeric_values(
+    item, active_ids: set[int]
+) -> bool:
     if isinstance(item, _UNSUPPORTED_SCALAR_TYPES):
         return True
     if isinstance(item, np.ndarray):
-        return _contains_unsupported_numeric_values(item)
+        return _contains_unsupported_numeric_values(item, active_ids)
     if isinstance(item, (list, tuple)):
-        return any(
-            _object_item_contains_unsupported_numeric_values(subitem)
-            for subitem in item
-        )
+        item_id = id(item)
+        if item_id in active_ids:
+            return True
+        active_ids.add(item_id)
+        try:
+            return any(
+                _object_item_contains_unsupported_numeric_values(
+                    subitem, active_ids
+                )
+                for subitem in item
+            )
+        finally:
+            active_ids.remove(item_id)
     return False
 
 
-def _contains_unsupported_numeric_values(value) -> bool:
+def _contains_unsupported_numeric_values(
+    value, active_ids: set[int] | None = None
+) -> bool:
     if np.ma.is_masked(value):
         return True
+    if active_ids is None:
+        active_ids = set()
+    value_id = id(value)
+    if value_id in active_ids:
+        return True
+    active_ids.add(value_id)
     try:
-        value_array = np.asarray(value)
-    except (TypeError, ValueError, OverflowError, RuntimeError):
-        return True
-    if value_array.dtype.kind in _UNSUPPORTED_NUMERIC_KINDS:
-        return True
-    if value_array.dtype.kind != "O":
-        return False
-    return any(
-        _object_item_contains_unsupported_numeric_values(item)
-        for item in value_array.flat
-    )
+        try:
+            value_array = np.asarray(value)
+        except (TypeError, ValueError, OverflowError, RuntimeError):
+            return True
+        if value_array.dtype.kind in _UNSUPPORTED_NUMERIC_KINDS:
+            return True
+        if value_array.dtype.kind != "O":
+            return False
+        return any(
+            _object_item_contains_unsupported_numeric_values(item, active_ids)
+            for item in value_array.flat
+        )
+    finally:
+        active_ids.remove(value_id)
 
 
 def _to_numpy_array(value, *, name: str = "matrix") -> np.ndarray:

--- a/tests/test_numerics_cyclic_inputs.py
+++ b/tests/test_numerics_cyclic_inputs.py
@@ -26,3 +26,19 @@ def test_covariance_helpers_reject_cyclic_object_matrix():
         nearest_symmetric_psd(matrix)
     with pytest.raises(ValueError, match="matrix must contain numeric values"):
         jittered_cholesky(matrix)
+
+
+def test_covariance_helpers_accept_shared_acyclic_nested_scalars():
+    one = np.array(1.0)
+    zero = np.array(0.0)
+    matrix = np.empty((2, 2), dtype=object)
+    matrix[0, 0] = one
+    matrix[0, 1] = zero
+    matrix[1, 0] = zero
+    matrix[1, 1] = one
+
+    assert is_symmetric(matrix)
+    assert is_positive_semidefinite(matrix)
+    np.testing.assert_array_equal(
+        np.asarray(assert_covariance_matrix(matrix)), np.eye(2)
+    )

--- a/tests/test_numerics_cyclic_inputs.py
+++ b/tests/test_numerics_cyclic_inputs.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+from pyrecest.numerics import (
+    assert_covariance_matrix,
+    is_positive_semidefinite,
+    is_symmetric,
+    jittered_cholesky,
+    nearest_symmetric_psd,
+    symmetrize_matrix,
+)
+
+
+def test_covariance_helpers_reject_cyclic_object_matrix():
+    matrix = np.empty((2, 2), dtype=object)
+    matrix[:] = 0.0
+    matrix[0, 0] = matrix
+
+    assert not is_symmetric(matrix)
+    assert not is_positive_semidefinite(matrix)
+
+    with pytest.raises(ValueError, match="covariance must contain numeric values"):
+        assert_covariance_matrix(matrix)
+    with pytest.raises(ValueError, match="matrix must contain numeric values"):
+        symmetrize_matrix(matrix)
+    with pytest.raises(ValueError, match="matrix must contain numeric values"):
+        nearest_symmetric_psd(matrix)
+    with pytest.raises(ValueError, match="matrix must contain numeric values"):
+        jittered_cholesky(matrix)


### PR DESCRIPTION
## Bug

The shared covariance conversion helper recursively inspects nested object arrays without tracking the containers currently being traversed. A self-referential object matrix therefore recurses until Python raises `RecursionError`.

This leaks through public helpers such as `is_symmetric()`, `is_positive_semidefinite()`, `assert_covariance_matrix()`, `symmetrize_matrix()`, `nearest_symmetric_psd()`, and `jittered_cholesky()` instead of treating the input as an invalid numeric matrix.

## Fix

- track active array/list/tuple identities during nested object inspection;
- reject a repeated identity as a cyclic, unsupported numeric structure;
- remove identities after each recursive branch so shared but acyclic nested arrays remain valid.

## Regression coverage

Focused tests verify that:

- a self-referential `2 x 2` object matrix makes predicate helpers return `False`;
- validating and repair helpers raise their normal controlled `ValueError` diagnostics;
- no `RecursionError` escapes;
- repeated references to acyclic nested real scalars remain accepted.

## Validation

- reproduced the pre-fix `RecursionError` with the current helper implementation;
- focused cycle, shared-object, and nested-complex checks passed locally;
- the compare diff is limited to `src/pyrecest/numerics.py` and the focused regression test.

GitHub Actions will provide the authoritative full-suite validation.