### PR TITLE
Fix partially wrapped normal hybrid moment ordering

### DIFF
--- a/src/pyrecest/distributions/cart_prod/partially_wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/partially_wrapped_normal_distribution.py
@@ -27,7 +27,6 @@ from pyrecest.backend import (
     repeat,
     reshape,
     sin,
-    stack,
     sum,
     tile,
     where,
@@ -244,10 +243,10 @@ class PartiallyWrappedNormalDistribution(AbstractHypercylindricalDistribution):
         return self.set_mean(new_mode)
 
     def hybrid_moment(self):
-        """
-        Calculates mean of [x1, x2, .., x_lin_dim, cos(x_(linD+1), sin(x_(linD+1)), ..., cos(x_(lin_dim+boundD), sin(x_(lin_dim+bound_dim))]
-        Returns:
-            mu (linD+2): expectation value of [x1, x2, .., x_lin_dim, cos(x_(lin_dim+1), sin(x_(lin_dim+1)), ..., cos(x_(lin_dim+bound_dim), sin(x_(lin_dim+bound_dim))]
+        """Return periodic trigonometric moments followed by linear means.
+
+        The periodic entries follow the package-wide hypercylindrical convention:
+        all cosine moments, then all sine moments, followed by the linear means.
         """
         mu_lin = self.mu[self.bound_dim :]  # noqa: E203
 
@@ -258,7 +257,7 @@ class PartiallyWrappedNormalDistribution(AbstractHypercylindricalDistribution):
             -diag(self.C)[: self.bound_dim] / 2
         )
 
-        mu_bound = stack([mu_bound_even, mu_bound_odd], axis=1).reshape(-1)
+        mu_bound = hstack((mu_bound_even, mu_bound_odd))
 
         return hstack((mu_bound, mu_lin))
 

--- a/tests/distributions/test_partially_wrapped_normal_hybrid_moment_order.py
+++ b/tests/distributions/test_partially_wrapped_normal_hybrid_moment_order.py
@@ -1,0 +1,42 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+from pyrecest.backend import array
+from pyrecest.distributions.cart_prod.partially_wrapped_normal_distribution import (
+    PartiallyWrappedNormalDistribution,
+)
+
+
+class PartiallyWrappedNormalHybridMomentOrderTest(unittest.TestCase):
+    def test_groups_all_cosines_before_all_sines(self):
+        mu = array([0.2, 1.1, 3.0])
+        covariance = array(
+            [
+                [0.4, 0.0, 0.0],
+                [0.0, 0.8, 0.0],
+                [0.0, 0.0, 1.0],
+            ]
+        )
+        distribution = PartiallyWrappedNormalDistribution(
+            mu,
+            covariance,
+            bound_dim=2,
+        )
+
+        expected = np.array(
+            [
+                np.cos(0.2) * np.exp(-0.4 / 2.0),
+                np.cos(1.1) * np.exp(-0.8 / 2.0),
+                np.sin(0.2) * np.exp(-0.4 / 2.0),
+                np.sin(1.1) * np.exp(-0.8 / 2.0),
+                3.0,
+            ]
+        )
+
+        npt.assert_allclose(distribution.hybrid_moment(), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`PartiallyWrappedNormalDistribution.hybrid_moment()` interleaved each periodic dimension's cosine and sine moments as

`[cos(theta_1), sin(theta_1), cos(theta_2), sin(theta_2), ...]`.

The package-wide hypercylindrical convention, used by the corresponding Dirac and subdivision distributions, is

`[cos(theta_1), cos(theta_2), ..., sin(theta_1), sin(theta_2), ..., linear means]`.

For `bound_dim > 1`, the old implementation therefore silently permuted moment-vector coordinates. The existing one-periodic-dimension tests could not expose the defect.

## Fix

- concatenate all cosine moments before all sine moments;
- document the ordering contract directly on `hybrid_moment()`;
- remove the now-unused stacking import;
- add a focused two-periodic-dimension regression with a trailing linear component.

## Impact

Multi-periodic partially wrapped normal distributions now return hybrid moments in the same coordinate order as the rest of the hypercylindrical distribution API. Consumers that compare, fuse, or convert these moments no longer receive silently permuted statistics.

## Validation

- rebased onto current `main` (`ae0a1c48336b5736c0af712f9ec3c9d003032004`);
- branch changes only the implementation and one focused regression test;
- branch is 2 commits ahead and 0 behind;
- GitHub Actions provides the authoritative repository-wide and backend-matrix validation.