### PR TITLE
Reject matrix-shaped HypersphericalUKF vectors

### DIFF
--- a/src/pyrecest/filters/hyperspherical_ukf.py
+++ b/src/pyrecest/filters/hyperspherical_ukf.py
@@ -31,7 +31,7 @@ from pyrecest.distributions import GaussianDistribution
 from pyrecest.sampling.sigma_points import MerweScaledSigmaPoints
 
 from ._ukf import UnscentedKalmanFilter as BayesianFiltersUKF
-from ._ukf import _UKFModel
+from ._ukf import _UKFModel, _as_vector
 from .abstract_filter import AbstractFilter
 from .manifold_mixins import HypersphericalFilterMixin
 
@@ -156,7 +156,7 @@ class HypersphericalUKF(AbstractFilter, HypersphericalFilterMixin):
 
         def _fx(x, _dt):
             x_unit = self._normalize(x)
-            y = reshape(asarray(f(array(x_unit)), dtype=float64), (-1,))
+            y = _as_vector(f(array(x_unit)), "transition function output")
             return self._normalize(y)
 
         ukf = self._build_ukf(dim_x, dim_x, _fx, lambda x: x)
@@ -191,7 +191,7 @@ class HypersphericalUKF(AbstractFilter, HypersphericalFilterMixin):
         _assert_supported_backend("pytorch", "jax")
 
         noise_samples = asarray(noise_samples, dtype=float64)
