### PR TITLE
Validate residual-MHT integer limits exactly

### DIFF
--- a/src/pyrecest/tracking/residual_hypothesis_mht.py
+++ b/src/pyrecest/tracking/residual_hypothesis_mht.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import operator
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from itertools import combinations
@@ -59,7 +60,6 @@ class ResidualHypothesis:
     @property
     def n_edits(self) -> int:
         """Return the number of edits in this hypothesis."""
-
         return len(self.candidate_ids)
 
 
@@ -121,12 +121,12 @@ def residual_mht_config_for_preset(
     else:
         raise ValueError(f"Unknown residual-MHT preset: {preset!r}")
     if max_edits is not None:
-        config = replace(config, max_edits=int(max_edits))
+        config = replace(config, max_edits=max_edits)
     if max_hypotheses is not None:
-        config = replace(config, max_hypotheses=int(max_hypotheses))
+        config = replace(config, max_hypotheses=max_hypotheses)
     if score_threshold is not None:
         config = replace(config, score_threshold=float(score_threshold))
-    return config
+    return _validated_config(config)
 
 
 def enumerate_residual_hypotheses(
@@ -136,10 +136,10 @@ def enumerate_residual_hypotheses(
 ) -> tuple[ResidualHypothesis, ...]:
     """Enumerate compatible bounded residual hypotheses."""
 
-    cfg = config or ResidualMHTConfig()
+    cfg = _validated_config(config or ResidualMHTConfig())
     ordered = _candidate_frontier(candidates, cfg)
-    max_edits = max(0, int(cfg.max_edits))
-    max_hypotheses = max(1, int(cfg.max_hypotheses))
+    max_edits = cfg.max_edits
+    max_hypotheses = cfg.max_hypotheses
     hypotheses: list[ResidualHypothesis] = []
     if cfg.include_empty:
         hypotheses.append(ResidualHypothesis((), 0.0, (), (), ()))
@@ -247,7 +247,7 @@ def _candidate_frontier(
         seen_candidate_ids.add(candidate_id)
         unique_candidates.append(candidate)
     if config.candidate_top_k is not None:
-        return tuple(unique_candidates[: max(0, int(config.candidate_top_k))])
+        return tuple(unique_candidates[: config.candidate_top_k])
     return tuple(unique_candidates)
 
 
@@ -269,12 +269,70 @@ def _compatible(
             family = str(candidate.family)
             family_counts[family] = family_counts.get(family, 0) + 1
             family_cap = max_edits_per_family.get(family)
-            if family_cap is not None and family_counts[family] > int(family_cap):
+            if family_cap is not None and family_counts[family] > family_cap:
                 return False
         if max_edits_per_group_key is not None:
             for group_key in candidate.group_keys:
                 group = str(group_key)
                 group_counts[group] = group_counts.get(group, 0) + 1
-                if group_counts[group] > int(max_edits_per_group_key):
+                if group_counts[group] > max_edits_per_group_key:
                     return False
     return True
+
+
+def _validated_config(config: ResidualMHTConfig) -> ResidualMHTConfig:
+    max_edits_per_family = {
+        family: _as_integer_limit(
+            cap,
+            f"max_edits_per_family[{family!r}]",
+            minimum=0,
+        )
+        for family, cap in config.max_edits_per_family.items()
+    }
+    return replace(
+        config,
+        max_edits=_as_integer_limit(config.max_edits, "max_edits", minimum=0),
+        max_hypotheses=_as_integer_limit(
+            config.max_hypotheses,
+            "max_hypotheses",
+            minimum=1,
+        ),
+        max_edits_per_family=max_edits_per_family,
+        max_edits_per_group_key=(
+            None
+            if config.max_edits_per_group_key is None
+            else _as_integer_limit(
+                config.max_edits_per_group_key,
+                "max_edits_per_group_key",
+                minimum=0,
+            )
+        ),
+        candidate_top_k=(
+            None
+            if config.candidate_top_k is None
+            else _as_integer_limit(
+                config.candidate_top_k,
+                "candidate_top_k",
+                minimum=0,
+            )
+        ),
+    )
+
+
+def _as_integer_limit(value: Any, name: str, *, minimum: int) -> int:
+    requirement = "a positive integer" if minimum == 1 else "a non-negative integer"
+    message = f"{name} must be {requirement}"
+    dtype = getattr(value, "dtype", None)
+    if isinstance(value, bool) or getattr(dtype, "kind", None) == "b" or str(dtype).lower() in {
+        "bool",
+        "bool_",
+        "torch.bool",
+    }:
+        raise ValueError(message)
+    try:
+        normalized = operator.index(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if normalized < minimum:
+        raise ValueError(message)
+    return int(normalized)

--- a/src/pyrecest/tracking/residual_hypothesis_mht.py
+++ b/src/pyrecest/tracking/residual_hypothesis_mht.py
@@ -60,6 +60,7 @@ class ResidualHypothesis:
     @property
     def n_edits(self) -> int:
         """Return the number of edits in this hypothesis."""
+
         return len(self.candidate_ids)
 
 

--- a/tests/tracking/test_residual_hypothesis_mht.py
+++ b/tests/tracking/test_residual_hypothesis_mht.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from pyrecest.tracking import (
     ResidualEditCandidate,
     ResidualMHTConfig,
@@ -165,3 +167,37 @@ def test_residual_mht_presets_are_generic_selector_breadth_controls():
     assert frontier.candidate_top_k == 8
     assert multi_family.max_edits == 4
     assert multi_family.max_hypotheses == 64
+
+
+@pytest.mark.parametrize(
+    ("config", "message"),
+    [
+        (ResidualMHTConfig(max_edits=1.5), "max_edits"),
+        (ResidualMHTConfig(max_edits=True), "max_edits"),
+        (ResidualMHTConfig(max_hypotheses=0), "max_hypotheses"),
+        (ResidualMHTConfig(candidate_top_k=-1), "candidate_top_k"),
+        (
+            ResidualMHTConfig(max_edits_per_group_key=1.5),
+            "max_edits_per_group_key",
+        ),
+        (
+            ResidualMHTConfig(max_edits_per_family={"cell_gated": 1.5}),
+            "max_edits_per_family",
+        ),
+    ],
+)
+def test_rejects_invalid_residual_mht_integer_limits(config, message):
+    with pytest.raises(ValueError, match=message):
+        enumerate_residual_hypotheses([], config=config)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"max_edits": 1.5}, "max_edits"),
+        ({"max_hypotheses": True}, "max_hypotheses"),
+    ],
+)
+def test_preset_rejects_invalid_integer_limit_overrides(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        residual_mht_config_for_preset("frontier", **kwargs)


### PR DESCRIPTION
## Bug

`ResidualMHTConfig` integer limits were normalized with `int(...)` or `max(..., int(...))`. This silently truncated fractional values, accepted booleans as integers, and converted invalid negative limits into different selector behavior. The preset override path had the same lossy coercion.

Examples included `max_edits=1.5` becoming `1`, `max_hypotheses=True` becoming `1`, and `candidate_top_k=-1` becoming an empty frontier.

## Fix

- validate residual-MHT limits centrally with Python's integer index protocol;
- reject booleans, floats, strings, and out-of-range values instead of coercing them;
- preserve valid non-negative semantics for edit and pruning caps and positive semantics for `max_hypotheses`;
- apply the same validation to preset overrides and per-family/group caps.

## Regression coverage

Tests cover fractional and boolean limits, non-positive hypothesis counts, negative frontier caps, invalid group/family caps, and lossy preset overrides.

## Validation

- branch comparison changes only the residual-MHT implementation and its focused test module;
- the branch is based on the current `main` head;
- GitHub Actions will provide the full repository test result on this PR.