### PR TITLE
Reject temporal mixture weights

### DIFF
--- a/src/pyrecest/distributions/abstract_mixture.py
+++ b/src/pyrecest/distributions/abstract_mixture.py
@@ -40,6 +40,7 @@ _INVALID_SAMPLE_COUNT_TYPES = (
     np.timedelta64,
 )
 _TEMPORAL_DTYPE_KINDS = {"M", "m"}
+_TEMPORAL_SCALAR_TYPES = (np.datetime64, np.timedelta64)
 
 
 def _validate_positive_sample_count(n) -> int:
@@ -89,14 +90,25 @@ def _validate_explicit_weight_shape(weights, num_distributions: int):
 def _validate_mixture_weight_values(weights) -> None:
     """Reject invalid mixture weights before backend scalar comparisons."""
     try:
-        weight_values = np.asarray(pyrecest.backend.to_numpy(weights), dtype=object)
+        converted_weights = pyrecest.backend.to_numpy(weights)
+        native_weight_values = np.asarray(converted_weights)
     except Exception as exc:  # pragma: no cover - backend-specific conversion type
+        raise ValueError("Mixture weights must be real-valued numeric") from exc
+
+    if getattr(native_weight_values.dtype, "kind", None) in _TEMPORAL_DTYPE_KINDS:
+        raise ValueError("Mixture weights must be real-valued numeric")
+
+    try:
+        weight_values = np.asarray(converted_weights, dtype=object)
+    except Exception as exc:  # pragma: no cover - NumPy object-conversion failure
         raise ValueError("Mixture weights must be real-valued numeric") from exc
 
     for weight in weight_values.reshape(-1):
         if isinstance(weight, _BOOLEAN_TYPES):
             raise ValueError("Mixture weights must be real-valued numeric, not boolean")
         if isinstance(weight, _TEXT_TYPES):
+            raise ValueError("Mixture weights must be real-valued numeric")
+        if isinstance(weight, _TEMPORAL_SCALAR_TYPES):
             raise ValueError("Mixture weights must be real-valued numeric")
         if isinstance(weight, _COMPLEX_TYPES):
             raise ValueError("Mixture weights must be real-valued numeric")

--- a/tests/distributions/test_abstract_mixture_temporal_weights.py
+++ b/tests/distributions/test_abstract_mixture_temporal_weights.py
@@ -1,0 +1,34 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.distributions.abstract_mixture import _validate_mixture_weight_values
+
+
+class AbstractMixtureTemporalWeightTest(unittest.TestCase):
+    def test_native_temporal_weight_arrays_are_rejected(self):
+        temporal_weights = [
+            np.array([1, 2], dtype="timedelta64[ns]"),
+            np.array([1, 2], dtype="timedelta64[us]"),
+            np.array(["2026-01-01", "2026-01-02"], dtype="datetime64[D]"),
+        ]
+
+        for weights in temporal_weights:
+            with self.subTest(dtype=str(weights.dtype)):
+                with self.assertRaisesRegex(ValueError, "real-valued numeric"):
+                    _validate_mixture_weight_values(weights)
+
+    def test_temporal_scalars_in_object_weight_arrays_are_rejected(self):
+        temporal_weights = [
+            np.array([np.timedelta64(1, "ns"), 1.0], dtype=object),
+            np.array([np.datetime64("2026-01-01"), 1.0], dtype=object),
+        ]
+
+        for weights in temporal_weights:
+            with self.subTest(weight=repr(weights[0])):
+                with self.assertRaisesRegex(ValueError, "real-valued numeric"):
+                    _validate_mixture_weight_values(weights)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`AbstractMixture` validated explicit weights by converting them directly to an object array and then calling `float(...)` on each value. For NumPy temporal inputs this is unsafe: a native `timedelta64[ns]` array loses its temporal dtype during object conversion and becomes plain integers, while temporal values in object arrays can also convert to floats. Invalid durations or timestamps could therefore pass the numeric precheck and fail later during backend normalization with an implementation-specific ufunc/type error.

## Fix

- preserve and inspect the native NumPy dtype before object conversion
- reject native `datetime64` and `timedelta64` arrays through the existing real-numeric `ValueError` contract
- reject temporal scalar values retained inside object arrays
- keep valid real-valued numeric arrays and object arrays unchanged

## Validation

- `python -m py_compile` succeeded for the modified source and new test module
- executed the new tests against the actual modified validator with a minimal NumPy backend harness: 2 tests passed
- checked valid float and numeric object-array controls remain accepted
- branch is 2 commits ahead of `main`, 0 behind; changes are limited to the shared mixture-weight validator and focused regression coverage