### PR TITLE
Reject invalid custom set-metric distances

### DIFF
--- a/src/pyrecest/utils/metrics.py
+++ b/src/pyrecest/utils/metrics.py
@@ -644,6 +644,8 @@ def _clipped_assignment_cost(
     if estimated.shape[0] == 0 or reference.shape[0] == 0:
         return 0.0, []
     distances = _pairwise_distances(estimated, reference, distance_fn)
+    if np.any(np.isnan(distances)) or np.any(distances < 0.0):
+        raise ValueError("pairwise distances must be non-negative and not NaN")
     clipped_costs = np.minimum(distances, cutoff) ** order
     row_ind, col_ind = linear_sum_assignment(clipped_costs)
     assignment_cost = float(clipped_costs[row_ind, col_ind].sum())

--- a/tests/test_metrics_distance_function_validation.py
+++ b/tests/test_metrics_distance_function_validation.py
@@ -1,0 +1,56 @@
+import numpy as np
+import pytest
+
+from pyrecest.utils.metrics import gospa_distance, mospa_distance, ospa_distance
+
+
+_POINTS = np.array([[0.0]])
+
+
+@pytest.mark.parametrize("invalid_distance", [-1.0, np.nan])
+@pytest.mark.parametrize(
+    "evaluate",
+    [
+        pytest.param(
+            lambda distance_fn: ospa_distance(
+                _POINTS,
+                _POINTS,
+                cutoff=3.0,
+                distance_fn=distance_fn,
+            ),
+            id="ospa",
+        ),
+        pytest.param(
+            lambda distance_fn: gospa_distance(
+                _POINTS,
+                _POINTS,
+                cutoff=3.0,
+                distance_fn=distance_fn,
+            ),
+            id="gospa",
+        ),
+        pytest.param(
+            lambda distance_fn: mospa_distance(
+                [_POINTS],
+                [_POINTS],
+                cutoff=3.0,
+                distance_fn=distance_fn,
+            ),
+            id="mospa",
+        ),
+    ],
+)
+def test_set_metrics_reject_invalid_pairwise_distances(evaluate, invalid_distance):
+    with pytest.raises(ValueError, match="pairwise distances must be non-negative"):
+        evaluate(lambda _estimate, _truth: invalid_distance)
+
+
+def test_positive_infinite_distance_is_clipped_to_cutoff():
+    distance = ospa_distance(
+        _POINTS,
+        _POINTS,
+        cutoff=3.0,
+        distance_fn=lambda _estimate, _truth: np.inf,
+    )
+
+    assert distance == pytest.approx(3.0)


### PR DESCRIPTION
## Summary
- reject negative and NaN pairwise distances before OSPA/GOSPA assignment
- preserve positive-infinity semantics by clipping those distances to the configured cutoff
- add regression coverage for OSPA, MOSPA, and GOSPA

## Bug
A custom distance function returning a negative value could make `ospa_distance` or `gospa_distance` return a negative result, violating metric non-negativity. A NaN result was only rejected later by SciPy with an opaque assignment-matrix error.

## Fix
Validate the pairwise distance matrix before clipping and assignment. Negative values and NaNs now raise a targeted `ValueError`; positive infinity remains supported because the cutoff converts it to a finite assignment cost.

## Validation
- `pytest -q tests/test_metrics_distance_function_validation.py` — 7 passed
- `python -m py_compile src/pyrecest/utils/metrics.py tests/test_metrics_distance_function_validation.py`
