### PR TITLE
Reject temporal sequence association controls

### DIFF
--- a/src/pyrecest/filters/sequence_association.py
+++ b/src/pyrecest/filters/sequence_association.py
@@ -351,13 +351,23 @@ def _validate_integer(value: object, name: str) -> int:
         raise ValueError(message) from exc
     if value_array.ndim != 0 or value_array.dtype == np.bool_:
         raise ValueError(message)
-    if value_array.dtype.kind in {"S", "U", "c"}:
+    if value_array.dtype.kind in {"M", "S", "U", "c", "m"}:
         raise ValueError(message)
 
     scalar = value_array.item()
     if isinstance(
         scalar,
-        (bool, np.bool_, str, bytes, bytearray, complex, np.complexfloating),
+        (
+            bool,
+            np.bool_,
+            str,
+            bytes,
+            bytearray,
+            complex,
+            np.complexfloating,
+            np.datetime64,
+            np.timedelta64,
+        ),
     ):
         raise ValueError(message)
     if isinstance(scalar, (int, np.integer)):
@@ -378,13 +388,30 @@ def _validate_cost(value: object, name: str) -> float:
     except (TypeError, ValueError) as exc:
         raise ValueError(numeric_message) from exc
 
-    if value_array.ndim != 0 or value_array.dtype.kind in {"b", "S", "U", "c"}:
+    if value_array.ndim != 0 or value_array.dtype.kind in {
+        "M",
+        "S",
+        "U",
+        "b",
+        "c",
+        "m",
+    }:
         raise ValueError(numeric_message)
 
     scalar = value_array.item()
     if isinstance(
         scalar,
-        (bool, np.bool_, str, bytes, bytearray, complex, np.complexfloating),
+        (
+            bool,
+            np.bool_,
+            str,
+            bytes,
+            bytearray,
+            complex,
+            np.complexfloating,
+            np.datetime64,
+            np.timedelta64,
+        ),
     ):
         raise ValueError(numeric_message)
 
@@ -403,11 +430,18 @@ def _validate_positive_integer(value: object, name: str) -> int:
         value_array = np.asarray(value)
     except (TypeError, ValueError) as exc:
         raise ValueError(message) from exc
-    if value_array.ndim != 0 or value_array.dtype == np.bool_:
+    if (
+        value_array.ndim != 0
+        or value_array.dtype == np.bool_
+        or value_array.dtype.kind in {"M", "m"}
+    ):
         raise ValueError(message)
 
     scalar = value_array.item()
-    if isinstance(scalar, (bool, np.bool_)):
+    if isinstance(
+        scalar,
+        (bool, np.bool_, np.datetime64, np.timedelta64),
+    ):
         raise ValueError(message)
     if isinstance(scalar, (int, np.integer)):
         result = int(scalar)

--- a/src/pyrecest/filters/sequence_association.py
+++ b/src/pyrecest/filters/sequence_association.py
@@ -16,6 +16,15 @@ from typing import Any
 
 import numpy as np
 
+_TEMPORAL_SCALAR_TYPES = (np.datetime64, np.timedelta64)
+
+
+def _is_temporal_scalar_array(value_array: np.ndarray) -> bool:
+    return value_array.dtype.kind in {"M", "m"} or (
+        value_array.dtype == object
+        and isinstance(value_array.item(), _TEMPORAL_SCALAR_TYPES)
+    )
+
 
 @dataclass(frozen=True)
 class SequenceAssociationNode:
@@ -351,23 +360,16 @@ def _validate_integer(value: object, name: str) -> int:
         raise ValueError(message) from exc
     if value_array.ndim != 0 or value_array.dtype == np.bool_:
         raise ValueError(message)
-    if value_array.dtype.kind in {"M", "S", "U", "c", "m"}:
+    if (
+        value_array.dtype.kind in {"S", "U", "c"}
+        or _is_temporal_scalar_array(value_array)
+    ):
         raise ValueError(message)
 
     scalar = value_array.item()
     if isinstance(
         scalar,
-        (
-            bool,
-            np.bool_,
-            str,
-            bytes,
-            bytearray,
-            complex,
-            np.complexfloating,
-            np.datetime64,
-            np.timedelta64,
-        ),
+        (bool, np.bool_, str, bytes, bytearray, complex, np.complexfloating),
     ):
         raise ValueError(message)
     if isinstance(scalar, (int, np.integer)):
@@ -388,30 +390,17 @@ def _validate_cost(value: object, name: str) -> float:
     except (TypeError, ValueError) as exc:
         raise ValueError(numeric_message) from exc
 
-    if value_array.ndim != 0 or value_array.dtype.kind in {
-        "M",
-        "S",
-        "U",
-        "b",
-        "c",
-        "m",
-    }:
+    if (
+        value_array.ndim != 0
+        or value_array.dtype.kind in {"b", "S", "U", "c"}
+        or _is_temporal_scalar_array(value_array)
+    ):
         raise ValueError(numeric_message)
 
     scalar = value_array.item()
     if isinstance(
         scalar,
-        (
-            bool,
-            np.bool_,
-            str,
-            bytes,
-            bytearray,
-            complex,
-            np.complexfloating,
-            np.datetime64,
-            np.timedelta64,
-        ),
+        (bool, np.bool_, str, bytes, bytearray, complex, np.complexfloating),
     ):
         raise ValueError(numeric_message)
 
