### PR TITLE
Reject temporal complex ACG sample counts

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/complex_angular_central_gaussian_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/complex_angular_central_gaussian_distribution.py
@@ -38,10 +38,14 @@ def _validate_positive_sample_count(n) -> int:
     count_array = np.asarray(n)
     if count_array.ndim != 0:
         raise ValueError("n must be a scalar integer")
+    if count_array.dtype.kind in "Mm":
+        raise ValueError("n must be an integer")
 
     count = count_array.item()
     if isinstance(count, (bool, np.bool_)):
         raise ValueError("n must be an integer, not a boolean")
+    if isinstance(count, (np.datetime64, np.timedelta64)):
+        raise ValueError("n must be an integer")
 
     try:
         count_int = int(count)

--- a/tests/distributions/test_complex_acg_sample_count_precision.py
+++ b/tests/distributions/test_complex_acg_sample_count_precision.py
@@ -1,6 +1,8 @@
 import unittest
 from fractions import Fraction
 
+import numpy as np
+
 from pyrecest.distributions.hypersphere_subset.complex_angular_central_gaussian_distribution import (
     _validate_positive_sample_count,
 )
@@ -21,6 +23,20 @@ class TestComplexAngularCentralGaussianSampleCountPrecision(unittest.TestCase):
             _validate_positive_sample_count(exact_integer),
             2**53 + 1,
         )
+
+    def test_rejects_temporal_sample_counts(self):
+        temporal_counts = (
+            np.timedelta64(2, "ns"),
+            np.timedelta64(2, "us"),
+            np.datetime64("1970-01-01T00:00:00.000000002", "ns"),
+            np.asarray(np.timedelta64(2, "ns")),
+            np.array(np.timedelta64(2, "ns"), dtype=object),
+        )
+
+        for count in temporal_counts:
+            with self.subTest(count=count):
+                with self.assertRaisesRegex(ValueError, "integer"):
+                    _validate_positive_sample_count(count)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Bug

`ComplexAngularCentralGaussianDistribution.sample()` normalizes its `n` argument by first calling `numpy.asarray(...).item()`. At nanosecond resolution, NumPy `datetime64` and `timedelta64` scalars become plain Python integers, so timestamps and durations such as `numpy.timedelta64(2, "ns")` were silently interpreted as a request for two samples. Coarser temporal units failed through a different exception path, making validation unit-dependent.

## Fix

- reject native NumPy temporal dtypes before scalar extraction
- reject object-wrapped NumPy datetime and timedelta scalars after extraction
- preserve existing support for exact integer-like scalar counts
- add focused regression coverage for datetime, timedelta, zero-dimensional, and object-wrapped temporal values

## Impact

The complex angular central Gaussian sampler can no longer interpret timestamps or durations as sample counts and now reports the existing integer-validation contract consistently.

## Validation

- reproduced the pre-fix behavior: nanosecond datetime/timedelta values normalize to integer `2`, while microsecond timedelta values fail differently
- compiled both modified Python modules in an isolated syntax harness
- verified the branch is 2 commits ahead of current `main` and 0 behind
- diff is limited to 4 production lines and 16 test lines

GitHub Actions should run the full backend matrix.