### PR TITLE
Validate tracklet overlap controls

### DIFF
--- a/src/pyrecest/tracking/tracklet_graph.py
+++ b/src/pyrecest/tracking/tracklet_graph.py
@@ -142,6 +142,10 @@ class TrackletGraphConfig:
                 "max_gap must be nonnegative when supplied",
             )
         )
+        allow_overlap = _boolean(
+            self.allow_overlap,
+            "allow_overlap must be a boolean",
+        )
         diversity_weight = _nonnegative_finite_float(
             self.diversity_weight,
             "diversity_weight",
@@ -154,6 +158,7 @@ class TrackletGraphConfig:
         )
         object.__setattr__(self, "top_k", top_k)
         object.__setattr__(self, "beam_width", beam_width)
+        object.__setattr__(self, "allow_overlap", allow_overlap)
         object.__setattr__(self, "max_gap", max_gap)
         object.__setattr__(self, "diversity_weight", diversity_weight)
         object.__setattr__(self, "candidate_multiplier", candidate_multiplier)
@@ -228,6 +233,10 @@ def build_tracklet_adjacency(
 ) -> dict[Hashable, list[tuple[Hashable, float]]]:
     """Build adjacency lists for a time-ordered tracklet DAG."""
 
+    allow_overlap = _boolean(
+        allow_overlap,
+        "allow_overlap must be a boolean",
+    )
     ordered = sort_tracklets(tracklets)
     _require_unique_tracklet_ids(ordered)
     max_gap_value = (
@@ -527,6 +536,18 @@ def _state_vector(value: Any, name: str) -> np.ndarray:
     if not np.isfinite(vector).all():
         raise ValueError(f"{name} must contain only finite values")
     return vector.copy()
+
+
+def _boolean(value: Any, message: str) -> bool:
+    if isinstance(value, (bool, np.bool_)):
+        return bool(value)
+    try:
+        value_array = np.asarray(value)
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise ValueError(message) from exc
+    if value_array.shape == () and value_array.dtype == np.bool_:
+        return bool(value_array.item())
+    raise ValueError(message)
 
 
 def _positive_integer(value: Any, name: str, message: str) -> int:

--- a/tests/tracking/test_tracklet_graph_allow_overlap_validation.py
+++ b/tests/tracking/test_tracklet_graph_allow_overlap_validation.py
@@ -1,0 +1,48 @@
+import numpy as np
+import pytest
+from pyrecest.tracking.tracklet_graph import (
+    Tracklet,
+    TrackletGraphConfig,
+    build_tracklet_adjacency,
+)
+
+
+def _overlapping_tracklets():
+    return [
+        Tracklet("left", 0.0, 2.0, [0.0], [1.0]),
+        Tracklet("right", 1.0, 3.0, [1.0], [2.0]),
+    ]
+
+
+def _edge_cost(_left, _right):
+    return 0.0
+
+
+def test_config_rejects_non_boolean_allow_overlap():
+    for value in ("false", 0, 1, [False], np.array([False])):
+        with pytest.raises(ValueError, match="allow_overlap must be a boolean"):
+            TrackletGraphConfig(allow_overlap=value)
+
+
+def test_config_accepts_scalar_numpy_boolean():
+    config = TrackletGraphConfig(allow_overlap=np.array(True))
+    assert config.allow_overlap is True
+
+
+def test_direct_adjacency_builder_rejects_non_boolean_allow_overlap():
+    with pytest.raises(ValueError, match="allow_overlap must be a boolean"):
+        build_tracklet_adjacency(
+            _overlapping_tracklets(),
+            _edge_cost,
+            allow_overlap="false",
+        )
+
+
+def test_boolean_allow_overlap_controls_overlapping_edges():
+    tracklets = _overlapping_tracklets()
+
+    blocked = build_tracklet_adjacency(tracklets, _edge_cost, allow_overlap=False)
+    allowed = build_tracklet_adjacency(tracklets, _edge_cost, allow_overlap=True)
+
+    assert blocked["left"] == []
+    assert allowed["left"] == [("right", 0.0)]


### PR DESCRIPTION
## Bug

`TrackletGraphConfig.allow_overlap` and the public `build_tracklet_adjacency()` entry point accepted arbitrary truthy and falsy objects. A value such as the string `"false"` is truthy in Python, so it silently enabled edges between overlapping tracklets instead of disabling them.

## Fix

- normalize Python and NumPy scalar booleans
- reject strings, integers, sequences, and non-scalar arrays
- validate both configuration construction and direct adjacency-builder calls
- add regression coverage for rejected inputs and the resulting overlap behavior

## Impact

Mis-typed configuration can no longer change tracklet-graph topology silently.

## Validation

- reproduced the pre-fix behavior where `allow_overlap="false"` admitted an overlapping edge
- targeted regression suite: 4 passed
- `python -m py_compile` for the changed production module and regression test
- branch is 2 commits ahead of `main` and 0 behind

GitHub Actions should run the full project matrix.