### PR TITLE
Validate MTT detection probabilities

### DIFF
--- a/src/pyrecest/evaluation/check_and_fix_config.py
+++ b/src/pyrecest/evaluation/check_and_fix_config.py
@@ -1,4 +1,4 @@
-from numbers import Integral
+from numbers import Integral, Real
 
 import numpy as np
 
@@ -9,6 +9,17 @@ def _is_integer_count(value):
     if isinstance(value, (bool, np.bool_, np.datetime64, np.timedelta64)):
         return False
     return isinstance(value, Integral)
+
+
+def _validate_probability(value, name):
+    if isinstance(value, (bool, np.bool_, np.datetime64, np.timedelta64)) or not isinstance(
+        value, Real
+    ):
+        raise TypeError(f"{name} must be a real scalar")
+    value = float(value)
+    if not np.isfinite(value) or not 0.0 <= value <= 1.0:
+        raise ValueError(f"{name} must be finite and between 0 and 1")
+    return value
 
 
 def _expand_meas_per_step(simulation_param):
@@ -118,6 +129,10 @@ def check_and_fix_config(simulation_param):
                 "detectionProbability"
             ]
         simulation_param.setdefault("detection_probability", 1)
+        simulation_param["detection_probability"] = _validate_probability(
+            simulation_param["detection_probability"],
+            "detection_probability",
+        )
         simulation_param.setdefault("clutter_rate", 0)
 
         if (

--- a/tests/test_mtt_detection_probability_validation.py
+++ b/tests/test_mtt_detection_probability_validation.py
@@ -1,0 +1,41 @@
+import numpy as np
+import pytest
+from pyrecest.backend import array, eye
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.evaluation import check_and_fix_config
+
+
+def _mtt_config(detection_probability):
+    return {
+        "mtt": True,
+        "eot": False,
+        "n_timesteps": 2,
+        "n_targets": 1,
+        "initial_prior": GaussianDistribution(array([0.0]), eye(1)),
+        "meas_matrix_for_each_target": eye(1),
+        "meas_noise": GaussianDistribution(array([0.0]), eye(1)),
+        "detection_probability": detection_probability,
+    }
+
+
+@pytest.mark.parametrize("probability", [-0.1, 1.1, np.nan, np.inf, -np.inf])
+def test_rejects_out_of_range_or_nonfinite_detection_probability(probability):
+    with pytest.raises(
+        ValueError,
+        match="detection_probability must be finite and between 0 and 1",
+    ):
+        check_and_fix_config(_mtt_config(probability))
+
+
+@pytest.mark.parametrize("probability", [True, False, "0.5", [0.5]])
+def test_rejects_non_real_detection_probability(probability):
+    with pytest.raises(TypeError, match="detection_probability must be a real scalar"):
+        check_and_fix_config(_mtt_config(probability))
+
+
+@pytest.mark.parametrize("probability", [0, 0.25, np.float32(0.5), 1])
+def test_accepts_valid_detection_probability(probability):
+    config = check_and_fix_config(_mtt_config(probability))
+
+    assert config["detection_probability"] == pytest.approx(float(probability))
+    assert isinstance(config["detection_probability"], float)


### PR DESCRIPTION
## Bug

MTT configuration accepted `detection_probability` without validation and passed it directly to `numpy.random.binomial`. This silently treated booleans as probabilities and exposed callers to backend-specific exceptions for strings, arrays, non-finite values, and probabilities outside `[0, 1]`.

## Fix

- validate that the detection probability is a real scalar
- reject booleans and non-scalar/non-numeric values
- reject NaN, infinities, and values outside `[0, 1]`
- normalize accepted values to a Python `float`
- preserve the legacy `detectionProbability` alias path

## Tests

Added focused regression coverage for:

- negative and greater-than-one probabilities
- NaN and positive/negative infinity
- booleans, strings, and arrays
- valid Python and NumPy real scalars, including boundary values

## Impact

Invalid MTT configurations now fail early with stable, actionable errors instead of reaching NumPy's random sampler or silently accepting booleans.

The branch is 2 commits ahead of `main` and 0 behind. GitHub Actions provides the authoritative full test and backend matrix.