### PR TITLE
Reject matrix-shaped measurement reliability inputs

### DIFF
--- a/src/pyrecest/filters/measurement_reliability.py
+++ b/src/pyrecest/filters/measurement_reliability.py
@@ -207,7 +207,10 @@ def normalize_measurement_weights(measurement_weights, n_measurements: int):
             raise ValueError("measurement_weights must be non-negative")
         weights = ones(n_measurements) * scalar_weight
     else:
-        weights = reshape(weights, (-1,))
+        if weights.ndim != 1:
+            raise ValueError(
+                "measurement_weights must be scalar or one-dimensional"
+            )
         if weights.shape[0] != n_measurements:
             raise ValueError(
                 "measurement_weights must be scalar or have one entry per measurement"
@@ -243,7 +246,10 @@ def normalize_active_measurement_mask(
         raise ValueError("active_measurement_mask must contain booleans")
     if mask.ndim == 0:
         return [bool(mask)] * n_measurements
-    mask = reshape(mask, (-1,))
+    if mask.ndim != 1:
+        raise ValueError(
+            "active_measurement_mask must be scalar or one-dimensional"
+        )
     if mask.shape[0] != n_measurements:
         raise ValueError(
             "active_measurement_mask must be scalar or have one entry per measurement"

--- a/tests/filters/test_measurement_reliability_shapes.py
+++ b/tests/filters/test_measurement_reliability_shapes.py
@@ -1,0 +1,40 @@
+import unittest
+
+import pyrecest.backend
+from pyrecest.backend import array
+from pyrecest.filters import (
+    normalize_active_measurement_mask,
+    normalize_measurement_weights,
+)
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ != "numpy",
+    reason="measurement reliability tests currently use backend array shape checks",
+)
+class TestMeasurementReliabilityShapes(unittest.TestCase):
+    def test_weight_matrices_are_rejected_instead_of_flattened(self):
+        matrix_weights = (
+            array([[1.0, 0.5]]),
+            array([[1.0], [0.5]]),
+        )
+
+        for weights in matrix_weights:
+            with self.subTest(shape=weights.shape):
+                with self.assertRaisesRegex(ValueError, "one-dimensional"):
+                    normalize_measurement_weights(weights, 2)
+
+    def test_mask_matrices_are_rejected_instead_of_flattened(self):
+        matrix_masks = (
+            array([[True, False]]),
+            array([[True], [False]]),
+        )
+
+        for mask in matrix_masks:
+            with self.subTest(shape=mask.shape):
+                with self.assertRaisesRegex(ValueError, "one-dimensional"):
+                    normalize_active_measurement_mask(mask, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- reject matrix-shaped `measurement_weights` instead of silently flattening them
- reject matrix-shaped `active_measurement_mask` inputs for the same reason
- preserve the documented scalar and one-dimensional vector forms
- add regression coverage for both row- and column-matrix inputs

## Bug

The normalization helpers document scalar-or-vector inputs, but their unconditional `reshape(..., (-1,))` accepted arbitrary matrices whenever the total element count matched `n_measurements`. This silently discarded the caller's dimensional structure and could assign reliability values in an unintended order.

## Validation

- inspected the resulting commit diff against current `main`
- branch is one commit ahead and zero commits behind
- added four regression cases covering row and column matrices for weights and masks

Full local test execution was not available in this environment because the GitHub CLI is unavailable and outbound repository cloning is blocked. GitHub Actions should provide the authoritative suite result on this PR.