### PR TITLE
Preserve singleton batch shape in stacked product PDFs

### DIFF
--- a/src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/cart_prod_stacked_distribution.py
@@ -73,14 +73,13 @@ class CartProdStackedDistribution(AbstractCartProdDistribution):
                 f"xs must have trailing dimension {self.input_dim}, got shape {xs.shape}."
             )
 
+        batch_shape = xs.shape[:-1]
         ps = []
         next_dim = 0
         for dist in self.dists:
             next_input_dim = next_dim + dist.input_dim
             xs_curr = xs[..., next_dim:next_input_dim]
-            pdf_value = asarray(dist.pdf(xs_curr))
-            if xs.ndim == 1:
-                pdf_value = reshape(pdf_value, ())
+            pdf_value = reshape(asarray(dist.pdf(xs_curr)), batch_shape)
             ps.append(pdf_value)
             next_dim = next_input_dim
         return prod(stack(ps), axis=0)

--- a/tests/distributions/test_cart_prod_stacked_pdf_batch_shape.py
+++ b/tests/distributions/test_cart_prod_stacked_pdf_batch_shape.py
@@ -38,6 +38,15 @@ class TestCartProdStackedPdfBatchShape(unittest.TestCase):
         self.assertEqual(actual.shape, (2, 2))
         self.assertTrue(allclose(actual, expected))
 
+    def test_pdf_preserves_singleton_batch_dimension(self):
+        xs = array([[1.0, 2.0, 3.0, 4.0, 5.0]])
+
+        actual = self.dist.pdf(xs)
+        expected = self.dist.pdf(xs[0])
+
+        self.assertEqual(actual.shape, (1,))
+        self.assertTrue(allclose(actual[0], expected))
+
     def test_pdf_rejects_surplus_event_coordinates(self):
         invalid_points = (
             array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),


### PR DESCRIPTION
## Bug

`CartProdStackedDistribution.pdf()` did not restore each component density to the leading batch shape before stacking the product terms.

For a one-row batch such as `xs.shape == (1, input_dim)`, SciPy's multivariate Gaussian density returns a scalar rather than a length-one array. Both component densities therefore became scalars, and their stacked product also returned a scalar with shape `()` instead of preserving the requested batch shape `(1,)`.

This makes the result shape depend on batch cardinality: `(n,)` for `n > 1`, but scalar for `n == 1`.

## Fix

- derive the expected leading batch shape from `xs.shape[:-1]`;
- reshape every component PDF to that shape before stacking and multiplying;
- retain scalar output for a single unbatched event vector;
- add a regression test for a `(1, 5)` Gaussian product batch.

## Validation

- reproduced the pre-fix behavior with SciPy: two scalar component PDFs produced scalar product shape `()`;
- verified the corrected reshape produces shape `(1,)` with the same numerical value;
- existing arbitrary-leading-batch and input-dimension tests remain unchanged;
- branch is 2 commits ahead of current `main`, 0 behind, and modifies only the implementation plus its focused test.

GitHub Actions provides the authoritative full backend and repository test matrix.