### PR TITLE
Reject masked and mixed-boolean model inputs

### DIFF
--- a/src/pyrecest/models/validation.py
+++ b/src/pyrecest/models/validation.py
@@ -20,8 +20,40 @@ _TEMPORAL_ARRAY_KINDS = {"M", "m"}
 _TEMPORAL_SCALAR_TYPES = (np.datetime64, np.timedelta64)
 
 
+def _contains_masked_value(value: Any) -> bool:
+    """Return whether ``value`` contains at least one masked entry."""
+    if np.ma.is_masked(value):
+        return True
+    if isinstance(value, np.ndarray):
+        if value.dtype == object:
+            return any(_contains_masked_value(item) for item in value.reshape(-1))
+        return False
+    if isinstance(value, (list, tuple)):
+        return any(_contains_masked_value(item) for item in value)
+    return False
+
+
+def _contains_boolean_value(value: Any) -> bool:
+    """Return whether ``value`` contains a Python or NumPy boolean entry."""
+    if isinstance(value, (bool, np.bool_)):
+        return True
+    if isinstance(value, np.ndarray):
+        if value.dtype == np.bool_:
+            return True
+        if value.dtype == object:
+            return any(_contains_boolean_value(item) for item in value.reshape(-1))
+        return False
+    if isinstance(value, (list, tuple)):
+        return any(_contains_boolean_value(item) for item in value)
+    return False
+
+
 def _as_backend_array(value: Any, name: str):
     """Convert ``value`` to a backend array and raise a user-facing error."""
+    if _contains_masked_value(value):
+        raise ValueError(f"{name} must not contain masked values.")
+    if _contains_boolean_value(value):
+        raise ValueError(f"{name} must contain numeric non-boolean values.")
     try:
         value_array = np.asarray(value)
     except (TypeError, ValueError, RuntimeError, OverflowError):
@@ -46,6 +78,8 @@ def _format_shape(shape: tuple[int, ...]) -> str:
 
 
 def _validate_bool_flag(value: Any, name: str) -> bool:
+    if _contains_masked_value(value):
+        raise TypeError(f"{name} must be a boolean.")
     if isinstance(value, (bool, np.bool_)):
         return bool(value)
     try:
@@ -87,6 +121,8 @@ def _contains_temporal_scalar(value: Any) -> bool:
 
 
 def _validate_nonnegative_finite_scalar(value: Any, name: str) -> float:
