### PR TITLE
Reject full smoothing without terminal posterior

### DIFF
--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -90,6 +90,8 @@ class EvidenceComputationMode:
             raise ValueError("evidence_only mode cannot return smoothed posteriors")
         if self.mode == "full_smoothing" and not return_smoothed:
             raise ValueError("full_smoothing mode must return smoothed posteriors")
+        if self.mode == "full_smoothing" and not terminal_posterior:
+            raise ValueError("full_smoothing mode must return a terminal posterior")
         metadata = _coerce_metadata(self.metadata)
         conflicting_metadata_keys = _RESERVED_DIAGNOSTIC_METADATA_KEYS.intersection(
             metadata

--- a/tests/test_evidence_terminal_posterior_validation.py
+++ b/tests/test_evidence_terminal_posterior_validation.py
@@ -1,0 +1,22 @@
+import pytest
+
+from pyrecest.evidence import EvidenceComputationMode
+
+
+def test_full_smoothing_requires_terminal_posterior():
+    with pytest.raises(ValueError, match="terminal posterior"):
+        EvidenceComputationMode(
+            mode="full_smoothing",
+            return_smoothed=True,
+            terminal_posterior=False,
+        )
+
+
+def test_evidence_only_may_omit_terminal_posterior():
+    mode = EvidenceComputationMode(
+        mode="evidence_only",
+        return_smoothed=False,
+        terminal_posterior=False,
+    )
+
+    assert mode.terminal_posterior is False


### PR DESCRIPTION
## Bug

`EvidenceComputationMode` accepted `mode="full_smoothing"` together with `terminal_posterior=False`.

That state is internally contradictory: full fixed-interval smoothing necessarily includes the terminal smoothed posterior. Allowing it produces diagnostics and downstream control flow that claim full smoothing while declaring that its terminal posterior is absent.

## Fix

- reject `full_smoothing` modes that disable `terminal_posterior`;
- preserve the valid evidence-only case where callers explicitly do not request a terminal posterior.

## Regression coverage

Added focused tests for both the rejected full-smoothing combination and the permitted evidence-only combination.

## Scope

The branch is 2 commits ahead of current `main`, 0 behind, and changes only `src/pyrecest/evidence.py` plus one regression test module.