### PR TITLE
Reject matrix-shaped bias timestamp vectors

### DIFF
--- a/src/pyrecest/calibration/bias.py
+++ b/src/pyrecest/calibration/bias.py
@@ -367,7 +367,12 @@ def _as_numeric_array(values: Any, name: str) -> np.ndarray:
 
 
 def _as_numeric_vector(values: Any, name: str) -> np.ndarray:
-    return _as_numeric_array(values, name).reshape(-1)
+    out = _as_numeric_array(values, name)
+    if out.ndim == 0:
+        return out.reshape(1)
+    if out.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional")
+    return out
 
 
 def _contains_invalid_numeric_values(values: np.ndarray) -> bool:

--- a/tests/calibration/test_bias_time_vector_shape_validation.py
+++ b/tests/calibration/test_bias_time_vector_shape_validation.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pytest
+from pyrecest.calibration.bias import make_bias_training_examples
+
+
+@pytest.mark.parametrize(
+    ("field", "matrix"),
+    [
+        ("measurement_times_s", np.array([[0.0, 1.0]])),
+        ("measurement_times_s", np.array([[0.0], [1.0]])),
+        ("reference_times_s", np.array([[0.0, 1.0]])),
+        ("reference_times_s", np.array([[0.0], [1.0]])),
+    ],
+)
+def test_make_bias_training_examples_rejects_matrix_time_vectors(field, matrix):
+    kwargs = {
+        "measurement_times_s": np.array([0.0, 1.0]),
+        "measurement_values": np.array([[1.0], [2.0]]),
+        "reference_times_s": np.array([0.0, 1.0]),
+        "reference_values": np.array([[0.0], [1.0]]),
+    }
+    kwargs[field] = matrix
+
+    with pytest.raises(ValueError, match=rf"{field} must be one-dimensional"):
+        make_bias_training_examples(**kwargs)
+
+
+def test_make_bias_training_examples_preserves_scalar_time_support():
+    examples = make_bias_training_examples(
+        measurement_times_s=0.0,
+        measurement_values=np.array([[2.0]]),
+        reference_times_s=0.0,
+        reference_values=np.array([[1.0]]),
+        max_time_delta_s=0.0,
+    )
+
+    np.testing.assert_allclose(examples.residual, np.array([[1.0]]))


### PR DESCRIPTION
## Summary

- require bias-calibration timestamp inputs to be scalars or one-dimensional vectors
- reject row and column matrices instead of silently flattening them
- preserve scalar timestamp support for one-sample calibration
- add focused regression coverage for measurement and reference timestamps

## Bug

`make_bias_training_examples` passed `measurement_times_s` and `reference_times_s` through `_as_numeric_vector`, which unconditionally called `reshape(-1)`. As a result, matrix-shaped timestamps were silently flattened and accepted whenever their element count matched the corresponding measurement rows.

For example, a `1 x 2` measurement-time matrix was interpreted as a two-sample vector. This hides upstream shape errors and can change timestamp ordering without any validation failure.

## Fix

The vector coercion helper now:

- converts scalar numeric inputs to length-one vectors;
- accepts explicitly one-dimensional numeric arrays;
- raises `ValueError` for arrays with more than one dimension.

## Validation

- reproduced the pre-fix acceptance of row and column timestamp matrices
- added regressions covering both matrix orientations for measurement and reference timestamps
- verified scalar timestamp compatibility
- ran the focused regression tests locally: `5 passed`
- compiled the modified production and test modules successfully
- confirmed the branch is two commits ahead and zero behind `main`
