### PR TITLE
Reject matrix-shaped point-registration vectors

### DIFF
--- a/src/pyrecest/utils/point_set_registration.py
+++ b/src/pyrecest/utils/point_set_registration.py
@@ -70,11 +70,15 @@ class AffineTransform:
 
     def __post_init__(self) -> None:
         matrix = asarray(self.matrix)
-        offset = asarray(self.offset).reshape(-1)
+        offset = asarray(self.offset)
         if matrix.ndim != 2:
             raise ValueError("matrix must be two-dimensional.")
         if matrix.shape[0] != matrix.shape[1]:
             raise ValueError("matrix must be square.")
+        if offset.ndim == 0:
+            offset = offset.reshape((1,))
+        elif offset.ndim != 1:
+            raise ValueError("offset must be one-dimensional.")
         if offset.shape[0] != matrix.shape[0]:
             raise ValueError("offset dimension must match matrix dimension.")
         if any(~isfinite(matrix)):
@@ -146,7 +150,11 @@ class RegistrationResult(
 def _normalize_weights(weights, n_points):
     if weights is None:
         return full((n_points,), 1.0 / n_points)
-    weights_array = asarray(weights).reshape(-1)
+    weights_array = asarray(weights)
+    if weights_array.ndim == 0:
+        weights_array = weights_array.reshape((1,))
+    elif weights_array.ndim != 1:
+        raise ValueError("weights must be one-dimensional.")
     if weights_array.shape[0] != n_points:
         raise ValueError("weights must have length n_points.")
     if any(~isfinite(weights_array)):

--- a/tests/test_point_set_registration_vector_shapes.py
+++ b/tests/test_point_set_registration_vector_shapes.py
@@ -1,0 +1,39 @@
+import unittest
+
+import pyrecest.backend
+from pyrecest.backend import array, eye
+from pyrecest.utils.point_set_registration import AffineTransform, estimate_transform
+
+
+class TestPointSetRegistrationVectorShapes(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_affine_transform_rejects_matrix_shaped_offsets(self):
+        for offset in (array([[1.0, -2.0]]), array([[1.0], [-2.0]])):
+            with self.subTest(offset_shape=offset.shape):
+                with self.assertRaisesRegex(ValueError, "offset must be one-dimensional"):
+                    AffineTransform(eye(2), offset)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_estimate_transform_rejects_matrix_shaped_weights(self):
+        source = array([[0.0, 0.0], [1.0, 0.0]])
+        target = source + array([1.0, -1.0])
+
+        for weights in (array([[1.0, 1.0]]), array([[1.0], [1.0]])):
+            with self.subTest(weights_shape=weights.shape):
+                with self.assertRaisesRegex(ValueError, "weights must be one-dimensional"):
+                    estimate_transform(
+                        source,
+                        target,
+                        model="translation",
+                        weights=weights,
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reject row- and column-matrix affine offsets instead of silently flattening them
- reject matrix-shaped point weights in `estimate_transform`
- preserve valid scalar inputs for one-dimensional transforms and single-point weights
- add regression coverage for both row and column matrices

## Bug
`AffineTransform.__post_init__` and `_normalize_weights` called `reshape(-1)` before validating input shape. As a result, malformed `(1, n)` and `(n, 1)` matrices were accepted as if they were documented one-dimensional vectors. This can hide transposition and batching mistakes at API boundaries.

## Fix
Normalize only scalar inputs to length-one vectors, require all other offset and weight inputs to be one-dimensional, and retain the existing length and finiteness checks.

## Validation
- `python -m py_compile src/pyrecest/utils/point_set_registration.py tests/test_point_set_registration_vector_shapes.py`
- focused standalone checks for row/column rejection and scalar/1-D compatibility
