### PR TITLE
Mask zero-support boxed likelihoods

### DIFF
--- a/src/pyrecest/filters/euclidean_boxed_particle_filter.py
+++ b/src/pyrecest/filters/euclidean_boxed_particle_filter.py
@@ -219,6 +219,11 @@ class EuclideanBoxedParticleFilter(EuclideanParticleFilter):
             likelihood_values = array(likelihood(self.filter_state.d))
             if likelihood_values.shape != self.filter_state.w.shape:
                 raise ValueError("likelihood must return one value per particle")
+            likelihood_values = where(
+                weight_update > 0,
+                likelihood_values,
+                zeros_like(likelihood_values),
+            )
             weight_update = weight_update * likelihood_values
 
         new_state = copy.deepcopy(self.filter_state)

--- a/tests/filters/test_euclidean_boxed_particle_filter_zero_support_likelihood.py
+++ b/tests/filters/test_euclidean_boxed_particle_filter_zero_support_likelihood.py
@@ -1,0 +1,37 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+from pyrecest.backend import array, to_numpy
+from pyrecest.distributions.nonperiodic.linear_dirac_distribution import (
+    LinearDiracDistribution,
+)
+from pyrecest.filters.euclidean_boxed_particle_filter import (
+    EuclideanBoxedParticleFilter,
+)
+
+
+class EuclideanBoxedParticleFilterZeroSupportLikelihoodTest(unittest.TestCase):
+    def test_reweight_ignores_nonfinite_likelihood_on_zero_support_particles(self):
+        pf = EuclideanBoxedParticleFilter(4, 1)
+        pf.set_resampling_criterion(lambda _state: False)
+        pf.filter_state = LinearDiracDistribution(
+            array([[0.0], [1.0], [2.0], [3.0]]),
+            array([0.2, 0.3, 0.0, 0.5]),
+        )
+
+        pf.reweight_by_box(
+            array([0.0]),
+            array([2.0]),
+            likelihood=lambda _particles: array([1.0, 2.0, np.nan, np.nan]),
+        )
+
+        npt.assert_allclose(
+            to_numpy(pf.filter_state.w),
+            [0.25, 0.75, 0.0, 0.0],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`EuclideanBoxedParticleFilter.reweight_by_box()` multiplied optional likelihood values into every gated particle weight, including entries whose support was already zero because the particle was outside the box or had zero prior weight.

An out-of-domain likelihood may legitimately be undefined and return `NaN` for those particles. IEEE arithmetic then turns `0 * NaN` into `NaN`, contaminating the weight vector and causing an otherwise valid update to fail.

## Fix

- mask optional likelihood values wherever the gated prior weight is zero;
- preserve the existing finite/nonnegative validation for particles that actually contribute;
- retain the existing zero-total-mass failure behavior.

## Regression coverage

Added a focused test with two contributing particles, one zero-prior in-box particle, and one out-of-box particle. The two zero-support likelihood values return `NaN`; the valid posterior remains `[0.25, 0.75, 0, 0]`.

## Validation

- reproduced the pre-fix arithmetic (`0 * NaN -> NaN`);
- verified the masked arithmetic normalizes to the expected posterior;
- syntax-compiled the modified implementation and regression test;
- reviewed the branch diff against current `main`: two files, 42 additions, no deletions;
- branch is 2 commits ahead and 0 behind `main`.

GitHub Actions provides the authoritative full backend and test matrix.