### PR TITLE
Reject masked calibration inputs

### DIFF
--- a/src/pyrecest/calibration/__init__.py
+++ b/src/pyrecest/calibration/__init__.py
@@ -34,6 +34,8 @@ def _is_rejected_real_scalar(value: Any) -> bool:
 
 
 def _as_finite_float(value: Any, name: str) -> float:
+    if np.ma.is_masked(value):
+        raise ValueError(f"{name} must be a finite scalar")
     arr = np.asarray(value)
     if arr.ndim != 0 or arr.dtype == np.bool_ or arr.dtype.kind in "USbcMm":
         raise ValueError(f"{name} must be a finite scalar")
@@ -50,6 +52,8 @@ def _as_finite_float(value: Any, name: str) -> float:
 
 
 def _as_nonnegative_time_delta(value: Any, name: str) -> float:
+    if np.ma.is_masked(value):
+        raise ValueError(f"{name} must be nonnegative")
     arr = np.asarray(value)
     if arr.ndim != 0 or arr.dtype == np.bool_ or arr.dtype.kind in "USbcMm":
         raise ValueError(f"{name} must be nonnegative")
@@ -66,6 +70,8 @@ def _as_nonnegative_time_delta(value: Any, name: str) -> float:
 
 
 def _as_real_numeric_array(value: Any, name: str) -> np.ndarray:
+    if np.ma.is_masked(value):
+        raise ValueError(f"{name} must contain real numeric values")
     arr = np.asarray(value)
     if arr.dtype == np.bool_ or arr.dtype.kind in "USbcMm":
         raise ValueError(f"{name} must contain real numeric values")
@@ -86,6 +92,8 @@ def _as_real_numeric_array(value: Any, name: str) -> np.ndarray:
 
 
 def _as_summary_scalar(value: Any, name: str, *, allow_nan: bool = False) -> float:
+    if np.ma.is_masked(value):
+        raise ValueError(f"{name} must be a real scalar")
     arr = np.asarray(value)
     if arr.ndim != 0 or arr.dtype == np.bool_ or arr.dtype.kind in "USbcMm":
         raise ValueError(f"{name} must be a real scalar")
@@ -137,9 +145,31 @@ _time_offset_module._aggregate_summary_metric = _aggregate_summary_metric
 
 from . import bias as _bias_module  # noqa: E402
 
+_base_bias_as_numeric_array = _bias_module._as_numeric_array
+_base_bias_as_nonnegative_int = _bias_module._as_nonnegative_int
+_base_bias_as_nonnegative_finite_float = _bias_module._as_nonnegative_finite_float
+
+
+def _as_bias_numeric_array(value: Any, name: str) -> np.ndarray:
+    if np.ma.is_masked(value):
+        raise ValueError(f"{name} must contain numeric values")
+    return _base_bias_as_numeric_array(value, name)
+
+
+def _as_bias_nonnegative_int(value: Any, name: str) -> int:
+    if np.ma.is_masked(value):
+        raise ValueError(f"{name} must be a nonnegative integer")
+    return _base_bias_as_nonnegative_int(value, name)
+
+
+def _as_bias_nonnegative_finite_float(value: Any, name: str) -> float:
+    if np.ma.is_masked(value):
+        raise ValueError(f"{name} must be a nonnegative finite scalar")
+    return _base_bias_as_nonnegative_finite_float(value, name)
+
 
 def _as_numeric_vector(value: Any, name: str) -> np.ndarray:
-    result = _bias_module._as_numeric_array(value, name)
+    result = _as_bias_numeric_array(value, name)
     if result.ndim == 0:
         return result.reshape(1)
     if result.ndim != 1:
@@ -147,6 +177,9 @@ def _as_numeric_vector(value: Any, name: str) -> np.ndarray:
     return result
 
 
+_bias_module._as_numeric_array = _as_bias_numeric_array
+_bias_module._as_nonnegative_int = _as_bias_nonnegative_int
+_bias_module._as_nonnegative_finite_float = _as_bias_nonnegative_finite_float
 _bias_module._as_numeric_vector = _as_numeric_vector
 
 from .bias import (  # noqa: E402

--- a/tests/calibration/test_masked_input_validation.py
+++ b/tests/calibration/test_masked_input_validation.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import numpy as np
+import pyrecest.calibration as calibration
+import pytest
+
+
+def test_calibration_scalar_helpers_reject_masked_values() -> None:
+    masked = np.ma.array(0.5, mask=True)
+
+    with pytest.raises(ValueError, match="offset_s must be a finite scalar"):
+        calibration._as_finite_float(masked, "offset_s")
+    with pytest.raises(ValueError, match="max_time_delta_s must be nonnegative"):
+        calibration._as_nonnegative_time_delta(masked, "max_time_delta_s")
+    with pytest.raises(ValueError, match="time_offset_s must be a real scalar"):
+        calibration._as_summary_scalar(masked, "time_offset_s")
+
+
+def test_apply_time_offset_rejects_partially_masked_times() -> None:
+    times = np.ma.array([0.0, 1.0], mask=[False, True])
+
+    with pytest.raises(ValueError, match="times_s must contain real numeric values"):
+        calibration.apply_time_offset(times, 0.25)
+
+
+def test_bias_training_rejects_partially_masked_measurements() -> None:
+    measurements = np.ma.array(
+        [[1.0], [2.0]],
+        mask=[[False], [True]],
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="measurement_values must contain numeric values",
+    ):
+        calibration.make_bias_training_examples(
+            measurement_times_s=[0.0, 1.0],
+            measurement_values=measurements,
+            reference_times_s=[0.0, 1.0],
+            reference_values=[[1.0], [2.0]],
+        )
+
+
+def test_bias_scalar_helpers_reject_masked_values() -> None:
+    masked = np.ma.array(1, mask=True)
+
+    with pytest.raises(ValueError, match="target_dim must be a nonnegative integer"):
+        calibration._bias_module._as_nonnegative_int(masked, "target_dim")
+    with pytest.raises(
+        ValueError,
+        match="ridge_alpha must be a nonnegative finite scalar",
+    ):
+        calibration._bias_module._as_nonnegative_finite_float(masked, "ridge_alpha")
+
+
+def test_fully_unmasked_masked_arrays_remain_supported() -> None:
+    times = np.ma.array([0.0, 1.0], mask=False)
+    offset = np.ma.array(0.25, mask=False)
+
+    np.testing.assert_allclose(
+        calibration.apply_time_offset(times, offset),
+        [0.25, 1.25],
+    )


### PR DESCRIPTION
## What changed

- Reject genuinely masked NumPy `MaskedArray` inputs in calibration scalar, timestamp, summary, and bias-validation paths before conversion.
- Apply the same guard to bias arrays, integer controls, and non-negative finite scalar controls through the calibration module's existing compatibility layer.
- Preserve support for fully unmasked `MaskedArray` inputs.
- Add regression tests covering public time-offset and bias-training APIs plus scalar validation helpers.

## Root cause

`np.asarray(masked_array)` exposes the backing data and discards the mask. Calibration inputs with hidden values could therefore silently participate in offset estimation, interpolation, or bias fitting as ordinary observations.

## Impact

Masked observations and controls now fail explicitly instead of producing results from hidden backing values. Ordinary arrays and fully unmasked masked arrays keep their previous behavior.

## Validation

- Python syntax compilation of the modified calibration module and new test module.
- Added targeted pytest regressions; repository CI should run the full backend/test matrix.