### PR TITLE
Handle zero-sized circular sample requests

### DIFF
--- a/src/pyrecest/sampling/hypertoroidal_sampler.py
+++ b/src/pyrecest/sampling/hypertoroidal_sampler.py
@@ -1,6 +1,6 @@
 # pylint: disable=no-name-in-module,no-member
 import numpy as np
-from pyrecest.backend import linspace, pi
+from pyrecest.backend import linspace, pi, zeros
 from pyrecest.distributions import CircularUniformDistribution
 
 from .abstract_sampler import AbstractSampler
@@ -55,6 +55,8 @@ class CircularUniformSampler(AbstractCircularSampler):
                 "CircularUniformSampler is supposed to be used for the circle "
                 "(which is one-dimensional) only."
             )
+        if n_samples == 0:
+            return zeros((0, dim))
         return CircularUniformDistribution().sample(n_samples)
 
     def get_grid(self, grid_density_parameter: int):

--- a/tests/test_hypertoroidal_sampler.py
+++ b/tests/test_hypertoroidal_sampler.py
@@ -28,6 +28,11 @@ class TestCircularUniformSampler(unittest.TestCase):
         self.assertTrue(all(samples >= 0.0))
         self.assertTrue(all(samples < 2.0 * pi))
 
+    def test_sample_stochastic_zero_samples_returns_empty_matrix(self):
+        samples = self.sampler.sample_stochastic(0)
+
+        self.assertEqual(samples.shape, (0, 1))
+
     def test_sample_stochastic_accepts_integer_like_scalars(self):
         samples = self.sampler.sample_stochastic(np.array(3.0), dim=np.array(1.0))
 


### PR DESCRIPTION
## Summary
- return a backend-native empty `(0, 1)` array when `CircularUniformSampler.sample_stochastic(0)` is requested
- avoid forwarding zero to `CircularUniformDistribution.sample`, whose contract requires a positive count
- add a regression test for the sampler-level nonnegative-count contract

## Validation
- reviewed the branch diff against current `main`
- added `test_sample_stochastic_zero_samples_returns_empty_matrix`
- local repository tests could not be executed because this environment has no GitHub CLI and cannot clone GitHub; GitHub Actions can validate the branch
