### PR TITLE
Fix SE(3) plot-state sample indexing

### DIFF
--- a/src/pyrecest/distributions/abstract_se3_distribution.py
+++ b/src/pyrecest/distributions/abstract_se3_distribution.py
@@ -47,14 +47,14 @@ class AbstractSE3Distribution(AbstractLinBoundedCartProdDistribution):
         h = []
         if showMarginalized:
             h.append(self.marginalize_periodic().plot_state())
-        for i in range(samples.shape[1]):
+        for i in range(samples.shape[0]):
             if showMarginalized:
                 linearPart = mode[4:]
             else:
-                linearPart = samples[4:, i]
+                linearPart = samples[i, 4:]
             h.append(
                 AbstractSE3Distribution.plot_point(
-                    concatenate((samples[:4, i], linearPart), axis=0)
+                    concatenate((samples[i, :4], linearPart), axis=0)
                 )
             )
         return h

--- a/tests/distributions/test_se3_dirac_distribution.py
+++ b/tests/distributions/test_se3_dirac_distribution.py
@@ -26,6 +26,39 @@ class SE3DiracDistributionTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "same number of samples"):
             AbstractSE3Distribution.plot_trajectory(periodic_states, lin_states)
 
+    def test_plot_state_treats_sample_rows_as_se3_points(self):
+        expected_samples = np.array(
+            [
+                [1.0, 0.0, 0.0, 0.0, 10.0, 20.0, 30.0],
+                [0.0, 1.0, 0.0, 0.0, 40.0, 50.0, 60.0],
+            ]
+        )
+        test_case = self
+
+        class SampleDistribution:
+            @staticmethod
+            def sample(n_samples):
+                test_case.assertEqual(n_samples, 2)
+                return array(expected_samples)
+
+            @staticmethod
+            def mode():
+                return array(expected_samples[0])
+
+        with patch.object(
+            AbstractSE3Distribution,
+            "plot_point",
+            side_effect=lambda point: np.asarray(point, dtype=float),
+        ):
+            plotted_points = AbstractSE3Distribution.plot_state(
+                SampleDistribution(),
+                orientationSamples=2,
+                showMarginalized=False,
+            )
+
+        self.assertEqual(len(plotted_points), 2)
+        npt.assert_allclose(np.asarray(plotted_points), expected_samples)
+
     def test_plot_point_draws_rotated_body_axes(self):
         class RecordingAxes:
             def __init__(self):


### PR DESCRIPTION
## Bug

`AbstractSE3Distribution.plot_state()` indexed sampled SE(3) states as if samples were stored in columns. PyRecEst's distribution sampling contract returns an array shaped `(n_samples, state_dim)`, including `AbstractDiracDistribution.sample()`.

For two SE(3) samples shaped `(2, 7)`, the previous implementation iterated over the seven state coordinates and assembled seven malformed vectors of shape `(2,)`. It mixed coordinates from different samples and could then fail inside `plot_point()` or plot incorrect poses.

## Fix

- iterate over the sample axis (`samples.shape[0]`);
- read quaternion and linear coordinates from each sample row;
- preserve the existing `showMarginalized=True` behavior by combining each sampled quaternion with the mode's linear position;
- add a regression asserting that two row-major SE(3) samples produce exactly two unchanged plotted states.

## Validation

- isolated pre-fix reproduction: 2 samples shaped `(2, 7)` became 7 vectors shaped `(2,)`;
- isolated patched reproduction: the same input remains 2 vectors shaped `(7,)` and matches the original samples;
- branch is 2 commits ahead and 0 behind `main`;
- final diff is limited to the SE(3) plotting method and its focused test.

GitHub Actions should run the repository's full supported backend and test matrix.