### PR TITLE
Handle zero-mass cells in hypercylindrical subdivision

### DIFF
--- a/src/pyrecest/distributions/cart_prod/hypercylindrical_state_space_subdivision_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/hypercylindrical_state_space_subdivision_distribution.py
@@ -38,6 +38,7 @@ from pyrecest.distributions.hypertorus.hypertoroidal_grid_distribution import (
 from pyrecest.distributions.nonperiodic.custom_linear_distribution import (
     CustomLinearDistribution,
 )
+from pyrecest.distributions.nonperiodic.gaussian_distribution import GaussianDistribution
 from pyrecest.distributions.nonperiodic.linear_mixture import LinearMixture
 
 
@@ -303,7 +304,6 @@ class HypercylindricalStateSpaceSubdivisionDistribution(
 
             # Unnormalized conditional to compute the marginal weight
             cd_unnorm = CustomLinearDistribution(lambda x, fc=fun_curr: fc(x), dim_lin)
-
             integral_val = float(
                 cd_unnorm.integrate(
                     left=array([float(int_range[0])]),
@@ -312,14 +312,24 @@ class HypercylindricalStateSpaceSubdivisionDistribution(
             )
             grid_values.append(integral_val)
 
-            # Normalized conditional: p(lin | bound = grid_i)
-            cds.append(
-                CustomLinearDistribution(
-                    lambda x, fc=fun_curr: fc(x),
-                    dim_lin,
-                    scale_by=1.0 / integral_val,
+            if integral_val == 0.0:
+                # The conditional distribution is undefined at a zero-mass grid
+                # point. Any normalized fallback is valid because the periodic
+                # marginal gives this component zero weight in PDFs, modes,
+                # mixtures, and sampling.
+                cds.append(GaussianDistribution(array([0.0]), array([[1.0]])))
+            else:
+                # Normalized conditional: p(lin | bound = grid_i)
+                cds.append(
+                    CustomLinearDistribution(
+                        lambda x, fc=fun_curr: fc(x),
+                        dim_lin,
+                        scale_by=1.0 / integral_val,
+                    )
                 )
-            )
+
+        if not any(value > 0.0 for value in grid_values):
+            raise ValueError("fun must have positive total mass on the generated grid")
 
         gd = HypertoroidalGridDistribution(
             array(grid_values),

--- a/tests/distributions/test_hypercylindrical_zero_marginals.py
+++ b/tests/distributions/test_hypercylindrical_zero_marginals.py
@@ -1,0 +1,48 @@
+import unittest
+from math import pi
+
+import numpy as np
+
+from pyrecest.backend import __backend_name__ as backend_name
+from pyrecest.backend import array
+from pyrecest.distributions.cart_prod.hypercylindrical_state_space_subdivision_distribution import (
+    HypercylindricalStateSpaceSubdivisionDistribution,
+)
+from pyrecest.distributions.nonperiodic.gaussian_distribution import (
+    GaussianDistribution,
+)
+
+
+@unittest.skipIf(backend_name != "numpy", reason="Not supported on this backend")
+class TestHypercylindricalZeroMarginals(unittest.TestCase):
+    def test_from_function_handles_zero_marginal_grid_points(self):
+        gaussian = GaussianDistribution(array([0.0]), array([[1.0]]))
+
+        def joint_pdf(xs):
+            angular_factor = np.sin(np.asarray(xs[:, 0])) ** 2
+            return angular_factor * np.asarray(gaussian.pdf(xs[:, 1:]))
+
+        dist = HypercylindricalStateSpaceSubdivisionDistribution.from_function(
+            joint_pdf, 8, 1, 1
+        )
+
+        grid_values = np.asarray(dist.gd.grid_values)
+        self.assertTrue(np.any(grid_values == 0.0))
+
+        values = np.asarray(dist.pdf(array([[0.0, 0.0], [pi / 2.0, 0.0]])))
+        self.assertTrue(np.all(np.isfinite(values)))
+        self.assertEqual(float(values[0]), 0.0)
+        self.assertGreater(float(values[1]), 0.0)
+
+    def test_from_function_rejects_zero_total_grid_mass(self):
+        def zero_pdf(xs):
+            return np.zeros(xs.shape[0])
+
+        with self.assertRaisesRegex(ValueError, "positive total mass"):
+            HypercylindricalStateSpaceSubdivisionDistribution.from_function(
+                zero_pdf, 8, 1, 1
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`HypercylindricalStateSpaceSubdivisionDistribution.from_function()` normalizes a conditional linear density independently at every periodic grid point. It previously computed `1.0 / integral_val` unconditionally.

A valid joint density can have an exactly zero periodic marginal at an individual grid point, for example `sin(theta)^2 * N(x; 0, 1)` at `theta = 0`. In that case the conditional distribution is mathematically undefined but irrelevant because the periodic component has zero weight. The implementation instead raised a division-by-zero error during construction.

An identically zero function also failed through the same low-level division rather than reporting that the generated grid has no probability mass.

## Fix

- retain zero marginal grid values;
- attach a normalized standard-Gaussian fallback conditional to zero-mass cells;
- keep positive-mass cells normalized from the supplied function as before;
- reject a generated grid whose total positive mass is zero with a clear `ValueError`.

The fallback cannot affect the represented joint density, mode selection, marginal mixture, or sampling because its grid component has zero weight.

## Validation

- added a regression using `sin(theta)^2 * N(x; 0, 1)`, whose grid includes a zero-mass cell at `theta = 0`;
- verifies construction succeeds, all evaluated densities are finite, the zero-mass location evaluates to zero, and a positive-mass location remains positive;
- added a regression requiring a clear error for an identically zero function;
- branch is 2 commits ahead of current `main`, 0 behind, and changes only the implementation plus one focused test module.

GitHub Actions provides the authoritative full repository and backend test matrix.