### PR TITLE
Fix DVS normal-flow overflow for extreme velocities

### DIFF
--- a/src/pyrecest/experimental/dvs/vectorized_flow.py
+++ b/src/pyrecest/experimental/dvs/vectorized_flow.py
@@ -34,21 +34,23 @@ def tracker_signed_normal_flows_vectorized(
     velocity = np.asarray(event_velocity, dtype=float).reshape(2)
     if not np.isfinite(velocity).all():
         raise ValueError("event_velocity must contain finite values")
-    velocity_norm = float(np.linalg.norm(velocity))
+    velocity_norm = float(np.hypot(velocity[0], velocity[1]))
     if velocity_norm <= 1e-12:
         return np.zeros(measurements.shape[0], dtype=float)
+    unit_velocity = velocity / velocity_norm
 
     try:
         return _tracker_signed_normal_flows_vectorized_impl(
             tracker,
             measurements,
-            velocity,
-            velocity_norm,
+            unit_velocity,
         )
     except Exception:  # pragma: no cover - backend-specific safety fallback
         return np.asarray(
             [
-                tracker.signed_normal_flow_for_measurement(measurement, velocity)
+                tracker.signed_normal_flow_for_measurement(
+                    measurement, unit_velocity
+                )
                 for measurement in measurements
             ],
             dtype=float,
@@ -58,8 +60,7 @@ def tracker_signed_normal_flows_vectorized(
 def _tracker_signed_normal_flows_vectorized_impl(
     tracker: DVSFullSCGPTracker,
     measurements: np.ndarray,
-    velocity: np.ndarray,
-    velocity_norm: float,
+    unit_velocity: np.ndarray,
 ) -> np.ndarray:
     position = np.asarray(tracker.kinematic_state[:2], dtype=float)
     orientation = float(tracker.kinematic_state[2])
@@ -97,4 +98,4 @@ def _tracker_signed_normal_flows_vectorized_impl(
         out=np.array(unit, dtype=float, copy=True),
         where=normal_norm[:, None] > 1e-12,
     )
-    return (normals @ velocity) / velocity_norm
+    return normals @ unit_velocity

--- a/tests/experimental/test_dvs_vectorized_flow.py
+++ b/tests/experimental/test_dvs_vectorized_flow.py
@@ -34,3 +34,33 @@ def test_vectorized_flow_matches_scalar_tracker(velocity):
         dtype=float,
     )
     assert np.allclose(vectorized, scalar, atol=1e-8)
+
+
+@pytest.mark.skipif(
+    pyrecest.backend.__backend_name__ != "numpy",
+    reason="DVS vectorized-flow tests currently use numpy.testing assertions",
+)
+def test_vectorized_flow_preserves_extreme_finite_velocity_direction():
+    tracker = DVSFullSCGPTracker(
+        16,
+        kinematic_state=np.asarray([50.0, 50.0, 0.1]),
+        kinematic_covariance=np.eye(3),
+        shape_state=np.full(16, 10.0),
+        shape_covariance=np.eye(16),
+        velocities=False,
+        measurement_noise=np.eye(2),
+    )
+    measurements = np.asarray(
+        [[60.0, 50.0], [40.0, 50.0], [50.0, 56.0], [50.0, 44.0]],
+        dtype=float,
+    )
+
+    reference = tracker_signed_normal_flows_vectorized(
+        tracker, measurements, [1.0, 1.0]
+    )
+    extreme = tracker_signed_normal_flows_vectorized(
+        tracker, measurements, [1e308, 1e308]
+    )
+
+    assert np.isfinite(extreme).all()
+    np.testing.assert_allclose(extreme, reference, atol=1e-8)


### PR DESCRIPTION
## Summary
- normalize 2-D event velocities with `np.hypot`, which remains finite for maximum-scale finite components
- pass the resulting unit direction through both the vectorized implementation and its scalar fallback
- add a regression showing that `[1e308, 1e308]` produces the same finite, scale-invariant flow scores as `[1.0, 1.0]`

## Root cause
`tracker_signed_normal_flows_vectorized()` used `np.linalg.norm(velocity)`. For finite velocity components near the floating-point maximum, the internal sum of squares overflows to `inf`. Dividing finite normal projections by that overflowed norm collapses valid signed normal-flow values to zero, even though normal flow depends only on velocity direction.

## Impact
Large but finite velocity inputs no longer silently erase DVS event activity. The fallback path is protected as well because it receives the normalized velocity rather than the original extreme-magnitude vector.

## Validation
- reproduced the old behavior locally: `np.linalg.norm([1e308, 1e308]) == inf`, yielding zero normalized projections
- verified `np.hypot(1e308, 1e308)` remains finite and produces the expected unit direction
- added a focused PyRecEst regression for finite output and scale invariance
- branch is two commits ahead of current `main` and zero behind