### PR TITLE
Fix small symmetric Leopardi partitions

### DIFF
--- a/src/pyrecest/sampling/leopardi_sampler/__init__.py
+++ b/src/pyrecest/sampling/leopardi_sampler/__init__.py
@@ -1,0 +1,49 @@
+"""Compatibility wrapper for Leopardi equal-area sampling utilities."""
+
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+
+_module_globals = runpy.run_path(
+    str(Path(__file__).resolve().parents[1] / "leopardi_sampler.py"),
+    run_name=__name__,
+)
+_original_get_equal_area_caps = _module_globals["get_equal_area_caps"]
+
+
+def get_equal_area_caps(dim, N, symmetric: bool = False):
+    """Return equal-area caps while preserving even symmetric collar counts."""
+    if not symmetric or dim == 1 or N <= 2:
+        return _original_get_equal_area_caps(dim, N, symmetric=symmetric)
+
+    get_polar_cap_colatitude = _module_globals["get_polar_cap_colatitude"]
+    get_ideal_collar_angle = _module_globals["get_ideal_collar_angle"]
+    get_ideal_region_counts = _module_globals["get_ideal_region_counts"]
+    round_region_counts = _module_globals["round_region_counts"]
+    get_cap_colatitudes = _module_globals["get_cap_colatitudes"]
+
+    c_polar = get_polar_cap_colatitude(dim, N)
+    ideal_angle = get_ideal_collar_angle(dim, N)
+    if not bool(ideal_angle > 0):
+        return _original_get_equal_area_caps(dim, N, symmetric=symmetric)
+
+    ratio_half = 0.5 * (_module_globals["pi"] - 2 * c_polar) / ideal_angle
+    # A symmetric partition needs at least one collar in each hemisphere.
+    n_half = _module_globals["max"](
+        _module_globals["array"]((1, _module_globals["round"](ratio_half)))
+    )
+    n_collars = int(2 * n_half)
+
+    region_counts = get_ideal_region_counts(dim, N, c_polar, n_collars)
+    n_regions = round_region_counts(region_counts)
+    cap_colatitudes = get_cap_colatitudes(dim, N, c_polar, n_regions)
+    return cap_colatitudes, n_regions
+
+
+# Functions loaded from the legacy module resolve globals through this dictionary.
+# Replacing the entry therefore fixes internal calls as well as public imports.
+_module_globals["get_equal_area_caps"] = get_equal_area_caps
+for _name, _value in _module_globals.items():
+    if not _name.startswith("__"):
+        globals()[_name] = _value

--- a/src/pyrecest/sampling/leopardi_sampler/__init__.py
+++ b/src/pyrecest/sampling/leopardi_sampler/__init__.py
@@ -10,6 +10,7 @@ _module_globals = runpy.run_path(
     run_name=__name__,
 )
 _original_get_equal_area_caps = _module_globals["get_equal_area_caps"]
+_legacy_globals = _original_get_equal_area_caps.__globals__
 
 
 def get_equal_area_caps(dim, N, symmetric: bool = False):
@@ -17,21 +18,21 @@ def get_equal_area_caps(dim, N, symmetric: bool = False):
     if not symmetric or dim == 1 or N <= 2:
         return _original_get_equal_area_caps(dim, N, symmetric=symmetric)
 
-    get_polar_cap_colatitude = _module_globals["get_polar_cap_colatitude"]
-    get_ideal_collar_angle = _module_globals["get_ideal_collar_angle"]
-    get_ideal_region_counts = _module_globals["get_ideal_region_counts"]
-    round_region_counts = _module_globals["round_region_counts"]
-    get_cap_colatitudes = _module_globals["get_cap_colatitudes"]
+    get_polar_cap_colatitude = _legacy_globals["get_polar_cap_colatitude"]
+    get_ideal_collar_angle = _legacy_globals["get_ideal_collar_angle"]
+    get_ideal_region_counts = _legacy_globals["get_ideal_region_counts"]
+    round_region_counts = _legacy_globals["round_region_counts"]
+    get_cap_colatitudes = _legacy_globals["get_cap_colatitudes"]
 
     c_polar = get_polar_cap_colatitude(dim, N)
     ideal_angle = get_ideal_collar_angle(dim, N)
     if not bool(ideal_angle > 0):
         return _original_get_equal_area_caps(dim, N, symmetric=symmetric)
 
