### PR TITLE
Fix URTS transition callback dispatch

### DIFF
--- a/src/pyrecest/smoothers/__init__.py
+++ b/src/pyrecest/smoothers/__init__.py
@@ -1,5 +1,6 @@
 from ._mem_rbpf_ffbsi_option_contract import install_mem_rbpf_ffbsi_option_contract
 from ._record_smoother_numeric_contract import install_record_smoother_numeric_contract
+from ._urts_transition_call_contract import install_urts_transition_call_contract
 from .abstract_smoother import AbstractSmoother
 from .delayed_output import DelayedStateOutput, DelayedStateOutputMixin
 from .fbfb_mem_qkf_smoother import (
@@ -72,6 +73,7 @@ from .unscented_rauch_tung_striebel_smoother import (
 
 install_mem_rbpf_ffbsi_option_contract()
 install_record_smoother_numeric_contract()
+install_urts_transition_call_contract()
 
 __all__ = [
     "AbstractSmoother",

--- a/src/pyrecest/smoothers/_urts_transition_call_contract.py
+++ b/src/pyrecest/smoothers/_urts_transition_call_contract.py
@@ -1,0 +1,81 @@
+"""Transition-callback calling contract for the unscented RTS smoother."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Callable
+
+from pyrecest.backend import asarray
+
+from . import unscented_rauch_tung_striebel_smoother as _urts
+
+# pylint: disable=protected-access
+
+
+def _time_step_call_mode(function: Callable) -> tuple[str, str | None] | None:
+    """Return how a transition callback accepts its time-step argument."""
+
+    try:
+        signature = inspect.signature(function)
+    except (TypeError, ValueError):
+        return None
+
+    parameters = tuple(signature.parameters.values())
+    for parameter_name in ("dt", "time_step"):
+        time_parameter = signature.parameters.get(parameter_name)
+        if time_parameter is None:
+            continue
+        if time_parameter.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.VAR_POSITIONAL,
+        ):
+            return "positional", None
+        return "keyword", parameter_name
+
+    if any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD for parameter in parameters
+    ):
+        return "keyword", "dt"
+
+    positional_parameters = [
+        parameter
+        for parameter in parameters
+        if parameter.kind
+        in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        )
+    ]
+    if any(
+        parameter.kind == inspect.Parameter.VAR_POSITIONAL for parameter in parameters
+    ) or len(positional_parameters) >= 2:
+        return "positional", None
+    return None
+
+
+def _call_transition(function: Callable, sigma_point, time_step):
+    """Call a transition callback without dropping supported time-step arguments."""
+
+    if time_step is None:
+        return asarray(function(sigma_point)).reshape(-1)
+
+    call_mode = _time_step_call_mode(function)
+    if call_mode is None:
+        return asarray(function(sigma_point)).reshape(-1)
+
+    mode, parameter_name = call_mode
+    if mode == "positional":
+        return asarray(function(sigma_point, time_step)).reshape(-1)
+    return asarray(function(sigma_point, **{parameter_name: time_step})).reshape(-1)
+
+
+def install_urts_transition_call_contract() -> None:
+    """Install keyword-aware transition dispatch on the unscented RTS smoother."""
+
+    marker = "_pyrecest_time_step_call_contract"
+    setattr(_call_transition, marker, True)
+    current = _urts.UnscentedRauchTungStriebelSmoother._call_transition
+    if not getattr(current, marker, False):
+        _urts.UnscentedRauchTungStriebelSmoother._call_transition = staticmethod(
+            _call_transition
+        )

--- a/tests/smoothers/test_urts_transition_call_contract.py
+++ b/tests/smoothers/test_urts_transition_call_contract.py
@@ -1,0 +1,49 @@
+import unittest
+
+import numpy.testing as npt
+
+# pylint: disable=no-name-in-module
+import pyrecest.backend
+from pyrecest.backend import array
+from pyrecest.smoothers import UnscentedRauchTungStriebelSmoother
+
+
+class URTSTransitionCallContractTest(unittest.TestCase):
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
+    def test_keyword_only_time_step_is_forwarded(self):
+        calls = []
+
+        def transition(state, *, dt):
+            calls.append(dt)
+            return state + dt
+
+        result = UnscentedRauchTungStriebelSmoother._call_transition(
+            transition,
+            array([1.0]),
+            0.5,
+        )
+
+        npt.assert_allclose(result, array([1.5]))
+        self.assertEqual(calls, [0.5])
+
+    @unittest.skipIf(
+        pyrecest.backend.__backend_name__ in ("pytorch", "jax"),
+        reason="Not supported on this backend",
+    )
+    def test_transition_type_error_is_not_replaced(self):
+        def transition(_state, _dt):
+            raise TypeError("transition failed internally")
+
+        with self.assertRaisesRegex(TypeError, "transition failed internally"):
+            UnscentedRauchTungStriebelSmoother._call_transition(
+                transition,
+                array([1.0]),
+                0.5,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix the unscented Rauch–Tung–Striebel smoother's transition callback dispatch when a time step is supplied.

## Root cause

`_call_transition` only detected positional time-step parameters. A callback such as `def transition(state, *, dt): ...` was therefore called without `dt` and failed with a missing-keyword error. The old `try` block also included the callback invocation, so a `TypeError` raised inside a valid transition function could be swallowed and replaced by a misleading argument error.

## Changes

- add a keyword-aware URTS transition-call contract, following the existing smoother contract-installer pattern
- support keyword-only `dt` and `time_step`, `**kwargs`, positional second arguments, and `*args`
- invoke callbacks outside signature-inspection exception handling so internal `TypeError`s propagate unchanged
- add regressions for keyword-only `dt` forwarding and callback error preservation

## Validation

- reproduced the pre-fix failure with a keyword-only `dt` callback
- exercised the installed contract in a minimal package environment: the state propagated from `[1.0]` to `[1.5]` for `dt=0.5`, and an internal callback `TypeError` propagated unchanged
- parsed all added/modified Python sources successfully

A full repository test run was not possible in the execution environment because no authenticated GitHub CLI or network checkout was available; repository CI should provide the complete backend/test matrix.