### PR TITLE
Handle zero-by-zero NumPy matrix functions

### DIFF
--- a/src/pyrecest/_backend/numpy/linalg.py
+++ b/src/pyrecest/_backend/numpy/linalg.py
@@ -22,23 +22,19 @@ from scipy.linalg import (
 
 from .._shared_numpy.linalg import (
     fractional_matrix_power as _fractional_matrix_power,
-)
-from .._shared_numpy.linalg import (
     is_single_matrix_pd,
-)
-from .._shared_numpy.linalg import logm as _logm
-from .._shared_numpy.linalg import (
+    logm as _logm,
     polar,
     qr,
     quadratic_assignment,
     solve,
     solve_sylvester,
+    sqrtm as _sqrtm,
 )
-from .._shared_numpy.linalg import sqrtm as _sqrtm
 
 
 def _empty_zero_by_zero_matrix_result(value):
-    """Return a SciPy-compatible result for matrices with trailing shape ``(0, 0)``."""
+    """Return a SciPy-compatible result for trailing zero-by-zero matrices."""
     matrix = _np.asarray(value)
     if matrix.ndim < 2 or matrix.shape[-2:] != (0, 0):
         return None

--- a/src/pyrecest/_backend/numpy/linalg.py
+++ b/src/pyrecest/_backend/numpy/linalg.py
@@ -21,13 +21,51 @@ from scipy.linalg import (
 )
 
 from .._shared_numpy.linalg import (
-    fractional_matrix_power,
+    fractional_matrix_power as _fractional_matrix_power,
+)
+from .._shared_numpy.linalg import (
     is_single_matrix_pd,
-    logm,
+)
+from .._shared_numpy.linalg import logm as _logm
+from .._shared_numpy.linalg import (
     polar,
     qr,
     quadratic_assignment,
     solve,
     solve_sylvester,
-    sqrtm,
 )
+from .._shared_numpy.linalg import sqrtm as _sqrtm
+
+
+def _empty_zero_by_zero_matrix_result(value):
+    """Return a SciPy-compatible result for matrices with trailing shape ``(0, 0)``."""
+    matrix = _np.asarray(value)
+    if matrix.ndim < 2 or matrix.shape[-2:] != (0, 0):
+        return None
+    if matrix.dtype.kind not in ("f", "c"):
+        matrix = matrix.astype(_np.float64)
+    return _np.empty_like(matrix)
+
+
+def logm(x):
+    """Compute a matrix logarithm, including zero-by-zero matrices."""
+    empty_result = _empty_zero_by_zero_matrix_result(x)
+    if empty_result is not None:
+        return empty_result
+    return _logm(x)
+
+
+def sqrtm(x):
+    """Compute a matrix square root, including zero-by-zero matrices."""
+    empty_result = _empty_zero_by_zero_matrix_result(x)
+    if empty_result is not None:
+        return empty_result
+    return _sqrtm(x)
+
+
+def fractional_matrix_power(a, t):
+    """Compute a fractional matrix power, including zero-by-zero matrices."""
+    empty_result = _empty_zero_by_zero_matrix_result(a)
+    if empty_result is not None:
+        return empty_result
+    return _fractional_matrix_power(a, t)

--- a/tests/backend/test_numpy_linalg_zero_by_zero_matrix_functions.py
+++ b/tests/backend/test_numpy_linalg_zero_by_zero_matrix_functions.py
@@ -1,0 +1,36 @@
+import numpy as np
+import pytest
+
+from pyrecest._backend.numpy import linalg
+
+
+@pytest.mark.parametrize(
+    ("matrix_function", "args"),
+    [
+        pytest.param(linalg.logm, (), id="logm"),
+        pytest.param(linalg.sqrtm, (), id="sqrtm"),
+        pytest.param(
+            linalg.fractional_matrix_power,
+            (0.5,),
+            id="fractional_matrix_power",
+        ),
+    ],
+)
+@pytest.mark.parametrize("shape", [(0, 0), (3, 0, 0), (2, 1, 0, 0)])
+@pytest.mark.parametrize(
+    ("dtype", "expected_dtype"),
+    [
+        pytest.param(np.float32, np.float32, id="float32"),
+        pytest.param(np.complex64, np.complex64, id="complex64"),
+        pytest.param(np.int64, np.float64, id="integer-promoted"),
+    ],
+)
+def test_zero_by_zero_matrix_functions_preserve_shape_and_dtype(
+    matrix_function, args, shape, dtype, expected_dtype
+):
+    matrices = np.empty(shape, dtype=dtype)
+
+    result = matrix_function(matrices, *args)
+
+    assert result.shape == shape
+    assert result.dtype == np.dtype(expected_dtype)


### PR DESCRIPTION
## Summary

- return shape-preserving empty results for NumPy `logm`, `sqrtm`, and `fractional_matrix_power` when the trailing matrix shape is `(0, 0)`
- preserve floating and complex input dtypes
- retain the existing SciPy-compatible promotion of integer inputs to `float64`
- add regression coverage for standalone matrices and batched zero-by-zero matrices

## Bug

The shared matrix-function implementation only short-circuited empty *leading batch dimensions*, such as `(2, 0, 3, 3)`. A valid zero-by-zero matrix has an empty trailing matrix dimension instead, for example `(0, 0)` or `(3, 0, 0)`, so it was forwarded to SciPy.

SciPy currently raises internal exceptions for `logm` and `fractional_matrix_power` on these inputs (`ValueError` from an empty argmax and `IndexError` from indexing an empty Schur spectrum). PyRecEst therefore failed to preserve a mathematically valid empty matrix shape even though it already supports related empty-batch cases.

## Fix

Add a NumPy-backend fast path that recognizes arrays whose trailing matrix shape is exactly `(0, 0)`, applies the same dtype promotion used by the SciPy bridge, and returns an empty result with the original batch shape. Rectangular empty matrices continue through the existing validation path and remain invalid.

## Validation

- exercised 27 combinations across `logm`, `sqrtm`, and `fractional_matrix_power`
- covered shapes `(0, 0)`, `(3, 0, 0)`, and `(2, 1, 0, 0)`
- covered `float32`, `complex64`, and integer-to-`float64` promotion
- verified nonempty matrices still use the existing SciPy-backed implementations
- branch is based on current `main` and is not behind

The full repository suite was not available locally in this connector environment; GitHub Actions should provide the authoritative matrix validation.