### PR TITLE
Make nonlinear particle predictions transactional

### DIFF
--- a/src/pyrecest/filters/abstract_particle_filter.py
+++ b/src/pyrecest/filters/abstract_particle_filter.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from pyrecest.backend import (
     all,
     array,
+    asarray,
     hstack,
     isfinite,
     ndim,
@@ -196,7 +197,7 @@ class AbstractParticleFilter(AbstractFilter):
         original_shape = self.filter_state.d.shape
         predicted_state = None
         if function_is_vectorized:
-            d_f_applied = array(f(self.filter_state.d))
+            d_f_applied = asarray(f(self.filter_state.d))
         else:
             predicted_state = self.filter_state.apply_function(
                 f, function_is_vectorized=False

--- a/src/pyrecest/filters/abstract_particle_filter.py
+++ b/src/pyrecest/filters/abstract_particle_filter.py
@@ -193,33 +193,44 @@ class AbstractParticleFilter(AbstractFilter):
                 f"Noise distribution dimension {noise_distribution.dim} does not match filter-state dimension {self.filter_state.dim}."
             )
 
-        if function_is_vectorized:
-            d_f_applied = f(self.filter_state.d)
-        else:
-            self.filter_state = self.filter_state.apply_function(f)
-            d_f_applied = self.filter_state.d
-
-        n_particles = self.filter_state.w.shape[0]
-        if noise_distribution is None:
-            updated_particles = d_f_applied
-        else:
-            updated_particles = []
-            for i in range(n_particles):
-                if not shift_instead_of_add:
-                    noise = noise_distribution.sample(1)
-                    updated_particles.append(d_f_applied[i] + noise)
-                else:
-                    noise_curr = copy.deepcopy(noise_distribution)
-                    shifted_noise = noise_curr.set_mean(d_f_applied[i])
-                    if shifted_noise is not None:
-                        noise_curr = shifted_noise
-                    updated_particles.append(noise_curr.sample(1))
-
-            updated_particles = _stack_particle_updates(
-                updated_particles, self.filter_state.d
+        original_shape = self.filter_state.d.shape
+        predicted_state = self.filter_state.apply_function(
+            f, function_is_vectorized=function_is_vectorized
+        )
+        d_f_applied = predicted_state.d
+        if d_f_applied.shape != original_shape:
+            raise ValueError(
+                "Prediction function returned particles with shape "
+                f"{d_f_applied.shape}, expected {original_shape}."
             )
 
-        self._filter_state.d = updated_particles
+        n_particles = predicted_state.w.shape[0]
+        if noise_distribution is None:
+            self._filter_state = predicted_state
+            return
+
+        updated_particles = []
+        for i in range(n_particles):
+            if not shift_instead_of_add:
+                noise = noise_distribution.sample(1)
+                updated_particles.append(d_f_applied[i] + noise)
+            else:
+                noise_curr = copy.deepcopy(noise_distribution)
+                shifted_noise = noise_curr.set_mean(d_f_applied[i])
+                if shifted_noise is not None:
+                    noise_curr = shifted_noise
+                updated_particles.append(noise_curr.sample(1))
+        updated_particles = _stack_particle_updates(
+            updated_particles, self.filter_state.d
+        )
+        if updated_particles.shape != original_shape:
+            raise ValueError(
+                "Noise sampling returned particles with shape "
+                f"{updated_particles.shape}, expected {original_shape}."
+            )
+
+        predicted_state.d = updated_particles
+        self._filter_state = predicted_state
 
     def predict_nonlinear_nonadditive(self, f, samples, weights):
         weights = array(weights, dtype=float)

--- a/src/pyrecest/filters/abstract_particle_filter.py
+++ b/src/pyrecest/filters/abstract_particle_filter.py
@@ -194,19 +194,26 @@ class AbstractParticleFilter(AbstractFilter):
             )
 
         original_shape = self.filter_state.d.shape
-        predicted_state = self.filter_state.apply_function(
-            f, function_is_vectorized=function_is_vectorized
-        )
-        d_f_applied = predicted_state.d
+        predicted_state = None
+        if function_is_vectorized:
+            d_f_applied = array(f(self.filter_state.d))
+        else:
+            predicted_state = self.filter_state.apply_function(
+                f, function_is_vectorized=False
+            )
+            d_f_applied = predicted_state.d
         if d_f_applied.shape != original_shape:
             raise ValueError(
                 "Prediction function returned particles with shape "
                 f"{d_f_applied.shape}, expected {original_shape}."
             )
 
-        n_particles = predicted_state.w.shape[0]
+        n_particles = self.filter_state.w.shape[0]
         if noise_distribution is None:
-            self._filter_state = predicted_state
+            if predicted_state is None:
+                self._filter_state.d = d_f_applied
+            else:
+                self._filter_state = predicted_state
             return
 
         updated_particles = []
@@ -229,8 +236,11 @@ class AbstractParticleFilter(AbstractFilter):
                 f"{updated_particles.shape}, expected {original_shape}."
             )
 
