### PR TITLE
Reject mismatched URTS callback dimensions

### DIFF
--- a/src/pyrecest/smoothers/unscented_rauch_tung_striebel_smoother.py
+++ b/src/pyrecest/smoothers/unscented_rauch_tung_striebel_smoother.py
@@ -179,6 +179,11 @@ class UnscentedRauchTungStriebelSmoother(AbstractSmoother):
             ],
             axis=0,
         )
+        if propagated_sigma_points.shape[1] != filtered_state.dim:
+            raise ValueError(
+                "transition function must return vectors with state dimension "
+                f"{filtered_state.dim}; got {propagated_sigma_points.shape[1]}."
+            )
 
         predicted_mean = self._weighted_sum(
             propagated_sigma_points,
@@ -231,6 +236,13 @@ class UnscentedRauchTungStriebelSmoother(AbstractSmoother):
             ],
             axis=0,
         )
+        measurement_output_dim = measurement_sigma_points.shape[1]
+        if measurement_output_dim != measurement.shape[0]:
+            raise ValueError(
+                "measurement dimension mismatch: measurement has dimension "
+                f"{measurement.shape[0]}, but measurement function returns dimension "
+                f"{measurement_output_dim}."
+            )
 
         predicted_measurement = self._weighted_sum(
             measurement_sigma_points,

--- a/tests/smoothers/test_unscented_rauch_tung_striebel_smoother.py
+++ b/tests/smoothers/test_unscented_rauch_tung_striebel_smoother.py
@@ -128,3 +128,49 @@ class UnscentedRauchTungStriebelSmootherTest(unittest.TestCase):
             smoothed_states_recomputed[-1].C,
             filtered_states[-1].C,
         )
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
+    def test_filter_rejects_measurement_function_dimension_mismatch(self):
+        smoother = UnscentedRauchTungStriebelSmoother()
+        initial_state = GaussianDistribution(
+            array([0.0, 0.0]),
+            array([[1.0, 0.0], [0.0, 1.0]]),
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "measurement has dimension 1, but measurement function returns dimension 2",
+        ):
+            smoother.filter(
+                initial_state=initial_state,
+                measurements=array([1.0]),
+                measurement_functions=lambda x: x,
+                meas_noise_covariances=array([[0.5]]),
+            )
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
+    def test_filter_rejects_transition_function_dimension_mismatch(self):
+        smoother = UnscentedRauchTungStriebelSmoother()
+        initial_state = GaussianDistribution(
+            array([0.0, 0.0]),
+            array([[1.0, 0.0], [0.0, 1.0]]),
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "transition function must return vectors with state dimension 2; got 1",
+        ):
+            smoother.filter(
+                initial_state=initial_state,
+                measurements=array([[0.0, 0.0], [0.0, 0.0]]),
+                measurement_functions=lambda x: x,
+                meas_noise_covariances=array([[1.0, 0.0], [0.0, 1.0]]),
+                transition_functions=lambda x, _dt: array([x[0]]),
+                sys_noise_covariances=array([[0.1, 0.0], [0.0, 0.1]]),
+            )


### PR DESCRIPTION
## Bug

`UnscentedRauchTungStriebelSmoother` did not validate nonlinear callback output dimensions before covariance arithmetic.

For example, a scalar observation combined with a measurement callback returning a two-dimensional vector was silently accepted. NumPy broadcast the scalar residual and the `1 x 1` measurement-noise covariance, yielding a plausible but invalid two-dimensional posterior instead of reporting the malformed model. Transition callbacks returning the wrong state dimension likewise reached lower-level covariance or distribution operations before failing.

## Fix

- require every propagated transition sigma point to retain the configured state dimension;
- require the measurement callback output dimension to equal the supplied observation dimension;
- raise targeted `ValueError` messages before any broadcasting or covariance update can occur;
- add regressions for both measurement and transition callback mismatches.

## Impact

Malformed nonlinear URTS models now fail deterministically at the callback boundary instead of silently corrupting estimates or producing confusing downstream shape errors. Valid URTS behavior is unchanged.

## Validation

- reproduced the pre-fix scalar/vector broadcast, which returned mean `[0.5, 0.5]` and covariance `[[0.25, 0.25], [0.25, 0.25]]` for an invalid model;
- ran the existing three URTS tests plus the two new regressions in a focused NumPy harness: `5 passed`;
- compiled the modified source and regression module successfully;
- verified the branch is based on current `main` and changes only the URTS implementation and its focused test file.

The full repository matrix was not available locally in this connector runtime; GitHub Actions remains the authoritative full-suite validation.