### PR TITLE
Fix overflow in hyperspherical UKF noise weights

### DIFF
--- a/src/pyrecest/filters/hyperspherical_ukf.py
+++ b/src/pyrecest/filters/hyperspherical_ukf.py
@@ -205,7 +205,9 @@ class HypersphericalUKF(AbstractFilter, HypersphericalFilterMixin):
             raise ValueError("noise_weights must be finite.")
         if not all(noise_weights > 0):
             raise ValueError("noise_weights must be strictly positive.")
-        noise_weights = noise_weights / noise_weights.sum()
+        weight_scale = noise_weights.max()
+        scaled_noise_weights = noise_weights / weight_scale
+        noise_weights = scaled_noise_weights / scaled_noise_weights.sum()
 
         mu = reshape(asarray(self._filter_state.mu, dtype=float64), (-1,))
         C = asarray(self._filter_state.C, dtype=float64)

--- a/tests/filters/test_hyperspherical_ukf_extreme_noise_weights.py
+++ b/tests/filters/test_hyperspherical_ukf_extreme_noise_weights.py
@@ -1,0 +1,48 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+import pyrecest.backend
+from pyrecest.backend import array
+from pyrecest.filters.hyperspherical_ukf import HypersphericalUKF
+
+
+class HypersphericalUKFExtremeNoiseWeightsTest(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Arbitrary-noise prediction is not supported on this backend",
+    )
+    def test_extreme_finite_weights_match_scaled_equivalent(self):
+        reference_filter = HypersphericalUKF(dim=2, alpha=1.0)
+        extreme_filter = HypersphericalUKF(dim=2, alpha=1.0)
+        noise_samples = np.array([[0.0, 1.0]])
+
+        def direction_from_noise(_x, noise):
+            if float(np.asarray(noise, dtype=float)[0]) < 0.5:
+                return array([1.0, 0.0])
+            return array([0.0, 1.0])
+
+        reference_filter.predict_nonlinear_arbitrary_noise(
+            direction_from_noise,
+            noise_samples,
+            np.array([1.0, 1.0]),
+        )
+        extreme_filter.predict_nonlinear_arbitrary_noise(
+            direction_from_noise,
+            noise_samples,
+            np.array([1.0e308, 1.0e308]),
+        )
+
+        reference_mean = np.asarray(reference_filter.filter_state.mu, dtype=float)
+        extreme_mean = np.asarray(extreme_filter.filter_state.mu, dtype=float)
+        reference_covariance = np.asarray(reference_filter.filter_state.C, dtype=float)
+        extreme_covariance = np.asarray(extreme_filter.filter_state.C, dtype=float)
+
+        self.assertTrue(np.all(np.isfinite(extreme_mean)))
+        self.assertTrue(np.all(np.isfinite(extreme_covariance)))
+        npt.assert_allclose(extreme_mean, reference_mean, atol=1.0e-12)
+        npt.assert_allclose(extreme_covariance, reference_covariance, atol=1.0e-12)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- normalize arbitrary-noise weights after scaling by their maximum
- preserve relative weights while avoiding overflow in the normalization sum
- add a regression showing `[1e308, 1e308]` behaves like the equivalent `[1, 1]`

## Bug
`HypersphericalUKF.predict_nonlinear_arbitrary_noise` validated each weight as finite, but then summed the unscaled weights. Large finite values could therefore overflow to infinity; division by that sum produced all-zero weights and subsequently non-finite predicted moments.

## Validation
- reviewed the branch diff against current `main`
- verified the old normalization maps `[1e308, 1e308]` to `[0, 0]`, while the scaled normalization returns `[0.5, 0.5]`
- added a focused unit regression for mean and covariance equivalence

CI will provide the full repository/backend validation.