### PR TITLE
Validate MEM-RBPF axis floor

### DIFF
--- a/src/pyrecest/smoothers/_mem_rbpf_ffbsi_option_contract.py
+++ b/src/pyrecest/smoothers/_mem_rbpf_ffbsi_option_contract.py
@@ -43,6 +43,44 @@ def _normalize_bool_option(value: Any, name: str) -> bool:
     raise ValueError(f"{name} must be a bool")
 
 
+def _normalize_positive_finite_real_option(value: Any, name: str) -> float:
+    """Return a finite positive real-valued scalar option."""
+
+    message = f"{name} must be a positive finite real scalar"
+    if np.ma.is_masked(value):
+        raise ValueError(message)
+    try:
+        value_array = np.asarray(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if value_array.shape != () or value_array.dtype.kind in {"M", "m"}:
+        raise ValueError(message)
+
+    scalar = value_array.item()
+    if isinstance(
+        scalar,
+        (
+            bool,
+            np.bool_,
+            str,
+            bytes,
+            bytearray,
+            complex,
+            np.complexfloating,
+            np.datetime64,
+            np.timedelta64,
+        ),
+    ):
+        raise ValueError(message)
+    try:
+        parsed = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
+    if not np.isfinite(parsed) or parsed <= 0.0:
+        raise ValueError(message)
+    return parsed
+
+
 def install_mem_rbpf_ffbsi_option_contract() -> None:
     """Install strict validation for constructor and per-call FFBSi options."""
 
@@ -69,6 +107,10 @@ def install_mem_rbpf_ffbsi_option_contract() -> None:
                 angle_wrap_terms,
                 "angle_wrap_terms",
                 minimum=0,
+            )
+            axis_floor = _normalize_positive_finite_real_option(
+                axis_floor,
+                "axis_floor",
             )
             return current_init(
                 self,

--- a/tests/smoothers/test_mem_rbpf_ffbsi_option_validation.py
+++ b/tests/smoothers/test_mem_rbpf_ffbsi_option_validation.py
@@ -49,9 +49,29 @@ def _single_particle_record() -> MEMRBPFForwardRecord:
             np.ma.array(2, mask=True),
             "angle_wrap_terms must be a non-negative integer",
         ),
+        (
+            "axis_floor",
+            np.nan,
+            "axis_floor must be a positive finite real scalar",
+        ),
+        (
+            "axis_floor",
+            np.inf,
+            "axis_floor must be a positive finite real scalar",
+        ),
+        (
+            "axis_floor",
+            True,
+            "axis_floor must be a positive finite real scalar",
+        ),
+        (
+            "axis_floor",
+            np.ma.array(1e-9, mask=True),
+            "axis_floor must be a positive finite real scalar",
+        ),
     ),
 )
-def test_constructor_rejects_lossy_or_invalid_integer_options(
+def test_constructor_rejects_lossy_or_invalid_options(
     option_name, invalid_value, message
 ):
     with pytest.raises(ValueError, match=message):
@@ -78,6 +98,7 @@ def test_exact_numpy_scalar_options_remain_supported():
         n_trajectories=np.int64(1),
         sample_axis=False,
         angle_wrap_terms=np.array(0),
+        axis_floor=np.ma.array(1e-8, mask=False),
     )
 
     result = smoother.smooth(
@@ -88,5 +109,6 @@ def test_exact_numpy_scalar_options_remain_supported():
         full_axis_lengths=np.bool_(False),
     )
 
+    assert smoother.axis_floor == 1e-8
     assert result.sample_states.shape == (2, 1, 4)
     npt.assert_allclose(result.sample_states[:, 0, -2:], [[1.0, 0.5], [1.0, 0.5]])


### PR DESCRIPTION
## What changed

- require `axis_floor` to be a positive, finite, real scalar before constructing `MEMRBPFFFBSiSmoother`
- reject masked, Boolean, temporal, complex, non-scalar, non-finite, zero, and negative values with a deterministic `ValueError`
- preserve NumPy scalar arrays and fully unmasked `MaskedArray` scalars
- extend the existing FFBSi option regression suite

## Root cause

The implementation only checked `axis_floor <= 0.0` before converting it to `float`. That comparison does not reject `NaN` or positive infinity, and converting a masked scalar can expose it as `NaN`. Boolean values were also treated as numeric configuration.

## Impact

A non-finite floor reaches both extent-output paths through `np.maximum(..., self.axis_floor)`, turning otherwise valid smoothed semi-axis estimates into all-`NaN` or all-infinite output. Invalid configuration now fails at construction instead of silently corrupting the result.

## Validation

- reproduced current behavior accepting `np.nan`, `np.inf`, `True`, and a masked scalar; `NaN`/infinite floors yielded non-finite extent output
- exercised the new normalizer against the invalid cases and a fully unmasked NumPy masked-array scalar
- syntax-compiled the modified source and regression test
- verified the branch is 2 commits ahead and 0 behind current `main`, with changes limited to the option contract and its focused test

GitHub Actions provides the authoritative full repository test matrix.