### PR TITLE
Support singular PyTorch Gaussian sampling

### DIFF
--- a/src/pyrecest/_backend/pytorch/random/__init__.py
+++ b/src/pyrecest/_backend/pytorch/random/__init__.py
@@ -289,14 +289,87 @@ def uniform(low=0.0, high=1.0, size=None, dtype=None):
     ) + low
 
 
+def _singular_multivariate_normal_factor(mean, cov, tol):
+    """Return a square-root factor for a valid singular covariance."""
+
+    torch = _LEGACY._torch
+    device = _LEGACY._tensor_device(mean, cov)
+    dtype = _LEGACY._floating_distribution_dtype(mean, cov)
+    try:
+        mean = _LEGACY._validate_multivariate_normal_parameter(
+            mean, "mean", dtype=dtype, device=device
+        )
+        cov = _LEGACY._validate_multivariate_normal_parameter(
+            cov, "cov", dtype=mean.dtype, device=mean.device
+        )
+    except (TypeError, ValueError, RuntimeError):
+        return None
+
+    if mean.ndim != 1 or cov.ndim != 2:
+        return None
+    if cov.shape != (mean.shape[0], mean.shape[0]) or mean.shape[0] == 0:
+        return None
+    if not bool(torch.allclose(cov, cov.T, rtol=0.0, atol=tol)):
+        return None
+
+    symmetric_cov = 0.5 * (cov + cov.T)
+    try:
+        eigenvalues, eigenvectors = torch.linalg.eigh(symmetric_cov)
+    except RuntimeError:
+        return None
+    if bool(torch.any(eigenvalues < -tol)):
+        return None
+
+    scale = torch.max(torch.abs(eigenvalues))
+    rank_tolerance = (
+        torch.finfo(cov.dtype).eps * max(mean.shape[0], 1) * scale
+    )
+    if bool(torch.all(eigenvalues > rank_tolerance)):
+        return None
+
+    factor = eigenvectors * torch.sqrt(
+        torch.clamp(eigenvalues, min=0.0)
+    ).unsqueeze(0)
+    return mean, factor
+
+
+def _sample_singular_multivariate_normal(mean, factor, size):
+    """Sample a singular Gaussian through its eigendecomposition factor."""
+
+    torch = _LEGACY._torch
+    sample_shape = _LEGACY._normal_sample_size(size)
+    standard_normal = torch.randn(
+        (*sample_shape, mean.shape[0]),
+        dtype=mean.dtype,
+        device=mean.device,
+    )
+    return mean + torch.matmul(standard_normal, factor.T)
+
+
 def multivariate_normal(mean, cov, size=None, *args, **kwargs):
     """Draw samples with NumPy-compatible validation keyword handling."""
 
     check_valid = kwargs.pop("check_valid", "warn")
     tol = kwargs.pop("tol", 1e-8)
     _validate_multivariate_normal_check_valid(check_valid)
-    _validate_multivariate_normal_tol(tol)
-    return _LEGACY.multivariate_normal(mean, cov, size=size, *args, **kwargs)
+    tol = _validate_multivariate_normal_tol(tol)
+
+    try:
+        return _LEGACY.multivariate_normal(
+            mean, cov, size=size, *args, **kwargs
+        )
+    except ValueError:
+        if args or kwargs:
+            raise
+        singular_parameters = _singular_multivariate_normal_factor(
+            mean, cov, tol
+        )
+        if singular_parameters is None:
+            raise
+        singular_mean, factor = singular_parameters
+        return _sample_singular_multivariate_normal(
+            singular_mean, factor, size
+        )
 
 
 __all__ = sorted(

--- a/tests/backend/test_pytorch_random_singular_multivariate_normal.py
+++ b/tests/backend/test_pytorch_random_singular_multivariate_normal.py
@@ -1,0 +1,50 @@
+import numpy as np
+import pytest
+
+
+torch = pytest.importorskip("torch")
+from pyrecest._backend.pytorch import random  # noqa: E402
+
+
+def test_multivariate_normal_zero_covariance_returns_mean():
+    random.seed(0)
+    mean = np.array([1.5, -2.0])
+
+    sample = (
+        random.multivariate_normal(mean, np.zeros((2, 2)), size=8)
+        .detach()
+        .cpu()
+        .numpy()
+    )
+
+    assert np.isfinite(sample).all()
+    np.testing.assert_allclose(
+        sample,
+        np.broadcast_to(mean, sample.shape),
+        rtol=0.0,
+        atol=0.0,
+    )
+
+
+def test_multivariate_normal_rank_one_covariance_stays_on_support():
+    random.seed(0)
+    mean = np.array([1.5, -2.0])
+
+    sample = (
+        random.multivariate_normal(
+            mean,
+            [[1.0, 1.0], [1.0, 1.0]],
+            size=8,
+        )
+        .detach()
+        .cpu()
+        .numpy()
+    )
+
+    assert np.isfinite(sample).all()
+    np.testing.assert_allclose(
+        sample[:, 0] - mean[0],
+        sample[:, 1] - mean[1],
+        rtol=1e-6,
+        atol=1e-6,
+    )


### PR DESCRIPTION
## What changed
- fall back to an eigendecomposition sampler when PyTorch rejects a valid positive-semidefinite covariance
- preserve the existing `torch.distributions.MultivariateNormal` path for positive-definite inputs
- add regressions for zero and rank-one covariance matrices

## Root cause
`torch.distributions.MultivariateNormal` requires covariance matrices to be positive definite, while PyRecEst's NumPy-compatible random facade is expected to accept positive-semidefinite covariance matrices. Valid degenerate Gaussians therefore raised before sampling.

## Impact
Deterministic and lower-rank Gaussian noise models now work under the PyTorch backend without changing the ordinary full-rank path.

## Validation
- reproduced the previous `PositiveDefinite()` failure in Torch 2.10 for zero and rank-one covariance matrices
- exercised the eigendecomposition sampler for zero, rank-one, and positive-definite covariances
- compiled the modified source module and regression test with `py_compile`

The full repository suite has not been run locally because this environment has no Git checkout or outbound Git access; GitHub Actions should provide the complete backend matrix.