-        noise_weights = reshape(asarray(noise_weights, dtype=float64), (-1,))
+        noise_weights = _as_vector(noise_weights, "noise_weights")
         if noise_samples.ndim != 2:
             raise ValueError(
                 "noise_samples must be a 2D array with shape (noise_dim, n_noise)."
@@ -225,12 +225,9 @@ class HypersphericalUKF(AbstractFilter, HypersphericalFilterMixin):
         k = 0
         for i in range(n_sigmas):
             for j in range(n_noise):
-                x_new = reshape(
-                    asarray(
-                        f(array(sigmas[i]), array(noise_samples[:, j])),
-                        dtype=float64,
-                    ),
-                    (-1,),
+                x_new = _as_vector(
+                    f(array(sigmas[i]), array(noise_samples[:, j])),
+                    "transition function output",
                 )
                 x_new = self._normalize(x_new)
                 new_samples[:, k] = x_new
@@ -292,14 +289,14 @@ class HypersphericalUKF(AbstractFilter, HypersphericalFilterMixin):
             gauss_meas = GaussianDistribution.from_distribution(gauss_meas)
         self._validate_zero_mean_noise(gauss_meas, "gauss_meas")
 
-        z_arr = reshape(asarray(z, dtype=float64), (-1,))
+        z_arr = _as_vector(z, "measurement z")
         dim_z = z_arr.shape[0]
         dim_x = self._filter_state.dim
         R = asarray(gauss_meas.C, dtype=float64)
 
         def _hx(x):
             x_unit = self._normalize(x)
-            return reshape(asarray(f(array(x_unit)), dtype=float64), (-1,))
+            return _as_vector(f(array(x_unit)), "measurement function output")
 
         ukf = self._build_ukf(dim_x, dim_z, lambda x, _dt: x, _hx)
         ukf.Q = zeros((dim_x, dim_x))

--- a/tests/filters/test_hyperspherical_ukf_vector_shape_validation.py
+++ b/tests/filters/test_hyperspherical_ukf_vector_shape_validation.py
@@ -1,0 +1,119 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+import pyrecest.backend
+from pyrecest.backend import array, reshape
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.filters.hyperspherical_ukf import HypersphericalUKF
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+    reason="Not supported on this backend",
+)
+class HypersphericalUKFVectorShapeValidationTest(unittest.TestCase):
+    @staticmethod
+    def _zero_mean_noise(dim):
+        return GaussianDistribution(
+            array(np.zeros(dim)),
+            array(0.1 * np.eye(dim)),
+        )
+
+    @staticmethod
+    def _assert_initial_state(filter_instance):
+        npt.assert_allclose(filter_instance.filter_state.mu, array([1.0, 0.0]))
+        npt.assert_allclose(filter_instance.filter_state.C, array(np.eye(2)))
+
+    def test_predict_rejects_matrix_transition_outputs_without_state_change(self):
+        for output_shape in ((1, 2), (2, 1)):
+            with self.subTest(output_shape=output_shape):
+                filter_instance = HypersphericalUKF(dim=2)
+
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "transition function output must be scalar or one-dimensional",
+                ):
+                    filter_instance.predict_nonlinear(
+                        lambda x, shape=output_shape: reshape(x, shape),
+                        self._zero_mean_noise(2),
+                    )
+
+                self._assert_initial_state(filter_instance)
+
+    def test_update_rejects_matrix_measurement_outputs_without_state_change(self):
+        for output_shape in ((1, 2), (2, 1)):
+            with self.subTest(output_shape=output_shape):
+                filter_instance = HypersphericalUKF(dim=2)
+
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "measurement function output must be scalar or one-dimensional",
+                ):
+                    filter_instance.update_nonlinear(
+                        lambda x, shape=output_shape: reshape(x, shape),
+                        self._zero_mean_noise(2),
+                        array([1.0, 0.0]),
+                    )
+
+                self._assert_initial_state(filter_instance)
+
+    def test_update_rejects_matrix_measurements_without_state_change(self):
+        for measurement_shape in ((1, 2), (2, 1)):
+            with self.subTest(measurement_shape=measurement_shape):
+                filter_instance = HypersphericalUKF(dim=2)
+                measurement = reshape(array([1.0, 0.0]), measurement_shape)
+
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "measurement z must be scalar or one-dimensional",
+                ):
+                    filter_instance.update_identity(
+                        self._zero_mean_noise(2),
+                        measurement,
+                    )
+
+                self._assert_initial_state(filter_instance)
+
+    def test_arbitrary_noise_rejects_matrix_weight_vectors(self):
+        for weights in (
+            array([[1.0, 1.0]]),
+            array([[1.0], [1.0]]),
+        ):
+            with self.subTest(weight_shape=weights.shape):
+                filter_instance = HypersphericalUKF(dim=2)
+
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "noise_weights must be scalar or one-dimensional",
+                ):
+                    filter_instance.predict_nonlinear_arbitrary_noise(
+                        lambda x, _v: x,
+                        array([[0.0, 0.0]]),
+                        weights,
+                    )
+
+                self._assert_initial_state(filter_instance)
+
+    def test_arbitrary_noise_rejects_matrix_transition_outputs(self):
+        for output_shape in ((1, 2), (2, 1)):
+            with self.subTest(output_shape=output_shape):
+                filter_instance = HypersphericalUKF(dim=2)
+
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "transition function output must be scalar or one-dimensional",
+                ):
+                    filter_instance.predict_nonlinear_arbitrary_noise(
+                        lambda x, _v, shape=output_shape: reshape(x, shape),
+                        array([[0.0]]),
+                        1.0,
+                    )
+
+                self._assert_initial_state(filter_instance)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`HypersphericalUKF` reshaped several caller-provided values with `reshape(..., (-1,))` before delegating to the core UKF. Consequently, row and column matrices were silently flattened and bypassed the scalar-or-vector validation introduced in #4745.

Affected inputs were:

- nonlinear transition outputs,
- nonlinear measurement outputs,
- measurement observations,
- arbitrary-noise transition outputs, and
- arbitrary-noise weights.

This could make malformed model interfaces appear valid and produce an update for data with the wrong semantic shape.

## Fix

- Reuse `_ukf._as_vector` at every affected `HypersphericalUKF` boundary.
- Preserve scalar support where the API permits it.
- Reject matrices before assigning a new filter state.

## Regression coverage

Added row- and column-matrix cases for prediction, update, arbitrary-noise prediction, and weight validation. The tests also verify that rejected inputs leave the filter state unchanged.

## Validation

- Changed source and regression test pass Python compilation and AST parsing.
- The complete repository test matrix is delegated to GitHub Actions because a repository checkout was unavailable in the execution environment.