### PR TITLE
Normalize NumPy scalar fills in PyTorch full_like

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_creation_shape_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_creation_shape_contract.py
@@ -198,6 +198,12 @@ def patch_pytorch_creation_shape_contract() -> None:
         if has_fill_value:
 
             def like_creation_helper(a, fill_value, dtype=None, *args, **kwargs):
+                fill_value = _pytorch_creation_scalar(
+                    fill_value,
+                    np,
+                    torch,
+                    argument_name="full_like fill_value",
+                )
                 return torch_helper(
                     raw_pytorch.array(a),
                     fill_value,

--- a/tests/backend_support/test_pytorch_full_like_scalar_contract.py
+++ b/tests/backend_support/test_pytorch_full_like_scalar_contract.py
@@ -1,0 +1,61 @@
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _subprocess_env(selected_backend):
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = selected_backend
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    return env
+
+
+@pytest.mark.backend_portable
+@pytest.mark.parametrize(
+    ("selected_backend", "helper_expression"),
+    [
+        ("pytorch", "backend"),
+        ("numpy", "raw_pytorch"),
+    ],
+)
+def test_pytorch_full_like_accepts_numpy_scalar_fill_values(
+    selected_backend,
+    helper_expression,
+):
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    code = f"""
+import numpy as np
+import pyrecest  # noqa: F401  # triggers raw-backend compatibility patches
+import pyrecest.backend as backend
+import pyrecest._backend.pytorch as raw_pytorch
+
+helper = {helper_expression}
+source = [[1, 2], [3, 4]]
+fill_value = np.asarray(7)
+assert fill_value.shape == ()
+
+filled = helper.full_like(source, fill_value)
+assert helper.to_numpy(filled).tolist() == [[7, 7], [7, 7]]
+
+print("ok")
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        env=_subprocess_env(selected_backend),
+        text=True,
+        timeout=30.0,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "ok" in completed.stdout


### PR DESCRIPTION
## Summary

- normalize `full_like` fill values through the existing PyTorch creation-scalar compatibility helper
- accept NumPy zero-dimensional scalar arrays consistently with `full`
- add subprocess regressions for the public PyTorch backend and the raw PyTorch backend while NumPy is selected

## Root cause

The PyTorch `full` compatibility wrapper converts NumPy zero-dimensional arrays to Python scalars before calling `torch.full`, but the corresponding `full_like` wrapper forwarded the NumPy array directly to `torch.full_like`. PyTorch rejects that argument as a non-number, even though it represents a scalar and is accepted by NumPy/PyRecEst's other creation helper.

## Validation

- branch diff is limited to the creation compatibility helper and one focused regression module
- regression covers both patched entry points in isolated subprocesses
- full repository CI is pending
