### PR TITLE
Fix JAX real FFT length array validation

### DIFF
--- a/src/pyrecest/_backend/jax/fft.py
+++ b/src/pyrecest/_backend/jax/fft.py
@@ -43,14 +43,14 @@ def _normalize_real_fft_length(n):
     if isinstance(n, _np.ndarray):
         if _np.issubdtype(n.dtype, _np.bool_):
             raise TypeError(_BOOLEAN_FFT_LENGTH_ERROR)
-        if n.size == 1 and _np.issubdtype(n.dtype, _np.integer):
+        if n.ndim == 0 and _np.issubdtype(n.dtype, _np.integer):
             return int(n.item())
         return n
     if isinstance(n, _jnp.ndarray):
         n_dtype = _np.asarray(n).dtype
         if _np.issubdtype(n_dtype, _np.bool_):
             raise TypeError(_BOOLEAN_FFT_LENGTH_ERROR)
-        if n.size == 1 and _np.issubdtype(n_dtype, _np.integer):
+        if n.ndim == 0 and _np.issubdtype(n_dtype, _np.integer):
             return int(n.item())
         return n
     if isinstance(n, _np.integer):

--- a/tests/test_jax_fft_scalar_array_axes.py
+++ b/tests/test_jax_fft_scalar_array_axes.py
@@ -20,25 +20,31 @@ def test_jax_fft_scalar_length_arrays_match_integer_length():
     from pyrecest._backend.jax import fft
 
     values = jnp.arange(4.0)
-    expected = fft.rfft(values, n=3)
 
-    for n in (np.array(3), jnp.array(3)):
-        actual = fft.rfft(values, n=n)
-        assert actual.shape == expected.shape
-        assert actual.tolist() == expected.tolist()
+    for transform in (fft.rfft, fft.irfft):
+        expected = transform(values, n=3)
+        for n in (np.array(3), jnp.array(3)):
+            actual = transform(values, n=n)
+            assert actual.shape == expected.shape
+            assert actual.tolist() == expected.tolist()
 
 
-def test_jax_fft_rejects_non_singleton_length_arrays():
+def test_jax_real_fft_rejects_nonscalar_length_arrays():
     jnp = pytest.importorskip("jax.numpy")
     from pyrecest._backend.jax import fft
 
     values = jnp.arange(4.0)
 
-    for n in (
-        np.array([3, 4]),
-        np.array([[3, 4]]),
-        jnp.array([3, 4]),
-        jnp.array([[3, 4]]),
-    ):
-        with pytest.raises(TypeError):
-            fft.rfft(values, n=n)
+    for transform in (fft.rfft, fft.irfft):
+        for n in (
+            np.array([3]),
+            np.array([[3]]),
+            np.array([3, 4]),
+            np.array([[3, 4]]),
+            jnp.array([3]),
+            jnp.array([[3]]),
+            jnp.array([3, 4]),
+            jnp.array([[3, 4]]),
+        ):
+            with pytest.raises(TypeError):
+                transform(values, n=n)


### PR DESCRIPTION
## Summary
- require NumPy/JAX array-valued `n` arguments for `rfft` and `irfft` to be zero-dimensional integer scalars
- stop silently converting one-element vectors and matrices into scalar FFT lengths
- preserve support for genuine zero-dimensional NumPy and JAX integer arrays
- cover both real FFT directions and singleton/non-singleton nonscalar arrays

## Bug
`_normalize_real_fft_length` used `n.size == 1`, so values such as `np.array([3])`, `np.array([[3]])`, and their JAX equivalents were converted to `3`. NumPy's FFT contract rejects these nonscalar arrays with `TypeError`; PyRecEst's JAX wrapper instead accepted them and changed the transform length.

## Validation
- `PYTHONPATH=/mnt/data/pyrecest_fft_fix pytest -q /mnt/data/pyrecest_fft_fix/tests/test_jax_fft_scalar_array_axes.py`
- result: `3 passed`
