### PR TITLE
Reject temporal EMA alpha values

### DIFF
--- a/src/pyrecest/filters/manifold_exponential_moving_average.py
+++ b/src/pyrecest/filters/manifold_exponential_moving_average.py
@@ -59,11 +59,25 @@ class ManifoldExponentialMovingAverage(AbstractFilter):
             raise TypeError(message) from exc
         if alpha_array.shape != () or alpha_array.dtype == np.bool_:
             raise TypeError(message)
+        if np.issubdtype(alpha_array.dtype, np.datetime64) or np.issubdtype(
+            alpha_array.dtype, np.timedelta64
+        ):
+            raise TypeError(message)
 
         alpha_scalar = alpha_array.item()
         if isinstance(
             alpha_scalar,
-            (bool, np.bool_, str, bytes, bytearray, np.str_, np.bytes_),
+            (
+                bool,
+                np.bool_,
+                str,
+                bytes,
+                bytearray,
+                np.str_,
+                np.bytes_,
+                np.datetime64,
+                np.timedelta64,
+            ),
         ):
             raise TypeError(message)
 

--- a/tests/filters/test_manifold_exponential_moving_average.py
+++ b/tests/filters/test_manifold_exponential_moving_average.py
@@ -123,6 +123,37 @@ class TestManifoldExponentialMovingAverage(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, "real scalar"):
             ema.alpha = "0.25"
 
+    def test_alpha_rejects_temporal_values(self):
+        temporal_values = (
+            np.timedelta64(0, "ns"),
+            np.timedelta64(1, "ns"),
+            np.datetime64(0, "ns"),
+            np.datetime64(1, "ns"),
+            np.array(np.timedelta64(1, "ns"), dtype=object),
+            np.array(np.datetime64(0, "ns"), dtype=object),
+        )
+        for alpha in temporal_values:
+            with self.subTest(alpha=alpha):
+                with self.assertRaisesRegex(TypeError, "real scalar"):
+                    ManifoldExponentialMovingAverage(
+                        initial_state=0.0,
+                        alpha=alpha,
+                        phi=_phi_so2,
+                        phi_inv=_phi_inv_so2,
+                    )
+
+        ema = ManifoldExponentialMovingAverage(
+            initial_state=0.0,
+            alpha=0.5,
+            phi=_phi_so2,
+            phi_inv=_phi_inv_so2,
+        )
+        for alpha in temporal_values:
+            with self.subTest(alpha=alpha):
+                with self.assertRaisesRegex(TypeError, "real scalar"):
+                    ema.alpha = alpha
+                self.assertEqual(ema.alpha, 0.5)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Bug
`ManifoldExponentialMovingAverage._validate_alpha()` converted scalar inputs with `numpy.asarray(...).item()` before excluding temporal dtypes. For nanosecond `numpy.datetime64` and `numpy.timedelta64` values, `.item()` exposes the raw integer storage value, so timestamps and durations representing `0` or `1` were silently accepted as valid EMA weights.

Object-wrapped temporal scalars followed the same path.

## Fix
- reject NumPy datetime and timedelta dtypes before scalar extraction;
- reject object-wrapped NumPy temporal scalars after extraction;
- preserve valid Python and NumPy real scalar alpha values;
- keep setter failures atomic so the previous alpha remains unchanged.

## Impact
Temporal metadata can no longer silently switch the filter to `alpha=0` or `alpha=1`, which would respectively freeze the estimate or replace it completely at every update.

## Validation
- reproduced the pre-fix acceptance for native and object-wrapped nanosecond temporal values;
- verified the patched validator rejects all temporal cases with the documented `TypeError` contract;
- verified valid scalar controls remain accepted;
- added focused constructor and setter regressions.