### PR TITLE
Reject temporal cart-product sample counts

### DIFF
--- a/src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py
@@ -9,6 +9,8 @@ def _validate_positive_sample_count(n) -> int:
     count_array = np.asarray(n)
     if count_array.ndim != 0:
         raise ValueError("n must be a scalar integer")
+    if getattr(count_array.dtype, "kind", None) in {"M", "m"}:
+        raise ValueError("n must be an integer")
 
     count = count_array.item()
     if isinstance(count, (bool, np.bool_)):

--- a/tests/distributions/test_cart_prod_stacked_temporal_sample_count.py
+++ b/tests/distributions/test_cart_prod_stacked_temporal_sample_count.py
@@ -1,0 +1,25 @@
+import unittest
+
+import numpy as np
+from pyrecest.backend import array, eye
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.distributions.cart_prod.cart_prod_stacked_distribution import (
+    CartProdStackedDistribution,
+)
+
+
+class TestCartProdStackedTemporalSampleCount(unittest.TestCase):
+    def setUp(self):
+        self.dist = CartProdStackedDistribution(
+            [GaussianDistribution(array([0.0]), eye(1))]
+        )
+
+    def test_sample_rejects_numpy_timedelta_counts(self):
+        for count in (np.timedelta64(4, "ns"), np.timedelta64(4, "us")):
+            with self.subTest(count=count):
+                with self.assertRaisesRegex(ValueError, "n must be an integer"):
+                    self.dist.sample(count)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- reject NumPy datetime and timedelta scalar dtypes before `CartProdStackedDistribution` converts sample counts with `.item()`
- preserve valid Python, NumPy-integer, and exact scalar-float sample counts
- add focused regression coverage for nanosecond and microsecond `numpy.timedelta64` inputs

## Bug

`CartProdStackedDistribution.sample()` validates its count by converting a zero-dimensional NumPy array with `.item()`. For `np.timedelta64(4, "ns")`, NumPy returns the plain Python integer `4`, so the temporal value is silently accepted and four samples are generated. Coarser timedelta units happen to raise later, making validation dependent on the timedelta unit.

## Fix

Inspect the original NumPy scalar dtype before `.item()` and reject temporal dtype kinds (`datetime64` and `timedelta64`) through the existing `ValueError("n must be an integer")` path.

## Validation

- both modified files compile with `python -m py_compile`
- isolated validator checks preserve `4`, `np.int64(4)`, and `np.array(4.0)`
- isolated validator checks reject `np.timedelta64(4, "ns")` and `np.timedelta64(4, "us")`
- branch is 2 commits ahead of current `main`, 0 behind, with changes limited to the validator and one regression test

The full backend test matrix is delegated to GitHub Actions.