### PR TITLE
Normalize Gaussian mixture moment weights

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/gaussian_mixture.py
+++ b/src/pyrecest/distributions/nonperiodic/gaussian_mixture.py
@@ -70,12 +70,13 @@ class GaussianMixture(LinearMixture, AbstractLinearDistribution):
         if weights is None:
             weights = ones(means.shape[0]) / means.shape[0]
         else:
-            weights = array(weights)
+            weights = reshape(array(weights), (-1,))
 
-        C_from_cov = sum(covariance_matrices * reshape(weights, (1, 1, -1)), axis=2)
+        weights = LinearDiracDistribution._normalized_weights(weights)
         mu, C_from_means = LinearDiracDistribution.weighted_samples_to_mean_and_cov(
             means, weights
         )
+        C_from_cov = sum(covariance_matrices * reshape(weights, (1, 1, -1)), axis=2)
         C = C_from_cov + C_from_means
 
         return mu, C

--- a/tests/distributions/test_gaussian_mixture_weight_scale.py
+++ b/tests/distributions/test_gaussian_mixture_weight_scale.py
@@ -1,0 +1,35 @@
+import numpy.testing as npt
+
+from pyrecest.backend import array, stack, to_numpy
+from pyrecest.distributions import GaussianMixture
+
+
+def test_gaussian_mixture_moment_match_is_invariant_to_weight_scale():
+    means = array([[0.0], [2.0]])
+    covariance_matrices = stack(
+        [
+            array([[1.0]]),
+            array([[1.0]]),
+        ],
+        axis=2,
+    )
+
+    normalized_mean, normalized_covariance = (
+        GaussianMixture.mixture_parameters_to_gaussian_parameters(
+            means,
+            covariance_matrices,
+            [0.25, 0.75],
+        )
+    )
+    scaled_mean, scaled_covariance = (
+        GaussianMixture.mixture_parameters_to_gaussian_parameters(
+            means,
+            covariance_matrices,
+            [1.0, 3.0],
+        )
+    )
+
+    npt.assert_allclose(to_numpy(normalized_mean), [1.5])
+    npt.assert_allclose(to_numpy(normalized_covariance), [[1.75]])
+    npt.assert_allclose(to_numpy(scaled_mean), to_numpy(normalized_mean))
+    npt.assert_allclose(to_numpy(scaled_covariance), to_numpy(normalized_covariance))


### PR DESCRIPTION
## Bug

`GaussianMixture.mixture_parameters_to_gaussian_parameters(...)` normalized explicit weights indirectly for the mixture mean and between-component covariance, but multiplied component covariances by the original unnormalized weights.

Consequently, proportional weight vectors represented different Gaussian reductions. For two unit-variance components with means `0` and `2`, weights `[0.25, 0.75]` produced covariance `1.75`, while the equivalent weights `[1, 3]` produced `4.75`.

## Fix

- reshape explicit sequence weights through the backend boundary;
- normalize weights once before either moment contribution is computed;
- use the same normalized weights for component covariance averaging and mean-spread covariance.

## Regression coverage

Added a focused scale-invariance test comparing `[0.25, 0.75]` with `[1, 3]`. Both reductions must return mean `1.5` and covariance `1.75`.

## Validation

- independently reproduced the old `4.75` covariance and corrected `1.75` result;
- inspected the committed branch files after publication;
- branch comparison is 2 commits ahead and 0 behind `main`;
- production diff is limited to 3 additions and 2 deletions in the Gaussian-mixture reduction helper.

Full repository and backend-matrix execution is delegated to GitHub Actions because this runtime cannot clone `github.com` and does not provide the GitHub CLI.