### PR TITLE
Prevent pruned costs from winning global assignments

### DIFF
--- a/src/pyrecest/utils/candidate_pruning.py
+++ b/src/pyrecest/utils/candidate_pruning.py
@@ -395,17 +395,18 @@ def _finite_percentile(costs: np.ndarray, percentile: float) -> float | None:
 
 def _effective_large_cost(costs: np.ndarray, penalty: float) -> float:
     finite = costs[np.isfinite(costs)]
-    if finite.size == 0:
+    assignment_size = min(costs.shape)
+    if finite.size == 0 or assignment_size == 0:
         return penalty
 
-    max_finite = float(np.max(finite))
-    if penalty > max_finite:
-        return penalty
-
-    adjusted_penalty = float(np.nextafter(max_finite, np.inf))
-    if not np.isfinite(adjusted_penalty):
-        raise ValueError("large_cost is too small to exceed finite costs")
-    return adjusted_penalty
+    scale = max(1.0, float(np.max(np.abs(finite))))
+    with np.errstate(over="ignore"):
+        minimum_penalty = scale * float(2 * assignment_size + 1)
+    if not np.isfinite(minimum_penalty):
+        raise ValueError(
+            "finite costs are too large to construct a safe pruning penalty"
+        )
+    return max(penalty, float(minimum_penalty))
 
 
 def _as_cost_matrix(

--- a/tests/test_candidate_pruning_assignment_penalty.py
+++ b/tests/test_candidate_pruning_assignment_penalty.py
@@ -1,0 +1,26 @@
+import numpy as np
+import numpy.testing as npt
+from scipy.optimize import linear_sum_assignment
+
+from pyrecest.utils import (
+    CandidatePruningConfig,
+    candidate_mask_from_costs,
+    prune_pairwise_cost_matrix,
+)
+
+
+def test_pruned_cost_cannot_undercut_complete_retained_assignment():
+    costs = np.array(
+        [
+            [600_000.0, 600_001.0],
+            [0.0, 600_000.0],
+        ]
+    )
+    config = CandidatePruningConfig(max_cost=600_000.0)
+
+    retained = candidate_mask_from_costs(costs, config=config)
+    pruned_costs = prune_pairwise_cost_matrix(costs, config=config)
+    row_indices, column_indices = linear_sum_assignment(pruned_costs)
+
+    npt.assert_array_equal(column_indices, np.array([0, 1]))
+    assert np.all(retained[row_indices, column_indices])


### PR DESCRIPTION
## Summary

- make replacement costs for pruned association candidates safe at the assignment level, rather than merely larger than the largest individual matrix entry
- scale the blocker by the rectangular assignment cardinality and maximum absolute finite cost
- add a Hungarian-assignment regression where the previous default penalty selected a pruned edge despite a complete retained assignment being available

## Bug

For sufficiently large finite costs, the default `large_cost=1e6` could be lower than the total cost of a valid multi-row assignment. `linear_sum_assignment` could therefore select a pruned entry and displace retained candidates.

## Testing

- reproduced the failure with a 2x2 cost matrix and `scipy.optimize.linear_sum_assignment`
- verified the corrected matrix selects only retained candidates
- verified the updated module compiles locally
