### PR TITLE
Reject temporal measurement counts

### DIFF
--- a/src/pyrecest/filters/measurement_reliability.py
+++ b/src/pyrecest/filters/measurement_reliability.py
@@ -34,11 +34,15 @@ def _normalize_integer_count(
         value_array = np.asarray(value)
     except (TypeError, ValueError) as exc:
         raise ValueError(message) from exc
-    if value_array.shape != () or value_array.dtype == np.bool_:
+    if (
+        value_array.shape != ()
+        or value_array.dtype == np.bool_
+        or value_array.dtype.kind in "Mm"
+    ):
         raise ValueError(message)
 
     scalar = value_array.item()
-    if isinstance(scalar, (bool, np.bool_)):
+    if isinstance(scalar, (bool, np.bool_, np.datetime64, np.timedelta64)):
         raise ValueError(message)
     if isinstance(scalar, (int, np.integer)):
         parsed = int(scalar)

--- a/tests/filters/test_measurement_reliability_temporal_counts.py
+++ b/tests/filters/test_measurement_reliability_temporal_counts.py
@@ -1,0 +1,52 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.filters import (
+    normalize_active_measurement_mask,
+    normalize_measurement_noise_covariances,
+    normalize_measurement_weights,
+)
+
+
+class TestMeasurementReliabilityTemporalCounts(unittest.TestCase):
+    def test_measurement_count_rejects_temporal_scalars(self):
+        invalid_counts = (
+            np.timedelta64(2, "ns"),
+            np.datetime64(2, "ns"),
+            np.array(np.timedelta64(2, "ns"), dtype=object),
+            np.array(np.datetime64(2, "ns"), dtype=object),
+        )
+
+        for value in invalid_counts:
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(ValueError, "non-negative integer"):
+                    normalize_measurement_weights(None, value)
+                with self.assertRaisesRegex(ValueError, "non-negative integer"):
+                    normalize_active_measurement_mask(None, value)
+
+    def test_measurement_dimension_rejects_temporal_scalars(self):
+        invalid_dimensions = (
+            np.timedelta64(1, "ns"),
+            np.datetime64(1, "ns"),
+            np.array(np.timedelta64(1, "ns"), dtype=object),
+            np.array(np.datetime64(1, "ns"), dtype=object),
+        )
+
+        for value in invalid_dimensions:
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(ValueError, "positive integer"):
+                    normalize_measurement_noise_covariances(
+                        1.0,
+                        1,
+                        value,
+                        as_covariance_matrix=lambda *_args: None,
+                    )
+
+    def test_numpy_integer_counts_remain_supported(self):
+        weights = normalize_measurement_weights(None, np.int64(2))
+        self.assertEqual(weights.shape, (2,))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

The measurement-reliability count validator converted NumPy scalar values with `.item()` before excluding temporal dtypes. At nanosecond resolution, `numpy.timedelta64` and `numpy.datetime64` values become plain integers, so durations and timestamps could be silently accepted as `n_measurements` or `measurement_dim`. Object-wrapped temporal scalars could follow the same path.

This made validation unit-dependent: nanosecond temporal values could allocate arrays or determine covariance dimensions, while coarser units failed differently.

## Fix

- reject NumPy datetime and timedelta dtypes before scalar extraction
- reject object-wrapped NumPy temporal scalars after extraction
- preserve supported Python and NumPy integer counts
- add focused regression coverage for measurement counts and dimensions

## Impact

Measurement reliability helpers now consistently raise their documented integer-validation errors for temporal inputs instead of interpreting timestamps or durations as counts.

## Validation

- isolated validator regression checks for datetime, timedelta, object-wrapped temporal scalars, booleans, fractional values, and valid NumPy integers
- branch is 2 commits ahead of current `main` and 0 behind

GitHub Actions should run the full project and backend matrix.