### PR TITLE
Validate Watson concentration scalars

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/watson_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/watson_distribution.py
@@ -2,6 +2,7 @@ import copy
 import math
 
 import mpmath
+import numpy as np
 import pyrecest.backend
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
@@ -29,6 +30,21 @@ from .abstract_hyperspherical_distribution import AbstractHypersphericalDistribu
 from .bingham_distribution import BinghamDistribution
 
 
+_INVALID_REAL_SCALAR_TYPES = (
+    bool,
+    np.bool_,
+    str,
+    bytes,
+    bytearray,
+    np.str_,
+    np.bytes_,
+    complex,
+    np.complexfloating,
+    np.datetime64,
+    np.timedelta64,
+)
+
+
 def _as_python_bool(value) -> bool:
     if isinstance(value, bool):
         return value
@@ -38,10 +54,29 @@ def _as_python_bool(value) -> bool:
 
 
 def _as_finite_scalar(value, name: str) -> float:
+    message = f"{name} must be a finite real scalar."
+    dtype_kind = getattr(getattr(value, "dtype", None), "kind", None)
+    if isinstance(value, _INVALID_REAL_SCALAR_TYPES) or dtype_kind in {
+        "b",
+        "c",
+        "S",
+        "U",
+        "M",
+        "m",
+    }:
+        raise ValueError(message)
+
+    shape = getattr(value, "shape", None)
+    if shape is not None and tuple(shape) != ():
+        raise ValueError(message)
+
+    scalar = value.item() if hasattr(value, "item") else value
+    if isinstance(scalar, _INVALID_REAL_SCALAR_TYPES):
+        raise ValueError(message)
     try:
-        scalar = float(value)
-    except (TypeError, ValueError) as exc:
-        raise ValueError(f"{name} must be a finite scalar.") from exc
+        scalar = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
 
     if not math.isfinite(scalar):
         raise ValueError(f"{name} must be finite.")
@@ -73,7 +108,7 @@ class WatsonDistribution(AbstractHypersphericalDistribution):
             kappa (float): The concentration parameter of the distribution.
         """
         mu = _as_unit_direction(mu, tolerance=self.EPSILON)
-        _as_finite_scalar(kappa, "kappa")
+        kappa = _as_finite_scalar(kappa, "kappa")
         AbstractHypersphericalDistribution.__init__(self, dim=mu.shape[0] - 1)
 
         self.mu = mu

--- a/tests/distributions/test_watson_scalar_validation.py
+++ b/tests/distributions/test_watson_scalar_validation.py
@@ -1,0 +1,43 @@
+import unittest
+
+import numpy as np
+from pyrecest.backend import array
+from pyrecest.distributions import WatsonDistribution
+
+
+class WatsonScalarValidationTest(unittest.TestCase):
+    def test_constructor_rejects_non_real_kappa_values(self):
+        invalid_values = (
+            True,
+            np.bool_(False),
+            "2.0",
+            b"2.0",
+            2.0 + 0.0j,
+            np.timedelta64(2, "ns"),
+            np.datetime64("1970-01-01T00:00:00.000000002", "ns"),
+            np.array(np.timedelta64(2, "ns"), dtype=object),
+            np.array(
+                np.datetime64("1970-01-01T00:00:00.000000002", "ns"),
+                dtype=object,
+            ),
+        )
+
+        for kappa in invalid_values:
+            with self.subTest(kappa=kappa):
+                with self.assertRaisesRegex(ValueError, "finite real scalar"):
+                    WatsonDistribution(array([1.0, 0.0, 0.0]), kappa)
+
+    def test_constructor_normalizes_numeric_scalar_kappa(self):
+        for kappa in (2, np.int64(2), np.float64(2.5), np.array(3.5)):
+            with self.subTest(kappa=kappa):
+                distribution = WatsonDistribution(
+                    array([1.0, 0.0, 0.0]),
+                    kappa,
+                )
+
+                self.assertIsInstance(distribution.kappa, float)
+                self.assertEqual(distribution.kappa, float(kappa))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`WatsonDistribution.__init__()` called `_as_finite_scalar(kappa, "kappa")` but discarded the returned normalized value and stored the original input.

This made validation internally inconsistent:

- numeric-looking strings such as `"2.0"` passed `float(...)` validation but were stored as strings, causing later density evaluation to fail during array multiplication;
- nanosecond `numpy.datetime64` and `numpy.timedelta64` values converted to their raw numeric storage and were accepted as concentration parameters;
- booleans were accepted as concentrations `1` and `0`;
- zero-dimensional numeric arrays remained stored as array objects rather than normalized scalars.

## Fix

- reject boolean, textual, complex, datetime, and timedelta scalar values before scalar extraction can erase their type;
- reject non-scalar array-shaped values;
- inspect object-wrapped scalar values after extraction;
- normalize valid Python, NumPy, backend, and zero-dimensional numeric scalars to a finite Python `float`;
- store the validated concentration instead of the original input.

## Impact

Malformed metadata can no longer silently become a Watson concentration or defer failure until PDF/log-PDF evaluation. Valid numerical concentrations retain their existing semantics with a stable scalar representation.

## Validation

- reproduced pre-fix acceptance of strings, booleans, and nanosecond temporal values;
- independently exercised the new scalar guard against native and object-wrapped invalid values;
- verified Python integers/floats, NumPy integers/floats, and zero-dimensional numeric arrays remain supported;
- `python -m py_compile` passed for the exact modified source and new regression test;
- branch is based on current `main`, two commits ahead and zero behind, and changes only two files.

The repository-wide NumPy, PyTorch, and JAX matrix should run in GitHub Actions.