### PR TITLE
Reject temporal hyperspherical sample counts

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/hyperspherical_uniform_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/hyperspherical_uniform_distribution.py
@@ -29,6 +29,8 @@ def _validate_positive_sample_count(n) -> int:
     count_array = np.asarray(n)
     if count_array.ndim != 0:
         raise ValueError("n must be a scalar integer")
+    if count_array.dtype.kind in ("m", "M"):
+        raise ValueError("n must be an integer")
 
     count = count_array.item()
     if isinstance(count, (bool, np.bool_)):

--- a/tests/distributions/test_hyperspherical_uniform_distribution.py
+++ b/tests/distributions/test_hyperspherical_uniform_distribution.py
@@ -83,6 +83,18 @@ class HypersphericalUniformDistributionTest(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     hud.sample(n)
 
+    def test_sample_rejects_temporal_count(self):
+        hud = HypersphericalUniformDistribution(2)
+
+        for n in (
+            np.timedelta64(4, "ns"),
+            np.timedelta64(4, "us"),
+            np.datetime64("2026-07-27"),
+        ):
+            with self.subTest(n=n):
+                with self.assertRaisesRegex(ValueError, "n must be an integer"):
+                    hud.sample(n)
+
     @unittest.skipIf(
         pyrecest.backend.__backend_name__ == "jax",
         "Numerical mean direction not supported for this backend",


### PR DESCRIPTION
## Bug

`HypersphericalUniformDistribution.sample()` normalizes its sample count through a zero-dimensional NumPy array followed by `.item()`. For `np.timedelta64(4, "ns")`, NumPy returns the plain Python integer `4`, so a duration is silently accepted and four samples are generated. Other temporal units fail differently, making validation depend on the datetime unit.

## Fix

- Reject NumPy `datetime64` and `timedelta64` scalar dtypes before calling `.item()`.
- Preserve existing support for Python integers, NumPy integer scalars, and exact scalar numeric counts.
- Add regression coverage for nanosecond and microsecond timedeltas and a datetime scalar.

## Validation

- Standalone validator regression passes for accepted numeric counts and rejected temporal scalars.
- Branch comparison is limited to the hyperspherical sample-count validator and its focused test module.
- Branch is 2 commits ahead of `main` and 0 behind.

GitHub Actions provides the full backend test matrix.