### PR TITLE
Reject non-finite model margin thresholds

### DIFF
--- a/src/pyrecest/evaluation/model_comparison.py
+++ b/src/pyrecest/evaluation/model_comparison.py
@@ -170,8 +170,8 @@ def paired_model_margin_decisions(
     """Classify paired model wins using a symmetric log-evidence margin."""
 
     threshold = float(margin_threshold)
-    if threshold < 0.0:
-        raise ValueError("margin_threshold must be non-negative")
+    if not np.isfinite(threshold) or threshold < 0.0:
+        raise ValueError("margin_threshold must be finite and non-negative")
     group_cols = tuple(group_cols)
     columns = [
         *group_cols,


### PR DESCRIPTION
## Bug

`paired_model_margin_decisions()` converted `margin_threshold` to `float` but only rejected negative values. `NaN` and positive infinity therefore passed validation.

For a `NaN` threshold, every nonzero evidence difference fails both threshold comparisons and is silently classified as `ambiguous`. Positive infinity has the same practical effect for finite evidence margins. This turns an invalid configuration into plausible but incorrect decision output.

The threshold-sweep helper delegates to the same function, so invalid entries in a sweep were affected as well.

## Fix

- require `margin_threshold` to be finite and non-negative;
- raise the diagnostic already expected by the regression test;
- preserve all behavior for finite thresholds, including exact-tie handling.

## Validation

- confirmed the current regression already covers `NaN`, positive infinity, and negative infinity through both direct decisions and threshold sweeps;
- branch is one focused commit ahead and zero behind current `main`;
- compare diff is limited to two changed validation lines in `model_comparison.py`;
- GitHub Actions will provide authoritative repository-wide validation.