### PR TITLE
Reject temporal Complex Watson sample counts

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/complex_watson_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/complex_watson_distribution.py
@@ -44,8 +44,12 @@ def _validate_positive_sample_count(n) -> int:
     count_array = np.asarray(n)
     if count_array.ndim != 0:
         raise ValueError("n must be a scalar integer")
+    if count_array.dtype.kind in {"M", "m"}:
+        raise ValueError("n must be an integer")
 
     count = count_array.item()
+    if isinstance(count, (np.datetime64, np.timedelta64)):
+        raise ValueError("n must be an integer")
     if isinstance(count, (bool, np.bool_)):
         raise ValueError("n must be an integer, not a boolean")
 

--- a/tests/distributions/test_complex_watson_temporal_sample_count.py
+++ b/tests/distributions/test_complex_watson_temporal_sample_count.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pytest
+
+import pyrecest.backend
+from pyrecest.backend import array, complex128
+from pyrecest.distributions import ComplexWatsonDistribution
+
+
+pytestmark = pytest.mark.skipif(
+    pyrecest.backend.__backend_name__ == "jax",
+    reason="Complex Watson sampling is not supported on the JAX backend",
+)
+
+
+@pytest.mark.parametrize(
+    "invalid_count",
+    [
+        np.timedelta64(3, "ns"),
+        np.datetime64("1970-01-01T00:00:00.000000003", "ns"),
+        np.array(np.timedelta64(3, "ns"), dtype=object),
+    ],
+)
+def test_complex_watson_rejects_temporal_sample_counts(invalid_count):
+    distribution = ComplexWatsonDistribution(
+        array([1.0, 0.0], dtype=complex128),
+        2.0,
+    )
+
+    with pytest.raises(ValueError, match="integer"):
+        distribution.sample(invalid_count)


### PR DESCRIPTION
## Summary
- reject NumPy datetime and timedelta scalars as `ComplexWatsonDistribution.sample()` counts
- cover fine-resolution temporal dtypes and object-wrapped temporal scalars with a regression test
- preserve accepted integer-like scalar counts

## Root cause
For fine-resolution NumPy temporal dtypes, `ndarray.item()` returns the raw integer storage value. The sample-count validator therefore interpreted values such as `np.timedelta64(3, "ns")` as a request for three samples.

## Impact
Invalid temporal values now fail deterministically with `ValueError` instead of silently controlling allocation and sampling work.

## Validation
- focused pre/post regression harness: 9 checks passed
- branch diff: 4 production-line additions and one 30-line regression test
- branch is 2 commits ahead of `main`, 0 behind

GitHub Actions should provide the full backend test matrix.