### PR TITLE
Handle exhausted Murty assignment subproblems

### DIFF
--- a/src/pyrecest/utils/assignment.py
+++ b/src/pyrecest/utils/assignment.py
@@ -262,7 +262,8 @@ def _get_large_cost(cost_matrix, row_non_assignment_costs, col_non_assignment_co
             col_non_assignment_costs.reshape(-1),
         )
     )
-    return 2.0 * (float(_sum(_abs(finite_entries))) + 1.0)
+    with _np.errstate(over="ignore"):
+        return 2.0 * (float(_sum(_abs(finite_entries))) + 1.0)
 
 
 def _build_augmented_cost_matrix(
@@ -327,7 +328,12 @@ def _solve_subproblem(  # pylint: disable=too-many-locals
             row_index, col_index
         ]
 
-    row_ind, col_ind = linear_sum_assignment(_to_numpy(modified_cost_matrix))
+    try:
+        row_ind, col_ind = linear_sum_assignment(_to_numpy(modified_cost_matrix))
+    except ValueError as exc:
+        if "infeasible" in str(exc).lower():
+            return None
+        raise
     chosen_costs = modified_cost_matrix[row_ind, col_ind]
     if _any(chosen_costs >= large_cost / 2.0):
         return None
@@ -431,6 +437,8 @@ def murty_k_best_assignments(  # pylint: disable=too-many-locals
                 "cost": solution["cost"],
             }
         )
+        if len(ranked_solutions) >= k:
+            break
 
         forced_prefix = list(subproblem.forced_pairs)
         for row_index in range(subproblem.branching_row_start, n_rows):

--- a/tests/utils/test_assignment_extreme_costs.py
+++ b/tests/utils/test_assignment_extreme_costs.py
@@ -1,0 +1,40 @@
+import unittest
+import warnings
+
+import numpy as np
+import numpy.testing as npt
+import pyrecest.backend
+from pyrecest.utils import murty_k_best_assignments
+
+
+class MurtyExtremeCostTest(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",  # pylint: disable=no-member
+        reason="Not supported on the JAX backend",
+    )
+    def test_returns_all_available_solutions_when_large_cost_overflows(self):
+        cost_matrix = np.array([[1.0e308]])
+
+        for requested_solutions in (2, 3):
+            with self.subTest(requested_solutions=requested_solutions):
+                with warnings.catch_warnings():
+                    warnings.simplefilter("error", RuntimeWarning)
+                    solutions = murty_k_best_assignments(
+                        cost_matrix,
+                        k=requested_solutions,
+                    )
+
+                self.assertEqual(len(solutions), 2)
+                npt.assert_array_equal(solutions[0]["assignment"], np.array([-1]))
+                npt.assert_array_equal(solutions[0]["unassigned_rows"], np.array([0]))
+                npt.assert_array_equal(solutions[0]["unassigned_cols"], np.array([0]))
+                self.assertEqual(solutions[0]["cost"], 0.0)
+
+                npt.assert_array_equal(solutions[1]["assignment"], np.array([0]))
+                npt.assert_array_equal(
+                    solutions[1]["unassigned_rows"], np.array([], dtype=int)
+                )
+                npt.assert_array_equal(
+                    solutions[1]["unassigned_cols"], np.array([], dtype=int)
+                )
+                self.assertEqual(solutions[1]["cost"], 1.0e308)


### PR DESCRIPTION
## Bug

`murty_k_best_assignments()` can fail after it has already found every valid partial assignment when the internal forbidden-cost sentinel overflows to positive infinity. In that case, an exhausted Murty child subproblem is passed to SciPy as an infeasible matrix, and `linear_sum_assignment()` raises `ValueError("cost matrix is infeasible")` instead of allowing the enumeration to terminate normally.

A one-by-one matrix containing the finite cost `1e308` reproduces this: there are exactly two partial assignments (leave the row/column unmatched, or match them), but requesting two or more solutions raises instead of returning those assignments.

## Fix

- treat SciPy's infeasible-assignment result as an exhausted Murty subproblem
- stop branching once the requested number of ranked solutions has been collected
- suppress the expected overflow warning when the safe forbidden-cost sentinel intentionally becomes positive infinity
- add regression coverage for requesting exactly and more than the number of available solutions

## Impact

Murty enumeration now returns the valid solutions it found for extreme but finite costs, rather than failing while exploring a provably exhausted child partition. Ordinary finite-cost ranking behavior is unchanged.

## Validation

- reproduced the failure with `cost_matrix = [[1e308]]`
- verified the corrected enumeration returns the two available assignments for `k=2` and `k=3`
- verified the returned costs are `0.0` and `1e308`
- regression test promotes `RuntimeWarning` to an error to ensure the overflow path remains quiet
- branch is 2 commits ahead of current `main` and 0 behind

GitHub Actions should run the full backend test matrix.