### PR TITLE
Ignore negative replay diagnostics in hypothesis scoring

### DIFF
--- a/src/pyrecest/tracking/hypothesis_replay.py
+++ b/src/pyrecest/tracking/hypothesis_replay.py
@@ -215,11 +215,12 @@ def score_hypothesis_replay(
     """Score one replayed hypothesis without using truth information."""
 
     cfg = InnovationConsistencyScoreConfig() if config is None else config
-    nis_values = _finite_record_values(replay.records, ("nis",))
+    nis_values = _finite_record_values(replay.records, ("nis",), nonnegative=True)
     residual_values = _finite_record_values(
         replay.records,
         ("residual_norm_m", "residual_norm", "innovation_norm", "innovation_norm_m"),
         fallback_norm_keys=("innovation", "residual"),
+        nonnegative=True,
     )
     robust_sum_nis = (
         float(np.sum(np.minimum(nis_values, float(cfg.nis_clip))))
@@ -312,6 +313,7 @@ def _finite_record_values(
     keys: tuple[str, ...],
     *,
     fallback_norm_keys: tuple[str, ...] = (),
+    nonnegative: bool = False,
 ) -> np.ndarray:
     values: list[float] = []
     for record in records:
@@ -331,7 +333,7 @@ def _finite_record_values(
             parsed = float(np.asarray(value, dtype=float))
         except (TypeError, ValueError, OverflowError):
             continue
-        if np.isfinite(parsed):
+        if np.isfinite(parsed) and (not nonnegative or parsed >= 0.0):
             values.append(parsed)
     return np.asarray(values, dtype=float)
 

--- a/tests/tracking/test_hypothesis_replay_negative_diagnostics.py
+++ b/tests/tracking/test_hypothesis_replay_negative_diagnostics.py
@@ -1,0 +1,22 @@
+from pyrecest.tracking import HypothesisReplay, rank_hypothesis_replays
+
+
+def test_negative_replay_diagnostics_cannot_reduce_hypothesis_score() -> None:
+    replay = HypothesisReplay(
+        hypothesis_id="malformed-diagnostics",
+        records=[
+            {
+                "nis": -100.0,
+                "residual_norm_m": -1000.0,
+                "action": "updated",
+            }
+        ],
+    )
+
+    score = rank_hypothesis_replays([replay])[0]
+
+    assert score.robust_sum_nis == 0.0
+    assert score.robust_sum_residual == 0.0
+    assert score.finite_nis_count == 0
+    assert score.finite_residual_count == 0
+    assert score.total_score == 0.0


### PR DESCRIPTION
## Bug

Replay-hypothesis scoring accepted every finite stored NIS and residual-norm value. Although both quantities are non-negative by definition, malformed negative values were summed directly and therefore reduced the total score.

For example, a record with `nis=-100` and `residual_norm_m=-1000` could make an invalid replay appear substantially better than a valid hypothesis.

## Fix

- add an optional non-negative filter to the shared record-value collector;
- apply it to NIS and residual-norm diagnostics;
- treat negative stored values as invalid observations, consistent with the existing handling of non-finite and non-numeric diagnostics;
- preserve fallback vector norms and clipping behavior for valid values.

## Regression coverage

Added a focused test verifying that negative NIS and residual norms:

- contribute zero to the robust sums;
- are excluded from the finite diagnostic counts;
- cannot produce a negative total hypothesis score.

## Validation

- branch is two commits ahead and zero behind current `main`;
- production diff is limited to four additions and two deletions in `hypothesis_replay.py`;
- committed diff was re-read after publication to confirm only the intended filtering behavior changed;
- GitHub Actions provides the authoritative full-suite validation.