### PR TITLE
Accept array-like samples in nonadditive particle prediction

### DIFF
--- a/src/pyrecest/filters/abstract_particle_filter.py
+++ b/src/pyrecest/filters/abstract_particle_filter.py
@@ -222,7 +222,12 @@ class AbstractParticleFilter(AbstractFilter):
         self._filter_state.d = updated_particles
 
     def predict_nonlinear_nonadditive(self, f, samples, weights):
+        samples = array(samples)
         weights = array(weights, dtype=float)
+        if samples.ndim == 0:
+            raise ValueError("samples must contain a leading sample dimension")
+        if weights.ndim != 1:
+            raise ValueError("weights must be one-dimensional")
         if samples.shape[0] != weights.shape[0]:
             raise ValueError("samples and weights must match in size")
 

--- a/tests/filters/test_nonadditive_arraylike_samples.py
+++ b/tests/filters/test_nonadditive_arraylike_samples.py
@@ -1,0 +1,23 @@
+import numpy.testing as npt
+
+from pyrecest.backend import array
+from pyrecest.distributions import LinearDiracDistribution
+from pyrecest.filters.euclidean_particle_filter import EuclideanParticleFilter
+
+
+def test_predict_nonlinear_nonadditive_accepts_array_like_samples_and_weights():
+    particle_filter = EuclideanParticleFilter(n_particles=3, dim=1)
+    particle_filter.filter_state = LinearDiracDistribution(
+        array([[0.0], [1.0], [2.0]])
+    )
+
+    particle_filter.predict_nonlinear_nonadditive(
+        lambda particle, noise: particle + noise,
+        samples=[[0.5], [0.5]],
+        weights=[1.0, 1.0],
+    )
+
+    npt.assert_allclose(
+        particle_filter.filter_state.d,
+        array([[0.5], [1.5], [2.5]]),
+    )


### PR DESCRIPTION
## Summary
- normalize nonadditive noise `samples` with the configured backend, matching the existing handling of `weights`
- reject scalar samples and non-vector weights with clear `ValueError`s instead of shape/index errors
- add a regression test covering Python-list samples and weights

## Bug
`AbstractParticleFilter.predict_nonlinear_nonadditive()` converted `weights` to a backend array but accessed `samples.shape` directly. Passing valid array-like samples such as a list therefore raised `AttributeError` before prediction.

## Testing
- added `test_predict_nonlinear_nonadditive_accepts_array_like_samples_and_weights`
- deterministic test uses identical noise samples, avoiding backend-dependent random outcomes