### PR TITLE
Reject temporal PyTorch multivariate-normal tolerances

### DIFF
--- a/src/pyrecest/_backend/pytorch/random/__init__.py
+++ b/src/pyrecest/_backend/pytorch/random/__init__.py
@@ -105,7 +105,11 @@ def _validate_multivariate_normal_tol(tol):
         tol_array = _np.asarray(tol)
     except (TypeError, ValueError) as exc:
         raise ValueError(message) from exc
-    if tol_array.shape != () or _np.issubdtype(tol_array.dtype, _np.bool_):
+    if (
+        tol_array.shape != ()
+        or tol_array.dtype.kind in "Mm"
+        or _np.issubdtype(tol_array.dtype, _np.bool_)
+    ):
         raise ValueError(message)
     scalar = tol_array.item()
     if isinstance(scalar, (bool, _np.bool_, str, bytes, _np.str_, _np.bytes_)):

--- a/tests/backend/test_pytorch_random_multivariate_normal_keywords.py
+++ b/tests/backend/test_pytorch_random_multivariate_normal_keywords.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+
 torch = pytest.importorskip("torch")
 from pyrecest._backend.pytorch import random  # noqa: E402
 
@@ -34,7 +35,18 @@ def test_multivariate_normal_rejects_invalid_check_valid_keyword(bad_check_valid
 
 @pytest.mark.parametrize(
     "bad_tol",
-    [-1.0, np.nan, np.inf, True, [1e-8], "1e-8"],
+    [
+        -1.0,
+        np.nan,
+        np.inf,
+        True,
+        [1e-8],
+        "1e-8",
+        np.timedelta64(2, "ns"),
+        np.timedelta64(2, "us"),
+        np.datetime64("1970-01-01T00:00:00.000000002"),
+        np.array(np.timedelta64(2, "ns")),
+    ],
 )
 def test_multivariate_normal_rejects_invalid_tol_keyword(bad_tol):
     with pytest.raises(ValueError, match="tol"):


### PR DESCRIPTION
## Bug

The PyTorch random-backend compatibility shim converted `tol` through a zero-dimensional NumPy scalar before rejecting invalid types. Nanosecond `numpy.timedelta64` and `numpy.datetime64` values therefore became plain integers and were silently accepted as tolerances. Coarser temporal units failed later with an unrelated `TypeError`, making validation unit-dependent.

## Fix

- reject NumPy temporal dtypes before scalar extraction
- preserve finite non-negative numeric scalar tolerances
- add regression coverage for nanosecond and microsecond timedeltas, nanosecond datetimes, and zero-dimensional temporal arrays

## Impact

`random.multivariate_normal(..., tol=...)` now consistently raises the documented `ValueError("tol must be a finite non-negative scalar")` for temporal inputs instead of interpreting timestamps or durations as numeric tolerances.

## Validation

- `python -m py_compile` for both modified files
- targeted validator checks for accepted numeric tolerances and rejected temporal scalars
- branch is 2 commits ahead of current `main` and 0 behind

GitHub Actions should run the full backend matrix.