### PR TITLE
Reject non-finite linear Gaussian model inputs

### DIFF
--- a/src/pyrecest/models/linear_gaussian.py
+++ b/src/pyrecest/models/linear_gaussian.py
@@ -3,9 +3,11 @@
 from numbers import Complex, Integral, Real
 
 from pyrecest.backend import (
+    all as backend_all,
     asarray,
     copy as backend_copy,
     eye,
+    isfinite,
     matmul,
     matvec,
     ndim,
@@ -51,6 +53,19 @@ def _contains_complex_values(value):
     return False
 
 
+def _ensure_finite(value, name):
+    try:
+        finite = backend_all(isfinite(value))
+    except Exception as exc:  # pragma: no cover - backend-specific exception type
+        raise ValueError(f"{name} must contain only finite values") from exc
+    try:
+        all_finite = bool(finite.item())
+    except AttributeError:
+        all_finite = bool(finite)
+    if not all_finite:
+        raise ValueError(f"{name} must contain only finite values")
+
+
 def _as_matrix(value, name):
     arr = asarray(value)
     if _has_boolean_dtype(arr):
@@ -59,6 +74,7 @@ def _as_matrix(value, name):
         raise ValueError(f"{name} must be real-valued")
     if ndim(arr) != 2:
         raise ValueError(f"{name} must be two-dimensional")
+    _ensure_finite(arr, name)
     return arr
 
 
@@ -72,6 +88,7 @@ def _as_vector(value, name):
         arr = reshape(arr, (1,))
     if ndim(arr) != 1:
         raise ValueError(f"{name} must be one-dimensional")
+    _ensure_finite(arr, name)
     return arr
 
 

--- a/tests/models/test_linear_gaussian_finite_inputs.py
+++ b/tests/models/test_linear_gaussian_finite_inputs.py
@@ -1,0 +1,81 @@
+import unittest
+
+import numpy as np
+from pyrecest.backend import array
+from pyrecest.models import (
+    IdentityGaussianMeasurementModel,
+    IdentityGaussianTransitionModel,
+    LinearGaussianMeasurementModel,
+    LinearGaussianTransitionModel,
+)
+
+
+class LinearGaussianFiniteInputsTest(unittest.TestCase):
+    def test_models_reject_nonfinite_system_and_measurement_matrices(self):
+        for value in (np.nan, np.inf, -np.inf):
+            with self.subTest(model="transition", value=value):
+                with self.assertRaisesRegex(ValueError, "matrix.*finite"):
+                    LinearGaussianTransitionModel(
+                        array([[value]]), array([[1.0]])
+                    )
+            with self.subTest(model="measurement", value=value):
+                with self.assertRaisesRegex(ValueError, "matrix.*finite"):
+                    LinearGaussianMeasurementModel(
+                        array([[value]]), array([[1.0]])
+                    )
+
+    def test_models_reject_nonfinite_noise_covariances(self):
+        for value in (np.nan, np.inf, -np.inf):
+            with self.subTest(model="transition", value=value):
+                with self.assertRaisesRegex(ValueError, "noise_cov.*finite"):
+                    LinearGaussianTransitionModel(
+                        array([[1.0]]), array([[value]])
+                    )
+            with self.subTest(model="measurement", value=value):
+                with self.assertRaisesRegex(ValueError, "noise_cov.*finite"):
+                    LinearGaussianMeasurementModel(
+                        array([[1.0]]), array([[value]])
+                    )
+
+    def test_transition_model_rejects_nonfinite_offset(self):
+        for value in (np.nan, np.inf, -np.inf):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(ValueError, "offset.*finite"):
+                    LinearGaussianTransitionModel(
+                        array([[1.0]]), array([[1.0]]), offset=array([value])
+                    )
+
+    def test_identity_models_reject_nonfinite_scalar_noise(self):
+        for value in (np.nan, np.inf, -np.inf):
+            with self.subTest(model="transition", value=value):
+                with self.assertRaisesRegex(ValueError, "noise_cov.*finite"):
+                    IdentityGaussianTransitionModel(1, value)
+            with self.subTest(model="measurement", value=value):
+                with self.assertRaisesRegex(ValueError, "noise_cov.*finite"):
+                    IdentityGaussianMeasurementModel(1, value)
+
+    def test_prediction_rejects_nonfinite_state_inputs(self):
+        transition = LinearGaussianTransitionModel(
+            array([[1.0]]), array([[1.0]])
+        )
+        measurement = LinearGaussianMeasurementModel(
+            array([[1.0]]), array([[1.0]])
+        )
+
+        for value in (np.nan, np.inf, -np.inf):
+            with self.subTest(method="transition mean", value=value):
+                with self.assertRaisesRegex(ValueError, "state_mean.*finite"):
+                    transition.predict_mean(array([value]))
+            with self.subTest(method="measurement mean", value=value):
+                with self.assertRaisesRegex(ValueError, "state_mean.*finite"):
+                    measurement.predict_mean(array([value]))
+            with self.subTest(method="transition covariance", value=value):
+                with self.assertRaisesRegex(ValueError, "state_covariance.*finite"):
+                    transition.predict_covariance(array([[value]]))
+            with self.subTest(method="measurement covariance", value=value):
+                with self.assertRaisesRegex(ValueError, "state_covariance.*finite"):
+                    measurement.innovation_covariance(array([[value]]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reject NaN and infinite transition/measurement matrices before model construction
- reject non-finite noise covariances, offsets, state means, and state covariances
- add regression tests covering constructors, identity-model scalar noise, and prediction-time inputs

## Bug
`LinearGaussianTransitionModel` and `LinearGaussianMeasurementModel` validated shape and numeric type but not finiteness. Inputs containing NaN or ±infinity were therefore accepted and silently propagated into predicted means and covariances.

## Validation
- branch is based on current `main` (`9ff3b62`)
- focused regression coverage added in `tests/models/test_linear_gaussian_finite_inputs.py`
- GitHub Actions checks will provide the executable backend matrix because the local GitHub CLI/runtime is unavailable in this connector session