### PR TITLE
Reject invalid linear Dirac support values

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/linear_dirac_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/linear_dirac_distribution.py
@@ -7,10 +7,37 @@ import numpy as np
 import pyrecest.backend
 
 # pylint: disable=no-name-in-module,no-member
-from pyrecest.backend import asarray, cov, ones, reshape, to_numpy, zeros
+from pyrecest.backend import all as backend_all
+from pyrecest.backend import (
+    asarray,
+    cov,
+    isfinite,
+    ones,
+    reshape,
+    to_numpy,
+    zeros,
+)
 
 from ..abstract_dirac_distribution import AbstractDiracDistribution
 from .abstract_linear_distribution import AbstractLinearDistribution
+
+
+def _validate_real_finite_values(value, name):
+    """Reject complex and non-finite Euclidean support values."""
+    dtype = getattr(value, "dtype", None)
+    try:
+        is_complex = bool(np.issubdtype(dtype, np.complexfloating))
+    except TypeError:
+        is_complex = "complex" in str(dtype).lower()
+    if is_complex:
+        raise ValueError(f"{name} must contain only real values.")
+
+    try:
+        finite = bool(backend_all(isfinite(value)))
+    except (OverflowError, TypeError, ValueError, RuntimeError) as exc:
+        raise ValueError(f"{name} must contain only finite real values.") from exc
+    if not finite:
+        raise ValueError(f"{name} must contain only finite values.")
 
 
 class LinearDiracDistribution(AbstractDiracDistribution, AbstractLinearDistribution):
@@ -18,6 +45,9 @@ class LinearDiracDistribution(AbstractDiracDistribution, AbstractLinearDistribut
         d = asarray(d)
         if d.ndim == 0:
             d = reshape(d, (1,))
+        elif d.ndim > 2:
+            raise ValueError("d must be a scalar, 1D array, or 2D array")
+        _validate_real_finite_values(d, "d")
         dim = d.shape[1] if d.ndim > 1 else 1
         AbstractLinearDistribution.__init__(self, dim)
         AbstractDiracDistribution.__init__(self, d, w)
@@ -38,6 +68,7 @@ class LinearDiracDistribution(AbstractDiracDistribution, AbstractLinearDistribut
             raise ValueError(
                 f"new_mean must have shape ({self.dim},), got {new_mean.shape}."
             )
+        _validate_real_finite_values(new_mean, "new_mean")
 
         mean_offset = new_mean - self.mean()
         if self.d.ndim == 1:
@@ -137,6 +168,7 @@ class LinearDiracDistribution(AbstractDiracDistribution, AbstractLinearDistribut
             raise ValueError("samples must be a scalar, 1D array, or 2D array")
         if sample_matrix.shape[0] == 0:
             raise ValueError("samples must contain at least one sample")
+        _validate_real_finite_values(sample_matrix, "samples")
 
         if weights is None:
             weights = ones(sample_matrix.shape[0]) / sample_matrix.shape[0]

--- a/tests/distributions/test_linear_dirac_support_validation.py
+++ b/tests/distributions/test_linear_dirac_support_validation.py
@@ -1,0 +1,61 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array, to_numpy
+from pyrecest.distributions.nonperiodic.linear_dirac_distribution import (
+    LinearDiracDistribution,
+)
+
+
+class LinearDiracSupportValidationTest(unittest.TestCase):
+    def test_constructor_rejects_invalid_support_values(self):
+        invalid_locations = (
+            (array([1.0 + 2.0j, 3.0 + 0.0j]), "real"),
+            (array([1.0, np.nan]), "finite"),
+            (array([1.0, np.inf]), "finite"),
+        )
+
+        for locations, message in invalid_locations:
+            with self.subTest(locations=locations):
+                with self.assertRaisesRegex(ValueError, message):
+                    LinearDiracDistribution(locations)
+
+    def test_constructor_rejects_rank_three_support(self):
+        with self.assertRaisesRegex(ValueError, "scalar, 1D array, or 2D array"):
+            LinearDiracDistribution(array([[[0.0], [1.0]]]))
+
+    def test_set_mean_rejects_invalid_values_without_mutating_distribution(self):
+        dist = LinearDiracDistribution(
+            array([[0.0, 0.0], [2.0, 4.0]]), array([0.25, 0.75])
+        )
+        original_locations = np.asarray(to_numpy(dist.d)).copy()
+        invalid_means = (
+            (array([1.0 + 2.0j, 3.0 + 0.0j]), "real"),
+            (array([1.0, np.nan]), "finite"),
+            (array([1.0, np.inf]), "finite"),
+        )
+
+        for new_mean, message in invalid_means:
+            with self.subTest(new_mean=new_mean):
+                with self.assertRaisesRegex(ValueError, message):
+                    dist.set_mean(new_mean)
+                npt.assert_allclose(to_numpy(dist.d), original_locations)
+
+    def test_moment_helper_rejects_invalid_samples(self):
+        invalid_samples = (
+            (array([1.0 + 2.0j, 3.0 + 0.0j]), "real"),
+            (array([1.0, np.nan]), "finite"),
+            (array([1.0, np.inf]), "finite"),
+        )
+
+        for samples, message in invalid_samples:
+            with self.subTest(samples=samples):
+                with self.assertRaisesRegex(ValueError, message):
+                    LinearDiracDistribution.weighted_samples_to_mean_and_cov(samples)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
- reject complex and non-finite support points when constructing `LinearDiracDistribution`
- reject rank-three support arrays instead of allowing malformed state geometry
- validate `set_mean` targets before mutating the distribution
- validate samples passed to `weighted_samples_to_mean_and_cov`
- add regression tests for complex, NaN, infinite, and rank-three inputs, including a non-mutation assertion

## Why
`LinearDiracDistribution` previously accepted complex or non-finite Euclidean support values. These values propagated into `mean()` and `covariance()` and caused invalid numerical state or delayed backend errors. Rank-three support arrays were also accepted even though the class and moment helper only define scalar, one-dimensional, and two-dimensional sample layouts.

## Impact
Invalid state support now fails immediately with a clear `ValueError`. Valid scalar, vector, and sample-matrix behavior is unchanged.

## Checks
- `python -m py_compile` on the modified source file
- `python -m py_compile` on the new regression test file
- full repository/backend checks delegated to GitHub Actions