### PR TITLE
Make IMM measurement updates transactional

### DIFF
--- a/src/pyrecest/filters/interacting_multiple_model_filter.py
+++ b/src/pyrecest/filters/interacting_multiple_model_filter.py
@@ -338,16 +338,21 @@ class InteractingMultipleModelFilter(AbstractFilter, EuclideanFilterMixin):
                 curr_meas_noise,
             )
 
-        self.latest_log_model_likelihoods = log_likelihoods
-        self.latest_model_likelihoods = exp(log_likelihoods)
-        self.update_mode_probabilities(log_likelihoods=log_likelihoods)
+        update_snapshot = self._snapshot_update_state()
+        try:
+            self.latest_log_model_likelihoods = log_likelihoods
+            self.latest_model_likelihoods = exp(log_likelihoods)
+            self.update_mode_probabilities(log_likelihoods=log_likelihoods)
 
-        for curr_filter, curr_measurement_matrix, curr_meas_noise in zip(
-            self.filter_bank, measurement_matrices, meas_noises
-        ):
-            curr_filter.update_linear(
-                measurement, curr_measurement_matrix, curr_meas_noise
-            )
+            for curr_filter, curr_measurement_matrix, curr_meas_noise in zip(
+                self.filter_bank, measurement_matrices, meas_noises
+            ):
+                curr_filter.update_linear(
+                    measurement, curr_measurement_matrix, curr_meas_noise
+                )
+        except Exception:
+            self._restore_update_state(update_snapshot)
+            raise
 
     def update_nonlinear(
         self,
@@ -377,17 +382,40 @@ class InteractingMultipleModelFilter(AbstractFilter, EuclideanFilterMixin):
         meas_noises = self._broadcast_model_argument(meas_noises, "meas_noises")
         hx_args = self._broadcast_keyword_argument(hx_args, "hx_args")
 
-        self.update_mode_probabilities(
-            likelihoods=likelihoods, log_likelihoods=log_likelihoods
+        update_snapshot = self._snapshot_update_state()
+        try:
+            self.update_mode_probabilities(
+                likelihoods=likelihoods, log_likelihoods=log_likelihoods
+            )
+
+            for curr_filter, curr_hx, curr_meas_noise, curr_hx_args in zip(
+                self.filter_bank, measurement_functions, meas_noises, hx_args
+            ):
+                curr_hx_args = {} if curr_hx_args is None else dict(curr_hx_args)
+                curr_filter.update_nonlinear(
+                    measurement, curr_hx, curr_meas_noise, **curr_hx_args
+                )
+        except Exception:
+            self._restore_update_state(update_snapshot)
+            raise
+
+    def _snapshot_update_state(self):
+        """Capture mutable IMM state before a multi-model measurement update."""
+        return (
+            copy.deepcopy(self.filter_bank),
+            copy.deepcopy(self.mode_probabilities),
+            copy.deepcopy(self.latest_model_likelihoods),
+            copy.deepcopy(self.latest_log_model_likelihoods),
         )
 
-        for curr_filter, curr_hx, curr_meas_noise, curr_hx_args in zip(
-            self.filter_bank, measurement_functions, meas_noises, hx_args
-        ):
-            curr_hx_args = {} if curr_hx_args is None else dict(curr_hx_args)
-            curr_filter.update_nonlinear(
-                measurement, curr_hx, curr_meas_noise, **curr_hx_args
-            )
+    def _restore_update_state(self, snapshot):
+        """Restore state after one subfilter rejects a measurement update."""
+        (
+            self.filter_bank,
+            self.mode_probabilities,
+            self.latest_model_likelihoods,
+            self.latest_log_model_likelihoods,
+        ) = snapshot
 
     def update_mode_probabilities(self, likelihoods=None, log_likelihoods=None):
         """Update model probabilities from external per-model likelihoods."""
@@ -437,7 +465,6 @@ class InteractingMultipleModelFilter(AbstractFilter, EuclideanFilterMixin):
 
         log_normalizer = logsumexp(log_posterior_unnormalized)
         posterior_probabilities = exp(log_posterior_unnormalized - log_normalizer)
-
         self.mode_probabilities = self._prepare_mode_probabilities(
             posterior_probabilities, self.n_models
         )

--- a/tests/filters/test_imm_update_transaction.py
+++ b/tests/filters/test_imm_update_transaction.py
@@ -1,0 +1,148 @@
+import copy
+import unittest
+
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member,unused-argument
+import pyrecest.backend
+from pyrecest.backend import array, eye
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.filters.interacting_multiple_model_filter import (
+    InteractingMultipleModelFilter,
+)
+
+
+class MutatingUpdateFilter:
+    def __init__(
+        self,
+        initial_state: GaussianDistribution,
+        *,
+        fail_linear: bool = False,
+        fail_nonlinear: bool = False,
+    ):
+        self.filter_state = copy.deepcopy(initial_state)
+        self.fail_linear = fail_linear
+        self.fail_nonlinear = fail_nonlinear
+
+    def update_linear(self, measurement, measurement_matrix, meas_noise):
+        self.filter_state = GaussianDistribution(
+            self.filter_state.mu + 1.0,
+            self.filter_state.C + 1.0,
+            check_validity=False,
+        )
+        if self.fail_linear:
+            raise RuntimeError("linear update failed")
+
+    def update_nonlinear(
+        self,
+        measurement,
+        measurement_function,
+        meas_noise,
+        **kwargs,
+    ):
+        self.filter_state = GaussianDistribution(
+            self.filter_state.mu + 1.0,
+            self.filter_state.C + 1.0,
+            check_validity=False,
+        )
+        if self.fail_nonlinear:
+            raise RuntimeError("nonlinear update failed")
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ != "numpy",
+    reason="Only supported on numpy backend",
+)
+class ImmUpdateTransactionTest(unittest.TestCase):
+    @staticmethod
+    def _make_imm(*, fail_linear=False, fail_nonlinear=False):
+        filter_bank = [
+            MutatingUpdateFilter(
+                GaussianDistribution(array([0.0]), array([[1.0]])),
+            ),
+            MutatingUpdateFilter(
+                GaussianDistribution(array([2.0]), array([[1.0]])),
+                fail_linear=fail_linear,
+                fail_nonlinear=fail_nonlinear,
+            ),
+        ]
+        return InteractingMultipleModelFilter(
+            filter_bank,
+            transition_matrix=eye(2),
+            mode_probabilities=array([0.4, 0.6]),
+        )
+
+    def _assert_update_rolled_back(
+        self,
+        imm,
+        previous_states,
+        previous_probabilities,
+        previous_likelihoods,
+        previous_log_likelihoods,
+    ):
+        for curr_filter, previous_state in zip(imm.filter_bank, previous_states):
+            npt.assert_allclose(curr_filter.filter_state.mu, previous_state.mu)
+            npt.assert_allclose(curr_filter.filter_state.C, previous_state.C)
+        npt.assert_allclose(imm.mode_probabilities, previous_probabilities)
+        npt.assert_allclose(imm.latest_model_likelihoods, previous_likelihoods)
+        npt.assert_allclose(
+            imm.latest_log_model_likelihoods,
+            previous_log_likelihoods,
+        )
+
+    def test_linear_update_rolls_back_all_models_on_failure(self):
+        imm = self._make_imm(fail_linear=True)
+        imm.latest_model_likelihoods = array([0.25, 0.75])
+        imm.latest_log_model_likelihoods = array([-1.0, -0.5])
+        previous_states = [
+            copy.deepcopy(curr_filter.filter_state) for curr_filter in imm.filter_bank
+        ]
+        previous_probabilities = copy.deepcopy(imm.mode_probabilities)
+        previous_likelihoods = copy.deepcopy(imm.latest_model_likelihoods)
+        previous_log_likelihoods = copy.deepcopy(imm.latest_log_model_likelihoods)
+
+        with self.assertRaisesRegex(RuntimeError, "linear update failed"):
+            imm.update_linear(
+                array([0.0]),
+                eye(1),
+                eye(1),
+            )
+
+        self._assert_update_rolled_back(
+            imm,
+            previous_states,
+            previous_probabilities,
+            previous_likelihoods,
+            previous_log_likelihoods,
+        )
+
+    def test_nonlinear_update_rolls_back_all_models_on_failure(self):
+        imm = self._make_imm(fail_nonlinear=True)
+        imm.latest_model_likelihoods = array([0.3, 0.7])
+        imm.latest_log_model_likelihoods = array([-1.2, -0.4])
+        previous_states = [
+            copy.deepcopy(curr_filter.filter_state) for curr_filter in imm.filter_bank
+        ]
+        previous_probabilities = copy.deepcopy(imm.mode_probabilities)
+        previous_likelihoods = copy.deepcopy(imm.latest_model_likelihoods)
+        previous_log_likelihoods = copy.deepcopy(imm.latest_log_model_likelihoods)
+
+        with self.assertRaisesRegex(RuntimeError, "nonlinear update failed"):
+            imm.update_nonlinear(
+                array([0.0]),
+                lambda state: state,
+                eye(1),
+                likelihoods=array([0.8, 0.2]),
+            )
+
+        self._assert_update_rolled_back(
+            imm,
+            previous_states,
+            previous_probabilities,
+            previous_likelihoods,
+            previous_log_likelihoods,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- roll back the entire IMM filter bank when any subfilter rejects a linear or nonlinear measurement update
- restore mode probabilities and likelihood diagnostics together with the filters
- add regression tests where an earlier model mutates successfully and a later model raises

## Bug

`update_linear` and `update_nonlinear` updated model probabilities before iterating over the filter bank. If a later subfilter raised, earlier filters and the IMM diagnostics remained mutated, leaving a partially updated state that could not safely be reused.

## Validation

- `python -m py_compile` on the modified implementation and new test module
- regression coverage for linear and nonlinear failure paths

Full repository validation is delegated to GitHub Actions because this environment cannot clone the repository directly.