### PR TITLE
Reject fractionally rounded piecewise sample counts

### DIFF
--- a/src/pyrecest/distributions/circle/piecewise_constant_distribution.py
+++ b/src/pyrecest/distributions/circle/piecewise_constant_distribution.py
@@ -51,11 +51,11 @@ def _validate_positive_sample_count(n) -> int:
 
     try:
         count_int = int(count)
-        count_float = float(count)
+        is_exact_integer = bool(count == count_int)
     except (OverflowError, TypeError, ValueError) as exc:
         raise ValueError("n must be an integer") from exc
 
-    if not np.isfinite(count_float) or not count_float.is_integer():
+    if not is_exact_integer:
         raise ValueError("n must be a finite integer")
     if count_int <= 0:
         raise ValueError("n must be positive")

--- a/tests/distributions/test_piecewise_constant_input_validation.py
+++ b/tests/distributions/test_piecewise_constant_input_validation.py
@@ -1,11 +1,14 @@
 """Regression tests for piecewise-constant input validation."""
 
+from fractions import Fraction
+
 import numpy as np
 import pytest
 import pyrecest.backend
 
 from pyrecest.distributions.circle.piecewise_constant_distribution import (
     PiecewiseConstantDistribution,
+    _validate_positive_sample_count,
 )
 
 
@@ -19,6 +22,18 @@ def test_piecewise_constant_pdf_rejects_complex_angles():
 
     with pytest.raises(ValueError, match="xs must contain real values"):
         distribution.pdf(np.asarray([0.0 + 1.0j]))
+
+
+def test_piecewise_constant_sample_count_rejects_fraction_rounded_by_binary64():
+    fractional_count = Fraction(2**54 + 1, 2)
+
+    assert float(fractional_count).is_integer()
+    with pytest.raises(ValueError, match="n must be a finite integer"):
+        _validate_positive_sample_count(fractional_count)
+
+
+def test_piecewise_constant_sample_count_accepts_exact_rational_integer():
+    assert _validate_positive_sample_count(Fraction(8, 2)) == 4
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Bug

`_validate_positive_sample_count` converted non-integer real values to binary64 before checking `is_integer()`. Exact fractions beyond binary64's consecutive-integer range can therefore round to an integer-valued float. For example, `Fraction(2**54 + 1, 2)` was accepted as `9007199254740992`, potentially causing an enormous sample allocation or interval loop.

## Fix

- compare the original scalar with its integer conversion;
- reject values that are not exactly integral;
- preserve exact rational integers and the existing supported numeric scalar forms.

## Regression coverage

- rejects an exact fraction that binary64 rounds to an integer;
- accepts a neighboring exact rational integer.

## Validation

- reproduced the previous binary64 rounding behavior independently;
- exercised the fixed validation logic for the fractional reproducer, an exact rational integer, an integral NumPy float, and the existing invalid-value cases;
- branch is two commits ahead and zero behind `main`, changing only the validator and its focused test file.

Full repository pytest was not available because this environment has no GitHub CLI and cannot clone through outbound Git. GitHub Actions should provide the authoritative full-suite validation.