### PR TITLE
Reject matrix-shaped online time-offset vectors

### DIFF
--- a/src/pyrecest/filters/online_time_offset_estimator.py
+++ b/src/pyrecest/filters/online_time_offset_estimator.py
@@ -66,8 +66,8 @@ class OnlineTimeOffsetEstimator:
         measurement_variance: float,
     ) -> float:
         """Update the offset from a position residual and return innovation NIS."""
-        residual = _as_real_numeric_array(residual, "residual").reshape(-1)
-        velocity = _as_real_numeric_array(velocity, "velocity").reshape(-1)
+        residual = _as_real_numeric_vector(residual, "residual")
+        velocity = _as_real_numeric_vector(velocity, "velocity")
         if residual.size != velocity.size:
             raise ValueError("residual and velocity must have the same dimension")
         if not np.isfinite(residual).all() or not np.isfinite(velocity).all():
@@ -118,6 +118,15 @@ def _as_real_numeric_array(value: Any, name: str) -> np.ndarray:
         return np.asarray(value, dtype=float)
     except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError(f"{name} must be real-valued numeric") from exc
+
+
+def _as_real_numeric_vector(value: Any, name: str) -> np.ndarray:
+    value_array = _as_real_numeric_array(value, name)
+    if value_array.ndim == 0:
+        return value_array.reshape(1)
+    if value_array.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional")
+    return value_array
 
 
 def _as_finite_scalar(value: Any, name: str) -> float:

--- a/tests/filters/test_online_time_offset_estimator_vector_shapes.py
+++ b/tests/filters/test_online_time_offset_estimator_vector_shapes.py
@@ -1,0 +1,49 @@
+import unittest
+
+import numpy as np
+from pyrecest.filters import OnlineTimeOffsetEstimator
+
+
+class OnlineTimeOffsetEstimatorVectorShapeTest(unittest.TestCase):
+    def test_update_rejects_matrix_vectors_without_state_change(self):
+        matrix_inputs = (
+            {"residual": np.array([[1.0, 2.0]])},
+            {"residual": np.array([[1.0], [2.0]])},
+            {"velocity": np.array([[2.0, 3.0]])},
+            {"velocity": np.array([[2.0], [3.0]])},
+        )
+
+        for override in matrix_inputs:
+            estimator = OnlineTimeOffsetEstimator(offset=1.0, variance=2.0)
+            kwargs = {
+                "residual": np.array([1.0, 2.0]),
+                "velocity": np.array([2.0, 3.0]),
+                "measurement_variance": 1.0,
+            }
+            kwargs.update(override)
+
+            with self.subTest(override=override):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "(residual|velocity) must be one-dimensional",
+                ):
+                    estimator.update_from_position_residual(**kwargs)
+                self.assertEqual(estimator.offset, 1.0)
+                self.assertEqual(estimator.variance, 2.0)
+
+    def test_update_preserves_scalar_one_dimensional_inputs(self):
+        estimator = OnlineTimeOffsetEstimator(offset=0.0, variance=1.0)
+
+        nis = estimator.update_from_position_residual(
+            residual=10.0,
+            velocity=5.0,
+            measurement_variance=1.0,
+        )
+
+        self.assertTrue(np.isfinite(nis))
+        self.assertGreater(estimator.offset, 0.0)
+        self.assertLess(estimator.offset, 2.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- require residual and velocity inputs to be scalars or one-dimensional vectors
- preserve scalar support for one-dimensional updates
- reject row and column matrices before any estimator state changes
- add focused regression coverage for malformed matrix inputs and valid scalar inputs

## Bug

`OnlineTimeOffsetEstimator.update_from_position_residual` converted residuals and velocities with `reshape(-1)`. Consequently, any matrix was silently flattened and interpreted as a longer state vector.

For example, a `2 x 2` residual and velocity pair was treated as a four-dimensional update rather than rejected. This can hide upstream shape errors and produce an offset estimate for an unintended ordering of position dimensions.

## Fix

Introduce a shared vector coercion helper that:

- converts scalar numeric values to length-one vectors;
- accepts explicitly one-dimensional numeric arrays;
- rejects arrays with more than one dimension.

Validation occurs before the offset or variance can be modified.

## Validation

- confirmed the branch is two commits ahead and zero behind current `main`;
- production diff is limited to 11 additions and 2 deletions;
- exercised row and column matrix rejection in an isolated NumPy check;
- verified scalar and one-dimensional vectors remain accepted;
- added repository regression tests for state preservation and scalar compatibility.

Full backend and repository validation is delegated to GitHub Actions.