### PR TITLE
Reject temporal piecewise interval indices

### DIFF
--- a/src/pyrecest/distributions/circle/piecewise_constant_distribution.py
+++ b/src/pyrecest/distributions/circle/piecewise_constant_distribution.py
@@ -62,7 +62,9 @@ def _validate_positive_sample_count(n) -> int:
 
 
 def _validate_interval_index(m, n) -> tuple[int, int]:
-    if isinstance(m, bool) or isinstance(n, bool):
+    if isinstance(m, _INVALID_SAMPLE_COUNT_TYPES) or isinstance(
+        n, _INVALID_SAMPLE_COUNT_TYPES
+    ):
         raise ValueError("m and n must be integers")
     if not isinstance(m, Integral) or not isinstance(n, Integral):
         raise ValueError("m and n must be integers")

--- a/tests/distributions/test_piecewise_constant_interval_index_validation.py
+++ b/tests/distributions/test_piecewise_constant_interval_index_validation.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+
+from pyrecest.distributions.circle.piecewise_constant_distribution import (
+    PiecewiseConstantDistribution,
+)
+
+
+@pytest.mark.parametrize(
+    "helper_name",
+    ("left_border", "right_border", "interval_center"),
+)
+@pytest.mark.parametrize(
+    ("m", "n"),
+    (
+        (np.timedelta64(1, "ns"), 4),
+        (1, np.timedelta64(4, "ns")),
+    ),
+)
+def test_interval_helpers_reject_temporal_indices(helper_name, m, n):
+    helper = getattr(PiecewiseConstantDistribution, helper_name)
+
+    with pytest.raises(ValueError, match="m and n must be integers"):
+        helper(m, n)
+
+
+def test_interval_helpers_preserve_numpy_integer_indices():
+    assert PiecewiseConstantDistribution.left_border(np.int64(1), np.int64(4)) == 0.0


### PR DESCRIPTION
## Summary
- reject NumPy temporal scalars in `PiecewiseConstantDistribution` interval-index helpers
- preserve ordinary Python and NumPy integer indices
- cover `left_border`, `right_border`, and `interval_center` with focused regressions

## Bug
Nanosecond `numpy.timedelta64` scalars satisfy `numbers.Integral` and convert cleanly with `int(...)`. The existing `_validate_interval_index()` therefore treated durations such as `np.timedelta64(1, "ns")` as valid interval numbers. This could silently produce plausible but meaningless interval borders instead of rejecting malformed input.

## Fix
Reuse the module's existing invalid-scalar type set before the `Integral` check. Temporal, boolean, textual, and complex scalar values now fail consistently, while `np.int64` indices remain supported.

## Validation
- reproduced the pre-fix acceptance of temporal `m` and `n` values
- `python -m py_compile` on the patched source
- focused local validation covering temporal rejection and NumPy integer preservation
- added repository tests for all three public interval helpers

The full repository suite was not run locally because this connector session cannot clone the repository; GitHub CI should run the matrix against the PR merge ref.