### PR TITLE
Count higher-rank measurement batches correctly

### DIFF
--- a/src/pyrecest/evaluation/evaluate_for_file.py
+++ b/src/pyrecest/evaluation/evaluate_for_file.py
@@ -49,10 +49,10 @@ def evaluate_for_file(
         inner_array = np.asarray(inner_array)
         if inner_array.ndim == 0:
             n_meas_at_individual_time_step[idx] = 1
-        elif inner_array.ndim == 2:
-            n_meas_at_individual_time_step[idx] = inner_array.shape[0]
         elif inner_array.ndim == 1:
             n_meas_at_individual_time_step[idx] = 0 if inner_array.size == 0 else 1
+        else:
+            n_meas_at_individual_time_step[idx] = inner_array.shape[0]
 
     scenario_config.setdefault(
         "n_meas_at_individual_time_step", n_meas_at_individual_time_step

--- a/tests/test_evaluate_for_file_higher_rank_measurement_counts.py
+++ b/tests/test_evaluate_for_file_higher_rank_measurement_counts.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+
+
+def test_evaluate_for_file_counts_higher_rank_measurement_batches(
+    tmp_path, monkeypatch
+):
+    module = importlib.import_module("pyrecest.evaluation.evaluate_for_file")
+    input_file = tmp_path / "higher_rank_scenario.npy"
+    measurements = np.empty((1, 3), dtype=object)
+    measurements[0, 0] = np.zeros((3, 2, 2), dtype=float)
+    measurements[0, 1] = np.zeros((0, 2, 2), dtype=float)
+    measurements[0, 2] = np.zeros((4, 3, 2, 1), dtype=float)
+    groundtruths = np.zeros((1, 3, 2), dtype=float)
+    np.save(input_file, {"groundtruths": groundtruths, "measurements": measurements})
+
+    captured = {}
+
+    def capture_call(
+        groundtruths_arg,
+        measurements_arg,
+        filter_configs,
+        scenario_config,
+        **kwargs,
+    ):
+        captured["scenario_config"] = dict(scenario_config)
+        return (
+            {},
+            [],
+            np.array([], dtype=bool),
+            groundtruths_arg,
+            measurements_arg,
+            scenario_config,
+            filter_configs,
+            kwargs,
+        )
+
+    monkeypatch.setattr(module, "evaluate_for_variables", capture_call)
+
+    module.evaluate_for_file(str(input_file), [], {}, save_folder=str(tmp_path))
+
+    np.testing.assert_array_equal(
+        captured["scenario_config"]["n_meas_at_individual_time_step"],
+        np.array([3, 0, 4], dtype=int),
+    )


### PR DESCRIPTION
## Bug

`evaluate_for_file()` derives `n_meas_at_individual_time_step` from each saved per-step measurement payload. It correctly uses the first axis as the measurement count for two-dimensional arrays, but leaves the zero-initialized count unchanged for arrays with rank three or higher.

For example, a payload with shape `(3, 2, 2)` is reported as containing zero measurements instead of three. This can misconfigure downstream evaluation control flow for matrix-, image-, or tensor-valued measurements stored as a batch.

## Fix

- preserve the existing scalar and one-dimensional conventions;
- treat every payload with at least two dimensions uniformly, using `shape[0]` as the number of measurements;
- add a regression covering nonempty rank-3 and rank-4 batches plus an empty higher-rank batch.

## Validation

- focused regression against current behavior: **1 failed**, with actual counts `[0, 0, 0]` instead of `[3, 0, 4]`;
- focused regression with the patch: **1 passed**;
- syntax parsing passed for the modified source and new test;
- branch comparison: 2 commits ahead, 0 behind `main`, with exactly two changed files.

GitHub Actions should provide the full repository validation matrix.