### PR TITLE
Reject fractionally rounded complex ACG sample counts

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/complex_angular_central_gaussian_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/complex_angular_central_gaussian_distribution.py
@@ -45,11 +45,14 @@ def _validate_positive_sample_count(n) -> int:
 
     try:
         count_int = int(count)
-        count_float = float(count)
     except (OverflowError, TypeError, ValueError) as exc:
         raise ValueError("n must be an integer") from exc
 
-    if not np.isfinite(count_float) or not count_float.is_integer():
+    try:
+        is_exact_integer = count == count_int
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("n must be a finite integer") from exc
+    if not bool(is_exact_integer):
         raise ValueError("n must be a finite integer")
     if count_int <= 0:
         raise ValueError("n must be positive")

--- a/tests/distributions/test_complex_acg_sample_count_precision.py
+++ b/tests/distributions/test_complex_acg_sample_count_precision.py
@@ -1,0 +1,27 @@
+from fractions import Fraction
+import unittest
+
+from pyrecest.distributions.hypersphere_subset.complex_angular_central_gaussian_distribution import (
+    _validate_positive_sample_count,
+)
+
+
+class TestComplexAngularCentralGaussianSampleCountPrecision(unittest.TestCase):
+    def test_rejects_fraction_rounded_to_integer_by_binary64(self):
+        rounded_half_integer = Fraction(2**54 + 1, 2)
+        self.assertTrue(float(rounded_half_integer).is_integer())
+
+        with self.assertRaisesRegex(ValueError, "finite integer"):
+            _validate_positive_sample_count(rounded_half_integer)
+
+    def test_accepts_adjacent_exact_integer(self):
+        exact_integer = Fraction(2**54 + 2, 2)
+
+        self.assertEqual(
+            _validate_positive_sample_count(exact_integer),
+            2**53 + 1,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`ComplexAngularCentralGaussianDistribution.sample` validated its sample count by converting the scalar to binary64 and calling `is_integer()`.

Above binary64's consecutive-integer range, an exact fractional value can round to an integer-valued float. For example, `Fraction(2**54 + 1, 2)` is exactly `9007199254740992.5`, but converts to `9007199254740992.0`. The previous validator accepted it and could proceed toward an enormous unintended random-array allocation.

## Fix

- convert the original scalar directly to `int`;
- compare that integer against the original exact scalar instead of a rounded float;
- preserve rejection of booleans, non-scalars, non-finite values, fractional values, and non-positive counts;
- preserve exact large integral numeric values.

## Regression coverage

- reject the half-integer whose fractional part disappears in binary64;
- accept the adjacent exact integral `Fraction` without allocating samples.

## Validation

- Python syntax compilation passed for the modified source and regression test;
- isolated validator checks passed for the precision regression and existing accepted/rejected count categories;
- branch comparison is limited to 5 additions/2 deletions in production code plus one focused 27-line regression file.

The full repository and backend matrix is left to GitHub Actions.