### PR TITLE
Reject temporal linear-Gaussian dimensions

### DIFF
--- a/src/pyrecest/models/linear_gaussian.py
+++ b/src/pyrecest/models/linear_gaussian.py
@@ -28,6 +28,11 @@ def _has_boolean_dtype(value):
     return dtype is not None and str(dtype).lower() in {"bool", "bool_", "torch.bool"}
 
 
+def _has_temporal_dtype(value):
+    dtype = getattr(value, "dtype", None)
+    return getattr(dtype, "kind", None) in {"M", "m"}
+
+
 def _has_complex_dtype(value):
     dtype = getattr(value, "dtype", None)
     return dtype is not None and "complex" in str(dtype).lower()
@@ -106,7 +111,7 @@ def _as_positive_integer(value, name):
         arr = asarray(value)
     except (TypeError, ValueError, OverflowError, RuntimeError) as exc:
         raise ValueError(message) from exc
-    if ndim(arr) != 0 or _has_boolean_dtype(arr):
+    if ndim(arr) != 0 or _has_boolean_dtype(arr) or _has_temporal_dtype(arr):
         raise ValueError(message)
     try:
         scalar = arr.item()

--- a/tests/models/test_linear_gaussian_temporal_dimensions.py
+++ b/tests/models/test_linear_gaussian_temporal_dimensions.py
@@ -1,0 +1,38 @@
+import unittest
+
+import numpy as np
+import pyrecest.backend
+from pyrecest.models.linear_gaussian import (
+    IdentityGaussianMeasurementModel,
+    IdentityGaussianTransitionModel,
+)
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ != "numpy",
+    reason="NumPy temporal scalar regression coverage is backend-specific",
+)
+class LinearGaussianTemporalDimensionTest(unittest.TestCase):
+    def test_identity_models_reject_temporal_dimensions(self):
+        temporal_dimensions = (
+            np.timedelta64(2, "ns"),
+            np.timedelta64(2, "us"),
+            np.datetime64("1970-01-01T00:00:00.000000002", "ns"),
+            np.asarray(np.timedelta64(2, "ns")),
+        )
+
+        for model_class in (
+            IdentityGaussianTransitionModel,
+            IdentityGaussianMeasurementModel,
+        ):
+            for dimension in temporal_dimensions:
+                with self.subTest(model=model_class.__name__, dimension=dimension):
+                    with self.assertRaisesRegex(
+                        ValueError,
+                        "dim must be a positive integer",
+                    ):
+                        model_class(dimension, noise_cov=1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

The positive-integer validator used by `IdentityGaussianTransitionModel` and `IdentityGaussianMeasurementModel` extracted zero-dimensional array values before checking their semantic dtype. With NumPy, nanosecond `datetime64` and `timedelta64` scalars become plain Python integers when `.item()` is called, so timestamps and durations such as `numpy.timedelta64(2, "ns")` were silently accepted as dimension `2`. Coarser temporal units failed instead, making validation unit-dependent.

## Fix

- detect NumPy temporal dtypes before scalar extraction
- reject temporal dimensions with the existing stable `ValueError("dim must be a positive integer")` contract
- preserve Python, NumPy, and zero-dimensional integer inputs
- add constructor-level regression coverage for transition and measurement identity models

## Impact

Identity linear-Gaussian models can no longer accidentally interpret timestamps or durations as state or measurement dimensions.

## Validation

- targeted constructor harness covering nanosecond and microsecond timedeltas, nanosecond datetimes, and zero-dimensional temporal arrays
- preservation checks for Python, NumPy, and zero-dimensional integer dimensions
- `python -m py_compile` for both changed files
- branch is 2 commits ahead of current `main` and 0 behind

GitHub Actions should run the full project matrix.