### PR TITLE
Reject temporal wrapped-Cauchy moment orders

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_cauchy_distribution.py
@@ -169,7 +169,7 @@ class WrappedCauchyDistribution(AbstractCircularDistribution):
         return mod(primitive(xs) - primitive(starting_point), 1.0)
 
     def trigonometric_moment(self, n):
-        if isinstance(n, bool) or not isinstance(n, Integral):
+        if isinstance(n, _INVALID_REAL_SCALAR_TYPES) or not isinstance(n, Integral):
             raise ValueError("n must be an integer.")
         n = int(n)
         return exp(1j * n * self.mu - abs(n) * self.gamma)

--- a/tests/distributions/test_wrapped_cauchy_distribution.py
+++ b/tests/distributions/test_wrapped_cauchy_distribution.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 import numpy.testing as npt
 
 # pylint: disable=no-name-in-module,no-member
@@ -81,7 +82,13 @@ class WrappedCauchyDistributionTest(unittest.TestCase):
     def test_trigonometric_moment_rejects_non_integer_orders(self):
         dist = WrappedCauchyDistribution(self.mu, self.gamma)
 
-        for order in (0.5, True, "1"):
+        for order in (
+            0.5,
+            True,
+            "1",
+            np.timedelta64(3, "ns"),
+            np.timedelta64(3, "us"),
+        ):
             with self.subTest(order=order):
                 with self.assertRaisesRegex(ValueError, "n must be an integer"):
                     dist.trigonometric_moment(order)


### PR DESCRIPTION
## Bug

`WrappedCauchyDistribution.trigonometric_moment()` validated its order with `isinstance(n, numbers.Integral)`. NumPy temporal scalars can satisfy that check: `np.timedelta64(3, "ns")` converts to the integer `3`, so a duration silently requested the third trigonometric moment. Coarser timedelta units passed the same guard but then raised a backend `TypeError`, making behavior depend on the time unit.

## Fix

- Reject the existing invalid scalar categories, including NumPy `datetime64` and `timedelta64`, before accepting integral moment orders.
- Preserve valid Python and NumPy integer orders, including negative orders.
- Extend the wrapped-Cauchy regression test with nanosecond and microsecond timedelta scalars.

## Validation

- Confirmed the original NumPy behavior locally: nanosecond timedeltas satisfy `numbers.Integral` and convert to an integer, while microsecond timedeltas fail later during `int(...)`.
- Branch is two commits ahead of `main`, zero behind, and changes only the wrapped-Cauchy implementation and focused test.
- Full repository CI is delegated to GitHub Actions because the connected environment cannot clone the repository or execute its dependency matrix.