### PR TITLE
Validate PyTorch randint array bounds against output dtype

### DIFF
--- a/src/pyrecest/_backend/pytorch/random.py
+++ b/src/pyrecest/_backend/pytorch/random.py
@@ -251,6 +251,28 @@ def _normalize_randint_dtype(dtype):
     return dtype
 
 
+def _validate_randint_array_dtype_bounds(low, high, dtype):
+    """Reject array bounds that cannot be represented by the output dtype."""
+    dtype_info = _torch.iinfo(dtype)
+    dtype_name = str(dtype).removeprefix("torch.")
+    low_int64 = low.to(dtype=_torch.int64)
+    high_int64 = high.to(dtype=_torch.int64)
+
+    if bool(_torch.any(low_int64 < dtype_info.min)) or bool(
+        _torch.any(low_int64 > dtype_info.max)
+    ):
+        raise ValueError(f"low is out of bounds for {dtype_name}")
+
+    # The exclusive upper endpoint may be one greater than the largest value
+    # representable by the output dtype, as in randint(255, 256, dtype=uint8).
+    # For int64, input tensors cannot represent max + 1, so every accepted high
+    # value is already within the valid endpoint range.
+    if dtype != _torch.int64 and bool(
+        _torch.any(high_int64 > dtype_info.max + 1)
+    ):
+        raise ValueError(f"high is out of bounds for {dtype_name}")
+
+
 def _normalize_torch_dtype_kwargs(kwargs):
     if "dtype" not in kwargs:
         return kwargs
@@ -285,6 +307,7 @@ def _randint_array(low, high, size, *args, **kwargs):
         raise ValueError("size, low, and high could not be broadcast together") from exc
     if bool(_torch.any(high <= low)):
         raise ValueError("high must be greater than low")
+    _validate_randint_array_dtype_bounds(low, high, dtype)
 
     span = high - low
     unit_samples = _torch.rand(sample_shape, device=device, generator=generator)

--- a/tests/backend/test_pytorch_randint_dtype_bounds.py
+++ b/tests/backend/test_pytorch_randint_dtype_bounds.py
@@ -13,7 +13,7 @@ from pyrecest._backend.pytorch import random  # noqa: E402
         ([-1], [1], torch.uint8, "low is out of bounds for uint8"),
         ([0], [257], torch.uint8, "high is out of bounds for uint8"),
         ([-129], [-128], torch.int8, "low is out of bounds for int8"),
-        ([0], [128], np.int8, "high is out of bounds for int8"),
+        ([0], [129], np.int8, "high is out of bounds for int8"),
     ],
 )
 def test_array_randint_rejects_bounds_outside_output_dtype(

--- a/tests/backend/test_pytorch_randint_dtype_bounds.py
+++ b/tests/backend/test_pytorch_randint_dtype_bounds.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pytest
+
+
+torch = pytest.importorskip("torch")
+
+from pyrecest._backend.pytorch import random  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    ("low", "high", "dtype", "message"),
+    [
+        ([-1], [1], torch.uint8, "low is out of bounds for uint8"),
+        ([0], [257], torch.uint8, "high is out of bounds for uint8"),
+        ([-129], [-128], torch.int8, "low is out of bounds for int8"),
+        ([0], [128], np.int8, "high is out of bounds for int8"),
+    ],
+)
+def test_array_randint_rejects_bounds_outside_output_dtype(
+    low, high, dtype, message
+):
+    with pytest.raises(ValueError, match=message):
+        random.randint(low, high, dtype=dtype)
+
+
+@pytest.mark.parametrize(
+    ("low", "high", "dtype", "expected"),
+    [
+        ([255], [256], torch.uint8, 255),
+        ([127], [128], torch.int8, 127),
+    ],
+)
+def test_array_randint_accepts_exclusive_endpoint_above_dtype_max(
+    low, high, dtype, expected
+):
+    sample = random.randint(low, high, dtype=dtype)
+
+    assert sample.dtype == dtype
+    assert sample.item() == expected


### PR DESCRIPTION
## Summary

- validate array-valued PyTorch `randint` bounds against the requested integer output dtype before sampling
- reject lower bounds outside the representable value range
- reject exclusive upper bounds above `dtype.max + 1`
- preserve valid endpoint intervals such as `[255, 256)` for `torch.uint8`
- add focused coverage for Torch and NumPy dtype specifications

## Bug

The array-valued PyTorch `randint` path sampled in floating point and then cast both the sample and lower bound to the requested output dtype. Bounds outside that dtype therefore wrapped silently. For example, `randint([300], [301], dtype=torch.uint8)` returned `44` instead of rejecting an impossible output contract.

The scalar-bound path already delegates to `torch.randint`, which rejects such bounds. This change makes the array-bound path consistent with it and with NumPy.

## Validation

- `python -m py_compile` passed for the modified backend and new test module
- focused isolated regression suite: **6 passed**
- verified rejection of out-of-range `uint8` and `int8` lower/upper bounds
- verified that exclusive endpoints one above the dtype maximum remain accepted
- branch comparison: 3 commits ahead of `main`, 0 behind; diff limited to 2 files

Full repository and backend-matrix validation is delegated to GitHub Actions.