### PR TITLE
Reject complex Gaussian mixture target means

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/gaussian_mixture.py
+++ b/src/pyrecest/distributions/nonperiodic/gaussian_mixture.py
@@ -6,7 +6,7 @@ from pyrecest.backend import all as backend_all
 from pyrecest.backend import array, isfinite, ones, reshape, stack, sum
 
 from .abstract_linear_distribution import AbstractLinearDistribution
-from .gaussian_distribution import GaussianDistribution
+from .gaussian_distribution import GaussianDistribution, _validate_real_values
 from .linear_dirac_distribution import LinearDiracDistribution
 from .linear_mixture import LinearMixture
 
@@ -34,6 +34,7 @@ class GaussianMixture(LinearMixture, AbstractLinearDistribution):
             raise ValueError(
                 f"new_mean must have shape ({self.dim},), got {new_mean.shape}."
             )
+        _validate_real_values(new_mean, "new_mean")
         if not bool(backend_all(isfinite(new_mean))):
             raise ValueError("new_mean must contain only finite values.")
 

--- a/tests/distributions/test_gaussian_mixture_complex_mean.py
+++ b/tests/distributions/test_gaussian_mixture_complex_mean.py
@@ -1,0 +1,40 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array, diag, to_numpy
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.distributions.nonperiodic.gaussian_mixture import GaussianMixture
+
+
+class GaussianMixtureComplexMeanTest(unittest.TestCase):
+    def test_set_mean_rejects_complex_target_without_mutating_components(self):
+        component_1 = GaussianDistribution(
+            array([0.0, 1.0]), diag(array([1.0, 2.0]))
+        )
+        component_2 = GaussianDistribution(
+            array([2.0, 3.0]), diag(array([3.0, 4.0]))
+        )
+        mixture = GaussianMixture([component_1, component_2], array([0.25, 0.75]))
+        original_means = [to_numpy(dist.mu).copy() for dist in mixture.dists]
+
+        invalid_means = (
+            [10.0 + 2.0j, -2.0],
+            np.array([10.0, -2.0 - 3.0j], dtype=np.complex64),
+        )
+        for invalid_mean in invalid_means:
+            with self.subTest(invalid_mean=invalid_mean):
+                with self.assertRaisesRegex(
+                    ValueError, "new_mean must contain only real values"
+                ):
+                    mixture.set_mean(invalid_mean)
+
+        for dist, original_mean in zip(mixture.dists, original_means):
+            npt.assert_allclose(to_numpy(dist.mu), original_mean)
+            self.assertFalse(np.iscomplexobj(to_numpy(dist.mu)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`GaussianMixture.set_mean()` checked the target mean's shape and finiteness, but not whether it was real-valued. Complex values are finite under NumPy and the supported numerical backends, so a target such as `[10 + 2j, -2]` passed validation.

The method then applied the complex mean offset directly to every component's `mu`. That bypassed `GaussianDistribution` construction and silently changed otherwise real Gaussian components into complex-valued states, violating the component distribution's real-valued invariant.

## Fix

- reuse the Gaussian distribution's existing real-value validator before applying the mean offset;
- retain the existing shape and finite-value validation;
- reject both Python complex inputs and NumPy complex arrays before copying or mutating components.

## Validation

- added a focused regression covering a Python complex sequence and a `complex64` NumPy array;
- verified rejected targets leave every original component mean unchanged and real-valued;
- syntax-compiled the exact modified source and regression test with `python -m py_compile`;
- the source change is limited to one validator import and one validation call, plus the focused regression.

GitHub Actions provides the authoritative repository-wide and backend test matrix.