### PR TITLE
Make EOT-OV prediction validation atomic

### DIFF
--- a/src/pyrecest/filters/orientation_vector_eot_tracker.py
+++ b/src/pyrecest/filters/orientation_vector_eot_tracker.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from math import isfinite
 from numbers import Integral
 
 # pylint: disable=no-name-in-module,no-member
@@ -172,8 +173,8 @@ class OrientationVectorEOTTracker(AbstractExtendedObjectTracker):
         self.velocity_indices = self._normalize_velocity_indices(velocity_indices)
         self.num_iterations = _as_positive_integer(num_iterations, "num_iterations")
         self.forgetting_factor = float(forgetting_factor)
-        if self.forgetting_factor <= 0.0:
-            raise ValueError("forgetting_factor must be positive")
+        if not isfinite(self.forgetting_factor) or self.forgetting_factor <= 0.0:
+            raise ValueError("forgetting_factor must be positive and finite")
         self.extent_scale = float(extent_scale)
         if self.extent_scale <= 0.0:
             raise ValueError("extent_scale must be positive")
@@ -420,10 +421,25 @@ class OrientationVectorEOTTracker(AbstractExtendedObjectTracker):
                 "sys_noise",
                 require_positive_definite=False,
             )
-        self.kinematic_state = system_matrix @ self.kinematic_state
+        gamma = (
+            self.forgetting_factor
+            if forgetting_factor is None
+            else float(forgetting_factor)
+        )
+        if not isfinite(gamma) or gamma <= 0.0:
+            raise ValueError("forgetting_factor must be positive and finite")
+        predicted_alpha = gamma * self.alpha
+        if float(predicted_alpha[0]) <= 1.0 or float(predicted_alpha[1]) <= 1.0:
+            raise ValueError(
+                "The prediction made inverse-gamma alpha <= 1; increase "
+                "inverse_gamma_shape or use a larger forgetting_factor."
+            )
+        predicted_beta = gamma * self.beta
+
+        predicted_kinematic_state = system_matrix @ self.kinematic_state
         if inputs is not None:
-            self.kinematic_state = self.kinematic_state + array(inputs)
-        self.covariance = self._symmetrize(
+            predicted_kinematic_state = predicted_kinematic_state + array(inputs)
+        predicted_covariance = self._symmetrize(
             system_matrix @ self.covariance @ system_matrix.T + sys_noise
         )
 
@@ -433,31 +449,23 @@ class OrientationVectorEOTTracker(AbstractExtendedObjectTracker):
             orientation_sys_noise,
             "orientation_sys_noise",
         )
-        self.orientation_vector_covariance = self._symmetrize(
+        predicted_orientation_covariance = self._symmetrize(
             self.orientation_vector_covariance + orientation_sys_noise * eye(2)
         )
         (
-            self.orientation_vector,
-            self.orientation_vector_covariance,
+            predicted_orientation_vector,
+            predicted_orientation_covariance,
         ) = self._project_orientation_gaussian(
             self.orientation_vector,
-            self.orientation_vector_covariance,
+            predicted_orientation_covariance,
         )
 
-        gamma = (
-            self.forgetting_factor
-            if forgetting_factor is None
-            else float(forgetting_factor)
-        )
-        if gamma <= 0.0:
-            raise ValueError("forgetting_factor must be positive")
-        self.alpha = gamma * self.alpha
-        self.beta = gamma * self.beta
-        if float(self.alpha[0]) <= 1.0 or float(self.alpha[1]) <= 1.0:
-            raise ValueError(
-                "The prediction made inverse-gamma alpha <= 1; increase "
-                "inverse_gamma_shape or use a larger forgetting_factor."
-            )
+        self.kinematic_state = predicted_kinematic_state
+        self.covariance = predicted_covariance
+        self.orientation_vector = predicted_orientation_vector
+        self.orientation_vector_covariance = predicted_orientation_covariance
+        self.alpha = predicted_alpha
+        self.beta = predicted_beta
 
         if self.log_prior_estimates:
             self.store_prior_estimates()

--- a/tests/filters/test_orientation_vector_eot_tracker.py
+++ b/tests/filters/test_orientation_vector_eot_tracker.py
@@ -117,6 +117,39 @@ class TestOrientationVectorEOTTracker(unittest.TestCase):
         npt.assert_allclose(alpha_post, 0.95 * alpha_prior)
         npt.assert_allclose(beta_post, 0.95 * beta_prior)
 
+    def test_rejected_prediction_does_not_mutate_state(self):
+        state_prior = self.tracker.kinematic_state.copy()
+        covariance_prior = self.tracker.covariance.copy()
+        orientation_prior, orientation_covariance_prior = (
+            self.tracker.get_orientation_vector_state()
+        )
+        alpha_prior, beta_prior = self.tracker.get_inverse_gamma_parameters()
+
+        for invalid_forgetting_factor in (0.0, 0.1, np.nan):
+            with (
+                self.subTest(forgetting_factor=invalid_forgetting_factor),
+                self.assertRaises(ValueError),
+            ):
+                self.tracker.predict_constant_velocity(
+                    time_delta=0.5,
+                    sys_noise=0.01 * eye(4),
+                    orientation_sys_noise=0.01,
+                    forgetting_factor=invalid_forgetting_factor,
+                )
+
+            npt.assert_allclose(self.tracker.kinematic_state, state_prior)
+            npt.assert_allclose(self.tracker.covariance, covariance_prior)
+            orientation_post, orientation_covariance_post = (
+                self.tracker.get_orientation_vector_state()
+            )
+            npt.assert_allclose(orientation_post, orientation_prior)
+            npt.assert_allclose(
+                orientation_covariance_post, orientation_covariance_prior
+            )
+            alpha_post, beta_post = self.tracker.get_inverse_gamma_parameters()
+            npt.assert_allclose(alpha_post, alpha_prior)
+            npt.assert_allclose(beta_post, beta_prior)
+
     def test_update_moves_centroid_and_keeps_positive_extent(self):
         tracker = OrientationVectorEOTTracker(
             array([0.0, 0.0, 1.0, 0.0]),


### PR DESCRIPTION
## Summary

- validate EOT-OV forgetting factors before changing tracker state
- reject non-finite forgetting factors
- stage kinematic, covariance, orientation, and inverse-gamma predictions before committing them
- add a regression ensuring rejected predictions leave all state components unchanged

## Bug

`OrientationVectorEOTTracker.predict_linear()` previously advanced the kinematic state and covariances before checking whether the forgetting factor was valid or would reduce the inverse-gamma shape parameter to `alpha <= 1`. A caller catching the resulting `ValueError` therefore retained a partially advanced and internally inconsistent tracker.

## Validation

- reproduced on the pre-fix implementation: the rejected prediction changed `[0, 0, 1, 0]` to `[0.5, 0, 1, 0]`
- focused NumPy-backed tracker suite: 8 tests passed after the fix
- Python compilation passed for the modified implementation and test module

Repository CI should provide the full backend and integration matrix.