### PR TITLE
Reject matrix-shaped non-assignment costs

### DIFF
--- a/src/pyrecest/utils/assignment.py
+++ b/src/pyrecest/utils/assignment.py
@@ -245,7 +245,9 @@ def _coerce_non_assignment_costs(costs, size: int, name: str):
             raise ValueError(f"{name} must be finite")
         return _full((size,), cost, dtype=float)
 
-    costs = costs_array.reshape(-1)
+    if costs_array.ndim != 1:
+        raise ValueError(f"{name} must be scalar or one-dimensional")
+    costs = costs_array
     if costs.shape[0] != size:
         raise ValueError(f"{name} must be scalar or have length {size}")
     if _any(~_isfinite(costs)):

--- a/tests/utils/test_assignment_non_assignment_cost_shape.py
+++ b/tests/utils/test_assignment_non_assignment_cost_shape.py
@@ -1,0 +1,42 @@
+import numpy as np
+import pytest
+import pyrecest.backend
+from pyrecest.utils import murty_k_best_assignments
+
+
+pytestmark = pytest.mark.skipif(
+    pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+    reason="Murty assignment is not supported on the JAX backend",
+)
+
+
+@pytest.mark.parametrize(
+    ("argument_name", "costs"),
+    [
+        ("row_non_assignment_costs", np.array([[1.0, 2.0]])),
+        ("row_non_assignment_costs", np.array([[1.0], [2.0]])),
+        ("col_non_assignment_costs", np.array([[1.0, 2.0]])),
+        ("col_non_assignment_costs", np.array([[1.0], [2.0]])),
+    ],
+)
+def test_murty_rejects_matrix_shaped_non_assignment_costs(argument_name, costs):
+    with pytest.raises(
+        ValueError,
+        match=rf"{argument_name} must be scalar or one-dimensional",
+    ):
+        murty_k_best_assignments(
+            np.eye(2),
+            **{argument_name: costs},
+        )
+
+
+def test_murty_preserves_scalar_and_vector_non_assignment_costs():
+    solutions = murty_k_best_assignments(
+        np.eye(2),
+        row_non_assignment_costs=3.0,
+        col_non_assignment_costs=np.array([4.0, 5.0]),
+    )
+
+    assert len(solutions) == 1
+    np.testing.assert_array_equal(solutions[0]["assignment"], np.array([0, 1]))
+    assert solutions[0]["cost"] == pytest.approx(2.0)

--- a/tests/utils/test_assignment_non_assignment_cost_shape.py
+++ b/tests/utils/test_assignment_non_assignment_cost_shape.py
@@ -32,7 +32,7 @@ def test_murty_rejects_matrix_shaped_non_assignment_costs(argument_name, costs):
 
 def test_murty_preserves_scalar_and_vector_non_assignment_costs():
     solutions = murty_k_best_assignments(
-        np.eye(2),
+        np.array([[1.0, 9.0], [9.0, 1.0]]),
         row_non_assignment_costs=3.0,
         col_non_assignment_costs=np.array([4.0, 5.0]),
     )


### PR DESCRIPTION
## Summary
- require Murty row and column non-assignment penalties to be scalars or one-dimensional vectors
- preserve scalar broadcasting and valid vector inputs
- add regression coverage for row- and column-shaped matrices

## Bug
`_coerce_non_assignment_costs` flattened every non-scalar input with `reshape(-1)`. A matrix such as `(1, n)` or `(n, 1)` was therefore silently accepted whenever its element count matched the number of rows or columns.

This hid upstream shape errors and could reinterpret matrix storage order as the per-row or per-column penalty ordering used by the assignment objective.

## Fix
Reject non-scalar inputs unless they are explicitly one-dimensional before checking their length and finiteness.

## Validation
- inspected the `main..agent/reject-matrix-non-assignment-costs` comparison: 3 source additions, 1 source deletion, and one focused test file
- syntax-checked the new regression test
- exercised the shape check in isolation for row matrices, column matrices, scalar broadcasting, and vectors

The full repository test matrix was not run locally because a repository checkout was unavailable in this connector session; GitHub CI should provide the authoritative backend coverage.