### PR TITLE
Fix PyTorch fftconvolve dtype promotion

### DIFF
--- a/src/pyrecest/_backend/pytorch/signal.py
+++ b/src/pyrecest/_backend/pytorch/signal.py
@@ -107,14 +107,16 @@ def _as_tensor_pair(in1, in2):
 
     x_is_inexact = _is_inexact_dtype(x.dtype)
     y_is_inexact = _is_inexact_dtype(y.dtype)
-    if x_is_inexact and y_is_inexact:
-        dtype = _torch.promote_types(x.dtype, y.dtype)
-    elif x_is_inexact:
-        dtype = x.dtype
-    elif y_is_inexact:
-        dtype = y.dtype
+    if not x_is_inexact or not y_is_inexact:
+        dtype = (
+            _torch.complex128
+            if x.dtype.is_complex or y.dtype.is_complex
+            else _torch.float64
+        )
     else:
-        dtype = _torch.get_default_dtype()
+        dtype = _torch.promote_types(x.dtype, y.dtype)
+        if dtype in {_torch.float16, _torch.bfloat16}:
+            dtype = _torch.float32
     return x.to(dtype=dtype), y.to(dtype=dtype)
 
 

--- a/tests/backend_support/test_pytorch_fftconvolve_dtype_promotion.py
+++ b/tests/backend_support/test_pytorch_fftconvolve_dtype_promotion.py
@@ -1,0 +1,60 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+from scipy.signal import fftconvolve as scipy_fftconvolve
+
+pytest.importorskip("torch")
+
+import pyrecest._backend.pytorch.signal as pytorch_signal  # noqa: E402
+
+
+@pytest.mark.backend_portable
+@pytest.mark.parametrize(
+    ("first", "second"),
+    [
+        (
+            np.array([1.0, 2.0], dtype=np.float32),
+            np.array([3, 4], dtype=np.int16),
+        ),
+        (
+            np.array([1.0 + 1.0j, 2.0 - 1.0j], dtype=np.complex64),
+            np.array([3, 4], dtype=np.int32),
+        ),
+        (
+            np.array([1, 2], dtype=np.int16),
+            np.array([3, 4], dtype=np.int64),
+        ),
+    ],
+    ids=["float-and-integer", "complex-and-integer", "integer-pair"],
+)
+def test_raw_pytorch_fftconvolve_matches_scipy_dtype_promotion(first, second):
+    actual = pytorch_signal.fftconvolve(first, second).cpu().numpy()
+    expected = scipy_fftconvolve(first, second)
+
+    assert actual.dtype == expected.dtype
+    npt.assert_allclose(actual, expected, rtol=1e-6, atol=1e-6)
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_fftconvolve_preserves_cancelling_integer_residual():
+    first = np.array([1.0, 1.0], dtype=np.float32)
+    second = np.array([2**24 + 1, -(2**24)], dtype=np.int64)
+
+    actual = pytorch_signal.fftconvolve(first, second).cpu().numpy()
+    expected = np.convolve(first.astype(np.float64), second.astype(np.float64))
+
+    assert actual.dtype == np.float64
+    npt.assert_allclose(actual, expected, rtol=1e-12, atol=1e-6)
+    assert actual[1] == pytest.approx(1.0, abs=1e-6)
+
+
+@pytest.mark.backend_portable
+def test_raw_pytorch_fftconvolve_promotes_half_precision_for_cpu_fft():
+    first = np.array([1.0, 2.0], dtype=np.float16)
+    second = np.array([3.0, 4.0], dtype=np.float16)
+
+    actual = pytorch_signal.fftconvolve(first, second).cpu().numpy()
+    expected = scipy_fftconvolve(first, second)
+
+    assert actual.dtype == expected.dtype == np.float32
+    npt.assert_allclose(actual, expected, rtol=1e-6, atol=1e-6)


### PR DESCRIPTION
## What changed

- promote mixed integer/inexact PyTorch `fftconvolve` inputs to SciPy-compatible `float64` or `complex128`
- promote `float16`/`bfloat16` FFT inputs to `float32`, avoiding unsupported CPU half-precision FFTs
- add focused regressions for mixed dtype output, cancellation-sensitive integer inputs, and half-precision CPU inputs

## Root cause

The PyTorch signal adapter selected the existing floating or complex dtype whenever the other input was integral, and used the PyTorch default floating dtype when both inputs were integral. This differs from SciPy's FFT convolution contract: integral participation promotes real results to `float64` and complex results to `complex128`. The lower precision can materially corrupt cancellation-sensitive convolutions.

For example, convolving `float32([1, 1])` with `int64([2**24 + 1, -2**24])` should retain the middle coefficient `1`; the previous `float32` path produced approximately `-0.667`.

## Impact

PyTorch-backend FFT convolution now preserves integer information across mixed dtypes, returns dtypes consistent with SciPy for these cases, and accepts CPU half-precision inputs by promoting them before the FFT. Existing all-inexact `float32`, `float64`, `complex64`, and `complex128` paths retain their normal promotion behavior.

## Validation

- focused regression suite: 3 tests passed
- syntax compilation passed
- 12 representative `full`/`same`/`valid`, selected-axis, real, and complex convolution cases matched SciPy within numerical tolerance
- branch is 2 commits ahead and 0 behind `main`; changes are limited to the PyTorch signal adapter and one focused test file

GitHub Actions should provide the authoritative full repository and backend matrix.