### PR TITLE
Validate PyTorch fractional matrix power exponents

### DIFF
--- a/src/pyrecest/_backend/pytorch/linalg.py
+++ b/src/pyrecest/_backend/pytorch/linalg.py
@@ -1,5 +1,6 @@
 """Pytorch based linear algebra backend."""
 
+import numbers as _numbers
 from operator import index as _operator_index
 
 import numpy as _np
@@ -534,14 +535,29 @@ def is_single_matrix_pd(mat):
         return False
 
 
+def _normalize_fractional_matrix_power_exponent(t):
+    """Return a finite, non-boolean real scalar exponent."""
+    exponent_array = _as_numpy_no_grad(t)
+    if exponent_array.ndim != 0 or exponent_array.dtype.kind in "mM":
+        raise TypeError("t must be a real scalar")
+
+    exponent = exponent_array.item()
+    if isinstance(
+        exponent, (bool, _np.bool_, _np.datetime64, _np.timedelta64)
+    ) or not isinstance(exponent, _numbers.Real):
+        raise TypeError("t must be a real scalar")
+
+    exponent = float(exponent)
+    if not _np.isfinite(exponent):
+        raise ValueError("t must be finite")
+    return exponent
+
+
 def fractional_matrix_power(A, t):
     """Compute the fractional power of a matrix."""
     A = _as_linalg_tensor(A)
+    exponent = _normalize_fractional_matrix_power_exponent(t)
     A_np = _as_numpy_no_grad(A)
-    exponent = _as_numpy_no_grad(t)
-    if exponent.ndim != 0:
-        raise TypeError("t must be a scalar")
-    exponent = exponent.item()
 
     empty_result = _empty_square_matrix_batch_result(A, "fractional_matrix_power")
     if empty_result is not None:

--- a/tests/backend_support/test_pytorch_fractional_matrix_power_exponent_validation.py
+++ b/tests/backend_support/test_pytorch_fractional_matrix_power_exponent_validation.py
@@ -1,0 +1,95 @@
+import importlib.util
+
+import pytest
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_pytorch_fractional_matrix_power_validates_exponents():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("PyTorch is not installed")
+
+    result = run_backend_code(
+        "pytorch",
+        """
+import numpy as np
+import torch
+from pyrecest.backend import linalg
+import pyrecest._backend.pytorch.linalg as raw_linalg
+
+matrix = [[4.0, 0.0], [0.0, 9.0]]
+invalid_exponents = [
+    True,
+    np.bool_(False),
+    np.array([0.5]),
+    np.array([[0.5]]),
+    np.timedelta64(2, "ns"),
+    np.datetime64("1970-01-01T00:00:00.000000002"),
+    np.array(np.timedelta64(2, "ns"), dtype=object),
+    np.array(
+        np.datetime64("1970-01-01T00:00:00.000000002"), dtype=object
+    ),
+    "0.5",
+    0.5 + 0.0j,
+    torch.tensor(True),
+    torch.tensor([0.5]),
+    torch.tensor(0.5 + 0.0j),
+]
+
+for exponent in invalid_exponents:
+    for linalg_module in (linalg, raw_linalg):
+        try:
+            linalg_module.fractional_matrix_power(matrix, exponent)
+        except TypeError as exc:
+            assert "real scalar" in str(exc)
+        else:
+            raise AssertionError(
+                "fractional_matrix_power accepted invalid exponent "
+                f"{exponent!r} via {linalg_module!r}"
+            )
+
+nonfinite_exponents = [
+    np.nan,
+    np.inf,
+    -np.inf,
+    np.array(np.nan),
+    torch.tensor(float("nan")),
+    torch.tensor(float("inf")),
+]
+for exponent in nonfinite_exponents:
+    for linalg_module in (linalg, raw_linalg):
+        try:
+            linalg_module.fractional_matrix_power(matrix, exponent)
+        except ValueError as exc:
+            assert "finite" in str(exc)
+        else:
+            raise AssertionError(
+                "fractional_matrix_power accepted nonfinite exponent "
+                f"{exponent!r} via {linalg_module!r}"
+            )
+
+expected = torch.tensor([[2.0, 0.0], [0.0, 3.0]], dtype=torch.float64)
+for exponent in (0.5, np.float64(0.5), np.array(0.5), torch.tensor(0.5)):
+    result = raw_linalg.fractional_matrix_power(
+        torch.tensor(matrix, dtype=torch.float64), exponent
+    )
+    assert result.dtype == torch.float64
+    assert torch.allclose(result, expected, atol=1e-10, rtol=1e-10)
+
+empty_batch = torch.empty((0, 2, 2), dtype=torch.float64)
+for linalg_module in (linalg, raw_linalg):
+    try:
+        linalg_module.fractional_matrix_power(
+            empty_batch, np.timedelta64(2, "ns")
+        )
+    except TypeError as exc:
+        assert "real scalar" in str(exc)
+    else:
+        raise AssertionError("empty batches bypassed exponent validation")
+
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## Bug

The PyTorch backend converted `fractional_matrix_power` exponents with `np.asarray(...).item()` and passed the result directly to SciPy. This silently treated non-numeric configuration values as matrix powers:

- `True` acted as exponent `1`;
- `np.bool_(False)` acted as exponent `0`;
- `np.timedelta64(2, "ns")` and an equivalent `np.datetime64` acted as exponent `2`.

Those inputs therefore produced valid-looking but incorrect matrices instead of failing at the backend boundary. Non-finite exponents were also left to deeper SciPy behavior, and invalid exponents could pass through the empty-batch fast path.

## Fix

- add a focused exponent normalizer to the PyTorch linear-algebra backend;
- require a zero-dimensional, finite, non-boolean real scalar;
- reject boolean, text, complex, temporal, object-wrapped temporal, and non-finite values consistently;
- retain valid Python, NumPy, and scalar PyTorch real exponents;
- validate the exponent before returning an empty batched result.

This brings the PyTorch contract in line with the existing NumPy backend validation.

## Impact

Malformed exponent data can no longer silently select a different matrix power. Valid scalar-tensor workflows and result dtype preservation remain unchanged.

## Validation

- reproduced the pre-fix boolean and temporal coercions with NumPy, SciPy, and PyTorch;
- exercised the modified module against invalid type, non-finite, valid scalar, dtype-preservation, and empty-batch cases;
- added a backend-portable regression covering both the public backend facade and raw PyTorch backend;
- `python -m py_compile` passes for the modified source and regression test;
- branch is based on current `main`, two commits ahead and zero behind, with changes limited to the implementation and one focused test file.

GitHub Actions provides the authoritative repository-wide and backend test matrix.