### PR TITLE
Stabilize UKF covariance symmetrization

### DIFF
--- a/src/pyrecest/filters/_ukf.py
+++ b/src/pyrecest/filters/_ukf.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
-    absolute,
+    abs,
     asarray,
     einsum,
     expand_dims,
@@ -53,7 +53,7 @@ def _as_vector(value, description):
 def _stable_symmetric_average(matrix):
     """Average a matrix with its transpose without finite overflow."""
     transposed = transpose(matrix)
-    scale = maximum(absolute(matrix), absolute(transposed))
+    scale = maximum(abs(matrix), abs(transposed))
     safe_scale = where(scale == 0.0, 1.0, scale)
     normalized_average = 0.5 * (matrix / safe_scale + transposed / safe_scale)
     return scale * normalized_average

--- a/src/pyrecest/filters/_ukf.py
+++ b/src/pyrecest/filters/_ukf.py
@@ -8,15 +8,18 @@ from copy import deepcopy
 
 # pylint: disable=no-name-in-module,no-member
 from pyrecest.backend import (
+    absolute,
     asarray,
     einsum,
     expand_dims,
     eye,
     float64,
     linalg,
+    maximum,
     reshape,
     stack,
     transpose,
+    where,
     zeros,
 )
 from pyrecest.sampling.sigma_points import JulierSigmaPoints, MerweScaledSigmaPoints
@@ -45,6 +48,15 @@ def _as_vector(value, description):
             f"{description} must be scalar or one-dimensional; got shape {value.shape}"
         )
     return value
+
+
+def _stable_symmetric_average(matrix):
+    """Average a matrix with its transpose without finite overflow."""
+    transposed = transpose(matrix)
+    scale = maximum(absolute(matrix), absolute(transposed))
+    safe_scale = where(scale == 0.0, 1.0, scale)
+    normalized_average = 0.5 * (matrix / safe_scale + transposed / safe_scale)
+    return scale * normalized_average
 
 
 # ---------------------------------------------------------------------------
@@ -121,7 +133,7 @@ class UnscentedKalmanFilter:
             d = expand_dims(sigmas_f[i] - x_pred, -1)
             P_pred = P_pred + Wc[i] * (d @ transpose(d))
         P_pred = P_pred + asarray(self.Q, dtype=float64)
-        P_pred = 0.5 * (P_pred + transpose(P_pred))
+        P_pred = _stable_symmetric_average(P_pred)
 
         self.x = x_pred
         self.P = P_pred
@@ -213,7 +225,7 @@ class UnscentedKalmanFilter:
 
         self.x = self.x + K @ (z - z_pred)
         self.P = self.P - K @ Pz @ transpose(K)
-        self.P = 0.5 * (self.P + transpose(self.P))
+        self.P = _stable_symmetric_average(self.P)
 
         self._sigmas_f = None  # clear cached sigma points
 

--- a/tests/filters/test_ukf_covariance_stability.py
+++ b/tests/filters/test_ukf_covariance_stability.py
@@ -1,0 +1,36 @@
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+import pyrecest.backend
+from pyrecest.backend import array, float64
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.filters.unscented_kalman_filter import UnscentedKalmanFilter
+
+
+class UnscentedKalmanFilterCovarianceStabilityTest(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
+    def test_predict_preserves_extreme_finite_process_covariance(self):
+        largest = np.finfo(np.float64).max
+        ukf = UnscentedKalmanFilter(
+            GaussianDistribution(
+                array([0.0], dtype=float64),
+                array([[1.0]], dtype=float64),
+            )
+        )
+
+        with np.errstate(over="raise", invalid="raise"):
+            ukf.predict_identity(array([[largest]], dtype=float64))
+
+        covariance = ukf.filter_state.covariance()
+        self.assertTrue(np.isfinite(covariance).all())
+        npt.assert_array_equal(covariance, array([[largest]], dtype=float64))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- symmetrize UKF prediction and update covariances with a scale-normalized average
- avoid overflow for finite covariance entries near the `float64` limit
- add a focused regression for maximum-finite process covariance

## Root cause
`src/pyrecest/filters/_ukf.py` used `0.5 * (P + P.T)`. For a symmetric covariance containing `np.finfo(np.float64).max`, the intermediate sum overflows even though the mathematical average remains finite.

## Impact
A valid finite process covariance could raise `FloatingPointError` under strict NumPy error handling or become non-finite during UKF prediction. The update path used the same vulnerable expression.

## Fix
The new helper scales each transposed entry pair by its largest magnitude before averaging, then restores the scale. This keeps finite pairs within `[-1, 1]` during the intermediate addition and also preserves subnormal values.

## Validation
- reproduced the original `FloatingPointError: overflow encountered in add`
- focused patched harness preserves `np.finfo(np.float64).max` exactly and regenerates finite sigma points
- helper edge cases cover same-sign maxima, opposite-sign extremes, zeros, and the minimum positive subnormal
- both modified Python files pass `python -m py_compile`
- full GitHub Actions matrix passes on NumPy 3.11–3.14, JAX 3.11–3.13, and PyTorch 3.11–3.13
- lint, packaging, minimal installation, documentation, MegaLinter, CodeQL, dependency review, security, and release-preview workflows pass
- comparison with the latest `main` remains limited to exactly two changed files