### PR TITLE
Make IMM filter-bank replacement atomic

### DIFF
--- a/src/pyrecest/filters/interacting_multiple_model_filter.py
+++ b/src/pyrecest/filters/interacting_multiple_model_filter.py
@@ -172,10 +172,11 @@ class InteractingMultipleModelFilter(AbstractFilter, EuclideanFilterMixin):
                     "model in the IMM."
                 )
             if all(hasattr(curr_state, "filter_state") for curr_state in new_state):
-                self.filter_bank = [
+                candidate_filter_bank = [
                     copy.deepcopy(curr_filter) for curr_filter in new_state
                 ]
-                self._validate_filter_bank()
+                self._validate_filter_bank(candidate_filter_bank)
+                self.filter_bank = candidate_filter_bank
                 return
             if all(
                 isinstance(curr_state, GaussianDistribution) for curr_state in new_state
@@ -494,13 +495,14 @@ class InteractingMultipleModelFilter(AbstractFilter, EuclideanFilterMixin):
         """Return the IMM mean estimate."""
         return self.combined_filter_state.mean()
 
-    def _validate_filter_bank(self):
-        if not self.filter_bank:
+    def _validate_filter_bank(self, filter_bank=None):
+        filter_bank = self.filter_bank if filter_bank is None else filter_bank
+        if not filter_bank:
             raise ValueError("filter_bank must contain at least one filter.")
 
         curr_dims = [
             self._as_gaussian(curr_filter.filter_state).dim
-            for curr_filter in self.filter_bank
+            for curr_filter in filter_bank
         ]
         if any(curr_dim != curr_dims[0] for curr_dim in curr_dims[1:]):
             raise ValueError(

--- a/tests/filters/test_imm_filter_state_transaction.py
+++ b/tests/filters/test_imm_filter_state_transaction.py
@@ -1,0 +1,56 @@
+import copy
+import unittest
+
+import numpy.testing as npt
+import pyrecest.backend
+from pyrecest.backend import array, eye
+from pyrecest.distributions import GaussianDistribution
+from pyrecest.filters.interacting_multiple_model_filter import (
+    InteractingMultipleModelFilter,
+)
+
+
+class StateOnlyGaussianFilter:
+    def __init__(self, initial_state):
+        self.filter_state = copy.deepcopy(initial_state)
+
+
+@unittest.skipIf(
+    pyrecest.backend.__backend_name__ != "numpy",
+    reason="Only supported on numpy backend",
+)
+class ImmFilterStateTransactionTest(unittest.TestCase):
+    def test_invalid_replacement_bank_preserves_current_bank(self):
+        imm = InteractingMultipleModelFilter(
+            [
+                StateOnlyGaussianFilter(
+                    GaussianDistribution(array([0.0]), array([[1.0]]))
+                ),
+                StateOnlyGaussianFilter(
+                    GaussianDistribution(array([1.0]), array([[2.0]]))
+                ),
+            ],
+            transition_matrix=eye(2),
+        )
+        previous_bank = list(imm.filter_bank)
+        previous_states = [
+            copy.deepcopy(curr_filter.filter_state) for curr_filter in imm.filter_bank
+        ]
+        invalid_bank = [
+            StateOnlyGaussianFilter(GaussianDistribution(array([2.0]), array([[1.0]]))),
+            StateOnlyGaussianFilter(GaussianDistribution(array([3.0, 4.0]), eye(2))),
+        ]
+
+        with self.assertRaisesRegex(ValueError, "same state dimension"):
+            imm.filter_state = invalid_bank
+
+        for curr_filter, previous_filter, previous_state in zip(
+            imm.filter_bank, previous_bank, previous_states
+        ):
+            self.assertIs(curr_filter, previous_filter)
+            npt.assert_allclose(curr_filter.filter_state.mu, previous_state.mu)
+            npt.assert_allclose(curr_filter.filter_state.C, previous_state.C)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

Assigning replacement filters through `InteractingMultipleModelFilter.filter_state` installed the deep-copied candidate bank before validating it. If the replacement filters had inconsistent state dimensions, validation raised but the previously valid IMM was left holding the invalid bank.

## Fix

- stage the copied replacement bank in a local variable
- validate that candidate before assigning it to `self.filter_bank`
- allow `_validate_filter_bank` to validate an explicit candidate while preserving its existing constructor behavior

## Regression coverage

Added a focused test that assigns a mixed-dimension replacement bank, checks the expected `ValueError`, and verifies that the original filter objects and Gaussian states remain unchanged.

## Validation

- exact minimal source patch and regression test compile successfully
- MegaLinter validated the materialized source and test successfully
- full repository CI is running on the final squashed commit
