### PR TITLE
Reject temporal wrapped-normal sample counts

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_normal_distribution.py
@@ -266,7 +266,13 @@ class WrappedNormalDistribution(
         )
 
     def sample(self, n: Union[int, int32, int64]):
-        if isinstance(n, bool) or not isinstance(n, Integral) or int(n) <= 0:
+        dtype_kind = getattr(getattr(n, "dtype", None), "kind", None)
+        if (
+            isinstance(n, bool)
+            or dtype_kind in {"M", "m"}
+            or not isinstance(n, Integral)
+            or int(n) <= 0
+        ):
             raise ValueError("n must be a positive integer.")
         n = int(n)
         return mod(self.scalar_mu + self.sigma * random.normal(size=(n,)), 2.0 * pi)

--- a/tests/distributions/test_wrapped_normal_temporal_sample_counts.py
+++ b/tests/distributions/test_wrapped_normal_temporal_sample_counts.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pytest
+
+from pyrecest.distributions import WrappedNormalDistribution
+
+
+@pytest.mark.parametrize(
+    "n",
+    [
+        np.timedelta64(3, "ns"),
+        np.timedelta64(3, "us"),
+        np.datetime64(3, "ns"),
+        np.array(np.timedelta64(3, "ns")),
+    ],
+)
+def test_sample_rejects_temporal_counts(n):
+    distribution = WrappedNormalDistribution(0.2, 0.5)
+
+    with pytest.raises(ValueError, match="positive integer"):
+        distribution.sample(n)
+
+
+def test_sample_preserves_numpy_integer_counts():
+    distribution = WrappedNormalDistribution(0.2, 0.5)
+
+    samples = distribution.sample(np.int64(3))
+
+    assert np.asarray(samples).shape == (3,)


### PR DESCRIPTION
## Bug

`WrappedNormalDistribution.sample()` validated `n` with `isinstance(n, numbers.Integral)`. NumPy classifies `numpy.timedelta64` scalars as integral-like; at nanosecond resolution, `int(np.timedelta64(3, "ns"))` returns `3`. A duration could therefore silently request samples instead of being rejected as malformed input. Coarser timedelta units failed through a lower-level `TypeError`, making behavior unit-dependent.

## Fix

- reject NumPy datetime and timedelta dtypes before the generic integral check;
- retain the existing positive-integer contract;
- preserve Python and NumPy integer sample counts;
- add focused regressions for fine-resolution, coarse-resolution, datetime, and zero-dimensional temporal inputs.

## Validation

- reproduced the pre-fix acceptance of `np.timedelta64(3, "ns")` as sample count `3`;
- verified the branch is exactly two commits ahead of current `main` and changes only the sampler plus one focused regression file;
- GitHub Actions provides the authoritative backend and repository test matrix.