### PR TITLE
Reject masked shared random parameters

### DIFF
--- a/src/pyrecest/_backend/_shared_numpy/random.py
+++ b/src/pyrecest/_backend/_shared_numpy/random.py
@@ -84,6 +84,8 @@ def _normalize_size(size):
 
 
 def _validate_uniform_bound(bound, name):
+    if _contains_masked_value(bound):
+        raise TypeError(f"{name} must be real numeric")
     if _contains_boolean_value(bound):
         raise TypeError(f"{name} must be real numeric, not boolean")
     try:
@@ -118,6 +120,8 @@ uniform = _modify_func_default_dtype(
 
 
 def _validate_normal_parameter(value, name):
+    if _contains_masked_value(value):
+        raise TypeError(f"{name} must be real numeric")
     if _contains_boolean_value(value):
         raise TypeError(f"{name} must be real numeric, not boolean")
     try:
@@ -150,6 +154,8 @@ normal = _modify_func_default_dtype(
 
 
 def _validate_multivariate_normal_parameter(value, name):
+    if _contains_masked_value(value):
+        raise TypeError(f"{name} must be real numeric")
     if _contains_boolean_value(value):
         raise TypeError(f"{name} must be real numeric, not boolean")
     try:
@@ -246,6 +252,8 @@ def _integer_choice_population_size(a_array):
 def _validate_choice_probabilities(p, population_size):
     if p is None:
         return None
+    if _contains_masked_value(p):
+        raise TypeError("p must be real numeric")
     if _contains_boolean_value(p):
         raise TypeError("p must be real numeric, not boolean")
     try:

--- a/tests/backend/test_numpy_random_masked_distribution_parameters.py
+++ b/tests/backend/test_numpy_random_masked_distribution_parameters.py
@@ -1,0 +1,89 @@
+import numpy as np
+import pytest
+from pyrecest._backend.numpy import random
+
+
+@pytest.mark.parametrize(
+    ("sampler", "message"),
+    (
+        (
+            lambda: random.uniform(low=np.ma.array(0.0, mask=True)),
+            "low must be real numeric",
+        ),
+        (
+            lambda: random.uniform(high=np.ma.array(1.0, mask=True)),
+            "high must be real numeric",
+        ),
+        (
+            lambda: random.normal(loc=np.ma.array(0.0, mask=True)),
+            "loc must be real numeric",
+        ),
+        (
+            lambda: random.normal(scale=np.ma.array(1.0, mask=True)),
+            "scale must be real numeric",
+        ),
+        (
+            lambda: random.multivariate_normal(
+                mean=np.ma.array([0.0, 1.0], mask=[False, True]),
+                cov=np.eye(2),
+            ),
+            "mean must be real numeric",
+        ),
+        (
+            lambda: random.multivariate_normal(
+                mean=np.zeros(2),
+                cov=np.ma.array(
+                    np.eye(2),
+                    mask=[[False, False], [False, True]],
+                ),
+            ),
+            "cov must be real numeric",
+        ),
+        (
+            lambda: random.choice(
+                2,
+                p=np.ma.array([0.25, 0.75], mask=[False, True]),
+            ),
+            "p must be real numeric",
+        ),
+        (
+            lambda: random.choice(2, p=[0.25, np.ma.masked]),
+            "p must be real numeric",
+        ),
+    ),
+)
+def test_numpy_random_rejects_masked_distribution_parameters(sampler, message):
+    with pytest.raises(TypeError, match=message):
+        sampler()
+
+
+def test_numpy_random_accepts_fully_unmasked_distribution_parameters():
+    uniform_samples = random.uniform(
+        low=np.ma.array(0.0, mask=False),
+        high=np.ma.array(1.0, mask=False),
+        size=4,
+    )
+    normal_samples = random.normal(
+        loc=np.ma.array(0.0, mask=False),
+        scale=np.ma.array(1.0, mask=False),
+        size=4,
+    )
+    multivariate_samples = random.multivariate_normal(
+        mean=np.ma.array([0.0, 1.0], mask=False),
+        cov=np.ma.array(np.eye(2), mask=False),
+        size=3,
+    )
+    choice_samples = random.choice(
+        2,
+        size=4,
+        p=np.ma.array([0.25, 0.75], mask=False),
+    )
+
+    assert uniform_samples.shape == (4,)
+    assert normal_samples.shape == (4,)
+    assert multivariate_samples.shape == (3, 2)
+    assert choice_samples.shape == (4,)
+    assert np.isfinite(uniform_samples).all()
+    assert np.isfinite(normal_samples).all()
+    assert np.isfinite(multivariate_samples).all()
+    assert np.isin(choice_samples, [0, 1]).all()


### PR DESCRIPTION
## Summary

- reject genuinely masked distribution parameters before shared NumPy/Autograd random wrappers coerce them with `asarray`
- cover uniform bounds, normal location/scale, multivariate-normal mean/covariance, and `choice` probabilities
- preserve ordinary NumPy inputs and fully unmasked `MaskedArray` values

## Root cause

The shared validators converted inputs with `asarray` before checking NumPy mask semantics. For a masked scalar or partially masked array, that conversion exposes the hidden data payload and discards the mask. Missing configuration values could therefore become real sampling parameters.

Examples include a masked normal scale being silently used as its hidden standard deviation and a masked `choice` probability being normalized and sampled from.

## Impact

NumPy and Autograd backend samplers now fail early instead of drawing reproducible-looking samples from missing data. The earlier masked-input fix for NumPy `randint` and `multinomial` did not cover these shared distribution samplers.

## Validation

- reproduced mask loss for scalar and partially masked arrays through NumPy `asarray`
- isolated exact-module regression: eight masked cases rejected and the fully unmasked compatibility path passed
- Python syntax compilation passed for the modified source and regression module
- branch comparison: 2 commits ahead, 0 behind `main`
- final diff is limited to 8 validator lines and one focused test file