### PR TITLE
Normalize extract-mean flag coercion failures

### DIFF
--- a/src/pyrecest/evaluation/get_extract_mean.py
+++ b/src/pyrecest/evaluation/get_extract_mean.py
@@ -20,7 +20,7 @@ def _coerce_mtt_scenario_flag(value: Any) -> bool:
         raise ValueError("mtt_scenario must be a bool")
     try:
         value_array = np.asarray(value)
-    except (TypeError, ValueError) as exc:
+    except (TypeError, ValueError, RuntimeError, OverflowError) as exc:
         raise ValueError("mtt_scenario must be a bool") from exc
     if value_array.shape == () and np.issubdtype(value_array.dtype, np.bool_):
         return bool(value_array.item())

--- a/tests/evaluation/test_get_extract_mean_mtt_flag.py
+++ b/tests/evaluation/test_get_extract_mean_mtt_flag.py
@@ -4,6 +4,15 @@ import pytest
 from pyrecest.evaluation.get_extract_mean import get_extract_mean
 
 
+class FailingArrayScalar:
+    def __init__(self, exception_type):
+        self.exception_type = exception_type
+
+    def __array__(self, dtype=None):
+        del dtype
+        raise self.exception_type("cannot convert")
+
+
 @pytest.mark.parametrize("mtt_scenario", ["False", "true", 1, [False]])
 def test_get_extract_mean_rejects_non_boolean_mtt_scenario(mtt_scenario):
     with pytest.raises(ValueError, match="mtt_scenario must be a bool"):
@@ -21,6 +30,15 @@ def test_get_extract_mean_rejects_non_boolean_mtt_scenario(mtt_scenario):
 def test_get_extract_mean_rejects_masked_boolean_mtt_scenario(mtt_scenario):
     with pytest.raises(ValueError, match="mtt_scenario must be a bool"):
         get_extract_mean("euclidean", mtt_scenario=mtt_scenario)
+
+
+@pytest.mark.parametrize("exception_type", [RuntimeError, OverflowError])
+def test_get_extract_mean_normalizes_array_conversion_failures(exception_type):
+    with pytest.raises(ValueError, match="mtt_scenario must be a bool"):
+        get_extract_mean(
+            "euclidean",
+            mtt_scenario=FailingArrayScalar(exception_type),
+        )
 
 
 def test_get_extract_mean_accepts_unmasked_boolean_mtt_scenario():


### PR DESCRIPTION
## Bug

`get_extract_mean(..., mtt_scenario=...)` validates the compatibility flag through `numpy.asarray`, but its exception normalization only handled `TypeError` and `ValueError`.

Array-like inputs whose conversion raises `RuntimeError` or `OverflowError` therefore leaked those implementation exceptions from the public helper instead of producing the established `ValueError("mtt_scenario must be a bool")` diagnostic.

## Fix

- normalize `RuntimeError` and `OverflowError` from NumPy array conversion to the existing public `ValueError`;
- preserve accepted Python, NumPy, and unmasked NumPy masked-array Boolean scalars;
- preserve rejection of strings, numeric scalars, vectors, and masked Boolean values.

## Regression coverage

A focused parameterized regression uses array-like objects whose `__array__` methods raise `RuntimeError` and `OverflowError`, and verifies that both are exposed as the documented `ValueError`.

## Validation

- reproduced the pre-fix leaked `RuntimeError` in isolation;
- focused test module: `10 passed`;
- Python syntax compilation passed for both changed files;
- branch is two focused commits ahead and zero behind current `main`;
- compare diff is limited to one production-line replacement and 18 regression-test lines.

GitHub Actions will provide the authoritative repository-wide validation.