### PR TITLE
Reject masked JAX matrix-power exponents

### DIFF
--- a/src/pyrecest/_backend/jax/linalg.py
+++ b/src/pyrecest/_backend/jax/linalg.py
@@ -18,6 +18,8 @@ def _as_linalg_array(value):
 
 def _as_integer_scalar(value, name):
     """Return a Python integer for JAX static integer arguments."""
+    if _np.ma.is_masked(value):
+        raise TypeError(f"{name} must be an integer scalar")
     if isinstance(value, (bool, _np.bool_)):
         raise TypeError(f"{name} must be an integer scalar")
     try:

--- a/tests/test_jax_linalg_matrix_power.py
+++ b/tests/test_jax_linalg_matrix_power.py
@@ -37,3 +37,24 @@ for exponent in (True, np.bool_(True), jnp.array(True)):
 """
     result = run_backend_code("jax", code)
     assert result.returncode == 0, result.stderr
+
+
+def test_jax_matrix_power_rejects_masked_exponents():
+    pytest.importorskip("jax")
+
+    code = """
+import numpy as np
+import pytest
+import pyrecest.backend as backend
+from pyrecest.backend import linalg
+
+matrix = [[1.0, 1.0], [0.0, 1.0]]
+for exponent in (np.ma.masked, np.ma.array(2, mask=True)):
+    with pytest.raises(TypeError, match="n must be an integer scalar"):
+        linalg.matrix_power(matrix, exponent)
+
+result = linalg.matrix_power(matrix, np.ma.array(2, mask=False))
+assert backend.to_numpy(result).tolist() == [[1.0, 2.0], [0.0, 1.0]]
+"""
+    result = run_backend_code("jax", code)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Bug

The JAX linalg backend normalized `matrix_power` exponents with `operator.index` before checking NumPy masked-array semantics. A masked scalar such as `np.ma.array(2, mask=True)` therefore exposed its hidden payload and was accepted as exponent `2`.

This can turn a missing configuration value into a real matrix operation instead of failing deterministically.

## Fix

- reject genuinely masked exponent inputs before integer coercion;
- preserve ordinary Python, NumPy, and JAX integer scalar handling;
- preserve fully unmasked integer-valued `MaskedArray` scalars;
- add focused subprocess regression coverage on the JAX backend.

## Validation

- reproduced that `operator.index(np.ma.array(2, mask=True))` returns the hidden value `2`;
- focused local JAX validation passed for two masked rejection cases and the unmasked compatibility case;
- branch comparison: **2 commits ahead, 0 behind** `main`;
- final diff is limited to **2 implementation lines and 21 test lines** across two files.

GitHub Actions provides the full supported JAX, Python-version, lint, and packaging matrix.