### PR TITLE
Reject matrix-shaped calibration time vectors

### DIFF
--- a/src/pyrecest/calibration/__init__.py
+++ b/src/pyrecest/calibration/__init__.py
@@ -19,6 +19,14 @@ _REJECTED_REAL_SCALAR_TYPES = (
     np.datetime64,
     np.timedelta64,
 )
+_TIME_VECTOR_NAMES = frozenset(
+    {
+        "measurement_times_s",
+        "query_times_s",
+        "reference_times_s",
+        "times_s",
+    }
+)
 
 
 def _is_rejected_real_scalar(value: Any) -> bool:
@@ -66,9 +74,15 @@ def _as_real_numeric_array(value: Any, name: str) -> np.ndarray:
             if _is_rejected_real_scalar(item):
                 raise ValueError(f"{name} must contain real numeric values")
     try:
-        return np.asarray(value, dtype=float)
+        result = np.asarray(value, dtype=float)
     except (TypeError, ValueError, OverflowError) as exc:
         raise ValueError(f"{name} must contain real numeric values") from exc
+    if name in _TIME_VECTOR_NAMES:
+        if result.ndim == 0:
+            return result.reshape(1)
+        if result.ndim != 1:
+            raise ValueError(f"{name} must be one-dimensional")
+    return result
 
 
 def _as_summary_scalar(value: Any, name: str, *, allow_nan: bool = False) -> float:
@@ -120,6 +134,20 @@ _time_offset_module._as_real_numeric_array = _as_real_numeric_array
 _time_offset_module._as_summary_scalar = _as_summary_scalar
 _time_offset_module._as_nonnegative_summary_count = _as_nonnegative_summary_count
 _time_offset_module._aggregate_summary_metric = _aggregate_summary_metric
+
+from . import bias as _bias_module  # noqa: E402
+
+
+def _as_numeric_vector(value: Any, name: str) -> np.ndarray:
+    result = _bias_module._as_numeric_array(value, name)
+    if result.ndim == 0:
+        return result.reshape(1)
+    if result.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional")
+    return result
+
+
+_bias_module._as_numeric_vector = _as_numeric_vector
 
 from .bias import (  # noqa: E402
     BiasTrainingExamples,

--- a/tests/calibration/test_time_vector_shape_validation.py
+++ b/tests/calibration/test_time_vector_shape_validation.py
@@ -1,0 +1,94 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+from pyrecest.calibration.bias import make_bias_training_examples
+from pyrecest.calibration.time_offset import (
+    apply_time_offset,
+    interpolate_reference_values,
+    nearest_time_indices,
+)
+
+
+class CalibrationTimeVectorShapeValidationTest(unittest.TestCase):
+    def test_time_offset_helpers_reject_matrix_shaped_time_vectors(self):
+        row_matrix = np.array([[0.0, 1.0]])
+        column_matrix = np.array([[0.0], [1.0]])
+
+        for invalid_times in (row_matrix, column_matrix):
+            with self.subTest(helper="apply_time_offset", shape=invalid_times.shape):
+                with self.assertRaisesRegex(
+                    ValueError, "times_s must be one-dimensional"
+                ):
+                    apply_time_offset(invalid_times, 0.25)
+
+            with self.subTest(helper="nearest_reference", shape=invalid_times.shape):
+                with self.assertRaisesRegex(
+                    ValueError, "reference_times_s must be one-dimensional"
+                ):
+                    nearest_time_indices(invalid_times, np.array([0.25]))
+
+            with self.subTest(helper="nearest_query", shape=invalid_times.shape):
+                with self.assertRaisesRegex(
+                    ValueError, "query_times_s must be one-dimensional"
+                ):
+                    nearest_time_indices(np.array([0.0, 1.0]), invalid_times)
+
+            with self.subTest(helper="interpolate_reference", shape=invalid_times.shape):
+                with self.assertRaisesRegex(
+                    ValueError, "reference_times_s must be one-dimensional"
+                ):
+                    interpolate_reference_values(
+                        invalid_times,
+                        np.array([[0.0], [1.0]]),
+                        np.array([0.25]),
+                    )
+
+            with self.subTest(helper="interpolate_query", shape=invalid_times.shape):
+                with self.assertRaisesRegex(
+                    ValueError, "query_times_s must be one-dimensional"
+                ):
+                    interpolate_reference_values(
+                        np.array([0.0, 1.0]),
+                        np.array([[0.0], [1.0]]),
+                        invalid_times,
+                    )
+
+    def test_bias_examples_reject_matrix_shaped_time_vectors(self):
+        valid_kwargs = {
+            "measurement_times_s": np.array([0.0, 1.0]),
+            "measurement_values": np.array([[1.0], [2.0]]),
+            "reference_times_s": np.array([0.0, 1.0]),
+            "reference_values": np.array([[0.0], [1.0]]),
+            "max_time_delta_s": 0.0,
+        }
+
+        for field in ("measurement_times_s", "reference_times_s"):
+            for invalid_times in (
+                np.array([[0.0, 1.0]]),
+                np.array([[0.0], [1.0]]),
+            ):
+                kwargs = dict(valid_kwargs)
+                kwargs[field] = invalid_times
+                with self.subTest(field=field, shape=invalid_times.shape):
+                    with self.assertRaisesRegex(
+                        ValueError, f"{field} must be one-dimensional"
+                    ):
+                        make_bias_training_examples(**kwargs)
+
+    def test_scalar_and_vector_time_inputs_remain_supported(self):
+        npt.assert_allclose(apply_time_offset(1.0, 0.25), np.array([1.25]))
+
+        examples = make_bias_training_examples(
+            measurement_times_s=0.0,
+            measurement_values=np.array([[2.0]]),
+            reference_times_s=0.0,
+            reference_values=np.array([[1.0]]),
+            max_time_delta_s=0.0,
+        )
+
+        npt.assert_allclose(examples.residual, np.array([[1.0]]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- reject row- and column-matrix timestamp inputs across the calibration time-offset helpers
- reject matrix-shaped `measurement_times_s` and `reference_times_s` in bias training
- preserve scalar and one-dimensional timestamp inputs
- add regression tests for `apply_time_offset`, nearest-neighbor matching, interpolation, and bias-example construction

## Root cause

Calibration timestamp inputs are vectors, but the implementation converted them with `reshape(-1)`. A malformed `(1, n)` or `(n, 1)` matrix was therefore silently flattened and accepted. This could hide caller shape errors and pair measurements with timestamps in unintended flattened order.

## Validation

The new tests cover both row and column matrices and verify that scalar inputs remain supported. Full repository CI is requested on this PR; local checkout execution was unavailable in the current connector runtime.