### PR TITLE
Reject masked NumPy random sampling parameters

### DIFF
--- a/src/pyrecest/_backend/numpy/random.py
+++ b/src/pyrecest/_backend/numpy/random.py
@@ -9,6 +9,7 @@ from numpy.random import (  # For PyRecEst
 )
 
 from .._shared_numpy.random import (
+    _contains_masked_value,
     _normalize_probability_values,
     _normalize_size,
     choice,
@@ -32,7 +33,7 @@ def _contains_boolean_value(value):
 
 
 def _validate_randint_bound(bound, name):
-    if _contains_boolean_value(bound):
+    if _contains_masked_value(bound) or _contains_boolean_value(bound):
         raise TypeError(f"{name} must contain integer values")
     try:
         bound_array = _np.asarray(bound)
@@ -67,7 +68,7 @@ def randint(low, high=None, size=None, dtype=int):
 
 
 def _validate_multinomial_sample_count(n):
-    if _contains_boolean_value(n):
+    if _contains_masked_value(n) or _contains_boolean_value(n):
         raise TypeError("n must be a non-negative integer")
     try:
         n_array = _np.asarray(n)
@@ -82,7 +83,7 @@ def _validate_multinomial_sample_count(n):
 
 
 def _validate_multinomial_pvals(pvals):
-    if _contains_boolean_value(pvals):
+    if _contains_masked_value(pvals) or _contains_boolean_value(pvals):
         raise TypeError("pvals must be real numeric, not boolean")
     try:
         pvals_array = _np.asarray(pvals)

--- a/tests/backend/test_numpy_random_masked_parameters.py
+++ b/tests/backend/test_numpy_random_masked_parameters.py
@@ -1,0 +1,61 @@
+import numpy as np
+import pytest
+
+from pyrecest._backend.numpy import random
+
+
+@pytest.mark.parametrize(
+    ("sampler", "message"),
+    (
+        (
+            lambda: random.randint(np.ma.array(5, mask=True)),
+            "high must contain integer values",
+        ),
+        (
+            lambda: random.randint(np.ma.array(1, mask=True), 5),
+            "low must contain integer values",
+        ),
+        (
+            lambda: random.randint(0, np.ma.array(5, mask=True)),
+            "high must contain integer values",
+        ),
+        (
+            lambda: random.multinomial(
+                np.ma.array(2, mask=True),
+                [0.25, 0.75],
+            ),
+            "n must be a non-negative integer",
+        ),
+        (
+            lambda: random.multinomial(
+                2,
+                np.ma.array([0.25, 0.75], mask=[False, True]),
+            ),
+            "pvals must be real numeric",
+        ),
+        (
+            lambda: random.multinomial(2, [0.25, np.ma.masked]),
+            "pvals must be real numeric",
+        ),
+    ),
+)
+def test_numpy_random_rejects_masked_sampling_parameters(sampler, message):
+    with pytest.raises(TypeError, match=message):
+        sampler()
+
+
+def test_numpy_random_accepts_fully_unmasked_masked_parameters():
+    samples = random.randint(
+        np.ma.array(1, mask=False),
+        np.ma.array(4, mask=False),
+        size=8,
+    )
+    counts = random.multinomial(
+        np.ma.array(3, mask=False),
+        np.ma.array([0.25, 0.75], mask=False),
+    )
+
+    assert samples.shape == (8,)
+    assert np.all((samples >= 1) & (samples < 4))
+    assert counts.shape == (2,)
+    assert counts.sum() == 3


### PR DESCRIPTION
## What changed

- reject genuinely masked NumPy values in `randint` bounds
- reject masked multinomial sample counts and probability vectors
- preserve support for fully unmasked `MaskedArray` inputs
- add focused regression coverage for low/high bounds, sample counts, direct masked probability arrays, and nested masked values

## Root cause

`numpy.asarray(masked_array)` discards the mask and exposes the backing data. The NumPy random backend validated bounds, counts, and probabilities only after that conversion, so unavailable values could silently control sampling.

For example, a masked `randint` lower bound was treated as its hidden integer payload, and a masked multinomial probability entry participated in normalization as an ordinary probability.

## Impact

Missing random-sampling parameters now fail explicitly at the backend boundary instead of producing draws from hidden data. Ordinary scalars, arrays, and fully unmasked `MaskedArray` inputs retain their previous behavior.

## Validation

- reproduced NumPy's mask-dropping conversion for integer bounds, sample counts, and probability vectors
- syntax-compiled the modified source and regression test
- ran the focused reconstructed regression module: `7 passed`
- branch is two commits ahead of current `main` and zero behind

GitHub Actions should provide the authoritative full repository and backend matrix.