### PR TITLE
Stabilize pairwise covariance symmetrization

### DIFF
--- a/src/pyrecest/utils/pairwise_covariance_features.py
+++ b/src/pyrecest/utils/pairwise_covariance_features.py
@@ -257,9 +257,7 @@ def _symmetrized_covariance_batch(covariances: Any) -> Any:
     transposed = transpose(moved, (0, 2, 1))
     scale = maximum(abs(moved), abs(transposed))
     safe_scale = where(scale == 0.0, 1.0, scale)
-    normalized_average = 0.5 * (
-        moved / safe_scale + transposed / safe_scale
-    )
+    normalized_average = 0.5 * (moved / safe_scale + transposed / safe_scale)
     return scale * normalized_average
 
 

--- a/src/pyrecest/utils/pairwise_covariance_features.py
+++ b/src/pyrecest/utils/pairwise_covariance_features.py
@@ -252,8 +252,15 @@ def _validate_covariance_stack(name: str, covariances: Any) -> Any:
 
 
 def _symmetrized_covariance_batch(covariances: Any) -> Any:
+    """Move and symmetrize a covariance stack without finite overflow."""
     moved = moveaxis(covariances, -1, 0)
-    return 0.5 * (moved + transpose(moved, (0, 2, 1)))
+    transposed = transpose(moved, (0, 2, 1))
+    scale = maximum(abs(moved), abs(transposed))
+    safe_scale = where(scale == 0.0, 1.0, scale)
+    normalized_average = 0.5 * (
+        moved / safe_scale + transposed / safe_scale
+    )
+    return scale * normalized_average
 
 
 def _batch_trace(matrices: Any) -> Any:

--- a/tests/test_pairwise_covariance_symmetrization_overflow.py
+++ b/tests/test_pairwise_covariance_symmetrization_overflow.py
@@ -1,0 +1,34 @@
+import math
+
+import numpy as np
+import numpy.testing as npt
+
+from pyrecest.backend import array
+from pyrecest.utils import pairwise_covariance_shape_components
+
+
+def test_shape_components_preserve_extreme_finite_covariances():
+    largest = np.finfo(np.float64).max
+    covariance_along_first_axis = array(
+        [
+            [[largest], [0.0]],
+            [[0.0], [0.0]],
+        ]
+    )
+    covariance_along_second_axis = array(
+        [
+            [[0.0], [0.0]],
+            [[0.0], [largest]],
+        ]
+    )
+
+    shape_cost, logdet_cost, shape_similarity = (
+        pairwise_covariance_shape_components(
+            covariance_along_first_axis,
+            covariance_along_second_axis,
+        )
+    )
+
+    npt.assert_allclose(shape_cost, array([[1.0]]))
+    npt.assert_allclose(logdet_cost, array([[0.0]]))
+    npt.assert_allclose(shape_similarity, array([[math.exp(-1.0)]]))


### PR DESCRIPTION
## Summary

- replace overflow-prone batch covariance symmetrization in pairwise association features
- scale each transposed entry pair before averaging, then restore its magnitude
- add a public regression for maximum-finite `float64` covariance scales

## Root cause

`_symmetrized_covariance_batch()` used `0.5 * (P + P.T)`. For a finite covariance entry near `np.finfo(np.float64).max`, the intermediate addition overflows even though the mathematical average remains finite.

## Impact

Accepted finite covariance stacks could become non-finite before trace normalization, eigendecomposition, or pseudoinversion. In particular, covariance-shape features could return `NaN` costs and similarities for representable inputs, which can contaminate association scores and assignment costs.

## Fix

The helper now divides each entry pair by the largest absolute magnitude in that pair, averages values bounded by `[-1, 1]`, and multiplies by the original scale. Zero pairs use a safe unit divisor. The implementation stays entirely in the active backend.

## Validation

- reproduced the pre-fix maximum-scale covariance becoming `inf` and yielding `NaN` shape features
- verified the patched calculation returns shape cost `1`, log-determinant cost `0`, and similarity `exp(-1)`
- exercised the scaled arithmetic with NumPy, PyTorch, and JAX `float64`
- compared the branch with current `main`: only the covariance-feature source and focused regression file differ

The full supported backend and lint matrices are delegated to GitHub Actions.