### PR TITLE
Reject temporal PyTorch split section counts

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_split_index_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_split_index_contract.py
@@ -24,8 +24,13 @@ def _normalize_split_section_count(indices_or_sections, torch_module):
     if torch_module.is_tensor(indices_or_sections):
         scalar = indices_or_sections.item()
     else:
-        scalar = np.asarray(indices_or_sections).item()
+        value_array = np.asarray(indices_or_sections)
+        if value_array.dtype.kind in "Mm":
+            raise TypeError(_SPLIT_INDEX_TYPE_MESSAGE)
+        scalar = value_array.item()
 
+    if isinstance(scalar, (np.datetime64, np.timedelta64)):
+        raise TypeError(_SPLIT_INDEX_TYPE_MESSAGE)
     if isinstance(scalar, (bool, np.bool_)):
         return int(scalar)
 

--- a/tests/test_pytorch_split_index_contract.py
+++ b/tests/test_pytorch_split_index_contract.py
@@ -1,6 +1,8 @@
 import unittest
 from fractions import Fraction
 
+import numpy as np
+
 from pyrecest.backend_support._pytorch_split_index_contract import (
     _normalize_split_section_count,
 )
@@ -26,6 +28,27 @@ class PytorchSplitIndexContractTest(unittest.TestCase):
         normalized = _normalize_split_section_count(exact_count, _TorchStub)
 
         self.assertEqual(normalized, 2**53 + 1)
+
+    def test_rejects_temporal_section_counts(self):
+        temporal_counts = (
+            np.timedelta64(2, "ns"),
+            np.timedelta64(2, "us"),
+            np.datetime64("1970-01-01T00:00:00.000000002"),
+            np.array(np.timedelta64(2, "ns"), dtype=object),
+        )
+
+        for temporal_count in temporal_counts:
+            with self.subTest(temporal_count=temporal_count):
+                with self.assertRaisesRegex(
+                    TypeError,
+                    "slice indices must be integers",
+                ):
+                    _normalize_split_section_count(temporal_count, _TorchStub)
+
+    def test_preserves_numpy_integer_count(self):
+        normalized = _normalize_split_section_count(np.int64(3), _TorchStub)
+
+        self.assertEqual(normalized, 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Bug

`_normalize_split_section_count()` converted non-tensor scalar inputs with `numpy.asarray(...).item()` before validating their dtype. For nanosecond `numpy.timedelta64` and `numpy.datetime64` values, `.item()` returns a plain Python integer, so a duration or timestamp could silently select the number of split sections. Coarser temporal units raised `TypeError`, making the public behavior depend on the temporal unit.

## Fix

- reject native NumPy datetime and timedelta dtypes before scalar extraction
- reject temporal scalars preserved inside object arrays
- preserve valid NumPy integer section counts and the existing exact-rational behavior

## Validation

- added regressions for nanosecond and microsecond timedeltas, a nanosecond datetime, and an object-wrapped temporal scalar
- added a preservation check for `numpy.int64`
- ran the isolated split-count contract suite locally: 4 tests passed
- branch is 2 commits ahead of `main`, 0 behind, and changes only the validator and its focused test module

The full backend matrix should run in GitHub Actions.