### PR TITLE
Stabilize SO(3) product quaternion normalization

### DIFF
--- a/src/pyrecest/distributions/so3_product_dirac_distribution.py
+++ b/src/pyrecest/distributions/so3_product_dirac_distribution.py
@@ -25,6 +25,7 @@ from pyrecest.backend import (
     where,
 )
 
+from ._so3_helpers import normalize_quaternions as _normalize_so3_quaternions
 from .cart_prod.hyperhemisphere_cart_prod_dirac_distribution import (
     HyperhemisphereCartProdDiracDistribution,
 )
@@ -157,14 +158,7 @@ class SO3ProductDiracDistribution(HyperhemisphereCartProdDiracDistribution):
 
     @staticmethod
     def _normalize_quaternions(quaternions):
-        norms = linalg.norm(quaternions, axis=-1)
-        if not all(isfinite(quaternions)):
-            raise ValueError("SO(3) quaternions must be finite.")
-        if not all(isfinite(norms)):
-            raise ValueError("SO(3) quaternion norms must be finite.")
-        if not all(norms > 0.0):
-            raise ValueError("SO(3) quaternions must be nonzero.")
-        return quaternions / reshape(norms, tuple(norms.shape) + (1,))
+        return _normalize_so3_quaternions(quaternions)
 
     @staticmethod
     def _canonicalize_quaternions(quaternions):

--- a/tests/distributions/test_so3_product_dirac_extreme_quaternions.py
+++ b/tests/distributions/test_so3_product_dirac_extreme_quaternions.py
@@ -1,0 +1,37 @@
+import math
+import unittest
+
+import numpy as np
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module,no-member
+from pyrecest.backend import array, float64, linalg, ones
+from pyrecest.distributions import SO3ProductDiracDistribution
+
+
+class SO3ProductDiracExtremeQuaternionTest(unittest.TestCase):
+    def test_constructor_normalizes_extreme_finite_quaternion(self):
+        component = 1.0e308
+        locations = array(
+            [[[component, component, 0.0, 0.0]]],
+            dtype=float64,
+        )
+        expected = array(
+            [[[math.sqrt(0.5), math.sqrt(0.5), 0.0, 0.0]]],
+            dtype=float64,
+        )
+
+        with np.errstate(over="raise", invalid="raise"):
+            distribution = SO3ProductDiracDistribution(locations)
+
+        npt.assert_allclose(distribution.d, expected, rtol=1.0e-15, atol=0.0)
+        npt.assert_allclose(
+            linalg.norm(distribution.d, axis=-1),
+            ones((1, 1), dtype=float64),
+            rtol=1.0e-15,
+            atol=0.0,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`SO3ProductDiracDistribution` normalized quaternions with a direct backend Euclidean norm. For large but finite values such as `[1e308, 1e308, 0, 0]`, the sum-of-squares intermediate overflows even though the true norm, approximately `1.4142e308`, is representable.

The constructor, geodesic-distance helper, and rotation-matrix conversion could therefore reject a finite, nonzero quaternion solely because of avoidable intermediate overflow.

## Fix

- reuse the existing scale-safe `normalize_quaternions()` helper shared by PyRecEst's other SO(3) distributions;
- retain finite/nonzero validation and canonical scalar-last quaternion handling;
- add a regression that constructs an SO(3) product Dirac distribution from extreme finite coordinates under strict overflow/invalid handling.

## Validation

- reproduced the old failure locally: `numpy.linalg.norm([1e308, 1e308, 0, 0])` raises `FloatingPointError` with overflow configured to raise;
- verified the scale-safe normalization returns `[sqrt(0.5), sqrt(0.5), 0, 0]` with unit norm;
- syntax-compiled the modified source and regression test;
- branch is 2 commits ahead and 0 behind `main`, with exactly two changed files.

The repository's pull-request workflows provide the full supported backend, Python-version, lint, and packaging validation matrix.