### PR TITLE
Reject matrix-shaped measurement standard deviations

### DIFF
--- a/src/pyrecest/models/weak_measurement.py
+++ b/src/pyrecest/models/weak_measurement.py
@@ -233,7 +233,11 @@ def _finite_real_numeric_array(value: Any, *, name: str) -> np.ndarray:
 
 
 def _standard_deviations_array(stds: Sequence[float] | np.ndarray) -> np.ndarray:
-    values = _real_numeric_array(stds, name="stds").reshape(-1)
+    values = _real_numeric_array(stds, name="stds")
+    if values.ndim == 0:
+        values = values.reshape((1,))
+    elif values.ndim != 1:
+        raise ValueError("stds must be one-dimensional")
     if values.size == 0:
         raise ValueError("stds must contain at least one standard deviation")
     if not np.isfinite(values).all() or np.any(values <= 0.0):

--- a/tests/models/test_weak_measurement_std_shape.py
+++ b/tests/models/test_weak_measurement_std_shape.py
@@ -1,0 +1,40 @@
+import numpy as np
+import pytest
+
+from pyrecest.models import (
+    MaskedLinearMeasurementModel,
+    WeakDimensionMeasurementModel,
+    block_diag_measurement_covariance,
+    diagonal_measurement_covariance,
+)
+
+
+@pytest.mark.parametrize(
+    "stds",
+    [
+        np.array([[1.0, 2.0]]),
+        np.array([[1.0], [2.0]]),
+    ],
+)
+def test_measurement_standard_deviations_reject_matrix_shapes(stds) -> None:
+    constructors = (
+        lambda: diagonal_measurement_covariance(stds),
+        lambda: block_diag_measurement_covariance(trusted_std=stds),
+        lambda: MaskedLinearMeasurementModel(
+            state_dim=2,
+            observed_dims=[0, 1],
+            stds=stds,
+        ),
+        lambda: WeakDimensionMeasurementModel(np.eye(2), stds=stds),
+    )
+
+    for constructor in constructors:
+        with pytest.raises(ValueError, match="one-dimensional"):
+            constructor()
+
+
+def test_scalar_standard_deviation_remains_supported() -> None:
+    covariance = diagonal_measurement_covariance(2.0)
+
+    assert covariance.shape == (1, 1)
+    assert np.allclose(covariance, [[4.0]])


### PR DESCRIPTION
## Bug

Weak-measurement covariance construction normalized standard deviations with `reshape(-1)`. Row and column matrices were therefore silently flattened and accepted as if they were one-dimensional standard-deviation vectors.

This can conceal upstream shape or dimension-order mistakes and construct a covariance for an unintended ordering of measurement dimensions.

## Fix

- preserve scalar input as a one-element vector for the existing singleton case;
- reject arrays with more than one dimension in the shared standard-deviation validator;
- keep the existing numeric, finiteness, positivity, and empty-input checks.

The shared validator covers `diagonal_measurement_covariance`, sequence-based `block_diag_measurement_covariance`, `MaskedLinearMeasurementModel`, and `WeakDimensionMeasurementModel`.

## Regression coverage

Added focused tests that:

- reject both row- and column-matrix standard deviations through all affected public entry points;
- verify that a scalar standard deviation remains supported for a one-dimensional covariance.

## Validation

- branch is two commits ahead and zero behind `main`;
- production diff is five additions and one deletion;
- the remaining change is a focused 40-line regression test module;
- full repository and backend-matrix validation is delegated to GitHub Actions because this runtime cannot clone GitHub or run the repository test environment.