### PR TITLE
Reject invalid hypertoroidal angle inputs

### DIFF
--- a/src/pyrecest/distributions/hypertorus/_input_validation.py
+++ b/src/pyrecest/distributions/hypertorus/_input_validation.py
@@ -81,6 +81,24 @@ def _reject_nonfinite_array(value, name: str) -> None:
         raise ValueError(f"{name} must contain only finite real angles.")
 
 
+def _reject_non_numeric_angle_types(value, name: str) -> None:
+    """Reject values that must not be interpreted as real angles."""
+
+    _reject_boolean_array(value, name)
+    _reject_complex_array(value, name)
+    _reject_temporal_array(value, name)
+
+
+def _validated_real_angle_array(value, name: str):
+    """Convert an input after validating its semantic and numeric domain."""
+
+    _reject_non_numeric_angle_types(value, name)
+    value = array(value)
+    _reject_non_numeric_angle_types(value, name)
+    _reject_nonfinite_array(value, name)
+    return value
+
+
 def as_shift_vector(shift_by, dim: int, *, name: str = "shift_by"):
     """Return ``shift_by`` as a one-dimensional backend vector of length ``dim``.
 
@@ -88,14 +106,7 @@ def as_shift_vector(shift_by, dim: int, *, name: str = "shift_by"):
     This keeps public APIs robust for ordinary Python scalar/list inputs before
     shape validation is performed.
     """
-    _reject_boolean_array(shift_by, name)
-    _reject_complex_array(shift_by, name)
-    _reject_temporal_array(shift_by, name)
-    shift_by = array(shift_by)
-    _reject_boolean_array(shift_by, name)
-    _reject_complex_array(shift_by, name)
-    _reject_temporal_array(shift_by, name)
-    _reject_nonfinite_array(shift_by, name)
+    shift_by = _validated_real_angle_array(shift_by, name)
     if shift_by.ndim == 0:
         if dim != 1:
             raise ValueError(f"{name} must have shape ({dim},), got scalar.")
@@ -113,14 +124,7 @@ def as_hypertoroidal_points(xs, dim: int, *, name: str = "xs"):
     For higher-dimensional distributions, a one-dimensional array of length
     ``dim`` is treated as a single query point.
     """
-    _reject_boolean_array(xs, name)
-    _reject_complex_array(xs, name)
-    _reject_temporal_array(xs, name)
-    xs = array(xs)
-    _reject_boolean_array(xs, name)
-    _reject_complex_array(xs, name)
-    _reject_temporal_array(xs, name)
-    _reject_nonfinite_array(xs, name)
+    xs = _validated_real_angle_array(xs, name)
     if xs.ndim == 0:
         if dim != 1:
             raise ValueError(f"{name} must have trailing dimension {dim}, got scalar.")

--- a/src/pyrecest/distributions/hypertorus/_input_validation.py
+++ b/src/pyrecest/distributions/hypertorus/_input_validation.py
@@ -1,13 +1,22 @@
 """Input-normalization helpers for hypertoroidal distributions."""
 
+import datetime as _datetime
+
 import numpy as np
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import array
+from pyrecest.backend import all, array, isfinite
 
 _BOOLEAN_DTYPE_NAMES = {"bool", "bool_", "torch.bool"}
 _BOOLEAN_SCALAR_TYPES = (bool, np.bool_)
 _COMPLEX_SCALAR_TYPES = (complex, np.complexfloating)
+_TEMPORAL_SCALAR_TYPES = (
+    np.datetime64,
+    np.timedelta64,
+    _datetime.date,
+    _datetime.datetime,
+    _datetime.timedelta,
+)
 
 
 def _reject_boolean_array(value, name: str) -> None:
@@ -43,6 +52,35 @@ def _reject_complex_array(value, name: str) -> None:
         raise ValueError(f"{name} must contain real angles, not complex values.")
 
 
+def _reject_temporal_array(value, name: str) -> None:
+    """Reject datetime and duration values before numeric conversion."""
+
+    if isinstance(value, _TEMPORAL_SCALAR_TYPES):
+        raise ValueError(f"{name} must contain real angles, not temporal values.")
+
+    dtype = getattr(value, "dtype", None)
+    if getattr(dtype, "kind", None) in {"M", "m"}:
+        raise ValueError(f"{name} must contain real angles, not temporal values.")
+
+    try:
+        object_values = np.asarray(value, dtype=object).reshape(-1)
+    except (TypeError, ValueError, RuntimeError):
+        return
+    if any(isinstance(item, _TEMPORAL_SCALAR_TYPES) for item in object_values):
+        raise ValueError(f"{name} must contain real angles, not temporal values.")
+
+
+def _reject_nonfinite_array(value, name: str) -> None:
+    """Reject NaN and infinite angles before circular operations."""
+
+    try:
+        finite = bool(all(isfinite(value)))
+    except (OverflowError, TypeError, ValueError, RuntimeError) as exc:
+        raise ValueError(f"{name} must contain only finite real angles.") from exc
+    if not finite:
+        raise ValueError(f"{name} must contain only finite real angles.")
+
+
 def as_shift_vector(shift_by, dim: int, *, name: str = "shift_by"):
     """Return ``shift_by`` as a one-dimensional backend vector of length ``dim``.
 
