### PR TITLE
Validate von Mises-Fisher concentration scalars

### DIFF
--- a/src/pyrecest/distributions/hypersphere_subset/von_mises_fisher_distribution.py
+++ b/src/pyrecest/distributions/hypersphere_subset/von_mises_fisher_distribution.py
@@ -3,6 +3,7 @@ import math
 from typing import Union
 
 # pylint: disable=no-name-in-module,no-member
+import numpy as np
 import pyrecest.backend
 
 # pylint: disable=redefined-builtin,no-name-in-module,no-member
@@ -33,6 +34,21 @@ from scipy.special import ive
 from .abstract_hyperspherical_distribution import AbstractHypersphericalDistribution
 
 
+_INVALID_REAL_SCALAR_TYPES = (
+    bool,
+    np.bool_,
+    str,
+    bytes,
+    bytearray,
+    np.str_,
+    np.bytes_,
+    complex,
+    np.complexfloating,
+    np.datetime64,
+    np.timedelta64,
+)
+
+
 def _as_python_bool(value) -> bool:
     if isinstance(value, bool):
         return value
@@ -42,10 +58,29 @@ def _as_python_bool(value) -> bool:
 
 
 def _as_finite_scalar(value, name: str) -> float:
+    message = f"{name} must be a finite real scalar."
+    dtype_kind = getattr(getattr(value, "dtype", None), "kind", None)
+    if isinstance(value, _INVALID_REAL_SCALAR_TYPES) or dtype_kind in {
+        "b",
+        "c",
+        "S",
+        "U",
+        "M",
+        "m",
+    }:
+        raise ValueError(message)
+
+    shape = getattr(value, "shape", None)
+    if shape is not None and tuple(shape) != ():
+        raise ValueError(message)
+
+    scalar = value.item() if hasattr(value, "item") else value
+    if isinstance(scalar, _INVALID_REAL_SCALAR_TYPES):
+        raise ValueError(message)
     try:
-        scalar = float(value)
-    except (TypeError, ValueError) as exc:
-        raise ValueError(f"{name} must be a finite scalar.") from exc
+        scalar = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
 
     if not math.isfinite(scalar):
         raise ValueError(f"{name} must be finite.")
@@ -117,7 +152,7 @@ class VonMisesFisherDistribution(AbstractHypersphericalDistribution):
         AbstractHypersphericalDistribution.__init__(self, dim=mu.shape[0] - 1)
 
         self.mu = mu
-        self.kappa = kappa
+        self.kappa = kappa_scalar
 
         if kappa_scalar <= self._KAPPA_EPS:
             self.C = 1.0 / self.compute_unit_hypersphere_surface(self.dim)

--- a/tests/distributions/test_von_mises_fisher_scalar_validation.py
+++ b/tests/distributions/test_von_mises_fisher_scalar_validation.py
@@ -1,0 +1,53 @@
+import unittest
+
+import numpy as np
+from pyrecest.backend import array, to_numpy
+from pyrecest.distributions import VonMisesFisherDistribution
+
+
+class VonMisesFisherScalarValidationTest(unittest.TestCase):
+    def test_constructor_rejects_non_real_kappa_values(self):
+        invalid_values = (
+            True,
+            np.bool_(False),
+            "2.0",
+            b"2.0",
+            2.0 + 0.0j,
+            np.timedelta64(2, "ns"),
+            np.datetime64("1970-01-01T00:00:00.000000002", "ns"),
+            np.array(np.timedelta64(2, "ns"), dtype=object),
+            np.array(
+                np.datetime64("1970-01-01T00:00:00.000000002", "ns"),
+                dtype=object,
+            ),
+            np.array([2.0]),
+        )
+
+        for kappa in invalid_values:
+            with self.subTest(kappa=kappa):
+                with self.assertRaisesRegex(ValueError, "finite real scalar"):
+                    VonMisesFisherDistribution(array([1.0, 0.0, 0.0]), kappa)
+
+    def test_constructor_normalizes_numeric_scalar_kappa(self):
+        for kappa in (2, np.int64(2), np.float64(2.5), np.array(3.5)):
+            with self.subTest(kappa=kappa):
+                distribution = VonMisesFisherDistribution(
+                    array([1.0, 0.0, 0.0]),
+                    kappa,
+                )
+
+                self.assertIsInstance(distribution.kappa, float)
+                self.assertEqual(distribution.kappa, float(kappa))
+
+    def test_normalized_kappa_supports_density_evaluation(self):
+        distribution = VonMisesFisherDistribution(
+            array([1.0, 0.0, 0.0]),
+            np.array(2.0),
+        )
+
+        density = float(to_numpy(distribution.pdf(array([1.0, 0.0, 0.0]))))
+        self.assertTrue(np.isfinite(density))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`VonMisesFisherDistribution.__init__()` converted `kappa` to a validated scalar for its range and normalization calculations, but stored the original input object in `self.kappa`.

That split representation admitted malformed values through Python/NumPy coercion and deferred failures into later operations:

- booleans became concentrations `1` and `0`;
- numeric-looking strings passed `float(...)` validation but failed during density arithmetic;
- NumPy datetime/timedelta scalars could be interpreted through their numeric storage;
- zero-dimensional numeric arrays remained stored as arrays instead of a stable scalar;
- one-element arrays relied on deprecated implicit scalar conversion.

## Fix

- require a zero-dimensional, non-boolean finite real scalar;
- reject textual, complex, datetime, timedelta, and array-shaped inputs before coercion;
- inspect object-wrapped scalar values after extraction;
- normalize valid Python, NumPy, and backend scalar inputs to a Python `float`;
- store the normalized concentration in `self.kappa`.

## Impact

Malformed metadata now fails at construction instead of producing type-dependent failures in PDF evaluation, sampling, multiplication, or convolution. Valid scalar-like concentrations retain their numerical semantics with a stable stored representation.

## Validation

- added regression coverage for booleans, text/bytes, complex values, datetime/timedelta values, object-wrapped temporal scalars, and non-scalar arrays;
- added controls for Python, NumPy, and zero-dimensional numeric scalars;
- verified density evaluation using a normalized zero-dimensional scalar;
- `python -m py_compile` passed for both modified files;
- an isolated harness against the exact modified module passed all rejection, normalization, and density-evaluation cases.

Repository-wide and backend-specific validation is delegated to GitHub Actions.