### PR TITLE
Reject out-of-range index-matrix fill values

### DIFF
--- a/src/pyrecest/utils/multisession_assignment_score.py
+++ b/src/pyrecest/utils/multisession_assignment_score.py
@@ -50,6 +50,7 @@ _INVALID_SCORE_SCALAR_TYPES = (
 )
 _REJECTED_SCORE_ARRAY_KINDS = frozenset({"b", "c", "S", "U", "M", "m"})
 _SCORE_TO_COST_ERROR = "score_to_cost must return real numeric cost matrices."
+_INT64_MIN = int(np.iinfo(np.int64).min)
 
 
 def _ensure_supported_backend(feature_name: str) -> None:
@@ -193,6 +194,8 @@ def _normalize_index_matrix_fill_value(fill_value: Any) -> int:
 
     if integer_fill_value >= 0:
         raise ValueError("fill_value must be a negative integer.")
+    if integer_fill_value < _INT64_MIN:
+        raise ValueError("fill_value must fit in int64.")
     return integer_fill_value
 
 

--- a/tests/test_multisession_assignment_index_matrix.py
+++ b/tests/test_multisession_assignment_index_matrix.py
@@ -44,6 +44,29 @@ class TestMultiSessionAssignmentIndexMatrix(unittest.TestCase):
 
         self.assertTrue(array_equal(matrix, array([[0, -1, 1]], dtype=int)))
 
+    @unittest.skipIf(
+        __backend_name__ == "jax",
+        reason="Not supported on this backend",
+    )
+    def test_fill_value_must_fit_in_int64(self):
+        int64_min = int(np.iinfo(np.int64).min)
+
+        for fill_value in (int64_min - 1, -(1 << 100)):
+            with self.subTest(fill_value=fill_value):
+                with self.assertRaisesRegex(ValueError, "fit in int64"):
+                    tracks_to_index_matrix(
+                        [{0: 0}],
+                        session_sizes=[1, 0],
+                        fill_value=fill_value,
+                    )
+
+        matrix = tracks_to_index_matrix(
+            [{0: 0}],
+            session_sizes=[1, 0],
+            fill_value=int64_min,
+        )
+        self.assertEqual(int(matrix[0, 1]), int64_min)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Bug

`tracks_to_index_matrix()` validates that `fill_value` is a negative integer, but did not validate that it is representable by the integer matrix it allocates. A value below `numpy.iinfo(numpy.int64).min` therefore passed the public validation and failed later inside the backend allocator with a raw `OverflowError`.

For example, `fill_value=numpy.iinfo(numpy.int64).min - 1` reached `numpy.full(..., dtype=int)` and raised `OverflowError: Python int too large to convert to C long`.

## Fix

- reject negative fill values below the `int64` range with a deterministic `ValueError`;
- preserve the valid `int64` minimum boundary;
- add regression coverage for both the immediate underflow case and a much larger negative Python integer.

## Validation

- reproduced the pre-fix `OverflowError` through the current module in an isolated NumPy-backend harness;
- the patched focused test module passes all three index-matrix tests;
- syntax compilation passes for both modified files;
- branch comparison is limited to two files: 3 source lines and 23 regression-test lines.

The repository's pull-request workflows provide the full supported Python/backend, lint, packaging, documentation, and security validation matrix.