### PR TITLE
Reject mixed-type registration booleans

### DIFF
--- a/src/pyrecest/utils/_point_set_registration_common.py
+++ b/src/pyrecest/utils/_point_set_registration_common.py
@@ -26,6 +26,22 @@ from scipy.optimize import linear_sum_assignment
 from scipy.spatial.distance import cdist
 
 
+_INVALID_REAL_SCALAR_TYPES = (
+    type(None),
+    bool,
+    np.bool_,
+    str,
+    bytes,
+    bytearray,
+    np.str_,
+    np.bytes_,
+    complex,
+    np.complexfloating,
+    np.datetime64,
+    np.timedelta64,
+)
+
+
 @dataclass(frozen=True)
 class RegistrationResultBase:  # pylint: disable=too-many-instance-attributes
     """Shared fields for registration result containers."""
@@ -82,6 +98,27 @@ class RegistrationLoopCallbacks:
     assignment_solver: Callable[..., Any]
 
 
+def _contains_invalid_real_values(value) -> bool:
+    """Detect invalid scalar values before array coercion can hide their types."""
+    if isinstance(value, _INVALID_REAL_SCALAR_TYPES):
+        return True
+
+    if isinstance(value, np.ndarray):
+        if value.dtype.kind != "O":
+            return False
+    elif not isinstance(value, (list, tuple)):
+        return False
+
+    try:
+        object_values = np.asarray(value, dtype=object)
+    except (OverflowError, TypeError, ValueError, RuntimeError):
+        return False
+    return any(
+        isinstance(item, _INVALID_REAL_SCALAR_TYPES)
+        for item in object_values.reshape(-1)
+    )
+
+
 def as_point_array(
     points,
     *,
@@ -89,6 +126,8 @@ def as_point_array(
     expected_dim_error: str | None = None,
 ):
     """Validate a point array and optionally enforce its ambient dimension."""
+    if _contains_invalid_real_values(points):
+        raise ValueError("points must contain real numeric values.")
     point_array = asarray(points)
     if point_array.ndim != 2:
         raise ValueError("points must have shape (n_points, dim).")
@@ -188,6 +227,8 @@ def _is_numpy_temporal_scalar(value) -> bool:
 
 
 def _coerce_cost_matrix(cost_matrix):
+    if _contains_invalid_real_values(cost_matrix):
+        raise ValueError("cost_matrix must contain real numeric values.")
     try:
         costs = asarray(cost_matrix)
     except (TypeError, ValueError, OverflowError, RuntimeError) as exc:

--- a/tests/test_point_set_registration_mixed_scalar_validation.py
+++ b/tests/test_point_set_registration_mixed_scalar_validation.py
@@ -1,0 +1,60 @@
+import unittest
+
+import numpy as np
+import pyrecest.backend
+from pyrecest.backend import array
+from pyrecest.utils.point_set_registration import (
+    estimate_transform,
+    solve_gated_assignment,
+)
+
+
+class TestPointSetRegistrationMixedScalarValidation(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_estimate_transform_rejects_booleans_hidden_by_mixed_coercion(self):
+        target = array([[0.0, 0.0], [1.0, 0.0]])
+        invalid_sources = (
+            [[0.0, False], [1.0, 0.0]],
+            [[0.0, np.bool_(False)], [1.0, 0.0]],
+        )
+
+        for source in invalid_sources:
+            with self.subTest(source=source):
+                with self.assertRaisesRegex(ValueError, "real numeric"):
+                    estimate_transform(source, target, model="translation")
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_assignment_rejects_booleans_hidden_by_mixed_coercion(self):
+        invalid_cost_matrices = (
+            [[0.0, True]],
+            [[0.0, np.bool_(True)]],
+        )
+
+        for cost_matrix in invalid_cost_matrices:
+            with self.subTest(cost_matrix=cost_matrix):
+                with self.assertRaisesRegex(ValueError, "real numeric"):
+                    solve_gated_assignment(cost_matrix)
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_real_mixed_numeric_inputs_remain_supported(self):
+        source = [[0, 0.0], [1, 0.0]]
+        target = array([[2.0, 3.0], [3.0, 3.0]])
+
+        transform = estimate_transform(source, target, model="translation")
+        assignment = solve_gated_assignment([[0, 1.5], [2.5, 0]])
+
+        np.testing.assert_allclose(transform.offset, [2.0, 3.0])
+        np.testing.assert_array_equal(assignment, [0, 1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

Point-set registration validated point arrays and cost matrices only after backend array coercion. Mixed Python sequences such as `[[0.0, True]]` are promoted to floating point, so booleans become `1.0` and bypass the explicit boolean-dtype rejection. This can silently treat metadata-like values as coordinates or assignment costs.

## Fix

- inspect list/tuple inputs and object arrays before backend coercion;
- reject boolean, textual, complex, temporal, and `None` scalar values before their types can be erased;
- apply the shared check to both point coordinates and registration cost matrices;
- preserve valid mixed integer/float inputs.

## Validation

- reproduced the pre-fix boolean-to-float coercion with NumPy;
- locally exercised the patched validation through a stubbed NumPy backend;
- added focused regressions for Python and NumPy booleans plus valid numeric controls;
- `python -m py_compile` passed for the modified source and new test file.

The container environment did not provide the repository's full dependency environment, so GitHub Actions should provide the authoritative full backend and test matrix.