### PR TITLE
Reject matrix-shaped Gaussian mixture moment weights

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/gaussian_mixture.py
+++ b/src/pyrecest/distributions/nonperiodic/gaussian_mixture.py
@@ -70,7 +70,11 @@ class GaussianMixture(LinearMixture, AbstractLinearDistribution):
         if weights is None:
             weights = ones(means.shape[0]) / means.shape[0]
         else:
-            weights = reshape(array(weights), (-1,))
+            weights = array(weights)
+            if weights.ndim == 0:
+                weights = reshape(weights, (1,))
+            elif weights.ndim != 1:
+                raise ValueError("weights must be scalar or one-dimensional")
 
         weights = LinearDiracDistribution._normalized_weights(weights)
         mu, C_from_means = LinearDiracDistribution.weighted_samples_to_mean_and_cov(

--- a/tests/distributions/test_gaussian_mixture_moment_weight_shape.py
+++ b/tests/distributions/test_gaussian_mixture_moment_weight_shape.py
@@ -1,0 +1,41 @@
+import unittest
+
+from pyrecest.backend import array
+from pyrecest.distributions import GaussianMixture
+
+
+class GaussianMixtureMomentWeightShapeTest(unittest.TestCase):
+    def test_rejects_matrix_shaped_moment_weights(self):
+        means = array([[0.0], [2.0]])
+        covariance_matrices = array([[[1.0, 1.0]]])
+        matrix_weights = (
+            array([[1.0, 3.0]]),
+            array([[1.0], [3.0]]),
+        )
+
+        for weights in matrix_weights:
+            with self.subTest(shape=weights.shape):
+                with self.assertRaisesRegex(ValueError, "one-dimensional"):
+                    GaussianMixture.mixture_parameters_to_gaussian_parameters(
+                        means,
+                        covariance_matrices,
+                        weights,
+                    )
+
+    def test_scalar_weight_remains_supported_for_single_component(self):
+        mean, covariance = (
+            GaussianMixture.mixture_parameters_to_gaussian_parameters(
+                array([[2.0]]),
+                array([[[3.0]]]),
+                array(4.0),
+            )
+        )
+
+        self.assertEqual(mean.shape, (1,))
+        self.assertEqual(covariance.shape, (1, 1))
+        self.assertEqual(float(mean[0]), 2.0)
+        self.assertEqual(float(covariance[0, 0]), 3.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`GaussianMixture.mixture_parameters_to_gaussian_parameters(...)` unconditionally flattened explicit weights with `reshape(..., (-1,))`. Row and column matrices were therefore silently accepted whenever their element count matched the number of Gaussian components.

Discarding the caller's dimensional structure can hide upstream shape errors and apply weights in an unintended order when moment-matching a Gaussian mixture.

## Fix

- preserve scalar weights as a one-element vector for the single-component case;
- accept explicitly one-dimensional weight vectors;
- reject arrays with two or more dimensions before normalization;
- retain the existing weight normalization and component-count validation.

## Regression coverage

Added focused tests that:

- reject both row- and column-matrix weights;
- verify scalar weights remain supported for a single Gaussian component;
- verify the resulting singleton mean and covariance remain correct.

## Validation

- branch is 2 commits ahead and 0 behind current `main`;
- production diff is limited to 5 additions and 1 deletion;
- remaining changes are a focused 41-line regression test module;
- full backend and repository validation is delegated to GitHub Actions because the local runtime has no GitHub CLI or network checkout access.