@@ -433,15 +422,12 @@ def _validate_positive_integer(value: object, name: str) -> int:
     if (
         value_array.ndim != 0
         or value_array.dtype == np.bool_
-        or value_array.dtype.kind in {"M", "m"}
+        or _is_temporal_scalar_array(value_array)
     ):
         raise ValueError(message)
 
     scalar = value_array.item()
-    if isinstance(
-        scalar,
-        (bool, np.bool_, np.datetime64, np.timedelta64),
-    ):
+    if isinstance(scalar, (bool, np.bool_)):
         raise ValueError(message)
     if isinstance(scalar, (int, np.integer)):
         result = int(scalar)

--- a/tests/filters/test_sequence_association_temporal_validation.py
+++ b/tests/filters/test_sequence_association_temporal_validation.py
@@ -61,7 +61,10 @@ def test_sequence_solver_rejects_temporal_counts_and_costs(temporal_value):
             top_k_terminal_paths=temporal_value,
         )
 
-    with pytest.raises(ValueError, match="transition_cost must be a scalar numeric cost"):
+    with pytest.raises(
+        ValueError,
+        match="transition_cost must be a scalar numeric cost",
+    ):
         solve_viterbi_sequence_association(
             frames,
             lambda _previous, _current, _context: temporal_value,

--- a/tests/filters/test_sequence_association_temporal_validation.py
+++ b/tests/filters/test_sequence_association_temporal_validation.py
@@ -1,0 +1,68 @@
+import numpy as np
+import pytest
+from pyrecest.filters import (
+    SequenceAssociationNode,
+    solve_top_k_viterbi_sequence_associations,
+    solve_viterbi_sequence_association,
+)
+
+
+_TEMPORAL_VALUES = (
+    pytest.param(np.timedelta64(1, "ns"), id="timedelta-ns"),
+    pytest.param(np.timedelta64(1, "us"), id="timedelta-us"),
+    pytest.param(
+        np.datetime64("1970-01-01T00:00:00.000000001", "ns"),
+        id="datetime-ns",
+    ),
+    pytest.param(
+        np.datetime64("1970-01-01T00:00:00.000001", "us"),
+        id="datetime-us",
+    ),
+    pytest.param(
+        np.array(np.timedelta64(1, "ns"), dtype=object),
+        id="object-timedelta",
+    ),
+    pytest.param(
+        np.array(
+            np.datetime64("1970-01-01T00:00:00.000000001", "ns"),
+            dtype=object,
+        ),
+        id="object-datetime",
+    ),
+)
+
+
+@pytest.mark.parametrize("temporal_value", _TEMPORAL_VALUES)
+def test_sequence_node_rejects_temporal_indices_and_costs(temporal_value):
+    with pytest.raises(ValueError, match="frame_index must be an integer"):
+        SequenceAssociationNode(temporal_value, 0)
+
+    with pytest.raises(ValueError, match="candidate_index must be an integer"):
+        SequenceAssociationNode(0, temporal_value)
+
+    with pytest.raises(ValueError, match="unary_cost must be a scalar numeric cost"):
+        SequenceAssociationNode(0, 0, unary_cost=temporal_value)
+
+
+@pytest.mark.parametrize("temporal_value", _TEMPORAL_VALUES)
+def test_sequence_solver_rejects_temporal_counts_and_costs(temporal_value):
+    frames = [
+        [SequenceAssociationNode(0, 0)],
+        [SequenceAssociationNode(1, 0)],
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match="top_k_terminal_paths must be a positive integer",
+    ):
+        solve_top_k_viterbi_sequence_associations(
+            frames,
+            lambda _previous, _current, _context: 0.0,
+            top_k_terminal_paths=temporal_value,
+        )
+
+    with pytest.raises(ValueError, match="transition_cost must be a scalar numeric cost"):
+        solve_viterbi_sequence_association(
+            frames,
+            lambda _previous, _current, _context: temporal_value,
+        )


### PR DESCRIPTION
## Bug

The sequence-association validators converted scalar inputs with `numpy.asarray(...).item()` before excluding temporal dtypes. At nanosecond resolution, NumPy returns plain integers for `datetime64` and `timedelta64` values, so timestamps and durations could be silently accepted as frame or candidate indices, unary and transition costs, or `top_k_terminal_paths`. Object-wrapped NumPy temporal scalars could follow the same path, while coarser temporal units failed differently.

## Fix

- reject NumPy datetime and timedelta dtypes before scalar extraction
- reject object-wrapped NumPy temporal scalars after extraction
- apply the validation consistently to node indices, costs, and terminal-path counts
- add focused regression coverage for nanosecond, microsecond, and object-wrapped temporal values

## Impact

Sequence association can no longer interpret timestamps or durations as integer controls or numeric costs. Existing Python, NumPy integer, and exact integer-like floating-point inputs remain unchanged.

## Validation

- reproduced the pre-fix behavior: 8 regression cases failed because invalid temporal values were accepted
- focused patched regression suite: 12 passed
- existing sequence-association tests plus the new regression: 25 passed, including 29 unittest subtests
- syntax-compiled the modified production module and regression test
- reviewed the final two-file GitHub patch against the current `main` merge base

GitHub Actions provides the full backend matrix.