### PR TITLE
Accept Python scalar integration callbacks

### DIFF
--- a/src/pyrecest/distributions/hypertorus/abstract_hypertoroidal_distribution.py
+++ b/src/pyrecest/distributions/hypertorus/abstract_hypertoroidal_distribution.py
@@ -92,7 +92,10 @@ class AbstractHypertoroidalDistribution(AbstractPeriodicDistribution):
             raise ValueError("integration_boundaries must have shape (dim, 2).")
 
         def scalar_f(*args):
-            return f(*args).item()  # ensures 0-dim scalar
+            result = f(*args)
+            if hasattr(result, "item"):
+                result = result.item()
+            return float(result)
 
         return nquad(scalar_f, integration_boundaries)[0]
 

--- a/tests/distributions/test_hypertoroidal_python_scalar_integrand.py
+++ b/tests/distributions/test_hypertoroidal_python_scalar_integrand.py
@@ -1,0 +1,20 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from pyrecest import backend
+from pyrecest.distributions import AbstractHypertoroidalDistribution
+
+pytestmark = pytest.mark.skipif(
+    backend.__backend_name__ != "numpy",
+    reason="SciPy nquad integration is supported only on the NumPy backend",
+)
+
+
+def test_integrate_fun_over_domain_part_accepts_python_scalar():
+    result = AbstractHypertoroidalDistribution.integrate_fun_over_domain_part(
+        lambda x: x,
+        np.array([[0.0, 1.0]]),
+    )
+
+    npt.assert_allclose(result, 0.5)


### PR DESCRIPTION
## Summary
- accept ordinary Python numeric scalars from hypertoroidal integration callbacks
- preserve existing `.item()` handling for NumPy/backend scalar-like values
- add a focused SciPy `nquad` regression

## Bug
`integrate_fun_over_domain_part()` unconditionally called `.item()` on the callback result. A valid callback such as `lambda x: x` returns a Python `float`, so integration aborted with `AttributeError`.

## Fix
Normalize scalar-like backend values through `.item()` when available, then convert the result to `float` for SciPy.

## Validation
- reproduced the pre-fix `AttributeError` with a Python-float callback
- verified the fixed adapter integrates Python floats, NumPy scalars, zero-dimensional arrays, and size-one arrays to the expected result
- reviewed the two-file branch diff against current `main`; the branch is two commits ahead and zero behind

Full repository CI provides the authoritative package-wide validation.