### PR TITLE
Reject masked evidence-support flags

### DIFF
--- a/src/pyrecest/diagnostics.py
+++ b/src/pyrecest/diagnostics.py
@@ -28,6 +28,8 @@ _WEIGHT_TEXT_OR_BOOL_TYPES = (bool, np.bool_, str, bytes, bytearray)
 
 def _coerce_metadata_bool(value: Any, name: str) -> bool:
     """Return a boolean metadata value without string truthiness surprises."""
+    if np.ma.is_masked(value):
+        raise ValueError(f"{name} must be a boolean value")
     if isinstance(value, bool):
         return value
     if isinstance(value, int) and value in (0, 1):

--- a/tests/test_evidence_support_masked_flags.py
+++ b/tests/test_evidence_support_masked_flags.py
@@ -1,0 +1,21 @@
+import numpy as np
+import pytest
+
+from pyrecest.diagnostics import EvidenceSupport
+
+
+@pytest.mark.parametrize("field", ["comparable", "lower_bound"])
+@pytest.mark.parametrize("payload", [True, False])
+def test_evidence_support_rejects_masked_boolean_flags(field, payload):
+    with pytest.raises(ValueError, match=rf"{field} must be a boolean value"):
+        EvidenceSupport(**{field: np.ma.array(payload, mask=True)})
+
+
+def test_evidence_support_accepts_fully_unmasked_boolean_scalars():
+    support = EvidenceSupport(
+        comparable=np.ma.array(True, mask=False),
+        lower_bound=np.ma.array(False, mask=False),
+    )
+
+    assert support.comparable is True
+    assert support.lower_bound is False


### PR DESCRIPTION
## Summary
- reject genuinely masked NumPy values for `EvidenceSupport.comparable` and `EvidenceSupport.lower_bound`
- preserve support for fully unmasked NumPy Boolean scalars
- add focused regressions for both fields and both hidden Boolean payloads

## Root cause
`_coerce_metadata_bool()` called `.item()` before checking masked-array semantics. For a value such as `np.ma.array(True, mask=True)`, `.item()` exposes the hidden payload, so unavailable metadata was silently interpreted as `True` or `False`.

## Impact
Evidence comparability and lower-bound metadata can no longer be determined by explicitly masked data. Invalid configuration now fails at construction with the existing Boolean-value error.

## Validation
- reproduced the pre-fix behavior for four field/payload combinations
- focused regression suite: `5 passed`
- Python syntax compilation passed for the modified source and new test
- branch comparison against `main`: 2 commits ahead, 0 behind; only the diagnostics guard and focused test file changed