### PR TITLE
Reject temporal values in protocol dimension checks

### DIFF
--- a/src/pyrecest/protocols/testing.py
+++ b/src/pyrecest/protocols/testing.py
@@ -6,6 +6,8 @@ from collections.abc import Callable, Iterable
 from numbers import Integral
 from typing import Any, TypeVar, cast
 
+import numpy as np
+
 from .common import SupportsDim, SupportsInputDim
 
 T = TypeVar("T")
@@ -41,7 +43,13 @@ def _shape_of(value: object, value_name: str) -> tuple[int, ...]:
 
 
 def _nonnegative_integer(value: object, value_name: str) -> int:
-    if isinstance(value, bool) or not isinstance(value, Integral):
+    dtype = getattr(value, "dtype", None)
+    if (
+        isinstance(value, bool)
+        or getattr(dtype, "kind", None) in {"M", "m"}
+        or isinstance(value, (np.datetime64, np.timedelta64))
+        or not isinstance(value, Integral)
+    ):
         raise ProtocolAssertionError(f"{value_name} must be an integer.")
     int_value = int(value)
     if int_value < 0:

--- a/tests/protocols/test_protocol_testing_temporal_dimensions.py
+++ b/tests/protocols/test_protocol_testing_temporal_dimensions.py
@@ -1,0 +1,79 @@
+"""Regression tests for temporal values used as protocol dimensions."""
+
+import numpy as np
+import pytest
+from pyrecest.protocols.testing import (
+    ProtocolAssertionError,
+    assert_shape,
+    assert_supports_dim,
+    assert_supports_input_dim,
+    assert_supports_sampling,
+    assert_supports_transition_sampling,
+    assert_trailing_dimension,
+)
+
+
+class _ArrayLike:
+    def __init__(self, shape):
+        self.shape = shape
+
+
+class _DimensionObject:
+    dim = np.timedelta64(2, "ns")
+    input_dim = np.datetime64("1970-01-01T00:00:00.000000003", "ns")
+
+
+class _Distribution:
+    def sample(self, n):
+        return _ArrayLike((n,))
+
+
+class _TransitionModel:
+    def sample_next(self, state, n=1):
+        return _ArrayLike((n, len(state)))
+
+
+_TEMPORAL_VALUES = (
+    np.timedelta64(2, "ns"),
+    np.timedelta64(2, "us"),
+    np.datetime64("1970-01-01T00:00:00.000000002", "ns"),
+)
+
+
+@pytest.mark.parametrize("temporal_value", _TEMPORAL_VALUES)
+def test_shape_helpers_reject_temporal_dimensions(temporal_value):
+    with pytest.raises(ProtocolAssertionError, match="must be an integer"):
+        assert_shape(_ArrayLike((temporal_value,)), (2,))
+
+    with pytest.raises(ProtocolAssertionError, match="must be an integer"):
+        assert_shape(_ArrayLike((2,)), (temporal_value,))
+
+    with pytest.raises(ProtocolAssertionError, match="must be an integer"):
+        assert_trailing_dimension(_ArrayLike((2,)), temporal_value)
+
+
+@pytest.mark.parametrize("temporal_value", _TEMPORAL_VALUES)
+def test_sampling_helpers_reject_temporal_counts(temporal_value):
+    with pytest.raises(ProtocolAssertionError, match="n must be an integer"):
+        assert_supports_sampling(_Distribution(), temporal_value)
+
+    with pytest.raises(ProtocolAssertionError, match="n must be an integer"):
+        assert_supports_transition_sampling(_TransitionModel(), (0.0,), temporal_value)
+
+
+def test_dimension_protocol_helpers_reject_temporal_attributes():
+    obj = _DimensionObject()
+
+    with pytest.raises(ProtocolAssertionError, match="dim must be an integer"):
+        assert_supports_dim(obj)
+
+    with pytest.raises(ProtocolAssertionError, match="input_dim must be an integer"):
+        assert_supports_input_dim(obj)
+
+
+def test_numpy_integer_dimensions_remain_supported():
+    assert assert_shape(_ArrayLike((np.int64(2),)), (2,)) == (2,)
+    assert assert_trailing_dimension(_ArrayLike((2, np.int64(3))), np.int64(3)) == (
+        2,
+        3,
+    )


### PR DESCRIPTION
## Bug

The reusable protocol-testing helpers accepted NumPy temporal scalars as dimensions and sample counts because nanosecond `numpy.timedelta64` values satisfy `numbers.Integral` and convert to plain integers. As a result, durations or timestamps could silently pass `assert_shape`, `assert_trailing_dimension`, `assert_supports_dim`, `assert_supports_input_dim`, and the sampling-contract helpers. Coarser temporal units could fail differently during integer conversion.

## Fix

- reject NumPy `datetime64` and `timedelta64` scalars before generic integral validation
- inspect scalar dtype metadata so temporal zero-dimensional values are rejected consistently
- preserve Python and NumPy integer dimensions
- add focused regression coverage for shape, dimension, and sampling helpers

## Impact

Protocol assertions now report the stable `ProtocolAssertionError(... must be an integer)` contract instead of silently interpreting temporal payloads as dimensions or leaking unit-dependent conversion errors.

## Validation

- regression coverage includes nanosecond and microsecond timedeltas and nanosecond datetimes
- preservation checks cover NumPy integer dimensions
- changes are limited to the protocol-testing helper and one focused test module

GitHub Actions should run the full project matrix.