### PR TITLE
Validate GNN pairwise cost weights

### DIFF
--- a/src/pyrecest/filters/global_nearest_neighbor.py
+++ b/src/pyrecest/filters/global_nearest_neighbor.py
@@ -139,10 +139,39 @@ class GlobalNearestNeighbor(AbstractNearestNeighborTracker):
             )
         return pairwise_cost_matrix
 
+    @staticmethod
+    def _validate_pairwise_cost_weight(pairwise_cost_weight):
+        error_message = (
+            "pairwise_cost_weight must be a finite non-negative real scalar."
+        )
+        if np.ma.is_masked(pairwise_cost_weight):
+            raise ValueError(error_message)
+        try:
+            raw_weight = np.asarray(pairwise_cost_weight)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(error_message) from exc
+        if (
+            raw_weight.shape != ()
+            or raw_weight.dtype.kind in _REJECTED_PAIRWISE_COST_DTYPE_KINDS
+        ):
+            raise ValueError(error_message)
+        scalar = raw_weight.item()
+        if isinstance(scalar, _INVALID_PAIRWISE_COST_SCALAR_TYPES):
+            raise ValueError(error_message)
+        try:
+            weight = float(scalar)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise ValueError(error_message) from exc
+        if not np.isfinite(weight) or weight < 0.0:
+            raise ValueError(error_message)
+        return weight
+
     def _apply_pairwise_cost_matrix(self, dists, pairwise_cost_matrix):
         if pairwise_cost_matrix is None:
             return dists
-        pairwise_cost_weight = self.association_param.get("pairwise_cost_weight", 1.0)
+        pairwise_cost_weight = self._validate_pairwise_cost_weight(
+            self.association_param.get("pairwise_cost_weight", 1.0)
+        )
         if pairwise_cost_weight == 0.0:
             return dists
         return dists + pairwise_cost_weight * pairwise_cost_matrix

--- a/tests/filters/test_gnn_pairwise_cost_weight_validation.py
+++ b/tests/filters/test_gnn_pairwise_cost_weight_validation.py
@@ -1,0 +1,69 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+from pyrecest.filters.global_nearest_neighbor import GlobalNearestNeighbor
+
+
+class GlobalNearestNeighborPairwiseCostWeightValidationTest(unittest.TestCase):
+    def test_rejects_invalid_pairwise_cost_weights(self):
+        invalid_weights = (
+            True,
+            "1.0",
+            1.0 + 0.0j,
+            np.nan,
+            np.inf,
+            -np.inf,
+            -1.0,
+            np.array([1.0]),
+            np.datetime64("2026-07-28"),
+            np.ma.masked,
+        )
+
+        for invalid_weight in invalid_weights:
+            with self.subTest(pairwise_cost_weight=invalid_weight):
+                tracker = GlobalNearestNeighbor(
+                    association_param={"pairwise_cost_weight": invalid_weight}
+                )
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "pairwise_cost_weight must be a finite non-negative real scalar",
+                ):
+                    tracker._apply_pairwise_cost_matrix(
+                        np.zeros((1, 1)), np.ones((1, 1))
+                    )
+
+    def test_accepts_finite_nonnegative_scalar_weights(self):
+        for valid_weight in (0, 0.5, np.float64(2.0)):
+            with self.subTest(pairwise_cost_weight=valid_weight):
+                validated_weight = (
+                    GlobalNearestNeighbor._validate_pairwise_cost_weight(valid_weight)
+                )
+                self.assertEqual(validated_weight, float(valid_weight))
+
+    def test_zero_weight_ignores_positive_infinite_pairwise_gate(self):
+        tracker = GlobalNearestNeighbor(
+            association_param={"pairwise_cost_weight": 0.0}
+        )
+        geometric_costs = np.array([[1.25]])
+
+        combined_costs = tracker._apply_pairwise_cost_matrix(
+            geometric_costs, np.array([[np.inf]])
+        )
+
+        npt.assert_array_equal(combined_costs, geometric_costs)
+
+    def test_positive_weight_scales_pairwise_costs(self):
+        tracker = GlobalNearestNeighbor(
+            association_param={"pairwise_cost_weight": 2.0}
+        )
+
+        combined_costs = tracker._apply_pairwise_cost_matrix(
+            np.array([[1.0, 2.0]]), np.array([[3.0, 4.0]])
+        )
+
+        npt.assert_array_equal(combined_costs, np.array([[7.0, 10.0]]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
- validate `association_param["pairwise_cost_weight"]` before combining geometric and external pairwise costs
- require a finite, real, scalar, non-negative weight
- preserve zero-weight behavior without multiplying positive-infinity gating costs
- add regression tests for malformed weights, zero-weight gating, and positive scaling

## Root cause
`pairwise_cost_weight` was consumed without validation. NaN or infinite weights could produce NaN assignment matrices, negative weights could turn supported positive-infinity pairwise gates into negative infinity, and nonnumeric values failed later with low-level NumPy/SciPy errors.

## Impact
Invalid configurations now fail early with a deterministic `ValueError`, while valid finite non-negative weights retain existing behavior.

## Validation
Added focused unit tests in `tests/filters/test_gnn_pairwise_cost_weight_validation.py`. Repository CI should execute the full backend/test matrix.