### PR TITLE
Preserve tuple keys in CLI expected-result comparisons

### DIFF
--- a/src/pyrecest/cli.py
+++ b/src/pyrecest/cli.py
@@ -99,7 +99,9 @@ def _comparison_value(value: Any) -> Any:
             _comparison_value(key): _comparison_value(item)
             for key, item in value.items()
         }
-    if isinstance(value, (list, tuple)):
+    if isinstance(value, tuple):
+        return tuple(_comparison_value(item) for item in value)
+    if isinstance(value, list):
         return [_comparison_value(item) for item in value]
     return value
 

--- a/tests/test_cli_tuple_mapping_keys.py
+++ b/tests/test_cli_tuple_mapping_keys.py
@@ -1,0 +1,16 @@
+"""Regression tests for tuple-valued mapping keys in CLI comparisons."""
+
+from pyrecest.cli import _values_equal
+
+
+def test_values_equal_preserves_tuple_mapping_keys():
+    value = {("session", 1): {("target", 2): "matched"}}
+
+    assert _values_equal(value, value)
+
+
+def test_values_equal_detects_different_tuple_mapping_keys():
+    actual = {("session", 1): "matched"}
+    expected = {("session", 2): "matched"}
+
+    assert not _values_equal(actual, expected)


### PR DESCRIPTION
## What changed
- Preserve tuples as tuples during recursive CLI comparison normalization.
- Keep list normalization unchanged.
- Add regression tests for equal and unequal nested tuple-valued mapping keys.

## Root cause
`_comparison_value` normalized both lists and tuples to lists. When a tuple appeared as a dictionary key, the normalized key became an unhashable list, so `_values_equal` raised `TypeError` while rebuilding the mapping instead of returning a boolean comparison result.

## Impact
Expected-result checks can now safely compare mappings that use tuple keys, including nested mappings, without crashing.

## Validation
- Confirmed the branch is two commits ahead of `main` and changes only `src/pyrecest/cli.py` plus the focused regression test file.
- The regression directly covers both matching and differing tuple keys.

Local test execution was unavailable because the environment has no local GitHub checkout/network path; GitHub Actions should provide the authoritative test run.