### PR TITLE
Fix SE(2) covariance plot scaling

### DIFF
--- a/src/pyrecest/distributions/abstract_se2_distribution.py
+++ b/src/pyrecest/distributions/abstract_se2_distribution.py
@@ -14,6 +14,7 @@ from pyrecest.backend import (
     linspace,
     mod,
     pi,
+    real,
     sin,
     sum,
     vstack,
@@ -59,6 +60,12 @@ class AbstractSE2Distribution(AbstractHypercylindricalDistribution):
         angle_color = self._matplotlib_color(angle_color)
 
         linear_covmat = self.linear_covariance()
+        # A covariance contour maps unit directions through a matrix square root.
+        # Using the covariance itself scales its semiaxes by variances instead of
+        # standard deviations.
+        linear_covmat_sqrt = real(
+            linalg.sqrtm(0.5 * (linear_covmat + linear_covmat.T))
+        )
         hybrid_moment = self.hybrid_moment()
         linear_mean = hybrid_moment[2:4]
         periodic_mean = arctan2(hybrid_moment[1], hybrid_moment[0])
@@ -70,7 +77,7 @@ class AbstractSE2Distribution(AbstractHypercylindricalDistribution):
             ax.set_label("hold")
 
         xs = hstack((linspace(0, 2 * pi, 100), array([0.0])))
-        ps = scaling_factor * linear_covmat @ vstack((cos(xs), sin(xs)))
+        ps = scaling_factor * linear_covmat_sqrt @ vstack((cos(xs), sin(xs)))
         (h1,) = ax.plot(
             ps[0, :] + linear_mean[0], ps[1, :] + linear_mean[1], color=circle_color
         )
@@ -79,10 +86,10 @@ class AbstractSE2Distribution(AbstractHypercylindricalDistribution):
         xs = linspace(
             periodic_mean - plot_ang_range, periodic_mean + plot_ang_range, 100
         )
-        ps = scaling_factor * linear_covmat @ vstack((cos(xs), sin(xs)))
+        ps = scaling_factor * linear_covmat_sqrt @ vstack((cos(xs), sin(xs)))
         scaled_mean_vec = (
             scaling_factor
-            * linear_covmat
+            * linear_covmat_sqrt
             @ array([cos(periodic_mean), sin(periodic_mean)])
         )
         h2 = ax.quiver(

--- a/tests/distributions/test_abstract_se2_plot_state_covariance.py
+++ b/tests/distributions/test_abstract_se2_plot_state_covariance.py
@@ -1,0 +1,41 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import numpy.testing as npt
+import pyrecest.backend
+import pytest
+from pyrecest.backend import array
+from pyrecest.distributions.abstract_se2_distribution import AbstractSE2Distribution
+
+plt.switch_backend("Agg")
+
+
+class _PlotStateFixture:
+    _get_2d_axes = staticmethod(AbstractSE2Distribution._get_2d_axes)
+    _matplotlib_color = staticmethod(AbstractSE2Distribution._matplotlib_color)
+    plot_state = AbstractSE2Distribution.plot_state
+
+    @staticmethod
+    def linear_covariance():
+        return array([[4.0, 0.0], [0.0, 9.0]])
+
+    @staticmethod
+    def hybrid_moment():
+        return array([1.0, 0.0, 1.5, -2.0])
+
+
+@pytest.mark.skipif(
+    pyrecest.backend.__backend_name__ == "jax",
+    reason="plot_state is not supported for the JAX backend",
+)
+def test_plot_state_uses_standard_deviation_axes():
+    fig, ax = plt.subplots()
+    plt.sca(ax)
+    try:
+        contour, *_ = _PlotStateFixture().plot_state()
+        x_data = np.asarray(contour.get_xdata(), dtype=float)
+        y_data = np.asarray(contour.get_ydata(), dtype=float)
+
+        npt.assert_allclose(x_data[0] - 1.5, 2.0, atol=1e-10)
+        npt.assert_allclose(y_data[0] + 2.0, 0.0, atol=1e-10)
+    finally:
+        plt.close(fig)


### PR DESCRIPTION
## Bug

`AbstractSE2Distribution.plot_state` maps unit-circle directions through the linear covariance matrix itself. Covariance eigenvalues are variances, so the plotted semiaxes are scaled by variance rather than standard deviation. For `diag(4, 9)`, the contour therefore has radii `4` and `9` instead of `2` and `3`.

## Fix

- symmetrize the linear covariance before taking its matrix square root;
- discard negligible imaginary numerical roundoff from `sqrtm`;
- use the square-root covariance consistently for the contour, orientation arc, and mean-direction vector;
- add a focused Matplotlib regression checking the first semiaxis for `diag(4, 9)`.

## Validation

- reproduced the old radius of `4` for the first axis;
- verified the square-root mapping produces radius `2`;
- branch changes only the SE(2) plotting implementation and one focused regression test.

Closes #4696.