### PR TITLE
Reject temporal wrapped-exponential integers

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
@@ -96,6 +96,22 @@ def _validate_positive_scalar(value, name):
     return value
 
 
+def _validate_integer(value, name, *, positive=False) -> int:
+    qualifier = "positive integer" if positive else "integer"
+    message = f"{name} must be a {qualifier}."
+    if isinstance(value, (bool, np.bool_, np.datetime64, np.timedelta64)) or not isinstance(
+        value, Integral
+    ):
+        raise ValueError(message)
+    try:
+        value = int(value)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError(message) from exc
+    if positive and value <= 0:
+        raise ValueError(message)
+    return value
+
+
 def _validate_pdf_points(value):
     message = "xs must contain only finite real values."
     if _contains_invalid_real_value(value):
@@ -147,15 +163,11 @@ class WrappedExponentialDistribution(AbstractCircularDistribution):
         return self._density_scale * exp(-self.lambda_ * xs)
 
     def trigonometric_moment(self, n):
-        if isinstance(n, (bool, np.bool_)) or not isinstance(n, Integral):
-            raise ValueError("n must be an integer.")
-        n = int(n)
+        n = _validate_integer(n, "n")
         return 1.0 / (1.0 - 1j * n / self.lambda_)
 
     def sample(self, n: Union[int, int32, int64]):
-        if isinstance(n, bool) or not isinstance(n, Integral) or int(n) <= 0:
-            raise ValueError("n must be a positive integer.")
-        n = int(n)
+        n = _validate_integer(n, "n", positive=True)
         # Use inverse CDF method: X = -ln(U)/lambda ~ Exp(lambda), then wrap
         u = random.uniform(size=(n,))
         u = u + (u == 0.0) * 1.0e-12

--- a/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
@@ -97,11 +97,10 @@ def _validate_positive_scalar(value, name):
 
 
 def _validate_integer(value, name, *, positive=False) -> int:
-    qualifier = "positive integer" if positive else "integer"
-    message = f"{name} must be a {qualifier}."
-    if isinstance(value, (bool, np.bool_, np.datetime64, np.timedelta64)) or not isinstance(
-        value, Integral
-    ):
+    message = f"{name} must be {'a positive integer' if positive else 'an integer'}."
+    if isinstance(
+        value, (bool, np.bool_, np.datetime64, np.timedelta64)
+    ) or not isinstance(value, Integral):
         raise ValueError(message)
     try:
         value = int(value)

--- a/tests/distributions/test_wrapped_exponential_distribution.py
+++ b/tests/distributions/test_wrapped_exponential_distribution.py
@@ -92,7 +92,7 @@ class WrappedExponentialDistributionTest(unittest.TestCase):
             )
 
     def test_trigonometric_moment_validates_order(self):
-        for order in (0.5, True, np.bool_(True), "1"):
+        for order in (0.5, True, np.bool_(True), "1", np.timedelta64(1, "s")):
             with self.subTest(order=order), self.assertRaisesRegex(
                 ValueError, "integer"
             ):
@@ -161,7 +161,7 @@ class WrappedExponentialDistributionTest(unittest.TestCase):
         self.assertEqual(samples.shape, (4,))
 
     def test_sample_rejects_invalid_count(self):
-        for n in (0, -1, 1.5, True):
+        for n in (0, -1, 1.5, True, np.timedelta64(1, "s")):
             with self.subTest(n=n):
                 with self.assertRaisesRegex(ValueError, "positive integer"):
                     self.we.sample(n)


### PR DESCRIPTION
## Summary
- add one shared integer validator for wrapped-exponential moment orders and sample counts
- reject NumPy temporal scalars with the documented `ValueError` contract
- preserve valid NumPy integer counts and negative trigonometric-moment orders
- extend the focused wrapped-exponential tests with `numpy.timedelta64` regressions

## Root cause
`numpy.timedelta64` is registered as `numbers.Integral`. The previous guards therefore accepted it and then called `int(...)`, which raises a lower-level `TypeError`. This affected both `WrappedExponentialDistribution.trigonometric_moment()` and `.sample()`.

## Impact
Malformed temporal inputs now fail deterministically at the API boundary instead of leaking backend-independent conversion errors. Valid integer-like inputs retain their existing behavior.

## Validation
- reproduced the previous `TypeError` for both affected methods' validation paths
- verified the shared validator returns `ValueError` with the existing public messages
- verified `numpy.int64(4)` remains accepted as a sample count
- verified negative integer moment orders remain accepted
- branch is 3 commits ahead of `main` and 0 behind

GitHub Actions provides the authoritative repository-wide and backend-matrix validation.