### PR TITLE
Reject matrix-shaped SO(3) chordal smoother weights

### DIFF
--- a/src/pyrecest/smoothers/so3_chordal_mean_smoother.py
+++ b/src/pyrecest/smoothers/so3_chordal_mean_smoother.py
@@ -96,7 +96,9 @@ class SO3ChordalMeanSmoother(AbstractSmoother):
         if weights is None:
             return None
 
-        weights_array = asarray(weights).reshape(-1)
+        weights_array = asarray(weights)
+        if ndim(weights_array) != 1:
+            raise ValueError(f"{name} must be one-dimensional.")
         if weights_array.shape[0] != length:
             raise ValueError(f"{name} must have length {length}.")
         if not bool(backend.all(isfinite(weights_array))):

--- a/tests/smoothers/test_so3_chordal_mean_weight_shapes.py
+++ b/tests/smoothers/test_so3_chordal_mean_weight_shapes.py
@@ -1,0 +1,35 @@
+"""Regression coverage for SO(3) chordal smoother weight-vector shapes."""
+
+import pytest
+
+from pyrecest.backend import eye
+from pyrecest.smoothers import SO3ChordalMeanSmoother
+
+
+@pytest.mark.parametrize(
+    "invalid_weights",
+    [
+        [[1.0, 1.0, 1.0]],
+        [[1.0], [1.0], [1.0]],
+    ],
+)
+def test_rejects_matrix_shaped_weights_at_all_entry_points(invalid_weights):
+    rotations = [eye(3), eye(3), eye(3)]
+
+    with pytest.raises(ValueError, match="one-dimensional"):
+        SO3ChordalMeanSmoother(
+            window_size=3,
+            kernel_weights=invalid_weights,
+        )
+
+    with pytest.raises(ValueError, match="one-dimensional"):
+        SO3ChordalMeanSmoother.chordal_mean(
+            rotations,
+            weights=invalid_weights,
+        )
+
+    with pytest.raises(ValueError, match="one-dimensional"):
+        SO3ChordalMeanSmoother(window_size=3).smooth(
+            rotations,
+            weights=invalid_weights,
+        )


### PR DESCRIPTION
## What changed

- require SO(3) chordal smoother weight inputs to be one-dimensional before validating their length
- add regression tests for row- and column-matrix weights at the constructor, `chordal_mean`, and `smooth` entry points

## Why

`_normalize_weight_vector` previously called `reshape(-1)` before validation. A matrix such as `[[1, 1, 1]]` therefore silently became a valid length-three vector, even though the public API specifies one weight vector. This can hide accidental broadcasting or transposition errors and changes malformed structured inputs into valid weights.

## Validation

- verified the branch is 2 commits ahead and 0 behind `main`
- exercised the dimensionality guard against row matrices, column matrices, scalars, and valid one-dimensional vectors in an isolated NumPy check
- GitHub Actions should run the repository's full configured test matrix on this PR