### PR TITLE
Reject masked hypertoroidal sampler controls

### DIFF
--- a/src/pyrecest/sampling/hypertoroidal_sampler.py
+++ b/src/pyrecest/sampling/hypertoroidal_sampler.py
@@ -6,9 +6,13 @@ from pyrecest.distributions import CircularUniformDistribution
 from .abstract_sampler import AbstractSampler
 
 _TEXT_TYPES = (str, bytes, bytearray, np.str_, np.bytes_)
+_TEMPORAL_TYPES = (np.datetime64, np.timedelta64)
 
 
 def _validate_integral_scalar(value, name: str, *, minimum: int) -> int:
+    if np.ma.is_masked(value):
+        raise ValueError(f"{name} must be an integer")
+
     scalar = np.asarray(value)
     if scalar.ndim != 0:
         raise ValueError(f"{name} must be a scalar integer")
@@ -18,7 +22,7 @@ def _validate_integral_scalar(value, name: str, *, minimum: int) -> int:
     scalar_value = scalar.item()
     if isinstance(scalar_value, (bool, np.bool_)):
         raise ValueError(f"{name} must be an integer, not a boolean")
-    if isinstance(scalar_value, _TEXT_TYPES):
+    if isinstance(scalar_value, (*_TEXT_TYPES, *_TEMPORAL_TYPES)):
         raise ValueError(f"{name} must be an integer")
 
     try:

--- a/tests/test_hypertoroidal_sampler_masked_controls.py
+++ b/tests/test_hypertoroidal_sampler_masked_controls.py
@@ -1,0 +1,59 @@
+import unittest
+
+import numpy as np
+
+from pyrecest.sampling.hypertoroidal_sampler import (
+    CircularUniformSampler,
+    _validate_integral_scalar,
+)
+
+
+class TestHypertoroidalSamplerMaskedControls(unittest.TestCase):
+    def setUp(self):
+        self.sampler = CircularUniformSampler()
+
+    def test_masked_integer_controls_are_rejected_before_item_unwrap(self):
+        invalid_values = (
+            np.ma.masked,
+            np.ma.array(3, mask=True),
+        )
+
+        for value in invalid_values:
+            with self.subTest(value=repr(value)):
+                with self.assertRaisesRegex(ValueError, "must be an integer"):
+                    _validate_integral_scalar(value, "value", minimum=0)
+                with self.assertRaisesRegex(ValueError, "must be an integer"):
+                    self.sampler.sample_stochastic(value)
+                with self.assertRaisesRegex(ValueError, "must be an integer"):
+                    self.sampler.get_grid(value)
+
+        with self.assertRaisesRegex(ValueError, "must be an integer"):
+            self.sampler.sample_stochastic(2, dim=np.ma.array(1, mask=True))
+
+    def test_object_wrapped_temporal_controls_are_rejected(self):
+        temporal_value = np.array(np.timedelta64(3, "ns"), dtype=object)
+
+        with self.assertRaisesRegex(ValueError, "must be an integer"):
+            _validate_integral_scalar(temporal_value, "value", minimum=0)
+        with self.assertRaisesRegex(ValueError, "must be an integer"):
+            self.sampler.sample_stochastic(temporal_value)
+        with self.assertRaisesRegex(ValueError, "must be an integer"):
+            self.sampler.get_grid(temporal_value)
+
+        temporal_dim = np.array(np.timedelta64(1, "ns"), dtype=object)
+        with self.assertRaisesRegex(ValueError, "must be an integer"):
+            self.sampler.sample_stochastic(2, dim=temporal_dim)
+
+    def test_fully_unmasked_masked_scalar_remains_supported(self):
+        self.assertEqual(
+            _validate_integral_scalar(
+                np.ma.array(3, mask=False),
+                "value",
+                minimum=0,
+            ),
+            3,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- reject genuinely masked integer controls before NumPy conversion exposes their hidden payload
- reject object-wrapped `numpy.datetime64` and `numpy.timedelta64` values before integer coercion
- preserve support for fully unmasked numeric `MaskedArray` scalars
- add focused regressions for sample counts, dimensions, and grid-density parameters

## Root cause

`numpy.asarray` removes the mask from a scalar `MaskedArray`, and `.item()` then returns the hidden payload. In addition, an object array containing a nanosecond `numpy.timedelta64` reaches `int(...)`, which converts the duration to its raw integer tick count. As a result, unavailable or temporal configuration could silently control sample cardinality, dimensional validation, or grid resolution.

## Impact

`CircularUniformSampler` now fails at the validation boundary rather than interpreting missing or temporal metadata as integer controls. Ordinary integer-like scalars and fully unmasked masked-array scalars retain their previous behavior.

## Validation

- reproduced the pre-fix behavior: a masked scalar exposed its hidden value and an object-wrapped nanosecond duration became an integer
- syntax-compiled the changed implementation and regression module
- ran the focused regression module against a reconstructed package surface: `3 passed, 2 subtests passed`
- verified the branch is 2 commits ahead and 0 behind current `main`, with a two-file diff

GitHub Actions provides the authoritative full repository and backend matrix.