### PR TITLE
Reject invalid partially wrapped count values

### DIFF
--- a/src/pyrecest/distributions/cart_prod/partially_wrapped_normal_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/partially_wrapped_normal_distribution.py
@@ -44,10 +44,17 @@ def _validate_positive_sample_count(n) -> int:
     count_array = np.asarray(n)
     if count_array.ndim != 0:
         raise ValueError("n must be a scalar integer")
+    if count_array.dtype.kind in {"c", "M", "m"}:
+        raise ValueError("n must be a finite integer")
 
     count = count_array.item()
     if isinstance(count, (bool, np.bool_)):
         raise ValueError("n must be an integer, not a boolean")
+    if isinstance(
+        count,
+        (complex, np.complexfloating, np.datetime64, np.timedelta64),
+    ):
+        raise ValueError("n must be a finite integer")
 
     try:
         count_int = int(count)
@@ -69,10 +76,17 @@ def _validate_nonnegative_wrap_count(m) -> int:
     count_array = np.asarray(m)
     if count_array.ndim != 0:
         raise ValueError("m must be a scalar integer")
+    if count_array.dtype.kind in {"c", "M", "m"}:
+        raise ValueError("m must be a finite integer")
 
     count = count_array.item()
     if isinstance(count, (bool, np.bool_)):
         raise ValueError("m must be an integer, not a boolean")
+    if isinstance(
+        count,
+        (complex, np.complexfloating, np.datetime64, np.timedelta64),
+    ):
+        raise ValueError("m must be a finite integer")
 
     try:
         count_int = int(count)

--- a/tests/distributions/test_partially_wrapped_count_precision.py
+++ b/tests/distributions/test_partially_wrapped_count_precision.py
@@ -2,6 +2,7 @@
 
 from fractions import Fraction
 
+import numpy as np
 import pytest
 from pyrecest.distributions.cart_prod.partially_wrapped_normal_distribution import (
     _validate_nonnegative_wrap_count,
@@ -31,3 +32,30 @@ def test_preserves_exact_large_integer(validator):
     exact_integer = Fraction(2**54 + 2, 2)
 
     assert validator(exact_integer) == 2**53 + 1
+
+
+@pytest.mark.parametrize(
+    "validator",
+    [_validate_positive_sample_count, _validate_nonnegative_wrap_count],
+)
+@pytest.mark.parametrize(
+    "invalid_count",
+    [
+        np.timedelta64(3, "ns"),
+        np.datetime64(3, "ns"),
+        np.array(np.timedelta64(3, "ns"), dtype=object),
+        np.array(np.datetime64(3, "ns"), dtype=object),
+        np.array(np.complex128(3 + 0j), dtype=object),
+    ],
+)
+def test_rejects_nonreal_or_temporal_counts(validator, invalid_count):
+    with pytest.raises(ValueError, match="finite integer"):
+        validator(invalid_count)
+
+
+@pytest.mark.parametrize(
+    "validator",
+    [_validate_positive_sample_count, _validate_nonnegative_wrap_count],
+)
+def test_preserves_object_wrapped_integer_counts(validator):
+    assert validator(np.array(3, dtype=object)) == 3


### PR DESCRIPTION
## Bug

The partially wrapped normal count validators converted zero-dimensional NumPy values with `.item()` before checking their semantic type. For nanosecond-resolution `np.timedelta64` and `np.datetime64` values, `.item()` returns an ordinary Python integer. Object-wrapped temporal values and zero-imaginary NumPy complex scalars could likewise compare equal to an integer.

Consequently:

- `PartiallyWrappedNormalDistribution.sample(np.timedelta64(3, "ns"))` silently requested three samples;
- `PartiallyWrappedNormalDistribution.pdf(xs, m=np.datetime64(3, "ns"))` silently selected three wrap terms;
- object-wrapped temporal or complex metadata could also be treated as valid counts.

## Fix

- reject complex and NumPy temporal dtypes before scalar extraction;
- reject object-wrapped complex and temporal scalars after extraction;
- retain valid Python, NumPy, exact rational, and object-wrapped integer counts;
- apply the same contract to positive sample counts and nonnegative PDF wrap counts.

## Impact

Malformed metadata can no longer silently change random sample cardinality or the number of periodic image terms used for density evaluation.

## Validation

- reproduced the pre-fix temporal dtype erasure with NumPy;
- exercised both validators against direct and object-wrapped temporal values plus object-wrapped complex values;
- preserved existing exact large-integer behavior and added an object-wrapped integer positive control;
- branch is 2 commits ahead of current `main`, 0 behind, and changes only the validator implementation and focused regression test.

GitHub Actions provides the authoritative repository and backend test matrix.