### PR TITLE
Preserve fractional estimate histories

### DIFF
--- a/src/pyrecest/evaluation/perform_predict_update_cycles.py
+++ b/src/pyrecest/evaluation/perform_predict_update_cycles.py
@@ -11,6 +11,10 @@ def _empty_estimates_like(groundtruth):
     """Create an estimate container matching dense or object groundtruth arrays."""
     if isinstance(groundtruth, _np.ndarray) and groundtruth.dtype == object:
         return _np.empty_like(groundtruth)
+
+    groundtruth_dtype = getattr(groundtruth, "dtype", None)
+    if getattr(groundtruth_dtype, "kind", None) in ("b", "i", "u"):
+        return empty_like(groundtruth, dtype=float)
     return empty_like(groundtruth)
 
 

--- a/tests/evaluation/test_integer_estimate_history.py
+++ b/tests/evaluation/test_integer_estimate_history.py
@@ -1,0 +1,54 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from pyrecest.backend import array, get_backend_name
+from pyrecest.evaluation import perform_predict_update_cycles
+from pyrecest.evaluation.configure_for_filter import register_filter_factory
+
+
+class _FractionalEstimateFilter:
+    @property
+    def filter_state(self):
+        return self
+
+    def get_point_estimate(self):
+        return array([0.5])
+
+
+def _fractional_estimate_factory(
+    _filter_config, _scenario_config, _precalculated_params
+):
+    return _FractionalEstimateFilter(), lambda: None, None, None
+
+
+@pytest.mark.skipif(
+    get_backend_name() != "numpy",
+    reason="Dense NumPy evaluation storage is covered on the NumPy backend.",
+)
+def test_integer_groundtruth_preserves_fractional_estimate_history():
+    filter_name = "integer_groundtruth_fractional_estimate_history_regression"
+    register_filter_factory(filter_name, _fractional_estimate_factory)
+    scenario_config = {
+        "n_timesteps": 2,
+        "n_meas_at_individual_time_step": [0, 0],
+        "apply_sys_noise_times": [False, False],
+        "mtt": False,
+        "eot": False,
+    }
+    groundtruth = np.array([[0], [1]], dtype=int)
+    measurements = np.empty(2, dtype=object)
+    measurements[0] = np.empty((0, 1))
+    measurements[1] = np.empty((0, 1))
+
+    _, _, last_estimate, all_estimates = perform_predict_update_cycles(
+        scenario_config,
+        {"name": filter_name, "parameter": None},
+        groundtruth,
+        measurements,
+        extract_all_estimates=True,
+    )
+
+    assert all_estimates.dtype.kind == "f"
+    npt.assert_allclose(last_estimate, array([0.5]))
+    npt.assert_allclose(all_estimates, np.array([[0.5], [0.5]]))


### PR DESCRIPTION
## Bug

`perform_predict_update_cycles(..., extract_all_estimates=True)` allocated the estimate-history buffer with `empty_like(groundtruth)`. When callers supplied an integer- or boolean-valued dense ground-truth array, the buffer inherited that dtype and silently truncated fractional point estimates during assignment.

For example, an estimate of `0.5` stored alongside integer ground truth became `0`, corrupting evaluation histories while the returned final estimate remained correct.

## Fix

- promote dense NumPy integer and boolean ground-truth dtypes to floating-point estimate storage
- preserve object-array storage for variable-shaped states
- preserve existing floating-point, complex, and non-NumPy backend dtype paths
- add an end-to-end regression using an integer ground-truth array and a fractional filter estimate

## Impact

Extracted estimate histories now retain fractional state values instead of silently quantizing them according to the ground-truth dtype. Existing object, floating-point, and complex histories are unchanged.

## Validation

- reproduced the pre-fix truncation in an isolated NumPy harness
- verified promoted storage preserves `0.5` and `1.5` values with floating-point dtype
- branch is 2 commits ahead of `main` and 0 behind

GitHub Actions provides the full repository and backend-matrix validation.