### PR TITLE
Reject invalid model margin threshold scalars

### DIFF
--- a/src/pyrecest/evaluation/__init__.py
+++ b/src/pyrecest/evaluation/__init__.py
@@ -181,9 +181,39 @@ def _classify_evidence_margin(delta_log_evidence: float) -> str:
 
 
 def _validated_margin_threshold(margin_threshold):
-    threshold = float(margin_threshold)
+    message = "margin_threshold must be finite and non-negative"
+    if _np.ma.is_masked(margin_threshold):
+        raise ValueError(message)
+    try:
+        threshold_array = _np.asarray(margin_threshold)
+    except (TypeError, ValueError, OverflowError, RuntimeError) as exc:
+        raise ValueError(message) from exc
+    if threshold_array.shape != () or threshold_array.dtype.kind in "bMmSUc":
+        raise ValueError(message)
+    scalar = threshold_array.item()
+    if isinstance(
+        scalar,
+        (
+            bool,
+            _np.bool_,
+            str,
+            bytes,
+            bytearray,
+            _np.str_,
+            _np.bytes_,
+            complex,
+            _np.complexfloating,
+            _np.datetime64,
+            _np.timedelta64,
+        ),
+    ):
+        raise ValueError(message)
+    try:
+        threshold = float(scalar)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(message) from exc
     if threshold < 0.0 or not _isfinite(threshold):
-        raise ValueError("margin_threshold must be finite and non-negative")
+        raise ValueError(message)
     return threshold
 
 

--- a/tests/test_model_comparison_margin_threshold_validation.py
+++ b/tests/test_model_comparison_margin_threshold_validation.py
@@ -1,0 +1,45 @@
+import numpy as np
+import pandas as pd
+import pytest
+from pyrecest.evaluation import paired_model_margin_decisions
+
+
+@pytest.mark.parametrize(
+    "bad_threshold",
+    [
+        True,
+        np.bool_(False),
+        "1.0",
+        b"1.0",
+        1.0 + 0.0j,
+        np.datetime64("2026-01-01"),
+        np.timedelta64(1, "D"),
+        np.asarray([1.0]),
+        np.ma.masked,
+        np.ma.array(1.0, mask=True),
+    ],
+)
+def test_paired_model_margin_decisions_rejects_invalid_threshold_scalars(
+    bad_threshold,
+):
+    with pytest.raises(
+        ValueError,
+        match="margin_threshold must be finite and non-negative",
+    ):
+        paired_model_margin_decisions(
+            pd.DataFrame(),
+            positive_model="positive",
+            reference_model="reference",
+            margin_threshold=bad_threshold,
+        )
+
+
+def test_paired_model_margin_decisions_accepts_unmasked_scalar_threshold():
+    decisions = paired_model_margin_decisions(
+        pd.DataFrame(),
+        positive_model="positive",
+        reference_model="reference",
+        margin_threshold=np.ma.array(1.5, mask=False),
+    )
+
+    assert decisions.empty


### PR DESCRIPTION
## What changed

- validate `margin_threshold` as a genuine scalar real number before float conversion
- reject Boolean, masked, textual, complex, temporal, and non-scalar array inputs
- preserve ordinary numeric scalars, zero-dimensional arrays, and fully unmasked `MaskedArray` scalars
- add focused regression coverage for the rejected and preserved cases

## Root cause

`float(margin_threshold)` was called directly. Python therefore interpreted `True` as `1.0` and `False` as `0.0`, while NumPy currently scalarizes one-element arrays with a deprecation warning. Those invalid configuration values could silently change the evidence-margin decision rule instead of failing at the public validation boundary.

## Impact

Model-comparison decisions can no longer be configured accidentally by Boolean flags, hidden masked payloads, numeric-looking text, temporal values, complex values, or vector inputs.

## Validation

- focused local validator harness covering all new rejected and accepted cases
- branch comparison: 2 commits ahead of `main`, 0 behind
- GitHub Actions will provide authoritative repository-wide validation