### PR TITLE
Normalize hypertoroidal mixture PDF inputs

### DIFF
--- a/src/pyrecest/distributions/hypertorus/hypertoroidal_mixture.py
+++ b/src/pyrecest/distributions/hypertorus/hypertoroidal_mixture.py
@@ -6,7 +6,7 @@ from typing import Union
 from pyrecest.backend import complex128, int32, int64, zeros
 
 from ..abstract_mixture import AbstractMixture
-from ._input_validation import as_shift_vector
+from ._input_validation import as_hypertoroidal_points, as_shift_vector
 from .abstract_hypertoroidal_distribution import AbstractHypertoroidalDistribution
 
 
@@ -35,6 +35,11 @@ class HypertoroidalMixture(AbstractMixture, AbstractHypertoroidalDistribution):
         self.dists: collections.abc.Sequence[AbstractHypertoroidalDistribution] = (
             self.dists
         )
+
+    def pdf(self, xs):
+        """Evaluate the mixture density at normalized hypertoroidal query points."""
+        xs = as_hypertoroidal_points(xs, self.dim)
+        return AbstractMixture.pdf(self, xs)
 
     def trigonometric_moment(self, n: Union[int, int32, int64]):
         """

--- a/tests/distributions/test_hypertoroidal_mixture_pdf.py
+++ b/tests/distributions/test_hypertoroidal_mixture_pdf.py
@@ -1,0 +1,27 @@
+import unittest
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import allclose, array
+from pyrecest.distributions.hypertorus.hypertoroidal_mixture import (
+    HypertoroidalMixture,
+)
+from pyrecest.distributions.hypertorus.hypertoroidal_wrapped_normal_distribution import (
+    HypertoroidalWrappedNormalDistribution,
+)
+
+
+class HypertoroidalMixturePdfTest(unittest.TestCase):
+    def test_pdf_accepts_scalar_for_one_dimensional_mixture(self):
+        first = HypertoroidalWrappedNormalDistribution(array([0.0]), array([[0.4]]))
+        second = HypertoroidalWrappedNormalDistribution(array([0.8]), array([[0.7]]))
+        mixture = HypertoroidalMixture([first, second], array([0.25, 0.75]))
+
+        result = mixture.pdf(0.3)
+        expected = 0.25 * first.pdf(array([0.3])) + 0.75 * second.pdf(array([0.3]))
+
+        self.assertEqual(result.shape, (1,))
+        self.assertTrue(allclose(result, expected))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`HypertoroidalMixture.pdf()` inherited the generic mixture implementation without first applying the hypertoroidal query-point normalizer. For a one-dimensional mixture, a valid scalar query such as `mixture.pdf(0.3)` therefore created a scalar accumulator, while wrapped-normal components returned a one-element density array. NumPy then raised a non-broadcastable-output `ValueError` instead of evaluating the density.

## Fix

- normalize mixture PDF queries with `as_hypertoroidal_points()` before generic mixture accumulation;
- align scalar, flat-batch, and higher-dimensional hypertoroidal query handling with the component distributions;
- add a focused regression for a scalar query on a one-dimensional wrapped-normal mixture.

## Impact

Valid scalar density evaluation now works for one-dimensional `HypertoroidalMixture` instances and returns the same one-value shape and weighted density as their components.

## Validation

- reproduced the pre-fix scalar/one-element broadcast failure;
- verified the normalized accumulator has shape `(1,)` and accepts component density vectors;
- syntax-compiled the modified implementation and regression test;
- reviewed the branch diff: two files, 33 additions and one deletion, two commits ahead and zero behind `main`.

GitHub Actions provides the authoritative full backend and test-matrix validation.