### PR TITLE
Make calibration hotfixes reload-safe

### DIFF
--- a/src/pyrecest/calibration/__init__.py
+++ b/src/pyrecest/calibration/__init__.py
@@ -27,6 +27,30 @@ _TIME_VECTOR_NAMES = frozenset(
         "times_s",
     }
 )
+_ORIGINAL_AGGREGATE_SUMMARY_METRIC_ATTR = (
+    "_pyrecest_original_aggregate_summary_metric"
+)
+_ORIGINAL_AGGREGATE_TIME_OFFSET_SWEEPS_ATTR = (
+    "_pyrecest_original_aggregate_time_offset_sweeps"
+)
+_ORIGINAL_BIAS_NUMERIC_ARRAY_ATTR = "_pyrecest_original_bias_as_numeric_array"
+_ORIGINAL_BIAS_NONNEGATIVE_INT_ATTR = "_pyrecest_original_bias_as_nonnegative_int"
+_ORIGINAL_BIAS_NONNEGATIVE_FINITE_FLOAT_ATTR = (
+    "_pyrecest_original_bias_as_nonnegative_finite_float"
+)
+
+if not hasattr(_time_offset_module, _ORIGINAL_AGGREGATE_SUMMARY_METRIC_ATTR):
+    setattr(
+        _time_offset_module,
+        _ORIGINAL_AGGREGATE_SUMMARY_METRIC_ATTR,
+        _time_offset_module._aggregate_summary_metric,
+    )
+if not hasattr(_time_offset_module, _ORIGINAL_AGGREGATE_TIME_OFFSET_SWEEPS_ATTR):
+    setattr(
+        _time_offset_module,
+        _ORIGINAL_AGGREGATE_TIME_OFFSET_SWEEPS_ATTR,
+        _time_offset_module.aggregate_time_offset_sweeps,
+    )
 
 
 def _is_rejected_real_scalar(value: Any) -> bool:
@@ -118,7 +142,9 @@ def _as_nonnegative_summary_count(value: Any, name: str) -> float:
     return result
 
 
