### PR TITLE
Honor masks in PyTorch nonzero

### DIFF
--- a/src/pyrecest/backend_support/_pytorch_nonzero_scalar_contract.py
+++ b/src/pyrecest/backend_support/_pytorch_nonzero_scalar_contract.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import numpy as np
+
 _NONZERO_SCALAR_MESSAGE = (
     "Calling nonzero on 0d arrays is not allowed. "
     "Use np.atleast_1d(scalar).nonzero() instead."
@@ -9,7 +11,7 @@ _NONZERO_SCALAR_MESSAGE = (
 
 
 def patch_pytorch_nonzero_scalar_contract() -> None:
-    """Make public and raw PyTorch ``nonzero`` reject 0-D inputs."""
+    """Make public and raw PyTorch ``nonzero`` reject 0-D inputs and honor masks."""
 
     try:
         import pyrecest._backend.pytorch as raw_pytorch  # pylint: disable=import-outside-toplevel
@@ -27,6 +29,8 @@ def patch_pytorch_nonzero_scalar_contract() -> None:
         return
 
     def nonzero(x):
+        if np.ma.isMaskedArray(x):
+            x = np.ma.filled(x, 0)
         values = x if torch.is_tensor(x) else torch.as_tensor(x)
         if values.ndim == 0:
             raise ValueError(_NONZERO_SCALAR_MESSAGE)

--- a/tests/backend_support/test_pytorch_nonzero_scalar_contract.py
+++ b/tests/backend_support/test_pytorch_nonzero_scalar_contract.py
@@ -5,13 +5,14 @@ from tests.support.backend_runner import run_backend_code
 
 
 @pytest.mark.backend_portable
-def test_pytorch_nonzero_rejects_zero_dimensional_inputs():
+def test_pytorch_nonzero_rejects_scalars_and_honors_masks():
     if importlib.util.find_spec("torch") is None:
         pytest.skip("PyTorch is not installed")
 
     result = run_backend_code(
         "pytorch",
         """
+import numpy as np
 import pyrecest._backend.pytorch as raw_pytorch
 import pyrecest.backend as backend
 import torch
@@ -33,6 +34,14 @@ for nonzero in (backend.nonzero, raw_pytorch.nonzero):
     rows, columns = nonzero([[0, 2], [3, 0]])
     assert rows.tolist() == [0, 1]
     assert columns.tolist() == [1, 0]
+
+    masked = np.ma.array(
+        [[0, 2], [3, 4]],
+        mask=[[False, True], [False, True]],
+    )
+    rows, columns = nonzero(masked)
+    assert rows.tolist() == [1]
+    assert columns.tolist() == [0]
 
 print("ok")
 """,


### PR DESCRIPTION
## Bug

The PyTorch backend wrapper converted NumPy `MaskedArray` inputs with `torch.as_tensor`. That conversion discards the mask and exposes the hidden payload, so `nonzero` could report masked entries as present.

For example, a masked 2×2 input whose only unmasked nonzero value is at `(1, 0)` returned `(0, 1)`, `(1, 0)`, and `(1, 1)` on the PyTorch backend.

## Fix

- fill masked entries with zero before converting to a PyTorch tensor;
- preserve the existing rejection of zero-dimensional inputs;
- preserve ordinary list, NumPy-array, and tensor handling;
- add regression coverage for both the public and raw PyTorch backend helpers.

## Validation

- reproduced the pre-fix mask loss with NumPy 2.3.5 and PyTorch 2.10.0;
- verified the patched helper matches `numpy.nonzero` for the masked input;
- verified existing scalar rejection and ordinary matrix behavior in the isolated harness;
- syntax-compiled both modified files;
- branch comparison: 2 commits ahead, 0 behind `main`, with only 2 files changed.

The full supported backend and Python-version matrix is delegated to GitHub Actions.