### PR TITLE
Reject fractionally rounded SO(3) tangent sample counts

### DIFF
--- a/src/pyrecest/distributions/so3_tangent_gaussian_distribution.py
+++ b/src/pyrecest/distributions/so3_tangent_gaussian_distribution.py
@@ -47,11 +47,14 @@ def _validate_positive_sample_count(n) -> int:
 
     try:
         count_int = int(count)
-        count_float = float(count)
     except (OverflowError, TypeError, ValueError) as exc:
         raise ValueError("n must be an integer") from exc
 
-    if not np.isfinite(count_float) or not count_float.is_integer():
+    try:
+        is_exact_integer = count == count_int
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("n must be a finite integer") from exc
+    if not bool(is_exact_integer):
         raise ValueError("n must be a finite integer")
     if count_int <= 0:
         raise ValueError("n must be positive")
@@ -177,53 +180,3 @@ class SO3TangentGaussianDistribution(AbstractBoundedDomainDistribution):
     def sample(self, n):
         """Draw ``n`` SO(3) samples as scalar-last unit quaternions."""
         return self.exp_map(self.sample_tangent(n), base=self.mu)
-
-    def mean(self):
-        """Return the mean rotation as a scalar-last unit quaternion."""
-        return self.mu
-
-    def mode(self):
-        """Return the modal rotation as a scalar-last unit quaternion."""
-        return self.mu
-
-    def mean_rotation_matrix(self):
-        """Return the mean rotation matrix."""
-        return self.as_rotation_matrices(self.mu)[0]
-
-    def covariance(self):
-        """Return the 3-by-3 tangent covariance matrix."""
-        return self.C
-
-    def set_mean(self, new_mean):
-        """Return a copy with a replaced mean rotation."""
-        return self.set_mode(new_mean)
-
-    def set_mode(self, new_mode):
-        """Return a copy with a replaced modal rotation."""
-        new_dist = self.__class__(new_mode, self.C, check_validity=False)
-        return new_dist
-
-    def get_manifold_size(self):
-        """Return the embedding half-sphere volume used for unit quaternions."""
-        return pi**2
-
-    def is_valid(self, tolerance=1e-6):
-        """Return whether the mean and covariance have valid SO(3) dimensions."""
-        covariance_is_symmetric = _to_python_bool(
-            amax(abs(self.C - transpose(self.C))) <= tolerance
-        )
-        if not (
-            _to_python_bool(all(isfinite(self.mu)))
-            and _to_python_bool(abs(linalg.norm(self.mu) - 1.0) <= tolerance)
-            and _to_python_bool(self.mu[-1] >= -tolerance)
-            and _to_python_bool(all(isfinite(self.C)))
-            and covariance_is_symmetric
-        ):
-            return False
-
-        return _to_python_bool(all(linalg.eigvalsh(self.C) > 0.0))
-
-    @staticmethod
-    def from_covariance_diagonal(mu, covariance_diagonal):
-        """Create a tangent Gaussian from a diagonal covariance vector."""
-        return SO3TangentGaussianDistribution(mu, diag(covariance_diagonal))

--- a/src/pyrecest/distributions/so3_tangent_gaussian_distribution.py
+++ b/src/pyrecest/distributions/so3_tangent_gaussian_distribution.py
@@ -180,3 +180,53 @@ class SO3TangentGaussianDistribution(AbstractBoundedDomainDistribution):
     def sample(self, n):
         """Draw ``n`` SO(3) samples as scalar-last unit quaternions."""
         return self.exp_map(self.sample_tangent(n), base=self.mu)
