### PR TITLE
Validate JAX sparse target dimensions exactly

### DIFF
--- a/src/pyrecest/backend_support/_jax_array_from_sparse_contract.py
+++ b/src/pyrecest/backend_support/_jax_array_from_sparse_contract.py
@@ -2,15 +2,41 @@
 
 from __future__ import annotations
 
+import operator
 
-def _normalize_sparse_target_shape(target_shape) -> tuple[int, ...]:
+import numpy as np
+
+_BOOLEAN_TYPES = (bool, np.bool_)
+_TEXT_TYPES = (str, bytes, bytearray, np.str_, np.bytes_)
+
+
+def _normalize_sparse_dimension(size) -> int:
+    if isinstance(size, _BOOLEAN_TYPES):
+        raise TypeError("target_shape dimensions must be integers")
+    dtype = getattr(size, "dtype", None)
+    if dtype is not None and str(dtype).lower() in {
+        "bool",
+        "bool_",
+        "torch.bool",
+    }:
+        raise TypeError("target_shape dimensions must be integers")
     try:
-        normalized = tuple(int(size) for size in target_shape)
-    except TypeError:
-        normalized = (int(target_shape),)
-    if any(size < 0 for size in normalized):
+        normalized = operator.index(size)
+    except TypeError as exc:
+        raise TypeError("target_shape dimensions must be integers") from exc
+    if normalized < 0:
         raise ValueError("negative dimensions are not allowed")
     return normalized
+
+
+def _normalize_sparse_target_shape(target_shape) -> tuple[int, ...]:
+    if isinstance(target_shape, _TEXT_TYPES):
+        raise TypeError("target_shape must be an integer or a sequence of integers")
+    try:
+        dimensions = tuple(target_shape)
+    except TypeError:
+        dimensions = (target_shape,)
+    return tuple(_normalize_sparse_dimension(size) for size in dimensions)
 
 
 def patch_jax_array_from_sparse_flat_index_contract() -> None:

--- a/tests/backend_support/test_jax_sparse_target_shape_validation.py
+++ b/tests/backend_support/test_jax_sparse_target_shape_validation.py
@@ -1,0 +1,40 @@
+"""Validation tests for JAX sparse reconstruction target shapes."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pyrecest.backend_support._jax_array_from_sparse_contract import (
+    _normalize_sparse_target_shape,
+)
+
+
+def test_sparse_target_shape_accepts_exact_integer_dimensions():
+    assert _normalize_sparse_target_shape(4) == (4,)
+    assert _normalize_sparse_target_shape(np.array(4, dtype=np.int64)) == (4,)
+    assert _normalize_sparse_target_shape((2, np.int32(3))) == (2, 3)
+    assert _normalize_sparse_target_shape(()) == ()
+
+
+@pytest.mark.parametrize(
+    "target_shape",
+    [
+        2.5,
+        (2.5,),
+        (np.array(2.0),),
+        True,
+        (np.bool_(False),),
+        (np.inf,),
+        "12",
+        ("2",),
+    ],
+)
+def test_sparse_target_shape_rejects_noninteger_dimensions(target_shape):
+    with pytest.raises(TypeError, match="integer"):
+        _normalize_sparse_target_shape(target_shape)
+
+
+def test_sparse_target_shape_preserves_negative_dimension_error():
+    with pytest.raises(ValueError, match="negative dimensions"):
+        _normalize_sparse_target_shape((2, -1))


### PR DESCRIPTION
## Bug

The JAX sparse reconstruction runtime patch normalized `target_shape` with `int(...)`. That silently accepted invalid shape specifications:

- fractional dimensions were truncated, so `(2.5,)` became `(2,)`;
- booleans became dimensions `0` or `1`;
- a top-level string such as `"12"` was iterated and interpreted as `(1, 2)`.

This could allocate an array with a shape different from the caller's request instead of failing at the API boundary.

## Fix

- normalize each dimension with `operator.index`, matching Python/NumPy integer-shape semantics;
- explicitly reject boolean and textual shape values;
- keep support for Python and NumPy integer scalars, iterable integer shapes, zero-dimensional integer arrays, and scalar-output shape `()`;
- preserve the existing negative-dimension `ValueError`.

## Regression coverage

Added focused tests covering valid integer forms and rejection of fractional, floating-array, boolean, infinite, and textual dimensions.

## Validation

- locally exercised the extracted normalizer against valid and invalid inputs;
- Python syntax compilation passed for the validation probe;
- branch is two commits ahead and zero behind current `main`;
- diff is limited to the JAX sparse target-shape normalizer and one focused test module.