### PR TITLE
Validate fractional matrix power exponents

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/linalg.py
+++ b/src/pyrecest/_backend/_shared_numpy/linalg.py
@@ -1,3 +1,7 @@
+import numbers as _numbers
+
+import numpy as _onp
+
 from ._dispatch import _common
 from ._dispatch import numpy as _np
 from ._dispatch import scipy as _scipy
@@ -227,8 +231,28 @@ def is_single_matrix_pd(mat):
         raise e
 
 
+def _normalize_fractional_matrix_power_exponent(t):
+    """Return a finite, non-boolean real scalar exponent."""
+
+    exponent_array = _onp.asarray(t)
+    if exponent_array.ndim != 0 or exponent_array.dtype.kind in "mM":
+        raise TypeError("t must be a real scalar")
+
+    exponent = exponent_array.item()
+    if isinstance(exponent, (bool, _onp.bool_)) or not isinstance(
+        exponent, _numbers.Real
+    ):
+        raise TypeError("t must be a real scalar")
+
+    exponent = float(exponent)
+    if not _onp.isfinite(exponent):
+        raise ValueError("t must be finite")
+    return exponent
+
+
 def fractional_matrix_power(A, t):
     A = _as_scipy_linalg_array(A)
+    t = _normalize_fractional_matrix_power_exponent(t)
     empty_result = _empty_batched_square_matrix_result(A)
     if empty_result is not None:
         return empty_result

--- a/src/pyrecest/_backend/_shared_numpy/linalg.py
+++ b/src/pyrecest/_backend/_shared_numpy/linalg.py
@@ -239,9 +239,9 @@ def _normalize_fractional_matrix_power_exponent(t):
         raise TypeError("t must be a real scalar")
 
     exponent = exponent_array.item()
-    if isinstance(exponent, (bool, _onp.bool_)) or not isinstance(
-        exponent, _numbers.Real
-    ):
+    if isinstance(
+        exponent, (bool, _onp.bool_, _onp.datetime64, _onp.timedelta64)
+    ) or not isinstance(exponent, _numbers.Real):
         raise TypeError("t must be a real scalar")
 
     exponent = float(exponent)

--- a/tests/backend/test_numpy_fractional_matrix_power_exponent_validation.py
+++ b/tests/backend/test_numpy_fractional_matrix_power_exponent_validation.py
@@ -1,0 +1,44 @@
+import numpy as np
+import pytest
+from pyrecest._backend.numpy import linalg
+
+
+_MATRIX = np.diag([4.0, 9.0])
+
+
+@pytest.mark.parametrize(
+    "exponent",
+    [
+        True,
+        np.bool_(False),
+        np.array([0.5]),
+        np.array([[0.5]]),
+        np.timedelta64(2, "ns"),
+        np.datetime64("1970-01-01T00:00:00.000000002"),
+        np.array(np.timedelta64(2, "ns"), dtype=object),
+        "0.5",
+        0.5 + 0.0j,
+    ],
+)
+def test_fractional_matrix_power_rejects_non_real_scalar_exponents(exponent):
+    with pytest.raises(TypeError, match="t must be a real scalar"):
+        linalg.fractional_matrix_power(_MATRIX, exponent)
+
+
+@pytest.mark.parametrize("exponent", [np.nan, np.inf, -np.inf, np.array(np.nan)])
+def test_fractional_matrix_power_rejects_nonfinite_exponents(exponent):
+    with pytest.raises(ValueError, match="t must be finite"):
+        linalg.fractional_matrix_power(_MATRIX, exponent)
+
+
+def test_fractional_matrix_power_accepts_zero_dimensional_real_exponent():
+    result = linalg.fractional_matrix_power(_MATRIX, np.array(0.5))
+
+    np.testing.assert_allclose(result, np.diag([2.0, 3.0]))
+
+
+def test_fractional_matrix_power_validates_exponent_for_empty_batches():
+    matrices = np.empty((0, 2, 2))
+
+    with pytest.raises(TypeError, match="t must be a real scalar"):
+        linalg.fractional_matrix_power(matrices, np.timedelta64(2, "ns"))

--- a/tests/backend/test_numpy_fractional_matrix_power_exponent_validation.py
+++ b/tests/backend/test_numpy_fractional_matrix_power_exponent_validation.py
@@ -16,6 +16,9 @@ _MATRIX = np.diag([4.0, 9.0])
         np.timedelta64(2, "ns"),
         np.datetime64("1970-01-01T00:00:00.000000002"),
         np.array(np.timedelta64(2, "ns"), dtype=object),
+        np.array(
+            np.datetime64("1970-01-01T00:00:00.000000002"), dtype=object
+        ),
         "0.5",
         0.5 + 0.0j,
     ],


### PR DESCRIPTION
## Bug

The shared NumPy/Autograd `fractional_matrix_power()` wrapper forwarded `t` directly to SciPy. SciPy accepts several malformed exponent values through implicit coercion:

- `np.timedelta64(2, "ns")` was interpreted as exponent `2`;
- `True` and `False` were interpreted as exponents `1` and `0`;
- one-element arrays such as `np.array([0.5])` were silently accepted despite not being scalars.

Non-finite, textual, complex, datetime, and higher-dimensional inputs failed through inconsistent lower-level exceptions. Empty matrix batches also bypassed exponent validation entirely.

The first implementation still missed temporal scalars hidden inside object-dtype zero-dimensional arrays because NumPy reports `np.timedelta64` as a `numbers.Real`. That caused the repository-wide test matrix to fail.

## Fix

- normalize exponents through a dedicated shared validator;
- require a zero-dimensional, non-boolean real scalar;
- reject NumPy datetime and timedelta dtypes both before and after scalar extraction, including object-dtype wrappers;
- require finite values;
- validate before the empty-batch shortcut;
- preserve Python/NumPy real scalars and zero-dimensional real arrays.

The shared implementation covers both the NumPy and Autograd backends.

## Impact

Temporal metadata, booleans, and array-shaped values can no longer silently change the requested matrix power. Callers now receive stable `TypeError` or `ValueError` messages at the PyRecEst boundary.

## Validation

- reproduced the pre-fix coercion of nanosecond timedeltas, booleans, and one-element arrays;
- reproduced and fixed the object-dtype `np.timedelta64` escape that failed the initial CI run;
- added regression coverage for object-wrapped `np.timedelta64` and `np.datetime64` scalars;
- ran an isolated validator harness covering valid Python/NumPy real scalars, non-scalar/type rejection, temporal wrappers, and non-finite values;
- GitHub Actions is rerunning the authoritative repository-wide and backend validation.