### PR TITLE
Reject fractionally rounded DVS event counts

### DIFF
--- a/src/pyrecest/experimental/dvs/synthetic.py
+++ b/src/pyrecest/experimental/dvs/synthetic.py
@@ -182,6 +182,30 @@ def _as_finite_real_scalar(value, name: str) -> float:
     return value_float
 
 
+def _as_exact_integer(value, name: str, integer_message: str) -> int:
+    """Return an integer scalar without losing exactness through float rounding."""
+    value_array = np.asarray(value)
+    if value_array.shape != () or value_array.dtype.kind in "bcSU":
+        raise ValueError(f"{name} must be a finite real scalar")
+    scalar = value_array.item()
+    if isinstance(scalar, _INVALID_REAL_SCALAR_TYPES):
+        raise ValueError(f"{name} must be a finite real scalar")
+    try:
+        value_float = float(scalar)
+        value_int = int(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"{name} must be a finite real scalar") from exc
+    if not np.isfinite(value_float):
+        raise ValueError(f"{name} must be a finite real scalar")
+    try:
+        is_exact_integer = bool(scalar == value_int)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(integer_message) from exc
+    if not is_exact_integer:
+        raise ValueError(integer_message)
+    return value_int
+
+
 def _validate_probability_floor(probability_floor: float) -> float:
     value = _as_finite_real_scalar(probability_floor, "probability_floor")
     if value <= 0.0 or value > 1.0:
@@ -197,20 +221,23 @@ def _nonnegative_real_scalar(value, name: str) -> float:
 
 
 def _positive_integer_count(value, name: str) -> int:
-    scalar = _as_finite_real_scalar(value, name)
-    if scalar <= 0.0 or not scalar.is_integer():
-        raise ValueError(f"{name} must be a positive integer")
-    return int(scalar)
+    message = f"{name} must be a positive integer"
+    value_int = _as_exact_integer(value, name, message)
+    if value_int <= 0:
+        raise ValueError(message)
+    return value_int
 
 
 def _edge_count(observed_counts: dict[str, int], edge: str) -> int:
-    value = _as_finite_real_scalar(
+    message = "observed_counts values must be non-negative integers"
+    value_int = _as_exact_integer(
         _mapping_value(observed_counts, edge, "observed_counts"),
         "observed_counts values",
+        message,
     )
-    if value < 0.0 or not value.is_integer():
-        raise ValueError("observed_counts values must be non-negative integers")
-    return int(value)
+    if value_int < 0:
+        raise ValueError(message)
+    return value_int
 
 
 def _edge_probability(

--- a/tests/experimental/test_dvs_synthetic.py
+++ b/tests/experimental/test_dvs_synthetic.py
@@ -1,3 +1,5 @@
+from fractions import Fraction
+
 import numpy as np
 import pytest
 from pyrecest.experimental.dvs import (
@@ -8,6 +10,7 @@ from pyrecest.experimental.dvs import (
 )
 
 _EDGES = ("left", "right", "top", "bottom")
+_ROUNDED_HALF_INTEGER = Fraction(2**54 + 1, 2)
 
 
 def test_motion_gated_counts_concentrate_on_vertical_edges():
@@ -53,7 +56,16 @@ def test_uniform_edge_probabilities_sum_to_one():
 def test_count_nll_rejects_invalid_observed_counts():
     probabilities = {edge: 0.25 for edge in _EDGES}
 
-    for bad_count in (-1, 1.5, np.nan, np.inf, True, "2", np.array([2])):
+    for bad_count in (
+        -1,
+        1.5,
+        _ROUNDED_HALF_INTEGER,
+        np.nan,
+        np.inf,
+        True,
+        "2",
+        np.array([2]),
+    ):
         observed_counts = {edge: 1 for edge in _EDGES}
         observed_counts["left"] = bad_count
         with pytest.raises(ValueError, match="observed_counts"):
@@ -118,7 +130,16 @@ def test_edge_probabilities_from_activity_rejects_invalid_weights():
 
 
 def test_simulate_rectangle_event_counts_rejects_invalid_total_events():
-    for bad_total_events in (0, -1, 1.5, np.nan, np.inf, True, "4"):
+    for bad_total_events in (
+        0,
+        -1,
+        1.5,
+        _ROUNDED_HALF_INTEGER,
+        np.nan,
+        np.inf,
+        True,
+        "4",
+    ):
         with pytest.raises(ValueError, match="total_events"):
             simulate_rectangle_event_counts(
                 np.array([1.0, 0.0]),


### PR DESCRIPTION
## Summary

- validate DVS event counts against their original scalar value instead of a binary64-rounded copy
- reject fractional values that round to integers above binary64's exact-integer range
- apply the fix to both `total_events` and observed per-edge counts
- add regressions using `Fraction(2**54 + 1, 2)`

## Bug

The DVS synthetic-count helpers converted candidate counts to `float` before checking `is_integer()`. A genuinely fractional value such as `Fraction(2**54 + 1, 2)` is exactly `9007199254740992.5`, but binary64 rounds it to `9007199254740992.0`. The old validation therefore accepted the fractional count.

For `total_events`, this could pass an unintended enormous count to NumPy's multinomial sampler. For observed edge counts, it could silently evaluate a likelihood using the rounded integer.

## Fix

The new helper preserves the original scalar, converts it to `int`, and checks exact equality against that original value. Existing validation for booleans, strings, complex values, non-scalars, and non-finite values remains intact.

## Validation

- added public regressions for rounded fractional `total_events` and observed edge counts
- checked representative Python, NumPy, and `Fraction` scalar behavior, including exact integer fractions and the rounded half-integer case
- branch is two commits ahead of current `main` and touches only the DVS synthetic module and its focused tests

Full repository CI is left to GitHub Actions.