### PR TITLE
Reject matrix-shaped UKF vectors

### DIFF
--- a/src/pyrecest/filters/_ukf.py
+++ b/src/pyrecest/filters/_ukf.py
@@ -35,6 +35,18 @@ __all__ = [
 ]
 
 
+def _as_vector(value, name):
+    """Coerce a scalar or vector without silently flattening matrices."""
+    value = asarray(value, dtype=float64)
+    if len(value.shape) == 0:
+        return reshape(value, (1,))
+    if len(value.shape) != 1:
+        raise ValueError(
+            f"{name} must be a scalar or one-dimensional vector; got shape {value.shape}"
+        )
+    return value
+
+
 # ---------------------------------------------------------------------------
 # Unscented Kalman Filter
 # ---------------------------------------------------------------------------
@@ -85,7 +97,7 @@ class UnscentedKalmanFilter:
         n_sigmas = sigmas.shape[0]
 
         sigma_rows = [
-            reshape(asarray(fx(sigmas[i], dt, **fx_args), dtype=float64), (-1,))
+            _as_vector(fx(sigmas[i], dt, **fx_args), "transition function output")
             for i in range(n_sigmas)
         ]
         for sigma_f in sigma_rows:
@@ -144,7 +156,7 @@ class UnscentedKalmanFilter:
         """
         if hx is None:
             hx = self._model.hx
-        z = reshape(asarray(z, dtype=float64), (-1,))
+        z = _as_vector(z, "measurement z")
 
         if self._sigmas_f is None:
             self._sigmas_f = self._model.points.sigma_points(self.x, self.P)
@@ -154,7 +166,7 @@ class UnscentedKalmanFilter:
         Wc = self._model.points.Wc
 
         sigma_rows = [
-            reshape(asarray(hx(sigmas_f[i], **hx_args), dtype=float64), (-1,))
+            _as_vector(hx(sigmas_f[i], **hx_args), "measurement function output")
             for i in range(sigmas_f.shape[0])
         ]
         dim_z = sigma_rows[0].shape[0]

--- a/tests/filters/test_ukf_vector_shape_validation.py
+++ b/tests/filters/test_ukf_vector_shape_validation.py
@@ -1,0 +1,99 @@
+import unittest
+
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+import pyrecest.backend
+from pyrecest.backend import array, eye
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.filters.unscented_kalman_filter import UnscentedKalmanFilter
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+    reason="Not supported on this backend",
+)
+class UnscentedKalmanFilterVectorShapeTest(unittest.TestCase):
+    @staticmethod
+    def _two_dimensional_filter():
+        return UnscentedKalmanFilter(
+            GaussianDistribution(array([0.0, 0.0]), eye(2))
+        )
+
+    def test_predict_rejects_matrix_transition_outputs(self):
+        matrix_outputs = (
+            array([[0.0, 0.0]]),
+            array([[0.0], [0.0]]),
+        )
+
+        for output in matrix_outputs:
+            with self.subTest(shape=output.shape):
+                kf = self._two_dimensional_filter()
+
+                def fx(_x, _dt, output=output):
+                    return output
+
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "transition function output must be a scalar or one-dimensional vector",
+                ):
+                    kf.predict_nonlinear(fx, eye(2), dt=1.0)
+
+    def test_update_rejects_matrix_measurement_function_outputs(self):
+        matrix_outputs = (
+            array([[0.0, 0.0]]),
+            array([[0.0], [0.0]]),
+        )
+
+        for output in matrix_outputs:
+            with self.subTest(shape=output.shape):
+                kf = self._two_dimensional_filter()
+
+                def hx(_x, output=output):
+                    return output
+
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "measurement function output must be a scalar or one-dimensional vector",
+                ):
+                    kf.update_nonlinear(array([0.0, 0.0]), hx, eye(2))
+
+    def test_update_rejects_matrix_measurements(self):
+        matrix_measurements = (
+            array([[0.0, 0.0]]),
+            array([[0.0], [0.0]]),
+        )
+
+        for measurement in matrix_measurements:
+            with self.subTest(shape=measurement.shape):
+                kf = self._two_dimensional_filter()
+
+                def hx(x):
+                    return x
+
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "measurement z must be a scalar or one-dimensional vector",
+                ):
+                    kf.update_nonlinear(measurement, hx, eye(2))
+
+    def test_scalar_outputs_and_measurements_remain_supported(self):
+        kf = UnscentedKalmanFilter(
+            GaussianDistribution(array([0.0]), array([[1.0]]))
+        )
+
+        def fx(x, _dt):
+            return x[0]
+
+        def hx(x):
+            return x[0]
+
+        kf.predict_nonlinear(fx, array([[0.0]]), dt=1.0)
+        kf.update_nonlinear(1.0, hx, array([[1.0]]))
+
+        npt.assert_allclose(kf.get_point_estimate(), array([0.5]), atol=1e-10)
+        self.assertEqual(kf.get_point_estimate().shape, (1,))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- validate UKF transition outputs, measurement-function outputs, and observations as scalars or one-dimensional vectors
- reject row and column matrices instead of silently flattening them
- preserve scalar support for one-dimensional state and measurement models
- add focused regression coverage for all three vector boundaries

## Bug

The UKF core normalized transition outputs, measurement-function outputs, and observations with `reshape(..., (-1,))`. A malformed row or column matrix was therefore silently accepted whenever its element count matched the expected dimension.

This can conceal upstream shape errors and reinterpret matrix storage order as state or measurement component order, allowing an unintended model output or observation to enter the filter update.

## Fix

Introduce a shared backend-portable `_as_vector` coercion helper that:

- promotes scalars to one-element vectors;
- accepts one-dimensional vectors unchanged;
- rejects arrays with two or more dimensions with a clear `ValueError`.

## Regression coverage

The new tests verify that both row and column matrices are rejected for:

- nonlinear transition-function outputs;
- nonlinear measurement-function outputs;
- measurement observations.

A one-dimensional predict/update test confirms that scalar transition outputs, scalar measurement outputs, and scalar observations remain supported.

## Validation

- both changed Python files pass `py_compile` and AST parsing
- the committed comparison is limited to 15 additions/3 deletions in `_ukf.py` plus one focused 99-line regression module
- the two newer `main` commits touch unrelated replay-scoring and weak-measurement files, so the branch has no known overlap
- full backend and repository validation is delegated to GitHub Actions because this runtime cannot clone the repository or install its test environment