### PR TITLE
Reject temporal point-registration count controls

### DIFF
--- a/src/pyrecest/utils/point_set_registration.py
+++ b/src/pyrecest/utils/point_set_registration.py
@@ -18,7 +18,6 @@ from dataclasses import dataclass
 from typing import Any, Callable, Literal
 
 import numpy as np
-
 import pyrecest.backend
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member,duplicate-code

--- a/src/pyrecest/utils/point_set_registration.py
+++ b/src/pyrecest/utils/point_set_registration.py
@@ -17,6 +17,8 @@ import math
 from dataclasses import dataclass
 from typing import Any, Callable, Literal
 
+import numpy as np
+
 import pyrecest.backend
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member,duplicate-code
@@ -197,13 +199,37 @@ def _validate_effective_weight_support(
 
 
 def _validate_positive_integer(value, name: str, *, minimum: int = 1) -> int:
-    value_array = asarray(value)
+    error_message = f"{name} must be a scalar integer."
+    temporal_types = (np.datetime64, np.timedelta64)
+
+    if isinstance(value, temporal_types):
+        raise ValueError(error_message)
+
+    value_dtype = getattr(value, "dtype", None)
+    if value_dtype is not None:
+        try:
+            if np.issubdtype(value_dtype, np.datetime64) or np.issubdtype(
+                value_dtype, np.timedelta64
+            ):
+                raise ValueError(error_message)
+        except TypeError:
+            pass
+
+    if isinstance(value, np.ndarray) and value.shape == () and isinstance(
+        value.item(), temporal_types
+    ):
+        raise ValueError(error_message)
+
+    try:
+        value_array = asarray(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(error_message) from exc
     if value_array.shape != ():
-        raise ValueError(f"{name} must be a scalar integer.")
+        raise ValueError(error_message)
 
     value_scalar = value_array.item()
-    if isinstance(value_scalar, bool):
-        raise ValueError(f"{name} must be a scalar integer.")
+    if isinstance(value_scalar, bool) or isinstance(value_scalar, temporal_types):
+        raise ValueError(error_message)
 
     try:
         value_float = float(value_scalar)

--- a/tests/test_point_registration_temporal_count_validation.py
+++ b/tests/test_point_registration_temporal_count_validation.py
@@ -1,0 +1,45 @@
+import unittest
+
+import numpy as np
+import pyrecest.backend
+from pyrecest.backend import array
+from pyrecest.utils.point_set_registration import joint_registration_assignment
+
+
+class TestPointRegistrationTemporalCountValidation(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Point-set registration is not supported on this backend",
+    )
+    def test_rejects_numpy_temporal_count_controls(self):
+        points = array([[0.0, 0.0], [1.0, 0.0]])
+        invalid_values = (
+            np.timedelta64(3, "ns"),
+            np.datetime64("1970-01-01T00:00:00.000000003", "ns"),
+            np.array(np.timedelta64(3, "ns"), dtype=object),
+            np.array(
+                np.datetime64("1970-01-01T00:00:00.000000003", "ns"),
+                dtype=object,
+            ),
+        )
+
+        for parameter_name in ("max_iterations", "min_matches"):
+            for invalid_value in invalid_values:
+                with self.subTest(
+                    parameter_name=parameter_name,
+                    invalid_value=invalid_value,
+                ):
+                    with self.assertRaisesRegex(
+                        ValueError,
+                        f"{parameter_name} must be a scalar integer",
+                    ):
+                        joint_registration_assignment(
+                            points,
+                            points,
+                            model="translation",
+                            **{parameter_name: invalid_value},
+                        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- reject NumPy `datetime64` and `timedelta64` values for point-registration integer controls
- cover both native temporal dtypes and zero-dimensional object-wrapped temporal scalars
- preserve valid Python, NumPy, and backend integer-like inputs

## Bug

`joint_registration_assignment()` normalizes `max_iterations` and `min_matches` through `_validate_positive_integer()`. For nanosecond-resolution NumPy temporal scalars, `ndarray.item()` exposes the raw integer storage value. As a result, values such as `np.timedelta64(3, "ns")` and a timestamp three nanoseconds after the Unix epoch were silently interpreted as the integer `3`.

## Fix

Detect NumPy temporal scalars and temporal dtypes before backend array conversion and scalar extraction. Object-wrapped zero-dimensional temporal arrays are also rejected, and backend conversion failures are normalized to the existing `ValueError` contract.

## Validation

- syntax-compiled the modified source and regression test
- isolated NumPy-backend regression rejects native and object-wrapped temporal values while accepting valid integer-like values
- isolated PyTorch-backend stub regression verifies temporal rejection and valid tensor integer handling
- branch is three commits ahead and zero behind `main`; diff is limited to the validator and one focused regression test
