### PR TITLE
Reject broadcastable JPDAF covariance shapes

### DIFF
--- a/src/pyrecest/filters/joint_probabilistic_data_association_filter.py
+++ b/src/pyrecest/filters/joint_probabilistic_data_association_filter.py
@@ -91,6 +91,18 @@ class JointProbabilisticDataAssociationFilter(AbstractNearestNeighborTracker):
         )
 
     @staticmethod
+    def _validate_measurement_covariance_shape(
+        cov_mats_meas, measurement_dim, n_meas
+    ):
+        shared_shape = (measurement_dim, measurement_dim)
+        per_measurement_shape = (measurement_dim, measurement_dim, n_meas)
+        if cov_mats_meas.shape not in (shared_shape, per_measurement_shape):
+            raise ValueError(
+                "cov_mats_meas must have shape (dim_meas, dim_meas) or "
+                "(dim_meas, dim_meas, n_meas)"
+            )
+
+    @staticmethod
     def _prepare_clutter_intensity(clutter_intensity, n_meas):
         if isscalar(clutter_intensity):
             clutter_intensity = full((n_meas,), float(clutter_intensity))
@@ -186,10 +198,9 @@ class JointProbabilisticDataAssociationFilter(AbstractNearestNeighborTracker):
             raise ValueError(
                 "State dimension of measurement_matrix and tracker state must match."
             )
-        if cov_mats_meas.ndim == 3 and cov_mats_meas.shape[2] != n_meas:
-            raise ValueError(
-                "If cov_mats_meas has three dimensions, the third dimension must be n_meas."
-            )
+        self._validate_measurement_covariance_shape(
+            cov_mats_meas, measurements.shape[0], n_meas
+        )
 
         detection_probability = float(self.association_param["detection_probability"])
         if not 0.0 < detection_probability < 1.0:

--- a/tests/filters/test_joint_probabilistic_data_association_filter.py
+++ b/tests/filters/test_joint_probabilistic_data_association_filter.py
@@ -212,6 +212,46 @@ class JointProbabilisticDataAssociationFilterTest(unittest.TestCase):
                 pairwise_cost_matrix=array([[0.0, 0.0], [0.0, 0.0]]),
             )
 
+    def test_rejects_broadcastable_shared_measurement_covariance(self):
+        tracker = JPDAF(self.kfs_init, association_param=self.association_param)
+        measurements = array([[-10.0], [0.0]])
+
+        with self.assertRaisesRegex(ValueError, "cov_mats_meas must have shape"):
+            tracker.find_association_probabilities(
+                measurements,
+                self.meas_mat,
+                array([[1.0]]),
+            )
+
+    def test_rejects_broadcastable_per_measurement_covariances(self):
+        tracker = JPDAF(self.kfs_init, association_param=self.association_param)
+        measurements = array([[-10.0, 10.0], [0.0, 0.0]])
+
+        with self.assertRaisesRegex(ValueError, "cov_mats_meas must have shape"):
+            tracker.find_association_probabilities(
+                measurements,
+                self.meas_mat,
+                array([[[1.0, 1.0]]]),
+            )
+
+    def test_accepts_matching_per_measurement_covariances(self):
+        tracker = JPDAF(self.kfs_init, association_param=self.association_param)
+        measurements = array([[-10.0, 10.0], [0.0, 0.0]])
+        covariances = array(
+            [
+                [[1.0, 2.0], [0.0, 0.0]],
+                [[0.0, 0.0], [1.0, 2.0]],
+            ]
+        )
+
+        association_probabilities, _ = tracker.find_association_probabilities(
+            measurements,
+            self.meas_mat,
+            covariances,
+        )
+
+        npt.assert_allclose(association_probabilities.sum(axis=1), array([1.0, 1.0]))
+
     def test_symmetric_ambiguous_case_leads_to_symmetric_probabilities(self):
         tracker = JPDAF(
             [


### PR DESCRIPTION
## Bug

`JointProbabilisticDataAssociationFilter.find_association_probabilities()` only checked the final axis of three-dimensional measurement-covariance inputs. It did not verify that the covariance rows and columns matched the measurement dimension.

For a two-dimensional measurement, a supplied covariance with shape `(1, 1)` therefore broadcast silently when added to the predicted `2 x 2` covariance. For example, `0.5 * I + [[1.0]]` becomes `[[1.5, 1.0], [1.0, 1.5]]`. The resulting artificial cross-correlation changes Gaussian likelihoods, gating, association probabilities, and Kalman updates instead of reporting a malformed input.

The same issue affected per-measurement covariance stacks such as `(1, 1, n_meas)`.

## Fix

- require exactly `(dim_meas, dim_meas)` for a shared covariance;
- require exactly `(dim_meas, dim_meas, n_meas)` for per-measurement covariances;
- validate the shape before the no-measurement fast path and before numerical updates.

## Regression coverage

- rejects a broadcastable shared `(1, 1)` covariance for two-dimensional measurements;
- rejects a broadcastable per-measurement `(1, 1, n_meas)` covariance stack;
- confirms a valid `(2, 2, n_meas)` stack remains accepted and produces normalized association probabilities.

## Validation

- reproduced NumPy's silent covariance broadcasting numerically;
- syntax-parsed the modified source and tests;
- verified the reconstructed pre-edit files matched the current Git blob SHAs exactly;
- inspected the branch comparison: two commits ahead of `main`, zero behind, modifying only the JPDAF implementation and its existing test module.

GitHub Actions provides the authoritative repository-wide test and lint matrix.