### PR TITLE
Preserve callable factor TypeErrors

### DIFF
--- a/src/pyrecest/filters/survival_aware_association.py
+++ b/src/pyrecest/filters/survival_aware_association.py
@@ -8,6 +8,7 @@ those prior weights into association-hypothesis costs.
 
 from __future__ import annotations
 
+import inspect
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, replace
 from math import log
@@ -465,21 +466,47 @@ def _resolve_value(
     if not callable(spec):
         return float(_as_numpy_array(spec).item())
 
-    call_attempts = (
-        lambda: spec(
-            track=track,
-            measurement=measurement,
-            measurement_index=measurement_index,
-            step=step,
+    call_candidates = (
+        (
+            (),
+            {
+                "track": track,
+                "measurement": measurement,
+                "measurement_index": measurement_index,
+                "step": step,
+            },
         ),
-        lambda: spec(track, measurement, measurement_index, step),
-        lambda: spec(track, measurement),
-        lambda: spec(track),
+        ((track, measurement, measurement_index, step), {}),
+        ((track, measurement), {}),
+        ((track,), {}),
     )
-    last_error: TypeError | None = None
-    for attempt in call_attempts:
+    try:
+        signature = inspect.signature(spec)
+    except (TypeError, ValueError):
+        return _resolve_uninspectable_callable(spec, call_candidates)
+
+    for args, kwargs in call_candidates:
         try:
-            return float(_as_numpy_array(attempt()).item())
+            signature.bind(*args, **kwargs)
+        except TypeError:
+            continue
+        return float(_as_numpy_array(spec(*args, **kwargs)).item())
+
+    raise TypeError(
+        "Callable factors must accept keyword arguments, "
+        "(track, measurement, measurement_index, step), "
+        "(track, measurement), or track"
+    )
+
+
+def _resolve_uninspectable_callable(
+    spec: Callable[..., float],
+    call_candidates: tuple[tuple[tuple[Any, ...], dict[str, Any]], ...],
+) -> float:
+    last_error: TypeError | None = None
+    for args, kwargs in call_candidates:
+        try:
+            return float(_as_numpy_array(spec(*args, **kwargs)).item())
         except TypeError as exc:
             last_error = exc
     raise TypeError(

--- a/tests/filters/test_survival_aware_association.py
+++ b/tests/filters/test_survival_aware_association.py
@@ -60,6 +60,22 @@ class SurvivalAwareAssociationTest(unittest.TestCase):
             expected_weight,
         )
 
+    def test_callable_factor_internal_type_error_is_not_retried_or_masked(self):
+        track = _track(0.0)
+        call_count = 0
+
+        def broken_factor(*_args, **_kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise TypeError("factor implementation failed")
+
+        config = SurvivalAwareAssociationConfig(survival_probability=broken_factor)
+
+        with self.assertRaisesRegex(TypeError, "factor implementation failed"):
+            survival_aware_track_log_prior(track, config=config)
+
+        self.assertEqual(call_count, 1)
+
     def test_prior_discounts_stale_tracks(self):
         config = SurvivalAwareAssociationConfig(
             survival_probability=0.8,


### PR DESCRIPTION
## Bug

Survival-aware association factor dispatch treated every `TypeError` as evidence that the callable had an incompatible signature. If a compatible callable raised `TypeError` inside its implementation, the dispatcher retried it under other calling conventions, potentially repeated side effects, and finally replaced the real exception with a misleading signature error.

## Fix

- inspect callable signatures before invocation
- select the first supported calling convention without executing probe calls
- invoke inspectable factors exactly once
- preserve exceptions raised by factor implementations
- retain the compatibility fallback for callables whose signatures cannot be inspected

## Regression coverage

Added a factor accepting arbitrary positional and keyword arguments that raises `TypeError`. The test verifies that the original message propagates and that the factor is called exactly once.

## Validation

- both modified Python files compile successfully
- focused dispatcher exercise covers all four supported calling conventions
- branch diff is limited to the dispatcher and its existing test module
- full repository CI is delegated to GitHub Actions