### PR TITLE
Preserve vector shape for 1D single-target ground truth

### DIFF
--- a/src/pyrecest/evaluation/generate_groundtruth.py
+++ b/src/pyrecest/evaluation/generate_groundtruth.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import atleast_2d, empty_like, squeeze
+from pyrecest.backend import atleast_2d, empty_like, reshape, squeeze
 
 
 def _validate_initial_state_shape(x0, simulation_param):
@@ -99,6 +99,6 @@ def generate_groundtruth(simulation_param, x0=None):
         raise RuntimeError("Generated groundtruth has the wrong state dimension.")
     for t in range(simulation_param["n_timesteps"]):
         if simulation_param["n_targets"] == 1:
-            groundtruth[t] = squeeze(groundtruth[t])
+            groundtruth[t] = reshape(groundtruth[t], (-1,))
 
     return groundtruth

--- a/tests/test_generate_groundtruth.py
+++ b/tests/test_generate_groundtruth.py
@@ -131,6 +131,28 @@ class TestGenerateGroundtruth(unittest.TestCase):
         npt.assert_allclose(groundtruth[0], x0)
         npt.assert_allclose(groundtruth[1], array([[1.0], [3.0]]))
 
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
+    def test_preserves_vector_shape_for_one_dimensional_single_target(self):
+        x0 = array([2.0])
+        step = array([1.0])
+        simulation_param = {
+            "initial_prior": GaussianDistribution(zeros(1), eye(1)),
+            "n_targets": 1,
+            "n_timesteps": 3,
+            "gen_next_state_with_noise": lambda state: state + step,
+        }
+
+        groundtruth = generate_groundtruth(simulation_param, x0)
+
+        for state in groundtruth:
+            self.assertEqual(state.shape, (1,))
+        npt.assert_allclose(groundtruth[0], array([2.0]))
+        npt.assert_allclose(groundtruth[1], array([3.0]))
+        npt.assert_allclose(groundtruth[2], array([4.0]))
+
     def test_rejects_vector_initial_state_for_multiple_targets(self):
         x0 = array([0.0, 1.0])
         simulation_param = {


### PR DESCRIPTION
## Summary

- keep single-target ground-truth states one-dimensional even when the state dimension is one
- replace unrestricted `squeeze` with an explicit flattening of the target axis
- add regression coverage for a one-target, one-dimensional trajectory

## Bug

`generate_groundtruth` stored each single-target state internally with shape `(1, state_dim)` and then called `squeeze` before returning it. For `state_dim == 1`, this removed both singleton axes and returned a scalar instead of a state vector. Downstream code expecting `state.shape == (state_dim,)` could therefore fail only in the one-dimensional case.

## Fix

Flatten the internal `(1, state_dim)` array to `(state_dim,)`. This preserves existing behavior for higher-dimensional single-target states while keeping a one-dimensional state as shape `(1,)`.

## Validation

A focused regression test checks all generated states and values for a three-step, one-target, one-dimensional trajectory. The branch is based on the current `main` head and contains only the implementation and regression-test changes.