### PR TITLE
Fix empty PyTorch fftconvolve results

### DIFF
--- a/src/pyrecest/_backend/pytorch/signal.py
+++ b/src/pyrecest/_backend/pytorch/signal.py
@@ -143,6 +143,8 @@ def fftconvolve(in1, in2, mode="full", axes=None):
     x, y = _as_tensor_pair(in1, in2)
     if x.ndim != y.ndim:
         raise ValueError("in1 and in2 should have the same dimensionality")
+    if x.numel() == 0 or y.numel() == 0:
+        return x.reshape(-1)[:0] + y.reshape(-1)[:0]
     if x.ndim == 0:
         return x * y
 

--- a/tests/backend_support/test_pytorch_fftconvolve_empty_inputs.py
+++ b/tests/backend_support/test_pytorch_fftconvolve_empty_inputs.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pyrecest.backend as backend
+import pytest
+from scipy.signal import fftconvolve as scipy_fftconvolve
+
+
+@pytest.mark.parametrize("mode", ["full", "same", "valid"])
+@pytest.mark.parametrize(
+    ("first_shape", "second_shape"),
+    [
+        ((0, 2), (3, 2)),
+        ((3, 2), (0, 2)),
+    ],
+    ids=["left-empty", "right-empty"],
+)
+def test_pytorch_fftconvolve_empty_input_matches_scipy(
+    mode,
+    first_shape,
+    second_shape,
+):
+    if backend.__backend_name__ != "pytorch":
+        pytest.skip("PyTorch-specific signal backend contract")
+
+    first = np.empty(first_shape)
+    second = np.ones(second_shape)
+
+    actual = backend.to_numpy(backend.signal.fftconvolve(first, second, mode=mode))
+    expected = scipy_fftconvolve(first, second, mode=mode)
+
+    assert actual.shape == expected.shape == (0,)
+    assert actual.size == 0


### PR DESCRIPTION
## Bug

The PyTorch `fftconvolve` path padded empty operands to a nonzero FFT length. Empty inputs could therefore produce nonempty zero arrays in `full` and `valid` modes, including shape-inconsistent multidimensional outputs, while SciPy returns a one-dimensional empty result for every mode.

For example, convolving shapes `(0, 2)` and `(3, 2)` previously produced shapes `(2, 3)` in `full` mode and `(1, 1)` in `valid` mode instead of `(0,)`.

## Fix

- detect empty operands after device/dtype normalization and dimensionality validation;
- return a one-dimensional empty tensor before axis, shape, and FFT processing;
- derive the empty result from zero-length views of both operands so the common dtype, selected device, and autograd connectivity are preserved.

## Regression coverage

- compare the PyTorch backend against `scipy.signal.fftconvolve` for both left-empty and right-empty operands;
- cover `full`, `same`, and `valid` modes.

## Validation

- isolated parity checks passed against SciPy for all three modes and representative one- and two-dimensional empty inputs;
- the branch is two commits ahead and zero behind `main`;
- the production change is limited to a two-line early return plus one focused regression file.