### PR TITLE
Discard zero-volume box intersections

### DIFF
--- a/src/pyrecest/filters/euclidean_box_particle_filter.py
+++ b/src/pyrecest/filters/euclidean_box_particle_filter.py
@@ -274,7 +274,7 @@ class EuclideanBoxParticleFilter(AbstractParticleFilter, EuclideanFilterMixin):
             contracted = contractor(predicted.lower, predicted.upper, measurement)
         contracted_lower, contracted_upper = self._coerce_box_result(contracted)
 
-        valid = all(contracted_upper >= contracted_lower, axis=1)
+        valid = all(contracted_upper > contracted_lower, axis=1)
         contracted_widths = maximum(contracted_upper - contracted_lower, 0.0)
         contracted_volumes = prod(contracted_widths, axis=1)
         safe_previous_volumes = where(

--- a/tests/filters/test_euclidean_box_particle_filter.py
+++ b/tests/filters/test_euclidean_box_particle_filter.py
@@ -41,6 +41,21 @@ class EuclideanBoxParticleFilterTest(unittest.TestCase):
         npt.assert_allclose(pf.filter_state.upper, array([[1.0], [4.0]]))
         npt.assert_allclose(pf.filter_state.w, array([1.0, 0.0]))
 
+    def test_identity_box_update_discards_boundary_only_intersection(self):
+        pf = EuclideanBoxParticleFilter(2, 1)
+        pf.filter_state = LinearBoxParticleDistribution(
+            array([[0.0], [2.0]]),
+            array([[1.0], [4.0]]),
+            array([0.5, 0.5]),
+        )
+        pf.set_resampling_criterion(lambda _state: False)
+
+        pf.update_identity_box(array([1.0]), array([3.0]))
+
+        npt.assert_allclose(pf.filter_state.lower, array([[0.0], [2.0]]))
+        npt.assert_allclose(pf.filter_state.upper, array([[1.0], [3.0]]))
+        npt.assert_allclose(pf.filter_state.w, array([0.0, 1.0]))
+
     def test_invalid_contraction_cannot_inject_nan_likelihood_weight(self):
         pf = EuclideanBoxParticleFilter(2, 1)
         pf.filter_state = LinearBoxParticleDistribution(


### PR DESCRIPTION
## Summary
- treat boundary-only box contractions as zero-support
- retain original valid geometry for discarded zero-weight boxes
- add an identity-measurement regression covering a touching interval

## Bug
`update_contracted()` considered `upper == lower` structurally valid. Such boxes have zero volume and zero posterior weight, but their degenerate bounds were still passed to `LinearBoxParticleDistribution`, which requires strict `upper > lower`. A single boundary-only intersection could therefore abort an update even when another box had positive support.

## Fix
Require strictly positive width in every dimension when selecting contracted geometry. Degenerate intersections now receive zero weight and retain their previous valid bounds.

## Validation
- focused regression: failed with `ValueError` on the old implementation and passes after the change
- `python -m py_compile` on the modified source and test