### PR TITLE
Reject non-table scenario sections

### DIFF
--- a/src/pyrecest/scenarios.py
+++ b/src/pyrecest/scenarios.py
@@ -41,6 +41,14 @@ def _normalize_scenario_type(scenario_type: Any) -> str:
     return scenario_type.strip()
 
 
+def _scenario_section(config: dict[str, Any]) -> dict[str, Any]:
+    """Return the optional ``scenario`` table and reject non-table values."""
+    section = config.get("scenario", {})
+    if not isinstance(section, dict):
+        raise ValueError("scenario must be a TOML table")
+    return section
+
+
 def register_scenario_runner(
     scenario_type: str, runner: ScenarioRunner
 ) -> ScenarioRunner:
@@ -209,7 +217,8 @@ def run_linear_gaussian_scenario(path: str | Path) -> ScenarioResult:
     covariance ``Q``, and measurement covariance ``R``.
     """
     config = load_scenario_config(path)
-    if config.get("scenario", {}).get("type") != "linear_gaussian":
+    scenario = _scenario_section(config)
+    if scenario.get("type") != "linear_gaussian":
         raise ValueError(
             "Only scenario.type = 'linear_gaussian' is supported by this runner."
         )
@@ -283,7 +292,7 @@ def run_linear_gaussian_scenario(path: str | Path) -> ScenarioResult:
         metrics["max_nis"] = max(nis_values)
 
     return ScenarioResult(
-        name=config.get("scenario", {}).get("name", Path(path).stem),
+        name=scenario.get("name", Path(path).stem),
         backend=getattr(be, "__backend_name__", "unknown"),
         final_estimate=final_estimate,
         estimates=estimates,
@@ -301,7 +310,8 @@ def run_particle_resampling_scenario(path: str | Path) -> ScenarioResult:
     large tracker configuration.
     """
     config = load_scenario_config(path)
-    if config.get("scenario", {}).get("type") != "particle_resampling":
+    scenario = _scenario_section(config)
+    if scenario.get("type") != "particle_resampling":
         raise ValueError(
             "Only scenario.type = 'particle_resampling' is supported by this runner."
         )
@@ -360,7 +370,7 @@ def run_particle_resampling_scenario(path: str | Path) -> ScenarioResult:
     }
 
     return ScenarioResult(
-        name=config.get("scenario", {}).get("name", Path(path).stem),
+        name=scenario.get("name", Path(path).stem),
         backend=getattr(be, "__backend_name__", "unknown"),
         final_estimate=final_estimate,
         estimates=[_to_float_list(row) for row in sampled_particles],
@@ -372,7 +382,7 @@ def run_particle_resampling_scenario(path: str | Path) -> ScenarioResult:
 def run_scenario(path: str | Path) -> ScenarioResult:
     """Run the scenario described by ``path``."""
     config = load_scenario_config(path)
-    raw_scenario_type = config.get("scenario", {}).get("type")
+    raw_scenario_type = _scenario_section(config).get("type")
     available = ", ".join(available_scenario_types()) or "none"
     try:
         scenario_type = _normalize_scenario_type(raw_scenario_type)

--- a/tests/test_scenario_section_validation.py
+++ b/tests/test_scenario_section_validation.py
@@ -1,0 +1,26 @@
+import pytest
+from pyrecest import scenarios
+
+
+@pytest.mark.parametrize(
+    "scenario_value",
+    ['"linear_gaussian"', "1", '["linear_gaussian"]'],
+)
+@pytest.mark.parametrize(
+    "runner",
+    [
+        scenarios.run_scenario,
+        scenarios.run_linear_gaussian_scenario,
+        scenarios.run_particle_resampling_scenario,
+    ],
+)
+def test_scenario_entry_points_reject_non_table_scenario_section(
+    tmp_path,
+    scenario_value,
+    runner,
+):
+    scenario_path = tmp_path / "bad_scenario.toml"
+    scenario_path.write_text(f"scenario = {scenario_value}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="scenario must be a TOML table"):
+        runner(scenario_path)


### PR DESCRIPTION
## Bug

A syntactically valid TOML file can define `scenario` as a scalar or array instead of a table, for example:

```toml
scenario = "linear_gaussian"
```

The scenario dispatcher and both direct scenario runners immediately called `.get(...)` on that value. This leaked an internal `AttributeError` instead of rejecting the malformed configuration through the public validation path.

## Fix

- add one shared `_scenario_section()` validator;
- reject non-table `scenario` values with `ValueError("scenario must be a TOML table")`;
- reuse the validated table for type and name lookup in both built-in runners;
- preserve the existing behavior for absent, empty, and unsupported scenario types.

## Regression coverage

The new test exercises all three public entry points against string-, integer-, and array-valued `scenario` entries (nine cases total).

## Validation

- updated module and regression test pass `python -m py_compile`;
- focused standalone reproduction passed for all nine cases;
- branch is 2 commits ahead of `main` and 0 behind;
- diff is limited to `src/pyrecest/scenarios.py` and `tests/test_scenario_section_validation.py`.

Repository CI should run the full backend and test matrices on this pull request.