### PR TITLE
Reject malformed expected-result sections

### DIFF
--- a/src/pyrecest/cli.py
+++ b/src/pyrecest/cli.py
@@ -205,6 +205,14 @@ def _cmd_run_scenario(args: argparse.Namespace) -> int:
         if not isinstance(expected, dict):
             print("expected results must be a JSON object", file=sys.stderr)
             return 2
+        for section_name in ("metrics", "diagnostics"):
+            section = expected.get(section_name)
+            if section is not None and not isinstance(section, dict):
+                print(
+                    f"expected results {section_name} must be a JSON object",
+                    file=sys.stderr,
+                )
+                return 2
         raw_tolerance = (
             args.tolerance
             if args.tolerance is not None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
 
+import pytest
+
 from pyrecest.cli import main
 
 
@@ -86,3 +88,33 @@ def test_cli_run_scenario_rejects_nonobject_expected_json(tmp_path, capsys):
         == 2
     )
     assert "expected results must be a JSON object" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("section_name", ["metrics", "diagnostics"])
+def test_cli_run_scenario_rejects_nonobject_expected_sections(
+    tmp_path, capsys, section_name
+):
+    expected = json.loads(
+        Path("scenarios/linear_gaussian_cv_1d/expected.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    expected[section_name] = []
+    expected_path = tmp_path / f"expected_invalid_{section_name}.json"
+    expected_path.write_text(json.dumps(expected), encoding="utf-8")
+
+    assert (
+        main(
+            [
+                "run-scenario",
+                "scenarios/linear_gaussian_cv_1d/config.toml",
+                "--expected",
+                str(expected_path),
+            ]
+        )
+        == 2
+    )
+    assert (
+        f"expected results {section_name} must be a JSON object"
+        in capsys.readouterr().err
+    )


### PR DESCRIPTION
## Summary
- validate `metrics` and `diagnostics` in expected-results JSON before comparison
- reject non-object section values with CLI configuration exit code 2
- add regressions for both malformed sections

## Bug
`pyrecest run-scenario --expected ...` only compared `metrics` and `diagnostics` when those values happened to be JSON objects. If either field was present as a list, string, number, or boolean, the CLI silently skipped the section and could report success without performing the requested checks.

## Fix
Treat a present non-object `metrics` or `diagnostics` section as malformed expected-results input. The CLI now emits a targeted error and returns exit code 2, consistent with other expected-file schema errors.

## Validation
- branch is 2 commits ahead of `main` and 0 behind
- focused pytest regressions added to `tests/test_cli.py`
- full tests were not run locally because this runtime cannot resolve GitHub for a checkout; GitHub Actions should validate the branch