### PR TITLE
Stabilize multisensor HDP sensor priors in log space

### DIFF
--- a/src/pyrecest/filters/multisensor_hdp_association.py
+++ b/src/pyrecest/filters/multisensor_hdp_association.py
@@ -336,12 +336,20 @@ def multisensor_hdp_association(
             f"clutter_weights[{sensor_id!r}]",
         )
 
-        target_prior_masses = (counts + concentration * base_target_weights) * detection
-        target_log_priors = _safe_log(target_prior_masses)
+        log_concentration = np.log(concentration)
+        target_log_priors = (
+            np.logaddexp(
+                _safe_log(counts),
+                log_concentration + _safe_log(base_target_weights),
+            )
+            + _safe_log(detection)
+        )
         existing_log_weights = log_likelihoods + target_log_priors[None, :]
 
-        birth_log_weights = birth_log_likelihood + _safe_log(
-            concentration * base_birth_weight
+        birth_log_weights = (
+            birth_log_likelihood
+            + log_concentration
+            + _safe_log(base_birth_weight)
         )
         clutter_log_weights = clutter_log_likelihood + _safe_log(clutter_weight)
         log_weights = np.concatenate(

--- a/tests/filters/test_multisensor_hdp_sensor_prior_log_domain.py
+++ b/tests/filters/test_multisensor_hdp_sensor_prior_log_domain.py
@@ -1,0 +1,53 @@
+import unittest
+
+import numpy as np
+from pyrecest.filters.multisensor_hdp_association import multisensor_hdp_association
+
+
+class MultisensorHDPSensorPriorLogDomainTest(unittest.TestCase):
+    def test_large_finite_counts_and_concentration_preserve_prior_ratio(self):
+        largest = np.finfo(float).max
+
+        with np.errstate(over="raise", invalid="raise"):
+            result = multisensor_hdp_association(
+                {"radar": np.zeros((1, 2))},
+                global_target_weights=np.ones(2),
+                global_birth_weight=0.0,
+                sensor_target_counts={"radar": np.array([largest, 0.0])},
+                sensor_concentrations={"radar": largest},
+                clutter_weights=0.0,
+            )["radar"]
+
+        np.testing.assert_allclose(
+            result.probabilities,
+            np.array([[0.75, 0.25, 0.0, 0.0]]),
+            rtol=0.0,
+            atol=1e-15,
+        )
+        self.assertTrue(np.all(np.isfinite(result.log_weights[0, :2])))
+
+    def test_tiny_concentration_and_base_mass_do_not_erase_target(self):
+        small = 1e-200
+        target_log_likelihood = -np.log(small)
+
+        with np.errstate(under="raise", invalid="raise"):
+            result = multisensor_hdp_association(
+                {"radar": np.array([[target_log_likelihood]])},
+                global_target_weights=np.array([small]),
+                global_birth_weight=1.0,
+                sensor_target_counts=0.0,
+                sensor_concentrations=small,
+                clutter_weights=0.0,
+            )["radar"]
+
+        np.testing.assert_allclose(
+            result.probabilities,
+            np.array([[0.5, 0.5, 0.0]]),
+            rtol=0.0,
+            atol=1e-15,
+        )
+        self.assertTrue(np.isfinite(result.log_weights[0, 0]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/filters/test_multisensor_hdp_sensor_prior_log_domain.py
+++ b/tests/filters/test_multisensor_hdp_sensor_prior_log_domain.py
@@ -22,7 +22,7 @@ class MultisensorHDPSensorPriorLogDomainTest(unittest.TestCase):
             result.probabilities,
             np.array([[0.75, 0.25, 0.0, 0.0]]),
             rtol=0.0,
-            atol=1e-15,
+            atol=64 * np.finfo(float).eps,
         )
         self.assertTrue(np.all(np.isfinite(result.log_weights[0, :2])))
 


### PR DESCRIPTION
## Summary
- compute HDP sensor-local target priors directly in log space
- avoid overflow in `counts + concentration * base_weight`
- avoid underflow in concentration/base-weight products that previously erased valid hypotheses
- add focused end-to-end regressions for both numeric extremes

## Root cause
`multisensor_hdp_association()` formed target prior masses in linear space before taking logarithms:

```python
(counts + concentration * base_target_weights) * detection
```

All inputs can be individually finite and valid while the addition overflows. Conversely, a small concentration multiplied by a small base mass can underflow to zero. In both cases the mathematically well-defined posterior is lost before the stable softmax is reached.

## Fix
Use `np.logaddexp()` for the reinforcement-plus-HDP-base term and add detection, concentration, and birth factors in log space. Ordinary-scale results remain algebraically unchanged while extreme finite inputs remain representable.

## Validation
- reproduced the old overflow with maximum finite counts and concentration
- verified the fixed target posterior preserves the expected `3:1` ratio (`0.75`, `0.25`)
- reproduced underflow for a `1e-200 * 1e-200` target prior
- verified compensating likelihood evidence preserves equal target/birth posterior probability (`0.5`, `0.5`)
- branch is two commits ahead of current `main` and zero behind