-_base_aggregate_summary_metric = _time_offset_module._aggregate_summary_metric
+_base_aggregate_summary_metric = getattr(
+    _time_offset_module, _ORIGINAL_AGGREGATE_SUMMARY_METRIC_ATTR
+)
 
 
 def _aggregate_summary_metric(
@@ -145,9 +171,34 @@ _time_offset_module._aggregate_summary_metric = _aggregate_summary_metric
 
 from . import bias as _bias_module  # noqa: E402
 
-_base_bias_as_numeric_array = _bias_module._as_numeric_array
-_base_bias_as_nonnegative_int = _bias_module._as_nonnegative_int
-_base_bias_as_nonnegative_finite_float = _bias_module._as_nonnegative_finite_float
+if not hasattr(_bias_module, _ORIGINAL_BIAS_NUMERIC_ARRAY_ATTR):
+    setattr(
+        _bias_module,
+        _ORIGINAL_BIAS_NUMERIC_ARRAY_ATTR,
+        _bias_module._as_numeric_array,
+    )
+if not hasattr(_bias_module, _ORIGINAL_BIAS_NONNEGATIVE_INT_ATTR):
+    setattr(
+        _bias_module,
+        _ORIGINAL_BIAS_NONNEGATIVE_INT_ATTR,
+        _bias_module._as_nonnegative_int,
+    )
+if not hasattr(_bias_module, _ORIGINAL_BIAS_NONNEGATIVE_FINITE_FLOAT_ATTR):
+    setattr(
+        _bias_module,
+        _ORIGINAL_BIAS_NONNEGATIVE_FINITE_FLOAT_ATTR,
+        _bias_module._as_nonnegative_finite_float,
+    )
+
+_base_bias_as_numeric_array = getattr(
+    _bias_module, _ORIGINAL_BIAS_NUMERIC_ARRAY_ATTR
+)
+_base_bias_as_nonnegative_int = getattr(
+    _bias_module, _ORIGINAL_BIAS_NONNEGATIVE_INT_ATTR
+)
+_base_bias_as_nonnegative_finite_float = getattr(
+    _bias_module, _ORIGINAL_BIAS_NONNEGATIVE_FINITE_FLOAT_ATTR
+)
 
 
 def _as_bias_numeric_array(value: Any, name: str) -> np.ndarray:
@@ -194,7 +245,6 @@ from .time_offset import (  # noqa: E402
     _aggregate_std_metric,
     _validate_error_metric,
 )
-from .time_offset import aggregate_time_offset_sweeps as _aggregate_time_offset_sweeps
 from .time_offset import (  # noqa: E402
     apply_time_offset,
     fit_time_offset,
@@ -203,6 +253,10 @@ from .time_offset import (  # noqa: E402
     nearest_time_indices,
     time_offset_error_summary,
     time_offset_sweep,
+)
+
+_base_aggregate_time_offset_sweeps = getattr(
+    _time_offset_module, _ORIGINAL_AGGREGATE_TIME_OFFSET_SWEEPS_ATTR
 )
 
 
@@ -215,7 +269,7 @@ def aggregate_time_offset_sweeps(
 
     metric = _validate_error_metric(metric)
     materialized_sweeps = [list(sweep) for sweep in sweeps]
-    rows = _aggregate_time_offset_sweeps(materialized_sweeps, metric=metric)
+    rows = _base_aggregate_time_offset_sweeps(materialized_sweeps, metric=metric)
     if metric == "std":
         return rows
 

--- a/tests/calibration/test_calibration_reload.py
+++ b/tests/calibration/test_calibration_reload.py
@@ -1,0 +1,35 @@
+import importlib
+
+import numpy as np
+import pyrecest.calibration as calibration
+
+
+def _summary_row() -> dict[str, float]:
+    return {
+        "time_offset_s": 0.0,
+        "count": 1.0,
+        "mean": 1.0,
+        "std": 0.0,
+        "rmse": 1.0,
+        "p95": 1.0,
+        "max": 1.0,
+    }
+
+
+def test_calibration_hotfixes_are_reload_idempotent():
+    module = calibration
+
+    for _ in range(2):
+        module = importlib.reload(module)
+
+        aggregated = module.aggregate_time_offset_sweeps([[_summary_row()]])
+        assert aggregated[0]["rmse"] == 1.0
+
+        examples = module.make_bias_training_examples(
+            measurement_times_s=np.array([0.0]),
+            measurement_values=np.array([[2.0]]),
+            reference_times_s=np.array([0.0]),
+            reference_values=np.array([[1.0]]),
+            max_time_delta_s=None,
+        )
+        np.testing.assert_array_equal(examples.residual, np.array([[1.0]]))


### PR DESCRIPTION
## Bug

`pyrecest.calibration` patches helpers in `calibration.time_offset` and `calibration.bias` at import time. On `importlib.reload(pyrecest.calibration)`, the module previously captured its already-patched wrappers as the new “base” functions. Because those wrappers resolve their base functions through the reloaded module globals, aggregation and bias-calibration calls then recurse until `RecursionError`.

This affects notebook autoreload, interactive development, test isolation, and applications that deliberately reload modules.

## Fix

- preserve the original time-offset and bias helper functions on their owning modules before applying calibration patches;
- always bind reload-time wrappers to those preserved originals;
- make the public `aggregate_time_offset_sweeps` patch reload-idempotent as well;
- add a regression that reloads `pyrecest.calibration` twice and exercises both aggregation and bias-example generation after each reload.

## Validation

- reproduced the pre-fix aggregation and bias recursion in an isolated harness matching the current patch/reload behavior;
- verified the patched wrappers survive three consecutive reloads in the same harness;
- syntax-compiled the modified module and regression test;
- branch is 2 commits ahead of and 0 behind current `main`, with changes limited to the calibration initializer and one focused test.

GitHub Actions will provide the full supported Python/backend and lint validation matrix.