### PR TITLE
Preserve score ordering in extreme similarity assignments

### DIFF
--- a/src/pyrecest/utils/_roi_assignment_extreme_range.py
+++ b/src/pyrecest/utils/_roi_assignment_extreme_range.py
@@ -31,7 +31,7 @@ def _stable_extreme_assignment(
     num_dummy,
     unmatched_value: int,
 ):
-    """Solve an unsafe finite-range assignment after positive score scaling."""
+    """Solve an unsafe finite-range assignment without collapsing score ordering."""
 
     n_rows, n_cols = similarities.shape
     if num_dummy is None:
@@ -43,35 +43,55 @@ def _stable_extreme_assignment(
         )
 
     finite_mask = roi_assignment_module.isfinite(similarities)
-    maximum = float(roi_assignment_module.amax(similarities[finite_mask]))
-    scale = max(1.0, abs(maximum), abs(minimum))
-    normalized_similarities = similarities / scale
-    normalized_maximum = maximum / scale
-    normalized_minimum = minimum / scale
-
-    threshold_cost = normalized_maximum - normalized_minimum
-    dummy_penalty = max(1e-12 / scale, sys.float_info.epsilon)
-    dummy_cost = threshold_cost + dummy_penalty
-    if dummy_cost <= threshold_cost:
-        dummy_cost = math.nextafter(threshold_cost, math.inf)
-
     valid_mask = finite_mask & (similarities >= minimum)
-    cost_matrix = roi_assignment_module.full_like(
-        normalized_similarities,
-        dummy_cost,
-    )
-    cost_matrix[valid_mask] = (
-        normalized_maximum - normalized_similarities[valid_mask]
-    )
-
+    maximum = float(roi_assignment_module.amax(similarities[finite_mask]))
     padded_size = max(n_rows, n_cols) + num_dummy
-    padded_cost = roi_assignment_module.full(
-        (padded_size, padded_size),
-        dummy_cost,
-        dtype=roi_assignment_module.float64,
-    )
-    padded_cost[:n_rows, :n_cols] = cost_matrix
-    row_ind, col_ind = roi_assignment_module.linear_sum_assignment(padded_cost)
+
+    dummy_similarity = math.nextafter(minimum, -math.inf)
+    if math.isfinite(dummy_similarity):
+        score_matrix = roi_assignment_module.full_like(
+            similarities,
+            dummy_similarity,
+        )
+        score_matrix[valid_mask] = similarities[valid_mask]
+        padded_matrix = roi_assignment_module.full(
+            (padded_size, padded_size),
+            dummy_similarity,
+            dtype=roi_assignment_module.float64,
+        )
+        padded_matrix[:n_rows, :n_cols] = score_matrix
+        row_ind, col_ind = roi_assignment_module.linear_sum_assignment(
+            padded_matrix,
+            maximize=True,
+        )
+    else:
+        # The smallest finite float has no finite predecessor for dummy matches.
+        # Retain the normalized cost fallback for that boundary-only case.
+        scale = max(1.0, abs(maximum), abs(minimum))
+        normalized_similarities = similarities / scale
+        normalized_maximum = maximum / scale
+        normalized_minimum = minimum / scale
+
+        threshold_cost = normalized_maximum - normalized_minimum
+        dummy_penalty = max(1e-12 / scale, sys.float_info.epsilon)
+        dummy_cost = threshold_cost + dummy_penalty
+        if dummy_cost <= threshold_cost:
+            dummy_cost = math.nextafter(threshold_cost, math.inf)
+
+        cost_matrix = roi_assignment_module.full_like(
+            normalized_similarities,
+            dummy_cost,
+        )
+        cost_matrix[valid_mask] = (
+            normalized_maximum - normalized_similarities[valid_mask]
+        )
+        padded_matrix = roi_assignment_module.full(
+            (padded_size, padded_size),
+            dummy_cost,
+            dtype=roi_assignment_module.float64,
+        )
+        padded_matrix[:n_rows, :n_cols] = cost_matrix
+        row_ind, col_ind = roi_assignment_module.linear_sum_assignment(padded_matrix)
 
     assignment = roi_assignment_module.full(
         (n_rows,),

--- a/tests/test_roi_assignment_extreme_similarity_range.py
+++ b/tests/test_roi_assignment_extreme_similarity_range.py
@@ -33,6 +33,25 @@ class TestExtremeSimilarityAssignment(unittest.TestCase):
             array([limit, limit], dtype=float64),
         )
 
+    def test_assignment_preserves_small_scores_beside_extreme_values(self):
+        limit = np.finfo(np.float64).max
+        minimum = -1.0e300
+        similarities = array(
+            [
+                [limit, minimum, minimum],
+                [minimum, 0.0, 3.0e-100],
+                [minimum, 2.0e-100, 0.0],
+            ],
+            dtype=float64,
+        )
+
+        assignment = assign_by_similarity_matrix(
+            similarities,
+            min_similarity=minimum,
+        )
+
+        npt.assert_array_equal(assignment, array([0, 2, 1]))
+
     def test_assignment_handles_dummy_cost_at_float64_limit(self):
         limit = np.finfo(np.float64).max
 


### PR DESCRIPTION
## What changed

- solve overflow-prone similarity assignments directly in score space with SciPy's maximization mode whenever a finite dummy score below the acceptance threshold is representable
- reserve the previous normalized-cost path for the boundary case where `min_similarity` is already the smallest finite `float64`
- add a regression combining a `float64`-maximum score with much smaller, assignment-relevant scores

## Root cause

The extreme-range fallback divided every similarity by the largest magnitude before converting scores to Hungarian costs. This prevents overflow, but it can underflow much smaller finite scores to identical zeros. Those artificial ties can change the optimal one-to-one assignment.

For example, an unrelated `float64`-maximum match caused scores of `2e-100` and `3e-100` in another block to collapse to zero, changing the assignment from `[0, 2, 1]` to `[0, 1, 2]`.

## Fix

When possible, the fallback now pads the original similarity matrix with `nextafter(min_similarity, -inf)` and calls `linear_sum_assignment(..., maximize=True)`. This avoids both the overflowing `max_similarity - min_similarity` conversion and the lossy global scaling. The normalized-cost implementation remains as a narrow fallback when no finite score below the minimum threshold exists.

## Validation

- reproduced the pre-fix underflow and incorrect assignment with NumPy/SciPy
- verified the patched result preserves the expected `[0, 2, 1]` assignment
- verified the three existing full-range, maximum-dummy-cost, and unmatched-above-threshold cases
- syntax-compiled the modified source and regression test
- branch is 2 commits ahead and 0 behind `main`; only the extreme-range helper and its focused test changed

GitHub Actions should provide the authoritative full repository and backend matrix.