### PR TITLE
Fix overflow in extreme similarity assignments

### DIFF
--- a/src/pyrecest/utils/_roi_assignment_extreme_range.py
+++ b/src/pyrecest/utils/_roi_assignment_extreme_range.py
@@ -23,6 +23,71 @@ def _cost_conversion_is_finite(
     )
 
 
+def _stable_extreme_assignment(
+    roi_assignment_module,
+    similarities,
+    *,
+    minimum: float,
+    num_dummy,
+    unmatched_value: int,
+):
+    """Solve an unsafe finite-range assignment after positive score scaling."""
+
+    n_rows, n_cols = similarities.shape
+    if num_dummy is None:
+        num_dummy = max(n_rows, n_cols)
+    else:
+        num_dummy = roi_assignment_module._as_nonnegative_integer(
+            num_dummy,
+            "num_dummy",
+        )
+
+    finite_mask = roi_assignment_module.isfinite(similarities)
+    maximum = float(roi_assignment_module.amax(similarities[finite_mask]))
+    scale = max(1.0, abs(maximum), abs(minimum))
+    normalized_similarities = similarities / scale
+    normalized_maximum = maximum / scale
+    normalized_minimum = minimum / scale
+
+    threshold_cost = normalized_maximum - normalized_minimum
+    dummy_penalty = max(1e-12 / scale, sys.float_info.epsilon)
+    dummy_cost = threshold_cost + dummy_penalty
+    if dummy_cost <= threshold_cost:
+        dummy_cost = math.nextafter(threshold_cost, math.inf)
+
+    valid_mask = finite_mask & (similarities >= minimum)
+    cost_matrix = roi_assignment_module.full_like(
+        normalized_similarities,
+        dummy_cost,
+    )
+    cost_matrix[valid_mask] = (
+        normalized_maximum - normalized_similarities[valid_mask]
+    )
+
+    padded_size = max(n_rows, n_cols) + num_dummy
+    padded_cost = roi_assignment_module.full(
+        (padded_size, padded_size),
+        dummy_cost,
+        dtype=roi_assignment_module.float64,
+    )
+    padded_cost[:n_rows, :n_cols] = cost_matrix
+    row_ind, col_ind = roi_assignment_module.linear_sum_assignment(padded_cost)
+
+    assignment = roi_assignment_module.full(
+        (n_rows,),
+        unmatched_value,
+        dtype=roi_assignment_module.int64,
+    )
+    for row_index, col_index in zip(row_ind, col_ind):
+        if (
+            row_index < n_rows
+            and col_index < n_cols
+            and valid_mask[row_index, col_index]
+        ):
+            assignment[row_index] = int(col_index)
+    return assignment
+
+
 def patch_similarity_assignment_extreme_range(roi_assignment_module) -> None:
     """Normalize only score ranges that overflow the Hungarian cost transform."""
 
@@ -109,14 +174,12 @@ def patch_similarity_assignment_extreme_range(roi_assignment_module) -> None:
                 return_result=return_result,
             )
 
