### PR TITLE
Reject temporal nonparametric cardinality counts

### DIFF
--- a/src/pyrecest/tracking/nonparametric_cardinality.py
+++ b/src/pyrecest/tracking/nonparametric_cardinality.py
@@ -194,10 +194,19 @@ class DirichletProcessCardinalityPrior(PitmanYorCardinalityPrior):
         super().__init__(strength=strength, discount=0.0)
 
 
+def _is_temporal_scalar(value: object) -> bool:
+    dtype = getattr(value, "dtype", None)
+    return getattr(dtype, "kind", None) in {"M", "m"}
+
+
 def _validate_cluster_sizes(cluster_sizes: Sequence[int]) -> tuple[int, ...]:
     sizes = tuple(cluster_sizes)
     for size in sizes:
-        if isinstance(size, bool) or not isinstance(size, Integral):
+        if (
+            isinstance(size, bool)
+            or _is_temporal_scalar(size)
+            or not isinstance(size, Integral)
+        ):
             raise TypeError("cluster sizes must be positive integers.")
         if int(size) <= 0:
             raise ValueError("cluster sizes must be positive integers.")
@@ -205,7 +214,11 @@ def _validate_cluster_sizes(cluster_sizes: Sequence[int]) -> tuple[int, ...]:
 
 
 def _validate_nonnegative_int(value: int, name: str) -> int:
-    if isinstance(value, bool) or not isinstance(value, Integral):
+    if (
+        isinstance(value, bool)
+        or _is_temporal_scalar(value)
+        or not isinstance(value, Integral)
+    ):
         raise TypeError(f"{name} must be a nonnegative integer.")
     value = int(value)
     if value < 0:

--- a/tests/tracking/test_nonparametric_cardinality.py
+++ b/tests/tracking/test_nonparametric_cardinality.py
@@ -1,5 +1,6 @@
 import math
 
+import numpy as np
 import pytest
 from pyrecest.tracking.nonparametric_cardinality import (
     DirichletProcessCardinalityPrior,
@@ -89,3 +90,27 @@ def test_cluster_size_validation():
         prior.predictive_probabilities((0, 1))
     with pytest.raises(TypeError):
         prior.predictive_probabilities((True, 1))
+
+
+@pytest.mark.parametrize(
+    "temporal_size",
+    [np.timedelta64(3, "ns"), np.timedelta64(3, "us")],
+)
+def test_cluster_sizes_reject_temporal_scalars(temporal_size):
+    prior = PitmanYorCardinalityPrior()
+
+    with pytest.raises(TypeError, match="cluster sizes"):
+        prior.predictive_probabilities((temporal_size,))
+
+
+@pytest.mark.parametrize(
+    "temporal_count",
+    [np.timedelta64(3, "ns"), np.timedelta64(3, "us")],
+)
+def test_cardinality_controls_reject_temporal_scalars(temporal_count):
+    prior = PitmanYorCardinalityPrior()
+
+    with pytest.raises(TypeError, match="num_observations"):
+        prior.cluster_count_pmf(temporal_count)
+    with pytest.raises(TypeError, match="min_clusters"):
+        prior.cluster_count_tail_probability(3, temporal_count)


### PR DESCRIPTION
## Bug

The nonparametric cardinality validators relied on `numbers.Integral`. NumPy temporal scalars also satisfy that protocol: `numpy.timedelta64(3, "ns")` converts to the integer `3`, so a duration could silently be used as a cluster size, observation count, or minimum cluster count. Coarser timedelta units followed the same validation path but leaked a raw `TypeError` during `int(...)`, making behavior depend on the timedelta unit.

## Fix

- reject NumPy `datetime64` and `timedelta64` scalar dtypes before generic integral validation
- apply the shared check to cluster sizes, `num_observations`, and `min_clusters`
- preserve valid Python and NumPy integer inputs
- add focused regressions for nanosecond and microsecond timedelta values

## Impact

Invalid temporal values now fail consistently through the existing public `TypeError` contracts instead of changing cardinality calculations or leaking backend conversion errors.

## Validation

- branch is 2 commits ahead of `main` and 0 behind
- diff is limited to the cardinality module and its focused test file
- regression cases cover both the silently accepted nanosecond form and the unit-dependent exception path

GitHub Actions provides the full project test matrix.