### PR TITLE
Reject matrix-shaped Gaussian hypothesis means

### DIFF
--- a/src/pyrecest/filters/gaussian_hypothesis_mixture.py
+++ b/src/pyrecest/filters/gaussian_hypothesis_mixture.py
@@ -34,7 +34,12 @@ class WeightedGaussianHypothesis:
     metadata: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
-        mean = _as_float_array(self.mean, "mean").reshape(-1).copy()
+        mean = _as_float_array(self.mean, "mean")
+        if mean.ndim == 0:
+            mean = mean.reshape(1)
+        elif mean.ndim != 1:
+            raise ValueError("mean must be scalar or one-dimensional")
+        mean = mean.copy()
         covariance = _as_float_array(self.covariance, "covariance")
         if not np.all(np.isfinite(mean)):
             raise ValueError("mean must contain only finite values")

--- a/tests/filters/test_gaussian_hypothesis_mean_shapes.py
+++ b/tests/filters/test_gaussian_hypothesis_mean_shapes.py
@@ -1,0 +1,29 @@
+import numpy as np
+import pytest
+
+from pyrecest.filters.gaussian_hypothesis_mixture import WeightedGaussianHypothesis
+
+
+@pytest.mark.parametrize(
+    "mean",
+    [
+        np.array([[1.0, 2.0]]),
+        np.array([[1.0], [2.0]]),
+    ],
+)
+def test_weighted_gaussian_hypothesis_rejects_matrix_shaped_means(mean) -> None:
+    with pytest.raises(ValueError, match="mean.*one-dimensional"):
+        WeightedGaussianHypothesis(mean, np.eye(2))
+
+
+def test_weighted_gaussian_hypothesis_preserves_scalar_mean_compatibility() -> None:
+    hypothesis = WeightedGaussianHypothesis(1.0, np.array([[2.0]]))
+
+    assert hypothesis.mean.shape == (1,)
+    assert np.array_equal(hypothesis.mean, np.array([1.0]))
+
+
+def test_weighted_gaussian_hypothesis_accepts_one_dimensional_means() -> None:
+    hypothesis = WeightedGaussianHypothesis(np.array([1.0, 2.0]), np.eye(2))
+
+    assert hypothesis.mean.shape == (2,)


### PR DESCRIPTION
## Bug

`WeightedGaussianHypothesis.__post_init__` called `reshape(-1)` before validating the state-mean shape. As a result, row matrices such as `(1, n)` and column matrices such as `(n, 1)` were silently accepted as ordinary one-dimensional mean vectors. This can conceal transposition or accidental batching errors at the hypothesis-construction boundary.

## Fix

- retain scalar means as length-one state vectors for backward compatibility
- require all non-scalar means to be one-dimensional
- reject row and column matrices with a targeted `ValueError`

## Regression coverage

Added focused tests that verify:

- `(1, n)` row means are rejected
- `(n, 1)` column means are rejected
- scalar one-dimensional-state means remain supported
- ordinary one-dimensional means remain supported

## Validation

- focused isolated pytest exercise: `4 passed`
- `python -m py_compile` on the modified module and regression test
- branch comparison: 2 commits ahead of `main`, 0 behind; 2 files changed