### PR TITLE
Reject masked mixture sample counts

### DIFF
--- a/src/pyrecest/distributions/abstract_mixture.py
+++ b/src/pyrecest/distributions/abstract_mixture.py
@@ -45,6 +45,8 @@ _TEMPORAL_SCALAR_TYPES = (np.datetime64, np.timedelta64)
 
 def _validate_positive_sample_count(n) -> int:
     message = "n must be a positive integer"
+    if np.ma.is_masked(n):
+        raise ValueError(message)
     try:
         count_array = np.asarray(n)
     except (OverflowError, TypeError, ValueError) as exc:

--- a/tests/distributions/test_mixture_masked_sample_count.py
+++ b/tests/distributions/test_mixture_masked_sample_count.py
@@ -1,0 +1,31 @@
+"""Regression tests for masked mixture sample counts."""
+
+import numpy as np
+import pytest
+from pyrecest.backend import array, eye
+from pyrecest.distributions.abstract_mixture import _validate_positive_sample_count
+from pyrecest.distributions.hypertorus.hypertoroidal_mixture import HypertoroidalMixture
+from pyrecest.distributions.hypertorus.toroidal_wrapped_normal_distribution import (
+    ToroidalWrappedNormalDistribution,
+)
+
+
+def _make_mixture():
+    component = ToroidalWrappedNormalDistribution(array([1.0, 0.0]), eye(2))
+    return HypertoroidalMixture(
+        [component, component.shift(array([1.0, 1.0]))],
+        array([0.5, 0.5]),
+    )
+
+
+@pytest.mark.parametrize(
+    "invalid_count",
+    [np.ma.masked, np.ma.array(3, mask=True)],
+)
+def test_mixture_sample_rejects_masked_count(invalid_count):
+    with pytest.raises(ValueError, match="n must be a positive integer"):
+        _make_mixture().sample(invalid_count)
+
+
+def test_unmasked_numeric_masked_array_count_remains_supported():
+    assert _validate_positive_sample_count(np.ma.array(3, mask=False)) == 3


### PR DESCRIPTION
## What changed

- reject masked scalar sample counts before NumPy coercion in `AbstractMixture.sample()`
- preserve support for ordinary numeric scalars and unmasked numeric `MaskedArray` scalars
- add focused regression coverage for both the public mixture sampling path and the validator

## Root cause

`_validate_positive_sample_count()` called `np.asarray(n)` before checking masked-array semantics. NumPy strips the mask during that conversion, so `np.ma.array(3, mask=True)` became the plain scalar `3` and silently requested three samples.

## Impact

Missing or masked configuration data can no longer control mixture sample cardinality through its hidden payload. Valid positive integer counts behave as before.

## Validation

- reproduced the pre-fix coercion of a fully masked scalar to its hidden payload
- isolated validation rejects `np.ma.masked` and `np.ma.array(3, mask=True)`
- isolated validation preserves `np.ma.array(3, mask=False)` and ordinary NumPy integers
- regression test module passes `python -m py_compile`
- branch is 2 commits ahead of current `main`, 0 behind, with a two-line source change plus focused tests

Full repository and backend-matrix checks are delegated to GitHub Actions.