### PR TITLE
Fix NaN parameter ordering in grouped results

### DIFF
--- a/src/pyrecest/evaluation/group_results_by_filter.py
+++ b/src/pyrecest/evaluation/group_results_by_filter.py
@@ -1,10 +1,16 @@
+import math
+
+
 def _parameter_sort_key(parameter):
     if parameter is None:
         return (0, "")
     try:
-        return (1, float(parameter))
+        numeric_parameter = float(parameter)
     except (TypeError, ValueError, OverflowError):
-        return (2, str(parameter))
+        return (3, str(parameter))
+    if math.isnan(numeric_parameter):
+        return (2, "")
+    return (1, numeric_parameter)
 
 
 def group_results_by_filter(data):

--- a/tests/test_group_results_by_filter.py
+++ b/tests/test_group_results_by_filter.py
@@ -1,3 +1,4 @@
+import math
 import unittest
 
 from pyrecest.evaluation.group_results_by_filter import group_results_by_filter
@@ -15,6 +16,22 @@ class TestGroupResultsByFilter(unittest.TestCase):
 
         self.assertEqual(grouped["pf"]["parameter"], [None, 1, "b"])
         self.assertEqual(grouped["pf"]["score"], [0.0, 1.0, 3.0])
+
+    def test_nan_parameter_does_not_disrupt_numeric_order(self):
+        rows = [
+            {"name": "pf", "parameter": 1.0, "score": "one"},
+            {"name": "pf", "parameter": float("nan"), "score": "nan"},
+            {"name": "pf", "parameter": 0.0, "score": "zero"},
+            {"name": "pf", "parameter": "b", "score": "category"},
+            {"name": "pf", "parameter": None, "score": "none"},
+        ]
+
+        grouped = group_results_by_filter(rows)["pf"]
+
+        self.assertEqual(
+            grouped["score"], ["none", "zero", "one", "nan", "category"]
+        )
+        self.assertTrue(math.isnan(grouped["parameter"][3]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- classify `NaN` parameters explicitly instead of passing them through as ordinary numeric sort keys
- keep deterministic ordering as `None`, numeric values, `NaN`, then categorical values
- add a regression covering a `NaN` placed between finite parameters

## Root cause

Python floating-point `NaN` is unordered: both `nan < x` and `x < nan` are false. The existing key returned `(1, nan)`, so a `NaN` entry could act as an equality barrier during stable sorting and leave finite values out of numeric order. For example, parameters `[1.0, NaN, 0.0]` remained in that order.

## Impact

Evaluation result tables can now be grouped in a deterministic parameter order even when one run reports a missing/`NaN` parameter. Finite configurations are no longer silently misordered around that entry.

## Validation

- reproduced the pre-fix order as `one, nan, zero`
- ran the focused regression module against the patched implementation: `2 tests passed`
- verified the branch is 2 commits ahead and 0 behind `main`, with changes limited to the grouping helper and its focused test

GitHub Actions provides the authoritative full repository and backend matrix.