### PR TITLE
Fix adaptive process-noise base scaling

### DIFF
--- a/src/pyrecest/filters/adaptive_process_noise.py
+++ b/src/pyrecest/filters/adaptive_process_noise.py
@@ -242,12 +242,7 @@ class RollingNISProcessNoiseAdapter:
     def scale(self, source_weights: Mapping[str, float] | None = None) -> float:
         """Return the adapted process-noise multiplier."""
 
-        scale = self.config.base_scale * adaptive_scale_from_ratio(
-            self.ratio(source_weights), self.config
-        )
-        return float(
-            np.clip(scale, float(self.config.min_scale), float(self.config.max_scale))
-        )
+        return adaptive_scale_from_ratio(self.ratio(source_weights), self.config)
 
     def scaled_covariance(
         self,
@@ -271,11 +266,16 @@ def adaptive_scale_from_ratio(
     config = AdaptiveProcessNoiseConfig() if config is None else config
     ratio = _normalize_nonnegative_finite_scalar(ratio, "ratio")
     if ratio > float(config.high_nis_ratio):
-        scale = 1.0 + float(config.scale_gain) * (ratio - float(config.high_nis_ratio))
+        multiplier = 1.0 + float(config.scale_gain) * (
+            ratio - float(config.high_nis_ratio)
+        )
     elif ratio < float(config.low_nis_ratio):
-        scale = 1.0 - float(config.scale_gain) * (float(config.low_nis_ratio) - ratio)
+        multiplier = 1.0 - float(config.scale_gain) * (
+            float(config.low_nis_ratio) - ratio
+        )
     else:
-        scale = 1.0
+        multiplier = 1.0
+    scale = float(config.base_scale) * multiplier
     return float(np.clip(scale, float(config.min_scale), float(config.max_scale)))
 
 

--- a/tests/filters/test_adaptive_process_noise_base_scale.py
+++ b/tests/filters/test_adaptive_process_noise_base_scale.py
@@ -1,0 +1,52 @@
+import pytest
+from pyrecest.filters.adaptive_process_noise import (
+    AdaptiveProcessNoiseConfig,
+    RollingNISProcessNoiseAdapter,
+    adaptive_scale_from_ratio,
+)
+
+
+@pytest.mark.parametrize(
+    ("base_scale", "min_scale", "max_scale"),
+    (
+        (0.5, 0.25, 0.8),
+        (2.0, 1.5, 3.0),
+    ),
+)
+def test_nominal_ratio_preserves_base_scale_when_bounds_exclude_one(
+    base_scale,
+    min_scale,
+    max_scale,
+):
+    config = AdaptiveProcessNoiseConfig(
+        base_scale=base_scale,
+        min_scale=min_scale,
+        max_scale=max_scale,
+    )
+
+    assert adaptive_scale_from_ratio(1.0, config) == pytest.approx(base_scale)
+    assert RollingNISProcessNoiseAdapter(config).scale() == pytest.approx(base_scale)
+
+
+def test_relative_adaptation_is_applied_before_absolute_bounds():
+    config = AdaptiveProcessNoiseConfig(
+        base_scale=0.5,
+        min_scale=0.25,
+        max_scale=0.8,
+        high_nis_ratio=1.5,
+        scale_gain=0.5,
+    )
+
+    assert adaptive_scale_from_ratio(2.0, config) == pytest.approx(0.625)
+
+
+def test_absolute_lower_bound_is_applied_after_relative_adaptation():
+    config = AdaptiveProcessNoiseConfig(
+        base_scale=2.0,
+        min_scale=1.5,
+        max_scale=3.0,
+        low_nis_ratio=0.6,
+        scale_gain=0.5,
+    )
+
+    assert adaptive_scale_from_ratio(0.0, config) == pytest.approx(1.5)


### PR DESCRIPTION
## Bug

`RollingNISProcessNoiseAdapter` applied `min_scale`/`max_scale` to the relative NIS adaptation factor before multiplying by `base_scale`, and then clipped the product again. When the configured absolute bounds excluded `1.0`, this changed the nominal scale and distorted non-nominal adaptation.

For example, with `base_scale=0.5`, `min_scale=0.25`, and `max_scale=0.8`, a nominal NIS ratio of `1.0` produced `0.4` instead of the documented nominal scale `0.5`.

## Fix

- compute the relative NIS multiplier first
- multiply it by `base_scale`
- apply the configured absolute scale bounds exactly once
- make `adaptive_scale_from_ratio` and `RollingNISProcessNoiseAdapter.scale` use the same final-scale semantics

## Regression coverage

- nominal scales below one with bounds excluding one
- nominal scales above one with bounds excluding one
- relative adaptation before absolute upper-bound clipping
- absolute lower-bound clipping after relative adaptation

## Validation

- branch is based on the current `main` head
- diff is limited to the adaptive process-noise implementation and a focused regression module
- mathematical cases were checked against the documented `base_scale` semantics

The full repository/backend test matrix should run in GitHub Actions.