-        predicted_state.d = updated_particles
-        self._filter_state = predicted_state
+        if predicted_state is None:
+            self._filter_state.d = updated_particles
+        else:
+            predicted_state.d = updated_particles
+            self._filter_state = predicted_state
 
     def predict_nonlinear_nonadditive(self, f, samples, weights):
         weights = array(weights, dtype=float)

--- a/tests/filters/test_particle_filter_prediction_atomicity.py
+++ b/tests/filters/test_particle_filter_prediction_atomicity.py
@@ -1,0 +1,59 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+from pyrecest.backend import array, reshape, to_numpy
+from pyrecest.distributions import LinearDiracDistribution
+from pyrecest.filters.euclidean_particle_filter import EuclideanParticleFilter
+
+
+class _FailingShiftNoise:
+    dim = 2
+
+    def set_mean(self, mean):
+        mean_numpy = np.asarray(to_numpy(mean), dtype=float)
+        if mean_numpy[0] >= 2.0:
+            raise RuntimeError("synthetic noise failure")
+        self._mean = array(mean_numpy)
+        return self
+
+    def sample(self, n):
+        if n != 1:
+            raise ValueError("test noise only supports one sample")
+        return reshape(self._mean, (1, -1))
+
+
+class ParticleFilterPredictionAtomicityTest(unittest.TestCase):
+    @staticmethod
+    def _make_filter():
+        particles = array([[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]])
+        filter_ = EuclideanParticleFilter(n_particles=3, dim=2)
+        filter_.filter_state = LinearDiracDistribution(particles)
+        return filter_, particles
+
+    def test_vectorized_prediction_rejects_shape_change_without_mutating_state(self):
+        filter_, particles = self._make_filter()
+
+        with self.assertRaisesRegex(ValueError, "Prediction function returned particles"):
+            filter_.predict_nonlinear(
+                lambda particle_matrix: particle_matrix[:, 0],
+                function_is_vectorized=True,
+            )
+
+        npt.assert_allclose(to_numpy(filter_.filter_state.d), to_numpy(particles))
+
+    def test_nonvectorized_prediction_rolls_back_when_noise_sampling_fails(self):
+        filter_, particles = self._make_filter()
+
+        with self.assertRaisesRegex(RuntimeError, "synthetic noise failure"):
+            filter_.predict_nonlinear(
+                lambda particle: particle + 1.0,
+                noise_distribution=_FailingShiftNoise(),
+                function_is_vectorized=False,
+            )
+
+        npt.assert_allclose(to_numpy(filter_.filter_state.d), to_numpy(particles))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- reject nonlinear transforms that change the particle-array shape
- keep nonvectorized predictions in a copied filter state until all additive-noise samples succeed
- commit vectorized predictions only after transform and noise-output validation
- add regressions for silent shape corruption and mid-prediction noise failure

## Bug

`AbstractParticleFilter.predict_nonlinear` handled its two execution modes inconsistently. The vectorized path assigned `f(filter_state.d)` without validating its shape, so a transform returning one scalar per multidimensional particle could silently corrupt the filter state. The nonvectorized path assigned the transformed filter state before sampling additive noise; if a later noise shift or sample raised, the filter remained partially predicted.

## Fix

Vectorized output is converted to a backend array and checked against the original particle shape before assignment. Nonvectorized output remains in the copied state returned by `apply_function`. Additive-noise samples are generated and shape-checked completely before either path commits its result, so failures leave the original particles and weights unchanged. The vectorized path retains its existing allocation-efficient behavior.

## Validation

- added focused regression coverage in `tests/filters/test_particle_filter_prediction_atomicity.py`
- verified the branch is based on current `main` and changes only the particle-filter implementation plus the focused test module
- GitHub Actions runs the repository's backend and test matrix
