### PR TITLE
Fix mixed-dtype PyTorch array_equal comparisons

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_array_equal_mixed_dtype_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_array_equal_mixed_dtype_contract.py
@@ -1,0 +1,95 @@
+"""PyTorch ``array_equal`` mixed-dtype compatibility hook."""
+
+from __future__ import annotations
+
+
+def _preferred_pytorch_device(torch_module, *values):
+    """Return a non-CPU tensor device when mixed-device operands are present."""
+    for value in values:
+        if torch_module.is_tensor(value) and value.device.type != "cpu":
+            return value.device
+    for value in values:
+        if torch_module.is_tensor(value):
+            return value.device
+    return None
+
+
+def _tensor_on_device(torch_module, value, *, device):
+    """Return ``value`` as a tensor on the preferred existing device."""
+    if torch_module.is_tensor(value):
+        if device is not None and value.device != device:
+            return value.to(device=device)
+        return value
+    return torch_module.as_tensor(value, device=device)
+
+
+def _is_integral_dtype(dtype) -> bool:
+    """Return whether a PyTorch dtype is integral or boolean."""
+    return not dtype.is_floating_point and not dtype.is_complex
+
+
+def _to_numpy_exact(value, torch_module):
+    """Convert a dense tensor to NumPy without losing bfloat16 values."""
+    if value.dtype == torch_module.bfloat16:
+        value = value.to(dtype=torch_module.float32)
+    return value.detach().cpu().numpy()
+
+
+def patch_pytorch_array_equal_mixed_dtype_contract() -> None:
+    """Prevent lossy or unsupported promotion in PyTorch ``array_equal``."""
+    try:
+        import numpy as np  # pylint: disable=import-outside-toplevel
+        import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+        import torch  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - PyTorch backend may be unavailable
+        return
+
+    original_array_equal = getattr(raw_pytorch, "array_equal", None)
+    if original_array_equal is None or not getattr(
+        original_array_equal,
+        "_pyrecest_equal_nan_contract",
+        False,
+    ):
+        return
+
+    active_pytorch_backend = getattr(backend, "__backend_name__", None) == "pytorch"
+    if getattr(
+        original_array_equal,
+        "_pyrecest_exact_mixed_dtype_contract",
+        False,
+    ):
+        if active_pytorch_backend:
+            backend.array_equal = original_array_equal
+        return
+
+    def array_equal(a, b, equal_nan=False):
+        device = _preferred_pytorch_device(torch, a, b)
+        a = _tensor_on_device(torch, a, device=device)
+        b = _tensor_on_device(torch, b, device=device)
+        if tuple(a.shape) != tuple(b.shape):
+            return False
+
+        if a.dtype != b.dtype and (
+            _is_integral_dtype(a.dtype) or _is_integral_dtype(b.dtype)
+        ):
+            return bool(
+                np.array_equal(
+                    _to_numpy_exact(a, torch),
+                    _to_numpy_exact(b, torch),
+                    equal_nan=equal_nan,
+                )
+            )
+        return original_array_equal(a, b, equal_nan=equal_nan)
+
+    array_equal.__name__ = getattr(original_array_equal, "__name__", "array_equal")
+    array_equal.__doc__ = getattr(original_array_equal, "__doc__", None)
+    array_equal._pyrecest_equal_nan_contract = True
+    array_equal._pyrecest_numpy_contract = True
+    array_equal._pyrecest_exact_mixed_dtype_contract = True
+    raw_pytorch.array_equal = array_equal
+    if active_pytorch_backend:
+        backend.array_equal = array_equal
+
+
+__all__ = ["patch_pytorch_array_equal_mixed_dtype_contract"]

--- a/src/pyrecest/backend_support/_pytorch_where_device_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_where_device_contract.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import importlib
 
+from pyrecest.backend_support._pytorch_array_equal_mixed_dtype_contract import (
+    patch_pytorch_array_equal_mixed_dtype_contract as _patch_pytorch_array_equal_mixed_dtype_contract,
+)
+
 
 def _preferred_pytorch_device(torch_module, *values):
     """Return a non-CPU tensor device when mixed-device operands are present."""
@@ -42,6 +46,8 @@ def _raw_pytorch_module():
 
 def patch_pytorch_where_device_contract() -> None:
     """Patch raw/public PyTorch ``where`` to preserve an existing non-CPU device."""
+    _patch_pytorch_array_equal_mixed_dtype_contract()
+
     try:
         import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
         import torch  # pylint: disable=import-outside-toplevel

--- a/tests/backend_support/test_pytorch_array_equal_mixed_dtype_contract.py
+++ b/tests/backend_support/test_pytorch_array_equal_mixed_dtype_contract.py
@@ -1,0 +1,61 @@
+import importlib.util
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+pytestmark = pytest.mark.backend_portable
+
+
+def _mixed_dtype_contract_code(target_module):
+    return f"""
+import torch
+import pyrecest.stability  # noqa: F401  # triggers backend compatibility patches
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+
+target = {target_module}
+
+# PyTorch cannot promote uint64 and int64, but array_equal must return a bool.
+assert not target.array_equal(
+    torch.tensor([2**63 - 1], dtype=torch.uint64),
+    torch.tensor([2**63 - 2], dtype=torch.int64),
+)
+assert target.array_equal(
+    torch.tensor([1], dtype=torch.uint64),
+    torch.tensor([1], dtype=torch.int64),
+)
+
+# Promoting int64 to float32 would round away this one-unit difference.
+assert not target.array_equal(
+    torch.tensor([2**24 + 1], dtype=torch.int64),
+    torch.tensor([float(2**24)], dtype=torch.float32),
+)
+assert target.array_equal(
+    torch.tensor([2**24], dtype=torch.int64),
+    torch.tensor([float(2**24)], dtype=torch.float32),
+)
+
+print("ok")
+"""
+
+
+def test_raw_pytorch_array_equal_handles_mixed_integral_dtypes_exactly():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code("numpy", _mixed_dtype_contract_code("raw_pytorch"))
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_public_pytorch_array_equal_handles_mixed_integral_dtypes_exactly():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code("pytorch", _mixed_dtype_contract_code("backend"))
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Summary

- prevent `array_equal` from calling unsupported PyTorch promotion for mixed `uint64`/signed-integer tensors
- avoid lossy integer-to-floating promotion that can make distinct values compare equal
- preserve the existing homogeneous/floating fast path and `equal_nan` behavior
- add raw-backend and public-backend regression coverage

## Root cause

The PyTorch compatibility wrapper normalized both operands with `torch.promote_types` before comparison. PyTorch rejects combinations such as `uint64` with `int64`; other combinations such as `int64` with `float32` can round integer values before comparison. NumPy's `array_equal` returns an exact boolean for both cases.

The new late compatibility hook delegates only mixed comparisons involving an integral or boolean dtype to NumPy after preserving tensor values. All other comparisons continue through the existing device-aware implementation.

## Validation

- compiled the new compatibility module locally
- ran isolated regression checks with NumPy 2.3.5 and PyTorch 2.10.0 for:
  - unequal and equal `uint64`/`int64` inputs
  - an `int64`/`float32` pair whose one-unit difference is lost by float32 promotion
  - existing `equal_nan=True` behavior
- full backend matrix is left to GitHub Actions
