### PR TITLE
Validate zero-by-zero fractional matrix exponents

### DIFF
--- a/src/pyrecest/_backend/numpy/linalg.py
+++ b/src/pyrecest/_backend/numpy/linalg.py
@@ -21,6 +21,7 @@ from scipy.linalg import (
 )
 
 from .._shared_numpy.linalg import (
+    _normalize_fractional_matrix_power_exponent,
     fractional_matrix_power as _fractional_matrix_power,
     is_single_matrix_pd,
     logm as _logm,
@@ -63,5 +64,6 @@ def fractional_matrix_power(a, t):
     """Compute a fractional matrix power, including zero-by-zero matrices."""
     empty_result = _empty_zero_by_zero_matrix_result(a)
     if empty_result is not None:
+        _normalize_fractional_matrix_power_exponent(t)
         return empty_result
     return _fractional_matrix_power(a, t)

--- a/tests/backend/test_numpy_fractional_matrix_power_exponent_validation.py
+++ b/tests/backend/test_numpy_fractional_matrix_power_exponent_validation.py
@@ -45,3 +45,31 @@ def test_fractional_matrix_power_validates_exponent_for_empty_batches():
 
     with pytest.raises(TypeError, match="t must be a real scalar"):
         linalg.fractional_matrix_power(matrices, np.timedelta64(2, "ns"))
+
+
+@pytest.mark.parametrize("shape", [(0, 0), (3, 0, 0), (2, 1, 0, 0)])
+@pytest.mark.parametrize(
+    ("exponent", "error_type", "message"),
+    [
+        pytest.param(
+            np.timedelta64(2, "ns"),
+            TypeError,
+            "t must be a real scalar",
+            id="temporal",
+        ),
+        pytest.param(
+            np.array([0.5]),
+            TypeError,
+            "t must be a real scalar",
+            id="non-scalar",
+        ),
+        pytest.param(np.nan, ValueError, "t must be finite", id="nonfinite"),
+    ],
+)
+def test_fractional_matrix_power_validates_exponent_for_zero_by_zero_matrices(
+    shape, exponent, error_type, message
+):
+    matrices = np.empty(shape)
+
+    with pytest.raises(error_type, match=message):
+        linalg.fractional_matrix_power(matrices, exponent)


### PR DESCRIPTION
## What changed

- validate the exponent before returning the NumPy zero-by-zero `fractional_matrix_power` fast-path result
- reuse the shared finite real-scalar exponent validator
- add regressions for standalone and batched matrices with trailing shape `(0, 0)`

## Root cause

The NumPy-only shortcut for zero-by-zero matrices returned before the shared implementation ran. That bypassed validation of `t`, so malformed exponents such as temporal values, non-scalar arrays, and non-finite values silently produced an empty result. The same inputs were already rejected for ordinary matrices and empty leading batches.

## Impact

Zero-dimensional-state matrix powers now reject invalid exponent configuration consistently while preserving the existing shape and dtype behavior for valid exponents.

## Validation

- reproduced the previous shortcut accepting temporal, array-shaped, and non-finite exponents
- `python -m py_compile` passed for the modified module and regression test
- focused local suites passed: **52 tests** covering exponent validation and zero-by-zero matrix-function compatibility
- branch comparison: 2 commits ahead of `main`, 0 behind; only the backend wrapper and focused test file changed

Full repository CI should provide the authoritative cross-environment validation.