### PR TITLE
Promote LinearDirac mean shifts

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/linear_dirac_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/linear_dirac_distribution.py
@@ -40,9 +40,9 @@ class LinearDiracDistribution(AbstractDiracDistribution, AbstractLinearDistribut
 
         mean_offset = new_mean - self.mean()
         if self.d.ndim == 1:
-            self.d += mean_offset
+            self.d = self.d + mean_offset
         else:
-            self.d += reshape(mean_offset, (1, -1))
+            self.d = self.d + reshape(mean_offset, (1, -1))
 
     def covariance(self):
         _, C = LinearDiracDistribution.weighted_samples_to_mean_and_cov(self.d, self.w)

--- a/tests/distributions/test_linear_dirac_distribution.py
+++ b/tests/distributions/test_linear_dirac_distribution.py
@@ -70,6 +70,38 @@ class LinearDiracDistributionTest(TestAbstractDiracDistribution):
         npt.assert_allclose(dist.mean(), array([10.0]))
         npt.assert_allclose(dist.d, array([8.5, 10.5]))
 
+    @unittest.skipUnless(
+        pyrecest.backend.__backend_name__ == "numpy",
+        reason="Regression targets NumPy integer in-place casting",
+    )
+    def test_set_mean_promotes_integer_locations_for_fractional_shift(self):
+        cases = (
+            (
+                "one-dimensional",
+                [0, 2],
+                [0.25, 0.75],
+                2.25,
+                [0.75, 2.75],
+            ),
+            (
+                "multidimensional",
+                [[0, 0], [2, 4]],
+                [0.5, 0.5],
+                [1.5, 2.5],
+                [[0.5, 0.5], [2.5, 4.5]],
+            ),
+        )
+
+        for name, samples, weights, new_mean, expected_samples in cases:
+            with self.subTest(name=name):
+                dist = LinearDiracDistribution(samples, weights)
+
+                dist.set_mean(new_mean)
+
+                self.assertTrue(np.issubdtype(np.asarray(dist.d).dtype, np.floating))
+                npt.assert_allclose(dist.d, expected_samples)
+                npt.assert_allclose(dist.mean(), np.atleast_1d(new_mean))
+
     def test_from_distribution(self):
         random.seed(0)
         C = wishart.rvs(3, eye(3))


### PR DESCRIPTION
## Bug

`LinearDiracDistribution.set_mean()` shifted particle locations with in-place addition. When the stored locations had an integer dtype and the requested mean required a fractional offset, NumPy rejected the update with a casting `UFuncTypeError`. The failure affected both one- and multi-dimensional distributions.

## Fix

- Use out-of-place addition so the active backend can promote the particle-location dtype.
- Add NumPy regression coverage for one- and multi-dimensional integer locations.
- Verify the shifted particles have a floating dtype and attain the requested fractional mean.

## Validation

- `python -m py_compile` succeeds for the modified implementation and test module.
- A standalone NumPy reproduction raises under the original in-place update and produces the expected particles and means after the fix.
- The branch changes only the implementation and its focused regression test.

GitHub Actions provides the full backend test matrix.