### PR TITLE
Skip zero-weight Gaussian hypotheses during moment matching

### DIFF
--- a/src/pyrecest/filters/gaussian_hypothesis_mixture.py
+++ b/src/pyrecest/filters/gaussian_hypothesis_mixture.py
@@ -79,6 +79,8 @@ def moment_match_gaussian_hypotheses(
     mean = weights @ means
     covariance = np.zeros((mean.size, mean.size), dtype=float)
     for weight, hypothesis in zip(weights, hypotheses):
+        if weight == 0.0:
+            continue
         diff = hypothesis.mean - mean
         covariance += float(weight) * (hypothesis.covariance + np.outer(diff, diff))
     return mean, _symmetrized(covariance), weights

--- a/tests/filters/test_gaussian_hypothesis_zero_weight.py
+++ b/tests/filters/test_gaussian_hypothesis_zero_weight.py
@@ -1,0 +1,35 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+from pyrecest.filters import (
+    WeightedGaussianHypothesis,
+    moment_match_gaussian_hypotheses,
+)
+
+
+class GaussianHypothesisZeroWeightTest(unittest.TestCase):
+    def test_zero_weight_hypothesis_cannot_contaminate_covariance(self):
+        hypotheses = [
+            WeightedGaussianHypothesis(
+                mean=np.array([0.0]),
+                covariance=np.array([[1.0]]),
+                log_weight=0.0,
+            ),
+            WeightedGaussianHypothesis(
+                mean=np.array([1e308]),
+                covariance=np.array([[1.0]]),
+                log_weight=-np.inf,
+            ),
+        ]
+
+        with np.errstate(over="raise", invalid="raise"):
+            mean, covariance, weights = moment_match_gaussian_hypotheses(hypotheses)
+
+        npt.assert_array_equal(weights, np.array([1.0, 0.0]))
+        npt.assert_array_equal(mean, np.array([0.0]))
+        npt.assert_array_equal(covariance, np.array([[1.0]]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- skip hypotheses whose normalized probability is exactly zero when accumulating the moment-matched covariance
- add a regression test with an excluded `1e308` mean under strict NumPy overflow handling

## Why

`moment_match_gaussian_hypotheses` previously evaluated every covariance contribution, including components normalized to zero probability. For an extreme excluded mean, the outer product overflows to infinity and the subsequent multiplication by zero produces `NaN`, contaminating the matched covariance even though the hypothesis has no posterior mass.

## Impact

Zero-probability Gaussian hypotheses can no longer affect or numerically corrupt the matched covariance. Positive-weight hypotheses and normal moment-matching behavior are unchanged.

## Validation

- reproduced the pre-fix result as `NaN` for weights `[1, 0]`, means `[0, 1e308]`, and unit covariances
- verified the patched accumulation returns mean `[0]`, covariance `[[1]]`, and weights `[1, 0]`
- added a focused repository regression test using `np.errstate(over="raise", invalid="raise")`