+
+    def mean(self):
+        """Return the mean rotation as a scalar-last unit quaternion."""
+        return self.mu
+
+    def mode(self):
+        """Return the modal rotation as a scalar-last unit quaternion."""
+        return self.mu
+
+    def mean_rotation_matrix(self):
+        """Return the mean rotation matrix."""
+        return self.as_rotation_matrices(self.mu)[0]
+
+    def covariance(self):
+        """Return the 3-by-3 tangent covariance matrix."""
+        return self.C
+
+    def set_mean(self, new_mean):
+        """Return a copy with a replaced mean rotation."""
+        return self.set_mode(new_mean)
+
+    def set_mode(self, new_mode):
+        """Return a copy with a replaced modal rotation."""
+        new_dist = self.__class__(new_mode, self.C, check_validity=False)
+        return new_dist
+
+    def get_manifold_size(self):
+        """Return the embedding half-sphere volume used for unit quaternions."""
+        return pi**2
+
+    def is_valid(self, tolerance=1e-6):
+        """Return whether the mean and covariance have valid SO(3) dimensions."""
+        covariance_is_symmetric = _to_python_bool(
+            amax(abs(self.C - transpose(self.C))) <= tolerance
+        )
+        if not (
+            _to_python_bool(all(isfinite(self.mu)))
+            and _to_python_bool(abs(linalg.norm(self.mu) - 1.0) <= tolerance)
+            and _to_python_bool(self.mu[-1] >= -tolerance)
+            and _to_python_bool(all(isfinite(self.C)))
+            and covariance_is_symmetric
+        ):
+            return False
+
+        return _to_python_bool(all(linalg.eigvalsh(self.C) > 0.0))
+
+    @staticmethod
+    def from_covariance_diagonal(mu, covariance_diagonal):
+        """Create a tangent Gaussian from a diagonal covariance vector."""
+        return SO3TangentGaussianDistribution(mu, diag(covariance_diagonal))

--- a/tests/distributions/test_so3_tangent_gaussian_sample_count_exactness.py
+++ b/tests/distributions/test_so3_tangent_gaussian_sample_count_exactness.py
@@ -1,0 +1,26 @@
+import unittest
+from fractions import Fraction
+
+from pyrecest.distributions.so3_tangent_gaussian_distribution import (
+    _validate_positive_sample_count,
+)
+
+
+class SO3TangentGaussianSampleCountExactnessTest(unittest.TestCase):
+    def test_rejects_fractional_count_rounded_to_integer_by_binary64(self):
+        rounded_half_integer = Fraction(2**54 + 1, 2)
+
+        with self.assertRaises(ValueError):
+            _validate_positive_sample_count(rounded_half_integer)
+
+    def test_preserves_exact_large_integral_count(self):
+        exact_integer = Fraction(2**54 + 2, 2)
+
+        self.assertEqual(
+            _validate_positive_sample_count(exact_integer),
+            2**53 + 1,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`SO3TangentGaussianDistribution` validated sample counts by converting the supplied scalar to binary `float` and calling `is_integer()`.

Exact numeric values above binary64's consecutive-integer range can lose their fractional part during that conversion. For example, `Fraction(2**54 + 1, 2)` is exactly a half-integer, but converts to the integer-valued float `2**53`. The old validator therefore accepted it as a huge truncated sample count, after which `sample()` or `sample_tangent()` could attempt an enormous allocation.

## Fix

- convert the original scalar directly with `int()`;
- compare that integer against the original exact scalar;
- reject values that are not exactly integral without narrowing through binary64;
- preserve ordinary Python/NumPy integer-like inputs and exact integral numeric values.

## Regression coverage

- reject a large exact half-integer whose fractional part disappears in binary64;
- preserve the adjacent exact integral `Fraction` without allocating samples.

## Validation

- reproduced the old acceptance deterministically (`float(value).is_integer()` is `True` while `int(value) != value`);
- isolated validator checks confirm the fractional case is rejected and integer-valued float, NumPy integer, and exact integral `Fraction` controls remain accepted;
- Python syntax compilation passed for the modified source and regression test;
- branch is three focused commits ahead and zero behind current `main`;
- aggregate diff is limited to seven changed source lines and one focused regression file.

GitHub Actions will provide the authoritative repository-wide and backend-matrix validation.