### PR TITLE
Reject fractionally rounded partially wrapped counts

### DIFF
--- a/src/pyrecest/distributions/cart_prod/partially_wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/partially_wrapped_normal_distribution.py
@@ -52,11 +52,14 @@ def _validate_positive_sample_count(n) -> int:
 
     try:
         count_int = int(count)
-        count_float = float(count)
     except (OverflowError, TypeError, ValueError) as exc:
         raise ValueError("n must be an integer") from exc
 
-    if not np.isfinite(count_float) or not count_float.is_integer():
+    try:
+        is_exact_integer = count == count_int
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("n must be a finite integer") from exc
+    if not bool(is_exact_integer):
         raise ValueError("n must be a finite integer")
     if count_int <= 0:
         raise ValueError("n must be positive")
@@ -74,11 +77,14 @@ def _validate_nonnegative_wrap_count(m) -> int:
 
     try:
         count_int = int(count)
-        count_float = float(count)
     except (OverflowError, TypeError, ValueError) as exc:
         raise ValueError("m must be an integer") from exc
 
-    if not np.isfinite(count_float) or not count_float.is_integer():
+    try:
+        is_exact_integer = count == count_int
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("m must be a finite integer") from exc
+    if not bool(is_exact_integer):
         raise ValueError("m must be a finite integer")
     if count_int < 0:
         raise ValueError("m must be non-negative")

--- a/tests/distributions/test_partially_wrapped_count_precision.py
+++ b/tests/distributions/test_partially_wrapped_count_precision.py
@@ -1,0 +1,34 @@
+"""Regression tests for exact partially wrapped count validation."""
+
+from fractions import Fraction
+
+import pytest
+
+from pyrecest.distributions.cart_prod.partially_wrapped_normal_distribution import (
+    _validate_nonnegative_wrap_count,
+    _validate_positive_sample_count,
+)
+
+
+@pytest.mark.parametrize(
+    ("validator", "message"),
+    [
+        (_validate_positive_sample_count, "n must be a finite integer"),
+        (_validate_nonnegative_wrap_count, "m must be a finite integer"),
+    ],
+)
+def test_rejects_fraction_rounded_to_integer_by_binary64(validator, message):
+    rounded_half_integer = Fraction(2**54 + 1, 2)
+
+    with pytest.raises(ValueError, match=message):
+        validator(rounded_half_integer)
+
+
+@pytest.mark.parametrize(
+    "validator",
+    [_validate_positive_sample_count, _validate_nonnegative_wrap_count],
+)
+def test_preserves_exact_large_integer(validator):
+    exact_integer = Fraction(2**54 + 2, 2)
+
+    assert validator(exact_integer) == 2**53 + 1


### PR DESCRIPTION
## Bug

`PartiallyWrappedNormalDistribution` validated both sample count `n` and wrap count `m` by converting the input to binary64 and calling `is_integer()`. Above binary64's exact-integer range, an exact fractional value can round to an integer and pass validation.

For example, `Fraction(2**54 + 1, 2)` is exactly `9007199254740992.5`, but converts to the binary64 value `9007199254740992.0`. This could admit an invalid sample count or trigger an unexpectedly enormous wrap grid.

## Fix

- convert scalar counts to `int` as before;
- compare the original scalar to that integer exactly instead of inspecting a rounded float;
- preserve existing rejection of booleans, non-scalars, non-finite values, negative wrap counts, and non-positive sample counts;
- add regressions for the rounded half-integer and the neighboring exact large integer for both validators.

## Validation

The branch differs from its merge base in exactly two files: 10 additions/4 deletions in the validators and one focused 34-line regression test file. Full backend CI is delegated to GitHub Actions.