-    ratio_half = 0.5 * (_module_globals["pi"] - 2 * c_polar) / ideal_angle
+    ratio_half = 0.5 * (_legacy_globals["pi"] - 2 * c_polar) / ideal_angle
     # A symmetric partition needs at least one collar in each hemisphere.
-    n_half = _module_globals["max"](
-        _module_globals["array"]((1, _module_globals["round"](ratio_half)))
+    n_half = _legacy_globals["max"](
+        _legacy_globals["array"]((1, _legacy_globals["round"](ratio_half)))
     )
     n_collars = int(2 * n_half)
 
@@ -41,8 +42,9 @@ def get_equal_area_caps(dim, N, symmetric: bool = False):
     return cap_colatitudes, n_regions
 
 
-# Functions loaded from the legacy module resolve globals through this dictionary.
-# Replacing the entry therefore fixes internal calls as well as public imports.
+# Legacy functions resolve global names through their original execution dictionary.
+# Patch that dictionary so internal calls use the corrected implementation as well.
+_legacy_globals["get_equal_area_caps"] = get_equal_area_caps
 _module_globals["get_equal_area_caps"] = get_equal_area_caps
 for _name, _value in _module_globals.items():
     if not _name.startswith("__"):

--- a/tests/test_leopardi_small_symmetric_partitions.py
+++ b/tests/test_leopardi_small_symmetric_partitions.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pyrecest.backend
+import pytest
+from pyrecest.sampling.leopardi_sampler import get_partition_points_cartesian
+
+
+pytestmark = pytest.mark.skipif(
+    pyrecest.backend.__backend_name__ == "jax",
+    reason="Leopardi sampling uses SciPy root finding.",
+)
+
+
+@pytest.mark.parametrize("symmetry_type", ["plane", "antipodal"])
+def test_small_symmetric_leopardi_partition_has_unique_points(symmetry_type):
+    half = np.asarray(
+        get_partition_points_cartesian(
+            2,
+            4,
+            delete_half=True,
+            symmetry_type=symmetry_type,
+        )
+    )
+    full = np.asarray(
+        get_partition_points_cartesian(
+            2,
+            4,
+            delete_half=False,
+            symmetry_type=symmetry_type,
+        )
+    )
+
+    assert half.shape == (2, 3)
+    assert full.shape == (4, 3)
+    np.testing.assert_allclose(np.linalg.norm(half, axis=1), 1.0, atol=1e-12)
+    np.testing.assert_allclose(np.linalg.norm(full, axis=1), 1.0, atol=1e-12)
+    assert np.unique(np.round(half, decimals=12), axis=0).shape[0] == 2
+    assert np.unique(np.round(full, decimals=12), axis=0).shape[0] == 4


### PR DESCRIPTION
## Summary

- enforce at least one Leopardi collar per hemisphere for symmetric partitions
- keep the total number of collars even for the smallest valid symmetric grid
- add an end-to-end regression for `N=4` in plane-reflection and antipodal modes

## Bug

For small symmetric partitions, the half-collar calculation used `0.5` as its lower bound. At `N=4`, this produced one total collar even though the algorithm requires an even collar count. The northern-half generator then evaluated `n_collars // 2` as zero, skipped the only collar, and left the second preallocated polar coordinate at zero. After Cartesian conversion, the grid therefore contained duplicate north-pole samples.

## Fix

The compatibility override now requires at least one collar in each hemisphere, yielding two total collars at minimum. Internal calls from the legacy implementation are patched through the legacy function globals so public and nested calls use the corrected calculation.

## Validation

- syntax-compiled the new implementation and focused regression
- reproduced the old `N=4` region layout as `[1, 2, 1]`
- verified the corrected layout is `[1, 1, 1, 1]`
- isolated import-level regression produces 2 unique northern points and 4 unique full-sphere points for both `plane` and `antipodal` symmetry

The full repository test matrix is left to GitHub Actions because this connector environment has no local repository checkout.