### PR TITLE
Count scalar measurements in file evaluation

### DIFF
--- a/src/pyrecest/evaluation/evaluate_for_file.py
+++ b/src/pyrecest/evaluation/evaluate_for_file.py
@@ -47,7 +47,9 @@ def evaluate_for_file(
 
     for idx, inner_array in enumerate(measurement_time_steps):
         inner_array = np.asarray(inner_array)
-        if inner_array.ndim == 2:
+        if inner_array.ndim == 0:
+            n_meas_at_individual_time_step[idx] = 1
+        elif inner_array.ndim == 2:
             n_meas_at_individual_time_step[idx] = inner_array.shape[0]
         elif inner_array.ndim == 1:
             n_meas_at_individual_time_step[idx] = 0 if inner_array.size == 0 else 1

--- a/tests/test_evaluate_for_file_measurement_counts.py
+++ b/tests/test_evaluate_for_file_measurement_counts.py
@@ -71,3 +71,22 @@ def test_evaluate_for_file_counts_flat_object_measurement_timesteps(
         captured["scenario_config"]["n_meas_at_individual_time_step"],
         np.array([0, 1, 2], dtype=int),
     )
+
+
+def test_evaluate_for_file_counts_scalar_measurements_as_one(tmp_path, monkeypatch):
+    module = importlib.import_module("pyrecest.evaluation.evaluate_for_file")
+    input_file = tmp_path / "scalar_scenario.npy"
+    measurements = np.empty(2, dtype=object)
+    measurements[0] = 4.0
+    measurements[1] = np.array(5.0)
+    groundtruths = np.zeros((1, 2, 1), dtype=float)
+    np.save(input_file, {"groundtruths": groundtruths, "measurements": measurements})
+
+    captured = _capture_evaluate_for_variables(monkeypatch, module)
+
+    module.evaluate_for_file(str(input_file), [], {}, save_folder=str(tmp_path))
+
+    np.testing.assert_array_equal(
+        captured["scenario_config"]["n_meas_at_individual_time_step"],
+        np.array([1, 1], dtype=int),
+    )


### PR DESCRIPTION
## Summary

- count zero-dimensional numeric measurements as one observation when loading evaluation files
- preserve the existing handling for empty vectors, one vector-valued measurement, and measurement matrices
- add regression coverage for Python numeric scalars and zero-dimensional NumPy arrays

## Bug

`evaluate_for_file()` inferred `n_meas_at_individual_time_step` from each saved measurement array, but only handled one- and two-dimensional inputs. A valid scalar measurement has zero dimensions, so its count remained at the zero-initialized default. This incorrectly described a present one-dimensional observation as an empty time step.

## Fix

Treat zero-dimensional measurement entries as one measurement before applying the existing one- and two-dimensional shape rules.

## Impact

File-based evaluations with scalar observations now receive the correct measurement-count schedule, avoiding skipped or mischaracterized updates downstream.

## Validation

- targeted regression file: `3 passed`
- reproduced the pre-fix counts `[0, 0, 0]` for two scalar measurements and one empty vector
- verified the fixed counts `[1, 1, 0]`
