### PR TITLE
Fix PyTorch randint overflow for narrow array bounds

### DIFF
--- a/src/pyrecest/_backend/pytorch/random/__init__.py
+++ b/src/pyrecest/_backend/pytorch/random/__init__.py
@@ -138,6 +138,50 @@ def _first_randint_bound_device(*values):
     )
 
 
+_LEGACY_ARRAY_RANDINT = _LEGACY._randint_array
+
+
+def _randint_array_with_wide_arithmetic(low, high, size, *args, **kwargs):
+    """Widen array bounds and intermediate samples before integer arithmetic."""
+
+    if args:
+        return _LEGACY_ARRAY_RANDINT(low, high, size, *args, **kwargs)
+
+    torch = _LEGACY._torch
+    requested_dtype = _LEGACY._normalize_randint_dtype(kwargs.get("dtype"))
+    device = _LEGACY._randint_device(low, high, device=kwargs.get("device"))
+    low = torch.as_tensor(low, device=device)
+    high = torch.as_tensor(high, device=device)
+    _LEGACY._validate_randint_array_bound("low", low)
+    _LEGACY._validate_randint_array_bound("high", high)
+    sample_shape = _LEGACY._randint_array_size(size, low, high)
+    try:
+        low = torch.broadcast_to(low, sample_shape)
+        high = torch.broadcast_to(high, sample_shape)
+    except RuntimeError as exc:
+        raise ValueError("size, low, and high could not be broadcast together") from exc
+    if bool(torch.any(high <= low)):
+        raise ValueError("high must be greater than low")
+    _LEGACY._validate_randint_array_dtype_bounds(low, high, requested_dtype)
+
+    sampling_kwargs = dict(kwargs)
+    out = sampling_kwargs.pop("out", None)
+    sampling_kwargs["dtype"] = torch.int64
+    result = _LEGACY_ARRAY_RANDINT(
+        low.to(dtype=torch.int64),
+        high.to(dtype=torch.int64),
+        size,
+        **sampling_kwargs,
+    ).to(dtype=requested_dtype)
+    if out is not None:
+        out.copy_(result)
+        return out
+    return result
+
+
+_LEGACY._randint_array = _randint_array_with_wide_arithmetic
+
+
 def randint(low, high=None, size=None, *args, **kwargs):
     """Draw integer samples with exact scalar-bound handling."""
 

--- a/tests/backend/test_pytorch_randint_dtype_bounds.py
+++ b/tests/backend/test_pytorch_randint_dtype_bounds.py
@@ -47,9 +47,7 @@ def test_array_randint_accepts_exclusive_endpoint_above_dtype_max(
         (torch.int32, -(2**31), 2**31 - 1),
     ],
 )
-def test_array_randint_avoids_narrow_bound_span_overflow(
-    bound_dtype, low, high
-):
+def test_array_randint_avoids_narrow_bound_span_overflow(bound_dtype, low, high):
     torch.manual_seed(0)
     samples = random.randint(
         torch.tensor([low], dtype=bound_dtype),
@@ -60,4 +58,5 @@ def test_array_randint_avoids_narrow_bound_span_overflow(
 
     assert bool(torch.all(samples >= low))
     assert bool(torch.all(samples < high))
-    assert torch.unique(samples).numel() > 1
+    assert bool(torch.any(samples < 0))
+    assert bool(torch.any(samples > 0))

--- a/tests/backend/test_pytorch_randint_dtype_bounds.py
+++ b/tests/backend/test_pytorch_randint_dtype_bounds.py
@@ -37,3 +37,27 @@ def test_array_randint_accepts_exclusive_endpoint_above_dtype_max(
 
     assert sample.dtype == dtype
     assert sample.item() == expected
+
+
+@pytest.mark.parametrize(
+    ("bound_dtype", "low", "high"),
+    [
+        (torch.int8, -128, 127),
+        (torch.int16, -32768, 32767),
+        (torch.int32, -(2**31), 2**31 - 1),
+    ],
+)
+def test_array_randint_avoids_narrow_bound_span_overflow(
+    bound_dtype, low, high
+):
+    torch.manual_seed(0)
+    samples = random.randint(
+        torch.tensor([low], dtype=bound_dtype),
+        torch.tensor([high], dtype=bound_dtype),
+        size=(1024,),
+        dtype=bound_dtype,
+    )
+
+    assert bool(torch.all(samples >= low))
+    assert bool(torch.all(samples < high))
+    assert torch.unique(samples).numel() > 1


### PR DESCRIPTION
## Summary

- widen PyTorch array-valued `randint` bounds and intermediate samples to `int64` before subtraction and addition
- preserve the requested output dtype and existing `out=` behavior after the widened calculation
- add regression coverage for `int8`, `int16`, and `int32` bound tensors spanning almost their full representable ranges

## Bug

The legacy PyTorch array-bound implementation computes `span = high - low` in the bounds' original tensor dtype. For narrow signed tensors this can overflow before sampling. For example, `int8` bounds `[-128, 127)` produce a wrapped span of `-1`; the sampler then returns `127`, which violates the exclusive upper bound.

The same failure occurs for wide `int16` and `int32` bound intervals. Casting only the final result is too late because both the span and the intermediate offset may already have overflowed.

## Fix

The compatibility shim now validates the original array bounds as before, broadcasts them, and delegates sampling with both bounds and the intermediate output widened to `int64`. It converts the final samples to the requested integer dtype only after adding the lower bound. Existing dtype-bound validation and exclusive-endpoint handling remain in place.

## Validation

- `python -m py_compile` passes for both modified files
- isolated Torch integration checks pass for `int8`, `int16`, and `int32` bound tensors: every sample lies in `[low, high)` and seeded samples cover both negative and positive portions of each range
- existing `uint8`/`int8` exclusive-endpoint cases pass in the same integration harness
- branch is rebased onto current `main`

The full repository test matrix is delegated to GitHub Actions.