### PR TITLE
Support callable objects in the deprecation decorator

### DIFF
--- a/src/pyrecest/deprecation.py
+++ b/src/pyrecest/deprecation.py
@@ -18,13 +18,34 @@ def _validate_nonempty_version(value: str, name: str) -> str:
     return value.strip()
 
 
+def _callable_display_name(func: Callable[..., object]) -> str:
+    """Return a stable display name for functions and callable objects."""
+
+    module = getattr(func, "__module__", func.__class__.__module__)
+    qualname = getattr(func, "__qualname__", None)
+    if qualname is None:
+        qualname = getattr(func, "__name__", func.__class__.__qualname__)
+    return f"{module}.{qualname}"
+
+
+def _wraps_callable(func: Callable[..., object]):
+    """Apply ``functools.wraps`` without requiring function-only attributes."""
+
+    assigned = tuple(
+        attribute
+        for attribute in functools.WRAPPER_ASSIGNMENTS
+        if hasattr(func, attribute)
+    )
+    return functools.wraps(func, assigned=assigned)
+
+
 def deprecated(
     *,
     since: str,
     remove_in: str,
     replacement: str | None = None,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
-    """Decorate a function or method with a standardized deprecation warning.
+    """Decorate a function, method, or callable object with a deprecation warning.
 
     Parameters
     ----------
@@ -42,8 +63,10 @@ def deprecated(
         replacement = _validate_nonempty_version(replacement, "replacement")
 
     def decorator(func: Callable[P, R]) -> Callable[P, R]:
+        if not callable(func):
+            raise TypeError("deprecated can only decorate callable objects")
         message = (
-            f"{func.__module__}.{func.__qualname__} is deprecated since "
+            f"{_callable_display_name(func)} is deprecated since "
             f"PyRecEst {since} and may be removed in PyRecEst {remove_in}."
         )
         if replacement:
@@ -51,7 +74,7 @@ def deprecated(
 
         if inspect.isasyncgenfunction(func):
 
-            @functools.wraps(func)
+            @_wraps_callable(func)
             async def async_generator_wrapper(*args: P.args, **kwargs: P.kwargs):
                 warnings.warn(message, DeprecationWarning, stacklevel=2)
                 async for item in func(*args, **kwargs):  # type: ignore[attr-defined]
@@ -64,7 +87,7 @@ def deprecated(
 
         if inspect.iscoroutinefunction(func):
 
-            @functools.wraps(func)
+            @_wraps_callable(func)
             async def async_wrapper(*args: P.args, **kwargs: P.kwargs):
                 warnings.warn(message, DeprecationWarning, stacklevel=2)
                 return await func(*args, **kwargs)
@@ -76,7 +99,7 @@ def deprecated(
 
         if inspect.isgeneratorfunction(func):
 
-            @functools.wraps(func)
+            @_wraps_callable(func)
             def generator_wrapper(*args: P.args, **kwargs: P.kwargs):
                 warnings.warn(message, DeprecationWarning, stacklevel=2)
                 return (yield from func(*args, **kwargs))  # type: ignore[misc]
@@ -86,7 +109,7 @@ def deprecated(
             generator_wrapper.__deprecated_replacement__ = replacement  # type: ignore[attr-defined]
             return generator_wrapper  # type: ignore[return-value]
 
-        @functools.wraps(func)
+        @_wraps_callable(func)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
             warnings.warn(message, DeprecationWarning, stacklevel=2)
             return func(*args, **kwargs)

--- a/tests/test_deprecation_helper.py
+++ b/tests/test_deprecation_helper.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 import inspect
 import warnings
 
@@ -18,6 +19,24 @@ def test_deprecated_decorator_emits_standard_warning():
     assert len(caught) == 1
     assert issubclass(caught[0].category, DeprecationWarning)
     assert "new_function" in str(caught[0].message)
+
+
+def test_deprecated_decorator_supports_partial_callables():
+    def add(left, right):
+        return left + right
+
+    legacy_add_one = deprecated(
+        since="2.3.0", remove_in="3.0.0", replacement="add"
+    )(functools.partial(add, 1))
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert legacy_add_one(2) == 3
+
+    assert len(caught) == 1
+    assert issubclass(caught[0].category, DeprecationWarning)
+    assert "functools.partial" in str(caught[0].message)
+    assert legacy_add_one.__wrapped__.func is add
 
 
 def test_deprecated_decorator_preserves_async_function_contract():


### PR DESCRIPTION
## Summary

- make `deprecated(...)` work with general callable objects such as `functools.partial`
- derive a stable warning name when `__module__`, `__qualname__`, or `__name__` is absent
- preserve available wrapper metadata and `__wrapped__` without requiring function-only attributes
- add regression coverage for partial callables

## Bug

The public decorator is typed to accept `Callable`, but it directly accessed `func.__module__` and `func.__qualname__` and used the default `functools.wraps` assignments. Valid callable objects such as `functools.partial` therefore failed during decoration with `AttributeError` instead of producing a working deprecated wrapper.

## Validation

The focused regression verifies that a decorated partial remains callable, emits one `DeprecationWarning`, retains `__wrapped__`, and returns the correct result. Existing sync, coroutine, generator, and async-generator behavior remains covered by the same test module.