### PR TITLE
Preserve empty padded history steps

### DIFF
--- a/src/pyrecest/utils/history_recorder.py
+++ b/src/pyrecest/utils/history_recorder.py
@@ -233,10 +233,17 @@ class HistoryRecorder:
 
     @staticmethod
     def append_padded(curr_ests, estimates_over_time):
-        """Append a column to a possibly growing 2-D history array."""
-        curr_ests = HistoryRecorder._ensure_2d(curr_ests)
+        """Append a column to a possibly growing 2-D history array.
 
+        Empty estimates still represent a time step and therefore append an
+        all-NaN column instead of silently leaving the history unchanged.
+        """
+        curr_ests = _as_padded_numeric_array(curr_ests)
         m, t = estimates_over_time.shape
+        if backend.size(curr_ests) == 0:
+            return hstack((estimates_over_time, full((m, 1), nan)))
+
+        curr_ests = HistoryRecorder._ensure_2d(curr_ests)
         n = curr_ests.shape[0]
 
         if n <= m:

--- a/tests/utils/test_history_recorder_empty_steps.py
+++ b/tests/utils/test_history_recorder_empty_steps.py
@@ -1,0 +1,30 @@
+import numpy as np
+import numpy.testing as npt
+import pyrecest.backend as backend
+from pyrecest.utils import HistoryRecorder
+
+
+def _to_numpy(value):
+    return np.asarray(backend.to_numpy(value), dtype=float)
+
+
+def test_empty_padded_record_preserves_time_axis():
+    recorder = HistoryRecorder()
+    recorder.register("estimate", pad_with_nan=True)
+
+    recorder.record("estimate", backend.array([1.0, 2.0]), pad_with_nan=True)
+    recorder.record("estimate", backend.array([]), pad_with_nan=True)
+    history = recorder.record(
+        "estimate", backend.array([3.0]), pad_with_nan=True
+    )
+
+    npt.assert_allclose(
+        _to_numpy(history),
+        np.array(
+            [
+                [1.0, np.nan, 3.0],
+                [2.0, np.nan, np.nan],
+            ]
+        ),
+        equal_nan=True,
+    )


### PR DESCRIPTION
## Summary

- record empty padded estimates as all-NaN columns
- preserve the time axis when a multitarget tracker reports zero targets
- add backend-portable regression coverage for a nonempty/empty/nonempty sequence

## Bug

`HistoryRecorder.append_padded()` normalized an empty estimate to an array with zero columns and then horizontally stacked it into the existing history. That operation added no column at all, so a valid zero-target time step silently disappeared from logged prior or posterior estimate histories.

## Fix

Detect empty numeric estimates before the standard column-shaping path and append one all-NaN column with the history's current row count. Empty values supplied when initially registering a history retain their existing no-column semantics.

## Impact

Logged histories now remain aligned with prediction/update cycles even when the estimated target set is temporarily empty. Subsequent estimates keep their correct time index instead of shifting one step earlier.

## Validation

- isolated NumPy-backend harness reproduces the old skipped-column behavior and verifies the patched `[[1, 2], [], [3]]` sequence as a three-column history
- existing nonempty growth behavior remains unchanged
- existing explicitly empty initial registration still creates no history column
- modified source syntax-compiles successfully

GitHub Actions provides the authoritative repository-wide and backend-matrix validation.