### PR TITLE
Avoid zero Mahalanobis distance for nonfinite NIS

### DIFF
--- a/src/pyrecest/tracking/innovation_diagnostics.py
+++ b/src/pyrecest/tracking/innovation_diagnostics.py
@@ -31,11 +31,14 @@ class InnovationDiagnostic:
 
     @property
     def mahalanobis_distance(self) -> float | None:
-        """Return ``sqrt(max(nis, 0))`` when NIS is available."""
+        """Return ``sqrt(max(nis, 0))`` when a finite NIS is available."""
 
         if self.nis is None:
             return None
-        return float(np.sqrt(max(0.0, float(self.nis))))
+        nis = float(self.nis)
+        if not np.isfinite(nis):
+            return None
+        return float(np.sqrt(max(0.0, nis)))
 
     def to_dict(self, *, include_arrays: bool = False) -> dict[str, Any]:
         """Return a JSON/CSV-friendly representation."""

--- a/tests/tracking/test_innovation_diagnostic_mahalanobis.py
+++ b/tests/tracking/test_innovation_diagnostic_mahalanobis.py
@@ -1,0 +1,21 @@
+import numpy as np
+import pytest
+
+from pyrecest.tracking import InnovationDiagnostic
+
+
+@pytest.mark.parametrize("nis", [np.nan, np.inf, -np.inf])
+def test_nonfinite_nis_has_no_mahalanobis_distance(nis):
+    diagnostic = InnovationDiagnostic(measurement_dim=1, nis=nis)
+
+    assert diagnostic.mahalanobis_distance is None
+    assert diagnostic.to_dict()["mahalanobis_distance"] is None
+
+
+def test_finite_nis_keeps_clamped_square_root_behavior():
+    assert InnovationDiagnostic(
+        measurement_dim=1, nis=4.0
+    ).mahalanobis_distance == pytest.approx(2.0)
+    assert InnovationDiagnostic(
+        measurement_dim=1, nis=-1e-12
+    ).mahalanobis_distance == pytest.approx(0.0)


### PR DESCRIPTION
## Bug

`InnovationDiagnostic.mahalanobis_distance` used `sqrt(max(0, nis))`. Python's scalar `max` makes `NaN` lose to `0.0`, so a diagnostic with `nis=np.nan` reported a Mahalanobis distance of `0.0`. Negative infinity also reported `0.0`, and positive infinity was exported as infinity. Because `to_dict()` includes this property, invalid diagnostics could be serialized as a perfect match or another non-finite value.

## Fix

- parse the NIS value once;
- return `None` when it is not finite;
- preserve zero-clamping for finite negative roundoff and ordinary square-root behavior for valid NIS values.

## Regression coverage

- `NaN`, positive infinity, and negative infinity return and export `None`;
- a finite NIS of `4.0` still produces `2.0`;
- a small finite negative roundoff value remains clamped to `0.0`.

## Validation

- isolated reproduction confirmed the old and corrected behavior;
- the branch is one focused commit ahead and zero behind current `main`;
- the diff is limited to seven changed source lines and one focused regression test;
- GitHub Actions will provide authoritative full-suite validation.