### PR TITLE
Reject masked manifold EMA weights

### DIFF
--- a/src/pyrecest/filters/manifold_exponential_moving_average.py
+++ b/src/pyrecest/filters/manifold_exponential_moving_average.py
@@ -53,6 +53,8 @@ class ManifoldExponentialMovingAverage(AbstractFilter):
     @staticmethod
     def _validate_alpha(alpha: float) -> float:
         message = "alpha must be a real scalar between 0 and 1"
+        if np.ma.is_masked(alpha):
+            raise TypeError(message)
         try:
             alpha_array = np.asarray(alpha)
         except (TypeError, ValueError) as exc:

--- a/tests/filters/test_manifold_exponential_moving_average.py
+++ b/tests/filters/test_manifold_exponential_moving_average.py
@@ -103,6 +103,35 @@ class TestManifoldExponentialMovingAverage(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, "real scalar"):
             ema.alpha = True
 
+    def test_alpha_rejects_masked_values_without_changing_current_weight(self):
+        masked_values = (
+            np.ma.masked,
+            np.ma.array(0.25, mask=True),
+        )
+        for alpha in masked_values:
+            with self.subTest(alpha=alpha):
+                with self.assertRaisesRegex(TypeError, "real scalar"):
+                    ManifoldExponentialMovingAverage(
+                        initial_state=0.0,
+                        alpha=alpha,
+                        phi=_phi_so2,
+                        phi_inv=_phi_inv_so2,
+                    )
+
+        ema = ManifoldExponentialMovingAverage(
+            initial_state=0.0,
+            alpha=np.ma.array(0.5, mask=False),
+            phi=_phi_so2,
+            phi_inv=_phi_inv_so2,
+        )
+        self.assertEqual(ema.alpha, 0.5)
+
+        for alpha in masked_values:
+            with self.subTest(alpha=alpha):
+                with self.assertRaisesRegex(TypeError, "real scalar"):
+                    ema.alpha = alpha
+                self.assertEqual(ema.alpha, 0.5)
+
     def test_alpha_rejects_text_values(self):
         for alpha in ("0.5", b"0.5", np.array("0.5")):
             with self.subTest(alpha=alpha):


### PR DESCRIPTION
## What changed

- reject genuinely masked `alpha` values before NumPy conversion can expose their hidden payload
- preserve support for fully unmasked scalar `MaskedArray` weights
- add constructor and setter regression coverage, including preservation of the previous weight after a rejected assignment

## Root cause

`np.asarray(...)` drops `MaskedArray` mask metadata. Consequently, `np.ma.masked` was interpreted as `0.0`, while a masked scalar such as `np.ma.array(0.25, mask=True)` was interpreted as its hidden value `0.25`. Both values silently changed the exponential moving average despite being explicitly unavailable data.

## Impact

A missing or invalid smoothing weight could freeze the filter or apply an unintended update rate without raising an error.

## Validation

- focused regression tests added in `tests/filters/test_manifold_exponential_moving_average.py`
- source and test files are syntactically valid
- GitHub CI should run the repository's supported backend/test matrix on this PR