-        scale = max(1.0, abs(maximum), abs(minimum))
-        normalized_similarities = similarities / scale
-        assignment = original_assign(
-            normalized_similarities,
-            min_similarity=minimum / scale,
+        assignment = _stable_extreme_assignment(
+            roi_assignment_module,
+            similarities,
+            minimum=minimum,
             num_dummy=num_dummy,
             unmatched_value=unmatched_value,
-            return_result=False,
         )
         if return_result:
             return roi_assignment_module._assignment_to_result(

--- a/src/pyrecest/utils/_roi_assignment_extreme_range.py
+++ b/src/pyrecest/utils/_roi_assignment_extreme_range.py
@@ -1,0 +1,140 @@
+"""Runtime patch for finite-range ROI similarity assignment costs."""
+
+from __future__ import annotations
+
+import math
+import sys
+
+
+def _cost_conversion_is_finite(
+    max_similarity: float,
+    min_similarity: float,
+) -> bool:
+    """Return whether the existing score-to-cost conversion stays finite."""
+
+    threshold_cost = max_similarity - min_similarity
+    dummy_penalty = max(
+        1e-12,
+        sys.float_info.epsilon
+        * max(1.0, abs(max_similarity), abs(min_similarity)),
+    )
+    return math.isfinite(threshold_cost) and math.isfinite(
+        threshold_cost + dummy_penalty
+    )
+
+
+def patch_similarity_assignment_extreme_range(roi_assignment_module) -> None:
+    """Normalize only score ranges that overflow the Hungarian cost transform."""
+
+    storage_name = "_assign_by_similarity_matrix_without_unmatched_value_validation"
+    current = getattr(
+        roi_assignment_module,
+        storage_name,
+        roi_assignment_module.assign_by_similarity_matrix,
+    )
+    if getattr(current, "_pyrecest_finite_similarity_cost_range", False):
+        return
+
+    original_assign = current
+
+    # pylint: disable=too-many-return-statements
+    def assign_by_similarity_matrix(
+        similarity_matrix,
+        min_similarity=0.0,
+        num_dummy=None,
+        unmatched_value=-1,
+        *,
+        return_result=False,
+    ):
+        """Solve a one-to-one assignment problem by maximizing similarity."""
+
+        if roi_assignment_module.pyrecest.backend.__backend_name__ == "jax":
+            return original_assign(
+                similarity_matrix,
+                min_similarity=min_similarity,
+                num_dummy=num_dummy,
+                unmatched_value=unmatched_value,
+                return_result=return_result,
+            )
+
+        similarities = roi_assignment_module.asarray(
+            similarity_matrix,
+            dtype=roi_assignment_module.float64,
+        )
+        if similarities.ndim != 2:
+            return original_assign(
+                similarity_matrix,
+                min_similarity=min_similarity,
+                num_dummy=num_dummy,
+                unmatched_value=unmatched_value,
+                return_result=return_result,
+            )
+
+        try:
+            minimum = float(min_similarity)
+        except (TypeError, ValueError, OverflowError):
+            return original_assign(
+                similarity_matrix,
+                min_similarity=min_similarity,
+                num_dummy=num_dummy,
+                unmatched_value=unmatched_value,
+                return_result=return_result,
+            )
+        if not math.isfinite(minimum):
+            return original_assign(
+                similarity_matrix,
+                min_similarity=min_similarity,
+                num_dummy=num_dummy,
+                unmatched_value=unmatched_value,
+                return_result=return_result,
+            )
+
+        finite_mask = roi_assignment_module.isfinite(similarities)
+        if not bool(roi_assignment_module.any(finite_mask)):
+            return original_assign(
+                similarity_matrix,
+                min_similarity=min_similarity,
+                num_dummy=num_dummy,
+                unmatched_value=unmatched_value,
+                return_result=return_result,
+            )
+
+        maximum = float(roi_assignment_module.amax(similarities[finite_mask]))
+        if _cost_conversion_is_finite(maximum, minimum):
+            return original_assign(
+                similarity_matrix,
+                min_similarity=min_similarity,
+                num_dummy=num_dummy,
+                unmatched_value=unmatched_value,
+                return_result=return_result,
+            )
+
+        scale = max(1.0, abs(maximum), abs(minimum))
+        normalized_similarities = similarities / scale
+        assignment = original_assign(
+            normalized_similarities,
+            min_similarity=minimum / scale,
+            num_dummy=num_dummy,
+            unmatched_value=unmatched_value,
+            return_result=False,
+        )
+        if return_result:
+            return roi_assignment_module._assignment_to_result(
+                assignment,
+                similarities,
+                unmatched_value=unmatched_value,
+            )
+        return assignment
+
+    assign_by_similarity_matrix.__name__ = getattr(
+        original_assign,
+        "__name__",
+        "assign_by_similarity_matrix",
+    )
+    assign_by_similarity_matrix.__doc__ = getattr(original_assign, "__doc__", None)
+    assign_by_similarity_matrix._pyrecest_finite_similarity_cost_range = True
+
+    if hasattr(roi_assignment_module, storage_name):
+        setattr(roi_assignment_module, storage_name, assign_by_similarity_matrix)
+    else:
+        roi_assignment_module.assign_by_similarity_matrix = assign_by_similarity_matrix

--- a/src/pyrecest/utils/_roi_assignment_otsu.py
+++ b/src/pyrecest/utils/_roi_assignment_otsu.py
@@ -1,8 +1,10 @@
-"""Runtime patches for ROI-assignment threshold semantics."""
+"""Runtime patches for ROI-assignment numeric semantics."""
 
 from __future__ import annotations
 
 import numpy as np
+
+from ._roi_assignment_extreme_range import patch_similarity_assignment_extreme_range
 
 
 def _as_positive_nbins(roi_assignment_module, nbins) -> int:
@@ -49,8 +51,9 @@ def _patch_minimum_similarity_threshold(roi_assignment_module) -> None:
 
 
 def patch_otsu_similarity_threshold(roi_assignment_module) -> None:
-    """Patch ROI threshold helpers for strict Otsu splitting and input validation."""
+    """Patch ROI threshold helpers and finite-range assignment costs."""
 
+    patch_similarity_assignment_extreme_range(roi_assignment_module)
     original_otsu = roi_assignment_module.otsu_similarity_threshold
     if getattr(original_otsu, "_pyrecest_strict_foreground_split", False) and getattr(
         original_otsu, "_pyrecest_positive_nbins_validation", False

--- a/tests/test_roi_assignment_extreme_similarity_range.py
+++ b/tests/test_roi_assignment_extreme_similarity_range.py
@@ -1,0 +1,63 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest import backend
+from pyrecest.backend import array, float64
+from pyrecest.utils.roi_assignment import assign_by_similarity_matrix
+
+
+@unittest.skipIf(
+    backend.__backend_name__ == "jax",
+    reason="Not supported on the jax backend",
+)
+class TestExtremeSimilarityAssignment(unittest.TestCase):
+    def test_assignment_handles_full_finite_float64_range(self):
+        limit = np.finfo(np.float64).max
+        similarities = array(
+            [[limit, -limit], [-limit, limit]],
+            dtype=float64,
+        )
+
+        result = assign_by_similarity_matrix(
+            similarities,
+            min_similarity=-limit,
+            return_result=True,
+        )
+
+        npt.assert_array_equal(result.assignment, array([0, 1]))
+        npt.assert_array_equal(
+            result.matched_similarities,
+            array([limit, limit], dtype=float64),
+        )
+
+    def test_assignment_handles_dummy_cost_at_float64_limit(self):
+        limit = np.finfo(np.float64).max
+
+        result = assign_by_similarity_matrix(
+            array([[limit]], dtype=float64),
+            min_similarity=0.0,
+            return_result=True,
+        )
+
+        npt.assert_array_equal(result.assignment, array([0]))
+        npt.assert_array_equal(
+            result.matched_similarities,
+            array([limit], dtype=float64),
+        )
+
+    def test_assignment_returns_unmatched_above_extreme_score(self):
+        limit = np.finfo(np.float64).max
+
+        assignment = assign_by_similarity_matrix(
+            array([[-limit]], dtype=float64),
+            min_similarity=limit,
+        )
+
+        npt.assert_array_equal(assignment, array([-1]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- keep Hungarian cost matrices finite when valid similarity scores span the extreme finite `float64` range
- preserve the existing assignment objective and dummy-match penalty after positive score scaling
- preserve original, unscaled similarities in `SimilarityAssignmentResult`
- add regressions for opposite finite extremes, dummy-cost overflow at `float64` max, and an extreme threshold with no valid match

## Root cause
`assign_by_similarity_matrix` converts similarities to minimization costs using `max_similarity - similarity` and constructs dummy costs from `max_similarity - min_similarity`. For finite values near opposite ends of `float64`, those subtractions—or the subsequent dummy penalty addition—overflow to `inf`/`-inf`. SciPy then rejects the padded cost matrix as infeasible even though every caller-provided score and threshold is finite.

## Fix
The runtime assignment patch detects only ranges whose existing cost conversion would become non-finite. It then scales scores and the threshold by one positive finite factor, constructs the same cost problem in normalized coordinates, and scales the original dummy penalty consistently. A one-ULP fallback keeps the dummy cost strictly worse than a threshold-equal real match. Ordinary score ranges continue through the existing implementation unchanged.

## Validation
- reproduced the pre-fix failure with finite `±np.finfo(np.float64).max` scores (`ValueError: cost matrix is infeasible`)
- syntax-checked the new patch and regression test with `python -m py_compile`
- focused NumPy harness passed the extreme-range, exact-threshold, and ordinary global-assignment cases
- focused PyTorch CPU harness passed the extreme-range cases
- focused Ruff lint, docs, packaging, minimal install, MegaLinter, CodeQL, security, dependency review, documentation examples, and release-notes preview are green
- the full backend/version test matrix is running; auto-merge is enabled and will merge only after required checks pass
