### PR TITLE
Preserve nested mapping key types in expected-result checks

### DIFF
--- a/src/pyrecest/cli.py
+++ b/src/pyrecest/cli.py
@@ -95,7 +95,10 @@ def _comparison_value(value: Any) -> Any:
     if isinstance(value, np.generic):
         return _comparison_value(value.item())
     if isinstance(value, dict):
-        return {str(key): _comparison_value(item) for key, item in value.items()}
+        return {
+            _comparison_value(key): _comparison_value(item)
+            for key, item in value.items()
+        }
     if isinstance(value, (list, tuple)):
         return [_comparison_value(item) for item in value]
     return value

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 
 import pytest
-from pyrecest.cli import main
+from pyrecest.cli import _values_equal, main
 
 
 def test_cli_backends_outputs_json(capsys):
@@ -117,3 +117,11 @@ def test_cli_run_scenario_rejects_nonobject_expected_sections(
         f"expected results {section_name} must be a JSON object"
         in capsys.readouterr().err
     )
+
+
+def test_values_equal_preserves_nested_mapping_key_types():
+    assert not _values_equal({1: "value"}, {"1": "value"})
+
+
+def test_values_equal_does_not_collapse_distinct_nested_keys():
+    assert not _values_equal({1: "numeric", "1": "text"}, {"1": "text"})


### PR DESCRIPTION
## Summary

- preserve nested mapping key types during CLI expected-result normalization
- prevent numeric keys from comparing equal to their string representations
- add regression tests for false equality and key-collision cases

## Root cause

`_comparison_value` converted every nested dictionary key with `str(key)`. Therefore `{1: "value"}` compared equal to `{"1": "value"}`, and dictionaries containing both key forms could lose an entry before comparison.

## Validation

Focused regression tests cover numeric-versus-string keys and the collision case.