### PR TITLE
Protect reserved cost-adjustment diagnostics key

### DIFF
--- a/src/pyrecest/utils/cost_matrix_adjustments.py
+++ b/src/pyrecest/utils/cost_matrix_adjustments.py
@@ -150,7 +150,7 @@ def compose_cost_matrix_adjustments(
 
     matrix = _as_cost_matrix(cost_matrix)
     diagnostics: dict[str, Any] = {"adjustment_order": []}
-    diagnostic_keys: set[str] = set()
+    diagnostic_keys: set[str] = set(diagnostics)
     current = matrix
     for index, adjustment in enumerate(adjustments):
         base_name = _adjustment_name(adjustment, index=index)

--- a/tests/test_cost_matrix_adjustments.py
+++ b/tests/test_cost_matrix_adjustments.py
@@ -113,6 +113,35 @@ class TestCostMatrixAdjustments(unittest.TestCase):
         self.assertEqual(result.diagnostics["shared"], {"step": 1})
         self.assertEqual(result.diagnostics["shared_2"], {"step": 2})
 
+    def test_compose_adjustments_protects_reserved_order_diagnostics_key(self):
+        reserved_name = CallableCostMatrixAdjustment(
+            name="adjustment_order",
+            function=lambda matrix, _metadata: CostMatrixAdjustmentResult(
+                matrix + 1.0,
+                {"step": 1},
+            ),
+        )
+        following = CallableCostMatrixAdjustment(
+            name="following",
+            function=lambda matrix, _metadata: CostMatrixAdjustmentResult(
+                matrix + 2.0,
+                {"step": 2},
+            ),
+        )
+
+        result = compose_cost_matrix_adjustments(
+            np.array([[0.0]]),
+            [reserved_name, following],
+        )
+
+        npt.assert_allclose(result.adjusted_cost_matrix, np.array([[3.0]]))
+        self.assertEqual(
+            result.diagnostics["adjustment_order"],
+            ["adjustment_order_2", "following"],
+        )
+        self.assertEqual(result.diagnostics["adjustment_order_2"], {"step": 1})
+        self.assertEqual(result.diagnostics["following"], {"step": 2})
+
     def test_additive_adjustment_rejects_shape_mismatch(self):
         adjustment = additive_cost_matrix_adjustment(np.ones((2, 2)))
 


### PR DESCRIPTION
## Bug

`compose_cost_matrix_adjustments()` reserves `diagnostics["adjustment_order"]` for the ordered list of applied adjustments, but its collision tracker started empty. An adjustment whose name was exactly `adjustment_order` therefore overwrote that list with its own diagnostics. A following adjustment then failed with `AttributeError: 'dict' object has no attribute 'append'`; with only one adjustment, the execution-order diagnostics were silently lost.

## Fix

- seed the diagnostics-name collision set from the reserved keys already present in the result mapping
- disambiguate a user adjustment named `adjustment_order` to `adjustment_order_2`, using the existing stable suffixing behavior
- add a regression covering a reserved-name adjustment followed by a second adjustment

## Impact

Composed cost adjustments can no longer corrupt their diagnostics namespace or crash solely because a caller-selected adjustment name collides with the reserved order key. Existing names and duplicate-name behavior are unchanged.

## Validation

- reproduced the pre-fix `AttributeError` with `adjustment_order` followed by another adjustment
- verified the corrected diagnostics are `['adjustment_order_2', 'following']`
- verified the adjusted matrix remains `[[3.0]]` and both per-adjustment diagnostic mappings are retained
- branch is 2 commits ahead of current `main` and 0 behind
- diff is limited to one production-line change and one focused regression test

GitHub Actions should run the full project matrix.