### PR TITLE
Fix MTT mean extraction for mapping tracks

### DIFF
--- a/src/pyrecest/evaluation/get_extract_mean.py
+++ b/src/pyrecest/evaluation/get_extract_mean.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import Any
 
 import numpy as np
@@ -82,6 +82,8 @@ def _point_estimate_or_mean(filter_state):
 
 
 def _extract_track_collection_mean(tracks):
+    if isinstance(tracks, Mapping):
+        tracks = tracks.values()
     return [_point_estimate_or_mean(track) for track in tracks]
 
 

--- a/tests/evaluation/test_get_extract_mean_mapping_tracks.py
+++ b/tests/evaluation/test_get_extract_mean_mapping_tracks.py
@@ -1,0 +1,44 @@
+import numpy as np
+
+from pyrecest.evaluation.get_extract_mean import get_extract_mean
+
+
+class Track:
+    def __init__(self, mean):
+        self.mu = np.asarray(mean)
+
+
+class TrackerWithTracksAttribute:
+    def __init__(self):
+        self.tracks = {
+            "track-a": Track([1.0, 2.0]),
+            "track-b": Track([3.0, 4.0]),
+        }
+
+
+class TrackerWithGetTracks:
+    def get_tracks(self):
+        return {
+            10: Track([5.0, 6.0]),
+            20: Track([7.0, 8.0]),
+        }
+
+
+def test_mtt_mean_extracts_mapping_values_from_tracks_attribute():
+    extract_mean = get_extract_mean("euclidean", mtt_scenario=True)
+
+    means = extract_mean(TrackerWithTracksAttribute())
+
+    assert len(means) == 2
+    np.testing.assert_array_equal(means[0], [1.0, 2.0])
+    np.testing.assert_array_equal(means[1], [3.0, 4.0])
+
+
+def test_mtt_mean_extracts_mapping_values_from_get_tracks():
+    extract_mean = get_extract_mean("euclidean", mtt_scenario=True)
+
+    means = extract_mean(TrackerWithGetTracks())
+
+    assert len(means) == 2
+    np.testing.assert_array_equal(means[0], [5.0, 6.0])
+    np.testing.assert_array_equal(means[1], [7.0, 8.0])


### PR DESCRIPTION
## Summary
- treat mapping-based track collections as collections of track objects rather than track IDs
- preserve insertion order by extracting means from `Mapping.values()`
- cover both a `.tracks` mapping and a `get_tracks()` mapping

## Bug
`get_extract_mean("euclidean", mtt_scenario=True)` passed mapping track collections directly to iteration. Python iterates mapping keys, so evaluation returned track IDs instead of the tracks' point estimates or means.

## Validation
- added two focused regression tests in `tests/evaluation/test_get_extract_mean_mapping_tracks.py`
- branch diff is limited to 4 source-line changes plus the test file
- full test execution is delegated to repository CI because a local checkout was unavailable in this environment