### PR TITLE
Parse serialized evidence comparability flags

### DIFF
--- a/src/pyrecest/evaluation/__init__.py
+++ b/src/pyrecest/evaluation/__init__.py
@@ -1,6 +1,8 @@
 from math import isfinite as _isfinite
 from math import isinf as _isinf
 
+import numpy as _np
+
 from . import get_distance_function as _get_distance_function_module
 from . import model_comparison as _model_comparison
 from .check_and_fix_config import check_and_fix_config
@@ -104,6 +106,36 @@ _original_paired_model_margin_decisions = getattr(
 _original_evidence_margin_table = getattr(
     _model_comparison, _ORIGINAL_EVIDENCE_TABLE_ATTR
 )
+
+
+def _is_explicitly_comparable(value):
+    """Return whether a serialized comparability flag explicitly denotes true."""
+
+    if isinstance(value, (bool, _np.bool_)):
+        return bool(value)
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "1", "yes"}
+    if isinstance(value, (int, float, _np.integer, _np.floating)):
+        try:
+            return bool(_np.isfinite(value) and float(value) == 1.0)
+        except (TypeError, ValueError, OverflowError):
+            return False
+    return False
+
+
+def _comparable_rows(scores):
+    """Filter evidence rows while parsing serialized comparability flags safely."""
+
+    ok = _model_comparison._successful_rows(scores)
+    if ok.empty:
+        return ok
+    if "evidence_comparable" in ok.columns:
+        comparable_mask = ok["evidence_comparable"].map(_is_explicitly_comparable)
+        ok = ok[comparable_mask].copy()
+    return ok
+
+
+_model_comparison._comparable_rows = _comparable_rows
 
 
 def _validate_symmetry_count(n_symm):

--- a/tests/test_model_comparison_comparable_flags.py
+++ b/tests/test_model_comparison_comparable_flags.py
@@ -1,0 +1,69 @@
+import pandas as pd
+
+from pyrecest.evaluation.model_comparison import (
+    evidence_margin_table,
+    paired_model_margin_decisions,
+)
+
+
+def _score(model, evidence, comparable):
+    return {
+        "status": "success",
+        "session": "s1",
+        "event_index": 0,
+        "model": model,
+        "log_evidence": evidence,
+        "evidence_comparable": comparable,
+    }
+
+
+def test_text_false_does_not_enter_evidence_ranking():
+    scores = pd.DataFrame(
+        [
+            _score("incomparable", 10.0, "False"),
+            _score("best_valid", 5.0, "TRUE"),
+            _score("runner_up", 4.0, True),
+        ]
+    )
+
+    margins = evidence_margin_table(scores)
+
+    assert margins["best_model_by_evidence"].tolist() == ["best_valid"]
+    assert margins["second_best_model_by_evidence"].tolist() == ["runner_up"]
+    assert margins["evidence_margin_to_second_best"].tolist() == [1.0]
+    assert margins["models_compared"].tolist() == [2]
+
+
+def test_comparability_flags_fail_closed_for_unknown_serializations():
+    scores = pd.DataFrame(
+        [
+            _score("yes", 3.0, "yes"),
+            _score("one", 2.0, 1),
+            _score("unknown", 100.0, "definitely"),
+            _score("two", 90.0, 2),
+            _score("missing", 80.0, pd.NA),
+        ]
+    )
+
+    margins = evidence_margin_table(scores)
+
+    assert margins["best_model_by_evidence"].tolist() == ["yes"]
+    assert margins["second_best_model_by_evidence"].tolist() == ["one"]
+    assert margins["models_compared"].tolist() == [2]
+
+
+def test_text_false_does_not_enter_paired_model_decisions():
+    scores = pd.DataFrame(
+        [
+            _score("positive", 100.0, "False"),
+            _score("reference", 2.0, "True"),
+        ]
+    )
+
+    decisions = paired_model_margin_decisions(
+        scores,
+        positive_model="positive",
+        reference_model="reference",
+    )
+
+    assert decisions.empty


### PR DESCRIPTION
## What changed
- parse string and numeric `evidence_comparable` values explicitly instead of relying on generic Boolean casting
- fail closed for missing, malformed, or unsupported comparability markers
- add regression coverage for evidence ranking and paired-model decisions

## Why
Pandas treats every non-empty string as truthy when converting to `bool`, so a serialized value such as `"False"` was interpreted as comparable. A high-scoring but explicitly incomparable row could therefore enter evidence rankings or paired-model decisions.

## Validation
- reproduced the defect with string-valued comparability flags
- focused regression suite: 3 passed
- Python compilation check passed for the patched model-comparison logic and tests

The branch diff contains only the compatibility-layer fix and its regression tests.