### PR TITLE
Reject non-singleton axes in shared NumPy squeeze

### DIFF
--- a/src/pyrecest/backend_support/_shared_numpy_squeeze_contract.py
+++ b/src/pyrecest/backend_support/_shared_numpy_squeeze_contract.py
@@ -10,13 +10,17 @@ def patch_shared_numpy_squeeze_numpy_contract() -> None:
     """Make shared NumPy ``squeeze`` reject non-singleton requested axes."""
 
     try:
-        import pyrecest._backend._shared_numpy as shared_numpy  # pylint: disable=import-outside-toplevel
         import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
     except ModuleNotFoundError:  # pragma: no cover - import fails before this module
         return
 
     backend_name = getattr(backend, "__backend_name__", None)
     if backend_name not in {"numpy", "autograd"}:
+        return
+
+    try:
+        import pyrecest._backend._shared_numpy as shared_numpy  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - selected backend import failed
         return
 
     original_squeeze = shared_numpy.squeeze

--- a/src/pyrecest/backend_support/_shared_numpy_squeeze_contract.py
+++ b/src/pyrecest/backend_support/_shared_numpy_squeeze_contract.py
@@ -1,0 +1,98 @@
+"""Shared NumPy/autograd ``squeeze`` compatibility hook."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from operator import index as _operator_index
+
+
+def patch_shared_numpy_squeeze_numpy_contract() -> None:
+    """Make shared NumPy ``squeeze`` reject non-singleton requested axes."""
+
+    try:
+        import pyrecest._backend._shared_numpy as shared_numpy  # pylint: disable=import-outside-toplevel
+        import pyrecest.backend as backend  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError:  # pragma: no cover - import fails before this module
+        return
+
+    backend_name = getattr(backend, "__backend_name__", None)
+    if backend_name not in {"numpy", "autograd"}:
+        return
+
+    original_squeeze = shared_numpy.squeeze
+    if getattr(original_squeeze, "_pyrecest_nonsingleton_axis_contract", False):
+        backend.squeeze = original_squeeze
+        raw_backend = import_module(f"pyrecest._backend.{backend_name}")
+        raw_backend.squeeze = original_squeeze
+        return
+
+    np_module = shared_numpy._np
+
+    def _normalize_axes(axis):
+        if isinstance(axis, (int, np_module.integer)):
+            return (int(axis),)
+        axis_array = np_module.asarray(axis)
+        if axis_array.shape == ():
+            try:
+                return (_operator_index(axis_array),)
+            except TypeError as exc:
+                raise TypeError(
+                    "only integer scalar arrays can be converted to a scalar index"
+                ) from exc
+        return tuple(axis)
+
+    def _axis_out_of_bounds_error(axis, ndim):
+        axis_error = getattr(getattr(np_module, "exceptions", None), "AxisError", None)
+        if axis_error is None:
+            axis_error = getattr(np_module, "AxisError", None)
+        if axis_error is None:
+            return ValueError(
+                f"axis {axis} is out of bounds for array of dimension {ndim}"
+            )
+        try:
+            return axis_error(axis, ndim=ndim)
+        except TypeError:  # pragma: no cover - compatibility with older NumPy APIs
+            return axis_error(axis, ndim)
+
+    def squeeze(x, axis=None):
+        x_arr = np_module.asarray(x)
+        if axis is None:
+            return original_squeeze(x_arr, axis=None)
+
+        axes = _normalize_axes(axis)
+        if not axes:
+            return x_arr
+
+        normalized_axes = []
+        for one_axis in axes:
+            try:
+                one_axis = _operator_index(one_axis)
+            except TypeError as exc:
+                raise TypeError("axis entries must be integers") from exc
+            normalized_axis = one_axis + x_arr.ndim if one_axis < 0 else one_axis
+            if normalized_axis < 0 or normalized_axis >= x_arr.ndim:
+                raise _axis_out_of_bounds_error(one_axis, x_arr.ndim)
+            normalized_axes.append(normalized_axis)
+        normalized_axes = tuple(normalized_axes)
+
+        if len(set(normalized_axes)) != len(normalized_axes):
+            raise ValueError("duplicate value in 'axis'")
+        if any(x_arr.shape[one_axis] != 1 for one_axis in normalized_axes):
+            raise ValueError(
+                "cannot select an axis to squeeze out which has size not equal to one"
+            )
+
+        squeeze_axis = (
+            normalized_axes[0] if len(normalized_axes) == 1 else normalized_axes
+        )
+        return original_squeeze(x_arr, axis=squeeze_axis)
+
+    squeeze.__name__ = getattr(original_squeeze, "__name__", "squeeze")
+    squeeze.__doc__ = getattr(original_squeeze, "__doc__", None)
+    squeeze._pyrecest_nonsingleton_axis_contract = True
+    squeeze._pyrecest_numpy_contract = True
+
+    shared_numpy.squeeze = squeeze
+    backend.squeeze = squeeze
+    raw_backend = import_module(f"pyrecest._backend.{backend_name}")
+    raw_backend.squeeze = squeeze

--- a/src/pyrecest/evidence.py
+++ b/src/pyrecest/evidence.py
@@ -254,9 +254,13 @@ try:
     from pyrecest.backend_support._pytorch_reduction_axis_contract import (
         patch_pytorch_reduction_axis_contract as _patch_pytorch_reduction_axis_contract,  # pylint: disable=import-outside-toplevel
     )
+    from pyrecest.backend_support._shared_numpy_squeeze_contract import (
+        patch_shared_numpy_squeeze_numpy_contract as _patch_shared_numpy_squeeze_numpy_contract,  # pylint: disable=import-outside-toplevel
+    )
 except ModuleNotFoundError:  # pragma: no cover - source tree corruption only
     pass
 else:
+    _patch_shared_numpy_squeeze_numpy_contract()
     _patch_pytorch_close_equal_nan_device_contract()
     _patch_pytorch_repeat_numpy_contract()
     _patch_pytorch_edge_pad_contract()

--- a/tests/test_backend_arraylike_contracts.py
+++ b/tests/test_backend_arraylike_contracts.py
@@ -27,8 +27,13 @@ def test_triangular_vector_helpers_accept_array_like_inputs():
     assert _to_python(backend.triu_to_vec(matrix)) == [1, 2, 3, 5, 6, 9]
 
 
-def test_squeeze_non_singleton_axis_is_noop():
+def test_squeeze_non_singleton_axis_matches_backend_contract():
     values = array([[[1], [2]]])
+
+    if backend.__backend_name__ in {"numpy", "autograd"}:
+        with pytest.raises(ValueError, match="size not equal to one"):
+            backend.squeeze(values, axis=1)
+        return
 
     result = backend.squeeze(values, axis=1)
 

--- a/tests/test_shared_numpy_squeeze.py
+++ b/tests/test_shared_numpy_squeeze.py
@@ -49,6 +49,35 @@ print("ok")
     assert "ok" in result.stdout
 
 
+@pytest.mark.parametrize("axis", [0, (0,), -2])
+def test_shared_numpy_squeeze_rejects_non_singleton_axis(axis):
+    if backend.__backend_name__ not in ("numpy", "autograd"):
+        pytest.skip("shared NumPy/autograd squeeze regression test")
+
+    with pytest.raises(ValueError, match="size not equal to one"):
+        backend.squeeze(array([[1, 2], [3, 4]]), axis=axis)
+
+
+def test_raw_numpy_squeeze_rejects_non_singleton_axis():
+    code = """
+import pyrecest  # noqa: F401
+import pyrecest._backend.numpy as raw_numpy
+
+for axis in (0, (0,), -2):
+    try:
+        raw_numpy.squeeze([[1, 2], [3, 4]], axis=axis)
+    except ValueError as exc:
+        assert "size not equal to one" in str(exc), str(exc)
+    else:
+        raise AssertionError("expected a non-singleton axis failure")
+print("ok")
+"""
+    result = run_backend_code("numpy", code)
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
 @pytest.mark.parametrize("axis", [3, -4])
 def test_shared_numpy_squeeze_rejects_out_of_bounds_axis(axis):
     if backend.__backend_name__ not in ("numpy", "autograd"):


### PR DESCRIPTION
## What changed

- add a final shared NumPy/autograd `squeeze` contract patch after backend initialization
- reject explicitly requested axes whose dimension is not one, matching NumPy behavior
- keep scalar-array axes, tuple axes, duplicate-axis checks, and out-of-bounds handling intact
- update the active public backend, shared backend module, and raw selected backend consistently
- add regressions for public NumPy/autograd access and raw NumPy access

## Root cause

The existing shared NumPy facade checked requested axis sizes but returned the unchanged array when any selected dimension was not one. NumPy instead raises `ValueError`, so invalid calls could silently continue with an unexpected shape.

## Impact

Callers now receive an immediate, NumPy-compatible failure instead of silently retaining dimensions, preventing downstream shape errors and incorrect calculations.

## Validation

- focused contract smoke test covering valid singleton axes, non-singleton axes, raw/public/shared entry points, and out-of-bounds axes
- repository regression tests added in `tests/test_shared_numpy_squeeze.py`