### PR TITLE
Fix PyTorch fftconvolve unsigned dtype promotion

### DIFF
--- a/src/pyrecest/_backend/pytorch/signal.py
+++ b/src/pyrecest/_backend/pytorch/signal.py
@@ -85,6 +85,10 @@ def _preferred_tensor_device(*values):
     )
 
 
+def _is_inexact_dtype(dtype):
+    return dtype.is_floating_point or dtype.is_complex
+
+
 def _as_tensor_pair(in1, in2):
     device = _preferred_tensor_device(in1, in2)
     x = (
@@ -101,8 +105,15 @@ def _as_tensor_pair(in1, in2):
     )
     y = y.to(device=x.device)
 
-    dtype = _torch.promote_types(x.dtype, y.dtype)
-    if not (dtype.is_floating_point or dtype.is_complex):
+    x_is_inexact = _is_inexact_dtype(x.dtype)
+    y_is_inexact = _is_inexact_dtype(y.dtype)
+    if x_is_inexact and y_is_inexact:
+        dtype = _torch.promote_types(x.dtype, y.dtype)
+    elif x_is_inexact:
+        dtype = x.dtype
+    elif y_is_inexact:
+        dtype = y.dtype
+    else:
         dtype = _torch.get_default_dtype()
     return x.to(dtype=dtype), y.to(dtype=dtype)
 

--- a/tests/backend_support/test_pytorch_fftconvolve_unsigned_promotion.py
+++ b/tests/backend_support/test_pytorch_fftconvolve_unsigned_promotion.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pyrecest.backend as backend
+import pytest
+from scipy.signal import fftconvolve as scipy_fftconvolve
+
+
+@pytest.mark.parametrize(
+    ("first", "second"),
+    [
+        (
+            np.array([1, 2], dtype=np.uint64),
+            np.array([3, 4], dtype=np.int64),
+        ),
+        (
+            np.array([1, 2], dtype=np.uint64),
+            np.array([1.0 + 1.0j, 2.0 - 1.0j], dtype=np.complex64),
+        ),
+    ],
+    ids=["unsigned-and-signed", "unsigned-and-complex"],
+)
+def test_pytorch_fftconvolve_handles_unsigned_mixed_dtypes(first, second):
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific signal backend contract")
+
+    actual = backend.to_numpy(backend.signal.fftconvolve(first, second))
+    expected = scipy_fftconvolve(first, second)
+
+    assert np.allclose(actual, expected)


### PR DESCRIPTION
## Bug

The PyTorch backend's `fftconvolve` called `torch.promote_types` before converting exact numeric inputs to an FFT-compatible floating or complex dtype. PyTorch does not support promotion for combinations such as `uint64` with `int64` or `complex64`, so otherwise valid convolution inputs raised `RuntimeError` before the FFT was evaluated.

SciPy accepts these inputs and returns the expected convolution.

## Fix

- promote two floating/complex operands normally;
- preserve the floating or complex dtype when only one operand is inexact;
- convert two integer/Boolean operands directly to PyTorch's default floating dtype without attempting unsupported exact-dtype promotion;
- retain the existing device-selection and negative-stride handling.

## Regression coverage

Added SciPy-comparison tests for:

- `uint64` convolved with `int64`;
- `uint64` convolved with `complex64`.

## Validation

- reproduced the pre-fix `torch.promote_types(torch.uint64, torch.int64)` failure with PyTorch 2.10.0;
- exercised the patched FFT path locally for both regression cases;
- both outputs match `scipy.signal.fftconvolve` with `numpy.allclose`;
- branch is two commits ahead and zero behind `main`, changing only the PyTorch signal backend and one focused test file.

GitHub Actions should provide the authoritative full backend matrix.