### PR TITLE
Reject masked JAX norm axes

### DIFF
--- a/src/pyrecest/_backend/jax/linalg.py
+++ b/src/pyrecest/_backend/jax/linalg.py
@@ -35,6 +35,8 @@ def _as_integer_scalar(value, name):
 
 def _norm_axis_entry(axis) -> int:
     """Return one non-boolean NumPy-style linalg.norm axis."""
+    if _np.ma.is_masked(axis):
+        raise TypeError(_AXIS_TYPE_ERROR)
     if isinstance(axis, (bool, _np.bool_)):
         raise TypeError(_AXIS_TYPE_ERROR)
     try:
@@ -54,6 +56,8 @@ def _normalize_norm_axis(axis):
     """Normalize JAX linalg.norm axes before they become static arguments."""
     if axis is None:
         return None
+    if _np.ma.is_masked(axis):
+        raise TypeError(_AXIS_TYPE_ERROR)
     if isinstance(axis, (list, tuple)):
         return tuple(_norm_axis_entry(one_axis) for one_axis in axis)
 

--- a/tests/backend_support/test_jax_linalg_masked_axis.py
+++ b/tests/backend_support/test_jax_linalg_masked_axis.py
@@ -1,0 +1,43 @@
+"""Regressions for masked JAX linear-algebra axis arguments."""
+
+import pytest
+
+from tests.support.backend_runner import run_backend_code
+
+
+@pytest.mark.backend_portable
+def test_jax_linalg_norm_rejects_masked_axes():
+    pytest.importorskip("jax")
+
+    result = run_backend_code(
+        "jax",
+        """
+import numpy as np
+import pytest
+import pyrecest.backend as backend
+
+values = backend.array([[3.0, 4.0], [5.0, 12.0]])
+masked_axes = (
+    np.ma.masked,
+    np.ma.array(1, mask=True),
+    np.ma.array([1], mask=[True]),
+    [np.ma.array(1, mask=True)],
+    (np.ma.array(1, mask=True),),
+)
+
+for axis in masked_axes:
+    with pytest.raises(
+        TypeError,
+        match="axis must be None, an integer, or a tuple of integers",
+    ):
+        backend.linalg.norm(values, axis=axis)
+
+unmasked_axis = [np.ma.array(1, mask=False)]
+result = backend.linalg.norm(values, axis=unmasked_axis)
+np.testing.assert_allclose(backend.to_numpy(result), [5.0, 13.0])
+print("ok")
+""",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
## What changed

- reject genuinely masked NumPy axis values before JAX/static-axis coercion
- cover direct masked axes and masked scalar entries nested in lists or tuples
- preserve valid ordinary static-axis inputs and fully unmasked nested scalar axes
- add a focused backend-portable regression

## Root cause

The JAX `linalg.norm` compatibility layer normalizes list and tuple axes entry by entry. For a masked NumPy scalar such as `np.ma.array(1, mask=True)`, `operator.index()` exposes the hidden payload. Consequently, `axis=[np.ma.array(1, mask=True)]` was silently normalized to `(1,)` and the norm was evaluated along axis 1 instead of rejecting a missing axis value.

Direct masked arrays could also leak backend-specific `ValueError`s during JAX conversion rather than producing the documented axis validation error.

## Impact

Missing or masked configuration can no longer become a real norm axis through its hidden payload. Callers now receive a deterministic `TypeError` for all genuinely masked axis forms.

## Validation

- reproduced the pre-fix nested-axis behavior: a masked scalar payload of `1` produced `[5.0, 13.0]`
- exercised the patched normalizer against scalar, vector, nested-list, and nested-tuple masked axes
- verified all masked cases raise the documented `TypeError`
- verified existing NumPy/JAX scalar, array, list, and tuple axis forms still produce `[5.0, 13.0]`
- final comparison is 2 commits ahead and 0 behind `main`, limited to 4 source lines and one focused regression file

GitHub Actions will run the repository's full supported backend and Python-version matrix.