### PR TITLE
Stabilize Euclidean MTT distances at extreme scales

### DIFF
--- a/src/pyrecest/evaluation/get_distance_function.py
+++ b/src/pyrecest/evaluation/get_distance_function.py
@@ -255,7 +255,7 @@ def _euclidean_mtt_distance(x1, x2, *, cutoff_distance: float) -> float:
         return float(cutoff_distance * abs(first.shape[0] - second.shape[0]))
 
     deltas = first[:, None, :] - second[None, :, :]
-    costs = numpy.linalg.norm(deltas, axis=2)
+    costs = numpy.hypot.reduce(deltas, axis=2)
     costs = numpy.minimum(costs, float(cutoff_distance))
     row_indices, column_indices = linear_sum_assignment(costs)
     matched_cost = float(costs[row_indices, column_indices].sum())

--- a/tests/evaluation/test_euclidean_mtt_distance_orientation.py
+++ b/tests/evaluation/test_euclidean_mtt_distance_orientation.py
@@ -41,3 +41,18 @@ def test_empty_target_dimension_disambiguates_small_dim_first_target_set():
 
     np.testing.assert_allclose(distance(no_targets, dim_first_targets), 21.0)
     np.testing.assert_allclose(distance(dim_first_targets, no_targets), 21.0)
+
+
+def test_euclidean_mtt_distance_preserves_extreme_finite_norm_below_cutoff():
+    distance = get_distance_function(
+        "euclidean_mtt",
+        {"cutoff_distance": 1.5e308},
+    )
+    first = np.array([[1.0e308, 1.0e308]])
+    second = np.array([[0.0, 0.0]])
+    expected = np.hypot(1.0e308, 1.0e308)
+
+    with np.errstate(over="raise", invalid="raise"):
+        result = distance(first, second)
+
+    np.testing.assert_allclose(result, expected, rtol=1.0e-15)


### PR DESCRIPTION
## Summary

- compute Euclidean MTT pairwise norms with `numpy.hypot.reduce` instead of `numpy.linalg.norm`
- preserve finite localization distances when coordinate magnitudes are close to the `float64` limit
- add a focused regression that runs with floating-point overflow configured to raise

## Bug

`_euclidean_mtt_distance()` formed finite displacement vectors and evaluated them with `numpy.linalg.norm`. For a displacement such as `[1e308, 1e308]`, the mathematically correct norm is approximately `1.4142e308` and is still representable, but `numpy.linalg.norm` squares the components internally and overflows to infinity.

With a cutoff of `1.5e308`, the overflow caused the pairwise cost to be clipped to `1.5e308`, overstating the localization error. Under `numpy.errstate(over="raise")`, the same valid input raised `FloatingPointError`.

## Fix

Use `numpy.hypot.reduce(..., axis=2)`, which accumulates Euclidean norms with scale-aware arithmetic and returns the correct finite value without an overflowing square.

## Validation

- reproduced the old result: `1.5e308` after erroneous cutoff clipping
- verified the patched calculation returns `1.4142135623730951e308`
- verified the patched path succeeds under `numpy.errstate(over="raise", invalid="raise")`
- added a regression to `tests/evaluation/test_euclidean_mtt_distance_orientation.py`
- branch is 2 commits ahead of and 0 behind current `main`; the diff contains only the implementation line and focused test

Full repository tests were not run locally because this environment could not resolve GitHub for a checkout; GitHub Actions should exercise the in-tree regression and full matrix.