### PR TITLE
Reject temporal replay controls and statistics

### DIFF
--- a/src/pyrecest/tracking/hypothesis_replay.py
+++ b/src/pyrecest/tracking/hypothesis_replay.py
@@ -21,6 +21,8 @@ except Exception:  # pragma: no cover - defensive for partial downstream copies
     TrackingRecord = object  # type: ignore[misc,assignment]
 
 _TEXT_TYPES = (str, bytes, bytearray, np.str_, np.bytes_)
+_TEMPORAL_SCALAR_TYPES = (np.datetime64, np.timedelta64)
+_TEMPORAL_DTYPE_KINDS = {"M", "m"}
 
 
 @dataclass(frozen=True)
@@ -308,6 +310,20 @@ def scores_to_dicts(scores: Iterable[HypothesisReplayScore]) -> list[dict[str, A
     return [score.to_dict() for score in scores]
 
 
+def _contains_temporal_values(value: Any) -> bool:
+    """Return whether an array-like value contains NumPy temporal scalars."""
+
+    try:
+        value_array = np.asarray(value)
+    except (TypeError, ValueError):
+        return False
+    if value_array.dtype.kind in _TEMPORAL_DTYPE_KINDS:
+        return True
+    if value_array.dtype != object:
+        return False
+    return any(isinstance(item, _TEMPORAL_SCALAR_TYPES) for item in value_array.flat)
+
+
 def _finite_record_values(
     records: Sequence[Any],
     keys: tuple[str, ...],
@@ -320,14 +336,14 @@ def _finite_record_values(
         value = _record_value(record, keys)
         if value is None and fallback_norm_keys:
             vector = _record_value(record, fallback_norm_keys)
-            if vector is not None:
+            if vector is not None and not _contains_temporal_values(vector):
                 try:
                     value = float(
                         np.linalg.norm(np.asarray(vector, dtype=float).reshape(-1))
                     )
                 except (TypeError, ValueError):
                     value = None
-        if value is None:
+        if value is None or _contains_temporal_values(value):
             continue
         try:
             parsed = float(np.asarray(value, dtype=float))
@@ -361,10 +377,18 @@ def _record_value(record: Any, keys: tuple[str, ...]) -> Any | None:
 
 def _finite_float(value: Any, name: str) -> float:
     value_array = np.asarray(value)
-    if value_array.shape != () or value_array.dtype == np.bool_:
+    if (
+        value_array.shape != ()
+        or value_array.dtype == np.bool_
+        or _contains_temporal_values(value_array)
+    ):
         raise ValueError(f"{name} must be finite")
     scalar = value_array.item()
-    if isinstance(scalar, (bool, np.bool_)) or isinstance(scalar, _TEXT_TYPES):
+    if (
+        isinstance(scalar, (bool, np.bool_))
+        or isinstance(scalar, _TEXT_TYPES)
+        or isinstance(scalar, _TEMPORAL_SCALAR_TYPES)
+    ):
         raise ValueError(f"{name} must be finite")
     try:
         parsed = float(scalar)
@@ -391,10 +415,18 @@ def _positive_float(value: Any, name: str) -> float:
 
 def _nonnegative_int(value: Any, name: str) -> int:
     value_array = np.asarray(value)
-    if value_array.shape != () or value_array.dtype == np.bool_:
+    if (
+        value_array.shape != ()
+        or value_array.dtype == np.bool_
+        or _contains_temporal_values(value_array)
+    ):
         raise ValueError(f"{name} must be a nonnegative integer")
     scalar = value_array.item()
-    if isinstance(scalar, (bool, np.bool_)) or isinstance(scalar, _TEXT_TYPES):
+    if (
+        isinstance(scalar, (bool, np.bool_))
+        or isinstance(scalar, _TEXT_TYPES)
+        or isinstance(scalar, _TEMPORAL_SCALAR_TYPES)
+    ):
         raise ValueError(f"{name} must be a nonnegative integer")
     if isinstance(scalar, (int, np.integer)):
         parsed = int(scalar)

--- a/tests/tracking/test_hypothesis_replay_temporal_validation.py
+++ b/tests/tracking/test_hypothesis_replay_temporal_validation.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from pyrecest.tracking import (
+    HypothesisReplay,
+    InnovationConsistencyScoreConfig,
+    rank_hypothesis_replays,
+)
+
+
+_TEMPORAL_VALUES = (
+    np.timedelta64(2, "ns"),
+    np.datetime64("1970-01-01T00:00:00.000000002"),
+    np.asarray(np.timedelta64(3, "ns"), dtype=object),
+)
+
+
+@pytest.mark.parametrize("value", _TEMPORAL_VALUES)
+def test_score_config_rejects_temporal_scalar_controls(value: object) -> None:
+    for field_name in ("nis_weight", "nis_clip", "residual_normalizer"):
+        with pytest.raises(ValueError):
+            InnovationConsistencyScoreConfig(**{field_name: value})
+
+
+@pytest.mark.parametrize("value", _TEMPORAL_VALUES)
+def test_hypothesis_replay_rejects_temporal_scalar_fields(value: object) -> None:
+    for field_name in (
+        "graph_cost",
+        "tail_duration_s",
+        "track_switches",
+        "coverage_count",
+    ):
+        with pytest.raises(ValueError):
+            HypothesisReplay(
+                hypothesis_id="invalid-temporal-field",
+                records=[],
+                **{field_name: value},
+            )
+
+
+def test_temporal_record_statistics_are_ignored() -> None:
+    replay = HypothesisReplay(
+        hypothesis_id="temporal-records",
+        records=[
+            {
+                "nis": np.timedelta64(4, "ns"),
+                "residual_norm_m": np.datetime64(
+                    "1970-01-01T00:00:00.000000005"
+                ),
+            },
+            {
+                "nis": np.asarray(np.timedelta64(6, "ns"), dtype=object),
+                "innovation": np.array([np.timedelta64(3, "ns")]),
+            },
+        ],
+    )
+
+    score = rank_hypothesis_replays([replay])[0]
+
+    assert score.finite_nis_count == 0
+    assert score.finite_residual_count == 0
+    assert score.robust_sum_nis == 0.0
+    assert score.robust_sum_residual == 0.0
+
+
+def test_numeric_numpy_scalars_remain_supported() -> None:
+    config = InnovationConsistencyScoreConfig(
+        nis_weight=np.float64(2.5),
+        nis_clip=np.int64(7),
+    )
+    replay = HypothesisReplay(
+        hypothesis_id="valid-numeric-scalars",
+        records=[],
+        track_switches=np.int64(2),
+    )
+
+    assert config.nis_weight == 2.5
+    assert config.nis_clip == 7.0
+    assert replay.track_switches == 2


### PR DESCRIPTION
## Bug

`hypothesis_replay` converted scalar controls through `numpy.asarray(...).item()` and then `float(...)`/`int(...)`. At nanosecond resolution, NumPy datetime and timedelta scalars expose their raw integer storage through those conversions. Values such as `np.timedelta64(2, "ns")` could therefore be accepted as replay weights, durations, or counts, and temporal values in replay records could silently contribute to NIS/residual scores.

## Fix

- detect native and object-wrapped NumPy temporal values before numeric coercion;
- reject temporal configuration, cost, duration, and count fields through the existing `ValueError` contracts;
- ignore temporal NIS/residual record statistics just like other malformed record values;
- preserve ordinary Python and NumPy numeric scalar support.

## Impact

Malformed timestamp or duration metadata can no longer be interpreted as plausible numeric evidence and alter hypothesis ranking.

## Validation

- reproduced the pre-fix acceptance of nanosecond `datetime64`/`timedelta64` values as floats and integers;
- added focused regressions for native temporal scalars, object-wrapped temporal scalars, replay-record statistics, and valid NumPy numeric scalars;
- targeted isolated regression run: `8 passed`;
- `python -m py_compile` passed for the modified module;
- branch is one commit ahead of current `main` and zero commits behind.

The repository-wide backend matrix should run in GitHub Actions.