### PR TITLE
Reject masked NumPy random size arguments

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/random.py
+++ b/src/pyrecest/_backend/_shared_numpy/random.py
@@ -1,5 +1,7 @@
 import operator as _operator
 
+import numpy as _onp
+
 from ._dispatch import _common
 from ._dispatch import numpy as _np
 
@@ -33,6 +35,16 @@ def _contains_boolean_value(value):
     return any(isinstance(item, _BOOLEAN_TYPES) for item in values)
 
 
+def _contains_masked_value(value):
+    if _onp.ma.is_masked(value):
+        return True
+    try:
+        values = _onp.asarray(value, dtype=object).reshape(-1)
+    except (TypeError, ValueError, RuntimeError):
+        return False
+    return any(_onp.ma.is_masked(item) for item in values)
+
+
 def _is_temporal_scalar_array(value_array):
     return value_array.ndim == 0 and value_array.dtype.kind in _TEMPORAL_DTYPE_KINDS
 
@@ -44,7 +56,11 @@ def _size_type_error():
 def _normalize_size(size):
     if size is None:
         return None
-    if _contains_boolean_value(size) or isinstance(size, (str, bytes)):
+    if (
+        _contains_boolean_value(size)
+        or _contains_masked_value(size)
+        or isinstance(size, (str, bytes))
+    ):
         raise _size_type_error()
     try:
         size_array = _np.asarray(size)

--- a/tests/backend/test_numpy_random_masked_size.py
+++ b/tests/backend/test_numpy_random_masked_size.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pytest
+from pyrecest._backend.numpy import random
+
+
+_MASKED_SIZE_ARGUMENTS = (
+    np.ma.masked,
+    np.ma.array(3, mask=True),
+    np.ma.array([2, 3], mask=[False, True]),
+    (2, np.ma.masked),
+)
+
+
+@pytest.mark.parametrize("bad_size", _MASKED_SIZE_ARGUMENTS)
+@pytest.mark.parametrize(
+    "sampler",
+    (
+        lambda size: random.rand(size=size),
+        lambda size: random.uniform(size=size),
+        lambda size: random.normal(size=size),
+        lambda size: random.multivariate_normal([0.0], [[1.0]], size=size),
+        lambda size: random.choice(np.arange(5), size=size),
+        lambda size: random.randint(0, 5, size=size),
+        lambda size: random.multinomial(2, [0.25, 0.75], size=size),
+    ),
+)
+def test_numpy_random_rejects_masked_size_arguments(sampler, bad_size):
+    with pytest.raises(TypeError, match="size must be None"):
+        sampler(bad_size)
+
+
+def test_numpy_random_accepts_fully_unmasked_masked_array_size():
+    samples = random.rand(size=np.ma.array([2, 3], mask=False))
+
+    assert samples.shape == (2, 3)


### PR DESCRIPTION
## What changed

- detect masked values before shared NumPy random-size normalization converts inputs with `asarray`
- reject directly masked, partially masked, and nested masked dimensions with the existing `size` contract error
- preserve support for fully unmasked `MaskedArray` size inputs
- add regression coverage across `rand`, `uniform`, `normal`, `multivariate_normal`, `choice`, `randint`, and `multinomial`

## Root cause

`numpy.asarray` drops a `MaskedArray`'s mask and exposes its underlying data. As a result, an input such as `np.ma.array(3, mask=True)` was silently normalized to the hidden dimension `3`; partially masked shape vectors likewise used hidden dimensions. This could produce samples, and potentially allocations, with a shape the caller had explicitly marked as unavailable.

## Impact

Masked dimensions are no longer interpreted as valid allocation sizes. Existing Boolean, text, non-integer, and negative-size behavior is unchanged, and fully unmasked masked arrays continue to work.

## Validation

- reproduced the pre-fix hidden-dimension behavior for masked scalar, vector, and nested size inputs
- ran the focused regression module against the patched shared and NumPy random modules: `29 passed`
- syntax-compiled the changed source and regression test

GitHub Actions provides the authoritative full repository and backend test matrix.