### PR TITLE
Fix diagnostics metadata mapping round trips

### DIFF
--- a/src/pyrecest/diagnostics.py
+++ b/src/pyrecest/diagnostics.py
@@ -190,27 +190,39 @@ class _DiagnosticsMappingMixin:
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)  # type: ignore[arg-type]
 
+    def _mapping_values(self) -> dict[str, Any]:
+        values = self.to_dict()
+        metadata = values.get("metadata")
+        if isinstance(metadata, Mapping):
+            for key, value in metadata.items():
+                values.setdefault(key, value)
+        return values
+
     def __contains__(self, key: str) -> bool:
-        return key in self.to_dict()
+        return key in self._mapping_values()
 
     def __getitem__(self, key: str) -> Any:
         try:
-            return self.to_dict()[key]
+            return self._mapping_values()[key]
         except KeyError as exc:
             raise KeyError(key) from exc
 
     def __setitem__(self, key: str, value: Any) -> None:
-        if hasattr(self, key):
+        field_names = {
+            dataclass_field.name
+            for dataclass_field in fields(self)  # type: ignore[arg-type]
+        }
+        if key in field_names:
             setattr(self, key, value)
             return
         metadata = getattr(self, "metadata")
         metadata[key] = value
 
     def get(self, key: str, default: Any = None) -> Any:
-        return self.to_dict().get(key, default)
+        return self._mapping_values().get(key, default)
 
     def items(self) -> Any:
-        return self.to_dict().items()
+        return self._mapping_values().items()
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -19,6 +19,26 @@ def test_diagnostics_are_dict_serializable_containers():
     assert association_diag.to_dict()["selected_assignments"] == [(0, 1)]
 
 
+def test_diagnostics_mapping_exposes_metadata_entries():
+    diagnostics = FilterDiagnostics.from_mapping({"nis": 1.5, "custom_score": 7.0})
+
+    assert diagnostics["custom_score"] == 7.0
+    assert diagnostics.get("custom_score") == 7.0
+    assert "custom_score" in diagnostics
+    assert dict(diagnostics.items())["custom_score"] == 7.0
+    assert diagnostics.to_dict()["metadata"] == {"custom_score": 7.0}
+
+
+def test_diagnostics_mapping_stores_method_name_keys_in_metadata():
+    diagnostics = FilterDiagnostics()
+
+    diagnostics["items"] = "custom-value"
+
+    assert diagnostics["items"] == "custom-value"
+    assert diagnostics.metadata == {"items": "custom-value"}
+    assert callable(diagnostics.items)
+
+
 def test_particle_diagnostics_clips_negative_weights_before_normalizing():
     diagnostics = ParticleDiagnostics.from_weights([2.0, -1.0, 2.0])
 


### PR DESCRIPTION
## Bug

`_DiagnosticsMappingMixin` stored unknown diagnostics keys in `metadata`, but mapping reads only consulted top-level dataclass fields. Consequently, values introduced by `FilterDiagnostics.from_mapping({"custom": ...})` or `diagnostics["custom"] = ...` could not be read back through subscription, `get`, containment, or `items`.

`__setitem__` also used `hasattr`, so a legitimate custom key that collided with a method or property name—such as `"items"`—attempted attribute assignment instead of being stored in metadata.

## Fix

- expose metadata entries through the legacy mapping-compatible read view
- preserve canonical dataclass fields when metadata contains a colliding key
- keep `to_dict()` canonical, with metadata nested under `metadata`
- detect actual dataclass fields for writes, routing method/property-name keys to metadata
- add focused regressions for metadata round trips and method-name collisions

## Validation

- focused behavioral smoke test for metadata read/write, field precedence, and method-name collisions
- Python syntax compilation of the focused implementation
- repository CI pending