### PR TITLE
Reject temporal ROI histogram bin counts

### DIFF
--- a/src/pyrecest/utils/_roi_assignment_otsu.py
+++ b/src/pyrecest/utils/_roi_assignment_otsu.py
@@ -2,6 +2,28 @@
 
 from __future__ import annotations
 
+import numpy as np
+
+
+def _as_positive_nbins(roi_assignment_module, nbins) -> int:
+    """Reject temporal scalars before backend integer coercion loses their dtype."""
+
+    message = "nbins must be a positive integer."
+    try:
+        value_array = np.asarray(nbins)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(message) from exc
+
+    if value_array.shape == ():
+        scalar = value_array.item()
+        if value_array.dtype.kind in {"M", "m"} or isinstance(
+            scalar,
+            (np.datetime64, np.timedelta64),
+        ):
+            raise ValueError(message)
+
+    return roi_assignment_module._as_positive_integer(nbins, "nbins")
+
 
 def _patch_minimum_similarity_threshold(roi_assignment_module) -> None:
     """Validate histogram bin counts before minimum-threshold early returns."""
@@ -13,7 +35,7 @@ def _patch_minimum_similarity_threshold(roi_assignment_module) -> None:
     def minimum_similarity_threshold(similarities, *, nbins: int = 256) -> float:
         """Estimate a threshold by locating a valley between the two strongest modes."""
 
-        nbins = roi_assignment_module._as_positive_integer(nbins, "nbins")
+        nbins = _as_positive_nbins(roi_assignment_module, nbins)
         return original_minimum(similarities, nbins=nbins)
 
     minimum_similarity_threshold.__name__ = getattr(
@@ -39,7 +61,7 @@ def patch_otsu_similarity_threshold(roi_assignment_module) -> None:
     def otsu_similarity_threshold(similarities, *, nbins: int = 256) -> float:
         """Estimate a threshold using Otsu's method on one-dimensional similarities."""
 
-        nbins = roi_assignment_module._as_positive_integer(nbins, "nbins")
+        nbins = _as_positive_nbins(roi_assignment_module, nbins)
         values = roi_assignment_module.asarray(
             similarities,
             dtype=roi_assignment_module.float64,

--- a/tests/test_roi_assignment_integer_controls.py
+++ b/tests/test_roi_assignment_integer_controls.py
@@ -1,5 +1,7 @@
 import unittest
 
+import numpy as np
+
 # pylint: disable=no-name-in-module,no-member
 from pyrecest import backend
 from pyrecest.backend import array
@@ -13,9 +15,19 @@ from pyrecest.utils.roi_assignment import (
 class TestRoiAssignmentIntegerControls(unittest.TestCase):
     def test_thresholds_reject_invalid_nbins(self):
         scores = array([0.05, 0.08, 0.1, 0.81, 0.84, 0.9])
+        invalid_nbins = (
+            0,
+            -1,
+            1.5,
+            True,
+            [2],
+            np.timedelta64(2, "ns"),
+            np.timedelta64(2, "us"),
+            np.datetime64("1970-01-01T00:00:00.000000002", "ns"),
+        )
 
         for threshold_fn in (otsu_similarity_threshold, minimum_similarity_threshold):
-            for nbins in (0, -1, 1.5, True, [2]):
+            for nbins in invalid_nbins:
                 with self.subTest(threshold_fn=threshold_fn.__name__, nbins=nbins):
                     with self.assertRaisesRegex(ValueError, "nbins"):
                         threshold_fn(scores, nbins=nbins)


### PR DESCRIPTION
## What changed
- validate ROI histogram `nbins` values before backend integer coercion
- reject NumPy `datetime64` and `timedelta64` scalars that can otherwise become integer nanosecond counts
- add regression coverage for Otsu and minimum-similarity threshold helpers

## Root cause
For nanosecond-resolution temporal scalars, NumPy's scalar extraction returns a plain integer. The existing positive-integer validator therefore accepted values such as `np.timedelta64(2, "ns")` as `nbins=2`, despite the argument not being an integer count.

## Impact
Invalid temporal controls now fail with the documented `nbins must be a positive integer` error instead of silently changing histogram resolution.

## Validation
- targeted syntax compilation
- targeted validation of accepted integer-like values
- targeted regression checks for nanosecond/microsecond `timedelta64` and nanosecond `datetime64` inputs