### PR TITLE
Accept array-like GM-PHD update model inputs

### DIFF
--- a/src/pyrecest/filters/gaussian_mixture_phd_filter.py
+++ b/src/pyrecest/filters/gaussian_mixture_phd_filter.py
@@ -380,6 +380,8 @@ class GaussianMixturePHDFilter(
             clutter_intensity = self.clutter_intensity
 
         measurements = array(measurements)
+        measurement_matrix = array(measurement_matrix)
+        cov_mat_meas = array(cov_mat_meas)
         if measurements.ndim == 1:
             measurements = measurements.reshape((-1, 1))
 

--- a/tests/filters/test_gaussian_mixture_phd_filter_arraylike_update.py
+++ b/tests/filters/test_gaussian_mixture_phd_filter_arraylike_update.py
@@ -1,0 +1,46 @@
+import numpy as np
+import numpy.testing as npt
+import pyrecest.backend
+import pytest
+from pyrecest.backend import array, eye
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.filters.gaussian_mixture_phd_filter import GaussianMixturePHDFilter
+
+
+pytestmark = pytest.mark.skipif(
+    pyrecest.backend.__backend_name__ != "numpy",
+    reason="Currently only supported for the numpy backend",
+)
+
+
+@pytest.mark.parametrize(
+    "measurement_covariance",
+    [
+        [[0.1, 0.0], [0.0, 0.1]],
+        [[[0.1], [0.0]], [[0.0], [0.1]]],
+    ],
+    ids=["shared-covariance", "per-measurement-covariance"],
+)
+def test_update_linear_accepts_nested_list_model_inputs(measurement_covariance):
+    tracker = GaussianMixturePHDFilter(
+        initial_components=[GaussianDistribution(array([0.0, 0.0]), eye(2))],
+        initial_weights=array([0.9]),
+        detection_probability=0.95,
+        clutter_intensity=1e-4,
+        extraction_threshold=0.3,
+        merging_threshold=0.01,
+        log_prior_estimates=False,
+        log_posterior_estimates=False,
+    )
+
+    tracker.update_linear(
+        [[0.2], [-0.1]],
+        [[1.0, 0.0], [0.0, 1.0]],
+        measurement_covariance,
+    )
+
+    npt.assert_allclose(
+        tracker.get_point_estimate().reshape((-1,)),
+        np.array([0.18181818, -0.09090909]),
+        atol=5e-3,
+    )


### PR DESCRIPTION
## Bug

`GaussianMixturePHDFilter.update_linear` converted `measurements` through the active backend, but left `measurement_matrix` and `cov_mat_meas` unchanged. Ordinary nested Python lists therefore failed before the filtering equations were evaluated: the matrix path accessed `.T`, while the covariance path accessed `.ndim`.

This was also inconsistent with `predict_linear`, which already accepts array-like system matrices and process-noise covariances.

## Fix

- convert the measurement matrix through `pyrecest.backend.array`;
- convert shared or per-measurement covariance inputs through the same backend boundary;
- retain all existing update equations and numerical defaults.

## Regression coverage

A focused NumPy-backend test exercises nested-list inputs for:

- a shared two-dimensional measurement covariance;
- a three-dimensional per-measurement covariance stack.

Both forms are checked against the existing linear-update point estimate.

## Validation

- reproduced the previous `AttributeError` failures for list inputs lacking `.T` and `.ndim`;
- compared the branch with current `main`: two commits ahead, zero behind;
- verified the production diff contains exactly two added coercion lines, plus one focused regression file.

GitHub Actions provides the authoritative repository test and lint validation.