### PR TITLE
Promote mixed PyTorch multivariate-normal dtypes

### DIFF
--- a/src/pyrecest/_backend/pytorch/random/__init__.py
+++ b/src/pyrecest/_backend/pytorch/random/__init__.py
@@ -89,6 +89,30 @@ _LEGACY._validate_choice_probabilities = _validate_choice_probabilities
 _LEGACY._validate_multinomial_pvals = _validate_multinomial_pvals
 
 
+def _promoted_multivariate_normal_dtype(*values):
+    """Promote precision across all tensor-valued distribution parameters."""
+
+    torch = _LEGACY._torch
+    promoted_dtype = None
+    for value in values:
+        if not torch.is_tensor(value):
+            continue
+        value_dtype = value.dtype
+        if value_dtype.is_complex:
+            value_dtype = _LEGACY._COMPLEX_TO_FLOAT_DTYPE[value_dtype]
+        elif not value_dtype.is_floating_point:
+            continue
+        promoted_dtype = (
+            value_dtype
+            if promoted_dtype is None
+            else torch.promote_types(promoted_dtype, value_dtype)
+        )
+    return promoted_dtype or torch.get_default_dtype()
+
+
+_LEGACY._floating_distribution_dtype = _promoted_multivariate_normal_dtype
+
+
 def _validate_multivariate_normal_check_valid(check_valid):
     if not isinstance(check_valid, str) or check_valid not in {
         "warn",

--- a/tests/backend/test_pytorch_multivariate_normal_dtype.py
+++ b/tests/backend/test_pytorch_multivariate_normal_dtype.py
@@ -1,0 +1,23 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from pyrecest._backend.pytorch import random  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    ("mean_dtype", "cov_dtype"),
+    [
+        (torch.float32, torch.float64),
+        (torch.float64, torch.float32),
+    ],
+)
+def test_multivariate_normal_promotes_mixed_tensor_precision(mean_dtype, cov_dtype):
+    random.seed(0)
+    mean = torch.tensor([0.0, 0.0], dtype=mean_dtype)
+    covariance = torch.eye(2, dtype=cov_dtype)
+
+    samples = random.multivariate_normal(mean, covariance, size=(4,))
+
+    assert samples.dtype == torch.float64
+    assert samples.shape == (4, 2)


### PR DESCRIPTION
## Summary
- promote floating precision across all tensor-valued `mean` and `cov` inputs in the PyTorch random backend
- prevent a `float64` covariance from being silently narrowed when paired with a `float32` mean
- add regression coverage for both mixed-dtype argument orders

## Root cause
The legacy PyTorch helper returned the dtype of the first floating tensor it encountered. Consequently, `multivariate_normal(float32_mean, float64_covariance)` selected `float32` and cast the covariance down before constructing `torch.distributions.MultivariateNormal`.

## Impact
Mixed-precision callers now receive samples in the promoted tensor dtype, independent of whether the higher-precision tensor is the mean or covariance. Existing single-dtype and array-like behavior remains unchanged.

## Validation
- reproduced the current silent downcast with the installed PyTorch runtime
- exercised the replacement promotion helper for `float16`/`float32` and both `float32`/`float64` argument orders
- syntax-compiled the modified compatibility shim and regression test
- branch diff is limited to 24 added production lines and one focused test file

Full repository tests could not be run locally because this runtime cannot clone GitHub repositories; GitHub Actions should run the project matrix on this PR.