### PR TITLE
Reject overflowing uint64 PyTorch scatter indices

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_scatter_add_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_scatter_add_contract.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 from operator import index as _operator_index
 
 
+_SCATTER_INDEX_RANGE_ERROR = (
+    "scatter_add indices must fit in signed 64-bit integers"
+)
+
+
 def _normalize_pytorch_scatter_dim(dim, torch_module) -> int:
     """Return one PyTorch scatter dimension while rejecting booleans."""
     if isinstance(dim, bool):
@@ -38,12 +43,31 @@ def _pytorch_scatter_index(index, numpy_module, torch_module, *, device):
             or index.dtype.is_complex
         ):
             raise TypeError("scatter_add indices must be integers")
+        uint64_dtype = getattr(torch_module, "uint64", None)
+        if (
+            uint64_dtype is not None
+            and index.dtype == uint64_dtype
+            and index.device.type != "meta"
+        ):
+            signed_index = index.to(dtype=torch_module.long)
+            if bool(torch_module.any(signed_index < 0).item()):
+                raise ValueError(_SCATTER_INDEX_RANGE_ERROR)
         return index.to(device=device, dtype=torch_module.long)
 
     index_array = numpy_module.asarray(index)
     if isinstance(index, numpy_module.ndarray) or index_array.size:
         if not _is_integer_scatter_index_dtype(index_array.dtype, numpy_module):
             raise TypeError("scatter_add indices must be integers")
+        if (
+            numpy_module.issubdtype(
+                index_array.dtype,
+                numpy_module.unsignedinteger,
+            )
+            and numpy_module.any(
+                index_array > numpy_module.iinfo(numpy_module.int64).max
+            )
+        ):
+            raise ValueError(_SCATTER_INDEX_RANGE_ERROR)
     return torch_module.as_tensor(index_array, dtype=torch_module.long, device=device)
 
 

--- a/src/pyrecest/backend_support/_pytorch_scatter_add_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_scatter_add_contract.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 from operator import index as _operator_index
 
 
-_SCATTER_INDEX_RANGE_ERROR = (
-    "scatter_add indices must fit in signed 64-bit integers"
-)
+_SCATTER_INDEX_RANGE_ERROR = "scatter_add indices must fit in signed 64-bit integers"
 
 
 def _normalize_pytorch_scatter_dim(dim, torch_module) -> int:

--- a/tests/backend_support/test_pytorch_scatter_add_contract.py
+++ b/tests/backend_support/test_pytorch_scatter_add_contract.py
@@ -45,6 +45,32 @@ def test_pytorch_scatter_add_rejects_non_integer_indices():
 
 
 @pytest.mark.backend_portable
+def test_pytorch_scatter_add_rejects_uint64_indices_outside_int64():
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific backend contract")
+
+    np = pytest.importorskip("numpy")
+    torch = pytest.importorskip("torch")
+    overflowing = np.array([np.iinfo(np.int64).max], dtype=np.uint64) + np.uint64(1)
+    bad_indices = [overflowing]
+    uint64_dtype = getattr(torch, "uint64", None)
+    if uint64_dtype is not None:
+        bad_indices.append(torch.tensor([2**63], dtype=uint64_dtype))
+
+    for bad_index in bad_indices:
+        with pytest.raises(ValueError, match="signed 64-bit"):
+            backend.scatter_add([1, 2], 0, bad_index, [1])
+
+    result = backend.scatter_add(
+        [1, 2],
+        0,
+        np.array([1], dtype=np.uint64),
+        [3],
+    )
+    assert _to_python(result) == [1, 5]
+
+
+@pytest.mark.backend_portable
 def test_raw_pytorch_scatter_add_rejects_non_integer_indices_with_numpy_backend():
     if importlib.util.find_spec("torch") is None:
         pytest.skip("PyTorch is not installed")
@@ -55,6 +81,7 @@ def test_raw_pytorch_scatter_add_rejects_non_integer_indices_with_numpy_backend(
 import numpy as np
 import pyrecest  # noqa: F401  # triggers raw-backend compatibility patches
 import pyrecest._backend.pytorch as raw_pytorch
+import torch
 
 for bad_index in ([0.0], [True], np.array([0.0])):
     try:
@@ -64,8 +91,24 @@ for bad_index in ([0.0], [True], np.array([0.0])):
     else:
         raise AssertionError("scatter_add accepted non-integer indices")
 
+overflowing = np.array([np.iinfo(np.int64).max], dtype=np.uint64) + np.uint64(1)
+bad_unsigned_indices = [overflowing]
+if getattr(torch, "uint64", None) is not None:
+    bad_unsigned_indices.append(torch.tensor([2**63], dtype=torch.uint64))
+for bad_index in bad_unsigned_indices:
+    try:
+        raw_pytorch.scatter_add([1, 2], 0, bad_index, [1])
+    except ValueError as exc:
+        assert "signed 64-bit" in str(exc)
+    else:
+        raise AssertionError("scatter_add accepted an overflowing uint64 index")
+
 empty_result = raw_pytorch.scatter_add([1, 2], 0, [], [])
 assert raw_pytorch.to_numpy(empty_result).tolist() == [1, 2]
+unsigned_result = raw_pytorch.scatter_add(
+    [1, 2], 0, np.array([1], dtype=np.uint64), [3]
+)
+assert raw_pytorch.to_numpy(unsigned_result).tolist() == [1, 5]
 print("ok")
 """,
     )


### PR DESCRIPTION
## Bug

The PyTorch `scatter_add` compatibility hook accepts integer index arrays and tensors, then converts them to `torch.long`. For `uint64` values above `2**63 - 1`, that conversion wraps modulo `2**64`; for example, `2**63` becomes `-2**63` and `2**64 - 1` becomes `-1`.

This leaks a truncating conversion into the public backend contract and produces a misleading downstream out-of-bounds error instead of rejecting an index that cannot be represented by PyTorch's signed 64-bit scatter index dtype.

## Fix

- reject NumPy unsigned index arrays containing values above `np.iinfo(np.int64).max`;
- detect overflow for concrete Torch `uint64` tensors by checking the signed conversion before moving it to the target device;
- retain support for representable `uint64` indices, empty Python index lists, and existing integer index dtypes;
- leave meta-tensor shape-only behavior unchanged because concrete values are unavailable there.

## Regression coverage

- public PyTorch backend rejects overflowing NumPy `uint64` arrays;
- public PyTorch backend rejects overflowing Torch `uint64` tensors when the dtype is available;
- raw PyTorch backend receives the same coverage while the selected public backend is NumPy;
- small representable `uint64` indices continue to work.

## Validation

- reproduced the pre-fix behavior with PyTorch 2.10.0: `uint64(2**63)` converts to `torch.long(-2**63)` and `uint64(2**64 - 1)` converts to `torch.long(-1)`;
- exercised the patched conversion locally for NumPy and Torch `uint64` inputs, valid small unsigned indices, empty indices, and existing float/Boolean rejection paths;
- branch is three commits ahead and zero behind `main`, changing only the compatibility hook and its focused test file;
- GitHub Actions focused Ruff lint has passed; the full backend matrix is running.