### PR TITLE
Reject temporal Gaussian marginal indices

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/__init__.py
+++ b/src/pyrecest/distributions/nonperiodic/__init__.py
@@ -1,0 +1,7 @@
+"""Nonperiodic distribution implementations."""
+
+from ._gaussian_marginal_temporal_patch import (
+    patch_gaussian_marginal_temporal_indices,
+)
+
+patch_gaussian_marginal_temporal_indices()

--- a/src/pyrecest/distributions/nonperiodic/_gaussian_marginal_temporal_patch.py
+++ b/src/pyrecest/distributions/nonperiodic/_gaussian_marginal_temporal_patch.py
@@ -1,0 +1,31 @@
+"""Compatibility fix for temporal Gaussian marginal indices."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def patch_gaussian_marginal_temporal_indices() -> None:
+    """Reject NumPy temporal scalars before integer-index coercion."""
+
+    from .gaussian_distribution import GaussianDistribution
+
+    original = GaussianDistribution.marginalize_out
+    if getattr(original, "_rejects_temporal_indices", False):
+        return
+
+    def marginalize_out(self, dimensions):
+        candidates = [dimensions] if np.ndim(dimensions) == 0 else dimensions
+        try:
+            temporal = any(np.asarray(dim).dtype.kind in {"M", "m"} for dim in candidates)
+        except (TypeError, ValueError):
+            temporal = False
+        if temporal:
+            raise ValueError(
+                "dimensions must contain valid zero-based integer indices; "
+                f"got {dimensions}."
+            )
+        return original(self, dimensions)
+
+    marginalize_out._rejects_temporal_indices = True
+    GaussianDistribution.marginalize_out = marginalize_out

--- a/src/pyrecest/distributions/nonperiodic/_gaussian_marginal_temporal_patch.py
+++ b/src/pyrecest/distributions/nonperiodic/_gaussian_marginal_temporal_patch.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from numbers import Integral
+
 import numpy as np
 
 
@@ -15,17 +17,26 @@ def patch_gaussian_marginal_temporal_indices() -> None:
         return
 
     def marginalize_out(self, dimensions):
-        candidates = [dimensions] if np.ndim(dimensions) == 0 else dimensions
-        try:
-            temporal = any(np.asarray(dim).dtype.kind in {"M", "m"} for dim in candidates)
-        except (TypeError, ValueError):
-            temporal = False
-        if temporal:
+        if isinstance(dimensions, (np.datetime64, np.timedelta64)):
+            candidates = [dimensions]
+            normalized_dimensions = dimensions
+        elif isinstance(dimensions, Integral):
+            candidates = [dimensions]
+            normalized_dimensions = dimensions
+        else:
+            normalized_dimensions = list(dimensions)
+            candidates = normalized_dimensions
+
+        if any(
+            isinstance(dim, (np.datetime64, np.timedelta64))
+            or getattr(getattr(dim, "dtype", None), "kind", None) in {"M", "m"}
+            for dim in candidates
+        ):
             raise ValueError(
                 "dimensions must contain valid zero-based integer indices; "
                 f"got {dimensions}."
             )
-        return original(self, dimensions)
+        return original(self, normalized_dimensions)
 
     marginalize_out._rejects_temporal_indices = True
     GaussianDistribution.marginalize_out = marginalize_out

--- a/tests/distributions/test_gaussian_marginalize_out_validation.py
+++ b/tests/distributions/test_gaussian_marginalize_out_validation.py
@@ -1,5 +1,7 @@
 import unittest
 
+import numpy as np
+
 from pyrecest.backend import array
 from pyrecest.distributions import GaussianDistribution
 
@@ -18,6 +20,23 @@ class GaussianMarginalizeOutValidationTest(unittest.TestCase):
     def test_rejects_empty_marginal(self):
         with self.assertRaisesRegex(ValueError, "leave at least one dimension"):
             self.distribution.marginalize_out([0, 1])
+
+    def test_rejects_temporal_dimensions(self):
+        temporal_dimensions = (
+            np.timedelta64(0, "ns"),
+            np.timedelta64(0, "us"),
+            np.datetime64("1970-01-01T00:00:00.000000000", "ns"),
+            [np.timedelta64(0, "ns")],
+        )
+
+        for dimensions in temporal_dimensions:
+            with self.subTest(dimensions=dimensions):
+                with self.assertRaisesRegex(ValueError, "integer indices"):
+                    self.distribution.marginalize_out(dimensions)
+
+    def test_preserves_numpy_integer_dimensions(self):
+        marginal = self.distribution.marginalize_out(np.int64(0))
+        self.assertEqual(marginal.dim, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Bug

`GaussianDistribution.marginalize_out` accepts nanosecond `numpy.timedelta64` scalars as dimension indices because NumPy classifies those values as `numbers.Integral` and `int(...)` returns the encoded duration. Other temporal units fail differently during conversion, so validation depends on the temporal unit.

## Fix

- reject NumPy `datetime64` and `timedelta64` scalar indices before integer coercion
- cover scalar, list-wrapped, and multiple temporal units
- preserve Python and NumPy integer indices
- preserve generator/iterable behavior by normalizing non-scalar inputs once

## Impact

Temporal values now consistently raise the existing `ValueError` contract instead of silently selecting a Gaussian state dimension or leaking a unit-dependent `TypeError`.

## Validation

- reproduced that `np.timedelta64(0, "ns")` is an `Integral` and converts to integer zero
- added focused regression tests for nanosecond/microsecond timedeltas, datetime values, list-wrapped temporal indices, and `np.int64`
- branch is based on the current `main` and contains only the compatibility patch, activation import, and focused tests

GitHub Actions should run the full backend matrix.