### PR TITLE
Fix innovation diagnostic record round trips

### DIFF
--- a/src/pyrecest/tracking/__init__.py
+++ b/src/pyrecest/tracking/__init__.py
@@ -1,5 +1,11 @@
 """Generic tracking event and replay-record helpers."""
 
+from ._innovation_diagnostic_record_contract import (
+    install_innovation_diagnostic_record_contract,
+)
+
+install_innovation_diagnostic_record_contract()
+
 from .event_records import (
     TrackingEvent,
     TrackingRecord,

--- a/src/pyrecest/tracking/_innovation_diagnostic_record_contract.py
+++ b/src/pyrecest/tracking/_innovation_diagnostic_record_contract.py
@@ -1,0 +1,133 @@
+"""Round-trip contract for serialized innovation diagnostics."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import numpy as np
+
+from . import innovation_diagnostics as _diagnostics
+
+# pylint: disable=protected-access
+
+
+def _record_value(
+    record: Mapping[str, Any], preferred_key: str, canonical_key: str
+) -> Any:
+    """Return a configured record field, falling back to its canonical name."""
+
+    if preferred_key in record:
+        return record[preferred_key]
+    return record.get(canonical_key)
+
+
+def _optional_finite_real_array(value: Any, name: str) -> np.ndarray | None:
+    """Deserialize an optional diagnostic array."""
+
+    if value is None:
+        return None
+    return _diagnostics._as_finite_real_array(value, name).copy()
+
+
+def diagnostic_from_record(
+    record: Mapping[str, Any],
+    *,
+    source_key: str = "source",
+    time_key: str = "time_s",
+    action_key: str = "update_action",
+    accepted_key: str = "accepted",
+    nis_key: str = "nis",
+    residual_norm_key: str = "residual_norm_m",
+    measurement_dim_key: str = "measurement_dim",
+    gate_threshold_key: str = "gate_threshold",
+) -> _diagnostics.InnovationDiagnostic:
+    """Restore a diagnostic from legacy records or ``InnovationDiagnostic.to_dict``."""
+
+    residual = _optional_finite_real_array(record.get("residual"), "residual")
+    innovation_covariance = _optional_finite_real_array(
+        record.get("innovation_covariance"),
+        "innovation_covariance",
+    )
+
+    measurement_dim_value = _record_value(
+        record,
+        measurement_dim_key,
+        "measurement_dim",
+    )
+    if measurement_dim_value is None:
+        measurement_dim_value = 0 if residual is None else residual.reshape(-1).size
+    measurement_dim = _diagnostics._nonnegative_integer(
+        measurement_dim_value,
+        measurement_dim_key,
+    )
+
+    raw_metadata = record.get("metadata")
+    if raw_metadata is None:
+        metadata: dict[str, Any] = {}
+    elif isinstance(raw_metadata, Mapping):
+        metadata = dict(raw_metadata)
+    else:
+        # Preserve permissive legacy behavior for non-mapping metadata values.
+        metadata = {"metadata": raw_metadata}
+
+    excluded = {
+        source_key,
+        time_key,
+        action_key,
+        accepted_key,
+        nis_key,
+        residual_norm_key,
+        measurement_dim_key,
+        gate_threshold_key,
+        "source",
+        "time",
+        "action",
+        "accepted",
+        "nis",
+        "residual_norm",
+        "measurement_dim",
+        "gate_threshold",
+        "residual",
+        "innovation_covariance",
+        "metadata",
+        "mahalanobis_distance",
+    }
+    metadata.update(
+        {key: value for key, value in record.items() if key not in excluded}
+    )
+
+    action = _record_value(record, action_key, "action")
+    source = _record_value(record, source_key, "source")
+    return _diagnostics.InnovationDiagnostic(
+        measurement_dim=measurement_dim,
+        nis=_diagnostics._optional_float(_record_value(record, nis_key, "nis")),
+        residual_norm=_diagnostics._optional_float(
+            _record_value(record, residual_norm_key, "residual_norm")
+        ),
+        gate_threshold=_diagnostics._optional_float(
+            _record_value(record, gate_threshold_key, "gate_threshold")
+        ),
+        accepted=_diagnostics._optional_bool(
+            _record_value(record, accepted_key, "accepted")
+        ),
+        action=None if action is None else str(action),
+        source=None if source is None else str(source),
+        time=_diagnostics._optional_float(_record_value(record, time_key, "time")),
+        residual=None if residual is None else residual.reshape(-1),
+        innovation_covariance=innovation_covariance,
+        metadata=metadata,
+    )
+
+
+def install_innovation_diagnostic_record_contract() -> None:
+    """Install round-trip-safe record deserialization."""
+
+    marker = "_pyrecest_round_trip_record_contract"
+    setattr(diagnostic_from_record, marker, True)
+    current = _diagnostics.diagnostic_from_record
+    if not getattr(current, marker, False):
+        _diagnostics.diagnostic_from_record = diagnostic_from_record
+
+
+__all__ = ["install_innovation_diagnostic_record_contract"]

--- a/tests/tracking/test_innovation_diagnostics_round_trip.py
+++ b/tests/tracking/test_innovation_diagnostics_round_trip.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+from pyrecest.tracking import diagnostic_from_record, innovation_diagnostic
+
+
+def test_diagnostic_record_round_trip_preserves_canonical_fields() -> None:
+    original = innovation_diagnostic(
+        np.array([1.0, -2.0]),
+        np.array([[2.0, 0.25], [0.25, 1.5]]),
+        gate_threshold=10.0,
+        action="updated",
+        source="radar",
+        time=3.5,
+        metadata={"sensor_id": 7},
+    )
+    serialized = original.to_dict(include_arrays=True)
+    serialized["extra"] = "kept"
+
+    restored = diagnostic_from_record(serialized)
+
+    assert restored.measurement_dim == original.measurement_dim
+    assert restored.nis == original.nis
+    assert restored.residual_norm == original.residual_norm
+    assert restored.gate_threshold == original.gate_threshold
+    assert restored.accepted == original.accepted
+    assert restored.action == original.action
+    assert restored.source == original.source
+    assert restored.time == original.time
+    assert np.array_equal(restored.residual, original.residual)
+    assert np.array_equal(
+        restored.innovation_covariance,
+        original.innovation_covariance,
+    )
+    assert restored.metadata == {"sensor_id": 7, "extra": "kept"}
+
+    # The deserialized object remains serializable instead of leaking NumPy arrays
+    # through a nested metadata field.
+    json.dumps(restored.to_dict(include_arrays=True))


### PR DESCRIPTION
## What changed

- restore canonical `InnovationDiagnostic.to_dict()` fields in `diagnostic_from_record`
- preserve `residual` and `innovation_covariance` as diagnostic arrays instead of leaking them into metadata
- flatten the serialized `metadata` mapping and ignore the derived `mahalanobis_distance` field
- retain compatibility with legacy tracking keys such as `time_s`, `update_action`, and `residual_norm_m`
- add a regression covering serialization, deserialization, metadata preservation, and JSON re-serialization

## Root cause

`InnovationDiagnostic.to_dict()` emits canonical dataclass keys (`time`, `action`, `residual_norm`) plus optional arrays and a nested `metadata` mapping. `diagnostic_from_record()` only recognized legacy tracking-record names and treated every other field as metadata. A round trip therefore lost canonical scalar fields and array fields, nested metadata under a second `metadata` key, and retained NumPy arrays in metadata, defeating the JSON/CSV-friendly serialization contract.

## Impact

Diagnostics can now be serialized with `include_arrays=True`, restored through the public tracking API, and serialized again without field loss or metadata pollution. Existing legacy record ingestion remains supported.

## Validation

- added `tests/tracking/test_innovation_diagnostics_round_trip.py`
- ran an isolated import/contract check for both `diagnostic_from_record` and `diagnostics_from_records`
- full repository tests were not runnable locally because the execution environment could not resolve GitHub for checkout; repository CI should provide full validation
