### PR TITLE
Accept NumPy simulation counts

### DIFF
--- a/src/pyrecest/evaluation/check_and_fix_config.py
+++ b/src/pyrecest/evaluation/check_and_fix_config.py
@@ -1,8 +1,14 @@
+from numbers import Integral
+
+import numpy as np
+
 from pyrecest.distributions import AbstractManifoldSpecificDistribution
 
 
 def _is_integer_count(value):
-    return isinstance(value, int) and not isinstance(value, bool)
+    if isinstance(value, (bool, np.bool_, np.datetime64, np.timedelta64)):
+        return False
+    return isinstance(value, Integral)
 
 
 def _expand_meas_per_step(simulation_param):
@@ -46,7 +52,7 @@ def check_and_fix_config(simulation_param):
     # Check for 'timesteps'
     timesteps = simulation_param["n_timesteps"]
     if timesteps is not None:
-        if not isinstance(timesteps, int):
+        if not _is_integer_count(timesteps):
             raise TypeError("n_timesteps must be an integer")
         if timesteps <= 0:
             raise ValueError("n_timesteps must be positive")

--- a/tests/evaluation/test_check_and_fix_config.py
+++ b/tests/evaluation/test_check_and_fix_config.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 from pyrecest.backend import eye, zeros
 from pyrecest.distributions import GaussianDistribution
@@ -35,6 +36,14 @@ def test_expand_meas_per_step_accepts_zero_count():
     assert "meas_per_step" not in simulation_param
 
 
+def test_expand_meas_per_step_accepts_numpy_integer_count():
+    simulation_param = {"n_timesteps": 4, "meas_per_step": np.int64(2)}
+
+    _expand_meas_per_step(simulation_param)
+
+    assert simulation_param["n_meas_at_individual_time_step"] == [2, 2, 2, 2]
+
+
 def test_expand_meas_per_step_rejects_negative_count():
     simulation_param = {"n_timesteps": 4, "meas_per_step": -1}
 
@@ -69,6 +78,16 @@ def test_validate_measurement_counts_rejects_noninteger_entries():
         _validate_measurement_counts(simulation_param)
 
 
+def test_validate_measurement_counts_rejects_temporal_entries():
+    simulation_param = {
+        "n_timesteps": 2,
+        "n_meas_at_individual_time_step": [1, np.timedelta64(2, "ns")],
+    }
+
+    with pytest.raises(TypeError, match="integer"):
+        _validate_measurement_counts(simulation_param)
+
+
 def test_validate_measurement_counts_rejects_negative_entries():
     simulation_param = {
         "n_timesteps": 2,
@@ -83,6 +102,15 @@ def test_validate_measurement_counts_accepts_zero_entries():
     simulation_param = {
         "n_timesteps": 3,
         "n_meas_at_individual_time_step": [1, 0, 2],
+    }
+
+    _validate_measurement_counts(simulation_param)
+
+
+def test_validate_measurement_counts_accepts_numpy_integer_entries():
+    simulation_param = {
+        "n_timesteps": 3,
+        "n_meas_at_individual_time_step": np.array([1, 0, 2], dtype=np.int64),
     }
 
     _validate_measurement_counts(simulation_param)
@@ -105,9 +133,21 @@ def test_check_and_fix_config_accepts_zero_measurement_counts():
     assert fixed_config["n_meas_at_individual_time_step"] == [1, 0, 2]
 
 
+def test_check_and_fix_config_accepts_numpy_integer_timesteps():
+    fixed_config = check_and_fix_config(_base_config(n_timesteps=np.int64(3)))
+
+    assert fixed_config["n_timesteps"] == 3
+    assert fixed_config["n_meas_at_individual_time_step"] == [1, 1, 1]
+
+
 def test_check_and_fix_config_rejects_nonpositive_timesteps():
     with pytest.raises(ValueError, match="n_timesteps must be positive"):
         check_and_fix_config(_base_config(n_timesteps=0))
+
+
+def test_check_and_fix_config_rejects_temporal_timesteps():
+    with pytest.raises(TypeError, match="n_timesteps must be an integer"):
+        check_and_fix_config(_base_config(n_timesteps=np.timedelta64(3, "ns")))
 
 
 def test_check_and_fix_config_rejects_intensity_without_eot_or_mtt():


### PR DESCRIPTION
## Summary

- accept `numpy.integer` values for `n_timesteps`, `meas_per_step`, and per-step measurement counts
- preserve rejection of booleans and NumPy temporal scalars
- add focused regressions for NumPy integer configurations and temporal lookalikes

## Bug

`check_and_fix_config()` recognized counts only with `isinstance(value, int)`. Valid counts originating from NumPy arrays, such as `np.int64(3)`, were therefore rejected with `TypeError` before a simulation could start. This affected timestep counts, constant measurements-per-step, and per-step measurement-count arrays.

A naive switch to `numbers.Integral` would introduce a second bug because NumPy classifies fine-resolution `np.timedelta64` values as integral-like. The validator therefore explicitly excludes boolean and temporal scalar types before accepting `Integral` values.

## Impact

Simulation configurations can now be passed directly from NumPy-derived data without converting every count to a built-in Python `int`, while invalid temporal values remain rejected.

## Validation

- syntax-compiled the modified implementation and regression test
- verified built-in and NumPy integer scalars are accepted
- verified booleans, `numpy.datetime64`, `numpy.timedelta64`, and floating-point values are rejected
- reviewed the branch diff: 1 commit ahead, 0 behind `main`; two files changed