### PR TITLE
Reject non-finite circular association PDF values

### DIFF
--- a/src/pyrecest/filters/abstract_circular_filter.py
+++ b/src/pyrecest/filters/abstract_circular_filter.py
@@ -1,6 +1,8 @@
 """Abstract base class for circular filters."""
 
 # pylint: disable=no-name-in-module,no-member
+from math import isfinite
+
 from pyrecest.backend import array, asarray, pi
 from scipy.integrate import quad
 
@@ -9,13 +11,23 @@ from .manifold_mixins import CircularFilterMixin
 
 
 def _scalar_pdf_value(value, owner: str):
-    """Return one PDF value and reject ambiguous vector outputs."""
+    """Return one finite real PDF value and reject ambiguous outputs."""
     flattened = asarray(value).reshape(-1)
     if flattened.shape[0] != 1:
         raise ValueError(
             f"{owner}.pdf must return exactly one value for one integration angle."
         )
-    return flattened[0]
+    try:
+        scalar = float(flattened[0])
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(
+            f"{owner}.pdf must return a finite real value for one integration angle."
+        ) from exc
+    if not isfinite(scalar):
+        raise ValueError(
+            f"{owner}.pdf must return a finite real value for one integration angle."
+        )
+    return scalar
 
 
 class AbstractCircularFilter(AbstractFilter, CircularFilterMixin):
@@ -47,7 +59,7 @@ class AbstractCircularFilter(AbstractFilter, CircularFilterMixin):
                 likelihood.pdf(angle_array),
                 "likelihood",
             )
-            return float(estimate_pdf * likelihood_pdf)
+            return estimate_pdf * likelihood_pdf
 
         likelihood_val, _ = quad(integrand, 0.0, 2.0 * pi)
         return likelihood_val

--- a/tests/filters/test_abstract_circular_filter.py
+++ b/tests/filters/test_abstract_circular_filter.py
@@ -58,3 +58,24 @@ def test_association_likelihood_rejects_vector_pdf_values(
 
     with pytest.raises(ValueError, match=message):
         filt.association_likelihood_numerical(likelihood)
+
+
+@pytest.mark.parametrize(
+    ("state_pdf", "likelihood_pdf", "message"),
+    [
+        (array([float("nan")]), array([1.0]), r"filter_state\.pdf"),
+        (array([float("inf")]), array([1.0]), r"filter_state\.pdf"),
+        (array([1.0]), array([float("nan")]), r"likelihood\.pdf"),
+        (array([1.0]), array([-float("inf")]), r"likelihood\.pdf"),
+    ],
+)
+def test_association_likelihood_rejects_nonfinite_pdf_values(
+    state_pdf,
+    likelihood_pdf,
+    message,
+):
+    filt = _TestCircularFilter(_PdfDistribution(state_pdf))
+    likelihood = _PdfDistribution(likelihood_pdf)
+
+    with pytest.raises(ValueError, match=message):
+        filt.association_likelihood_numerical(likelihood)


### PR DESCRIPTION
## Summary
- validate scalar PDF outputs used by numerical circular association likelihoods
- reject `NaN`, positive/negative infinity, and non-real scalar outputs with a targeted `ValueError`
- add regression coverage for invalid outputs from both the filter state and the candidate likelihood

## Bug
`AbstractCircularFilter.association_likelihood_numerical` previously passed PDF outputs directly into `scipy.integrate.quad`. If either PDF returned `NaN` or infinity for an integration angle, the invalid value could silently propagate into a non-finite association likelihood (typically accompanied only by an integration warning). That result can subsequently poison association scores or evidence calculations.

## Fix
Convert each one-element PDF result to a Python real scalar and require it to be finite before multiplication and integration. Existing support for scalar and one-element array outputs is preserved, as is the existing rejection of multi-element outputs.

## Validation
- `python -m py_compile` on the modified filter module
- isolated scalar-validation check covering finite, `NaN`, and ±infinity inputs
- added focused pytest regressions in `tests/filters/test_abstract_circular_filter.py`

The full package test suite could not be run locally because this execution environment cannot clone the repository or import an installed PyRecEst checkout; repository CI should run the focused and full test suites.