### PR TITLE
Mask zero-support box likelihoods

### DIFF
--- a/src/pyrecest/filters/euclidean_box_particle_filter.py
+++ b/src/pyrecest/filters/euclidean_box_particle_filter.py
@@ -286,9 +286,16 @@ class EuclideanBoxParticleFilter(AbstractParticleFilter, EuclideanFilterMixin):
             zeros_like(previous_volumes),
         )
 
+        valid_column = expand_dims(valid, 1)
+        safe_lower = where(valid_column, contracted_lower, predicted.lower)
+        safe_upper = where(valid_column, contracted_upper, predicted.upper)
+
         if likelihood is not None:
-            centers = 0.5 * (contracted_lower + contracted_upper)
+            centers = 0.5 * (safe_lower + safe_upper)
             likelihood_values = likelihood(centers)
+            likelihood_values = where(
+                ratios > 0, likelihood_values, zeros_like(ratios)
+            )
             ratios = ratios * likelihood_values
 
         new_weights = predicted.w * ratios
@@ -299,9 +306,6 @@ class EuclideanBoxParticleFilter(AbstractParticleFilter, EuclideanFilterMixin):
             )
         new_weights = new_weights / sum(new_weights)
 
-        valid_column = expand_dims(valid, 1)
-        safe_lower = where(valid_column, contracted_lower, predicted.lower)
-        safe_upper = where(valid_column, contracted_upper, predicted.upper)
         self._filter_state = LinearBoxParticleDistribution(
             safe_lower,
             safe_upper,

--- a/tests/filters/test_euclidean_box_particle_filter.py
+++ b/tests/filters/test_euclidean_box_particle_filter.py
@@ -41,6 +41,27 @@ class EuclideanBoxParticleFilterTest(unittest.TestCase):
         npt.assert_allclose(pf.filter_state.upper, array([[1.0], [4.0]]))
         npt.assert_allclose(pf.filter_state.w, array([1.0, 0.0]))
 
+    def test_invalid_contraction_cannot_inject_nan_likelihood_weight(self):
+        pf = EuclideanBoxParticleFilter(2, 1)
+        pf.filter_state = LinearBoxParticleDistribution(
+            array([[0.0], [2.0]]),
+            array([[2.0], [4.0]]),
+            array([0.5, 0.5]),
+        )
+        pf.set_resampling_criterion(lambda _state: False)
+
+        pf.update_contracted(
+            lambda _lower, _upper: (
+                array([[0.0], [3.0]]),
+                array([[1.0], [2.0]]),
+            ),
+            likelihood=lambda _centers: array([1.0, float("nan")]),
+        )
+
+        npt.assert_allclose(pf.filter_state.lower, array([[0.0], [2.0]]))
+        npt.assert_allclose(pf.filter_state.upper, array([[1.0], [4.0]]))
+        npt.assert_allclose(pf.filter_state.w, array([1.0, 0.0]))
+
     def test_resample_splits_duplicate_boxes_along_widest_dimension(self):
         random.seed(1)
         pf = EuclideanBoxParticleFilter(4, 1)


### PR DESCRIPTION
## Bug

`EuclideanBoxParticleFilter.update_contracted` multiplied every optional point-likelihood value into the geometric contraction ratio, including boxes whose ratio was already zero because the contractor returned an empty intersection.

For such a rejected box, an out-of-domain likelihood can legitimately produce `NaN`. IEEE arithmetic then turns `0 * NaN` into `NaN`, contaminating the normalized weight vector and causing `LinearBoxParticleDistribution` to reject the update as non-finite even when another box has valid positive support.

## Fix

- preserve the original predicted bounds for invalid contractions before evaluating the optional likelihood;
- mask likelihood values wherever the geometric contraction ratio is zero;
- retain the existing volume-ratio update and zero-total-likelihood error behavior for contributing boxes.

## Regression coverage

Added a focused two-box test where one contraction is valid and the other is empty. The optional likelihood returns a finite value for the contributing box and `NaN` for the rejected box. The update must retain finite weights `[1, 0]` and preserve the rejected box's original bounds.

## Validation

- Python syntax compilation passed for the modified implementation and regression test;
- the failure mechanism was reproduced directly (`0 * NaN -> NaN`) and the masked arithmetic yields zero;
- the branch is one commit ahead and zero behind current `main`;
- the diff is limited to the box-particle update and its existing test module.

GitHub Actions provides the authoritative full-suite and backend validation.