### PR TITLE
Reject mixed boolean hypertoroidal angles

### DIFF
--- a/src/pyrecest/distributions/hypertorus/_input_validation.py
+++ b/src/pyrecest/distributions/hypertorus/_input_validation.py
@@ -23,7 +23,7 @@ def _reject_boolean_array(value, name: str) -> None:
     dtype = getattr(value, "dtype", None)
     if dtype is not None and str(dtype) in _BOOLEAN_DTYPE_NAMES:
         raise ValueError(f"{name} must contain real angles, not boolean values.")
-    if dtype is not None and str(dtype) == "object":
+    if dtype is None or str(dtype) == "object":
         try:
             object_values = np.asarray(value, dtype=object).reshape(-1)
         except (TypeError, ValueError, RuntimeError):

--- a/tests/distributions/test_hypertoroidal_mixed_boolean_input_validation.py
+++ b/tests/distributions/test_hypertoroidal_mixed_boolean_input_validation.py
@@ -1,0 +1,32 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+from pyrecest.distributions.hypertorus._input_validation import (
+    as_hypertoroidal_points,
+    as_shift_vector,
+)
+
+
+class TestHypertoroidalMixedBooleanInputValidation(unittest.TestCase):
+    def test_rejects_mixed_boolean_shift_angles(self):
+        for value in ([0.0, True], (np.bool_(False), 0.25)):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(ValueError, "boolean"):
+                    as_shift_vector(value, 2)
+
+    def test_rejects_mixed_boolean_evaluation_points(self):
+        for value in ([[0.0, True]], [[np.bool_(False), 0.25]]):
+            with self.subTest(value=value):
+                with self.assertRaisesRegex(ValueError, "boolean"):
+                    as_hypertoroidal_points(value, 2)
+
+    def test_numeric_python_sequences_remain_valid(self):
+        npt.assert_allclose(as_shift_vector([0.0, 1.0], 2), [0.0, 1.0])
+        npt.assert_allclose(
+            as_hypertoroidal_points([[0.0, 1.0]], 2), [[0.0, 1.0]]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

The shared hypertoroidal angle validator rejected boolean arrays and object-dtype arrays, but it did not inspect ordinary Python sequences when they mixed booleans with numeric values.

For example, `[0.0, True]` and `[[0.0, True]]` bypassed the initial boolean guard. Backend array coercion then promoted `True` to the floating-point angle `1.0`, so malformed metadata-like input could silently alter shifts or density-evaluation points.

## Fix

- inspect inputs without a native `dtype` through an object-preserving NumPy view before backend coercion;
- retain the existing fast path for typed non-object numeric arrays;
- reject Python and NumPy booleans embedded in mixed sequences;
- preserve valid numeric Python sequences.

The shared fix covers every hypertoroidal distribution and filter path that uses `as_shift_vector()` or `as_hypertoroidal_points()`.

## Validation

- focused isolated regression harness: `5 passed`;
- covered mixed Python lists and tuples containing `bool` / `numpy.bool_`;
- covered both shift vectors and batched evaluation points;
- verified ordinary numeric Python sequences remain accepted;
- branch is 2 commits ahead of `main`, 0 behind, and changes only the validator and its regression test.

GitHub Actions should provide the authoritative full backend and repository test matrix.