### PR TITLE
Handle scalar arrays in diagnostic JSON summaries

### DIFF
--- a/src/pyrecest/evaluation/diagnostic_summaries.py
+++ b/src/pyrecest/evaluation/diagnostic_summaries.py
@@ -347,6 +347,8 @@ def _json_value(value: Any) -> Any:
     if value is None:
         return None
     if isinstance(value, np.ndarray):
+        if value.ndim == 0:
+            return _json_value(value.item())
         return [_json_value(item) for item in value.tolist()]
     if isinstance(value, Mapping):
         return _json_record(value)

--- a/tests/evaluation/test_diagnostic_summary_scalar_arrays.py
+++ b/tests/evaluation/test_diagnostic_summary_scalar_arrays.py
@@ -1,0 +1,27 @@
+import json
+
+import numpy as np
+
+from pyrecest.evaluation.diagnostic_summaries import top_residuals
+
+
+def test_top_residuals_serializes_zero_dimensional_numpy_arrays():
+    rows = top_residuals(
+        [
+            {
+                "residual_norm": np.array(2.0),
+                "backend_scalar": np.array(3.5),
+                "backend_flag": np.array(True),
+            }
+        ],
+        top_n=1,
+    )
+
+    assert rows == [
+        {
+            "residual_norm": 2.0,
+            "backend_scalar": 3.5,
+            "backend_flag": True,
+        }
+    ]
+    json.dumps(rows)


### PR DESCRIPTION
## Bug

`diagnostic_summaries._json_value` treated every NumPy array as an iterable after calling `.tolist()`. For a zero-dimensional array such as `np.array(3.5)`, `.tolist()` returns a Python scalar, so the list comprehension raised `TypeError: 'float' object is not iterable`.

This could make otherwise valid diagnostic records fail during conversion even though the module promises JSON-serializable summaries.

## Fix

- detect zero-dimensional NumPy arrays;
- unwrap them with `.item()`;
- pass the resulting scalar back through the existing JSON normalization path;
- preserve the existing recursive behavior for non-scalar arrays.

## Regression coverage

Added a focused test that includes zero-dimensional float and boolean arrays in a `top_residuals` record. It verifies the normalized Python values and confirms that `json.dumps` succeeds.

## Validation

- reproduced the pre-fix `TypeError` directly;
- focused patched execution returned the expected plain-Python record;
- `json.dumps` succeeded;
- Python syntax compilation passed for the modified module and regression test;
- branch comparison is two commits ahead and zero behind `main`, changing only the diagnostic serializer and one test file.