### PR TITLE
Reject boolean linear-Gaussian model inputs

### DIFF
--- a/src/pyrecest/models/linear_gaussian.py
+++ b/src/pyrecest/models/linear_gaussian.py
@@ -53,6 +53,8 @@ def _contains_complex_values(value):
 
 def _as_matrix(value, name):
     arr = asarray(value)
+    if _has_boolean_dtype(arr):
+        raise ValueError(f"{name} must contain real numeric values")
     if _contains_complex_values(arr):
         raise ValueError(f"{name} must be real-valued")
     if ndim(arr) != 2:
@@ -62,6 +64,8 @@ def _as_matrix(value, name):
 
 def _as_vector(value, name):
     arr = asarray(value)
+    if _has_boolean_dtype(arr):
+        raise ValueError(f"{name} must contain real numeric values")
     if _contains_complex_values(arr):
         raise ValueError(f"{name} must be real-valued")
     if ndim(arr) == 0:

--- a/tests/models/test_linear_gaussian_boolean_inputs.py
+++ b/tests/models/test_linear_gaussian_boolean_inputs.py
@@ -1,0 +1,39 @@
+import pytest
+
+from pyrecest.models import (
+    LinearGaussianMeasurementModel,
+    LinearGaussianTransitionModel,
+)
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: LinearGaussianTransitionModel([[True]], [[1.0]]),
+        lambda: LinearGaussianTransitionModel([[1.0]], [[True]]),
+        lambda: LinearGaussianTransitionModel([[1.0]], [[1.0]], offset=[True]),
+        lambda: LinearGaussianMeasurementModel([[True]], [[1.0]]),
+        lambda: LinearGaussianMeasurementModel([[1.0]], [[True]]),
+    ],
+)
+def test_linear_gaussian_constructors_reject_boolean_parameters(factory) -> None:
+    with pytest.raises(ValueError, match="real numeric"):
+        factory()
+
+
+def test_transition_model_rejects_boolean_state_inputs() -> None:
+    model = LinearGaussianTransitionModel([[1.0]], [[1.0]])
+
+    with pytest.raises(ValueError, match="real numeric"):
+        model.predict_mean([True])
+    with pytest.raises(ValueError, match="real numeric"):
+        model.predict_covariance([[True]])
+
+
+def test_measurement_model_rejects_boolean_state_inputs() -> None:
+    model = LinearGaussianMeasurementModel([[1.0]], [[1.0]])
+
+    with pytest.raises(ValueError, match="real numeric"):
+        model.predict_mean([True])
+    with pytest.raises(ValueError, match="real numeric"):
+        model.innovation_covariance([[True]])


### PR DESCRIPTION
## Bug

The linear-Gaussian model helpers rejected complex values and shape mismatches but accepted boolean arrays. Booleans were therefore silently interpreted as numeric `0`/`1` values when supplied as transition or measurement matrices, covariance matrices, offsets, state means, or state covariances.

That behavior can conceal malformed model configuration and produce valid-looking but unintended predictions.

## Fix

- reject boolean-dtype arrays in the shared matrix validator;
- reject boolean-dtype arrays in the shared vector validator;
- preserve the existing complex-value and dimensionality checks.

## Regression coverage

Added focused tests covering boolean inputs in:

- transition matrices, process covariances, and offsets;
- measurement matrices and measurement covariances;
- transition-model state means and covariances;
- measurement-model state means and covariances.

## Validation

- branch is two commits ahead and zero commits behind the `main` revision used for the fix;
- production diff is limited to four validation lines;
- the remaining diff is a focused regression test module;
- full repository and backend-matrix execution is delegated to GitHub Actions because this runtime does not provide the GitHub CLI and cannot clone `github.com`.