### PR TITLE
Reject temporal hypertoroidal angle inputs

### DIFF
--- a/src/pyrecest/distributions/hypertorus/_input_validation.py
+++ b/src/pyrecest/distributions/hypertorus/_input_validation.py
@@ -1,5 +1,7 @@
 """Input-normalization helpers for hypertoroidal distributions."""
 
+import datetime as _datetime
+
 import numpy as np
 
 # pylint: disable=no-name-in-module,no-member
@@ -8,6 +10,13 @@ from pyrecest.backend import array
 _BOOLEAN_DTYPE_NAMES = {"bool", "bool_", "torch.bool"}
 _BOOLEAN_SCALAR_TYPES = (bool, np.bool_)
 _COMPLEX_SCALAR_TYPES = (complex, np.complexfloating)
+_TEMPORAL_SCALAR_TYPES = (
+    np.datetime64,
+    np.timedelta64,
+    _datetime.date,
+    _datetime.datetime,
+    _datetime.timedelta,
+)
 
 
 def _reject_boolean_array(value, name: str) -> None:
@@ -43,6 +52,22 @@ def _reject_complex_array(value, name: str) -> None:
         raise ValueError(f"{name} must contain real angles, not complex values.")
 
 
+def _reject_temporal_array(value, name: str) -> None:
+    if isinstance(value, _TEMPORAL_SCALAR_TYPES):
+        raise ValueError(f"{name} must contain real angles, not temporal values.")
+
+    dtype = getattr(value, "dtype", None)
+    if getattr(dtype, "kind", None) in {"M", "m"}:
+        raise ValueError(f"{name} must contain real angles, not temporal values.")
+
+    try:
+        object_values = np.asarray(value, dtype=object).reshape(-1)
+    except (TypeError, ValueError, RuntimeError):
+        return
+    if any(isinstance(item, _TEMPORAL_SCALAR_TYPES) for item in object_values):
+        raise ValueError(f"{name} must contain real angles, not temporal values.")
+
+
 def as_shift_vector(shift_by, dim: int, *, name: str = "shift_by"):
     """Return ``shift_by`` as a one-dimensional backend vector of length ``dim``.
 
@@ -52,9 +77,11 @@ def as_shift_vector(shift_by, dim: int, *, name: str = "shift_by"):
     """
     _reject_boolean_array(shift_by, name)
     _reject_complex_array(shift_by, name)
+    _reject_temporal_array(shift_by, name)
     shift_by = array(shift_by)
     _reject_boolean_array(shift_by, name)
     _reject_complex_array(shift_by, name)
+    _reject_temporal_array(shift_by, name)
     if shift_by.ndim == 0:
         if dim != 1:
             raise ValueError(f"{name} must have shape ({dim},), got scalar.")
@@ -74,9 +101,11 @@ def as_hypertoroidal_points(xs, dim: int, *, name: str = "xs"):
     """
     _reject_boolean_array(xs, name)
     _reject_complex_array(xs, name)
+    _reject_temporal_array(xs, name)
     xs = array(xs)
     _reject_boolean_array(xs, name)
     _reject_complex_array(xs, name)
+    _reject_temporal_array(xs, name)
     if xs.ndim == 0:
         if dim != 1:
             raise ValueError(f"{name} must have trailing dimension {dim}, got scalar.")

--- a/tests/distributions/test_hypertoroidal_temporal_input_validation.py
+++ b/tests/distributions/test_hypertoroidal_temporal_input_validation.py
@@ -1,0 +1,36 @@
+import datetime
+
+import numpy as np
+import pytest
+
+from pyrecest.distributions.circle.circular_uniform_distribution import (
+    CircularUniformDistribution,
+)
+from pyrecest.distributions.hypertorus._input_validation import (
+    as_hypertoroidal_points,
+    as_shift_vector,
+)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        np.datetime64(1, "ns"),
+        np.timedelta64(1, "ns"),
+        datetime.datetime(2026, 1, 1),
+        datetime.timedelta(seconds=1),
+        np.array([np.datetime64(1, "ns")], dtype=object),
+    ],
+)
+def test_hypertoroidal_angle_helpers_reject_temporal_values(value) -> None:
+    with pytest.raises(ValueError, match="temporal"):
+        as_shift_vector(value, 1)
+    with pytest.raises(ValueError, match="temporal"):
+        as_hypertoroidal_points(value, 1)
+
+
+def test_circular_uniform_shift_rejects_temporal_angle() -> None:
+    distribution = CircularUniformDistribution()
+
+    with pytest.raises(ValueError, match="temporal"):
+        distribution.shift(np.timedelta64(1, "ns"))


### PR DESCRIPTION
## Summary

- reject NumPy and Python datetime/duration values in shared hypertoroidal angle normalization
- apply the validation to both shift vectors and evaluation points before and after backend conversion
- add regression coverage for native temporal scalars, Python temporal objects, object-wrapped values, and the public circular-uniform shift path

## Bug

The shared hypertoroidal input helpers rejected boolean and complex values but did not reject temporal values. Nanosecond-resolution `numpy.datetime64` and `numpy.timedelta64` scalars can expose integer payloads during conversion, while `CircularUniformDistribution.shift(...)` ignores the shift entirely because the distribution is invariant.

Consequently, malformed temporal inputs such as `np.timedelta64(1, "ns")` could be silently accepted as angular shifts instead of being rejected. This can hide unit/type errors at API boundaries.

## Fix

Add explicit temporal-value detection for:

- NumPy `datetime64` and `timedelta64`
- Python `date`, `datetime`, and `timedelta`
- temporal values wrapped in object arrays

The checks run before backend conversion and again afterward, matching the existing boolean and complex validation pattern.

## Validation

- source and regression test files pass `python -m py_compile`
- focused local validation confirms all temporal cases are rejected while ordinary numeric vectors remain accepted
- branch comparison: 2 commits ahead, 0 behind `main`
- diff is limited to 29 source additions and one focused 36-line regression test module

GitHub Actions should provide the authoritative full backend-matrix validation.