### PR TITLE
Preserve mixture sample dtype

### DIFF
--- a/src/pyrecest/distributions/abstract_mixture.py
+++ b/src/pyrecest/distributions/abstract_mixture.py
@@ -10,7 +10,6 @@ import pyrecest.backend
 from pyrecest.backend import (
     array,
     asarray,
-    empty,
     int32,
     int64,
     ones,
@@ -248,16 +247,26 @@ class AbstractMixture(AbstractDistributionType):
             ]
             return pyrecest.backend.concatenate(samples, axis=0)
 
-        s = empty((n, self.input_dim))
+        sample_blocks = []
+        position_blocks = []
         for component_index in range(len(self.dists)):
             positions = np.flatnonzero(component_indices_np == component_index)
             occ_val = int(positions.size)
             if occ_val == 0:
                 continue
-            sample_i = self._sample_component_matrix(component_index, occ_val)
-            s[array(positions, dtype=int64)] = sample_i
+            sample_blocks.append(
+                self._sample_component_matrix(component_index, occ_val)
+            )
+            position_blocks.append(positions)
 
-        return s
+        sample_blocks = pyrecest.backend.convert_to_wider_dtype(sample_blocks)
+        samples_by_component = pyrecest.backend.concatenate(sample_blocks, axis=0)
+        positions_by_component = np.concatenate(position_blocks)
+        sampled_position_order = array(
+            np.argsort(positions_by_component),
+            dtype=int64,
+        )
+        return samples_by_component[sampled_position_order]
 
     def pdf(self, xs):
         xs = asarray(xs)

--- a/tests/backend_support/test_pytorch_mixture_sample_dtype_contract.py
+++ b/tests/backend_support/test_pytorch_mixture_sample_dtype_contract.py
@@ -1,0 +1,55 @@
+"""Regression test for PyTorch mixture-sample dtype preservation."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+def _backend_subprocess_env(backend_name):
+    env = os.environ.copy()
+    env["PYRECEST_BACKEND"] = backend_name
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    return env
+
+
+@pytest.mark.backend_portable
+def test_pytorch_mixture_sampling_preserves_component_dtype():
+    if importlib.util.find_spec("torch") is None:
+        pytest.skip("torch is not installed")
+
+    env = _backend_subprocess_env("pytorch")
+    code = """
+import pyrecest.backend as backend
+from pyrecest.distributions.nonperiodic.linear_dirac_distribution import (
+    LinearDiracDistribution,
+)
+from pyrecest.distributions.nonperiodic.linear_mixture import LinearMixture
+
+assert backend.__backend_name__ == "pytorch"
+precise_value = 1.0 + 2.0**-40
+component = LinearDiracDistribution(
+    backend.asarray([precise_value], dtype=backend.float64),
+    backend.asarray([1.0], dtype=backend.float64),
+)
+mixture = LinearMixture(
+    [component],
+    backend.asarray([1.0], dtype=backend.float64),
+)
+
+backend.random.seed(0)
+samples = mixture.sample(1)
+
+assert samples.dtype == backend.float64
+assert float(samples[0, 0]) == precise_value
+"""
+    subprocess.run([sys.executable, "-c", code], check=True, env=env)


### PR DESCRIPTION
## What changed

- reconstruct non-JAX mixture samples from backend-promoted component sample blocks instead of a default-dtype output buffer
- restore the original independently drawn component-label order after concatenation
- add a PyTorch regression proving that `float64` component samples retain sub-float32 precision

## Root cause

`AbstractMixture.sample()` allocated its non-JAX output with `empty((n, input_dim))`. On the PyTorch backend, that buffer uses the current default floating dtype, commonly `float32`. Assigning samples from an explicitly `float64` component therefore silently downcast the draws. For example, the exactly representable double value `1 + 2**-40` became `1.0` in the returned mixture sample.

## Impact

Mixture sampling now preserves the common promoted dtype of sampled components, including genuine `float64` precision on PyTorch. Component-label probabilities and the original per-draw ordering remain unchanged. The existing JAX-specific sampling path is untouched.

## Validation

- reproduced the pre-fix PyTorch downcast with a `float64` value below float32 resolution
- verified the replacement concatenation/reordering path returns `torch.float64` and preserves the exact value
- syntax-compiled the modified module and regression test
- ran an isolated PyTorch smoke test of the patched sampling path

A full repository test run was not available in this connector-only environment; GitHub Actions should provide the complete matrix.