### PR TITLE
Reject temporal controls in circular sampler

### DIFF
--- a/src/pyrecest/sampling/hypertoroidal_sampler.py
+++ b/src/pyrecest/sampling/hypertoroidal_sampler.py
@@ -12,6 +12,8 @@ def _validate_integral_scalar(value, name: str, *, minimum: int) -> int:
     scalar = np.asarray(value)
     if scalar.ndim != 0:
         raise ValueError(f"{name} must be a scalar integer")
+    if scalar.dtype.kind in ("M", "m"):
+        raise ValueError(f"{name} must be an integer")
 
     scalar_value = scalar.item()
     if isinstance(scalar_value, (bool, np.bool_)):

--- a/tests/test_hypertoroidal_sampler.py
+++ b/tests/test_hypertoroidal_sampler.py
@@ -51,6 +51,20 @@ class TestCircularUniformSampler(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     self.sampler.sample_stochastic(2, dim=dim)
 
+    def test_sample_stochastic_rejects_temporal_controls(self):
+        temporal_values = (
+            np.timedelta64(3, "ns"),
+            np.timedelta64(3, "us"),
+            np.datetime64("2026-07-27"),
+        )
+        for value in temporal_values:
+            with self.subTest(n_samples=value):
+                with self.assertRaisesRegex(ValueError, "must be an integer"):
+                    self.sampler.sample_stochastic(value)
+            with self.subTest(dim=value):
+                with self.assertRaisesRegex(ValueError, "must be an integer"):
+                    self.sampler.sample_stochastic(2, dim=value)
+
     def test_integral_controls_reject_fractional_values_rounded_by_binary64(self):
         rounded_half_integer = Fraction(2**54 + 1, 2)
 
@@ -94,6 +108,16 @@ class TestCircularUniformSampler(unittest.TestCase):
         for density in (2.5, True, "3", b"3", [3]):
             with self.subTest(density=density):
                 with self.assertRaises(ValueError):
+                    self.sampler.get_grid(density)
+
+    def test_get_grid_rejects_temporal_density(self):
+        for density in (
+            np.timedelta64(4, "ns"),
+            np.timedelta64(4, "us"),
+            np.datetime64("2026-07-27"),
+        ):
+            with self.subTest(density=density):
+                with self.assertRaisesRegex(ValueError, "must be an integer"):
                     self.sampler.get_grid(density)
 
 


### PR DESCRIPTION
## Bug

`_validate_integral_scalar()` converted zero-dimensional NumPy inputs with `.item()` before excluding temporal dtypes. For nanosecond `numpy.timedelta64` values, `.item()` returns a plain Python integer, so durations could silently be accepted as `n_samples`, `dim`, or `grid_density_parameter`. Other temporal units failed differently, making validation unit-dependent.

## Fix

- reject NumPy `datetime64` and `timedelta64` scalar dtypes before scalar conversion
- preserve valid Python integers, NumPy integer scalars, exact scalar floats, and exact large rational integers
- add regression coverage for sampling controls and grid density using nanosecond/microsecond timedeltas and datetime scalars

## Validation

- changes are limited to the shared hypertoroidal scalar validator and its existing focused test module
- regression coverage exercises all three affected public controls
- GitHub Actions provides the full backend test matrix