### PR TITLE
Reject temporal von Mises sample counts

### DIFF
--- a/src/pyrecest/distributions/circle/von_mises_distribution.py
+++ b/src/pyrecest/distributions/circle/von_mises_distribution.py
@@ -3,6 +3,7 @@ import copy
 import math
 from numbers import Integral
 
+import numpy as np
 from pyrecest.backend import (
     abs,
     arctan2,
@@ -80,7 +81,13 @@ class VonMisesDistribution(AbstractCircularDistribution):
 
     def sample(self, n):
         """Draw samples from the von Mises distribution."""
-        if isinstance(n, bool) or not isinstance(n, Integral) or int(n) <= 0:
+        dtype_kind = getattr(getattr(n, "dtype", None), "kind", None)
+        if (
+            isinstance(n, (bool, np.bool_, np.datetime64, np.timedelta64))
+            or dtype_kind in {"b", "M", "m"}
+            or not isinstance(n, Integral)
+            or int(n) <= 0
+        ):
             raise ValueError("n must be a positive integer.")
         n = int(n)
         return mod(

--- a/tests/distributions/test_von_mises_temporal_sample_count.py
+++ b/tests/distributions/test_von_mises_temporal_sample_count.py
@@ -1,0 +1,18 @@
+import numpy as np
+import pytest
+
+from pyrecest.distributions import VonMisesDistribution
+
+
+@pytest.mark.parametrize(
+    "n",
+    (
+        np.timedelta64(3, "ns"),
+        np.timedelta64(3, "us"),
+    ),
+)
+def test_von_mises_sample_rejects_temporal_counts(n):
+    distribution = VonMisesDistribution(0.3, 1.0)
+
+    with pytest.raises(ValueError, match="positive integer"):
+        distribution.sample(n)


### PR DESCRIPTION
## Bug

`VonMisesDistribution.sample()` validated its sample count with `numbers.Integral` followed by `int(n)`. NumPy classifies fine-resolution `numpy.timedelta64` scalars as integral-like, so `np.timedelta64(3, "ns")` was silently interpreted as the sample count `3`. Coarser temporal units reached the same branch but leaked a lower-level `TypeError` during integer conversion.

## Fix

- reject NumPy datetime and timedelta scalar values before generic integer handling;
- reject zero-dimensional temporal and boolean dtypes consistently;
- preserve valid Python and NumPy integer sample counts;
- retain the existing positive-integer error contract.

## Impact

Duration or timestamp metadata can no longer silently control random sample cardinality, and invalid temporal values now fail deterministically at the public API boundary.

## Validation

- reproduced the pre-fix acceptance of `np.timedelta64(3, "ns")` as integer `3`;
- reproduced the inconsistent `TypeError` for a coarser timedelta unit;
- added focused regressions covering nanosecond and microsecond timedeltas;
- preserved the existing `np.int64` positive control;
- syntax-compiled the modified implementation and regression test;
- branch is one focused commit based on the current `main` used for inspection.

GitHub Actions provides the authoritative full repository and backend test matrix.