### PR TITLE
Fix 3D ellipsoid scaling around its center

### DIFF
--- a/src/pyrecest/utils/plotting.py
+++ b/src/pyrecest/utils/plotting.py
@@ -42,7 +42,7 @@ def plot_ellipsoid_3d(center, shape_matrix, scaling_factor=1, color="blue"):
     z = outer(ones(u.shape[0]), cos(v))
 
     D, V = linalg.eigh(shape_matrix)
-    all_coords = (V * sqrt(D)) @ array(
+    all_coords = scaling_factor * (V * sqrt(D)) @ array(
         [x.ravel(), y.ravel(), z.ravel()]
     ) + center.reshape(-1, 1)
     x = reshape(all_coords[0], x.shape)
@@ -50,9 +50,9 @@ def plot_ellipsoid_3d(center, shape_matrix, scaling_factor=1, color="blue"):
     z = reshape(all_coords[2], z.shape)
 
     ax.plot_surface(
-        scaling_factor * x,
-        scaling_factor * y,
-        scaling_factor * z,
+        x,
+        y,
+        z,
         color=color,
         alpha=0.7,
         linewidth=0,

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+from pyrecest.utils import plotting
+
+
+class _Axes:
+    def __init__(self) -> None:
+        self.surface: tuple[np.ndarray, np.ndarray, np.ndarray] | None = None
+
+    def plot_surface(self, x: Any, y: Any, z: Any, **_kwargs: Any) -> None:
+        self.surface = (np.asarray(x), np.asarray(y), np.asarray(z))
+
+
+class _Figure:
+    def __init__(self, axes: _Axes) -> None:
+        self.axes = axes
+
+    def add_subplot(self, *_args: Any, **_kwargs: Any) -> _Axes:
+        return self.axes
+
+
+def test_plot_ellipsoid_3d_scaling_preserves_center(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    axes = _Axes()
+    monkeypatch.setattr(plotting.plt, "figure", lambda: _Figure(axes))
+    monkeypatch.setattr(plotting.plt, "show", lambda: None)
+
+    plotting.plot_ellipsoid_3d(
+        np.array([3.0, 4.0, 5.0]),
+        np.eye(3),
+        scaling_factor=2.0,
+    )
+
+    assert axes.surface is not None
+    _, _, z = axes.surface
+    np.testing.assert_allclose(z[:, 0], 7.0)
+    np.testing.assert_allclose(z[:, -1], 3.0)


### PR DESCRIPTION
## Bug

`plot_ellipsoid_3d()` applied `scaling_factor` to the already translated surface coordinates. For an ellipsoid centered away from the origin, changing its scale therefore moved the center as well as resizing the axes.

For example, an identity ellipsoid centered at `[3, 4, 5]` with `scaling_factor=2` produced a vertical extent from `8` to `12`, centered at `10`, instead of the correct extent from `3` to `7`, centered at `5`.

## Root cause

The helper first added `center` to the unit-sphere transform and then multiplied `x`, `y`, and `z` by `scaling_factor` in `plot_surface()`. Algebraically, this computed `scale * (shape @ point + center)` rather than `center + scale * shape @ point`.

## Fix

- apply `scaling_factor` only to the transformed ellipsoid offsets;
- translate by `center` afterward;
- pass the final world coordinates directly to Matplotlib;
- add a regression using a non-origin center and a scale factor of two.

## Validation

- the regression fails against the previous implementation with `z=12` where `z=7` is expected;
- the focused regression passes with the patch;
- syntax compilation passes for both the modified implementation and the new test;
- branch is 2 commits ahead and 0 behind `main`, with changes limited to the plotting helper and one regression test.