### PR TITLE
Reject temporal SO(3) conversion controls

### DIFF
--- a/src/pyrecest/distributions/so3_conversion.py
+++ b/src/pyrecest/distributions/so3_conversion.py
@@ -18,6 +18,7 @@ from .so3_tangent_gaussian_distribution import SO3TangentGaussianDistribution
 _COVARIANCE_REGULARIZATION_ERROR = (
     "covariance_regularization must be a nonnegative finite scalar"
 )
+_TEMPORAL_SCALAR_TYPES = (np.datetime64, np.timedelta64)
 
 
 def _sample_so3_product_dirac(distribution, n_particles):
@@ -28,7 +29,7 @@ def _sample_so3_product_dirac(distribution, n_particles):
 
 def _validate_particle_count(n_particles):
     if (
-        isinstance(n_particles, bool)
+        isinstance(n_particles, (bool, np.bool_, *_TEMPORAL_SCALAR_TYPES))
         or not isinstance(n_particles, Integral)
         or int(n_particles) <= 0
     ):
@@ -42,13 +43,22 @@ def _validate_covariance_regularization(covariance_regularization):
     except (TypeError, ValueError) as exc:
         raise ValueError(_COVARIANCE_REGULARIZATION_ERROR) from exc
 
-    if regularization_array.shape != () or regularization_array.dtype.kind in "bSU":
+    if regularization_array.shape != () or regularization_array.dtype.kind in "bSUMm":
         raise ValueError(_COVARIANCE_REGULARIZATION_ERROR)
 
     regularization_scalar = regularization_array.item()
     if isinstance(
         regularization_scalar,
-        (bool, np.bool_, str, bytes, bytearray, np.str_, np.bytes_),
+        (
+            bool,
+            np.bool_,
+            str,
+            bytes,
+            bytearray,
+            np.str_,
+            np.bytes_,
+            *_TEMPORAL_SCALAR_TYPES,
+        ),
     ):
         raise ValueError(_COVARIANCE_REGULARIZATION_ERROR)
 

--- a/tests/distributions/test_so3_conversion_validation.py
+++ b/tests/distributions/test_so3_conversion_validation.py
@@ -1,5 +1,7 @@
 import unittest
 
+import numpy as np
+
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import array
 from pyrecest.distributions.conversion import convert_distribution
@@ -12,6 +14,16 @@ from pyrecest.distributions.so3_product_tangent_gaussian_distribution import (
 )
 from pyrecest.distributions.so3_tangent_gaussian_distribution import (
     SO3TangentGaussianDistribution,
+)
+
+
+_TEMPORAL_VALUES = (
+    np.timedelta64(3, "ns"),
+    np.timedelta64(3, "us"),
+    np.datetime64(3, "ns"),
+    np.datetime64(3, "us"),
+    np.asarray(np.timedelta64(3, "ns"), dtype=object),
+    np.asarray(np.datetime64(3, "ns"), dtype=object),
 )
 
 
@@ -30,6 +42,7 @@ class SO3ConversionValidationTest(unittest.TestCase):
             float("nan"),
             float("inf"),
             "1e-3",
+            *_TEMPORAL_VALUES,
         ):
             with self.subTest(covariance_regularization=covariance_regularization):
                 with self.assertRaisesRegex(
@@ -64,6 +77,7 @@ class SO3ConversionValidationTest(unittest.TestCase):
             float("nan"),
             float("inf"),
             "1e-3",
+            *_TEMPORAL_VALUES,
         ):
             with self.subTest(covariance_regularization=covariance_regularization):
                 with self.assertRaisesRegex(
@@ -74,6 +88,28 @@ class SO3ConversionValidationTest(unittest.TestCase):
                         particles,
                         "so3_product_tangent_gaussian",
                         covariance_regularization=covariance_regularization,
+                    )
+
+    def test_so3_product_dirac_rejects_temporal_particle_counts(self):
+        mean = array([[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.0, 1.0]])
+        distribution = SO3ProductTangentGaussianDistribution(
+            mean,
+            array(0.01 * np.eye(6)),
+        )
+
+        for n_particles in (
+            np.timedelta64(3, "ns"),
+            np.timedelta64(3, "us"),
+        ):
+            with self.subTest(n_particles=n_particles):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "n_particles must be a positive integer",
+                ):
+                    convert_distribution(
+                        distribution,
+                        "so3_product_dirac",
+                        n_particles=n_particles,
                     )
 
 


### PR DESCRIPTION
## Summary

- reject NumPy datetime and timedelta values as SO(3) covariance-regularization controls
- reject NumPy timedelta values as SO(3) product particle counts
- add regression coverage for fine-resolution, coarse-resolution, and object-wrapped temporal scalars

## Bug

The SO(3) conversion validators inspected temporal values only after NumPy scalar extraction. For nanosecond `numpy.datetime64` and `numpy.timedelta64` values, `.item()` exposes their raw integer storage, so covariance regularization silently accepted them as ordinary numbers. `numpy.timedelta64` also satisfies `numbers.Integral`, allowing a fine-resolution duration to control product-particle sampling; coarser units could instead leak a lower-level `TypeError`.

## Fix

Reject temporal dtypes before scalar extraction and temporal scalar objects after extraction. The particle-count validator now excludes both Python/NumPy booleans and NumPy temporal scalar types before the generic integral check.

## Impact

Malformed temporal controls now fail deterministically with the documented `ValueError` contracts instead of being interpreted as numeric regularization or allocation counts.

## Validation

- reproduced the pre-fix acceptance of `np.timedelta64(3, "ns")` as particle count `3`
- reproduced the pre-fix acceptance of nanosecond datetime/timedelta values as regularization `3.0`
- isolated patched regression checks pass for fine-resolution, coarse-resolution, and object-wrapped temporal values
- modified source and test files pass `python -m py_compile`
- branch is 2 commits ahead of current `main` and 0 behind

GitHub Actions provides the authoritative repository-wide and backend-matrix validation.