### PR TITLE
Reject masked model validation inputs

### DIFF
--- a/src/pyrecest/models/__init__.py
+++ b/src/pyrecest/models/__init__.py
@@ -4,6 +4,7 @@ evolve and how measurements are evaluated. These objects are deliberately small
 and capability-oriented so filters can opt into the pieces they need.
 """
 
+from ._masked_array_backend_compat import install_masked_array_backend_compat
 from ._sampleable_transition_validation import install_sampleable_transition_validation
 from ._validated_motion_models import nearly_coordinated_turn_model
 from ._validated_sensor_models import install_sensor_state_validation
@@ -39,6 +40,7 @@ from .likelihood import (
     SupportsTransitionSampling,
 )
 
+install_masked_array_backend_compat()
 install_sampleable_transition_validation()
 install_sensor_state_validation()
 

--- a/src/pyrecest/models/_masked_array_backend_compat.py
+++ b/src/pyrecest/models/_masked_array_backend_compat.py
@@ -1,0 +1,31 @@
+"""Backend compatibility for fully unmasked NumPy masked arrays."""
+
+from __future__ import annotations
+
+from functools import wraps
+from typing import Any
+
+import numpy as np
+
+from . import validation as _validation
+
+
+def _unwrap_fully_unmasked_array(value: Any) -> Any:
+    """Expose ordinary NumPy data only when no entries are masked."""
+    if isinstance(value, np.ma.MaskedArray) and not np.ma.is_masked(value):
+        return np.asarray(value.data)
+    return value
+
+
+def install_masked_array_backend_compat() -> None:
+    """Allow backend conversion of fully unmasked ``MaskedArray`` inputs."""
+    current = _validation._as_backend_array
+    if getattr(current, "_pyrecest_masked_array_backend_compat", False):
+        return
+
+    @wraps(current)
+    def wrapped(value: Any, name: str):
+        return current(_unwrap_fully_unmasked_array(value), name)
+
+    wrapped._pyrecest_masked_array_backend_compat = True
+    _validation._as_backend_array = wrapped

--- a/src/pyrecest/models/additive_noise.py
+++ b/src/pyrecest/models/additive_noise.py
@@ -4,10 +4,10 @@ import inspect
 from collections.abc import Callable
 from typing import Any
 
-import numpy as np
-
 # pylint: disable=no-name-in-module,no-member,too-many-instance-attributes,too-many-positional-arguments
 from pyrecest.backend import asarray, is_array
+
+from .validation import _validate_bool_flag
 
 
 def _as_optional_array(value):
@@ -79,16 +79,6 @@ def _reject_unexpected_kwargs(kwargs: dict[str, Any]) -> None:
     if kwargs:
         unexpected = ", ".join(sorted(kwargs))
         raise TypeError(f"Unexpected keyword argument(s): {unexpected}")
-
-
-def _validate_bool_flag(value: Any, name: str) -> bool:
-    try:
-        value_array = np.asarray(value)
-    except (TypeError, ValueError, RuntimeError) as exc:
-        raise TypeError(f"{name} must be a boolean") from exc
-    if value_array.shape != () or not np.issubdtype(value_array.dtype, np.bool_):
-        raise TypeError(f"{name} must be a boolean")
-    return bool(value_array.item())
 
 
 def _dt_call_mode(function: Callable[..., Any]) -> str | None:

--- a/src/pyrecest/models/validation.py
+++ b/src/pyrecest/models/validation.py
@@ -20,8 +20,23 @@ _TEMPORAL_ARRAY_KINDS = {"M", "m"}
 _TEMPORAL_SCALAR_TYPES = (np.datetime64, np.timedelta64)
 
 
+def _contains_masked_value(value: Any) -> bool:
+    """Return whether ``value`` contains genuinely masked NumPy entries."""
+    if np.ma.is_masked(value):
+        return True
+    if isinstance(value, np.ndarray):
+        if value.dtype != object:
+            return False
+        return any(_contains_masked_value(item) for item in value.reshape(-1))
+    if isinstance(value, (list, tuple)):
+        return any(_contains_masked_value(item) for item in value)
+    return False
+
+
 def _as_backend_array(value: Any, name: str):
     """Convert ``value`` to a backend array and raise a user-facing error."""
+    if _contains_masked_value(value):
+        raise ValueError(f"{name} must not contain masked values.")
     try:
         value_array = np.asarray(value)
     except (TypeError, ValueError, RuntimeError, OverflowError):
@@ -46,6 +61,8 @@ def _format_shape(shape: tuple[int, ...]) -> str:
 
 
 def _validate_bool_flag(value: Any, name: str) -> bool:
+    if _contains_masked_value(value):
+        raise TypeError(f"{name} must be a boolean.")
     if isinstance(value, (bool, np.bool_)):
         return bool(value)
     try:
@@ -87,6 +104,8 @@ def _contains_temporal_scalar(value: Any) -> bool:
 
 
 def _validate_nonnegative_finite_scalar(value: Any, name: str) -> float:
+    if _contains_masked_value(value):
+        raise ValueError(f"{name} must be a finite nonnegative scalar.")
     value_array = np.asarray(value)
     if (
         value_array.shape != ()
@@ -133,6 +152,8 @@ def _validate_expected_dim(
 
 
 def _validate_expected_dim_scalar(value: Any, dim_name: str) -> int:
+    if _contains_masked_value(value):
+        raise TypeError(f"{dim_name} must be an integer or None.")
     try:
         value_array = np.asarray(value)
     except (TypeError, ValueError, OverflowError) as exc:
@@ -407,6 +428,8 @@ def _maybe_call(value: Any, *, allow_methods: bool) -> Any:
 
 
 def _positive_int_or_none(value: Any) -> int | None:
+    if _contains_masked_value(value):
+        return None
     if isinstance(value, (bool, np.bool_, *_TEMPORAL_SCALAR_TYPES)):
         return None
     try:

--- a/tests/models/test_validation_masked_inputs.py
+++ b/tests/models/test_validation_masked_inputs.py
@@ -1,0 +1,111 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from pyrecest import backend
+from pyrecest.models.additive_noise import (
+    AdditiveNoiseMeasurementModel,
+    AdditiveNoiseTransitionModel,
+)
+from pyrecest.models.validation import (
+    infer_state_dim_from_distribution,
+    validate_covariance_matrix,
+    validate_measurement_matrix,
+    validate_noise_covariance,
+    validate_state_vector,
+)
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda: validate_state_vector(
+            np.ma.array([1.0, 999.0], mask=[False, True]), state_dim=2
+        ),
+        lambda: validate_covariance_matrix(
+            np.ma.array([[1.0, 9.0], [9.0, 1.0]], mask=[[False, True], [True, False]])
+        ),
+        lambda: validate_noise_covariance([[np.ma.array(1.0, mask=True)]]),
+        lambda: validate_measurement_matrix(
+            np.array([[np.ma.masked]], dtype=object), state_dim=1, meas_dim=1
+        ),
+    ],
+)
+def test_model_validators_reject_masked_numeric_inputs(call):
+    with pytest.raises(ValueError, match="masked"):
+        call()
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda: validate_state_vector([1.0, 2.0], state_dim=np.ma.array(2, mask=True)),
+        lambda: validate_state_vector(1.0, allow_scalar=np.ma.array(True, mask=True)),
+        lambda: validate_covariance_matrix(
+            [[1.0]], check_symmetric=np.ma.array(False, mask=True)
+        ),
+        lambda: infer_state_dim_from_distribution(
+            SimpleNamespace(mean=lambda: np.array([1.0, 2.0])),
+            allow_methods=np.ma.array(True, mask=True),
+        ),
+    ],
+)
+def test_model_validators_reject_masked_metadata(call):
+    with pytest.raises(TypeError):
+        call()
+
+
+@pytest.mark.parametrize("keyword", ["symmetric_rtol", "symmetric_atol"])
+def test_covariance_validator_rejects_masked_tolerances(keyword):
+    with pytest.raises(ValueError, match="finite nonnegative scalar"):
+        validate_covariance_matrix(
+            [[1.0]],
+            check_symmetric=True,
+            **{keyword: np.ma.array(1e-7, mask=True)},
+        )
+
+
+def test_dimension_inference_does_not_use_masked_hidden_payload():
+    distribution = SimpleNamespace(
+        dim=np.ma.array(7, mask=True),
+        mu=np.array([1.0, 2.0]),
+    )
+
+    assert infer_state_dim_from_distribution(distribution) == 2
+
+
+def test_fully_unmasked_masked_arrays_remain_supported():
+    state = validate_state_vector(
+        np.ma.array([1.0, 2.0], mask=False),
+        state_dim=np.ma.array(2, mask=False),
+    )
+    covariance = validate_covariance_matrix(
+        np.ma.array([[1.0]], mask=False),
+        allow_scalar=np.ma.array(False, mask=False),
+        check_symmetric=np.ma.array(True, mask=False),
+        symmetric_rtol=np.ma.array(1e-7, mask=False),
+    )
+
+    transition_model = AdditiveNoiseTransitionModel(
+        lambda value: value, vectorized=np.ma.array(True, mask=False)
+    )
+
+    assert tuple(int(dim) for dim in backend.shape(state)) == (2,)
+    assert tuple(int(dim) for dim in backend.shape(covariance)) == (1, 1)
+    assert transition_model.vectorized is True
+
+
+@pytest.mark.parametrize("payload", [True, False])
+def test_additive_noise_models_reject_masked_vectorized_flags(payload):
+    flag = np.ma.array(payload, mask=True)
+
+    with pytest.raises(TypeError, match="vectorized"):
+        AdditiveNoiseTransitionModel(lambda state: state, vectorized=flag)
+    with pytest.raises(TypeError, match="vectorized"):
+        AdditiveNoiseMeasurementModel(lambda state: state, vectorized=flag)
+
+    model = AdditiveNoiseTransitionModel(lambda state: state)
+    with pytest.raises(TypeError, match="vectorized"):
+        model.vectorized = flag
+    with pytest.raises(TypeError, match="function_is_vectorized"):
+        model.function_is_vectorized = flag


### PR DESCRIPTION
## What changed

- reject genuinely masked numeric values before model vector and matrix validation converts them through NumPy or backend arrays
- reject masked Boolean flags, expected dimensions, and covariance tolerances instead of interpreting hidden payloads
- ignore masked explicit distribution dimensions during inference and fall back to valid shape information
- route additive-noise model vectorization flags through the shared validation helper
- preserve fully unmasked `MaskedArray` inputs

## Root cause

`numpy.asarray` drops `MaskedArray` masks and exposes the underlying data. Shared model validators and the additive-noise Boolean validator therefore accepted unavailable values such as a masked state entry, `state_dim`, `allow_scalar`, or `vectorized` flag based on inaccessible payloads.

## Impact

Missing model data and metadata now fail at the validation boundary rather than silently influencing shapes, symmetry checks, vectorization behavior, or inferred dimensions.

## Validation

- reproduced the pre-fix hidden-payload behavior for masked vectors, dimensions, flags, tolerances, and inferred distribution dimensions
- ran the focused masked-input regression module against the patched validation and additive-noise modules: `14 passed`
- ran Python syntax compilation for both changed source files and the regression test
- verified the branch is 3 commits ahead and 0 behind current `main`, with changes limited to the two source modules and one focused test module

GitHub Actions provides the authoritative full repository and backend matrix.