### PR TITLE
Reject masked boolean flags in HistoryRecorder

### DIFF
--- a/src/pyrecest/utils/history_recorder.py
+++ b/src/pyrecest/utils/history_recorder.py
@@ -44,6 +44,8 @@ def _contains_masked_value(value: Any) -> bool:
 
 
 def _validate_bool_flag(value: Any, name: str) -> bool:
+    if _contains_masked_value(value):
+        raise TypeError(f"{name} must be a boolean")
     if isinstance(value, bool):
         return value
     try:

--- a/tests/test_history_recorder_masked_flags.py
+++ b/tests/test_history_recorder_masked_flags.py
@@ -1,0 +1,46 @@
+import numpy as np
+import pytest
+
+from pyrecest.utils import HistoryRecorder
+
+
+@pytest.mark.parametrize(
+    "masked_flag",
+    [
+        np.ma.array(True, mask=True),
+        np.ma.array(False, mask=True),
+    ],
+)
+def test_register_rejects_masked_pad_with_nan(masked_flag):
+    recorder = HistoryRecorder()
+
+    with pytest.raises(TypeError, match="pad_with_nan must be a boolean"):
+        recorder.register("state", pad_with_nan=masked_flag)
+
+
+@pytest.mark.parametrize(
+    "masked_flag",
+    [
+        np.ma.array(True, mask=True),
+        np.ma.array(False, mask=True),
+    ],
+)
+def test_record_rejects_masked_pad_with_nan(masked_flag):
+    recorder = HistoryRecorder()
+
+    with pytest.raises(TypeError, match="pad_with_nan must be a boolean"):
+        recorder.record("state", 1.0, pad_with_nan=masked_flag)
+
+
+@pytest.mark.parametrize(
+    "masked_flag",
+    [
+        np.ma.array(True, mask=True),
+        np.ma.array(False, mask=True),
+    ],
+)
+def test_record_rejects_masked_copy_value(masked_flag):
+    recorder = HistoryRecorder()
+
+    with pytest.raises(TypeError, match="copy_value must be a boolean"):
+        recorder.record("state", 1.0, copy_value=masked_flag)


### PR DESCRIPTION
## What changed

- reject genuinely masked NumPy values before converting `HistoryRecorder` boolean controls through the active backend
- cover `register(..., pad_with_nan=...)`, `record(..., pad_with_nan=...)`, and `record(..., copy_value=...)`
- add regressions for masked `True` and masked `False` payloads

## Root cause

Backend array conversion discards a NumPy masked scalar's mask and exposes its hidden boolean payload. As a result, a missing control value such as `np.ma.array(True, mask=True)` was silently treated as `True`.

## Impact

History configuration can no longer change based on data that is explicitly marked missing. Ordinary Python and NumPy boolean scalars remain accepted.

## Validation

- inspected the branch diff against `main` (2-line implementation change plus 6 parameterized regression cases)
- local execution was unavailable because this environment has neither GitHub CLI nor outbound repository access; GitHub Actions should run the repository test matrix on this PR