### PR TITLE
Reject temporal LinearDirac particle counts

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/linear_dirac_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/linear_dirac_distribution.py
@@ -1,6 +1,7 @@
 from numbers import Integral
 
 import matplotlib.pyplot as plt
+import numpy as np
 
 # pylint: disable=no-name-in-module,no-member
 import pyrecest.backend
@@ -121,7 +122,7 @@ class LinearDiracDistribution(AbstractDiracDistribution, AbstractLinearDistribut
         from ..conversion import ConversionError
 
         if (
-            isinstance(value, bool)
+            isinstance(value, (bool, np.datetime64, np.timedelta64))
             or not isinstance(value, Integral)
             or int(value) <= 0
         ):

--- a/tests/distributions/test_linear_dirac_distribution.py
+++ b/tests/distributions/test_linear_dirac_distribution.py
@@ -110,6 +110,27 @@ class LinearDiracDistributionTest(TestAbstractDiracDistribution):
         npt.assert_allclose(hwd.mean(), hwn.mean(), atol=0.015)
         npt.assert_allclose(hwd.covariance(), hwn.covariance(), atol=0.1)
 
+    def test_from_distribution_rejects_temporal_particle_counts(self):
+        distribution = GaussianDistribution(array([0.0]), array([[1.0]]))
+        temporal_counts = (
+            np.timedelta64(3, "ns"),
+            np.timedelta64(3, "us"),
+            np.datetime64("1970-01-01T00:00:00.000000003"),
+        )
+
+        for alias in ("n_particles", "n_samples", "n"):
+            for count in temporal_counts:
+                with self.subTest(alias=alias, count=count):
+                    with self.assertRaisesRegex(ValueError, "positive integer"):
+                        LinearDiracDistribution.from_distribution(
+                            distribution, **{alias: count}
+                        )
+
+        valid = LinearDiracDistribution.from_distribution(
+            distribution, n_particles=np.int64(3)
+        )
+        self.assertEqual(valid.d.shape[0], 3)
+
     def test_mean_and_cov(self):
         random.seed(0)
         gd = GaussianDistribution(array([1.0, 2.0]), array([[2.0, -0.3], [-0.3, 1.0]]))


### PR DESCRIPTION
## Bug

`LinearDiracDistribution.from_distribution()` validated particle-count aliases with `numbers.Integral`. NumPy temporal scalars behave inconsistently under that contract: `np.timedelta64(3, "ns")` satisfies `Integral` and converts to the integer `3`, so it silently requests three particles, while coarser timedelta units reach `int(...)` and leak a raw `TypeError`.

## Fix

- Reject NumPy `datetime64` and `timedelta64` scalars before integral particle-count validation.
- Apply the fix to all public aliases (`n_particles`, `n_samples`, and `n`) through their shared validator.
- Preserve valid Python and NumPy integer counts.

## Validation

- Added regression coverage for nanosecond and microsecond timedeltas and a datetime scalar across every particle-count alias.
- Added a preservation check for `np.int64` particle counts.
- Branch is two commits ahead of `main`, zero behind, with changes limited to the validator and its focused test.

GitHub Actions provides the full backend test matrix.