### PR TITLE
Reject temporal additive-noise sample counts

### DIFF
--- a/src/pyrecest/models/_additive_noise_sample_count_validation.py
+++ b/src/pyrecest/models/_additive_noise_sample_count_validation.py
@@ -5,7 +5,24 @@ from __future__ import annotations
 from functools import wraps
 from typing import Any
 
+import numpy as np
+
 from .likelihood import _validate_sample_count
+
+
+def _validated_additive_noise_sample_count(value: Any) -> int:
+    """Reject temporal NumPy scalars before generic integer normalization."""
+
+    dtype = getattr(value, "dtype", None)
+    if dtype is not None:
+        try:
+            if np.issubdtype(dtype, np.datetime64) or np.issubdtype(
+                dtype, np.timedelta64
+            ):
+                raise ValueError("n must be a nonnegative integer.")
+        except TypeError:
+            pass
+    return _validate_sample_count(value)
 
 
 def _patch_sample_count(model_cls: type, method_name: str) -> None:
@@ -17,7 +34,13 @@ def _patch_sample_count(model_cls: type, method_name: str) -> None:
 
     @wraps(original)
     def checked_sample(self, state: Any, n: int = 1, *args: Any, **kwargs: Any):
-        return original(self, state, _validate_sample_count(n), *args, **kwargs)
+        return original(
+            self,
+            state,
+            _validated_additive_noise_sample_count(n),
+            *args,
+            **kwargs,
+        )
 
     setattr(checked_sample, "_pyrecest_sample_count_checked", True)
     setattr(model_cls, method_name, checked_sample)

--- a/tests/models/test_additive_noise_sample_count_validation.py
+++ b/tests/models/test_additive_noise_sample_count_validation.py
@@ -37,7 +37,16 @@ class AdditiveNoiseSampleCountValidationTest(unittest.TestCase):
         )
 
     def test_invalid_counts_are_rejected_before_sampling(self):
-        invalid_counts = (True, -1, 1.5, np.array([1]), "1")
+        invalid_counts = (
+            True,
+            -1,
+            1.5,
+            np.array([1]),
+            "1",
+            np.timedelta64(4, "ns"),
+            np.timedelta64(4, "us"),
+            np.datetime64("2026-07-27"),
+        )
 
         for invalid_count in invalid_counts:
             for model_index in range(2):


### PR DESCRIPTION
## Bug

Additive-noise transition and measurement samplers accepted some NumPy temporal scalars as sample counts. In particular, `np.timedelta64(4, "ns")` is converted by NumPy's `.item()` to the plain integer `4`, so a duration silently requested four samples. Behavior also depended on the temporal unit because coarser units failed differently.

## Fix

- Detect NumPy `datetime64` and `timedelta64` dtypes before generic sample-count normalization.
- Route them through the existing `ValueError("n must be a nonnegative integer.")` contract.
- Preserve valid Python and NumPy integer scalar counts.

## Tests

Extended the additive-noise sample-count regression test for both transition and measurement models with nanosecond/microsecond timedeltas and a datetime scalar. The test verifies rejection occurs before the noise distribution is sampled.

The connector-only environment prevented executing the local test suite; GitHub Actions provides the full backend matrix.