### PR TITLE
Reject temporal metric count arguments

### DIFF
--- a/src/pyrecest/utils/metrics.py
+++ b/src/pyrecest/utils/metrics.py
@@ -579,7 +579,11 @@ def _as_covariance_stack(
 
 def _as_positive_int(value: Any, name: str) -> int:
     array = np.asarray(value)
-    if array.ndim != 0 or array.dtype == np.bool_:
+    if (
+        array.ndim != 0
+        or array.dtype == np.bool_
+        or array.dtype.kind in {"M", "m"}
+    ):
         raise ValueError(f"{name} must be a positive integer")
     scalar = array.item()
     if isinstance(scalar, (int, np.integer)) and not isinstance(scalar, bool):

--- a/tests/test_metrics_temporal_counts.py
+++ b/tests/test_metrics_temporal_counts.py
@@ -1,0 +1,26 @@
+import numpy as np
+import pytest
+
+from pyrecest.utils.metrics import chi_square_confidence_bounds
+
+
+_TEMPORAL_COUNTS = (
+    np.timedelta64(2, "ns"),
+    np.timedelta64(2, "us"),
+    np.datetime64("1970-01-01T00:00:00.000000002", "ns"),
+)
+
+
+@pytest.mark.parametrize("value", _TEMPORAL_COUNTS)
+def test_chi_square_bounds_reject_temporal_degrees_of_freedom(value):
+    with pytest.raises(
+        ValueError,
+        match="degrees_of_freedom must be a positive integer",
+    ):
+        chi_square_confidence_bounds(value)
+
+
+@pytest.mark.parametrize("value", _TEMPORAL_COUNTS)
+def test_chi_square_bounds_reject_temporal_sample_counts(value):
+    with pytest.raises(ValueError, match="n_samples must be a positive integer"):
+        chi_square_confidence_bounds(2, n_samples=value)


### PR DESCRIPTION
## Bug

`numpy.timedelta64` and `numpy.datetime64` values with nanosecond precision can become plain Python integers when a zero-dimensional array is converted with `.item()`. As a result, `chi_square_confidence_bounds()` can silently accept temporal values as `degrees_of_freedom` or `n_samples`.

## Fix

Reject NumPy datetime and timedelta dtypes before scalar extraction in the positive-integer validator.

## Regression coverage

- nanosecond and microsecond `numpy.timedelta64` values
- nanosecond `numpy.datetime64` values
- both `degrees_of_freedom` and `n_samples`

## Local validation

- `python -m py_compile` for the modified source and regression test
- focused execution of the patched module against all regression cases
- valid integer-like inputs remain unchanged
