### PR TITLE
Preserve valid evidence across duplicate model rows

### DIFF
--- a/src/pyrecest/evaluation/__init__.py
+++ b/src/pyrecest/evaluation/__init__.py
@@ -197,7 +197,9 @@ def _evidence_margin_table(
             evidence_col=evidence_col,
             model_col=model_col,
         )
-    distinct = comparable.drop_duplicates([*group_cols, model_col], keep="last")
+    distinct = comparable.dropna(subset=[evidence_col]).drop_duplicates(
+        [*group_cols, model_col], keep="last"
+    )
     return _original_evidence_margin_table(
         distinct,
         group_cols=group_cols,

--- a/tests/test_model_comparison_duplicate_missing_evidence.py
+++ b/tests/test_model_comparison_duplicate_missing_evidence.py
@@ -1,0 +1,43 @@
+import numpy as np
+import pandas as pd
+from pyrecest.evaluation.model_comparison import evidence_margin_table
+
+
+def test_evidence_margin_keeps_latest_valid_duplicate_per_model():
+    scores = pd.DataFrame(
+        [
+            {
+                "status": "success",
+                "session": "s1",
+                "event_index": 0,
+                "model": "a",
+                "log_evidence": 10.0,
+                "evidence_comparable": True,
+            },
+            {
+                "status": "success",
+                "session": "s1",
+                "event_index": 0,
+                "model": "b",
+                "log_evidence": 7.0,
+                "evidence_comparable": True,
+            },
+            {
+                "status": "success",
+                "session": "s1",
+                "event_index": 0,
+                "model": "a",
+                "log_evidence": np.nan,
+                "evidence_comparable": True,
+            },
+        ]
+    )
+
+    margins = evidence_margin_table(scores)
+
+    assert margins["best_model_by_evidence"].tolist() == ["a"]
+    assert margins["second_best_model_by_evidence"].tolist() == ["b"]
+    assert margins["best_log_evidence"].tolist() == [10.0]
+    assert margins["second_best_log_evidence"].tolist() == [7.0]
+    assert margins["evidence_margin_to_second_best"].tolist() == [3.0]
+    assert margins["models_compared"].tolist() == [2]


### PR DESCRIPTION
## Summary

- discard missing evidence rows before collapsing duplicate model entries
- preserve the latest valid score for each model within an evidence-comparison group
- add a regression test covering a valid score followed by a duplicate row with `NaN` evidence

## Bug

The public `evidence_margin_table` wrapper deduplicated model rows before the underlying implementation removed missing evidence. If a later duplicate contained `NaN`, it replaced an earlier valid score and was then discarded. The model vanished from the comparison, potentially changing the winner and producing an infinite one-model margin.

## Fix

Apply the same ordering already used by paired-model decisions: remove rows with missing evidence first, then retain the latest remaining row per group and model.

## Validation

- branch diff is limited to the wrapper ordering change and one focused regression test
- the regression asserts the winner, runner-up, evidence values, finite margin, and number of compared models
- GitHub Actions will run the repository test and lint matrix