+    if _contains_masked_value(value):
+        raise ValueError(f"{name} must be a finite nonnegative scalar.")
     value_array = np.asarray(value)
     if (
         value_array.shape != ()
@@ -133,6 +169,8 @@ def _validate_expected_dim(
 
 
 def _validate_expected_dim_scalar(value: Any, dim_name: str) -> int:
+    if _contains_masked_value(value):
+        raise TypeError(f"{dim_name} must be an integer or None.")
     try:
         value_array = np.asarray(value)
     except (TypeError, ValueError, OverflowError) as exc:
@@ -407,6 +445,8 @@ def _maybe_call(value: Any, *, allow_methods: bool) -> Any:
 
 
 def _positive_int_or_none(value: Any) -> int | None:
+    if _contains_masked_value(value):
+        return None
     if isinstance(value, (bool, np.bool_, *_TEMPORAL_SCALAR_TYPES)):
         return None
     try:

--- a/tests/models/test_validation_precoercion.py
+++ b/tests/models/test_validation_precoercion.py
@@ -1,0 +1,94 @@
+from types import SimpleNamespace
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+from pyrecest.models.validation import (
+    infer_state_dim_from_distribution,
+    validate_covariance_matrix,
+    validate_state_vector,
+    validate_transition_matrix,
+)
+
+
+@pytest.mark.parametrize(
+    ("validator", "value", "message"),
+    (
+        (
+            lambda value: validate_state_vector(value, state_dim=2),
+            np.ma.array([1.0, 9.0], mask=[False, True]),
+            "state must not contain masked values",
+        ),
+        (
+            lambda value: validate_transition_matrix(
+                value, state_dim=2, pred_dim=2
+            ),
+            np.ma.array(
+                [[1.0, 0.0], [0.0, 1.0]],
+                mask=[[False, False], [True, False]],
+            ),
+            "system_matrix must not contain masked values",
+        ),
+        (
+            lambda value: validate_state_vector(value, state_dim=2),
+            [1.0, True],
+            "state must contain numeric non-boolean values",
+        ),
+        (
+            lambda value: validate_transition_matrix(
+                value, state_dim=2, pred_dim=2
+            ),
+            [[1.0, 0.0], [False, 1.0]],
+            "system_matrix must contain numeric non-boolean values",
+        ),
+    ),
+)
+def test_model_array_validation_rejects_values_hidden_by_coercion(
+    validator, value, message
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        validator(value)
+
+
+def test_model_scalar_metadata_rejects_masked_values() -> None:
+    with pytest.raises(TypeError, match="allow_scalar must be a boolean"):
+        validate_state_vector(
+            1.0,
+            state_dim=1,
+            allow_scalar=np.ma.array(True, mask=True),
+        )
+
+    with pytest.raises(TypeError, match="dim must be an integer or None"):
+        validate_state_vector(
+            [1.0, 2.0],
+            state_dim=np.ma.array(2, mask=True),
+        )
+
+    with pytest.raises(ValueError, match="symmetric_rtol must be a finite"):
+        validate_covariance_matrix(
+            [[1.0]],
+            check_symmetric=True,
+            symmetric_rtol=np.ma.array(1e-7, mask=True),
+        )
+
+
+def test_dimension_inference_rejects_masked_explicit_dimension() -> None:
+    distribution = SimpleNamespace(dim=np.ma.array(4, mask=True))
+
+    with pytest.raises(ValueError, match="Could not infer"):
+        infer_state_dim_from_distribution(distribution)
+
+
+def test_model_validation_accepts_fully_unmasked_masked_arrays() -> None:
+    state = validate_state_vector(
+        np.ma.array([1.0, 2.0], mask=False),
+        state_dim=np.ma.array(2, mask=False),
+    )
+    covariance = validate_covariance_matrix(
+        np.ma.array([[1.0]], mask=False),
+        check_symmetric=np.ma.array(True, mask=False),
+        symmetric_rtol=np.ma.array(1e-7, mask=False),
+    )
+
+    npt.assert_allclose(np.asarray(state), [1.0, 2.0])
+    npt.assert_allclose(np.asarray(covariance), [[1.0]])


### PR DESCRIPTION
## What changed

- inspect raw model-validation inputs before NumPy/backend coercion
- reject masked vector and matrix entries instead of consuming their hidden payloads
- reject masked Boolean flags, dimensions, symmetry tolerances, and inferred dimensions
- reject Python sequences that mix Boolean and numeric entries before `True`/`False` are promoted to `1`/`0`
- preserve support for fully unmasked `numpy.ma.MaskedArray` inputs
- add focused regression coverage for array inputs, scalar metadata, dimension inference, and unmasked compatibility

## Root cause

`numpy.asarray` and backend conversion can discard a `MaskedArray` mask and expose its underlying data. They can also promote mixed numeric/Boolean Python sequences to a numeric dtype. The existing validation therefore ran after the information needed to reject those inputs had already been lost.

## Impact

Missing state, measurement, covariance, or model-matrix entries can no longer silently affect estimation through hidden values. Boolean configuration mistakes in numeric sequences also fail at the model boundary rather than changing values numerically.

## Validation

- reproduced the pre-fix acceptance of masked state entries, masked dimensions/flags/tolerances, masked inferred dimensions, and mixed Boolean/numeric arrays
- ran the focused regression module against the patched validation code with a NumPy-backed test harness: `7 passed`
- syntax-compiled the changed source and regression test

GitHub Actions provides the authoritative full repository and backend test matrix.