### PR TITLE
Reject matrix-shaped LinearDirac moment weights

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/linear_dirac_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/linear_dirac_distribution.py
@@ -140,7 +140,11 @@ class LinearDiracDistribution(AbstractDiracDistribution, AbstractLinearDistribut
         if weights is None:
             weights = ones(sample_matrix.shape[0]) / sample_matrix.shape[0]
         else:
-            weights = reshape(asarray(weights), (-1,))
+            weights = asarray(weights)
+            if weights.ndim == 0:
+                weights = reshape(weights, (1,))
+            elif weights.ndim != 1:
+                raise ValueError("weights must be scalar or one-dimensional")
             if weights.shape[0] != sample_matrix.shape[0]:
                 raise ValueError("Number of weights and samples must match")
             weights = AbstractDiracDistribution._normalized_weights(weights)

--- a/tests/distributions/test_linear_dirac_weight_shape.py
+++ b/tests/distributions/test_linear_dirac_weight_shape.py
@@ -1,0 +1,36 @@
+import unittest
+
+from pyrecest.backend import array
+from pyrecest.distributions import LinearDiracDistribution
+
+
+class LinearDiracWeightShapeTest(unittest.TestCase):
+    def test_rejects_matrix_shaped_moment_weights(self):
+        samples = array([0.0, 2.0])
+        matrix_weights = (
+            array([[1.0, 3.0]]),
+            array([[1.0], [3.0]]),
+        )
+
+        for weights in matrix_weights:
+            with self.subTest(shape=weights.shape):
+                with self.assertRaisesRegex(ValueError, "one-dimensional"):
+                    LinearDiracDistribution.weighted_samples_to_mean_and_cov(
+                        samples,
+                        weights,
+                    )
+
+    def test_scalar_weight_remains_supported_for_single_sample(self):
+        mean, covariance = LinearDiracDistribution.weighted_samples_to_mean_and_cov(
+            array(2.0),
+            array(4.0),
+        )
+
+        self.assertEqual(mean.shape, (1,))
+        self.assertEqual(covariance.shape, (1, 1))
+        self.assertEqual(float(mean[0]), 2.0)
+        self.assertEqual(float(covariance[0, 0]), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`LinearDiracDistribution.weighted_samples_to_mean_and_cov(...)` unconditionally flattened explicit weights with `reshape(..., (-1,))`. Row and column matrices were therefore silently accepted whenever their element count matched the number of samples.

Discarding the caller's dimensional structure can hide upstream shape mistakes and apply weights in an unintended order.

## Fix

- preserve scalar input as a one-element vector for the single-sample case;
- require non-scalar weights to be one-dimensional;
- retain the existing sample-count matching and normalization behavior.

## Regression coverage

Added focused tests that reject both row- and column-matrix weights and verify that scalar weights remain supported for a singleton sample.

## Validation

- branch is two commits ahead and zero behind current `main`;
- production diff is limited to five additions and one deletion;
- regression coverage is isolated to one new test module;
- GitHub Actions provides the authoritative full backend and test-suite validation.