### PR TITLE
Reject temporal particle counts

### DIFF
--- a/src/pyrecest/distributions/se2_dirac_distribution.py
+++ b/src/pyrecest/distributions/se2_dirac_distribution.py
@@ -109,8 +109,10 @@ class SE2DiracDistribution(HypercylindricalDiracDistribution, AbstractSE2Distrib
 
     @staticmethod
     def _validate_particle_count(n_particles):
+        dtype_kind = getattr(getattr(n_particles, "dtype", None), "kind", None)
         if (
             isinstance(n_particles, bool)
+            or dtype_kind in {"M", "m"}
             or not isinstance(n_particles, Integral)
             or int(n_particles) <= 0
         ):

--- a/src/pyrecest/filters/euclidean_particle_filter.py
+++ b/src/pyrecest/filters/euclidean_particle_filter.py
@@ -72,11 +72,15 @@ class EuclideanParticleFilter(AbstractParticleFilter, EuclideanFilterMixin):
     def _validate_positive_int(value, name: str):
         message = f"{name} must be a positive integer"
         value_array = np.asarray(value)
-        if value_array.shape != () or value_array.dtype == np.bool_:
+        if (
+            value_array.shape != ()
+            or value_array.dtype == np.bool_
+            or value_array.dtype.kind in {"M", "m"}
+        ):
             raise ValueError(message)
 
         scalar = value_array.item()
-        if isinstance(scalar, (bool, np.bool_)):
+        if isinstance(scalar, (bool, np.bool_, np.datetime64, np.timedelta64)):
             raise ValueError(message)
         if isinstance(scalar, (str, bytes, bytearray, np.str_, np.bytes_)):
             raise ValueError(message)

--- a/src/pyrecest/filters/hypertoroidal_particle_filter.py
+++ b/src/pyrecest/filters/hypertoroidal_particle_filter.py
@@ -26,11 +26,15 @@ from .manifold_mixins import HypertoroidalFilterMixin
 def _validate_positive_integer(value, name: str) -> int:
     message = f"{name} must be a positive integer."
     value_array = np.asarray(value)
-    if value_array.shape != () or value_array.dtype == np.bool_:
+    if (
+        value_array.shape != ()
+        or value_array.dtype == np.bool_
+        or value_array.dtype.kind in {"M", "m"}
+    ):
         raise ValueError(message)
 
     scalar = value_array.item()
-    if isinstance(scalar, (bool, np.bool_)):
+    if isinstance(scalar, (bool, np.bool_, np.datetime64, np.timedelta64)):
         raise ValueError(message)
     if isinstance(scalar, (str, bytes, bytearray, np.str_, np.bytes_)):
         raise ValueError(message)

--- a/tests/distributions/test_se2_dirac_temporal_particle_count.py
+++ b/tests/distributions/test_se2_dirac_temporal_particle_count.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pytest
+
+from pyrecest.distributions import SE2DiracDistribution
+from pyrecest.distributions.cart_prod.abstract_hypercylindrical_distribution import (
+    AbstractHypercylindricalDistribution,
+)
+
+
+class _NoSamplingSE2Distribution(AbstractHypercylindricalDistribution):
+    def __init__(self):
+        super().__init__(bound_dim=1, lin_dim=2)
+
+    def pdf(self, xs):
+        raise AssertionError("pdf must not be evaluated for count validation")
+
+    def sample(self, n):
+        raise AssertionError("invalid temporal counts must not reach sampling")
+
+
+@pytest.mark.parametrize(
+    "n_particles",
+    (
+        np.timedelta64(3, "ns"),
+        np.timedelta64(3, "us"),
+    ),
+)
+def test_se2_dirac_from_distribution_rejects_temporal_particle_counts(n_particles):
+    with pytest.raises(ValueError, match="positive integer"):
+        SE2DiracDistribution.from_distribution(
+            _NoSamplingSE2Distribution(), n_particles
+        )

--- a/tests/distributions/test_se2_dirac_temporal_particle_count.py
+++ b/tests/distributions/test_se2_dirac_temporal_particle_count.py
@@ -17,6 +17,12 @@ class _NoSamplingSE2Distribution(AbstractHypercylindricalDistribution):
     def sample(self, n):
         raise AssertionError("invalid temporal counts must not reach sampling")
 
+    def marginalize_linear(self):
+        raise AssertionError("marginalization must not be evaluated for count validation")
+
+    def marginalize_periodic(self):
+        raise AssertionError("marginalization must not be evaluated for count validation")
+
 
 @pytest.mark.parametrize(
     "n_particles",

--- a/tests/filters/test_particle_filter_count_precision.py
+++ b/tests/filters/test_particle_filter_count_precision.py
@@ -1,5 +1,6 @@
 from fractions import Fraction
 
+import numpy as np
 import pytest
 from pyrecest.filters.euclidean_particle_filter import EuclideanParticleFilter
 from pyrecest.filters.hypertoroidal_particle_filter import _validate_positive_integer
@@ -26,3 +27,27 @@ def test_particle_filter_count_validation_is_exact(validator):
         validator(rounded_half_integer)
 
     assert validator(exact_large_integer) == 2**53 + 1
+
+
+@pytest.mark.parametrize(
+    "temporal_value",
+    [
+        np.timedelta64(3, "ns"),
+        np.datetime64("1970-01-01T00:00:00.000000003"),
+        np.array(np.timedelta64(3, "ns"), dtype=object),
+        np.array(
+            np.datetime64("1970-01-01T00:00:00.000000003"), dtype=object
+        ),
+    ],
+    ids=["timedelta", "datetime", "object-timedelta", "object-datetime"],
+)
+@pytest.mark.parametrize(
+    "validator",
+    [_validate_euclidean, _validate_hypertoroidal],
+    ids=["euclidean", "hypertoroidal"],
+)
+def test_particle_filter_count_validation_rejects_temporal_scalars(
+    validator, temporal_value
+):
+    with pytest.raises(ValueError, match="positive integer"):
+        validator(temporal_value)


### PR DESCRIPTION
## What changed

- reject NumPy temporal scalar dtypes in `SE2DiracDistribution._validate_particle_count`
- reject direct and object-wrapped `numpy.datetime64` and `numpy.timedelta64` values in the Euclidean and hypertoroidal particle-filter count validators
- cover temporal count rejection for SE(2), Euclidean, and hypertoroidal paths while preserving exact large-integer handling

## Why

NumPy temporal scalars can masquerade as integers. For nanosecond values, `numpy.asarray(value).item()` can return a plain integer; for example, a three-nanosecond duration or a timestamp three nanoseconds after the Unix epoch becomes `3`. The existing validators could therefore accept temporal values as `n_particles` or `dim`, while other temporal units failed later through inconsistent low-level exceptions.

Particle counts and dimensions must accept only positive integer counts and reject temporal data deterministically.

## Impact

Invalid temporal values no longer reach samplers or array-allocation paths as accidental particle counts or dimensions. Normal Python integers, NumPy integer scalars, and exact large integral values retain their existing behavior.

## Validation

- reproduced the pre-fix conversion of nanosecond `datetime64` and `timedelta64` values to integer `3`
- syntax-compiled both modified filter modules and the extended regression test
- ran an isolated validator harness covering two validators, four temporal representations, ordinary integers, NumPy integers, and exact large `Fraction` values
- verified the PR remains mergeable and its diff is limited to the three validators and their regression tests

Full repository and backend-matrix validation remains delegated to GitHub Actions.