### PR TITLE
Reject masked sigma-point parameters

### DIFF
--- a/src/pyrecest/sampling/sigma_points.py
+++ b/src/pyrecest/sampling/sigma_points.py
@@ -56,6 +56,8 @@ def _has_complex_dtype(value) -> bool:
 def _scalar_item(value, name: str):
     """Return a scalar value while rejecting arrays and booleans."""
 
+    if np.ma.is_masked(value):
+        raise ValueError(f"{name} must be a scalar")
     if isinstance(value, (bool, np.bool_)):
         raise ValueError(f"{name} must be a scalar")
     shape = getattr(value, "shape", ())

--- a/tests/test_sigma_points_masked_parameters.py
+++ b/tests/test_sigma_points_masked_parameters.py
@@ -1,0 +1,68 @@
+import numpy as np
+import pytest
+
+from pyrecest.sampling import JulierSigmaPoints, MerweScaledSigmaPoints
+
+
+def test_sigma_point_dimensions_reject_masked_scalars():
+    masked_dimension = np.ma.array(2, mask=True)
+
+    with pytest.raises(ValueError, match="n must be a scalar"):
+        MerweScaledSigmaPoints(
+            n=masked_dimension,
+            alpha=0.5,
+            beta=2.0,
+            kappa=0.0,
+        )
+
+    with pytest.raises(ValueError, match="n must be a scalar"):
+        JulierSigmaPoints(n=masked_dimension, kappa=0.0)
+
+
+@pytest.mark.parametrize(
+    ("parameter_name", "masked_value"),
+    (
+        ("alpha", np.ma.array(0.5, mask=True)),
+        ("beta", np.ma.array(2.0, mask=True)),
+        ("kappa", np.ma.array(0.0, mask=True)),
+    ),
+)
+def test_merwe_scaling_parameters_reject_masked_scalars(
+    parameter_name,
+    masked_value,
+):
+    parameters = {
+        "n": 2,
+        "alpha": 0.5,
+        "beta": 2.0,
+        "kappa": 0.0,
+    }
+    parameters[parameter_name] = masked_value
+
+    with pytest.raises(ValueError, match=rf"{parameter_name} must be a scalar"):
+        MerweScaledSigmaPoints(**parameters)
+
+
+def test_julier_kappa_rejects_masked_scalars():
+    with pytest.raises(ValueError, match="kappa must be a scalar"):
+        JulierSigmaPoints(n=2, kappa=np.ma.array(0.0, mask=True))
+
+
+def test_sigma_point_parameters_accept_unmasked_masked_array_scalars():
+    merwe = MerweScaledSigmaPoints(
+        n=np.ma.array(2, mask=False),
+        alpha=np.ma.array(0.5, mask=False),
+        beta=np.ma.array(2.0, mask=False),
+        kappa=np.ma.array(0.0, mask=False),
+    )
+    julier = JulierSigmaPoints(
+        n=np.ma.array(2, mask=False),
+        kappa=np.ma.array(0.0, mask=False),
+    )
+
+    assert merwe.n == 2
+    assert merwe.alpha == 0.5
+    assert merwe.beta == 2.0
+    assert merwe.kappa == 0.0
+    assert julier.n == 2
+    assert julier.kappa == 0.0


### PR DESCRIPTION
## Summary

- reject masked NumPy scalar values for sigma-point dimensions and scaling parameters
- preserve support for unmasked `numpy.ma` scalar values
- add focused regression coverage for Merwe and Julier sigma-point constructors

## Bug

The scalar validator called `.item()` without first checking whether the input was masked. For values such as `np.ma.array(2, mask=True)`, `.item()` exposes the hidden payload (`2`), so a missing dimension or tuning parameter was silently treated as valid configuration. This could construct a sigma-point scheme using data that had explicitly been marked unavailable.

## Validation

- reproduced the pre-fix behavior: a masked scalar yielded its hidden payload
- verified the patched guard raises `ValueError` while an unmasked `numpy.ma` scalar remains accepted
- added pytest coverage for `n`, Merwe `alpha`/`beta`/`kappa`, Julier `kappa`, and the unmasked compatibility case

The full repository test suite is delegated to GitHub Actions because this execution environment has no repository checkout or GitHub CLI.