### PR TITLE
Keep wrapped-exponential outputs finite at extreme rates

### DIFF
--- a/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
+++ b/src/pyrecest/distributions/circle/wrapped_exponential_distribution.py
@@ -26,6 +26,7 @@ from pyrecest.backend import (
 from .abstract_circular_distribution import AbstractCircularDistribution
 
 _SMALL_RATE_SERIES_THRESHOLD = 1e-4
+_LARGE_RATE_ASYMPTOTIC_THRESHOLD = 100.0
 _INVALID_REAL_SCALAR_TYPES = (
     bool,
     np.bool_,
@@ -130,14 +131,20 @@ def _validate_pdf_points(value):
     return value
 
 
-def _density_scale_from_log_beta(log_beta):
-    """Return ``lambda / (1 - exp(-2*pi*lambda))`` without overflow."""
+def _density_scale_from_rate(rate):
+    """Return ``rate / (1 - exp(-2*pi*rate))`` without overflow."""
+    if bool(all(rate >= _LARGE_RATE_ASYMPTOTIC_THRESHOLD)):
+        # At this rate exp(-2*pi*rate) is below binary64 precision. Returning
+        # rate also avoids overflowing the intermediate product 2*pi*rate.
+        return rate
+
+    log_beta = 2.0 * pi * rate
     if bool(all(log_beta < _SMALL_RATE_SERIES_THRESHOLD)):
         # x / (1 - exp(-x)) = 1 + x/2 + x**2/12 - x**4/720 + O(x**6).
         return (1.0 + log_beta / 2.0 + log_beta**2 / 12.0 - log_beta**4 / 720.0) / (
             2.0 * pi
         )
-    return (log_beta / (2.0 * pi)) / (1.0 - exp(-log_beta))
+    return rate / (1.0 - exp(-log_beta))
 
 
 class WrappedExponentialDistribution(AbstractCircularDistribution):
@@ -153,8 +160,7 @@ class WrappedExponentialDistribution(AbstractCircularDistribution):
         AbstractCircularDistribution.__init__(self)
         lambda_ = backend_copy(_validate_positive_scalar(lambda_, "lambda_"))
         self.lambda_ = lambda_
-        self._log_beta = 2.0 * pi * lambda_
-        self._density_scale = _density_scale_from_log_beta(self._log_beta)
+        self._density_scale = _density_scale_from_rate(lambda_)
 
     def pdf(self, xs):
         xs = _validate_pdf_points(xs)
@@ -173,7 +179,12 @@ class WrappedExponentialDistribution(AbstractCircularDistribution):
         return mod(-log(u) / self.lambda_, 2.0 * pi)
 
     def entropy(self):
-        log_beta = self._log_beta
+        if bool(all(self.lambda_ >= _LARGE_RATE_ASYMPTOTIC_THRESHOLD)):
+            # The wrapping correction is below binary64 precision, and this path
+            # avoids the indeterminate product inf * 0 for extreme finite rates.
+            return 1.0 - log(self.lambda_)
+
+        log_beta = 2.0 * pi * self.lambda_
         if bool(all(log_beta < _SMALL_RATE_SERIES_THRESHOLD)):
             # As lambda approaches zero, the distribution approaches the uniform
             # distribution on [0, 2*pi).  The direct expression evaluates

--- a/tests/distributions/test_wrapped_exponential_extreme_rate.py
+++ b/tests/distributions/test_wrapped_exponential_extreme_rate.py
@@ -1,0 +1,35 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+import pyrecest.backend
+from pyrecest.backend import array
+from pyrecest.distributions.circle.wrapped_exponential_distribution import (
+    WrappedExponentialDistribution,
+)
+
+
+@unittest.skipUnless(
+    pyrecest.backend.__backend_name__ == "numpy",
+    "Extreme binary64 regression is specific to the NumPy backend.",
+)
+class WrappedExponentialExtremeRateTest(unittest.TestCase):
+    def test_pdf_and_entropy_remain_finite_for_extreme_rate(self):
+        lambda_ = 1.0e308
+
+        with np.errstate(over="raise", invalid="raise"):
+            distribution = WrappedExponentialDistribution(array(lambda_))
+            density_at_zero = np.asarray(
+                pyrecest.backend.to_numpy(distribution.pdf(array(0.0)))
+            )
+            entropy = np.asarray(pyrecest.backend.to_numpy(distribution.entropy()))
+
+        self.assertTrue(np.isfinite(density_at_zero).all())
+        self.assertTrue(np.isfinite(entropy).all())
+        npt.assert_allclose(density_at_zero, lambda_, rtol=5e-7)
+        npt.assert_allclose(entropy, 1.0 - np.log(lambda_), rtol=5e-7)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- use the concentrated-distribution asymptote before forming `2*pi*lambda_` for very large rates
- compute the ordinary density scale directly from `lambda_` instead of recovering it from a potentially overflowing intermediate
- return the exact large-rate entropy limit when the wrapping correction is below binary64 precision
- add a NumPy regression at `lambda_=1e308` under strict overflow/invalid floating-point handling

## Root cause

`WrappedExponentialDistribution` unconditionally formed `2*pi*lambda_`. A finite binary64 rate such as `1e308` therefore overflowed the intermediate to infinity. The density normalization became infinite, while the entropy correction evaluated the indeterminate product `inf * 0` and returned `NaN`.

## Impact

Valid highly concentrated wrapped-exponential distributions now retain finite density and entropy values. Tiny- and ordinary-rate paths are unchanged, and the existing small-rate series remains in place.

## Validation

- reproduced the pre-fix NumPy result: infinite density scale and `NaN` entropy for `lambda_=1e308`
- syntax-compiled the modified source and focused regression
- numerically checked tiny, ordinary, large, and extreme rates against the analytic limiting forms
- branch is 2 commits ahead and 0 behind `main`, with changes limited to the distribution and focused regression

GitHub Actions provides the authoritative full repository and backend matrix.