@@ -52,9 +90,12 @@ def as_shift_vector(shift_by, dim: int, *, name: str = "shift_by"):
     """
     _reject_boolean_array(shift_by, name)
     _reject_complex_array(shift_by, name)
+    _reject_temporal_array(shift_by, name)
     shift_by = array(shift_by)
     _reject_boolean_array(shift_by, name)
     _reject_complex_array(shift_by, name)
+    _reject_temporal_array(shift_by, name)
+    _reject_nonfinite_array(shift_by, name)
     if shift_by.ndim == 0:
         if dim != 1:
             raise ValueError(f"{name} must have shape ({dim},), got scalar.")
@@ -74,9 +115,12 @@ def as_hypertoroidal_points(xs, dim: int, *, name: str = "xs"):
     """
     _reject_boolean_array(xs, name)
     _reject_complex_array(xs, name)
+    _reject_temporal_array(xs, name)
     xs = array(xs)
     _reject_boolean_array(xs, name)
     _reject_complex_array(xs, name)
+    _reject_temporal_array(xs, name)
+    _reject_nonfinite_array(xs, name)
     if xs.ndim == 0:
         if dim != 1:
             raise ValueError(f"{name} must have trailing dimension {dim}, got scalar.")

--- a/tests/distributions/hypertorus/test_input_validation_nonfinite.py
+++ b/tests/distributions/hypertorus/test_input_validation_nonfinite.py
@@ -8,15 +8,25 @@ from pyrecest.distributions.hypertorus._input_validation import (
 
 
 @pytest.mark.parametrize("invalid", [np.nan, np.inf, -np.inf])
-def test_shift_vector_rejects_nonfinite_angles(invalid) -> None:
+@pytest.mark.parametrize(
+    "validate",
+    [
+        pytest.param(
+            lambda value: as_shift_vector([0.0, value], dim=2),
+            id="shift-vector",
+        ),
+        pytest.param(
+            lambda value: as_hypertoroidal_points(
+                [[0.0, 1.0], [value, 2.0]],
+                dim=2,
+            ),
+            id="evaluation-points",
+        ),
+    ],
+)
+def test_angle_inputs_reject_nonfinite_values(invalid, validate) -> None:
     with pytest.raises(ValueError, match="finite real angles"):
-        as_shift_vector([0.0, invalid], dim=2)
-
-
-@pytest.mark.parametrize("invalid", [np.nan, np.inf, -np.inf])
-def test_hypertoroidal_points_reject_nonfinite_angles(invalid) -> None:
-    with pytest.raises(ValueError, match="finite real angles"):
-        as_hypertoroidal_points([[0.0, 1.0], [invalid, 2.0]], dim=2)
+        validate(invalid)
 
 
 def test_finite_inputs_keep_existing_shapes() -> None:

--- a/tests/distributions/hypertorus/test_input_validation_nonfinite.py
+++ b/tests/distributions/hypertorus/test_input_validation_nonfinite.py
@@ -1,0 +1,27 @@
+import numpy as np
+import pytest
+
+from pyrecest.distributions.hypertorus._input_validation import (
+    as_hypertoroidal_points,
+    as_shift_vector,
+)
+
+
+@pytest.mark.parametrize("invalid", [np.nan, np.inf, -np.inf])
+def test_shift_vector_rejects_nonfinite_angles(invalid) -> None:
+    with pytest.raises(ValueError, match="finite real angles"):
+        as_shift_vector([0.0, invalid], dim=2)
+
+
+@pytest.mark.parametrize("invalid", [np.nan, np.inf, -np.inf])
+def test_hypertoroidal_points_reject_nonfinite_angles(invalid) -> None:
+    with pytest.raises(ValueError, match="finite real angles"):
+        as_hypertoroidal_points([[0.0, 1.0], [invalid, 2.0]], dim=2)
+
+
+def test_finite_inputs_keep_existing_shapes() -> None:
+    shift = as_shift_vector([0.1, 0.2], dim=2)
+    points = as_hypertoroidal_points([[0.1, 0.2], [0.3, 0.4]], dim=2)
+
+    assert shift.shape == (2,)
+    assert points.shape == (2, 2)

--- a/tests/distributions/test_hypertoroidal_temporal_input_validation.py
+++ b/tests/distributions/test_hypertoroidal_temporal_input_validation.py
@@ -1,0 +1,36 @@
+import datetime
+
+import numpy as np
+import pytest
+
+from pyrecest.distributions.circle.circular_uniform_distribution import (
+    CircularUniformDistribution,
+)
+from pyrecest.distributions.hypertorus._input_validation import (
+    as_hypertoroidal_points,
+    as_shift_vector,
+)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        np.datetime64(1, "ns"),
+        np.timedelta64(1, "ns"),
+        datetime.datetime(2026, 1, 1),
+        datetime.timedelta(seconds=1),
+        np.array([np.datetime64(1, "ns")], dtype=object),
+    ],
+)
+def test_hypertoroidal_angle_helpers_reject_temporal_values(value) -> None:
+    with pytest.raises(ValueError, match="temporal"):
+        as_shift_vector(value, 1)
+    with pytest.raises(ValueError, match="temporal"):
+        as_hypertoroidal_points(value, 1)
+
+
+def test_circular_uniform_shift_rejects_temporal_angle() -> None:
+    distribution = CircularUniformDistribution()
+
+    with pytest.raises(ValueError, match="temporal"):
+        distribution.shift(np.timedelta64(1, "ns"))

