### PR TITLE
Reject temporal sigma-point parameters

### DIFF
--- a/src/pyrecest/sampling/sigma_points.py
+++ b/src/pyrecest/sampling/sigma_points.py
@@ -23,6 +23,7 @@ from pyrecest.backend import (
 
 _TEXT_SCALAR_TYPES = (str, bytes, np.str_, np.bytes_)
 _COMPLEX_SCALAR_TYPES = (complex, np.complexfloating)
+_TEMPORAL_SCALAR_TYPES = (np.datetime64, np.timedelta64)
 
 
 def _has_complex_dtype(value) -> bool:
@@ -60,11 +61,21 @@ def _scalar_item(value, name: str):
     shape = getattr(value, "shape", ())
     if tuple(shape) != ():
         raise ValueError(f"{name} must be a scalar")
+
+    dtype = getattr(value, "dtype", None)
+    if dtype is not None:
+        try:
+            dtype_kind = np.dtype(dtype).kind
+        except (TypeError, ValueError):
+            dtype_kind = None
+        if dtype_kind in {"M", "m"}:
+            raise ValueError(f"{name} must be a scalar")
+
     try:
         scalar = value.item() if hasattr(value, "item") else value
     except (TypeError, ValueError, AttributeError) as exc:
         raise ValueError(f"{name} must be a scalar") from exc
-    if isinstance(scalar, (bool, np.bool_)):
+    if isinstance(scalar, (bool, np.bool_) + _TEMPORAL_SCALAR_TYPES):
         raise ValueError(f"{name} must be a scalar")
     return scalar
 

--- a/tests/test_sigma_points_temporal_parameters.py
+++ b/tests/test_sigma_points_temporal_parameters.py
@@ -1,0 +1,50 @@
+import numpy as np
+import pytest
+
+from pyrecest.sampling import JulierSigmaPoints, MerweScaledSigmaPoints
+
+
+_TEMPORAL_VALUES = (
+    np.timedelta64(2, "ns"),
+    np.timedelta64(2, "us"),
+    np.datetime64("1970-01-01T00:00:00.000000002"),
+    np.array(np.timedelta64(2, "ns"), dtype=object),
+)
+
+
+@pytest.mark.parametrize("temporal_value", _TEMPORAL_VALUES)
+def test_sigma_point_dimensions_reject_temporal_scalars(temporal_value):
+    with pytest.raises(ValueError, match="n must be a scalar"):
+        MerweScaledSigmaPoints(
+            n=temporal_value,
+            alpha=0.5,
+            beta=2.0,
+            kappa=0.0,
+        )
+
+    with pytest.raises(ValueError, match="n must be a scalar"):
+        JulierSigmaPoints(n=temporal_value, kappa=0.0)
+
+
+@pytest.mark.parametrize("parameter_name", ("alpha", "beta", "kappa"))
+@pytest.mark.parametrize("temporal_value", _TEMPORAL_VALUES)
+def test_merwe_scaling_parameters_reject_temporal_scalars(
+    parameter_name,
+    temporal_value,
+):
+    parameters = {
+        "n": 2,
+        "alpha": 0.5,
+        "beta": 2.0,
+        "kappa": 0.0,
+    }
+    parameters[parameter_name] = temporal_value
+
+    with pytest.raises(ValueError, match=rf"{parameter_name} must be a scalar"):
+        MerweScaledSigmaPoints(**parameters)
+
+
+@pytest.mark.parametrize("temporal_value", _TEMPORAL_VALUES)
+def test_julier_kappa_rejects_temporal_scalars(temporal_value):
+    with pytest.raises(ValueError, match="kappa must be a scalar"):
+        JulierSigmaPoints(n=2, kappa=temporal_value)


### PR DESCRIPTION
## Bug

The sigma-point constructors normalize scalar inputs with `.item()` before excluding NumPy temporal dtypes. For nanosecond values, NumPy exposes the temporal payload as a plain Python integer: for example, `np.timedelta64(2, "ns")` is accepted as state dimension `2`, and temporal values can likewise be accepted as `alpha`, `beta`, or `kappa`. Coarser temporal units fail differently, so behavior depends on the datetime/timedelta unit.

## Fix

- reject native NumPy `datetime64` and `timedelta64` scalar dtypes before calling `.item()`
- reject temporal scalars retained inside zero-dimensional object arrays
- apply the shared guard to both dimension and finite scaling-parameter validation
- preserve valid Python integers, NumPy integer scalars, Python floats, and zero-dimensional numeric arrays

## Impact

`MerweScaledSigmaPoints` and `JulierSigmaPoints` now consistently reject durations and timestamps instead of silently interpreting their raw payloads as dimensions or scaling parameters.

## Validation

- standalone reproduction confirms the original nanosecond temporal inputs convert to integer payloads
- standalone regression exercises native nanosecond/microsecond timedeltas, nanosecond datetimes, and object-wrapped timedeltas across `n`, `alpha`, `beta`, and `kappa`
- valid integer and finite numeric controls remain accepted
- branch is 2 commits ahead of current `main`, 0 behind, and changes only the sigma-point validator plus focused regression coverage

GitHub Actions provides the full backend test matrix.