### PR TITLE
Handle empty zero-class PyTorch one-hot inputs

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_one_hot_scalar_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_one_hot_scalar_contract.py
@@ -97,6 +97,12 @@ def _patch_pytorch_one_hot_scalar_contract(
         ):
             return original_one_hot(labels, num_classes)
         labels = labels.to(dtype=torch_module.long)
+        if labels.numel() == 0 and num_classes == 0:
+            return torch_module.empty(
+                (*labels.shape, 0),
+                dtype=torch_module.uint8,
+                device=labels.device,
+            )
         return torch_module.nn.functional.one_hot(labels, num_classes).to(
             dtype=torch_module.uint8
         )

--- a/tests/backend_support/test_pytorch_one_hot_zero_classes_contract.py
+++ b/tests/backend_support/test_pytorch_one_hot_zero_classes_contract.py
@@ -1,0 +1,57 @@
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+pytestmark = pytest.mark.backend_portable
+
+
+def _zero_class_contract_code(target_module):
+    return f"""
+import torch
+import pyrecest  # noqa: F401  # triggers backend-support compatibility patches
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+
+target = {target_module}
+
+for labels in (
+    torch.empty((0,), dtype=torch.int32),
+    torch.empty((2, 0), dtype=torch.int64),
+):
+    result = target.one_hot(labels, 0)
+    assert result.dtype == torch.uint8
+    assert tuple(result.shape) == tuple(labels.shape) + (0,)
+    assert result.device == labels.device
+
+device = torch.device("cuda") if torch.cuda.is_available() else torch.device("meta")
+device_labels = torch.empty((0,), dtype=torch.int32, device=device)
+device_result = target.one_hot(device_labels, 0)
+assert tuple(device_result.shape) == (0, 0)
+assert device_result.dtype == torch.uint8
+assert device_result.device.type == device.type
+
+print("ok")
+"""
+
+
+def test_raw_pytorch_one_hot_handles_empty_zero_class_inputs_after_import():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code("numpy", _zero_class_contract_code("raw_pytorch"))
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_public_pytorch_one_hot_handles_empty_zero_class_inputs():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code("pytorch", _zero_class_contract_code("backend"))
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary

- return a correctly shaped empty `uint8` tensor for integer labels when `num_classes=0`
- preserve the input label device, including CUDA and meta devices
- add backend-portable regressions for both the raw PyTorch module and public PyTorch backend

## Bug

The compatibility wrapper explicitly accepts non-negative `num_classes`, including zero. However, `torch.nn.functional.one_hot` raises `RuntimeError: Can not infer total number of classes from empty tensor` for empty integer labels with `num_classes=0`. This makes a valid boundary case fail instead of producing the natural shape `labels.shape + (0,)`.

## Fix

Special-case only the empty, zero-class, valid-integer-label case and allocate an empty `uint8` tensor on the labels' device. Other inputs continue through the existing PyTorch validation and encoding paths.

## Validation

- reproduced the upstream PyTorch failure on empty integer labels with zero classes
- compiled the modified source and regression test with `py_compile`
- ran a focused smoke test covering vector and batched empty labels, positive class counts, and CPU/meta device preservation
- branch comparison: 2 commits ahead of `main`, 0 behind; two files changed