### PR TITLE
Reject matrix-shaped UKF vectors

### DIFF
--- a/src/pyrecest/filters/_ukf.py
+++ b/src/pyrecest/filters/_ukf.py
@@ -35,6 +35,18 @@ __all__ = [
 ]
 
 
+def _as_vector(value, description):
+    """Return scalar or vector input without silently flattening matrices."""
+    value = asarray(value, dtype=float64)
+    if len(value.shape) == 0:
+        return reshape(value, (1,))
+    if len(value.shape) != 1:
+        raise ValueError(
+            f"{description} must be scalar or one-dimensional; got shape {value.shape}"
+        )
+    return value
+
+
 # ---------------------------------------------------------------------------
 # Unscented Kalman Filter
 # ---------------------------------------------------------------------------
@@ -85,7 +97,10 @@ class UnscentedKalmanFilter:
         n_sigmas = sigmas.shape[0]
 
         sigma_rows = [
-            reshape(asarray(fx(sigmas[i], dt, **fx_args), dtype=float64), (-1,))
+            _as_vector(
+                fx(sigmas[i], dt, **fx_args),
+                "transition function output",
+            )
             for i in range(n_sigmas)
         ]
         for sigma_f in sigma_rows:
@@ -144,7 +159,7 @@ class UnscentedKalmanFilter:
         """
         if hx is None:
             hx = self._model.hx
-        z = reshape(asarray(z, dtype=float64), (-1,))
+        z = _as_vector(z, "measurement z")
 
         if self._sigmas_f is None:
             self._sigmas_f = self._model.points.sigma_points(self.x, self.P)
@@ -154,7 +169,10 @@ class UnscentedKalmanFilter:
         Wc = self._model.points.Wc
 
         sigma_rows = [
-            reshape(asarray(hx(sigmas_f[i], **hx_args), dtype=float64), (-1,))
+            _as_vector(
+                hx(sigmas_f[i], **hx_args),
+                "measurement function output",
+            )
             for i in range(sigmas_f.shape[0])
         ]
         dim_z = sigma_rows[0].shape[0]

--- a/tests/filters/test_ukf_vector_shape_validation.py
+++ b/tests/filters/test_ukf_vector_shape_validation.py
@@ -1,0 +1,81 @@
+import unittest
+
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+import pyrecest.backend
+from pyrecest.backend import array, eye, reshape, zeros
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.filters.unscented_kalman_filter import UnscentedKalmanFilter
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+    reason="Not supported on this backend",
+)
+class UnscentedKalmanFilterVectorShapeValidationTest(unittest.TestCase):
+    @staticmethod
+    def _make_two_dimensional_filter():
+        return UnscentedKalmanFilter(
+            GaussianDistribution(array([0.0, 1.0]), eye(2))
+        )
+
+    def test_predict_rejects_matrix_transition_outputs(self):
+        for output_shape in ((1, 2), (2, 1)):
+            with self.subTest(output_shape=output_shape):
+                kf = self._make_two_dimensional_filter()
+
+                def fx(x, _dt):
+                    return reshape(x, output_shape)
+
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "transition function output must be scalar or one-dimensional",
+                ):
+                    kf.predict_nonlinear(fx, zeros((2, 2)))
+
+                npt.assert_allclose(kf.get_point_estimate(), array([0.0, 1.0]))
+                npt.assert_allclose(kf.filter_state.covariance(), eye(2))
+
+    def test_update_rejects_matrix_measurement_outputs(self):
+        for output_shape in ((1, 2), (2, 1)):
+            with self.subTest(output_shape=output_shape):
+                kf = self._make_two_dimensional_filter()
+                kf.predict_identity(zeros((2, 2)))
+
+                def hx(x):
+                    return reshape(x, output_shape)
+
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "measurement function output must be scalar or one-dimensional",
+                ):
+                    kf.update_nonlinear(array([0.0, 1.0]), hx, eye(2))
+
+    def test_update_rejects_matrix_measurements(self):
+        for measurement_shape in ((1, 2), (2, 1)):
+            with self.subTest(measurement_shape=measurement_shape):
+                kf = self._make_two_dimensional_filter()
+                kf.predict_identity(zeros((2, 2)))
+                measurement = reshape(array([0.0, 1.0]), measurement_shape)
+
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "measurement z must be scalar or one-dimensional",
+                ):
+                    kf.update_nonlinear(measurement, lambda x: x, eye(2))
+
+    def test_scalar_transition_measurement_and_output_remain_supported(self):
+        kf = UnscentedKalmanFilter(
+            GaussianDistribution(array([0.0]), array([[1.0]]))
+        )
+
+        kf.predict_nonlinear(lambda x, _dt: x[0] + 1.0, array([[0.0]]))
+        kf.update_nonlinear(1.0, lambda x: x[0], 1.0)
+
+        npt.assert_allclose(kf.get_point_estimate(), array([1.0]))
+        npt.assert_allclose(kf.filter_state.covariance(), array([[0.5]]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- stop silently flattening row/column matrices returned by UKF transition and measurement functions
- reject matrix-shaped measurement inputs where the API requires a vector
- retain scalar support for one-dimensional state and measurement models
- add focused regression coverage for row matrices, column matrices, unchanged state on failed prediction, and scalar compatibility

## Bug

The UKF core normalized transition outputs, measurement-function outputs, and measurements with `reshape(..., (-1,))`. Consequently, values shaped `(1, n)` or `(n, 1)` were silently accepted whenever their element count matched the expected dimension.

This can conceal model-interface and dimension-order mistakes. A malformed matrix can be reinterpreted as a valid vector and produce a plausible but incorrect estimate instead of failing at the boundary documented as shape `(dim,)`.

## Fix

Introduce a shared scalar-or-vector coercion helper that:

- promotes scalar values to length-one vectors;
- preserves proper one-dimensional vectors;
- rejects arrays with two or more dimensions with a descriptive `ValueError`.

The existing dimension and covariance checks remain unchanged.

## Validation

- branch is two commits ahead and zero behind current `main` at `f293f2c`
- committed diff is limited to 21 source additions, 3 source deletions, and one focused 81-line regression test module
- reviewed the committed patches after publication
- full repository and backend-matrix validation is delegated to GitHub Actions because this runtime cannot clone the repository or execute its dependency environment
