### PR TITLE
Reject invalid Gauss-von-Mises scalar inputs

### DIFF
--- a/src/pyrecest/distributions/cart_prod/gauss_von_mises_distribution.py
+++ b/src/pyrecest/distributions/cart_prod/gauss_von_mises_distribution.py
@@ -38,14 +38,47 @@ from ..nonperiodic.gaussian_distribution import GaussianDistribution
 from .abstract_hypercylindrical_distribution import AbstractHypercylindricalDistribution
 
 
-def _validate_positive_sample_count(n) -> int:
-    count_array = np.asarray(n)
-    if count_array.ndim != 0:
-        raise ValueError("n must be a scalar integer")
+_INVALID_SCALAR_TYPES = (
+    str,
+    bytes,
+    bytearray,
+    np.str_,
+    np.bytes_,
+    complex,
+    np.complexfloating,
+    np.datetime64,
+    np.timedelta64,
+)
+_INVALID_SCALAR_DTYPE_KINDS = frozenset({"c", "S", "U", "M", "m"})
 
+
+def _as_scalar_array(value, shape_message: str, value_message: str) -> np.ndarray:
+    if np.ma.is_masked(value):
+        raise ValueError(value_message)
+
+    try:
+        scalar_array = np.asarray(value)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError(value_message) from exc
+
+    if scalar_array.shape != ():
+        raise ValueError(shape_message)
+    if scalar_array.dtype.kind in _INVALID_SCALAR_DTYPE_KINDS:
+        raise ValueError(value_message)
+    return scalar_array
+
+
+def _validate_positive_sample_count(n) -> int:
+    count_array = _as_scalar_array(
+        n,
+        "n must be a scalar integer",
+        "n must be a finite integer",
+    )
     count = count_array.item()
     if isinstance(count, (bool, np.bool_)):
         raise ValueError("n must be an integer, not a boolean")
+    if isinstance(count, _INVALID_SCALAR_TYPES):
+        raise ValueError("n must be a finite integer")
 
     try:
         count_int = int(count)
@@ -64,40 +97,36 @@ def _validate_positive_sample_count(n) -> int:
 
 
 def _validate_finite_scalar(value, name: str) -> float:
-    scalar_array = np.asarray(value)
-    if scalar_array.shape != ():
-        raise ValueError(f"{name} must be a scalar")
-
+    message = f"{name} must be a finite scalar"
+    scalar_array = _as_scalar_array(value, f"{name} must be a scalar", message)
     scalar = scalar_array.item()
-    if isinstance(scalar, (bool, np.bool_)):
-        raise ValueError(f"{name} must be a finite scalar")
+    if isinstance(scalar, (bool, np.bool_, *_INVALID_SCALAR_TYPES)):
+        raise ValueError(message)
 
     try:
         scalar_float = float(scalar)
     except (OverflowError, TypeError, ValueError) as exc:
-        raise ValueError(f"{name} must be a finite scalar") from exc
+        raise ValueError(message) from exc
 
     if not np.isfinite(scalar_float):
-        raise ValueError(f"{name} must be a finite scalar")
+        raise ValueError(message)
     return scalar_float
 
 
 def _validate_nonnegative_finite_scalar(value, name: str) -> float:
-    scalar_array = np.asarray(value)
-    if scalar_array.shape != ():
-        raise ValueError(f"{name} must be a scalar")
-
+    message = f"{name} must be a nonnegative finite scalar"
+    scalar_array = _as_scalar_array(value, f"{name} must be a scalar", message)
     scalar = scalar_array.item()
-    if isinstance(scalar, (bool, np.bool_)):
-        raise ValueError(f"{name} must be a nonnegative finite scalar")
+    if isinstance(scalar, (bool, np.bool_, *_INVALID_SCALAR_TYPES)):
+        raise ValueError(message)
 
     try:
         scalar_float = float(scalar)
     except (OverflowError, TypeError, ValueError) as exc:
