### PR TITLE
Reject non-finite hypertoroidal inputs

### DIFF
--- a/src/pyrecest/distributions/hypertorus/_input_validation.py
+++ b/src/pyrecest/distributions/hypertorus/_input_validation.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array
+from pyrecest.backend import all, array, isfinite
 
 _BOOLEAN_DTYPE_NAMES = {"bool", "bool_", "torch.bool"}
 _BOOLEAN_SCALAR_TYPES = (bool, np.bool_)
@@ -43,6 +43,16 @@ def _reject_complex_array(value, name: str) -> None:
         raise ValueError(f"{name} must contain real angles, not complex values.")
 
 
+def _reject_nonfinite_array(value, name: str) -> None:
+    """Reject NaN and infinite angles before they reach circular operations."""
+    try:
+        finite = bool(all(isfinite(value)))
+    except (OverflowError, TypeError, ValueError, RuntimeError) as exc:
+        raise ValueError(f"{name} must contain only finite real angles.") from exc
+    if not finite:
+        raise ValueError(f"{name} must contain only finite real angles.")
+
+
 def as_shift_vector(shift_by, dim: int, *, name: str = "shift_by"):
     """Return ``shift_by`` as a one-dimensional backend vector of length ``dim``.
 
@@ -55,6 +65,7 @@ def as_shift_vector(shift_by, dim: int, *, name: str = "shift_by"):
     shift_by = array(shift_by)
     _reject_boolean_array(shift_by, name)
     _reject_complex_array(shift_by, name)
+    _reject_nonfinite_array(shift_by, name)
     if shift_by.ndim == 0:
         if dim != 1:
             raise ValueError(f"{name} must have shape ({dim},), got scalar.")
@@ -77,6 +88,7 @@ def as_hypertoroidal_points(xs, dim: int, *, name: str = "xs"):
     xs = array(xs)
     _reject_boolean_array(xs, name)
     _reject_complex_array(xs, name)
+    _reject_nonfinite_array(xs, name)
     if xs.ndim == 0:
         if dim != 1:
             raise ValueError(f"{name} must have trailing dimension {dim}, got scalar.")

--- a/tests/distributions/hypertorus/test_input_validation_nonfinite.py
+++ b/tests/distributions/hypertorus/test_input_validation_nonfinite.py
@@ -1,0 +1,27 @@
+import numpy as np
+import pytest
+
+from pyrecest.distributions.hypertorus._input_validation import (
+    as_hypertoroidal_points,
+    as_shift_vector,
+)
+
+
+@pytest.mark.parametrize("invalid", [np.nan, np.inf, -np.inf])
+def test_shift_vector_rejects_nonfinite_angles(invalid) -> None:
+    with pytest.raises(ValueError, match="finite real angles"):
+        as_shift_vector([0.0, invalid], dim=2)
+
+
+@pytest.mark.parametrize("invalid", [np.nan, np.inf, -np.inf])
+def test_hypertoroidal_points_reject_nonfinite_angles(invalid) -> None:
+    with pytest.raises(ValueError, match="finite real angles"):
+        as_hypertoroidal_points([[0.0, 1.0], [invalid, 2.0]], dim=2)
+
+
+def test_finite_inputs_keep_existing_shapes() -> None:
+    shift = as_shift_vector([0.1, 0.2], dim=2)
+    points = as_hypertoroidal_points([[0.1, 0.2], [0.3, 0.4]], dim=2)
+
+    assert shift.shape == (2,)
+    assert points.shape == (2, 2)


### PR DESCRIPTION
## Bug

The shared hypertorus input-normalization helpers accepted `NaN`, `+inf`, and `-inf` as valid real angles. These values then reached wrapping, density, and shifting operations, where they could silently propagate non-finite outputs through otherwise valid distribution objects.

## Fix

- validate backend arrays with the active backend's `isfinite`/`all` operations;
- reject non-finite shift vectors and hypertoroidal evaluation points at the shared input boundary;
- preserve the existing boolean, complex, scalar, and shape validation behavior.

## Regression coverage

Added focused tests for `NaN`, positive infinity, and negative infinity through both `as_shift_vector` and `as_hypertoroidal_points`, plus a valid-input shape check.

## Scope

The branch is two commits ahead and zero behind `main`. The production change is limited to 13 additions and one deletion in the shared hypertorus input validator.