### PR TITLE
Reject nested invalid assignment cost values

### DIFF
--- a/src/pyrecest/utils/assignment.py
+++ b/src/pyrecest/utils/assignment.py
@@ -107,44 +107,61 @@ def _has_temporal_dtype(value) -> bool:
         return "datetime64" in dtype_name or "timedelta64" in dtype_name
 
 
-def _contains_boolean_values(value) -> bool:
-    if isinstance(value, _BOOLEAN_TYPES):
+def _contains_values_of_type(
+    value,
+    types: tuple[type, ...],
+    active_ids: set[int] | None = None,
+) -> bool:
+    if isinstance(value, types):
         return True
-    try:
-        values = _np.asarray(_to_numpy(value), dtype=object).reshape(-1)
-    except (TypeError, ValueError, RuntimeError):
+
+    if isinstance(value, _np.ndarray):
+        items = value.reshape(-1)
+    elif isinstance(value, (list, tuple)):
+        items = value
+    else:
+        try:
+            converted = _np.asarray(_to_numpy(value), dtype=object)
+        except (TypeError, ValueError, OverflowError, RuntimeError):
+            return False
+        if converted.shape == ():
+            item = converted.item()
+            if isinstance(item, types):
+                return True
+            if isinstance(item, (_np.ndarray, list, tuple)):
+                return _contains_values_of_type(item, types, active_ids)
+            return False
+        value = converted
+        items = converted.reshape(-1)
+
+    if active_ids is None:
+        active_ids = set()
+    value_id = id(value)
+    if value_id in active_ids:
         return False
-    return any(isinstance(item, _BOOLEAN_TYPES) for item in values)
+    active_ids.add(value_id)
+    try:
+        return any(
+            _contains_values_of_type(item, types, active_ids) for item in items
+        )
+    finally:
+        active_ids.remove(value_id)
+
+
+def _contains_boolean_values(value) -> bool:
+    return _contains_values_of_type(value, _BOOLEAN_TYPES)
 
 
 def _contains_text_values(value) -> bool:
-    if isinstance(value, _TEXT_TYPES):
-        return True
-    try:
-        values = _np.asarray(_to_numpy(value), dtype=object).reshape(-1)
-    except (TypeError, ValueError, RuntimeError):
-        return False
-    return any(isinstance(item, _TEXT_TYPES) for item in values)
+    return _contains_values_of_type(value, _TEXT_TYPES)
 
 
 def _contains_temporal_values(value) -> bool:
-    if isinstance(value, _TEMPORAL_TYPES):
-        return True
-    try:
-        values = _np.asarray(_to_numpy(value), dtype=object).reshape(-1)
-    except (TypeError, ValueError, RuntimeError):
-        return False
-    return any(isinstance(item, _TEMPORAL_TYPES) for item in values)
+    return _contains_values_of_type(value, _TEMPORAL_TYPES)
 
 
 def _contains_complex_values(value) -> bool:
-    if isinstance(value, _COMPLEX_TYPES):
-        return True
-    try:
-        values = _np.asarray(_to_numpy(value), dtype=object).reshape(-1)
-    except (TypeError, ValueError, RuntimeError):
-        return False
-    return any(isinstance(item, _COMPLEX_TYPES) for item in values)
+    return _contains_values_of_type(value, _COMPLEX_TYPES)
 
 
 def _coerce_cost_matrix(cost_matrix):

--- a/tests/utils/test_assignment_nested_value_validation.py
+++ b/tests/utils/test_assignment_nested_value_validation.py
@@ -1,0 +1,71 @@
+import unittest
+
+import numpy as np
+import pyrecest.backend
+from pyrecest.utils import (
+    min_cost_max_cardinality_assignment,
+    murty_k_best_assignments,
+)
+
+
+def _nested_object_array(value, shape):
+    result = np.empty(shape, dtype=object)
+    result.flat[0] = np.asarray(value)
+    return result
+
+
+class AssignmentNestedValueValidationTest(unittest.TestCase):
+    @staticmethod
+    def _solvers():
+        return (
+            ("murty", lambda matrix: murty_k_best_assignments(matrix, k=1)),
+            ("max_cardinality", min_cost_max_cardinality_assignment),
+        )
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on the JAX backend",
+    )
+    def test_nested_complex_cost_matrix_entries_are_rejected(self):
+        matrix = _nested_object_array(1.0 + 2.0j, (1, 1))
+
+        for solver_name, solver in self._solvers():
+            with self.subTest(solver=solver_name):
+                with self.assertRaisesRegex(ValueError, "real-valued"):
+                    solver(matrix)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on the JAX backend",
+    )
+    def test_nested_complex_non_assignment_costs_are_rejected(self):
+        invalid_costs = _nested_object_array(1.0 + 2.0j, (1,))
+
+        for name in ("row_non_assignment_costs", "col_non_assignment_costs"):
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(ValueError, "real-valued"):
+                    murty_k_best_assignments(
+                        np.array([[0.0]]),
+                        k=1,
+                        **{name: invalid_costs},
+                    )
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on the JAX backend",
+    )
+    def test_nested_real_scalar_arrays_remain_supported(self):
+        solutions = murty_k_best_assignments(
+            _nested_object_array(0.25, (1, 1)),
+            k=1,
+            row_non_assignment_costs=_nested_object_array(2.0, (1,)),
+            col_non_assignment_costs=_nested_object_array(0.0, (1,)),
+        )
+
+        self.assertEqual(len(solutions), 1)
+        np.testing.assert_array_equal(solutions[0]["assignment"], np.array([0]))
+        self.assertAlmostEqual(solutions[0]["cost"], 0.25)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

Assignment cost validation inspected only the immediate elements of object arrays. A zero-dimensional complex array nested inside a cost matrix or non-assignment cost vector therefore bypassed the complex-value check.

The later floating-point conversion emitted a `ComplexWarning` and silently discarded the imaginary component, so Murty and maximum-cardinality assignment could solve a different real-valued problem than the caller supplied.

## Fix

- recursively inspect NumPy arrays, lists, tuples, and backend-convertible arrays for invalid scalar types;
- guard recursive inspection against cyclic containers;
- reject nested complex cost-matrix and non-assignment values before any floating-point cast;
- preserve support for nested zero-dimensional real scalar arrays.

## Validation

- reproduced the old silent complex-to-real cast for cost matrices and row/column non-assignment costs;
- `python -m py_compile` passed for the modified module and regression test;
- isolated NumPy/SciPy execution passed all three new regression tests;
- additional smoke checks covered nested Boolean, text, temporal, complex, real, and cyclic object values.

GitHub Actions should run the full repository and backend matrices.