### PR TITLE
Reject out-of-range multisession fill values

### DIFF
--- a/src/pyrecest/utils/_multisession_assignment_labels.py
+++ b/src/pyrecest/utils/_multisession_assignment_labels.py
@@ -20,6 +20,7 @@ from .multisession_assignment import (  # pylint: disable=protected-access
 
 _TEXT_TYPES = (str, bytes, np.str_, np.bytes_)
 _TEMPORAL_TYPES = (np.datetime64, np.timedelta64)
+_INT64_INFO = np.iinfo(np.int64)
 
 
 def _normalize_fill_value(fill_value: Any, track_count: int) -> int:
@@ -55,6 +56,8 @@ def _normalize_fill_value(fill_value: Any, track_count: int) -> int:
         if not bool(is_exact_integer):
             raise ValueError("fill_value must be an integer.")
 
+    if not _INT64_INFO.min <= integer_fill_value <= _INT64_INFO.max:
+        raise ValueError("fill_value must fit in int64.")
     if 0 <= integer_fill_value < int(track_count):
         raise ValueError("fill_value must not collide with track labels.")
     return integer_fill_value

--- a/tests/test_multisession_assignment_fill_value_range.py
+++ b/tests/test_multisession_assignment_fill_value_range.py
@@ -1,0 +1,66 @@
+"""Regression tests for dense multi-session label fill-value ranges."""
+
+import unittest
+
+import numpy as np
+import pyrecest.utils.multisession_assignment as multisession_assignment_module
+from pyrecest.backend import __backend_name__
+from pyrecest.utils import MultiSessionAssignmentResult, tracks_to_session_labels
+
+
+class TestMultiSessionAssignmentFillValueRange(unittest.TestCase):
+    @staticmethod
+    def _converters():
+        return (
+            ("public", tracks_to_session_labels),
+            ("module", multisession_assignment_module.tracks_to_session_labels),
+            (
+                "result_method",
+                lambda track_list, **kwargs: MultiSessionAssignmentResult(
+                    tracks=track_list,
+                    matched_edges=[],
+                    total_cost=0.0,
+                ).to_session_labels(**kwargs),
+            ),
+        )
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_fill_values_outside_int64_range_are_rejected(self):
+        int64_info = np.iinfo(np.int64)
+        invalid_fill_values = (
+            int(int64_info.max) + 1,
+            int(int64_info.min) - 1,
+            np.uint64(int64_info.max) + np.uint64(1),
+        )
+
+        for fill_value in invalid_fill_values:
+            for name, converter in self._converters():
+                with self.subTest(converter=name, fill_value=repr(fill_value)):
+                    with self.assertRaisesRegex(ValueError, "fit in int64"):
+                        converter([], session_sizes=[1], fill_value=fill_value)
+
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_int64_boundary_fill_values_are_preserved(self):
+        int64_info = np.iinfo(np.int64)
+        valid_fill_values = (
+            int(int64_info.min),
+            int(int64_info.max),
+            np.int64(int64_info.min),
+            np.uint64(int64_info.max),
+        )
+
+        for fill_value in valid_fill_values:
+            for name, converter in self._converters():
+                with self.subTest(converter=name, fill_value=repr(fill_value)):
+                    labels = converter([], session_sizes=[1], fill_value=fill_value)
+                    self.assertEqual(int(labels[0][0]), int(fill_value))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- validate `tracks_to_session_labels(..., fill_value=...)` against the `int64` range used by its output arrays
- reject oversized Python and NumPy integers with a deterministic `ValueError` instead of allowing backend-dependent overflow or wrapping
- preserve both valid `int64` boundary values
- add regressions for the public helper, module-level helper, and `MultiSessionAssignmentResult.to_session_labels`

## Bug fixed
`fill_value` was normalized to an arbitrary-precision Python integer, but label arrays are always allocated with the backend's `int64` dtype. Values outside `[-2**63, 2**63 - 1]` therefore passed validation and only failed later during allocation, or could wrap depending on the backend. The helper now validates the representation contract before constructing the output.

## Validation
- `python -m py_compile src/pyrecest/utils/_multisession_assignment_labels.py tests/test_multisession_assignment_fill_value_range.py`
- isolated functional regression check with NumPy-backed stubs: valid `int64` boundaries preserved; values immediately outside the range rejected
- branch comparison: 2 commits ahead of `main`, 0 behind; only the helper and focused regression file changed

Full repository CI should run the regression across configured backends.