### PR TITLE
Fix stacked shifts for embedded manifold components

### DIFF
--- a/src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py
@@ -85,15 +85,16 @@ class CartProdStackedDistribution(AbstractCartProdDistribution):
         return prod(stack(ps), axis=0)
 
     def shift(self, shift_by):
-        if len(shift_by) != self.dim:
+        shift_by = asarray(shift_by)
+        if shift_by.ndim != 1 or shift_by.shape[0] != self.input_dim:
             raise ValueError("Incorrect number of offsets.")
+
         shifted_dists = []
-        curr_dim = 0
+        curr_input_dim = 0
         for dist in self.dists:
-            shifted_dists.append(
-                dist.shift(shift_by[curr_dim : curr_dim + dist.dim])  # noqa: E203
-            )
-            curr_dim += dist.dim
+            next_input_dim = curr_input_dim + dist.input_dim
+            shifted_dists.append(dist.shift(shift_by[curr_input_dim:next_input_dim]))
+            curr_input_dim = next_input_dim
         return self.__class__(shifted_dists)
 
     def set_mode(self, new_mode):

--- a/tests/distributions/test_cart_prod_stacked_shift_input_dimensions.py
+++ b/tests/distributions/test_cart_prod_stacked_shift_input_dimensions.py
@@ -1,0 +1,25 @@
+from pyrecest.backend import allclose, array
+from pyrecest.distributions import (
+    GaussianDistribution,
+    HyperhemisphericalWatsonDistribution,
+)
+from pyrecest.distributions.cart_prod.cart_prod_stacked_distribution import (
+    CartProdStackedDistribution,
+)
+
+
+def test_shift_partitions_offsets_by_component_input_dimensions():
+    distribution = CartProdStackedDistribution(
+        [
+            GaussianDistribution(array([1.0]), array([[1.0]])),
+            HyperhemisphericalWatsonDistribution(array([0.0, 0.0, 1.0]), 2.0),
+        ]
+    )
+
+    assert distribution.dim == 3
+    assert distribution.input_dim == 4
+
+    shifted = distribution.shift(array([2.0, 1.0, 0.0, 0.0]))
+
+    assert allclose(shifted.dists[0].mu, array([3.0]))
+    assert allclose(shifted.dists[1].mu, array([1.0, 0.0, 0.0]))


### PR DESCRIPTION
## Bug

`CartProdStackedDistribution.shift()` validated and partitioned `shift_by` using each component's intrinsic manifold dimension (`dim`). Component `shift()` methods, however, consume coordinates in their embedding representation (`input_dim`).

For a product containing a one-dimensional Gaussian and an upper-spherical distribution on the embedded unit sphere in `R^3`, the product has `dim == 3` but `input_dim == 4`. A valid four-coordinate shift was rejected before dispatch, while a three-coordinate vector was split into an invalid two-coordinate hyperhemisphere mode.

## Fix

- normalize `shift_by` as a one-dimensional backend array;
- validate its length against the product `input_dim`;
- partition offsets using each component's `input_dim`;
- preserve the existing error wording for invalid offset counts.

## Regression coverage

A focused test shifts a Gaussian × `HyperhemisphericalWatsonDistribution` product and verifies that the scalar Gaussian offset and three-coordinate hyperhemisphere mode reach the correct components.

## Validation

- Python syntax compilation passed for the modified implementation and regression test;
- branch is two commits ahead and zero behind current `main`;
- the diff changes only the stacked-distribution shift logic and one focused test.

GitHub Actions should provide the authoritative backend and full-suite validation.