### PR TITLE
Preserve zero replay-grid likelihoods

### DIFF
--- a/src/pyrecest/filters/replay_grid_likelihood.py
+++ b/src/pyrecest/filters/replay_grid_likelihood.py
@@ -426,14 +426,11 @@ def _nearest_grid_values(
 
     indices = _nearest_bin_indices(positions[finite_positions], bin_tree)
     nearest_values = values[indices]
-    if not np.all(np.isfinite(nearest_values)):
-        finite_values = values[np.isfinite(values)]
-        replacement = (
-            float(np.min(finite_values)) if finite_values.size else float(log_zero)
-        )
-        nearest_values = np.where(
-            np.isfinite(nearest_values), nearest_values, replacement
-        )
+    # A non-finite grid value represents zero or undefined likelihood. Borrowing
+    # the minimum finite value from another bin would create spurious mass.
+    nearest_values = np.where(
+        np.isfinite(nearest_values), nearest_values, float(log_zero)
+    )
     output[finite_positions] = nearest_values
     return output
 

--- a/tests/filters/test_replay_grid_log_zero.py
+++ b/tests/filters/test_replay_grid_log_zero.py
@@ -35,6 +35,26 @@ class TestReplayGridLogZero(unittest.TestCase):
 
         np.testing.assert_allclose(result, [-123.0])
 
+    def test_linear_fallback_preserves_log_zero_near_nonfinite_grid_bin(self):
+        bin_centers = np.asarray(
+            [
+                [0.0, 0.0],
+                [0.0, 1.0],
+                [1.0, 0.0],
+                [1.0, 1.0],
+            ]
+        )
+        log_likelihood = np.asarray([-np.inf, 1.0, 2.0, 3.0])
+
+        result = replay_grid_log_likelihood_values(
+            np.asarray([[0.1, 0.1]]),
+            log_likelihood,
+            bin_centers,
+            interpolation="linear",
+        )
+
+        self.assertTrue(np.isneginf(result[0]))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/filters/test_replay_grid_log_zero.py
+++ b/tests/filters/test_replay_grid_log_zero.py
@@ -1,0 +1,40 @@
+import unittest
+
+import numpy as np
+
+# pylint: disable=no-name-in-module
+from pyrecest.filters import replay_grid_log_likelihood_values
+
+
+class TestReplayGridLogZero(unittest.TestCase):
+    def test_nearest_preserves_default_log_zero_for_nonfinite_grid_bin(self):
+        bin_centers = np.asarray([[0.0, 0.0], [1.0, 0.0]])
+        log_likelihood = np.asarray([0.0, -np.inf])
+
+        result = replay_grid_log_likelihood_values(
+            np.asarray([[1.0, 0.0], [0.0, 0.0]]),
+            log_likelihood,
+            bin_centers,
+            interpolation="nearest",
+        )
+
+        self.assertTrue(np.isneginf(result[0]))
+        self.assertEqual(result[1], 0.0)
+
+    def test_nearest_uses_custom_log_zero_for_nonfinite_grid_bin(self):
+        bin_centers = np.asarray([[0.0, 0.0], [1.0, 0.0]])
+        log_likelihood = np.asarray([0.0, -np.inf])
+
+        result = replay_grid_log_likelihood_values(
+            np.asarray([[1.0, 0.0]]),
+            log_likelihood,
+            bin_centers,
+            interpolation="nearest",
+            log_zero=-123.0,
+        )
+
+        np.testing.assert_allclose(result, [-123.0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- preserve `log_zero` when nearest-neighbour lookup lands on a non-finite grid log-likelihood
- stop borrowing the minimum finite value from an unrelated grid bin
- add regressions for direct nearest lookup, the default linear-interpolation fallback, and a custom finite `log_zero`

## Root cause

`_nearest_grid_values` replaced every non-finite nearest-bin value with the minimum finite value anywhere on the grid. A bin encoded as `-inf` therefore acquired positive likelihood mass, and an all-impossible particle set could bypass the existing non-finite guard whenever another grid bin was finite.

## Impact

Zero-likelihood or undefined bins now remain zero according to the caller's `log_zero` convention. Finite nearest-neighbour values and non-finite particle positions are unchanged.

## Validation

- focused reproduction: old output `[0.0, 0.0]`, corrected output `[-inf, 0.0]`
- custom floor regression: corrected output `[-123.0]`
- regression coverage for both direct nearest lookup and the default linear fallback
- branch is current with `main` and the diff is limited to the helper plus regression coverage
- full repository checks delegated to GitHub Actions