### PR TITLE
Reject matrix-shaped bias calibration timestamps

### DIFF
--- a/src/pyrecest/calibration/bias.py
+++ b/src/pyrecest/calibration/bias.py
@@ -367,7 +367,12 @@ def _as_numeric_array(values: Any, name: str) -> np.ndarray:
 
 
 def _as_numeric_vector(values: Any, name: str) -> np.ndarray:
-    return _as_numeric_array(values, name).reshape(-1)
+    out = _as_numeric_array(values, name)
+    if out.ndim == 0:
+        return out.reshape(1)
+    if out.ndim != 1:
+        raise ValueError(f"{name} must be one-dimensional")
+    return out
 
 
 def _contains_invalid_numeric_values(values: np.ndarray) -> bool:

--- a/tests/calibration/test_bias_time_vector_shapes.py
+++ b/tests/calibration/test_bias_time_vector_shapes.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pytest
+
+from pyrecest.calibration.bias import make_bias_training_examples
+
+
+@pytest.mark.parametrize(
+    ("field_name", "matrix_times"),
+    [
+        ("measurement_times_s", np.array([[0.0, 1.0]])),
+        ("measurement_times_s", np.array([[0.0], [1.0]])),
+        ("reference_times_s", np.array([[0.0, 1.0]])),
+        ("reference_times_s", np.array([[0.0], [1.0]])),
+    ],
+)
+def test_make_bias_training_examples_rejects_matrix_timestamps(
+    field_name, matrix_times
+):
+    kwargs = {
+        "measurement_times_s": np.array([0.0, 1.0]),
+        "measurement_values": np.array([[1.0], [2.0]]),
+        "reference_times_s": np.array([0.0, 1.0]),
+        "reference_values": np.array([[0.5], [1.5]]),
+        "max_time_delta_s": 0.0,
+    }
+    kwargs[field_name] = matrix_times
+
+    with pytest.raises(ValueError, match=rf"{field_name} must be one-dimensional"):
+        make_bias_training_examples(**kwargs)
+
+
+def test_make_bias_training_examples_keeps_scalar_single_timestamp_support():
+    examples = make_bias_training_examples(
+        measurement_times_s=0.0,
+        measurement_values=np.array([[2.0]]),
+        reference_times_s=0.0,
+        reference_values=np.array([[1.0]]),
+        max_time_delta_s=0.0,
+    )
+
+    np.testing.assert_allclose(examples.residual, np.array([[1.0]]))


### PR DESCRIPTION
## Bug

`make_bias_training_examples` normalized timestamp inputs with `.reshape(-1)`. As a result, row and column matrices such as `(1, n)` and `(n, 1)` were silently flattened and accepted as timestamp vectors. This can conceal an upstream orientation error and pair measurements with timestamps under an unintended shape contract.

## Fix

- preserve scalar timestamps for the single-sample case;
- accept ordinary one-dimensional timestamp vectors;
- reject higher-dimensional `measurement_times_s` and `reference_times_s` with a clear `ValueError`;
- add regressions for row and column matrices on both timestamp inputs.

## Validation

- Before the fix: the four matrix-shape regression cases fail because no exception is raised.
- After the fix: `5 passed` in `tests/calibration/test_bias_time_vector_shapes.py`.
- `python -m py_compile src/pyrecest/calibration/bias.py` passes.