-        raise ValueError(f"{name} must be a nonnegative finite scalar") from exc
+        raise ValueError(message) from exc
 
     if not np.isfinite(scalar_float) or scalar_float < 0.0:
-        raise ValueError(f"{name} must be a nonnegative finite scalar")
+        raise ValueError(message)
     return scalar_float
 
 

--- a/tests/distributions/test_gauss_von_mises_scalar_validation.py
+++ b/tests/distributions/test_gauss_von_mises_scalar_validation.py
@@ -1,0 +1,68 @@
+"""Regression tests for strict Gauss-von-Mises scalar validation."""
+
+import numpy as np
+import pytest
+from pyrecest.distributions.cart_prod.gauss_von_mises_distribution import (
+    GaussVonMisesDistribution,
+    _validate_positive_sample_count,
+)
+
+
+def _make_distribution(**overrides):
+    parameters = {
+        "mu": 2.0,
+        "P": 1.3,
+        "alpha": 0.2,
+        "beta": 0.0,
+        "Gamma": 0.001,
+        "kappa": 0.7,
+    }
+    parameters.update(overrides)
+    return GaussVonMisesDistribution(**parameters)
+
+
+@pytest.mark.parametrize(
+    "invalid_count",
+    [
+        np.timedelta64(3, "ns"),
+        np.datetime64("1970-01-01T00:00:00.000000003"),
+        np.array(np.timedelta64(3, "ns"), dtype=object),
+        np.ma.array(3, mask=True),
+        "3",
+        3.0 + 0.0j,
+    ],
+)
+def test_rejects_nonreal_or_masked_sample_counts(invalid_count):
+    with pytest.raises(ValueError, match="integer"):
+        _validate_positive_sample_count(invalid_count)
+
+
+@pytest.mark.parametrize("parameter_name", ["alpha", "kappa"])
+@pytest.mark.parametrize(
+    "invalid_value",
+    [
+        np.timedelta64(3, "ns"),
+        np.datetime64("1970-01-01T00:00:00.000000003"),
+        np.array(np.timedelta64(3, "ns"), dtype=object),
+        np.ma.array(0.5, mask=True),
+        "0.5",
+        0.5 + 0.0j,
+    ],
+)
+def test_constructor_rejects_nonreal_or_masked_scalars(
+    parameter_name, invalid_value
+):
+    with pytest.raises(ValueError, match=parameter_name):
+        _make_distribution(**{parameter_name: invalid_value})
+
+
+def test_unmasked_numeric_scalars_remain_supported():
+    assert _validate_positive_sample_count(np.ma.array(3, mask=False)) == 3
+
+    distribution = _make_distribution(
+        alpha=np.ma.array(0.5, mask=False),
+        kappa=np.ma.array(0.7, mask=False),
+    )
+
+    assert np.isclose(distribution.alpha, 0.5)
+    assert np.isclose(distribution.kappa, 0.7)


### PR DESCRIPTION
## What changed
- centralize scalar extraction for Gauss-von-Mises configuration values
- reject masked, temporal, string, and complex scalars before integer/float coercion
- apply the validation consistently to sample counts, `alpha`, and `kappa`
- add regression coverage for native and object-wrapped temporal values, masked scalars, numeric-looking strings, complex values, and valid unmasked scalars

## Why
For nanosecond `numpy.datetime64` and `numpy.timedelta64` values, `.item()` can return an integer payload. Masked scalar arrays can likewise expose their underlying payload. The previous validators therefore silently accepted invalid temporal or masked values as sample counts or distribution parameters. Numeric-looking strings and zero-imaginary complex values were also coercible through `int`/`float`.

## Impact
Invalid non-real scalar configuration now fails early with `ValueError`, while ordinary NumPy scalars, exact large integers/Fractions, and unmasked numeric masked-array scalars remain supported.

## Validation
- `python -m py_compile` on the modified module and regression test
- isolated validator checks for temporal, masked, string, complex, exact-integer, and unmasked numeric cases
- full repository CI will run on this PR