### PR TITLE
Stabilize SO(3) Bingham log-density evaluation

### DIFF
--- a/src/pyrecest/distributions/so3_bingham_distribution.py
+++ b/src/pyrecest/distributions/so3_bingham_distribution.py
@@ -162,7 +162,13 @@ class SO3BinghamDistribution(HyperhemisphericalBinghamDistribution):
 
     def ln_pdf(self, xs):
         """Evaluate the natural logarithm of the SO(3) density."""
-        return log(self.pdf(xs))
+        xs = self._normalize_quaternions(xs)
+        exponent_matrix = self.concentration_matrix()
+        return (
+            log(array(2.0))
+            - log(self.distFullSphere.F)
+            + sum(xs * (xs @ exponent_matrix), axis=-1)
+        )
 
     def mode(self):
         """Return the modal rotation as a canonical scalar-last quaternion."""

--- a/tests/distributions/test_so3_bingham_logpdf_stability.py
+++ b/tests/distributions/test_so3_bingham_logpdf_stability.py
@@ -1,0 +1,31 @@
+import math
+import unittest
+
+from pyrecest.backend import array
+from pyrecest.distributions import SO3BinghamDistribution
+from tests.distributions.so3_test_helpers import scalar
+
+
+class SO3BinghamLogPdfStabilityTest(unittest.TestCase):
+    def test_log_pdf_remains_finite_when_pdf_underflows(self):
+        concentration = 1000.0
+        distribution = SO3BinghamDistribution.from_mode_and_concentration(
+            array([0.0, 0.0, 0.0, 1.0]), concentration
+        )
+        orthogonal_quaternion = array([1.0, 0.0, 0.0, 0.0])
+
+        self.assertEqual(scalar(distribution.pdf(orthogonal_quaternion)), 0.0)
+
+        log_density = scalar(distribution.ln_pdf(orthogonal_quaternion))
+        expected = (
+            math.log(2.0)
+            - math.log(scalar(distribution.distFullSphere.F))
+            - concentration
+        )
+
+        self.assertTrue(math.isfinite(log_density))
+        self.assertAlmostEqual(log_density, expected, places=10)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/distributions/test_so3_bingham_logpdf_stability.py
+++ b/tests/distributions/test_so3_bingham_logpdf_stability.py
@@ -24,7 +24,7 @@ class SO3BinghamLogPdfStabilityTest(unittest.TestCase):
         )
 
         self.assertTrue(math.isfinite(log_density))
-        self.assertAlmostEqual(log_density, expected, places=10)
+        self.assertAlmostEqual(log_density, expected, delta=1e-4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- evaluate `SO3BinghamDistribution.ln_pdf()` directly in log space
- preserve quaternion normalization and the SO(3) hemisphere factor
- add a concentrated-distribution regression where the ordinary PDF underflows

## Bug

`ln_pdf()` called `log(self.pdf(xs))`. For valid concentrated Bingham distributions, the exponential density can underflow to zero even though the logarithmic density is finite. For concentration `1000` at an orthogonal quaternion, the PDF evaluates to `0.0`, so the old implementation returned `-inf` instead of approximately `-991.3562`.

## Fix

Compute

`log(2) - log(F) + x^T M diag(Z) M^T x`

directly after normalizing the input quaternions. This is algebraically equivalent to the PDF but avoids the intermediate exponential underflow.

## Validation

- reproduced the old underflow numerically at concentration `1000`
- verified the direct log-domain expression is finite and equals approximately `-991.3562`
- added a backend-tolerant regression test covering the underflow case
- branch is based on current `main` and changes only the SO(3) Bingham implementation plus its focused test

The full backend and package test matrix is left to GitHub Actions.