### PR TITLE
Validate custom normalization integrals

### DIFF
--- a/src/pyrecest/distributions/abstract_custom_distribution.py
+++ b/src/pyrecest/distributions/abstract_custom_distribution.py
@@ -1,11 +1,63 @@
 import copy
+import math
 import warnings
 from abc import abstractmethod
+
+import numpy as np
 
 # pylint: disable=no-name-in-module,no-member
 import pyrecest.backend
 
 from .abstract_distribution_type import AbstractDistributionType
+
+
+_INVALID_INTEGRAL_TYPES = (
+    bool,
+    np.bool_,
+    str,
+    bytes,
+    bytearray,
+    np.str_,
+    np.bytes_,
+    complex,
+    np.complexfloating,
+    np.datetime64,
+    np.timedelta64,
+)
+
+
+def _validated_positive_integral(integral, name: str) -> float:
+    """Return a finite positive scalar integral value."""
+    message = f"{name} must be a finite positive scalar."
+    if isinstance(integral, tuple):
+        if not integral:
+            raise ValueError(message)
+        integral = integral[0]
+
+    try:
+        integral_array = np.asarray(integral)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError(message) from exc
+    if integral_array.ndim != 0 or integral_array.dtype.kind in {
+        "b",
+        "c",
+        "S",
+        "U",
+        "M",
+        "m",
+    }:
+        raise ValueError(message)
+
+    scalar = integral_array.item()
+    if isinstance(scalar, _INVALID_INTEGRAL_TYPES):
+        raise ValueError(message)
+    try:
+        scalar = float(scalar)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError(message) from exc
+    if not math.isfinite(scalar) or scalar <= 0.0:
+        raise ValueError(message)
+    return scalar
 
 
 class AbstractCustomDistribution(AbstractDistributionType):
@@ -67,16 +119,16 @@ class AbstractCustomDistribution(AbstractDistributionType):
             raise NotImplementedError("Only supported for numpy backend.")
         cd = copy.deepcopy(self)
 
-        integral = self.integrate()
-        if isinstance(integral, tuple):
-            integral = integral[0]
+        integral = _validated_positive_integral(
+            self.integrate(), "Normalization integral"
+        )
         cd.scale_by = cd.scale_by / integral
 
         if verify:
-            verification_integral = cd.integrate()
-            if isinstance(verification_integral, tuple):
-                verification_integral = verification_integral[0]
-            if abs(float(verification_integral) - 1) > 0.001:
+            verification_integral = _validated_positive_integral(
+                cd.integrate(), "Verification integral"
+            )
+            if abs(verification_integral - 1) > 0.001:
                 warnings.warn("Density is not yet properly normalized.", UserWarning)
 
         return cd

--- a/tests/distributions/test_custom_distribution_tuple_integral.py
+++ b/tests/distributions/test_custom_distribution_tuple_integral.py
@@ -1,5 +1,6 @@
-"""Regression tests for tuple-valued custom-distribution integrals."""
+"""Regression tests for custom-distribution integral normalization."""
 
+import numpy as np
 import pyrecest.backend
 import pytest
 from pyrecest.distributions.circle.custom_circular_distribution import (
@@ -15,6 +16,18 @@ class _TupleIntegralCircularDistribution(CustomCircularDistribution):
         return 2.0 * self.scale_by, 1.0e-12
 
 
+class _FixedIntegralCircularDistribution(CustomCircularDistribution):
+    """Circular test distribution returning a configured integral value."""
+
+    def __init__(self, integral):
+        super().__init__(lambda xs: xs * 0.0 + 1.0)
+        self.integral = integral
+
+    def integrate(self, integration_boundaries=None):
+        del integration_boundaries
+        return self.integral
+
+
 @pytest.mark.skipif(
     pyrecest.backend.__backend_name__ != "numpy",
     reason="Custom-distribution normalization is NumPy-only",
@@ -26,4 +39,31 @@ def test_normalize_accepts_value_error_integral_tuple():
 
     assert normalized.scale_by == pytest.approx(0.5)
     assert normalized.integrate()[0] == pytest.approx(1.0)
+    assert distribution.scale_by == pytest.approx(1.0)
+
+
+@pytest.mark.skipif(
+    pyrecest.backend.__backend_name__ != "numpy",
+    reason="Custom-distribution normalization is NumPy-only",
+)
+@pytest.mark.parametrize(
+    "integral",
+    (
+        0.0,
+        -1.0,
+        float("nan"),
+        float("inf"),
+        np.array([1.0]),
+        "1.0",
+        True,
+        np.timedelta64(1, "ns"),
+        (0.0, 1.0e-12),
+    ),
+)
+def test_normalize_rejects_invalid_integrals(integral):
+    distribution = _FixedIntegralCircularDistribution(integral)
+
+    with pytest.raises(ValueError, match="finite positive scalar"):
+        distribution.normalize()
+
     assert distribution.scale_by == pytest.approx(1.0)


### PR DESCRIPTION
## Bug

`AbstractCustomDistribution.normalize()` extracted SciPy-style `(value, error)` integration results but divided by the returned value without validating its scalar type, sign, or finiteness.

Consequently:

- a zero integral leaked a low-level division-by-zero failure;
- negative integrals produced a sign-flipped scale factor;
- `NaN` or infinite integrals could create non-finite normalized densities;
- vector, textual, boolean, complex, or temporal values could reach coercion or division through inconsistent failure paths;
- non-finite verification integrals could bypass the existing tolerance warning because comparisons with `NaN` are false.

## Fix

- add one shared integral normalizer for both the initial normalization and optional verification pass;
- retain support for scalar integration results and SciPy-style `(value, error)` tuples;
- require the integral value to be a finite positive scalar;
- reject malformed values with a stable `ValueError` before changing the copied distribution's scale.

## Impact

Custom density normalization now fails deterministically when the represented function has no valid positive finite total mass. Valid scalar and tuple-returning integrators keep their existing behavior.

## Validation

- syntax-compiled the modified implementation and regression test;
- ran an isolated harness against the exact modified module: valid tuple normalization plus 10 malformed integral cases passed;
- expanded the existing custom-integral regression with zero, negative, non-finite, vector, text, boolean, temporal, and invalid tuple cases;
- branch is two commits ahead of current `main`, zero behind, and changes only two files.

GitHub Actions provides the authoritative repository-wide and backend test matrix.