### PR TITLE
Validate relaxed S3F process-noise covariance

### DIFF
--- a/src/pyrecest/filters/relaxed_s3f_circular.py
+++ b/src/pyrecest/filters/relaxed_s3f_circular.py
@@ -40,6 +40,8 @@ from pyrecest.backend import (
     zeros,
     zeros_like,
 )
+from pyrecest.exceptions import NumericalStabilityError, ShapeError
+from pyrecest.numerics import assert_covariance_matrix
 
 from .state_space_subdivision_filter import StateSpaceSubdivisionFilter
 
@@ -200,15 +202,23 @@ def predict_circular_relaxed(
         displacements = stats.mean_displacements
         covariance_inflations = stats.covariance_inflations
 
-    q_base = (
-        zeros((2, 2), dtype=float)
-        if process_noise_cov is None
-        else asarray(process_noise_cov, dtype=float)
-    )
-    if q_base.shape != (2, 2):
-        raise ValueError("process_noise_cov must have shape (2, 2).")
-    if not bool(all(isfinite(q_base))):
-        raise ValueError("process_noise_cov must be finite.")
+    if process_noise_cov is None:
+        q_base = zeros((2, 2), dtype=float)
+    else:
+        try:
+            q_base = asarray(
+                assert_covariance_matrix(
+                    process_noise_cov,
+                    name="process_noise_cov",
+                    dim=2,
+                ),
+                dtype=float,
+            )
+        except (ValueError, ShapeError, NumericalStabilityError) as exc:
+            raise ValueError(
+                "process_noise_cov must be a finite symmetric positive-semidefinite "
+                "matrix with shape (2, 2)."
+            ) from exc
 
     covariance_matrices = stack(
         [q_base + covariance_inflations[idx] for idx in range(n_cells)],

--- a/tests/filters/test_relaxed_s3f_process_noise_validation.py
+++ b/tests/filters/test_relaxed_s3f_process_noise_validation.py
@@ -1,0 +1,74 @@
+import unittest
+
+from pyrecest.backend import array, eye, linspace, ones, pi, zeros
+from pyrecest.distributions.cart_prod.state_space_subdivision_gaussian_distribution import (
+    StateSpaceSubdivisionGaussianDistribution,
+)
+from pyrecest.distributions.hypertorus.hypertoroidal_grid_distribution import (
+    HypertoroidalGridDistribution,
+)
+from pyrecest.distributions.nonperiodic.gaussian_distribution import (
+    GaussianDistribution,
+)
+from pyrecest.filters.relaxed_s3f_circular import predict_circular_relaxed
+from pyrecest.filters.state_space_subdivision_filter import StateSpaceSubdivisionFilter
+
+
+class RelaxedS3FProcessNoiseValidationTest(unittest.TestCase):
+    def test_rejects_nonsymmetric_process_noise_without_mutating_state(self):
+        filter_ = _make_filter(8)
+        covariance_before = array(filter_.filter_state.linear_distributions[0].C)
+
+        with self.assertRaisesRegex(ValueError, "positive-semidefinite"):
+            predict_circular_relaxed(
+                filter_,
+                array([0.4, 0.1]),
+                process_noise_cov=array([[1.0, 0.5], [0.0, 1.0]]),
+            )
+
+        self.assertTrue(
+            bool(
+                (filter_.filter_state.linear_distributions[0].C == covariance_before).all()
+            )
+        )
+
+    def test_rejects_indefinite_process_noise_without_mutating_state(self):
+        filter_ = _make_filter(8)
+        covariance_before = array(filter_.filter_state.linear_distributions[0].C)
+
+        with self.assertRaisesRegex(ValueError, "positive-semidefinite"):
+            predict_circular_relaxed(
+                filter_,
+                array([0.4, 0.1]),
+                process_noise_cov=array([[1.0, 0.0], [0.0, -0.1]]),
+            )
+
+        self.assertTrue(
+            bool(
+                (filter_.filter_state.linear_distributions[0].C == covariance_before).all()
+            )
+        )
+
+
+def _make_filter(n_cells: int) -> StateSpaceSubdivisionFilter:
+    grid = linspace(0.0, 2.0 * pi, n_cells, endpoint=False).reshape(-1, 1)
+    gd = HypertoroidalGridDistribution(
+        ones(n_cells) / (2.0 * pi),
+        grid_type="custom",
+        grid=grid,
+    )
+    gd.normalize_in_place(warn_unnorm=False)
+    gaussians = [
+        GaussianDistribution(
+            zeros(2),
+            eye(2) * 0.1,
+            check_validity=False,
+        )
+        for _ in range(n_cells)
+    ]
+    state = StateSpaceSubdivisionGaussianDistribution(gd, gaussians)
+    return StateSpaceSubdivisionFilter(state)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`predict_circular_relaxed(...)` only checked that `process_noise_cov` had shape `(2, 2)` and finite entries. Nonsymmetric and indefinite matrices were therefore accepted and added directly to every Gaussian covariance, allowing the helper to create invalid filter states.

For example, both of these previously passed validation:

```python
array([[1.0, 0.5], [0.0, 1.0]])   # nonsymmetric
array([[1.0, 0.0], [0.0, -0.1]])  # indefinite
```

## Fix

- validate supplied process noise through the shared covariance contract;
- require shape `(2, 2)`, finite values, symmetry, and positive semidefiniteness;
- normalize validation failures to a targeted public `ValueError`;
- perform validation before `predict_linear`, preserving the filter state on rejection.

## Regression coverage

Added focused tests for nonsymmetric and indefinite process-noise matrices. Both tests also verify that rejection leaves the component covariance unchanged.

## Validation

- branch is 2 commits ahead of current `main` and 0 behind;
- diff is limited to the relaxed circular S3F helper and one focused regression module;
- repository CI should run the configured backend/test matrix.