### PR TITLE
Preserve alignment for sparse grouped results

### DIFF
--- a/src/pyrecest/evaluation/group_results_by_filter.py
+++ b/src/pyrecest/evaluation/group_results_by_filter.py
@@ -15,18 +15,24 @@ def group_results_by_filter(data):
     )
 
     output_dict = {}
+    group_sizes = {}
     for entry in sorted_data:
         name = entry["name"]
         # Remove the 'name' key-value pair from the entry
         entry_values = {k: v for k, v in entry.items() if k != "name"}
 
-        # Check if the name already exists in the output_dict
-        if name in output_dict:
-            for key, value in entry_values.items():
-                # Append values to the existing lists
-                output_dict[name][key].append(value)
-        else:
-            # Initialize the entry in the output_dict with lists for each value
+        if name not in output_dict:
             output_dict[name] = {k: [v] for k, v in entry_values.items()}
+            group_sizes[name] = 1
+            continue
+
+        grouped_values = output_dict[name]
+        n_existing = group_sizes[name]
+        for key in tuple(grouped_values):
+            grouped_values[key].append(entry_values.get(key))
+        for key, value in entry_values.items():
+            if key not in grouped_values:
+                grouped_values[key] = [None] * n_existing + [value]
+        group_sizes[name] += 1
 
     return output_dict

--- a/tests/evaluation/test_group_results_by_filter_sparse_fields.py
+++ b/tests/evaluation/test_group_results_by_filter_sparse_fields.py
@@ -1,0 +1,32 @@
+from pyrecest.evaluation.group_results_by_filter import group_results_by_filter
+
+
+def test_group_results_by_filter_aligns_sparse_fields():
+    data = [
+        {
+            "name": "pf",
+            "parameter": 2,
+            "error_mean": 0.2,
+            "time_std": 0.02,
+        },
+        {
+            "name": "pf",
+            "parameter": 1,
+            "error_mean": 0.1,
+        },
+        {
+            "name": "pf",
+            "parameter": 3,
+            "time_std": 0.03,
+        },
+    ]
+
+    grouped = group_results_by_filter(data)
+
+    assert grouped == {
+        "pf": {
+            "parameter": [1, 2, 3],
+            "error_mean": [0.1, 0.2, None],
+            "time_std": [None, 0.02, 0.03],
+        }
+    }


### PR DESCRIPTION
## Bug

`group_results_by_filter` assumed that every result entry for a given filter had exactly the same fields. If a later entry introduced an optional metric, grouping raised `KeyError`. If a later entry omitted a field, the corresponding value list became shorter than the parameter and other metric lists, silently breaking row alignment.

## Fix

- track the number of grouped rows per filter;
- append `None` for fields missing from a later entry;
- backfill `None` when a field first appears after earlier rows;
- preserve the existing parameter sorting and output structure.

## Regression coverage

A focused test groups three parameter settings where `error_mean` and `time_std` are present on different subsets of rows. It verifies that all grouped lists stay sorted and index-aligned.

## Validation

- focused regression executed locally and passed;
- Python syntax compilation passed for the modified utility;
- branch is two commits ahead and zero behind current `main`;
- diff is limited to the grouping helper and one regression test.