### PR TITLE
Reject temporal hyperspherical sample counts

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/hyperspherical_uniform_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/hyperspherical_uniform_distribution.py
@@ -29,6 +29,8 @@ def _validate_positive_sample_count(n) -> int:
     count_array = np.asarray(n)
     if count_array.ndim != 0:
         raise ValueError("n must be a scalar integer")
+    if count_array.dtype.kind in {"M", "m"}:
+        raise ValueError("n must be an integer")
 
     count = count_array.item()
     if isinstance(count, (bool, np.bool_)):

--- a/tests/distributions/test_hyperspherical_uniform_sample_count_exactness.py
+++ b/tests/distributions/test_hyperspherical_uniform_sample_count_exactness.py
@@ -1,5 +1,6 @@
 from fractions import Fraction
 
+import numpy as np
 import pytest
 from pyrecest.distributions.hypersphere_subset.hyperspherical_uniform_distribution import (
     _validate_positive_sample_count,
@@ -18,3 +19,13 @@ def test_hyperspherical_uniform_sample_count_preserves_large_exact_integer():
     count = Fraction(2**54 + 2, 2)
 
     assert _validate_positive_sample_count(count) == 2**53 + 1
+
+
+def test_hyperspherical_uniform_sample_count_rejects_temporal_scalars():
+    for count in (
+        np.timedelta64(3, "ns"),
+        np.timedelta64(3, "us"),
+        np.datetime64("2026-07-27"),
+    ):
+        with pytest.raises(ValueError, match="integer"):
+            _validate_positive_sample_count(count)


### PR DESCRIPTION
## Bug

`HypersphericalUniformDistribution.sample()` accepted `numpy.timedelta64(3, "ns")` as a request for three samples. NumPy converts that zero-dimensional temporal scalar to the plain Python integer `3` through `.item()`, so validation depended on the timedelta unit instead of consistently requiring a numeric sample count.

## Fix

- Reject NumPy `datetime64` and `timedelta64` dtypes before scalar conversion.
- Preserve valid Python integers, NumPy integer scalars, exact scalar floats, and the existing large-exact-integer behavior.
- Add regression coverage for nanosecond and microsecond timedeltas and a datetime scalar.

## Validation

- Reproduced the original nanosecond-timedelta acceptance locally.
- Executed the patched validator in isolation against temporal and valid integer-like inputs.
- `python -m py_compile` succeeded for both modified files.
- Branch is 2 commits ahead of `main`, 0 behind, with changes limited to the validator and its focused regression test.

GitHub Actions provides the full backend test matrix.