### PR TITLE
Validate MEM-RBPF FFBSi options

### DIFF
--- a/src/pyrecest/smoothers/__init__.py
+++ b/src/pyrecest/smoothers/__init__.py
@@ -1,3 +1,4 @@
+from ._mem_rbpf_ffbsi_option_contract import install_mem_rbpf_ffbsi_option_contract
 from ._record_smoother_numeric_contract import install_record_smoother_numeric_contract
 from .abstract_smoother import AbstractSmoother
 from .delayed_output import DelayedStateOutput, DelayedStateOutputMixin
@@ -69,6 +70,7 @@ from .unscented_rauch_tung_striebel_smoother import (
     URTSSmoother,
 )
 
+install_mem_rbpf_ffbsi_option_contract()
 install_record_smoother_numeric_contract()
 
 __all__ = [

--- a/src/pyrecest/smoothers/_mem_rbpf_ffbsi_option_contract.py
+++ b/src/pyrecest/smoothers/_mem_rbpf_ffbsi_option_contract.py
@@ -1,0 +1,125 @@
+"""Strict option validation for the MEM-RBPF FFBSi smoother."""
+
+from __future__ import annotations
+
+from functools import wraps
+from operator import index as _operator_index
+from typing import Any
+
+import numpy as np
+
+from . import mem_rbpf_ffbsi_smoother as _implementation
+
+
+def _normalize_integer_option(
+    value: Any,
+    name: str,
+    *,
+    minimum: int,
+) -> int:
+    """Return an exact integer option satisfying the requested lower bound."""
+
+    qualifier = "positive" if minimum == 1 else "non-negative"
+    message = f"{name} must be a {qualifier} integer"
+    if np.ma.is_masked(value) or isinstance(
+        value,
+        (bool, np.bool_, np.datetime64, np.timedelta64),
+    ):
+        raise ValueError(message)
+    try:
+        parsed = _operator_index(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if parsed < minimum:
+        raise ValueError(message)
+    return int(parsed)
+
+
+def _normalize_bool_option(value: Any, name: str) -> bool:
+    """Return a strict Python Boolean without truthiness coercion."""
+
+    if isinstance(value, (bool, np.bool_)):
+        return bool(value)
+    raise ValueError(f"{name} must be a bool")
+
+
+def install_mem_rbpf_ffbsi_option_contract() -> None:
+    """Install strict validation for constructor and per-call FFBSi options."""
+
+    smoother_type = _implementation.MEMRBPFFFBSiSmoother
+
+    current_init = smoother_type.__init__
+    if not getattr(current_init, "_pyrecest_strict_option_contract", False):
+
+        @wraps(current_init)
+        def validated_init(
+            self,
+            n_trajectories: int | None = None,
+            sample_axis: bool = True,
+            angle_wrap_terms: int = 2,
+            axis_floor: float = 1e-9,
+        ):
+            if n_trajectories is not None:
+                n_trajectories = _normalize_integer_option(
+                    n_trajectories,
+                    "n_trajectories",
+                    minimum=1,
+                )
+            angle_wrap_terms = _normalize_integer_option(
+                angle_wrap_terms,
+                "angle_wrap_terms",
+                minimum=0,
+            )
+            return current_init(
+                self,
+                n_trajectories=n_trajectories,
+                sample_axis=sample_axis,
+                angle_wrap_terms=angle_wrap_terms,
+                axis_floor=axis_floor,
+            )
+
+        validated_init._pyrecest_strict_option_contract = True
+        smoother_type.__init__ = validated_init
+
+    current_smooth = smoother_type.smooth
+    if not getattr(current_smooth, "_pyrecest_strict_option_contract", False):
+
+        @wraps(current_smooth)
+        def validated_smooth(
+            self,
+            records,
+            rng=None,
+            *,
+            n_trajectories: int | None = None,
+            sample_axis: bool | None = None,
+            angle_wrap_terms: int | None = None,
+            full_axis_lengths: bool = True,
+        ):
+            if n_trajectories is not None:
+                n_trajectories = _normalize_integer_option(
+                    n_trajectories,
+                    "n_trajectories",
+                    minimum=1,
+                )
+            if angle_wrap_terms is not None:
+                angle_wrap_terms = _normalize_integer_option(
+                    angle_wrap_terms,
+                    "angle_wrap_terms",
+                    minimum=0,
+                )
+            full_axis_lengths = _normalize_bool_option(
+                full_axis_lengths,
+                "full_axis_lengths",
+            )
+            return current_smooth(
+                self,
+                records,
+                rng,
+                n_trajectories=n_trajectories,
+                sample_axis=sample_axis,
+                angle_wrap_terms=angle_wrap_terms,
+                full_axis_lengths=full_axis_lengths,
+            )
+
+        validated_smooth._pyrecest_strict_option_contract = True
+        smoother_type.smooth = validated_smooth

--- a/tests/smoothers/test_mem_rbpf_ffbsi_option_validation.py
+++ b/tests/smoothers/test_mem_rbpf_ffbsi_option_validation.py
@@ -1,0 +1,92 @@
+"""Regression tests for strict MEM-RBPF FFBSi option validation."""
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+from pyrecest import backend
+from pyrecest.smoothers import MEMRBPFFFBSiSmoother, MEMRBPFForwardRecord
+
+
+pytestmark = pytest.mark.skipif(
+    backend.__backend_name__ != "numpy",
+    reason="MEM-RBPF FFBSi tests use NumPy sampling paths",
+)
+
+
+def _single_particle_record() -> MEMRBPFForwardRecord:
+    return MEMRBPFForwardRecord(
+        kinematic_state=np.array([0.0]),
+        covariance=np.array([[1.0]]),
+        theta=np.array([0.0]),
+        axis_mean=np.array([[1.0, 0.5]]),
+        axis_covariance=np.array([0.1 * np.eye(2)]),
+        weights=np.array([1.0]),
+    )
+
+
+@pytest.mark.parametrize(
+    ("option_name", "invalid_value", "message"),
+    (
+        ("n_trajectories", 1.5, "n_trajectories must be a positive integer"),
+        ("n_trajectories", True, "n_trajectories must be a positive integer"),
+        (
+            "n_trajectories",
+            np.timedelta64(3, "ns"),
+            "n_trajectories must be a positive integer",
+        ),
+        (
+            "angle_wrap_terms",
+            -1,
+            "angle_wrap_terms must be a non-negative integer",
+        ),
+        (
+            "angle_wrap_terms",
+            0.5,
+            "angle_wrap_terms must be a non-negative integer",
+        ),
+        (
+            "angle_wrap_terms",
+            np.ma.array(2, mask=True),
+            "angle_wrap_terms must be a non-negative integer",
+        ),
+    ),
+)
+def test_constructor_rejects_lossy_or_invalid_integer_options(
+    option_name, invalid_value, message
+):
+    with pytest.raises(ValueError, match=message):
+        MEMRBPFFFBSiSmoother(**{option_name: invalid_value})
+
+
+@pytest.mark.parametrize(
+    ("options", "message"),
+    (
+        ({"n_trajectories": 1.5}, "n_trajectories must be a positive integer"),
+        ({"angle_wrap_terms": -1}, "angle_wrap_terms must be a non-negative integer"),
+        ({"full_axis_lengths": "False"}, "full_axis_lengths must be a bool"),
+    ),
+)
+def test_smooth_rejects_invalid_per_call_options(options, message):
+    smoother = MEMRBPFFFBSiSmoother(n_trajectories=1, sample_axis=False)
+
+    with pytest.raises(ValueError, match=message):
+        smoother.smooth([_single_particle_record()], rng=0, **options)
+
+
+def test_exact_numpy_scalar_options_remain_supported():
+    smoother = MEMRBPFFFBSiSmoother(
+        n_trajectories=np.int64(1),
+        sample_axis=False,
+        angle_wrap_terms=np.array(0),
+    )
+
+    result = smoother.smooth(
+        [_single_particle_record()],
+        rng=0,
+        n_trajectories=np.int64(2),
+        angle_wrap_terms=np.array(0),
+        full_axis_lengths=np.bool_(False),
+    )
+
+    assert result.sample_states.shape == (2, 1, 4)
+    npt.assert_allclose(result.sample_states[:, 0, -2:], [[1.0, 0.5], [1.0, 0.5]])


### PR DESCRIPTION
## What changed

- require exact positive integer `n_trajectories` values in both the constructor and per-call override
- require exact non-negative integer `angle_wrap_terms` values in both paths
- require `full_axis_lengths` to be an actual Boolean rather than using generic truthiness
- preserve NumPy integer scalars, scalar integer arrays, and NumPy Boolean scalars
- add focused regression coverage

## Root cause

The smoother normalized discrete options with `int(...)` and consumed `full_axis_lengths` through ordinary truthiness. Fractional trajectory counts were silently truncated, per-call negative wrap counts bypassed constructor validation, and strings such as `"False"` enabled full-axis scaling.

A negative per-call wrap count produces an empty wrapped-normal shift set. The resulting non-finite log probabilities trigger the fallback to uniform probabilities, silently discarding the intended backward transition kernel.

## Impact

Malformed smoothing configuration now fails at the API boundary instead of changing trajectory cardinality, replacing transition probabilities with a uniform fallback, or doubling reported axis lengths.

## Validation

- syntax-compiled the new validation module and regression test
- exercised the installer against a stub smoother to verify exact NumPy integers are preserved and lossy or invalid values are rejected
- added focused NumPy-backend regression tests for constructor and per-call options
- rebased the three-file change onto the current `main`

GitHub Actions provides the authoritative repository test matrix.