### PR TITLE
Reject fractionally rounded SE2 Bingham sample counts

### DIFF
--- a/src/pyrecest/distributions/cart_prod/__init__.py
+++ b/src/pyrecest/distributions/cart_prod/__init__.py
@@ -1,0 +1,33 @@
+"""Cartesian-product distributions and compatibility fixes."""
+
+from __future__ import annotations
+
+from . import se2_bingham_distribution as _se2_bingham_distribution
+
+
+def _validate_se2_bingham_sample_count(n) -> int:
+    """Validate SE(2) Bingham sample counts without binary64 rounding."""
+    count_array = _se2_bingham_distribution.np.asarray(n)
+    if count_array.ndim != 0:
+        raise ValueError("n must be a scalar integer")
+
+    count = count_array.item()
+    if isinstance(count, (bool, _se2_bingham_distribution.np.bool_)):
+        raise ValueError("n must be an integer, not a boolean")
+
+    try:
+        count_int = int(count)
+        is_exact_integer = bool(count == count_int)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError("n must be an integer") from exc
+
+    if not is_exact_integer:
+        raise ValueError("n must be a finite integer")
+    if count_int <= 0:
+        raise ValueError("n must be positive")
+    return count_int
+
+
+_se2_bingham_distribution._validate_positive_sample_count = (
+    _validate_se2_bingham_sample_count
+)

--- a/tests/distributions/test_se2_bingham_sample_count_precision.py
+++ b/tests/distributions/test_se2_bingham_sample_count_precision.py
@@ -1,0 +1,23 @@
+"""Regression tests for exact SE(2) Bingham sample-count validation."""
+
+from fractions import Fraction
+
+import pytest
+
+from pyrecest.distributions.cart_prod.se2_bingham_distribution import (
+    _validate_positive_sample_count,
+)
+
+
+def test_rejects_fraction_rounded_to_integer_by_binary64():
+    rounded_half_integer = Fraction(2**54 + 1, 2)
+
+    assert float(rounded_half_integer).is_integer()
+    with pytest.raises(ValueError, match="finite integer"):
+        _validate_positive_sample_count(rounded_half_integer)
+
+
+def test_preserves_exact_large_integer():
+    exact_integer = Fraction(2**54 + 2, 2)
+
+    assert _validate_positive_sample_count(exact_integer) == 2**53 + 1


### PR DESCRIPTION
## Bug

`SE2BinghamDistribution.sample` validates `n` by converting the original scalar to binary64 and calling `float.is_integer()`. Above binary64's consecutive-integer range, an exact fractional value can lose its fractional part during conversion.

For example, `Fraction(2**54 + 1, 2)` is exactly a half-integer, but converts to the integer-valued float `2**53`. The validator therefore accepts it and can proceed toward an unintended enormous allocation.

## Fix

- require exact equality between the original scalar and its integer conversion;
- preserve rejection of booleans, non-scalars, fractional values, non-finite values, and non-positive counts;
- preserve exact large integer-valued inputs;
- install the corrected validator when the Cartesian-product distribution package is initialized.

## Regression coverage

- rejects the exact half-integer whose fractional part disappears in binary64;
- accepts the neighboring exact large integer without allocating samples.

GitHub Actions should provide the authoritative full backend and repository validation.