### PR TITLE
Validate sticky mode transition counts

### DIFF
--- a/src/pyrecest/filters/discrete_state/__init__.py
+++ b/src/pyrecest/filters/discrete_state/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import runpy
 from functools import wraps
+from numbers import Integral
 from pathlib import Path
 from typing import Any
 
@@ -30,6 +31,9 @@ _original_discrete_forward_backward_time_varying = _module_globals[
 _original_imm_forward_backward = _module_globals["imm_forward_backward"]
 _original_sparse_gaussian_transition_matrix = _module_globals[
     "sparse_gaussian_transition_matrix"
+]
+_original_sticky_mode_transition_matrix = _module_globals[
+    "sticky_mode_transition_matrix"
 ]
 
 
@@ -207,6 +211,22 @@ def _validated_positive_scalar(
     return parsed
 
 
+def _validated_positive_integer(value: Any, name: str) -> int:
+    try:
+        raw_value = np.asarray(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a positive integer") from exc
+    if raw_value.shape != () or raw_value.dtype.kind in _REJECTED_STATE_KINDS:
+        raise ValueError(f"{name} must be a positive integer")
+    scalar = raw_value.item()
+    if isinstance(scalar, _BOOLEAN_TYPES) or not isinstance(scalar, Integral):
+        raise ValueError(f"{name} must be a positive integer")
+    parsed = int(scalar)
+    if parsed <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return parsed
+
+
 def _validated_probability_vector(
     probabilities: Any,
     n_entries: int,
@@ -247,6 +267,13 @@ def _validated_probability_vector(
     return values / total
 
 
+@wraps(_original_sticky_mode_transition_matrix)
+def sticky_mode_transition_matrix(n_modes, stickiness):
+    n_modes = _validated_positive_integer(n_modes, "n_modes")
+    return _original_sticky_mode_transition_matrix(n_modes, stickiness)
+
+
+@wraps(_original_sparse_gaussian_transition_matrix)
 def sparse_gaussian_transition_matrix(
     state_vectors,
     sigma,
@@ -278,6 +305,8 @@ _module_globals["discrete_forward_backward_time_varying"] = (
     discrete_forward_backward_time_varying
 )
 _module_globals["imm_forward_backward"] = imm_forward_backward
+_module_globals["sticky_mode_transition_matrix"] = sticky_mode_transition_matrix
+_module_globals["mode_transition_matrix"] = sticky_mode_transition_matrix
 _module_globals["sparse_gaussian_transition_matrix"] = sparse_gaussian_transition_matrix
 _module_globals["_normalize_probability_vector"] = _validated_probability_vector
 for name in _module_globals["__all__"]:

--- a/tests/filters/test_discrete_state_mode_count_validation.py
+++ b/tests/filters/test_discrete_state_mode_count_validation.py
@@ -1,0 +1,47 @@
+import unittest
+
+import numpy as np
+from pyrecest.filters.discrete_state import (
+    mode_transition_matrix,
+    sticky_mode_transition_matrix,
+)
+
+
+class TestStickyModeTransitionCountValidation(unittest.TestCase):
+    def test_rejects_non_integer_mode_counts(self):
+        invalid_counts = (
+            True,
+            np.bool_(True),
+            2.0,
+            2.5,
+            np.array([2]),
+            np.timedelta64(2, "ns"),
+        )
+
+        for n_modes in invalid_counts:
+            with self.subTest(n_modes=n_modes):
+                with self.assertRaisesRegex(
+                    ValueError, "n_modes must be a positive integer"
+                ):
+                    sticky_mode_transition_matrix(n_modes, stickiness=0.8)
+
+    def test_alias_uses_the_same_validation(self):
+        with self.assertRaisesRegex(ValueError, "n_modes must be a positive integer"):
+            mode_transition_matrix(False, stickiness=0.8)
+
+    def test_accepts_numpy_integer_scalar(self):
+        matrix = sticky_mode_transition_matrix(np.int64(2), stickiness=0.75)
+
+        np.testing.assert_allclose(
+            matrix,
+            np.array(
+                [
+                    [0.75, 0.25],
+                    [0.25, 0.75],
+                ]
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`sticky_mode_transition_matrix` accepted booleans as mode counts because `bool` is an integer subtype. For example, `sticky_mode_transition_matrix(True, 0.8)` silently returned a one-mode matrix. Other invalid count-like inputs, including fractional floats, non-scalar arrays, and NumPy temporal scalars, leaked backend-specific `TypeError` or ufunc exceptions instead of following a stable validation contract.

## Fix

- validate `n_modes` as a positive integral scalar before constructing the matrix
- explicitly reject booleans, non-scalar arrays, temporal dtypes, and fractional values
- preserve Python and NumPy integer scalar support
- apply the same validated function to the `mode_transition_matrix` compatibility alias

## Impact

Invalid mode counts now fail deterministically with `ValueError("n_modes must be a positive integer")` instead of silently changing model cardinality or exposing NumPy implementation errors. Valid transition matrices are unchanged.

## Validation

- reproduced the previous boolean acceptance and raw NumPy exceptions
- added focused regression coverage for both public aliases
- verified NumPy integer scalar compatibility
- syntax-compiled the modified wrapper and test
- focused local import harness: `3 passed, 6 subtests passed`