### PR TITLE
Avoid invalid pooled time-offset percentiles

### DIFF
--- a/src/pyrecest/calibration/__init__.py
+++ b/src/pyrecest/calibration/__init__.py
@@ -96,11 +96,30 @@ def _as_nonnegative_summary_count(value: Any, name: str) -> float:
     return result
 
 
+_base_aggregate_summary_metric = _time_offset_module._aggregate_summary_metric
+
+
+def _aggregate_summary_metric(
+    key: str,
+    values: np.ndarray,
+    counts: np.ndarray,
+) -> float:
+    """Aggregate composable metrics without inventing pooled percentiles."""
+    if key != "p95":
+        return _base_aggregate_summary_metric(key, values, counts)
+
+    valid = np.isfinite(values) & (counts > 0.0)
+    if np.count_nonzero(valid) == 1:
+        return float(values[valid][0])
+    return float("nan")
+
+
 _time_offset_module._as_finite_float = _as_finite_float
 _time_offset_module._as_nonnegative_time_delta = _as_nonnegative_time_delta
 _time_offset_module._as_real_numeric_array = _as_real_numeric_array
 _time_offset_module._as_summary_scalar = _as_summary_scalar
 _time_offset_module._as_nonnegative_summary_count = _as_nonnegative_summary_count
+_time_offset_module._aggregate_summary_metric = _aggregate_summary_metric
 
 from .bias import (  # noqa: E402
     BiasTrainingExamples,

--- a/tests/calibration/test_time_offset_p95_aggregation.py
+++ b/tests/calibration/test_time_offset_p95_aggregation.py
@@ -1,0 +1,48 @@
+import math
+
+from pyrecest.calibration import aggregate_time_offset_sweeps
+from pyrecest.calibration.time_offset import (
+    aggregate_time_offset_sweeps as aggregate_time_offset_sweeps_from_module,
+)
+
+
+def _summary_row(*, count: float, p95: float) -> dict[str, float]:
+    return {
+        "time_offset_s": 0.0,
+        "count": count,
+        "mean": 0.0,
+        "std": 0.0,
+        "rmse": 0.0,
+        "p95": p95,
+        "max": p95,
+    }
+
+
+def test_aggregate_time_offset_sweeps_does_not_average_percentiles():
+    sweeps = [
+        [_summary_row(count=100.0, p95=0.0)],
+        [_summary_row(count=1.0, p95=100.0)],
+    ]
+
+    for aggregate in (
+        aggregate_time_offset_sweeps,
+        aggregate_time_offset_sweeps_from_module,
+    ):
+        aggregated = aggregate(sweeps)
+
+        assert math.isnan(aggregated[0]["p95"])
+
+
+def test_aggregate_time_offset_sweeps_preserves_single_nonempty_percentile():
+    sweeps = [
+        [_summary_row(count=0.0, p95=float("nan"))],
+        [_summary_row(count=4.0, p95=2.5)],
+    ]
+
+    for aggregate in (
+        aggregate_time_offset_sweeps,
+        aggregate_time_offset_sweeps_from_module,
+    ):
+        aggregated = aggregate(sweeps)
+
+        assert aggregated[0]["p95"] == 2.5


### PR DESCRIPTION
## Summary

- stop computing pooled `p95` as a count-weighted average of per-sweep percentiles
- preserve a percentile when exactly one nonempty sweep contributes it
- report `NaN` when multiple nonempty summaries are combined because the exact pooled percentile cannot be reconstructed without raw errors
- keep the existing exact aggregation for mean, RMSE, standard deviation, and maximum

## Bug

Percentiles are not composable summary statistics. For example, combining a 100-sample sweep with `p95 = 0` and a one-sample sweep with `p95 = 100` currently reports approximately `0.99`, even though the pooled 95th percentile is `0`. Returning an invented weighted-average percentile can therefore alter offset comparisons and downstream reporting.

## Validation

- added regression coverage for both `pyrecest.calibration.aggregate_time_offset_sweeps` and `pyrecest.calibration.time_offset.aggregate_time_offset_sweeps`
- verifies that multiple nonempty percentile summaries produce `NaN`
- verifies that a single nonempty percentile is preserved
- Python syntax compilation passed for the modified module and new test file

Full repository CI is left to GitHub Actions.