### PR TITLE
Prevent invalid GNN pairs from undercutting valid matches

### DIFF
--- a/src/pyrecest/filters/track_manager.py
+++ b/src/pyrecest/filters/track_manager.py
@@ -721,7 +721,9 @@ def solve_global_nearest_neighbor(  # pylint: disable=too-many-locals
         leaving a measurement unmatched. If omitted, ``unassigned_track_cost``
         is reused.
     invalid_cost:
-        Replacement for non-finite costs.
+        Minimum replacement for non-finite costs. The effective blocker is
+        increased when necessary so an invalid pair cannot undercut a feasible
+        assignment.
     dummy_dummy_cost:
         Cost placed in the dummy-dummy block. The default ``0.0`` matches the
         common rectangular-assignment interpretation. Some legacy trackers use a
@@ -762,10 +764,24 @@ def solve_global_nearest_neighbor(  # pylint: disable=too-many-locals
         name="unassigned_measurement_cost",
     )
 
-    finite_matrix = matrix.copy()
-    finite_matrix[~np.isfinite(finite_matrix)] = float(invalid_cost)
-
     assignment_size = num_tracks + num_measurements
+    minimum_invalid_cost = _forbidden_assignment_cost(
+        assignment_size,
+        matrix,
+        track_unassigned_costs,
+        measurement_unassigned_costs,
+        np.asarray([dummy_dummy_cost]),
+    )
+    invalid_cost_value = float(invalid_cost)
+    if np.isnan(invalid_cost_value):
+        raise ValueError("invalid_cost must not be NaN")
+
+    finite_matrix = matrix.copy()
+    finite_matrix[~np.isfinite(finite_matrix)] = max(
+        invalid_cost_value,
+        minimum_invalid_cost,
+    )
+
     structural_cost = _forbidden_assignment_cost(
         assignment_size,
         finite_matrix,

--- a/tests/filters/test_track_manager_structural_cost.py
+++ b/tests/filters/test_track_manager_structural_cost.py
@@ -15,3 +15,15 @@ def test_invalid_pair_replacement_is_not_used_for_structural_dummy_edges():
     assert association.matches == [(0, 0)]
     assert association.unmatched_track_indices == [1]
     assert association.unmatched_measurement_indices == []
+
+
+def test_default_invalid_pair_cost_cannot_undercut_large_valid_matches():
+    association = solve_global_nearest_neighbor(
+        np.array([[5.0e12, np.inf], [6.0e12, 7.0e12]]),
+        unassigned_track_cost=1.0e13,
+        unassigned_measurement_cost=1.0e13,
+    )
+
+    assert association.matches == [(0, 0), (1, 1)]
+    assert association.unmatched_track_indices == []
+    assert association.unmatched_measurement_indices == []


### PR DESCRIPTION
## What changed

- derive a scale-safe blocker for non-finite pair costs before constructing the augmented Hungarian cost matrix
- treat the configured `invalid_cost` as a minimum rather than an absolute replacement
- reject `NaN` as an invalid blocker configuration
- add a regression where valid association costs exceed the previous fixed `1e12` replacement

## Root cause

`solve_global_nearest_neighbor` replaced every non-finite pair with the fixed `invalid_cost` value. When legitimate assignment and missed-detection costs were larger than that replacement, the Hungarian solver could select an impossible pair because it appeared artificially cheap. The result was filtered afterward, but the impossible edge had already displaced valid matches.

## Impact

Non-finite association pairs can no longer suppress feasible assignments solely because the problem's cost scale exceeds the default blocker.

## Validation

- focused regression for large valid costs with a non-finite pair
- existing structural-dummy-edge regression
- existing all-infinite association edge case
- Python bytecode compilation of the modified source and test files