### PR TITLE
Reject inconsistent RTS measurement matrix rows

### DIFF
--- a/src/pyrecest/smoothers/rauch_tung_striebel_smoother.py
+++ b/src/pyrecest/smoothers/rauch_tung_striebel_smoother.py
@@ -123,6 +123,15 @@ class RauchTungStriebelSmoother(AbstractSmoother):
             state_dim,
             default=identity_matrix,
         )
+        expected_measurement_matrix_shape = (measurement_dim, state_dim)
+        if any(
+            tuple(matrix.shape) != expected_measurement_matrix_shape
+            for matrix in measurement_matrices_list
+        ):
+            raise ValueError(
+                "measurement_matrices must contain matrices with shape "
+                f"{expected_measurement_matrix_shape}."
+            )
         meas_noise_covariances_list = self._normalize_matrix_sequence(
             meas_noise_covariances,
             len(measurement_list),

--- a/tests/smoothers/test_rts_measurement_matrix_shape.py
+++ b/tests/smoothers/test_rts_measurement_matrix_shape.py
@@ -1,0 +1,27 @@
+import unittest
+
+from pyrecest.backend import array, eye, zeros
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.smoothers import RauchTungStriebelSmoother
+
+
+class RauchTungStriebelMeasurementMatrixShapeTest(unittest.TestCase):
+    def test_rejects_measurement_matrix_with_wrong_row_count(self):
+        smoother = RauchTungStriebelSmoother()
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"measurement_matrices must contain matrices with shape \(1, 2\)",
+        ):
+            smoother.filter(
+                initial_state=GaussianDistribution(zeros(2), eye(2)),
+                measurements=array([1.0, 2.0]),
+                measurement_matrices=eye(2),
+                meas_noise_covariances=array([1.0, 1.0]),
+                system_matrices=eye(2),
+                sys_noise_covariances=zeros((2, 2)),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`RauchTungStriebelSmoother.filter()` derives the measurement dimension from the normalized measurements, but previously accepted any rectangular observation matrix whose column count matched the state dimension.

For scalar measurements of a two-dimensional state, passing `H = eye(2)` therefore produced an innovation with shape `(2,)`: NumPy broadcast the scalar measurement to both observation rows. The filter silently processed two identical observations instead of rejecting an inconsistent model specification.

## Fix

- require every normalized linear measurement matrix to have exact shape `(measurement_dim, state_dim)`;
- raise a deterministic `ValueError` before the Kalman update can broadcast incompatible inputs;
- add a regression for scalar measurements paired with a two-row observation matrix.

## Impact

Malformed RTS observation models now fail at the input boundary instead of silently changing the effective measurement dimension. Valid rectangular matrices such as shape `(1, 2)` remain supported.

## Validation

- reproduced the pre-fix broadcast in an isolated NumPy check: a `(1,)` measurement minus a `(2,)` predicted observation becomes `[1.0, 1.0]` with shape `(2,)`;
- syntax-compiled the modified smoother and regression test;
- branch is 2 commits ahead and 0 behind `main`;
- final diff is limited to 9 source lines and one 27-line regression test.

GitHub Actions provides the repository's full supported Python and backend validation matrix.