### PR TITLE
Fix Gaussian mixture sequence weights

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/gaussian_mixture.py
+++ b/src/pyrecest/distributions/nonperiodic/gaussian_mixture.py
@@ -69,8 +69,10 @@ class GaussianMixture(LinearMixture, AbstractLinearDistribution):
     ):
         if weights is None:
             weights = ones(means.shape[0]) / means.shape[0]
+        else:
+            weights = array(weights)
 
-        C_from_cov = sum(covariance_matrices * weights.reshape(1, 1, -1), axis=2)
+        C_from_cov = sum(covariance_matrices * reshape(weights, (1, 1, -1)), axis=2)
         mu, C_from_means = LinearDiracDistribution.weighted_samples_to_mean_and_cov(
             means, weights
         )

--- a/tests/distributions/test_gaussian_mixture_constructor.py
+++ b/tests/distributions/test_gaussian_mixture_constructor.py
@@ -1,7 +1,9 @@
 import unittest
 
+import numpy as np
+
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array
+from pyrecest.backend import array, to_numpy
 from pyrecest.distributions.nonperiodic.gaussian_mixture import GaussianMixture
 from pyrecest.distributions.nonperiodic.linear_dirac_distribution import (
     LinearDiracDistribution,
@@ -18,6 +20,21 @@ class GaussianMixtureConstructorTest(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "GaussianDistribution"):
             GaussianMixture([component], array([1.0]))
+
+    def test_parameter_conversion_accepts_sequence_weights(self):
+        means = array([[0.0], [2.0]])
+        covariance_matrices = array([[[1.0, 3.0]]])
+
+        for weights in ([0.25, 0.75], (0.25, 0.75)):
+            with self.subTest(weight_type=type(weights).__name__):
+                mean, covariance = (
+                    GaussianMixture.mixture_parameters_to_gaussian_parameters(
+                        means, covariance_matrices, weights
+                    )
+                )
+
+                np.testing.assert_allclose(to_numpy(mean), [1.5])
+                np.testing.assert_allclose(to_numpy(covariance), [[3.25]])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Bug

`GaussianMixture.mixture_parameters_to_gaussian_parameters` accepted backend arrays for explicit weights but crashed for ordinary Python lists or tuples because it called `weights.reshape(...)` directly.

This is inconsistent with the rest of the mixture API, where sequence weights are valid, and makes the public static conversion helper fail before performing any numerical work.

## Fix

- convert explicit weights through the active PyRecEst backend;
- use the backend `reshape` operation instead of an array-instance method;
- add regression coverage for both list and tuple weights;
- verify the resulting mean and covariance numerically.

## Validation

The branch is two commits ahead of `main` and changes only the Gaussian-mixture conversion helper and its focused test. GitHub Actions should run the repository's full backend matrix.