### PR TITLE
Reject invalid GNN pairwise association costs

### DIFF
--- a/src/pyrecest/filters/global_nearest_neighbor.py
+++ b/src/pyrecest/filters/global_nearest_neighbor.py
@@ -1,4 +1,5 @@
 # pylint: disable=redefined-builtin,no-name-in-module,no-member,duplicate-code
+import builtins
 import warnings
 
 import numpy as np
@@ -20,6 +21,23 @@ from scipy.spatial.distance import cdist
 from scipy.stats import chi2
 
 from .abstract_nearest_neighbor_tracker import AbstractNearestNeighborTracker
+
+
+_INVALID_PAIRWISE_COST_SCALAR_TYPES = (
+    type(None),
+    bool,
+    np.bool_,
+    str,
+    bytes,
+    bytearray,
+    np.str_,
+    np.bytes_,
+    complex,
+    np.complexfloating,
+    np.datetime64,
+    np.timedelta64,
+)
+_REJECTED_PAIRWISE_COST_DTYPE_KINDS = frozenset({"b", "c", "S", "U", "M", "m"})
 
 
 class GlobalNearestNeighbor(AbstractNearestNeighborTracker):
@@ -75,13 +93,38 @@ class GlobalNearestNeighbor(AbstractNearestNeighborTracker):
             return None
         try:
             raw_pairwise_cost_matrix = np.asarray(pairwise_cost_matrix)
-        except (TypeError, ValueError) as exc:
+        except (TypeError, ValueError, OverflowError) as exc:
             raise ValueError(
                 "pairwise_cost_matrix must contain real numeric costs."
             ) from exc
-        if raw_pairwise_cost_matrix.dtype.kind in {"b", "c", "S", "U"}:
+        if raw_pairwise_cost_matrix.dtype.kind in _REJECTED_PAIRWISE_COST_DTYPE_KINDS:
             raise ValueError("pairwise_cost_matrix must contain real numeric costs.")
-        pairwise_cost_matrix = asarray(pairwise_cost_matrix, dtype=float)
+
+        inspect_scalar_types = raw_pairwise_cost_matrix.dtype.kind == "O" or isinstance(
+            pairwise_cost_matrix, (list, tuple)
+        )
+        if inspect_scalar_types:
+            try:
+                object_pairwise_cost_matrix = np.asarray(
+                    pairwise_cost_matrix, dtype=object
+                )
+            except (TypeError, ValueError, OverflowError) as exc:
+                raise ValueError(
+                    "pairwise_cost_matrix must contain real numeric costs."
+                ) from exc
+            if builtins.any(
+                isinstance(value, _INVALID_PAIRWISE_COST_SCALAR_TYPES)
+                for value in object_pairwise_cost_matrix.reshape(-1)
+            ):
+                raise ValueError(
+                    "pairwise_cost_matrix must contain real numeric costs."
+                )
+        try:
+            pairwise_cost_matrix = asarray(raw_pairwise_cost_matrix, dtype=float)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(
+                "pairwise_cost_matrix must contain real numeric costs."
+            ) from exc
         if pairwise_cost_matrix.shape != (n_targets, n_meas):
             raise ValueError(
                 "pairwise_cost_matrix must have shape "

--- a/tests/filters/test_gnn_pairwise_object_cost_validation.py
+++ b/tests/filters/test_gnn_pairwise_object_cost_validation.py
@@ -1,0 +1,93 @@
+import unittest
+
+import numpy as np
+from pyrecest.filters.global_nearest_neighbor import GlobalNearestNeighbor
+
+
+class GlobalNearestNeighborPairwiseObjectCostValidationTest(unittest.TestCase):
+    @staticmethod
+    def _object_matrix(value):
+        matrix = np.empty((1, 1), dtype=object)
+        matrix[0, 0] = value
+        return matrix
+
+    def test_rejects_non_real_values_hidden_in_object_arrays(self):
+        invalid_values = (
+            None,
+            True,
+            np.bool_(True),
+            "1.0",
+            b"1.0",
+            bytearray(b"1.0"),
+            np.str_("1.0"),
+            np.bytes_(b"1.0"),
+            1.0 + 0.0j,
+            np.complex128(1.0 + 0.0j),
+            np.datetime64("2026-07-27"),
+            np.timedelta64(3, "ns"),
+        )
+
+        for invalid_value in invalid_values:
+            with self.subTest(value=invalid_value, type=type(invalid_value).__name__):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "pairwise_cost_matrix must contain real numeric costs",
+                ):
+                    GlobalNearestNeighbor._validate_pairwise_cost_matrix(
+                        self._object_matrix(invalid_value),
+                        1,
+                        1,
+                    )
+
+    def test_rejects_invalid_values_hidden_by_mixed_type_coercion(self):
+        invalid_matrices = (
+            [[1.0, True]],
+            [[1.0, "2.0"]],
+            [[1.0, np.datetime64("2026-07-27")]],
+            [[1.0, np.timedelta64(3, "ns")]],
+        )
+
+        for invalid_matrix in invalid_matrices:
+            with self.subTest(matrix=invalid_matrix):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "pairwise_cost_matrix must contain real numeric costs",
+                ):
+                    GlobalNearestNeighbor._validate_pairwise_cost_matrix(
+                        invalid_matrix,
+                        1,
+                        2,
+                    )
+
+    def test_rejects_native_temporal_dtypes(self):
+        invalid_matrices = (
+            np.array([["2026-07-27"]], dtype="datetime64[D]"),
+            np.array([[3]], dtype="timedelta64[ns]"),
+        )
+
+        for invalid_matrix in invalid_matrices:
+            with self.subTest(dtype=invalid_matrix.dtype):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "pairwise_cost_matrix must contain real numeric costs",
+                ):
+                    GlobalNearestNeighbor._validate_pairwise_cost_matrix(
+                        invalid_matrix,
+                        1,
+                        1,
+                    )
+
+    def test_accepts_real_numeric_values(self):
+        pairwise_cost_matrix = (
+            GlobalNearestNeighbor._validate_pairwise_cost_matrix(
+                [[1, 2.5]],
+                1,
+                2,
+            )
+        )
+
+        np.testing.assert_allclose(pairwise_cost_matrix, [[1.0, 2.5]])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`GlobalNearestNeighbor._validate_pairwise_cost_matrix()` rejected obviously non-numeric array dtypes, but it did not preserve element types while validating object arrays or mixed Python sequences. NumPy could therefore coerce malformed values into ordinary floating costs before PyRecEst inspected them. For example, object-wrapped booleans became `1.0`, numeric-looking strings became their parsed values, and `datetime64`/`timedelta64` values could become their integer storage.

That allowed metadata-like values to silently alter GNN assignments instead of failing at the public validation boundary.

## Fix

- inspect an object-preserving view before numeric coercion;
- reject booleans, text/bytes, complex values, temporal values, and `None`, including values hidden inside object arrays or mixed sequences;
- reject native NumPy temporal dtypes;
- normalize conversion failures to the documented `ValueError` contract;
- preserve valid real numeric matrices and positive-infinity gating.

## Impact

Malformed external association cues now fail deterministically instead of being interpreted as valid pairwise costs.

## Validation

- reproduced the pre-fix conversion of object-wrapped booleans, strings, datetimes, and timedeltas into floating values;
- added regressions for object arrays, mixed-type sequences, native temporal dtypes, and a valid numeric positive control;
- isolated execution of the existing validator tests plus the new regressions: 7 tests passed;
- `py_compile` passed for the modified module and new test file.