### PR TITLE
Normalize singleton von Mises parameters

### DIFF
--- a/src/pyrecest/distributions/circle/von_mises_distribution.py
+++ b/src/pyrecest/distributions/circle/von_mises_distribution.py
@@ -43,13 +43,15 @@ class VonMisesDistribution(AbstractCircularDistribution):
         kappa,
         norm_const: float | None = None,
     ):
-        self._as_float_scalar(mu, "mu")
-        kappa_scalar = self._as_float_scalar(kappa, "kappa")
+        mu, _ = self._as_scalar_and_float(mu, "mu")
+        kappa, kappa_scalar = self._as_scalar_and_float(kappa, "kappa")
         if kappa_scalar < 0.0:
             raise ValueError("kappa must be nonnegative.")
         if norm_const is not None:
-            norm_const = self._as_float_scalar(norm_const, "norm_const")
-            if norm_const <= 0.0:
+            norm_const, norm_const_scalar = self._as_scalar_and_float(
+                norm_const, "norm_const"
+            )
+            if norm_const_scalar <= 0.0:
                 raise ValueError("norm_const must be positive.")
         super().__init__()
         self.mu = mu
@@ -94,7 +96,7 @@ class VonMisesDistribution(AbstractCircularDistribution):
         mu : scalar
             New mean direction.
         """
-        self._as_float_scalar(mu, "mu")
+        mu, _ = self._as_scalar_and_float(mu, "mu")
         new_dist = copy.deepcopy(self)
         new_dist.mu = mu
         return new_dist
@@ -159,7 +161,7 @@ class VonMisesDistribution(AbstractCircularDistribution):
         return r
 
     @staticmethod
-    def _as_float_scalar(value, name: str) -> float:
+    def _as_scalar_and_float(value, name: str):
         try:
             value_array = array(value)
         except (TypeError, ValueError, RuntimeError) as exc:
@@ -168,15 +170,20 @@ class VonMisesDistribution(AbstractCircularDistribution):
         if value_array.ndim > 0:
             if value_array.shape != (1,):
                 raise ValueError(f"{name} must be a scalar.")
-            value = value_array[0]
+            value_array = value_array[0]
 
         try:
-            scalar = float(value)
+            scalar = float(value_array)
         except (OverflowError, TypeError, ValueError) as exc:
             raise ValueError(f"{name} must be a scalar.") from exc
 
         if not math.isfinite(scalar):
             raise ValueError(f"{name} must be finite.")
+        return value_array, scalar
+
+    @staticmethod
+    def _as_float_scalar(value, name: str) -> float:
+        _, scalar = VonMisesDistribution._as_scalar_and_float(value, name)
         return scalar
 
     @staticmethod

--- a/src/pyrecest/distributions/circle/von_mises_distribution.py
+++ b/src/pyrecest/distributions/circle/von_mises_distribution.py
@@ -167,19 +167,20 @@ class VonMisesDistribution(AbstractCircularDistribution):
         except (TypeError, ValueError, RuntimeError) as exc:
             raise ValueError(f"{name} must be a scalar.") from exc
 
+        normalized_value = value
         if value_array.ndim > 0:
             if value_array.shape != (1,):
                 raise ValueError(f"{name} must be a scalar.")
-            value_array = value_array[0]
+            normalized_value = value_array[0]
 
         try:
-            scalar = float(value_array)
+            scalar = float(normalized_value)
         except (OverflowError, TypeError, ValueError) as exc:
             raise ValueError(f"{name} must be a scalar.") from exc
 
         if not math.isfinite(scalar):
             raise ValueError(f"{name} must be finite.")
-        return value_array, scalar
+        return normalized_value, scalar
 
     @staticmethod
     def _as_float_scalar(value, name: str) -> float:

--- a/tests/distributions/test_von_mises_singleton_parameters.py
+++ b/tests/distributions/test_von_mises_singleton_parameters.py
@@ -1,0 +1,28 @@
+import numpy as np
+from pyrecest.backend import to_numpy
+from pyrecest.distributions import VonMisesDistribution
+
+
+def _numpy_shape(value):
+    return np.asarray(to_numpy(value)).shape
+
+
+def test_constructor_normalizes_singleton_sequence_parameters():
+    distribution = VonMisesDistribution([0.3], [2.0], norm_const=[1.5])
+
+    assert _numpy_shape(distribution.mu) == ()
+    assert _numpy_shape(distribution.kappa) == ()
+    assert _numpy_shape(distribution.norm_const) == ()
+
+    samples = np.asarray(to_numpy(distribution.sample(5)))
+    assert samples.shape == (5,)
+    assert np.all(np.isfinite(samples))
+
+
+def test_set_mean_normalizes_singleton_sequence():
+    distribution = VonMisesDistribution(0.3, 2.0).set_mean([0.7])
+
+    assert _numpy_shape(distribution.mu) == ()
+    density = np.asarray(to_numpy(distribution.pdf([0.7])))
+    assert density.shape == (1,)
+    assert np.all(np.isfinite(density))


### PR DESCRIPTION
## Summary

- normalize accepted singleton `mu`, `kappa`, and explicit `norm_const` inputs to scalar values
- apply the same normalization in `set_mean`
- add regressions covering scalar storage, sampling, density evaluation, and explicit normalization constants

## Bug

`VonMisesDistribution._as_float_scalar` accepted one-element sequences such as `[2.0]`, but the constructor only used the converted value for validation and stored the original sequence. Construction therefore succeeded while later methods could fail; in particular, `sample()` calls `float(self.kappa)`, which raises `TypeError` for a stored Python list.

## Fix

The scalar validator now returns both the normalized value and its finite Python-float view. Singleton arrays and sequences are reduced to their sole backend scalar, while already scalar inputs keep their native representation.

## Validation

- isolated regression reproducer confirms the original `float([2.0])` failure and successful sampling after normalization
- new focused pytest coverage in `tests/distributions/test_von_mises_singleton_parameters.py`
- branch is based on the current `main` and contains no unrelated changes

Full backend and repository validation is delegated to GitHub Actions because the local execution environment cannot access the repository checkout.