--- a/tests/distributions/test_hypertoroidal_temporal_input_validation.py
+++ b/tests/distributions/test_hypertoroidal_temporal_input_validation.py
@@ -22,11 +22,19 @@ from pyrecest.distributions.hypertorus._input_validation import (
         np.array([np.datetime64(1, "ns")], dtype=object),
     ],
 )
-def test_hypertoroidal_angle_helpers_reject_temporal_values(value) -> None:
+@pytest.mark.parametrize(
+    "validate",
+    [
+        pytest.param(lambda value: as_shift_vector(value, 1), id="shift-vector"),
+        pytest.param(
+            lambda value: as_hypertoroidal_points(value, 1),
+            id="evaluation-points",
+        ),
+    ],
+)
+def test_hypertoroidal_angle_helpers_reject_temporal_values(value, validate) -> None:
     with pytest.raises(ValueError, match="temporal"):
-        as_shift_vector(value, 1)
-    with pytest.raises(ValueError, match="temporal"):
-        as_hypertoroidal_points(value, 1)
+        validate(value)
 
 
 def test_circular_uniform_shift_rejects_temporal_angle() -> None:


### PR DESCRIPTION
## Summary

Combine the two overlapping hypertorus input-validation fixes on current `main`.

- reject `NaN`, positive infinity, and negative infinity;
- reject NumPy/Python datetime and duration values, including object-array wrappers;
- retain existing boolean, complex, scalar, and shape validation;
- preserve finite numeric input shapes;
- include both focused regression suites.

Supersedes #4741 and #4743 without dropping either validation class.