### PR TITLE
Reject fractionally rounded particle-filter counts

### DIFF
--- a/src/pyrecest/filters/euclidean_particle_filter.py
+++ b/src/pyrecest/filters/euclidean_particle_filter.py
@@ -84,13 +84,16 @@ class EuclideanParticleFilter(AbstractParticleFilter, EuclideanFilterMixin):
             raise ValueError(message)
 
         try:
-            scalar_float = float(scalar)
+            integer = int(scalar)
         except (TypeError, ValueError, OverflowError) as exc:
             raise ValueError(message) from exc
-        if not np.isfinite(scalar_float) or not scalar_float.is_integer():
+        try:
+            is_exact_integer = bool(scalar == integer)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(message) from exc
+        if not is_exact_integer:
             raise ValueError(message)
 
-        integer = int(scalar_float)
         if integer <= 0:
             raise ValueError(message)
         return integer

--- a/src/pyrecest/filters/hypertoroidal_particle_filter.py
+++ b/src/pyrecest/filters/hypertoroidal_particle_filter.py
@@ -38,13 +38,16 @@ def _validate_positive_integer(value, name: str) -> int:
         raise ValueError(message)
 
     try:
-        scalar_float = float(scalar)
+        integer = int(scalar)
     except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError(message) from exc
-    if not np.isfinite(scalar_float) or not scalar_float.is_integer():
+    try:
+        is_exact_integer = bool(scalar == integer)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if not is_exact_integer:
         raise ValueError(message)
 
-    integer = int(scalar_float)
     if integer <= 0:
         raise ValueError(message)
     return integer

--- a/tests/filters/test_particle_filter_count_precision.py
+++ b/tests/filters/test_particle_filter_count_precision.py
@@ -1,0 +1,29 @@
+from fractions import Fraction
+
+import pytest
+
+from pyrecest.filters.euclidean_particle_filter import EuclideanParticleFilter
+from pyrecest.filters.hypertoroidal_particle_filter import _validate_positive_integer
+
+
+def _validate_euclidean(value):
+    return EuclideanParticleFilter._validate_positive_int(value, "count")
+
+
+def _validate_hypertoroidal(value):
+    return _validate_positive_integer(value, "count")
+
+
+@pytest.mark.parametrize(
+    "validator",
+    [_validate_euclidean, _validate_hypertoroidal],
+    ids=["euclidean", "hypertoroidal"],
+)
+def test_particle_filter_count_validation_is_exact(validator):
+    rounded_half_integer = Fraction(2**54 + 1, 2)
+    exact_large_integer = Fraction(2**54 + 2, 2)
+
+    with pytest.raises(ValueError, match="positive integer"):
+        validator(rounded_half_integer)
+
+    assert validator(exact_large_integer) == 2**53 + 1


### PR DESCRIPTION
## Bug

The Euclidean and hypertoroidal particle-filter count validators converted candidate values to binary64 and then used `float.is_integer()`.

For exact numeric inputs above binary64's consecutive-integer range, a fractional value can round to an integer. In particular, `Fraction(2**54 + 1, 2)` is exactly `9007199254740992.5`, but converts to the integer-valued float `9007199254740992.0`. Both constructors therefore accepted it as an enormous particle count and could proceed toward an unintended allocation.

## Fix

- convert the original scalar directly with `int()`;
- compare the integer against the original scalar without a binary64 round-trip;
- preserve rejection of booleans, text, complex values, non-scalars, non-finite values, and non-positive counts;
- apply the same validation correction to both Euclidean and hypertoroidal particle filters.

## Regression coverage

A focused non-allocating test verifies for both validators that:

- the rounded exact half-integer is rejected;
- the adjacent exact large integer remains accepted.

## Validation

- reproduced that the old binary64-based logic accepts the half-integer;
- verified the patched logic rejects it;
- verified ordinary positive integer-like inputs remain accepted;
- verified zero, negative, fractional, NaN, and infinite controls remain rejected;
- branch comparison shows only the two validators and one focused regression file changed.

GitHub Actions should provide the authoritative full backend and repository test matrix.