### PR TITLE
Fix exact multi-session integer validation

### DIFF
--- a/src/pyrecest/utils/multisession_assignment_score.py
+++ b/src/pyrecest/utils/multisession_assignment_score.py
@@ -144,55 +144,42 @@ def _normalize_min_score(min_score: Any) -> float:
     return min_score_float
 
 
-def _normalize_max_gap(max_gap: Any) -> int:
-    max_gap_array = np.asarray(max_gap)
-    if max_gap_array.shape != () or _is_rejected_scalar_array(max_gap_array):
-        raise ValueError("max_gap must be a non-negative integer.")
+def _normalize_exact_integer(value: Any, message: str) -> int:
+    """Return an exact integer scalar without binary64 rounding."""
+    value_array = np.asarray(value)
+    if value_array.shape != () or _is_rejected_scalar_array(value_array):
+        raise ValueError(message)
 
-    max_gap_value = max_gap_array.item()
-    if _is_rejected_scalar(max_gap_value):
-        raise ValueError("max_gap must be a non-negative integer.")
-
-    if isinstance(max_gap_value, (int, np.integer)):
-        if max_gap_value < 0:
-            raise ValueError("max_gap must be a non-negative integer.")
-        return int(max_gap_value)
+    scalar = value_array.item()
+    if _is_rejected_scalar(scalar):
+        raise ValueError(message)
 
     try:
-        max_gap_float = float(max_gap_value)
+        parsed = int(scalar)
     except (TypeError, ValueError, OverflowError) as exc:
-        raise ValueError("max_gap must be a non-negative integer.") from exc
-    if (
-        not math.isfinite(max_gap_float)
-        or max_gap_float < 0
-        or not max_gap_float.is_integer()
-    ):
-        raise ValueError("max_gap must be a non-negative integer.")
-    return int(max_gap_float)
+        raise ValueError(message) from exc
+    try:
+        is_exact_integer = bool(scalar == parsed)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if not is_exact_integer:
+        raise ValueError(message)
+    return parsed
+
+
+def _normalize_max_gap(max_gap: Any) -> int:
+    message = "max_gap must be a non-negative integer."
+    parsed = _normalize_exact_integer(max_gap, message)
+    if parsed < 0:
+        raise ValueError(message)
+    return parsed
 
 
 def _normalize_index_matrix_fill_value(fill_value: Any) -> int:
-    fill_value_array = np.asarray(fill_value)
-    if fill_value_array.shape != () or _is_rejected_scalar_array(fill_value_array):
-        raise ValueError("fill_value must be a negative integer.")
-
-    fill_value_value = fill_value_array.item()
-    if _is_rejected_scalar(fill_value_value):
-        raise ValueError("fill_value must be a negative integer.")
-
-    if isinstance(fill_value_value, (int, np.integer)):
-        integer_fill_value = int(fill_value_value)
-    else:
-        try:
-            fill_value_float = float(fill_value_value)
-        except (TypeError, ValueError, OverflowError) as exc:
-            raise ValueError("fill_value must be a negative integer.") from exc
-        if not math.isfinite(fill_value_float) or not fill_value_float.is_integer():
-            raise ValueError("fill_value must be a negative integer.")
-        integer_fill_value = int(fill_value_float)
-
+    message = "fill_value must be a negative integer."
+    integer_fill_value = _normalize_exact_integer(fill_value, message)
     if integer_fill_value >= 0:
-        raise ValueError("fill_value must be a negative integer.")
+        raise ValueError(message)
     return integer_fill_value
 
 

--- a/tests/utils/test_multisession_assignment_score_exact_integer_validation.py
+++ b/tests/utils/test_multisession_assignment_score_exact_integer_validation.py
@@ -1,0 +1,39 @@
+"""Regression tests for exact multi-session integer validation."""
+
+from fractions import Fraction
+
+import pytest
+
+from pyrecest.utils.multisession_assignment_score import (
+    _normalize_index_matrix_fill_value,
+    _normalize_max_gap,
+)
+
+
+@pytest.mark.parametrize(
+    ("normalizer", "value", "message"),
+    [
+        (
+            _normalize_max_gap,
+            Fraction(2**54 + 1, 2),
+            "max_gap must be a non-negative integer",
+        ),
+        (
+            _normalize_index_matrix_fill_value,
+            -Fraction(2**54 + 1, 2),
+            "fill_value must be a negative integer",
+        ),
+    ],
+)
+def test_rejects_fraction_rounded_to_integer_by_binary64(normalizer, value, message):
+    assert float(value).is_integer()
+
+    with pytest.raises(ValueError, match=message):
+        normalizer(value)
+
+
+def test_preserves_exact_large_integer_values():
+    exact_integer = Fraction(2**54, 2)
+
+    assert _normalize_max_gap(exact_integer) == 2**53
+    assert _normalize_index_matrix_fill_value(-exact_integer) == -(2**53)


### PR DESCRIPTION
## Summary

- validate `max_gap` and index-matrix `fill_value` against the original numeric scalar instead of a binary64-rounded copy;
- reject exact fractional values that happen to round to integer-valued floats;
- preserve support for ordinary integers, integral floats, and exact rational integers;
- add focused regressions for both validation paths.

## Bug

The multi-session score helpers converted non-integer numeric scalars to `float` and then called `is_integer()`. Above binary64's consecutive-integer range, an exact fractional value can therefore be accepted as an integer. For example, `Fraction(2**54 + 1, 2)` is exactly `9007199254740992.5`, but converts to `9007199254740992.0`.

For `max_gap`, accepting such a value can silently alter which inter-session edges are admitted to the assignment graph. For `fill_value`, the same rounding can silently replace an invalid fractional sentinel with an integer sentinel.

## Fix

A shared helper now converts the original scalar to `int` and requires exact equality with that original scalar. The existing sign constraints remain unchanged: `max_gap` must be non-negative and `fill_value` must be negative.

## Validation

- reproduced the pre-fix binary64 rounding behavior for both positive and negative exact fractions;
- added regression coverage that rejects the rounded fractions and accepts neighboring exact rational integers;
- verified the branch is two commits ahead and zero behind `main`, changing only the validator module and its focused test file;
- full repository CI is delegated to GitHub Actions because this execution environment has no working GitHub CLI or networked checkout.