### PR TITLE
Prevent overflow in online time-offset projections

### DIFF
--- a/src/pyrecest/filters/online_time_offset_estimator.py
+++ b/src/pyrecest/filters/online_time_offset_estimator.py
@@ -79,11 +79,27 @@ class OnlineTimeOffsetEstimator:
         if measurement_variance < 0.0:
             raise ValueError("measurement_variance must be nonnegative")
 
-        speed2 = float(velocity @ velocity)
-        if speed2 <= 0.0 or speed2 < float(self.min_speed) ** 2:
+        speed = float(np.hypot.reduce(np.abs(velocity)))
+        if speed <= 0.0 or speed < float(self.min_speed):
             return float("nan")
-        measured_offset = float((residual @ velocity) / speed2)
-        variance = max(float(measurement_variance) / speed2, 1.0e-12)
+
+        velocity_scale = float(np.max(np.abs(velocity)))
+        scaled_velocity = velocity / velocity_scale
+        scaled_speed2 = float(scaled_velocity @ scaled_velocity)
+        residual_scale = float(np.max(np.abs(residual)))
+        if residual_scale == 0.0:
+            measured_offset = 0.0
+        else:
+            scaled_residual = residual / residual_scale
+            measured_offset = float(
+                (residual_scale / velocity_scale)
+                * float(scaled_residual @ scaled_velocity)
+                / scaled_speed2
+            )
+        if not np.isfinite(measured_offset):
+            raise ValueError("position residual implies a non-finite time offset")
+
+        variance = max(float((measurement_variance / speed) / speed), 1.0e-12)
         innovation = measured_offset - float(self.offset)
         innovation_variance = float(self.variance + variance)
         gain = float(self.variance / innovation_variance)

--- a/tests/filters/test_online_time_offset_estimator.py
+++ b/tests/filters/test_online_time_offset_estimator.py
@@ -20,6 +20,25 @@ class OnlineTimeOffsetEstimatorTest(unittest.TestCase):
         self.assertLess(estimator.offset, 2.0)
         self.assertLess(estimator.variance, 1.0)
 
+    def test_large_finite_vectors_do_not_overflow_projection(self):
+        estimator = OnlineTimeOffsetEstimator(
+            offset=0.0,
+            variance=1.0,
+            min_speed=0.0,
+        )
+
+        with np.errstate(over="raise", invalid="raise"):
+            nis = estimator.update_from_position_residual(
+                residual=np.array([1.0e308, 1.0e308]),
+                velocity=np.array([1.0e308, 1.0e308]),
+                measurement_variance=1.0,
+            )
+
+        self.assertTrue(math.isfinite(nis))
+        self.assertTrue(math.isfinite(estimator.offset))
+        self.assertTrue(math.isfinite(estimator.variance))
+        self.assertAlmostEqual(estimator.offset, 1.0, places=10)
+
     def test_low_speed_returns_nan_without_update(self):
         estimator = OnlineTimeOffsetEstimator(offset=1.0, variance=2.0, min_speed=10.0)
 


### PR DESCRIPTION
## Summary

- compute velocity magnitude with a stable `hypot` reduction
- evaluate the residual projection on normalized vectors instead of squaring raw values
- reject an unrepresentable projected offset before mutating estimator state
- add regression coverage for finite vectors near the `float64` limit

## Bug

`OnlineTimeOffsetEstimator.update_from_position_residual` formed `velocity @ velocity` and `residual @ velocity` directly. Large but finite inputs such as `[1e308, 1e308]` overflowed both dot products, producing `inf / inf`. The resulting `NaN` was then written to `estimator.offset`.

## Fix

The update now obtains the speed through `np.hypot.reduce`, normalizes the velocity and residual before their dot products, and rescales only the final scalar projection. The projected measurement variance is divided by the speed twice, avoiding an explicit squared norm. A non-finite projected offset is rejected before state mutation.

## Validation

- isolated full estimator test module: 9 tests passed
- regression runs under `np.errstate(over="raise", invalid="raise")` with `1e308` residual and velocity components
- branch is limited to the estimator implementation and its focused tests