### PR TITLE
Promote Gaussian mixture mean shifts

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/gaussian_mixture.py
+++ b/src/pyrecest/distributions/nonperiodic/gaussian_mixture.py
@@ -40,7 +40,7 @@ class GaussianMixture(LinearMixture, AbstractLinearDistribution):
         new_mixture = copy.deepcopy(self)
         mean_offset = new_mean - self.mean()
         for dist in new_mixture.dists:
-            dist.mu += mean_offset  # type: ignore
+            dist.mu = dist.mu + mean_offset  # type: ignore
         return new_mixture
 
     def to_gaussian(self, check_validity=True):

--- a/tests/distributions/test_gaussian_mixture_set_mean_validation.py
+++ b/tests/distributions/test_gaussian_mixture_set_mean_validation.py
@@ -22,6 +22,20 @@ class GaussianMixtureSetMeanValidationTest(unittest.TestCase):
         npt.assert_allclose(shifted.w, gmix.w)
         npt.assert_allclose(shifted.covariance(), gmix.covariance())
 
+    def test_set_mean_promotes_integer_component_means(self):
+        gm1 = GaussianDistribution(array([0]), array([[1.0]]))
+        gm2 = GaussianDistribution(array([2]), array([[3.0]]))
+        gmix = GaussianMixture([gm1, gm2], array([0.25, 0.75]))
+
+        shifted = gmix.set_mean([4.25])
+
+        npt.assert_allclose(shifted.mean(), array([4.25]))
+        npt.assert_allclose(shifted.dists[0].mu, array([2.75]))
+        npt.assert_allclose(shifted.dists[1].mu, array([4.75]))
+        npt.assert_allclose(gmix.dists[0].mu, array([0]))
+        npt.assert_allclose(gmix.dists[1].mu, array([2]))
+        npt.assert_allclose(shifted.covariance(), gmix.covariance())
+
     def test_set_mean_rejects_wrong_shape(self):
         gm1 = GaussianDistribution(array([0.0, 1.0]), diag(array([1.0, 2.0])))
         gm2 = GaussianDistribution(array([2.0, 3.0]), diag(array([3.0, 4.0])))


### PR DESCRIPTION
## Summary

- shift Gaussian-mixture component means out of place so backend dtype promotion can occur
- preserve the original mixture while returning the translated copy
- add a regression covering integer-valued component means and a fractional target mean

## Bug

`GaussianMixture.set_mean()` deep-copied the mixture and then updated each component with `dist.mu += mean_offset`. When a valid Gaussian used an integer-valued mean array, the weighted mixture mean and requested shift were floating point. NumPy therefore rejected the in-place update with a casting error instead of returning the shifted distribution.

For example, component means `[0]` and `[2]` with weights `[0.25, 0.75]` cannot be shifted to mean `4.25`, even though the operation is mathematically valid.

## Fix

Assign `dist.mu + mean_offset` back to each copied component. This retains the intended translation and allows NumPy, PyTorch, and JAX to apply their normal numeric promotion rules.

## Validation

- reproduced the pre-fix NumPy `UFuncTypeError` for integer arrays shifted by floating-point offsets
- verified the out-of-place operation promotes the result to floating point
- added regression assertions for the target mean, both translated components, covariance preservation, and immutability of the original mixture
- branch is 2 commits ahead of current `main`, 0 behind; diff is limited to 2 files