### PR TITLE
Treat non-finite evaluation deviations as failures

### DIFF
--- a/src/pyrecest/evaluation/determine_all_deviations.py
+++ b/src/pyrecest/evaluation/determine_all_deviations.py
@@ -3,7 +3,7 @@ import warnings
 import pyrecest.backend
 from beartype import beartype
 from beartype.typing import Callable
-from pyrecest.backend import any, empty, is_array, isinf, sum
+from pyrecest.backend import any, empty, is_array, isfinite, sum
 
 
 def _shape_size(container):
@@ -72,8 +72,9 @@ def determine_all_deviations(
                 warnings.warn("No estimate for this filter, setting error to inf.")
                 all_deviations_last_mat[config_no][run] = float("inf")
 
-        failed_mask = isinf(all_deviations_last_mat[config_no])
+        failed_mask = ~isfinite(all_deviations_last_mat[config_no])
         if any(failed_mask):
+            all_deviations_last_mat[config_no][failed_mask] = float("inf")
             warnings.warn(
                 f"Filter result {config_no} apparently failed "
                 f"{int(sum(failed_mask))} times. Check if this is plausible."

--- a/tests/evaluation/test_determine_all_deviations_nonfinite.py
+++ b/tests/evaluation/test_determine_all_deviations_nonfinite.py
@@ -1,0 +1,26 @@
+import numpy as np
+import pyrecest.backend
+import pytest
+from pyrecest.backend import array, isinf
+from pyrecest.evaluation.determine_all_deviations import determine_all_deviations
+
+pytestmark = pytest.mark.skipif(
+    pyrecest.backend.__backend_name__ == "jax",
+    reason="determine_all_deviations is not supported on the JAX backend",
+)
+
+
+def test_nonfinite_distance_is_treated_as_failed_run():
+    groundtruths = np.empty((1, 1), dtype=object)
+    groundtruths[0, 0] = array([0.0])
+    results = [[array([0.0])]]
+
+    with pytest.warns(UserWarning, match="apparently failed 1 times"):
+        deviations = determine_all_deviations(
+            results,
+            None,
+            lambda estimate, expected: float("nan"),
+            groundtruths,
+        )
+
+    assert bool(isinf(deviations[0, 0]))


### PR DESCRIPTION
## Bug

`determine_all_deviations` classified failed runs with `isinf(...)` only. A distance function returning `NaN` therefore bypassed the failure warning and remained in the deviation matrix. Downstream aggregation then produced `NaN` error statistics instead of the established failed-run representation.

## Fix

- detect all non-finite deviations with `~isfinite(...)`;
- canonicalize `NaN`, `+inf`, and `-inf` deviations to `+inf`;
- retain the existing aggregate failed-run warning and missing-estimate behavior;
- add a focused regression proving that a `NaN` distance is counted and stored as a failed run.

## Impact

Numerically invalid distance results can no longer silently poison evaluation means. They are handled consistently with missing estimates and other failed filter runs.

## Validation

- modified production and test modules compile successfully in isolation;
- isolated reproduction confirms the old `isinf` mask misses `NaN`, while the new non-finite mask converts it to `+inf`;
- branch is 2 commits ahead and 0 behind current `main`;
- the full configured backend test matrix is delegated to GitHub Actions.