### PR TITLE
Reject temporal values in measurement generation

### DIFF
--- a/src/pyrecest/evaluation/generate_measurements.py
+++ b/src/pyrecest/evaluation/generate_measurements.py
@@ -15,14 +15,33 @@ from scipy.stats import poisson
 from shapely.affinity import rotate, translate
 from shapely.geometry import Polygon
 
+_TEMPORAL_SCALAR_TYPES = (np.datetime64, np.timedelta64)
+_TEMPORAL_DTYPE_KINDS = {"M", "m"}
+
 
 def _as_shapely_scalar(value, name="groundtruth component"):
     value_array = np.asarray(value)
-    if value_array.dtype == np.bool_ or value_array.size != 1:
+    if (
+        value_array.dtype == np.bool_
+        or value_array.dtype.kind in _TEMPORAL_DTYPE_KINDS
+        or value_array.size != 1
+    ):
         raise ValueError(f"{name} must be a finite scalar.")
 
     scalar = value_array.reshape(-1)[0]
-    if isinstance(scalar, (bool, np.bool_, str, bytes, bytearray, np.str_, np.bytes_)):
+    if isinstance(
+        scalar,
+        (
+            bool,
+            np.bool_,
+            str,
+            bytes,
+            bytearray,
+            np.str_,
+            np.bytes_,
+            *_TEMPORAL_SCALAR_TYPES,
+        ),
+    ):
         raise ValueError(f"{name} must be a finite scalar.")
     try:
         result = float(scalar)
@@ -35,11 +54,27 @@ def _as_shapely_scalar(value, name="groundtruth component"):
 
 def _as_nonnegative_measurement_count(value, name="measurement count") -> int:
     value_array = np.asarray(value)
-    if value_array.shape != () or value_array.dtype == np.bool_:
+    if (
+        value_array.shape != ()
+        or value_array.dtype == np.bool_
+        or value_array.dtype.kind in _TEMPORAL_DTYPE_KINDS
+    ):
         raise ValueError(f"{name} must be a non-negative integer.")
 
     scalar = value_array.item()
-    if isinstance(scalar, (bool, np.bool_, str, bytes, bytearray, np.str_, np.bytes_)):
+    if isinstance(
+        scalar,
+        (
+            bool,
+            np.bool_,
+            str,
+            bytes,
+            bytearray,
+            np.str_,
+            np.bytes_,
+            *_TEMPORAL_SCALAR_TYPES,
+        ),
+    ):
         raise ValueError(f"{name} must be a non-negative integer.")
     if isinstance(scalar, (int, np.integer)):
         count = int(scalar)
@@ -59,11 +94,25 @@ def _as_nonnegative_measurement_count(value, name="measurement count") -> int:
 
 def _as_nonnegative_finite_scalar(value, name: str) -> float:
     value_array = np.asarray(value)
-    if value_array.shape != () or value_array.dtype == np.bool_:
+    if (
+        value_array.shape != ()
+        or value_array.dtype == np.bool_
+        or value_array.dtype.kind in _TEMPORAL_DTYPE_KINDS
+    ):
         raise ValueError(f"{name} must be a finite non-negative scalar.")
 
     scalar = value_array.item()
-    if isinstance(scalar, (bool, np.bool_, str, bytes, bytearray)):
+    if isinstance(
+        scalar,
+        (
+            bool,
+            np.bool_,
+            str,
+            bytes,
+            bytearray,
+            *_TEMPORAL_SCALAR_TYPES,
+        ),
+    ):
         raise ValueError(f"{name} must be a finite non-negative scalar.")
     try:
         result = float(scalar)

--- a/tests/evaluation/test_generate_measurements_temporal_validation.py
+++ b/tests/evaluation/test_generate_measurements_temporal_validation.py
@@ -1,0 +1,46 @@
+import numpy as np
+import pytest
+from pyrecest.evaluation.generate_measurements import (
+    _as_nonnegative_measurement_count,
+    _as_shapely_scalar,
+    generate_n_measurements_PPP,
+)
+
+_TEMPORAL_SCALARS = (
+    np.datetime64("1970-01-01T00:00:00.000000001"),
+    np.timedelta64(1, "ns"),
+)
+
+
+@pytest.mark.parametrize("value", _TEMPORAL_SCALARS)
+def test_measurement_count_rejects_temporal_scalar_payloads(value):
+    with pytest.raises(ValueError, match="measurement count"):
+        _as_nonnegative_measurement_count(value)
+
+
+@pytest.mark.parametrize("value", _TEMPORAL_SCALARS)
+def test_shapely_scalar_rejects_temporal_scalar_payloads(value):
+    with pytest.raises(ValueError, match="groundtruth x must be a finite scalar"):
+        _as_shapely_scalar(value, "groundtruth x")
+
+
+@pytest.mark.parametrize("value", _TEMPORAL_SCALARS)
+@pytest.mark.parametrize("argument", ("area", "intensity_lambda"))
+def test_poisson_measurement_count_rejects_temporal_scalar_payloads(value, argument):
+    kwargs = {"area": 1.0, "intensity_lambda": 1.0}
+    kwargs[argument] = value
+
+    with pytest.raises(ValueError, match=argument):
+        generate_n_measurements_PPP(**kwargs)
+
+
+@pytest.mark.parametrize("value", _TEMPORAL_SCALARS)
+def test_object_wrapped_temporal_scalars_are_also_rejected(value):
+    wrapped = np.array(value, dtype=object)
+
+    with pytest.raises(ValueError, match="measurement count"):
+        _as_nonnegative_measurement_count(wrapped)
+    with pytest.raises(ValueError, match="groundtruth x must be a finite scalar"):
+        _as_shapely_scalar(wrapped, "groundtruth x")
+    with pytest.raises(ValueError, match="area"):
+        generate_n_measurements_PPP(wrapped, 1.0)


### PR DESCRIPTION
## Bug

NumPy can expose nanosecond-resolution `datetime64` and `timedelta64` scalars as their raw integer payload when `.item()` or `float(...)` is used. The measurement-generation validators therefore silently accepted temporal values such as `np.timedelta64(1, "ns")` as the numeric value `1`.

This affected:

- explicit measurement counts;
- EOT coordinates passed to Shapely;
- Poisson point-process area and intensity inputs.

## Fix

- reject temporal dtypes before scalar conversion;
- reject temporal scalar objects inside object-valued scalar arrays;
- preserve the existing support for ordinary numeric scalar-like inputs;
- add focused regressions for `datetime64`, `timedelta64`, and object-wrapped variants.

## Validation

- reproduced that the previous count validator converts both nanosecond temporal examples to `1`;
- verified the patched validation rejects direct and object-wrapped temporal scalars;
- compared against current `main`: two commits ahead, zero behind, changing only the measurement generator and one focused test file.

Full repository CI is left to GitHub Actions.