### PR TITLE
Protect reserved evidence diagnostics from metadata mutation

### DIFF
--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -148,13 +148,15 @@ class EvidenceComputationMode:
         """Return stable scalar diagnostics for reports and artifacts."""
 
         diagnostics = {
-            f"{prefix}_computation_mode": self.mode,
-            f"{prefix}_only": int(self.evidence_only_requested),
-            f"{prefix}_return_smoothed": int(self.return_smoothed),
-            f"{prefix}_terminal_posterior": int(self.terminal_posterior),
+            f"{prefix}_{key}": value for key, value in self.metadata.items()
         }
         diagnostics.update(
-            {f"{prefix}_{key}": value for key, value in self.metadata.items()}
+            {
+                f"{prefix}_computation_mode": self.mode,
+                f"{prefix}_only": int(self.evidence_only_requested),
+                f"{prefix}_return_smoothed": int(self.return_smoothed),
+                f"{prefix}_terminal_posterior": int(self.terminal_posterior),
+            }
         )
         return diagnostics
 

--- a/tests/test_evidence_only_mode.py
+++ b/tests/test_evidence_only_mode.py
@@ -32,6 +32,26 @@ def test_evidence_computation_mode_accepts_none_metadata_constructor():
     assert mode.to_diagnostics()["evidence_computation_mode"] == "full_smoothing"
 
 
+def test_mutated_metadata_cannot_overwrite_reserved_evidence_diagnostics():
+    mode = EvidenceComputationMode.full_smoothing(metadata={"source": "test"})
+    mode.metadata.update(
+        {
+            "computation_mode": "corrupted",
+            "only": 99,
+            "return_smoothed": 0,
+            "terminal_posterior": 0,
+        }
+    )
+
+    diagnostics = mode.to_diagnostics()
+
+    assert diagnostics["evidence_source"] == "test"
+    assert diagnostics["evidence_computation_mode"] == "full_smoothing"
+    assert diagnostics["evidence_only"] == 0
+    assert diagnostics["evidence_return_smoothed"] == 1
+    assert diagnostics["evidence_terminal_posterior"] == 1
+
+
 def test_evidence_computation_mode_rejects_invalid_boolean_strings():
     with pytest.raises(ValueError, match="return_smoothed"):
         resolve_evidence_computation_mode(return_smoothed="definitely")


### PR DESCRIPTION
## Bug

`EvidenceComputationMode` rejects reserved metadata keys during construction, but its frozen dataclass still exposes the nested metadata dictionary. A caller can therefore add a reserved key after construction. `to_diagnostics()` previously applied metadata last, allowing those late mutations to overwrite authoritative fields such as the computation mode, evidence-only flag, and posterior-return flags.

This can make reports and artifacts describe a different execution mode than the filter actually used.

## Fix

- emit caller metadata first;
- apply the authoritative evidence diagnostics last so reserved fields always win;
- retain ordinary custom metadata unchanged.

## Regression coverage

Added a focused test that mutates all four reserved metadata keys after construction and verifies that the generated diagnostics still report the actual mode and flags while preserving unrelated metadata.

## Validation

- reproduced the pre-fix overwrite behavior in an isolated check;
- verified the corrected merge order preserves all authoritative diagnostics;
- branch is two commits ahead and zero commits behind the `main` revision used for the fix;
- diff is limited to `evidence.py` and its existing test module.