### PR TITLE
Fix exact candidate-pruning top-k validation

### DIFF
--- a/src/pyrecest/utils/candidate_pruning.py
+++ b/src/pyrecest/utils/candidate_pruning.py
@@ -137,12 +137,15 @@ def _normalize_positive_integer(value: Any, name: str) -> int:
         parsed = int(scalar)
     else:
         try:
-            scalar_float = float(scalar)
+            parsed = int(scalar)
         except (TypeError, ValueError, OverflowError) as exc:
             raise ValueError(message) from exc
-        if not np.isfinite(scalar_float) or not scalar_float.is_integer():
+        try:
+            is_exact_integer = bool(scalar == parsed)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(message) from exc
+        if not is_exact_integer:
             raise ValueError(message)
-        parsed = int(scalar_float)
 
     if parsed <= 0:
         raise ValueError(message)

--- a/tests/test_candidate_pruning_exact_top_k.py
+++ b/tests/test_candidate_pruning_exact_top_k.py
@@ -1,5 +1,5 @@
-from fractions import Fraction
 import unittest
+from fractions import Fraction
 
 from pyrecest.utils import CandidatePruningConfig
 

--- a/tests/test_candidate_pruning_exact_top_k.py
+++ b/tests/test_candidate_pruning_exact_top_k.py
@@ -1,0 +1,26 @@
+from fractions import Fraction
+import unittest
+
+from pyrecest.utils import CandidatePruningConfig
+
+
+class TestCandidatePruningExactTopK(unittest.TestCase):
+    def test_rejects_fraction_rounded_to_integer_by_binary64(self):
+        fractional_top_k = Fraction(2**54 + 1, 2)
+
+        for field_name in ("row_top_k", "column_top_k"):
+            with self.subTest(field_name=field_name):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    f"{field_name} must be a positive integer or None",
+                ):
+                    CandidatePruningConfig(**{field_name: fractional_top_k})
+
+    def test_accepts_exact_rational_integer(self):
+        config = CandidatePruningConfig(row_top_k=Fraction(4, 2))
+
+        self.assertEqual(config.row_top_k, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- validate `row_top_k` and `column_top_k` against the original numeric scalar instead of a rounded binary64 conversion
- reject non-integral exact numeric values that happen to round to an integral float
- add regression coverage for both top-k fields and preserve exact rational integers

## Bug
`CandidatePruningConfig` previously converted non-integer real values to `float` before checking `is_integer()`. For values beyond binary64's consecutive-integer range, an exact fractional value such as `Fraction(2**54 + 1, 2)` rounds to `9007199254740992.0` and was accepted. A huge accepted top-k can silently retain every finite candidate, defeating the requested pruning.

## Validation
- reproduced the old rounding behavior independently
- compiled and imported the modified module
- verified the fractional reproducer is rejected for both `row_top_k` and `column_top_k`
- verified integral floats and exact rational integers remain accepted

Full repository CI is left to GitHub Actions because this environment did not provide a working GitHub CLI or networked checkout.