### PR TITLE
Reject fractionally rounded symmetry counts

### DIFF
--- a/src/pyrecest/evaluation/__init__.py
+++ b/src/pyrecest/evaluation/__init__.py
@@ -1,6 +1,7 @@
 from math import isfinite as _isfinite
 from math import isinf as _isinf
 
+from . import get_distance_function as _get_distance_function_module
 from . import model_comparison as _model_comparison
 from .check_and_fix_config import check_and_fix_config
 from .configure_for_filter import configure_for_filter
@@ -103,6 +104,41 @@ _original_paired_model_margin_decisions = getattr(
 _original_evidence_margin_table = getattr(
     _model_comparison, _ORIGINAL_EVIDENCE_TABLE_ATTR
 )
+
+
+def _validate_symmetry_count(n_symm):
+    """Validate symmetry counts without binary64 integer rounding."""
+
+    count_array = _get_distance_function_module.numpy.asarray(
+        _get_distance_function_module.to_numpy(n_symm)
+    )
+    if (
+        count_array.shape != ()
+        or count_array.dtype.kind in "bMm"
+        or _get_distance_function_module._contains_unsupported_numeric_config_values(
+            n_symm
+        )
+        or _get_distance_function_module._contains_unsupported_numeric_config_values(
+            count_array
+        )
+    ):
+        raise ValueError("nSymm must be a finite positive integer")
+    scalar = count_array.item()
+    try:
+        count = int(scalar)
+        is_exact_integer = scalar == count
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("nSymm must be a finite positive integer") from exc
+    try:
+        is_exact_integer = bool(is_exact_integer)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("nSymm must be a finite positive integer") from exc
+    if not is_exact_integer or count <= 0:
+        raise ValueError("nSymm must be a finite positive integer")
+    return count
+
+
+_get_distance_function_module._validate_symmetry_count = _validate_symmetry_count
 
 
 def _classify_evidence_margin(delta_log_evidence: float) -> str:

--- a/tests/evaluation/test_symmetry_count_exactness.py
+++ b/tests/evaluation/test_symmetry_count_exactness.py
@@ -1,0 +1,22 @@
+from fractions import Fraction
+
+import pytest
+
+from pyrecest.evaluation.get_distance_function import _validate_symmetry_count
+
+
+def test_symmetry_count_rejects_fraction_rounded_to_integer_by_float():
+    fractionally_rounded = Fraction(2**54 + 1, 2)
+
+    assert float(fractionally_rounded).is_integer()
+    with pytest.raises(
+        ValueError,
+        match="nSymm must be a finite positive integer",
+    ):
+        _validate_symmetry_count(fractionally_rounded)
+
+
+def test_symmetry_count_preserves_exact_large_integer_values():
+    exact_integer = Fraction(2**54, 2)
+
+    assert _validate_symmetry_count(exact_integer) == 2**53


### PR DESCRIPTION
## Bug

`_validate_symmetry_count` converts `nSymm` to binary64 before checking whether it is integral. Exact rational values can therefore round to an integer-valued float and be accepted even though they are not integers. For example, `Fraction(2**54 + 1, 2)` becomes `9007199254740992.0` when converted to `float`.

## Fix

Validate integrality against the original scalar value instead of a rounded binary64 representation:

- reject non-scalar, Boolean, temporal, complex, non-finite, non-positive, and genuinely fractional values;
- compare the original scalar with its integer conversion to require exact equality;
- preserve support for very large exact integer-valued scalars.

## Regression coverage

- rejects an exact `Fraction` that binary64 rounds to an integer;
- accepts the neighboring exact large integer value.

## Validation

A focused reproduction confirmed that the current implementation accepts the fractional value after float rounding, while the patched implementation rejects it and still returns `2**53` for `Fraction(2**54, 2)`.

Closes #4697.