### PR TITLE
Fix squeeze validation for non-singleton axes

### DIFF
--- a/src/pyrecest/backend_support/_shared_numpy_squeeze_contract.py
+++ b/src/pyrecest/backend_support/_shared_numpy_squeeze_contract.py
@@ -1,0 +1,40 @@
+"""Compatibility patch for NumPy-style squeeze axis validation."""
+
+from __future__ import annotations
+
+
+def patch_shared_numpy_squeeze_nonsingleton_axis_contract() -> None:
+    """Reject explicitly selected axes whose extent is not one."""
+    try:
+        import pyrecest._backend._shared_numpy as shared_numpy  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - source tree corruption only
+        return
+
+    if getattr(backend, "__backend_name__", None) not in {"autograd", "numpy"}:
+        return
+
+    original_squeeze = shared_numpy.squeeze
+    if getattr(original_squeeze, "_pyrecest_nonsingleton_axis_contract", False):
+        backend.squeeze = original_squeeze
+        return
+
+    np_module = shared_numpy._np
+
+    def squeeze(x, axis=None):
+        values = np_module.asarray(x)
+        if axis is not None:
+            axes = shared_numpy._normalize_squeeze_axes(axis)
+            for one_axis in axes:
+                normalized_axis = one_axis + values.ndim if one_axis < 0 else one_axis
+                if 0 <= normalized_axis < values.ndim and values.shape[normalized_axis] != 1:
+                    raise ValueError(
+                        "cannot select an axis to squeeze out which has size not equal to one"
+                    )
+        return original_squeeze(values, axis=axis)
+
+    squeeze.__name__ = getattr(original_squeeze, "__name__", "squeeze")
+    squeeze.__doc__ = getattr(original_squeeze, "__doc__", None)
+    squeeze._pyrecest_nonsingleton_axis_contract = True
+    shared_numpy.squeeze = squeeze
+    backend.squeeze = squeeze

--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -240,6 +240,9 @@ try:
     from pyrecest.backend_support._pytorch_reduction_axis_contract import (  # pylint: disable=import-outside-toplevel
         patch_pytorch_reduction_axis_contract as _patch_pytorch_reduction_axis_contract,
     )
+    from pyrecest.backend_support._shared_numpy_squeeze_contract import (  # pylint: disable=import-outside-toplevel
+        patch_shared_numpy_squeeze_nonsingleton_axis_contract as _patch_shared_numpy_squeeze_nonsingleton_axis_contract,
+    )
 except ModuleNotFoundError:  # pragma: no cover - source tree corruption only
     pass
 else:
@@ -255,3 +258,4 @@ else:
     _patch_pytorch_quantile_empty_batch_contract()
     _patch_pytorch_reduction_axis_contract()
     _patch_jax_array_from_sparse_flat_index_contract()
+    _patch_shared_numpy_squeeze_nonsingleton_axis_contract()

--- a/tests/backend/test_shared_numpy_squeeze_contract.py
+++ b/tests/backend/test_shared_numpy_squeeze_contract.py
@@ -1,0 +1,34 @@
+import unittest
+
+import numpy as np
+
+import pyrecest.backend as backend
+
+
+@unittest.skipUnless(
+    backend.__backend_name__ in {"autograd", "numpy"},
+    reason="Shared NumPy squeeze contract only applies to NumPy-style backends",
+)
+class SharedNumPySqueezeContractTest(unittest.TestCase):
+    def test_explicit_nonsingleton_axis_is_rejected(self):
+        values = backend.array([[1.0, 2.0]])
+
+        with self.assertRaisesRegex(ValueError, "size not equal to one"):
+            backend.squeeze(values, axis=1)
+
+    def test_singleton_axis_is_squeezed(self):
+        values = backend.array([[1.0, 2.0]])
+
+        result = backend.squeeze(values, axis=0)
+
+        np.testing.assert_array_equal(backend.to_numpy(result), np.array([1.0, 2.0]))
+
+    def test_out_of_bounds_axis_remains_rejected(self):
+        values = backend.array([[1.0, 2.0]])
+
+        with self.assertRaises((IndexError, ValueError)):
+            backend.squeeze(values, axis=2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- reject explicit NumPy/Autograd squeeze axes whose extent is not one
- preserve existing singleton-axis and out-of-bounds behavior
- add focused regression coverage for the public backend facade

## Bug

`backend.squeeze(values, axis=...)` silently returned the unchanged array when the requested axis had size greater than one. NumPy raises `ValueError` for this invalid operation. The silent return can hide incorrect shape assumptions and allow downstream code to continue with an unexpected rank.

## Validation

- added regression tests for non-singleton, singleton, and out-of-bounds axes
- full validation is delegated to GitHub Actions because the local execution environment cannot resolve GitHub to install or run the checkout