### PR TITLE
Stabilize scalar DVS normal-flow normalization

### DIFF
--- a/src/pyrecest/experimental/dvs/active_contour.py
+++ b/src/pyrecest/experimental/dvs/active_contour.py
@@ -21,6 +21,14 @@ def unit_vector_from_angle(angle: float) -> np.ndarray:
     return np.array([np.cos(angle), np.sin(angle)], dtype=float)
 
 
+def _stable_euclidean_norm(vector: np.ndarray) -> float:
+    """Return a scale-safe Euclidean norm for a finite vector."""
+    absolute_values = np.abs(vector).reshape(-1)
+    if absolute_values.size == 0:
+        return 0.0
+    return float(np.hypot.reduce(absolute_values))
+
+
 def signed_normal_flow(normal: np.ndarray, velocity: np.ndarray) -> float:
     """Return signed normalized normal flow for one contour normal.
 
@@ -29,11 +37,11 @@ def signed_normal_flow(normal: np.ndarray, velocity: np.ndarray) -> float:
     """
     normal = np.asarray(normal, dtype=float)
     velocity = np.asarray(velocity, dtype=float)
-    velocity_norm = np.linalg.norm(velocity)
-    normal_norm = np.linalg.norm(normal)
+    velocity_norm = _stable_euclidean_norm(velocity)
+    normal_norm = _stable_euclidean_norm(normal)
     if velocity_norm <= 0.0 or normal_norm <= 0.0:
         return 0.0
-    return float((normal / normal_norm) @ velocity / velocity_norm)
+    return float((normal / normal_norm) @ (velocity / velocity_norm))
 
 
 def normal_flow_activity(normal: np.ndarray, velocity: np.ndarray) -> float:

--- a/tests/experimental/test_dvs_active_contour.py
+++ b/tests/experimental/test_dvs_active_contour.py
@@ -1,14 +1,36 @@
 import numpy as np
+import pytest
 from pyrecest.experimental.dvs import (
     activity_profile,
     normal_flow_activity,
     rectangle_contour_samples,
+    signed_normal_flow,
+    signed_normal_flow_profile,
 )
 
 
 def test_normal_flow_activity_uses_normal_component():
     assert normal_flow_activity(np.array([1.0, 0.0]), np.array([2.0, 0.0])) == 1.0
     assert normal_flow_activity(np.array([0.0, 1.0]), np.array([2.0, 0.0])) == 0.0
+
+
+def test_signed_normal_flow_preserves_extreme_finite_directions():
+    velocity = np.array([1e308, 1e308])
+    normals = np.array(
+        [
+            [1e308, 0.0],
+            [0.0, 1e308],
+            [-1e308, 0.0],
+        ]
+    )
+    expected = np.sqrt(0.5)
+
+    with np.errstate(over="raise", invalid="raise"):
+        scalar_flow = signed_normal_flow(normals[0], velocity)
+        profile = signed_normal_flow_profile(normals, velocity)
+
+    assert scalar_flow == pytest.approx(expected)
+    np.testing.assert_allclose(profile, [expected, expected, -expected])
 
 
 def test_rectangle_activity_matches_horizontal_translation():


### PR DESCRIPTION
## Bug

`pyrecest.experimental.dvs.signed_normal_flow()` normalized contour normals and velocities with `numpy.linalg.norm`. For large but finite vectors such as `[1e308, 1e308]`, the internal sum of squares overflows even though the true Euclidean norm remains representable.

For a horizontal normal and a 45-degree velocity at that scale, the helper returned `0.0` instead of `sqrt(0.5)`. With NumPy overflow handling configured to raise, it raised `FloatingPointError`. The profile and activity helpers inherit the same failure because they call this scalar path.

The vectorized DVS tracker path already uses scale-safe velocity normalization, but the public scalar active-contour helpers remained vulnerable.

## Fix

- compute Euclidean norms with a scale-safe `numpy.hypot.reduce` helper;
- normalize both the normal and velocity before taking their dot product, keeping the final arithmetic bounded;
- preserve the existing zero-vector behavior;
- add focused scalar and profile regressions using extreme finite normals and velocity.

## Validation

- reproduced the pre-fix result: `0.0` instead of `0.7071067811865475`;
- reproduced the pre-fix `FloatingPointError` under `numpy.errstate(over="raise", invalid="raise")`;
- verified the patched scalar/profile calculation returns `[sqrt(0.5), sqrt(0.5), -sqrt(0.5)]` without overflow;
- branch is 2 commits ahead and 0 behind `main`;
- final diff is limited to the active-contour helper and its focused test module.

GitHub Actions should provide the full supported Python, backend, lint, packaging, documentation, and security validation matrix.