### PR TITLE
Validate weak-measurement dimension order hashability

### DIFF
--- a/src/pyrecest/models/weak_measurement.py
+++ b/src/pyrecest/models/weak_measurement.py
@@ -72,7 +72,11 @@ def block_diag_measurement_covariance(
             order = provided_order
         else:
             order = list(dimension_order)
-            if len(set(order)) != len(order):
+            try:
+                has_duplicates = len(set(order)) != len(order)
+            except TypeError as exc:
+                raise ValueError("dimension_order entries must be hashable") from exc
+            if has_duplicates:
                 raise ValueError("dimension_order must not contain duplicate entries")
             omitted = [key for key in provided_order if key not in order]
             if omitted:

--- a/tests/models/test_weak_measurement_dimension_order_hashability.py
+++ b/tests/models/test_weak_measurement_dimension_order_hashability.py
@@ -1,0 +1,24 @@
+import numpy as np
+import pytest
+
+from pyrecest.models.weak_measurement import (
+    WeakDimensionMeasurementModel,
+    block_diag_measurement_covariance,
+)
+
+
+def test_block_covariance_rejects_unhashable_dimension_order_entries_cleanly():
+    with pytest.raises(ValueError, match="dimension_order entries must be hashable"):
+        block_diag_measurement_covariance(
+            trusted_std={"x": 1.0},
+            dimension_order=[["x"]],
+        )
+
+
+def test_weak_dimension_model_rejects_unhashable_dimension_order_entries_cleanly():
+    with pytest.raises(ValueError, match="dimension_order entries must be hashable"):
+        WeakDimensionMeasurementModel(
+            np.eye(1),
+            stds={"x": 1.0},
+            dimension_order=[["x"]],
+        )


### PR DESCRIPTION
## Bug

`block_diag_measurement_covariance` checked duplicate `dimension_order` entries with `set(order)`. When an entry was unhashable, such as a nested list, Python leaked a raw `TypeError` instead of reporting an invalid public API argument. `WeakDimensionMeasurementModel` inherited the same behavior.

## Fix

- catch unhashable `dimension_order` entries at the validation boundary;
- raise a stable `ValueError` explaining that entries must be hashable;
- preserve the existing duplicate-entry validation for valid hashable labels.

## Regression coverage

Added focused tests for both the covariance helper and `WeakDimensionMeasurementModel`.

## Validation

The branch is two commits ahead of current `main` and changes only the weak-measurement validation plus its regression test. The focused behavior is covered directly; full CI is delegated to GitHub Actions.