### PR TITLE
Preserve one-dimensional Dirac mean shape

### DIFF
--- a/src/pyrecest/distributions/nonperiodic/linear_dirac_distribution.py
+++ b/src/pyrecest/distributions/nonperiodic/linear_dirac_distribution.py
@@ -53,8 +53,10 @@ class LinearDiracDistribution(AbstractDiracDistribution, AbstractLinearDistribut
         AbstractDiracDistribution.__init__(self, d, w)
 
     def mean(self):
-        # Like np.average(self.d, weights=self.w, axis=0) but for all backends
-        return self.w @ self.d
+        # Keep the state-vector convention even when one-dimensional support is
+        # stored as a flat array of scalar samples.
+        sample_matrix = reshape(self.d, (-1, 1)) if self.d.ndim == 1 else self.d
+        return self.w @ sample_matrix
 
     def set_mean(self, new_mean):
         new_mean = asarray(new_mean)

--- a/tests/distributions/test_linear_dirac_distribution.py
+++ b/tests/distributions/test_linear_dirac_distribution.py
@@ -31,6 +31,14 @@ class LinearDiracDistributionTest(TestAbstractDiracDistribution):
         npt.assert_allclose(multidimensional.d, array([[1.0, 2.0], [3.0, 4.0]]))
         npt.assert_allclose(multidimensional.w, array([0.25, 0.75]))
 
+    def test_one_dimensional_mean_preserves_state_vector_shape(self):
+        dist = LinearDiracDistribution([1.0, 3.0], [0.25, 0.75])
+
+        mean = dist.mean()
+
+        self.assertEqual(mean.shape, (1,))
+        npt.assert_allclose(mean, array([2.5]))
+
     def test_constructor_accepts_scalar_location(self):
         scalar_dist = LinearDiracDistribution(2.5)
 


### PR DESCRIPTION
## Bug

`LinearDiracDistribution` stores one-dimensional support locations as a flat `(n_particles,)` array. Its `mean()` implementation directly evaluated `self.w @ self.d`, which collapses to a scalar with shape `()`.

That contradicts PyRecEst's linear-state convention: a distribution with `dim == 1` must expose its mean as a one-dimensional state vector with shape `(1,)`. Scalar means can break downstream code that indexes the state dimension, concatenates state vectors, or validates a returned point estimate by shape.

## Fix

- reshape flat one-dimensional support locations to `(n_particles, 1)` only for the mean calculation;
- preserve the existing `(state_dim,)` result for multidimensional support;
- retain backend-native matrix multiplication and dtype/device behavior.

## Regression coverage

A focused test checks both the numerical weighted mean and the exact `(1,)` shape for a one-dimensional `LinearDiracDistribution`.

## Validation

- confirmed the old expression returns shape `()` under NumPy, PyTorch, and JAX;
- confirmed the reshaped expression returns `(1,)` with the same value under all three backends;
- branch comparison is limited to the distribution implementation and its existing test module.

Repository CI remains the authoritative full backend and lint matrix.