### PR TITLE
Enforce transition sample-count support in core models

### DIFF
--- a/src/pyrecest/models/likelihood.py
+++ b/src/pyrecest/models/likelihood.py
@@ -214,6 +214,8 @@ class SampleableTransitionModel:
         """Draw ``n`` next-state samples conditioned on ``state``."""
 
         n = _validate_sample_count(n)
+        if self._sample_next_count_call_mode is None and n != 1:
+            raise TypeError("sample count is not supported by this sampler.")
         if self._sample_next_count_call_mode == "positional":
             return self._sample_next(state, n)
         if self._sample_next_count_call_mode == "keyword":
@@ -266,6 +268,8 @@ class DensityTransitionModel:
         if self._sample_next is None:
             raise NotImplementedError("No sample_next callback was provided.")
         n = _validate_sample_count(n)
+        if self._sample_next_count_call_mode is None and n != 1:
+            raise TypeError("sample count is not supported by this sampler.")
         if self._sample_next_count_call_mode == "positional":
             return self._sample_next(state, n)
         if self._sample_next_count_call_mode == "keyword":


### PR DESCRIPTION
## Bug

Unsupported sample counts were rejected only by a validation wrapper installed later through package initialization. The core `SampleableTransitionModel.sample_next` and `DensityTransitionModel.sample_next` methods themselves silently ignored `n != 1` when the callback had no sample-count argument.

That made correctness depend on runtime monkey-patching and left the unwrapped methods inconsistent with their documented contract and existing regression expectations.

## Fix

- validate `n` in the core methods as before;
- raise `TypeError` directly when the sampler cannot accept a count and `n != 1`;
- retain the existing single-sample behavior and positional/keyword count forwarding.

## Coverage

The repository already contains focused regression tests in `tests/models/test_transition_sample_count_unsupported.py` for both transition-model classes. This change makes the invariant intrinsic rather than dependent on the installation wrapper.

## Scope

The diff changes only four lines in `src/pyrecest/models/likelihood.py`.