### PR TITLE
Reject temporal SO(3) tangent sample counts

### DIFF
--- a/src/pyrecest/distributions/so3_tangent_gaussian_distribution.py
+++ b/src/pyrecest/distributions/so3_tangent_gaussian_distribution.py
@@ -40,6 +40,8 @@ def _validate_positive_sample_count(n) -> int:
     count_array = np.asarray(n)
     if count_array.ndim != 0:
         raise ValueError("n must be a scalar integer")
+    if count_array.dtype.kind in {"M", "m"}:
+        raise ValueError("n must be an integer")
 
     count = count_array.item()
     if isinstance(count, (bool, np.bool_)):

--- a/tests/distributions/test_so3_tangent_gaussian_distribution.py
+++ b/tests/distributions/test_so3_tangent_gaussian_distribution.py
@@ -124,6 +124,22 @@ class SO3TangentGaussianDistributionTest(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     dist.sample_tangent(n)
 
+    def test_sampling_rejects_temporal_count(self):
+        dist = SO3TangentGaussianDistribution.from_covariance_diagonal(
+            array([0.0, 0.0, 0.0, 1.0]), array([0.01, 0.01, 0.01])
+        )
+
+        for n in (
+            np.timedelta64(3, "ns"),
+            np.timedelta64(3, "us"),
+            np.datetime64("2026-01-01"),
+        ):
+            with self.subTest(n=n):
+                with self.assertRaisesRegex(ValueError, "integer"):
+                    dist.sample(n)
+                with self.assertRaisesRegex(ValueError, "integer"):
+                    dist.sample_tangent(n)
+
     def test_geodesic_distance_respects_antipodal_equivalence(self):
         identity = array([0.0, 0.0, 0.0, 1.0])
         identity_antipodal = array([0.0, 0.0, 0.0, -1.0])


### PR DESCRIPTION
## Bug

`SO3TangentGaussianDistribution.sample()` and `sample_tangent()` validate the requested sample count through a zero-dimensional NumPy array followed by `.item()`. For `np.timedelta64(3, "ns")`, NumPy returns the plain Python integer `3`, so a temporal value is silently accepted and three samples are generated. Other temporal units fail later, making validation depend on the timedelta unit.

## Fix

- Reject NumPy `datetime64` and `timedelta64` scalar dtypes before converting with `.item()`.
- Preserve Python integers, NumPy integer scalars, and exact scalar floats already accepted by the API.
- Add regression coverage for nanosecond and microsecond timedeltas and datetime scalars through both `sample()` and `sample_tangent()`.

## Validation

- Isolated reproduction confirms that the original validator accepts `np.timedelta64(3, "ns")` as `3`.
- The patched validator accepts `3`, `np.int64(3)`, and `np.array(3.0)` while rejecting temporal scalars and the existing invalid-count cases.
- Branch is 2 commits ahead of `main`, 0 behind, with changes limited to the validator and its regression test.

The full backend test matrix is delegated to GitHub Actions.