### PR TITLE
Reject masked random seeds

### DIFF
--- a/src/pyrecest/reproducibility.py
+++ b/src/pyrecest/reproducibility.py
@@ -58,6 +58,9 @@ def _normalize_seed(seed: int | None) -> int | None:
 
     message = "seed must be a non-negative integer or None"
 
+    if np.ma.is_masked(seed):
+        raise ValueError(message)
+
     if _is_temporal_seed_scalar(seed):
         raise ValueError(message)
 

--- a/tests/test_reproducibility_seed_validation.py
+++ b/tests/test_reproducibility_seed_validation.py
@@ -32,9 +32,24 @@ class TestReproducibilitySeedValidation(unittest.TestCase):
                 ):
                     _normalize_seed(invalid_value)
 
+    def test_masked_seed_scalars_are_rejected_before_item_unwrap(self) -> None:
+        invalid_values = (
+            np.ma.masked,
+            np.ma.array(7, mask=True),
+        )
+
+        for invalid_value in invalid_values:
+            with self.subTest(invalid_value=repr(invalid_value)):
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "seed must be a non-negative integer or None",
+                ):
+                    _normalize_seed(invalid_value)
+
     def test_numeric_scalar_arrays_are_still_valid_seeds(self) -> None:
         self.assertEqual(_normalize_seed(np.array(0, dtype=np.int64)), 0)
         self.assertEqual(_normalize_seed(np.array(1.0, dtype=np.float64)), 1)
+        self.assertEqual(_normalize_seed(np.ma.array(7, mask=False)), 7)
         self.assertIsNone(_normalize_seed(None))
 
 


### PR DESCRIPTION
## Bug

`_normalize_seed()` unwraps scalar-like inputs with `.item()` before accounting for NumPy masked-array semantics. A missing seed can therefore be silently converted into its hidden payload:

- `np.ma.masked` is interpreted as seed `0`;
- `np.ma.array(7, mask=True)` is interpreted as seed `7`.

This violates the documented contract that seeds must be non-negative integers or `None`, and can make missing configuration data select an unintended deterministic seed.

## Fix

- reject genuinely masked scalar inputs before temporal and scalar normalization;
- retain support for ordinary NumPy scalar arrays;
- retain support for unmasked integer-valued `MaskedArray` scalars;
- add focused regression coverage for masked and unmasked cases.

This is a clean current-`main` replacement for the still-applicable but closed, unmerged #4470.

## Validation

- isolated seed-validation suite: **3 tests passed**;
- Python syntax compilation passed for the implementation and regression test;
- final branch comparison: **1 commit ahead, 0 behind** `main`;
- diff is limited to 3 implementation lines and 15 test lines across two files.