### PR TITLE
Reject temporal transition sample counts

### DIFF
--- a/src/pyrecest/models/_sampleable_transition_validation.py
+++ b/src/pyrecest/models/_sampleable_transition_validation.py
@@ -57,13 +57,14 @@ def _patch_sampler_count_check(model_cls) -> None:
         return
 
     def checked_sample_next(self, state, n=1):
+        normalized_n = _requested_sample_count(n)
         has_sampler = getattr(self, "_sample_next", None) is not None
         has_count_argument = (
             getattr(self, "_sample_next_count_call_mode", None) is not None
         )
-        if has_sampler and not has_count_argument and _requested_sample_count(n) != 1:
+        if has_sampler and not has_count_argument and normalized_n != 1:
             raise TypeError("sample count is not supported by this sampler.")
-        return original(self, state, n=_requested_sample_count(n))
+        return original(self, state, n=normalized_n)
 
     checked_sample_next._pyrecest_sampler_count_checked = True
     model_cls.sample_next = checked_sample_next

--- a/src/pyrecest/models/_sampleable_transition_validation.py
+++ b/src/pyrecest/models/_sampleable_transition_validation.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import numpy as np
+
 from ._additive_noise_sample_count_validation import (
     install_additive_noise_sample_count_validation,
 )
@@ -29,7 +31,23 @@ def _set_function_is_vectorized(
     )
 
 
+def _is_temporal_sample_count(value: Any) -> bool:
+    """Return whether a scalar count contains a NumPy temporal value."""
+
+    try:
+        value_array = np.asarray(value)
+    except (TypeError, ValueError, OverflowError):
+        return False
+    if value_array.shape != ():
+        return False
+    if value_array.dtype.kind in {"M", "m"}:
+        return True
+    return isinstance(value_array.item(), (np.datetime64, np.timedelta64))
+
+
 def _requested_sample_count(value: Any) -> int:
+    if _is_temporal_sample_count(value):
+        raise ValueError("n must be a nonnegative integer.")
     return _validate_sample_count(value)
 
 
@@ -45,7 +63,7 @@ def _patch_sampler_count_check(model_cls) -> None:
         )
         if has_sampler and not has_count_argument and _requested_sample_count(n) != 1:
             raise TypeError("sample count is not supported by this sampler.")
-        return original(self, state, n=n)
+        return original(self, state, n=_requested_sample_count(n))
 
     checked_sample_next._pyrecest_sampler_count_checked = True
     model_cls.sample_next = checked_sample_next

--- a/tests/models/test_transition_sample_count_validation.py
+++ b/tests/models/test_transition_sample_count_validation.py
@@ -10,6 +10,12 @@ from pyrecest.models import (
     sample_next_state,
 )
 
+_TEMPORAL_COUNTS = (
+    np.timedelta64(2, "ns"),
+    np.datetime64("1970-01-01T00:00:00.000000002", "ns"),
+    np.array(np.timedelta64(2, "ns"), dtype=object),
+)
+
 
 class TransitionSampleCountValidationTest(unittest.TestCase):
     def test_sampleable_transition_model_rejects_invalid_sample_counts(self):
@@ -31,7 +37,7 @@ class TransitionSampleCountValidationTest(unittest.TestCase):
             np.array(True, dtype=object),
             np.array("2"),
             np.ma.array(2, mask=True),
-        )
+        ) + _TEMPORAL_COUNTS
 
         for n in invalid_counts:
             with self.subTest(n=n):
@@ -67,7 +73,14 @@ class TransitionSampleCountValidationTest(unittest.TestCase):
 
         model = DensityTransitionModel(transition_density, sample_next=sample_next)
 
-        for n in (True, -1, "2", np.array([2]), np.ma.array(2, mask=True)):
+        invalid_counts = (
+            True,
+            -1,
+            "2",
+            np.array([2]),
+            np.ma.array(2, mask=True),
+        ) + _TEMPORAL_COUNTS
+        for n in invalid_counts:
             with self.subTest(n=n):
                 with self.assertRaisesRegex(ValueError, "n must be"):
                     model.sample_next(array([0.0]), n=n)


### PR DESCRIPTION
## Bug

Generic `SampleableTransitionModel` and `DensityTransitionModel` count validation accepted nanosecond `numpy.datetime64` and `numpy.timedelta64` values because NumPy can expose their integer storage through scalar extraction. Object-wrapped temporal scalars could also pass the `numbers.Integral` check.

## Fix

- reject scalar NumPy temporal dtypes before generic count normalization;
- reject temporal scalars recovered from object arrays;
- normalize valid counts once before delegating to the original sampler method.

## Regression coverage

- direct `timedelta64` counts;
- direct `datetime64` counts;
- object-wrapped `timedelta64` counts;
- both generic transition model classes;
- existing NumPy integer normalization remains covered.

## Validation

- isolated reproducer confirmed the pre-fix temporal payloads are integral-like;
- isolated post-fix validation rejected all temporal payloads and preserved NumPy integer normalization;
- branch is three commits ahead and zero behind current `main`;
- the branch diff is limited to the shared transition-count wrapper and its focused regression test.

GitHub Actions provides the authoritative full test and backend-matrix validation.