### PR TITLE
Reject non-finite residual candidate scores

### DIFF
--- a/src/pyrecest/tracking/residual_hypothesis_mht.py
+++ b/src/pyrecest/tracking/residual_hypothesis_mht.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from itertools import combinations
+from math import isfinite
 from typing import Any, Literal
 
 ResidualMHTPreset = Literal["conservative", "frontier", "multi_family"]
@@ -34,6 +35,15 @@ class ResidualEditCandidate:
     metadata: Mapping[str, Any] = field(default_factory=dict)
     family: str | None = None
     group_keys: frozenset[str] = field(default_factory=frozenset)
+
+    def __post_init__(self) -> None:
+        try:
+            score = float(self.score)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError("Residual candidate score must be finite.") from exc
+        if not isfinite(score):
+            raise ValueError("Residual candidate score must be finite.")
+        object.__setattr__(self, "score", score)
 
 
 @dataclass(frozen=True)

--- a/tests/tracking/test_residual_hypothesis_mht_duplicate_ids.py
+++ b/tests/tracking/test_residual_hypothesis_mht_duplicate_ids.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from pyrecest.tracking import (
     ResidualEditCandidate,
     ResidualMHTConfig,
@@ -34,3 +36,9 @@ def test_duplicate_candidate_ids_are_deduplicated_before_frontier_limits():
         ("a",),
         ("b",),
     }
+
+
+@pytest.mark.parametrize("score", [float("nan"), float("inf"), float("-inf")])
+def test_residual_edit_candidate_rejects_nonfinite_scores(score):
+    with pytest.raises(ValueError, match="score must be finite"):
+        ResidualEditCandidate("invalid", score)


### PR DESCRIPTION
## Bug

`ResidualEditCandidate` accepted `NaN` and infinite scores. The residual-MHT frontier sorts candidates by negated score before deduplicating candidate IDs. Because `NaN` does not define a total ordering, an earlier `NaN` duplicate could be retained instead of a later finite, higher-scoring candidate. Non-finite values could also propagate into hypothesis ranking and serialized diagnostics.

## Fix

- normalize candidate scores to plain Python floats during construction;
- reject non-numeric, `NaN`, and infinite scores with a clear `ValueError`;
- leave finite candidate ordering, duplicate-ID handling, and hypothesis enumeration unchanged.

## Regression coverage

The duplicate-frontier test now parametrically verifies rejection of `NaN`, positive infinity, and negative infinity.

## Validation

- reproduced the pre-fix `NaN` sorting behavior in isolation;
- syntax-checked the modified module;
- exercised finite and invalid candidate construction in isolation;
- branch is two focused commits ahead and zero behind current `main`;
- GitHub Actions will provide authoritative full-suite validation.