### PR TITLE
Reject fractionally rounded circular sampler counts

### DIFF
--- a/src/pyrecest/sampling/hypertoroidal_sampler.py
+++ b/src/pyrecest/sampling/hypertoroidal_sampler.py
@@ -25,11 +25,11 @@ def _validate_integral_scalar(value, name: str, *, minimum: int) -> int:
         raise ValueError(f"{name} must be an integer") from exc
 
     try:
-        float_value = float(scalar_value)
+        is_exact_integer = bool(scalar_value == integer_value)
     except (OverflowError, TypeError, ValueError) as exc:
         raise ValueError(f"{name} must be an integer") from exc
 
-    if not np.isfinite(float_value) or not float_value.is_integer():
+    if not is_exact_integer:
         raise ValueError(f"{name} must be a finite integer")
     if integer_value < minimum:
         if minimum == 0:

--- a/tests/test_hypertoroidal_sampler.py
+++ b/tests/test_hypertoroidal_sampler.py
@@ -1,4 +1,5 @@
 import unittest
+from fractions import Fraction
 
 import numpy as np
 import numpy.testing as npt
@@ -6,7 +7,10 @@ import numpy.testing as npt
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import all, diff, pi, std
-from pyrecest.sampling.hypertoroidal_sampler import CircularUniformSampler
+from pyrecest.sampling.hypertoroidal_sampler import (
+    CircularUniformSampler,
+    _validate_integral_scalar,
+)
 
 
 class TestCircularUniformSampler(unittest.TestCase):
@@ -41,6 +45,20 @@ class TestCircularUniformSampler(unittest.TestCase):
             with self.subTest(dim=dim):
                 with self.assertRaises(ValueError):
                     self.sampler.sample_stochastic(2, dim=dim)
+
+    def test_integral_controls_reject_fractional_values_rounded_by_binary64(self):
+        rounded_half_integer = Fraction(2**54 + 1, 2)
+
+        with self.assertRaisesRegex(ValueError, "must be a finite integer"):
+            _validate_integral_scalar(rounded_half_integer, "value", minimum=0)
+
+    def test_integral_controls_preserve_exact_large_integer(self):
+        exact_integer = Fraction(2**54 + 2, 2)
+
+        self.assertEqual(
+            _validate_integral_scalar(exact_integer, "value", minimum=0),
+            2**53 + 1,
+        )
 
     def test_get_grid(self):
         grid_density_parameter = 100


### PR DESCRIPTION
## Bug

`_validate_integral_scalar()` converted count-like inputs to binary64 and used `float.is_integer()` to decide whether they were integral. Exact numeric values above binary64's consecutive-integer range can lose their fractional part during that conversion.

For example, `Fraction(2**54 + 1, 2)` is exactly a half-integer, but converts to the integer-valued float `2**53`. The old validator therefore accepted it as an enormous count. Public callers could then pass that count into random-sample allocation or `linspace` grid construction.

## Fix

- convert the original scalar directly with `int()`;
- compare that integer against the original exact scalar;
- reject values that are not exactly integral without narrowing through binary64;
- preserve ordinary Python/NumPy integer-like inputs and exact integral numeric values.

## Regression coverage

- reject a large exact half-integer whose fractional part disappears in binary64;
- preserve the adjacent exact integral `Fraction` without allocating samples or a grid.

## Validation

- reproduced the old acceptance deterministically (`float(value).is_integer()` is true while `value != int(value)`);
- exercised the patched validator for standard integer-like arrays, non-finite values, invalid scalar types, the rounded half-integer, and the adjacent exact integer;
- syntax-compiled the exact modified source and test files;
- checked the exact files with local Black/isort when available;
- branch is two focused commits ahead and zero behind current `main`.

GitHub Actions will provide the authoritative repository-wide and backend validation.