### PR TITLE
Reject matrix-shaped Gaussian hypothesis log weights

### DIFF
--- a/src/pyrecest/filters/gaussian_hypothesis_mixture.py
+++ b/src/pyrecest/filters/gaussian_hypothesis_mixture.py
@@ -81,7 +81,10 @@ def moment_match_gaussian_hypotheses(
 
 def normalize_log_weights(log_weights: list[float] | np.ndarray) -> np.ndarray:
     """Normalize log weights to probabilities in a numerically stable way."""
-    values = _as_float_array(log_weights, "log_weights").reshape(-1)
+    values = _as_float_array(log_weights, "log_weights")
+    if values.ndim > 1:
+        raise ValueError("log_weights must be scalar or one-dimensional")
+    values = values.reshape(-1)
     if values.size == 0:
         raise ValueError("log_weights must not be empty")
     if np.any(np.isnan(values)):

--- a/tests/filters/test_gaussian_hypothesis_log_weight_shape.py
+++ b/tests/filters/test_gaussian_hypothesis_log_weight_shape.py
@@ -1,0 +1,28 @@
+import unittest
+
+import numpy as np
+from pyrecest.filters import normalize_log_weights
+
+
+class GaussianHypothesisLogWeightShapeTest(unittest.TestCase):
+    def test_matrix_log_weights_are_rejected(self):
+        for log_weights in (
+            np.array([[0.0, 1.0]]),
+            np.array([[0.0], [1.0]]),
+        ):
+            with self.subTest(shape=log_weights.shape):
+                with self.assertRaisesRegex(ValueError, "one-dimensional"):
+                    normalize_log_weights(log_weights)
+
+    def test_scalar_and_vector_log_weights_remain_supported(self):
+        self.assertTrue(np.allclose(normalize_log_weights(0.0), np.array([1.0])))
+        self.assertTrue(
+            np.allclose(
+                normalize_log_weights(np.array([0.0, 0.0])),
+                np.array([0.5, 0.5]),
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`normalize_log_weights` unconditionally flattened its input. Row and column matrices were therefore accepted and converted into a one-dimensional probability vector, silently discarding the caller's dimensional structure.

This can detach normalized weights from the hypothesis layout the matrix represented and differs from the scalar-or-vector semantics of a log-weight collection.

## Fix

- reject inputs with more than one dimension before flattening;
- preserve the existing scalar and one-dimensional input behavior;
- retain all existing numerical handling for NaN, infinite, and finite log weights.

## Regression coverage

Added focused tests that:

- reject both row- and column-matrix log weights;
- verify scalar and one-dimensional inputs remain supported.

## Validation

- branch is two commits ahead and zero commits behind current `main`;
- the diff is limited to four added validation lines, one replaced normalization line, and one focused regression file;
- GitHub Actions will provide the authoritative full-suite and backend validation.