### PR TITLE
Reject temporal linear-box particle counts

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/linear_box_particle_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/linear_box_particle_distribution.py
@@ -324,8 +324,10 @@ class LinearBoxParticleDistribution(AbstractLinearDistribution):
 
     @staticmethod
     def _validate_particle_count(value):
+        dtype = getattr(value, "dtype", None)
         if (
             isinstance(value, bool)
+            or getattr(dtype, "kind", None) in ("M", "m")
             or not isinstance(value, Integral)
             or int(value) <= 0
         ):

--- a/tests/distributions/test_linear_box_particle_temporal_count.py
+++ b/tests/distributions/test_linear_box_particle_temporal_count.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pytest
+
+from pyrecest.backend import array
+from pyrecest.distributions.nonperiodic.linear_box_particle_distribution import (
+    LinearBoxParticleDistribution,
+)
+
+
+@pytest.mark.parametrize(
+    "particle_count",
+    [
+        np.timedelta64(4, "ns"),
+        np.timedelta64(4, "us"),
+    ],
+)
+def test_sample_rejects_temporal_particle_counts(particle_count):
+    distribution = LinearBoxParticleDistribution(array([[0.0]]), array([[1.0]]))
+
+    with pytest.raises(ValueError, match="positive integer"):
+        distribution.sample(particle_count)
+
+
+@pytest.mark.parametrize(
+    "particle_count",
+    [
+        np.timedelta64(4, "ns"),
+        np.timedelta64(4, "us"),
+    ],
+)
+def test_from_distribution_rejects_temporal_particle_counts(particle_count):
+    with pytest.raises(ValueError, match="positive integer"):
+        LinearBoxParticleDistribution.from_distribution(
+            object(), n_particles=particle_count
+        )


### PR DESCRIPTION
## Summary

- reject NumPy datetime/timedelta scalar dtypes before integer particle-count coercion
- apply the fix to both `LinearBoxParticleDistribution.sample()` and `from_distribution()` through their shared validator
- add focused regressions for nanosecond and microsecond `numpy.timedelta64` values

## Bug

`LinearBoxParticleDistribution._validate_particle_count()` relied on `numbers.Integral`. NumPy temporal scalars have inconsistent behavior under that contract: `np.timedelta64(4, "ns")` satisfies `Integral` and converts to the integer `4`, so it silently requests four particles, while `np.timedelta64(4, "us")` reaches `int(...)` and leaks a raw `TypeError`.

## Fix

Inspect the input dtype before generic integral validation and reject NumPy temporal dtype kinds (`datetime64` and `timedelta64`) through the existing `ValueError("Number of particles must be a positive integer.")` contract.

## Validation

- branch is 2 commits ahead of `main`, 0 behind
- diff is limited to 2 source lines and one focused 35-line regression module
- both modified Python files compile successfully
- standalone reproduction verifies the original silent acceptance and exception leak, the patched rejection behavior, and preservation of Python/NumPy integer counts

GitHub Actions provides the full backend test matrix.