### PR TITLE
Reject masked padded history values

### DIFF
--- a/src/pyrecest/utils/history_recorder.py
+++ b/src/pyrecest/utils/history_recorder.py
@@ -29,6 +29,20 @@ class _HistoryEntry:
     pad_with_nan: bool
 
 
+def _contains_masked_value(value: Any) -> bool:
+    """Return whether *value* contains genuinely masked NumPy entries."""
+
+    if np.ma.is_masked(value):
+        return True
+    if isinstance(value, np.ndarray):
+        if value.dtype != object:
+            return False
+        return any(_contains_masked_value(item) for item in value.reshape(-1))
+    if isinstance(value, (list, tuple)):
+        return any(_contains_masked_value(item) for item in value)
+    return False
+
+
 def _validate_bool_flag(value: Any, name: str) -> bool:
     if isinstance(value, bool):
         return value
@@ -88,6 +102,8 @@ def _padded_history_input_dtype(value: Any):
 
 def _as_padded_numeric_array(curr_ests):
     message = "padded history values must be real numeric"
+    if _contains_masked_value(curr_ests):
+        raise ValueError("padded history values must not contain masked values")
     if _is_invalid_padded_history_dtype(_padded_history_input_dtype(curr_ests)):
         raise TypeError(message)
 

--- a/tests/test_history_recorder_masked_values.py
+++ b/tests/test_history_recorder_masked_values.py
@@ -1,0 +1,52 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+import pyrecest.backend as backend
+from pyrecest.utils import HistoryRecorder
+
+
+def _to_numpy(value):
+    return np.asarray(backend.to_numpy(value), dtype=float)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        np.ma.array([1.0, 999.0], mask=[False, True]),
+        [np.ma.array(1.0, mask=True)],
+        np.array([np.ma.masked], dtype=object),
+    ],
+)
+def test_padded_history_record_rejects_masked_values(value):
+    recorder = HistoryRecorder()
+
+    with pytest.raises(ValueError, match="masked"):
+        recorder.record("state", value, pad_with_nan=True)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        np.ma.array([1.0, 999.0], mask=[False, True]),
+        [np.ma.array(1.0, mask=True)],
+        np.array([np.ma.masked], dtype=object),
+    ],
+)
+def test_padded_history_registration_rejects_masked_values(value):
+    recorder = HistoryRecorder()
+
+    with pytest.raises(ValueError, match="masked"):
+        recorder.register("state", value, pad_with_nan=True)
+
+
+def test_padded_history_accepts_fully_unmasked_masked_arrays():
+    recorder = HistoryRecorder()
+
+    history = recorder.record(
+        "state",
+        np.ma.array([1.0, 2.0], mask=False),
+        pad_with_nan=True,
+    )
+
+    npt.assert_allclose(_to_numpy(history), np.array([[1.0], [2.0]]))


### PR DESCRIPTION
## Bug

`HistoryRecorder` accepted genuinely masked numeric inputs for padded histories. NumPy conversion drops the mask and exposes the hidden payload, so a value such as `np.ma.array([1.0, 999.0], mask=[False, True])` could be recorded as the ordinary estimate `[1.0, 999.0]`.

This affects both explicit padded-history registration and subsequent padded records, including nested masked scalars and object arrays containing `np.ma.masked`.

## Fix

- detect genuinely masked values recursively before backend conversion
- reject masked padded-history inputs with a clear `ValueError`
- preserve support for fully unmasked `MaskedArray` inputs
- add focused regressions for registration, recording, nested/object masked values, and unmasked compatibility

## Validation

- reproduced NumPy's mask-dropping conversion locally
- validated the recursive masked-value detection against direct, nested, object-array, ordinary, and fully unmasked inputs
- branch comparison against `main`: 2 files, 2 commits, 68 additions, 0 deletions, 0 commits behind

The full repository test matrix was not run locally because this execution environment could not obtain a source checkout; PR CI should provide integration and backend validation.