### PR TITLE
Reject undefined circular weighted means

### DIFF
--- a/src/pyrecest/filters/relaxed_s3f_circular.py
+++ b/src/pyrecest/filters/relaxed_s3f_circular.py
@@ -254,6 +254,14 @@ def circular_weighted_mean(angles: Any, weights: Any) -> float:
         raise ValueError("angles and weights must contain the same number of entries.")
 
     moment = backend_sum(weights * exp(1j * angles))
+    resultant_length = float(backend_abs(moment))
+    dtype_name = str(getattr(moment, "dtype", np.dtype(float))).replace("torch.", "")
+    try:
+        machine_epsilon = float(np.finfo(np.dtype(dtype_name)).eps)
+    except (TypeError, ValueError):
+        machine_epsilon = float(np.finfo(float).eps)
+    if resultant_length <= 8.0 * machine_epsilon:
+        raise ValueError("circular mean is undefined for zero resultant length.")
     return float(mod(backend_angle(moment), 2.0 * pi))
 
 

--- a/tests/filters/test_relaxed_s3f_circular_weighted_mean_validation.py
+++ b/tests/filters/test_relaxed_s3f_circular_weighted_mean_validation.py
@@ -25,6 +25,13 @@ class CircularWeightedMeanValidationTest(unittest.TestCase):
                         array([0.0, invalid_angle]), array([0.5, 0.5])
                     )
 
+    def test_rejects_undefined_antipodal_mean(self):
+        with self.assertRaisesRegex(ValueError, "undefined"):
+            circular_weighted_mean(
+                array([0.0, math.pi]),
+                array([0.5, 0.5]),
+            )
+
     def test_valid_inputs_are_unchanged(self):
         mean_angle = circular_weighted_mean(
             array([0.0, 0.5 * math.pi]), array([0.5, 0.5])


### PR DESCRIPTION
## Summary

- detect numerically zero first trigonometric moments in `circular_weighted_mean`
- use the active backend scalar dtype to choose a machine-precision tolerance
- raise a clear `ValueError` instead of returning an arbitrary angle
- add regression coverage for equal antipodal mass while retaining the existing valid-mean check

## Bug

For equal weight at angles `0` and `pi`, the weighted resultant vector is zero, so the circular mean is mathematically undefined. The previous implementation called `angle` on that near-zero floating-point vector and silently returned an arbitrary direction (typically `pi/2` from the residual imaginary roundoff, or backend-dependent output).

This can turn a symmetric orientation posterior into a spurious point estimate.

## Validation

- checked the resultant criterion with float32 and float64 antipodal inputs; both are rejected
- checked the existing `[0, pi/2]` equal-weight case; it remains `pi/4`
- added a focused unit regression in `test_relaxed_s3f_circular_weighted_mean_validation.py`

Full repository CI is left to GitHub Actions.