### PR TITLE
Preserve fractional groundtruth transitions

### DIFF
--- a/src/pyrecest/evaluation/generate_groundtruth.py
+++ b/src/pyrecest/evaluation/generate_groundtruth.py
@@ -1,7 +1,13 @@
 import numpy as np
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import atleast_2d, empty_like, reshape, squeeze
+from pyrecest.backend import (
+    atleast_2d,
+    empty_like,
+    get_default_dtype,
+    reshape,
+    squeeze,
+)
 
 
 def _validate_initial_state_shape(x0, simulation_param):
@@ -50,8 +56,15 @@ def generate_groundtruth(simulation_param, x0=None):
 
     groundtruth[0] = atleast_2d(x0)
     state_dtype = groundtruth[0].dtype
-    if getattr(state_dtype, "kind", None) in ("b", "i", "u"):
-        state_dtype = float
+    dtype_kind = getattr(state_dtype, "kind", None)
+    integer_or_bool_dtype = dtype_kind in ("b", "i", "u")
+    if dtype_kind is None:
+        integer_or_bool_dtype = (
+            getattr(state_dtype, "is_floating_point", None) is False
+            and getattr(state_dtype, "is_complex", None) is False
+        )
+    if integer_or_bool_dtype:
+        state_dtype = get_default_dtype()
 
     for t in range(1, simulation_param["n_timesteps"]):
         groundtruth[t] = empty_like(groundtruth[0], dtype=state_dtype)
@@ -92,7 +105,6 @@ def generate_groundtruth(simulation_param, x0=None):
 
                 sys_noise_sample = squeeze(simulation_param["sys_noise"].sample(1))
                 groundtruth[t][target_no, :] = state_to_add_noise_to + sys_noise_sample
-
             else:
                 raise ValueError("Cannot generate groundtruth.")
 

--- a/src/pyrecest/evaluation/generate_groundtruth.py
+++ b/src/pyrecest/evaluation/generate_groundtruth.py
@@ -49,9 +49,14 @@ def generate_groundtruth(simulation_param, x0=None):
             raise ValueError("Mismatch in number of timesteps.")
 
     groundtruth[0] = atleast_2d(x0)
+    state_dtype = groundtruth[0].dtype
+    if np.issubdtype(state_dtype, np.integer) or np.issubdtype(
+        state_dtype, np.bool_
+    ):
+        state_dtype = float
 
     for t in range(1, simulation_param["n_timesteps"]):
-        groundtruth[t] = empty_like(groundtruth[0])
+        groundtruth[t] = empty_like(groundtruth[0], dtype=state_dtype)
         for target_no in range(simulation_param["n_targets"]):
             previous_state = groundtruth[t - 1][target_no, :]
             if "gen_next_state_with_noise" in simulation_param:

--- a/src/pyrecest/evaluation/generate_groundtruth.py
+++ b/src/pyrecest/evaluation/generate_groundtruth.py
@@ -50,9 +50,7 @@ def generate_groundtruth(simulation_param, x0=None):
 
     groundtruth[0] = atleast_2d(x0)
     state_dtype = groundtruth[0].dtype
-    if np.issubdtype(state_dtype, np.integer) or np.issubdtype(
-        state_dtype, np.bool_
-    ):
+    if getattr(state_dtype, "kind", None) in ("b", "i", "u"):
         state_dtype = float
 
     for t in range(1, simulation_param["n_timesteps"]):

--- a/tests/test_generate_groundtruth.py
+++ b/tests/test_generate_groundtruth.py
@@ -47,6 +47,26 @@ class TestGenerateGroundtruth(unittest.TestCase):
         pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
         reason="Not supported on this backend",
     )
+    def test_integer_initial_state_preserves_fractional_transition_values(self):
+        x0 = array([[0, 1], [2, 3]])
+        step = array([0.5, 0.25])
+        simulation_param = {
+            "initial_prior": GaussianDistribution(zeros(2), eye(2)),
+            "n_targets": 2,
+            "n_timesteps": 3,
+            "gen_next_state_with_noise": lambda state: state + step,
+        }
+
+        groundtruth = generate_groundtruth(simulation_param, x0)
+
+        npt.assert_allclose(groundtruth[0], x0)
+        npt.assert_allclose(groundtruth[1], array([[0.5, 1.25], [2.5, 3.25]]))
+        npt.assert_allclose(groundtruth[2], array([[1.0, 1.5], [3.0, 3.5]]))
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
     def test_custom_noiseless_transition_reads_previous_object_entry(self):
         x0 = array([[0.0, 1.0], [2.0, 3.0]])
         step = array([0.5, 1.0])


### PR DESCRIPTION
## Summary
- promote integer and boolean initial-state storage to floating point for generated future states
- preserve existing floating-point and complex state dtypes
- keep non-NumPy backend dtype objects on their native path
- add a regression test covering fractional dynamics from an integer-valued initial state

## Root cause
`generate_groundtruth()` allocated every future state with `empty_like(groundtruth[0])`. When callers supplied an integer-valued `x0`, the destination arrays inherited that integer dtype and silently truncated fractional transition or process-noise values.

## Impact
Generated trajectories now retain fractional state updates instead of producing numerically incorrect, quantized ground truth.

## Validation
- reproduced the original truncation in an isolated NumPy harness
- focused patched regression harness passes
- both edited files compile successfully
- branch is 3 commits ahead of `main`, 0 behind