### PR TITLE
Reject masked JAX FFT parameters

### DIFF
--- a/src/pyrecest/_backend/jax/fft.py
+++ b/src/pyrecest/_backend/jax/fft.py
@@ -8,13 +8,24 @@ from jax.numpy import fft as _fft
 
 _BOOLEAN_FFT_AXIS_ERROR = "axis must be an integer, not boolean"
 _BOOLEAN_FFT_LENGTH_ERROR = "n must be an integer length, not boolean"
+_FFT_AXIS_ERROR = "axis must be an integer"
+_FFT_LENGTH_ERROR = "n must be an integer length"
 _FFT_SHAPE_SEQUENCE_ERROR = "s must be None or a sequence of integer lengths"
 _FFT_AXES_SEQUENCE_ERROR = "axes must be None or a sequence of integer axes"
 _SHIFT_AXES_ERROR = "axes must be None, an integer axis, or a sequence of integer axes"
 
 
+def _has_masked_values(value):
+    """Return whether a NumPy masked array contains missing values."""
+    return isinstance(value, _np.ma.MaskedArray) and bool(
+        _np.any(_np.ma.getmaskarray(value))
+    )
+
+
 def _normalize_real_fft_axis(axis):
     """Return a Python ``int`` for integer scalar-array FFT axes."""
+    if _has_masked_values(axis):
+        raise TypeError(_FFT_AXIS_ERROR)
     if isinstance(axis, (bool, _np.bool_)):
         raise TypeError(_BOOLEAN_FFT_AXIS_ERROR)
     if isinstance(axis, _np.ndarray):
@@ -39,6 +50,8 @@ def _normalize_real_fft_length(n):
     """Return a Python ``int`` for integer scalar-array real FFT lengths."""
     if n is None:
         return None
+    if _has_masked_values(n):
+        raise TypeError(_FFT_LENGTH_ERROR)
     if isinstance(n, (bool, _np.bool_)):
         raise TypeError(_BOOLEAN_FFT_LENGTH_ERROR)
     if isinstance(n, _np.ndarray):
@@ -61,6 +74,8 @@ def _normalize_real_fft_length(n):
 
 def _normalize_fft_sequence_item(value, boolean_error, integer_error):
     """Return a Python ``int`` for one FFT shape or axis sequence entry."""
+    if _has_masked_values(value):
+        raise TypeError(integer_error)
     if isinstance(value, (bool, _np.bool_)):
         raise TypeError(boolean_error)
     if isinstance(value, _np.ndarray):
@@ -88,6 +103,8 @@ def _normalize_fft_integer_sequence(
     """Normalize NumPy/JAX scalar-array entries inside FFT integer sequences."""
     if value is None:
         return None
+    if _has_masked_values(value):
+        raise TypeError(integer_error)
     if isinstance(value, (bool, _np.bool_)):
         raise TypeError(sequence_error)
     if isinstance(value, _np.ndarray):
@@ -143,6 +160,8 @@ def _normalize_shift_axes(axes):
     """Normalize scalar or sequence axis inputs accepted by FFT shifts."""
     if axes is None:
         return None
+    if _has_masked_values(axes):
+        raise TypeError(_SHIFT_AXES_ERROR)
     if isinstance(axes, (bool, _np.bool_)):
         raise TypeError(_BOOLEAN_FFT_AXIS_ERROR)
     if isinstance(axes, _np.ndarray):

--- a/tests/backend/test_jax_fft_masked_parameter_rejection.py
+++ b/tests/backend/test_jax_fft_masked_parameter_rejection.py
@@ -1,0 +1,48 @@
+import numpy as np
+import pytest
+
+pytest.importorskip("jax")
+
+from pyrecest._backend.jax import fft  # noqa: E402
+
+
+@pytest.mark.parametrize("transform", [fft.rfft, fft.irfft])
+def test_real_fft_rejects_masked_length(transform):
+    with pytest.raises(TypeError, match="n must be an integer length"):
+        transform(np.arange(4.0), n=np.ma.array(4, mask=True))
+
+
+@pytest.mark.parametrize("transform", [fft.rfft, fft.irfft])
+def test_real_fft_rejects_masked_axis(transform):
+    with pytest.raises(TypeError, match="axis must be an integer"):
+        transform(np.arange(4.0), axis=np.ma.array(0, mask=True))
+
+
+@pytest.mark.parametrize("transform", [fft.fftn, fft.ifftn])
+def test_complex_fft_rejects_masked_shape_entry(transform):
+    with pytest.raises(TypeError, match="s entries must be integer lengths"):
+        transform(np.ones((2, 2)), s=(np.ma.array(2, mask=True), 2))
+
+
+@pytest.mark.parametrize("transform", [fft.fftn, fft.ifftn])
+def test_complex_fft_rejects_masked_axis_entry(transform):
+    with pytest.raises(TypeError, match="axes entries must be integers"):
+        transform(np.ones((2, 2)), axes=(np.ma.array(0, mask=True), 1))
+
+
+@pytest.mark.parametrize("shift", [fft.fftshift, fft.ifftshift])
+def test_shift_rejects_masked_axis(shift):
+    with pytest.raises(
+        TypeError,
+        match="axes must be None, an integer axis, or a sequence of integer axes",
+    ):
+        shift(np.arange(4), axes=np.ma.array(0, mask=True))
+
+
+def test_unmasked_masked_integer_parameter_remains_supported():
+    values = np.arange(4.0)
+
+    actual = np.asarray(fft.rfft(values, n=np.ma.array(4, mask=False)))
+    expected = np.asarray(fft.rfft(values, n=4))
+
+    np.testing.assert_array_equal(actual, expected)


### PR DESCRIPTION
## Bug

The JAX FFT compatibility layer accepts NumPy `MaskedArray` scalar parameters by calling `.item()` or `operator.index()` on them. Those operations expose the hidden payload even when the scalar is masked.

For example, `n=np.ma.array(4, mask=True)` is silently normalized to `4`, so `rfft` executes a real transform instead of rejecting a missing length. The same issue affects real-FFT axes, scalar entries inside `fftn`/`ifftn` shape and axis sequences, and FFT-shift axes.

## Fix

- detect NumPy masked arrays containing masked values before integer normalization;
- reject masked real-FFT lengths and axes with parameter-specific `TypeError`s;
- reject masked entries in complex FFT shape/axis sequences;
- reject masked FFT-shift axes;
- preserve support for fully unmasked `MaskedArray` integer parameters.

## Impact

Missing FFT configuration can no longer become a reproducible-looking transform through the masked value's hidden payload. Ordinary Python, NumPy, and JAX integer parameters retain their existing behavior.

## Validation

- reproduced the pre-fix behavior with NumPy 2.3.5 and JAX 0.9.0.1: a masked `n=4` was accepted and executed;
- exercised the patched normalization for masked `n`, real-FFT `axis`, complex FFT `s`/`axes` entries, and shift axes;
- verified fully unmasked `MaskedArray` integer parameters remain accepted;
- syntax-compiled the isolated patched module;
- branch comparison is limited to the JAX FFT wrapper and one focused regression file.

GitHub Actions will provide the repository's full supported Python, backend, lint, and packaging validation matrix.