### PR TITLE
Support low-precision JAX positive-definite checks

### DIFF
--- a/src/pyrecest/_backend/jax/linalg.py
+++ b/src/pyrecest/_backend/jax/linalg.py
@@ -188,6 +188,12 @@ def is_single_matrix_pd(mat):
     if mat.ndim != 2 or mat.shape[0] != mat.shape[1]:
         return False
 
+    # JAX's Cholesky and Hermitian eigensolvers do not support float16 or
+    # bfloat16. Promote only for this predicate so valid low-precision inputs
+    # produce a boolean result instead of leaking NotImplementedError.
+    if mat.dtype in (_jnp.float16, _jnp.bfloat16):
+        mat = mat.astype(_jnp.float32)
+
     if mat.dtype in (_jnp.complex64, _jnp.complex128):
         is_hermitian = _jnp.all(_jnp.abs(mat - _jnp.conj(_jnp.transpose(mat))) < atol)
         eigvals = _jnp.linalg.eigvalsh(mat)

--- a/tests/backend_support/test_jax_linalg_low_precision_pd.py
+++ b/tests/backend_support/test_jax_linalg_low_precision_pd.py
@@ -1,0 +1,26 @@
+"""Regression coverage for low-precision JAX positive-definite checks."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+
+@pytest.mark.backend_portable
+def test_jax_pd_predicate_supports_low_precision_real_matrices():
+    if importlib.util.find_spec("jax") is None:
+        pytest.skip("JAX is not installed")
+
+    import jax.numpy as jnp
+
+    from pyrecest._backend.jax import linalg
+
+    positive_definite = [[2.0, 0.0], [0.0, 1.0]]
+    indefinite = [[1.0, 2.0], [2.0, 1.0]]
+
+    for dtype in (jnp.float16, jnp.bfloat16):
+        assert bool(
+            linalg.is_single_matrix_pd(jnp.asarray(positive_definite, dtype=dtype))
+        )
+        assert not bool(linalg.is_single_matrix_pd(jnp.asarray(indefinite, dtype=dtype)))


### PR DESCRIPTION
## Bug

`pyrecest._backend.jax.linalg.is_single_matrix_pd()` called JAX Cholesky directly for real matrices. JAX does not implement Cholesky for `float16` or `bfloat16`, so the predicate raised `NotImplementedError` for otherwise valid low-precision matrices instead of returning a boolean result.

This broke the backend predicate contract for common mixed-precision inputs and affected both positive-definite and indefinite matrices before classification could complete.

## Fix

- promote only `float16` and `bfloat16` inputs to `float32` inside the positive-definite predicate;
- leave the input object unchanged;
- preserve the existing complex, symmetry, and finite-factor checks for supported dtypes.

## Regression coverage

A focused JAX backend test verifies that both low-precision dtypes:

- return `True` for a positive-definite matrix;
- return `False` for an indefinite matrix;
- no longer leak `NotImplementedError`.

## Validation

- reproduced the pre-fix `NotImplementedError` locally for both `float16` and `bfloat16` Cholesky;
- exercised the promoted predicate logic for positive-definite and indefinite controls;
- syntax-checked the modified module and regression test;
- branch is two focused commits ahead and zero behind current `main`;
- diff is limited to six source lines and one focused backend test.

GitHub Actions will provide the authoritative repository-wide backend validation.