### PR TITLE
Reject nested invalid candidate matrix values

### DIFF
--- a/src/pyrecest/utils/candidate_pruning.py
+++ b/src/pyrecest/utils/candidate_pruning.py
@@ -188,14 +188,32 @@ def _normalize_bounded_scalar(
     return parsed
 
 
-def _contains_values_of_type(value: Any, types: tuple[type, ...]) -> bool:
+def _contains_values_of_type(
+    value: Any,
+    types: tuple[type, ...],
+    active_ids: set[int] | None = None,
+) -> bool:
     if isinstance(value, types):
         return True
-    try:
-        values = np.asarray(value, dtype=object).reshape(-1)
-    except (TypeError, ValueError, RuntimeError):
+    if isinstance(value, np.ndarray):
+        items = value.reshape(-1)
+    elif isinstance(value, (list, tuple)):
+        items = value
+    else:
         return False
-    return any(isinstance(item, types) for item in values)
+
+    if active_ids is None:
+        active_ids = set()
+    value_id = id(value)
+    if value_id in active_ids:
+        return False
+    active_ids.add(value_id)
+    try:
+        return any(
+            _contains_values_of_type(item, types, active_ids) for item in items
+        )
+    finally:
+        active_ids.remove(value_id)
 
 
 def _contains_text_values(value: Any) -> bool:

--- a/tests/utils/test_candidate_pruning_nested_values.py
+++ b/tests/utils/test_candidate_pruning_nested_values.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pytest
+
+from pyrecest.utils import CandidatePruningConfig, candidate_mask_from_costs
+
+
+def _nested_object_matrix(value):
+    matrix = np.empty((1, 1), dtype=object)
+    matrix[0, 0] = np.asarray(value)
+    return matrix
+
+
+def test_candidate_pruning_rejects_nested_complex_cost_values():
+    costs = _nested_object_matrix(1.0 + 2.0j)
+
+    with pytest.raises(ValueError, match="cost_matrix must be real-valued numeric"):
+        candidate_mask_from_costs(costs)
+
+
+def test_candidate_pruning_rejects_nested_complex_probability_values():
+    probabilities = _nested_object_matrix(0.75 + 0.25j)
+
+    with pytest.raises(
+        ValueError,
+        match="probability_matrix must be real-valued numeric",
+    ):
+        candidate_mask_from_costs(
+            np.array([[1.0]]),
+            probability_matrix=probabilities,
+            config=CandidatePruningConfig(probability_threshold=0.5),
+        )
+
+
+def test_candidate_pruning_accepts_nested_real_scalar_arrays():
+    mask = candidate_mask_from_costs(
+        _nested_object_matrix(1.0),
+        probability_matrix=_nested_object_matrix(0.75),
+        config=CandidatePruningConfig(probability_threshold=0.5),
+    )
+
+    np.testing.assert_array_equal(mask, np.array([[True]]))


### PR DESCRIPTION
## Bug

Candidate-pruning matrix validation inspected only the immediate elements of object arrays. A zero-dimensional complex NumPy array nested inside a cost or probability matrix therefore bypassed the complex-value check.

The subsequent `np.asarray(..., dtype=float)` conversion silently discarded the imaginary component with a `ComplexWarning`, so candidate selection could run on different values than the caller supplied.

## Fix

- recursively inspect NumPy arrays, lists, and tuples for invalid scalar payloads;
- track active container identities so cyclic structures terminate safely;
- preserve support for shared and nested real scalar arrays.

## Regression coverage

Focused tests verify that:

- nested complex cost values are rejected;
- nested complex probability values are rejected;
- nested real zero-dimensional arrays remain accepted.

## Validation

- reproduced NumPy's prior silent complex-to-real truncation;
- inspected the final branch diff and focused regression cases;
- the branch changes only `candidate_pruning.py` and one focused test module;
- GitHub Actions will provide authoritative repository-wide validation.