### PR TITLE
Reject object-wrapped temporal additive-noise sample counts

### DIFF
--- a/src/pyrecest/models/_additive_noise_sample_count_validation.py
+++ b/src/pyrecest/models/_additive_noise_sample_count_validation.py
@@ -10,18 +10,25 @@ import numpy as np
 from .likelihood import _validate_sample_count
 
 
+def _is_temporal_sample_count(value: Any) -> bool:
+    """Return whether a scalar count contains a NumPy temporal value."""
+
+    try:
+        value_array = np.asarray(value)
+    except (TypeError, ValueError, OverflowError):
+        return False
+    if value_array.shape != ():
+        return False
+    if value_array.dtype.kind in {"M", "m"}:
+        return True
+    return isinstance(value_array.item(), (np.datetime64, np.timedelta64))
+
+
 def _validated_additive_noise_sample_count(value: Any) -> int:
     """Reject temporal NumPy scalars before generic integer normalization."""
 
-    dtype = getattr(value, "dtype", None)
-    if dtype is not None:
-        try:
-            if np.issubdtype(dtype, np.datetime64) or np.issubdtype(
-                dtype, np.timedelta64
-            ):
-                raise ValueError("n must be a nonnegative integer.")
-        except TypeError:
-            pass
+    if _is_temporal_sample_count(value):
+        raise ValueError("n must be a nonnegative integer.")
     return _validate_sample_count(value)
 
 

--- a/tests/models/test_additive_noise_sample_count_validation.py
+++ b/tests/models/test_additive_noise_sample_count_validation.py
@@ -46,6 +46,11 @@ class AdditiveNoiseSampleCountValidationTest(unittest.TestCase):
             np.timedelta64(4, "ns"),
             np.timedelta64(4, "us"),
             np.datetime64("2026-07-27"),
+            np.array(np.timedelta64(4, "ns"), dtype=object),
+            np.array(
+                np.datetime64("1970-01-01T00:00:00.000000004", "ns"),
+                dtype=object,
+            ),
         )
 
         for invalid_count in invalid_counts:


### PR DESCRIPTION
## Bug

Additive-noise transition and measurement samplers rejected native NumPy temporal sample counts by inspecting the input dtype, but the guard did not inspect scalar values hidden inside zero-dimensional object arrays.

For example, `np.array(np.timedelta64(4, "ns"), dtype=object)` reached the generic integer validator. NumPy classifies a nanosecond `timedelta64` scalar as `numbers.Integral`, so the duration was silently normalized to the integer sample count `4` and the noise sampler was invoked. Coarser temporal values failed instead, making behavior dependent on the temporal unit and container dtype.

## Fix

- normalize candidate counts with `np.asarray` before scalar extraction;
- reject native datetime/timedelta dtypes;
- reject object-wrapped `np.datetime64` and `np.timedelta64` scalar values after extraction;
- preserve ordinary Python and NumPy integer counts;
- add regressions for both additive-noise transition and measurement sampling paths.

## Impact

Temporal metadata can no longer silently request samples. Invalid counts fail before the noise distribution is called, consistently with the generic sampleable-transition model validation.

## Validation

- reproduced the pre-fix acceptance of an object-wrapped nanosecond duration as sample count `4`;
- `py_compile` passed for the patched validation module;
- focused validation confirmed native and object-wrapped temporal values are rejected while `np.int64(2)` is normalized to Python `int` value `2`;
- branch is based on current `main`, is 2 commits ahead and 0 behind, and changes only the validator plus its focused regression test.

The full repository/backend matrix was not available locally in this connector environment; GitHub Actions should provide the authoritative integration validation.