### PR TITLE
Reject matrix-shaped smoother window weights

### DIFF
--- a/src/pyrecest/smoothers/sliding_window_manifold_mean_smoother.py
+++ b/src/pyrecest/smoothers/sliding_window_manifold_mean_smoother.py
@@ -99,7 +99,11 @@ class SlidingWindowManifoldMeanSmoother(AbstractSmoother):
         if window_weights is None:
             self.window_weights = None
         else:
-            self.window_weights = asarray(window_weights).reshape(-1)
+            self.window_weights = asarray(window_weights)
+            if ndim(self.window_weights) == 0:
+                self.window_weights = self.window_weights.reshape((1,))
+            elif ndim(self.window_weights) != 1:
+                raise ValueError("window_weights must be one-dimensional.")
             if self.window_weights.shape[0] != self.window_size:
                 raise ValueError("window_weights must have length window_size.")
             if not backend_all(isfinite(self.window_weights)):

--- a/tests/smoothers/test_sliding_window_window_weight_shape.py
+++ b/tests/smoothers/test_sliding_window_window_weight_shape.py
@@ -1,0 +1,32 @@
+import unittest
+
+from pyrecest.backend import array
+from pyrecest.smoothers import SlidingWindowManifoldMeanSmoother
+
+
+class SlidingWindowWindowWeightShapeTest(unittest.TestCase):
+    def test_rejects_matrix_shaped_window_weights(self):
+        matrix_weights = (
+            array([[1.0, 2.0, 1.0]]),
+            array([[1.0], [2.0], [1.0]]),
+        )
+
+        for window_weights in matrix_weights:
+            with self.subTest(shape=window_weights.shape):
+                with self.assertRaisesRegex(ValueError, "one-dimensional"):
+                    SlidingWindowManifoldMeanSmoother(
+                        window_size=3,
+                        window_weights=window_weights,
+                    )
+
+    def test_scalar_weight_remains_supported_for_singleton_window(self):
+        smoother = SlidingWindowManifoldMeanSmoother(
+            window_size=1,
+            window_weights=array(2.0),
+        )
+
+        self.assertEqual(smoother.window_weights.shape, (1,))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`SlidingWindowManifoldMeanSmoother` documented `window_weights` as a one-dimensional sequence, but normalized every input with `.reshape(-1)`. Row and column matrices such as `[[1, 2, 1]]` and `[[1], [2], [1]]` were therefore silently flattened and accepted whenever their element count matched `window_size`.

Discarding the caller's dimensional structure can hide upstream shape mistakes and apply weights in an unintended order.

## Fix

- convert `window_weights` through the backend without flattening;
- preserve scalar input as a one-element vector for `window_size == 1`;
- reject inputs with more than one dimension;
- retain the existing length, finiteness, non-negativity, and positive-mass validation.

## Regression coverage

Added focused tests that reject both row- and column-matrix weights and verify that a scalar weight remains supported for a singleton window.

## Validation

- branch is two commits ahead and zero behind `main`;
- the production diff is limited to five additions and one deletion in the smoother constructor;
- committed branch files were re-read to verify the shape guard and regression coverage;
- GitHub Actions provides the authoritative full backend and test-suite validation.