### PR TITLE
Promote Gaussian mixture mean shifts

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/gaussian_mixture.py
+++ b/src/pyrecest/distributions/nonperiodic/gaussian_mixture.py
@@ -40,7 +40,7 @@ class GaussianMixture(LinearMixture, AbstractLinearDistribution):
         new_mixture = copy.deepcopy(self)
         mean_offset = new_mean - self.mean()
         for dist in new_mixture.dists:
-            dist.mu += mean_offset  # type: ignore
+            dist.mu = dist.mu + mean_offset  # type: ignore
         return new_mixture
 
     def to_gaussian(self, check_validity=True):

--- a/tests/distributions/test_gaussian_mixture_set_mean_validation.py
+++ b/tests/distributions/test_gaussian_mixture_set_mean_validation.py
@@ -22,6 +22,20 @@ class GaussianMixtureSetMeanValidationTest(unittest.TestCase):
         npt.assert_allclose(shifted.w, gmix.w)
         npt.assert_allclose(shifted.covariance(), gmix.covariance())
 
+    def test_set_mean_promotes_integer_component_means(self):
+        gm1 = GaussianDistribution(array([0]), array([[1.0]]))
+        gm2 = GaussianDistribution(array([2]), array([[3.0]]))
+        gmix = GaussianMixture([gm1, gm2], array([0.25, 0.75]))
+
+        shifted = gmix.set_mean([4.25])
+
+        npt.assert_allclose(shifted.mean(), array([4.25]))
+        npt.assert_allclose(shifted.dists[0].mu, array([2.75]))
+        npt.assert_allclose(shifted.dists[1].mu, array([4.75]))
+        npt.assert_allclose(gmix.dists[0].mu, array([0]))
+        npt.assert_allclose(gmix.dists[1].mu, array([2]))
+        npt.assert_allclose(shifted.covariance(), gmix.covariance())
+
     def test_set_mean_rejects_wrong_shape(self):
         gm1 = GaussianDistribution(array([0.0, 1.0]), diag(array([1.0, 2.0])))
         gm2 = GaussianDistribution(array([2.0, 3.0]), diag(array([3.0, 4.0])))

--- a/tests/distributions/test_gaussian_mixture_set_mean_validation.py
+++ b/tests/distributions/test_gaussian_mixture_set_mean_validation.py
@@ -34,7 +34,7 @@ class GaussianMixtureSetMeanValidationTest(unittest.TestCase):
         npt.assert_allclose(shifted.dists[1].mu, array([4.75]))
         npt.assert_allclose(gmix.dists[0].mu, array([0]))
         npt.assert_allclose(gmix.dists[1].mu, array([2]))
-        npt.assert_allclose(shifted.covariance(), gmix.covariance())
+        npt.assert_allclose(shifted.covariance(), array([[3.25]]))
 
     def test_set_mean_rejects_wrong_shape(self):
         gm1 = GaussianDistribution(array([0.0, 1.0]), diag(array([1.0, 2.0])))


### PR DESCRIPTION
## Summary
- replace the in-place component-mean shift with an out-of-place assignment so integer-valued means can be shifted by fractional offsets
- preserve the original mixture, weights, and covariance
- add focused regression coverage

## Root cause
`GaussianMixture.set_mean()` attempted to add a floating-point offset in place to component mean arrays. NumPy rejects that cast when the stored means have integer dtype, raising `UFuncTypeError` for a mathematically valid translation.

## Validation
- reproduced the original failure
- focused patched harness: 4 tests passed
- both modified files pass `python -m py_compile`
- branch is 2 commits ahead of `main`, 0 behind

This rebuilds the valid fix from closed, unmerged PR #4787 on the current `main` head. GitHub Actions provides the full backend matrix.