### PR TITLE
Preserve multidimensional SE3 product PDF batches

### DIFF
--- a/src/pyrecest/distributions/cart_prod/se3_lin_vel_cart_prod_stacked_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/se3_lin_vel_cart_prod_stacked_distribution.py
@@ -1,5 +1,3 @@
-from pyrecest.backend import asarray, prod, stack
-
 from ..hypersphere_subset.abstract_hyperhemispherical_distribution import (
     AbstractHyperhemisphericalDistribution,
 )
@@ -44,20 +42,6 @@ class SE3LinVelCartProdStackedDistribution(CartProdStackedDistribution):
     def marginalize_periodic(self):
         """Marginalize out orientation, retaining the linear velocity component."""
         return self.dists[1]
-
-    def pdf(self, xs):
-        xs = asarray(xs)
-        ps = []
-        next_dim = 0
-        for dist in self.dists:
-            next_input_dim = next_dim + dist.input_dim
-            if xs.ndim == 1:
-                xs_curr = xs[next_dim:next_input_dim]
-            else:
-                xs_curr = xs[:, next_dim:next_input_dim]
-            ps.append(dist.pdf(xs_curr))
-            next_dim = next_input_dim
-        return prod(stack(ps), axis=0)
 
     def get_manifold_size(self):
         return float("inf")

--- a/tests/distributions/test_se3_lin_vel_cart_prod_stacked_distribution.py
+++ b/tests/distributions/test_se3_lin_vel_cart_prod_stacked_distribution.py
@@ -94,6 +94,22 @@ class TestSE3LinVelCartProdStackedDistribution(unittest.TestCase):
         pdf_values = cpd.pdf(ones((100, 10)))
         self.assertTrue(allclose(diff(pdf_values), zeros(99)))
 
+    def test_pdf_preserves_arbitrary_leading_batch_shape(self):
+        cpd = SE3LinVelCartProdStackedDistribution(
+            [
+                HyperhemisphericalUniformDistribution(3),
+                GaussianDistribution(
+                    array([1.0, 2.0, 0.0, -2.0, -1.0, 3.0]),
+                    diag(array([3.0, 2.0, 3.0, 3.0, 4.0, 5.0])),
+                ),
+            ]
+        )
+
+        pdf_values = cpd.pdf(ones((2, 3, 10)))
+
+        self.assertEqual(pdf_values.shape, (2, 3))
+        self.assertTrue(allclose(pdf_values, pdf_values[0, 0] * ones((2, 3))))
+
     def test_pdf_accepts_list_inputs(self):
         cpd = SE3LinVelCartProdStackedDistribution(
             [


### PR DESCRIPTION
## Bug

`SE3LinVelCartProdStackedDistribution.pdf()` implemented its own component slicing with `xs[:, start:stop]`. That only slices the second axis and therefore assumes at most one leading batch dimension.

For a valid input with shape `(2, 3, 10)`, the orientation component received the unchanged trailing dimension `10` instead of its required dimension `4`, so PDF evaluation failed. This contradicted the generic `CartProdStackedDistribution` contract, which accepts evaluation arrays with arbitrary leading batch dimensions and a trailing event dimension.

## Fix

- remove the narrower SE(3)-specific `pdf()` override;
- inherit the generic stacked-product implementation, which slices the trailing axis with `...` and validates the total input dimension;
- remove the now-unused backend imports;
- add a regression for a `(2, 3, 10)` batch and require a `(2, 3)` density result.

## Impact

SE(3)+linear-velocity product densities now support arbitrary leading batch shapes consistently with the parent distribution and their component distributions. Existing unbatched and one-batch-axis calls retain the same behavior.

## Validation

- reproduced the pre-fix failure with a multidimensional batch: the orientation density received shape `(2, 3, 10)` instead of trailing dimension `4`;
- verified the inherited trailing-axis slicing returns density shape `(2, 3)`;
- syntax-compiled the modified implementation and regression test;
- branch is 2 commits ahead of current `main`, 0 behind, and changes only the implementation plus its focused test.

GitHub Actions provides the authoritative full backend and repository test matrix.