### PR TITLE
Validate fixed-lag buffer maxlen exactly

### DIFF
--- a/src/pyrecest/filters/out_of_sequence.py
+++ b/src/pyrecest/filters/out_of_sequence.py
@@ -10,6 +10,7 @@ order.
 import copy
 from dataclasses import dataclass
 from math import isfinite
+from operator import index as operator_index
 
 from pyrecest.backend import asarray, atleast_1d, atleast_2d, float64, linalg, transpose
 from pyrecest.distributions import GaussianDistribution
@@ -45,6 +46,32 @@ def _coerce_optional_max_lag(max_lag):
     if not isfinite(max_lag) or max_lag < 0.0:
         raise ValueError("max_lag must be finite and nonnegative or None")
     return max_lag
+
+
+def _coerce_optional_maxlen(maxlen):
+    if maxlen is None:
+        return None
+
+    message = "maxlen must be a positive integer or None"
+    scalar = maxlen
+    shape = getattr(maxlen, "shape", None)
+    if shape is not None:
+        try:
+            if tuple(shape) != ():
+                raise ValueError(message)
+            scalar = maxlen.item()
+        except (AttributeError, TypeError, ValueError, RuntimeError) as exc:
+            raise ValueError(message) from exc
+
+    if isinstance(scalar, bool):
+        raise ValueError(message)
+    try:
+        parsed = operator_index(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if parsed <= 0:
+        raise ValueError(message)
+    return parsed
 
 
 def _coerce_bool_flag(value, name):
@@ -128,9 +155,7 @@ class FixedLagBuffer:
 
     def __init__(self, max_lag=None, maxlen=None, *, copy_values=True):
         self.max_lag = _coerce_optional_max_lag(max_lag)
-        self.maxlen = None if maxlen is None else int(maxlen)
-        if self.maxlen is not None and self.maxlen <= 0:
-            raise ValueError("maxlen must be positive or None")
+        self.maxlen = _coerce_optional_maxlen(maxlen)
         self.copy_values = _coerce_bool_flag(copy_values, "copy_values")
         self._items = []
         self._next_sequence = 0

--- a/tests/filters/test_out_of_sequence_maxlen_validation.py
+++ b/tests/filters/test_out_of_sequence_maxlen_validation.py
@@ -32,4 +32,4 @@ def test_fixed_lag_buffers_accept_integer_scalar_maxlen(buffer_type, maxlen):
     if buffer_type is FixedLagBuffer:
         assert [item.value for item in buffer.items] == [1, 2]
     else:
-        assert buffer.measurements == (1, 2)
+        assert [record.measurement for record in buffer.measurements] == [1, 2]

--- a/tests/filters/test_out_of_sequence_maxlen_validation.py
+++ b/tests/filters/test_out_of_sequence_maxlen_validation.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pytest
+
+from pyrecest.filters import FixedLagBuffer, MeasurementTimeBuffer
+
+
+_BUFFER_TYPES = (FixedLagBuffer, MeasurementTimeBuffer)
+
+
+@pytest.mark.parametrize("buffer_type", _BUFFER_TYPES)
+@pytest.mark.parametrize(
+    "maxlen",
+    [True, 1.5, 2.0, "2", [2], np.array([2]), 0, -1],
+)
+def test_fixed_lag_buffers_reject_invalid_maxlen(buffer_type, maxlen):
+    with pytest.raises(ValueError, match="maxlen must be a positive integer or None"):
+        buffer_type(maxlen=maxlen)
+
+
+@pytest.mark.parametrize("buffer_type", _BUFFER_TYPES)
+@pytest.mark.parametrize("maxlen", [2, np.int64(2), np.array(2, dtype=np.int64)])
+def test_fixed_lag_buffers_accept_integer_scalar_maxlen(buffer_type, maxlen):
+    buffer = buffer_type(maxlen=maxlen)
+
+    for time in range(3):
+        if buffer_type is FixedLagBuffer:
+            buffer.append(time, time)
+        else:
+            buffer.add(time, time)
+
+    assert len(buffer) == 2
+    if buffer_type is FixedLagBuffer:
+        assert [item.value for item in buffer.items] == [1, 2]
+    else:
+        assert buffer.measurements == (1, 2)


### PR DESCRIPTION
## Bug

`FixedLagBuffer` normalized `maxlen` with `int(maxlen)`. This silently truncated fractional values such as `1.5` to `1`, accepted booleans as `1`, and parsed numeric strings. Because trimming uses the resulting value, invalid configuration could unexpectedly discard buffered measurements. `MeasurementTimeBuffer` inherited the same behavior through delegation.

## Fix

- normalize array/tensor-like inputs only when they are scalar-shaped;
- reject booleans, floats, strings, non-scalar containers, zero, and negative values;
- use the integer index protocol to accept genuine Python, NumPy, and scalar-array integer values without truncation;
- apply the validation centrally in `FixedLagBuffer`, covering `MeasurementTimeBuffer` as well.

## Regression coverage

Focused tests verify both buffer classes reject invalid `maxlen` inputs and preserve two-entry trimming for Python integers, NumPy integer scalars, and zero-dimensional NumPy integer arrays.

## Validation

- reconstructed the pre-change source and matched its Git blob SHA to ensure the production diff contains only the intended edit;
- Python syntax compilation passed for the modified module and regression test;
- focused coercion checks passed for all accepted and rejected cases;
- branch comparison changes only the buffer implementation and one test file.

Closes #4675.