### PR TITLE
Reject fractionally rounded Bingham sample counts

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/bingham_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/bingham_distribution.py
@@ -48,11 +48,14 @@ def _validate_positive_sample_count(n) -> int:
 
     try:
         count_int = int(count)
-        count_float = float(count)
     except (OverflowError, TypeError, ValueError) as exc:
         raise ValueError("n must be an integer") from exc
 
-    if not _np.isfinite(count_float) or not count_float.is_integer():
+    try:
+        is_exact_integer = count == count_int
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("n must be a finite integer") from exc
+    if not bool(is_exact_integer):
         raise ValueError("n must be a finite integer")
     if count_int <= 0:
         raise ValueError("n must be positive")

--- a/tests/distributions/test_bingham_sample_count_precision.py
+++ b/tests/distributions/test_bingham_sample_count_precision.py
@@ -1,0 +1,22 @@
+"""Regression tests for exact Bingham sample-count validation."""
+
+from fractions import Fraction
+
+import pytest
+
+from pyrecest.distributions.hypersphere_subset.bingham_distribution import (
+    _validate_positive_sample_count,
+)
+
+
+def test_rejects_fraction_rounded_to_integer_by_binary64():
+    rounded_half_integer = Fraction(2**54 + 1, 2)
+
+    with pytest.raises(ValueError, match="finite integer"):
+        _validate_positive_sample_count(rounded_half_integer)
+
+
+def test_preserves_exact_large_integer():
+    exact_integer = Fraction(2**54 + 2, 2)
+
+    assert _validate_positive_sample_count(exact_integer) == 2**53 + 1


### PR DESCRIPTION
## Bug

`BinghamDistribution.sample` validated sample counts by converting them to binary64 and then calling `is_integer()`. Above the exact-integer range of binary64, a genuinely fractional value can round to an integer and pass validation.

For example, `Fraction(2**54 + 1, 2)` is exactly `9007199254740992.5`, but its binary64 representation is `9007199254740992.0`. The previous validator therefore accepted it and could proceed toward an enormous unintended allocation.

## Fix

- convert the scalar to `int` as before;
- check exact equality against the original scalar instead of checking a rounded float;
- retain the existing rejection of booleans, non-scalars, non-finite values, and non-positive counts;
- add regressions for the rounded half-integer and the adjacent exact large integer.

## Validation

- reproduced that the old logic accepts the fractional `Fraction` after binary64 rounding;
- verified that the new logic rejects it;
- verified that `Fraction(2**54 + 2, 2)` remains accepted as `2**53 + 1`;
- compared the branch with `main`: two files changed, with 5 additions/2 deletions in production code and one focused 22-line test file.

The full backend matrix is left to GitHub Actions.