### PR TITLE
Validate nonlinear turn thresholds

### DIFF
--- a/src/pyrecest/models/_validated_motion_models.py
+++ b/src/pyrecest/models/_validated_motion_models.py
@@ -10,6 +10,8 @@ from . import motion_models as _motion_models
 
 _nearly_coordinated_turn_model_impl = _motion_models.nearly_coordinated_turn_model
 _continuous_to_discrete_lti_impl = _motion_models.continuous_to_discrete_lti
+_coordinated_turn_transition_impl = _motion_models.coordinated_turn_transition
+_se2_unicycle_transition_impl = _motion_models.se2_unicycle_transition
 
 
 def _contains_complex_values(value: Any, seen: set[int] | None = None) -> bool:
@@ -76,6 +78,40 @@ def continuous_to_discrete_lti(
     )
 
 
+def coordinated_turn_transition(
+    state: Any, dt: float = 1.0, turn_threshold: float = 1e-8
+) -> Any:
+    """Propagate a coordinated-turn state with a valid branch threshold."""
+    turn_threshold = (
+        _motion_models._as_positive_float(  # pylint: disable=protected-access
+            turn_threshold,
+            "turn_threshold",
+        )
+    )
+    return _coordinated_turn_transition_impl(
+        state,
+        dt=dt,
+        turn_threshold=turn_threshold,
+    )
+
+
+def se2_unicycle_transition(
+    state: Any, dt: float = 1.0, turn_threshold: float = 1e-8
+) -> Any:
+    """Propagate an SE(2) unicycle state with a valid branch threshold."""
+    turn_threshold = (
+        _motion_models._as_positive_float(  # pylint: disable=protected-access
+            turn_threshold,
+            "turn_threshold",
+        )
+    )
+    return _se2_unicycle_transition_impl(
+        state,
+        dt=dt,
+        turn_threshold=turn_threshold,
+    )
+
+
 def nearly_coordinated_turn_model(
     dt: float = 1.0,
     position_spectral_density: float = 1.0,
@@ -100,7 +136,14 @@ def nearly_coordinated_turn_model(
 
 
 _motion_models.continuous_to_discrete_lti = continuous_to_discrete_lti
+_motion_models.coordinated_turn_transition = coordinated_turn_transition
 _motion_models.nearly_coordinated_turn_model = nearly_coordinated_turn_model
+_motion_models.se2_unicycle_transition = se2_unicycle_transition
 
 
-__all__ = ["continuous_to_discrete_lti", "nearly_coordinated_turn_model"]
+__all__ = [
+    "continuous_to_discrete_lti",
+    "coordinated_turn_transition",
+    "nearly_coordinated_turn_model",
+    "se2_unicycle_transition",
+]

--- a/tests/test_motion_model_turn_thresholds.py
+++ b/tests/test_motion_model_turn_thresholds.py
@@ -1,0 +1,34 @@
+"""Regression tests for nonlinear motion-model turn thresholds."""
+
+import unittest
+
+import numpy as np
+from pyrecest.backend import array
+from pyrecest.models import coordinated_turn_transition, se2_unicycle_transition
+
+
+class TestTurnThresholdValidation(unittest.TestCase):
+    def test_nonlinear_turn_transitions_reject_invalid_thresholds(self):
+        transitions = (
+            (
+                coordinated_turn_transition,
+                array([0.0, 0.0, 1.0, 0.0, 0.0]),
+            ),
+            (
+                se2_unicycle_transition,
+                array([0.0, 0.0, 0.0, 1.0, 0.0]),
+            ),
+        )
+        invalid_thresholds = (0.0, -1e-8, np.nan, np.inf, True, "1e-8", b"1e-8")
+
+        for transition, state in transitions:
+            for turn_threshold in invalid_thresholds:
+                with self.subTest(
+                    transition=transition.__name__, turn_threshold=turn_threshold
+                ):
+                    with self.assertRaisesRegex(ValueError, "turn_threshold"):
+                        transition(state, turn_threshold=turn_threshold)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- validate `turn_threshold` for coordinated-turn and SE(2) unicycle transitions through the existing motion-model validation layer
- reject zero, negative, non-finite, boolean, and text thresholds before branch selection
- add regression coverage for both transition helpers

## Why

With `turn_threshold <= 0`, a state with zero angular velocity does not select the straight-line branch. The implementation then divides by zero in the curved-motion equations and returns `NaN` positions instead of a finite propagation result or a clear input error.

## Validation

- reproduced the pre-fix failure for both transition helpers (`turn_threshold=0`, zero angular velocity)
- focused test: `1 passed, 14 subtests passed`
- verified ordinary zero-angular-velocity propagation still follows the expected straight-line result
- verified public imports and direct `pyrecest.models.motion_models` imports resolve to the validated wrappers

The focused checks were run against a local reconstruction of the current source files because the GitHub CLI and direct shell network access are unavailable in this environment.