### PR TITLE
Reject temporal ellipsoidal sample counts

### DIFF
--- a/src/pyrecest/distributions/ellipsoidal_ball_uniform_distribution.py
+++ b/src/pyrecest/distributions/ellipsoidal_ball_uniform_distribution.py
@@ -129,7 +129,13 @@ class EllipsoidalBallUniformDistribution(
         :param n: Number of samples to generate.
         :returns: Generated samples.
         """
-        if isinstance(n, bool) or not isinstance(n, Integral) or int(n) <= 0:
+        dtype = getattr(n, "dtype", None)
+        if (
+            isinstance(n, bool)
+            or getattr(dtype, "kind", None) in ("M", "m")
+            or not isinstance(n, Integral)
+            or int(n) <= 0
+        ):
             raise ValueError("n must be a positive integer.")
         n = int(n)
         if self.dim == 0:

--- a/tests/distributions/test_ellipsoidal_ball_temporal_sample_count.py
+++ b/tests/distributions/test_ellipsoidal_ball_temporal_sample_count.py
@@ -1,0 +1,21 @@
+import numpy as np
+import pytest
+
+from pyrecest.backend import array, diag
+from pyrecest.distributions import EllipsoidalBallUniformDistribution
+
+
+@pytest.mark.parametrize(
+    "sample_count",
+    [
+        np.timedelta64(4, "ns"),
+        np.timedelta64(4, "us"),
+    ],
+)
+def test_sampling_rejects_numpy_timedelta_counts(sample_count):
+    dist = EllipsoidalBallUniformDistribution(
+        array([0.0, 0.0]), diag(array([1.0, 1.0]))
+    )
+
+    with pytest.raises(ValueError, match="positive integer"):
+        dist.sample(sample_count)


### PR DESCRIPTION
## Summary

- reject NumPy temporal scalars before ellipsoidal-ball sample-count coercion
- preserve valid Python and NumPy integer sample counts
- add focused regressions for nanosecond and microsecond `numpy.timedelta64` inputs

## Bug

`EllipsoidalBallUniformDistribution.sample()` used `isinstance(n, numbers.Integral)` as its main type check. NumPy's `timedelta64` scalars satisfy that check. A nanosecond duration such as `np.timedelta64(4, "ns")` was therefore interpreted as the integer sample count `4`, while coarser units could leak a raw `TypeError` from `int(n)`.

## Fix

Reject NumPy datetime/timedelta dtypes before the integral conversion. All invalid temporal inputs now follow the public `ValueError("n must be a positive integer.")` path.

## Validation

- modified source compiles with `python -m py_compile`
- standalone validation confirms ordinary integers and `np.int64` remain accepted
- regression coverage exercises both the silently accepted nanosecond case and the exception-leaking microsecond case
- branch is 2 commits ahead of current `main`, 0 behind, with changes limited to the implementation and one focused test module