### PR TITLE
Fix canonical rolling NIS adapter import path

### DIFF
--- a/src/pyrecest/filters/rolling_nis_process_noise_adapter.py
+++ b/src/pyrecest/filters/rolling_nis_process_noise_adapter.py
@@ -1,0 +1,22 @@
+"""Compatibility import for the canonical rolling NIS adapter name.
+
+The implementation lives in :mod:`pyrecest.filters.adaptive_process_noise`.
+This module keeps the class discoverable through the conventional module path
+that matches its public class name.
+"""
+
+from .adaptive_process_noise import (
+    AdaptiveProcessNoiseConfig,
+    RollingNISAdaptiveProcessNoise,
+    RollingNISProcessNoiseAdapter,
+    adaptive_process_noise_scale_from_nis_ratio,
+    adaptive_scale_from_ratio,
+)
+
+__all__ = [
+    "AdaptiveProcessNoiseConfig",
+    "RollingNISAdaptiveProcessNoise",
+    "RollingNISProcessNoiseAdapter",
+    "adaptive_process_noise_scale_from_nis_ratio",
+    "adaptive_scale_from_ratio",
+]

--- a/tests/filters/test_rolling_nis_process_noise_adapter_import.py
+++ b/tests/filters/test_rolling_nis_process_noise_adapter_import.py
@@ -1,0 +1,22 @@
+"""Regression tests for the canonical adaptive-process-noise import path."""
+
+
+def test_canonical_rolling_nis_adapter_module_reexports_implementation():
+    from pyrecest.filters.adaptive_process_noise import (
+        AdaptiveProcessNoiseConfig as ImplementationConfig,
+    )
+    from pyrecest.filters.adaptive_process_noise import (
+        RollingNISProcessNoiseAdapter as ImplementationAdapter,
+    )
+    from pyrecest.filters.adaptive_process_noise import (
+        adaptive_scale_from_ratio as implementation_scale,
+    )
+    from pyrecest.filters.rolling_nis_process_noise_adapter import (
+        AdaptiveProcessNoiseConfig,
+        RollingNISProcessNoiseAdapter,
+        adaptive_scale_from_ratio,
+    )
+
+    assert RollingNISProcessNoiseAdapter is ImplementationAdapter
+    assert AdaptiveProcessNoiseConfig is ImplementationConfig
+    assert adaptive_scale_from_ratio is implementation_scale


### PR DESCRIPTION
## Bug

`RollingNISProcessNoiseAdapter` is the canonical class name implemented by `adaptive_process_noise.py`, but there was no matching module import path. Code following the package's class-to-module naming convention therefore failed with:

```python
from pyrecest.filters.rolling_nis_process_noise_adapter import RollingNISProcessNoiseAdapter
```

This is particularly confusing because the legacy alias `RollingNISAdaptiveProcessNoise` and the canonical class coexist in the implementation module.

## Fix

- add a lightweight compatibility module for the canonical adapter name;
- re-export the configuration, canonical and legacy adapter names, and both scale-function names;
- add a regression test confirming that the compatibility imports resolve to the original implementation objects rather than duplicate definitions.

## Scope

The change is isolated to the adaptive process-noise public import surface and does not overlap the open matrix-shape validation PRs.